### PR TITLE
Recent opponents + dedicated player search (closes #90)

### DIFF
--- a/api/app/players.py
+++ b/api/app/players.py
@@ -1,8 +1,9 @@
 from collections.abc import Iterable
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from app.db import get_session
 from app.models import Match, MatchSidePlayer, User
@@ -40,40 +41,43 @@ async def list_recent_opponents(
     A player with little or no match history is backfilled with other
     registered users, alphabetically, so the list is never short or empty.
     """
-    my_match_ids = select(MatchSidePlayer.match_id).where(
-        MatchSidePlayer.user_id == current_user.id
-    )
-    recent_rows = (
-        await db.execute(
-            select(MatchSidePlayer.user_id)
-            .join(Match, Match.id == MatchSidePlayer.match_id)
-            .where(
-                MatchSidePlayer.match_id.in_(my_match_ids),
-                MatchSidePlayer.user_id != current_user.id,
+    # Join the caller's side and the opponent's side of each shared match so
+    # the database returns hydrated User rows already ordered by recency —
+    # one round trip, no Python re-sort.
+    opp = aliased(MatchSidePlayer)
+    mine = aliased(MatchSidePlayer)
+    opponents = list(
+        (
+            await db.execute(
+                select(User)
+                .join(opp, opp.user_id == User.id)
+                .join(Match, Match.id == opp.match_id)
+                .join(
+                    mine,
+                    and_(
+                        mine.match_id == opp.match_id,
+                        mine.user_id == current_user.id,
+                    ),
+                )
+                .where(User.id != current_user.id)
+                .group_by(User.id)
+                .order_by(func.max(Match.created_at).desc())
+                .limit(limit)
             )
-            .group_by(MatchSidePlayer.user_id)
-            .order_by(func.max(Match.created_at).desc())
-            .limit(limit)
         )
-    ).all()
-    recent_ids = [row.user_id for row in recent_rows]
-
-    users_by_id = {
-        user.id: user
-        for user in (
-            await db.execute(select(User).where(User.id.in_(recent_ids)))
-        ).scalars()
-    }
-    opponents = [users_by_id[user_id] for user_id in recent_ids]
+        .scalars()
+        .all()
+    )
 
     if len(opponents) < limit:
+        played_ids = [user.id for user in opponents]
         backfill = (
             (
                 await db.execute(
                     select(User)
                     .where(
                         User.id != current_user.id,
-                        User.id.notin_(recent_ids),
+                        User.id.notin_(played_ids),
                     )
                     .order_by(User.username)
                     .limit(limit - len(opponents))

--- a/api/app/players.py
+++ b/api/app/players.py
@@ -1,25 +1,117 @@
-from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from collections.abc import Iterable
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
-from app.models import User
+from app.models import Match, MatchSidePlayer, User
 from app.schemas.player import PlayerRead
 from app.sessions import get_current_user
 
 router = APIRouter(prefix="/v1")
 
+# Sizes for the two opponent-picker endpoints. The recent grid shows six
+# chips; the typeahead caps its dropdown well below the full roster.
+RECENT_DEFAULT_LIMIT = 6
+SEARCH_DEFAULT_LIMIT = 10
+MAX_LIMIT = 50
 
-@router.get("/players", response_model=list[PlayerRead])
-async def list_players(
+
+def _serialize(users: Iterable[User]) -> list[PlayerRead]:
+    return [PlayerRead.model_validate(user) for user in users]
+
+
+def _escape_like(term: str) -> str:
+    """Escape LIKE wildcards so a query of ``%`` matches a literal percent
+    sign rather than every username."""
+    return term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+@router.get("/players/recent", response_model=list[PlayerRead])
+async def list_recent_opponents(
+    limit: int = Query(RECENT_DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> list[PlayerRead]:
-    """List registered users the caller can pick as an opponent (everyone but
-    themselves)."""
+    """Opponents to feature in the new-match picker.
+
+    Ranked by how recently the caller last played them (most recent first).
+    A player with little or no match history is backfilled with other
+    registered users, alphabetically, so the list is never short or empty.
+    """
+    my_match_ids = select(MatchSidePlayer.match_id).where(
+        MatchSidePlayer.user_id == current_user.id
+    )
+    recent_rows = (
+        await db.execute(
+            select(MatchSidePlayer.user_id)
+            .join(Match, Match.id == MatchSidePlayer.match_id)
+            .where(
+                MatchSidePlayer.match_id.in_(my_match_ids),
+                MatchSidePlayer.user_id != current_user.id,
+            )
+            .group_by(MatchSidePlayer.user_id)
+            .order_by(func.max(Match.created_at).desc())
+            .limit(limit)
+        )
+    ).all()
+    recent_ids = [row.user_id for row in recent_rows]
+
+    users_by_id = {
+        user.id: user
+        for user in (
+            await db.execute(select(User).where(User.id.in_(recent_ids)))
+        ).scalars()
+    }
+    opponents = [users_by_id[user_id] for user_id in recent_ids]
+
+    if len(opponents) < limit:
+        backfill = (
+            (
+                await db.execute(
+                    select(User)
+                    .where(
+                        User.id != current_user.id,
+                        User.id.notin_(recent_ids),
+                    )
+                    .order_by(User.username)
+                    .limit(limit - len(opponents))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        opponents.extend(backfill)
+
+    return _serialize(opponents)
+
+
+@router.get("/players/search", response_model=list[PlayerRead])
+async def search_players(
+    q: str = Query(..., description="Username substring to match against."),
+    limit: int = Query(SEARCH_DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> list[PlayerRead]:
+    """Username substring search backing the opponent typeahead.
+
+    Case-insensitive, excludes the caller, and caps the result count so the
+    client never has to fetch and filter the whole roster. An empty query
+    matches nothing.
+    """
+    term = q.strip()
+    if not term:
+        return []
+
+    pattern = f"%{_escape_like(term)}%"
     result = await db.execute(
         select(User)
-        .where(User.id != current_user.id)
+        .where(
+            User.id != current_user.id,
+            User.username.ilike(pattern, escape="\\"),
+        )
         .order_by(User.username)
+        .limit(limit)
     )
-    return [PlayerRead.model_validate(user) for user in result.scalars().all()]
+    return _serialize(result.scalars().all())

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -1,0 +1,31 @@
+"""Shared test helpers for the API test suite.
+
+The leading underscore keeps pytest from auto-collecting this as a test module;
+fixtures still belong in ``conftest.py``.
+"""
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import User
+
+
+async def start_session(
+    api_client: AsyncClient, db_session: AsyncSession
+) -> User:
+    """Establish a session cookie on the client and return the signed-in user."""
+    response = await api_client.get("/v1/session")
+    assert response.status_code == 200
+    username = response.json()["data"]["user"]["username"]
+    return (
+        await db_session.execute(select(User).where(User.username == username))
+    ).scalar_one()
+
+
+async def make_user(db_session: AsyncSession, username: str) -> User:
+    user = User(username=username)
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator, Iterator
 import fakeredis
 import pytest
 import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
 from rq import Queue
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -13,7 +14,8 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from app import queue as queue_module
-from app.db import Base
+from app.db import Base, get_session
+from app.main import app as fastapi_app
 import app.models  # noqa: F401  -- ensures models register on Base.metadata
 
 
@@ -58,3 +60,20 @@ async def db_session(engine: AsyncEngine) -> AsyncIterator[AsyncSession]:
     async with engine.begin() as conn:
         for table in reversed(Base.metadata.sorted_tables):
             await conn.execute(table.delete())
+
+
+@pytest_asyncio.fixture
+async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    """HTTP client bound to the test app, sharing the per-test ``db_session``
+    so commits inside endpoints are visible to assertions in the same test."""
+
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    fastapi_app.dependency_overrides[get_session] = _override
+    transport = ASGITransport(app=fastapi_app)
+    async with AsyncClient(
+        transport=transport, base_url="https://testserver"
+    ) as client:
+        yield client
+    fastapi_app.dependency_overrides.clear()

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1,48 +1,11 @@
 import uuid
-from collections.abc import AsyncIterator
 
-import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
+from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db import get_session
-from app.main import app
-from app.models import Match, MatchSide, User
-
-
-@pytest_asyncio.fixture
-async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
-    async def _override() -> AsyncIterator[AsyncSession]:
-        yield db_session
-
-    app.dependency_overrides[get_session] = _override
-    transport = ASGITransport(app=app)
-    async with AsyncClient(
-        transport=transport, base_url="https://testserver"
-    ) as client:
-        yield client
-    app.dependency_overrides.clear()
-
-
-async def _start_session(
-    api_client: AsyncClient, db_session: AsyncSession
-) -> User:
-    """Establish a session cookie on the client; return the signed-in user."""
-    response = await api_client.get("/v1/session")
-    assert response.status_code == 200
-    username = response.json()["data"]["user"]["username"]
-    return (
-        await db_session.execute(select(User).where(User.username == username))
-    ).scalar_one()
-
-
-async def _make_user(db_session: AsyncSession, username: str) -> User:
-    user = User(username=username)
-    db_session.add(user)
-    await db_session.commit()
-    await db_session.refresh(user)
-    return user
+from app.models import Match, MatchSide
+from tests._helpers import make_user, start_session
 
 
 async def test_create_match_requires_a_session(api_client: AsyncClient):
@@ -53,8 +16,8 @@ async def test_create_match_requires_a_session(api_client: AsyncClient):
 async def test_create_rated_match_with_registered_opponent(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    me = await _start_session(api_client, db_session)
-    opponent = await _make_user(db_session, "rival")
+    me = await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "rival")
 
     response = await api_client.post(
         "/v1/matches",
@@ -84,8 +47,8 @@ async def test_create_rated_match_with_registered_opponent(
 async def test_create_unrated_match_with_opponent(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
-    opponent = await _make_user(db_session, "casual-rival")
+    await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "casual-rival")
 
     response = await api_client.post(
         "/v1/matches",
@@ -104,7 +67,7 @@ async def test_create_unrated_match_with_opponent(
 async def test_create_match_without_opponent_has_a_single_side(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    me = await _start_session(api_client, db_session)
+    me = await start_session(api_client, db_session)
 
     response = await api_client.post(
         "/v1/matches", json={"best_of": 7, "rated": False}
@@ -123,7 +86,7 @@ async def test_create_match_without_opponent_has_a_single_side(
 async def test_rated_match_without_opponent_is_rejected(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
 
     response = await api_client.post(
         "/v1/matches", json={"best_of": 5, "rated": True}
@@ -136,7 +99,7 @@ async def test_rated_match_without_opponent_is_rejected(
 async def test_cannot_start_a_match_against_yourself(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    me = await _start_session(api_client, db_session)
+    me = await start_session(api_client, db_session)
 
     response = await api_client.post(
         "/v1/matches",
@@ -149,7 +112,7 @@ async def test_cannot_start_a_match_against_yourself(
 async def test_unknown_opponent_is_rejected(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
 
     response = await api_client.post(
         "/v1/matches",
@@ -166,8 +129,8 @@ async def test_unknown_opponent_is_rejected(
 async def test_even_best_of_is_rejected(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
-    opponent = await _make_user(db_session, "rival")
+    await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "rival")
 
     response = await api_client.post(
         "/v1/matches",
@@ -183,8 +146,8 @@ async def test_even_best_of_is_rejected(
 async def test_get_match_returns_the_created_match(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
-    opponent = await _make_user(db_session, "rival")
+    await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "rival")
     created = (
         await api_client.post(
             "/v1/matches",

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -1,12 +1,24 @@
 from collections.abc import AsyncIterator
+from datetime import datetime, timedelta, timezone
 
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
 from app.main import app
-from app.models import User
+from app.models import (
+    Match,
+    MatchSettings,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    User,
+)
+
+# A fixed anchor so recency-ordering assertions don't depend on wall-clock time.
+BASE_TIME = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
 
 @pytest_asyncio.fixture
@@ -23,22 +35,276 @@ async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
     app.dependency_overrides.clear()
 
 
-async def test_list_players_requires_a_session(api_client: AsyncClient):
-    response = await api_client.get("/v1/players")
+async def _start_session(
+    api_client: AsyncClient, db_session: AsyncSession
+) -> User:
+    """Establish a session cookie on the client; return the signed-in user."""
+    response = await api_client.get("/v1/session")
+    assert response.status_code == 200
+    username = response.json()["data"]["user"]["username"]
+    return (
+        await db_session.execute(select(User).where(User.username == username))
+    ).scalar_one()
+
+
+async def _make_user(db_session: AsyncSession, username: str) -> User:
+    user = User(username=username)
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+async def _record_match(
+    db_session: AsyncSession,
+    *players: User,
+    created_at: datetime,
+) -> Match:
+    """Persist a singles match between ``players`` stamped with an explicit
+    ``created_at`` so recency-ordering tests stay deterministic."""
+    settings = MatchSettings(team_size=1, best_of=5, affects_rating=False)
+    match = Match(
+        match_settings=settings,
+        created_by_user_id=players[0].id,
+        status=MatchStatus.completed,
+        created_at=created_at,
+    )
+    for side_number, player in enumerate(players, start=1):
+        side = MatchSide(match=match, side_number=side_number)
+        side.players.append(MatchSidePlayer(match=match, user=player))
+    db_session.add(match)
+    await db_session.commit()
+    return match
+
+
+def _usernames(response) -> list[str]:
+    return [player["username"] for player in response.json()]
+
+
+# ----- recent opponents ----------------------------------------------------
+
+
+async def test_recent_opponents_requires_a_session(api_client: AsyncClient):
+    response = await api_client.get("/v1/players/recent")
     assert response.status_code == 401
 
 
-async def test_list_players_excludes_the_current_user(
+async def test_recent_opponents_orders_by_most_recent_match(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    session_response = await api_client.get("/v1/session")
-    my_username = session_response.json()["data"]["user"]["username"]
+    me = await _start_session(api_client, db_session)
+    ana = await _make_user(db_session, "ana")
+    bo = await _make_user(db_session, "bo")
+    cy = await _make_user(db_session, "cy")
 
-    db_session.add_all([User(username="ana"), User(username="bo")])
+    # Played ana longest ago, then cy, then bo most recently.
+    await _record_match(db_session, me, ana, created_at=BASE_TIME - timedelta(days=3))
+    await _record_match(db_session, me, cy, created_at=BASE_TIME - timedelta(days=2))
+    await _record_match(db_session, me, bo, created_at=BASE_TIME - timedelta(days=1))
+
+    response = await api_client.get("/v1/players/recent")
+    assert response.status_code == 200
+    assert _usernames(response) == ["bo", "cy", "ana"]
+
+
+async def test_recent_opponents_dedupes_repeated_opponents(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await _start_session(api_client, db_session)
+    ana = await _make_user(db_session, "ana")
+    bo = await _make_user(db_session, "bo")
+
+    # ana appears twice; her most recent match is newer than the bo match.
+    await _record_match(db_session, me, ana, created_at=BASE_TIME - timedelta(days=5))
+    await _record_match(db_session, me, bo, created_at=BASE_TIME - timedelta(days=3))
+    await _record_match(db_session, me, ana, created_at=BASE_TIME - timedelta(days=1))
+
+    response = await api_client.get("/v1/players/recent")
+    assert response.status_code == 200
+    assert _usernames(response) == ["ana", "bo"]
+
+
+async def test_recent_opponents_backfills_with_other_players(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await _start_session(api_client, db_session)
+    rival = await _make_user(db_session, "rival")
+    await _make_user(db_session, "zoe")
+    await _make_user(db_session, "amy")
+
+    await _record_match(db_session, me, rival, created_at=BASE_TIME)
+
+    response = await api_client.get("/v1/players/recent")
+    assert response.status_code == 200
+    # The played opponent leads; never-played users backfill alphabetically.
+    assert _usernames(response) == ["rival", "amy", "zoe"]
+
+
+async def test_recent_opponents_for_a_new_player_is_a_non_empty_default(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    db_session.add_all(
+        [User(username="charlie"), User(username="alice"), User(username="bob")]
+    )
     await db_session.commit()
 
-    response = await api_client.get("/v1/players")
+    response = await api_client.get("/v1/players/recent")
     assert response.status_code == 200
-    usernames = [player["username"] for player in response.json()]
-    assert usernames == ["ana", "bo"]
-    assert my_username not in usernames
+    # No match history at all — fall back to the alphabetical roster.
+    assert _usernames(response) == ["alice", "bob", "charlie"]
+
+
+async def test_recent_opponents_excludes_the_current_user(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await _start_session(api_client, db_session)
+    rival = await _make_user(db_session, "rival")
+    await _record_match(db_session, me, rival, created_at=BASE_TIME)
+
+    response = await api_client.get("/v1/players/recent")
+    assert response.status_code == 200
+    assert me.username not in _usernames(response)
+
+
+async def test_recent_opponents_is_empty_without_other_users(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+
+    response = await api_client.get("/v1/players/recent")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_recent_opponents_respects_the_limit(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await _start_session(api_client, db_session)
+    for name in ("ana", "bo", "cy", "di"):
+        await _make_user(db_session, name)
+
+    response = await api_client.get("/v1/players/recent", params={"limit": 2})
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+    # The default fits the six-chip grid.
+    default_response = await api_client.get("/v1/players/recent")
+    assert len(default_response.json()) == 4
+
+    assert (
+        await api_client.get("/v1/players/recent", params={"limit": 0})
+    ).status_code == 422
+
+
+# ----- player search -------------------------------------------------------
+
+
+async def test_search_requires_a_session(api_client: AsyncClient):
+    response = await api_client.get("/v1/players/search", params={"q": "a"})
+    assert response.status_code == 401
+
+
+async def test_search_requires_a_query(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    response = await api_client.get("/v1/players/search")
+    assert response.status_code == 422
+
+
+async def test_search_matches_substring_case_insensitively(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    await _make_user(db_session, "Ada.Lovelace")
+    await _make_user(db_session, "grace.hopper")
+
+    response = await api_client.get("/v1/players/search", params={"q": "ADA"})
+    assert response.status_code == 200
+    assert _usernames(response) == ["Ada.Lovelace"]
+
+    mid = await api_client.get("/v1/players/search", params={"q": "hop"})
+    assert _usernames(mid) == ["grace.hopper"]
+
+
+async def test_search_excludes_the_current_user(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await _start_session(api_client, db_session)
+
+    response = await api_client.get(
+        "/v1/players/search", params={"q": me.username}
+    )
+    assert response.status_code == 200
+    assert me.username not in _usernames(response)
+
+
+async def test_search_with_a_blank_query_matches_nothing(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    await _make_user(db_session, "ada.lovelace")
+
+    response = await api_client.get("/v1/players/search", params={"q": "   "})
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_search_with_no_match_returns_empty(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    await _make_user(db_session, "ada.lovelace")
+
+    response = await api_client.get(
+        "/v1/players/search", params={"q": "nobody-here"}
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_search_caps_the_result_count(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    for i in range(15):
+        await _make_user(db_session, f"player{i:02d}")
+
+    capped = await api_client.get("/v1/players/search", params={"q": "player"})
+    assert capped.status_code == 200
+    assert len(capped.json()) == 10  # SEARCH_DEFAULT_LIMIT
+
+    smaller = await api_client.get(
+        "/v1/players/search", params={"q": "player", "limit": 3}
+    )
+    assert len(smaller.json()) == 3
+
+
+async def test_search_escapes_like_wildcards(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    await _make_user(db_session, "alice")
+    await _make_user(db_session, "bob")
+
+    # A bare "%" must match a literal percent sign, not every username.
+    response = await api_client.get("/v1/players/search", params={"q": "%"})
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_search_orders_results_alphabetically(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    await _make_user(db_session, "match.charlie")
+    await _make_user(db_session, "match.alice")
+    await _make_user(db_session, "match.bob")
+
+    response = await api_client.get("/v1/players/search", params={"q": "match."})
+    assert _usernames(response) == [
+        "match.alice",
+        "match.bob",
+        "match.charlie",
+    ]

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -1,13 +1,8 @@
-from collections.abc import AsyncIterator
 from datetime import datetime, timedelta, timezone
 
-import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
-from sqlalchemy import select
+from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db import get_session
-from app.main import app
 from app.models import (
     Match,
     MatchSettings,
@@ -16,43 +11,10 @@ from app.models import (
     MatchStatus,
     User,
 )
+from tests._helpers import make_user, start_session
 
 # A fixed anchor so recency-ordering assertions don't depend on wall-clock time.
 BASE_TIME = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-
-
-@pytest_asyncio.fixture
-async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
-    async def _override() -> AsyncIterator[AsyncSession]:
-        yield db_session
-
-    app.dependency_overrides[get_session] = _override
-    transport = ASGITransport(app=app)
-    async with AsyncClient(
-        transport=transport, base_url="https://testserver"
-    ) as client:
-        yield client
-    app.dependency_overrides.clear()
-
-
-async def _start_session(
-    api_client: AsyncClient, db_session: AsyncSession
-) -> User:
-    """Establish a session cookie on the client; return the signed-in user."""
-    response = await api_client.get("/v1/session")
-    assert response.status_code == 200
-    username = response.json()["data"]["user"]["username"]
-    return (
-        await db_session.execute(select(User).where(User.username == username))
-    ).scalar_one()
-
-
-async def _make_user(db_session: AsyncSession, username: str) -> User:
-    user = User(username=username)
-    db_session.add(user)
-    await db_session.commit()
-    await db_session.refresh(user)
-    return user
 
 
 async def _record_match(
@@ -92,10 +54,10 @@ async def test_recent_opponents_requires_a_session(api_client: AsyncClient):
 async def test_recent_opponents_orders_by_most_recent_match(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    me = await _start_session(api_client, db_session)
-    ana = await _make_user(db_session, "ana")
-    bo = await _make_user(db_session, "bo")
-    cy = await _make_user(db_session, "cy")
+    me = await start_session(api_client, db_session)
+    ana = await make_user(db_session, "ana")
+    bo = await make_user(db_session, "bo")
+    cy = await make_user(db_session, "cy")
 
     # Played ana longest ago, then cy, then bo most recently.
     await _record_match(db_session, me, ana, created_at=BASE_TIME - timedelta(days=3))
@@ -110,9 +72,9 @@ async def test_recent_opponents_orders_by_most_recent_match(
 async def test_recent_opponents_dedupes_repeated_opponents(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    me = await _start_session(api_client, db_session)
-    ana = await _make_user(db_session, "ana")
-    bo = await _make_user(db_session, "bo")
+    me = await start_session(api_client, db_session)
+    ana = await make_user(db_session, "ana")
+    bo = await make_user(db_session, "bo")
 
     # ana appears twice; her most recent match is newer than the bo match.
     await _record_match(db_session, me, ana, created_at=BASE_TIME - timedelta(days=5))
@@ -127,10 +89,10 @@ async def test_recent_opponents_dedupes_repeated_opponents(
 async def test_recent_opponents_backfills_with_other_players(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    me = await _start_session(api_client, db_session)
-    rival = await _make_user(db_session, "rival")
-    await _make_user(db_session, "zoe")
-    await _make_user(db_session, "amy")
+    me = await start_session(api_client, db_session)
+    rival = await make_user(db_session, "rival")
+    await make_user(db_session, "zoe")
+    await make_user(db_session, "amy")
 
     await _record_match(db_session, me, rival, created_at=BASE_TIME)
 
@@ -143,7 +105,7 @@ async def test_recent_opponents_backfills_with_other_players(
 async def test_recent_opponents_for_a_new_player_is_a_non_empty_default(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     db_session.add_all(
         [User(username="charlie"), User(username="alice"), User(username="bob")]
     )
@@ -158,8 +120,8 @@ async def test_recent_opponents_for_a_new_player_is_a_non_empty_default(
 async def test_recent_opponents_excludes_the_current_user(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    me = await _start_session(api_client, db_session)
-    rival = await _make_user(db_session, "rival")
+    me = await start_session(api_client, db_session)
+    rival = await make_user(db_session, "rival")
     await _record_match(db_session, me, rival, created_at=BASE_TIME)
 
     response = await api_client.get("/v1/players/recent")
@@ -170,7 +132,7 @@ async def test_recent_opponents_excludes_the_current_user(
 async def test_recent_opponents_is_empty_without_other_users(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
 
     response = await api_client.get("/v1/players/recent")
     assert response.status_code == 200
@@ -180,9 +142,9 @@ async def test_recent_opponents_is_empty_without_other_users(
 async def test_recent_opponents_respects_the_limit(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    me = await _start_session(api_client, db_session)
+    me = await start_session(api_client, db_session)
     for name in ("ana", "bo", "cy", "di"):
-        await _make_user(db_session, name)
+        await make_user(db_session, name)
 
     response = await api_client.get("/v1/players/recent", params={"limit": 2})
     assert response.status_code == 200
@@ -208,7 +170,7 @@ async def test_search_requires_a_session(api_client: AsyncClient):
 async def test_search_requires_a_query(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     response = await api_client.get("/v1/players/search")
     assert response.status_code == 422
 
@@ -216,9 +178,9 @@ async def test_search_requires_a_query(
 async def test_search_matches_substring_case_insensitively(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
-    await _make_user(db_session, "Ada.Lovelace")
-    await _make_user(db_session, "grace.hopper")
+    await start_session(api_client, db_session)
+    await make_user(db_session, "Ada.Lovelace")
+    await make_user(db_session, "grace.hopper")
 
     response = await api_client.get("/v1/players/search", params={"q": "ADA"})
     assert response.status_code == 200
@@ -231,7 +193,7 @@ async def test_search_matches_substring_case_insensitively(
 async def test_search_excludes_the_current_user(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    me = await _start_session(api_client, db_session)
+    me = await start_session(api_client, db_session)
 
     response = await api_client.get(
         "/v1/players/search", params={"q": me.username}
@@ -243,8 +205,8 @@ async def test_search_excludes_the_current_user(
 async def test_search_with_a_blank_query_matches_nothing(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
-    await _make_user(db_session, "ada.lovelace")
+    await start_session(api_client, db_session)
+    await make_user(db_session, "ada.lovelace")
 
     response = await api_client.get("/v1/players/search", params={"q": "   "})
     assert response.status_code == 200
@@ -254,8 +216,8 @@ async def test_search_with_a_blank_query_matches_nothing(
 async def test_search_with_no_match_returns_empty(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
-    await _make_user(db_session, "ada.lovelace")
+    await start_session(api_client, db_session)
+    await make_user(db_session, "ada.lovelace")
 
     response = await api_client.get(
         "/v1/players/search", params={"q": "nobody-here"}
@@ -267,9 +229,9 @@ async def test_search_with_no_match_returns_empty(
 async def test_search_caps_the_result_count(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     for i in range(15):
-        await _make_user(db_session, f"player{i:02d}")
+        await make_user(db_session, f"player{i:02d}")
 
     capped = await api_client.get("/v1/players/search", params={"q": "player"})
     assert capped.status_code == 200
@@ -284,9 +246,9 @@ async def test_search_caps_the_result_count(
 async def test_search_escapes_like_wildcards(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
-    await _make_user(db_session, "alice")
-    await _make_user(db_session, "bob")
+    await start_session(api_client, db_session)
+    await make_user(db_session, "alice")
+    await make_user(db_session, "bob")
 
     # A bare "%" must match a literal percent sign, not every username.
     response = await api_client.get("/v1/players/search", params={"q": "%"})
@@ -297,10 +259,10 @@ async def test_search_escapes_like_wildcards(
 async def test_search_orders_results_alphabetically(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
-    await _make_user(db_session, "match.charlie")
-    await _make_user(db_session, "match.alice")
-    await _make_user(db_session, "match.bob")
+    await start_session(api_client, db_session)
+    await make_user(db_session, "match.charlie")
+    await make_user(db_session, "match.alice")
+    await make_user(db_session, "match.bob")
 
     response = await api_client.get("/v1/players/search", params={"q": "match."})
     assert _usernames(response) == [

--- a/web-client/e2e/match-creation.spec.ts
+++ b/web-client/e2e/match-creation.spec.ts
@@ -9,8 +9,9 @@ const LINUS = { id: 'pl-linus', username: 'linus.torvalds' }
 
 const ROSTER = [ADA, GRACE, LINUS]
 
-// More than the six players the grid features, so the picker offers its
-// "Search all players" affordance and the typeahead becomes reachable.
+// A roster with one player (Barbara) past the six the recent grid features,
+// so the typeahead test proves search reaches the whole roster server-side,
+// not just the chips already on screen.
 const BARBARA = { id: 'pl-barbara', username: 'barbara.liskov' }
 const BIG_ROSTER = [
   ADA,

--- a/web-client/e2e/opponent-picker.spec.ts
+++ b/web-client/e2e/opponent-picker.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from '@playwright/test'
+import { NewMatchPage } from './page-objects/matches/new-match.page'
+
+// Stable, explicit ids so DOM-order and request-body assertions can name them.
+const ADA = { id: 'pl-ada', username: 'ada.lovelace' }
+const GRACE = { id: 'pl-grace', username: 'grace.hopper' }
+const LINUS = { id: 'pl-linus', username: 'linus.torvalds' }
+const MARGARET = { id: 'pl-margaret', username: 'margaret.hamilton' }
+
+const ROSTER = [ADA, GRACE, LINUS, MARGARET]
+
+test.describe('Opponent picker — recent opponents', () => {
+  test('shows a skeleton while recent opponents load, then the chips', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, {
+      players: ROSTER,
+      // Held long enough that the skeleton is reliably observable.
+      recentDelayMs: 2000,
+    })
+
+    await expect(nm.recentSkeleton).toBeVisible()
+    // The delayed response lands and the real chips replace the placeholder.
+    await expect(nm.playerChip(ADA.username)).toBeVisible()
+    await expect(nm.recentSkeleton).toBeHidden()
+  })
+
+  test('renders recent opponents in the order the endpoint returns them', async ({
+    page,
+  }) => {
+    // The endpoint ranks opponents by recency; the client must preserve that
+    // order rather than re-sorting (the old picker was alphabetical).
+    const nm = await NewMatchPage.open(page, {
+      players: ROSTER,
+      recentOpponents: [LINUS, ADA, MARGARET, GRACE],
+    })
+
+    await expect(nm.playerChip(LINUS.username)).toBeVisible()
+    const names = await page.locator('.nm-chip .n').allTextContents()
+    expect(names).toEqual([
+      LINUS.username,
+      ADA.username,
+      MARGARET.username,
+      GRACE.username,
+    ])
+  })
+
+  test('shows an empty state and hides search when nobody else exists', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: [] })
+
+    await expect(nm.emptyPlayers).toBeVisible()
+    await expect(nm.searchAllButton).toBeHidden()
+  })
+
+  test('surfaces a retry button when recent opponents fail to load', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, {
+      players: ROSTER,
+      failRecent: { status: 500, detail: 'database unavailable' },
+    })
+
+    await expect(nm.pickerError).toBeVisible()
+    await expect(nm.pickerError).toContainText(/couldn.t load players/i)
+
+    // The queued failure is consumed by the first request, so retry recovers.
+    await nm.pickerRetry.click()
+    await expect(nm.playerChip(ADA.username)).toBeVisible()
+    await expect(nm.pickerError).toBeHidden()
+  })
+
+  test('still lets the player add a guest after a failed recent load', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, {
+      players: ROSTER,
+      failRecent: { status: 500 },
+    })
+
+    await expect(nm.pickerError).toBeVisible()
+    // The skip row sits outside the picker boundary, so guest / no-opponent
+    // flows keep working even when the players request fails.
+    await nm.addGuest()
+    await nm.start()
+
+    await expect(page).toHaveURL(/\/dashboard$/)
+    expect(nm.store.createdMatches).toEqual([
+      { opponent_user_id: null, best_of: 5, rated: false },
+    ])
+  })
+})
+
+test.describe('Opponent picker — search', () => {
+  test('opens to a hint and fires no request until the player types', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.openSearch()
+    await expect(nm.searchHint).toBeVisible()
+    // An empty search box never hits the network — no fetch-all-and-filter.
+    expect(nm.store.searchQueries).toHaveLength(0)
+  })
+
+  test('searches the dedicated endpoint and selects a server-side result', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.openSearch()
+    await nm.search('hamilton')
+    await nm.searchResult(MARGARET.username).click()
+
+    await expect(nm.selectedOpponentName).toHaveText(MARGARET.username)
+    // The typed term reached the endpoint — nothing was filtered client-side.
+    expect(nm.store.searchQueries).toContain('hamilton')
+
+    await nm.start()
+    await expect(page).toHaveURL(/\/dashboard$/)
+    expect(nm.store.createdMatches).toEqual([
+      { opponent_user_id: MARGARET.id, best_of: 5, rated: true },
+    ])
+  })
+
+  test('shows a no-match message for an unknown name', async ({ page }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.openSearch()
+    await nm.search('nobody-here')
+
+    await expect(nm.searchNoMatch).toBeVisible()
+  })
+
+  test('surfaces the error boundary when a search request fails', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+    nm.store.failNextSearch({ status: 500, detail: 'search unavailable' })
+
+    await nm.openSearch()
+    await nm.search('ada')
+
+    await expect(nm.pickerError).toBeVisible()
+    await expect(nm.pickerError).toContainText(/couldn.t load players/i)
+  })
+})

--- a/web-client/e2e/page-objects/matches/match-store.ts
+++ b/web-client/e2e/page-objects/matches/match-store.ts
@@ -118,25 +118,13 @@ export class MatchStore {
 
   private async handleRecent(route: Route): Promise<void> {
     if (this.recentDelayMs) await wait(this.recentDelayMs)
-    const failure = this.recentFailures.shift()
-    if (failure) {
-      if (failure.delayMs) await wait(failure.delayMs)
-      return this.json(route, failure.status, {
-        detail: failure.detail ?? `mock ${failure.status}`,
-      })
-    }
+    if (await this.consumeFailure(route, this.recentFailures)) return
     return this.json(route, 200, this.recentOpponents)
   }
 
   private async handleSearch(route: Route, request: PWRequest): Promise<void> {
     if (this.searchDelayMs) await wait(this.searchDelayMs)
-    const failure = this.searchFailures.shift()
-    if (failure) {
-      if (failure.delayMs) await wait(failure.delayMs)
-      return this.json(route, failure.status, {
-        detail: failure.detail ?? `mock ${failure.status}`,
-      })
-    }
+    if (await this.consumeFailure(route, this.searchFailures)) return
     const q =
       new URL(request.url()).searchParams.get('q')?.trim().toLowerCase() ?? ''
     this.searchQueries.push(q)
@@ -150,14 +138,7 @@ export class MatchStore {
   private async handleCreate(route: Route, request: PWRequest): Promise<void> {
     const body = readJson(request) as MatchCreate
     this.createdMatches.push(body)
-
-    const failure = this.createFailures.shift()
-    if (failure) {
-      if (failure.delayMs) await wait(failure.delayMs)
-      return this.json(route, failure.status, {
-        detail: failure.detail ?? `mock ${failure.status}`,
-      })
-    }
+    if (await this.consumeFailure(route, this.createFailures)) return
 
     const opponent =
       body.opponent_user_id == null
@@ -174,6 +155,21 @@ export class MatchStore {
         rated: body.rated,
       }),
     )
+  }
+
+  /** Pop the next queued failure (if any) and reply with it; returns whether
+   *  a failure was consumed so callers can early-return. */
+  private async consumeFailure(
+    route: Route,
+    queue: FailureSpec[],
+  ): Promise<boolean> {
+    const failure = queue.shift()
+    if (!failure) return false
+    if (failure.delayMs) await wait(failure.delayMs)
+    await this.json(route, failure.status, {
+      detail: failure.detail ?? `mock ${failure.status}`,
+    })
+    return true
   }
 
   private json(route: Route, status: number, body: unknown): Promise<void> {

--- a/web-client/e2e/page-objects/matches/match-store.ts
+++ b/web-client/e2e/page-objects/matches/match-store.ts
@@ -10,6 +10,11 @@ export const CREATOR_USERNAME = 'rita.kovac'
 
 const SESSION = sessionResponse({ user: { username: CREATOR_USERNAME } })
 
+/** The recent-opponents endpoint is capped at six chips. */
+const RECENT_LIMIT = 6
+/** The search endpoint caps its result count. */
+const SEARCH_LIMIT = 10
+
 export interface FailureSpec {
   status: number
   /** `detail` string the API would return; the form surfaces it inline. */
@@ -19,26 +24,54 @@ export interface FailureSpec {
 }
 
 export interface MatchStoreSeed {
-  /** Registered players the opponent picker can choose from. */
+  /** Registered players the typeahead search can match against. */
   players?: Player[]
+  /**
+   * Opponents the default picker grid shows, in order (most-recently-played
+   * first). Defaults to the first six `players`.
+   */
+  recentOpponents?: Player[]
+  /**
+   * Hold the recent / search responses this long before replying, so specs
+   * can observe the skeleton and loading states.
+   */
+  recentDelayMs?: number
+  searchDelayMs?: number
+  /** Fail the first recent / search request (drives the error boundary). */
+  failRecent?: FailureSpec
+  failSearch?: FailureSpec
 }
 
 /**
- * Mocks the three endpoints the New Match page touches — `GET /v1/session`,
- * `GET /v1/players`, and `POST /v1/matches` — entirely in the browser via
- * `page.route`, so the e2e suite never needs a live API. Records every
- * create-match body the client sends so specs can assert on the payload.
+ * Mocks the endpoints the New Match page touches — `GET /v1/session`,
+ * `GET /v1/players/recent`, `GET /v1/players/search`, and `POST /v1/matches` —
+ * entirely in the browser via `page.route`, so the e2e suite never needs a
+ * live API. Records the create-match bodies and the search terms the client
+ * sends so specs can assert on them.
  */
 export class MatchStore {
   readonly creatorUsername = CREATOR_USERNAME
   /** Bodies of every `POST /v1/matches`, in the order the client sent them. */
   readonly createdMatches: MatchCreate[] = []
+  /** `q` values the client sent to `GET /v1/players/search`, in order. */
+  readonly searchQueries: string[] = []
 
   private readonly players: Player[]
+  private readonly recentOpponents: Player[]
+  private readonly recentDelayMs: number
+  private readonly searchDelayMs: number
   private readonly createFailures: FailureSpec[] = []
+  private readonly recentFailures: FailureSpec[] = []
+  private readonly searchFailures: FailureSpec[] = []
 
   constructor(seed: MatchStoreSeed = {}) {
     this.players = seed.players ?? []
+    this.recentOpponents =
+      seed.recentOpponents ?? this.players.slice(0, RECENT_LIMIT)
+    this.recentDelayMs = seed.recentDelayMs ?? 0
+    this.searchDelayMs = seed.searchDelayMs ?? 0
+    if (seed.failRecent) this.recentFailures.push({ ...seed.failRecent })
+    if (seed.failSearch) this.searchFailures.push({ ...seed.failSearch })
   }
 
   /**
@@ -47,6 +80,16 @@ export class MatchStore {
    */
   failNextCreate(spec: FailureSpec): void {
     this.createFailures.push({ ...spec })
+  }
+
+  /** Queue a failure for the next `GET /v1/players/recent`. */
+  failNextRecent(spec: FailureSpec): void {
+    this.recentFailures.push({ ...spec })
+  }
+
+  /** Queue a failure for the next `GET /v1/players/search`. */
+  failNextSearch(spec: FailureSpec): void {
+    this.searchFailures.push({ ...spec })
   }
 
   async install(page: Page): Promise<void> {
@@ -61,13 +104,47 @@ export class MatchStore {
     if (path === '/v1/session') {
       return this.json(route, 200, SESSION)
     }
-    if (path === '/v1/players' && method === 'GET') {
-      return this.json(route, 200, this.players)
+    if (path === '/v1/players/recent' && method === 'GET') {
+      return this.handleRecent(route)
+    }
+    if (path === '/v1/players/search' && method === 'GET') {
+      return this.handleSearch(route, request)
     }
     if (path === '/v1/matches' && method === 'POST') {
       return this.handleCreate(route, request)
     }
     return this.json(route, 404, { detail: `unmocked ${method} ${path}` })
+  }
+
+  private async handleRecent(route: Route): Promise<void> {
+    if (this.recentDelayMs) await wait(this.recentDelayMs)
+    const failure = this.recentFailures.shift()
+    if (failure) {
+      if (failure.delayMs) await wait(failure.delayMs)
+      return this.json(route, failure.status, {
+        detail: failure.detail ?? `mock ${failure.status}`,
+      })
+    }
+    return this.json(route, 200, this.recentOpponents)
+  }
+
+  private async handleSearch(route: Route, request: PWRequest): Promise<void> {
+    if (this.searchDelayMs) await wait(this.searchDelayMs)
+    const failure = this.searchFailures.shift()
+    if (failure) {
+      if (failure.delayMs) await wait(failure.delayMs)
+      return this.json(route, failure.status, {
+        detail: failure.detail ?? `mock ${failure.status}`,
+      })
+    }
+    const q =
+      new URL(request.url()).searchParams.get('q')?.trim().toLowerCase() ?? ''
+    this.searchQueries.push(q)
+    if (!q) return this.json(route, 200, [])
+    const matches = this.players
+      .filter((p) => p.username.toLowerCase().includes(q))
+      .slice(0, SEARCH_LIMIT)
+    return this.json(route, 200, matches)
   }
 
   private async handleCreate(route: Route, request: PWRequest): Promise<void> {

--- a/web-client/e2e/page-objects/matches/new-match.page.ts
+++ b/web-client/e2e/page-objects/matches/new-match.page.ts
@@ -25,6 +25,17 @@ export class NewMatchPage {
   readonly summaryTop: Locator
   readonly summarySub: Locator
   readonly emptyPlayers: Locator
+  /** Placeholder grid shown while recent opponents load. */
+  readonly recentSkeleton: Locator
+  /** Inline fallback when a players request fails. */
+  readonly pickerError: Locator
+  /** "Try again" button inside the picker error fallback. */
+  readonly pickerRetry: Locator
+  /** Hint shown in the typeahead before anything is typed. */
+  readonly searchHint: Locator
+  /** "No one matches …" message in the typeahead dropdown. */
+  readonly searchNoMatch: Locator
+  readonly searchAllButton: Locator
 
   static async open(
     page: Page,
@@ -46,12 +57,20 @@ export class NewMatchPage {
     this.youName = page.locator('.nm-you-strip .name')
     this.startButton = page.getByRole('button', { name: /start match/i })
     this.cancelButton = page.getByRole('button', { name: /^cancel$/i })
-    this.error = page.getByRole('alert')
+    this.error = page.locator('.nm-error')
     this.ratedSwitch = page.getByRole('switch', { name: /rated match/i })
     this.selectedOpponentName = page.locator('.nm-selected .name')
     this.summaryTop = page.locator('.nm-summary .top')
     this.summarySub = page.locator('.nm-summary .sub')
     this.emptyPlayers = page.getByText(/no other players yet/i)
+    this.recentSkeleton = page.getByRole('status', { name: /loading players/i })
+    this.pickerError = page.locator('.nm-picker-error')
+    this.pickerRetry = page.getByRole('button', { name: /try again/i })
+    this.searchHint = page.getByText(/start typing to search/i)
+    this.searchNoMatch = page.getByText(/no one matches/i)
+    this.searchAllButton = page.getByRole('button', {
+      name: /search all players/i,
+    })
   }
 
   /** A registered-player chip in the default picker grid. */
@@ -83,9 +102,7 @@ export class NewMatchPage {
   }
 
   async openSearch(): Promise<void> {
-    await this.page
-      .getByRole('button', { name: /search all players/i })
-      .click()
+    await this.searchAllButton.click()
   }
 
   async search(term: string): Promise<void> {

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -36,20 +36,19 @@ export function useRecentOpponents() {
  * Server-side username search backing the opponent typeahead. The query is
  * disabled until `term` is non-empty, so an empty search box never hits the
  * network and the client never fetches the whole roster to filter locally.
- * Pass an already-debounced term.
+ * Pass an already-trimmed, already-debounced term.
  */
 export function usePlayerSearch(term: string) {
-  const trimmed = term.trim()
   return useQuery({
-    queryKey: playerSearchQueryKey(trimmed),
+    queryKey: playerSearchQueryKey(term),
     queryFn: async (): Promise<Player[]> =>
       unwrap(
         'search players',
         await api.GET('/v1/players/search', {
-          params: { query: { q: trimmed } },
+          params: { query: { q: term } },
         }),
       ),
-    enabled: trimmed.length > 0,
+    enabled: term.length > 0,
     staleTime: 1000 * 60,
     // Keep the previous matches on screen while the next term loads, so the
     // dropdown doesn't flicker empty between keystrokes.

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -6,15 +6,57 @@ export type Player = components['schemas']['PlayerRead']
 export type Match = components['schemas']['MatchRead']
 export type MatchCreate = components['schemas']['MatchCreate']
 
-export const PLAYERS_QUERY_KEY = ['players'] as const
+export const RECENT_OPPONENTS_QUERY_KEY = ['players', 'recent'] as const
 
-/** Registered users the signed-in player can pick as an opponent. */
-export function usePlayers() {
+/** Query key for a player search; the term is part of the key so each query is
+ * cached independently and `enabled` can gate the empty-term case. */
+export function playerSearchQueryKey(term: string) {
+  return ['players', 'search', term] as const
+}
+
+/**
+ * Opponents to feature in the new-match picker, most-recently-played first
+ * (backfilled with other registered players by the API). Errors are thrown so
+ * the surrounding error boundary can render a retry affordance.
+ */
+export function useRecentOpponents() {
   return useQuery({
-    queryKey: PLAYERS_QUERY_KEY,
+    queryKey: RECENT_OPPONENTS_QUERY_KEY,
     queryFn: async (): Promise<Player[]> =>
-      unwrap('load players', await api.GET('/v1/players')),
+      unwrap('load recent opponents', await api.GET('/v1/players/recent')),
     staleTime: 1000 * 60 * 5,
+    // Fail fast to the error boundary's explicit "Try again" button rather
+    // than silently retrying behind the skeleton.
+    retry: false,
+    throwOnError: true,
+  })
+}
+
+/**
+ * Server-side username search backing the opponent typeahead. The query is
+ * disabled until `term` is non-empty, so an empty search box never hits the
+ * network and the client never fetches the whole roster to filter locally.
+ * Pass an already-debounced term.
+ */
+export function usePlayerSearch(term: string) {
+  const trimmed = term.trim()
+  return useQuery({
+    queryKey: playerSearchQueryKey(trimmed),
+    queryFn: async (): Promise<Player[]> =>
+      unwrap(
+        'search players',
+        await api.GET('/v1/players/search', {
+          params: { query: { q: trimmed } },
+        }),
+      ),
+    enabled: trimmed.length > 0,
+    staleTime: 1000 * 60,
+    // Keep the previous matches on screen while the next term loads, so the
+    // dropdown doesn't flicker empty between keystrokes.
+    placeholderData: (previous) => previous,
+    // Fail fast to the error boundary's "Try again" rather than retrying.
+    retry: false,
+    throwOnError: true,
   })
 }
 

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -182,7 +182,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/players": {
+    "/v1/players/recent": {
         parameters: {
             query?: never;
             header?: never;
@@ -190,11 +190,38 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List Players
-         * @description List registered users the caller can pick as an opponent (everyone but
-         *     themselves).
+         * List Recent Opponents
+         * @description Opponents to feature in the new-match picker.
+         *
+         *     Ranked by how recently the caller last played them (most recent first).
+         *     A player with little or no match history is backfilled with other
+         *     registered users, alphabetically, so the list is never short or empty.
          */
-        get: operations["list_players_v1_players_get"];
+        get: operations["list_recent_opponents_v1_players_recent_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/players/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search Players
+         * @description Username substring search backing the opponent typeahead.
+         *
+         *     Case-insensitive, excludes the caller, and caps the result count so the
+         *     client never has to fetch and filter the whole roster. An empty query
+         *     matches nothing.
+         */
+        get: operations["search_players_v1_players_search_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1027,9 +1054,46 @@ export interface operations {
             };
         };
     };
-    list_players_v1_players_get: {
+    list_recent_opponents_v1_players_recent_get: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlayerRead"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    search_players_v1_players_search_get: {
+        parameters: {
+            query: {
+                /** @description Username substring to match against. */
+                q: string;
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: {

--- a/web-client/src/components/matches/opponent-picker-boundary.tsx
+++ b/web-client/src/components/matches/opponent-picker-boundary.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react'
+import { AlertTriangle, RotateCw } from 'lucide-react'
+import { ErrorBoundary, type FallbackProps } from 'react-error-boundary'
+import { QueryErrorResetBoundary } from '@tanstack/react-query'
+
+/**
+ * Fallback for a failed opponent-picker load (recent opponents or a typeahead
+ * search). Stays inside the match card and offers an explicit retry rather
+ * than dead-ending the whole page.
+ */
+function OpponentPickerError({ resetErrorBoundary }: FallbackProps) {
+  return (
+    <div className="nm-picker-error" role="alert">
+      <AlertTriangle size={20} strokeWidth={1.75} className="icon" />
+      <div className="body">
+        <div className="t">Couldn’t load players</div>
+        <div className="d">
+          Something went wrong reaching the server. You can still add a guest
+          or start without an opponent.
+        </div>
+      </div>
+      <button
+        type="button"
+        className="nm-picker-retry"
+        onClick={resetErrorBoundary}
+      >
+        <RotateCw size={14} strokeWidth={2} />
+        Try again
+      </button>
+    </div>
+  )
+}
+
+/**
+ * Wraps the opponent picker so a failed players request renders an inline
+ * error with a retry button instead of crashing the New Match page. The
+ * `QueryErrorResetBoundary` lets "Try again" clear React Query's cached error
+ * so the picker's queries refetch on reset.
+ */
+export function OpponentPickerBoundary({ children }: { children: ReactNode }) {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary FallbackComponent={OpponentPickerError} onReset={reset}>
+          {children}
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  )
+}

--- a/web-client/src/lib/use-debounced-value.ts
+++ b/web-client/src/lib/use-debounced-value.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Returns `value` only after it has stopped changing for `delayMs`. Used to
+ * keep fast-changing inputs (e.g. a search box) from firing a request on every
+ * keystroke.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(id)
+  }, [value, delayMs])
+
+  return debounced
+}

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -22,6 +22,10 @@ export const mockPlayers = [
   player({ username: 'park.j' }),
 ]
 
+// The recent-opponents endpoint is capped at six chips; the dev/test mock just
+// serves the first slice in roster order.
+export const mockRecentOpponents = mockPlayers.slice(0, 6)
+
 const state = createRbacState(DEMO_SEED)
 
 async function readJson(request: Request): Promise<unknown> {
@@ -67,9 +71,19 @@ export const handlers = [
     await delay(600)
     return HttpResponse.json(mockSession)
   }),
-  http.get('*/v1/players', async () => {
+  http.get('*/v1/players/recent', async () => {
     await delay(300)
-    return HttpResponse.json(mockPlayers)
+    return HttpResponse.json(mockRecentOpponents)
+  }),
+  http.get('*/v1/players/search', async ({ request }) => {
+    await delay(200)
+    const q = new URL(request.url).searchParams.get('q')?.trim().toLowerCase()
+    if (!q) return HttpResponse.json([])
+    return HttpResponse.json(
+      mockPlayers
+        .filter((p) => p.username.toLowerCase().includes(q))
+        .slice(0, 10),
+    )
   }),
   http.post('*/v1/matches', async ({ request }) => {
     await delay(400)

--- a/web-client/src/routes/matches/new.css
+++ b/web-client/src/routes/matches/new.css
@@ -455,6 +455,105 @@
   color: var(--fg-3);
 }
 
+/* --- Recent picker — skeleton --- */
+.nm-chip-skel {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--ink-900);
+  border: 1px solid var(--ink-600);
+  border-radius: 10px;
+}
+.nm-chip-skel .av,
+.nm-chip-skel .line {
+  background: var(--ink-700);
+  animation: nm-skel-pulse 1.4s var(--ease-out) infinite;
+}
+.nm-chip-skel .av {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+}
+.nm-chip-skel .lines {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 7px;
+}
+.nm-chip-skel .line {
+  height: 9px;
+  border-radius: 4px;
+}
+.nm-chip-skel .line.short {
+  width: 55%;
+}
+@keyframes nm-skel-pulse {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 0.9;
+  }
+}
+
+/* --- Recent picker — load error --- */
+.nm-picker-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 14px 16px;
+  background: rgba(255, 77, 109, 0.05);
+  border: 1px solid rgba(255, 77, 109, 0.35);
+  border-radius: 12px;
+}
+.nm-picker-error .icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: var(--loss, #ff4d6d);
+}
+.nm-picker-error .body {
+  flex: 1;
+  min-width: 0;
+}
+.nm-picker-error .t {
+  font: 600 14px var(--font-ui);
+  color: var(--fg-1);
+}
+.nm-picker-error .d {
+  margin-top: 3px;
+  font: 400 12px var(--font-ui);
+  line-height: 1.45;
+  color: var(--fg-3);
+}
+.nm-picker-retry {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  background: transparent;
+  border: 1px solid var(--ink-500);
+  border-radius: 8px;
+  font: 600 12px var(--font-ui);
+  color: var(--fg-2);
+  cursor: pointer;
+  transition: color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+}
+.nm-picker-retry:hover {
+  background: var(--bg-hover);
+  border-color: var(--ball-500);
+  color: var(--ball-500);
+}
+.nm-picker-retry:focus-visible {
+  outline: 2px solid var(--ball-400);
+  outline-offset: 2px;
+}
+
 /* --- Settings row --- */
 .nm-settings {
   display: grid;

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -8,7 +8,7 @@ import {
   createRouter,
 } from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { http, HttpResponse } from 'msw'
+import { delay, http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 import type { components } from '@/api/schema'
 import { server } from '@/mocks/server'
@@ -87,7 +87,7 @@ describe('NewMatchPage', () => {
     const user = userEvent.setup()
     let captured: unknown = null
     server.use(
-      http.get('*/v1/players', () =>
+      http.get('*/v1/players/recent', () =>
         HttpResponse.json([
           { id: 'pl-1', username: 'ada.lovelace' },
           { id: 'pl-2', username: 'grace.hopper' },
@@ -145,14 +145,11 @@ describe('NewMatchPage', () => {
   it('surfaces the API error detail when match creation fails', async () => {
     const user = userEvent.setup()
     server.use(
-      http.get('*/v1/players', () =>
+      http.get('*/v1/players/recent', () =>
         HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }]),
       ),
       http.post('*/v1/matches', () =>
-        HttpResponse.json(
-          { detail: 'opponent not found' },
-          { status: 404 },
-        ),
+        HttpResponse.json({ detail: 'opponent not found' }, { status: 404 }),
       ),
     )
     renderNewMatch()
@@ -164,6 +161,176 @@ describe('NewMatchPage', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
       /opponent not found/i,
+    )
+  })
+})
+
+describe('NewMatchPage — recent opponents', () => {
+  it('shows a skeleton while recent opponents load, then the chips', async () => {
+    server.use(
+      http.get('*/v1/players/recent', async () => {
+        await delay(80)
+        return HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }])
+      }),
+    )
+    renderNewMatch()
+
+    // The placeholder grid is up while the request is in flight.
+    expect(
+      await screen.findByRole('status', { name: /loading players/i }),
+    ).toBeInTheDocument()
+
+    // ...then the real chip replaces it.
+    expect(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('status', { name: /loading players/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders recent opponents in the order the endpoint returns them', async () => {
+    server.use(
+      http.get('*/v1/players/recent', () =>
+        HttpResponse.json([
+          { id: 'pl-3', username: 'carol.recent' },
+          { id: 'pl-1', username: 'alice.older' },
+          { id: 'pl-2', username: 'bob.oldest' },
+        ]),
+      ),
+    )
+    const { container } = renderNewMatch()
+
+    await screen.findByRole('button', { name: /carol\.recent/i })
+    const names = [...container.querySelectorAll('.nm-chip .n')].map(
+      (node) => node.textContent,
+    )
+    // Most-recently-played first — the client preserves the endpoint's order.
+    expect(names).toEqual(['carol.recent', 'alice.older', 'bob.oldest'])
+  })
+
+  it('shows an empty state when there are no other players', async () => {
+    server.use(http.get('*/v1/players/recent', () => HttpResponse.json([])))
+    renderNewMatch()
+
+    expect(
+      await screen.findByText(/no other players yet/i),
+    ).toBeInTheDocument()
+    // With nobody to find, the search affordance is hidden.
+    expect(
+      screen.queryByRole('button', { name: /search all players/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows a retry button when recent opponents fail to load, and recovers', async () => {
+    const user = userEvent.setup()
+    let calls = 0
+    server.use(
+      http.get('*/v1/players/recent', () => {
+        calls += 1
+        if (calls === 1) {
+          return HttpResponse.json(
+            { detail: 'database unavailable' },
+            { status: 500 },
+          )
+        }
+        return HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }])
+      }),
+    )
+    renderNewMatch()
+
+    // The picker boundary catches the failed load and offers a retry.
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /couldn.t load players/i,
+    )
+
+    await user.click(screen.getByRole('button', { name: /try again/i }))
+
+    // The retried request succeeds and the picker renders normally.
+    expect(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('NewMatchPage — opponent search', () => {
+  function recentWithOne() {
+    return http.get('*/v1/players/recent', () =>
+      HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }]),
+    )
+  }
+
+  it('hits the dedicated search endpoint as the player types', async () => {
+    const user = userEvent.setup()
+    const queries: string[] = []
+    server.use(
+      recentWithOne(),
+      http.get('*/v1/players/search', ({ request }) => {
+        queries.push(new URL(request.url).searchParams.get('q') ?? '')
+        return HttpResponse.json([
+          { id: 'pl-9', username: 'barbara.liskov' },
+        ])
+      }),
+    )
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /search all players/i }),
+    )
+    await user.type(
+      screen.getByPlaceholderText(/search by username/i),
+      'liskov',
+    )
+
+    // The server-side result is selectable straight from the dropdown.
+    await user.click(
+      await screen.findByRole('button', { name: /barbara\.liskov/i }),
+    )
+    expect(screen.getByText(/registered player/i)).toBeInTheDocument()
+    // The query reached the endpoint — nothing was filtered client-side.
+    expect(queries.at(-1)).toBe('liskov')
+  })
+
+  it('shows a hint before typing and a no-match message for an unknown name', async () => {
+    const user = userEvent.setup()
+    server.use(
+      recentWithOne(),
+      http.get('*/v1/players/search', () => HttpResponse.json([])),
+    )
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /search all players/i }),
+    )
+    expect(screen.getByText(/start typing to search/i)).toBeInTheDocument()
+
+    await user.type(
+      screen.getByPlaceholderText(/search by username/i),
+      'nobody-here',
+    )
+    expect(await screen.findByText(/no one matches/i)).toBeInTheDocument()
+  })
+
+  it('catches a failed search in the picker error boundary', async () => {
+    const user = userEvent.setup()
+    server.use(
+      recentWithOne(),
+      http.get('*/v1/players/search', () =>
+        HttpResponse.json({ detail: 'search unavailable' }, { status: 500 }),
+      ),
+    )
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /search all players/i }),
+    )
+    await user.type(
+      screen.getByPlaceholderText(/search by username/i),
+      'ada',
+    )
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /couldn.t load players/i,
     )
   })
 })

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -247,7 +247,6 @@ function SelectedOpponent({
 /*  Opponent — player grid (default)                                  */
 /* ------------------------------------------------------------------ */
 
-/** Placeholder grid shown while the recent-opponents request is in flight. */
 function RecentSkeleton() {
   return (
     <div className="nm-recent-grid" role="status" aria-label="Loading players">
@@ -266,8 +265,6 @@ function RecentSkeleton() {
 
 function RecentPicker({ onPick }: { onPick: (player: Player) => void }) {
   const [showSearch, setShowSearch] = useState(false)
-  // Recent opponents come from their own endpoint, ordered most-recently-played
-  // first; a failure here throws to the surrounding OpponentPickerBoundary.
   const { data: players = [], isLoading } = useRecentOpponents()
 
   if (showSearch) return <TypeaheadPicker onPick={onPick} />
@@ -324,12 +321,10 @@ function TypeaheadPicker({ onPick }: { onPick: (player: Player) => void }) {
   const [activeIdx, setActiveIdx] = useState(0)
   const wrapRef = useRef<HTMLDivElement>(null)
 
-  // Debounced so the search endpoint is hit once typing settles, not on every
-  // keystroke. The query itself is the React Query key, so each term is cached.
-  const debouncedQuery = useDebouncedValue(query, 250)
-  const term = debouncedQuery.trim()
-  // A failed search throws to the surrounding OpponentPickerBoundary.
-  const { data: results = [], isFetching } = usePlayerSearch(debouncedQuery)
+  // Trimmed and debounced; the (already-trimmed) term is the React Query key,
+  // so each search lands in its own cache slot.
+  const term = useDebouncedValue(query, 250).trim()
+  const { data: results = [], isFetching } = usePlayerSearch(term)
 
   useEffect(() => {
     function onClickOutside(e: MouseEvent) {
@@ -363,9 +358,48 @@ function TypeaheadPicker({ onPick }: { onPick: (player: Player) => void }) {
     }
   }
 
-  // `placeholderData` keeps the prior term's rows on screen while the next term
-  // loads, so an empty list only shows on the very first search.
+  // `placeholderData` on the search query keeps the prior term's rows visible
+  // while the next term loads, so this only fires on the very first search.
   const loadingFirstResults = isFetching && results.length === 0
+
+  function renderBody() {
+    if (!term) {
+      return (
+        <div className="nm-no-match">
+          Start typing to search players by username.
+        </div>
+      )
+    }
+    if (loadingFirstResults) {
+      return (
+        <div className="nm-no-match" role="status">
+          Searching…
+        </div>
+      )
+    }
+    if (results.length === 0) {
+      return (
+        <div className="nm-no-match">
+          No one matches “{term}”. Try a different name.
+        </div>
+      )
+    }
+    return results.map((p, i) => (
+      <button
+        type="button"
+        key={p.id}
+        className={cn('nm-item', i === activeIdx && 'active')}
+        onMouseEnter={() => setActiveIdx(i)}
+        onClick={() => onPick(p)}
+      >
+        <div className="av">{initialsOf(p.username)}</div>
+        <div className="body">
+          <div className="n">{p.username}</div>
+          <div className="m">REGISTERED PLAYER</div>
+        </div>
+      </button>
+    ))
+  }
 
   return (
     <div className="nm-search" ref={wrapRef}>
@@ -394,39 +428,7 @@ function TypeaheadPicker({ onPick }: { onPick: (player: Player) => void }) {
           </button>
         )}
       </div>
-      {open && (
-        <div className="nm-dropdown">
-          {!term ? (
-            <div className="nm-no-match">
-              Start typing to search players by username.
-            </div>
-          ) : loadingFirstResults ? (
-            <div className="nm-no-match" role="status">
-              Searching…
-            </div>
-          ) : results.length === 0 ? (
-            <div className="nm-no-match">
-              No one matches “{term}”. Try a different name.
-            </div>
-          ) : (
-            results.map((p, i) => (
-              <button
-                type="button"
-                key={p.id}
-                className={cn('nm-item', i === activeIdx && 'active')}
-                onMouseEnter={() => setActiveIdx(i)}
-                onClick={() => onPick(p)}
-              >
-                <div className="av">{initialsOf(p.username)}</div>
-                <div className="body">
-                  <div className="n">{p.username}</div>
-                  <div className="m">REGISTERED PLAYER</div>
-                </div>
-              </button>
-            ))
-          )}
-        </div>
-      )}
+      {open && <div className="nm-dropdown">{renderBody()}</div>}
     </div>
   )
 }

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { ArrowRight, Search } from 'lucide-react'
 import { z } from 'zod'
@@ -6,7 +6,14 @@ import { z } from 'zod'
 import { AppShell } from '@/components/app-shell'
 import { ApiError } from '@/api/client'
 import { useSession } from '@/api/session'
-import { useCreateMatch, usePlayers, type Player } from '@/api/matches'
+import {
+  useCreateMatch,
+  usePlayerSearch,
+  useRecentOpponents,
+  type Player,
+} from '@/api/matches'
+import { OpponentPickerBoundary } from '@/components/matches/opponent-picker-boundary'
+import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { cn } from '@/lib/utils'
 import './new.css'
 
@@ -98,7 +105,6 @@ function NewMatchPage() {
 function MatchCard() {
   const navigate = useNavigate()
   const { data: session } = useSession()
-  const { data: players = [], isLoading: playersLoading } = usePlayers()
   const createMatch = useCreateMatch()
 
   const [opponent, setOpponent] = useState<Opponent | null>(null)
@@ -167,11 +173,11 @@ function MatchCard() {
             onChange={() => setOpponent(null)}
           />
         ) : (
-          <RecentPicker
-            players={players}
-            loading={playersLoading}
-            onPick={(player) => setOpponent(registeredOpponent(player))}
-          />
+          <OpponentPickerBoundary>
+            <RecentPicker
+              onPick={(player) => setOpponent(registeredOpponent(player))}
+            />
+          </OpponentPickerBoundary>
         )}
 
         {!opponent && (
@@ -241,26 +247,36 @@ function SelectedOpponent({
 /*  Opponent — player grid (default)                                  */
 /* ------------------------------------------------------------------ */
 
-function RecentPicker({
-  players,
-  loading,
-  onPick,
-}: {
-  players: Player[]
-  loading: boolean
-  onPick: (player: Player) => void
-}) {
+/** Placeholder grid shown while the recent-opponents request is in flight. */
+function RecentSkeleton() {
+  return (
+    <div className="nm-recent-grid" role="status" aria-label="Loading players">
+      {Array.from({ length: 6 }, (_, i) => (
+        <div key={i} className="nm-chip-skel" aria-hidden="true">
+          <div className="av" />
+          <div className="lines">
+            <div className="line" />
+            <div className="line short" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function RecentPicker({ onPick }: { onPick: (player: Player) => void }) {
   const [showSearch, setShowSearch] = useState(false)
+  // Recent opponents come from their own endpoint, ordered most-recently-played
+  // first; a failure here throws to the surrounding OpponentPickerBoundary.
+  const { data: players = [], isLoading } = useRecentOpponents()
 
-  if (showSearch) return <TypeaheadPicker players={players} onPick={onPick} />
-
-  const featured = players.slice(0, 6)
+  if (showSearch) return <TypeaheadPicker onPick={onPick} />
 
   return (
     <div>
       <div className="nm-recent-label">
-        <span>Players</span>
-        {players.length > featured.length && (
+        <span>Recent opponents</span>
+        {!isLoading && players.length > 0 && (
           <button
             type="button"
             className="search-btn"
@@ -270,15 +286,15 @@ function RecentPicker({
           </button>
         )}
       </div>
-      {loading ? (
-        <div className="nm-no-match">Loading players…</div>
+      {isLoading ? (
+        <RecentSkeleton />
       ) : players.length === 0 ? (
         <div className="nm-no-match">
           No other players yet. Add a guest, or start without an opponent.
         </div>
       ) : (
         <div className="nm-recent-grid">
-          {featured.map((p) => (
+          {players.map((p) => (
             <button
               type="button"
               key={p.id}
@@ -302,23 +318,18 @@ function RecentPicker({
 /*  Opponent — typeahead search                                       */
 /* ------------------------------------------------------------------ */
 
-function TypeaheadPicker({
-  players,
-  onPick,
-}: {
-  players: Player[]
-  onPick: (player: Player) => void
-}) {
+function TypeaheadPicker({ onPick }: { onPick: (player: Player) => void }) {
   const [query, setQuery] = useState('')
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(true)
   const [activeIdx, setActiveIdx] = useState(0)
   const wrapRef = useRef<HTMLDivElement>(null)
 
-  const filtered = useMemo(() => {
-    const term = query.trim().toLowerCase()
-    if (!term) return players.slice(0, 8)
-    return players.filter((p) => p.username.toLowerCase().includes(term))
-  }, [players, query])
+  // Debounced so the search endpoint is hit once typing settles, not on every
+  // keystroke. The query itself is the React Query key, so each term is cached.
+  const debouncedQuery = useDebouncedValue(query, 250)
+  const term = debouncedQuery.trim()
+  // A failed search throws to the surrounding OpponentPickerBoundary.
+  const { data: results = [], isFetching } = usePlayerSearch(debouncedQuery)
 
   useEffect(() => {
     function onClickOutside(e: MouseEvent) {
@@ -339,20 +350,22 @@ function TypeaheadPicker({
     if (!open) return
     if (e.key === 'ArrowDown') {
       e.preventDefault()
-      setActiveIdx((i) => Math.min(filtered.length - 1, i + 1))
+      setActiveIdx((i) => Math.min(results.length - 1, i + 1))
     } else if (e.key === 'ArrowUp') {
       e.preventDefault()
       setActiveIdx((i) => Math.max(0, i - 1))
     } else if (e.key === 'Enter') {
       e.preventDefault()
-      const picked = filtered[activeIdx]
+      const picked = results[activeIdx]
       if (picked) onPick(picked)
     } else if (e.key === 'Escape') {
       setOpen(false)
     }
   }
 
-  const showHeader = !query.trim()
+  // `placeholderData` keeps the prior term's rows on screen while the next term
+  // loads, so an empty list only shows on the very first search.
+  const loadingFirstResults = isFetching && results.length === 0
 
   return (
     <div className="nm-search" ref={wrapRef}>
@@ -362,6 +375,7 @@ function TypeaheadPicker({
           className="nm-input"
           placeholder="Search by username"
           value={query}
+          autoFocus
           onChange={(e) => {
             changeQuery(e.target.value)
             setOpen(true)
@@ -382,33 +396,35 @@ function TypeaheadPicker({
       </div>
       {open && (
         <div className="nm-dropdown">
-          {showHeader && (
-            <div className="nm-opt-section">
-              Players <span className="line" />
-            </div>
-          )}
-          {filtered.length === 0 && (
+          {!term ? (
             <div className="nm-no-match">
-              {query
-                ? `No one matches “${query}”. Try a different name.`
-                : 'No other players yet.'}
+              Start typing to search players by username.
             </div>
+          ) : loadingFirstResults ? (
+            <div className="nm-no-match" role="status">
+              Searching…
+            </div>
+          ) : results.length === 0 ? (
+            <div className="nm-no-match">
+              No one matches “{term}”. Try a different name.
+            </div>
+          ) : (
+            results.map((p, i) => (
+              <button
+                type="button"
+                key={p.id}
+                className={cn('nm-item', i === activeIdx && 'active')}
+                onMouseEnter={() => setActiveIdx(i)}
+                onClick={() => onPick(p)}
+              >
+                <div className="av">{initialsOf(p.username)}</div>
+                <div className="body">
+                  <div className="n">{p.username}</div>
+                  <div className="m">REGISTERED PLAYER</div>
+                </div>
+              </button>
+            ))
           )}
-          {filtered.map((p, i) => (
-            <button
-              type="button"
-              key={p.id}
-              className={cn('nm-item', i === activeIdx && 'active')}
-              onMouseEnter={() => setActiveIdx(i)}
-              onClick={() => onPick(p)}
-            >
-              <div className="av">{initialsOf(p.username)}</div>
-              <div className="body">
-                <div className="n">{p.username}</div>
-                <div className="m">REGISTERED PLAYER</div>
-              </div>
-            </button>
-          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #90.

## What changed

**API.** Replaces fetch-all `GET /v1/players` with two focused endpoints:

- `GET /v1/players/recent?limit=6` — ranks opponents by recency of matches against the caller (most recent first), backfilled with other registered users alphabetically so a brand-new player still gets a non-empty list. One ordered join, hydrated User rows from a single round-trip.
- `GET /v1/players/search?q=&limit=10` — case-insensitive substring match, excludes the caller, escapes LIKE wildcards, capped result count.

**Web client.** The New Match opponent picker is wired to the new endpoints:

- `useRecentOpponents` drives the chip grid; a `RecentSkeleton` placeholder shows while it loads.
- `usePlayerSearch` (debounced 250ms via a small `useDebouncedValue` hook) backs the typeahead — the client no longer downloads the whole roster to filter locally.
- An `OpponentPickerBoundary` (react-error-boundary + `QueryErrorResetBoundary`) catches load failures and renders an inline "Couldn't load players" message with a **Try again** button. The guest / no-opponent skip row sits outside the boundary and stays usable while it's showing.

`schema.d.ts` regenerated; MSW handlers and the e2e `MatchStore` mock the new endpoints with delay + failure injection.

## Acceptance criteria (#90)

- [x] Default picker chips ordered by most-recently-played opponent
- [x] New player with no history still gets a non-empty default list
- [x] Typeahead hits a dedicated endpoint; no full-list fetch on the client
- [x] API + web tests cover recency ordering and the search endpoint, including empty / no-match states
- [x] `schema.d.ts` regenerated and committed

## Tests

- API pytest: **76 passed** (17 new in `test_players.py` covering recency order, dedupe, backfill, no-history fallback, exclude-self, limit cap, search substring/case/empty/no-match/cap/wildcard-escape, auth)
- Web vitest: **17 passed** (6 new — skeleton, recency order preserved, empty state, recent-failure retry+recovery, search-endpoint hit, no-match, search-failure error boundary)
- Playwright e2e: **116 passed** (9 new in `opponent-picker.spec.ts` — skeleton, recency order, empty state, retry-recovers, guest-after-failure, search hint / no-premature-request, server-side search, no-match, search-failure boundary)
- ESLint + `tsc -b && vite build`: clean
- OpenAPI schema drift: up to date

## Follow-ups from QA pass (Quinn)

A separate exploratory QA pass against the deployed build surfaced 9 issues — filed as #93–#101. They're not part of this PR; flagged for follow-up:

- #93 Critical — mobile chip grid overflows viewport ≤640px (CSS-only fix)
- #94 High — typeahead missing ARIA combobox semantics (a11y)
- #95 Medium ⚠️ unverified — "Start match" no-opponent silent (likely QA missed the inline error; needs reproduction)
- #96 Medium — search-failure Try again loses the typed query
- #97 Medium — Escape leaves input populated but tears down dropdown
- #98 Medium — cold-start race: recent 401s before session lands
- #99 Low — chip / dropdown accessible names include avatar initials
- #100 Low — typeahead doesn't support Home / End
- #101 Low — empty / emoji username falls back to "?" with no readable name

## Notes

- `GET /v1/players` is removed (no other consumer; the issue's whole point is that fetch-all doesn't scale).
- Picker queries use `retry: false` so failures fall fast to the explicit Try again rather than backing off silently behind the skeleton.
- API test fixtures (`api_client`) and helpers (`start_session`, `make_user`) were lifted to `tests/conftest.py` / `tests/_helpers.py` to dedupe with `test_matches.py` while I was in there.
- The local `docker-compose.dev.override.yml` is intentionally untracked (per its own comment, machine-local port overrides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)