### PR TITLE
Add RBAC tables and expose user permissions on session

### DIFF
--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -1,4 +1,15 @@
+from app.models.permission import Permission
+from app.models.role import Role
+from app.models.role_permission import RolePermission
 from app.models.user import User
+from app.models.user_role import UserRole
 from app.models.user_token import UserToken
 
-__all__ = ["User", "UserToken"]
+__all__ = [
+    "Permission",
+    "Role",
+    "RolePermission",
+    "User",
+    "UserRole",
+    "UserToken",
+]

--- a/api/app/models/permission.py
+++ b/api/app/models/permission.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class Permission(Base):
+    __tablename__ = "permissions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    name: Mapped[str] = mapped_column(
+        String(255), unique=True, nullable=False, index=True
+    )
+    description: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/api/app/models/role.py
+++ b/api/app/models/role.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class Role(Base):
+    __tablename__ = "roles"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    name: Mapped[str] = mapped_column(
+        String(255), unique=True, nullable=False, index=True
+    )
+    description: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/api/app/models/role_permission.py
+++ b/api/app/models/role_permission.py
@@ -1,0 +1,26 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import ForeignKey, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class RolePermission(Base):
+    __tablename__ = "roles_permissions"
+
+    role_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("roles.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    permission_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("permissions.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(), nullable=False
+    )

--- a/api/app/models/user_role.py
+++ b/api/app/models/user_role.py
@@ -1,0 +1,26 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import ForeignKey, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class UserRole(Base):
+    __tablename__ = "users_roles"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    role_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("roles.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(), nullable=False
+    )

--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 
 class SessionUser(BaseModel):
     username: str
+    permissions: list[str]
 
 
 class SessionData(BaseModel):

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
-from app.models import User, UserToken
+from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
 from app.schemas.session import SessionData, SessionResponse, SessionUser
 
 router = APIRouter()
@@ -44,6 +44,19 @@ async def _find_session_user(db: AsyncSession, raw_token: str) -> User | None:
         return None
     user_result = await db.execute(select(User).where(User.id == token.user_id))
     return user_result.scalar_one_or_none()
+
+
+async def _load_permissions(db: AsyncSession, user_id) -> list[str]:
+    result = await db.execute(
+        select(Permission.name)
+        .join(RolePermission, RolePermission.permission_id == Permission.id)
+        .join(Role, Role.id == RolePermission.role_id)
+        .join(UserRole, UserRole.role_id == Role.id)
+        .where(UserRole.user_id == user_id)
+        .distinct()
+        .order_by(Permission.name)
+    )
+    return list(result.scalars().all())
 
 
 async def _create_session(db: AsyncSession) -> tuple[User, str]:
@@ -90,4 +103,9 @@ async def get_session_endpoint(
     if user is None:
         user, raw_token = await _create_session(db)
         _set_session_cookie(response, raw_token)
-    return SessionResponse(data=SessionData(user=SessionUser(username=user.username)))
+    permissions = await _load_permissions(db, user.id)
+    return SessionResponse(
+        data=SessionData(
+            user=SessionUser(username=user.username, permissions=permissions)
+        )
+    )

--- a/api/migrations/versions/20260512_0000_0003_create_rbac_tables.py
+++ b/api/migrations/versions/20260512_0000_0003_create_rbac_tables.py
@@ -1,0 +1,115 @@
+"""create rbac tables
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-05-12 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "roles",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.String(length=1024), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("name", name="uq_roles_name"),
+    )
+    op.create_index("ix_roles_name", "roles", ["name"])
+
+    op.create_table(
+        "permissions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.String(length=1024), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("name", name="uq_permissions_name"),
+    )
+    op.create_index("ix_permissions_name", "permissions", ["name"])
+
+    op.create_table(
+        "roles_permissions",
+        sa.Column(
+            "role_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("roles.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "permission_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("permissions.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_table(
+        "users_roles",
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "role_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("roles.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("users_roles")
+    op.drop_table("roles_permissions")
+    op.drop_index("ix_permissions_name", table_name="permissions")
+    op.drop_table("permissions")
+    op.drop_index("ix_roles_name", table_name="roles")
+    op.drop_table("roles")

--- a/api/tests/test_rbac_models.py
+++ b/api/tests/test_rbac_models.py
@@ -1,0 +1,123 @@
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Permission, Role, RolePermission, User, UserRole
+
+
+async def test_create_role_assigns_uuid_and_timestamps(db_session: AsyncSession):
+    role = Role(name="admin", description="full access")
+    db_session.add(role)
+    await db_session.commit()
+    await db_session.refresh(role)
+    assert isinstance(role.id, uuid.UUID)
+    assert role.created_at is not None
+    assert role.updated_at is not None
+
+
+async def test_role_name_is_unique(db_session: AsyncSession):
+    db_session.add(Role(name="admin"))
+    await db_session.commit()
+    db_session.add(Role(name="admin"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_create_permission_assigns_uuid_and_timestamps(
+    db_session: AsyncSession,
+):
+    perm = Permission(name="solver:run")
+    db_session.add(perm)
+    await db_session.commit()
+    await db_session.refresh(perm)
+    assert isinstance(perm.id, uuid.UUID)
+    assert perm.created_at is not None
+    assert perm.updated_at is not None
+
+
+async def test_permission_name_is_unique(db_session: AsyncSession):
+    db_session.add(Permission(name="solver:run"))
+    await db_session.commit()
+    db_session.add(Permission(name="solver:run"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_role_permission_links_role_and_permission(
+    db_session: AsyncSession,
+):
+    role = Role(name="editor")
+    perm = Permission(name="puzzle:write")
+    db_session.add_all([role, perm])
+    await db_session.commit()
+
+    db_session.add(RolePermission(role_id=role.id, permission_id=perm.id))
+    await db_session.commit()
+
+    fetched = (
+        await db_session.execute(
+            select(RolePermission).where(
+                RolePermission.role_id == role.id,
+                RolePermission.permission_id == perm.id,
+            )
+        )
+    ).scalar_one()
+    assert fetched.created_at is not None
+
+
+async def test_role_permission_cascades_when_role_deleted(
+    db_session: AsyncSession,
+):
+    role = Role(name="viewer")
+    perm = Permission(name="puzzle:read")
+    db_session.add_all([role, perm])
+    await db_session.commit()
+
+    db_session.add(RolePermission(role_id=role.id, permission_id=perm.id))
+    await db_session.commit()
+
+    await db_session.delete(role)
+    await db_session.commit()
+    db_session.expunge_all()
+
+    remaining = (await db_session.execute(select(RolePermission))).scalars().all()
+    assert remaining == []
+
+
+async def test_user_role_links_user_and_role(db_session: AsyncSession):
+    user = User(username="alice")
+    role = Role(name="member")
+    db_session.add_all([user, role])
+    await db_session.commit()
+
+    db_session.add(UserRole(user_id=user.id, role_id=role.id))
+    await db_session.commit()
+
+    fetched = (
+        await db_session.execute(
+            select(UserRole).where(
+                UserRole.user_id == user.id, UserRole.role_id == role.id
+            )
+        )
+    ).scalar_one()
+    assert fetched.created_at is not None
+
+
+async def test_user_role_cascades_when_user_deleted(db_session: AsyncSession):
+    user = User(username="bob")
+    role = Role(name="member")
+    db_session.add_all([user, role])
+    await db_session.commit()
+
+    db_session.add(UserRole(user_id=user.id, role_id=role.id))
+    await db_session.commit()
+
+    await db_session.delete(user)
+    await db_session.commit()
+    db_session.expunge_all()
+
+    remaining = (await db_session.execute(select(UserRole))).scalars().all()
+    assert remaining == []

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
 from app.main import app
-from app.models import User, UserToken
+from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
 from app.sessions import SESSION_COOKIE_NAME, SESSION_TOKEN_CONTEXT
 
 
@@ -32,8 +32,10 @@ async def test_creates_session_when_no_cookie(
     response = await api_client.get("/v1/session")
     assert response.status_code == 200
 
-    username = response.json()["data"]["user"]["username"]
+    body_user = response.json()["data"]["user"]
+    username = body_user["username"]
     assert username
+    assert body_user["permissions"] == []
 
     cookie_header = response.headers.get("set-cookie", "").lower()
     assert "httponly" in cookie_header
@@ -115,3 +117,68 @@ async def test_token_is_stored_hashed_not_plaintext(
         tokens[0].token
         == hashlib.sha256(raw_token.encode("utf-8")).digest()
     )
+
+
+async def test_session_response_includes_user_permissions(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    first = await api_client.get("/v1/session")
+    username = first.json()["data"]["user"]["username"]
+
+    user = (
+        await db_session.execute(select(User).where(User.username == username))
+    ).scalar_one()
+
+    role = Role(name="member")
+    other_role = Role(name="bystander")
+    perm_a = Permission(name="puzzle:read")
+    perm_b = Permission(name="puzzle:write")
+    perm_unused = Permission(name="admin:all")
+    db_session.add_all([role, other_role, perm_a, perm_b, perm_unused])
+    await db_session.commit()
+
+    db_session.add_all(
+        [
+            UserRole(user_id=user.id, role_id=role.id),
+            RolePermission(role_id=role.id, permission_id=perm_a.id),
+            RolePermission(role_id=role.id, permission_id=perm_b.id),
+            RolePermission(role_id=other_role.id, permission_id=perm_unused.id),
+        ]
+    )
+    await db_session.commit()
+
+    second = await api_client.get("/v1/session")
+    assert second.status_code == 200
+    body_user = second.json()["data"]["user"]
+    assert body_user["username"] == username
+    assert body_user["permissions"] == ["puzzle:read", "puzzle:write"]
+
+
+async def test_session_deduplicates_permissions_across_roles(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    first = await api_client.get("/v1/session")
+    username = first.json()["data"]["user"]["username"]
+
+    user = (
+        await db_session.execute(select(User).where(User.username == username))
+    ).scalar_one()
+
+    role_a = Role(name="reader")
+    role_b = Role(name="auditor")
+    perm = Permission(name="puzzle:read")
+    db_session.add_all([role_a, role_b, perm])
+    await db_session.commit()
+
+    db_session.add_all(
+        [
+            UserRole(user_id=user.id, role_id=role_a.id),
+            UserRole(user_id=user.id, role_id=role_b.id),
+            RolePermission(role_id=role_a.id, permission_id=perm.id),
+            RolePermission(role_id=role_b.id, permission_id=perm.id),
+        ]
+    )
+    await db_session.commit()
+
+    second = await api_client.get("/v1/session")
+    assert second.json()["data"]["user"]["permissions"] == ["puzzle:read"]

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -74,6 +74,8 @@ export interface components {
         SessionUser: {
             /** Username */
             username: string;
+            /** Permissions */
+            permissions: string[];
         };
         /** ValidationError */
         ValidationError: {

--- a/web-client/src/components/user-menu.test.tsx
+++ b/web-client/src/components/user-menu.test.tsx
@@ -51,7 +51,7 @@ describe('UserMenu', () => {
 
   it('renders avatar initials derived from the username', async () => {
     const typed: SessionResponse = {
-      data: { user: { username: 'maria.rossi' } },
+      data: { user: { username: 'maria.rossi', permissions: [] } },
     }
     server.use(
       http.get('*/v1/session', () => HttpResponse.json(typed)),
@@ -66,7 +66,7 @@ describe('UserMenu', () => {
   it('truncates very long usernames via class and exposes full name as a tooltip', async () => {
     const longName = 'a-really-extraordinarily-long-username-that-should-truncate'
     const typed: SessionResponse = {
-      data: { user: { username: longName } },
+      data: { user: { username: longName, permissions: [] } },
     }
     server.use(
       http.get('*/v1/session', () => HttpResponse.json(typed)),

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -50,6 +50,7 @@ export function healthCheck(
 export function sessionUser(overrides: Partial<SessionUser> = {}): SessionUser {
   return {
     username: faker.internet.username().toLowerCase(),
+    permissions: [],
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary
- Adds four RBAC tables (`roles`, `permissions`, `roles_permissions`, `users_roles`) as Alembic revision `0003`, with cascading FKs on the join tables.
- `/v1/session` now joins through the new tables and returns a sorted, deduped `permissions: string[]` on `SessionUser`, so the web client can gate UI by capability.
- Regenerates `web-client/src/api/schema.d.ts` from the live OpenAPI spec and updates MSW fixtures / user-menu tests to satisfy the new required field.

## Test plan
- [ ] `cd api && .venv/bin/pytest` — full suite green (24 tests)
- [ ] `alembic upgrade head` + `alembic downgrade base` round-trip against a fresh Postgres
- [ ] `cd web-client && npm run test:run` and `npx tsc -b`
- [ ] Hit `/v1/session` in dev: confirm `data.user.permissions` is `[]` for a fresh session and populated after seeding `users_roles` + `roles_permissions` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)