### PR TITLE
Add zod validation to the New Permission form (backend + frontend)

### DIFF
--- a/api/app/schemas/rbac.py
+++ b/api/app/schemas/rbac.py
@@ -3,6 +3,12 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# Permission names follow a `resource.action` convention (e.g. `tournament.publish`).
+# Allowed chars per segment: lowercase letters, digits, underscores. At least
+# one dot is required so the UI's prefix grouping doesn't bucket everything as
+# `other.*`.
+PERMISSION_NAME_PATTERN = r"^[a-z0-9_]+(?:\.[a-z0-9_]+)+$"
+
 
 class PermissionBase(BaseModel):
     name: str = Field(min_length=1, max_length=255)
@@ -10,11 +16,20 @@ class PermissionBase(BaseModel):
 
 
 class PermissionCreate(PermissionBase):
-    pass
+    # Pattern is enforced on write only — historical rows that predate this
+    # constraint must still serialize cleanly through PermissionRead.
+    name: str = Field(
+        min_length=1, max_length=255, pattern=PERMISSION_NAME_PATTERN
+    )
 
 
 class PermissionUpdate(BaseModel):
-    name: str | None = Field(default=None, min_length=1, max_length=255)
+    name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=255,
+        pattern=PERMISSION_NAME_PATTERN,
+    )
     description: str | None = Field(default=None, max_length=1024)
 
 

--- a/api/tests/test_rbac.py
+++ b/api/tests/test_rbac.py
@@ -48,9 +48,30 @@ async def test_create_and_list_permissions(
 
 
 async def test_create_permission_rejects_duplicate_name(api_client: AsyncClient):
-    await api_client.post("/v1/permissions", json={"name": "dup"})
-    second = await api_client.post("/v1/permissions", json={"name": "dup"})
+    await api_client.post("/v1/permissions", json={"name": "perm.dup"})
+    second = await api_client.post(
+        "/v1/permissions", json={"name": "perm.dup"}
+    )
     assert second.status_code == 409
+
+
+async def test_create_permission_rejects_undotted_name(api_client: AsyncClient):
+    response = await api_client.post(
+        "/v1/permissions", json={"name": "invalidname"}
+    )
+    assert response.status_code == 422
+
+
+async def test_create_permission_rejects_malformed_name(api_client: AsyncClient):
+    response = await api_client.post(
+        "/v1/permissions", json={"name": "Has Spaces!"}
+    )
+    assert response.status_code == 422
+
+
+async def test_create_permission_rejects_empty_name(api_client: AsyncClient):
+    response = await api_client.post("/v1/permissions", json={"name": ""})
+    assert response.status_code == 422
 
 
 async def test_update_permission(
@@ -58,25 +79,38 @@ async def test_update_permission(
 ):
     created = (
         await api_client.post(
-            "/v1/permissions", json={"name": "before", "description": "old"}
+            "/v1/permissions",
+            json={"name": "perm.before", "description": "old"},
         )
     ).json()
 
     patched = await api_client.patch(
         f"/v1/permissions/{created['id']}",
-        json={"name": "after", "description": "new"},
+        json={"name": "perm.after", "description": "new"},
     )
     assert patched.status_code == 200
     body = patched.json()
-    assert body["name"] == "after"
+    assert body["name"] == "perm.after"
     assert body["description"] == "new"
+
+
+async def test_update_permission_rejects_undotted_name(api_client: AsyncClient):
+    created = (
+        await api_client.post(
+            "/v1/permissions", json={"name": "perm.start"}
+        )
+    ).json()
+    response = await api_client.patch(
+        f"/v1/permissions/{created['id']}", json={"name": "invalidname"}
+    )
+    assert response.status_code == 422
 
 
 async def test_delete_permission(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     created = (
-        await api_client.post("/v1/permissions", json={"name": "doomed"})
+        await api_client.post("/v1/permissions", json={"name": "perm.doomed"})
     ).json()
     deleted = await api_client.delete(f"/v1/permissions/{created['id']}")
     assert deleted.status_code == 204
@@ -97,8 +131,12 @@ async def test_get_permission_not_found(api_client: AsyncClient):
 async def test_create_role_with_explicit_permissions(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    p1 = (await api_client.post("/v1/permissions", json={"name": "a"})).json()
-    p2 = (await api_client.post("/v1/permissions", json={"name": "b"})).json()
+    p1 = (
+        await api_client.post("/v1/permissions", json={"name": "perm.a"})
+    ).json()
+    p2 = (
+        await api_client.post("/v1/permissions", json={"name": "perm.b"})
+    ).json()
 
     role_resp = await api_client.post(
         "/v1/roles",
@@ -121,8 +159,12 @@ async def test_create_role_with_explicit_permissions(
 async def test_create_role_from_template_copies_permissions(
     api_client: AsyncClient,
 ):
-    p1 = (await api_client.post("/v1/permissions", json={"name": "a"})).json()
-    p2 = (await api_client.post("/v1/permissions", json={"name": "b"})).json()
+    p1 = (
+        await api_client.post("/v1/permissions", json={"name": "perm.a"})
+    ).json()
+    p2 = (
+        await api_client.post("/v1/permissions", json={"name": "perm.b"})
+    ).json()
     tmpl = (
         await api_client.post(
             "/v1/roles",
@@ -168,7 +210,9 @@ async def test_create_role_rejects_unknown_permission(api_client: AsyncClient):
 async def test_list_roles_returns_permission_ids(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    p = (await api_client.post("/v1/permissions", json={"name": "a"})).json()
+    p = (
+        await api_client.post("/v1/permissions", json={"name": "perm.a"})
+    ).json()
     await api_client.post(
         "/v1/roles", json={"name": "alpha", "permission_ids": [p["id"]]}
     )
@@ -182,9 +226,15 @@ async def test_list_roles_returns_permission_ids(
 
 
 async def test_update_role_replaces_permissions(api_client: AsyncClient):
-    p1 = (await api_client.post("/v1/permissions", json={"name": "a"})).json()
-    p2 = (await api_client.post("/v1/permissions", json={"name": "b"})).json()
-    p3 = (await api_client.post("/v1/permissions", json={"name": "c"})).json()
+    p1 = (
+        await api_client.post("/v1/permissions", json={"name": "perm.a"})
+    ).json()
+    p2 = (
+        await api_client.post("/v1/permissions", json={"name": "perm.b"})
+    ).json()
+    p3 = (
+        await api_client.post("/v1/permissions", json={"name": "perm.c"})
+    ).json()
     role = (
         await api_client.post(
             "/v1/roles",
@@ -201,7 +251,9 @@ async def test_update_role_replaces_permissions(api_client: AsyncClient):
 
 
 async def test_update_role_clears_permissions(api_client: AsyncClient):
-    p = (await api_client.post("/v1/permissions", json={"name": "a"})).json()
+    p = (
+        await api_client.post("/v1/permissions", json={"name": "perm.a"})
+    ).json()
     role = (
         await api_client.post(
             "/v1/roles", json={"name": "r", "permission_ids": [p["id"]]}
@@ -215,7 +267,9 @@ async def test_update_role_clears_permissions(api_client: AsyncClient):
 
 
 async def test_update_role_partial_keeps_permissions(api_client: AsyncClient):
-    p = (await api_client.post("/v1/permissions", json={"name": "a"})).json()
+    p = (
+        await api_client.post("/v1/permissions", json={"name": "perm.a"})
+    ).json()
     role = (
         await api_client.post(
             "/v1/roles", json={"name": "r", "permission_ids": [p["id"]]}

--- a/web-client/e2e/rbac-permissions.spec.ts
+++ b/web-client/e2e/rbac-permissions.spec.ts
@@ -91,19 +91,68 @@ test.describe('Administration · Permissions', () => {
   })
 
   test('rejects a duplicate name in the create form (client-side guard)', async ({ page }) => {
-    const { pom } = await PermissionsPage.navigateTo(page, BASE_SEED)
+    const { pom, store } = await PermissionsPage.navigateTo(page, BASE_SEED)
     await pom.newButton.click()
     await pom.dialogNameInput.fill('tournament.view')
     await expect(page.getByText(/already exists/i)).toBeVisible()
-    await expect(pom.dialogCreateButton).toBeDisabled()
+    await pom.dialogCreateButton.click()
+    await expect(pom.dialogNameInput).toBeVisible()
+    expect(store.listPermissions().filter((p) => p.name === 'tournament.view')).toHaveLength(1)
   })
 
   test('rejects a malformed name (client-side guard)', async ({ page }) => {
-    const { pom } = await PermissionsPage.navigateTo(page, BASE_SEED)
+    const { pom, store } = await PermissionsPage.navigateTo(page, BASE_SEED)
     await pom.newButton.click()
     await pom.dialogNameInput.fill('Has Spaces!')
     await expect(page.getByText(/lowercase letters/i)).toBeVisible()
-    await expect(pom.dialogCreateButton).toBeDisabled()
+    await pom.dialogCreateButton.click()
+    await expect(pom.dialogNameInput).toBeVisible()
+    expect(store.listPermissions()).toHaveLength(3)
+  })
+
+  test('flags an empty name on submit (client-side guard)', async ({ page }) => {
+    const { pom, store } = await PermissionsPage.navigateTo(page, BASE_SEED)
+    await pom.newButton.click()
+    // Submit without typing anything — zod's .min(1) message must surface.
+    await pom.dialogCreateButton.click()
+    await expect(page.getByText('Name is required.')).toBeVisible()
+    await expect(pom.dialogNameInput).toBeVisible()
+    expect(store.listPermissions()).toHaveLength(3)
+  })
+
+  test('flags an undotted name (resource.action convention is required)', async ({ page }) => {
+    const { pom, store } = await PermissionsPage.navigateTo(page, BASE_SEED)
+    await pom.newButton.click()
+    // Passes the character-class check but has no dot — the refine still rejects.
+    await pom.dialogNameInput.fill('invalidname')
+    await expect(page.getByText(/lowercase letters/i)).toBeVisible()
+    await expect(page.getByText(/at least one dot/i)).toBeVisible()
+    await pom.dialogCreateButton.click()
+    await expect(pom.dialogNameInput).toBeVisible()
+    expect(store.listPermissions().some((p) => p.name === 'invalidname')).toBe(false)
+  })
+
+  test('flags a name longer than 255 characters (client-side guard)', async ({ page }) => {
+    const { pom, store } = await PermissionsPage.navigateTo(page, BASE_SEED)
+    await pom.newButton.click()
+    // 'a.' + 254 b's → length 256, passes the regex, fails .max(255).
+    const tooLong = 'a.' + 'b'.repeat(254)
+    await pom.dialogNameInput.fill(tooLong)
+    await expect(page.getByText(/255 characters or fewer/i)).toBeVisible()
+    await pom.dialogCreateButton.click()
+    await expect(pom.dialogNameInput).toBeVisible()
+    expect(store.listPermissions()).toHaveLength(3)
+  })
+
+  test('flags a description longer than 1024 characters (client-side guard)', async ({ page }) => {
+    const { pom, store } = await PermissionsPage.navigateTo(page, BASE_SEED)
+    await pom.newButton.click()
+    await pom.dialogNameInput.fill('courts.score')
+    await pom.dialogDescriptionInput.fill('x'.repeat(1025))
+    await expect(page.getByText(/1024 characters or fewer/i)).toBeVisible()
+    await pom.dialogCreateButton.click()
+    await expect(pom.dialogNameInput).toBeVisible()
+    expect(store.listPermissions().some((p) => p.name === 'courts.score')).toBe(false)
   })
 
   test('surfaces a server 500 on create as a toast (UI does not crash)', async ({ page }) => {
@@ -115,18 +164,75 @@ test.describe('Administration · Permissions', () => {
     await expect(pom.toast()).toBeVisible()
     await expect(pom.toast()).toContainText(/Couldn't create the permission/i)
     await expect(pom.toast()).toContainText('database is down')
-    // List unchanged
-    await expect(page.getByText('courts.score')).toHaveCount(0)
+    // Modal stays open and the store is unchanged.
+    await expect(pom.dialogNameInput).toBeVisible()
+    expect(store.listPermissions().some((p) => p.name === 'courts.score')).toBe(false)
   })
 
-  test('surfaces a 409 conflict from the server as a toast', async ({ page }) => {
+  test('surfaces a 409 conflict from the server inline on the name field', async ({ page }) => {
     const { pom, store } = await PermissionsPage.navigateTo(page, BASE_SEED)
     // Race: someone created the permission between page load and submit.
     store.fail({ pattern: 'POST', status: 409, body: { detail: 'permission name already exists' }, times: 1 })
     await pom.newButton.click()
     await pom.dialogNameInput.fill('courts.brand_new')
     await pom.dialogCreateButton.click()
-    await expect(pom.toast()).toContainText('permission name already exists')
+    await expect(page.getByText('permission name already exists')).toBeVisible()
+    // Modal stays open so the user can correct the name.
+    await expect(pom.dialogNameInput).toBeVisible()
+  })
+
+  test('surfaces a 422 server validation error inline on the name field', async ({ page }) => {
+    const { pom, store } = await PermissionsPage.navigateTo(page, BASE_SEED)
+    // Stricter server pattern than the client (or client/server drift) —
+    // the API rejects with 422 and the detail must surface inline.
+    store.fail({
+      pattern: 'POST',
+      status: 422,
+      body: { detail: 'permission name must match resource.action convention' },
+      times: 1,
+    })
+    await pom.newButton.click()
+    await pom.dialogNameInput.fill('courts.brand_new')
+    await pom.dialogCreateButton.click()
+    await expect(
+      page.getByText('permission name must match resource.action convention'),
+    ).toBeVisible()
+    await expect(pom.dialogNameInput).toBeVisible()
+  })
+
+  test('surfaces a 409 conflict on update inline on the name field', async ({ page }) => {
+    const { pom, store } = await PermissionsPage.navigateTo(page, BASE_SEED)
+    store.fail({
+      pattern: 'PATCH',
+      status: 409,
+      body: { detail: 'permission name already exists' },
+      times: 1,
+    })
+    await pom.permissionRow('tournament.view').getByRole('button', { name: 'Edit' }).click()
+    // Use a name the client-side guard accepts (not in seed) so the request
+    // actually hits the server, where the mock returns 409.
+    await pom.dialogNameInput.fill('courts.score')
+    await pom.dialogSaveButton.click()
+    await expect(page.getByText('permission name already exists')).toBeVisible()
+    await expect(pom.dialogNameInput).toBeVisible()
+  })
+
+  test('surfaces an arbitrary 4xx (e.g. 403) from the server as a toast', async ({ page }) => {
+    const { pom, store } = await PermissionsPage.navigateTo(page, BASE_SEED)
+    // 403 isn't a field-level error — the form should fall through to the toast
+    // path so the user still learns what happened.
+    store.fail({
+      pattern: 'POST',
+      status: 403,
+      body: { detail: 'you do not have permission to create permissions' },
+      times: 1,
+    })
+    await pom.newButton.click()
+    await pom.dialogNameInput.fill('courts.score')
+    await pom.dialogCreateButton.click()
+    await expect(pom.toast()).toContainText(/Couldn't create the permission/i)
+    await expect(pom.toast()).toContainText('you do not have permission to create permissions')
+    await expect(pom.dialogNameInput).toBeVisible()
   })
 
   test('edits a permission description and the row reflects it', async ({ page }) => {
@@ -144,8 +250,10 @@ test.describe('Administration · Permissions', () => {
     await pom.dialogDescriptionInput.fill('Updated description text')
     await pom.dialogSaveButton.click()
     await expect(pom.toast()).toContainText("Couldn't update the permission")
-    await expect(page.getByText('See tournaments.')).toBeVisible()
-    await expect(page.getByText('Updated description text')).toHaveCount(0)
+    // The row in the list still shows the original description (the rollback
+    // is implicit — we never optimistically updated the cache).
+    await expect(pom.permissionRow('tournament.view')).toContainText('See tournaments.')
+    await expect(pom.permissionRow('tournament.view')).not.toContainText('Updated description text')
   })
 
   test('deletes a permission after confirming and removes it from the list', async ({ page }) => {

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
+        "@hookform/resolvers": "^5.2.2",
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/react-query": "^5.100.9",
         "@tanstack/react-router": "^1.169.2",
@@ -26,13 +27,15 @@
         "react-day-picker": "^10.0.0",
         "react-dom": "^19.2.5",
         "react-error-boundary": "^6.1.1",
+        "react-hook-form": "^7.75.0",
         "react-resizable-panels": "^4.11.0",
         "shadcn": "^4.7.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.3.0",
         "tw-animate-css": "^1.4.0",
-        "vaul": "^1.1.2"
+        "vaul": "^1.1.2",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -2165,6 +2168,18 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4805,6 +4820,12 @@
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -10775,6 +10796,22 @@
         "react": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
+      "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -13393,6 +13430,8 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.8",
+    "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/react-query": "^5.100.9",
     "@tanstack/react-router": "^1.169.2",
@@ -33,13 +34,15 @@
     "react-day-picker": "^10.0.0",
     "react-dom": "^19.2.5",
     "react-error-boundary": "^6.1.1",
+    "react-hook-form": "^7.75.0",
     "react-resizable-panels": "^4.11.0",
     "shadcn": "^4.7.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/web-client/src/api/client.ts
+++ b/web-client/src/api/client.ts
@@ -29,21 +29,38 @@ export function extractDetail(value: unknown): string | null {
 }
 
 /**
- * Throws Error(detail || `Failed to ${label}`) when the openapi-fetch result has
- * an error or no data. Pass `{ allowEmpty: true }` for endpoints that legitimately
- * return no body (e.g. 204 DELETEs).
+ * Thrown by `unwrap` for non-2xx responses. Carries the HTTP status so callers
+ * can branch on it (e.g. surface a 409 inline on a form field instead of as a
+ * toast). For network/decode failures with no response, status is 0.
+ */
+export class ApiError extends Error {
+  readonly status: number
+  readonly detail: string | null
+
+  constructor(status: number, detail: string | null, label: string) {
+    super(detail ?? `Failed to ${label}`)
+    this.name = 'ApiError'
+    this.status = status
+    this.detail = detail
+  }
+}
+
+/**
+ * Throws ApiError when the openapi-fetch result has an error or no data. Pass
+ * `{ allowEmpty: true }` for endpoints that legitimately return no body (e.g.
+ * 204 DELETEs).
  */
 export function unwrap<T>(
   label: string,
-  result: { data?: T; error?: unknown },
+  result: { data?: T; error?: unknown; response?: Response },
   options: { allowEmpty?: boolean } = {},
 ): T {
-  const { data, error } = result
+  const { data, error, response } = result
   if (error) {
-    throw new Error(extractDetail(error) ?? `Failed to ${label}`)
+    throw new ApiError(response?.status ?? 0, extractDetail(error), label)
   }
   if (data === undefined && !options.allowEmpty) {
-    throw new Error(`Failed to ${label}`)
+    throw new ApiError(response?.status ?? 0, null, label)
   }
   return data as T
 }

--- a/web-client/src/components/rbac/permissions-page.tsx
+++ b/web-client/src/components/rbac/permissions-page.tsx
@@ -1,6 +1,20 @@
 import { useMemo, useState, type CSSProperties } from 'react'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import { z } from 'zod'
 import { ChevronDown, Folder, Info, Key, Pencil, Plus, Search, Trash2 } from 'lucide-react'
+import { ApiError } from '@/api/client'
 import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import {
@@ -30,9 +44,37 @@ import {
   useRoles,
   useUpdatePermission,
 } from './queries'
-import { EmptyState, Field, PageHeader, Stat, StatsGrid } from './primitives'
+import { EmptyState, PageHeader, Stat, StatsGrid } from './primitives'
 import { PermissionCode, PrefixLabel } from './roles-page'
 import { colorFor, fmtDate, fmtDateRel, groupPermissions, permPrefix } from './helpers'
+
+// Mirrors PERMISSION_NAME_PATTERN in api/app/schemas/rbac.py.
+const PERMISSION_NAME_RE = /^[a-z0-9_]+(?:\.[a-z0-9_]+)+$/
+
+function buildPermissionSchema(existingNames: string[]) {
+  const taken = new Set(existingNames.map((n) => n.toLowerCase()))
+  return z.object({
+    name: z
+      .string()
+      .trim()
+      .min(1, { message: 'Name is required.' })
+      .max(255, { message: 'Name must be 255 characters or fewer.' })
+      .refine((v) => PERMISSION_NAME_RE.test(v), {
+        message:
+          'Use lowercase letters, numbers, underscores, and at least one dot (e.g. tournament.publish).',
+      })
+      .refine((v) => !taken.has(v.toLowerCase()), {
+        message: 'A permission with this name already exists.',
+      }),
+    description: z
+      .string()
+      .trim()
+      .max(1024, { message: 'Description must be 1024 characters or fewer.' })
+      .optional(),
+  })
+}
+
+type PermissionFormValues = z.infer<ReturnType<typeof buildPermissionSchema>>
 
 export function PermissionsPage() {
   const { data: permissions = [], isLoading: permsLoading } = usePermissions()
@@ -113,10 +155,11 @@ export function PermissionsPage() {
           <PermissionFormModal
             title="New permission"
             submitLabel="Create permission"
+            verb="create"
             existingNames={[]}
             onClose={() => setCreating(false)}
-            onSubmit={(data) => {
-              createPermission.mutate(data)
+            onSubmit={async (data) => {
+              await createPermission.mutateAsync(data)
               setCreating(false)
             }}
           />
@@ -243,10 +286,11 @@ export function PermissionsPage() {
         <PermissionFormModal
           title="New permission"
           submitLabel="Create permission"
+          verb="create"
           existingNames={permissions.map((p) => p.name)}
           onClose={() => setCreating(false)}
-          onSubmit={(data) => {
-            createPermission.mutate(data)
+          onSubmit={async (data) => {
+            await createPermission.mutateAsync(data)
             setCreating(false)
             setCollapsed((c) => {
               const next = new Set(c)
@@ -260,11 +304,12 @@ export function PermissionsPage() {
         <PermissionFormModal
           title="Edit permission"
           submitLabel="Save changes"
+          verb="update"
           existingNames={permissions.filter((p) => p.id !== editing.id).map((p) => p.name)}
           initial={editing}
           onClose={() => setEditing(null)}
-          onSubmit={(data) => {
-            updatePermission.mutate({ id: editing.id, patch: data })
+          onSubmit={async (data) => {
+            await updatePermission.mutateAsync({ id: editing.id, patch: data })
             setEditing(null)
           }}
         />
@@ -355,6 +400,7 @@ function OwnerPill({ name }: { name: string }) {
 function PermissionFormModal({
   title,
   submitLabel,
+  verb,
   existingNames,
   initial,
   onClose,
@@ -362,18 +408,40 @@ function PermissionFormModal({
 }: {
   title: string
   submitLabel: string
+  verb: 'create' | 'update'
   existingNames: string[]
   initial?: Permission
   onClose: () => void
-  onSubmit: (data: { name: string; description: string }) => void
+  onSubmit: (data: { name: string; description: string }) => Promise<void>
 }) {
-  const [name, setName] = useState(initial?.name || '')
-  const [description, setDescription] = useState(initial?.description || '')
-  const trimmed = name.trim()
-  const taken = existingNames.some((n) => n.toLowerCase() === trimmed.toLowerCase())
-  const validShape = /^[a-z0-9_]+(?:\.[a-z0-9_]+)*$/i.test(trimmed)
-  const valid = trimmed && validShape && !taken
-  const { hint, hintTone } = validateName({ trimmed, taken, validShape })
+  const schema = useMemo(() => buildPermissionSchema(existingNames), [existingNames])
+  const form = useForm<PermissionFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: initial?.name ?? '',
+      description: initial?.description ?? '',
+    },
+    mode: 'onChange',
+  })
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    try {
+      await onSubmit({ name: values.name, description: values.description ?? '' })
+    } catch (err) {
+      // 4xx errors that target a field land inline; everything else (5xx,
+      // network) goes to the toast so the user still sees what failed.
+      if (err instanceof ApiError && (err.status === 409 || err.status === 422)) {
+        form.setError('name', {
+          type: 'server',
+          message: err.detail ?? 'Server rejected this name.',
+        })
+        return
+      }
+      toast.error(`Couldn't ${verb} the permission`, {
+        description: err instanceof Error ? err.message : String(err),
+      })
+    }
+  })
 
   return (
     <Dialog open onOpenChange={(o) => !o && onClose()}>
@@ -381,69 +449,79 @@ function PermissionFormModal({
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
-        <div style={{ display: 'grid', gap: 16 }}>
-          <Field label="Name" hint={hint} hintTone={hintTone}>
-            <Input
-              autoFocus
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="tournament.publish"
-              style={{ fontFamily: 'var(--font-mono)' }}
-            />
-          </Field>
-          <Field label="Description" hint="What does this permission let someone do?">
-            <Textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="e.g. Publish a tournament to the spectator view."
-              style={{ minHeight: 80 }}
-            />
-          </Field>
-          {initial && (
-            <div
-              style={{
-                display: 'flex',
-                gap: 24,
-                padding: '12px 14px',
-                background: 'var(--ink-900)',
-                border: '1px solid var(--border-subtle)',
-                borderRadius: 'var(--r-md, 10px)',
-              }}
-            >
-              <Stat label="Created" value={fmtDate(initial.created_at)} />
-              <Stat label="Updated" value={fmtDateRel(initial.updated_at)} />
-              <Stat label="ID" value={initial.id} mono />
+        <Form {...form}>
+          <form onSubmit={handleSubmit} noValidate>
+            <div style={{ display: 'grid', gap: 16 }}>
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input
+                        autoFocus
+                        placeholder="tournament.publish"
+                        style={{ fontFamily: 'var(--font-mono)' }}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Convention: resource.action (e.g. courts.score)
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="e.g. Publish a tournament to the spectator view."
+                        style={{ minHeight: 80 }}
+                        {...field}
+                        value={field.value ?? ''}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      What does this permission let someone do?
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              {initial && (
+                <div
+                  style={{
+                    display: 'flex',
+                    gap: 24,
+                    padding: '12px 14px',
+                    background: 'var(--ink-900)',
+                    border: '1px solid var(--border-subtle)',
+                    borderRadius: 'var(--r-md, 10px)',
+                  }}
+                >
+                  <Stat label="Created" value={fmtDate(initial.created_at)} />
+                  <Stat label="Updated" value={fmtDateRel(initial.updated_at)} />
+                  <Stat label="ID" value={initial.id} mono />
+                </div>
+              )}
             </div>
-          )}
-        </div>
-        <DialogFooter>
-          <Button variant="outline" onClick={onClose}>Cancel</Button>
-          <Button disabled={!valid} onClick={() => onSubmit({ name: trimmed, description: description.trim() })}>
-            {submitLabel}
-          </Button>
-        </DialogFooter>
+            <DialogFooter style={{ marginTop: 16 }}>
+              <Button variant="outline" type="button" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button type="submit">{submitLabel}</Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   )
-}
-
-function validateName({
-  trimmed,
-  taken,
-  validShape,
-}: {
-  trimmed: string
-  taken: boolean
-  validShape: boolean
-}): { hint: string; hintTone: 'neutral' | 'loss' } {
-  if (taken) return { hint: 'A permission with this name already exists.', hintTone: 'loss' }
-  if (trimmed && !validShape) {
-    return {
-      hint: 'Use lowercase letters, numbers, underscores, and dots (e.g. tournament.publish).',
-      hintTone: 'loss',
-    }
-  }
-  return { hint: 'Convention: resource.action (e.g. courts.score)', hintTone: 'neutral' }
 }
 
 function DeletePermissionDialog({

--- a/web-client/src/components/rbac/queries.ts
+++ b/web-client/src/components/rbac/queries.ts
@@ -48,13 +48,16 @@ export function useRbacUsers() {
   })
 }
 
+// The permission form awaits these via mutateAsync so it can surface 4xx
+// errors inline on the matching field — that's why neither hook attaches a
+// global onError toast. If a non-form caller is added later, it must handle
+// errors itself or wrap with notifyError at the call site.
 export function useCreatePermission() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: async (input: { name: string; description?: string | null }) =>
       unwrap('create permission', await api.POST('/v1/permissions', { body: input })),
     onSuccess: () => qc.invalidateQueries({ queryKey: PERMISSIONS_KEY }),
-    onError: notifyError('create the permission'),
   })
 }
 
@@ -76,7 +79,6 @@ export function useUpdatePermission() {
     // payloads — no ROLES_KEY invalidation needed (role detail re-renders from
     // the fresh permissions cache).
     onSuccess: () => qc.invalidateQueries({ queryKey: PERMISSIONS_KEY }),
-    onError: notifyError('update the permission'),
   })
 }
 

--- a/web-client/src/components/ui/form.tsx
+++ b/web-client/src/components/ui/form.tsx
@@ -1,0 +1,168 @@
+import * as React from "react"
+import { Slot } from "radix-ui"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  useFormState,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+function FormField<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({ ...props }: ControllerProps<TFieldValues, TName>) {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+function useFormField() {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn("grid gap-2", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  )
+}
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn("data-[error=true]:text-[color:var(--loss)]", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+}
+
+function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot.Root
+      data-slot="form-control"
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+}
+
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn(
+        "text-xs leading-normal text-[color:var(--fg-3)]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? "") : props.children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn(
+        "text-xs leading-normal text-[color:var(--loss)]",
+        className
+      )}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+}
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/web-client/src/mocks/rbac-engine.ts
+++ b/web-client/src/mocks/rbac-engine.ts
@@ -56,6 +56,19 @@ type Body = {
   role_ids?: string[]
 }
 
+// Mirrors PERMISSION_NAME_PATTERN in api/app/schemas/rbac.py.
+const PERMISSION_NAME_RE = /^[a-z0-9_]+(?:\.[a-z0-9_]+)+$/
+
+function invalidPermissionName(name: string | undefined): DispatchResult | null {
+  if (!name || !PERMISSION_NAME_RE.test(name)) {
+    return {
+      status: 422,
+      body: { detail: 'permission name must match resource.action convention' },
+    }
+  }
+  return null
+}
+
 const sortedPermissions = (s: RbacState) =>
   [...s.permissions.values()].sort((a, b) => a.name.localeCompare(b.name))
 const sortedRoles = (s: RbacState) =>
@@ -80,6 +93,8 @@ export function dispatchRbac(
     return { status: 200, body: sortedPermissions(state) }
   }
   if (path === '/v1/permissions' && method === 'POST') {
+    const invalid = invalidPermissionName(body.name)
+    if (invalid) return invalid
     if ([...state.permissions.values()].some((p) => p.name === body.name)) {
       return { status: 409, body: { detail: 'permission name already exists' } }
     }
@@ -94,6 +109,10 @@ export function dispatchRbac(
     if (!existing) return { status: 404, body: { detail: 'permission not found' } }
     if (method === 'GET') return { status: 200, body: existing }
     if (method === 'PATCH') {
+      if (body.name !== undefined) {
+        const invalid = invalidPermissionName(body.name)
+        if (invalid) return invalid
+      }
       if (
         body.name &&
         [...state.permissions.values()].some((p) => p.id !== id && p.name === body.name)

--- a/web-client/src/routes/design-system.tsx
+++ b/web-client/src/routes/design-system.tsx
@@ -1,4 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
 import {
   AlertCircle,
   Calendar as CalendarIcon,
@@ -102,6 +105,15 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from '@/components/ui/hover-card'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import {
   InputOTP,
@@ -266,6 +278,108 @@ function DesignSystemPage() {
   )
 }
 
+const playerProfileSchema = z.object({
+  playerTag: z
+    .string()
+    .min(2, { message: 'Player tag must be at least 2 characters.' })
+    .max(20, { message: 'Player tag must be 20 characters or fewer.' })
+    .regex(/^@[a-zA-Z0-9._-]+$/, {
+      message: 'Start with @ and use letters, numbers, dots, dashes, or underscores.',
+    }),
+  email: z.string().email({ message: 'Enter a valid email address.' }),
+  matchNotes: z
+    .string()
+    .max(280, { message: 'Keep notes under 280 characters.' })
+    .optional(),
+})
+
+type PlayerProfileValues = z.infer<typeof playerProfileSchema>
+
+function PlayerProfileForm() {
+  const form = useForm<PlayerProfileValues>({
+    resolver: zodResolver(playerProfileSchema),
+    defaultValues: {
+      playerTag: '@nguyen.t',
+      email: 'not-an-email',
+      matchNotes: '',
+    },
+    mode: 'onTouched',
+  })
+
+  const onSubmit = form.handleSubmit((values) => {
+    console.log('player profile submitted', values)
+  })
+
+  return (
+    <Form {...form}>
+      <form onSubmit={onSubmit} className="grid grid-cols-1 gap-4 md:grid-cols-2" noValidate>
+        <FormField
+          control={form.control}
+          name="playerTag"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Player tag</FormLabel>
+              <FormControl>
+                <Input placeholder="@yourname" {...field} />
+              </FormControl>
+              <FormDescription>
+                Visible to opponents in match invites.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Email <span className="text-[color:var(--loss)]">*</span>
+              </FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="you@example.com" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="matchNotes"
+          render={({ field }) => (
+            <FormItem className="md:col-span-2">
+              <FormLabel>Match notes</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Add context — venue, conditions, anything memorable."
+                  className="min-h-24"
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>Optional · up to 280 characters.</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="md:col-span-2 flex items-center gap-3">
+          <Button type="submit" disabled={form.formState.isSubmitting}>
+            Save profile
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => form.reset()}
+            disabled={!form.formState.isDirty}
+          >
+            Reset
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}
+
 function FormsSection() {
   return (
     <Section
@@ -335,6 +449,10 @@ function FormsSection() {
             />
           </div>
         </div>
+      </Showcase>
+
+      <Showcase title="Form · Validation" tag="zod + react-hook-form">
+        <PlayerProfileForm />
       </Showcase>
 
       <Showcase title="Textarea" tag="resizable">


### PR DESCRIPTION
## Summary
- Backend: `POST/PATCH /v1/permissions` now enforces the `resource.action` convention via a pydantic `pattern` and rejects empty / undotted / malformed names with `422`. `PermissionRead` is left permissive so historical rows still serialize cleanly.
- Frontend: the New / Edit Permission form is rewritten on react-hook-form + zod through a new shadcn `Form` primitive (`src/components/ui/form.tsx`). Schema is the single source of truth for required / length / regex / duplicate rules. Submit button has no `disabled` gate — `handleSubmit` + zodResolver block invalid submits and `FormMessage` already surfaces the errors.
- Backend errors flow through a typed `ApiError` (carries HTTP status) so the form routes 4xx (`409`, `422`) inline on the matching field via `form.setError`, while `5xx` / network / other 4xx fall through to the existing toast. MSW mock mirrors the same pattern check so dev and tests behave like the real API.
- Bonus: the `/design-system` route gains a `Form · Validation` showcase using the same pattern.

## Test plan
- [x] `api/.venv/bin/pytest -q` → 49 passed (added 3 new validation tests: undotted name, malformed name, empty name; plus an update-rejects-undotted PATCH test)
- [x] `web-client$ npm run build` clean (`tsc -b && vite build`)
- [x] `web-client$ npm run lint` clean
- [x] `web-client$ npm run test:run` → 6 passed (vitest)
- [x] `web-client$ PLAYWRIGHT_PORT=5188 npm run test:e2e` → 71 passed, including 7 new tests in `rbac-permissions.spec.ts` covering:
  - empty name on submit ("Name is required.")
  - undotted name ("lowercase letters / at least one dot")
  - over-length name (>255 chars) and description (>1024 chars)
  - 422 from the server surfacing inline on the name field
  - 409 on update surfacing inline on the name field
  - arbitrary 4xx (403) falling through to a toast
- [ ] Manual smoke: open `/admin/permissions`, click **New permission**, submit empty / undotted / duplicate — inline messages render under the field; modal stays open; submit succeeds for `courts.score`.

> Run e2e with `PLAYWRIGHT_PORT=5188` (or any free port) locally if the rbac dev compose stack is up — its web-client container holds port `5174` by default and Playwright will silently test against it otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)