### PR TITLE
Disable needrestart interactive prompt for Playwright install

### DIFF
--- a/.github/workflows/web-client.yml
+++ b/.github/workflows/web-client.yml
@@ -31,3 +31,16 @@ jobs:
       - run: npm run build
 
       - run: npm run test:run
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: web-client/playwright-report
+          retention-days: 7

--- a/.github/workflows/web-client.yml
+++ b/.github/workflows/web-client.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: npm run test:run
 
-      - name: Install Playwright browsers
-        run: npx playwright install
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
 
       - run: npm run test:e2e
 

--- a/.github/workflows/web-client.yml
+++ b/.github/workflows/web-client.yml
@@ -33,7 +33,19 @@ jobs:
       - run: npm run test:run
 
       - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
+        env:
+          NEEDRESTART_MODE: a
+          NEEDRESTART_SUSPEND: '1'
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          # The ubuntu-latest runner (Noble) ships needrestart, whose apt
+          # hook prompts interactively after package installs and hangs CI.
+          # Force it into automatic mode globally so the sudo apt-get call
+          # that --with-deps performs can't get stuck waiting for input.
+          if [ -f /etc/needrestart/needrestart.conf ]; then
+            sudo sed -i "s/^#\\?\\\$nrconf{restart} = .*/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf
+          fi
+          npx playwright install --with-deps chromium
 
       - run: npm run test:e2e
 

--- a/.github/workflows/web-client.yml
+++ b/.github/workflows/web-client.yml
@@ -15,6 +15,7 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -32,10 +33,26 @@ jobs:
 
       - run: npm run test:run
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
 
-      - run: npm run test:e2e
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '26.1.0'
+          cache: npm
+          cache-dependency-path: web-client/package-lock.json
+
+      - run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - run: npm run build
+
+      - run: npm run test:e2e -- --project=chromium
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
@@ -44,3 +61,4 @@ jobs:
           name: playwright-report
           path: web-client/playwright-report
           retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/web-client.yml
+++ b/.github/workflows/web-client.yml
@@ -15,7 +15,6 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -33,26 +32,10 @@ jobs:
 
       - run: npm run test:run
 
-  e2e:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '26.1.0'
-          cache: npm
-          cache-dependency-path: web-client/package-lock.json
-
-      - run: npm ci
-
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install
 
-      - run: npm run build
-
-      - run: npm run test:e2e -- --project=chromium
+      - run: npm run test:e2e
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
@@ -61,4 +44,3 @@ jobs:
           name: playwright-report
           path: web-client/playwright-report
           retention-days: 7
-          if-no-files-found: ignore

--- a/web-client/.gitignore
+++ b/web-client/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+/playwright-report
+/test-results
+/playwright/.cache
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/web-client/e2e/landing.spec.ts
+++ b/web-client/e2e/landing.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('landing page', () => {
+  test('renders the FortyMM hero', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: /play more\.\s*pay never\./i }),
+    ).toBeVisible()
+  })
+
+  test('switches the active product feature when a tab is clicked', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(
+      page.getByRole('heading', { name: /scores in, history out\./i }),
+    ).toBeVisible()
+
+    await page.getByRole('tab', { name: /run tournaments/i }).click()
+
+    await expect(
+      page.getByRole('heading', { name: /the schedule, solved\./i }),
+    ).toBeVisible()
+  })
+})

--- a/web-client/eslint.config.js
+++ b/web-client/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'src/routeTree.gen.ts']),
+  globalIgnores(['dist', 'src/routeTree.gen.ts', 'playwright-report', 'test-results']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -35,6 +35,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.59.1",
         "@tanstack/react-query-devtools": "^5.100.9",
         "@tanstack/react-router-devtools": "^1.166.13",
         "@tanstack/router-plugin": "^1.167.35",
@@ -1297,6 +1298,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -3627,8 +3644,6 @@
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3727,8 +3742,6 @@
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4265,8 +4278,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4988,8 +4999,6 @@
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6712,8 +6721,6 @@
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7386,6 +7393,53 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -7469,8 +7523,6 @@
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7697,8 +7749,6 @@
     },
     "node_modules/react-is": {
       "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
     },

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -11,6 +11,8 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:ui": "vitest --ui",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "gen:api": "openapi-typescript ${API_URL:-http://localhost:8000}/openapi.json -o ./src/api/schema.d.ts"
   },
   "dependencies": {
@@ -41,6 +43,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.59.1",
     "@tanstack/react-query-devtools": "^5.100.9",
     "@tanstack/react-router-devtools": "^1.166.13",
     "@tanstack/router-plugin": "^1.167.35",

--- a/web-client/playwright.config.ts
+++ b/web-client/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT = 4173
+const baseURL = `http://localhost:${PORT}`
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+  webServer: {
+    command: `npm run preview -- --port ${PORT} --strictPort`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/web-client/playwright.config.ts
+++ b/web-client/playwright.config.ts
@@ -19,14 +19,6 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
   ],
   webServer: {
     command: `npm run preview -- --port ${PORT} --strictPort`,

--- a/web-client/tsconfig.e2e.json
+++ b/web-client/tsconfig.e2e.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.e2e.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023", "DOM"],
+    "module": "esnext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["e2e", "playwright.config.ts"]
+}

--- a/web-client/tsconfig.json
+++ b/web-client/tsconfig.json
@@ -2,7 +2,8 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.e2e.json" }
   ],
   "compilerOptions": {
     "paths": {

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -25,5 +25,6 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     css: true,
+    exclude: ['node_modules', 'dist', 'e2e', 'playwright-report', 'test-results'],
   },
 })


### PR DESCRIPTION
## Summary

The `web-client` CI job hangs in `npx playwright install --with-deps` and gets cancelled at the 6h GitHub Actions timeout. Root cause: the `ubuntu-latest` runner (Ubuntu 24.04 Noble) ships `needrestart`, which registers an apt hook that **prompts interactively** after any package install. Under Actions there's no stdin, so the apt-get call never returns. Commit 2ac1607 diagnosed this and dropped `--with-deps`, but 75368fb put it back with the reasoning "we are now installing a single browser" — that doesn't address the needrestart hook, which runs regardless of how many packages are touched.

## Fix

- Before calling `playwright install --with-deps chromium`, rewrite `/etc/needrestart/needrestart.conf` to put needrestart in automatic mode (`$nrconf{restart} = 'a';`). This is the only thing that reliably stops the interactive prompt because the `sudo apt-get` that Playwright spawns doesn't necessarily propagate env vars.
- Also set `NEEDRESTART_MODE=a`, `NEEDRESTART_SUSPEND=1`, and `DEBIAN_FRONTEND=noninteractive` on the step — belt-and-suspenders for any Playwright version that does propagate env through `sudo -E`.
- Keeps `--with-deps` so the install is self-contained and not coupled to which libs happen to be pre-installed on the runner image.

## Test plan

- [x] `npm ci && npm run build && CI=1 npx playwright test` locally on Ubuntu 24.04 → 2/2 pass (5.8s).
- [x] `sed` expression verified against a synthetic `needrestart.conf` (correctly uncomments and rewrites the `$nrconf{restart}` line, leaves other lines alone).
- [x] YAML parses; the literal block scalar produces the intended shell script.
- [ ] CI run on this PR completes without the apt-get hang.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVxHcwc4gugt2PpNyxRb5X)_