### PR TITLE
Add System Health widget on the Administration page

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -2,8 +2,9 @@ import time
 
 from fastapi import FastAPI
 from pydantic import BaseModel
+from sqlalchemy import text
 
-from app import queue
+from app import db, queue
 from app.sessions import router as sessions_router
 
 app = FastAPI(title="FortyMM API")
@@ -12,36 +13,86 @@ app.include_router(sessions_router)
 SOLVER_HEALTH_TIMEOUT = 10.0
 
 
-class SolverHealth(BaseModel):
+class ComponentHealth(BaseModel):
     healthy: bool
+    latency_ms: float | None = None
+    error: str | None = None
 
 
 class HealthResponse(BaseModel):
-    solver: SolverHealth
+    redis: ComponentHealth
+    database: ComponentHealth
+    solver: ComponentHealth
 
 
 @app.get("/v1/health")
-def health() -> HealthResponse:
-    return HealthResponse(solver=_check_solver())
+async def health() -> HealthResponse:
+    return HealthResponse(
+        redis=_check_redis(),
+        database=await _check_database(),
+        solver=_check_solver(),
+    )
 
 
-def _check_solver() -> SolverHealth:
+def _check_redis() -> ComponentHealth:
+    started = time.monotonic()
+    try:
+        connection = queue.get_queue().connection
+        if not connection.ping():
+            return ComponentHealth(healthy=False, error="redis ping returned falsy")
+    except Exception as exc:
+        return ComponentHealth(healthy=False, error=str(exc) or exc.__class__.__name__)
+    return ComponentHealth(healthy=True, latency_ms=_elapsed_ms(started))
+
+
+async def _check_database() -> ComponentHealth:
+    started = time.monotonic()
+    try:
+        engine = db.get_engine()
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+    except Exception as exc:
+        return ComponentHealth(healthy=False, error=str(exc) or exc.__class__.__name__)
+    return ComponentHealth(healthy=True, latency_ms=_elapsed_ms(started))
+
+
+def _check_solver() -> ComponentHealth:
+    started = time.monotonic()
     try:
         job = queue.get_queue().enqueue(
             "app.solver.solve_hello_world", job_timeout=10
         )
-    except Exception:
-        return SolverHealth(healthy=False)
+    except Exception as exc:
+        return ComponentHealth(healthy=False, error=str(exc) or exc.__class__.__name__)
 
     deadline = time.monotonic() + SOLVER_HEALTH_TIMEOUT
     while time.monotonic() < deadline:
         try:
             job.refresh()
-        except Exception:
-            return SolverHealth(healthy=False)
+        except Exception as exc:
+            return ComponentHealth(
+                healthy=False, error=str(exc) or exc.__class__.__name__
+            )
         if job.is_finished:
-            return SolverHealth(healthy=bool(job.return_value()))
+            healthy = bool(job.return_value())
+            return ComponentHealth(
+                healthy=healthy,
+                latency_ms=_elapsed_ms(started),
+                error=None if healthy else "solver returned an unsatisfiable result",
+            )
         if job.is_failed:
-            return SolverHealth(healthy=False)
+            return ComponentHealth(
+                healthy=False,
+                latency_ms=_elapsed_ms(started),
+                error="solver job failed",
+            )
         time.sleep(0.1)
-    return SolverHealth(healthy=False)
+    return ComponentHealth(
+        healthy=False,
+        latency_ms=_elapsed_ms(started),
+        error=f"timeout after {SOLVER_HEALTH_TIMEOUT * 1000:.0f}ms",
+    )
+
+
+def _elapsed_ms(started: float) -> float:
+    return round((time.monotonic() - started) * 1000, 1)

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -1,19 +1,36 @@
 from fastapi.testclient import TestClient
 
+from app import main as main_module
 from app import queue as queue_module
-from app.main import app
+from app.main import ComponentHealth, app
 
 client = TestClient(app)
 
 
-def test_health_reports_solver_healthy():
+def test_health_reports_all_components_healthy(monkeypatch):
+    async def fake_db_check():
+        return ComponentHealth(healthy=True, latency_ms=2.3)
+
+    monkeypatch.setattr(main_module, "_check_database", fake_db_check)
+
     response = client.get("/v1/health")
     assert response.status_code == 200
-    assert response.json() == {"solver": {"healthy": True}}
+    body = response.json()
+
+    assert set(body.keys()) == {"redis", "database", "solver"}
+    for component in body.values():
+        assert component["healthy"] is True
+        assert component.get("error") is None
+        assert component.get("latency_ms") is not None
     assert response.headers["content-type"] == "application/json"
 
 
-def test_health_reports_solver_unhealthy_when_queue_unavailable(monkeypatch):
+def test_health_reports_redis_and_solver_unhealthy_when_queue_unavailable(monkeypatch):
+    async def fake_db_check():
+        return ComponentHealth(healthy=True, latency_ms=1.0)
+
+    monkeypatch.setattr(main_module, "_check_database", fake_db_check)
+
     def boom():
         raise RuntimeError("redis unreachable")
 
@@ -21,4 +38,27 @@ def test_health_reports_solver_unhealthy_when_queue_unavailable(monkeypatch):
 
     response = client.get("/v1/health")
     assert response.status_code == 200
-    assert response.json() == {"solver": {"healthy": False}}
+    body = response.json()
+
+    assert body["redis"]["healthy"] is False
+    assert "redis unreachable" in body["redis"]["error"]
+    assert body["solver"]["healthy"] is False
+    assert "redis unreachable" in body["solver"]["error"]
+    assert body["database"]["healthy"] is True
+
+
+def test_health_reports_database_unhealthy_when_engine_broken(monkeypatch):
+    class BrokenEngine:
+        def connect(self):
+            raise RuntimeError("postgres unreachable")
+
+    from app import db as db_module
+
+    monkeypatch.setattr(db_module, "get_engine", BrokenEngine)
+
+    response = client.get("/v1/health")
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["database"]["healthy"] is False
+    assert "postgres unreachable" in body["database"]["error"]

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,7 +8,25 @@
       "name": "fortymm-e2e",
       "version": "0.0.0",
       "devDependencies": {
+        "@faker-js/faker": "^10.4.0",
         "@playwright/test": "^1.50.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@playwright/test": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
     "test:ui": "playwright test --ui"
   },
   "devDependencies": {
+    "@faker-js/faker": "^10.4.0",
     "@playwright/test": "^1.50.0"
   }
 }

--- a/e2e/tests/admin-system-health.spec.ts
+++ b/e2e/tests/admin-system-health.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Administration · System Health (live stack)', () => {
+  test('the admin page reports every dependency as healthy', async ({
+    page,
+  }) => {
+    await page.goto('/admin')
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Administration' }),
+    ).toBeVisible()
+
+    const widget = page.getByTestId('system-health')
+    await expect(widget).toBeVisible()
+    await expect(widget).toHaveAttribute('data-state', 'ok', { timeout: 30_000 })
+
+    for (const service of ['redis', 'database', 'solver'] as const) {
+      await expect(page.getByTestId(`system-health-row-${service}`)).toHaveAttribute(
+        'data-status',
+        'ok',
+      )
+      await expect(page.getByTestId(`system-health-pill-${service}`)).toHaveText(
+        'healthy',
+      )
+    }
+
+    await expect(page.getByTestId('system-health-eyebrow')).toHaveText(
+      'Operational',
+    )
+  })
+})

--- a/web-client/e2e/admin-system-health.spec.ts
+++ b/web-client/e2e/admin-system-health.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test'
+import { AdminPage } from './page-objects/admin.page'
+
+test.describe('Administration · System Health', () => {
+  test('renders the Administration heading', async ({ page }) => {
+    const admin = await AdminPage.navigateTo(page)
+    await expect(admin.heading).toBeVisible()
+  })
+
+  test('shows operational state when every dependency is healthy', async ({
+    page,
+  }) => {
+    const admin = await AdminPage.navigateTo(page, { scenario: 'healthy' })
+
+    await expect(admin.widget).toHaveAttribute('data-state', 'ok')
+    await expect(admin.eyebrow).toHaveText('Operational')
+
+    await expect(admin.row('redis')).toHaveAttribute('data-status', 'ok')
+    await expect(admin.row('database')).toHaveAttribute('data-status', 'ok')
+    await expect(admin.row('solver')).toHaveAttribute('data-status', 'ok')
+
+    await expect(admin.pill('redis')).toHaveText('healthy')
+    await expect(admin.pill('database')).toHaveText('healthy')
+    await expect(admin.pill('solver')).toHaveText('healthy')
+
+    await expect(admin.widget).toContainText('All systems')
+    await expect(admin.widget).toContainText('go')
+  })
+
+  test('flags a slow dependency as degraded', async ({ page }) => {
+    const admin = await AdminPage.navigateTo(page, { scenario: 'degraded' })
+
+    await expect(admin.widget).toHaveAttribute('data-state', 'deg')
+    await expect(admin.eyebrow).toHaveText('Partial degradation')
+
+    await expect(admin.row('database')).toHaveAttribute('data-status', 'deg')
+    await expect(admin.pill('database')).toHaveText('degraded')
+
+    await expect(admin.row('redis')).toHaveAttribute('data-status', 'ok')
+    await expect(admin.row('solver')).toHaveAttribute('data-status', 'ok')
+
+    await expect(admin.widget).toContainText('sluggish')
+  })
+
+  test('surfaces error chips and bad state when a dependency is down', async ({
+    page,
+  }) => {
+    const admin = await AdminPage.navigateTo(page, { scenario: 'failing' })
+
+    await expect(admin.widget).toHaveAttribute('data-state', 'bad')
+    await expect(admin.eyebrow).toHaveText('Interruption')
+
+    await expect(admin.row('database')).toHaveAttribute('data-status', 'bad')
+    await expect(admin.row('solver')).toHaveAttribute('data-status', 'bad')
+
+    await expect(admin.pill('database')).toHaveText('down')
+    await expect(admin.pill('solver')).toHaveText('down')
+
+    await expect(admin.errorChip('database')).toContainText(
+      'connection refused (ECONNREFUSED)',
+    )
+    await expect(admin.errorChip('solver')).toContainText('OOMKilled')
+
+    await expect(admin.widget).toContainText('down')
+  })
+
+  test('treats a 5xx response as a bad overall state', async ({ page }) => {
+    const admin = await AdminPage.navigateTo(page, { scenario: 'serverError' })
+
+    await expect(admin.widget).toHaveAttribute('data-state', 'bad')
+    await expect(admin.row('redis')).toHaveAttribute('data-status', 'bad')
+    await expect(admin.row('database')).toHaveAttribute('data-status', 'bad')
+    await expect(admin.row('solver')).toHaveAttribute('data-status', 'bad')
+  })
+
+  test('shows checking state while a refetch is in flight, then resolves', async ({
+    page,
+  }) => {
+    const admin = await AdminPage.navigateTo(page, { scenario: 'failing' })
+
+    await expect(admin.widget).toHaveAttribute('data-state', 'bad')
+
+    let resolvePending: (() => void) | null = null
+    await admin.page.unroute('**/v1/health')
+    await admin.page.route('**/v1/health', async (route) => {
+      await new Promise<void>((resolve) => {
+        resolvePending = resolve
+      })
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          redis: { healthy: true, latency_ms: 4 },
+          database: { healthy: true, latency_ms: 12 },
+          solver: { healthy: true, latency_ms: 38 },
+        }),
+      })
+    })
+
+    await admin.recheckButton.click()
+    await expect(admin.eyebrow).toHaveText('Checking')
+    await expect(admin.widget).toHaveAttribute('data-state', 'loading')
+    await expect(admin.recheckButton).toBeDisabled()
+
+    resolvePending?.()
+
+    await expect(admin.widget).toHaveAttribute('data-state', 'ok')
+    await expect(admin.eyebrow).toHaveText('Operational')
+    await expect(admin.recheckButton).toBeEnabled()
+  })
+
+  test('refetches when the recheck button is clicked', async ({ page }) => {
+    let calls = 0
+    const admin = await AdminPage.navigateTo(page, {
+      scenario: 'healthy',
+      onHealthRequest: () => {
+        calls += 1
+      },
+    })
+
+    await expect(admin.widget).toHaveAttribute('data-state', 'ok')
+    expect(calls).toBe(1)
+
+    await admin.recheckButton.click()
+    await expect.poll(() => calls).toBe(2)
+    await expect(admin.widget).toHaveAttribute('data-state', 'ok')
+  })
+})

--- a/web-client/e2e/page-objects/admin.page.ts
+++ b/web-client/e2e/page-objects/admin.page.ts
@@ -1,10 +1,10 @@
 import type { Locator, Page, Route } from '@playwright/test'
 import type { components } from '../../src/api/schema'
 import {
-  degradedComponent,
-  downComponent,
-  healthResponse,
+  databaseCheck,
+  healthCheck,
   sessionResponse,
+  solverCheck,
 } from '../../src/test/factories'
 
 type HealthResponse = components['schemas']['HealthResponse']
@@ -13,15 +13,23 @@ export const HEALTH_SCENARIOS: Record<
   'healthy' | 'degraded' | 'failing' | 'serverError',
   (() => HealthResponse) | null
 > = {
-  healthy: () => healthResponse(),
+  healthy: () => healthCheck(),
   degraded: () =>
-    healthResponse({
-      database: degradedComponent({ latency_ms: 1840 }),
+    healthCheck({
+      database: databaseCheck({ latency_ms: 1840 }),
     }),
   failing: () =>
-    healthResponse({
-      database: downComponent({ error: 'connection refused (ECONNREFUSED)' }),
-      solver: downComponent({ error: 'timeout after 5000ms · OOMKilled' }),
+    healthCheck({
+      database: databaseCheck({
+        healthy: false,
+        latency_ms: null,
+        error: 'connection refused (ECONNREFUSED)',
+      }),
+      solver: solverCheck({
+        healthy: false,
+        latency_ms: null,
+        error: 'timeout after 5000ms · OOMKilled',
+      }),
     }),
   serverError: null,
 }

--- a/web-client/e2e/page-objects/admin.page.ts
+++ b/web-client/e2e/page-objects/admin.page.ts
@@ -1,0 +1,137 @@
+import type { Locator, Page, Route } from '@playwright/test'
+
+export type HealthScenario = {
+  redis: { healthy: boolean; latency_ms?: number | null; error?: string | null }
+  database: { healthy: boolean; latency_ms?: number | null; error?: string | null }
+  solver: { healthy: boolean; latency_ms?: number | null; error?: string | null }
+}
+
+export const HEALTH_SCENARIOS = {
+  healthy: {
+    redis: { healthy: true, latency_ms: 4 },
+    database: { healthy: true, latency_ms: 12 },
+    solver: { healthy: true, latency_ms: 38 },
+  },
+  degraded: {
+    redis: { healthy: true, latency_ms: 6 },
+    database: {
+      healthy: true,
+      latency_ms: 1840,
+      error: null,
+    },
+    solver: { healthy: true, latency_ms: 42 },
+  },
+  failing: {
+    redis: { healthy: true, latency_ms: 5 },
+    database: {
+      healthy: false,
+      latency_ms: null,
+      error: 'connection refused (ECONNREFUSED)',
+    },
+    solver: {
+      healthy: false,
+      latency_ms: null,
+      error: 'timeout after 5000ms · OOMKilled',
+    },
+  },
+  serverError: null,
+} as const satisfies Record<string, HealthScenario | null>
+
+export type ScenarioName = keyof typeof HEALTH_SCENARIOS
+
+type SessionResponse = {
+  data: { user: { username: string } }
+}
+
+const SESSION_RESPONSE: SessionResponse = {
+  data: { user: { username: 'rita.kovac' } },
+}
+
+export class AdminPage {
+  static async navigateTo(
+    page: Page,
+    options: {
+      scenario?: ScenarioName
+      healthDelayMs?: number
+      onHealthRequest?: () => void
+    } = {},
+  ): Promise<AdminPage> {
+    const admin = new AdminPage(page)
+    await admin.mockSession()
+    await admin.mockHealth(
+      options.scenario ?? 'healthy',
+      options.healthDelayMs ?? 0,
+      options.onHealthRequest,
+    )
+    await page.goto('/admin')
+    return admin
+  }
+
+  constructor(public readonly page: Page) {}
+
+  async mockSession() {
+    await this.page.route('**/v1/session', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SESSION_RESPONSE),
+      })
+    })
+  }
+
+  async mockHealth(
+    scenario: ScenarioName,
+    delayMs = 0,
+    onRequest?: () => void,
+  ) {
+    await this.page.unroute('**/v1/health').catch(() => undefined)
+    await this.page.route('**/v1/health', async (route: Route) => {
+      onRequest?.()
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs))
+      }
+      if (scenario === 'serverError') {
+        await route.fulfill({
+          status: 503,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'service unavailable' }),
+        })
+        return
+      }
+      const payload = HEALTH_SCENARIOS[scenario]
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(payload),
+      })
+    })
+  }
+
+  get widget(): Locator {
+    return this.page.getByTestId('system-health')
+  }
+
+  row(service: 'redis' | 'database' | 'solver'): Locator {
+    return this.page.getByTestId(`system-health-row-${service}`)
+  }
+
+  pill(service: 'redis' | 'database' | 'solver'): Locator {
+    return this.page.getByTestId(`system-health-pill-${service}`)
+  }
+
+  errorChip(service: 'redis' | 'database' | 'solver'): Locator {
+    return this.page.getByTestId(`system-health-error-${service}`)
+  }
+
+  get eyebrow(): Locator {
+    return this.page.getByTestId('system-health-eyebrow')
+  }
+
+  get recheckButton(): Locator {
+    return this.page.getByTestId('system-health-recheck')
+  }
+
+  get heading(): Locator {
+    return this.page.getByRole('heading', { level: 1, name: 'Administration' })
+  }
+}

--- a/web-client/e2e/page-objects/admin.page.ts
+++ b/web-client/e2e/page-objects/admin.page.ts
@@ -1,51 +1,34 @@
 import type { Locator, Page, Route } from '@playwright/test'
+import type { components } from '../../src/api/schema'
+import {
+  degradedComponent,
+  downComponent,
+  healthResponse,
+  sessionResponse,
+} from '../../src/test/factories'
 
-export type HealthScenario = {
-  redis: { healthy: boolean; latency_ms?: number | null; error?: string | null }
-  database: { healthy: boolean; latency_ms?: number | null; error?: string | null }
-  solver: { healthy: boolean; latency_ms?: number | null; error?: string | null }
-}
+type HealthResponse = components['schemas']['HealthResponse']
 
-export const HEALTH_SCENARIOS = {
-  healthy: {
-    redis: { healthy: true, latency_ms: 4 },
-    database: { healthy: true, latency_ms: 12 },
-    solver: { healthy: true, latency_ms: 38 },
-  },
-  degraded: {
-    redis: { healthy: true, latency_ms: 6 },
-    database: {
-      healthy: true,
-      latency_ms: 1840,
-      error: null,
-    },
-    solver: { healthy: true, latency_ms: 42 },
-  },
-  failing: {
-    redis: { healthy: true, latency_ms: 5 },
-    database: {
-      healthy: false,
-      latency_ms: null,
-      error: 'connection refused (ECONNREFUSED)',
-    },
-    solver: {
-      healthy: false,
-      latency_ms: null,
-      error: 'timeout after 5000ms · OOMKilled',
-    },
-  },
+export const HEALTH_SCENARIOS: Record<
+  'healthy' | 'degraded' | 'failing' | 'serverError',
+  (() => HealthResponse) | null
+> = {
+  healthy: () => healthResponse(),
+  degraded: () =>
+    healthResponse({
+      database: degradedComponent({ latency_ms: 1840 }),
+    }),
+  failing: () =>
+    healthResponse({
+      database: downComponent({ error: 'connection refused (ECONNREFUSED)' }),
+      solver: downComponent({ error: 'timeout after 5000ms · OOMKilled' }),
+    }),
   serverError: null,
-} as const satisfies Record<string, HealthScenario | null>
+}
 
 export type ScenarioName = keyof typeof HEALTH_SCENARIOS
 
-type SessionResponse = {
-  data: { user: { username: string } }
-}
-
-const SESSION_RESPONSE: SessionResponse = {
-  data: { user: { username: 'rita.kovac' } },
-}
+const SESSION_RESPONSE = sessionResponse({ user: { username: 'rita.kovac' } })
 
 export class AdminPage {
   static async navigateTo(
@@ -90,7 +73,8 @@ export class AdminPage {
       if (delayMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, delayMs))
       }
-      if (scenario === 'serverError') {
+      const build = HEALTH_SCENARIOS[scenario]
+      if (build === null) {
         await route.fulfill({
           status: 503,
           contentType: 'application/json',
@@ -98,11 +82,10 @@ export class AdminPage {
         })
         return
       }
-      const payload = HEALTH_SCENARIOS[scenario]
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(payload),
+        body: JSON.stringify(build()),
       })
     })
   }

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -35,6 +35,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@faker-js/faker": "^10.4.0",
         "@playwright/test": "^1.60.0",
         "@tanstack/react-query-devtools": "^5.100.9",
         "@tanstack/react-router-devtools": "^1.166.13",
@@ -909,6 +910,23 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@floating-ui/core": {

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@faker-js/faker": "^10.4.0",
     "@playwright/test": "^1.60.0",
     "@tanstack/react-query-devtools": "^5.100.9",
     "@tanstack/react-router-devtools": "^1.166.13",

--- a/web-client/playwright.config.ts
+++ b/web-client/playwright.config.ts
@@ -32,5 +32,9 @@ export default defineConfig({
     stdout: 'pipe',
     stderr: 'pipe',
     timeout: 120_000,
+    env: {
+      // Disable MSW so Playwright's page.route can intercept API calls instead.
+      VITE_ENABLE_MSW: 'false',
+    },
   },
 })

--- a/web-client/src/api/health.ts
+++ b/web-client/src/api/health.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from './client'
+import type { components } from './schema'
+
+export type HealthResponse = components['schemas']['HealthResponse']
+export type ComponentHealth = components['schemas']['ComponentHealth']
+
+export const HEALTH_QUERY_KEY = ['health'] as const
+
+export function useHealth() {
+  return useQuery({
+    queryKey: HEALTH_QUERY_KEY,
+    queryFn: async (): Promise<HealthResponse> => {
+      const { data, error } = await api.GET('/v1/health')
+      if (error || !data) {
+        throw new Error('Failed to load health status')
+      }
+      return data
+    },
+    refetchOnWindowFocus: false,
+    staleTime: 0,
+    retry: false,
+  })
+}

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -42,6 +42,15 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** ComponentHealth */
+        ComponentHealth: {
+            /** Healthy */
+            healthy: boolean;
+            /** Latency Ms */
+            latency_ms?: number | null;
+            /** Error */
+            error?: string | null;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -49,7 +58,9 @@ export interface components {
         };
         /** HealthResponse */
         HealthResponse: {
-            solver: components["schemas"]["SolverHealth"];
+            redis: components["schemas"]["ComponentHealth"];
+            database: components["schemas"]["ComponentHealth"];
+            solver: components["schemas"]["ComponentHealth"];
         };
         /** SessionData */
         SessionData: {
@@ -63,11 +74,6 @@ export interface components {
         SessionUser: {
             /** Username */
             username: string;
-        };
-        /** SolverHealth */
-        SolverHealth: {
-            /** Healthy */
-            healthy: boolean;
         };
         /** ValidationError */
         ValidationError: {

--- a/web-client/src/components/system-health.tsx
+++ b/web-client/src/components/system-health.tsx
@@ -1,0 +1,281 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import {
+  HEALTH_QUERY_KEY,
+  useHealth,
+  type ComponentHealth,
+  type HealthResponse,
+} from '@/api/health'
+
+type ServiceKey = 'redis' | 'database' | 'solver'
+type ServiceStatus = 'ok' | 'deg' | 'bad' | 'loading'
+type OverallState = ServiceStatus
+
+const DEGRADED_LATENCY_MS = 1500
+
+const SERVICES: Array<{ key: ServiceKey; name: string; host: string; icon: ReactNode }> = [
+  {
+    key: 'redis',
+    name: 'Redis',
+    host: 'cache.fortymm.internal:6379',
+    icon: (
+      <svg viewBox="0 0 24 24">
+        <ellipse cx="12" cy="5" rx="8" ry="3" />
+        <path d="M4 5v6c0 1.7 3.6 3 8 3s8-1.3 8-3V5" />
+        <path d="M4 11v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6" />
+      </svg>
+    ),
+  },
+  {
+    key: 'database',
+    name: 'Database',
+    host: 'pg-primary.fortymm.internal:5432',
+    icon: (
+      <svg viewBox="0 0 24 24">
+        <ellipse cx="12" cy="5" rx="9" ry="3" />
+        <path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5" />
+        <path d="M3 12c0 1.7 4 3 9 3s9-1.3 9-3" />
+      </svg>
+    ),
+  },
+  {
+    key: 'solver',
+    name: 'Solver',
+    host: 'smt-solver.fortymm.internal:9100',
+    icon: (
+      <svg viewBox="0 0 24 24">
+        <path d="M4 4h6v6H4z" />
+        <path d="M14 4h6v6h-6z" />
+        <path d="M4 14h6v6H4z" />
+        <circle cx="17" cy="17" r="3" />
+      </svg>
+    ),
+  },
+]
+
+const HEADLINES: Record<OverallState, { reg: string; acc: string }> = {
+  ok: { reg: 'All systems', acc: 'go' },
+  deg: { reg: 'Something is', acc: 'sluggish' },
+  bad: { reg: 'Something is', acc: 'down' },
+  loading: { reg: 'Pinging the', acc: 'stack' },
+}
+
+const LEDES: Record<OverallState, string> = {
+  ok: 'Cache, database, and solver are answering on time.',
+  deg: 'A dependency is responding slower than expected.',
+  bad: "A dependency isn’t answering. Page the on-call.",
+  loading: 'Probing redis, database, and solver.',
+}
+
+const EYEBROWS: Record<OverallState, string> = {
+  ok: 'Operational',
+  deg: 'Partial degradation',
+  bad: 'Interruption',
+  loading: 'Checking',
+}
+
+const PILL_LABELS: Record<ServiceStatus, string> = {
+  ok: 'healthy',
+  deg: 'degraded',
+  bad: 'down',
+  loading: 'checking…',
+}
+
+function classifyComponent(component: ComponentHealth | undefined): ServiceStatus {
+  if (!component) return 'loading'
+  if (!component.healthy) return 'bad'
+  if (component.latency_ms != null && component.latency_ms > DEGRADED_LATENCY_MS) {
+    return 'deg'
+  }
+  return 'ok'
+}
+
+function deriveOverall(statuses: ServiceStatus[]): OverallState {
+  if (statuses.some((s) => s === 'bad')) return 'bad'
+  if (statuses.some((s) => s === 'deg')) return 'deg'
+  return 'ok'
+}
+
+function formatLatency(ms: number): string {
+  if (ms < 1) return ms.toFixed(1)
+  if (ms < 100) return ms.toFixed(0)
+  return Math.round(ms).toLocaleString()
+}
+
+function useTimeAgo(): (date: Date | null) => string {
+  const [, setTick] = useState(0)
+  useEffect(() => {
+    const id = window.setInterval(() => setTick((v) => v + 1), 1000)
+    return () => window.clearInterval(id)
+  }, [])
+
+  return (date: Date | null) => {
+    if (!date) return '—'
+    const seconds = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000))
+    if (seconds < 5) return 'just now'
+    if (seconds < 60) return `${seconds}s ago`
+    const minutes = Math.floor(seconds / 60)
+    if (minutes < 60) return `${minutes}m ago`
+    return `${Math.floor(minutes / 60)}h ago`
+  }
+}
+
+export function SystemHealth() {
+  const queryClient = useQueryClient()
+  const query = useHealth()
+  const formatTimeAgo = useTimeAgo()
+
+  const running = query.isFetching
+  const data: HealthResponse | undefined = query.data
+  const errored = !running && query.isError
+  const checkedAt =
+    !running && query.dataUpdatedAt ? new Date(query.dataUpdatedAt) : null
+
+  const serviceStatuses: Record<ServiceKey, ServiceStatus> = {
+    redis: running ? 'loading' : errored ? 'bad' : classifyComponent(data?.redis),
+    database: running
+      ? 'loading'
+      : errored
+        ? 'bad'
+        : classifyComponent(data?.database),
+    solver: running ? 'loading' : errored ? 'bad' : classifyComponent(data?.solver),
+  }
+
+  const overall: OverallState = running
+    ? 'loading'
+    : errored
+      ? 'bad'
+      : deriveOverall(Object.values(serviceStatuses))
+
+  const headline = HEADLINES[overall]
+
+  function recheck() {
+    queryClient.invalidateQueries({ queryKey: HEALTH_QUERY_KEY })
+  }
+
+  return (
+    <section
+      className={`sys-health sys-health--${overall}`}
+      data-testid="system-health"
+      data-state={overall}
+      aria-label="System health"
+    >
+      <div className="sys-health__head">
+        <span className="sys-health__eyebrow">
+          <span className="sys-health__pulse" aria-hidden />
+          <span data-testid="system-health-eyebrow">{EYEBROWS[overall]}</span>
+        </span>
+        <span
+          className="sys-health__ts"
+          data-testid="system-health-checked"
+          aria-live="polite"
+        >
+          checked {formatTimeAgo(checkedAt)}
+        </span>
+      </div>
+
+      <div className="sys-health__headline">
+        <h2>
+          {headline.reg}{' '}
+          <span className="sys-health__headline-accent">{headline.acc}</span>
+          <span className="sys-health__end-dot">.</span>
+        </h2>
+        <div className="sys-health__ball-art" aria-hidden="true">
+          <div className="sys-health__halo" />
+          <div className="sys-health__ball" />
+        </div>
+      </div>
+
+      <p className="sys-health__lede">{LEDES[overall]}</p>
+
+      <div className="sys-health__list">
+        {SERVICES.map((service) => {
+          const status = serviceStatuses[service.key]
+          const component = data?.[service.key]
+          const latencyMs = component?.latency_ms ?? null
+          const error = component?.error ?? null
+          const pillCls =
+            status === 'ok'
+              ? 'sys-health__pill sys-health__pill--ok'
+              : status === 'deg'
+                ? 'sys-health__pill sys-health__pill--deg'
+                : status === 'bad'
+                  ? 'sys-health__pill sys-health__pill--bad'
+                  : 'sys-health__pill'
+          const latCls =
+            status === 'bad'
+              ? ' sys-health__svc-lat--bad'
+              : status === 'deg'
+                ? ' sys-health__svc-lat--deg'
+                : ''
+
+          return (
+            <div
+              className="sys-health__row"
+              key={service.key}
+              data-testid={`system-health-row-${service.key}`}
+              data-status={status}
+            >
+              <div className="sys-health__svc-ico">{service.icon}</div>
+              <div className="sys-health__svc-meta">
+                <div className="sys-health__svc-name">{service.name}</div>
+                <div className="sys-health__svc-host">{service.host}</div>
+              </div>
+              <div className={`sys-health__svc-lat${latCls}`}>
+                {status === 'loading' ? (
+                  <span
+                    className="sys-health__skel"
+                    style={{ width: 46, height: 14 }}
+                  />
+                ) : latencyMs != null ? (
+                  <>
+                    {formatLatency(latencyMs)}
+                    <span className="unit">ms</span>
+                  </>
+                ) : (
+                  <>
+                    —<span className="unit"> n/a</span>
+                  </>
+                )}
+              </div>
+              <div className={pillCls}>
+                <span className="dot" aria-hidden />
+                <span data-testid={`system-health-pill-${service.key}`}>
+                  {PILL_LABELS[status]}
+                </span>
+              </div>
+              {status === 'bad' && error && (
+                <div
+                  className="sys-health__error"
+                  data-testid={`system-health-error-${service.key}`}
+                >
+                  ● {error}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="sys-health__foot">
+        <button
+          type="button"
+          className={`sys-health__btn sys-health__btn--primary${
+            running ? ' sys-health__btn--spinning' : ''
+          }`}
+          onClick={recheck}
+          disabled={running}
+          data-testid="system-health-recheck"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden>
+            <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+            <path d="M21 3v5h-5" />
+            <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+            <path d="M3 21v-5h5" />
+          </svg>
+          {running ? 'Checking…' : 'Recheck now'}
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -374,6 +374,11 @@ code {
    instead of inheriting the global 118%/145% rules. Load-bearing for the
    button screenshot assertions in e2e/design-system.spec.ts — fractional
    line-heights would let AA bleed +1px into the captured bbox. */
+.fortymm-theme h1,
+.fortymm-theme h2 {
+  color: var(--fg-1);
+}
+
 .dark.fortymm-theme h1,
 .dark.fortymm-theme h2 {
   line-height: 1;
@@ -907,5 +912,494 @@ code {
   }
   .app-shell__nav-badge--live::before {
     animation: none !important;
+  }
+}
+
+/* =========================================================================
+   System Health widget — operations card for the Administration page
+   ========================================================================= */
+.fortymm-theme .sys-health {
+  --health-accent: var(--ball-500);
+  --health-accent-glow: rgba(255, 122, 26, 0.3);
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 20px 20px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  overflow: hidden;
+  transition:
+    border-color 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 360ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.fortymm-theme .sys-health::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(
+    circle at center,
+    rgba(255, 122, 26, 0.06) 1.2px,
+    transparent 1.8px
+  );
+  background-size: 28px 28px;
+  mask-image: radial-gradient(
+    ellipse at 100% 0%,
+    rgba(0, 0, 0, 0.5),
+    transparent 60%
+  );
+  -webkit-mask-image: radial-gradient(
+    ellipse at 100% 0%,
+    rgba(0, 0, 0, 0.5),
+    transparent 60%
+  );
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.fortymm-theme .sys-health--ok {
+  --health-accent: var(--serve-500);
+  --health-accent-glow: rgba(0, 226, 154, 0.35);
+  border-color: rgba(0, 226, 154, 0.3);
+  box-shadow:
+    0 0 0 1px rgba(0, 226, 154, 0.1),
+    0 0 24px rgba(0, 226, 154, 0.08);
+}
+.fortymm-theme .sys-health--ok::before {
+  background-image: radial-gradient(
+    circle at center,
+    rgba(0, 226, 154, 0.07) 1.2px,
+    transparent 1.8px
+  );
+}
+
+.fortymm-theme .sys-health--deg {
+  --health-accent: var(--warn);
+  --health-accent-glow: rgba(255, 196, 61, 0.3);
+  border-color: rgba(255, 196, 61, 0.3);
+  box-shadow: 0 0 0 1px rgba(255, 196, 61, 0.12);
+}
+
+.fortymm-theme .sys-health--bad {
+  --health-accent: var(--loss);
+  --health-accent-glow: rgba(255, 77, 109, 0.3);
+  border-color: rgba(255, 77, 109, 0.35);
+  box-shadow: 0 0 0 1px rgba(255, 77, 109, 0.18);
+}
+.fortymm-theme .sys-health--bad::before {
+  background-image: radial-gradient(
+    circle at center,
+    rgba(255, 77, 109, 0.07) 1.2px,
+    transparent 1.8px
+  );
+}
+
+.fortymm-theme .sys-health__head {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.fortymm-theme .sys-health__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+
+.fortymm-theme .sys-health__pulse {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--health-accent);
+  box-shadow: 0 0 6px var(--health-accent-glow);
+  animation: ball-pulse 1.4s ease-in-out infinite;
+}
+.fortymm-theme .sys-health--loading .sys-health__pulse {
+  background: var(--fg-muted);
+  box-shadow: none;
+}
+
+.fortymm-theme .sys-health__ts {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.fortymm-theme .sys-health__headline {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.fortymm-theme .sys-health__headline h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 44px;
+  line-height: 1;
+  letter-spacing: 0.015em;
+  text-transform: uppercase;
+  color: var(--fg-1);
+}
+
+.fortymm-theme .sys-health__headline-accent {
+  color: var(--health-accent);
+}
+
+.fortymm-theme .sys-health__end-dot {
+  color: var(--ball-500);
+  margin-left: 4px;
+}
+
+.fortymm-theme .sys-health__ball-art {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  flex-shrink: 0;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fortymm-theme .sys-health__halo {
+  position: absolute;
+  inset: -14px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at center,
+    var(--health-accent-glow) 0%,
+    transparent 60%
+  );
+  transition: background 360ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.fortymm-theme .sys-health--loading .sys-health__halo {
+  background: radial-gradient(
+    circle at center,
+    rgba(255, 255, 255, 0.04) 0%,
+    transparent 60%
+  );
+  animation: hover-halo 2.2s ease-in-out infinite;
+}
+
+@keyframes hover-halo {
+  0%, 100% { transform: scale(0.92); opacity: 0.6; }
+  50% { transform: scale(1.05); opacity: 1; }
+}
+
+.fortymm-theme .sys-health__ball {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 35% 30%,
+    #ffb178 0%,
+    var(--ball-500) 35%,
+    var(--ball-600) 75%,
+    var(--ball-700) 100%
+  );
+  box-shadow:
+    0 6px 18px rgba(0, 0, 0, 0.5),
+    inset -4px -5px 10px rgba(0, 0, 0, 0.3),
+    inset 3px 3px 8px rgba(255, 255, 255, 0.18);
+  transition: background 360ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.fortymm-theme .sys-health--ok .sys-health__ball {
+  background: radial-gradient(
+    circle at 35% 30%,
+    #b9ffe4 0%,
+    var(--serve-500) 35%,
+    var(--serve-700) 80%,
+    #00604a 100%
+  );
+}
+.fortymm-theme .sys-health--deg .sys-health__ball {
+  background: radial-gradient(
+    circle at 35% 30%,
+    #ffe7a0 0%,
+    var(--warn) 35%,
+    #b08400 80%,
+    #6a4f00 100%
+  );
+}
+.fortymm-theme .sys-health--bad .sys-health__ball {
+  background: radial-gradient(
+    circle at 35% 30%,
+    #ffb2c0 0%,
+    var(--loss) 35%,
+    #a82240 80%,
+    #5f1024 100%
+  );
+}
+.fortymm-theme .sys-health--loading .sys-health__ball {
+  background: radial-gradient(
+    circle at 35% 30%,
+    #4a5060 0%,
+    #2a3040 50%,
+    #171b24 100%
+  );
+}
+.fortymm-theme .sys-health--loading .sys-health__ball::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: 50%;
+  border: 1.5px solid transparent;
+  border-top-color: var(--ball-500);
+  border-right-color: rgba(255, 122, 26, 0.4);
+  animation: sys-health-spin 1.1s linear infinite;
+}
+
+@keyframes sys-health-spin { to { transform: rotate(360deg); } }
+
+.fortymm-theme .sys-health__lede {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  color: var(--fg-3);
+  font-size: 13px;
+  line-height: 1.4;
+  max-width: 420px;
+}
+
+.fortymm-theme .sys-health__list {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background: var(--border-subtle);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.fortymm-theme .sys-health__row {
+  display: grid;
+  grid-template-columns: 22px 1fr auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 12px;
+  background: var(--bg-card);
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.fortymm-theme .sys-health__row:hover { background: var(--bg-raised); }
+
+.fortymm-theme .sys-health__svc-ico {
+  width: 22px;
+  height: 22px;
+  color: var(--fg-3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.fortymm-theme .sys-health__svc-ico svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 1.75;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.fortymm-theme .sys-health__svc-meta { min-width: 0; }
+.fortymm-theme .sys-health__svc-name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--fg-1);
+}
+.fortymm-theme .sys-health__svc-host {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fortymm-theme .sys-health__svc-lat {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-1);
+  text-align: right;
+  line-height: 1;
+}
+.fortymm-theme .sys-health__svc-lat--bad { color: var(--loss); }
+.fortymm-theme .sys-health__svc-lat--deg { color: var(--warn); }
+.fortymm-theme .sys-health__svc-lat .unit {
+  font-size: 10px;
+  color: var(--fg-muted);
+  margin-left: 1px;
+  font-weight: 500;
+}
+
+.fortymm-theme .sys-health__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-default);
+  background: var(--bg-panel);
+  color: var(--fg-3);
+  text-transform: lowercase;
+}
+.fortymm-theme .sys-health__pill .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--fg-muted);
+}
+.fortymm-theme .sys-health__pill--ok {
+  background: var(--bg-live-soft);
+  border-color: rgba(0, 226, 154, 0.3);
+  color: var(--serve-500);
+}
+.fortymm-theme .sys-health__pill--ok .dot {
+  background: var(--serve-500);
+  box-shadow: 0 0 5px rgba(0, 226, 154, 0.7);
+}
+.fortymm-theme .sys-health__pill--deg {
+  background: rgba(255, 196, 61, 0.12);
+  border-color: rgba(255, 196, 61, 0.3);
+  color: var(--warn);
+}
+.fortymm-theme .sys-health__pill--deg .dot { background: var(--warn); }
+.fortymm-theme .sys-health__pill--bad {
+  background: rgba(255, 77, 109, 0.14);
+  border-color: rgba(255, 77, 109, 0.35);
+  color: var(--loss);
+}
+.fortymm-theme .sys-health__pill--bad .dot {
+  background: var(--loss);
+  box-shadow: 0 0 5px rgba(255, 77, 109, 0.7);
+}
+
+.fortymm-theme .sys-health__error {
+  grid-column: 2 / -1;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--loss);
+  background: rgba(255, 77, 109, 0.06);
+  border: 1px solid rgba(255, 77, 109, 0.2);
+  border-radius: 4px;
+  padding: 4px 8px;
+}
+
+.fortymm-theme .sys-health__skel {
+  display: inline-block;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.04) 0%,
+    rgba(255, 255, 255, 0.1) 50%,
+    rgba(255, 255, 255, 0.04) 100%
+  );
+  background-size: 200% 100%;
+  animation: sys-health-shimmer 1.4s ease-in-out infinite;
+  border-radius: 4px;
+}
+
+@keyframes sys-health-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+.fortymm-theme .sys-health__foot {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.fortymm-theme .sys-health__btn {
+  appearance: none;
+  border: 1px solid var(--border-default);
+  background: var(--bg-card);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-weight: 600;
+  font-size: 13px;
+  padding: 7px 12px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition:
+    background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.fortymm-theme .sys-health__btn:hover { background: var(--bg-raised); }
+.fortymm-theme .sys-health__btn:active { transform: scale(0.97); }
+.fortymm-theme .sys-health__btn:focus-visible {
+  outline: 2px solid var(--ball-500);
+  outline-offset: 2px;
+}
+.fortymm-theme .sys-health__btn--primary {
+  background: var(--ball-500);
+  color: var(--ink-950);
+  border-color: var(--ball-500);
+}
+.fortymm-theme .sys-health__btn--primary:hover {
+  background: var(--ball-400);
+  border-color: var(--ball-400);
+  box-shadow: var(--shadow-glow);
+}
+.fortymm-theme .sys-health__btn--primary:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}
+.fortymm-theme .sys-health__btn svg {
+  width: 13px;
+  height: 13px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: transform 700ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.fortymm-theme .sys-health__btn--spinning svg { transform: rotate(720deg); }
+
+@media (max-width: 540px) {
+  .fortymm-theme .sys-health__headline h2 { font-size: 32px; }
+  .fortymm-theme .sys-health__ball-art { width: 44px; height: 44px; }
+  .fortymm-theme .sys-health__ball { width: 36px; height: 36px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fortymm-theme .sys-health__pulse,
+  .fortymm-theme .sys-health__halo,
+  .fortymm-theme .sys-health__ball::after,
+  .fortymm-theme .sys-health__skel {
+    animation: none !important;
+  }
+  .fortymm-theme .sys-health__btn svg {
+    transition: none !important;
   }
 }

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -1,8 +1,8 @@
 import { delay, http, HttpResponse } from 'msw'
-import { healthResponse, sessionResponse } from '@/test/factories'
+import { healthCheck, sessionResponse } from '@/test/factories'
 
 export const mockSession = sessionResponse({ user: { username: 'rita.kovac' } })
-export const mockHealthy = healthResponse()
+export const mockHealthy = healthCheck()
 
 export const handlers = [
   http.get('*/v1/health', async () => {

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -1,22 +1,8 @@
 import { delay, http, HttpResponse } from 'msw'
-import type { components } from '@/api/schema'
+import { healthResponse, sessionResponse } from '@/test/factories'
 
-type SessionResponse = components['schemas']['SessionResponse']
-type HealthResponse = components['schemas']['HealthResponse']
-
-export const mockSession: SessionResponse = {
-  data: {
-    user: {
-      username: 'rita.kovac',
-    },
-  },
-}
-
-export const mockHealthy: HealthResponse = {
-  redis: { healthy: true, latency_ms: 4 },
-  database: { healthy: true, latency_ms: 12 },
-  solver: { healthy: true, latency_ms: 38 },
-}
+export const mockSession = sessionResponse({ user: { username: 'rita.kovac' } })
+export const mockHealthy = healthResponse()
 
 export const handlers = [
   http.get('*/v1/health', async () => {

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -2,6 +2,7 @@ import { delay, http, HttpResponse } from 'msw'
 import type { components } from '@/api/schema'
 
 type SessionResponse = components['schemas']['SessionResponse']
+type HealthResponse = components['schemas']['HealthResponse']
 
 export const mockSession: SessionResponse = {
   data: {
@@ -11,9 +12,16 @@ export const mockSession: SessionResponse = {
   },
 }
 
+export const mockHealthy: HealthResponse = {
+  redis: { healthy: true, latency_ms: 4 },
+  database: { healthy: true, latency_ms: 12 },
+  solver: { healthy: true, latency_ms: 38 },
+}
+
 export const handlers = [
-  http.get('/api/health', () => {
-    return HttpResponse.json({ status: 'ok' })
+  http.get('*/v1/health', async () => {
+    await delay(400)
+    return HttpResponse.json(mockHealthy)
   }),
 
   http.get('*/v1/session', async () => {

--- a/web-client/src/routes/admin.tsx
+++ b/web-client/src/routes/admin.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { AppShell } from '@/components/app-shell'
+import { SystemHealth } from '@/components/system-health'
 
 export const Route = createFileRoute('/admin')({
   component: AdminPage,
@@ -9,7 +10,13 @@ function AdminPage() {
   return (
     <AppShell>
       <div className="mx-auto max-w-[1200px] px-12 pt-16 pb-32">
-        <h1 className="font-display text-4xl text-foreground">Administration</h1>
+        <header className="mb-10">
+          <h1 className="font-display text-4xl text-foreground">Administration</h1>
+        </header>
+
+        <section aria-label="Operations" className="mb-12 max-w-[640px]">
+          <SystemHealth />
+        </section>
       </div>
     </AppShell>
   )

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -6,9 +6,7 @@ type HealthResponse = components['schemas']['HealthResponse']
 type SessionUser = components['schemas']['SessionUser']
 type SessionResponse = components['schemas']['SessionResponse']
 
-export function healthyComponent(
-  overrides: Partial<ComponentHealth> = {},
-): ComponentHealth {
+function fastCheck(overrides: Partial<ComponentHealth> = {}): ComponentHealth {
   return {
     healthy: true,
     latency_ms: faker.number.float({ min: 1, max: 80, fractionDigits: 1 }),
@@ -17,46 +15,34 @@ export function healthyComponent(
   }
 }
 
-export function degradedComponent(
+export function redisCheck(
   overrides: Partial<ComponentHealth> = {},
 ): ComponentHealth {
-  return {
-    healthy: true,
-    latency_ms: faker.number.float({
-      min: 1600,
-      max: 3500,
-      fractionDigits: 1,
-    }),
-    error: null,
-    ...overrides,
-  }
+  return fastCheck(overrides)
 }
 
-const DOWN_ERRORS = [
-  'connection refused (ECONNREFUSED)',
-  'timeout after 5000ms',
-  'connection reset by peer',
-  'host unreachable',
-] as const
-
-export function downComponent(
+export function databaseCheck(
   overrides: Partial<ComponentHealth> = {},
 ): ComponentHealth {
-  return {
-    healthy: false,
-    latency_ms: null,
-    error: faker.helpers.arrayElement(DOWN_ERRORS),
-    ...overrides,
-  }
+  return fastCheck(overrides)
 }
 
-export function healthResponse(
+export function solverCheck(
+  overrides: Partial<ComponentHealth> = {},
+): ComponentHealth {
+  return fastCheck({
+    latency_ms: faker.number.float({ min: 30, max: 250, fractionDigits: 1 }),
+    ...overrides,
+  })
+}
+
+export function healthCheck(
   overrides: Partial<HealthResponse> = {},
 ): HealthResponse {
   return {
-    redis: healthyComponent(),
-    database: healthyComponent(),
-    solver: healthyComponent(),
+    redis: redisCheck(),
+    database: databaseCheck(),
+    solver: solverCheck(),
     ...overrides,
   }
 }

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -1,0 +1,77 @@
+import { faker } from '@faker-js/faker'
+import type { components } from '@/api/schema'
+
+type ComponentHealth = components['schemas']['ComponentHealth']
+type HealthResponse = components['schemas']['HealthResponse']
+type SessionUser = components['schemas']['SessionUser']
+type SessionResponse = components['schemas']['SessionResponse']
+
+export function healthyComponent(
+  overrides: Partial<ComponentHealth> = {},
+): ComponentHealth {
+  return {
+    healthy: true,
+    latency_ms: faker.number.float({ min: 1, max: 80, fractionDigits: 1 }),
+    error: null,
+    ...overrides,
+  }
+}
+
+export function degradedComponent(
+  overrides: Partial<ComponentHealth> = {},
+): ComponentHealth {
+  return {
+    healthy: true,
+    latency_ms: faker.number.float({
+      min: 1600,
+      max: 3500,
+      fractionDigits: 1,
+    }),
+    error: null,
+    ...overrides,
+  }
+}
+
+const DOWN_ERRORS = [
+  'connection refused (ECONNREFUSED)',
+  'timeout after 5000ms',
+  'connection reset by peer',
+  'host unreachable',
+] as const
+
+export function downComponent(
+  overrides: Partial<ComponentHealth> = {},
+): ComponentHealth {
+  return {
+    healthy: false,
+    latency_ms: null,
+    error: faker.helpers.arrayElement(DOWN_ERRORS),
+    ...overrides,
+  }
+}
+
+export function healthResponse(
+  overrides: Partial<HealthResponse> = {},
+): HealthResponse {
+  return {
+    redis: healthyComponent(),
+    database: healthyComponent(),
+    solver: healthyComponent(),
+    ...overrides,
+  }
+}
+
+export function sessionUser(overrides: Partial<SessionUser> = {}): SessionUser {
+  return {
+    username: faker.internet.username().toLowerCase(),
+    ...overrides,
+  }
+}
+
+export function sessionResponse(
+  overrides: { user?: Partial<SessionUser> } = {},
+): SessionResponse {
+  return {
+    data: { user: sessionUser(overrides.user) },
+  }
+}


### PR DESCRIPTION
## Summary
- Expanded `GET /v1/health` to report `redis`, `database`, and `solver` as `ComponentHealth` objects (`healthy`, `latency_ms`, `error`) so the UI can render per-dependency state instead of just a solver flag.
- Built a `SystemHealth` widget on `/admin` matching the System Health v2.html design — eyebrow + headline + three compact service rows + recheck button — classifying overall state as `ok` / `deg` / `bad` from liveness plus a 1500ms latency threshold. Also fixed `.fortymm-theme` h1/h2 color so the page heading stops inheriting the near-black global `--text-h`.
- Added two tiers of Playwright coverage: web-client specs that fake every health scenario (healthy / degraded / failing / 5xx / in-flight loading / refetch) via `page.route` (MSW disabled in the e2e webServer env), and a root e2e spec that hits the full docker-compose stack and asserts every dependency reports healthy.

## Test plan
- [x] `pytest` (api) — 15 passed
- [x] `npx tsc -b` + `npx eslint .` + `npm run test:run` (web-client) — clean
- [x] `npx playwright test` in `web-client/e2e` — 8 passed (admin + landing)
- [x] `npx playwright test` in `e2e/` (live docker-compose stack) — 2 passed (admin health + landing)
- [x] Visual check against running stack at `http://localhost:8080/admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)