### PR TITLE
Drop duplicate <Toaster /> from __root.tsx

### DIFF
--- a/web-client/src/routes/__root.tsx
+++ b/web-client/src/routes/__root.tsx
@@ -1,6 +1,5 @@
 import { Outlet, createRootRoute } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
-import { Toaster } from '@/components/ui/sonner'
 import { ServiceWorkerUpdater } from '@/components/service-worker-updater'
 
 export const Route = createRootRoute({
@@ -11,7 +10,6 @@ function RootComponent() {
   return (
     <>
       <Outlet />
-      <Toaster />
       <ServiceWorkerUpdater />
       <TanStackRouterDevtools />
     </>


### PR DESCRIPTION
## Summary
- The root route still rendered a default-position `<Toaster />` after `main.tsx` got its own (`richColors`, `position="top-right"`).
- With two Toasters mounted, every toast renders twice, which fails strict-mode locators — the rbac-permissions e2e at `rbac-permissions.spec.ts:115` has been red on main since PR #45.
- Keeping the configured top-right Toaster in `main.tsx`; removing the legacy default in `__root.tsx`.

## Test plan
- [x] \`npx playwright test rbac-permissions\` passes (16/16)
- [x] \`npx playwright test\` passes (64/64) on darwin
- [ ] CI green on this branch (unblocks main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)