### PR TITLE
Wire Dashboard sidenav link to /dashboard route

### DIFF
--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -20,7 +20,7 @@ const NAV_SECTIONS: NavSection[] = [
     items: [
       {
         label: 'Dashboard',
-        active: true,
+        to: '/dashboard',
         icon: (
           <svg
             width="18"


### PR DESCRIPTION
## Summary
- Wire the Dashboard sidenav item to navigate to `/dashboard` (previously it was a static `active: true` placeholder).
- Administration continues to navigate to `/admin`; all other sidenav items remain non-navigating.

## Test plan
- [ ] Open the app, click Dashboard in the sidenav → routes to `/dashboard` and shows as active.
- [ ] Click Administration → routes to `/admin` and shows as active.
- [ ] Click any other sidenav item → no navigation, only visual active highlight.

https://claude.ai/code/session_015t341Faku9ZRTB14zAVdW9

---
_Generated by [Claude Code](https://claude.ai/code/session_015t341Faku9ZRTB14zAVdW9)_