### PR TITLE
Wire match creation UI to the backend

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -5,12 +5,16 @@ from pydantic import BaseModel
 from sqlalchemy import text
 
 from app import db, queue
+from app.matches import router as matches_router
+from app.players import router as players_router
 from app.rbac import router as rbac_router
 from app.sessions import router as sessions_router
 
 app = FastAPI(title="FortyMM API")
 app.include_router(sessions_router)
 app.include_router(rbac_router)
+app.include_router(matches_router)
+app.include_router(players_router)
 
 SOLVER_HEALTH_TIMEOUT = 10.0
 

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1,0 +1,151 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.db import get_session
+from app.models import (
+    Match,
+    MatchSettings,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    User,
+)
+from app.schemas.match import (
+    MatchCreate,
+    MatchRead,
+    MatchSettingsRead,
+    MatchSidePlayerRead,
+    MatchSideRead,
+)
+from app.sessions import get_current_user
+
+router = APIRouter(prefix="/v1")
+
+
+# ----- helpers -------------------------------------------------------------
+
+
+async def _load_match(db: AsyncSession, match_id: uuid.UUID) -> Match | None:
+    """Fetch a match with every relationship the serializer touches eagerly
+    loaded — async SQLAlchemy can't lazy-load once the request is in flight."""
+    result = await db.execute(
+        select(Match)
+        .where(Match.id == match_id)
+        .options(
+            selectinload(Match.match_settings),
+            selectinload(Match.sides)
+            .selectinload(MatchSide.players)
+            .selectinload(MatchSidePlayer.user),
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+def _serialize_match(match: Match) -> MatchRead:
+    sides = sorted(match.sides, key=lambda side: side.side_number)
+    return MatchRead(
+        id=match.id,
+        status=match.status,
+        created_by_user_id=match.created_by_user_id,
+        created_at=match.created_at,
+        settings=MatchSettingsRead.model_validate(match.match_settings),
+        sides=[
+            MatchSideRead(
+                side_number=side.side_number,
+                score=side.score,
+                won=side.won,
+                players=[
+                    MatchSidePlayerRead(
+                        user_id=player.user_id, username=player.user.username
+                    )
+                    for player in sorted(
+                        side.players, key=lambda p: p.user.username
+                    )
+                ],
+            )
+            for side in sides
+        ],
+    )
+
+
+def _add_side(match: Match, side_number: int, player: User) -> None:
+    """Attach a single-player side to ``match``.
+
+    Wiring up the ``match`` relationship on both the side and the side-player
+    is what populates their (non-null, denormalized) ``match_id`` columns on
+    flush."""
+    side = MatchSide(match=match, side_number=side_number)
+    side.players.append(MatchSidePlayer(match=match, user=player))
+
+
+# ----- endpoints -----------------------------------------------------------
+
+
+@router.post(
+    "/matches", response_model=MatchRead, status_code=status.HTTP_201_CREATED
+)
+async def create_match(
+    payload: MatchCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> MatchRead:
+    opponent: User | None = None
+    if payload.opponent_user_id is not None:
+        if payload.opponent_user_id == current_user.id:
+            raise HTTPException(
+                status_code=422,
+                detail="you cannot start a match against yourself",
+            )
+        opponent = (
+            await db.execute(
+                select(User).where(User.id == payload.opponent_user_id)
+            )
+        ).scalar_one_or_none()
+        if opponent is None:
+            raise HTTPException(status_code=404, detail="opponent not found")
+
+    if payload.rated and opponent is None:
+        raise HTTPException(
+            status_code=422,
+            detail="a rated match needs a registered opponent",
+        )
+
+    # Guest / "start without opponent" matches have only the creator's side,
+    # so they can never affect ratings regardless of the requested flag.
+    affects_rating = payload.rated and opponent is not None
+
+    settings = MatchSettings(
+        team_size=1,
+        best_of=payload.best_of,
+        affects_rating=affects_rating,
+    )
+    match = Match(
+        match_settings=settings,
+        created_by_user_id=current_user.id,
+        status=MatchStatus.pending,
+    )
+    _add_side(match, 1, current_user)
+    if opponent is not None:
+        _add_side(match, 2, opponent)
+
+    db.add(match)
+    await db.commit()
+
+    created = await _load_match(db, match.id)
+    assert created is not None  # just committed; the row exists
+    return _serialize_match(created)
+
+
+@router.get("/matches/{match_id}", response_model=MatchRead)
+async def get_match(
+    match_id: uuid.UUID,
+    db: AsyncSession = Depends(get_session),
+) -> MatchRead:
+    match = await _load_match(db, match_id)
+    if match is None:
+        raise HTTPException(status_code=404, detail="match not found")
+    return _serialize_match(match)

--- a/api/app/players.py
+++ b/api/app/players.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_session
+from app.models import User
+from app.schemas.player import PlayerRead
+from app.sessions import get_current_user
+
+router = APIRouter(prefix="/v1")
+
+
+@router.get("/players", response_model=list[PlayerRead])
+async def list_players(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> list[PlayerRead]:
+    """List registered users the caller can pick as an opponent (everyone but
+    themselves)."""
+    result = await db.execute(
+        select(User)
+        .where(User.id != current_user.id)
+        .order_by(User.username)
+    )
+    return [PlayerRead.model_validate(user) for user in result.scalars().all()]

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -1,0 +1,62 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.models.match import MatchStatus
+from app.models.match_settings import VerificationPolicy
+
+# Match lengths the client offers. All odd so one side can always reach a
+# strict majority of games; the DB additionally enforces "odd and >= 1".
+ALLOWED_BEST_OF = (1, 3, 5, 7)
+
+
+class MatchCreate(BaseModel):
+    """Request body for ``POST /v1/matches``.
+
+    ``opponent_user_id`` is optional: a match created without a registered
+    opponent (a guest, or "start without opponent") gets a single side and is
+    always unrated, since the rating system needs two registered sides.
+    """
+
+    opponent_user_id: uuid.UUID | None = None
+    best_of: int = Field(description="Total games to play; one of 1, 3, 5, 7.")
+    rated: bool = True
+
+    @field_validator("best_of")
+    @classmethod
+    def _best_of_allowed(cls, value: int) -> int:
+        if value not in ALLOWED_BEST_OF:
+            allowed = ", ".join(str(n) for n in ALLOWED_BEST_OF)
+            raise ValueError(f"best_of must be one of {allowed}")
+        return value
+
+
+class MatchSidePlayerRead(BaseModel):
+    user_id: uuid.UUID
+    username: str
+
+
+class MatchSideRead(BaseModel):
+    side_number: int
+    score: int
+    won: bool | None
+    players: list[MatchSidePlayerRead]
+
+
+class MatchSettingsRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    team_size: int
+    best_of: int
+    affects_rating: bool
+    verification_policy: VerificationPolicy
+
+
+class MatchRead(BaseModel):
+    id: uuid.UUID
+    status: MatchStatus
+    created_by_user_id: uuid.UUID
+    created_at: datetime
+    settings: MatchSettingsRead
+    sides: list[MatchSideRead]

--- a/api/app/schemas/player.py
+++ b/api/app/schemas/player.py
@@ -1,0 +1,12 @@
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PlayerRead(BaseModel):
+    """A user the current player can pick as a match opponent."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    username: str

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from typing import Annotated
 
 from coolname import generate_slug
-from fastapi import APIRouter, Cookie, Depends, Response
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -109,3 +109,26 @@ async def get_session_endpoint(
             user=SessionUser(username=user.username, permissions=permissions)
         )
     )
+
+
+async def get_current_user(
+    session_cookie: Annotated[
+        str | None, Cookie(alias=SESSION_COOKIE_NAME)
+    ] = None,
+    db: AsyncSession = Depends(get_session),
+) -> User:
+    """Resolve the authenticated user from the session cookie.
+
+    Unlike ``GET /v1/session``, this dependency never mints a new session —
+    endpoints that create or mutate data require an already-established
+    session and respond ``401`` otherwise.
+    """
+    user = (
+        await _find_session_user(db, session_cookie) if session_cookie else None
+    )
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="authentication required",
+        )
+    return user

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1,0 +1,206 @@
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_session
+from app.main import app
+from app.models import Match, MatchSide, User
+
+
+@pytest_asyncio.fixture
+async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    app.dependency_overrides[get_session] = _override
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="https://testserver"
+    ) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+async def _start_session(
+    api_client: AsyncClient, db_session: AsyncSession
+) -> User:
+    """Establish a session cookie on the client; return the signed-in user."""
+    response = await api_client.get("/v1/session")
+    assert response.status_code == 200
+    username = response.json()["data"]["user"]["username"]
+    return (
+        await db_session.execute(select(User).where(User.username == username))
+    ).scalar_one()
+
+
+async def _make_user(db_session: AsyncSession, username: str) -> User:
+    user = User(username=username)
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+async def test_create_match_requires_a_session(api_client: AsyncClient):
+    response = await api_client.post("/v1/matches", json={"best_of": 5})
+    assert response.status_code == 401
+
+
+async def test_create_rated_match_with_registered_opponent(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await _start_session(api_client, db_session)
+    opponent = await _make_user(db_session, "rival")
+
+    response = await api_client.post(
+        "/v1/matches",
+        json={
+            "opponent_user_id": str(opponent.id),
+            "best_of": 5,
+            "rated": True,
+        },
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["status"] == "pending"
+    assert body["created_by_user_id"] == str(me.id)
+    assert body["settings"]["best_of"] == 5
+    assert body["settings"]["team_size"] == 1
+    assert body["settings"]["affects_rating"] is True
+
+    sides = sorted(body["sides"], key=lambda side: side["side_number"])
+    assert [side["side_number"] for side in sides] == [1, 2]
+    assert sides[0]["players"][0]["user_id"] == str(me.id)
+    assert sides[1]["players"][0]["user_id"] == str(opponent.id)
+
+    match = (await db_session.execute(select(Match))).scalar_one()
+    assert str(match.id) == body["id"]
+
+
+async def test_create_unrated_match_with_opponent(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    opponent = await _make_user(db_session, "casual-rival")
+
+    response = await api_client.post(
+        "/v1/matches",
+        json={
+            "opponent_user_id": str(opponent.id),
+            "best_of": 3,
+            "rated": False,
+        },
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["settings"]["affects_rating"] is False
+    assert len(body["sides"]) == 2
+
+
+async def test_create_match_without_opponent_has_a_single_side(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await _start_session(api_client, db_session)
+
+    response = await api_client.post(
+        "/v1/matches", json={"best_of": 7, "rated": False}
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["settings"]["affects_rating"] is False
+    assert len(body["sides"]) == 1
+    assert body["sides"][0]["side_number"] == 1
+    assert body["sides"][0]["players"][0]["user_id"] == str(me.id)
+
+    sides = (await db_session.execute(select(MatchSide))).scalars().all()
+    assert len(sides) == 1
+
+
+async def test_rated_match_without_opponent_is_rejected(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+
+    response = await api_client.post(
+        "/v1/matches", json={"best_of": 5, "rated": True}
+    )
+    assert response.status_code == 422
+    assert "rated" in response.json()["detail"].lower()
+    assert (await db_session.execute(select(Match))).first() is None
+
+
+async def test_cannot_start_a_match_against_yourself(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await _start_session(api_client, db_session)
+
+    response = await api_client.post(
+        "/v1/matches",
+        json={"opponent_user_id": str(me.id), "best_of": 5, "rated": True},
+    )
+    assert response.status_code == 422
+    assert "yourself" in response.json()["detail"].lower()
+
+
+async def test_unknown_opponent_is_rejected(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+
+    response = await api_client.post(
+        "/v1/matches",
+        json={
+            "opponent_user_id": str(uuid.uuid4()),
+            "best_of": 5,
+            "rated": True,
+        },
+    )
+    assert response.status_code == 404
+    assert "opponent" in response.json()["detail"].lower()
+
+
+async def test_even_best_of_is_rejected(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    opponent = await _make_user(db_session, "rival")
+
+    response = await api_client.post(
+        "/v1/matches",
+        json={
+            "opponent_user_id": str(opponent.id),
+            "best_of": 4,
+            "rated": True,
+        },
+    )
+    assert response.status_code == 422
+
+
+async def test_get_match_returns_the_created_match(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    opponent = await _make_user(db_session, "rival")
+    created = (
+        await api_client.post(
+            "/v1/matches",
+            json={
+                "opponent_user_id": str(opponent.id),
+                "best_of": 5,
+                "rated": True,
+            },
+        )
+    ).json()
+
+    response = await api_client.get(f"/v1/matches/{created['id']}")
+    assert response.status_code == 200
+    assert response.json() == created
+
+
+async def test_get_unknown_match_is_404(api_client: AsyncClient):
+    response = await api_client.get(f"/v1/matches/{uuid.uuid4()}")
+    assert response.status_code == 404

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -1,0 +1,44 @@
+from collections.abc import AsyncIterator
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_session
+from app.main import app
+from app.models import User
+
+
+@pytest_asyncio.fixture
+async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    app.dependency_overrides[get_session] = _override
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="https://testserver"
+    ) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+async def test_list_players_requires_a_session(api_client: AsyncClient):
+    response = await api_client.get("/v1/players")
+    assert response.status_code == 401
+
+
+async def test_list_players_excludes_the_current_user(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    session_response = await api_client.get("/v1/session")
+    my_username = session_response.json()["data"]["user"]["username"]
+
+    db_session.add_all([User(username="ana"), User(username="bo")])
+    await db_session.commit()
+
+    response = await api_client.get("/v1/players")
+    assert response.status_code == 200
+    usernames = [player["username"] for player in response.json()]
+    assert usernames == ["ana", "bo"]
+    assert my_username not in usernames

--- a/web-client/e2e/match-creation.spec.ts
+++ b/web-client/e2e/match-creation.spec.ts
@@ -1,0 +1,221 @@
+import { expect, test } from '@playwright/test'
+import { NewMatchPage } from './page-objects/matches/new-match.page'
+import { CREATOR_USERNAME } from './page-objects/matches/match-store'
+
+// Stable, explicit ids so request-body assertions can name them.
+const ADA = { id: 'pl-ada', username: 'ada.lovelace' }
+const GRACE = { id: 'pl-grace', username: 'grace.hopper' }
+const LINUS = { id: 'pl-linus', username: 'linus.torvalds' }
+
+const ROSTER = [ADA, GRACE, LINUS]
+
+// More than the six players the grid features, so the picker offers its
+// "Search all players" affordance and the typeahead becomes reachable.
+const BARBARA = { id: 'pl-barbara', username: 'barbara.liskov' }
+const BIG_ROSTER = [
+  ADA,
+  GRACE,
+  LINUS,
+  { id: 'pl-margaret', username: 'margaret.hamilton' },
+  { id: 'pl-katherine', username: 'katherine.johnson' },
+  { id: 'pl-radia', username: 'radia.perlman' },
+  BARBARA,
+]
+
+test.describe('New match — page', () => {
+  test('renders the setup card for the signed-in player', async ({ page }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await expect(nm.heading).toBeVisible()
+    await expect(nm.youName).toHaveText(CREATOR_USERNAME)
+    await expect(nm.startButton).toBeEnabled()
+    // Rated is on by default before an opponent is chosen.
+    await expect(nm.ratedSwitch).toBeChecked()
+  })
+
+  test('lists the registered players in the picker', async ({ page }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    for (const player of ROSTER) {
+      await expect(nm.playerChip(player.username)).toBeVisible()
+    }
+  })
+
+  test('shows an empty state when there are no other players', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: [] })
+
+    await expect(nm.emptyPlayers).toBeVisible()
+  })
+})
+
+test.describe('New match — validation', () => {
+  test('blocks a rated match with no opponent and sends no request', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.start()
+
+    await expect(nm.error).toHaveText(/rated match needs an opponent/i)
+    await expect(page).toHaveURL(/\/matches\/new$/)
+    expect(nm.store.createdMatches).toHaveLength(0)
+  })
+})
+
+test.describe('New match — creating a match', () => {
+  test('creates a rated match against a registered opponent', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.pickPlayer(GRACE.username)
+    await expect(nm.selectedOpponentName).toHaveText(GRACE.username)
+    await expect(nm.summaryTop).toContainText('You vs')
+    await nm.start()
+
+    await expect(page).toHaveURL(/\/dashboard$/)
+    expect(nm.store.createdMatches).toEqual([
+      { opponent_user_id: GRACE.id, best_of: 5, rated: true },
+    ])
+  })
+
+  test('respects the chosen match length', async ({ page }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.pickPlayer(ADA.username)
+    await nm.setBestOf(7)
+    await expect(nm.bestOfOption(7)).toHaveAttribute('aria-checked', 'true')
+    await expect(nm.summarySub).toContainText('Best of 7 · first to 4')
+    await nm.start()
+
+    await expect(page).toHaveURL(/\/dashboard$/)
+    expect(nm.store.createdMatches).toEqual([
+      { opponent_user_id: ADA.id, best_of: 7, rated: true },
+    ])
+  })
+
+  test('creates an unrated match when Rated is toggled off', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.pickPlayer(ADA.username)
+    await nm.toggleRated()
+    await expect(nm.ratedSwitch).not.toBeChecked()
+    await expect(nm.summarySub).toContainText('Unrated')
+    await nm.start()
+
+    await expect(page).toHaveURL(/\/dashboard$/)
+    expect(nm.store.createdMatches).toEqual([
+      { opponent_user_id: ADA.id, best_of: 5, rated: false },
+    ])
+  })
+
+  test('starts a single-sided unrated match without an opponent', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.startWithoutOpponent()
+    await nm.start()
+
+    await expect(page).toHaveURL(/\/dashboard$/)
+    expect(nm.store.createdMatches).toEqual([
+      { opponent_user_id: null, best_of: 5, rated: false },
+    ])
+  })
+
+  test('forces a guest match unrated regardless of the toggle', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.addGuest()
+    // A guest can't be rated, so the switch is disabled and off.
+    await expect(nm.ratedSwitch).toBeDisabled()
+    await expect(nm.ratedSwitch).not.toBeChecked()
+    await expect(nm.summarySub).toContainText('Unrated')
+    await nm.start()
+
+    await expect(page).toHaveURL(/\/dashboard$/)
+    expect(nm.store.createdMatches).toEqual([
+      { opponent_user_id: null, best_of: 5, rated: false },
+    ])
+  })
+})
+
+test.describe('New match — picking an opponent', () => {
+  test('swaps the opponent via Change', async ({ page }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.pickPlayer(ADA.username)
+    await expect(nm.selectedOpponentName).toHaveText(ADA.username)
+
+    await nm.changeOpponent()
+    await nm.pickPlayer(LINUS.username)
+    await expect(nm.selectedOpponentName).toHaveText(LINUS.username)
+
+    await nm.start()
+    await expect(page).toHaveURL(/\/dashboard$/)
+    expect(nm.store.createdMatches).toEqual([
+      { opponent_user_id: LINUS.id, best_of: 5, rated: true },
+    ])
+  })
+
+  test('finds a player through typeahead search', async ({ page }) => {
+    const nm = await NewMatchPage.open(page, { players: BIG_ROSTER })
+
+    await nm.openSearch()
+    await nm.search('liskov')
+    await nm.searchResult(BARBARA.username).click()
+
+    await expect(nm.selectedOpponentName).toHaveText(BARBARA.username)
+    await nm.start()
+
+    await expect(page).toHaveURL(/\/dashboard$/)
+    expect(nm.store.createdMatches).toEqual([
+      { opponent_user_id: BARBARA.id, best_of: 5, rated: true },
+    ])
+  })
+})
+
+test.describe('New match — error handling', () => {
+  test('surfaces the API error detail inline', async ({ page }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+    nm.store.failNextCreate({ status: 404, detail: 'opponent not found' })
+
+    await nm.pickPlayer(GRACE.username)
+    await nm.start()
+
+    await expect(nm.error).toHaveText(/opponent not found/i)
+    // The failed create leaves the player on the form, not the dashboard.
+    await expect(page).toHaveURL(/\/matches\/new$/)
+  })
+
+  test('lets the player retry after a failed create', async ({ page }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+    nm.store.failNextCreate({ status: 500, detail: 'database unavailable' })
+
+    await nm.pickPlayer(GRACE.username)
+    await nm.start()
+    await expect(nm.error).toHaveText(/database unavailable/i)
+
+    // Only the first create was queued to fail — the retry goes through.
+    await nm.start()
+    await expect(page).toHaveURL(/\/dashboard$/)
+    expect(nm.store.createdMatches).toHaveLength(2)
+  })
+})
+
+test.describe('New match — navigation', () => {
+  test('Cancel returns to the dashboard', async ({ page }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.cancelButton.click()
+
+    await expect(page).toHaveURL(/\/dashboard$/)
+    expect(nm.store.createdMatches).toHaveLength(0)
+  })
+})

--- a/web-client/e2e/page-objects/matches/match-store.ts
+++ b/web-client/e2e/page-objects/matches/match-store.ts
@@ -1,0 +1,118 @@
+import type { Page, Request as PWRequest, Route } from '@playwright/test'
+import type { components } from '../../../src/api/schema'
+import { matchResponse, sessionResponse } from '../../../src/test/factories'
+
+type Player = components['schemas']['PlayerRead']
+type MatchCreate = components['schemas']['MatchCreate']
+
+/** Username the mocked session resolves to — the "You" side of every match. */
+export const CREATOR_USERNAME = 'rita.kovac'
+
+const SESSION = sessionResponse({ user: { username: CREATOR_USERNAME } })
+
+export interface FailureSpec {
+  status: number
+  /** `detail` string the API would return; the form surfaces it inline. */
+  detail?: string
+  /** Hold the response this many ms before replying. */
+  delayMs?: number
+}
+
+export interface MatchStoreSeed {
+  /** Registered players the opponent picker can choose from. */
+  players?: Player[]
+}
+
+/**
+ * Mocks the three endpoints the New Match page touches — `GET /v1/session`,
+ * `GET /v1/players`, and `POST /v1/matches` — entirely in the browser via
+ * `page.route`, so the e2e suite never needs a live API. Records every
+ * create-match body the client sends so specs can assert on the payload.
+ */
+export class MatchStore {
+  readonly creatorUsername = CREATOR_USERNAME
+  /** Bodies of every `POST /v1/matches`, in the order the client sent them. */
+  readonly createdMatches: MatchCreate[] = []
+
+  private readonly players: Player[]
+  private readonly createFailures: FailureSpec[] = []
+
+  constructor(seed: MatchStoreSeed = {}) {
+    this.players = seed.players ?? []
+  }
+
+  /**
+   * Queue a failure for the next `POST /v1/matches`. Call once per failure you
+   * want — later creates succeed, which makes retry-after-error testable.
+   */
+  failNextCreate(spec: FailureSpec): void {
+    this.createFailures.push({ ...spec })
+  }
+
+  async install(page: Page): Promise<void> {
+    await page.route('**/api/v1/**', (route) => this.handle(route))
+  }
+
+  private async handle(route: Route): Promise<void> {
+    const request = route.request()
+    const method = request.method()
+    const path = new URL(request.url()).pathname.replace(/^\/api/, '')
+
+    if (path === '/v1/session') {
+      return this.json(route, 200, SESSION)
+    }
+    if (path === '/v1/players' && method === 'GET') {
+      return this.json(route, 200, this.players)
+    }
+    if (path === '/v1/matches' && method === 'POST') {
+      return this.handleCreate(route, request)
+    }
+    return this.json(route, 404, { detail: `unmocked ${method} ${path}` })
+  }
+
+  private async handleCreate(route: Route, request: PWRequest): Promise<void> {
+    const body = readJson(request) as MatchCreate
+    this.createdMatches.push(body)
+
+    const failure = this.createFailures.shift()
+    if (failure) {
+      if (failure.delayMs) await wait(failure.delayMs)
+      return this.json(route, failure.status, {
+        detail: failure.detail ?? `mock ${failure.status}`,
+      })
+    }
+
+    const opponent =
+      body.opponent_user_id == null
+        ? null
+        : (this.players.find((p) => p.id === body.opponent_user_id) ?? null)
+
+    return this.json(
+      route,
+      201,
+      matchResponse({
+        creatorUsername: this.creatorUsername,
+        opponent,
+        bestOf: body.best_of,
+        rated: body.rated,
+      }),
+    )
+  }
+
+  private json(route: Route, status: number, body: unknown): Promise<void> {
+    return route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    })
+  }
+}
+
+function readJson(request: PWRequest): unknown {
+  const text = request.postData()
+  return text ? JSON.parse(text) : undefined
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/web-client/e2e/page-objects/matches/new-match.page.ts
+++ b/web-client/e2e/page-objects/matches/new-match.page.ts
@@ -1,0 +1,110 @@
+import type { Locator, Page } from '@playwright/test'
+import { MatchStore, type MatchStoreSeed } from './match-store'
+
+/** Best-of value → the segmented control's label, used to target each radio. */
+const BEST_OF_LABEL: Record<number, string> = {
+  1: 'Single',
+  3: 'Short',
+  5: 'Std',
+  7: 'Long',
+}
+
+/**
+ * Page object for `/matches/new`. `open()` installs a `MatchStore` mock,
+ * navigates, and waits for the card to render; everything else is a thin
+ * locator or a small action wrapper.
+ */
+export class NewMatchPage {
+  readonly heading: Locator
+  readonly youName: Locator
+  readonly startButton: Locator
+  readonly cancelButton: Locator
+  readonly error: Locator
+  readonly ratedSwitch: Locator
+  readonly selectedOpponentName: Locator
+  readonly summaryTop: Locator
+  readonly summarySub: Locator
+  readonly emptyPlayers: Locator
+
+  static async open(
+    page: Page,
+    seed: MatchStoreSeed = {},
+  ): Promise<NewMatchPage> {
+    const store = new MatchStore(seed)
+    await store.install(page)
+    await page.goto('/matches/new')
+    const pom = new NewMatchPage(page, store)
+    await pom.heading.waitFor()
+    return pom
+  }
+
+  constructor(
+    public readonly page: Page,
+    public readonly store: MatchStore,
+  ) {
+    this.heading = page.getByRole('heading', { level: 1, name: /new match/i })
+    this.youName = page.locator('.nm-you-strip .name')
+    this.startButton = page.getByRole('button', { name: /start match/i })
+    this.cancelButton = page.getByRole('button', { name: /^cancel$/i })
+    this.error = page.getByRole('alert')
+    this.ratedSwitch = page.getByRole('switch', { name: /rated match/i })
+    this.selectedOpponentName = page.locator('.nm-selected .name')
+    this.summaryTop = page.locator('.nm-summary .top')
+    this.summarySub = page.locator('.nm-summary .sub')
+    this.emptyPlayers = page.getByText(/no other players yet/i)
+  }
+
+  /** A registered-player chip in the default picker grid. */
+  playerChip(username: string): Locator {
+    return this.page.locator('.nm-chip', { hasText: username })
+  }
+
+  /** A row in the typeahead search dropdown. */
+  searchResult(username: string): Locator {
+    return this.page.locator('.nm-item', { hasText: username })
+  }
+
+  async pickPlayer(username: string): Promise<void> {
+    await this.playerChip(username).click()
+  }
+
+  async addGuest(): Promise<void> {
+    await this.page.getByRole('button', { name: /add guest opponent/i }).click()
+  }
+
+  async startWithoutOpponent(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: /start without opponent/i })
+      .click()
+  }
+
+  async changeOpponent(): Promise<void> {
+    await this.page.getByRole('button', { name: /^change$/i }).click()
+  }
+
+  async openSearch(): Promise<void> {
+    await this.page
+      .getByRole('button', { name: /search all players/i })
+      .click()
+  }
+
+  async search(term: string): Promise<void> {
+    await this.page.getByPlaceholder(/search by username/i).fill(term)
+  }
+
+  bestOfOption(games: number): Locator {
+    return this.page.getByRole('radio', { name: BEST_OF_LABEL[games] })
+  }
+
+  async setBestOf(games: number): Promise<void> {
+    await this.bestOfOption(games).click()
+  }
+
+  async toggleRated(): Promise<void> {
+    await this.ratedSwitch.click()
+  }
+
+  async start(): Promise<void> {
+    await this.startButton.click()
+  }
+}

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { api, unwrap } from './client'
+import type { components } from './schema'
+
+export type Player = components['schemas']['PlayerRead']
+export type Match = components['schemas']['MatchRead']
+export type MatchCreate = components['schemas']['MatchCreate']
+
+export const PLAYERS_QUERY_KEY = ['players'] as const
+
+/** Registered users the signed-in player can pick as an opponent. */
+export function usePlayers() {
+  return useQuery({
+    queryKey: PLAYERS_QUERY_KEY,
+    queryFn: async (): Promise<Player[]> =>
+      unwrap('load players', await api.GET('/v1/players')),
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+/**
+ * Creates a match. Callers await `mutateAsync` so they can surface the API's
+ * 4xx `detail` inline on the form — no global error toast is attached here.
+ */
+export function useCreateMatch() {
+  return useMutation({
+    mutationFn: async (input: MatchCreate): Promise<Match> =>
+      unwrap('create match', await api.POST('/v1/matches', { body: input })),
+  })
+}

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -148,6 +148,61 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/matches": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Match */
+        post: operations["create_match_v1_matches_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/matches/{match_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Match */
+        get: operations["get_match_v1_matches__match_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/players": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Players
+         * @description List registered users the caller can pick as an opponent (everyone but
+         *     themselves).
+         */
+        get: operations["list_players_v1_players_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/health": {
         parameters: {
             query?: never;
@@ -189,6 +244,86 @@ export interface components {
             database: components["schemas"]["ComponentHealth"];
             solver: components["schemas"]["ComponentHealth"];
         };
+        /**
+         * MatchCreate
+         * @description Request body for ``POST /v1/matches``.
+         *
+         *     ``opponent_user_id`` is optional: a match created without a registered
+         *     opponent (a guest, or "start without opponent") gets a single side and is
+         *     always unrated, since the rating system needs two registered sides.
+         */
+        MatchCreate: {
+            /** Opponent User Id */
+            opponent_user_id?: string | null;
+            /**
+             * Best Of
+             * @description Total games to play; one of 1, 3, 5, 7.
+             */
+            best_of: number;
+            /**
+             * Rated
+             * @default true
+             */
+            rated: boolean;
+        };
+        /** MatchRead */
+        MatchRead: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            status: components["schemas"]["MatchStatus"];
+            /**
+             * Created By User Id
+             * Format: uuid
+             */
+            created_by_user_id: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            settings: components["schemas"]["MatchSettingsRead"];
+            /** Sides */
+            sides: components["schemas"]["MatchSideRead"][];
+        };
+        /** MatchSettingsRead */
+        MatchSettingsRead: {
+            /** Team Size */
+            team_size: number;
+            /** Best Of */
+            best_of: number;
+            /** Affects Rating */
+            affects_rating: boolean;
+            verification_policy: components["schemas"]["VerificationPolicy"];
+        };
+        /** MatchSidePlayerRead */
+        MatchSidePlayerRead: {
+            /**
+             * User Id
+             * Format: uuid
+             */
+            user_id: string;
+            /** Username */
+            username: string;
+        };
+        /** MatchSideRead */
+        MatchSideRead: {
+            /** Side Number */
+            side_number: number;
+            /** Score */
+            score: number;
+            /** Won */
+            won: boolean | null;
+            /** Players */
+            players: components["schemas"]["MatchSidePlayerRead"][];
+        };
+        /**
+         * MatchStatus
+         * @enum {string}
+         */
+        MatchStatus: "pending" | "in_progress" | "completed" | "disputed" | "voided";
         /** PermissionCreate */
         PermissionCreate: {
             /** Name */
@@ -224,6 +359,19 @@ export interface components {
             name?: string | null;
             /** Description */
             description?: string | null;
+        };
+        /**
+         * PlayerRead
+         * @description A user the current player can pick as a match opponent.
+         */
+        PlayerRead: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Username */
+            username: string;
         };
         /** RbacUserCreate */
         RbacUserCreate: {
@@ -324,6 +472,11 @@ export interface components {
             /** Context */
             ctx?: Record<string, never>;
         };
+        /**
+         * VerificationPolicy
+         * @enum {string}
+         */
+        VerificationPolicy: "none" | "self_report" | "opponent_confirms" | "all_players_confirm";
     };
     responses: never;
     parameters: never;
@@ -795,6 +948,103 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RbacUserRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_match_v1_matches_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MatchCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_match_v1_matches__match_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                match_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_players_v1_players_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlayerRead"][];
                 };
             };
             /** @description Validation Error */

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -1,10 +1,26 @@
 import { delay, http, HttpResponse } from 'msw'
-import { healthCheck, sessionResponse } from '@/test/factories'
+import type { components } from '@/api/schema'
+import {
+  healthCheck,
+  matchResponse,
+  player,
+  sessionResponse,
+} from '@/test/factories'
 import { createRbacState, dispatchRbac } from './rbac-engine'
 import { DEMO_SEED } from './rbac-store'
 
 export const mockSession = sessionResponse({ user: { username: 'rita.kovac' } })
 export const mockHealthy = healthCheck()
+
+export const mockPlayers = [
+  player({ username: 'nguyen.t' }),
+  player({ username: 'okafor.d' }),
+  player({ username: 'silva.r' }),
+  player({ username: 'patel.m' }),
+  player({ username: 'johansen.a' }),
+  player({ username: 'chen.w' }),
+  player({ username: 'park.j' }),
+]
 
 const state = createRbacState(DEMO_SEED)
 
@@ -50,6 +66,26 @@ export const handlers = [
   http.get('*/v1/session', async () => {
     await delay(600)
     return HttpResponse.json(mockSession)
+  }),
+  http.get('*/v1/players', async () => {
+    await delay(300)
+    return HttpResponse.json(mockPlayers)
+  }),
+  http.post('*/v1/matches', async ({ request }) => {
+    await delay(400)
+    const body = (await readJson(request)) as components['schemas']['MatchCreate']
+    const opponent = body.opponent_user_id
+      ? (mockPlayers.find((p) => p.id === body.opponent_user_id) ?? null)
+      : null
+    return HttpResponse.json(
+      matchResponse({
+        creatorUsername: mockSession.data.user.username,
+        opponent,
+        bestOf: body.best_of,
+        rated: body.rated,
+      }),
+      { status: 201 },
+    )
   }),
   ...RBAC_PATHS.flatMap((path) => [
     http.get(path, rbacHandler),

--- a/web-client/src/routes/matches/new.css
+++ b/web-client/src/routes/matches/new.css
@@ -595,15 +595,6 @@
   font: 600 15px var(--font-ui);
   color: var(--fg-1);
 }
-.nm-rated-info .t .delta {
-  padding: 2px 6px;
-  background: var(--bg-accent-soft);
-  border-radius: 4px;
-  font: 700 12px var(--font-mono);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 0.04em;
-  color: var(--ball-500);
-}
 .nm-rated-info .d {
   margin-top: 2px;
   font: 400 12px var(--font-ui);
@@ -652,6 +643,12 @@
   margin: 0 10px;
   color: var(--ink-500);
 }
+.nm-summary .read .nm-error {
+  margin-top: 6px;
+  font: 500 12px var(--font-ui);
+  line-height: 1.4;
+  color: var(--loss, #ef4444);
+}
 .nm-summary .actions {
   display: flex;
   flex-shrink: 0;
@@ -697,6 +694,14 @@
 .nm-btn-primary:focus-visible {
   outline: 2px solid var(--ball-400);
   outline-offset: 2px;
+}
+.nm-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.nm-btn-primary:disabled:hover {
+  background: var(--ball-500);
+  box-shadow: none;
 }
 
 /* --- Responsive --- */

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import type { components } from '@/api/schema'
+import { server } from '@/mocks/server'
+import { Route } from './new'
+
+type MatchRead = components['schemas']['MatchRead']
+
+// The page component isn't exported (route files should only export `Route`,
+// so the router plugin can code-split them) — pull it off the route instead.
+const NewMatchPage = Route.options.component!
+
+function pendingMatch(): MatchRead {
+  return {
+    id: 'm-test',
+    status: 'pending',
+    created_by_user_id: 'u-test',
+    created_at: '2026-05-14T00:00:00Z',
+    settings: {
+      team_size: 1,
+      best_of: 5,
+      affects_rating: false,
+      verification_policy: 'none',
+    },
+    sides: [],
+  }
+}
+
+// NewMatchPage navigates to /dashboard on success, so the test router needs
+// both routes mounted.
+function renderNewMatch() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute()
+  const newMatchRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches/new',
+    component: NewMatchPage,
+  })
+  const dashboardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/dashboard',
+    component: () => <div>Dashboard route</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([newMatchRoute, dashboardRoute]),
+    history: createMemoryHistory({ initialEntries: ['/matches/new'] }),
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('NewMatchPage', () => {
+  it('blocks a rated match with no opponent and shows an inline error', async () => {
+    const user = userEvent.setup()
+    renderNewMatch()
+
+    // Rated is on by default and no opponent is picked yet.
+    await user.click(
+      await screen.findByRole('button', { name: /start match/i }),
+    )
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /rated match needs an opponent/i,
+    )
+    // Still on the match page — nothing was submitted.
+    expect(
+      screen.getByRole('heading', { level: 1, name: /new match/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('creates a match against a picked opponent and navigates to the dashboard', async () => {
+    const user = userEvent.setup()
+    let captured: unknown = null
+    server.use(
+      http.get('*/v1/players', () =>
+        HttpResponse.json([
+          { id: 'pl-1', username: 'ada.lovelace' },
+          { id: 'pl-2', username: 'grace.hopper' },
+        ]),
+      ),
+      http.post('*/v1/matches', async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json(pendingMatch(), { status: 201 })
+      }),
+    )
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    )
+    await user.click(screen.getByRole('button', { name: /start match/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText('Dashboard route')).toBeInTheDocument(),
+    )
+    expect(captured).toEqual({
+      opponent_user_id: 'pl-1',
+      best_of: 5,
+      rated: true,
+    })
+  })
+
+  it('starts a single-sided unrated match when no opponent is chosen', async () => {
+    const user = userEvent.setup()
+    let captured: unknown = null
+    server.use(
+      http.post('*/v1/matches', async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json(pendingMatch(), { status: 201 })
+      }),
+    )
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /start without opponent/i }),
+    )
+    await user.click(screen.getByRole('button', { name: /start match/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText('Dashboard route')).toBeInTheDocument(),
+    )
+    // Guest / TBD opponents can't be rated, so `rated` is forced false.
+    expect(captured).toEqual({
+      opponent_user_id: null,
+      best_of: 5,
+      rated: false,
+    })
+  })
+
+  it('surfaces the API error detail when match creation fails', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/players', () =>
+        HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }]),
+      ),
+      http.post('*/v1/matches', () =>
+        HttpResponse.json(
+          { detail: 'opponent not found' },
+          { status: 404 },
+        ),
+      ),
+    )
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    )
+    await user.click(screen.getByRole('button', { name: /start match/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /opponent not found/i,
+    )
+  })
+})

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { ArrowRight, Search } from 'lucide-react'
+import { z } from 'zod'
 
 import { AppShell } from '@/components/app-shell'
+import { ApiError } from '@/api/client'
+import { useSession } from '@/api/session'
+import { useCreateMatch, usePlayers, type Player } from '@/api/matches'
 import { cn } from '@/lib/utils'
 import './new.css'
 
@@ -11,71 +15,62 @@ export const Route = createFileRoute('/matches/new')({
 })
 
 /* ------------------------------------------------------------------ */
-/*  Mock data — no backend wired up yet, this is UI only.             */
+/*  Opponent model                                                    */
 /* ------------------------------------------------------------------ */
 
-type PlayerKind = 'registered' | 'guest' | 'tbd'
+type OpponentKind = 'registered' | 'guest' | 'tbd'
 
-interface Player {
+interface Opponent {
+  /** A real user id for `registered`; a sentinel string for guest / tbd. */
   id: string
-  kind: PlayerKind
+  kind: OpponentKind
   name: string
-  initials: string
-  rating: number | null
-  club: string
-  lastPlayed: string
-  recent: boolean
 }
 
-const ME = { id: 'me', name: 'You', initials: 'YZ', rating: 1742 }
+const GUEST: Opponent = { id: 'guest', kind: 'guest', name: 'Guest player' }
+const OPPONENT_TBD: Opponent = { id: 'tbd', kind: 'tbd', name: 'Opponent TBD' }
 
-const PLAYERS: Player[] = [
-  { id: 'p1', kind: 'registered', name: 'Nguyen, T.', initials: 'NT', rating: 2145, club: 'Hanoi TT', lastPlayed: '3 days ago', recent: true },
-  { id: 'p2', kind: 'registered', name: 'Okafor, D.', initials: 'OD', rating: 1988, club: 'Lagos Club', lastPlayed: '1 week ago', recent: true },
-  { id: 'p3', kind: 'registered', name: 'Silva, R.', initials: 'SR', rating: 1820, club: 'São Paulo', lastPlayed: 'Yesterday', recent: true },
-  { id: 'p4', kind: 'registered', name: 'Patel, M.', initials: 'PM', rating: 1756, club: 'Hanoi TT', lastPlayed: '2 weeks ago', recent: true },
-  { id: 'p5', kind: 'registered', name: 'Johansen, A.', initials: 'JA', rating: 1912, club: 'Oslo Bat', lastPlayed: '—', recent: false },
-  { id: 'p6', kind: 'registered', name: 'Chen, W.', initials: 'CW', rating: 1680, club: 'Hanoi TT', lastPlayed: '—', recent: false },
-  { id: 'p7', kind: 'registered', name: 'Park, J.', initials: 'PJ', rating: 2041, club: 'Seoul Open', lastPlayed: '—', recent: false },
-  { id: 'p8', kind: 'registered', name: 'Tran, L.', initials: 'TL', rating: 1604, club: 'Hanoi TT', lastPlayed: '—', recent: false },
-  { id: 'p9', kind: 'registered', name: 'Rossi, G.', initials: 'RG', rating: 1845, club: 'Roma TT', lastPlayed: '—', recent: false },
-  { id: 'p10', kind: 'registered', name: 'Dubois, C.', initials: 'DC', rating: 1720, club: 'Paris Smash', lastPlayed: '—', recent: false },
-]
-
-const RECENT_PLAYERS = PLAYERS.filter((p) => p.recent)
-
-const GUEST: Player = {
-  id: 'guest',
-  kind: 'guest',
-  name: 'Guest player',
-  initials: '?',
-  rating: null,
-  club: '',
-  lastPlayed: '',
-  recent: false,
+function registeredOpponent(player: Player): Opponent {
+  return { id: player.id, kind: 'registered', name: player.username }
 }
 
-const OPPONENT_TBD: Player = {
-  id: 'tbd',
-  kind: 'tbd',
-  name: 'Opponent TBD',
-  initials: '?',
-  rating: null,
-  club: '',
-  lastPlayed: '',
-  recent: false,
+/** Two-letter monogram for an avatar bubble. */
+function initialsOf(name: string): string {
+  const parts = name.split(/[^a-zA-Z0-9]+/).filter(Boolean)
+  const letters =
+    parts.length >= 2
+      ? parts[0][0] + parts[1][0]
+      : name.replace(/[^a-zA-Z0-9]/g, '').slice(0, 2)
+  return letters.toUpperCase() || '?'
 }
 
 /** Whether a match against this opponent can count toward ratings. */
-function canRate(opponent: Player | null) {
+function canRate(opponent: Opponent | null) {
   return !opponent || opponent.kind === 'registered'
 }
 
-/** Feel-good Elo-ish swing preview — not a real rating calculation. */
-function estimateDelta(myRating: number, oppRating: number) {
-  const mod = Math.max(-8, Math.min(8, Math.round((oppRating - myRating) / 60)))
-  return 16 + mod
-}
+/* ------------------------------------------------------------------ */
+/*  Validation                                                        */
+/* ------------------------------------------------------------------ */
+
+// The backend independently enforces these rules; the client copy gives
+// immediate, inline feedback before a round-trip. The two refinements are
+// ordered so the rated-specific message wins when both would apply.
+const matchFormSchema = z
+  .object({
+    opponentKind: z.enum(['registered', 'guest', 'tbd']).nullable(),
+    rated: z.boolean(),
+    bestOf: z.number(),
+  })
+  .refine((value) => !(value.rated && value.opponentKind === null), {
+    message:
+      'A rated match needs an opponent — pick one, or switch off Rated to play without one.',
+    path: ['opponent'],
+  })
+  .refine((value) => value.opponentKind !== null, {
+    message: "Choose an opponent, or pick 'Start without opponent'.",
+    path: ['opponent'],
+  })
 
 /* ------------------------------------------------------------------ */
 /*  Page                                                              */
@@ -101,25 +96,56 @@ function NewMatchPage() {
 /* ------------------------------------------------------------------ */
 
 function MatchCard() {
-  const [opponent, setOpponent] = useState<Player | null>(null)
+  const navigate = useNavigate()
+  const { data: session } = useSession()
+  const { data: players = [], isLoading: playersLoading } = usePlayers()
+  const createMatch = useCreateMatch()
+
+  const [opponent, setOpponent] = useState<Opponent | null>(null)
   const [bestOf, setBestOf] = useState(5)
   const [rated, setRated] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const me = session?.data.user ?? null
+
+  async function handleSubmit() {
+    const parsed = matchFormSchema.safeParse({
+      opponentKind: opponent?.kind ?? null,
+      rated,
+      bestOf,
+    })
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? 'Check the match setup.')
+      return
+    }
+    setError(null)
+
+    // Guest / "start without opponent" matches have a single side, so they
+    // can never be rated regardless of the toggle.
+    const isRegistered = opponent?.kind === 'registered'
+    try {
+      await createMatch.mutateAsync({
+        opponent_user_id: isRegistered ? opponent.id : null,
+        best_of: bestOf,
+        rated: isRegistered && rated,
+      })
+      navigate({ to: '/dashboard' })
+    } catch (err) {
+      setError(
+        err instanceof ApiError
+          ? (err.detail ?? err.message)
+          : 'Could not start the match. Try again.',
+      )
+    }
+  }
 
   return (
     <div className="nm-card">
       <div className="nm-you-strip">
-        <div className="av">{ME.initials}</div>
+        <div className="av">{me ? initialsOf(me.username) : '··'}</div>
         <div className="block">
           <span className="lbl">You</span>
-          <span className="name">{ME.name}</span>
-        </div>
-        <div className="stats">
-          <span>
-            Rating <b>{ME.rating}</b>
-          </span>
-          <span className="streak">
-            Streak <b>W4</b>
-          </span>
+          <span className="name">{me?.username ?? 'Loading…'}</span>
         </div>
       </div>
 
@@ -141,7 +167,11 @@ function MatchCard() {
             onChange={() => setOpponent(null)}
           />
         ) : (
-          <RecentPicker onPick={setOpponent} />
+          <RecentPicker
+            players={players}
+            loading={playersLoading}
+            onPick={(player) => setOpponent(registeredOpponent(player))}
+          />
         )}
 
         {!opponent && (
@@ -162,7 +192,15 @@ function MatchCard() {
         <RatedField rated={rated} setRated={setRated} opponent={opponent} />
       </div>
 
-      <SubmitRow opponent={opponent} bestOf={bestOf} rated={rated} />
+      <SubmitRow
+        opponent={opponent}
+        bestOf={bestOf}
+        rated={rated}
+        error={error}
+        submitting={createMatch.isPending}
+        onSubmit={handleSubmit}
+        onCancel={() => navigate({ to: '/dashboard' })}
+      />
     </div>
   )
 }
@@ -175,24 +213,22 @@ function SelectedOpponent({
   opponent,
   onChange,
 }: {
-  opponent: Player
+  opponent: Opponent
   onChange: () => void
 }) {
   const guest = opponent.kind !== 'registered'
+  const tag =
+    opponent.kind === 'registered'
+      ? 'REGISTERED PLAYER'
+      : opponent.kind === 'guest'
+        ? 'UNRATED GUEST'
+        : 'TO BE DECIDED'
   return (
     <div className={cn('nm-selected', guest && 'guest')}>
-      <div className="av">{opponent.initials}</div>
+      <div className="av">{initialsOf(opponent.name)}</div>
       <div className="info">
         <div className="name">{opponent.name}</div>
-        <div className="rating">
-          {guest ? (
-            'UNRATED GUEST'
-          ) : (
-            <>
-              RATING · <b>{opponent.rating}</b> · {opponent.club}
-            </>
-          )}
-        </div>
+        <div className="rating">{tag}</div>
       </div>
       <button type="button" className="change" onClick={onChange}>
         Change
@@ -202,44 +238,62 @@ function SelectedOpponent({
 }
 
 /* ------------------------------------------------------------------ */
-/*  Opponent — recent grid (default)                                  */
+/*  Opponent — player grid (default)                                  */
 /* ------------------------------------------------------------------ */
 
-function RecentPicker({ onPick }: { onPick: (player: Player) => void }) {
+function RecentPicker({
+  players,
+  loading,
+  onPick,
+}: {
+  players: Player[]
+  loading: boolean
+  onPick: (player: Player) => void
+}) {
   const [showSearch, setShowSearch] = useState(false)
 
-  if (showSearch) return <TypeaheadPicker onPick={onPick} />
+  if (showSearch) return <TypeaheadPicker players={players} onPick={onPick} />
+
+  const featured = players.slice(0, 6)
 
   return (
     <div>
       <div className="nm-recent-label">
-        <span>Recent</span>
-        <button
-          type="button"
-          className="search-btn"
-          onClick={() => setShowSearch(true)}
-        >
-          Search all players
-        </button>
-      </div>
-      <div className="nm-recent-grid">
-        {RECENT_PLAYERS.map((p) => (
+        <span>Players</span>
+        {players.length > featured.length && (
           <button
             type="button"
-            key={p.id}
-            className="nm-chip"
-            onClick={() => onPick(p)}
+            className="search-btn"
+            onClick={() => setShowSearch(true)}
           >
-            <div className="av">{p.initials}</div>
-            <div className="body">
-              <div className="n">{p.name}</div>
-              <div className="m">
-                {p.rating} · {p.lastPlayed.toUpperCase()}
-              </div>
-            </div>
+            Search all players
           </button>
-        ))}
+        )}
       </div>
+      {loading ? (
+        <div className="nm-no-match">Loading players…</div>
+      ) : players.length === 0 ? (
+        <div className="nm-no-match">
+          No other players yet. Add a guest, or start without an opponent.
+        </div>
+      ) : (
+        <div className="nm-recent-grid">
+          {featured.map((p) => (
+            <button
+              type="button"
+              key={p.id}
+              className="nm-chip"
+              onClick={() => onPick(p)}
+            >
+              <div className="av">{initialsOf(p.username)}</div>
+              <div className="body">
+                <div className="n">{p.username}</div>
+                <div className="m">REGISTERED PLAYER</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   )
 }
@@ -248,22 +302,23 @@ function RecentPicker({ onPick }: { onPick: (player: Player) => void }) {
 /*  Opponent — typeahead search                                       */
 /* ------------------------------------------------------------------ */
 
-function TypeaheadPicker({ onPick }: { onPick: (player: Player) => void }) {
+function TypeaheadPicker({
+  players,
+  onPick,
+}: {
+  players: Player[]
+  onPick: (player: Player) => void
+}) {
   const [query, setQuery] = useState('')
   const [open, setOpen] = useState(false)
   const [activeIdx, setActiveIdx] = useState(0)
   const wrapRef = useRef<HTMLDivElement>(null)
 
   const filtered = useMemo(() => {
-    if (!query.trim()) return RECENT_PLAYERS
-    const s = query.toLowerCase()
-    return PLAYERS.filter(
-      (p) =>
-        p.name.toLowerCase().includes(s) || p.club.toLowerCase().includes(s),
-    )
-  }, [query])
-
-  const results = useMemo(() => [...filtered, GUEST], [filtered])
+    const term = query.trim().toLowerCase()
+    if (!term) return players.slice(0, 8)
+    return players.filter((p) => p.username.toLowerCase().includes(term))
+  }, [players, query])
 
   useEffect(() => {
     function onClickOutside(e: MouseEvent) {
@@ -284,21 +339,20 @@ function TypeaheadPicker({ onPick }: { onPick: (player: Player) => void }) {
     if (!open) return
     if (e.key === 'ArrowDown') {
       e.preventDefault()
-      setActiveIdx((i) => Math.min(results.length - 1, i + 1))
+      setActiveIdx((i) => Math.min(filtered.length - 1, i + 1))
     } else if (e.key === 'ArrowUp') {
       e.preventDefault()
       setActiveIdx((i) => Math.max(0, i - 1))
     } else if (e.key === 'Enter') {
       e.preventDefault()
-      const picked = results[activeIdx]
+      const picked = filtered[activeIdx]
       if (picked) onPick(picked)
     } else if (e.key === 'Escape') {
       setOpen(false)
     }
   }
 
-  const showRecentHeader = !query.trim()
-  const guestIdx = results.length - 1
+  const showHeader = !query.trim()
 
   return (
     <div className="nm-search" ref={wrapRef}>
@@ -306,7 +360,7 @@ function TypeaheadPicker({ onPick }: { onPick: (player: Player) => void }) {
         <Search className="search-icon" size={20} strokeWidth={1.75} />
         <input
           className="nm-input"
-          placeholder="Search by name or club"
+          placeholder="Search by username"
           value={query}
           onChange={(e) => {
             changeQuery(e.target.value)
@@ -328,14 +382,16 @@ function TypeaheadPicker({ onPick }: { onPick: (player: Player) => void }) {
       </div>
       {open && (
         <div className="nm-dropdown">
-          {showRecentHeader && (
+          {showHeader && (
             <div className="nm-opt-section">
-              Recent opponents <span className="line" />
+              Players <span className="line" />
             </div>
           )}
-          {filtered.length === 0 && query && (
+          {filtered.length === 0 && (
             <div className="nm-no-match">
-              No one matches &ldquo;{query}&rdquo;. Try a different name.
+              {query
+                ? `No one matches “${query}”. Try a different name.`
+                : 'No other players yet.'}
             </div>
           )}
           {filtered.map((p, i) => (
@@ -346,34 +402,13 @@ function TypeaheadPicker({ onPick }: { onPick: (player: Player) => void }) {
               onMouseEnter={() => setActiveIdx(i)}
               onClick={() => onPick(p)}
             >
-              <div className="av">{p.initials}</div>
+              <div className="av">{initialsOf(p.username)}</div>
               <div className="body">
-                <div className="n">{p.name}</div>
-                <div className="m">
-                  {p.club} · LAST PLAYED {p.lastPlayed.toUpperCase()}
-                </div>
+                <div className="n">{p.username}</div>
+                <div className="m">REGISTERED PLAYER</div>
               </div>
-              <div className="r">{p.rating}</div>
             </button>
           ))}
-          <div className="nm-opt-section">
-            Or <span className="line" />
-          </div>
-          <button
-            type="button"
-            className={cn('nm-item', 'guest', activeIdx === guestIdx && 'active')}
-            onMouseEnter={() => setActiveIdx(guestIdx)}
-            onClick={() => onPick(GUEST)}
-          >
-            <div className="av">?</div>
-            <div className="body">
-              <div className="n">Log as guest</div>
-              <div className="m">NO FORTYMM ACCOUNT · UNRATED</div>
-            </div>
-            <div className="r" style={{ color: 'var(--fg-muted)' }}>
-              —
-            </div>
-          </button>
         </div>
       )}
     </div>
@@ -436,24 +471,16 @@ function RatedField({
 }: {
   rated: boolean
   setRated: (rated: boolean) => void
-  opponent: Player | null
+  opponent: Opponent | null
 }) {
   const ratable = canRate(opponent)
   const effectiveRated = rated && ratable
-  // A registered opponent's rating; null for guest / TBD / no opponent.
-  const opponentRating =
-    opponent && opponent.kind === 'registered' ? opponent.rating : null
-  const delta =
-    opponentRating != null ? estimateDelta(ME.rating, opponentRating) : null
 
   let description: string
   if (effectiveRated) {
-    description =
-      opponentRating != null
-        ? `Result will update both ratings. Based on a ${Math.abs(
-            opponentRating - ME.rating,
-          )}-point gap.`
-        : 'Pick a rated opponent to see the swing.'
+    description = opponent
+      ? 'Result will update both ratings.'
+      : 'Pick a registered opponent for this to count.'
   } else if (ratable) {
     description = opponent
       ? 'No rating change. Still logged to history.'
@@ -481,9 +508,6 @@ function RatedField({
         <div className="nm-rated-info">
           <div className="t">
             {effectiveRated ? 'Counts toward rating' : 'Just for fun'}
-            {effectiveRated && delta != null && (
-              <span className="delta">±{delta}</span>
-            )}
           </div>
           <div className="d">{description}</div>
         </div>
@@ -500,12 +524,20 @@ function SubmitRow({
   opponent,
   bestOf,
   rated,
+  error,
+  submitting,
+  onSubmit,
+  onCancel,
 }: {
-  opponent: Player | null
+  opponent: Opponent | null
   bestOf: number
   rated: boolean
+  error: string | null
+  submitting: boolean
+  onSubmit: () => void
+  onCancel: () => void
 }) {
-  const effectivelyRated = rated && canRate(opponent)
+  const effectivelyRated = rated && opponent?.kind === 'registered'
   const gamesToWin = Math.ceil(bestOf / 2)
   const lengthCopy =
     bestOf === 1 ? 'Single game' : `Best of ${bestOf} · first to ${gamesToWin}`
@@ -514,9 +546,13 @@ function SubmitRow({
     <div className="nm-summary">
       <div className="read">
         <div className="top">
-          {opponent && opponent.kind !== 'tbd' ? (
+          {opponent?.kind === 'registered' ? (
             <>
               Ready: <b>You</b> vs <b>{opponent.name}</b>
+            </>
+          ) : opponent ? (
+            <>
+              You vs <span className="opp-tbd">{opponent.name}</span>
             </>
           ) : (
             <>
@@ -535,15 +571,29 @@ function SubmitRow({
           <span className="dot">·</span>
           games to 11, win by 2
         </div>
+        {error && (
+          <p className="nm-error" role="alert">
+            {error}
+          </p>
+        )}
       </div>
       <div className="actions">
-        {/* No backend yet — these actions are intentionally inert. */}
-        <button type="button" className="nm-btn nm-btn-ghost">
+        <button
+          type="button"
+          className="nm-btn nm-btn-ghost"
+          onClick={onCancel}
+          disabled={submitting}
+        >
           Cancel
         </button>
-        <button type="button" className="nm-btn nm-btn-primary">
-          Start match
-          <ArrowRight size={16} strokeWidth={2.5} />
+        <button
+          type="button"
+          className="nm-btn nm-btn-primary"
+          onClick={onSubmit}
+          disabled={submitting}
+        >
+          {submitting ? 'Starting…' : 'Start match'}
+          {!submitting && <ArrowRight size={16} strokeWidth={2.5} />}
         </button>
       </div>
     </div>

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -8,6 +8,8 @@ type SessionResponse = components['schemas']['SessionResponse']
 type Permission = components['schemas']['PermissionRead']
 type Role = components['schemas']['RoleRead']
 type RbacUser = components['schemas']['RbacUserRead']
+type Player = components['schemas']['PlayerRead']
+type MatchRead = components['schemas']['MatchRead']
 
 function fastCheck(overrides: Partial<ComponentHealth> = {}): ComponentHealth {
   return {
@@ -105,5 +107,59 @@ export function rbacUser(overrides: Partial<RbacUser> = {}): RbacUser {
     role_ids: [],
     created_at: ISO,
     ...overrides,
+  }
+}
+
+export function player(overrides: Partial<Player> = {}): Player {
+  return {
+    id: nextId('pl'),
+    username: faker.internet.username().toLowerCase(),
+    ...overrides,
+  }
+}
+
+/**
+ * Builds a `MatchRead` the way the API would for a `POST /v1/matches` body:
+ * the creator always gets side 1, a registered opponent gets side 2, and
+ * guest / no-opponent matches stay single-sided and unrated.
+ */
+export function matchResponse(input: {
+  creatorUsername: string
+  opponent: Player | null
+  bestOf: number
+  rated: boolean
+}): MatchRead {
+  const creatorId = nextId('u')
+  const affectsRating = input.rated && input.opponent !== null
+  const sides: MatchRead['sides'] = [
+    {
+      side_number: 1,
+      score: 0,
+      won: null,
+      players: [{ user_id: creatorId, username: input.creatorUsername }],
+    },
+  ]
+  if (input.opponent) {
+    sides.push({
+      side_number: 2,
+      score: 0,
+      won: null,
+      players: [
+        { user_id: input.opponent.id, username: input.opponent.username },
+      ],
+    })
+  }
+  return {
+    id: nextId('m'),
+    status: 'pending',
+    created_by_user_id: creatorId,
+    created_at: ISO,
+    settings: {
+      team_size: 1,
+      best_of: input.bestOf,
+      affects_rating: affectsRating,
+      verification_policy: 'none',
+    },
+    sides,
   }
 }

--- a/web-client/src/test/setup.ts
+++ b/web-client/src/test/setup.ts
@@ -2,6 +2,22 @@ import '@testing-library/jest-dom/vitest'
 import { afterAll, afterEach, beforeAll } from 'vitest'
 import { server } from '../mocks/server'
 
+// jsdom doesn't implement matchMedia; responsive components (e.g. AppShell)
+// read it on mount, so provide an inert stub.
+if (!window.matchMedia) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList
+}
+
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
     tanstackRouter({
       target: 'react',
       autoCodeSplitting: true,
+      // Test files colocated next to their route (e.g. routes/matches/
+      // new.test.tsx) aren't routes — keep the generator from scanning them.
+      routeFileIgnorePattern: '\\.test\\.[jt]sx?$',
     }),
     react(),
     tailwindcss(),


### PR DESCRIPTION
## Summary

Wires the existing `/matches/new` page to real backend match tables — the API endpoints didn't exist before, so this builds them and connects the form end to end.

### API
- **`POST /v1/matches`** — creates a match (settings + sides) for the signed-in user.
- **`GET /v1/matches/{id}`** — reads a match back.
- **`GET /v1/players`** — lists registered users (excluding self) for the opponent picker.
- New `get_current_user` dependency for session-gated endpoints.
- **Validations:** a rated match needs a registered opponent; you can't play yourself; `best_of` must be one of 1/3/5/7. Guest / "start without opponent" matches get a single side and are always unrated (the rating system needs two registered sides).

### Web client
- `new.tsx` drives the opponent picker from `GET /v1/players` and submits via `POST /v1/matches`, surfacing the API's 4xx `detail` inline and navigating to `/dashboard` on success.
- Regenerated `schema.d.ts`; added the matches API hooks, MSW handlers, and test factories.

### Tests
- **api:** `test_matches.py` / `test_players.py` cover every endpoint and validation branch (61 pytest pass).
- **web-client:** `new.test.tsx` (vitest, 10 pass) plus a 14-test Playwright suite `match-creation.spec.ts` with a fully mocked backend via `page.route` (full e2e suite 106 pass).
- `npm run build` and `npm run lint` clean.

## Notes
- A local `docker-compose.dev.override.yml` (offset host ports for this machine) is intentionally left untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)