### PR TITLE
Apply dark fortymm-theme on <body> for Radix portals

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>web-client</title>
   </head>
-  <body>
+  <body class="dark fortymm-theme">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/web-client/src/routes/design-system.tsx
+++ b/web-client/src/routes/design-system.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useEffect } from 'react'
 import {
   AlertCircle,
   Calendar as CalendarIcon,
@@ -228,12 +227,6 @@ function Showcase({
 }
 
 function DesignSystemPage() {
-  useEffect(() => {
-    const cls = ['dark', 'fortymm-theme']
-    document.body.classList.add(...cls)
-    return () => document.body.classList.remove(...cls)
-  }, [])
-
   return (
     <TooltipProvider>
       <div className="dark fortymm-theme min-h-screen">


### PR DESCRIPTION
## Summary
- The design-system page used a useEffect to mirror its theme classes onto `<body>` so Radix-portal'd overlays (Dialog, Sheet, AlertDialog) inherit the FortyMM dark theme.
- Admin pages need the same treatment or their modals render with shadcn's default light theme. Moving the classes to `<body>` in \`index.html\` covers every route at once and drops the per-route hack.
- Landing and AppShell wrappers still set their own theme classes for layout-scoped styles; this just makes `<body>` the source of truth for portals.

## Test plan
- [x] \`design-system.spec.ts\` (5/5) still passes
- [x] Visual check on /admin/permissions, /admin/roles, /admin/users — dialogs/sheets now use the FortyMM dark theme
- [x] Local rbac-roles spec improved 1→19 passes (many dialogs were unreachable before because they rendered as white-on-white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)