### PR TITLE
Add score entry page at /matches/:matchId/games/:gameId/scores/new

### DIFF
--- a/web-client/e2e/page-objects/score-entry.page.ts
+++ b/web-client/e2e/page-objects/score-entry.page.ts
@@ -1,0 +1,51 @@
+import { Locator, Page } from '@playwright/test'
+
+type NavigateOptions = {
+  matchId?: string
+  gameId?: string
+}
+
+export class ScoreEntryPage {
+  public readonly page: Page
+  public readonly heading: Locator
+  public readonly gameTag: Locator
+  public readonly metaLine: Locator
+  public readonly meInput: Locator
+  public readonly oppInput: Locator
+  public readonly saveButton: Locator
+  public readonly backButton: Locator
+  public readonly editPreviousButton: Locator
+  public readonly scorelineCells: Locator
+  public readonly activeCell: Locator
+
+  static async navigateTo(
+    page: Page,
+    { matchId = 'm-2207', gameId = '3' }: NavigateOptions = {},
+  ): Promise<ScoreEntryPage> {
+    await page.goto(`/matches/${matchId}/games/${gameId}/scores/new`)
+    return new ScoreEntryPage(page)
+  }
+
+  constructor(page: Page) {
+    this.page = page
+    this.heading = page.getByRole('heading', { level: 2 })
+    this.gameTag = page.locator('.live-bar .tag')
+    this.metaLine = page.locator('.live-bar .meta')
+    this.meInput = page.getByRole('textbox', { name: 'You score' })
+    this.oppInput = page.getByRole('textbox', { name: 'Nguyen, T. score' })
+    this.saveButton = page.getByRole('button', { name: /save .*game/i })
+    this.backButton = page.getByRole('button', { name: 'Back to match' })
+    this.editPreviousButton = page.getByRole('button', { name: /edit game/i })
+    this.scorelineCells = page.locator('.sl-cell')
+    this.activeCell = page.locator('.sl-cell[aria-current="step"]')
+  }
+
+  cell(gameNumber: number): Locator {
+    return this.scorelineCells.nth(gameNumber - 1)
+  }
+
+  async enterScores(me: string, opp: string): Promise<void> {
+    await this.meInput.fill(me)
+    await this.oppInput.fill(opp)
+  }
+}

--- a/web-client/e2e/page-objects/score-entry.page.ts
+++ b/web-client/e2e/page-objects/score-entry.page.ts
@@ -13,8 +13,6 @@ export class ScoreEntryPage {
   public readonly meInput: Locator
   public readonly oppInput: Locator
   public readonly saveButton: Locator
-  public readonly backButton: Locator
-  public readonly editPreviousButton: Locator
   public readonly scorelineCells: Locator
   public readonly activeCell: Locator
 
@@ -34,8 +32,6 @@ export class ScoreEntryPage {
     this.meInput = page.getByRole('textbox', { name: 'You score' })
     this.oppInput = page.getByRole('textbox', { name: 'Nguyen, T. score' })
     this.saveButton = page.getByRole('button', { name: /save .*game/i })
-    this.backButton = page.getByRole('button', { name: 'Back to match' })
-    this.editPreviousButton = page.getByRole('button', { name: /edit game/i })
     this.scorelineCells = page.locator('.sl-cell')
     this.activeCell = page.locator('.sl-cell[aria-current="step"]')
   }

--- a/web-client/e2e/score-entry.spec.ts
+++ b/web-client/e2e/score-entry.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test'
+import { ScoreEntryPage } from './page-objects/score-entry.page'
+
+test.describe('Score entry', () => {
+  test('renders the current game entry with match context', async ({ page }) => {
+    const scoreEntry = await ScoreEntryPage.navigateTo(page, { gameId: '3' })
+
+    await expect(scoreEntry.heading).toHaveText('Enter game 3 score.')
+    await expect(scoreEntry.gameTag).toContainText('GAME 03 OF 05')
+    await expect(scoreEntry.metaLine).toContainText(
+      'RATED · BEST OF 5 · FIRST TO 3',
+    )
+    await expect(scoreEntry.meInput).toBeVisible()
+    await expect(scoreEntry.oppInput).toBeVisible()
+  })
+
+  test('keeps the save button disabled until a valid score is entered', async ({
+    page,
+  }) => {
+    const scoreEntry = await ScoreEntryPage.navigateTo(page, { gameId: '3' })
+
+    await expect(scoreEntry.saveButton).toBeDisabled()
+
+    // A drawn game is not a valid table tennis result.
+    await scoreEntry.enterScores('11', '11')
+    await expect(scoreEntry.saveButton).toBeDisabled()
+
+    await scoreEntry.enterScores('11', '7')
+    await expect(scoreEntry.saveButton).toBeEnabled()
+  })
+
+  test('advances to the next game when the score is saved', async ({ page }) => {
+    const scoreEntry = await ScoreEntryPage.navigateTo(page, { gameId: '3' })
+
+    await scoreEntry.enterScores('11', '7')
+    await scoreEntry.saveButton.click()
+
+    await expect(page).toHaveURL(/\/matches\/m-2207\/games\/4\/scores\/new$/)
+    await expect(scoreEntry.heading).toHaveText('Enter game 4 score.')
+  })
+
+  test('shows every game in the scoreline with the current game active', async ({
+    page,
+  }) => {
+    const scoreEntry = await ScoreEntryPage.navigateTo(page, { gameId: '3' })
+
+    await expect(scoreEntry.scorelineCells).toHaveCount(5)
+    await expect(scoreEntry.activeCell).toContainText('G3')
+    // Games already played carry their stored score into the strip.
+    await expect(scoreEntry.cell(1)).toContainText('11')
+    await expect(scoreEntry.cell(1)).toContainText('8')
+  })
+
+  test('opens a played game from the scoreline with its score prefilled', async ({
+    page,
+  }) => {
+    const scoreEntry = await ScoreEntryPage.navigateTo(page, { gameId: '3' })
+
+    await scoreEntry.cell(1).click()
+
+    await expect(page).toHaveURL(/\/matches\/m-2207\/games\/1\/scores\/new$/)
+    await expect(scoreEntry.heading).toHaveText('Enter game 1 score.')
+    await expect(scoreEntry.meInput).toHaveValue('11')
+    await expect(scoreEntry.oppInput).toHaveValue('8')
+  })
+})

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1500,7 +1500,7 @@ body.dark.fortymm-theme {
 
 /* =========================================================================
    Score entry — single-game score capture
-   (route: /matches/:matchId/games/:gameId/score/new)
+   (route: /matches/:matchId/games/:gameId/scores/new)
    Ported from the "Match Settings Page v2" design handoff (LiveScreen).
    ========================================================================= */
 .fortymm-theme .score-entry-screen {

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1497,3 +1497,469 @@ body.dark.fortymm-theme {
     transition: none !important;
   }
 }
+
+/* =========================================================================
+   Score entry — single-game score capture
+   (route: /matches/:matchId/games/:gameId/score/new)
+   Ported from the "Match Settings Page v2" design handoff (LiveScreen).
+   ========================================================================= */
+.fortymm-theme .score-entry-screen {
+  /* Motion/shadow tokens the design defines at :root — kept local so the
+     port stays faithful without expanding the shared token set. */
+  --dur-fast: 120ms;
+  --dur-base: 200ms;
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+
+  position: fixed;
+  inset: 0;
+  background: var(--ink-950);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+}
+.fortymm-theme .score-entry-screen *,
+.fortymm-theme .score-entry-screen *::before,
+.fortymm-theme .score-entry-screen *::after {
+  box-sizing: border-box;
+}
+
+/* ---------- Top bar ---------- */
+.fortymm-theme .live-bar {
+  padding: 18px 40px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  border-bottom: 1px solid var(--ink-600);
+}
+.fortymm-theme .live-bar .back {
+  background: transparent;
+  border: 1px solid var(--ink-500);
+  color: var(--fg-2);
+  height: 36px;
+  padding: 0 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  font: 600 13px var(--font-ui);
+}
+.fortymm-theme .live-bar .back:hover {
+  background: var(--bg-hover);
+  color: var(--fg-1);
+}
+.fortymm-theme .live-bar .tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font: 700 11px var(--font-mono);
+  letter-spacing: 0.2em;
+  color: var(--ball-500);
+}
+.fortymm-theme .live-bar .tag .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--ball-500);
+  box-shadow: 0 0 10px rgba(255, 122, 26, 0.7);
+  animation: ball-pulse 1.4s ease-in-out infinite;
+}
+.fortymm-theme .live-bar .meta {
+  font: 600 11px var(--font-mono);
+  letter-spacing: 0.14em;
+  color: var(--fg-3);
+  margin-left: auto;
+}
+
+/* ---------- Entry layout ---------- */
+.fortymm-theme .entry-wrap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 36px 40px 40px;
+  width: 100%;
+  gap: 24px;
+}
+.fortymm-theme .entry-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+}
+.fortymm-theme .entry-head h2 {
+  font-family: var(--font-display);
+  font-size: 40px;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  color: var(--fg-1);
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+}
+.fortymm-theme .entry-head .hint {
+  font: 500 12px/1.5 var(--font-mono);
+  letter-spacing: 0.12em;
+  color: var(--fg-3);
+  text-align: right;
+  text-transform: uppercase;
+}
+.fortymm-theme .entry-head .hint kbd {
+  display: inline-block;
+  font: 600 11px var(--font-mono);
+  padding: 2px 6px;
+  margin: 0 2px;
+  border: 1px solid var(--ink-500);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  color: var(--fg-2);
+  background: var(--ink-800);
+  letter-spacing: 0;
+}
+
+/* ---------- Single-game big entry ---------- */
+.fortymm-theme .single-entry {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0;
+  background: var(--ink-800);
+  border: 1px solid var(--ink-600);
+  border-radius: 16px;
+  overflow: hidden;
+}
+.fortymm-theme .se-side {
+  padding: 28px 32px 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+.fortymm-theme .se-side.me {
+  background: linear-gradient(180deg, rgba(255, 122, 26, 0.06), transparent 60%);
+}
+.fortymm-theme .se-side.opp {
+  text-align: right;
+  align-items: flex-end;
+}
+.fortymm-theme .se-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.fortymm-theme .se-head.right {
+  justify-content: flex-end;
+}
+.fortymm-theme .se-head .av {
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  background: var(--ink-700);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: 700 16px var(--font-ui);
+  color: var(--fg-1);
+  flex-shrink: 0;
+}
+.fortymm-theme .se-side.me .av {
+  background: linear-gradient(135deg, #ff7a1a, #b94700);
+  color: #fff;
+  box-shadow: 0 0 0 1px var(--ball-500);
+}
+.fortymm-theme .se-side.opp.guest .av {
+  background: transparent;
+  border: 1.5px dashed var(--ink-500);
+  color: var(--fg-3);
+}
+.fortymm-theme .se-head .nm {
+  font: 600 20px var(--font-ui);
+  color: var(--fg-1);
+}
+.fortymm-theme .se-head .rt {
+  font: 500 11px var(--font-mono);
+  letter-spacing: 0.14em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+}
+.fortymm-theme .se-head .rt b {
+  color: var(--fg-1);
+  font-weight: 700;
+}
+
+.fortymm-theme .big-input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--fg-1);
+  -webkit-text-fill-color: var(--fg-1);
+  font: 700 160px var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  text-align: center;
+  padding: 8px 0 0;
+  caret-color: var(--ball-500);
+  text-shadow: none;
+}
+.fortymm-theme .se-side.opp .big-input {
+  text-align: center;
+}
+.fortymm-theme .big-input::placeholder {
+  color: var(--ink-500);
+  opacity: 1;
+  font-weight: 400;
+  -webkit-text-fill-color: var(--ink-500);
+}
+.fortymm-theme .big-input:focus {
+  color: var(--ball-500);
+  -webkit-text-fill-color: var(--ball-500);
+}
+.fortymm-theme .big-input:disabled {
+  color: var(--fg-2);
+  -webkit-text-fill-color: var(--fg-2);
+  opacity: 1;
+}
+
+.fortymm-theme .se-mid {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 28px 10px;
+  min-width: 120px;
+  border-left: 1px solid var(--ink-600);
+  border-right: 1px solid var(--ink-600);
+  background: var(--ink-900);
+}
+.fortymm-theme .se-vs {
+  font-family: var(--font-display);
+  font-size: 36px;
+  letter-spacing: 0.05em;
+  color: var(--ink-400);
+}
+.fortymm-theme .se-games {
+  margin-top: 8px;
+  font: 700 18px var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-2);
+  letter-spacing: 0.05em;
+}
+
+.fortymm-theme .single-entry.complete .big-input {
+  color: var(--fg-2);
+}
+.fortymm-theme .single-entry.complete {
+  opacity: 0.95;
+}
+
+/* ---------- Action row ---------- */
+.fortymm-theme .single-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 4px 4px;
+}
+.fortymm-theme .result-line {
+  font: 500 14px var(--font-ui);
+  color: var(--fg-2);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.fortymm-theme .result-line.subtle {
+  color: var(--fg-3);
+}
+.fortymm-theme .result-line .trophy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: var(--serve-500);
+  color: var(--ink-950);
+  font: 700 11px var(--font-ui);
+}
+.fortymm-theme .result-line .dot-sep {
+  color: var(--ink-500);
+}
+.fortymm-theme .result-line .final {
+  font: 700 12px var(--font-mono);
+  letter-spacing: 0.18em;
+  color: var(--fg-1);
+}
+
+.fortymm-theme .action-btns {
+  display: flex;
+  gap: 10px;
+}
+.fortymm-theme .action-btns .btn {
+  background: var(--ink-700);
+  border: 1px solid var(--ink-500);
+  color: var(--fg-1);
+  font: 600 14px var(--font-ui);
+  padding: 0 20px;
+  height: 46px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+.fortymm-theme .action-btns .btn:hover {
+  border-color: var(--fg-3);
+}
+.fortymm-theme .action-btns .btn.ghost {
+  background: transparent;
+  color: var(--fg-3);
+}
+.fortymm-theme .action-btns .btn.ghost:hover {
+  color: var(--fg-1);
+}
+.fortymm-theme .action-btns .btn.primary {
+  background: var(--ball-500);
+  border-color: var(--ball-500);
+  color: var(--ink-950);
+}
+.fortymm-theme .action-btns .btn.primary:disabled {
+  background: var(--ink-700);
+  color: var(--fg-3);
+  border-color: var(--ink-500);
+  cursor: not-allowed;
+}
+
+/* ---------- Scoreline strip ---------- */
+.fortymm-theme .scoreline {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  background: var(--ink-900);
+  border: 1px solid var(--ink-600);
+  border-radius: 12px;
+}
+.fortymm-theme .scoreline .sl-label {
+  font: 700 10px var(--font-mono);
+  letter-spacing: 0.2em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+.fortymm-theme .sl-cells {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.fortymm-theme .sl-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 18px;
+  min-width: 78px;
+  background: var(--ink-800);
+  border: 1px solid var(--ink-600);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all var(--dur-fast) var(--ease-out);
+  font-family: inherit;
+}
+.fortymm-theme .sl-cell:hover:not(:disabled) {
+  border-color: var(--fg-3);
+}
+.fortymm-theme .sl-cell:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+.fortymm-theme .sl-cell.active {
+  border-color: var(--ball-500);
+  background: rgba(255, 122, 26, 0.08);
+  box-shadow: 0 0 0 2px rgba(255, 122, 26, 0.2);
+}
+.fortymm-theme .sl-cell.pending:not(.active) {
+  opacity: 0.5;
+  border-style: dashed;
+}
+.fortymm-theme .sl-cell .sl-n {
+  font: 600 10px var(--font-mono);
+  letter-spacing: 0.14em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+}
+.fortymm-theme .sl-cell.active .sl-n {
+  color: var(--ball-500);
+}
+.fortymm-theme .sl-cell .sl-scores {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font: 700 16px var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-1);
+}
+.fortymm-theme .sl-cell .sl-scores .dash {
+  color: var(--ink-500);
+}
+.fortymm-theme .sl-cell .sl-scores .s.w {
+  color: var(--serve-500);
+}
+.fortymm-theme .sl-cell.pending .sl-scores {
+  color: var(--fg-3);
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 820px) {
+  .fortymm-theme .live-bar {
+    padding: 14px 16px;
+  }
+  .fortymm-theme .entry-wrap {
+    padding: 20px 16px;
+  }
+  .fortymm-theme .entry-head h2 {
+    font-size: 32px;
+  }
+  .fortymm-theme .entry-head .hint {
+    display: none;
+  }
+  .fortymm-theme .single-entry {
+    grid-template-columns: 1fr;
+  }
+  .fortymm-theme .se-mid {
+    flex-direction: row;
+    gap: 16px;
+    border-left: none;
+    border-right: none;
+    border-top: 1px solid var(--ink-600);
+    border-bottom: 1px solid var(--ink-600);
+    padding: 14px;
+  }
+  .fortymm-theme .big-input {
+    font-size: 120px;
+  }
+  .fortymm-theme .se-side.opp {
+    align-items: stretch;
+    text-align: left;
+  }
+  .fortymm-theme .se-head.right {
+    justify-content: flex-start;
+  }
+  .fortymm-theme .single-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+  .fortymm-theme .action-btns {
+    justify-content: flex-end;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fortymm-theme .live-bar .tag .dot {
+    animation: none !important;
+  }
+  .fortymm-theme .sl-cell {
+    transition: none !important;
+  }
+}

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as AdminIndexRouteImport } from './routes/admin.index'
 import { Route as AdminUsersRouteImport } from './routes/admin.users'
 import { Route as AdminRolesRouteImport } from './routes/admin.roles'
 import { Route as AdminPermissionsRouteImport } from './routes/admin.permissions'
+import { Route as MatchesMatchIdGamesGameIdScoresNewRouteImport } from './routes/matches.$matchId.games.$gameId.scores.new'
 
 const DesignSystemRoute = DesignSystemRouteImport.update({
   id: '/design-system',
@@ -58,6 +59,12 @@ const AdminPermissionsRoute = AdminPermissionsRouteImport.update({
   path: '/permissions',
   getParentRoute: () => AdminRoute,
 } as any)
+const MatchesMatchIdGamesGameIdScoresNewRoute =
+  MatchesMatchIdGamesGameIdScoresNewRouteImport.update({
+    id: '/matches/$matchId/games/$gameId/scores/new',
+    path: '/matches/$matchId/games/$gameId/scores/new',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -68,6 +75,7 @@ export interface FileRoutesByFullPath {
   '/admin/roles': typeof AdminRolesRoute
   '/admin/users': typeof AdminUsersRoute
   '/admin/': typeof AdminIndexRoute
+  '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -77,6 +85,7 @@ export interface FileRoutesByTo {
   '/admin/roles': typeof AdminRolesRoute
   '/admin/users': typeof AdminUsersRoute
   '/admin': typeof AdminIndexRoute
+  '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -88,6 +97,7 @@ export interface FileRoutesById {
   '/admin/roles': typeof AdminRolesRoute
   '/admin/users': typeof AdminUsersRoute
   '/admin/': typeof AdminIndexRoute
+  '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -100,6 +110,7 @@ export interface FileRouteTypes {
     | '/admin/roles'
     | '/admin/users'
     | '/admin/'
+    | '/matches/$matchId/games/$gameId/scores/new'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -109,6 +120,7 @@ export interface FileRouteTypes {
     | '/admin/roles'
     | '/admin/users'
     | '/admin'
+    | '/matches/$matchId/games/$gameId/scores/new'
   id:
     | '__root__'
     | '/'
@@ -119,6 +131,7 @@ export interface FileRouteTypes {
     | '/admin/roles'
     | '/admin/users'
     | '/admin/'
+    | '/matches/$matchId/games/$gameId/scores/new'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -126,6 +139,7 @@ export interface RootRouteChildren {
   AdminRoute: typeof AdminRouteWithChildren
   DashboardRoute: typeof DashboardRoute
   DesignSystemRoute: typeof DesignSystemRoute
+  MatchesMatchIdGamesGameIdScoresNewRoute: typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -186,6 +200,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminPermissionsRouteImport
       parentRoute: typeof AdminRoute
     }
+    '/matches/$matchId/games/$gameId/scores/new': {
+      id: '/matches/$matchId/games/$gameId/scores/new'
+      path: '/matches/$matchId/games/$gameId/scores/new'
+      fullPath: '/matches/$matchId/games/$gameId/scores/new'
+      preLoaderRoute: typeof MatchesMatchIdGamesGameIdScoresNewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -210,6 +231,8 @@ const rootRouteChildren: RootRouteChildren = {
   AdminRoute: AdminRouteWithChildren,
   DashboardRoute: DashboardRoute,
   DesignSystemRoute: DesignSystemRoute,
+  MatchesMatchIdGamesGameIdScoresNewRoute:
+    MatchesMatchIdGamesGameIdScoresNewRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/web-client/src/routes/matches.$matchId.games.$gameId.scores.new.tsx
+++ b/web-client/src/routes/matches.$matchId.games.$gameId.scores.new.tsx
@@ -1,0 +1,318 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+
+export const Route = createFileRoute(
+  '/matches/$matchId/games/$gameId/scores/new',
+)({
+  component: ScoreEntryRoute,
+})
+
+/**
+ * Match context is mocked here. The matches API is not wired up yet, so this
+ * mirrors the static stubs used by the dashboard and admin routes — replace
+ * MATCH with loader-fed data once the endpoint exists. Saving a game then
+ * advances through the match instead of persisting.
+ */
+const ME = { name: 'You', initials: 'YZ' } as const
+
+type LoggedGame = { me: number; opp: number }
+type MatchGame = LoggedGame | null
+
+const MATCH = {
+  bestOf: 5,
+  rated: true,
+  opponent: { name: 'Nguyen, T.', initials: 'NT', rating: 2145, isGuest: false },
+  // Index = game number - 1. `null` marks a game that has not been played yet.
+  games: [{ me: 11, opp: 8 }, { me: 9, opp: 11 }, null, null, null] as MatchGame[],
+}
+
+function ScoreEntryRoute() {
+  const { matchId, gameId } = Route.useParams()
+  // Remount the entry form whenever the game in the URL changes so the score
+  // fields reset cleanly to that game's stored value.
+  return <ScoreEntry key={gameId} matchId={matchId} gameId={gameId} />
+}
+
+function ScoreEntry({ matchId, gameId }: { matchId: string; gameId: string }) {
+  const navigate = useNavigate()
+
+  const { bestOf, rated, opponent, games } = MATCH
+  const gamesToWin = Math.ceil(bestOf / 2)
+  const isGuest = opponent.isGuest
+
+  // The game this route targets (1-based), clamped to the match length.
+  const gameNumber = useMemo(() => {
+    const parsed = Number.parseInt(gameId, 10)
+    if (!Number.isFinite(parsed)) return 1
+    return Math.min(Math.max(parsed, 1), bestOf)
+  }, [gameId, bestOf])
+  const activeIdx = gameNumber - 1
+
+  const stored = games[activeIdx]
+  const [me, setMe] = useState(() => (stored ? String(stored.me) : ''))
+  const [opp, setOpp] = useState(() => (stored ? String(stored.opp) : ''))
+  const meRef = useRef<HTMLInputElement>(null)
+  const oppRef = useRef<HTMLInputElement>(null)
+
+  // Game tally so far, counted from every *other* logged game in the match.
+  const meWins = games.filter(
+    (g, i) => i !== activeIdx && g != null && g.me > g.opp,
+  ).length
+  const oppWins = games.filter(
+    (g, i) => i !== activeIdx && g != null && g.opp > g.me,
+  ).length
+  const matchComplete = meWins >= gamesToWin || oppWins >= gamesToWin
+  const winner = meWins > oppWins ? 'me' : oppWins > meWins ? 'opp' : null
+
+  const sanitize = (value: string) => value.replace(/[^0-9]/g, '').slice(0, 2)
+  const canSave =
+    me !== '' && opp !== '' && Number(me) !== Number(opp) && !matchComplete
+
+  function goToGame(number: number) {
+    navigate({
+      to: '/matches/$matchId/games/$gameId/scores/new',
+      params: { matchId, gameId: String(number) },
+    })
+  }
+
+  function saveGame() {
+    if (!canSave) return
+    // No persistence layer yet — advance to the next game's entry screen, or
+    // hand off to the (future) match summary once the match is decided.
+    const meScore = Number(me)
+    const oppScore = Number(opp)
+    const nextMeWins = meWins + (meScore > oppScore ? 1 : 0)
+    const nextOppWins = oppWins + (oppScore > meScore ? 1 : 0)
+    const decided = nextMeWins >= gamesToWin || nextOppWins >= gamesToWin
+    if (!decided && gameNumber < bestOf) {
+      goToGame(gameNumber + 1)
+    } else {
+      navigate({ to: '/dashboard' })
+    }
+  }
+
+  function handleKey(
+    e: React.KeyboardEvent<HTMLInputElement>,
+    side: 'me' | 'opp',
+  ) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      if (side === 'me' && me !== '') {
+        oppRef.current?.focus()
+        oppRef.current?.select()
+      } else if (side === 'opp') {
+        saveGame()
+      }
+    } else if (e.key === 'ArrowRight' && side === 'me') {
+      e.preventDefault()
+      oppRef.current?.focus()
+      oppRef.current?.select()
+    } else if (e.key === 'ArrowLeft' && side === 'opp') {
+      e.preventDefault()
+      meRef.current?.focus()
+      meRef.current?.select()
+    }
+  }
+
+  // Focus the first score field on arrival.
+  useEffect(() => {
+    const timer = setTimeout(() => meRef.current?.focus(), 60)
+    return () => clearTimeout(timer)
+  }, [])
+
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const gameLabel = `GAME ${pad(gameNumber)} OF ${pad(bestOf)}`
+  const oppName = opponent.name
+
+  return (
+    <div className="fortymm-theme dark score-entry-screen">
+      <div className="live-bar">
+        <button
+          type="button"
+          className="back"
+          onClick={() => navigate({ to: '/dashboard' })}
+        >
+          ← Back to match
+        </button>
+        <span className="tag">
+          <span className="dot" /> {gameLabel}
+        </span>
+        <span className="meta">
+          {rated && !isGuest ? 'RATED' : 'UNRATED'} · BEST OF {bestOf} · FIRST TO{' '}
+          {gamesToWin}
+        </span>
+      </div>
+
+      <div className="entry-wrap">
+        <div className="entry-head">
+          <h2>
+            {matchComplete
+              ? 'Match complete.'
+              : `Enter game ${gameNumber} score.`}
+          </h2>
+          {!matchComplete && (
+            <div className="hint">
+              <kbd>0</kbd>–<kbd>9</kbd> score &nbsp;·&nbsp; <kbd>Enter</kbd> next
+              / save game
+            </div>
+          )}
+        </div>
+
+        {/* Big side-by-side entry for the current game */}
+        <div className={`single-entry${matchComplete ? ' complete' : ''}`}>
+          <div className="se-side me">
+            <div className="se-head">
+              <div className="av">{ME.initials}</div>
+              <div>
+                <div className="nm">{ME.name}</div>
+                <div className="rt">
+                  Games won · <b>{meWins}</b>
+                </div>
+              </div>
+            </div>
+            <input
+              ref={meRef}
+              className="big-input"
+              type="text"
+              inputMode="numeric"
+              aria-label={`${ME.name} score`}
+              placeholder="0"
+              value={me}
+              disabled={matchComplete}
+              onFocus={(e) => e.target.select()}
+              onChange={(e) => setMe(sanitize(e.target.value))}
+              onKeyDown={(e) => handleKey(e, 'me')}
+            />
+          </div>
+
+          <div className="se-mid">
+            <div className="se-vs">VS</div>
+            <div className="se-games">
+              {meWins} – {oppWins}
+            </div>
+          </div>
+
+          <div className={`se-side opp${isGuest ? ' guest' : ''}`}>
+            <div className="se-head right">
+              <div>
+                <div className="nm">{oppName}</div>
+                <div className="rt">
+                  Games won · <b>{oppWins}</b>
+                </div>
+              </div>
+              <div className="av">{opponent.initials}</div>
+            </div>
+            <input
+              ref={oppRef}
+              className="big-input"
+              type="text"
+              inputMode="numeric"
+              aria-label={`${oppName} score`}
+              placeholder="0"
+              value={opp}
+              disabled={matchComplete}
+              onFocus={(e) => e.target.select()}
+              onChange={(e) => setOpp(sanitize(e.target.value))}
+              onKeyDown={(e) => handleKey(e, 'opp')}
+            />
+          </div>
+        </div>
+
+        {/* Action row */}
+        <div className="single-actions">
+          {matchComplete ? (
+            <div className="result-line">
+              <span className="trophy">▲</span>
+              <span>
+                {winner === 'me'
+                  ? `${ME.name} won the match`
+                  : `${oppName} won the match`}
+              </span>
+              <span className="dot-sep">·</span>
+              <span className="final">
+                FINAL {meWins}–{oppWins}
+              </span>
+            </div>
+          ) : (
+            <div className="result-line subtle">
+              {gameNumber < bestOf
+                ? `Save this game to continue to game ${gameNumber + 1}.`
+                : 'Final game. Save to finish the match.'}
+            </div>
+          )}
+          <div className="action-btns">
+            {!matchComplete && gameNumber > 1 && (
+              <button
+                type="button"
+                className="btn ghost"
+                onClick={() => goToGame(gameNumber - 1)}
+              >
+                ← Edit game {gameNumber - 1}
+              </button>
+            )}
+            {!matchComplete && (
+              <button
+                type="button"
+                className="btn primary"
+                disabled={!canSave}
+                onClick={saveGame}
+              >
+                {gameNumber < bestOf
+                  ? 'Save game & next →'
+                  : 'Save final game →'}
+              </button>
+            )}
+            {matchComplete && (
+              <button
+                type="button"
+                className="btn primary"
+                onClick={() => navigate({ to: '/dashboard' })}
+              >
+                Back to match
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Scoreline strip — all games in the match */}
+        <div className="scoreline">
+          <div className="sl-label">SCORELINE</div>
+          <div className="sl-cells">
+            {games.map((g, i) => {
+              const isActive = i === activeIdx
+              const logged = !isActive && g != null
+              const meVal = isActive ? me : g ? String(g.me) : ''
+              const oppVal = isActive ? opp : g ? String(g.opp) : ''
+              const meWon = !isActive && g != null && g.me > g.opp
+              const oppWon = !isActive && g != null && g.opp > g.me
+              return (
+                <button
+                  type="button"
+                  key={i}
+                  className={`sl-cell ${logged ? 'done' : 'pending'}${
+                    isActive ? ' active' : ''
+                  }`}
+                  aria-current={isActive ? 'step' : undefined}
+                  onClick={() => {
+                    if (!isActive) goToGame(i + 1)
+                  }}
+                >
+                  <div className="sl-n">G{i + 1}</div>
+                  <div className="sl-scores">
+                    <span className={`s${meWon ? ' w' : ''}`}>
+                      {meVal || '—'}
+                    </span>
+                    <span className="dash">–</span>
+                    <span className={`s${oppWon ? ' w' : ''}`}>
+                      {oppVal || '—'}
+                    </span>
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web-client/src/routes/matches.$matchId.games.$gameId.scores.new.tsx
+++ b/web-client/src/routes/matches.$matchId.games.$gameId.scores.new.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { cn } from '@/lib/utils'
 
 export const Route = createFileRoute(
   '/matches/$matchId/games/$gameId/scores/new',
@@ -10,13 +11,14 @@ export const Route = createFileRoute(
 /**
  * Match context is mocked here. The matches API is not wired up yet, so this
  * mirrors the static stubs used by the dashboard and admin routes — replace
- * MATCH with loader-fed data once the endpoint exists. Saving a game then
- * advances through the match instead of persisting.
+ * MATCH with loader-fed data once the endpoint exists. Nothing entered here is
+ * persisted: saving a game just advances through the match.
  */
 const ME = { name: 'You', initials: 'YZ' } as const
 
 type LoggedGame = { me: number; opp: number }
 type MatchGame = LoggedGame | null
+type Side = 'me' | 'opp'
 
 const MATCH = {
   bestOf: 5,
@@ -24,6 +26,12 @@ const MATCH = {
   opponent: { name: 'Nguyen, T.', initials: 'NT', rating: 2145, isGuest: false },
   // Index = game number - 1. `null` marks a game that has not been played yet.
   games: [{ me: 11, opp: 8 }, { me: 9, opp: 11 }, null, null, null] as MatchGame[],
+}
+
+function gameResult(game: LoggedGame): Side | null {
+  if (game.me > game.opp) return 'me'
+  if (game.opp > game.me) return 'opp'
+  return null
 }
 
 function ScoreEntryRoute() {
@@ -39,13 +47,13 @@ function ScoreEntry({ matchId, gameId }: { matchId: string; gameId: string }) {
   const { bestOf, rated, opponent, games } = MATCH
   const gamesToWin = Math.ceil(bestOf / 2)
   const isGuest = opponent.isGuest
+  const oppName = opponent.name
 
   // The game this route targets (1-based), clamped to the match length.
-  const gameNumber = useMemo(() => {
-    const parsed = Number.parseInt(gameId, 10)
-    if (!Number.isFinite(parsed)) return 1
-    return Math.min(Math.max(parsed, 1), bestOf)
-  }, [gameId, bestOf])
+  const parsedGame = Number.parseInt(gameId, 10)
+  const gameNumber = Number.isFinite(parsedGame)
+    ? Math.min(Math.max(parsedGame, 1), bestOf)
+    : 1
   const activeIdx = gameNumber - 1
 
   const stored = games[activeIdx]
@@ -56,10 +64,10 @@ function ScoreEntry({ matchId, gameId }: { matchId: string; gameId: string }) {
 
   // Game tally so far, counted from every *other* logged game in the match.
   const meWins = games.filter(
-    (g, i) => i !== activeIdx && g != null && g.me > g.opp,
+    (g, i) => i !== activeIdx && g != null && gameResult(g) === 'me',
   ).length
   const oppWins = games.filter(
-    (g, i) => i !== activeIdx && g != null && g.opp > g.me,
+    (g, i) => i !== activeIdx && g != null && gameResult(g) === 'opp',
   ).length
   const matchComplete = meWins >= gamesToWin || oppWins >= gamesToWin
   const winner = meWins > oppWins ? 'me' : oppWins > meWins ? 'opp' : null
@@ -77,8 +85,8 @@ function ScoreEntry({ matchId, gameId }: { matchId: string; gameId: string }) {
 
   function saveGame() {
     if (!canSave) return
-    // No persistence layer yet — advance to the next game's entry screen, or
-    // hand off to the (future) match summary once the match is decided.
+    // Advance to the next game's entry screen, or hand off to the (future)
+    // match summary once the match is decided.
     const meScore = Number(me)
     const oppScore = Number(opp)
     const nextMeWins = meWins + (meScore > oppScore ? 1 : 0)
@@ -91,10 +99,7 @@ function ScoreEntry({ matchId, gameId }: { matchId: string; gameId: string }) {
     }
   }
 
-  function handleKey(
-    e: React.KeyboardEvent<HTMLInputElement>,
-    side: 'me' | 'opp',
-  ) {
+  function handleKey(e: React.KeyboardEvent<HTMLInputElement>, side: Side) {
     if (e.key === 'Enter') {
       e.preventDefault()
       if (side === 'me' && me !== '') {
@@ -114,7 +119,7 @@ function ScoreEntry({ matchId, gameId }: { matchId: string; gameId: string }) {
     }
   }
 
-  // Focus the first score field on arrival.
+  // Defer focus briefly so it lands after the route transition settles.
   useEffect(() => {
     const timer = setTimeout(() => meRef.current?.focus(), 60)
     return () => clearTimeout(timer)
@@ -122,7 +127,6 @@ function ScoreEntry({ matchId, gameId }: { matchId: string; gameId: string }) {
 
   const pad = (n: number) => String(n).padStart(2, '0')
   const gameLabel = `GAME ${pad(gameNumber)} OF ${pad(bestOf)}`
-  const oppName = opponent.name
 
   return (
     <div className="fortymm-theme dark score-entry-screen">
@@ -158,32 +162,18 @@ function ScoreEntry({ matchId, gameId }: { matchId: string; gameId: string }) {
           )}
         </div>
 
-        {/* Big side-by-side entry for the current game */}
-        <div className={`single-entry${matchComplete ? ' complete' : ''}`}>
-          <div className="se-side me">
-            <div className="se-head">
-              <div className="av">{ME.initials}</div>
-              <div>
-                <div className="nm">{ME.name}</div>
-                <div className="rt">
-                  Games won · <b>{meWins}</b>
-                </div>
-              </div>
-            </div>
-            <input
-              ref={meRef}
-              className="big-input"
-              type="text"
-              inputMode="numeric"
-              aria-label={`${ME.name} score`}
-              placeholder="0"
-              value={me}
-              disabled={matchComplete}
-              onFocus={(e) => e.target.select()}
-              onChange={(e) => setMe(sanitize(e.target.value))}
-              onKeyDown={(e) => handleKey(e, 'me')}
-            />
-          </div>
+        <div className={cn('single-entry', matchComplete && 'complete')}>
+          <ScoreSide
+            side="me"
+            name={ME.name}
+            initials={ME.initials}
+            wins={meWins}
+            value={me}
+            inputRef={meRef}
+            disabled={matchComplete}
+            onChange={(value) => setMe(sanitize(value))}
+            onKeyDown={(e) => handleKey(e, 'me')}
+          />
 
           <div className="se-mid">
             <div className="se-vs">VS</div>
@@ -192,106 +182,99 @@ function ScoreEntry({ matchId, gameId }: { matchId: string; gameId: string }) {
             </div>
           </div>
 
-          <div className={`se-side opp${isGuest ? ' guest' : ''}`}>
-            <div className="se-head right">
-              <div>
-                <div className="nm">{oppName}</div>
-                <div className="rt">
-                  Games won · <b>{oppWins}</b>
-                </div>
-              </div>
-              <div className="av">{opponent.initials}</div>
-            </div>
-            <input
-              ref={oppRef}
-              className="big-input"
-              type="text"
-              inputMode="numeric"
-              aria-label={`${oppName} score`}
-              placeholder="0"
-              value={opp}
-              disabled={matchComplete}
-              onFocus={(e) => e.target.select()}
-              onChange={(e) => setOpp(sanitize(e.target.value))}
-              onKeyDown={(e) => handleKey(e, 'opp')}
-            />
-          </div>
+          <ScoreSide
+            side="opp"
+            name={oppName}
+            initials={opponent.initials}
+            wins={oppWins}
+            value={opp}
+            inputRef={oppRef}
+            disabled={matchComplete}
+            isGuest={isGuest}
+            onChange={(value) => setOpp(sanitize(value))}
+            onKeyDown={(e) => handleKey(e, 'opp')}
+          />
         </div>
 
-        {/* Action row */}
         <div className="single-actions">
           {matchComplete ? (
-            <div className="result-line">
-              <span className="trophy">▲</span>
-              <span>
-                {winner === 'me'
-                  ? `${ME.name} won the match`
-                  : `${oppName} won the match`}
-              </span>
-              <span className="dot-sep">·</span>
-              <span className="final">
-                FINAL {meWins}–{oppWins}
-              </span>
-            </div>
+            <>
+              <div className="result-line">
+                <span className="trophy">▲</span>
+                <span>
+                  {winner === 'me'
+                    ? `${ME.name} won the match`
+                    : `${oppName} won the match`}
+                </span>
+                <span className="dot-sep">·</span>
+                <span className="final">
+                  FINAL {meWins}–{oppWins}
+                </span>
+              </div>
+              <div className="action-btns">
+                <button
+                  type="button"
+                  className="btn primary"
+                  onClick={() => navigate({ to: '/dashboard' })}
+                >
+                  Back to match
+                </button>
+              </div>
+            </>
           ) : (
-            <div className="result-line subtle">
-              {gameNumber < bestOf
-                ? `Save this game to continue to game ${gameNumber + 1}.`
-                : 'Final game. Save to finish the match.'}
-            </div>
-          )}
-          <div className="action-btns">
-            {!matchComplete && gameNumber > 1 && (
-              <button
-                type="button"
-                className="btn ghost"
-                onClick={() => goToGame(gameNumber - 1)}
-              >
-                ← Edit game {gameNumber - 1}
-              </button>
-            )}
-            {!matchComplete && (
-              <button
-                type="button"
-                className="btn primary"
-                disabled={!canSave}
-                onClick={saveGame}
-              >
+            <>
+              <div className="result-line subtle">
                 {gameNumber < bestOf
-                  ? 'Save game & next →'
-                  : 'Save final game →'}
-              </button>
-            )}
-            {matchComplete && (
-              <button
-                type="button"
-                className="btn primary"
-                onClick={() => navigate({ to: '/dashboard' })}
-              >
-                Back to match
-              </button>
-            )}
-          </div>
+                  ? `Save this game to continue to game ${gameNumber + 1}.`
+                  : 'Final game. Save to finish the match.'}
+              </div>
+              <div className="action-btns">
+                {gameNumber > 1 && (
+                  <button
+                    type="button"
+                    className="btn ghost"
+                    onClick={() => goToGame(gameNumber - 1)}
+                  >
+                    ← Edit game {gameNumber - 1}
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className="btn primary"
+                  disabled={!canSave}
+                  onClick={saveGame}
+                >
+                  {gameNumber < bestOf
+                    ? 'Save game & next →'
+                    : 'Save final game →'}
+                </button>
+              </div>
+            </>
+          )}
         </div>
 
-        {/* Scoreline strip — all games in the match */}
         <div className="scoreline">
           <div className="sl-label">SCORELINE</div>
           <div className="sl-cells">
             {games.map((g, i) => {
               const isActive = i === activeIdx
-              const logged = !isActive && g != null
-              const meVal = isActive ? me : g ? String(g.me) : ''
-              const oppVal = isActive ? opp : g ? String(g.opp) : ''
-              const meWon = !isActive && g != null && g.me > g.opp
-              const oppWon = !isActive && g != null && g.opp > g.me
+              const cellGame = isActive ? null : g
+              const result = cellGame ? gameResult(cellGame) : null
+              const meVal = isActive ? me : cellGame ? String(cellGame.me) : ''
+              const oppVal = isActive
+                ? opp
+                : cellGame
+                  ? String(cellGame.opp)
+                  : ''
               return (
                 <button
                   type="button"
                   key={i}
-                  className={`sl-cell ${logged ? 'done' : 'pending'}${
-                    isActive ? ' active' : ''
-                  }`}
+                  className={cn(
+                    'sl-cell',
+                    cellGame ? 'done' : 'pending',
+                    isActive && 'active',
+                  )}
                   aria-current={isActive ? 'step' : undefined}
                   onClick={() => {
                     if (!isActive) goToGame(i + 1)
@@ -299,11 +282,11 @@ function ScoreEntry({ matchId, gameId }: { matchId: string; gameId: string }) {
                 >
                   <div className="sl-n">G{i + 1}</div>
                   <div className="sl-scores">
-                    <span className={`s${meWon ? ' w' : ''}`}>
+                    <span className={cn('s', result === 'me' && 'w')}>
                       {meVal || '—'}
                     </span>
                     <span className="dash">–</span>
-                    <span className={`s${oppWon ? ' w' : ''}`}>
+                    <span className={cn('s', result === 'opp' && 'w')}>
                       {oppVal || '—'}
                     </span>
                   </div>
@@ -313,6 +296,63 @@ function ScoreEntry({ matchId, gameId }: { matchId: string; gameId: string }) {
           </div>
         </div>
       </div>
+    </div>
+  )
+}
+
+function ScoreSide({
+  side,
+  name,
+  initials,
+  wins,
+  value,
+  inputRef,
+  disabled,
+  isGuest,
+  onChange,
+  onKeyDown,
+}: {
+  side: Side
+  name: string
+  initials: string
+  wins: number
+  value: string
+  inputRef: React.RefObject<HTMLInputElement | null>
+  disabled: boolean
+  isGuest?: boolean
+  onChange: (value: string) => void
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void
+}) {
+  const avatar = <div className="av">{initials}</div>
+  const identity = (
+    <div>
+      <div className="nm">{name}</div>
+      <div className="rt">
+        Games won · <b>{wins}</b>
+      </div>
+    </div>
+  )
+
+  return (
+    <div className={cn('se-side', side, side === 'opp' && isGuest && 'guest')}>
+      <div className={cn('se-head', side === 'opp' && 'right')}>
+        {side === 'opp' && identity}
+        {avatar}
+        {side === 'me' && identity}
+      </div>
+      <input
+        ref={inputRef}
+        className="big-input"
+        type="text"
+        inputMode="numeric"
+        aria-label={`${name} score`}
+        placeholder="0"
+        value={value}
+        disabled={disabled}
+        onFocus={(e) => e.target.select()}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## What

Adds the single-game score entry route `/matches/$matchId/games/$gameId/scores/new`, ported from the **"Match Settings Page v2"** design handoff (the LiveScreen / score-capture screen). It's a full-screen takeover: top bar with game label + match meta, big side-by-side score inputs with keyboard navigation, an action row, and a scoreline strip showing every game in the match.

## Design fidelity & decisions

- **Param names**: the request said `:id` twice, which no router allows — used distinct `$matchId` / `$gameId`.
- **Per-game route vs. the design's single screen**: the prototype kept all games in one screen with internal state; here each game is its own URL (scoreline cells and "save" navigate between them), keeping the full visual design.
- **Mocked match data**: there's no matches API in the schema yet, so `MATCH` is a static stub — consistent with the existing `dashboard`/`admin` route stubs. Nothing entered is persisted; saving advances through the games. **Known limitation**: editing an already-played game and saving does not update the scoreline (the stub array is immutable). Wiring to a real API + a match-detail route is a follow-up.
- **CSS** ported into `index.css` scoped under `.fortymm-theme`, reusing existing FortyMM tokens.

## Tests

- New Playwright page object + 5 e2e specs (render/context, save-button validation, advance-on-save, scoreline rendering, navigate-to-played-game).
- Full verification: `vitest` 6/6 · `lint` + `build` ✓ · Playwright e2e **76/76** (new specs + existing suites).

## Notes for review

- The `matchComplete` UI branch is faithful to the design but unreachable with the current mock data — it becomes live once real match data exists.
- Two unused CSS custom properties (`--dur-base`, `--shadow-sm`) left over from the port — trivial to drop if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)