### PR TITLE
Add User model and bootstrap async SQLAlchemy + Alembic

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -32,8 +32,30 @@ rq worker solver --url "$REDIS_URL"
 
 `GET /v1/health` enqueues a small CP-SAT hello-world problem, waits for the worker to solve it, and returns `{"solver": {"healthy": true}}` when the round trip succeeds.
 
+## Database
+
+PostgreSQL via async SQLAlchemy. Set `DATABASE_URL` (defaults to `postgresql+asyncpg://postgres:postgres@localhost:5432/fortymm`).
+
+Start a local Postgres:
+
+```bash
+docker run --rm -d --name fortymm-pg \
+  -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=fortymm -p 5432:5432 postgres:16-alpine
+```
+
+Apply migrations:
+
+```bash
+alembic upgrade head
+```
+
 ## Test
+
+The test suite uses [testcontainers](https://testcontainers-python.readthedocs.io/) to spin up an ephemeral Postgres for DB-backed tests, so a working Docker daemon is required by default. To use an already-running Postgres instead, set `TEST_DATABASE_URL`:
 
 ```bash
 pytest
+# or, against a local Postgres:
+TEST_DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/fortymm_test" pytest
 ```

--- a/api/alembic.ini
+++ b/api/alembic.ini
@@ -1,0 +1,40 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+sqlalchemy.url =
+file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
+timezone = UTC
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/api/app/db.py
+++ b/api/app/db.py
@@ -1,0 +1,40 @@
+import os
+from collections.abc import AsyncIterator
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.orm import DeclarativeBase
+
+DEFAULT_DATABASE_URL = "postgresql+asyncpg://postgres:postgres@localhost:5432/fortymm"
+
+
+def get_database_url() -> str:
+    return os.environ.get("DATABASE_URL", DEFAULT_DATABASE_URL)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+_engine: AsyncEngine | None = None
+_sessionmaker: async_sessionmaker[AsyncSession] | None = None
+
+
+def get_engine() -> AsyncEngine:
+    global _engine, _sessionmaker
+    if _engine is None:
+        _engine = create_async_engine(get_database_url(), pool_pre_ping=True)
+        _sessionmaker = async_sessionmaker(_engine, expire_on_commit=False)
+    return _engine
+
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    if _sessionmaker is None:
+        get_engine()
+    assert _sessionmaker is not None
+    async with _sessionmaker() as session:
+        yield session

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -1,0 +1,3 @@
+from app.models.user import User
+
+__all__ = ["User"]

--- a/api/app/models/user.py
+++ b/api/app/models/user.py
@@ -1,0 +1,27 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    username: Mapped[str] = mapped_column(
+        String(255), unique=True, nullable=False, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/api/app/schemas/user.py
+++ b/api/app/schemas/user.py
@@ -1,0 +1,20 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class UserBase(BaseModel):
+    username: str = Field(min_length=1, max_length=255)
+
+
+class UserCreate(UserBase):
+    pass
+
+
+class UserRead(UserBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime

--- a/api/migrations/env.py
+++ b/api/migrations/env.py
@@ -1,0 +1,50 @@
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from app.db import Base, get_database_url
+import app.models  # noqa: F401  -- ensures models register on Base.metadata
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+config.set_main_option("sqlalchemy.url", get_database_url())
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+    )
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/api/migrations/script.py.mako
+++ b/api/migrations/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/api/migrations/versions/20260510_0000_0001_create_users_table.py
+++ b/api/migrations/versions/20260510_0000_0001_create_users_table.py
@@ -1,0 +1,45 @@
+"""create users table
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-05-10 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("username", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("username", name="uq_users_username"),
+    )
+    op.create_index("ix_users_username", "users", ["username"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_username", table_name="users")
+    op.drop_table("users")

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -9,13 +9,18 @@ dependencies = [
     "ortools>=9.12",
     "redis>=5.0",
     "rq>=1.16,<2.0",
+    "sqlalchemy[asyncio]>=2.0.36",
+    "asyncpg>=0.30",
+    "alembic>=1.14",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.3.0",
+    "pytest-asyncio>=0.24",
     "httpx>=0.27.0",
     "fakeredis>=2.20",
+    "testcontainers[postgres]>=4.8",
 ]
 
 [build-system]
@@ -27,3 +32,6 @@ include = ["app*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,8 +1,20 @@
+import os
+from collections.abc import AsyncIterator, Iterator
+
 import fakeredis
 import pytest
+import pytest_asyncio
 from rq import Queue
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from app import queue as queue_module
+from app.db import Base
+import app.models  # noqa: F401  -- ensures models register on Base.metadata
 
 
 @pytest.fixture(autouse=True)
@@ -11,3 +23,38 @@ def fake_solver_queue(monkeypatch):
     q = Queue(queue_module.SOLVER_QUEUE, connection=connection, is_async=False)
     monkeypatch.setattr(queue_module, "get_queue", lambda: q)
     return q
+
+
+@pytest.fixture(scope="session")
+def postgres_url() -> Iterator[str]:
+    override = os.environ.get("TEST_DATABASE_URL")
+    if override:
+        yield override
+        return
+
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine", driver="asyncpg") as pg:
+        yield pg.get_connection_url()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def engine(postgres_url: str) -> AsyncIterator[AsyncEngine]:
+    eng = create_async_engine(postgres_url)
+    async with eng.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def db_session(engine: AsyncEngine) -> AsyncIterator[AsyncSession]:
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    async with sessionmaker() as session:
+        try:
+            yield session
+        finally:
+            await session.rollback()
+    async with engine.begin() as conn:
+        for table in reversed(Base.metadata.sorted_tables):
+            await conn.execute(table.delete())

--- a/api/tests/test_user_model.py
+++ b/api/tests/test_user_model.py
@@ -1,0 +1,31 @@
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import User
+
+
+async def test_create_user_assigns_uuid_and_timestamps(db_session: AsyncSession):
+    user = User(username="alice")
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    assert isinstance(user.id, uuid.UUID)
+    assert user.created_at is not None
+    assert user.updated_at is not None
+
+
+async def test_username_is_unique(db_session: AsyncSession):
+    db_session.add(User(username="bob"))
+    await db_session.commit()
+    db_session.add(User(username="bob"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_username_is_required(db_session: AsyncSession):
+    db_session.add(User(username=None))  # type: ignore[arg-type]
+    with pytest.raises(IntegrityError):
+        await db_session.commit()


### PR DESCRIPTION
## Summary

- First database-backed model: `User` with UUID `id`, unique `username`, `created_at`, and `updated_at`.
- Bootstraps the API's database stack: async SQLAlchemy 2.0 (`asyncpg`), an async engine/session factory in `app/db.py`, and Alembic with an async-mode `env.py`.
- Initial migration creates the `users` table with a unique index on `username`.
- Pydantic schemas (`UserBase`, `UserCreate`, `UserRead`) for future API serialization.
- Test fixtures spin up Postgres via `testcontainers` by default; a `TEST_DATABASE_URL` env var lets you point at an already-running Postgres instead.

No endpoints added — this PR is "just the model" as requested.

## Test plan

- [x] `pytest` passes (3 existing + 3 new user-model tests) against a local Postgres via `TEST_DATABASE_URL`
- [x] `alembic upgrade head` creates the expected `users` schema; `alembic downgrade base` drops it
- [x] `app.main` route table is unchanged (`/v1/health` only — no User endpoints leaked in)
- [ ] CI runs the suite via testcontainers (Docker-backed)

https://claude.ai/code/session_01RuzxuRc5RcdoCspsLsnrqQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuzxuRc5RcdoCspsLsnrqQ)_