### PR TITLE
Reduce flakiness in landing-page e2e tests

### DIFF
--- a/.github/workflows/web-client-e2e.yml
+++ b/.github/workflows/web-client-e2e.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
+      - name: Build production bundle for preview server
+        run: npm run build
+
       - run: npm run test:e2e
 
       - uses: actions/upload-artifact@v4

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,9 +1,33 @@
 import { spawnSync } from 'node:child_process'
 import { resolve } from 'node:path'
+import { setTimeout as sleep } from 'node:timers/promises'
 
 const repoRoot = resolve(__dirname, '..')
 const baseFile = resolve(repoRoot, 'docker-compose.dev.yml')
 const overrideFile = resolve(repoRoot, 'docker-compose.e2e.yml')
+
+const NGINX_PORT = process.env.E2E_NGINX_PORT ?? '18080'
+const BASE_URL = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${NGINX_PORT}`
+
+// Docker compose `--wait` only gates on declared healthchecks. The web-client
+// service has none, so the container is considered ready as soon as the
+// process starts — well before Vite's first compile finishes. Without this
+// probe the first test request races Vite's JIT transforms and times out.
+async function waitForReady(url: string, timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { redirect: 'manual' })
+      if (response.status < 500) return
+      lastError = new Error(`status ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+    await sleep(1000)
+  }
+  throw new Error(`Timed out waiting for ${url} to respond: ${String(lastError)}`)
+}
 
 export default async function globalSetup() {
   if (process.env.E2E_BASE_URL) return
@@ -22,4 +46,6 @@ export default async function globalSetup() {
   if (result.status !== 0) {
     throw new Error(`docker compose up failed with exit code ${result.status}`)
   }
+
+  await waitForReady(BASE_URL, 120_000)
 }

--- a/e2e/page-objects/landing.page.ts
+++ b/e2e/page-objects/landing.page.ts
@@ -1,0 +1,17 @@
+import { Locator, Page } from "@playwright/test";
+
+export class LandingPage {
+    public readonly heroHeading: Locator;
+
+    static async navigateTo(page: Page): Promise<LandingPage> {
+        await page.goto('/');
+        return new LandingPage(page);
+    }
+
+    constructor(page: Page) {
+        this.heroHeading = page.getByRole('heading', {
+            level: 1,
+            name: /play more\.\s*pay never\./i,
+        });
+    }
+}

--- a/e2e/tests/landing.spec.ts
+++ b/e2e/tests/landing.spec.ts
@@ -3,8 +3,9 @@ import { expect, test } from '@playwright/test'
 test('landing page shows the hero heading', async ({ page }) => {
   await page.goto('/')
 
-  const heading = page.getByRole('heading', { level: 1 })
+  const heading = page.getByRole('heading', {
+    level: 1,
+    name: /play more\.\s*pay never\./i,
+  })
   await expect(heading).toBeVisible()
-  await expect(heading).toContainText('Play more.')
-  await expect(heading).toContainText('Pay never.')
 })

--- a/e2e/tests/landing.spec.ts
+++ b/e2e/tests/landing.spec.ts
@@ -1,11 +1,8 @@
 import { expect, test } from '@playwright/test'
+import { LandingPage } from '../page-objects/landing.page'
 
 test('landing page shows the hero heading', async ({ page }) => {
-  await page.goto('/')
+  const landingPage = await LandingPage.navigateTo(page)
 
-  const heading = page.getByRole('heading', {
-    level: 1,
-    name: /play more\.\s*pay never\./i,
-  })
-  await expect(heading).toBeVisible()
+  await expect(landingPage.heroHeading).toBeVisible()
 })

--- a/web-client/e2e/landing.spec.ts
+++ b/web-client/e2e/landing.spec.ts
@@ -1,11 +1,8 @@
 import { expect, test } from '@playwright/test'
+import { LandingPage } from './page-objects/landing.page'
 
 test('landing page renders the hero heading', async ({ page }) => {
-  await page.goto('/')
+  const landingPage = await LandingPage.navigateTo(page)
 
-  const heading = page.getByRole('heading', {
-    level: 1,
-    name: /play more\.\s*pay never\./i,
-  })
-  await expect(heading).toBeVisible()
+  await expect(landingPage.heroHeading).toBeVisible()
 })

--- a/web-client/e2e/landing.spec.ts
+++ b/web-client/e2e/landing.spec.ts
@@ -3,7 +3,9 @@ import { expect, test } from '@playwright/test'
 test('landing page renders the hero heading', async ({ page }) => {
   await page.goto('/')
 
-  const heading = page.getByRole('heading', { level: 1 })
-  await expect(heading).toContainText('Play more.')
-  await expect(heading).toContainText('Pay never.')
+  const heading = page.getByRole('heading', {
+    level: 1,
+    name: /play more\.\s*pay never\./i,
+  })
+  await expect(heading).toBeVisible()
 })

--- a/web-client/e2e/page-objects/landing.page.ts
+++ b/web-client/e2e/page-objects/landing.page.ts
@@ -1,0 +1,17 @@
+import { Locator, Page } from "@playwright/test";
+
+export class LandingPage {
+    public readonly heroHeading: Locator;
+
+    static async navigateTo(page: Page): Promise<LandingPage> {
+        await page.goto('/');
+        return new LandingPage(page);
+    }
+
+    constructor(page: Page) {
+        this.heroHeading = page.getByRole('heading', {
+            level: 1,
+            name: /play more\.\s*pay never\./i,
+        });
+    }
+}

--- a/web-client/playwright.config.ts
+++ b/web-client/playwright.config.ts
@@ -26,7 +26,12 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `npm run dev -- --host 127.0.0.1 --port ${PORT} --strictPort`,
+    // CI serves the production build via `vite preview` to avoid first-request
+    // JIT-compile latency from the dev server, which causes intermittent
+    // timeouts on cold runners. Local runs keep `vite dev` for fast iteration.
+    command: process.env.CI
+      ? `npx vite preview --host 127.0.0.1 --port ${PORT} --strictPort`
+      : `npm run dev -- --host 127.0.0.1 --port ${PORT} --strictPort`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',


### PR DESCRIPTION
## Summary
- Anchor both Playwright landing specs to the hero h1's accessible name (matching the existing unit test) and rely on a single `toBeVisible` — survives a second h1 being added and gives cleaner failures than chained `toContainText` calls.
- Switch `web-client/e2e` to serve the production build via `vite preview` in CI so the first request doesn't race Vite dev-server JIT-compile latency. Local runs keep `vite dev`.
- Add a readiness probe to the root `e2e/global-setup.ts` — `docker compose --wait` returns before the `web-client` service (which has no healthcheck) is actually serving requests.

## Test plan
- [x] `npm run test:e2e` in `web-client/` (dev path) — passes
- [x] `npm run build` + `CI=1 npx playwright test` in `web-client/` (preview path) — passes
- [x] `npx playwright test --list` in `e2e/` — config parses, test discovered
- [ ] CI: both `web-client-e2e` and `e2e` workflows green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)