### PR TITLE
Add RBAC administration UI: roles, permissions, users

### DIFF
--- a/web-client/e2e/rbac-smoke.spec.ts
+++ b/web-client/e2e/rbac-smoke.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test'
+
+test('roles page renders list and detail', async ({ page }) => {
+  await page.goto('/admin/roles')
+  await expect(page.getByText('Tournament Director').first()).toBeVisible()
+  await expect(page.getByText('Permissions', { exact: false }).first()).toBeVisible()
+})
+
+test('permissions page renders groups', async ({ page }) => {
+  await page.goto('/admin/permissions')
+  await expect(page.getByRole('heading', { name: 'Permissions', level: 1 })).toBeVisible()
+  await expect(page.getByText('tournament.*')).toBeVisible()
+  await expect(page.getByText('tournament.view').first()).toBeVisible()
+})
+
+test('users page renders table', async ({ page }) => {
+  await page.goto('/admin/users')
+  await expect(page.getByRole('heading', { name: 'Users', level: 1 })).toBeVisible()
+  await expect(page.getByText('tim.nguyen').first()).toBeVisible()
+  await expect(page.getByText('alex.johansen').first()).toBeVisible()
+})
+
+test('sidebar shows administration sub-nav', async ({ page }) => {
+  await page.goto('/admin/roles')
+  // Sub-nav items: Roles / Permissions / Users (sidebar)
+  const sidebar = page.locator('.app-shell__sidebar')
+  await expect(sidebar.getByRole('link', { name: /Roles/ })).toBeVisible()
+  await expect(sidebar.getByRole('link', { name: /Permissions/ })).toBeVisible()
+  await expect(sidebar.getByRole('link', { name: /Users/ })).toBeVisible()
+})
+
+test('sub-nav navigates between admin pages', async ({ page }) => {
+  await page.goto('/admin/roles')
+  await page.locator('.app-shell__sidebar').getByRole('link', { name: /Permissions/ }).click()
+  await page.waitForURL('**/admin/permissions')
+  await expect(page.getByRole('heading', { name: 'Permissions', level: 1 })).toBeVisible()
+  await page.locator('.app-shell__sidebar').getByRole('link', { name: /^Users$/ }).click()
+  await page.waitForURL('**/admin/users')
+  await expect(page.getByRole('heading', { name: 'Users', level: 1 })).toBeVisible()
+})

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
+import { Key, Shield, Users } from 'lucide-react'
 import { UserMenu } from './user-menu'
 
 type NavItem = {
@@ -8,6 +9,7 @@ type NavItem = {
   badge?: { label: string; live?: boolean }
   active?: boolean
   to?: string
+  children?: Array<{ label: string; to: string; icon: ReactNode }>
 }
 
 type NavSection = {
@@ -252,6 +254,11 @@ const NAV_SECTIONS: NavSection[] = [
             <path d="M9 12l2 2 4-4" />
           </svg>
         ),
+        children: [
+          { label: 'Roles', to: '/admin/roles', icon: <Shield size={15} strokeWidth={1.75} /> },
+          { label: 'Permissions', to: '/admin/permissions', icon: <Key size={15} strokeWidth={1.75} /> },
+          { label: 'Users', to: '/admin/users', icon: <Users size={15} strokeWidth={1.75} /> },
+        ],
       },
     ],
   },
@@ -348,10 +355,11 @@ export function AppShell({ children }: AppShellProps) {
               <div className="app-shell__nav-label">{section.label}</div>
               <ul className="app-shell__nav-list">
                 {section.items.map((item) => {
+                  const childActive = item.children?.some((c) => pathname === c.to) ?? false
                   const isActive = item.to
-                    ? pathname === item.to
+                    ? pathname === item.to || childActive
                     : activeLabel === item.label
-                  const linkClassName = `app-shell__nav-link${isActive ? ' is-active' : ''}`
+                  const linkClassName = `app-shell__nav-link${isActive && !item.children ? ' is-active' : ''}${item.children && childActive ? ' is-parent-active' : ''}`
                   const inner = (
                     <>
                       <span className="app-shell__nav-icon">{item.icon}</span>
@@ -363,6 +371,26 @@ export function AppShell({ children }: AppShellProps) {
                           }`}
                         >
                           {item.badge.label}
+                        </span>
+                      ) : null}
+                      {item.children ? (
+                        <span
+                          className="app-shell__nav-chev"
+                          aria-hidden="true"
+                          style={{ marginLeft: 'auto', display: 'inline-flex' }}
+                        >
+                          <svg
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          >
+                            <path d="M6 9l6 6 6-6" />
+                          </svg>
                         </span>
                       ) : null}
                     </>
@@ -386,6 +414,25 @@ export function AppShell({ children }: AppShellProps) {
                           {inner}
                         </a>
                       )}
+                      {item.children && (isActive || childActive) ? (
+                        <ul className="app-shell__sub-nav-list">
+                          {item.children.map((child) => {
+                            const childIsActive = pathname === child.to
+                            return (
+                              <li key={child.label}>
+                                <Link
+                                  to={child.to}
+                                  className={`app-shell__sub-nav-link${childIsActive ? ' is-active' : ''}`}
+                                  onClick={() => handleRouteNavClick(child.label)}
+                                >
+                                  <span className="app-shell__nav-icon">{child.icon}</span>
+                                  {child.label}
+                                </Link>
+                              </li>
+                            )
+                          })}
+                        </ul>
+                      ) : null}
                     </li>
                   )
                 })}

--- a/web-client/src/components/rbac/admin-layout.tsx
+++ b/web-client/src/components/rbac/admin-layout.tsx
@@ -1,0 +1,74 @@
+import { useRouterState } from '@tanstack/react-router'
+import { useRbacData } from './use-rbac'
+
+const TAB_LABELS: Record<string, string> = {
+  '/admin/roles': 'Roles',
+  '/admin/permissions': 'Permissions',
+  '/admin/users': 'Users',
+}
+
+export function AdminBreadcrumbAndCounts() {
+  const { users, roles, permissions } = useRbacData()
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const current = TAB_LABELS[pathname] ?? 'Overview'
+
+  return (
+    <div
+      style={{
+        height: 56,
+        display: 'flex',
+        alignItems: 'center',
+        padding: '0 24px',
+        gap: 14,
+        borderBottom: '1px solid var(--border-subtle)',
+        background: 'var(--bg-app)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontSize: 12, color: 'var(--fg-muted)', fontWeight: 500 }}>Administration</span>
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--fg-muted)" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M9 6l6 6-6 6" />
+        </svg>
+        <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg-1)' }}>{current}</span>
+      </div>
+      <div style={{ flex: 1 }} />
+      <div
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 10,
+          padding: '4px 12px',
+          borderRadius: 999,
+          background: 'var(--bg-card)',
+          border: '1px solid var(--border-subtle)',
+          fontSize: 11,
+          fontFamily: 'var(--font-mono)',
+          color: 'var(--fg-3)',
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        <span
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            background: 'var(--serve-500)',
+            boxShadow: '0 0 6px var(--serve-500)',
+            animation: 'ball-pulse 1.4s ease-in-out infinite',
+          }}
+        />
+        <span>
+          <span style={{ color: 'var(--fg-1)', fontWeight: 600 }}>{users.length}</span> users
+        </span>
+        <span style={{ color: 'var(--ink-500)' }}>·</span>
+        <span>
+          <span style={{ color: 'var(--fg-1)', fontWeight: 600 }}>{roles.length}</span> roles
+        </span>
+        <span style={{ color: 'var(--ink-500)' }}>·</span>
+        <span>
+          <span style={{ color: 'var(--fg-1)', fontWeight: 600 }}>{permissions.length}</span> perms
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/web-client/src/components/rbac/helpers.ts
+++ b/web-client/src/components/rbac/helpers.ts
@@ -1,0 +1,77 @@
+import { format, formatDistanceToNowStrict } from 'date-fns'
+import type { Permission } from './seed'
+
+const ROLE_PALETTE = ['#FF7A1A', '#00E29A', '#6FB5FF', '#FFC43D', '#A87BFF', '#FF4D6D', '#8CFFD4']
+
+function hash(s: string): number {
+  let h = 0
+  for (const c of s) h = (h * 31 + c.charCodeAt(0)) | 0
+  return Math.abs(h)
+}
+
+export function colorFor(name: string): string {
+  return ROLE_PALETTE[hash(name) % ROLE_PALETTE.length]
+}
+
+export function permPrefix(name: string): string {
+  const dot = name.indexOf('.')
+  return dot === -1 ? 'other' : name.slice(0, dot)
+}
+
+// Stable order for known resource prefixes; unknown prefixes sort to the end alphabetically.
+const PREFIX_ORDER = ['tournament', 'draws', 'courts', 'players', 'ratings', 'members', 'roles', 'permissions', 'system', 'other']
+
+export function groupPermissions(perms: Permission[]): Array<{ prefix: string; items: Permission[] }> {
+  const groups = new Map<string, Permission[]>()
+  for (const p of perms) {
+    const k = permPrefix(p.name)
+    if (!groups.has(k)) groups.set(k, [])
+    groups.get(k)!.push(p)
+  }
+  return [...groups.entries()]
+    .sort(([a], [b]) => {
+      const ai = PREFIX_ORDER.indexOf(a)
+      const bi = PREFIX_ORDER.indexOf(b)
+      return (ai < 0 ? 99 : ai) - (bi < 0 ? 99 : bi)
+    })
+    .map(([prefix, items]) => ({ prefix, items }))
+}
+
+export function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  return format(new Date(iso), 'MMM d, yyyy')
+}
+
+export function fmtDateRel(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  return formatDistanceToNowStrict(new Date(iso), { addSuffix: true })
+}
+
+export const newId = (prefix: string) =>
+  prefix + '_' + (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID().slice(0, 8) : Math.random().toString(36).slice(2, 10))
+
+export const nowIso = () => new Date().toISOString()
+
+export function initialsFor(name: string): string {
+  return name
+    .replace(/[._-]/g, ' ')
+    .split(/\s+/)
+    .map((n) => n[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+}
+
+const AVATAR_PALETTE: Array<[string, string]> = [
+  ['#FF7A1A', '#fff'],
+  ['#00E29A', '#0B0D12'],
+  ['#6FB5FF', '#0B0D12'],
+  ['#FFC43D', '#0B0D12'],
+  ['#FF4D6D', '#fff'],
+  ['#A87BFF', '#fff'],
+]
+
+export function avatarColorsFor(name: string): [string, string] {
+  return AVATAR_PALETTE[hash(name) % AVATAR_PALETTE.length]
+}

--- a/web-client/src/components/rbac/permissions-page.tsx
+++ b/web-client/src/components/rbac/permissions-page.tsx
@@ -1,0 +1,518 @@
+import { useMemo, useState, type CSSProperties } from 'react'
+import { ChevronDown, Folder, Info, Pencil, Plus, Search, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { useRbacActions, useRbacData } from './use-rbac'
+import { Field, PageHeader, Stat, StatsGrid } from './primitives'
+import { PermissionCode, PrefixLabel } from './roles-page'
+import { colorFor, fmtDate, fmtDateRel, groupPermissions, permPrefix } from './helpers'
+import type { Permission, Role } from './seed'
+
+export function PermissionsPage() {
+  const { permissions, roles } = useRbacData()
+  const actions = useRbacActions()
+  const [search, setSearch] = useState('')
+  const [expanded, setExpanded] = useState<Set<string>>(
+    () => new Set(groupPermissions(permissions).map((g) => g.prefix)),
+  )
+  const [creating, setCreating] = useState(false)
+  const [editing, setEditing] = useState<Permission | null>(null)
+  const [confirmDel, setConfirmDel] = useState<Permission | null>(null)
+
+  const ownersByPerm = useMemo(() => {
+    const m = new Map<string, Role[]>()
+    for (const r of roles) for (const pid of r.permission_ids) {
+      const list = m.get(pid)
+      if (list) list.push(r)
+      else m.set(pid, [r])
+    }
+    return m
+  }, [roles])
+
+  const allGroupPrefixes = useMemo(
+    () => groupPermissions(permissions).map((g) => g.prefix),
+    [permissions],
+  )
+
+  const grouped = useMemo(() => {
+    if (!search) return groupPermissions(permissions)
+    const q = search.toLowerCase()
+    return groupPermissions(
+      permissions.filter((p) => p.name.toLowerCase().includes(q) || (p.description || '').toLowerCase().includes(q)),
+    )
+  }, [permissions, search])
+
+  const grandTotal = permissions.length
+  const assigned = useMemo(
+    () => permissions.filter((p) => (ownersByPerm.get(p.id) ?? []).length > 0).length,
+    [permissions, ownersByPerm],
+  )
+
+  function toggleGroup(prefix: string) {
+    setExpanded((s) => {
+      const next = new Set(s)
+      if (next.has(prefix)) next.delete(prefix)
+      else next.add(prefix)
+      return next
+    })
+  }
+
+  return (
+    <div style={{ padding: '24px 32px 40px', maxWidth: 1280, margin: '0 auto' }}>
+      <PageHeader
+        title="Permissions"
+        subtitle={
+          <>
+            Every action a role can grant. Names follow <code style={inlineCode}>resource.action</code> — we
+            group by the prefix so the list stays scannable.
+          </>
+        }
+        action={
+          <Button size="sm" onClick={() => setCreating(true)}>
+            <Plus size={14} /> New permission
+          </Button>
+        }
+      />
+
+      <StatsGrid>
+        <Stat variant="card" label="Permissions" value={grandTotal} />
+        <Stat variant="card" label="Name prefixes" value={allGroupPrefixes.length} />
+        <Stat variant="card" label="In use" value={`${assigned} / ${grandTotal}`} tone="live" />
+        <Stat
+          variant="card"
+          label="Unassigned"
+          value={grandTotal - assigned}
+          tone={grandTotal - assigned > 0 ? 'warn' : 'live'}
+        />
+      </StatsGrid>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
+        <div style={{ position: 'relative', width: 320 }}>
+          <Search size={15} style={{ position: 'absolute', left: 10, top: 10, color: 'var(--fg-3)' }} />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by name or description"
+            style={{ paddingLeft: 32 }}
+          />
+        </div>
+        <div style={{ flex: 1 }} />
+        <button type="button" onClick={() => setExpanded(new Set(allGroupPrefixes))} style={linkBtn}>
+          Expand all
+        </button>
+        <span style={{ color: 'var(--fg-muted)' }}>·</span>
+        <button type="button" onClick={() => setExpanded(new Set())} style={linkBtn}>
+          Collapse all
+        </button>
+      </div>
+
+      <div style={{ display: 'grid', gap: 10 }}>
+        {grouped.map(({ prefix, items }) => {
+          const open = expanded.has(prefix)
+          return (
+            <div key={prefix} style={groupCardStyle}>
+              <div onClick={() => toggleGroup(prefix)} style={groupHeaderStyle(open)}>
+                <Folder size={16} color="var(--ball-400)" strokeWidth={1.75} />
+                <PrefixLabel prefix={prefix} />
+                <div style={{ flex: 1 }} />
+                <span style={countTextStyle}>
+                  {items.length} {items.length === 1 ? 'permission' : 'permissions'}
+                </span>
+                <div style={{ transform: open ? 'rotate(0)' : 'rotate(-90deg)', transition: 'transform 160ms', display: 'flex' }}>
+                  <ChevronDown size={16} color="var(--fg-3)" strokeWidth={1.75} />
+                </div>
+              </div>
+              {open && (
+                <div>
+                  <div style={tableHeaderStyle}>
+                    <div>Name</div>
+                    <div>Description</div>
+                    <div>Used by</div>
+                    <div style={{ textAlign: 'right' }}>Actions</div>
+                  </div>
+                  {items.map((p) => (
+                    <PermissionListRow
+                      key={p.id}
+                      p={p}
+                      owners={ownersByPerm.get(p.id) ?? []}
+                      onEdit={() => setEditing(p)}
+                      onDelete={() => setConfirmDel(p)}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })}
+        {grouped.length === 0 && (
+          <div
+            style={{
+              padding: '48px 20px',
+              textAlign: 'center',
+              color: 'var(--fg-3)',
+              fontSize: 13,
+              background: 'var(--bg-card)',
+              border: '1px dashed var(--border-subtle)',
+              borderRadius: 'var(--r-md, 10px)',
+            }}
+          >
+            No permissions match.
+          </div>
+        )}
+      </div>
+
+      <div style={infoBoxStyle}>
+        <Info size={18} color="var(--info)" strokeWidth={1.75} />
+        <div style={{ fontSize: 12, color: 'var(--fg-3)', lineHeight: 1.6 }}>
+          <strong style={{ color: 'var(--fg-1)', fontWeight: 600 }}>Permissions are flat.</strong> The grouping
+          above is just visual — we split on the dot in the name. Granting{' '}
+          <code style={inlineCode}>tournament.edit</code> does not imply{' '}
+          <code style={inlineCode}>draws.edit</code>. Use roles to bundle permissions together.
+        </div>
+      </div>
+
+      {creating && (
+        <PermissionFormModal
+          title="New permission"
+          submitLabel="Create permission"
+          existingNames={permissions.map((p) => p.name)}
+          onClose={() => setCreating(false)}
+          onSubmit={(data) => {
+            actions.createPermission(data)
+            setCreating(false)
+            setExpanded((e) => new Set([...e, permPrefix(data.name)]))
+          }}
+        />
+      )}
+      {editing && (
+        <PermissionFormModal
+          title="Edit permission"
+          submitLabel="Save changes"
+          existingNames={permissions.filter((p) => p.id !== editing.id).map((p) => p.name)}
+          initial={editing}
+          onClose={() => setEditing(null)}
+          onSubmit={(data) => {
+            actions.updatePermission(editing.id, data)
+            setEditing(null)
+          }}
+        />
+      )}
+      {confirmDel && (
+        <DeletePermissionDialog
+          permission={confirmDel}
+          ownerCount={(ownersByPerm.get(confirmDel.id) ?? []).length}
+          onCancel={() => setConfirmDel(null)}
+          onConfirm={() => {
+            actions.deletePermission(confirmDel.id)
+            setConfirmDel(null)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function PermissionListRow({
+  p,
+  owners,
+  onEdit,
+  onDelete,
+}: {
+  p: Permission
+  owners: Role[]
+  onEdit: () => void
+  onDelete: () => void
+}) {
+  return (
+    <div className="rbac-row" style={listRowStyle}>
+      <PermissionCode name={p.name} active />
+      <div
+        style={{
+          fontSize: 13,
+          color: p.description ? 'var(--fg-2)' : 'var(--fg-muted)',
+          fontStyle: p.description ? 'normal' : 'italic',
+          lineHeight: 1.5,
+        }}
+      >
+        {p.description || 'No description'}
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+        {owners.length === 0 ? (
+          <span style={{ fontSize: 11, color: 'var(--fg-muted)', fontStyle: 'italic' }}>unassigned</span>
+        ) : (
+          owners.slice(0, 3).map((r) => <OwnerPill key={r.id} name={r.name} />)
+        )}
+        {owners.length > 3 && (
+          <span style={{ fontSize: 11, color: 'var(--fg-3)', alignSelf: 'center' }}>+{owners.length - 3}</span>
+        )}
+      </div>
+      <div style={{ display: 'flex', gap: 4, justifyContent: 'flex-end' }}>
+        <button type="button" onClick={onEdit} title="Edit" style={iconBtnStyle}>
+          <Pencil size={14} color="var(--fg-2)" strokeWidth={1.75} />
+        </button>
+        <button type="button" onClick={onDelete} title="Delete" style={iconBtnStyle}>
+          <Trash2 size={14} color="var(--loss)" strokeWidth={1.75} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function OwnerPill({ name }: { name: string }) {
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        padding: '2px 8px',
+        borderRadius: 999,
+        background: 'var(--ink-700)',
+        border: '1px solid var(--border-subtle)',
+        fontSize: 11,
+        color: 'var(--fg-2)',
+        fontWeight: 500,
+      }}
+    >
+      <span style={{ width: 5, height: 5, borderRadius: '50%', background: colorFor(name) }} />
+      {name}
+    </span>
+  )
+}
+
+function PermissionFormModal({
+  title,
+  submitLabel,
+  existingNames,
+  initial,
+  onClose,
+  onSubmit,
+}: {
+  title: string
+  submitLabel: string
+  existingNames: string[]
+  initial?: Permission
+  onClose: () => void
+  onSubmit: (data: { name: string; description: string }) => void
+}) {
+  const [name, setName] = useState(initial?.name || '')
+  const [description, setDescription] = useState(initial?.description || '')
+  const trimmed = name.trim()
+  const taken = existingNames.some((n) => n.toLowerCase() === trimmed.toLowerCase())
+  const validShape = /^[a-z0-9_]+(?:\.[a-z0-9_]+)*$/i.test(trimmed)
+  const valid = trimmed && validShape && !taken
+  const { hint, hintTone } = validateName({ trimmed, taken, validShape })
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <div style={{ display: 'grid', gap: 16 }}>
+          <Field label="Name" hint={hint} hintTone={hintTone}>
+            <Input
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="tournament.publish"
+              style={{ fontFamily: 'var(--font-mono)' }}
+            />
+          </Field>
+          <Field label="Description" hint="What does this permission let someone do?">
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="e.g. Publish a tournament to the spectator view."
+              style={{ minHeight: 80 }}
+            />
+          </Field>
+          {initial && (
+            <div
+              style={{
+                display: 'flex',
+                gap: 24,
+                padding: '12px 14px',
+                background: 'var(--ink-900)',
+                border: '1px solid var(--border-subtle)',
+                borderRadius: 'var(--r-md, 10px)',
+              }}
+            >
+              <Stat label="Created" value={fmtDate(initial.created_at)} />
+              <Stat label="Updated" value={fmtDateRel(initial.updated_at)} />
+              <Stat label="ID" value={initial.id} mono />
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button disabled={!valid} onClick={() => onSubmit({ name: trimmed, description: description.trim() })}>
+            {submitLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function validateName({
+  trimmed,
+  taken,
+  validShape,
+}: {
+  trimmed: string
+  taken: boolean
+  validShape: boolean
+}): { hint: string; hintTone: 'neutral' | 'loss' } {
+  if (taken) return { hint: 'A permission with this name already exists.', hintTone: 'loss' }
+  if (trimmed && !validShape) {
+    return {
+      hint: 'Use lowercase letters, numbers, underscores, and dots (e.g. tournament.publish).',
+      hintTone: 'loss',
+    }
+  }
+  return { hint: 'Convention: resource.action (e.g. courts.score)', hintTone: 'neutral' }
+}
+
+function DeletePermissionDialog({
+  permission,
+  ownerCount,
+  onCancel,
+  onConfirm,
+}: {
+  permission: Permission
+  ownerCount: number
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const body =
+    ownerCount === 0
+      ? 'No roles currently include this permission. It will be removed permanently.'
+      : `${ownerCount} role${ownerCount === 1 ? '' : 's'} currently include this permission. They will lose it. This can't be undone.`
+  return (
+    <AlertDialog open onOpenChange={(o) => !o && onCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete {permission.name}?</AlertDialogTitle>
+          <AlertDialogDescription>{body}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>Delete permission</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+const groupCardStyle: CSSProperties = {
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border-subtle)',
+  borderRadius: 'var(--r-md, 10px)',
+  overflow: 'hidden',
+}
+
+function groupHeaderStyle(open: boolean): CSSProperties {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+    padding: '14px 18px',
+    cursor: 'pointer',
+    userSelect: 'none',
+    background: 'var(--ink-800)',
+    borderBottom: open ? '1px solid var(--border-subtle)' : 'none',
+  }
+}
+
+const countTextStyle: CSSProperties = {
+  fontSize: 11,
+  fontFamily: 'var(--font-mono)',
+  color: 'var(--fg-3)',
+  fontVariantNumeric: 'tabular-nums',
+}
+
+const tableHeaderStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'minmax(220px, 0.9fr) 1.4fr 200px 80px',
+  padding: '8px 18px',
+  borderBottom: '1px solid var(--border-subtle)',
+  background: 'var(--ink-900)',
+  fontSize: 10,
+  fontWeight: 600,
+  letterSpacing: '0.14em',
+  color: 'var(--fg-muted)',
+  textTransform: 'uppercase',
+}
+
+const listRowStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'minmax(220px, 0.9fr) 1.4fr 200px 80px',
+  padding: '12px 18px',
+  alignItems: 'center',
+  gap: 12,
+  borderTop: '1px solid var(--border-subtle)',
+}
+
+const infoBoxStyle: CSSProperties = {
+  marginTop: 24,
+  padding: 16,
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border-subtle)',
+  borderRadius: 'var(--r-md, 10px)',
+  display: 'flex',
+  gap: 14,
+  alignItems: 'flex-start',
+}
+
+const linkBtn: CSSProperties = {
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  color: 'var(--fg-3)',
+  fontSize: 12,
+  fontFamily: 'var(--font-ui)',
+  fontWeight: 500,
+  padding: '4px 6px',
+  textDecoration: 'underline',
+  textUnderlineOffset: 3,
+}
+const inlineCode: CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 11,
+  color: 'var(--ball-400)',
+  background: 'var(--ink-900)',
+  padding: '1px 5px',
+  borderRadius: 3,
+  border: '1px solid var(--border-subtle)',
+}
+const iconBtnStyle: CSSProperties = {
+  width: 28,
+  height: 28,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'transparent',
+  border: '1px solid var(--border-subtle)',
+  borderRadius: 6,
+  cursor: 'pointer',
+  padding: 0,
+}

--- a/web-client/src/components/rbac/primitives.tsx
+++ b/web-client/src/components/rbac/primitives.tsx
@@ -1,0 +1,190 @@
+import { type CSSProperties, type ReactNode } from 'react'
+import type { LucideIcon } from 'lucide-react'
+import { avatarColorsFor, initialsFor } from './helpers'
+
+export function Avatar({ name, size = 28 }: { name: string; size?: number }) {
+  const [bg, fg] = avatarColorsFor(name)
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: bg,
+        color: fg,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: 'var(--font-ui)',
+        fontWeight: 700,
+        fontSize: size * 0.4,
+        flexShrink: 0,
+        letterSpacing: 0.02,
+      }}
+    >
+      {initialsFor(name)}
+    </div>
+  )
+}
+
+type StatVariant = 'card' | 'inline'
+type StatTone = 'default' | 'live' | 'warn'
+
+export function Stat({
+  label,
+  value,
+  variant = 'inline',
+  tone = 'default',
+  mono,
+}: {
+  label: string
+  value: string | number
+  variant?: StatVariant
+  tone?: StatTone
+  mono?: boolean
+}) {
+  const toneColor =
+    tone === 'live' ? 'var(--serve-500)' : tone === 'warn' ? 'var(--warn)' : 'var(--fg-1)'
+  const isCard = variant === 'card'
+  const wrapper: CSSProperties = isCard
+    ? {
+        padding: '14px 16px',
+        background: 'var(--bg-card)',
+        border: '1px solid var(--border-subtle)',
+        borderRadius: 'var(--r-md, 10px)',
+      }
+    : {}
+  return (
+    <div style={wrapper}>
+      <div
+        style={{
+          fontSize: 10,
+          fontWeight: 600,
+          letterSpacing: '0.14em',
+          color: 'var(--fg-muted)',
+          textTransform: 'uppercase',
+          marginBottom: isCard ? 4 : 2,
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontSize: isCard ? 26 : 13,
+          fontWeight: isCard ? 700 : 600,
+          color: toneColor,
+          fontFamily: mono || isCard ? 'var(--font-mono)' : 'var(--font-ui)',
+          fontVariantNumeric: 'tabular-nums',
+          lineHeight: isCard ? 1.1 : undefined,
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+export function Field({
+  label,
+  hint,
+  hintTone = 'neutral',
+  children,
+}: {
+  label: string
+  hint?: string | null
+  hintTone?: 'neutral' | 'loss'
+  children: ReactNode
+}) {
+  return (
+    <div>
+      <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg-2)', marginBottom: 6 }}>{label}</div>
+      {children}
+      {hint && (
+        <div
+          style={{
+            fontSize: 11,
+            marginTop: 6,
+            color: hintTone === 'loss' ? 'var(--loss)' : 'var(--fg-3)',
+          }}
+        >
+          {hint}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function EmptyState({
+  icon: IconComponent,
+  title,
+  body,
+}: {
+  icon: LucideIcon
+  title: string
+  body: string
+}) {
+  return (
+    <div
+      style={{
+        padding: '48px 24px',
+        textAlign: 'center',
+        border: '1px dashed var(--border-subtle)',
+        borderRadius: 'var(--r-md, 10px)',
+        background: 'var(--bg-card)',
+      }}
+    >
+      <div
+        style={{
+          display: 'inline-flex',
+          padding: 14,
+          background: 'var(--ink-900)',
+          borderRadius: 999,
+          marginBottom: 14,
+        }}
+      >
+        <IconComponent size={22} color="var(--fg-muted)" strokeWidth={1.75} />
+      </div>
+      <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--fg-1)', marginBottom: 6 }}>{title}</div>
+      <div style={{ fontSize: 13, color: 'var(--fg-3)', maxWidth: 360, margin: '0 auto 16px' }}>{body}</div>
+    </div>
+  )
+}
+
+export function PageHeader({
+  title,
+  subtitle,
+  action,
+}: {
+  title: string
+  subtitle?: ReactNode
+  action?: ReactNode
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-end',
+        justifyContent: 'space-between',
+        marginBottom: 6,
+        flexWrap: 'wrap',
+        gap: 12,
+      }}
+    >
+      <div>
+        <h1 style={{ fontSize: 24, fontWeight: 700, color: 'var(--fg-1)', margin: 0 }}>{title}</h1>
+        {subtitle && (
+          <p style={{ fontSize: 13, color: 'var(--fg-3)', margin: '6px 0 0', maxWidth: 620 }}>{subtitle}</p>
+        )}
+      </div>
+      {action && <div style={{ display: 'flex', gap: 8 }}>{action}</div>}
+    </div>
+  )
+}
+
+export function StatsGrid({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 12, margin: '24px 0 20px' }}>
+      {children}
+    </div>
+  )
+}

--- a/web-client/src/components/rbac/rbac-context-internal.ts
+++ b/web-client/src/components/rbac/rbac-context-internal.ts
@@ -1,0 +1,27 @@
+import { createContext } from 'react'
+import type { Permission, Role, User } from './seed'
+
+export type RbacData = {
+  roles: Role[]
+  permissions: Permission[]
+  users: User[]
+}
+
+export type RbacActions = {
+  createRole: (input: { name: string; description: string; templateId?: string }) => string
+  updateRole: (id: string, patch: Partial<Pick<Role, 'name' | 'description' | 'permission_ids'>>) => void
+  deleteRole: (id: string) => void
+  duplicateRole: (id: string) => string | null
+
+  createPermission: (input: { name: string; description: string }) => void
+  updatePermission: (id: string, patch: Partial<Pick<Permission, 'name' | 'description'>>) => void
+  deletePermission: (id: string) => void
+
+  addUser: (username: string) => string
+  removeUser: (id: string) => void
+  setUserRoles: (id: string, role_ids: string[]) => void
+  revokeRoleFromUser: (userId: string, roleId: string) => void
+}
+
+export const RbacDataCtx = createContext<RbacData | null>(null)
+export const RbacActionsCtx = createContext<RbacActions | null>(null)

--- a/web-client/src/components/rbac/rbac-context.tsx
+++ b/web-client/src/components/rbac/rbac-context.tsx
@@ -1,0 +1,94 @@
+import { useMemo, useState, type ReactNode } from 'react'
+import { PERMISSIONS_SEED, ROLES_SEED, USERS_SEED, type Permission, type Role, type User } from './seed'
+import { newId, nowIso } from './helpers'
+import { RbacActionsCtx, RbacDataCtx, type RbacActions } from './rbac-context-internal'
+
+export function RbacProvider({ children }: { children: ReactNode }) {
+  const [roles, setRoles] = useState<Role[]>(ROLES_SEED)
+  const [permissions, setPermissions] = useState<Permission[]>(PERMISSIONS_SEED)
+  const [users, setUsers] = useState<User[]>(USERS_SEED)
+
+  const data = useMemo(() => ({ roles, permissions, users }), [roles, permissions, users])
+
+  const actions = useMemo<RbacActions>(() => ({
+    createRole({ name, description, templateId }) {
+      const id = newId('r')
+      setRoles((rs) => {
+        const tmpl = templateId ? rs.find((r) => r.id === templateId) : null
+        return [...rs, {
+          id,
+          name,
+          description: description || '',
+          permission_ids: tmpl ? [...tmpl.permission_ids] : [],
+          created_at: nowIso(),
+          updated_at: nowIso(),
+        }]
+      })
+      return id
+    },
+    updateRole(id, patch) {
+      setRoles((rs) => rs.map((r) => (r.id === id ? { ...r, ...patch, updated_at: nowIso() } : r)))
+    },
+    deleteRole(id) {
+      setRoles((rs) => rs.filter((r) => r.id !== id))
+      setUsers((us) => us.map((u) => ({ ...u, role_ids: u.role_ids.filter((rid) => rid !== id) })))
+    },
+    duplicateRole(id) {
+      let newRoleId: string | null = null
+      setRoles((rs) => {
+        const src = rs.find((r) => r.id === id)
+        if (!src) return rs
+        newRoleId = newId('r')
+        return [...rs, {
+          id: newRoleId,
+          name: `${src.name} (copy)`,
+          description: src.description || '',
+          permission_ids: [...src.permission_ids],
+          created_at: nowIso(),
+          updated_at: nowIso(),
+        }]
+      })
+      return newRoleId
+    },
+
+    createPermission({ name, description }) {
+      setPermissions((ps) => [...ps, {
+        id: newId('p'),
+        name,
+        description: description || '',
+        created_at: nowIso(),
+        updated_at: nowIso(),
+      }])
+    },
+    updatePermission(id, patch) {
+      setPermissions((ps) => ps.map((p) => (p.id === id ? { ...p, ...patch, updated_at: nowIso() } : p)))
+    },
+    deletePermission(id) {
+      setPermissions((ps) => ps.filter((p) => p.id !== id))
+      setRoles((rs) => rs.map((r) => ({ ...r, permission_ids: r.permission_ids.filter((pid) => pid !== id) })))
+    },
+
+    addUser(username) {
+      const id = newId('u')
+      setUsers((us) => [...us, { id, username, role_ids: [], created_at: nowIso() }])
+      return id
+    },
+    removeUser(id) {
+      setUsers((us) => us.filter((u) => u.id !== id))
+    },
+    setUserRoles(id, role_ids) {
+      setUsers((us) => us.map((u) => (u.id === id ? { ...u, role_ids } : u)))
+    },
+    revokeRoleFromUser(userId, roleId) {
+      setUsers((us) =>
+        us.map((u) => (u.id === userId ? { ...u, role_ids: u.role_ids.filter((rid) => rid !== roleId) } : u)),
+      )
+    },
+  }), [])
+
+  return (
+    <RbacActionsCtx.Provider value={actions}>
+      <RbacDataCtx.Provider value={data}>{children}</RbacDataCtx.Provider>
+    </RbacActionsCtx.Provider>
+  )
+}

--- a/web-client/src/components/rbac/roles-page.tsx
+++ b/web-client/src/components/rbac/roles-page.tsx
@@ -1,0 +1,725 @@
+import { useMemo, useState, type CSSProperties } from 'react'
+import { Check, Copy, Folder, Plus, Search, Shield, Trash2, Users, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { useRbacActions, useRbacData } from './use-rbac'
+import { Avatar, EmptyState, Field, Stat } from './primitives'
+import { colorFor, fmtDate, fmtDateRel, groupPermissions } from './helpers'
+import type { Permission, Role, User } from './seed'
+
+export function RolesPage() {
+  const { roles, permissions, users } = useRbacData()
+  const actions = useRbacActions()
+  const [search, setSearch] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  const memberCounts = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const u of users) for (const rid of u.role_ids) m.set(rid, (m.get(rid) ?? 0) + 1)
+    return m
+  }, [users])
+
+  const totalAssignments = useMemo(() => users.reduce((a, u) => a + u.role_ids.length, 0), [users])
+
+  const filtered = useMemo(() => {
+    if (!search) return roles
+    const q = search.toLowerCase()
+    return roles.filter((r) => r.name.toLowerCase().includes(q) || (r.description || '').toLowerCase().includes(q))
+  }, [roles, search])
+
+  const selected = roles.find((r) => r.id === selectedId) ?? roles[0] ?? null
+
+  return (
+    <div style={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+      <div
+        style={{
+          width: 380,
+          borderRight: '1px solid var(--border-subtle)',
+          display: 'flex',
+          flexDirection: 'column',
+          background: 'var(--bg-panel)',
+        }}
+      >
+        <div style={{ padding: '18px 18px 12px', borderBottom: '1px solid var(--border-subtle)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+            <div>
+              <div style={{ fontSize: 18, fontWeight: 700, color: 'var(--fg-1)' }}>Roles</div>
+              <div style={{ fontSize: 12, color: 'var(--fg-3)', marginTop: 2 }}>
+                <span style={{ fontFamily: 'var(--font-mono)' }}>{roles.length}</span> roles ·{' '}
+                <span style={{ fontFamily: 'var(--font-mono)' }}>{totalAssignments}</span> assignments
+              </div>
+            </div>
+            <Button size="sm" onClick={() => setCreating(true)}>
+              <Plus size={14} /> New role
+            </Button>
+          </div>
+          <div style={{ position: 'relative' }}>
+            <Search size={15} style={{ position: 'absolute', left: 10, top: 10, color: 'var(--fg-3)' }} />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search roles"
+              style={{ paddingLeft: 32 }}
+            />
+          </div>
+        </div>
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          {filtered.map((r) => (
+            <RoleRow
+              key={r.id}
+              role={r}
+              memberCount={memberCounts.get(r.id) ?? 0}
+              active={r.id === selected?.id}
+              onClick={() => setSelectedId(r.id)}
+            />
+          ))}
+          {filtered.length === 0 && (
+            <div style={{ padding: '40px 20px', textAlign: 'center', color: 'var(--fg-3)', fontSize: 13 }}>
+              No roles match.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', background: 'var(--bg-app)' }}>
+        {selected ? (
+          <RoleDetail role={selected} permissions={permissions} users={users} onSelect={setSelectedId} />
+        ) : (
+          <div style={{ padding: 40, color: 'var(--fg-3)' }}>
+            No role selected.{' '}
+            <a onClick={() => setCreating(true)} style={{ color: 'var(--ball-400)', cursor: 'pointer' }}>
+              Create one.
+            </a>
+          </div>
+        )}
+      </div>
+
+      {creating && (
+        <NewRoleModal
+          existing={roles}
+          onClose={() => setCreating(false)}
+          onCreate={(input) => {
+            const id = actions.createRole(input)
+            setSelectedId(id)
+            setCreating(false)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function RoleRow({
+  role,
+  memberCount,
+  active,
+  onClick,
+}: {
+  role: Role
+  memberCount: number
+  active: boolean
+  onClick: () => void
+}) {
+  const accent = colorFor(role.name)
+  return (
+    <div
+      onClick={onClick}
+      className="rbac-row"
+      data-active={active || undefined}
+      style={{
+        padding: '14px 18px 14px 15px',
+        cursor: 'pointer',
+        borderLeft: `3px solid ${active ? 'var(--ball-500)' : 'transparent'}`,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+        <div
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            background: accent,
+            flexShrink: 0,
+            boxShadow: `0 0 8px ${accent}55`,
+          }}
+        />
+        <div style={{ flex: 1, fontSize: 14, fontWeight: 600, color: 'var(--fg-1)' }}>{role.name}</div>
+      </div>
+      <div
+        style={{
+          fontSize: 12,
+          color: 'var(--fg-3)',
+          marginBottom: 8,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          display: '-webkit-box',
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: 'vertical',
+          lineHeight: 1.4,
+          minHeight: role.description ? undefined : 18,
+        }}
+      >
+        {role.description || (
+          <span style={{ fontStyle: 'italic', color: 'var(--fg-muted)' }}>No description</span>
+        )}
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          gap: 14,
+          fontSize: 11,
+          color: 'var(--fg-muted)',
+          fontFamily: 'var(--font-mono)',
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        <span>
+          <span style={{ color: 'var(--fg-2)', fontWeight: 600 }}>{memberCount}</span> users
+        </span>
+        <span>
+          <span style={{ color: 'var(--fg-2)', fontWeight: 600 }}>{role.permission_ids.length}</span> perms
+        </span>
+        <span style={{ marginLeft: 'auto' }}>{fmtDateRel(role.updated_at)}</span>
+      </div>
+    </div>
+  )
+}
+
+function RoleDetail({
+  role,
+  permissions,
+  users,
+  onSelect,
+}: {
+  role: Role
+  permissions: Permission[]
+  users: User[]
+  onSelect: (id: string | null) => void
+}) {
+  const actions = useRbacActions()
+  const [tab, setTab] = useState<'permissions' | 'members'>('permissions')
+  const [editingName, setEditingName] = useState(false)
+  const [editingDesc, setEditingDesc] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  const accent = colorFor(role.name)
+  const members = useMemo(() => users.filter((u) => u.role_ids.includes(role.id)), [users, role.id])
+  const permSet = useMemo(() => new Set(role.permission_ids), [role.permission_ids])
+
+  function togglePerm(id: string) {
+    const next = permSet.has(id)
+      ? role.permission_ids.filter((p) => p !== id)
+      : [...role.permission_ids, id]
+    actions.updateRole(role.id, { permission_ids: next })
+  }
+  function toggleGroup(ids: string[], allOn: boolean) {
+    const next = allOn
+      ? role.permission_ids.filter((p) => !ids.includes(p))
+      : [...new Set([...role.permission_ids, ...ids])]
+    actions.updateRole(role.id, { permission_ids: next })
+  }
+
+  return (
+    <div>
+      <div style={{ padding: '24px 32px 20px', borderBottom: '1px solid var(--border-subtle)' }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 14 }}>
+          <div
+            style={{
+              width: 42,
+              height: 42,
+              borderRadius: 'var(--r-md, 10px)',
+              background: `${accent}22`,
+              border: `1px solid ${accent}55`,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >
+            <Shield size={20} color={accent} strokeWidth={1.75} />
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {editingName ? (
+              <Input
+                autoFocus
+                defaultValue={role.name}
+                onBlur={(e) => {
+                  actions.updateRole(role.id, { name: e.target.value.trim() || role.name })
+                  setEditingName(false)
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+                  if (e.key === 'Escape') {
+                    ;(e.target as HTMLInputElement).value = role.name
+                    ;(e.target as HTMLInputElement).blur()
+                  }
+                }}
+                style={{ fontSize: 22, fontWeight: 700, height: 38, maxWidth: 420 }}
+              />
+            ) : (
+              <h1 onClick={() => setEditingName(true)} className="rbac-inline-edit" style={titleStyle}>
+                {role.name}
+              </h1>
+            )}
+            {editingDesc ? (
+              <Textarea
+                autoFocus
+                defaultValue={role.description || ''}
+                onBlur={(e) => {
+                  actions.updateRole(role.id, { description: e.target.value.trim() })
+                  setEditingDesc(false)
+                }}
+                placeholder="Describe what this role can do…"
+                style={{ maxWidth: 640, minHeight: 50, fontSize: 13 }}
+              />
+            ) : (
+              <div onClick={() => setEditingDesc(true)} className="rbac-inline-edit" style={descStyle(!!role.description)}>
+                {role.description || 'No description — click to add one'}
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: 24, marginTop: 14, flexWrap: 'wrap' }}>
+              <Stat label="Users" value={members.length} />
+              <Stat label="Permissions" value={`${role.permission_ids.length} / ${permissions.length}`} />
+              <Stat label="Created" value={fmtDate(role.created_at)} />
+              <Stat label="Updated" value={fmtDateRel(role.updated_at)} />
+              <Stat label="ID" value={role.id} mono />
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                const id = actions.duplicateRole(role.id)
+                if (id) onSelect(id)
+              }}
+            >
+              <Copy size={14} /> Duplicate
+            </Button>
+            <Button variant="destructive" size="sm" onClick={() => setConfirmDelete(true)}>
+              <Trash2 size={14} /> Delete
+            </Button>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 2, marginTop: 20, marginBottom: -20 }}>
+          {TABS.map(({ key, label }) => {
+            const count = key === 'permissions' ? role.permission_ids.length : members.length
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setTab(key)}
+                style={tabStyle(tab === key)}
+              >
+                {label}
+                <span style={tabCountStyle}>{count}</span>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div style={{ padding: '24px 32px 40px' }}>
+        {tab === 'permissions' && (
+          <PermissionsEditor
+            permissions={permissions}
+            permSet={permSet}
+            onToggle={togglePerm}
+            onToggleGroup={toggleGroup}
+          />
+        )}
+        {tab === 'members' && (
+          <RoleMembers
+            role={role}
+            members={members}
+            onRevoke={(uid) => actions.revokeRoleFromUser(uid, role.id)}
+          />
+        )}
+      </div>
+
+      <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {role.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {members.length} user{members.length === 1 ? '' : 's'} will lose this role. This can't be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => actions.deleteRole(role.id)}>Delete role</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}
+
+const TABS = [
+  { key: 'permissions' as const, label: 'Permissions' },
+  { key: 'members' as const, label: 'Users' },
+]
+
+function PermissionsEditor({
+  permissions,
+  permSet,
+  onToggle,
+  onToggleGroup,
+}: {
+  permissions: Permission[]
+  permSet: Set<string>
+  onToggle: (id: string) => void
+  onToggleGroup: (ids: string[], allOn: boolean) => void
+}) {
+  const grouped = useMemo(() => groupPermissions(permissions), [permissions])
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
+        <div style={{ fontSize: 13, color: 'var(--fg-3)' }}>
+          Tick the permissions this role grants. Changes save instantly.
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            onToggleGroup(
+              permissions.map((p) => p.id),
+              permSet.size === permissions.length,
+            )
+          }
+        >
+          {permSet.size === permissions.length ? 'Clear all' : 'Select all'}
+        </Button>
+      </div>
+      <div style={{ display: 'grid', gap: 10 }}>
+        {grouped.map(({ prefix, items }) => {
+          const ids = items.map((p) => p.id)
+          const ownedInGroup = ids.filter((k) => permSet.has(k))
+          const allOn = ownedInGroup.length === ids.length
+          const someOn = ownedInGroup.length > 0 && !allOn
+          return (
+            <div
+              key={prefix}
+              style={{
+                border: '1px solid var(--border-subtle)',
+                borderRadius: 'var(--r-md, 10px)',
+                background: 'var(--bg-card)',
+                overflow: 'hidden',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 12,
+                  padding: '12px 16px',
+                  background: 'var(--ink-800)',
+                  borderBottom: '1px solid var(--border-subtle)',
+                }}
+              >
+                <Folder size={15} color="var(--fg-3)" strokeWidth={1.75} />
+                <PrefixLabel prefix={prefix} />
+                <div style={{ flex: 1 }} />
+                <span
+                  style={{
+                    fontSize: 11,
+                    fontFamily: 'var(--font-mono)',
+                    color: 'var(--fg-3)',
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {ownedInGroup.length} / {ids.length}
+                </span>
+                <Checkbox
+                  checked={allOn ? true : someOn ? 'indeterminate' : false}
+                  onCheckedChange={() => onToggleGroup(ids, allOn)}
+                />
+              </div>
+              <div>
+                {items.map((p) => (
+                  <PermRow key={p.id} p={p} on={permSet.has(p.id)} onToggle={() => onToggle(p.id)} />
+                ))}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function PermRow({ p, on, onToggle }: { p: Permission; on: boolean; onToggle: () => void }) {
+  return (
+    <div
+      onClick={onToggle}
+      className="rbac-row"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 14,
+        padding: '12px 16px',
+        cursor: 'pointer',
+        borderTop: '1px solid var(--border-subtle)',
+      }}
+    >
+      <Checkbox checked={on} onCheckedChange={onToggle} />
+      <PermissionCode name={p.name} active={on} />
+      <div style={{ flex: 1, minWidth: 0, fontSize: 12.5, color: 'var(--fg-3)', lineHeight: 1.4 }}>
+        {p.description || (
+          <span style={{ fontStyle: 'italic', color: 'var(--fg-muted)' }}>No description</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function PermissionCode({ name, active }: { name: string; active?: boolean }) {
+  return (
+    <code
+      style={{
+        fontSize: 12.5,
+        fontFamily: 'var(--font-mono)',
+        color: active ? 'var(--fg-1)' : 'var(--fg-2)',
+        background: 'var(--ink-900)',
+        padding: '3px 9px',
+        borderRadius: 4,
+        border: '1px solid var(--border-subtle)',
+        flexShrink: 0,
+        justifySelf: 'start',
+        fontWeight: 600,
+      }}
+    >
+      {name}
+    </code>
+  )
+}
+
+export function PrefixLabel({ prefix }: { prefix: string }) {
+  return (
+    <code
+      style={{
+        fontSize: 13,
+        fontWeight: 600,
+        fontFamily: 'var(--font-mono)',
+        color: 'var(--fg-1)',
+        background: 'transparent',
+        border: 'none',
+        padding: 0,
+      }}
+    >
+      {prefix}.*
+    </code>
+  )
+}
+
+function RoleMembers({
+  role,
+  members,
+  onRevoke,
+}: {
+  role: Role
+  members: User[]
+  onRevoke: (uid: string) => void
+}) {
+  if (members.length === 0) {
+    return (
+      <EmptyState
+        icon={Users}
+        title="No users have this role yet"
+        body={`Go to Users to assign ${role.name} to someone.`}
+      />
+    )
+  }
+  return (
+    <div>
+      <div style={{ fontSize: 13, color: 'var(--fg-3)', marginBottom: 14 }}>
+        <span style={{ color: 'var(--fg-1)', fontWeight: 600, fontFamily: 'var(--font-mono)' }}>
+          {members.length}
+        </span>{' '}
+        user{members.length === 1 ? '' : 's'} {members.length === 1 ? 'has' : 'have'} this role.
+      </div>
+      <div style={{ display: 'grid', gap: 8 }}>
+        {members.map((m) => (
+          <div
+            key={m.id}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 14,
+              padding: '12px 16px',
+              background: 'var(--bg-card)',
+              border: '1px solid var(--border-subtle)',
+              borderRadius: 'var(--r-md, 10px)',
+            }}
+          >
+            <Avatar name={m.username} size={32} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg-1)', fontFamily: 'var(--font-mono)' }}>
+                {m.username}
+              </div>
+              <div style={{ fontSize: 11, color: 'var(--fg-muted)', marginTop: 2 }}>
+                user id <span style={{ fontFamily: 'var(--font-mono)' }}>{m.id}</span>
+              </div>
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>
+              added {fmtDateRel(m.created_at)}
+            </div>
+            <Button size="sm" variant="ghost" onClick={() => onRevoke(m.id)}>
+              <X size={14} /> Revoke
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function NewRoleModal({
+  existing,
+  onClose,
+  onCreate,
+}: {
+  existing: Role[]
+  onClose: () => void
+  onCreate: (input: { name: string; description: string; templateId?: string }) => void
+}) {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [templateId, setTemplateId] = useState('')
+  const trimmed = name.trim()
+  const taken = existing.some((r) => r.name.toLowerCase() === trimmed.toLowerCase())
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New role</DialogTitle>
+        </DialogHeader>
+        <div style={{ display: 'grid', gap: 16 }}>
+          <Field
+            label="Name"
+            hint={taken ? 'A role with this name already exists.' : null}
+            hintTone={taken ? 'loss' : 'neutral'}
+          >
+            <Input autoFocus value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Volunteer scorer" />
+          </Field>
+          <Field label="Description" hint="Optional. Helps the next admin understand what this role does.">
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What can people with this role do?"
+              style={{ minHeight: 70 }}
+            />
+          </Field>
+          <Field label="Copy permissions from" hint="Optional. Lets you start from an existing role.">
+            <select value={templateId} onChange={(e) => setTemplateId(e.target.value)} style={nativeSelectStyle}>
+              <option value="">Blank — no permissions</option>
+              {existing.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.name} ({r.permission_ids.length} perms)
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button
+            disabled={!trimmed || taken}
+            onClick={() => onCreate({ name: trimmed, description: description.trim(), templateId: templateId || undefined })}
+          >
+            <Check size={14} /> Create role
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const titleStyle: CSSProperties = {
+  fontSize: 22,
+  fontWeight: 700,
+  color: 'var(--fg-1)',
+  margin: '0 0 4px',
+  cursor: 'text',
+  display: 'inline-block',
+  padding: '2px 6px',
+  marginLeft: -6,
+  borderRadius: 6,
+}
+
+function descStyle(hasDescription: boolean): CSSProperties {
+  return {
+    fontSize: 13,
+    color: hasDescription ? 'var(--fg-3)' : 'var(--fg-muted)',
+    fontStyle: hasDescription ? 'normal' : 'italic',
+    maxWidth: 640,
+    cursor: 'text',
+    padding: '4px 6px',
+    marginLeft: -6,
+    borderRadius: 6,
+    lineHeight: 1.5,
+  }
+}
+
+function tabStyle(active: boolean): CSSProperties {
+  return {
+    padding: '10px 14px',
+    background: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: 13,
+    fontWeight: 600,
+    fontFamily: 'var(--font-ui)',
+    color: active ? 'var(--ball-400)' : 'var(--fg-3)',
+    borderBottom: active ? '2px solid var(--ball-500)' : '2px solid transparent',
+    marginBottom: -1,
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 8,
+  }
+}
+
+const tabCountStyle: CSSProperties = {
+  padding: '1px 7px',
+  borderRadius: 999,
+  fontSize: 10,
+  fontFamily: 'var(--font-mono)',
+  fontVariantNumeric: 'tabular-nums',
+  background: 'var(--ink-700)',
+  color: 'var(--fg-3)',
+}
+
+const nativeSelectStyle: CSSProperties = {
+  width: '100%',
+  height: 38,
+  padding: '0 12px',
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border-default)',
+  borderRadius: 'var(--r-md, 10px)',
+  color: 'var(--fg-1)',
+  fontFamily: 'var(--font-ui)',
+  fontSize: 13,
+  outline: 'none',
+  cursor: 'pointer',
+}

--- a/web-client/src/components/rbac/seed.ts
+++ b/web-client/src/components/rbac/seed.ts
@@ -1,0 +1,151 @@
+export type Permission = {
+  id: string
+  name: string
+  description: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type Role = {
+  id: string
+  name: string
+  description: string | null
+  created_at: string
+  updated_at: string
+  permission_ids: string[]
+}
+
+export type User = {
+  id: string
+  username: string
+  role_ids: string[]
+  created_at: string
+}
+
+export const PERMISSIONS_SEED: Permission[] = (
+  [
+    { id: 'p_tv', name: 'tournament.view', description: 'See tournament list and details.' },
+    { id: 'p_tc', name: 'tournament.create', description: 'Spin up a new tournament event.' },
+    { id: 'p_te', name: 'tournament.edit', description: 'Rename, reschedule, change format.' },
+    { id: 'p_td', name: 'tournament.delete', description: 'Permanently remove a tournament.' },
+    { id: 'p_tp', name: 'tournament.publish', description: 'Publish a tournament to the spectator view.' },
+
+    { id: 'p_dv', name: 'draws.view', description: 'View brackets and seeds.' },
+    { id: 'p_dg', name: 'draws.generate', description: 'Run the SMT solver to build a draw.' },
+    { id: 'p_de', name: 'draws.edit', description: 'Re-seed or manually swap matchups.' },
+    { id: 'p_dp', name: 'draws.publish', description: 'Lock the draw and notify players.' },
+    { id: 'p_dl', name: 'draws.lock', description: 'Freeze a draw against further edits.' },
+
+    { id: 'p_cv', name: 'courts.view', description: 'See live court status.' },
+    { id: 'p_ca', name: 'courts.assign', description: 'Send the next match to a court.' },
+    { id: 'p_cs', name: 'courts.score', description: 'Tap in points during live play.' },
+    { id: 'p_co', name: 'courts.override', description: 'Correct a posted score after the fact.' },
+
+    { id: 'p_pv', name: 'players.view', description: 'Browse the player directory.' },
+    { id: 'p_pc', name: 'players.create', description: 'Register a new player.' },
+    { id: 'p_pe', name: 'players.edit', description: 'Update contact info, club, rating cap.' },
+    { id: 'p_pd', name: 'players.delete', description: 'Soft-delete a player profile.' },
+    { id: 'p_pm', name: 'players.merge', description: 'Combine two player records.' },
+
+    { id: 'p_rv', name: 'ratings.view', description: 'See rating history and deltas.' },
+    { id: 'p_rr', name: 'ratings.recalculate', description: 'Re-run the rating engine.' },
+
+    { id: 'p_mv', name: 'members.view', description: 'See workspace members.' },
+    { id: 'p_ma', name: 'members.add', description: 'Add a user to the workspace.' },
+    { id: 'p_mr', name: 'members.remove', description: 'Remove a user from the workspace.' },
+    { id: 'p_rm', name: 'roles.manage', description: 'Create, edit, and delete roles.' },
+    { id: 'p_pa', name: 'permissions.assign', description: 'Attach permissions to roles.' },
+
+    { id: 'p_sv', name: 'system.view', description: 'See system status.' },
+    { id: 'p_sc', name: 'system.configure', description: 'Edit org-wide settings.' },
+    { id: 'p_sx', name: 'system.export', description: 'Download backups and reports.' },
+  ] as const
+).map((p) => ({
+  ...p,
+  created_at: '2026-01-04T09:00:00Z',
+  updated_at: '2026-01-04T09:00:00Z',
+}))
+
+const ALL_PERM_IDS = PERMISSIONS_SEED.map((p) => p.id)
+
+export const ROLES_SEED: Role[] = [
+  {
+    id: 'r_owner',
+    name: 'Owner',
+    description: 'Full control of the workspace. Granted to founding admins.',
+    created_at: '2026-01-04T09:00:00Z',
+    updated_at: '2026-01-04T09:00:00Z',
+    permission_ids: ALL_PERM_IDS,
+  },
+  {
+    id: 'r_td',
+    name: 'Tournament Director',
+    description: 'Runs events end-to-end. Cannot edit org-wide settings.',
+    created_at: '2026-01-12T15:22:11Z',
+    updated_at: '2026-04-22T18:04:00Z',
+    permission_ids: [
+      'p_tv', 'p_tc', 'p_te', 'p_tp',
+      'p_dv', 'p_dg', 'p_de', 'p_dp', 'p_dl',
+      'p_cv', 'p_ca', 'p_cs', 'p_co',
+      'p_pv', 'p_pc', 'p_pe', 'p_pm',
+      'p_rv', 'p_rr',
+      'p_mv', 'p_sx',
+    ],
+  },
+  {
+    id: 'r_score',
+    name: 'Scorekeeper',
+    description: 'Taps in points at courtside. Read-only everywhere else.',
+    created_at: '2026-01-12T15:24:01Z',
+    updated_at: '2026-04-18T12:30:00Z',
+    permission_ids: ['p_tv', 'p_dv', 'p_cv', 'p_cs', 'p_pv'],
+  },
+  {
+    id: 'r_umpire',
+    name: 'Umpire',
+    description: 'Calls matches. Can override scores after the fact.',
+    created_at: '2026-01-20T08:11:43Z',
+    updated_at: '2026-03-30T09:15:00Z',
+    permission_ids: ['p_tv', 'p_dv', 'p_cv', 'p_cs', 'p_co', 'p_pv'],
+  },
+  {
+    id: 'r_club',
+    name: 'Club Admin',
+    description: 'Manages the player roster. No live scoring.',
+    created_at: '2026-02-02T11:08:12Z',
+    updated_at: '2026-02-11T14:18:00Z',
+    permission_ids: ['p_tv', 'p_dv', 'p_pv', 'p_pc', 'p_pe', 'p_pm', 'p_rv', 'p_mv'],
+  },
+  {
+    id: 'r_read',
+    name: 'Read-only',
+    description: 'Sees everything, changes nothing.',
+    created_at: '2026-01-04T09:00:00Z',
+    updated_at: '2026-01-04T09:00:00Z',
+    permission_ids: PERMISSIONS_SEED.filter((p) => p.name.endsWith('.view')).map((p) => p.id),
+  },
+  {
+    id: 'r_weekend',
+    name: 'Weekend Volunteer',
+    description: 'One-off scorer role for weekend tournaments.',
+    created_at: '2026-05-01T10:02:18Z',
+    updated_at: '2026-05-09T16:42:00Z',
+    permission_ids: ['p_tv', 'p_dv', 'p_cv', 'p_cs', 'p_pv'],
+  },
+]
+
+export const USERS_SEED: User[] = [
+  { id: 'u1', username: 'tim.nguyen', role_ids: ['r_owner'], created_at: '2026-01-04T09:00:00Z' },
+  { id: 'u2', username: 'alex.johansen', role_ids: ['r_td'], created_at: '2026-01-12T16:00:00Z' },
+  { id: 'u3', username: 'maya.okafor', role_ids: ['r_td', 'r_club'], created_at: '2026-01-12T16:08:00Z' },
+  { id: 'u4', username: 'riley.park', role_ids: ['r_score'], created_at: '2026-02-04T09:11:00Z' },
+  { id: 'u5', username: 'sam.patel', role_ids: ['r_score', 'r_umpire'], created_at: '2026-02-04T09:12:00Z' },
+  { id: 'u6', username: 'lin.chen', role_ids: ['r_umpire'], created_at: '2026-02-19T11:42:00Z' },
+  { id: 'u7', username: 'robin.kim', role_ids: ['r_club'], created_at: '2026-02-21T08:30:00Z' },
+  { id: 'u8', username: 'dean.silva', role_ids: ['r_read'], created_at: '2026-03-02T15:00:00Z' },
+  { id: 'u9', username: 'carlos.rossi', role_ids: ['r_read'], created_at: '2026-03-04T17:21:00Z' },
+  { id: 'u10', username: 'jamie.tran', role_ids: ['r_weekend', 'r_umpire'], created_at: '2026-05-01T10:05:00Z' },
+  { id: 'u11', username: 'priya.desai', role_ids: ['r_score'], created_at: '2026-03-18T14:48:00Z' },
+  { id: 'u12', username: 'marcus.webb', role_ids: ['r_weekend'], created_at: '2026-05-08T12:00:00Z' },
+  { id: 'u13', username: 'eun.han', role_ids: [], created_at: '2026-05-10T09:14:00Z' },
+]

--- a/web-client/src/components/rbac/use-rbac.ts
+++ b/web-client/src/components/rbac/use-rbac.ts
@@ -1,0 +1,19 @@
+import { useContext } from 'react'
+import {
+  RbacActionsCtx,
+  RbacDataCtx,
+  type RbacActions,
+  type RbacData,
+} from './rbac-context-internal'
+
+export function useRbacData(): RbacData {
+  const v = useContext(RbacDataCtx)
+  if (!v) throw new Error('useRbacData must be used inside <RbacProvider>')
+  return v
+}
+
+export function useRbacActions(): RbacActions {
+  const v = useContext(RbacActionsCtx)
+  if (!v) throw new Error('useRbacActions must be used inside <RbacProvider>')
+  return v
+}

--- a/web-client/src/components/rbac/users-page.tsx
+++ b/web-client/src/components/rbac/users-page.tsx
@@ -1,0 +1,592 @@
+import { useMemo, useState, type CSSProperties } from 'react'
+import { ChevronRight, Plus, Search, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useRbacActions, useRbacData } from './use-rbac'
+import { Avatar, Field, PageHeader, Stat, StatsGrid } from './primitives'
+import { colorFor, fmtDate, fmtDateRel } from './helpers'
+import type { Permission, Role, User } from './seed'
+
+export function UsersPage() {
+  const { users, roles, permissions } = useRbacData()
+  const actions = useRbacActions()
+  const [search, setSearch] = useState('')
+  const [roleFilter, setRoleFilter] = useState<string>('all')
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [adding, setAdding] = useState(false)
+  const [confirmRemove, setConfirmRemove] = useState<User | null>(null)
+
+  const rolesById = useMemo(() => new Map(roles.map((r) => [r.id, r])), [roles])
+  const userCountByRole = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const u of users) for (const rid of u.role_ids) m.set(rid, (m.get(rid) ?? 0) + 1)
+    return m
+  }, [users])
+  const unassigned = useMemo(() => users.filter((u) => u.role_ids.length === 0).length, [users])
+  const totalAssignments = useMemo(() => users.reduce((a, u) => a + u.role_ids.length, 0), [users])
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase()
+    return users.filter((u) => {
+      if (search && !u.username.toLowerCase().includes(q)) return false
+      if (roleFilter === 'unassigned') return u.role_ids.length === 0
+      if (roleFilter !== 'all') return u.role_ids.includes(roleFilter)
+      return true
+    })
+  }, [users, search, roleFilter])
+
+  const selected = users.find((u) => u.id === selectedId) ?? null
+
+  return (
+    <div style={{ padding: '24px 32px 40px', maxWidth: 1400, margin: '0 auto' }}>
+      <PageHeader
+        title="Users"
+        subtitle="Every account in the workspace. Click a row to attach or detach roles."
+        action={
+          <Button size="sm" onClick={() => setAdding(true)}>
+            <Plus size={14} /> Add user
+          </Button>
+        }
+      />
+
+      <StatsGrid>
+        <Stat variant="card" label="Users" value={users.length} />
+        <Stat variant="card" label="Role assignments" value={totalAssignments} />
+        <Stat variant="card" label="Multi-role users" value={users.filter((u) => u.role_ids.length > 1).length} />
+        <Stat variant="card" label="No role" value={unassigned} tone={unassigned > 0 ? 'warn' : 'live'} />
+      </StatsGrid>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14, flexWrap: 'wrap' }}>
+        <div style={{ position: 'relative', width: 320 }}>
+          <Search size={15} style={{ position: 'absolute', left: 10, top: 10, color: 'var(--fg-3)' }} />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by username"
+            style={{ paddingLeft: 32 }}
+          />
+        </div>
+        <select value={roleFilter} onChange={(e) => setRoleFilter(e.target.value)} style={nativeSelectStyle}>
+          <option value="all">All users ({users.length})</option>
+          <option value="unassigned">No role ({unassigned})</option>
+          {roles.map((r) => (
+            <option key={r.id} value={r.id}>
+              {r.name} ({userCountByRole.get(r.id) ?? 0})
+            </option>
+          ))}
+        </select>
+        <div style={{ flex: 1 }} />
+        <div style={{ fontSize: 12, color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>
+          showing <span style={{ color: 'var(--fg-1)', fontWeight: 600 }}>{filtered.length}</span> of{' '}
+          <span style={{ color: 'var(--fg-1)', fontWeight: 600 }}>{users.length}</span>
+        </div>
+      </div>
+
+      <div
+        style={{
+          background: 'var(--bg-card)',
+          border: '1px solid var(--border-subtle)',
+          borderRadius: 'var(--r-md, 10px)',
+          overflow: 'hidden',
+        }}
+      >
+        <div style={tableHeaderStyle}>
+          <div>User</div>
+          <div>Roles</div>
+          <div>Created</div>
+          <div />
+        </div>
+        {filtered.map((u) => (
+          <UserRow key={u.id} u={u} rolesById={rolesById} onClick={() => setSelectedId(u.id)} />
+        ))}
+        {filtered.length === 0 && (
+          <div style={{ padding: '48px 20px', textAlign: 'center', color: 'var(--fg-3)', fontSize: 13 }}>
+            No users match this filter.
+          </div>
+        )}
+      </div>
+
+      <UserDrawer
+        user={selected}
+        roles={roles}
+        permissions={permissions}
+        onSave={(next) => selected && actions.setUserRoles(selected.id, next)}
+        onRemove={() => selected && setConfirmRemove(selected)}
+        onClose={() => setSelectedId(null)}
+      />
+      {adding && (
+        <AddUserModal
+          existingUsernames={users.map((u) => u.username)}
+          onClose={() => setAdding(false)}
+          onAdd={(username) => {
+            const id = actions.addUser(username)
+            setAdding(false)
+            setSelectedId(id)
+          }}
+        />
+      )}
+      {confirmRemove && (
+        <AlertDialog open onOpenChange={(o) => !o && setConfirmRemove(null)}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Remove {confirmRemove.username}?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This deletes the user record. Their role assignments will be removed automatically. This can't be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  actions.removeUser(confirmRemove.id)
+                  setConfirmRemove(null)
+                  setSelectedId(null)
+                }}
+              >
+                Remove user
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </div>
+  )
+}
+
+function UserRow({
+  u,
+  rolesById,
+  onClick,
+}: {
+  u: User
+  rolesById: Map<string, Role>
+  onClick: () => void
+}) {
+  return (
+    <div onClick={onClick} className="rbac-row" style={userRowStyle}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, minWidth: 0 }}>
+        <Avatar name={u.username} size={34} />
+        <div style={{ minWidth: 0 }}>
+          <div
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: 'var(--fg-1)',
+              fontFamily: 'var(--font-mono)',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {u.username}
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--fg-muted)', marginTop: 2, fontFamily: 'var(--font-mono)' }}>
+            {u.id}
+          </div>
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+        {u.role_ids.length === 0 ? (
+          <span style={{ fontSize: 11, color: 'var(--loss)', fontStyle: 'italic' }}>no role</span>
+        ) : (
+          u.role_ids.map((rid) => {
+            const role = rolesById.get(rid)
+            if (!role) return null
+            return <RolePill key={rid} name={role.name} />
+          })
+        )}
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>
+        {fmtDateRel(u.created_at)}
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <ChevronRight size={16} color="var(--fg-muted)" strokeWidth={1.75} />
+      </div>
+    </div>
+  )
+}
+
+export function RolePill({ name }: { name: string }) {
+  const c = colorFor(name)
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        padding: '2px 9px',
+        borderRadius: 999,
+        background: `${c}15`,
+        border: `1px solid ${c}40`,
+        fontSize: 11,
+        color: c,
+        fontWeight: 600,
+      }}
+    >
+      <span style={{ width: 5, height: 5, borderRadius: '50%', background: c }} />
+      {name}
+    </span>
+  )
+}
+
+function UserDrawer({
+  user,
+  roles,
+  permissions,
+  onSave,
+  onRemove,
+  onClose,
+}: {
+  user: User | null
+  roles: Role[]
+  permissions: Permission[]
+  onSave: (role_ids: string[]) => void
+  onRemove: () => void
+  onClose: () => void
+}) {
+  return (
+    <Sheet open={!!user} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent side="right" className="!w-[560px] !max-w-full !sm:max-w-full p-0">
+        {user && (
+          <UserDrawerBody
+            key={user.id}
+            user={user}
+            roles={roles}
+            permissions={permissions}
+            onSave={onSave}
+            onRemove={onRemove}
+            onClose={onClose}
+          />
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function UserDrawerBody({
+  user,
+  roles,
+  permissions,
+  onSave,
+  onRemove,
+  onClose,
+}: {
+  user: User
+  roles: Role[]
+  permissions: Permission[]
+  onSave: (role_ids: string[]) => void
+  onRemove: () => void
+  onClose: () => void
+}) {
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(user.role_ids))
+  const dirty = useMemo(() => {
+    if (selected.size !== user.role_ids.length) return true
+    for (const rid of user.role_ids) if (!selected.has(rid)) return true
+    return false
+  }, [selected, user.role_ids])
+
+  const rolesById = useMemo(() => new Map(roles.map((r) => [r.id, r])), [roles])
+  const { resolvedPermIds, resolvedPerms } = useMemo(() => {
+    const ids = new Set<string>()
+    for (const rid of selected) {
+      const r = rolesById.get(rid)
+      if (r) r.permission_ids.forEach((pid) => ids.add(pid))
+    }
+    return { resolvedPermIds: ids, resolvedPerms: permissions.filter((p) => ids.has(p.id)) }
+  }, [selected, rolesById, permissions])
+
+  function toggle(rid: string) {
+    setSelected((s) => {
+      const next = new Set(s)
+      if (next.has(rid)) next.delete(rid)
+      else next.add(rid)
+      return next
+    })
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: 'var(--bg-panel)' }}>
+      <SheetHeader className="border-b border-[color:var(--border-subtle)] p-[22px_24px_18px] gap-0">
+        <SheetTitle className="sr-only">User {user.username}</SheetTitle>
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 14 }}>
+          <Avatar name={user.username} size={48} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <h2
+              style={{
+                fontSize: 18,
+                fontWeight: 700,
+                color: 'var(--fg-1)',
+                margin: 0,
+                fontFamily: 'var(--font-mono)',
+              }}
+            >
+              {user.username}
+            </h2>
+            <div style={{ display: 'flex', gap: 18, marginTop: 10 }}>
+              <Stat label="User ID" value={user.id} mono />
+              <Stat label="Created" value={fmtDate(user.created_at)} />
+              <Stat label="Roles" value={selected.size} />
+            </div>
+          </div>
+        </div>
+      </SheetHeader>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '20px 24px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+          <div>
+            <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg-1)', marginBottom: 2 }}>Assigned roles</div>
+            <div style={{ fontSize: 12, color: 'var(--fg-3)' }}>
+              <span style={{ color: 'var(--fg-2)', fontFamily: 'var(--font-mono)', fontWeight: 600 }}>
+                {selected.size}
+              </span>{' '}
+              of {roles.length} · grants{' '}
+              <span style={{ color: 'var(--ball-400)', fontFamily: 'var(--font-mono)', fontWeight: 600 }}>
+                {resolvedPermIds.size}
+              </span>{' '}
+              permissions
+            </div>
+          </div>
+        </div>
+
+        <div style={{ display: 'grid', gap: 8 }}>
+          {roles.map((r) => (
+            <RoleAssignRow key={r.id} role={r} on={selected.has(r.id)} onToggle={() => toggle(r.id)} />
+          ))}
+        </div>
+
+        <div style={{ marginTop: 24 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg-1)', marginBottom: 6 }}>
+            Effective permissions
+          </div>
+          <div style={{ fontSize: 12, color: 'var(--fg-3)', marginBottom: 10 }}>
+            Union of every permission granted by the roles above.
+          </div>
+          {resolvedPerms.length === 0 ? (
+            <div
+              style={{
+                padding: '18px',
+                textAlign: 'center',
+                fontSize: 12,
+                color: 'var(--loss)',
+                background: 'rgba(255,77,109,0.05)',
+                border: '1px dashed rgba(255,77,109,0.3)',
+                borderRadius: 'var(--r-md, 10px)',
+              }}
+            >
+              This user can't do anything. Attach at least one role.
+            </div>
+          ) : (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+              {resolvedPerms.map((p) => (
+                <code
+                  key={p.id}
+                  style={{
+                    fontSize: 10.5,
+                    fontFamily: 'var(--font-mono)',
+                    color: 'var(--fg-2)',
+                    background: 'var(--ink-900)',
+                    padding: '2px 7px',
+                    borderRadius: 4,
+                    border: '1px solid var(--border-subtle)',
+                  }}
+                >
+                  {p.name}
+                </code>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <SheetFooter
+        className="border-t border-[color:var(--border-subtle)] bg-[color:var(--ink-900)]"
+        style={{ flexDirection: 'row', justifyContent: 'space-between', padding: '16px 24px' }}
+      >
+        <Button variant="destructive" onClick={onRemove}>
+          <Trash2 size={14} /> Remove user
+        </Button>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button disabled={!dirty} onClick={() => onSave([...selected])}>
+            {dirty ? 'Save changes' : 'No changes'}
+          </Button>
+        </div>
+      </SheetFooter>
+    </div>
+  )
+}
+
+function RoleAssignRow({ role, on, onToggle }: { role: Role; on: boolean; onToggle: () => void }) {
+  const accent = colorFor(role.name)
+  return (
+    <div
+      onClick={onToggle}
+      className="rbac-row"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '12px 14px',
+        cursor: 'pointer',
+        background: on ? `${accent}10` : 'var(--bg-card)',
+        border: `1px solid ${on ? accent + '55' : 'var(--border-subtle)'}`,
+        borderRadius: 'var(--r-md, 10px)',
+        transition: 'all 120ms cubic-bezier(0.2, 0.8, 0.2, 1)',
+      }}
+    >
+      <Checkbox checked={on} onCheckedChange={onToggle} />
+      <div
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          background: accent,
+          flexShrink: 0,
+          boxShadow: on ? `0 0 8px ${accent}88` : 'none',
+        }}
+      />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, fontWeight: 600, color: on ? 'var(--fg-1)' : 'var(--fg-2)' }}>{role.name}</div>
+        <div
+          style={{
+            fontSize: 11,
+            color: role.description ? 'var(--fg-3)' : 'var(--fg-muted)',
+            fontStyle: role.description ? 'normal' : 'italic',
+            lineHeight: 1.4,
+            marginTop: 2,
+          }}
+        >
+          {role.description || 'No description'}
+        </div>
+      </div>
+      <div
+        style={{
+          fontSize: 11,
+          fontFamily: 'var(--font-mono)',
+          color: 'var(--fg-3)',
+          fontVariantNumeric: 'tabular-nums',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {role.permission_ids.length} perms
+      </div>
+    </div>
+  )
+}
+
+function AddUserModal({
+  existingUsernames,
+  onClose,
+  onAdd,
+}: {
+  existingUsernames: string[]
+  onClose: () => void
+  onAdd: (username: string) => void
+}) {
+  const [username, setUsername] = useState('')
+  const trimmed = username.trim()
+  const taken = existingUsernames.some((u) => u.toLowerCase() === trimmed.toLowerCase())
+  const validShape = /^[a-z0-9._-]{2,}$/i.test(trimmed)
+  const valid = trimmed && validShape && !taken
+  const { hint, hintTone } = validateUsername({ trimmed, taken, validShape })
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add user</DialogTitle>
+        </DialogHeader>
+        <Field label="Username" hint={hint} hintTone={hintTone}>
+          <Input
+            autoFocus
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="e.g. jamie.tran"
+            style={{ fontFamily: 'var(--font-mono)' }}
+          />
+        </Field>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button disabled={!valid} onClick={() => onAdd(trimmed)}>Add user</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function validateUsername({
+  trimmed,
+  taken,
+  validShape,
+}: {
+  trimmed: string
+  taken: boolean
+  validShape: boolean
+}): { hint: string; hintTone: 'neutral' | 'loss' } {
+  if (taken) return { hint: 'That username is already taken.', hintTone: 'loss' }
+  if (trimmed && !validShape) {
+    return { hint: 'Letters, numbers, dots, dashes, underscores. Min 2 characters.', hintTone: 'loss' }
+  }
+  return { hint: 'Must be unique. After creating, click the row to attach roles.', hintTone: 'neutral' }
+}
+
+const tableHeaderStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '1fr 1.4fr 130px 40px',
+  padding: '10px 20px',
+  borderBottom: '1px solid var(--border-subtle)',
+  background: 'var(--ink-800)',
+  fontSize: 10,
+  fontWeight: 600,
+  letterSpacing: '0.14em',
+  color: 'var(--fg-muted)',
+  textTransform: 'uppercase',
+}
+
+const userRowStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '1fr 1.4fr 130px 40px',
+  padding: '14px 20px',
+  alignItems: 'center',
+  gap: 12,
+  borderTop: '1px solid var(--border-subtle)',
+  cursor: 'pointer',
+}
+
+const nativeSelectStyle: CSSProperties = {
+  height: 34,
+  padding: '0 12px',
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border-default)',
+  borderRadius: 'var(--r-md, 10px)',
+  color: 'var(--fg-2)',
+  fontSize: 13,
+  fontFamily: 'var(--font-ui)',
+  outline: 'none',
+  cursor: 'pointer',
+}

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -779,6 +779,78 @@ code {
   box-shadow: 0 0 8px rgba(255, 122, 26, 0.6);
 }
 
+.app-shell__nav-link.is-parent-active .app-shell__nav-icon {
+  color: var(--ball-400);
+}
+
+.app-shell__sub-nav-list {
+  list-style: none;
+  margin: 4px 0 4px 24px;
+  padding: 4px 0 4px 14px;
+  border-left: 1px solid var(--ink-600);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.app-shell__sub-nav-link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  border-radius: 6px;
+  color: var(--fg-2);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.app-shell__sub-nav-link:hover {
+  background: var(--bg-hover);
+  color: var(--fg-1);
+}
+.app-shell__sub-nav-link .app-shell__nav-icon {
+  color: var(--fg-3);
+}
+.app-shell__sub-nav-link.is-active {
+  background: var(--bg-accent-soft);
+  color: var(--ball-400);
+}
+.app-shell__sub-nav-link.is-active .app-shell__nav-icon {
+  color: var(--ball-500);
+}
+.app-shell__sub-nav-link.is-active::before {
+  content: '';
+  position: absolute;
+  left: -15px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2px;
+  height: 18px;
+  border-radius: 2px;
+  background: var(--ball-500);
+}
+
+.rbac-row {
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.rbac-row:hover {
+  background: var(--bg-hover);
+}
+.rbac-row[data-active] {
+  background: var(--bg-accent-soft);
+}
+
+.rbac-inline-edit {
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.rbac-inline-edit:hover {
+  background: var(--bg-hover);
+}
+
 .app-shell__sidebar-footer {
   border-top: 1px solid var(--border-subtle);
   padding: 12px;

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -13,6 +13,10 @@ import { Route as DesignSystemRouteImport } from './routes/design-system'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as AdminRouteImport } from './routes/admin'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AdminIndexRouteImport } from './routes/admin.index'
+import { Route as AdminUsersRouteImport } from './routes/admin.users'
+import { Route as AdminRolesRouteImport } from './routes/admin.roles'
+import { Route as AdminPermissionsRouteImport } from './routes/admin.permissions'
 
 const DesignSystemRoute = DesignSystemRouteImport.update({
   id: '/design-system',
@@ -34,37 +38,92 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminIndexRoute = AdminIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminUsersRoute = AdminUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminRolesRoute = AdminRolesRouteImport.update({
+  id: '/roles',
+  path: '/roles',
+  getParentRoute: () => AdminRoute,
+} as any)
+const AdminPermissionsRoute = AdminPermissionsRouteImport.update({
+  id: '/permissions',
+  path: '/permissions',
+  getParentRoute: () => AdminRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/admin': typeof AdminRoute
+  '/admin': typeof AdminRouteWithChildren
   '/dashboard': typeof DashboardRoute
   '/design-system': typeof DesignSystemRoute
+  '/admin/permissions': typeof AdminPermissionsRoute
+  '/admin/roles': typeof AdminRolesRoute
+  '/admin/users': typeof AdminUsersRoute
+  '/admin/': typeof AdminIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/admin': typeof AdminRoute
   '/dashboard': typeof DashboardRoute
   '/design-system': typeof DesignSystemRoute
+  '/admin/permissions': typeof AdminPermissionsRoute
+  '/admin/roles': typeof AdminRolesRoute
+  '/admin/users': typeof AdminUsersRoute
+  '/admin': typeof AdminIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
-  '/admin': typeof AdminRoute
+  '/admin': typeof AdminRouteWithChildren
   '/dashboard': typeof DashboardRoute
   '/design-system': typeof DesignSystemRoute
+  '/admin/permissions': typeof AdminPermissionsRoute
+  '/admin/roles': typeof AdminRolesRoute
+  '/admin/users': typeof AdminUsersRoute
+  '/admin/': typeof AdminIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/admin' | '/dashboard' | '/design-system'
+  fullPaths:
+    | '/'
+    | '/admin'
+    | '/dashboard'
+    | '/design-system'
+    | '/admin/permissions'
+    | '/admin/roles'
+    | '/admin/users'
+    | '/admin/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/admin' | '/dashboard' | '/design-system'
-  id: '__root__' | '/' | '/admin' | '/dashboard' | '/design-system'
+  to:
+    | '/'
+    | '/dashboard'
+    | '/design-system'
+    | '/admin/permissions'
+    | '/admin/roles'
+    | '/admin/users'
+    | '/admin'
+  id:
+    | '__root__'
+    | '/'
+    | '/admin'
+    | '/dashboard'
+    | '/design-system'
+    | '/admin/permissions'
+    | '/admin/roles'
+    | '/admin/users'
+    | '/admin/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
-  AdminRoute: typeof AdminRoute
+  AdminRoute: typeof AdminRouteWithChildren
   DashboardRoute: typeof DashboardRoute
   DesignSystemRoute: typeof DesignSystemRoute
 }
@@ -99,12 +158,56 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin/': {
+      id: '/admin/'
+      path: '/'
+      fullPath: '/admin/'
+      preLoaderRoute: typeof AdminIndexRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/users': {
+      id: '/admin/users'
+      path: '/users'
+      fullPath: '/admin/users'
+      preLoaderRoute: typeof AdminUsersRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/roles': {
+      id: '/admin/roles'
+      path: '/roles'
+      fullPath: '/admin/roles'
+      preLoaderRoute: typeof AdminRolesRouteImport
+      parentRoute: typeof AdminRoute
+    }
+    '/admin/permissions': {
+      id: '/admin/permissions'
+      path: '/permissions'
+      fullPath: '/admin/permissions'
+      preLoaderRoute: typeof AdminPermissionsRouteImport
+      parentRoute: typeof AdminRoute
+    }
   }
 }
 
+interface AdminRouteChildren {
+  AdminPermissionsRoute: typeof AdminPermissionsRoute
+  AdminRolesRoute: typeof AdminRolesRoute
+  AdminUsersRoute: typeof AdminUsersRoute
+  AdminIndexRoute: typeof AdminIndexRoute
+}
+
+const AdminRouteChildren: AdminRouteChildren = {
+  AdminPermissionsRoute: AdminPermissionsRoute,
+  AdminRolesRoute: AdminRolesRoute,
+  AdminUsersRoute: AdminUsersRoute,
+  AdminIndexRoute: AdminIndexRoute,
+}
+
+const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-  AdminRoute: AdminRoute,
+  AdminRoute: AdminRouteWithChildren,
   DashboardRoute: DashboardRoute,
   DesignSystemRoute: DesignSystemRoute,
 }

--- a/web-client/src/routes/admin.index.tsx
+++ b/web-client/src/routes/admin.index.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SystemHealth } from '@/components/system-health'
+
+export const Route = createFileRoute('/admin/')({
+  component: AdminOverview,
+})
+
+function AdminOverview() {
+  return (
+    <div className="mx-auto max-w-[1200px] px-12 pt-16 pb-32">
+      <header className="mb-10">
+        <h1 className="font-display text-4xl text-foreground">Administration</h1>
+      </header>
+      <section aria-label="Operations" className="mb-12 max-w-[640px]">
+        <SystemHealth />
+      </section>
+    </div>
+  )
+}

--- a/web-client/src/routes/admin.permissions.tsx
+++ b/web-client/src/routes/admin.permissions.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { PermissionsPage } from '@/components/rbac/permissions-page'
+
+export const Route = createFileRoute('/admin/permissions')({
+  component: PermissionsPage,
+})

--- a/web-client/src/routes/admin.roles.tsx
+++ b/web-client/src/routes/admin.roles.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { RolesPage } from '@/components/rbac/roles-page'
+
+export const Route = createFileRoute('/admin/roles')({
+  component: RolesPage,
+})

--- a/web-client/src/routes/admin.tsx
+++ b/web-client/src/routes/admin.tsx
@@ -1,23 +1,30 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { Outlet, createFileRoute } from '@tanstack/react-router'
 import { AppShell } from '@/components/app-shell'
-import { SystemHealth } from '@/components/system-health'
+import { RbacProvider } from '@/components/rbac/rbac-context'
+import { AdminBreadcrumbAndCounts } from '@/components/rbac/admin-layout'
 
 export const Route = createFileRoute('/admin')({
-  component: AdminPage,
+  component: AdminLayout,
 })
 
-function AdminPage() {
+function AdminLayout() {
   return (
-    <AppShell>
-      <div className="mx-auto max-w-[1200px] px-12 pt-16 pb-32">
-        <header className="mb-10">
-          <h1 className="font-display text-4xl text-foreground">Administration</h1>
-        </header>
-
-        <section aria-label="Operations" className="mb-12 max-w-[640px]">
-          <SystemHealth />
-        </section>
-      </div>
-    </AppShell>
+    <RbacProvider>
+      <AppShell>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            height: 'calc(100vh - 64px)',
+            minHeight: 0,
+          }}
+        >
+          <AdminBreadcrumbAndCounts />
+          <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+            <Outlet />
+          </div>
+        </div>
+      </AppShell>
+    </RbacProvider>
   )
 }

--- a/web-client/src/routes/admin.users.tsx
+++ b/web-client/src/routes/admin.users.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { UsersPage } from '@/components/rbac/users-page'
+
+export const Route = createFileRoute('/admin/users')({
+  component: UsersPage,
+})


### PR DESCRIPTION
## Summary
- Three CRUD pages under `/admin` (Roles split-pane, Permissions catalogue, Users + role-assignment Sheet) matching the Permission / Role / User / RolePermission / UserRole schema. UI only — in-memory RbacProvider seeded from mock data, no backend wiring yet.
- Administration sidebar item now expands to Roles / Permissions / Users; `/admin` keeps the existing SystemHealth overview.
- Reuses shadcn primitives (Button, Input, Textarea, Checkbox, Dialog, AlertDialog, Sheet) and lucide-react icons. Context is split into Data + Actions so action consumers don't re-render on data changes; functional `setState` keeps the actions object referentially stable. Per-page lookups (member count by role, role count by permission, role-by-id) build a single `Map` via `useMemo` to avoid N×M scans per render.

## Test plan
- [x] `npx tsc -b --noEmit` clean
- [x] `npm run lint` 0 errors
- [x] `npm run test:run` 6/6
- [x] `npx playwright test` 14/14 (includes new `e2e/rbac-smoke.spec.ts`)
- [ ] Manually click through `/admin/roles`, `/admin/permissions`, `/admin/users`: create/edit/delete a role, toggle permissions, assign roles to a user, search/filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)