### PR TITLE
Add deploy/ Helm chart + Dockerfile for web-client

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,60 @@
+# deploy/
+
+Kubernetes deployment artifacts for fortymm. Currently this stands up the
+web-client only and routes HTTP traffic to it via an Ingress.
+
+## Layout
+
+```
+deploy/
+└── helm/
+    └── web-client/   Helm chart for the Vite + React SPA (served by nginx)
+```
+
+The `Dockerfile` and `nginx.conf` for the web-client image live next to the
+app source in [`web-client/`](../web-client).
+
+## Build the image
+
+From the repo root:
+
+```sh
+docker build -t ghcr.io/mightymoose/fortymm-web-client:dev web-client
+```
+
+The image is a multi-stage build: Node builds the static bundle, then
+nginx (running as non-root on port 8080) serves `dist/` with an SPA
+fallback to `index.html` and a `/healthz` probe endpoint.
+
+## Install the chart
+
+```sh
+helm upgrade --install web-client deploy/helm/web-client \
+  --namespace fortymm --create-namespace \
+  --set image.tag=dev
+```
+
+Useful overrides:
+
+| Flag | Effect |
+| --- | --- |
+| `--set image.repository=...` / `--set image.tag=...` | Point at a different image |
+| `--set ingress.enabled=false` | Skip the Ingress (e.g. when port-forwarding) |
+| `--set ingress.hosts[0].host=fortymm.example.com` | Change the host the Ingress matches |
+| `--set ingress.className=nginx` | Pin a specific IngressClass |
+| `--set replicaCount=3` | Scale replicas (or enable `autoscaling`) |
+
+## Local smoke test
+
+```sh
+# Render manifests without touching a cluster.
+helm template web-client deploy/helm/web-client
+
+# Lint the chart.
+helm lint deploy/helm/web-client
+```
+
+To try it on a local cluster (kind / minikube / k3d), build the image,
+load it into the cluster, then `helm upgrade --install` as above. With
+the default `fortymm.local` host, add an `/etc/hosts` entry pointing at
+your ingress controller's external IP.

--- a/deploy/helm/web-client/.helmignore
+++ b/deploy/helm/web-client/.helmignore
@@ -1,0 +1,16 @@
+# Patterns to ignore when packaging the chart.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.hg/
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/web-client/Chart.yaml
+++ b/deploy/helm/web-client/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: web-client
+description: fortymm web client (Vite + React SPA served by nginx)
+type: application
+version: 0.1.0
+appVersion: "0.0.0"

--- a/deploy/helm/web-client/templates/_helpers.tpl
+++ b/deploy/helm/web-client/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "web-client.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "web-client.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart name + version label.
+*/}}
+{{- define "web-client.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "web-client.labels" -}}
+helm.sh/chart: {{ include "web-client.chart" . }}
+{{ include "web-client.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "web-client.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "web-client.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Image reference (repository + resolved tag).
+*/}}
+{{- define "web-client.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}

--- a/deploy/helm/web-client/templates/deployment.yaml
+++ b/deploy/helm/web-client/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "web-client.fullname" . }}
+  labels:
+    {{- include "web-client.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "web-client.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "web-client.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: web-client
+          image: {{ include "web-client.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.writableTmpVolumes }}
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
+          {{- end }}
+      {{- if .Values.writableTmpVolumes }}
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/web-client/templates/hpa.yaml
+++ b/deploy/helm/web-client/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "web-client.fullname" . }}
+  labels:
+    {{- include "web-client.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "web-client.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/web-client/templates/ingress.yaml
+++ b/deploy/helm/web-client/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "web-client.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "web-client.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/web-client/templates/service.yaml
+++ b/deploy/helm/web-client/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "web-client.fullname" . }}
+  labels:
+    {{- include "web-client.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "web-client.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/web-client/values.yaml
+++ b/deploy/helm/web-client/values.yaml
@@ -1,0 +1,82 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/mightymoose/fortymm-web-client
+  tag: ""  # Defaults to .Chart.AppVersion when empty.
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  fsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 80
+
+# nginx in the image listens on 8080 (unprivileged).
+containerPort: 8080
+
+# Mount emptyDir volumes for paths nginx writes to so the root FS can stay read-only.
+writableTmpVolumes: true
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: fortymm.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 2
+  periodSeconds: 5
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 70
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/web-client/.dockerignore
+++ b/web-client/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.git
+.github
+*.log
+.env
+.env.*
+coverage
+.vscode
+.idea

--- a/web-client/Dockerfile
+++ b/web-client/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:26.1.0-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine AS runtime
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/web-client/nginx.conf
+++ b/web-client/nginx.conf
@@ -1,0 +1,26 @@
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA: fall back to index.html for client-side routes.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Long-lived caching for hashed Vite assets.
+    location /assets/ {
+        access_log off;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Container health probe.
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `deploy/helm/web-client/` Helm chart that stands the Vite SPA up on Kubernetes — Deployment, Service, Ingress, and an optional HPA, with sane non-root pod/container security contexts.
- Adds a multi-stage `web-client/Dockerfile` (Node build → nginx runtime) plus an `nginx.conf` that serves `dist/`, falls back to `index.html` for client-side routes, and exposes `/healthz` for probes. Image runs as non-root on port 8080.
- Adds `deploy/README.md` covering the build and `helm upgrade --install` flow, plus common value overrides (image, ingress host/className, replicas).

Validated locally with `helm lint` (clean) and `helm template` for both default and `autoscaling.enabled=true` configs.

## Test plan
- [ ] `docker build -t ghcr.io/mightymoose/fortymm-web-client:dev web-client` succeeds.
- [ ] `helm lint deploy/helm/web-client` passes.
- [ ] `helm template web-client deploy/helm/web-client` renders Deployment + Service + Ingress as expected.
- [ ] On a kind/minikube cluster: `helm upgrade --install web-client deploy/helm/web-client --set image.tag=dev`, then hit the ingress host and confirm the SPA loads and client-side routes return 200.

https://claude.ai/code/session_017Q42r4r78wiAWrbYRF7ERR

---
_Generated by [Claude Code](https://claude.ai/code/session_017Q42r4r78wiAWrbYRF7ERR)_