### PR TITLE
Add docker-compose.dev stack with nginx fronting api and web-client

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,6 @@
+.venv/
+.pytest_cache/
+__pycache__/
+*.pyc
+tests/
+README.md

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -1,0 +1,22 @@
+FROM python:3.13-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml ./
+COPY app ./app
+COPY migrations ./migrations
+COPY alembic.ini ./alembic.ini
+
+RUN pip install -e '.[dev]'
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,87 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: fortymm
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d fortymm"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  api:
+    build:
+      context: ./api
+      dockerfile: Dockerfile.dev
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm
+      REDIS_URL: redis://redis:6379/0
+      SESSION_COOKIE_SECURE: "false"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./api:/app
+    ports:
+      - "8000:8000"
+    command: >
+      sh -c "alembic upgrade head &&
+             uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
+
+  worker:
+    build:
+      context: ./api
+      dockerfile: Dockerfile.dev
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./api:/app
+    command: rq worker --url redis://redis:6379/0 solver
+
+  web-client:
+    build:
+      context: ./web-client
+      dockerfile: Dockerfile.dev
+    environment:
+      CHOKIDAR_USEPOLLING: "true"
+    volumes:
+      - ./web-client:/app
+      - web-client-node-modules:/app/node_modules
+    ports:
+      - "5173:5173"
+
+  nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx/dev.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - api
+      - web-client
+
+volumes:
+  postgres-data:
+  web-client-node-modules:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -66,6 +66,7 @@ services:
       dockerfile: Dockerfile.dev
     environment:
       CHOKIDAR_USEPOLLING: "true"
+      VITE_ENABLE_MSW: "false"
     volumes:
       - ./web-client:/app
       - web-client-node-modules:/app/node_modules

--- a/nginx/dev.conf
+++ b/nginx/dev.conf
@@ -1,0 +1,35 @@
+upstream api_upstream {
+    server api:8000;
+}
+
+upstream web_upstream {
+    server web-client:5173;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    client_max_body_size 25m;
+
+    location /api/ {
+        rewrite ^/api/(.*)$ /$1 break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        proxy_pass http://web_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/web-client/.dockerignore
+++ b/web-client/.dockerignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.vite/
+playwright-report/
+test-results/
+e2e/

--- a/web-client/Dockerfile.dev
+++ b/web-client/Dockerfile.dev
@@ -1,0 +1,12 @@
+FROM node:26-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json .npmrc ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/web-client/src/api/client.ts
+++ b/web-client/src/api/client.ts
@@ -5,9 +5,9 @@ function resolveBaseUrl(): string {
   const explicit = import.meta.env.VITE_API_URL
   if (explicit) return explicit
   if (typeof window !== 'undefined' && window.location?.origin) {
-    return window.location.origin
+    return `${window.location.origin}/api`
   }
-  return 'http://localhost'
+  return 'http://localhost/api'
 }
 
 export const api = createClient<paths>({

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -17,6 +17,7 @@ declare module '@tanstack/react-router' {
 
 async function enableMocking() {
   if (!import.meta.env.DEV) return
+  if (import.meta.env.VITE_ENABLE_MSW === 'false') return
   const { worker } = await import('./mocks/browser')
   await worker.start({
     onUnhandledRequest: 'bypass',

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -20,6 +20,15 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: process.env.VITE_DEV_API_PROXY ?? 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- New `docker-compose.dev.yml` brings up the full app locally: postgres, redis, api (alembic auto-migrate + uvicorn `--reload`), an rq worker, the vite web-client, and nginx on `http://localhost:8080`.
- nginx proxies `/api/*` to the API with the prefix stripped (so `/api/v1/session` → `/v1/session`) and serves the rest from vite (with HMR websocket upgrade).
- Web-client default baseUrl is now `${origin}/api`. Added a matching Vite dev proxy (`/api` → `http://localhost:8000`, override via `VITE_DEV_API_PROXY`) so `npm run dev` standalone still works against a host-run API.
- Host ports stay exposed (api 8000, postgres 5432, redis 6379, vite 5173) so `mise regen-api-types` and existing Playwright runs are unaffected.

## Usage
```
docker compose -f docker-compose.dev.yml up --build
# open http://localhost:8080
```

## Test plan
- [x] `docker compose -f docker-compose.dev.yml up --build` brings all six services to healthy state
- [x] `GET http://localhost:8080/api/v1/health` returns `{"solver":{"healthy":true}}` (worker picks up the job)
- [x] `GET http://localhost:8080/api/v1/session` returns a session and sets a `session` cookie at `Path=/`
- [x] `GET http://localhost:8080/` serves the vite-rendered app HTML
- [ ] `npm run dev` standalone (outside docker) against a host-run API on `:8000` still works via the Vite `/api` proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)