### PR TITLE
Add zustand with example UI store

### DIFF
--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -31,7 +31,8 @@
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.3.0",
         "tw-animate-css": "^1.4.0",
-        "vaul": "^1.1.2"
+        "vaul": "^1.1.2",
+        "zustand": "^5.0.13"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -9195,6 +9196,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -37,7 +37,8 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/web-client/src/stores/use-ui-store.test.ts
+++ b/web-client/src/stores/use-ui-store.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useUiStore } from './use-ui-store'
+
+const initialState = useUiStore.getState()
+
+describe('useUiStore', () => {
+  beforeEach(() => {
+    useUiStore.setState(initialState, true)
+  })
+
+  it('starts with the sidebar closed', () => {
+    expect(useUiStore.getState().sidebarOpen).toBe(false)
+  })
+
+  it('opens, closes, and toggles the sidebar', () => {
+    useUiStore.getState().openSidebar()
+    expect(useUiStore.getState().sidebarOpen).toBe(true)
+
+    useUiStore.getState().closeSidebar()
+    expect(useUiStore.getState().sidebarOpen).toBe(false)
+
+    useUiStore.getState().toggleSidebar()
+    expect(useUiStore.getState().sidebarOpen).toBe(true)
+  })
+})

--- a/web-client/src/stores/use-ui-store.ts
+++ b/web-client/src/stores/use-ui-store.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand'
+
+interface UiState {
+  sidebarOpen: boolean
+  openSidebar: () => void
+  closeSidebar: () => void
+  toggleSidebar: () => void
+}
+
+export const useUiStore = create<UiState>((set) => ({
+  sidebarOpen: false,
+  openSidebar: () => set({ sidebarOpen: true }),
+  closeSidebar: () => set({ sidebarOpen: false }),
+  toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
+}))


### PR DESCRIPTION
## Summary
- Adds `zustand` to `web-client` as a runtime dependency.
- Establishes `src/stores/` with a minimal `useUiStore` (sidebar open/close/toggle) as the pattern to follow for future stores.
- Adds a unit test demonstrating how to reset and assert on a zustand store.

No existing code is migrated to zustand in this PR — that's a follow-up. Local state in `AppShell` (`sidebarOpen`, `activeLabel`) is the most obvious migration candidate.

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npm run build`


---
_Generated by [Claude Code](https://claude.ai/code/session_017fwJb5zL1cfGrnAXSwVLch)_