### PR TITLE
Add match schema: models and migration

### DIFF
--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -1,3 +1,8 @@
+from app.models.match import Match, MatchStatus
+from app.models.match_game import MatchGame
+from app.models.match_settings import MatchSettings, VerificationPolicy
+from app.models.match_side import MatchSide
+from app.models.match_side_player import MatchSidePlayer
 from app.models.permission import Permission
 from app.models.role import Role
 from app.models.role_permission import RolePermission
@@ -6,10 +11,17 @@ from app.models.user_role import UserRole
 from app.models.user_token import UserToken
 
 __all__ = [
+    "Match",
+    "MatchGame",
+    "MatchSettings",
+    "MatchSide",
+    "MatchSidePlayer",
+    "MatchStatus",
     "Permission",
     "Role",
     "RolePermission",
     "User",
     "UserRole",
     "UserToken",
+    "VerificationPolicy",
 ]

--- a/api/app/models/match.py
+++ b/api/app/models/match.py
@@ -1,0 +1,90 @@
+import enum
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Index, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+from app.models.match_settings import MatchSettings
+
+if TYPE_CHECKING:
+    from app.models.match_game import MatchGame
+    from app.models.match_side import MatchSide
+    from app.models.match_side_player import MatchSidePlayer
+    from app.models.user import User
+
+
+class MatchStatus(enum.Enum):
+    pending = "pending"
+    in_progress = "in_progress"
+    completed = "completed"
+    disputed = "disputed"
+    voided = "voided"
+
+
+class Match(Base):
+    """Top-level match record. Thin by design; most data lives in related tables."""
+
+    __tablename__ = "matches"
+    __table_args__ = (
+        Index(
+            "ix_matches_created_by_user_id_created_at",
+            "created_by_user_id",
+            text("created_at DESC"),
+        ),
+        Index("ix_matches_status", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    match_settings_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("match_settings.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    status: Mapped[MatchStatus] = mapped_column(
+        Enum(MatchStatus, name="match_status"),
+        nullable=False,
+        server_default=MatchStatus.pending.value,
+    )
+    created_by_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    match_settings: Mapped[MatchSettings] = relationship(back_populates="matches")
+    created_by: Mapped["User"] = relationship("User")
+    sides: Mapped[list["MatchSide"]] = relationship(
+        back_populates="match",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    games: Mapped[list["MatchGame"]] = relationship(
+        back_populates="match",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    # A side player is "owned" by its MatchSide (which carries delete-orphan);
+    # this denormalized convenience collection only needs delete cascade so a
+    # deleted match takes its side players with it via the DB ON DELETE CASCADE.
+    side_players: Mapped[list["MatchSidePlayer"]] = relationship(
+        back_populates="match",
+        cascade="all",
+        passive_deletes=True,
+    )

--- a/api/app/models/match_game.py
+++ b/api/app/models/match_game.py
@@ -1,0 +1,49 @@
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    CheckConstraint,
+    ForeignKey,
+    Index,
+    SmallInteger,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.match import Match
+
+
+class MatchGame(Base):
+    """Per-game scores within a match. Each row is one game."""
+
+    __tablename__ = "match_games"
+    __table_args__ = (
+        UniqueConstraint(
+            "match_id", "game_number", name="uq_match_games_match_id_game_number"
+        ),
+        CheckConstraint("game_number >= 1", name="ck_match_games_game_number"),
+        CheckConstraint("side_1_points >= 0", name="ck_match_games_side_1_points"),
+        CheckConstraint("side_2_points >= 0", name="ck_match_games_side_2_points"),
+        Index("ix_match_games_match_id", "match_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    match_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("matches.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    game_number: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    side_1_points: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    side_2_points: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+
+    match: Mapped["Match"] = relationship(back_populates="games")

--- a/api/app/models/match_settings.py
+++ b/api/app/models/match_settings.py
@@ -1,0 +1,64 @@
+import enum
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, CheckConstraint, DateTime, Enum, SmallInteger, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.match import Match
+
+
+class VerificationPolicy(enum.Enum):
+    none = "none"
+    self_report = "self_report"
+    opponent_confirms = "opponent_confirms"
+    all_players_confirm = "all_players_confirm"
+
+
+class MatchSettings(Base):
+    """Rules and policies for a single match.
+
+    Each match owns its own row; rows are never shared between matches.
+    Future templates (tournament events, club ladders) will hold their own
+    rows that get copied at match-creation time.
+    """
+
+    __tablename__ = "match_settings"
+    __table_args__ = (
+        CheckConstraint("team_size IN (1, 2)", name="ck_match_settings_team_size"),
+        CheckConstraint(
+            "best_of >= 1 AND best_of % 2 = 1", name="ck_match_settings_best_of"
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    team_size: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    best_of: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    affects_rating: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("true")
+    )
+    verification_policy: Mapped[VerificationPolicy] = mapped_column(
+        Enum(VerificationPolicy, name="verification_policy"),
+        nullable=False,
+        server_default=VerificationPolicy.none.value,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    matches: Mapped[list["Match"]] = relationship(back_populates="match_settings")

--- a/api/app/models/match_side.py
+++ b/api/app/models/match_side.py
@@ -1,0 +1,57 @@
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    ForeignKey,
+    Index,
+    SmallInteger,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.match import Match
+    from app.models.match_side_player import MatchSidePlayer
+
+
+class MatchSide(Base):
+    """One of the two sides of a match. The unit the rating system operates on."""
+
+    __tablename__ = "match_sides"
+    __table_args__ = (
+        UniqueConstraint(
+            "match_id", "side_number", name="uq_match_sides_match_id_side_number"
+        ),
+        CheckConstraint("side_number IN (1, 2)", name="ck_match_sides_side_number"),
+        CheckConstraint("score >= 0", name="ck_match_sides_score"),
+        Index("ix_match_sides_match_id", "match_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    match_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("matches.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    side_number: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    score: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default=text("0")
+    )
+    won: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+
+    match: Mapped["Match"] = relationship(back_populates="sides")
+    players: Mapped[list["MatchSidePlayer"]] = relationship(
+        back_populates="match_side",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )

--- a/api/app/models/match_side_player.py
+++ b/api/app/models/match_side_player.py
@@ -1,0 +1,60 @@
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Index, UniqueConstraint, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.match import Match
+    from app.models.match_side import MatchSide
+    from app.models.user import User
+
+
+class MatchSidePlayer(Base):
+    """Join row placing a user on a side of a match.
+
+    One row per side for singles, two for doubles. ``match_id`` is denormalized
+    so a user can be constrained to a single side of a given match.
+    """
+
+    __tablename__ = "match_side_players"
+    __table_args__ = (
+        UniqueConstraint(
+            "match_side_id",
+            "user_id",
+            name="uq_match_side_players_match_side_id_user_id",
+        ),
+        UniqueConstraint(
+            "match_id", "user_id", name="uq_match_side_players_match_id_user_id"
+        ),
+        Index("ix_match_side_players_user_id", "user_id"),
+        Index("ix_match_side_players_match_side_id", "match_side_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    match_side_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("match_sides.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    match_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("matches.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+
+    match_side: Mapped["MatchSide"] = relationship(back_populates="players")
+    match: Mapped["Match"] = relationship(back_populates="side_players")
+    user: Mapped["User"] = relationship("User")

--- a/api/migrations/versions/20260514_0000_0004_create_match_tables.py
+++ b/api/migrations/versions/20260514_0000_0004_create_match_tables.py
@@ -1,0 +1,252 @@
+"""create match tables
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-05-14 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0004"
+down_revision: Union[str, None] = "0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Enum types are created explicitly in upgrade() via `.create(...)` and
+# referenced with create_type=False so neither op.create_table nor Alembic
+# autogenerate attempts to create them a second time.
+verification_policy_enum = postgresql.ENUM(
+    "none",
+    "self_report",
+    "opponent_confirms",
+    "all_players_confirm",
+    name="verification_policy",
+    create_type=False,
+)
+match_status_enum = postgresql.ENUM(
+    "pending",
+    "in_progress",
+    "completed",
+    "disputed",
+    "voided",
+    name="match_status",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    verification_policy_enum.create(bind, checkfirst=True)
+    match_status_enum.create(bind, checkfirst=True)
+
+    op.create_table(
+        "match_settings",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("team_size", sa.SmallInteger(), nullable=False),
+        sa.Column("best_of", sa.SmallInteger(), nullable=False),
+        sa.Column(
+            "affects_rating",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "verification_policy",
+            verification_policy_enum,
+            nullable=False,
+            server_default="none",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "team_size IN (1, 2)", name="ck_match_settings_team_size"
+        ),
+        sa.CheckConstraint(
+            "best_of >= 1 AND best_of % 2 = 1", name="ck_match_settings_best_of"
+        ),
+    )
+
+    op.create_table(
+        "matches",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "match_settings_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("match_settings.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            match_status_enum,
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column(
+            "created_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_matches_created_by_user_id_created_at",
+        "matches",
+        ["created_by_user_id", sa.text("created_at DESC")],
+    )
+    op.create_index("ix_matches_status", "matches", ["status"])
+
+    op.create_table(
+        "match_sides",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "match_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("matches.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("side_number", sa.SmallInteger(), nullable=False),
+        sa.Column(
+            "score",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("won", sa.Boolean(), nullable=True),
+        sa.UniqueConstraint(
+            "match_id", "side_number", name="uq_match_sides_match_id_side_number"
+        ),
+        sa.CheckConstraint(
+            "side_number IN (1, 2)", name="ck_match_sides_side_number"
+        ),
+        sa.CheckConstraint("score >= 0", name="ck_match_sides_score"),
+    )
+    op.create_index("ix_match_sides_match_id", "match_sides", ["match_id"])
+
+    op.create_table(
+        "match_side_players",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "match_side_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("match_sides.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "match_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("matches.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "match_side_id",
+            "user_id",
+            name="uq_match_side_players_match_side_id_user_id",
+        ),
+        sa.UniqueConstraint(
+            "match_id", "user_id", name="uq_match_side_players_match_id_user_id"
+        ),
+    )
+    op.create_index(
+        "ix_match_side_players_user_id", "match_side_players", ["user_id"]
+    )
+    op.create_index(
+        "ix_match_side_players_match_side_id",
+        "match_side_players",
+        ["match_side_id"],
+    )
+
+    op.create_table(
+        "match_games",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "match_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("matches.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("game_number", sa.SmallInteger(), nullable=False),
+        sa.Column("side_1_points", sa.SmallInteger(), nullable=False),
+        sa.Column("side_2_points", sa.SmallInteger(), nullable=False),
+        sa.UniqueConstraint(
+            "match_id", "game_number", name="uq_match_games_match_id_game_number"
+        ),
+        sa.CheckConstraint("game_number >= 1", name="ck_match_games_game_number"),
+        sa.CheckConstraint(
+            "side_1_points >= 0", name="ck_match_games_side_1_points"
+        ),
+        sa.CheckConstraint(
+            "side_2_points >= 0", name="ck_match_games_side_2_points"
+        ),
+    )
+    op.create_index("ix_match_games_match_id", "match_games", ["match_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("match_games")
+    op.drop_table("match_side_players")
+    op.drop_table("match_sides")
+    op.drop_table("matches")
+    op.drop_table("match_settings")
+
+    bind = op.get_bind()
+    match_status_enum.drop(bind, checkfirst=True)
+    verification_policy_enum.drop(bind, checkfirst=True)


### PR DESCRIPTION
## Summary

Adds the initial schema for matches and related tables — five SQLAlchemy 2.0 declarative models plus a single Alembic migration (revision `0004`). Tournament-event integration is deferred; the schema is designed to accommodate it later.

- **`match_settings`** — per-match rules (`team_size`, `best_of`, `affects_rating`, `verification_policy`) with CHECK constraints enforcing best-of being odd and `team_size IN (1, 2)`
- **`matches`** — thin top-level record with a `match_status` enum, indexed for "my recent matches" and status-filtered queries
- **`match_sides`** — the two sides of a match, the unit the rating system operates on
- **`match_side_players`** — side↔user join; `match_id` is denormalized so a user can be constrained to a single side of a match
- **`match_games`** — per-game scores

Relationships use `back_populates`. FKs to `users`/`match_settings` are `ON DELETE RESTRICT` (preserve history); FKs from child tables to `matches` are `ON DELETE CASCADE`. The migration creates the two enum types explicitly (`create_type=False`) and the five tables in dependency order; `downgrade()` reverses it cleanly, dropping tables then enum types.

## Notes

- **Revision is `0004`**, chaining after the existing RBAC migration (`0003`) on `main`.
- The new models intentionally use server-side `gen_random_uuid()` and `TIMESTAMP WITH TIME ZONE` per the schema spec — this diverges from the existing `User`/`Role` models (Python-side `uuid4`, naive `DateTime`).
- `Match.side_players` uses `cascade="all"` rather than `delete-orphan`: `MatchSide.players` is the orphan-owning relationship, while `Match.side_players` is a denormalized convenience collection torn down with the match.

## Testing

Verified end-to-end against Postgres 16:
- `alembic upgrade head` / `downgrade` / re-upgrade — clean, linear chain, single head
- `\d` inspection of all five tables — columns, `gen_random_uuid()` defaults, `timestamptz`, CHECK/UNIQUE/FK constraints, and the `(created_by_user_id, created_at DESC)` index match the spec
- ORM round-trip: creation flow → completion flow → relationship navigation → match delete cascades to sides/players/games while `match_settings` and `users` are preserved
- Constraint enforcement: rejects even `best_of`, `team_size=3`, a user on both sides, duplicate `side_number`, and deleting a user referenced by a match

Out of scope (follow-ups): ORM service layer, application-level rule validation, rating-system integration, API endpoints, and unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)