### PR TITLE
Fetch session in user menu with MSW mock, skeleton, and tests

### DIFF
--- a/web-client/src/api/client.ts
+++ b/web-client/src/api/client.ts
@@ -1,6 +1,16 @@
 import createClient from 'openapi-fetch'
 import type { paths } from './schema'
 
+function resolveBaseUrl(): string {
+  const explicit = import.meta.env.VITE_API_URL
+  if (explicit) return explicit
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin
+  }
+  return 'http://localhost'
+}
+
 export const api = createClient<paths>({
-  baseUrl: import.meta.env.VITE_API_URL ?? '/',
+  baseUrl: resolveBaseUrl(),
+  fetch: (...args) => globalThis.fetch(...args),
 })

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from './client'
+import type { components } from './schema'
+
+export type Session = components['schemas']['SessionResponse']
+export type SessionUser = components['schemas']['SessionUser']
+
+export const SESSION_QUERY_KEY = ['session'] as const
+
+export function useSession() {
+  return useQuery({
+    queryKey: SESSION_QUERY_KEY,
+    queryFn: async (): Promise<Session> => {
+      const { data, error } = await api.GET('/v1/session')
+      if (error || !data) {
+        throw new Error('Failed to load session')
+      }
+      return data
+    },
+    staleTime: 1000 * 60 * 5,
+  })
+}

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
+import { UserMenu } from './user-menu'
 
 type NavItem = {
   label: string
@@ -451,28 +452,7 @@ export function AppShell({ children }: AppShellProps) {
           <div className="app-shell__spacer" />
 
           <div className="app-shell__actions">
-            <button
-              type="button"
-              className="app-shell__user-menu"
-              aria-label="User menu"
-            >
-              <div className="app-shell__user-avatar">RK</div>
-              <div className="app-shell__user-name">Rita Kovač</div>
-              <span className="app-shell__user-chev">
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M6 9l6 6 6-6" />
-                </svg>
-              </span>
-            </button>
+            <UserMenu />
           </div>
         </header>
 

--- a/web-client/src/components/user-menu.test.tsx
+++ b/web-client/src/components/user-menu.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse, delay } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { server } from '@/mocks/server'
+import { mockSession } from '@/mocks/handlers'
+import type { components } from '@/api/schema'
+import { UserMenu } from './user-menu'
+
+type SessionResponse = components['schemas']['SessionResponse']
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+describe('UserMenu', () => {
+  it('shows a loading skeleton while the session is fetching', async () => {
+    server.use(
+      http.get('*/v1/session', async () => {
+        await delay(50)
+        return HttpResponse.json(mockSession)
+      }),
+    )
+
+    renderWithClient(<UserMenu />)
+
+    expect(screen.getByTestId('user-menu-skeleton')).toBeInTheDocument()
+    expect(screen.getByLabelText('Loading user menu')).toHaveAttribute(
+      'aria-busy',
+      'true',
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('user-menu-skeleton')).not.toBeInTheDocument()
+    })
+  })
+
+  it("displays the user's username once the session resolves", async () => {
+    renderWithClient(<UserMenu />)
+
+    expect(
+      await screen.findByText(mockSession.data.user.username),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /user menu/i })).toBeInTheDocument()
+  })
+
+  it('renders avatar initials derived from the username', async () => {
+    const typed: SessionResponse = {
+      data: { user: { username: 'maria.rossi' } },
+    }
+    server.use(
+      http.get('*/v1/session', () => HttpResponse.json(typed)),
+    )
+
+    renderWithClient(<UserMenu />)
+
+    expect(await screen.findByText('maria.rossi')).toBeInTheDocument()
+    expect(screen.getByText('MR')).toBeInTheDocument()
+  })
+
+  it('truncates very long usernames via class and exposes full name as a tooltip', async () => {
+    const longName = 'a-really-extraordinarily-long-username-that-should-truncate'
+    const typed: SessionResponse = {
+      data: { user: { username: longName } },
+    }
+    server.use(
+      http.get('*/v1/session', () => HttpResponse.json(typed)),
+    )
+
+    renderWithClient(<UserMenu />)
+
+    const nameEl = await screen.findByText(longName)
+    expect(nameEl).toHaveClass('app-shell__user-name--truncate')
+    expect(nameEl).toHaveAttribute('title', longName)
+  })
+})

--- a/web-client/src/components/user-menu.tsx
+++ b/web-client/src/components/user-menu.tsx
@@ -1,0 +1,69 @@
+import { useSession } from '@/api/session'
+
+function getInitials(username: string): string {
+  const cleaned = username.replace(/[._-]+/g, ' ').trim()
+  const parts = cleaned.split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return '??'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[1][0]).toUpperCase()
+}
+
+export function UserMenu() {
+  const { data, isLoading, isError } = useSession()
+
+  if (isLoading) {
+    return (
+      <div
+        className="app-shell__user-menu app-shell__user-menu--loading"
+        aria-busy="true"
+        aria-label="Loading user menu"
+        data-testid="user-menu-skeleton"
+      >
+        <div className="app-shell__user-avatar app-shell__skeleton app-shell__skeleton--avatar" />
+        <div className="app-shell__user-name app-shell__skeleton app-shell__skeleton--name" />
+        <span className="app-shell__user-chev" aria-hidden="true">
+          <Chevron />
+        </span>
+      </div>
+    )
+  }
+
+  const username = !isError && data ? data.data.user.username : 'Guest'
+  const initials = getInitials(username)
+
+  return (
+    <button
+      type="button"
+      className="app-shell__user-menu"
+      aria-label="User menu"
+    >
+      <div className="app-shell__user-avatar">{initials}</div>
+      <div
+        className="app-shell__user-name app-shell__user-name--truncate"
+        title={username}
+      >
+        {username}
+      </div>
+      <span className="app-shell__user-chev" aria-hidden="true">
+        <Chevron />
+      </span>
+    </button>
+  )
+}
+
+function Chevron() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M6 9l6 6 6-6" />
+    </svg>
+  )
+}

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -556,10 +556,60 @@ code {
   font-size: 13px;
   font-weight: 500;
 }
+.app-shell__user-name--truncate {
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .app-shell__user-chev {
   color: var(--fg-3);
   display: grid;
   place-items: center;
+}
+
+.app-shell__user-menu--loading {
+  cursor: default;
+}
+.app-shell__user-menu--loading:hover {
+  background: var(--bg-card);
+  border-color: var(--border-subtle);
+}
+.app-shell__skeleton {
+  position: relative;
+  overflow: hidden;
+  background: var(--bg-raised);
+}
+.app-shell__skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.06) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: app-shell-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+.app-shell__skeleton--avatar {
+  background: var(--bg-raised);
+}
+.app-shell__skeleton--name {
+  width: 96px;
+  height: 12px;
+  border-radius: 4px;
+}
+@keyframes app-shell-skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .app-shell__skeleton::after {
+    animation: none;
+  }
 }
 
 /* ---------- Sidebar ---------- */

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -15,11 +15,21 @@ declare module '@tanstack/react-router' {
   }
 }
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
-  </StrictMode>,
-)
+async function enableMocking() {
+  if (!import.meta.env.DEV) return
+  const { worker } = await import('./mocks/browser')
+  await worker.start({
+    onUnhandledRequest: 'bypass',
+  })
+}
+
+enableMocking().then(() => {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </StrictMode>,
+  )
+})

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -1,7 +1,23 @@
-import { http, HttpResponse } from 'msw'
+import { delay, http, HttpResponse } from 'msw'
+import type { components } from '@/api/schema'
+
+type SessionResponse = components['schemas']['SessionResponse']
+
+export const mockSession: SessionResponse = {
+  data: {
+    user: {
+      username: 'rita.kovac',
+    },
+  },
+}
 
 export const handlers = [
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' })
+  }),
+
+  http.get('*/v1/session', async () => {
+    await delay(600)
+    return HttpResponse.json(mockSession)
   }),
 ]

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -23,6 +23,11 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    environmentOptions: {
+      jsdom: {
+        url: 'http://localhost/',
+      },
+    },
     setupFiles: ['./src/test/setup.ts'],
     css: true,
   },


### PR DESCRIPTION
## Summary
- Wires the topbar user menu to `GET /v1/session` via a new `useSession` TanStack Query hook, replacing the hard-coded "Rita Kovač" placeholder with the real username.
- Adds a loading skeleton (shimmering avatar + name bar) while the request is in flight, and truncates long usernames with an ellipsis + `title` tooltip so the layout stays stable.
- Adds an MSW handler for `/v1/session` with a ~600ms delay so the loading state is exercised in dev, plus a `mockSession` constant typed against `components['schemas']['SessionResponse']` to make backend schema regressions a type error.
- Enables MSW in dev via `main.tsx` (`worker.start` is dynamically imported and only runs when `import.meta.env.DEV`).
- Switches the API client to resolve an absolute `baseUrl` (`window.location.origin` fallback) and to wrap `fetch` so MSW's interceptor patch is picked up at call time rather than module-load time — without this, the test-environment fetch reference was captured before `server.listen()`.
- Vitest jsdom `url` set to `http://localhost/` so relative URLs are resolvable.

## Test plan
- [x] `npm run test:run` — 6/6 tests pass (existing `App.test.tsx` plus new `user-menu.test.tsx` covering skeleton, resolved username, derived initials, and truncation class/title).
- [x] `npm run lint` — clean (only the pre-existing `mockServiceWorker.js` warning).
- [x] `npm run build` — succeeds.
- [ ] Manual: open `/dashboard` in dev and confirm the skeleton renders for ~600ms before the username appears, that a long mock username truncates with `…` and shows the full value on hover.

https://claude.ai/code/session_01Qh6qnSoZoLWUXq4KhYnscF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qh6qnSoZoLWUXq4KhYnscF)_