### PR TITLE
Refactor session fetching to queryOptions, prefetch on landing page

### DIFF
--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { queryOptions, useQuery } from '@tanstack/react-query'
 import { api, unwrap } from './client'
 import type { components } from './schema'
 
@@ -7,11 +7,15 @@ export type SessionUser = components['schemas']['SessionUser']
 
 export const SESSION_QUERY_KEY = ['session'] as const
 
-export function useSession() {
-  return useQuery({
+export function sessionQueryOptions() {
+  return queryOptions({
     queryKey: SESSION_QUERY_KEY,
     queryFn: async (): Promise<Session> =>
       unwrap('load session', await api.GET('/v1/session')),
     staleTime: 1000 * 60 * 5,
   })
+}
+
+export function useSession() {
+  return useQuery(sessionQueryOptions())
 }

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -7,7 +7,6 @@ import './index.css'
 import { Toaster } from '@/components/ui/sonner'
 import { routeTree } from './routeTree.gen'
 
-const router = createRouter({ routeTree })
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -16,6 +15,7 @@ const queryClient = new QueryClient({
     },
   },
 })
+const router = createRouter({ routeTree, context: { queryClient } })
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/web-client/src/routes/__root.tsx
+++ b/web-client/src/routes/__root.tsx
@@ -1,8 +1,13 @@
-import { Outlet, createRootRoute } from '@tanstack/react-router'
+import { Outlet, createRootRouteWithContext } from '@tanstack/react-router'
+import type { QueryClient } from '@tanstack/react-query'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { ServiceWorkerUpdater } from '@/components/service-worker-updater'
 
-export const Route = createRootRoute({
+export interface RouterContext {
+  queryClient: QueryClient
+}
+
+export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootComponent,
 })
 

--- a/web-client/src/routes/index.tsx
+++ b/web-client/src/routes/index.tsx
@@ -1,6 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { sessionQueryOptions } from '@/api/session'
 import App from '../App'
 
 export const Route = createFileRoute('/')({
+  loader: ({ context: { queryClient } }) => {
+    void queryClient.prefetchQuery(sessionQueryOptions())
+  },
   component: App,
 })


### PR DESCRIPTION
## What

Refactors session fetching to TanStack Query's `queryOptions` factory pattern and prefetches the session on the landing page.

## Changes

- **`src/api/session.ts`** — Extracted `sessionQueryOptions()` using `queryOptions()`. The same options object now drives `useQuery`, `useSuspenseQuery`, `prefetchQuery`, `ensureQueryData`, etc. `useSession()` is now `useQuery(sessionQueryOptions())`; its public API (`useSession`, `SESSION_QUERY_KEY`, types) is unchanged, so `user-menu.tsx` and `rbac/users-page.tsx` needed no edits.
- **`src/routes/__root.tsx`** — `createRootRoute` → `createRootRouteWithContext<RouterContext>()` so route loaders can reach the `queryClient`.
- **`src/main.tsx`** — `queryClient` constructed before the router and passed as `createRouter({ routeTree, context: { queryClient } })`.
- **`src/routes/index.tsx`** — Added a `loader` that fire-and-forget prefetches the session (`void queryClient.prefetchQuery(sessionQueryOptions())`), warming the cache without blocking the marketing landing page render.

## Testing

- `tsc -b` — clean
- `eslint` — clean
- `vitest run` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)