### PR TITLE
ci(web-client): use jdx/mise-action instead of setup-node

### DIFF
--- a/.github/workflows/web-client.yml
+++ b/.github/workflows/web-client.yml
@@ -18,11 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '26.1.0'
-          cache: npm
-          cache-dependency-path: web-client/package-lock.json
+      - uses: jdx/mise-action@v2
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary
- Swap `actions/setup-node@v4` for `jdx/mise-action@v2` in the web-client workflow.
- Node version is now sourced from the existing root `mise.toml` (`node = "26.1.0"`), so CI matches local mise-managed development.

## Test plan
- [ ] CI run on this PR completes the `test` job (lint, build, test:run) successfully.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WaEF9fsMS4hp8WXNTvEqAE)_