### PR TITLE
Add CP-SAT hello-world solver behind RQ-backed health check

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -16,11 +16,21 @@ pip install -e '.[dev]'
 
 ## Run
 
+The API needs Redis for the solver queue. Set `REDIS_URL` (defaults to `redis://localhost:6379/0`).
+
+Start the API:
+
 ```bash
 uvicorn app.main:app --reload
 ```
 
-The health endpoint is available at `GET /v1/health` and returns an empty JSON body.
+Start an RQ worker in a separate process so health checks can complete:
+
+```bash
+rq worker solver --url "$REDIS_URL"
+```
+
+`GET /v1/health` enqueues a small CP-SAT hello-world problem, waits for the worker to solve it, and returns `{"solver": {"healthy": true}}` when the round trip succeeds.
 
 ## Test
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,8 +1,36 @@
+import time
+
 from fastapi import FastAPI
 
+from app import queue
+
 app = FastAPI(title="FortyMM API")
+
+SOLVER_HEALTH_TIMEOUT = 10.0
 
 
 @app.get("/v1/health")
 def health() -> dict:
-    return {}
+    return {"solver": _check_solver()}
+
+
+def _check_solver() -> dict:
+    try:
+        job = queue.get_queue().enqueue(
+            "app.solver.solve_hello_world", job_timeout=10
+        )
+    except Exception:
+        return {"healthy": False}
+
+    deadline = time.monotonic() + SOLVER_HEALTH_TIMEOUT
+    while time.monotonic() < deadline:
+        try:
+            job.refresh()
+        except Exception:
+            return {"healthy": False}
+        if job.is_finished:
+            return {"healthy": bool(job.return_value())}
+        if job.is_failed:
+            return {"healthy": False}
+        time.sleep(0.1)
+    return {"healthy": False}

--- a/api/app/queue.py
+++ b/api/app/queue.py
@@ -1,0 +1,11 @@
+import os
+
+from redis import Redis
+from rq import Queue
+
+SOLVER_QUEUE = "solver"
+
+
+def get_queue() -> Queue:
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    return Queue(SOLVER_QUEUE, connection=Redis.from_url(redis_url))

--- a/api/app/solver.py
+++ b/api/app/solver.py
@@ -1,0 +1,11 @@
+from ortools.sat.python import cp_model
+
+
+def solve_hello_world() -> bool:
+    model = cp_model.CpModel()
+    x = model.NewIntVar(0, 10, "x")
+    y = model.NewIntVar(0, 10, "y")
+    model.Add(x + y == 10)
+    solver = cp_model.CpSolver()
+    status = solver.Solve(model)
+    return status in (cp_model.OPTIMAL, cp_model.FEASIBLE)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -6,12 +6,16 @@ requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
+    "ortools>=9.12",
+    "redis>=5.0",
+    "rq>=1.16,<2.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.3.0",
     "httpx>=0.27.0",
+    "fakeredis>=2.20",
 ]
 
 [build-system]

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,0 +1,13 @@
+import fakeredis
+import pytest
+from rq import Queue
+
+from app import queue as queue_module
+
+
+@pytest.fixture(autouse=True)
+def fake_solver_queue(monkeypatch):
+    connection = fakeredis.FakeStrictRedis()
+    q = Queue(queue_module.SOLVER_QUEUE, connection=connection, is_async=False)
+    monkeypatch.setattr(queue_module, "get_queue", lambda: q)
+    return q

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -1,12 +1,24 @@
 from fastapi.testclient import TestClient
 
+from app import queue as queue_module
 from app.main import app
 
 client = TestClient(app)
 
 
-def test_health_returns_empty_json():
+def test_health_reports_solver_healthy():
     response = client.get("/v1/health")
     assert response.status_code == 200
-    assert response.json() == {}
+    assert response.json() == {"solver": {"healthy": True}}
     assert response.headers["content-type"] == "application/json"
+
+
+def test_health_reports_solver_unhealthy_when_queue_unavailable(monkeypatch):
+    def boom():
+        raise RuntimeError("redis unreachable")
+
+    monkeypatch.setattr(queue_module, "get_queue", boom)
+
+    response = client.get("/v1/health")
+    assert response.status_code == 200
+    assert response.json() == {"solver": {"healthy": False}}

--- a/api/tests/test_solver.py
+++ b/api/tests/test_solver.py
@@ -1,0 +1,5 @@
+from app.solver import solve_hello_world
+
+
+def test_solve_hello_world_returns_true():
+    assert solve_hello_world() is True


### PR DESCRIPTION
## Summary
- Add a tiny CP-SAT hello-world problem (`x + y == 10`) in `app/solver.py` that runs on an RQ `solver` queue.
- `GET /v1/health` now enqueues that job, waits for the worker to return, and responds `{"solver": {"healthy": true}}` only when the whole round trip succeeds; any failure (Redis down, worker missing, solver error, timeout) reports `healthy: false`.
- Add `ortools`, `rq`, and `redis` runtime deps plus `fakeredis` as a dev dep so tests can drive the queue inline without a real Redis.

## Test plan
- [x] `pytest` (3 tests: solver returns true, health reports healthy via fake queue, health reports unhealthy when queue construction raises)
- [ ] Manual end-to-end check against a real Redis + `rq worker solver` (not run in this session)

https://claude.ai/code/session_01UXar3HUmHgxpLs1DFrss7U

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXar3HUmHgxpLs1DFrss7U)_