### PR TITLE
Add authenticated app shell to /dashboard

### DIFF
--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -1,0 +1,442 @@
+import { useEffect, useState, type ReactNode } from 'react'
+
+type NavItem = {
+  label: string
+  icon: ReactNode
+  badge?: { label: string; live?: boolean }
+  active?: boolean
+}
+
+type NavSection = {
+  label: string
+  items: NavItem[]
+}
+
+const NAV_SECTIONS: NavSection[] = [
+  {
+    label: 'Play',
+    items: [
+      {
+        label: 'Dashboard',
+        active: true,
+        icon: (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="3" y="3" width="7" height="9" />
+            <rect x="14" y="3" width="7" height="5" />
+            <rect x="14" y="12" width="7" height="9" />
+            <rect x="3" y="16" width="7" height="5" />
+          </svg>
+        ),
+      },
+      {
+        label: 'Live Matches',
+        badge: { label: '12', live: true },
+        icon: (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="9" />
+            <path d="M3 12h18M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18" />
+          </svg>
+        ),
+      },
+      {
+        label: 'Brackets',
+        icon: (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M3 6h18M3 12h18M3 18h18" />
+          </svg>
+        ),
+      },
+      {
+        label: 'Schedule',
+        icon: (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="3" y="4" width="18" height="18" rx="2" />
+            <path d="M16 2v4M8 2v4M3 10h18" />
+          </svg>
+        ),
+      },
+      {
+        label: 'Tournaments',
+        badge: { label: '3' },
+        icon: (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M6 2h12l-2 7H8z" />
+            <path d="M9 9v6a3 3 0 0 0 6 0V9" />
+            <path d="M5 22h14M10 18h4v4h-4z" />
+          </svg>
+        ),
+      },
+    ],
+  },
+  {
+    label: 'Manage',
+    items: [
+      {
+        label: 'Players',
+        badge: { label: '128' },
+        icon: (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+            <circle cx="9" cy="7" r="4" />
+            <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+          </svg>
+        ),
+      },
+      {
+        label: 'Courts',
+        icon: (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="3" y="3" width="18" height="18" rx="2" />
+            <path d="M3 9h18M9 21V9" />
+          </svg>
+        ),
+      },
+      {
+        label: 'Stats & Rankings',
+        icon: (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M3 3v18h18" />
+            <path d="M7 14l4-4 4 4 5-5" />
+          </svg>
+        ),
+      },
+      {
+        label: 'Achievements',
+        icon: (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="8" r="6" />
+            <path d="M15.5 13.5L17 22l-5-3-5 3 1.5-8.5" />
+          </svg>
+        ),
+      },
+    ],
+  },
+  {
+    label: 'Workspace',
+    items: [
+      {
+        label: 'Messages',
+        badge: { label: '5' },
+        icon: (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+          </svg>
+        ),
+      },
+      {
+        label: 'Settings',
+        icon: (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+        ),
+      },
+    ],
+  },
+]
+
+interface AppShellProps {
+  children: ReactNode
+}
+
+export function AppShell({ children }: AppShellProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [activeLabel, setActiveLabel] = useState(
+    () =>
+      NAV_SECTIONS.flatMap((s) => s.items).find((i) => i.active)?.label ??
+      'Dashboard',
+  )
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setSidebarOpen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [])
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 960px)')
+    function onChange(e: MediaQueryListEvent) {
+      if (!e.matches) setSidebarOpen(false)
+    }
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+
+  useEffect(() => {
+    const previous = document.body.style.overflow
+    document.body.style.overflow = sidebarOpen ? 'hidden' : ''
+    return () => {
+      document.body.style.overflow = previous
+    }
+  }, [sidebarOpen])
+
+  function handleNavClick(e: React.MouseEvent<HTMLAnchorElement>, label: string) {
+    e.preventDefault()
+    setActiveLabel(label)
+    if (window.matchMedia('(max-width: 960px)').matches) {
+      setSidebarOpen(false)
+    }
+  }
+
+  return (
+    <div className="app-shell dark fortymm-theme">
+      <aside
+        className={`app-shell__sidebar${sidebarOpen ? ' is-open' : ''}`}
+        aria-label="Main navigation"
+      >
+        <div className="app-shell__sidebar-header">
+          <div className="app-shell__wordmark">
+            FORTY<span className="accent">MM</span>
+          </div>
+          <button
+            type="button"
+            className="app-shell__sidebar-close"
+            aria-label="Close navigation"
+            onClick={() => setSidebarOpen(false)}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 6L6 18" />
+              <path d="M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <nav className="app-shell__nav">
+          {NAV_SECTIONS.map((section) => (
+            <div className="app-shell__nav-section" key={section.label}>
+              <div className="app-shell__nav-label">{section.label}</div>
+              <ul className="app-shell__nav-list">
+                {section.items.map((item) => {
+                  const isActive = activeLabel === item.label
+                  return (
+                    <li key={item.label}>
+                      <a
+                        href="#"
+                        className={`app-shell__nav-link${isActive ? ' is-active' : ''}`}
+                        onClick={(e) => handleNavClick(e, item.label)}
+                      >
+                        <span className="app-shell__nav-icon">{item.icon}</span>
+                        {item.label}
+                        {item.badge ? (
+                          <span
+                            className={`app-shell__nav-badge${
+                              item.badge.live ? ' app-shell__nav-badge--live' : ''
+                            }`}
+                          >
+                            {item.badge.label}
+                          </span>
+                        ) : null}
+                      </a>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+          ))}
+        </nav>
+
+        <div className="app-shell__sidebar-footer">
+          <div className="app-shell__promo">
+            <div className="app-shell__promo-title">SPRING OPEN '26</div>
+            <div className="app-shell__promo-copy">
+              Registration closes in 6 days. 64 spots, double elim.
+            </div>
+            <a href="#" className="app-shell__promo-btn">
+              Register
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M5 12h14M13 5l7 7-7 7" />
+              </svg>
+            </a>
+          </div>
+        </div>
+      </aside>
+
+      <div className="app-shell__main">
+        <header className="app-shell__topbar">
+          <button
+            type="button"
+            className="app-shell__menu-btn"
+            aria-label="Open navigation"
+            aria-controls="app-shell-sidebar"
+            aria-expanded={sidebarOpen}
+            onClick={() => setSidebarOpen((v) => !v)}
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M3 6h18M3 12h18M3 18h18" />
+            </svg>
+          </button>
+
+          <a href="#" className="app-shell__brand">
+            <div className="app-shell__wordmark">
+              FORTY<span className="accent">MM</span>
+            </div>
+          </a>
+
+          <div className="app-shell__spacer" />
+
+          <div className="app-shell__actions">
+            <button
+              type="button"
+              className="app-shell__user-menu"
+              aria-label="User menu"
+            >
+              <div className="app-shell__user-avatar">RK</div>
+              <div className="app-shell__user-name">Rita Kovač</div>
+              <span className="app-shell__user-chev">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M6 9l6 6 6-6" />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </header>
+
+        <main className="app-shell__content">{children}</main>
+      </div>
+
+      <div
+        className={`app-shell__backdrop${sidebarOpen ? ' is-open' : ''}`}
+        aria-hidden="true"
+        onClick={() => setSidebarOpen(false)}
+      />
+    </div>
+  )
+}

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -423,3 +423,423 @@ code {
   text-transform: uppercase;
   color: var(--fg-3);
 }
+
+/* =========================================================================
+   App Shell — authenticated layout (sticky sidebar + topbar, responsive)
+   ========================================================================= */
+
+/* The landing page (#root) is constrained to 1126px wide. The app shell
+   needs the full viewport, so reset #root when it contains a shell. */
+#root:has(.app-shell) {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  text-align: left;
+  border-inline: 0;
+  min-height: 0;
+  display: block;
+}
+
+.app-shell {
+  --sidebar-w: 256px;
+  --topbar-h: 64px;
+
+  display: grid;
+  grid-template-columns: var(--sidebar-w) 1fr;
+  min-height: 100vh;
+  background: var(--bg-app);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+}
+
+.app-shell *,
+.app-shell *::before,
+.app-shell *::after {
+  box-sizing: border-box;
+}
+
+/* ---------- Topbar ---------- */
+.app-shell__topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  height: var(--topbar-h);
+  background: rgba(11, 13, 18, 0.78);
+  backdrop-filter: saturate(140%) blur(14px);
+  -webkit-backdrop-filter: saturate(140%) blur(14px);
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 24px;
+}
+
+.app-shell__menu-btn {
+  display: none;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  color: var(--fg-1);
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.app-shell__menu-btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-default);
+}
+
+.app-shell__brand {
+  display: none;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  color: var(--fg-1);
+}
+
+.app-shell__wordmark {
+  font-family: var(--font-display);
+  font-size: 22px;
+  letter-spacing: 0.06em;
+  color: var(--fg-1);
+}
+.app-shell__wordmark .accent {
+  color: var(--ball-500);
+}
+
+.app-shell__spacer {
+  flex: 1;
+}
+
+.app-shell__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.app-shell__user-menu {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px 4px 4px;
+  height: 40px;
+  border-radius: 999px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  color: var(--fg-1);
+  cursor: pointer;
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.app-shell__user-menu:hover {
+  background: var(--bg-raised);
+  border-color: var(--border-default);
+}
+.app-shell__user-avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #2a6fdb, #00e29a);
+  color: var(--ink-950);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 12px;
+}
+.app-shell__user-name {
+  font-size: 13px;
+  font-weight: 500;
+}
+.app-shell__user-chev {
+  color: var(--fg-3);
+  display: grid;
+  place-items: center;
+}
+
+/* ---------- Sidebar ---------- */
+.app-shell__sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  width: var(--sidebar-w);
+  background: var(--bg-panel);
+  display: flex;
+  flex-direction: column;
+  z-index: 40;
+}
+.app-shell__sidebar-header {
+  height: var(--topbar-h);
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  border-bottom: 1px solid var(--border-subtle);
+  gap: 12px;
+  background: rgba(11, 13, 18, 0.78);
+  backdrop-filter: saturate(140%) blur(14px);
+  -webkit-backdrop-filter: saturate(140%) blur(14px);
+}
+.app-shell__sidebar-header .app-shell__wordmark {
+  display: block;
+  font-size: 24px;
+}
+.app-shell__sidebar-close {
+  display: none;
+  margin-left: auto;
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  color: var(--fg-2);
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+}
+.app-shell__sidebar-close:hover {
+  background: var(--bg-hover);
+  color: var(--fg-1);
+}
+
+.app-shell__nav {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.app-shell__nav-label {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  padding: 0 12px;
+  margin-bottom: 8px;
+}
+.app-shell__nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.app-shell__nav-link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 12px;
+  border-radius: 10px;
+  color: var(--fg-2);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.app-shell__nav-link:hover {
+  background: var(--bg-hover);
+  color: var(--fg-1);
+}
+.app-shell__nav-icon {
+  color: var(--fg-3);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.app-shell__nav-link:hover .app-shell__nav-icon {
+  color: var(--fg-2);
+}
+
+.app-shell__nav-badge {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--fg-3);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  padding: 2px 6px;
+  border-radius: 999px;
+  line-height: 1;
+}
+.app-shell__nav-badge--live {
+  color: var(--ink-950);
+  background: var(--serve-500);
+  border-color: transparent;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.app-shell__nav-badge--live::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ink-950);
+  animation: ball-pulse 1.4s ease-in-out infinite;
+}
+
+.app-shell__nav-link.is-active {
+  background: var(--bg-accent-soft);
+  color: var(--ball-200);
+}
+.app-shell__nav-link.is-active .app-shell__nav-icon {
+  color: var(--ball-400);
+}
+.app-shell__nav-link.is-active::before {
+  content: '';
+  position: absolute;
+  left: -3px;
+  top: 8px;
+  bottom: 8px;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: var(--ball-500);
+  box-shadow: 0 0 8px rgba(255, 122, 26, 0.6);
+}
+
+.app-shell__sidebar-footer {
+  border-top: 1px solid var(--border-subtle);
+  padding: 12px;
+}
+.app-shell__promo {
+  background: linear-gradient(
+    160deg,
+    rgba(255, 122, 26, 0.14),
+    rgba(255, 122, 26, 0.04) 60%,
+    transparent
+  );
+  border: 1px solid rgba(255, 122, 26, 0.25);
+  border-radius: 10px;
+  padding: 16px;
+}
+.app-shell__promo-title {
+  font-family: var(--font-display);
+  font-size: 18px;
+  letter-spacing: 0.04em;
+  color: var(--fg-1);
+  margin-bottom: 4px;
+}
+.app-shell__promo-copy {
+  font-size: 11px;
+  color: var(--fg-3);
+  line-height: 1.25;
+  margin-bottom: 12px;
+}
+.app-shell__promo-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--ball-500);
+  color: var(--ink-950);
+  border: none;
+  border-radius: 6px;
+  font-family: var(--font-ui);
+  font-weight: 600;
+  font-size: 12px;
+  padding: 7px 12px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.app-shell__promo-btn:hover {
+  background: var(--ball-400);
+}
+
+/* ---------- Main column ---------- */
+.app-shell__main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-app);
+}
+.app-shell__content {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ---------- Backdrop ---------- */
+.app-shell__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+  z-index: 35;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.app-shell__backdrop.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+  .app-shell__menu-btn {
+    display: inline-flex;
+  }
+  .app-shell__brand {
+    display: flex;
+  }
+
+  .app-shell__sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    height: 100vh;
+    transform: translateX(-100%);
+    transition: transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
+      box-shadow 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+    box-shadow: none;
+  }
+  .app-shell__sidebar.is-open {
+    transform: translateX(0);
+    box-shadow: 24px 0 60px rgba(0, 0, 0, 0.6);
+  }
+  .app-shell__sidebar-close {
+    display: inline-flex;
+  }
+
+  .app-shell__user-name {
+    display: none;
+  }
+  .app-shell__user-menu {
+    padding: 4px;
+  }
+}
+
+@media (max-width: 520px) {
+  .app-shell__topbar {
+    padding: 0 12px;
+  }
+  .app-shell__brand .app-shell__wordmark {
+    font-size: 18px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-shell__sidebar,
+  .app-shell__backdrop,
+  .app-shell__menu-btn,
+  .app-shell__nav-link,
+  .app-shell__user-menu {
+    transition: none !important;
+  }
+  .app-shell__nav-badge--live::before {
+    animation: none !important;
+  }
+}

--- a/web-client/src/routes/dashboard.tsx
+++ b/web-client/src/routes/dashboard.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { AppShell } from '@/components/app-shell'
 
 export const Route = createFileRoute('/dashboard')({
   component: DashboardPage,
@@ -6,10 +7,10 @@ export const Route = createFileRoute('/dashboard')({
 
 function DashboardPage() {
   return (
-    <div className="dark fortymm-theme min-h-screen">
+    <AppShell>
       <div className="mx-auto max-w-[1200px] px-12 pt-16 pb-32">
         <h1 className="font-display text-4xl text-foreground">Dashboard</h1>
       </div>
-    </div>
+    </AppShell>
   )
 }


### PR DESCRIPTION
## Summary

- Implements the FortyMM **App Shell** design (`App Shell.html` from the design handoff): sticky sidebar with grouped nav (Play / Manage / Workspace) and a Spring Open promo card; sticky topbar with the user menu (and a brand mark on mobile).
- Wraps the existing `/dashboard` route in the new `<AppShell>` component so the dashboard now renders inside the authenticated chrome. Dashboard content itself is unchanged.
- Responsive: at `≤960px` the sidebar pulls out of flow and slides in from the left over a dimmed backdrop, toggled by a hamburger button. Closes on backdrop click, the close button, `Esc`, or when the viewport grows past the breakpoint. Body scroll is locked while the sidebar is open.

## Changes

- `web-client/src/components/app-shell.tsx` — new `<AppShell>` React component (nav config, sidebar/topbar/backdrop markup, open/close + keyboard + media-query effects).
- `web-client/src/index.css` — adds scoped `.app-shell` styles (layout grid, sidebar, topbar, nav links + active rail, promo card, backdrop, responsive breakpoints, reduced-motion). Adds a `#root:has(.app-shell)` reset so the shell can fill the viewport (the existing `#root` rule constrains the landing page to 1126px).
- `web-client/src/routes/dashboard.tsx` — wraps the dashboard content in `<AppShell>`.

## Test plan

- [ ] `npm run build` succeeds (verified locally).
- [ ] `npm run lint` clean (verified locally).
- [ ] `npm run test:run` passes (verified locally).
- [ ] Visit `/dashboard` on a wide viewport — sidebar pinned left with FortyMM brand, grouped nav, promo card; topbar shows only the user menu.
- [ ] Resize below 960px — sidebar collapses; hamburger toggles it as a slide-in over the backdrop; topbar now also shows the brand.
- [ ] `Esc`, backdrop click, and the close button all dismiss the mobile sidebar.
- [ ] Other routes (`/`, `/design-system`) are visually unchanged.

https://claude.ai/code/session_01Td8u2HZNqdJmVR1WrcVjGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Td8u2HZNqdJmVR1WrcVjGM)_