### PR TITLE
Add empty Administration page and sidenav entry

### DIFF
--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState, type ReactNode } from 'react'
+import { Link, useRouterState } from '@tanstack/react-router'
 
 type NavItem = {
   label: string
   icon: ReactNode
   badge?: { label: string; live?: boolean }
   active?: boolean
+  to?: string
 }
 
 type NavSection = {
@@ -231,6 +233,25 @@ const NAV_SECTIONS: NavSection[] = [
           </svg>
         ),
       },
+      {
+        label: 'Administration',
+        to: '/admin',
+        icon: (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12 2l9 4v6c0 5-3.5 9-9 10-5.5-1-9-5-9-10V6l9-4z" />
+            <path d="M9 12l2 2 4-4" />
+          </svg>
+        ),
+      },
     ],
   },
 ]
@@ -241,6 +262,7 @@ interface AppShellProps {
 
 export function AppShell({ children }: AppShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
   const [activeLabel, setActiveLabel] = useState(
     () =>
       NAV_SECTIONS.flatMap((s) => s.items).find((i) => i.active)?.label ??
@@ -274,6 +296,13 @@ export function AppShell({ children }: AppShellProps) {
 
   function handleNavClick(e: React.MouseEvent<HTMLAnchorElement>, label: string) {
     e.preventDefault()
+    setActiveLabel(label)
+    if (window.matchMedia('(max-width: 960px)').matches) {
+      setSidebarOpen(false)
+    }
+  }
+
+  function handleRouteNavClick(label: string) {
     setActiveLabel(label)
     if (window.matchMedia('(max-width: 960px)').matches) {
       setSidebarOpen(false)
@@ -318,26 +347,44 @@ export function AppShell({ children }: AppShellProps) {
               <div className="app-shell__nav-label">{section.label}</div>
               <ul className="app-shell__nav-list">
                 {section.items.map((item) => {
-                  const isActive = activeLabel === item.label
+                  const isActive = item.to
+                    ? pathname === item.to
+                    : activeLabel === item.label
+                  const linkClassName = `app-shell__nav-link${isActive ? ' is-active' : ''}`
+                  const inner = (
+                    <>
+                      <span className="app-shell__nav-icon">{item.icon}</span>
+                      {item.label}
+                      {item.badge ? (
+                        <span
+                          className={`app-shell__nav-badge${
+                            item.badge.live ? ' app-shell__nav-badge--live' : ''
+                          }`}
+                        >
+                          {item.badge.label}
+                        </span>
+                      ) : null}
+                    </>
+                  )
                   return (
                     <li key={item.label}>
-                      <a
-                        href="#"
-                        className={`app-shell__nav-link${isActive ? ' is-active' : ''}`}
-                        onClick={(e) => handleNavClick(e, item.label)}
-                      >
-                        <span className="app-shell__nav-icon">{item.icon}</span>
-                        {item.label}
-                        {item.badge ? (
-                          <span
-                            className={`app-shell__nav-badge${
-                              item.badge.live ? ' app-shell__nav-badge--live' : ''
-                            }`}
-                          >
-                            {item.badge.label}
-                          </span>
-                        ) : null}
-                      </a>
+                      {item.to ? (
+                        <Link
+                          to={item.to}
+                          className={linkClassName}
+                          onClick={() => handleRouteNavClick(item.label)}
+                        >
+                          {inner}
+                        </Link>
+                      ) : (
+                        <a
+                          href="#"
+                          className={linkClassName}
+                          onClick={(e) => handleNavClick(e, item.label)}
+                        >
+                          {inner}
+                        </a>
+                      )}
                     </li>
                   )
                 })}

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as DesignSystemRouteImport } from './routes/design-system'
 import { Route as DashboardRouteImport } from './routes/dashboard'
+import { Route as AdminRouteImport } from './routes/admin'
 import { Route as IndexRouteImport } from './routes/index'
 
 const DesignSystemRoute = DesignSystemRouteImport.update({
@@ -23,6 +24,11 @@ const DashboardRoute = DashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminRoute = AdminRouteImport.update({
+  id: '/admin',
+  path: '/admin',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -31,30 +37,34 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/admin': typeof AdminRoute
   '/dashboard': typeof DashboardRoute
   '/design-system': typeof DesignSystemRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/admin': typeof AdminRoute
   '/dashboard': typeof DashboardRoute
   '/design-system': typeof DesignSystemRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/admin': typeof AdminRoute
   '/dashboard': typeof DashboardRoute
   '/design-system': typeof DesignSystemRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/dashboard' | '/design-system'
+  fullPaths: '/' | '/admin' | '/dashboard' | '/design-system'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/dashboard' | '/design-system'
-  id: '__root__' | '/' | '/dashboard' | '/design-system'
+  to: '/' | '/admin' | '/dashboard' | '/design-system'
+  id: '__root__' | '/' | '/admin' | '/dashboard' | '/design-system'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AdminRoute: typeof AdminRoute
   DashboardRoute: typeof DashboardRoute
   DesignSystemRoute: typeof DesignSystemRoute
 }
@@ -75,6 +85,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin': {
+      id: '/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof AdminRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -87,6 +104,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AdminRoute: AdminRoute,
   DashboardRoute: DashboardRoute,
   DesignSystemRoute: DesignSystemRoute,
 }

--- a/web-client/src/routes/admin.tsx
+++ b/web-client/src/routes/admin.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { AppShell } from '@/components/app-shell'
+
+export const Route = createFileRoute('/admin')({
+  component: AdminPage,
+})
+
+function AdminPage() {
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-[1200px] px-12 pt-16 pb-32">
+        <h1 className="font-display text-4xl text-foreground">Administration</h1>
+      </div>
+    </AppShell>
+  )
+}


### PR DESCRIPTION
## Summary
- Add a new `/admin` route in the web client rendering an empty Administration page inside the existing `AppShell`.
- Add an "Administration" sidenav item to the Workspace section, wired up as a real TanStack Router `Link` with active state derived from the current pathname.
- Extend `NavItem` with an optional `to` so future nav entries can opt into real routing without disturbing the existing items.

## Test plan
- [ ] `npm run lint`
- [ ] `npm run test:run`
- [ ] `npm run build`
- [ ] Visit `/admin` and confirm the page renders inside the app shell with the Administration sidenav item highlighted.
- [ ] From `/admin`, click other sidenav items and confirm existing local-state behavior is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_019U4b5vpgB4WdypFcsCD7gt)_