### PR TITLE
Add UserToken model and users_tokens migration

### DIFF
--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -1,3 +1,4 @@
 from app.models.user import User
+from app.models.user_token import UserToken
 
-__all__ = ["User"]
+__all__ = ["User", "UserToken"]

--- a/api/app/models/user_token.py
+++ b/api/app/models/user_token.py
@@ -1,0 +1,33 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import ForeignKey, LargeBinary, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+from app.models.user import User
+
+
+class UserToken(Base):
+    __tablename__ = "users_tokens"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    token: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    context: Mapped[str] = mapped_column(String(255), nullable=False)
+    sent_to: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship(User)

--- a/api/migrations/versions/20260511_0000_0002_create_users_tokens_table.py
+++ b/api/migrations/versions/20260511_0000_0002_create_users_tokens_table.py
@@ -1,0 +1,48 @@
+"""create users_tokens table
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-05-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users_tokens",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("token", sa.LargeBinary(), nullable=False),
+        sa.Column("context", sa.String(length=255), nullable=False),
+        sa.Column("sent_to", sa.String(length=255), nullable=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_users_tokens_user_id", "users_tokens", ["user_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_tokens_user_id", table_name="users_tokens")
+    op.drop_table("users_tokens")

--- a/api/tests/test_user_token_model.py
+++ b/api/tests/test_user_token_model.py
@@ -1,0 +1,68 @@
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import User, UserToken
+
+
+async def test_create_user_token_assigns_uuid_and_timestamp(db_session: AsyncSession):
+    user = User(username="alice")
+    db_session.add(user)
+    await db_session.commit()
+
+    token = UserToken(
+        token=b"secret-bytes",
+        context="session",
+        sent_to=None,
+        user_id=user.id,
+    )
+    db_session.add(token)
+    await db_session.commit()
+    await db_session.refresh(token)
+
+    assert isinstance(token.id, uuid.UUID)
+    assert token.token == b"secret-bytes"
+    assert token.context == "session"
+    assert token.sent_to is None
+    assert token.user_id == user.id
+    assert token.created_at is not None
+
+
+async def test_user_token_requires_user(db_session: AsyncSession):
+    db_session.add(
+        UserToken(token=b"x", context="session", user_id=None)  # type: ignore[arg-type]
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_user_token_requires_token_and_context(db_session: AsyncSession):
+    user = User(username="carol")
+    db_session.add(user)
+    await db_session.commit()
+
+    db_session.add(
+        UserToken(token=None, context="session", user_id=user.id)  # type: ignore[arg-type]
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_user_token_cascades_on_user_delete(db_session: AsyncSession):
+    user = User(username="dave")
+    db_session.add(user)
+    await db_session.commit()
+
+    token = UserToken(token=b"t", context="session", user_id=user.id)
+    db_session.add(token)
+    await db_session.commit()
+
+    token_id = token.id
+    await db_session.delete(user)
+    await db_session.commit()
+    db_session.expunge_all()
+
+    fetched = await db_session.get(UserToken, token_id)
+    assert fetched is None


### PR DESCRIPTION
## Summary
- Adds a `users_tokens` table mirroring the requested Ecto schema (`token` bytea, `context`, `sent_to`, `user_id` FK, insertion-only timestamp).
- Adds the SQLAlchemy `UserToken` model with `user_id` ON DELETE CASCADE and a `user_id` index.
- Adds Alembic migration `0002_create_users_tokens_table`.
- Adds model tests covering creation, NOT NULL constraints, and FK cascade.

## Translation notes
The schema you provided is Ecto/Elixir, but this project uses SQLAlchemy + Alembic, so I translated it idiomatically:
- `field :token, :binary` → `LargeBinary` (Postgres `bytea`), `NOT NULL`.
- `field :context, :string` → `String(255)`, `NOT NULL`.
- `field :sent_to, :string` → `String(255)`, nullable (e.g. for tokens not yet sent).
- `belongs_to :user, User` → `user_id` UUID FK to `users.id` with `ON DELETE CASCADE` and an index.
- `timestamps(updated_at: false)` → single `created_at` column (matching the existing `users` table's naming).
- Primary key uses UUID for consistency with `User`.

## Test plan
- [x] `pytest tests/test_user_token_model.py tests/test_user_model.py` — 7/7 passing
- [x] `alembic upgrade head` then `alembic downgrade base` — both succeed
- [x] `\d users_tokens` shows correct columns, FK, and index

---
_Generated by [Claude Code](https://claude.ai/code/session_019LYixbJ2S5u2Kk52b8iNVj)_