### PR TITLE
Add e2e test that /dashboard issues a session

### DIFF
--- a/e2e/page-objects/dashboard-page/user-menu.page.ts
+++ b/e2e/page-objects/dashboard-page/user-menu.page.ts
@@ -1,0 +1,15 @@
+import { Locator, Page } from '@playwright/test';
+
+export class UserMenuPage {
+    public readonly skeleton: Locator;
+    public readonly menu: Locator;
+
+    constructor(page: Page) {
+        this.skeleton = page.getByTestId('user-menu-skeleton');
+        this.menu = page.getByRole('button', { name: 'User menu' });
+    }
+
+    async isLoading(): Promise<boolean> {
+        return this.skeleton.isVisible();
+    }
+}

--- a/e2e/page-objects/dashboard.page.ts
+++ b/e2e/page-objects/dashboard.page.ts
@@ -1,0 +1,15 @@
+import { Page } from "@playwright/test";
+import { UserMenuPage } from "./dashboard-page/user-menu.page";
+
+export class DashboardPage {
+    public readonly userMenu: UserMenuPage;
+
+    static async navigateTo(page: Page): Promise<DashboardPage> {
+        await page.goto('/dashboard');
+        return new DashboardPage(page);
+    }
+
+    constructor(page: Page) {
+        this.userMenu = new UserMenuPage(page);
+    }
+}

--- a/e2e/tests/dashboard-session.spec.ts
+++ b/e2e/tests/dashboard-session.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+import { DashboardPage } from '../page-objects/dashboard.page';
+
+test.describe('Dashboard', () => {
+    test('issues a session to a first-time visitor', async ({ page, context }) => {
+        const dashboard = await DashboardPage.navigateTo(page);
+
+        await expect(dashboard.userMenu.skeleton).not.toBeVisible();
+        await expect(dashboard.userMenu.menu).not.toContainText('Guest');
+
+        const cookies = await context.cookies();
+        const session = cookies.find((cookie) => cookie.name === 'session');
+        expect(session, 'session cookie should be set').toBeDefined();
+        expect(session?.value).not.toBe('');
+        expect(session?.httpOnly).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- New root-level Playwright spec asserts that visiting `/dashboard` causes the API to issue a real session: user menu loads a non-`Guest` username and an httpOnly `session` cookie is set on the browser context.
- Mirrors the web-client page-object pattern with a `DashboardPage` and a `UserMenuPage` sub-component that exposes `skeleton`, `menu`, and `isLoading()`.

## Test plan
- [x] `npx playwright test` from `e2e/` against the docker-compose stack (2 passed)
- [ ] CI e2e workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)