### PR TITLE
Add Vercel SPA rewrite for TanStack Router history mode

### DIFF
--- a/web-client/vercel.json
+++ b/web-client/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `web-client/vercel.json` that rewrites every path to `/index.html` so TanStack Router (which uses HTML5 history mode by default) can handle deep links on Vercel without 404s.

## Test plan
- [ ] Deploy to Vercel and load the site at `/`.
- [ ] Hard-refresh on a non-root route (e.g. a future `/foo`) and confirm the SPA loads instead of a 404.
- [ ] Confirm static assets under `/assets/*` still resolve correctly.

https://claude.ai/code/session_01W4UiyFzaDvRZEcaKMe9BYy

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4UiyFzaDvRZEcaKMe9BYy)_