### PR TITLE
Run root e2e against full docker-compose stack

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,12 +7,16 @@ on:
     paths:
       - 'e2e/**'
       - 'web-client/**'
+      - 'api/**'
+      - 'nginx/**'
+      - 'docker-compose.dev.yml'
+      - 'docker-compose.e2e.yml'
       - '.github/workflows/e2e.yml'
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -20,13 +24,7 @@ jobs:
         with:
           node-version: '26.1.0'
           cache: npm
-          cache-dependency-path: |
-            e2e/package-lock.json
-            web-client/package-lock.json
-
-      - name: Install web-client dependencies
-        run: npm ci
-        working-directory: web-client
+          cache-dependency-path: e2e/package-lock.json
 
       - name: Install e2e dependencies
         run: npm ci
@@ -39,6 +37,10 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test
         working-directory: e2e
+
+      - name: Dump docker compose logs on failure
+        if: ${{ failure() }}
+        run: docker compose -f docker-compose.dev.yml -f docker-compose.e2e.yml logs --no-color
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,16 @@
+# Overrides docker-compose.dev.yml for end-to-end tests.
+# The dev file publishes ports for local developer convenience; for e2e we
+# only need nginx reachable from the host, on a port that won't collide with
+# anything the developer is already running (including the dev nginx on 8080).
+services:
+  postgres:
+    ports: !reset []
+  redis:
+    ports: !reset []
+  api:
+    ports: !reset []
+  web-client:
+    ports: !reset []
+  nginx:
+    ports: !override
+      - "${E2E_NGINX_PORT:-18080}:80"

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,25 @@
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+const repoRoot = resolve(__dirname, '..')
+const baseFile = resolve(repoRoot, 'docker-compose.dev.yml')
+const overrideFile = resolve(repoRoot, 'docker-compose.e2e.yml')
+
+export default async function globalSetup() {
+  if (process.env.E2E_BASE_URL) return
+
+  const result = spawnSync(
+    'docker',
+    [
+      'compose',
+      '-f', baseFile,
+      '-f', overrideFile,
+      'up', '-d', '--wait', '--build',
+    ],
+    { stdio: 'inherit' },
+  )
+
+  if (result.status !== 0) {
+    throw new Error(`docker compose up failed with exit code ${result.status}`)
+  }
+}

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,17 @@
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+const repoRoot = resolve(__dirname, '..')
+const baseFile = resolve(repoRoot, 'docker-compose.dev.yml')
+const overrideFile = resolve(repoRoot, 'docker-compose.e2e.yml')
+
+export default async function globalTeardown() {
+  if (process.env.E2E_BASE_URL) return
+  if (process.env.E2E_KEEP_STACK) return
+
+  spawnSync(
+    'docker',
+    ['compose', '-f', baseFile, '-f', overrideFile, 'down', '-v'],
+    { stdio: 'inherit' },
+  )
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
 
-const PORT = 5173
-const BASE_URL = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${PORT}`
+const NGINX_PORT = process.env.E2E_NGINX_PORT ?? '18080'
+const BASE_URL = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${NGINX_PORT}`
 
 export default defineConfig({
   testDir: './tests',
@@ -9,6 +9,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  globalSetup: './global-setup.ts',
+  globalTeardown: './global-teardown.ts',
   use: {
     baseURL: BASE_URL,
     trace: 'on-first-retry',
@@ -19,12 +21,4 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: process.env.E2E_BASE_URL
-    ? undefined
-    : {
-        command: 'npm --prefix ../web-client run dev -- --host 127.0.0.1 --port ' + PORT,
-        url: BASE_URL,
-        reuseExistingServer: !process.env.CI,
-        timeout: 120_000,
-      },
 })


### PR DESCRIPTION
## Summary
- Playwright globalSetup/Teardown now bring up `docker-compose.dev.yml` (plus a small e2e override) instead of running the web-client vite dev server directly, so tests exercise the full api + web-client + nginx stack.
- New `docker-compose.e2e.yml` `!reset`s the convenience port publishings on postgres/redis/api/web-client (so e2e doesn't collide with anything the developer already has running) and remaps nginx to `${E2E_NGINX_PORT:-18080}:80` to avoid clashing with the dev nginx on 8080.
- CI workflow drops the now-unused web-client npm install, expands the path triggers to `api/**`, `nginx/**`, and both compose files, dumps compose logs on failure, and bumps the timeout to 30 min for the cold image build.

`E2E_BASE_URL=...` still bypasses docker compose entirely if you want to point at an already-running stack. `E2E_KEEP_STACK=1` skips teardown for iterative debugging.

## Test plan
- [x] `npx playwright test` locally — stack builds, landing test passes against nginx, stack tears down (verified twice, 1/1 green).
- [ ] CI run on this PR is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)