### PR TITLE
Auto-deploy web-client to Vercel

### DIFF
--- a/.github/workflows/web-client.yml
+++ b/.github/workflows/web-client.yml
@@ -12,6 +12,10 @@ defaults:
   run:
     working-directory: web-client
 
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -31,3 +35,41 @@ jobs:
       - run: npm run build
 
       - run: npm run test:run
+
+  deploy-preview:
+    needs: test
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '26.1.0'
+
+      - run: npm install --global vercel@latest
+
+      - run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+
+  deploy-production:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '26.1.0'
+
+      - run: npm install --global vercel@latest
+
+      - run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `deploy-preview` and `deploy-production` jobs to `.github/workflows/web-client.yml`, gated on the existing test job.
- Preview deploys run on PRs that touch `web-client/**` or the workflow file. Production deploys run on push to `main`.
- Uses the Vercel CLI with `vercel pull` / `vercel build` / `vercel deploy --prebuilt` so build settings come from the Vercel project (no `vercel.json` needed in the repo).

## Required setup before this works
Add these GitHub repo secrets:
- `VERCEL_TOKEN` — a Vercel access token (Account Settings -> Tokens).
- `VERCEL_ORG_ID` — from `.vercel/project.json` after running `vercel link` locally.
- `VERCEL_PROJECT_ID` — same file.

In the Vercel project settings, set **Root Directory** to `web-client` so Vercel picks up the Vite project and ignores the rest of the monorepo. Framework preset: Vite.

If you'd rather use Vercel's native Git integration (auto previews + comments) instead of GitHub Actions, we can drop these jobs and just configure the project in Vercel's dashboard — let me know.

## Test plan
- [ ] Add the three secrets in GitHub repo settings.
- [ ] Create / link a Vercel project with Root Directory = `web-client`.
- [ ] Open a PR touching `web-client/` and confirm `deploy-preview` succeeds and produces a preview URL in the job log.
- [ ] Merge to `main` and confirm `deploy-production` succeeds.

https://claude.ai/code/session_01XHvdMeZskoJ94xHm57yfns

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHvdMeZskoJ94xHm57yfns)_