### PR TITLE
Add Playwright e2e smoke tests at the repo root

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,65 @@
+name: e2e
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'api/**'
+      - 'web-client/**'
+      - 'e2e/**'
+      - '.github/workflows/e2e.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    env:
+      REDIS_URL: redis://127.0.0.1:6379/0
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: api/pyproject.toml
+
+      - run: pip install -e '.[dev]'
+        working-directory: api
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '26.1.0'
+          cache: npm
+          cache-dependency-path: |
+            web-client/package-lock.json
+            e2e/package-lock.json
+
+      - run: npm ci
+        working-directory: web-client
+
+      - run: npm ci
+        working-directory: e2e
+
+      - run: npx playwright install --with-deps chromium
+        working-directory: e2e
+
+      - run: npm test
+        working-directory: e2e
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/playwright-report
+          retention-days: 7

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+test-results
+playwright-report
+blob-report
+playwright/.cache

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,35 @@
+# FortyMM e2e
+
+Minimal Playwright smoke tests that boot the entire stack (Redis, RQ worker,
+FastAPI, web client) and verify the pieces wire together.
+
+## What is covered
+
+- `tests/health.spec.ts` — calls `GET /v1/health`, which enqueues a CP-SAT job
+  on Redis, the RQ worker pulls it and runs `solve_hello_world`, and the API
+  returns `{ solver: { healthy: true } }`. A pass means the API ↔ Redis ↔
+  worker ↔ ortools chain is wired correctly.
+- `tests/landing.spec.ts` — loads the Vite-served landing page and checks the
+  hero copy renders.
+
+## Prerequisites
+
+- Redis on `redis://127.0.0.1:6379/0` (override with `REDIS_URL`).
+- The `api/` venv created and `.[dev]` installed (`python -m venv api/.venv &&
+  api/.venv/bin/pip install -e 'api[dev]'`). If `api/.venv` is missing the
+  helper falls back to `uvicorn`/`rq` on `PATH`.
+- `web-client/` deps installed (`npm ci` from `web-client/`).
+
+## Run
+
+From this directory:
+
+```bash
+npm ci
+npx playwright install --with-deps chromium
+npm test
+```
+
+Playwright spins up the API + RQ worker (via `scripts/run-api-stack.sh`) and
+the Vite dev server, then runs the tests. Override endpoints with
+`API_URL` / `WEB_URL` if you want to point at already-running services.

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,96 @@
+{
+  "name": "fortymm-e2e",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fortymm-e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "@types/node": "^22.10.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "fortymm-e2e",
+  "private": true,
+  "version": "0.0.0",
+  "description": "End-to-end smoke tests that exercise the full FortyMM stack (Redis, RQ worker, FastAPI, web client).",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^22.10.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const API_URL = process.env.API_URL ?? 'http://127.0.0.1:8000'
+const WEB_URL = process.env.WEB_URL ?? 'http://127.0.0.1:5173'
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: WEB_URL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: devices['Desktop Chrome'],
+    },
+  ],
+  webServer: [
+    {
+      command: './scripts/run-api-stack.sh',
+      url: `${API_URL}/openapi.json`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+    {
+      command: 'npm --prefix ../web-client run dev -- --port 5173 --strictPort',
+      url: WEB_URL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  ],
+})

--- a/e2e/scripts/run-api-stack.sh
+++ b/e2e/scripts/run-api-stack.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Boots an RQ worker and the FastAPI server together so Playwright can wait on
+# /openapi.json. Either child exiting brings the script down, and SIGTERM from
+# Playwright cleanly terminates both. Shares REDIS_URL with both processes.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_DIR="$(cd "$SCRIPT_DIR/../../api" && pwd)"
+
+cd "$API_DIR"
+
+if [ -x ".venv/bin/uvicorn" ]; then
+  UVICORN=".venv/bin/uvicorn"
+  RQ=".venv/bin/rq"
+else
+  UVICORN="$(command -v uvicorn)"
+  RQ="$(command -v rq)"
+fi
+
+REDIS_URL="${REDIS_URL:-redis://127.0.0.1:6379/0}"
+export REDIS_URL
+
+"$RQ" worker solver --url "$REDIS_URL" &
+WORKER_PID=$!
+
+"$UVICORN" app.main:app --host 127.0.0.1 --port "${API_PORT:-8000}" &
+UVICORN_PID=$!
+
+cleanup() {
+  trap - EXIT INT TERM
+  kill -TERM "$WORKER_PID" "$UVICORN_PID" 2>/dev/null || true
+  wait "$WORKER_PID" 2>/dev/null || true
+  wait "$UVICORN_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+wait -n "$WORKER_PID" "$UVICORN_PID"

--- a/e2e/tests/health.spec.ts
+++ b/e2e/tests/health.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test'
+
+const API_URL = process.env.API_URL ?? 'http://127.0.0.1:8000'
+
+test('GET /v1/health round-trips through Redis, RQ worker and the solver', async ({
+  request,
+}) => {
+  const response = await request.get(`${API_URL}/v1/health`)
+  expect(response.status()).toBe(200)
+  expect(await response.json()).toEqual({ solver: { healthy: true } })
+})

--- a/e2e/tests/landing.spec.ts
+++ b/e2e/tests/landing.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test'
+
+test('landing page renders the hero copy served by the web client', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByRole('heading', { name: /Play more/ })).toBeVisible()
+  await expect(
+    page.getByRole('link', { name: /Start a match in your browser/ }),
+  ).toBeVisible()
+})


### PR DESCRIPTION
## Summary

Adds a minimal Playwright suite at the repo root (`e2e/`) so we can verify the
whole stack wires together — Redis ↔ RQ worker ↔ ortools ↔ FastAPI ↔ web
client — rather than only testing each piece in isolation.

Two tests, kept deliberately small:

- `tests/health.spec.ts` — `GET /v1/health` enqueues a CP-SAT job on Redis,
  the worker pulls and runs `solve_hello_world`, and the API returns
  `{ solver: { healthy: true } }`. A pass means the full backend pipeline is
  connected.
- `tests/landing.spec.ts` — loads the Vite-served landing page and checks the
  hero copy + primary CTA.

Playwright's `webServer` boots both halves of the stack:

- `scripts/run-api-stack.sh` starts the RQ worker and the FastAPI server
  together, propagates SIGTERM cleanly, and exits when either child dies.
- `npm --prefix ../web-client run dev` serves the web client.

`.github/workflows/e2e.yml` runs the suite on PRs that touch `api/`,
`web-client/`, `e2e/`, or the workflow itself, with a Redis service container.

## Test plan

- [x] `npm test` from `e2e/` passes locally with Redis running on
      `127.0.0.1:6379` and the api venv populated.
- [ ] CI workflow passes on this PR.

https://claude.ai/code/session_0189H5Fypz1rbSUPaWdXZcbw

---
_Generated by [Claude Code](https://claude.ai/code/session_0189H5Fypz1rbSUPaWdXZcbw)_