### PR TITLE
Add Match List page at /matches

### DIFF
--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -43,7 +43,8 @@ const NAV_SECTIONS: NavSection[] = [
         ),
       },
       {
-        label: 'Live Matches',
+        label: 'Matches',
+        to: '/matches',
         badge: { label: '12', live: true },
         icon: (
           <svg

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as DesignSystemRouteImport } from './routes/design-system'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as AdminRouteImport } from './routes/admin'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as MatchesIndexRouteImport } from './routes/matches/index'
 import { Route as AdminIndexRouteImport } from './routes/admin.index'
 import { Route as MatchesNewRouteImport } from './routes/matches/new'
 import { Route as AdminUsersRouteImport } from './routes/admin.users'
@@ -44,6 +45,11 @@ const AdminRoute = AdminRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MatchesIndexRoute = MatchesIndexRouteImport.update({
+  id: '/matches/',
+  path: '/matches/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AdminIndexRoute = AdminIndexRouteImport.update({
@@ -89,6 +95,7 @@ export interface FileRoutesByFullPath {
   '/admin/users': typeof AdminUsersRoute
   '/matches/new': typeof MatchesNewRoute
   '/admin/': typeof AdminIndexRoute
+  '/matches/': typeof MatchesIndexRoute
   '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 export interface FileRoutesByTo {
@@ -101,6 +108,7 @@ export interface FileRoutesByTo {
   '/admin/users': typeof AdminUsersRoute
   '/matches/new': typeof MatchesNewRoute
   '/admin': typeof AdminIndexRoute
+  '/matches': typeof MatchesIndexRoute
   '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 export interface FileRoutesById {
@@ -115,6 +123,7 @@ export interface FileRoutesById {
   '/admin/users': typeof AdminUsersRoute
   '/matches/new': typeof MatchesNewRoute
   '/admin/': typeof AdminIndexRoute
+  '/matches/': typeof MatchesIndexRoute
   '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 export interface FileRouteTypes {
@@ -130,6 +139,7 @@ export interface FileRouteTypes {
     | '/admin/users'
     | '/matches/new'
     | '/admin/'
+    | '/matches/'
     | '/matches/$matchId/games/$gameId/scores/new'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -142,6 +152,7 @@ export interface FileRouteTypes {
     | '/admin/users'
     | '/matches/new'
     | '/admin'
+    | '/matches'
     | '/matches/$matchId/games/$gameId/scores/new'
   id:
     | '__root__'
@@ -155,6 +166,7 @@ export interface FileRouteTypes {
     | '/admin/users'
     | '/matches/new'
     | '/admin/'
+    | '/matches/'
     | '/matches/$matchId/games/$gameId/scores/new'
   fileRoutesById: FileRoutesById
 }
@@ -165,6 +177,7 @@ export interface RootRouteChildren {
   DesignSystemRoute: typeof DesignSystemRoute
   SettingsRoute: typeof SettingsRoute
   MatchesNewRoute: typeof MatchesNewRoute
+  MatchesIndexRoute: typeof MatchesIndexRoute
   MatchesMatchIdGamesGameIdScoresNewRoute: typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 
@@ -203,6 +216,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/matches/': {
+      id: '/matches/'
+      path: '/matches'
+      fullPath: '/matches/'
+      preLoaderRoute: typeof MatchesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/admin/': {
@@ -273,6 +293,7 @@ const rootRouteChildren: RootRouteChildren = {
   DesignSystemRoute: DesignSystemRoute,
   SettingsRoute: SettingsRoute,
   MatchesNewRoute: MatchesNewRoute,
+  MatchesIndexRoute: MatchesIndexRoute,
   MatchesMatchIdGamesGameIdScoresNewRoute:
     MatchesMatchIdGamesGameIdScoresNewRoute,
 }

--- a/web-client/src/routes/matches/index.css
+++ b/web-client/src/routes/matches/index.css
@@ -1,0 +1,794 @@
+/* =========================================================================
+   Match list page — ported from Claude Design "Match list.html".
+   All selectors scoped to .match-list-page so they don't bleed.
+   ========================================================================= */
+
+.match-list-page {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - var(--topbar-h));
+  overflow: hidden;
+  background: var(--bg-app);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+}
+
+/* ============ Action bar ============ */
+.match-list-page .action-bar {
+  height: 56px;
+  min-height: 56px;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+  gap: 16px;
+  background: var(--bg-app);
+}
+.match-list-page .action-bar-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--fg-1);
+}
+.match-list-page .action-bar-crumb {
+  color: var(--fg-3);
+  font-size: 13px;
+}
+.match-list-page .action-bar-crumb::before {
+  content: '·';
+  margin: 0 8px;
+}
+.match-list-page .live-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--serve-500);
+  letter-spacing: 0.14em;
+}
+.match-list-page .live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--serve-500);
+  box-shadow: 0 0 8px var(--serve-500);
+  animation: ball-pulse 1.4s ease-in-out infinite;
+}
+
+/* ============ Buttons ============ */
+.match-list-page .ml-btn {
+  font-family: var(--font-ui);
+  font-weight: 600;
+  font-size: 13px;
+  height: 36px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.match-list-page .ml-btn:active {
+  transform: scale(0.97);
+}
+.match-list-page .ml-btn.ghost {
+  background: transparent;
+  color: var(--fg-2);
+  border-color: var(--border-default);
+}
+.match-list-page .ml-btn.ghost:hover {
+  background: var(--bg-hover);
+  color: var(--fg-1);
+}
+.match-list-page .ml-btn.primary {
+  background: var(--ball-500);
+  color: var(--fg-inverse);
+}
+.match-list-page .ml-btn.primary:hover {
+  background: var(--ball-400);
+  box-shadow: var(--shadow-glow);
+}
+.match-list-page .ml-btn.danger {
+  background: transparent;
+  color: var(--loss);
+  border: 1px solid rgba(255, 77, 109, 0.4);
+}
+.match-list-page .ml-btn.danger:hover {
+  background: rgba(255, 77, 109, 0.1);
+  color: var(--loss);
+}
+.match-list-page .ml-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ============ Filter row ============ */
+.match-list-page .filter-row {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  background: var(--bg-app);
+}
+.match-list-page .ml-search {
+  position: relative;
+  flex: 0 1 320px;
+  min-width: 220px;
+}
+.match-list-page .ml-search input {
+  width: 100%;
+  height: 36px;
+  padding: 0 12px 0 36px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  transition: border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.match-list-page .ml-search input::placeholder {
+  color: var(--fg-3);
+}
+.match-list-page .ml-search input:focus {
+  outline: none;
+  border-color: var(--ball-500);
+  box-shadow: 0 0 0 2px rgba(255, 122, 26, 0.15);
+}
+.match-list-page .ml-search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--fg-3);
+  pointer-events: none;
+  display: inline-flex;
+}
+.match-list-page .ml-search-clear {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--bg-raised);
+  color: var(--fg-3);
+  border: none;
+  cursor: pointer;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  font-size: 14px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.match-list-page .ml-search-clear:hover {
+  color: var(--fg-1);
+}
+
+.match-list-page .seg {
+  display: inline-flex;
+  background: var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  padding: 3px;
+  gap: 2px;
+}
+.match-list-page .seg-btn {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg-3);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 5px 12px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.match-list-page .seg-btn:hover {
+  color: var(--fg-1);
+}
+.match-list-page .seg-btn.is-active {
+  background: var(--bg-raised);
+  color: var(--fg-1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+.match-list-page .seg-btn .live-dot {
+  width: 6px;
+  height: 6px;
+}
+.match-list-page .seg-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-3);
+  font-variant-numeric: tabular-nums;
+  padding: 0 5px;
+  border-radius: 4px;
+  background: var(--bg-app);
+}
+.match-list-page .seg-btn.is-active .seg-count {
+  background: var(--ink-600);
+  color: var(--fg-1);
+}
+
+.match-list-page .filter-spacer {
+  flex: 1;
+}
+
+.match-list-page .select-wrap {
+  position: relative;
+}
+.match-list-page .ml-select {
+  appearance: none;
+  -webkit-appearance: none;
+  height: 36px;
+  padding: 0 32px 0 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  cursor: pointer;
+  min-width: 120px;
+}
+.match-list-page .ml-select:focus {
+  outline: none;
+  border-color: var(--ball-500);
+  box-shadow: 0 0 0 2px rgba(255, 122, 26, 0.15);
+}
+.match-list-page .select-caret {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--fg-3);
+  display: inline-flex;
+}
+.match-list-page .filter-label {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+  margin-right: -4px;
+}
+
+/* ============ Table ============ */
+.match-list-page .table-wrap {
+  flex: 1;
+  min-width: 0;
+  overflow: auto;
+}
+.match-list-page table.matches {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-family: var(--font-ui);
+}
+.match-list-page table.matches thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--bg-panel);
+  text-align: left;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  white-space: nowrap;
+  user-select: none;
+}
+.match-list-page table.matches thead th.sortable {
+  cursor: pointer;
+  transition: color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.match-list-page table.matches thead th.sortable:hover {
+  color: var(--fg-1);
+}
+.match-list-page table.matches thead th .sort-arrow {
+  display: inline-block;
+  margin-left: 4px;
+  font-family: var(--font-mono);
+  color: var(--ball-500);
+  opacity: 0;
+  transition: opacity 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.match-list-page table.matches thead th.is-sorted {
+  color: var(--fg-1);
+}
+.match-list-page table.matches thead th.is-sorted .sort-arrow {
+  opacity: 1;
+}
+
+.match-list-page table.matches tbody td {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 14px;
+  color: var(--fg-1);
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.match-list-page table.matches tbody tr {
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  cursor: pointer;
+}
+.match-list-page table.matches tbody tr:hover {
+  background: var(--bg-hover);
+}
+.match-list-page table.matches tbody tr.is-live td:first-child {
+  box-shadow: inset 2px 0 0 var(--serve-500);
+}
+
+.match-list-page .mono {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+.match-list-page .id-cell {
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+.match-list-page .round-chip {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--bg-card);
+  color: var(--fg-2);
+  border: 1px solid var(--border-subtle);
+  letter-spacing: 0.04em;
+}
+.match-list-page .round-chip.is-final {
+  background: var(--bg-accent-soft);
+  color: var(--ball-400);
+  border-color: rgba(255, 122, 26, 0.3);
+}
+.match-list-page .court-cell {
+  font-family: var(--font-mono);
+  color: var(--fg-2);
+  font-size: 13px;
+}
+.match-list-page .player {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.match-list-page .ml-avatar {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--fg-1);
+  border: 1px solid var(--border-subtle);
+}
+.match-list-page .player-name {
+  font-size: 14px;
+  color: var(--fg-1);
+}
+.match-list-page .player-name.is-winner {
+  color: var(--serve-500);
+  font-weight: 600;
+}
+.match-list-page .player-name.is-loser {
+  color: var(--fg-3);
+}
+.match-list-page .seed-tag {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-3);
+  margin-left: 6px;
+}
+.match-list-page .vs {
+  color: var(--fg-3);
+  font-size: 11px;
+  margin: 0 6px;
+  font-family: var(--font-mono);
+}
+.match-list-page .score-cell {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 14px;
+  font-weight: 600;
+}
+.match-list-page .score-cell .games {
+  color: var(--fg-1);
+}
+.match-list-page .score-cell .games .lost {
+  color: var(--fg-3);
+}
+.match-list-page .score-cell .pending {
+  color: var(--fg-3);
+}
+.match-list-page .score-cell .score-sep {
+  color: var(--fg-3);
+  margin: 0 4px;
+}
+.match-list-page .score-cell .score-meta {
+  color: var(--fg-3);
+  margin-left: 8px;
+  font-weight: 500;
+}
+
+.match-list-page .status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+.match-list-page .status.is-live {
+  color: var(--serve-500);
+  background: var(--bg-live-soft);
+}
+.match-list-page .status.is-final {
+  color: var(--fg-2);
+  background: var(--bg-raised);
+}
+.match-list-page .status.is-scheduled {
+  color: var(--warn);
+  background: rgba(255, 196, 61, 0.12);
+}
+.match-list-page .status.is-called {
+  color: var(--info);
+  background: rgba(111, 181, 255, 0.12);
+}
+.match-list-page .status .live-dot {
+  width: 6px;
+  height: 6px;
+}
+
+.match-list-page .time-cell {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-3);
+}
+.match-list-page .time-cell .strong {
+  color: var(--fg-2);
+}
+
+.match-list-page .row-action {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  color: var(--fg-3);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.match-list-page .row-action:hover {
+  background: var(--bg-raised);
+  color: var(--fg-1);
+}
+
+/* ============ Context chips ============ */
+.match-list-page .ctx-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg-2);
+  line-height: 1;
+}
+.match-list-page .ctx-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.match-list-page .ctx-tournament .ctx-dot {
+  background: var(--ball-500);
+  box-shadow: 0 0 6px rgba(255, 122, 26, 0.55);
+}
+.match-list-page .ctx-club .ctx-dot {
+  background: var(--info);
+}
+.match-list-page .ctx-casual .ctx-dot {
+  background: var(--fg-3);
+}
+.match-list-page .ctx-ladder .ctx-dot {
+  background: var(--warn);
+}
+.match-list-page .ctx-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-3);
+  margin-top: 3px;
+  letter-spacing: 0.02em;
+}
+.match-list-page .cell-na {
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+}
+
+/* ============ Skeleton / loading ============ */
+@keyframes match-list-shimmer {
+  0% {
+    background-position: -200px 0;
+  }
+  100% {
+    background-position: calc(200px + 100%) 0;
+  }
+}
+.match-list-page .skeleton {
+  display: inline-block;
+  background: linear-gradient(
+    90deg,
+    var(--ink-800) 0%,
+    var(--ink-700) 50%,
+    var(--ink-800) 100%
+  );
+  background-size: 200px 100%;
+  animation: match-list-shimmer 1.4s linear infinite;
+  border-radius: 4px;
+  height: 12px;
+  vertical-align: middle;
+}
+.match-list-page .skeleton.s-avatar {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+}
+.match-list-page .skeleton.s-chip {
+  width: 44px;
+  height: 18px;
+  border-radius: 999px;
+}
+.match-list-page .skeleton.s-text-sm {
+  width: 60px;
+}
+.match-list-page .skeleton.s-text-md {
+  width: 110px;
+}
+.match-list-page .skeleton.s-text-lg {
+  width: 160px;
+}
+.match-list-page .skeleton-row td {
+  vertical-align: middle;
+}
+.match-list-page .loading-bar {
+  height: 2px;
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+  background: var(--ink-800);
+}
+.match-list-page .loading-bar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: 40%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--ball-500),
+    transparent
+  );
+  animation: match-list-loading-bar 1.1s cubic-bezier(0.65, 0, 0.35, 1) infinite;
+}
+@keyframes match-list-loading-bar {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(350%);
+  }
+}
+
+/* ============ Error state ============ */
+.match-list-page .error-state {
+  padding: 56px 24px;
+  text-align: center;
+  max-width: 520px;
+  margin: 24px auto;
+  background: var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-radius: 14px;
+}
+.match-list-page .error-icon {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 16px;
+  border-radius: 50%;
+  background: rgba(255, 77, 109, 0.12);
+  color: var(--loss);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.match-list-page .error-title {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--fg-1);
+  margin-bottom: 6px;
+}
+.match-list-page .error-sub {
+  font-size: 13px;
+  color: var(--fg-3);
+  margin-bottom: 18px;
+}
+.match-list-page .error-code {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-3);
+  padding: 3px 8px;
+  border-radius: 4px;
+  background: var(--bg-app);
+  border: 1px solid var(--border-subtle);
+  margin-bottom: 18px;
+}
+.match-list-page .error-actions {
+  display: inline-flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+/* Inline retry banner */
+.match-list-page .inline-error {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  margin: 16px 24px;
+  background: rgba(255, 77, 109, 0.08);
+  border: 1px solid rgba(255, 77, 109, 0.3);
+  border-radius: 10px;
+}
+.match-list-page .inline-error-icon {
+  color: var(--loss);
+  flex-shrink: 0;
+  display: inline-flex;
+}
+.match-list-page .inline-error-text {
+  flex: 1;
+  font-size: 13px;
+  color: var(--fg-2);
+}
+.match-list-page .inline-error-text .strong {
+  color: var(--fg-1);
+  font-weight: 600;
+}
+
+/* ============ Empty state ============ */
+.match-list-page .empty {
+  padding: 80px 24px;
+  text-align: center;
+  color: var(--fg-3);
+}
+.match-list-page .empty-icon {
+  width: 56px;
+  height: 56px;
+  opacity: 0.4;
+  margin: 0 auto 16px;
+}
+.match-list-page .empty-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--fg-2);
+  margin-bottom: 4px;
+}
+.match-list-page .empty-sub {
+  font-size: 13px;
+  color: var(--fg-3);
+}
+.match-list-page .empty-clear {
+  margin-top: 16px;
+}
+
+/* ============ Pagination ============ */
+.match-list-page .footer {
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-app);
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+.match-list-page .footer-info {
+  font-size: 13px;
+  color: var(--fg-3);
+}
+.match-list-page .footer-info .mono {
+  color: var(--fg-1);
+}
+.match-list-page .footer-spacer {
+  flex: 1;
+}
+.match-list-page .page-size {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--fg-3);
+}
+.match-list-page .pagination {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.match-list-page .page-btn {
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--fg-2);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.match-list-page .page-btn:hover:not(:disabled):not(.is-current) {
+  background: var(--bg-hover);
+  color: var(--fg-1);
+}
+.match-list-page .page-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+.match-list-page .page-btn.is-current {
+  background: var(--ball-500);
+  color: var(--fg-inverse);
+  font-weight: 700;
+}
+.match-list-page .page-btn.is-ellipsis {
+  color: var(--fg-3);
+  cursor: default;
+  pointer-events: none;
+}
+.match-list-page .page-btn.is-nav {
+  color: var(--fg-3);
+}
+.match-list-page .page-btn.is-nav:not(:disabled):hover {
+  color: var(--fg-1);
+  background: var(--bg-hover);
+}

--- a/web-client/src/routes/matches/index.css
+++ b/web-client/src/routes/matches/index.css
@@ -1,8 +1,3 @@
-/* =========================================================================
-   Match list page — ported from Claude Design "Match list.html".
-   All selectors scoped to .match-list-page so they don't bleed.
-   ========================================================================= */
-
 .match-list-page {
   display: flex;
   flex-direction: column;

--- a/web-client/src/routes/matches/index.css
+++ b/web-client/src/routes/matches/index.css
@@ -51,59 +51,6 @@
   animation: ball-pulse 1.4s ease-in-out infinite;
 }
 
-/* ============ Buttons ============ */
-.match-list-page .ml-btn {
-  font-family: var(--font-ui);
-  font-weight: 600;
-  font-size: 13px;
-  height: 36px;
-  padding: 0 14px;
-  border-radius: 8px;
-  border: 1px solid transparent;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-    color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-    border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-    box-shadow 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-    transform 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-.match-list-page .ml-btn:active {
-  transform: scale(0.97);
-}
-.match-list-page .ml-btn.ghost {
-  background: transparent;
-  color: var(--fg-2);
-  border-color: var(--border-default);
-}
-.match-list-page .ml-btn.ghost:hover {
-  background: var(--bg-hover);
-  color: var(--fg-1);
-}
-.match-list-page .ml-btn.primary {
-  background: var(--ball-500);
-  color: var(--fg-inverse);
-}
-.match-list-page .ml-btn.primary:hover {
-  background: var(--ball-400);
-  box-shadow: var(--shadow-glow);
-}
-.match-list-page .ml-btn.danger {
-  background: transparent;
-  color: var(--loss);
-  border: 1px solid rgba(255, 77, 109, 0.4);
-}
-.match-list-page .ml-btn.danger:hover {
-  background: rgba(255, 77, 109, 0.1);
-  color: var(--loss);
-}
-.match-list-page .ml-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
 /* ============ Filter row ============ */
 .match-list-page .filter-row {
   padding: 16px 24px;
@@ -119,26 +66,6 @@
   flex: 0 1 320px;
   min-width: 220px;
 }
-.match-list-page .ml-search input {
-  width: 100%;
-  height: 36px;
-  padding: 0 12px 0 36px;
-  background: var(--bg-card);
-  border: 1px solid var(--border-default);
-  border-radius: 8px;
-  color: var(--fg-1);
-  font-family: var(--font-ui);
-  font-size: 13px;
-  transition: border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-.match-list-page .ml-search input::placeholder {
-  color: var(--fg-3);
-}
-.match-list-page .ml-search input:focus {
-  outline: none;
-  border-color: var(--ball-500);
-  box-shadow: 0 0 0 2px rgba(255, 122, 26, 0.15);
-}
 .match-list-page .ml-search-icon {
   position: absolute;
   left: 12px;
@@ -147,6 +74,7 @@
   color: var(--fg-3);
   pointer-events: none;
   display: inline-flex;
+  z-index: 1;
 }
 .match-list-page .ml-search-clear {
   position: absolute;
@@ -160,8 +88,6 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  font-size: 14px;
-  line-height: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -170,42 +96,6 @@
   color: var(--fg-1);
 }
 
-.match-list-page .seg {
-  display: inline-flex;
-  background: var(--bg-card);
-  border: 1px solid var(--border-default);
-  border-radius: 8px;
-  padding: 3px;
-  gap: 2px;
-}
-.match-list-page .seg-btn {
-  font-family: var(--font-ui);
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--fg-3);
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 5px 12px;
-  border-radius: 6px;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-    color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-.match-list-page .seg-btn:hover {
-  color: var(--fg-1);
-}
-.match-list-page .seg-btn.is-active {
-  background: var(--bg-raised);
-  color: var(--fg-1);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
-}
-.match-list-page .seg-btn .live-dot {
-  width: 6px;
-  height: 6px;
-}
 .match-list-page .seg-count {
   font-family: var(--font-mono);
   font-size: 11px;
@@ -215,7 +105,7 @@
   border-radius: 4px;
   background: var(--bg-app);
 }
-.match-list-page .seg-btn.is-active .seg-count {
+.match-list-page [data-state='active'] .seg-count {
   background: var(--ink-600);
   color: var(--fg-1);
 }
@@ -224,37 +114,6 @@
   flex: 1;
 }
 
-.match-list-page .select-wrap {
-  position: relative;
-}
-.match-list-page .ml-select {
-  appearance: none;
-  -webkit-appearance: none;
-  height: 36px;
-  padding: 0 32px 0 12px;
-  background: var(--bg-card);
-  border: 1px solid var(--border-default);
-  border-radius: 8px;
-  color: var(--fg-1);
-  font-family: var(--font-ui);
-  font-size: 13px;
-  cursor: pointer;
-  min-width: 120px;
-}
-.match-list-page .ml-select:focus {
-  outline: none;
-  border-color: var(--ball-500);
-  box-shadow: 0 0 0 2px rgba(255, 122, 26, 0.15);
-}
-.match-list-page .select-caret {
-  position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
-  pointer-events: none;
-  color: var(--fg-3);
-  display: inline-flex;
-}
 .match-list-page .filter-label {
   font-family: var(--font-ui);
   font-size: 10px;
@@ -371,20 +230,6 @@
   gap: 8px;
   min-width: 0;
 }
-.match-list-page .ml-avatar {
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 700;
-  color: var(--fg-1);
-  border: 1px solid var(--border-subtle);
-}
 .match-list-page .player-name {
   font-size: 14px;
   color: var(--fg-1);
@@ -433,35 +278,34 @@
   font-weight: 500;
 }
 
-.match-list-page .status {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+/* ============ Status tones (shadcn Badge + overrides) ============ */
+.match-list-page .status-pill {
   font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   padding: 4px 10px;
-  border-radius: 999px;
+  height: auto;
+  gap: 6px;
 }
-.match-list-page .status.is-live {
+.match-list-page .status-tone-live {
   color: var(--serve-500);
   background: var(--bg-live-soft);
 }
-.match-list-page .status.is-final {
+.match-list-page .status-tone-final {
   color: var(--fg-2);
   background: var(--bg-raised);
 }
-.match-list-page .status.is-scheduled {
+.match-list-page .status-tone-scheduled {
   color: var(--warn);
   background: rgba(255, 196, 61, 0.12);
 }
-.match-list-page .status.is-called {
+.match-list-page .status-tone-called {
   color: var(--info);
   background: rgba(111, 181, 255, 0.12);
 }
-.match-list-page .status .live-dot {
+.match-list-page .status-pill .live-dot {
   width: 6px;
   height: 6px;
 }
@@ -536,155 +380,6 @@
   font-family: var(--font-mono);
 }
 
-/* ============ Skeleton / loading ============ */
-@keyframes match-list-shimmer {
-  0% {
-    background-position: -200px 0;
-  }
-  100% {
-    background-position: calc(200px + 100%) 0;
-  }
-}
-.match-list-page .skeleton {
-  display: inline-block;
-  background: linear-gradient(
-    90deg,
-    var(--ink-800) 0%,
-    var(--ink-700) 50%,
-    var(--ink-800) 100%
-  );
-  background-size: 200px 100%;
-  animation: match-list-shimmer 1.4s linear infinite;
-  border-radius: 4px;
-  height: 12px;
-  vertical-align: middle;
-}
-.match-list-page .skeleton.s-avatar {
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-}
-.match-list-page .skeleton.s-chip {
-  width: 44px;
-  height: 18px;
-  border-radius: 999px;
-}
-.match-list-page .skeleton.s-text-sm {
-  width: 60px;
-}
-.match-list-page .skeleton.s-text-md {
-  width: 110px;
-}
-.match-list-page .skeleton.s-text-lg {
-  width: 160px;
-}
-.match-list-page .skeleton-row td {
-  vertical-align: middle;
-}
-.match-list-page .loading-bar {
-  height: 2px;
-  width: 100%;
-  overflow: hidden;
-  position: relative;
-  background: var(--ink-800);
-}
-.match-list-page .loading-bar::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  width: 40%;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    var(--ball-500),
-    transparent
-  );
-  animation: match-list-loading-bar 1.1s cubic-bezier(0.65, 0, 0.35, 1) infinite;
-}
-@keyframes match-list-loading-bar {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(350%);
-  }
-}
-
-/* ============ Error state ============ */
-.match-list-page .error-state {
-  padding: 56px 24px;
-  text-align: center;
-  max-width: 520px;
-  margin: 24px auto;
-  background: var(--bg-card);
-  border: 1px solid var(--border-default);
-  border-radius: 14px;
-}
-.match-list-page .error-icon {
-  width: 56px;
-  height: 56px;
-  margin: 0 auto 16px;
-  border-radius: 50%;
-  background: rgba(255, 77, 109, 0.12);
-  color: var(--loss);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-.match-list-page .error-title {
-  font-size: 17px;
-  font-weight: 600;
-  color: var(--fg-1);
-  margin-bottom: 6px;
-}
-.match-list-page .error-sub {
-  font-size: 13px;
-  color: var(--fg-3);
-  margin-bottom: 18px;
-}
-.match-list-page .error-code {
-  display: inline-block;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--fg-3);
-  padding: 3px 8px;
-  border-radius: 4px;
-  background: var(--bg-app);
-  border: 1px solid var(--border-subtle);
-  margin-bottom: 18px;
-}
-.match-list-page .error-actions {
-  display: inline-flex;
-  gap: 10px;
-  justify-content: center;
-}
-
-/* Inline retry banner */
-.match-list-page .inline-error {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 16px;
-  margin: 16px 24px;
-  background: rgba(255, 77, 109, 0.08);
-  border: 1px solid rgba(255, 77, 109, 0.3);
-  border-radius: 10px;
-}
-.match-list-page .inline-error-icon {
-  color: var(--loss);
-  flex-shrink: 0;
-  display: inline-flex;
-}
-.match-list-page .inline-error-text {
-  flex: 1;
-  font-size: 13px;
-  color: var(--fg-2);
-}
-.match-list-page .inline-error-text .strong {
-  color: var(--fg-1);
-  font-weight: 600;
-}
-
 /* ============ Empty state ============ */
 .match-list-page .empty {
   padding: 80px 24px;
@@ -711,7 +406,7 @@
   margin-top: 16px;
 }
 
-/* ============ Pagination ============ */
+/* ============ Footer layout ============ */
 .match-list-page .footer {
   border-top: 1px solid var(--border-subtle);
   background: var(--bg-app);
@@ -738,52 +433,4 @@
   gap: 8px;
   font-size: 12px;
   color: var(--fg-3);
-}
-.match-list-page .pagination {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-.match-list-page .page-btn {
-  min-width: 32px;
-  height: 32px;
-  padding: 0 8px;
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  color: var(--fg-2);
-  font-family: var(--font-mono);
-  font-size: 13px;
-  font-variant-numeric: tabular-nums;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-    color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-.match-list-page .page-btn:hover:not(:disabled):not(.is-current) {
-  background: var(--bg-hover);
-  color: var(--fg-1);
-}
-.match-list-page .page-btn:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
-}
-.match-list-page .page-btn.is-current {
-  background: var(--ball-500);
-  color: var(--fg-inverse);
-  font-weight: 700;
-}
-.match-list-page .page-btn.is-ellipsis {
-  color: var(--fg-3);
-  cursor: default;
-  pointer-events: none;
-}
-.match-list-page .page-btn.is-nav {
-  color: var(--fg-3);
-}
-.match-list-page .page-btn.is-nav:not(:disabled):hover {
-  color: var(--fg-1);
-  background: var(--bg-hover);
 }

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -719,11 +719,6 @@ function PaginationFooter(props: PaginationProps) {
                     e.preventDefault()
                     setPage(t)
                   }}
-                  className={
-                    t === page
-                      ? 'bg-primary text-primary-foreground hover:bg-[color:var(--ball-400)] hover:text-primary-foreground'
-                      : undefined
-                  }
                 >
                   {t}
                 </PaginationLink>

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -1,5 +1,15 @@
 import { Fragment, useMemo, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  Inbox,
+  MoreHorizontal,
+  Search,
+} from 'lucide-react'
 
 import { AppShell } from '@/components/app-shell'
 import './index.css'
@@ -7,11 +17,6 @@ import './index.css'
 export const Route = createFileRoute('/matches/')({
   component: MatchesPage,
 })
-
-/* ------------------------------------------------------------------ */
-/*  Mock data — ported from Claude Design "Match list" handoff.       */
-/*  No backend yet; everything in this file is seeded & client-only.  */
-/* ------------------------------------------------------------------ */
 
 type ContextKey = 'tournament' | 'club' | 'casual' | 'ladder'
 type StatusKey = 'live' | 'final' | 'called' | 'scheduled'
@@ -78,6 +83,8 @@ const CONTEXTS: Record<ContextKey, { label: string; short: string }> = {
 
 const TOURNAMENTS = ['Spring Open', 'City Cup', 'River League']
 const CLUBS = ['Riverside TT', 'East Side Pong', 'Downtown Paddle']
+
+const MOCK_TODAY_MS = new Date('2026-05-16T00:00:00').getTime()
 
 const ROUND_DEFS = [
   { code: 'R64', label: 'Round of 64', order: 1 },
@@ -242,79 +249,6 @@ function buildMatch(input: BuildMatchInput): Match {
   }
 }
 
-/* ------------------------------------------------------------------ */
-/*  Icons                                                             */
-/* ------------------------------------------------------------------ */
-
-function IconSearch() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="11" cy="11" r="7" />
-      <line x1="21" y1="21" x2="16.65" y2="16.65" />
-    </svg>
-  )
-}
-function IconCaret() {
-  return (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
-      <polyline points="6 9 12 15 18 9" />
-    </svg>
-  )
-}
-function IconChevL() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
-      <polyline points="15 18 9 12 15 6" />
-    </svg>
-  )
-}
-function IconChevR() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
-      <polyline points="9 18 15 12 9 6" />
-    </svg>
-  )
-}
-function IconChevLL() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
-      <polyline points="11 17 6 12 11 7" />
-      <polyline points="18 17 13 12 18 7" />
-    </svg>
-  )
-}
-function IconChevRR() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
-      <polyline points="13 17 18 12 13 7" />
-      <polyline points="6 17 11 12 6 7" />
-    </svg>
-  )
-}
-function IconMore() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="5" cy="12" r="1.4" />
-      <circle cx="12" cy="12" r="1.4" />
-      <circle cx="19" cy="12" r="1.4" />
-    </svg>
-  )
-}
-function IconEmpty() {
-  return (
-    <svg viewBox="0 0 64 64" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <ellipse cx="32" cy="44" rx="22" ry="4" />
-      <path d="M14 44V20l36-4v24" />
-      <line x1="14" y1="20" x2="50" y2="16" />
-      <circle cx="46" cy="14" r="3" fill="currentColor" opacity="0.5" />
-    </svg>
-  )
-}
-
-/* ------------------------------------------------------------------ */
-/*  Sub-components                                                    */
-/* ------------------------------------------------------------------ */
-
 interface Counts {
   total: number
   live: number
@@ -332,7 +266,7 @@ function ActionBar({ liveCount }: { liveCount: number }) {
         <span className="live-dot" />
         {String(liveCount).padStart(2, '0')} LIVE
       </span>
-      <div style={{ flex: 1 }} />
+      <div className="filter-spacer" />
       <button type="button" className="ml-btn ghost">Export CSV</button>
       <button type="button" className="ml-btn primary">+ New match</button>
     </div>
@@ -387,7 +321,7 @@ function FilterRow(props: FilterRowProps) {
   return (
     <div className="filter-row">
       <div className="ml-search">
-        <span className="ml-search-icon"><IconSearch /></span>
+        <span className="ml-search-icon"><Search size={16} strokeWidth={2} /></span>
         <input
           placeholder="Search players or match #…"
           value={q}
@@ -422,7 +356,7 @@ function FilterRow(props: FilterRowProps) {
             <option key={k} value={k}>{v.label}</option>
           ))}
         </select>
-        <span className="select-caret"><IconCaret /></span>
+        <span className="select-caret"><ChevronDown size={12} strokeWidth={2.4} /></span>
       </div>
 
       <span className="filter-label">Round</span>
@@ -433,7 +367,7 @@ function FilterRow(props: FilterRowProps) {
             <option key={r.code} value={r.code}>{r.label}</option>
           ))}
         </select>
-        <span className="select-caret"><IconCaret /></span>
+        <span className="select-caret"><ChevronDown size={12} strokeWidth={2.4} /></span>
       </div>
 
       <span className="filter-label">Court</span>
@@ -444,7 +378,7 @@ function FilterRow(props: FilterRowProps) {
             <option key={c} value={String(c)}>Court {c}</option>
           ))}
         </select>
-        <span className="select-caret"><IconCaret /></span>
+        <span className="select-caret"><ChevronDown size={12} strokeWidth={2.4} /></span>
       </div>
 
       {anyFilter && (
@@ -512,10 +446,11 @@ function ScoreCell({ m }: { m: Match }) {
       </span>
     )
   }
+  const winnerIdx = m.winner === 'a' ? 0 : 1
   return (
     <span className="score-cell games">
       {m.games.map((g, i) => {
-        const lost = m.winner === 'a' ? g[0] <= g[1] : g[1] <= g[0]
+        const lost = g[winnerIdx] < g[1 - winnerIdx]
         return (
           <Fragment key={i}>
             <span className={lost ? 'lost' : ''}>{g[0]}–{g[1]}</span>
@@ -542,10 +477,8 @@ function StatusBadge({ status }: { status: StatusKey }) {
 function TimeCell({ t }: { t: Date }) {
   const hh = String(t.getHours()).padStart(2, '0')
   const mm = String(t.getMinutes()).padStart(2, '0')
-  const today = new Date('2026-05-16T00:00:00')
-  const day = new Date(t)
-  day.setHours(0, 0, 0, 0)
-  const diffDays = Math.round((today.getTime() - day.getTime()) / 86400000)
+  const dayMs = new Date(t.getFullYear(), t.getMonth(), t.getDate()).getTime()
+  const diffDays = Math.round((MOCK_TODAY_MS - dayMs) / 86400000)
   let when: string
   if (diffDays === 0) when = `${hh}:${mm}`
   else if (diffDays === 1) when = `yest ${hh}:${mm}`
@@ -651,7 +584,7 @@ function MatchTable({ rows, sort, setSort, onClear, loading, pageSize }: MatchTa
   if (rows.length === 0) {
     return (
       <div className="empty">
-        <div className="empty-icon"><IconEmpty /></div>
+        <div className="empty-icon"><Inbox size={56} strokeWidth={1.5} /></div>
         <div className="empty-title">No matches match these filters</div>
         <div className="empty-sub">Try widening the context, round, or court — or clear the search.</div>
         <button type="button" className="ml-btn ghost empty-clear" onClick={onClear}>Clear filters</button>
@@ -701,7 +634,7 @@ function MatchTable({ rows, sort, setSort, onClear, loading, pageSize }: MatchTa
                 onClick={(e) => e.stopPropagation()}
                 aria-label="Row actions"
               >
-                <IconMore />
+                <MoreHorizontal size={16} strokeWidth={2} />
               </button>
             </td>
           </tr>
@@ -710,10 +643,6 @@ function MatchTable({ rows, sort, setSort, onClear, loading, pageSize }: MatchTa
     </table>
   )
 }
-
-/* ------------------------------------------------------------------ */
-/*  Pagination                                                        */
-/* ------------------------------------------------------------------ */
 
 function paginationRange(current: number, total: number): (number | 'ell-l' | 'ell-r')[] {
   const delta = 1
@@ -767,7 +696,7 @@ function PaginationFooter(props: PaginationProps) {
               <option key={n} value={n}>{n}</option>
             ))}
           </select>
-          <span className="select-caret"><IconCaret /></span>
+          <span className="select-caret"><ChevronDown size={12} strokeWidth={2.4} /></span>
         </div>
       </div>
       <div className="pagination">
@@ -778,7 +707,7 @@ function PaginationFooter(props: PaginationProps) {
           onClick={() => setPage(1)}
           aria-label="First page"
         >
-          <IconChevLL />
+          <ChevronsLeft size={14} strokeWidth={2.4} />
         </button>
         <button
           type="button"
@@ -787,7 +716,7 @@ function PaginationFooter(props: PaginationProps) {
           onClick={() => setPage(page - 1)}
           aria-label="Previous"
         >
-          <IconChevL />
+          <ChevronLeft size={14} strokeWidth={2.4} />
         </button>
         {tokens.map((t, i) =>
           typeof t === 'number' ? (
@@ -811,7 +740,7 @@ function PaginationFooter(props: PaginationProps) {
           onClick={() => setPage(page + 1)}
           aria-label="Next"
         >
-          <IconChevR />
+          <ChevronRight size={14} strokeWidth={2.4} />
         </button>
         <button
           type="button"
@@ -820,18 +749,33 @@ function PaginationFooter(props: PaginationProps) {
           onClick={() => setPage(total)}
           aria-label="Last page"
         >
-          <IconChevRR />
+          <ChevronsRight size={14} strokeWidth={2.4} />
         </button>
       </div>
     </div>
   )
 }
 
-/* ------------------------------------------------------------------ */
-/*  Page component                                                    */
-/* ------------------------------------------------------------------ */
-
 const ALL_MATCHES = buildMatches()
+
+const STATUS_ORDER: Record<StatusKey, number> = { live: 0, called: 1, scheduled: 2, final: 3 }
+const CONTEXT_ORDER: Record<ContextKey, number> = { tournament: 0, club: 1, ladder: 2, casual: 3 }
+
+const COUNTS: Counts = (() => {
+  const out: Counts = { total: ALL_MATCHES.length, live: 0, called: 0, scheduled: 0, final: 0 }
+  ALL_MATCHES.forEach((m) => {
+    out[m.status]++
+  })
+  return out
+})()
+
+const COURT_OPTIONS = (() => {
+  const s = new Set<number>()
+  ALL_MATCHES.forEach((m) => {
+    if (m.court != null) s.add(m.court)
+  })
+  return [...s].sort((a, b) => a - b)
+})()
 
 function MatchesPage() {
   const [q, setQ] = useState('')
@@ -843,28 +787,12 @@ function MatchesPage() {
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(15)
 
-  const filterSig = `${q}|${status}|${context}|${round}|${court}|${pageSize}`
+  const filterSig = `${q}|${status}|${context}|${round}|${court}`
   const [lastFilterSig, setLastFilterSig] = useState(filterSig)
   if (lastFilterSig !== filterSig) {
     setLastFilterSig(filterSig)
     setPage(1)
   }
-
-  const counts: Counts = useMemo(() => {
-    const out: Counts = { total: ALL_MATCHES.length, live: 0, called: 0, scheduled: 0, final: 0 }
-    ALL_MATCHES.forEach((m) => {
-      out[m.status]++
-    })
-    return out
-  }, [])
-
-  const courtOptions = useMemo(() => {
-    const s = new Set<number>()
-    ALL_MATCHES.forEach((m) => {
-      if (m.court != null) s.add(m.court)
-    })
-    return [...s].sort((a, b) => a - b)
-  }, [])
 
   const filtered = useMemo(() => {
     const ql = q.trim().toLowerCase()
@@ -884,8 +812,6 @@ function MatchesPage() {
   const sorted = useMemo(() => {
     const arr = filtered.slice()
     const dirMul = sort.dir === 'asc' ? 1 : -1
-    const STATUS_ORDER: Record<StatusKey, number> = { live: 0, called: 1, scheduled: 2, final: 3 }
-    const CONTEXT_ORDER: Record<ContextKey, number> = { tournament: 0, club: 1, ladder: 2, casual: 3 }
     arr.sort((a, b) => {
       switch (sort.key) {
         case 'id':
@@ -932,15 +858,15 @@ function MatchesPage() {
   return (
     <AppShell>
       <div className="match-list-page">
-        <ActionBar liveCount={counts.live} />
+        <ActionBar liveCount={COUNTS.live} />
         <FilterRow
           q={q} setQ={setQ}
           status={status} setStatus={setStatus}
           context={context} setContext={setContext}
           round={round} setRound={setRound}
           court={court} setCourt={setCourt}
-          counts={counts}
-          courtOptions={courtOptions}
+          counts={COUNTS}
+          courtOptions={COURT_OPTIONS}
           onClear={onClear}
           anyFilter={anyFilter}
         />

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -1,0 +1,966 @@
+import { Fragment, useMemo, useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+
+import { AppShell } from '@/components/app-shell'
+import './index.css'
+
+export const Route = createFileRoute('/matches/')({
+  component: MatchesPage,
+})
+
+/* ------------------------------------------------------------------ */
+/*  Mock data — ported from Claude Design "Match list" handoff.       */
+/*  No backend yet; everything in this file is seeded & client-only.  */
+/* ------------------------------------------------------------------ */
+
+type ContextKey = 'tournament' | 'club' | 'casual' | 'ladder'
+type StatusKey = 'live' | 'final' | 'called' | 'scheduled'
+type Winner = 'a' | 'b' | null
+type Player = { name: string; seed: number }
+
+interface Match {
+  id: number
+  context: ContextKey
+  contextLabel: string
+  round: string | null
+  roundOrder: number
+  court: number | null
+  a: Player
+  b: Player
+  status: StatusKey
+  games: [number, number][]
+  aGames: number
+  bGames: number
+  winner: Winner
+  time: Date
+  bestOf: number
+}
+
+const PLAYERS: [string, number][] = [
+  ['Nguyen, T.', 1], ['Silva, R.', 2], ['Okafor, D.', 3], ['Johansen, A.', 4],
+  ['Tran, L.', 5], ['Patel, M.', 6], ['Chen, W.', 7], ['Park, J.', 8],
+  ['Kim, H.', 9], ['Ali, R.', 10], ['Rossi, G.', 11], ['Dubois, C.', 12],
+  ['Garcia, P.', 13], ['Müller, F.', 14], ['Tanaka, K.', 15], ['Yamamoto, S.', 16],
+  ['Ahmadi, B.', 17], ['Schmidt, L.', 18], ['Ivanova, N.', 19], ['Petrov, M.', 20],
+  ['Hassan, Y.', 21], ['O’Brien, P.', 22], ['Andersson, E.', 23], ['Lopez, R.', 24],
+  ['Becker, T.', 25], ['Cohen, D.', 26], ['Fernandez, J.', 27], ['Gupta, A.', 28],
+  ['Holm, V.', 29], ['Iwasaki, R.', 30], ['Jansen, K.', 31], ['Khan, S.', 32],
+  ['Lee, M.', 33], ['Moreau, A.', 34], ['Novak, J.', 35], ['Owens, B.', 36],
+  ['Pham, Q.', 37], ['Quinn, R.', 38], ['Reyes, T.', 39], ['Sato, H.', 40],
+  ['Torres, M.', 41], ['Ueda, K.', 42], ['Vargas, P.', 43], ['Wang, X.', 44],
+  ['Xu, L.', 45], ['Yusupov, F.', 46], ['Zhao, M.', 47], ['Abbas, N.', 48],
+  ['Brun, T.', 49], ['Costa, E.', 50], ['Diallo, S.', 51], ['Eriksen, J.', 52],
+  ['Fischer, M.', 53], ['Gomez, H.', 54], ['Hartmann, P.', 55], ['Inoue, R.', 56],
+  ['Jakobsen, A.', 57], ['Klein, S.', 58], ['Lindgren, O.', 59], ['Mancini, G.', 60],
+  ['Nakamura, T.', 61], ['Olsen, K.', 62], ['Pavlov, D.', 63], ['Rahman, M.', 64],
+]
+
+const AVATAR_PALETTE: [string, string][] = [
+  ['#3A4152', '#E4E7EF'], ['#1F2430', '#FFCFA8'], ['#171B24', '#8CFFD4'],
+  ['#11141B', '#FF9A4A'], ['#2A3040', '#A9B0C2'], ['#1F2430', '#6FB5FF'],
+]
+
+function avatarColors(seed: number): [string, string] {
+  return AVATAR_PALETTE[(seed - 1) % AVATAR_PALETTE.length]
+}
+
+function initials(name: string): string {
+  const [last, first] = name.split(',').map((s) => s.trim())
+  return ((first || '')[0] || '') + (last[0] || '')
+}
+
+const CONTEXTS: Record<ContextKey, { label: string; short: string }> = {
+  tournament: { label: 'Tournament', short: 'Tournament' },
+  club: { label: 'Club night', short: 'Club' },
+  casual: { label: 'Casual', short: 'Casual' },
+  ladder: { label: 'Ladder', short: 'Ladder' },
+}
+
+const TOURNAMENTS = ['Spring Open', 'City Cup', 'River League']
+const CLUBS = ['Riverside TT', 'East Side Pong', 'Downtown Paddle']
+
+const ROUND_DEFS = [
+  { code: 'R64', label: 'Round of 64', order: 1 },
+  { code: 'R32', label: 'Round of 32', order: 2 },
+  { code: 'R16', label: 'Round of 16', order: 3 },
+  { code: 'QF', label: 'Quarterfinal', order: 4 },
+  { code: 'SF', label: 'Semifinal', order: 5 },
+  { code: 'F', label: 'Final', order: 6 },
+] as const
+
+function buildMatches(): Match[] {
+  let s = 17
+  const rnd = () => (s = (s * 9301 + 49297) % 233280) / 233280
+  const pickPlayers = (): [[string, number], [string, number]] => {
+    const aIdx = Math.floor(rnd() * PLAYERS.length)
+    let bIdx = Math.floor(rnd() * PLAYERS.length)
+    while (bIdx === aIdx) bIdx = Math.floor(rnd() * PLAYERS.length)
+    return [PLAYERS[aIdx], PLAYERS[bIdx]]
+  }
+
+  const start = new Date('2026-05-16T09:00:00')
+  const out: Match[] = []
+  let id = 1001
+
+  const tName = TOURNAMENTS[0]
+  ROUND_DEFS.forEach((r) => {
+    const counts: Record<string, number> = {
+      R64: 16, R32: 10, R16: 8, QF: 4, SF: 2, F: 1,
+    }
+    const n = counts[r.code]
+    for (let i = 0; i < n; i++) {
+      const [a, b] = pickPlayers()
+      const minute = (r.order - 1) * 110 + i * 16 + Math.floor(rnd() * 6)
+      const when = new Date(start.getTime() + minute * 60000)
+      let status: StatusKey
+      if (r.order <= 2) status = 'final'
+      else if (r.order === 3)
+        status = rnd() < 0.7 ? 'final' : rnd() < 0.5 ? 'live' : 'called'
+      else if (r.order === 4)
+        status = rnd() < 0.4 ? 'final' : rnd() < 0.55 ? 'live' : 'scheduled'
+      else status = rnd() < 0.5 ? 'scheduled' : 'called'
+      out.push(
+        buildMatch({
+          id: id++, rnd,
+          context: 'tournament', contextLabel: tName,
+          round: r.code, roundOrder: r.order,
+          court: 1 + Math.floor(rnd() * 8),
+          a, b, status, time: when, bestOf: 7,
+        }),
+      )
+    }
+  })
+
+  for (let i = 0; i < 14; i++) {
+    const [a, b] = pickPlayers()
+    const dayOffset = (i % 3) - 2
+    const evening = new Date(
+      start.getTime() +
+        dayOffset * 86400000 +
+        (12 * 60 + Math.floor(rnd() * 180)) * 60000,
+    )
+    const status: StatusKey = i < 2 ? 'live' : 'final'
+    out.push(
+      buildMatch({
+        id: id++, rnd,
+        context: 'club', contextLabel: CLUBS[i % CLUBS.length],
+        round: null, roundOrder: 0,
+        court: 1 + Math.floor(rnd() * 4),
+        a, b, status, time: evening, bestOf: 5,
+      }),
+    )
+  }
+
+  for (let i = 0; i < 16; i++) {
+    const [a, b] = pickPlayers()
+    const dayOffset = -Math.floor(rnd() * 7)
+    const when = new Date(
+      start.getTime() + dayOffset * 86400000 + Math.floor(rnd() * 720) * 60000,
+    )
+    out.push(
+      buildMatch({
+        id: id++, rnd,
+        context: 'casual', contextLabel: 'Casual',
+        round: null, roundOrder: 0, court: null,
+        a, b, status: 'final', time: when, bestOf: 3,
+      }),
+    )
+  }
+
+  for (let i = 0; i < 8; i++) {
+    const [a, b] = pickPlayers()
+    const dayOffset = -Math.floor(rnd() * 14)
+    const when = new Date(
+      start.getTime() + dayOffset * 86400000 + Math.floor(rnd() * 720) * 60000,
+    )
+    const status: StatusKey = i === 0 ? 'scheduled' : 'final'
+    out.push(
+      buildMatch({
+        id: id++, rnd,
+        context: 'ladder', contextLabel: 'Club ladder',
+        round: null, roundOrder: 0, court: null,
+        a, b, status, time: when, bestOf: 5,
+      }),
+    )
+  }
+
+  return out
+}
+
+interface BuildMatchInput {
+  id: number
+  rnd: () => number
+  context: ContextKey
+  contextLabel: string
+  round: string | null
+  roundOrder: number
+  court: number | null
+  a: [string, number]
+  b: [string, number]
+  status: StatusKey
+  time: Date
+  bestOf: number
+}
+
+function buildMatch(input: BuildMatchInput): Match {
+  const { id, rnd, context, contextLabel, round, roundOrder, court, a, b, status, time, bestOf } = input
+  const target = Math.ceil(bestOf / 2)
+  const games: [number, number][] = []
+  let aGames = 0
+  let bGames = 0
+  if (status === 'final') {
+    const aWins = rnd() < 0.55
+    while (aGames < target && bGames < target) {
+      if (rnd() < (aWins ? 0.6 : 0.4)) aGames++
+      else bGames++
+    }
+    const total = aGames + bGames
+    for (let g = 0; g < total; g++) {
+      const aIsGameWinner = rnd() < (aWins ? 0.6 : 0.4)
+      const winnerScore = 11 + Math.floor(rnd() * 3)
+      const loserScore = Math.max(0, winnerScore - 2 - Math.floor(rnd() * 8))
+      games.push(aIsGameWinner ? [winnerScore, loserScore] : [loserScore, winnerScore])
+    }
+  } else if (status === 'live') {
+    const done = Math.min(target - 1, 1 + Math.floor(rnd() * (target - 1)))
+    for (let g = 0; g < done; g++) {
+      const aIsGameWinner = rnd() < 0.5
+      const winnerScore = 11 + Math.floor(rnd() * 3)
+      const loserScore = Math.max(0, winnerScore - 2 - Math.floor(rnd() * 8))
+      games.push(aIsGameWinner ? [winnerScore, loserScore] : [loserScore, winnerScore])
+      if (aIsGameWinner) aGames++
+      else bGames++
+    }
+    games.push([Math.floor(rnd() * 11), Math.floor(rnd() * 11)])
+  }
+  const winner: Winner = status === 'final' ? (aGames > bGames ? 'a' : 'b') : null
+  return {
+    id, context, contextLabel, round, roundOrder, court,
+    a: { name: a[0], seed: a[1] },
+    b: { name: b[0], seed: b[1] },
+    status, games, aGames, bGames, winner, time, bestOf,
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Icons                                                             */
+/* ------------------------------------------------------------------ */
+
+function IconSearch() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="11" cy="11" r="7" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+  )
+}
+function IconCaret() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  )
+}
+function IconChevL() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="15 18 9 12 15 6" />
+    </svg>
+  )
+}
+function IconChevR() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="9 18 15 12 9 6" />
+    </svg>
+  )
+}
+function IconChevLL() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="11 17 6 12 11 7" />
+      <polyline points="18 17 13 12 18 7" />
+    </svg>
+  )
+}
+function IconChevRR() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="13 17 18 12 13 7" />
+      <polyline points="6 17 11 12 6 7" />
+    </svg>
+  )
+}
+function IconMore() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="5" cy="12" r="1.4" />
+      <circle cx="12" cy="12" r="1.4" />
+      <circle cx="19" cy="12" r="1.4" />
+    </svg>
+  )
+}
+function IconEmpty() {
+  return (
+    <svg viewBox="0 0 64 64" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <ellipse cx="32" cy="44" rx="22" ry="4" />
+      <path d="M14 44V20l36-4v24" />
+      <line x1="14" y1="20" x2="50" y2="16" />
+      <circle cx="46" cy="14" r="3" fill="currentColor" opacity="0.5" />
+    </svg>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sub-components                                                    */
+/* ------------------------------------------------------------------ */
+
+interface Counts {
+  total: number
+  live: number
+  called: number
+  scheduled: number
+  final: number
+}
+
+function ActionBar({ liveCount }: { liveCount: number }) {
+  return (
+    <div className="action-bar">
+      <div className="action-bar-title">Matches</div>
+      <div className="action-bar-crumb">Across tournaments, club nights, ladder &amp; casual</div>
+      <span className="live-pill">
+        <span className="live-dot" />
+        {String(liveCount).padStart(2, '0')} LIVE
+      </span>
+      <div style={{ flex: 1 }} />
+      <button type="button" className="ml-btn ghost">Export CSV</button>
+      <button type="button" className="ml-btn primary">+ New match</button>
+    </div>
+  )
+}
+
+interface StatusTabProps {
+  value: 'all' | StatusKey
+  label: string
+  count: number
+  current: string
+  onClick: (v: 'all' | StatusKey) => void
+  live?: boolean
+}
+
+function StatusTab({ value, label, count, current, onClick, live }: StatusTabProps) {
+  return (
+    <button
+      type="button"
+      className={'seg-btn' + (current === value ? ' is-active' : '')}
+      onClick={() => onClick(value)}
+    >
+      {live && <span className="live-dot" />}
+      {label}
+      <span className="seg-count">{count}</span>
+    </button>
+  )
+}
+
+interface FilterRowProps {
+  q: string
+  setQ: (v: string) => void
+  status: 'all' | StatusKey
+  setStatus: (v: 'all' | StatusKey) => void
+  context: 'all' | ContextKey
+  setContext: (v: 'all' | ContextKey) => void
+  round: string
+  setRound: (v: string) => void
+  court: string
+  setCourt: (v: string) => void
+  counts: Counts
+  courtOptions: number[]
+  onClear: () => void
+  anyFilter: boolean
+}
+
+function FilterRow(props: FilterRowProps) {
+  const {
+    q, setQ, status, setStatus, context, setContext, round, setRound, court, setCourt,
+    counts, courtOptions, onClear, anyFilter,
+  } = props
+  return (
+    <div className="filter-row">
+      <div className="ml-search">
+        <span className="ml-search-icon"><IconSearch /></span>
+        <input
+          placeholder="Search players or match #…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        {q && (
+          <button type="button" className="ml-search-clear" onClick={() => setQ('')} aria-label="Clear search">
+            ×
+          </button>
+        )}
+      </div>
+
+      <div className="seg" role="tablist">
+        <StatusTab value="all" label="All" count={counts.total} current={status} onClick={setStatus} />
+        <StatusTab value="live" label="Live" count={counts.live} current={status} onClick={setStatus} live />
+        <StatusTab value="called" label="Called" count={counts.called} current={status} onClick={setStatus} />
+        <StatusTab value="scheduled" label="Up next" count={counts.scheduled} current={status} onClick={setStatus} />
+        <StatusTab value="final" label="Final" count={counts.final} current={status} onClick={setStatus} />
+      </div>
+
+      <div className="filter-spacer" />
+
+      <span className="filter-label">Context</span>
+      <div className="select-wrap">
+        <select
+          className="ml-select"
+          value={context}
+          onChange={(e) => setContext(e.target.value as 'all' | ContextKey)}
+        >
+          <option value="all">All contexts</option>
+          {(Object.entries(CONTEXTS) as [ContextKey, { label: string }][]).map(([k, v]) => (
+            <option key={k} value={k}>{v.label}</option>
+          ))}
+        </select>
+        <span className="select-caret"><IconCaret /></span>
+      </div>
+
+      <span className="filter-label">Round</span>
+      <div className="select-wrap">
+        <select className="ml-select" value={round} onChange={(e) => setRound(e.target.value)}>
+          <option value="all">All rounds</option>
+          {ROUND_DEFS.map((r) => (
+            <option key={r.code} value={r.code}>{r.label}</option>
+          ))}
+        </select>
+        <span className="select-caret"><IconCaret /></span>
+      </div>
+
+      <span className="filter-label">Court</span>
+      <div className="select-wrap">
+        <select className="ml-select" value={court} onChange={(e) => setCourt(e.target.value)}>
+          <option value="all">All courts</option>
+          {courtOptions.map((c) => (
+            <option key={c} value={String(c)}>Court {c}</option>
+          ))}
+        </select>
+        <span className="select-caret"><IconCaret /></span>
+      </div>
+
+      {anyFilter && (
+        <button type="button" className="ml-btn ghost" onClick={onClear}>Clear filters</button>
+      )}
+    </div>
+  )
+}
+
+function Avatar({ name, seed }: { name: string; seed: number }) {
+  const [bg, fg] = avatarColors(seed)
+  return (
+    <span className="ml-avatar" style={{ background: bg, color: fg }}>
+      {initials(name)}
+    </span>
+  )
+}
+
+function ContextCell({ m }: { m: Match }) {
+  return (
+    <div className={'ctx-chip ctx-' + m.context}>
+      <span className="ctx-dot" />
+      <div>
+        <div>{CONTEXTS[m.context].short}</div>
+        <div className="ctx-meta">{m.contextLabel}</div>
+      </div>
+    </div>
+  )
+}
+
+function PlayerCell({ a, b, winner, status }: { a: Player; b: Player; winner: Winner; status: StatusKey }) {
+  const aClass =
+    'player-name' + (status === 'final' ? (winner === 'a' ? ' is-winner' : ' is-loser') : '')
+  const bClass =
+    'player-name' + (status === 'final' ? (winner === 'b' ? ' is-winner' : ' is-loser') : '')
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
+      <div className="player">
+        <Avatar name={a.name} seed={a.seed} />
+        <span className={aClass}>{a.name}</span>
+        <span className="seed-tag">#{a.seed}</span>
+      </div>
+      <span className="vs">vs</span>
+      <div className="player">
+        <Avatar name={b.name} seed={b.seed} />
+        <span className={bClass}>{b.name}</span>
+        <span className="seed-tag">#{b.seed}</span>
+      </div>
+    </div>
+  )
+}
+
+function ScoreCell({ m }: { m: Match }) {
+  if (m.status === 'scheduled' || m.status === 'called') {
+    return <span className="score-cell pending">—</span>
+  }
+  if (m.status === 'live') {
+    const last = m.games[m.games.length - 1]
+    return (
+      <span className="score-cell">
+        <span className="games">{m.aGames}–{m.bGames}</span>
+        {last && (
+          <span className="score-meta">({last[0]}–{last[1]})</span>
+        )}
+      </span>
+    )
+  }
+  return (
+    <span className="score-cell games">
+      {m.games.map((g, i) => {
+        const lost = m.winner === 'a' ? g[0] <= g[1] : g[1] <= g[0]
+        return (
+          <Fragment key={i}>
+            <span className={lost ? 'lost' : ''}>{g[0]}–{g[1]}</span>
+            {i < m.games.length - 1 && <span className="score-sep">·</span>}
+          </Fragment>
+        )
+      })}
+    </span>
+  )
+}
+
+function StatusBadge({ status }: { status: StatusKey }) {
+  if (status === 'live')
+    return (
+      <span className="status is-live">
+        <span className="live-dot" />Live
+      </span>
+    )
+  if (status === 'final') return <span className="status is-final">Final</span>
+  if (status === 'called') return <span className="status is-called">Called</span>
+  return <span className="status is-scheduled">Scheduled</span>
+}
+
+function TimeCell({ t }: { t: Date }) {
+  const hh = String(t.getHours()).padStart(2, '0')
+  const mm = String(t.getMinutes()).padStart(2, '0')
+  const today = new Date('2026-05-16T00:00:00')
+  const day = new Date(t)
+  day.setHours(0, 0, 0, 0)
+  const diffDays = Math.round((today.getTime() - day.getTime()) / 86400000)
+  let when: string
+  if (diffDays === 0) when = `${hh}:${mm}`
+  else if (diffDays === 1) when = `yest ${hh}:${mm}`
+  else if (diffDays > 1) when = `${diffDays}d ago`
+  else when = `+${-diffDays}d`
+  return (
+    <span className="time-cell">
+      <span className="strong">{when}</span>
+    </span>
+  )
+}
+
+type SortKey = 'id' | 'context' | 'round' | 'court' | 'score' | 'status' | 'time'
+type SortState = { key: SortKey; dir: 'asc' | 'desc' }
+
+interface SortHeaderProps {
+  id: SortKey
+  label: string
+  sort: SortState
+  setSort: (v: SortState) => void
+  width?: number
+}
+
+function SortHeader({ id, label, sort, setSort, width }: SortHeaderProps) {
+  const isSorted = sort.key === id
+  const dir = isSorted ? sort.dir : null
+  return (
+    <th
+      className={'sortable' + (isSorted ? ' is-sorted' : '')}
+      onClick={() =>
+        setSort(
+          sort.key === id
+            ? { key: id, dir: sort.dir === 'asc' ? 'desc' : 'asc' }
+            : { key: id, dir: 'asc' },
+        )
+      }
+      style={{ width }}
+    >
+      {label}
+      <span className="sort-arrow">{dir === 'asc' ? '↑' : '↓'}</span>
+    </th>
+  )
+}
+
+function SkeletonRow() {
+  return (
+    <tr className="skeleton-row">
+      <td><span className="skeleton s-text-sm" style={{ width: 50 }} /></td>
+      <td><span className="skeleton s-chip" style={{ width: 84, height: 30, borderRadius: 6 }} /></td>
+      <td><span className="skeleton s-chip" /></td>
+      <td><span className="skeleton s-text-sm" style={{ width: 40 }} /></td>
+      <td>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+          <span className="skeleton s-avatar" />
+          <span className="skeleton s-text-md" />
+          <span style={{ width: 24, display: 'inline-block' }} />
+          <span className="skeleton s-avatar" />
+          <span className="skeleton s-text-md" />
+        </span>
+      </td>
+      <td><span className="skeleton s-text-lg" /></td>
+      <td><span className="skeleton s-chip" style={{ width: 64 }} /></td>
+      <td><span className="skeleton s-text-sm" /></td>
+      <td />
+    </tr>
+  )
+}
+
+interface MatchTableProps {
+  rows: Match[]
+  sort: SortState
+  setSort: (v: SortState) => void
+  onClear: () => void
+  loading: boolean
+  pageSize: number
+}
+
+function MatchTable({ rows, sort, setSort, onClear, loading, pageSize }: MatchTableProps) {
+  if (loading) {
+    return (
+      <table className="matches">
+        <thead>
+          <tr>
+            <th style={{ width: 84 }}>#</th>
+            <th style={{ width: 130 }}>Context</th>
+            <th style={{ width: 90 }}>Round</th>
+            <th style={{ width: 70 }}>Court</th>
+            <th>Players</th>
+            <th style={{ width: 220 }}>Score</th>
+            <th style={{ width: 120 }}>Status</th>
+            <th style={{ width: 100 }}>Time</th>
+            <th style={{ width: 36 }} />
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: Math.min(pageSize, 10) }).map((_, i) => (
+            <SkeletonRow key={i} />
+          ))}
+        </tbody>
+      </table>
+    )
+  }
+  if (rows.length === 0) {
+    return (
+      <div className="empty">
+        <div className="empty-icon"><IconEmpty /></div>
+        <div className="empty-title">No matches match these filters</div>
+        <div className="empty-sub">Try widening the context, round, or court — or clear the search.</div>
+        <button type="button" className="ml-btn ghost empty-clear" onClick={onClear}>Clear filters</button>
+      </div>
+    )
+  }
+  return (
+    <table className="matches">
+      <thead>
+        <tr>
+          <SortHeader id="id" label="#" sort={sort} setSort={setSort} width={84} />
+          <SortHeader id="context" label="Context" sort={sort} setSort={setSort} width={130} />
+          <SortHeader id="round" label="Round" sort={sort} setSort={setSort} width={90} />
+          <SortHeader id="court" label="Court" sort={sort} setSort={setSort} width={70} />
+          <th>Players</th>
+          <SortHeader id="score" label="Score" sort={sort} setSort={setSort} width={220} />
+          <SortHeader id="status" label="Status" sort={sort} setSort={setSort} width={120} />
+          <SortHeader id="time" label="Time" sort={sort} setSort={setSort} width={100} />
+          <th style={{ width: 36 }} />
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((m) => (
+          <tr key={m.id} className={m.status === 'live' ? 'is-live' : ''}>
+            <td className="id-cell">M-{m.id}</td>
+            <td><ContextCell m={m} /></td>
+            <td>
+              {m.round ? (
+                <span className={'round-chip' + (m.round === 'F' || m.round === 'SF' ? ' is-final' : '')}>
+                  {m.round}
+                </span>
+              ) : (
+                <span className="cell-na">—</span>
+              )}
+            </td>
+            <td className="court-cell">
+              {m.court != null ? `C${m.court}` : <span className="cell-na">—</span>}
+            </td>
+            <td><PlayerCell a={m.a} b={m.b} winner={m.winner} status={m.status} /></td>
+            <td><ScoreCell m={m} /></td>
+            <td><StatusBadge status={m.status} /></td>
+            <td><TimeCell t={m.time} /></td>
+            <td>
+              <button
+                type="button"
+                className="row-action"
+                onClick={(e) => e.stopPropagation()}
+                aria-label="Row actions"
+              >
+                <IconMore />
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Pagination                                                        */
+/* ------------------------------------------------------------------ */
+
+function paginationRange(current: number, total: number): (number | 'ell-l' | 'ell-r')[] {
+  const delta = 1
+  const range: (number | 'ell-l' | 'ell-r')[] = []
+  const left = Math.max(2, current - delta)
+  const right = Math.min(total - 1, current + delta)
+  range.push(1)
+  if (left > 2) range.push('ell-l')
+  for (let i = left; i <= right; i++) range.push(i)
+  if (right < total - 1) range.push('ell-r')
+  if (total > 1) range.push(total)
+  return range
+}
+
+interface PaginationProps {
+  page: number
+  setPage: (n: number) => void
+  total: number
+  pageSize: number
+  setPageSize: (n: number) => void
+  filteredCount: number
+  disabled: boolean
+}
+
+function PaginationFooter(props: PaginationProps) {
+  const { page, setPage, total, pageSize, setPageSize, filteredCount, disabled } = props
+  const first = filteredCount === 0 ? 0 : (page - 1) * pageSize + 1
+  const last = Math.min(filteredCount, page * pageSize)
+  const tokens = paginationRange(page, total || 1)
+
+  return (
+    <div className="footer">
+      <div className="footer-info">
+        Showing <span className="mono">{first}–{last}</span> of{' '}
+        <span className="mono">{filteredCount}</span> matches
+      </div>
+      <div className="footer-spacer" />
+      <div className="page-size">
+        Rows per page
+        <div className="select-wrap">
+          <select
+            className="ml-select"
+            style={{ minWidth: 0, height: 32, padding: '0 28px 0 10px' }}
+            value={pageSize}
+            onChange={(e) => {
+              setPageSize(Number(e.target.value))
+              setPage(1)
+            }}
+          >
+            {[10, 15, 25, 50].map((n) => (
+              <option key={n} value={n}>{n}</option>
+            ))}
+          </select>
+          <span className="select-caret"><IconCaret /></span>
+        </div>
+      </div>
+      <div className="pagination">
+        <button
+          type="button"
+          className="page-btn is-nav"
+          disabled={disabled || page <= 1}
+          onClick={() => setPage(1)}
+          aria-label="First page"
+        >
+          <IconChevLL />
+        </button>
+        <button
+          type="button"
+          className="page-btn is-nav"
+          disabled={disabled || page <= 1}
+          onClick={() => setPage(page - 1)}
+          aria-label="Previous"
+        >
+          <IconChevL />
+        </button>
+        {tokens.map((t, i) =>
+          typeof t === 'number' ? (
+            <button
+              key={i}
+              type="button"
+              disabled={disabled}
+              className={'page-btn' + (t === page ? ' is-current' : '')}
+              onClick={() => setPage(t)}
+            >
+              {t}
+            </button>
+          ) : (
+            <span key={i} className="page-btn is-ellipsis">…</span>
+          ),
+        )}
+        <button
+          type="button"
+          className="page-btn is-nav"
+          disabled={disabled || page >= total}
+          onClick={() => setPage(page + 1)}
+          aria-label="Next"
+        >
+          <IconChevR />
+        </button>
+        <button
+          type="button"
+          className="page-btn is-nav"
+          disabled={disabled || page >= total}
+          onClick={() => setPage(total)}
+          aria-label="Last page"
+        >
+          <IconChevRR />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Page component                                                    */
+/* ------------------------------------------------------------------ */
+
+const ALL_MATCHES = buildMatches()
+
+function MatchesPage() {
+  const [q, setQ] = useState('')
+  const [status, setStatus] = useState<'all' | StatusKey>('all')
+  const [context, setContext] = useState<'all' | ContextKey>('all')
+  const [round, setRound] = useState<string>('all')
+  const [court, setCourt] = useState<string>('all')
+  const [sort, setSort] = useState<SortState>({ key: 'time', dir: 'desc' })
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(15)
+
+  const filterSig = `${q}|${status}|${context}|${round}|${court}|${pageSize}`
+  const [lastFilterSig, setLastFilterSig] = useState(filterSig)
+  if (lastFilterSig !== filterSig) {
+    setLastFilterSig(filterSig)
+    setPage(1)
+  }
+
+  const counts: Counts = useMemo(() => {
+    const out: Counts = { total: ALL_MATCHES.length, live: 0, called: 0, scheduled: 0, final: 0 }
+    ALL_MATCHES.forEach((m) => {
+      out[m.status]++
+    })
+    return out
+  }, [])
+
+  const courtOptions = useMemo(() => {
+    const s = new Set<number>()
+    ALL_MATCHES.forEach((m) => {
+      if (m.court != null) s.add(m.court)
+    })
+    return [...s].sort((a, b) => a - b)
+  }, [])
+
+  const filtered = useMemo(() => {
+    const ql = q.trim().toLowerCase()
+    return ALL_MATCHES.filter((m) => {
+      if (status !== 'all' && m.status !== status) return false
+      if (context !== 'all' && m.context !== context) return false
+      if (round !== 'all' && m.round !== round) return false
+      if (court !== 'all' && String(m.court) !== String(court)) return false
+      if (ql) {
+        const hay = `${m.a.name} ${m.b.name} m-${m.id} ${m.contextLabel}`.toLowerCase()
+        if (!hay.includes(ql)) return false
+      }
+      return true
+    })
+  }, [q, status, context, round, court])
+
+  const sorted = useMemo(() => {
+    const arr = filtered.slice()
+    const dirMul = sort.dir === 'asc' ? 1 : -1
+    const STATUS_ORDER: Record<StatusKey, number> = { live: 0, called: 1, scheduled: 2, final: 3 }
+    const CONTEXT_ORDER: Record<ContextKey, number> = { tournament: 0, club: 1, ladder: 2, casual: 3 }
+    arr.sort((a, b) => {
+      switch (sort.key) {
+        case 'id':
+          return (a.id - b.id) * dirMul
+        case 'context':
+          return (
+            (CONTEXT_ORDER[a.context] - CONTEXT_ORDER[b.context]) * dirMul ||
+            a.contextLabel.localeCompare(b.contextLabel)
+          )
+        case 'round':
+          return ((a.roundOrder || 99) - (b.roundOrder || 99)) * dirMul || a.id - b.id
+        case 'court':
+          return (
+            ((a.court ?? 99) - (b.court ?? 99)) * dirMul || a.time.getTime() - b.time.getTime()
+          )
+        case 'status':
+          return (
+            (STATUS_ORDER[a.status] - STATUS_ORDER[b.status]) * dirMul ||
+            a.time.getTime() - b.time.getTime()
+          )
+        case 'score':
+          return ((a.aGames + a.bGames) - (b.aGames + b.bGames)) * dirMul
+        case 'time':
+        default:
+          return (a.time.getTime() - b.time.getTime()) * dirMul
+      }
+    })
+    return arr
+  }, [filtered, sort])
+
+  const total = Math.max(1, Math.ceil(sorted.length / pageSize))
+  const pageRows = sorted.slice((page - 1) * pageSize, page * pageSize)
+
+  const onClear = () => {
+    setQ('')
+    setStatus('all')
+    setContext('all')
+    setRound('all')
+    setCourt('all')
+  }
+  const anyFilter =
+    q !== '' || status !== 'all' || context !== 'all' || round !== 'all' || court !== 'all'
+
+  return (
+    <AppShell>
+      <div className="match-list-page">
+        <ActionBar liveCount={counts.live} />
+        <FilterRow
+          q={q} setQ={setQ}
+          status={status} setStatus={setStatus}
+          context={context} setContext={setContext}
+          round={round} setRound={setRound}
+          court={court} setCourt={setCourt}
+          counts={counts}
+          courtOptions={courtOptions}
+          onClear={onClear}
+          anyFilter={anyFilter}
+        />
+        <div className="table-wrap">
+          <MatchTable
+            rows={pageRows}
+            sort={sort} setSort={setSort}
+            onClear={onClear}
+            loading={false}
+            pageSize={pageSize}
+          />
+        </div>
+        <PaginationFooter
+          page={page} setPage={setPage}
+          total={total}
+          pageSize={pageSize} setPageSize={setPageSize}
+          filteredCount={sorted.length}
+          disabled={false}
+        />
+      </div>
+    </AppShell>
+  )
+}

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -1,7 +1,6 @@
 import { Fragment, useMemo, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import {
-  ChevronDown,
   ChevronLeft,
   ChevronRight,
   ChevronsLeft,
@@ -9,9 +8,29 @@ import {
   Inbox,
   MoreHorizontal,
   Search,
+  X,
 } from 'lucide-react'
 
 import { AppShell } from '@/components/app-shell'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+} from '@/components/ui/pagination'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import './index.css'
 
 export const Route = createFileRoute('/matches/')({
@@ -267,32 +286,9 @@ function ActionBar({ liveCount }: { liveCount: number }) {
         {String(liveCount).padStart(2, '0')} LIVE
       </span>
       <div className="filter-spacer" />
-      <button type="button" className="ml-btn ghost">Export CSV</button>
-      <button type="button" className="ml-btn primary">+ New match</button>
+      <Button variant="ghost" size="sm">Export CSV</Button>
+      <Button variant="default" size="sm">+ New match</Button>
     </div>
-  )
-}
-
-interface StatusTabProps {
-  value: 'all' | StatusKey
-  label: string
-  count: number
-  current: string
-  onClick: (v: 'all' | StatusKey) => void
-  live?: boolean
-}
-
-function StatusTab({ value, label, count, current, onClick, live }: StatusTabProps) {
-  return (
-    <button
-      type="button"
-      className={'seg-btn' + (current === value ? ' is-active' : '')}
-      onClick={() => onClick(value)}
-    >
-      {live && <span className="live-dot" />}
-      {label}
-      <span className="seg-count">{count}</span>
-    </button>
   )
 }
 
@@ -313,87 +309,113 @@ interface FilterRowProps {
   anyFilter: boolean
 }
 
+const STATUS_TABS: { value: 'all' | StatusKey; label: string; live?: boolean }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'live', label: 'Live', live: true },
+  { value: 'called', label: 'Called' },
+  { value: 'scheduled', label: 'Up next' },
+  { value: 'final', label: 'Final' },
+]
+
 function FilterRow(props: FilterRowProps) {
   const {
     q, setQ, status, setStatus, context, setContext, round, setRound, court, setCourt,
     counts, courtOptions, onClear, anyFilter,
   } = props
+  const statusCount = (v: 'all' | StatusKey) => (v === 'all' ? counts.total : counts[v])
   return (
     <div className="filter-row">
       <div className="ml-search">
-        <span className="ml-search-icon"><Search size={16} strokeWidth={2} /></span>
-        <input
+        <Search className="ml-search-icon" size={16} strokeWidth={2} />
+        <Input
+          className="h-9 pl-9 pr-9"
           placeholder="Search players or match #…"
           value={q}
           onChange={(e) => setQ(e.target.value)}
         />
         {q && (
-          <button type="button" className="ml-search-clear" onClick={() => setQ('')} aria-label="Clear search">
-            ×
+          <button
+            type="button"
+            className="ml-search-clear"
+            onClick={() => setQ('')}
+            aria-label="Clear search"
+          >
+            <X size={12} strokeWidth={2.4} />
           </button>
         )}
       </div>
 
-      <div className="seg" role="tablist">
-        <StatusTab value="all" label="All" count={counts.total} current={status} onClick={setStatus} />
-        <StatusTab value="live" label="Live" count={counts.live} current={status} onClick={setStatus} live />
-        <StatusTab value="called" label="Called" count={counts.called} current={status} onClick={setStatus} />
-        <StatusTab value="scheduled" label="Up next" count={counts.scheduled} current={status} onClick={setStatus} />
-        <StatusTab value="final" label="Final" count={counts.final} current={status} onClick={setStatus} />
-      </div>
+      <Tabs value={status} onValueChange={(v) => setStatus(v as 'all' | StatusKey)}>
+        <TabsList>
+          {STATUS_TABS.map((t) => (
+            <TabsTrigger key={t.value} value={t.value} className="gap-1.5">
+              {t.live && <span className="live-dot" />}
+              {t.label}
+              <span className="seg-count">{statusCount(t.value)}</span>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
 
       <div className="filter-spacer" />
 
       <span className="filter-label">Context</span>
-      <div className="select-wrap">
-        <select
-          className="ml-select"
-          value={context}
-          onChange={(e) => setContext(e.target.value as 'all' | ContextKey)}
-        >
-          <option value="all">All contexts</option>
+      <Select value={context} onValueChange={(v) => setContext(v as 'all' | ContextKey)}>
+        <SelectTrigger className="h-9 min-w-[140px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All contexts</SelectItem>
           {(Object.entries(CONTEXTS) as [ContextKey, { label: string }][]).map(([k, v]) => (
-            <option key={k} value={k}>{v.label}</option>
+            <SelectItem key={k} value={k}>{v.label}</SelectItem>
           ))}
-        </select>
-        <span className="select-caret"><ChevronDown size={12} strokeWidth={2.4} /></span>
-      </div>
+        </SelectContent>
+      </Select>
 
       <span className="filter-label">Round</span>
-      <div className="select-wrap">
-        <select className="ml-select" value={round} onChange={(e) => setRound(e.target.value)}>
-          <option value="all">All rounds</option>
+      <Select value={round} onValueChange={setRound}>
+        <SelectTrigger className="h-9 min-w-[140px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All rounds</SelectItem>
           {ROUND_DEFS.map((r) => (
-            <option key={r.code} value={r.code}>{r.label}</option>
+            <SelectItem key={r.code} value={r.code}>{r.label}</SelectItem>
           ))}
-        </select>
-        <span className="select-caret"><ChevronDown size={12} strokeWidth={2.4} /></span>
-      </div>
+        </SelectContent>
+      </Select>
 
       <span className="filter-label">Court</span>
-      <div className="select-wrap">
-        <select className="ml-select" value={court} onChange={(e) => setCourt(e.target.value)}>
-          <option value="all">All courts</option>
+      <Select value={court} onValueChange={setCourt}>
+        <SelectTrigger className="h-9 min-w-[120px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All courts</SelectItem>
           {courtOptions.map((c) => (
-            <option key={c} value={String(c)}>Court {c}</option>
+            <SelectItem key={c} value={String(c)}>Court {c}</SelectItem>
           ))}
-        </select>
-        <span className="select-caret"><ChevronDown size={12} strokeWidth={2.4} /></span>
-      </div>
+        </SelectContent>
+      </Select>
 
       {anyFilter && (
-        <button type="button" className="ml-btn ghost" onClick={onClear}>Clear filters</button>
+        <Button variant="ghost" size="sm" onClick={onClear}>Clear filters</Button>
       )}
     </div>
   )
 }
 
-function Avatar({ name, seed }: { name: string; seed: number }) {
+function PlayerAvatar({ name, seed }: { name: string; seed: number }) {
   const [bg, fg] = avatarColors(seed)
   return (
-    <span className="ml-avatar" style={{ background: bg, color: fg }}>
-      {initials(name)}
-    </span>
+    <Avatar className="size-[26px]">
+      <AvatarFallback
+        className="font-mono text-[11px] font-bold"
+        style={{ background: bg, color: fg }}
+      >
+        {initials(name)}
+      </AvatarFallback>
+    </Avatar>
   )
 }
 
@@ -417,13 +439,13 @@ function PlayerCell({ a, b, winner, status }: { a: Player; b: Player; winner: Wi
   return (
     <div style={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
       <div className="player">
-        <Avatar name={a.name} seed={a.seed} />
+        <PlayerAvatar name={a.name} seed={a.seed} />
         <span className={aClass}>{a.name}</span>
         <span className="seed-tag">#{a.seed}</span>
       </div>
       <span className="vs">vs</span>
       <div className="player">
-        <Avatar name={b.name} seed={b.seed} />
+        <PlayerAvatar name={b.name} seed={b.seed} />
         <span className={bClass}>{b.name}</span>
         <span className="seed-tag">#{b.seed}</span>
       </div>
@@ -462,16 +484,21 @@ function ScoreCell({ m }: { m: Match }) {
   )
 }
 
+const STATUS_BADGE: Record<StatusKey, { label: string; className: string }> = {
+  live: { label: 'Live', className: 'status-tone-live' },
+  final: { label: 'Final', className: 'status-tone-final' },
+  called: { label: 'Called', className: 'status-tone-called' },
+  scheduled: { label: 'Scheduled', className: 'status-tone-scheduled' },
+}
+
 function StatusBadge({ status }: { status: StatusKey }) {
-  if (status === 'live')
-    return (
-      <span className="status is-live">
-        <span className="live-dot" />Live
-      </span>
-    )
-  if (status === 'final') return <span className="status is-final">Final</span>
-  if (status === 'called') return <span className="status is-called">Called</span>
-  return <span className="status is-scheduled">Scheduled</span>
+  const meta = STATUS_BADGE[status]
+  return (
+    <Badge variant="secondary" className={`status-pill ${meta.className}`}>
+      {status === 'live' && <span className="live-dot" />}
+      {meta.label}
+    </Badge>
+  )
 }
 
 function TimeCell({ t }: { t: Date }) {
@@ -523,71 +550,23 @@ function SortHeader({ id, label, sort, setSort, width }: SortHeaderProps) {
   )
 }
 
-function SkeletonRow() {
-  return (
-    <tr className="skeleton-row">
-      <td><span className="skeleton s-text-sm" style={{ width: 50 }} /></td>
-      <td><span className="skeleton s-chip" style={{ width: 84, height: 30, borderRadius: 6 }} /></td>
-      <td><span className="skeleton s-chip" /></td>
-      <td><span className="skeleton s-text-sm" style={{ width: 40 }} /></td>
-      <td>
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
-          <span className="skeleton s-avatar" />
-          <span className="skeleton s-text-md" />
-          <span style={{ width: 24, display: 'inline-block' }} />
-          <span className="skeleton s-avatar" />
-          <span className="skeleton s-text-md" />
-        </span>
-      </td>
-      <td><span className="skeleton s-text-lg" /></td>
-      <td><span className="skeleton s-chip" style={{ width: 64 }} /></td>
-      <td><span className="skeleton s-text-sm" /></td>
-      <td />
-    </tr>
-  )
-}
-
 interface MatchTableProps {
   rows: Match[]
   sort: SortState
   setSort: (v: SortState) => void
   onClear: () => void
-  loading: boolean
-  pageSize: number
 }
 
-function MatchTable({ rows, sort, setSort, onClear, loading, pageSize }: MatchTableProps) {
-  if (loading) {
-    return (
-      <table className="matches">
-        <thead>
-          <tr>
-            <th style={{ width: 84 }}>#</th>
-            <th style={{ width: 130 }}>Context</th>
-            <th style={{ width: 90 }}>Round</th>
-            <th style={{ width: 70 }}>Court</th>
-            <th>Players</th>
-            <th style={{ width: 220 }}>Score</th>
-            <th style={{ width: 120 }}>Status</th>
-            <th style={{ width: 100 }}>Time</th>
-            <th style={{ width: 36 }} />
-          </tr>
-        </thead>
-        <tbody>
-          {Array.from({ length: Math.min(pageSize, 10) }).map((_, i) => (
-            <SkeletonRow key={i} />
-          ))}
-        </tbody>
-      </table>
-    )
-  }
+function MatchTable({ rows, sort, setSort, onClear }: MatchTableProps) {
   if (rows.length === 0) {
     return (
       <div className="empty">
         <div className="empty-icon"><Inbox size={56} strokeWidth={1.5} /></div>
         <div className="empty-title">No matches match these filters</div>
         <div className="empty-sub">Try widening the context, round, or court — or clear the search.</div>
-        <button type="button" className="ml-btn ghost empty-clear" onClick={onClear}>Clear filters</button>
+        <Button variant="ghost" size="sm" className="empty-clear" onClick={onClear}>
+          Clear filters
+        </Button>
       </div>
     )
   }
@@ -644,15 +623,17 @@ function MatchTable({ rows, sort, setSort, onClear, loading, pageSize }: MatchTa
   )
 }
 
-function paginationRange(current: number, total: number): (number | 'ell-l' | 'ell-r')[] {
+type PageToken = number | 'ellipsis'
+
+function paginationRange(current: number, total: number): PageToken[] {
   const delta = 1
-  const range: (number | 'ell-l' | 'ell-r')[] = []
+  const range: PageToken[] = []
   const left = Math.max(2, current - delta)
   const right = Math.min(total - 1, current + delta)
   range.push(1)
-  if (left > 2) range.push('ell-l')
+  if (left > 2) range.push('ellipsis')
   for (let i = left; i <= right; i++) range.push(i)
-  if (right < total - 1) range.push('ell-r')
+  if (right < total - 1) range.push('ellipsis')
   if (total > 1) range.push(total)
   return range
 }
@@ -664,14 +645,15 @@ interface PaginationProps {
   pageSize: number
   setPageSize: (n: number) => void
   filteredCount: number
-  disabled: boolean
 }
 
 function PaginationFooter(props: PaginationProps) {
-  const { page, setPage, total, pageSize, setPageSize, filteredCount, disabled } = props
+  const { page, setPage, total, pageSize, setPageSize, filteredCount } = props
   const first = filteredCount === 0 ? 0 : (page - 1) * pageSize + 1
   const last = Math.min(filteredCount, page * pageSize)
   const tokens = paginationRange(page, total || 1)
+  const atFirst = page <= 1
+  const atLast = page >= total
 
   return (
     <div className="footer">
@@ -682,76 +664,96 @@ function PaginationFooter(props: PaginationProps) {
       <div className="footer-spacer" />
       <div className="page-size">
         Rows per page
-        <div className="select-wrap">
-          <select
-            className="ml-select"
-            style={{ minWidth: 0, height: 32, padding: '0 28px 0 10px' }}
-            value={pageSize}
-            onChange={(e) => {
-              setPageSize(Number(e.target.value))
-              setPage(1)
-            }}
-          >
+        <Select
+          value={String(pageSize)}
+          onValueChange={(v) => {
+            setPageSize(Number(v))
+            setPage(1)
+          }}
+        >
+          <SelectTrigger size="sm" className="min-w-[64px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
             {[10, 15, 25, 50].map((n) => (
-              <option key={n} value={n}>{n}</option>
+              <SelectItem key={n} value={String(n)}>{n}</SelectItem>
             ))}
-          </select>
-          <span className="select-caret"><ChevronDown size={12} strokeWidth={2.4} /></span>
-        </div>
+          </SelectContent>
+        </Select>
       </div>
-      <div className="pagination">
-        <button
-          type="button"
-          className="page-btn is-nav"
-          disabled={disabled || page <= 1}
-          onClick={() => setPage(1)}
-          aria-label="First page"
-        >
-          <ChevronsLeft size={14} strokeWidth={2.4} />
-        </button>
-        <button
-          type="button"
-          className="page-btn is-nav"
-          disabled={disabled || page <= 1}
-          onClick={() => setPage(page - 1)}
-          aria-label="Previous"
-        >
-          <ChevronLeft size={14} strokeWidth={2.4} />
-        </button>
-        {tokens.map((t, i) =>
-          typeof t === 'number' ? (
-            <button
-              key={i}
-              type="button"
-              disabled={disabled}
-              className={'page-btn' + (t === page ? ' is-current' : '')}
-              onClick={() => setPage(t)}
+      <Pagination className="mx-0 w-auto justify-end">
+        <PaginationContent>
+          <PaginationItem>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              disabled={atFirst}
+              onClick={() => setPage(1)}
+              aria-label="First page"
             >
-              {t}
-            </button>
-          ) : (
-            <span key={i} className="page-btn is-ellipsis">…</span>
-          ),
-        )}
-        <button
-          type="button"
-          className="page-btn is-nav"
-          disabled={disabled || page >= total}
-          onClick={() => setPage(page + 1)}
-          aria-label="Next"
-        >
-          <ChevronRight size={14} strokeWidth={2.4} />
-        </button>
-        <button
-          type="button"
-          className="page-btn is-nav"
-          disabled={disabled || page >= total}
-          onClick={() => setPage(total)}
-          aria-label="Last page"
-        >
-          <ChevronsRight size={14} strokeWidth={2.4} />
-        </button>
-      </div>
+              <ChevronsLeft size={14} strokeWidth={2.4} />
+            </Button>
+          </PaginationItem>
+          <PaginationItem>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              disabled={atFirst}
+              onClick={() => setPage(page - 1)}
+              aria-label="Previous page"
+            >
+              <ChevronLeft size={14} strokeWidth={2.4} />
+            </Button>
+          </PaginationItem>
+          {tokens.map((t, i) =>
+            t === 'ellipsis' ? (
+              <PaginationItem key={i}>
+                <PaginationEllipsis />
+              </PaginationItem>
+            ) : (
+              <PaginationItem key={i}>
+                <PaginationLink
+                  href="#"
+                  isActive={t === page}
+                  onClick={(e) => {
+                    e.preventDefault()
+                    setPage(t)
+                  }}
+                  className={
+                    t === page
+                      ? 'bg-primary text-primary-foreground hover:bg-[color:var(--ball-400)] hover:text-primary-foreground'
+                      : undefined
+                  }
+                >
+                  {t}
+                </PaginationLink>
+              </PaginationItem>
+            ),
+          )}
+          <PaginationItem>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              disabled={atLast}
+              onClick={() => setPage(page + 1)}
+              aria-label="Next page"
+            >
+              <ChevronRight size={14} strokeWidth={2.4} />
+            </Button>
+          </PaginationItem>
+          <PaginationItem>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              disabled={atLast}
+              onClick={() => setPage(total)}
+              aria-label="Last page"
+            >
+              <ChevronsRight size={14} strokeWidth={2.4} />
+            </Button>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
     </div>
   )
 }
@@ -875,8 +877,6 @@ function MatchesPage() {
             rows={pageRows}
             sort={sort} setSort={setSort}
             onClear={onClear}
-            loading={false}
-            pageSize={pageSize}
           />
         </div>
         <PaginationFooter
@@ -884,7 +884,6 @@ function MatchesPage() {
           total={total}
           pageSize={pageSize} setPageSize={setPageSize}
           filteredCount={sorted.length}
-          disabled={false}
         />
       </div>
     </AppShell>


### PR DESCRIPTION
## What

Adds a new **`/matches`** route to the web client — a heterogeneous match list (tournament / club / casual / ladder) ported from the Claude Design "Match list" handoff.

UI only: seeded mock data lives in the route file, no backend wiring (per the design's chat transcript — "no backend logic behind it quite yet").

## Changes

- **`src/routes/matches/index.tsx`** — page component: action bar (title + live count + Export / + New match), filter row (search, status segmented control with counts, context / round / court dropdowns, clear-filters), sortable table (#, Context, Round, Court, Players, Score, Status, Time) with sticky header, empty state, and pagination footer with rows-per-page + first/prev/numbered/next/last.
- **`src/routes/matches/index.css`** — scoped styles under `.match-list-page` so they don't bleed. Page is height-constrained to viewport so only the table body scrolls; everything else stays put.
- **`src/components/app-shell.tsx`** — wires the previously-inert "Live Matches" sidebar item to `/matches` (renamed to "Matches" to match the page title).
- **`src/routeTree.gen.ts`** — regenerated by the router plugin.

Icons come from `lucide-react` (already a project dep). Mock data is heterogeneous on purpose — round / court are nullable so the row renders `—` for casual / ladder / club-night matches.

The design-tool-only Tweaks panel and the prototype's loading / inline-error / full-error / offline states were intentionally dropped — the JSX and CSS are preserved in the handoff bundle and can be wired back in when the backend lands.

## Testing

- `npm run test:run` — **17 passed**
- `npm run lint && npm run build` — clean (1 pre-existing warning in generated `public/mockServiceWorker.js`)
- `npm run test:e2e` — **116 passed**
- `pytest` in `api/` — **76 passed** (no api changes, sanity only)
- Smoke-verified in the browser: filtering, sorting, pagination, search, sticky header, inner-scroll all behave as designed

🤖 Generated with [Claude Code](https://claude.com/claude-code)