### PR TITLE
Add /matches/:matchId design route and link match list rows

### DIFF
--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2003,9 +2003,7 @@ body.dark.fortymm-theme {
 }
 
 /* =========================================================================
-   Match Details Page
-   (route: /matches/:matchId)
-   Ported from the "Match Details Page" design handoff.
+   Match Details Page (route: /matches/:matchId)
    ========================================================================= */
 .fortymm-theme .match-details {
   --r-xs: 4px;
@@ -2039,14 +2037,15 @@ body.dark.fortymm-theme {
   cursor: pointer;
 }
 
-/* ---------- Page width ---------- */
 .fortymm-theme .md-page {
   max-width: 1180px;
   margin: 0 auto;
   padding: 0 32px;
 }
+.fortymm-theme .md-page--y {
+  padding: 32px 32px 80px;
+}
 
-/* ---------- Brand logo (footer only, now that the top nav lives in AppShell) ---------- */
 .fortymm-theme .md-logo {
   display: flex;
   align-items: center;
@@ -2090,6 +2089,11 @@ body.dark.fortymm-theme {
 }
 .fortymm-theme .md-btn--primary:disabled {
   cursor: not-allowed;
+  opacity: 0.45;
+}
+.fortymm-theme .md-btn--primary:disabled:hover {
+  background: var(--ball-500);
+  box-shadow: none;
 }
 .fortymm-theme .md-btn--ghost {
   background: transparent;
@@ -3196,16 +3200,6 @@ body.dark.fortymm-theme {
   cursor: pointer;
 }
 
-/* ---------- Fade swap ---------- */
-.fortymm-theme .md-fade-swap {
-  animation: md-fade-up 320ms var(--ease-out);
-}
-@keyframes md-fade-up {
-  from { opacity: 0; transform: translateY(6px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-/* ---------- Responsive ---------- */
 @media (max-width: 880px) {
   .fortymm-theme .md-col-2 {
     grid-template-columns: 1fr;
@@ -3256,7 +3250,6 @@ body.dark.fortymm-theme {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .fortymm-theme .md-fade-swap,
   .fortymm-theme .md-modal,
   .fortymm-theme .md-modal-scrim {
     animation: none !important;

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2001,3 +2001,1264 @@ body.dark.fortymm-theme {
     transition: none !important;
   }
 }
+
+/* =========================================================================
+   Match Details Page
+   (route: /matches/:matchId)
+   Ported from the "Match Details Page" design handoff.
+   ========================================================================= */
+.fortymm-theme .match-details {
+  --r-xs: 4px;
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+  --r-xl: 20px;
+  --r-pill: 999px;
+
+  --dur-fast: 120ms;
+  --dur-base: 200ms;
+  --dur-slow: 360ms;
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --ease-snap: cubic-bezier(0.5, 1.6, 0.4, 1);
+  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+}
+.fortymm-theme .match-details *,
+.fortymm-theme .match-details *::before,
+.fortymm-theme .match-details *::after {
+  box-sizing: border-box;
+}
+.fortymm-theme .match-details a {
+  color: inherit;
+  text-decoration: none;
+}
+.fortymm-theme .match-details button {
+  font-family: inherit;
+  cursor: pointer;
+}
+
+/* ---------- Page width ---------- */
+.fortymm-theme .md-page {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+/* ---------- Brand logo (footer only, now that the top nav lives in AppShell) ---------- */
+.fortymm-theme .md-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.fortymm-theme .md-logo__word {
+  font-family: 'Bebas Neue', sans-serif;
+  letter-spacing: 0.04em;
+  color: var(--fg-1);
+  line-height: 1;
+}
+.fortymm-theme .md-logo__word .accent {
+  color: var(--ball-500);
+}
+
+/* ---------- Buttons ---------- */
+.fortymm-theme .md-btn {
+  font: 600 13px var(--font-ui);
+  height: 36px;
+  padding: 0 14px;
+  border-radius: var(--r-md);
+  border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: all var(--dur-base) var(--ease-out);
+  white-space: nowrap;
+  background: transparent;
+  color: var(--fg-1);
+}
+.fortymm-theme .md-btn:active {
+  transform: scale(0.97);
+}
+.fortymm-theme .md-btn--primary {
+  background: var(--ball-500);
+  color: var(--ink-950);
+}
+.fortymm-theme .md-btn--primary:hover {
+  background: var(--ball-400);
+  box-shadow: var(--shadow-glow);
+}
+.fortymm-theme .md-btn--primary:disabled {
+  cursor: not-allowed;
+}
+.fortymm-theme .md-btn--ghost {
+  background: transparent;
+  color: var(--fg-1);
+  border-color: var(--ink-500);
+}
+.fortymm-theme .md-btn--ghost:hover {
+  background: var(--bg-hover);
+  border-color: var(--chalk-500);
+}
+.fortymm-theme .md-btn--icon {
+  width: 36px;
+  padding: 0;
+  justify-content: center;
+}
+.fortymm-theme .md-btn--sm {
+  height: 30px;
+  font-size: 12px;
+  padding: 0 12px;
+}
+.fortymm-theme .md-btn--sm.md-btn--icon {
+  width: 30px;
+  padding: 0;
+}
+
+/* ---------- Page header row ---------- */
+.fortymm-theme .md-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+.fortymm-theme .md-header__right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.fortymm-theme .md-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font: 500 12px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.fortymm-theme .md-breadcrumb a {
+  color: var(--fg-2);
+  cursor: pointer;
+}
+.fortymm-theme .md-breadcrumb__current {
+  color: var(--fg-1);
+}
+
+/* ---------- State tabs ---------- */
+.fortymm-theme .md-tabs {
+  display: inline-flex;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  padding: 4px;
+  gap: 2px;
+}
+.fortymm-theme .md-tab {
+  font: 600 12px var(--font-ui);
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 7px;
+  border: 0;
+  background: transparent;
+  color: var(--fg-3);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: all var(--dur-fast) var(--ease-out);
+  letter-spacing: 0.02em;
+}
+.fortymm-theme .md-tab:hover {
+  color: var(--fg-1);
+}
+.fortymm-theme .md-tab[aria-selected='true'] {
+  background: var(--bg-raised);
+  color: var(--fg-1);
+  box-shadow: var(--shadow-inset);
+}
+.fortymm-theme .md-tab .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--fg-3);
+}
+.fortymm-theme .md-tab[data-state='live'][aria-selected='true'] .dot {
+  background: var(--serve-500);
+  box-shadow: 0 0 8px var(--serve-500);
+  animation: ball-pulse 1.4s ease-in-out infinite;
+}
+.fortymm-theme .md-tab[data-state='final'][aria-selected='true'] .dot {
+  background: var(--ball-500);
+}
+.fortymm-theme .md-tab[data-state='upcoming'][aria-selected='true'] .dot {
+  background: var(--warn);
+}
+
+/* ---------- Cards ---------- */
+.fortymm-theme .md-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+}
+.fortymm-theme .md-card__hd {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.fortymm-theme .md-card__hd h3 {
+  font: 600 13px var(--font-ui);
+  margin: 0;
+  color: var(--fg-1);
+  letter-spacing: 0.01em;
+}
+.fortymm-theme .md-card__body {
+  padding: 18px;
+}
+
+/* ---------- Avatar ---------- */
+.fortymm-theme .md-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--r-pill);
+  background: var(--ink-700);
+  color: var(--fg-1);
+  font-weight: 700;
+  font-family: var(--font-ui);
+  flex-shrink: 0;
+  position: relative;
+}
+.fortymm-theme .md-avatar--win {
+  background: linear-gradient(135deg, #ff7a1a, #b94700);
+  color: #fff;
+  box-shadow: 0 0 0 2px var(--ball-500), 0 0 0 5px rgba(255, 122, 26, 0.18);
+}
+.fortymm-theme .md-avatar--loss {
+  background: linear-gradient(135deg, #2a3040, #11141b);
+  color: var(--fg-2);
+}
+
+/* ---------- Hero scoreboard ---------- */
+.fortymm-theme .md-hero {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-lg);
+  padding: 32px 36px 28px;
+  position: relative;
+  overflow: hidden;
+}
+.fortymm-theme .md-hero__grid-bg {
+  position: absolute;
+  inset: 0;
+  opacity: 0.4;
+  background-image: radial-gradient(
+    circle at center,
+    rgba(255, 122, 26, 0.14) 1.5px,
+    transparent 2px
+  );
+  background-size: 40px 40px;
+  mask-image: radial-gradient(
+    ellipse 50% 70% at 100% 0%,
+    black,
+    transparent 70%
+  );
+  -webkit-mask-image: radial-gradient(
+    ellipse 50% 70% at 100% 0%,
+    black,
+    transparent 70%
+  );
+  pointer-events: none;
+}
+.fortymm-theme .md-hero__strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+  position: relative;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.fortymm-theme .md-hero__strip-l,
+.fortymm-theme .md-hero__strip-r {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.fortymm-theme .md-hero__strip-r {
+  gap: 18px;
+}
+.fortymm-theme .md-hero__row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 32px;
+  position: relative;
+}
+.fortymm-theme .md-hero__player {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.fortymm-theme .md-hero__player--l {
+  align-items: flex-start;
+}
+.fortymm-theme .md-hero__player--r {
+  align-items: flex-end;
+}
+.fortymm-theme .md-hero__player-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.fortymm-theme .md-hero__player--r .md-hero__player-row {
+  flex-direction: row-reverse;
+}
+.fortymm-theme .md-hero__player-text--l {
+  text-align: left;
+}
+.fortymm-theme .md-hero__player-text--r {
+  text-align: right;
+}
+.fortymm-theme .md-hero__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.fortymm-theme .md-hero__player--r .md-hero__meta {
+  justify-content: flex-end;
+}
+.fortymm-theme .md-hero__seed {
+  font: 700 11px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.18em;
+}
+.fortymm-theme .md-hero__flag {
+  font: 600 10px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.14em;
+}
+.fortymm-theme .md-hero__serving {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font: 700 10px var(--font-mono);
+  color: var(--ball-500);
+  letter-spacing: 0.18em;
+}
+.fortymm-theme .md-hero__serving .ball-dot {
+  width: 7px;
+  height: 7px;
+}
+.fortymm-theme .md-hero__name {
+  font: 700 28px var(--font-ui);
+  color: var(--fg-1);
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+.fortymm-theme .md-hero__name--win {
+  color: var(--serve-500);
+}
+.fortymm-theme .md-hero__club {
+  font: 500 12px var(--font-ui);
+  color: var(--fg-3);
+  margin-top: 4px;
+}
+
+.fortymm-theme .md-hero__doubles-row {
+  display: flex;
+}
+.fortymm-theme .md-hero__doubles-row--r {
+  flex-direction: row-reverse;
+}
+.fortymm-theme .md-hero__doubles-row .md-avatar {
+  width: 56px;
+  height: 56px;
+  font-size: 18px;
+}
+.fortymm-theme .md-hero__doubles-row .md-avatar + .md-avatar {
+  margin-left: -14px;
+}
+.fortymm-theme .md-hero__doubles-row--r .md-avatar + .md-avatar {
+  margin-left: 0;
+  margin-right: -14px;
+}
+.fortymm-theme .md-hero__avatar-singles {
+  width: 64px;
+  height: 64px;
+  font-size: 20px;
+}
+
+.fortymm-theme .md-hero__score-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+}
+.fortymm-theme .md-hero__score-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 16px;
+}
+.fortymm-theme .md-hero__score {
+  font-family: 'Bebas Neue', sans-serif;
+  font-weight: 400;
+  font-size: 112px;
+  line-height: 0.85;
+  letter-spacing: 0.02em;
+  color: var(--fg-1);
+  font-variant-numeric: tabular-nums;
+}
+.fortymm-theme .md-hero__score--l {
+  text-align: right;
+}
+.fortymm-theme .md-hero__score--r {
+  text-align: left;
+}
+.fortymm-theme .md-hero__score--win {
+  color: var(--serve-500);
+}
+.fortymm-theme .md-hero__score-dash {
+  font: 700 18px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.1em;
+}
+.fortymm-theme .md-hero__score-caption {
+  font: 500 11px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.18em;
+  margin-top: 4px;
+}
+.fortymm-theme .md-hero__vs-label {
+  font: 500 11px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.18em;
+}
+.fortymm-theme .md-hero__vs-dash {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 96px;
+  line-height: 0.9;
+  color: var(--ink-700);
+  letter-spacing: 0.04em;
+}
+.fortymm-theme .md-hero__strip-meta {
+  font: 500 12px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.14em;
+  white-space: nowrap;
+}
+.fortymm-theme .md-hero__strip-meta--with-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  letter-spacing: 0.1em;
+}
+
+/* ---------- Chips ---------- */
+.fortymm-theme .md-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 24px;
+  padding: 0 10px;
+  border-radius: var(--r-pill);
+  font: 600 11px var(--font-ui);
+  letter-spacing: 0.04em;
+  background: var(--bg-panel);
+  color: var(--fg-2);
+  border: 1px solid var(--border-subtle);
+}
+.fortymm-theme .md-chip--live {
+  background: rgba(0, 226, 154, 0.12);
+  color: var(--serve-500);
+  border-color: rgba(0, 226, 154, 0.3);
+}
+.fortymm-theme .md-chip--final {
+  background: rgba(255, 122, 26, 0.1);
+  color: var(--ball-500);
+  border-color: rgba(255, 122, 26, 0.3);
+}
+.fortymm-theme .md-chip--upcoming {
+  background: rgba(255, 196, 61, 0.1);
+  color: var(--warn);
+  border-color: rgba(255, 196, 61, 0.3);
+}
+.fortymm-theme .md-chip .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.fortymm-theme .md-chip--live .dot {
+  box-shadow: 0 0 8px currentColor;
+  animation: ball-pulse 1.4s ease-in-out infinite;
+}
+
+/* ---------- Per-game grid ---------- */
+.fortymm-theme .md-games {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border-subtle);
+}
+.fortymm-theme .md-games__grid {
+  display: grid;
+  grid-template-columns: 130px repeat(5, 1fr) 90px;
+  gap: 8px;
+  align-items: center;
+}
+.fortymm-theme .md-games__kicker {
+  font: 600 11px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.fortymm-theme .md-games__col-label {
+  text-align: center;
+  font: 600 10px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.18em;
+}
+.fortymm-theme .md-games__player {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.fortymm-theme .md-games__player .md-avatar {
+  width: 28px;
+  height: 28px;
+  font-size: 11px;
+  box-shadow: none;
+}
+.fortymm-theme .md-games__player-name {
+  font: 600 13px var(--font-ui);
+  color: var(--fg-1);
+}
+.fortymm-theme .md-games__cell {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 12px 8px;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: 700 22px var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.fortymm-theme .md-games__cell--win {
+  color: var(--serve-500);
+}
+.fortymm-theme .md-games__cell--loss {
+  color: var(--fg-3);
+}
+.fortymm-theme .md-games__cell--live {
+  border-color: rgba(0, 226, 154, 0.4);
+  box-shadow: 0 0 12px rgba(0, 226, 154, 0.1);
+}
+.fortymm-theme .md-games__cell--empty {
+  visibility: hidden;
+}
+.fortymm-theme .md-games__total {
+  text-align: center;
+  font: 700 24px var(--font-mono);
+  color: var(--fg-1);
+}
+.fortymm-theme .md-games__total--win {
+  color: var(--serve-500);
+}
+
+/* ---------- Two-column layout ---------- */
+.fortymm-theme .md-col-2 {
+  display: grid;
+  grid-template-columns: 1fr 340px;
+  gap: 28px;
+  align-items: start;
+  margin-top: 28px;
+}
+.fortymm-theme .md-col-2__main {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+}
+.fortymm-theme .md-col-2__aside {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  position: sticky;
+  top: 88px;
+}
+
+/* ---------- Players & form card ---------- */
+.fortymm-theme .md-players {
+  display: grid;
+  grid-template-columns: 1fr 1px 1fr;
+}
+.fortymm-theme .md-players__divider {
+  background: var(--border-subtle);
+}
+.fortymm-theme .md-profile {
+  padding: 22px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+.fortymm-theme .md-profile__identity {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.fortymm-theme .md-profile__identity .md-avatar {
+  width: 48px;
+  height: 48px;
+  font-size: 15px;
+  box-shadow: none;
+}
+.fortymm-theme .md-profile__doubles-avatars {
+  display: flex;
+}
+.fortymm-theme .md-profile__doubles-avatars .md-avatar {
+  width: 44px;
+  height: 44px;
+  font-size: 13px;
+  box-shadow: 0 0 0 2px var(--bg-card);
+}
+.fortymm-theme .md-profile__doubles-avatars .md-avatar + .md-avatar {
+  margin-left: -10px;
+}
+.fortymm-theme .md-profile__id-text {
+  flex: 1;
+  min-width: 0;
+}
+.fortymm-theme .md-profile__tag-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 3px;
+}
+.fortymm-theme .md-profile__seed {
+  font: 700 10px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.18em;
+}
+.fortymm-theme .md-profile__name {
+  font: 700 16px var(--font-ui);
+  color: var(--fg-1);
+  letter-spacing: -0.005em;
+  line-height: 1.2;
+}
+.fortymm-theme .md-profile__club {
+  font: 500 12px var(--font-ui);
+  color: var(--fg-3);
+  margin-top: 2px;
+}
+.fortymm-theme .md-profile__rating-box {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 10px 12px;
+  background: var(--bg-panel);
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border-subtle);
+}
+.fortymm-theme .md-kicker {
+  font: 600 11px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.fortymm-theme .md-profile__rating-value {
+  font: 700 22px var(--font-mono);
+  color: var(--fg-1);
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+  margin-top: 2px;
+}
+.fortymm-theme .md-profile__rating-value .dim {
+  color: var(--fg-3);
+  font-size: 13px;
+}
+.fortymm-theme .md-form-row {
+  display: grid;
+  grid-template-columns: 18px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.fortymm-theme .md-form-row:last-child {
+  border-bottom: 0;
+}
+.fortymm-theme .md-form-row__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  font: 700 10px var(--font-mono);
+}
+.fortymm-theme .md-form-row__badge--w {
+  background: rgba(0, 226, 154, 0.18);
+  color: var(--serve-500);
+}
+.fortymm-theme .md-form-row__badge--l {
+  background: rgba(255, 77, 109, 0.18);
+  color: var(--loss);
+}
+.fortymm-theme .md-form-row__opp {
+  font: 500 13px var(--font-ui);
+  color: var(--fg-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.fortymm-theme .md-form-row__when {
+  font: 500 10px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.06em;
+}
+.fortymm-theme .md-form-row__score {
+  font: 700 13px var(--font-mono);
+  color: var(--fg-1);
+  font-variant-numeric: tabular-nums;
+}
+.fortymm-theme .md-form-row__score--loss {
+  color: var(--fg-3);
+}
+.fortymm-theme .md-profile__career {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-subtle);
+}
+.fortymm-theme .md-profile__career-value {
+  font: 700 18px var(--font-mono);
+  color: var(--fg-1);
+  font-variant-numeric: tabular-nums;
+  margin-top: 4px;
+}
+.fortymm-theme .md-profile__career-value--good {
+  color: var(--serve-500);
+}
+
+/* ---------- Match info card rows ---------- */
+.fortymm-theme .md-info-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.fortymm-theme .md-info-row:last-child {
+  border-bottom: 0;
+}
+.fortymm-theme .md-info-row__k {
+  font: 500 12px var(--font-ui);
+  color: var(--fg-3);
+  letter-spacing: 0.04em;
+}
+.fortymm-theme .md-info-row__v {
+  font: 600 12px var(--font-mono);
+  color: var(--fg-1);
+  letter-spacing: 0.04em;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------- Rating card ---------- */
+.fortymm-theme .md-rating-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.fortymm-theme .md-rating-row .md-avatar {
+  width: 40px;
+  height: 40px;
+  font-size: 13px;
+  box-shadow: none;
+}
+.fortymm-theme .md-rating-row__text {
+  flex: 1;
+  min-width: 0;
+}
+.fortymm-theme .md-rating-row__name {
+  font: 600 13px var(--font-ui);
+  color: var(--fg-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.fortymm-theme .md-rating-row__numbers {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-top: 2px;
+}
+.fortymm-theme .md-rating-row__numbers .from {
+  font: 600 13px var(--font-mono);
+  color: var(--fg-2);
+}
+.fortymm-theme .md-rating-row__numbers .to {
+  font: 700 13px var(--font-mono);
+  color: var(--fg-1);
+}
+.fortymm-theme .md-rating-row__delta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+.fortymm-theme .md-rating-row__delta-num {
+  font: 700 13px var(--font-mono);
+  letter-spacing: 0.04em;
+}
+.fortymm-theme .md-delta-up {
+  color: var(--serve-500);
+}
+.fortymm-theme .md-delta-down {
+  color: var(--loss);
+}
+.fortymm-theme .md-rating-divider {
+  border: 0;
+  height: 1px;
+  background: var(--border-subtle);
+  margin: 0;
+}
+
+/* ---------- Head to head ---------- */
+.fortymm-theme .md-h2h {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.fortymm-theme .md-h2h__counts {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+}
+.fortymm-theme .md-h2h__count {
+  font: 700 28px var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  color: var(--fg-1);
+}
+.fortymm-theme .md-h2h__count--win {
+  color: var(--serve-500);
+}
+.fortymm-theme .md-h2h__count-label {
+  font: 500 11px var(--font-ui);
+  color: var(--fg-3);
+  margin-top: 2px;
+}
+.fortymm-theme .md-h2h__sep {
+  font: 700 13px var(--font-mono);
+  color: var(--fg-3);
+}
+.fortymm-theme .md-h2h__bar {
+  height: 10px;
+  border-radius: var(--r-pill);
+  background: var(--ink-700);
+  overflow: hidden;
+  display: flex;
+}
+.fortymm-theme .md-h2h__bar > div {
+  height: 100%;
+  transition: width var(--dur-slow) var(--ease-out);
+}
+.fortymm-theme .md-h2h__row {
+  display: grid;
+  grid-template-columns: 70px 1fr auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.fortymm-theme .md-h2h__row:last-child {
+  border-bottom: 0;
+}
+.fortymm-theme .md-h2h__date {
+  font: 500 11px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.06em;
+}
+.fortymm-theme .md-h2h__label {
+  font: 500 12px var(--font-ui);
+  color: var(--fg-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.fortymm-theme .md-h2h__label--tonight {
+  font-weight: 600;
+  color: var(--ball-500);
+}
+.fortymm-theme .md-h2h__score {
+  font: 700 13px var(--font-mono);
+  color: var(--fg-1);
+  font-variant-numeric: tabular-nums;
+}
+.fortymm-theme .md-h2h__score--win {
+  color: var(--serve-500);
+}
+.fortymm-theme .md-h2h__result {
+  font: 600 10px var(--font-mono);
+  letter-spacing: 0.14em;
+  min-width: 18px;
+  text-align: right;
+}
+.fortymm-theme .md-h2h__result--w {
+  color: var(--serve-500);
+}
+.fortymm-theme .md-h2h__result--l {
+  color: var(--loss);
+}
+
+/* ---------- Comments ---------- */
+.fortymm-theme .md-comments__form {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.fortymm-theme .md-comments__form .md-avatar {
+  width: 32px;
+  height: 32px;
+  font-size: 11px;
+  background: var(--ink-700);
+}
+.fortymm-theme .md-input {
+  flex: 1;
+  width: 100%;
+  height: 38px;
+  padding: 0 12px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-default);
+  border-radius: var(--r-sm);
+  color: var(--fg-1);
+  font: 500 13px var(--font-ui);
+  outline: none;
+  transition: border-color var(--dur-fast) var(--ease-out);
+}
+.fortymm-theme .md-input:focus {
+  border-color: var(--ball-500);
+}
+.fortymm-theme .md-comment {
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.fortymm-theme .md-comment:last-child {
+  border-bottom: 0;
+}
+.fortymm-theme .md-comment .md-avatar {
+  width: 32px;
+  height: 32px;
+  font-size: 11px;
+  align-self: flex-start;
+}
+.fortymm-theme .md-comment__meta {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.fortymm-theme .md-comment__who {
+  font: 600 13px var(--font-ui);
+  color: var(--fg-1);
+}
+.fortymm-theme .md-comment__when {
+  font: 500 11px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.1em;
+}
+.fortymm-theme .md-comment__body {
+  font: 400 14px/1.45 var(--font-ui);
+  color: var(--fg-2);
+}
+.fortymm-theme .md-comment__reacts {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+.fortymm-theme .md-react {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: var(--r-pill);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-subtle);
+  color: var(--fg-3);
+  font: 500 11px var(--font-mono);
+  transition: all var(--dur-fast) var(--ease-out);
+  cursor: pointer;
+}
+.fortymm-theme .md-react:hover {
+  color: var(--fg-1);
+  border-color: var(--chalk-500);
+}
+.fortymm-theme .md-react.is-on {
+  background: rgba(255, 122, 26, 0.12);
+  border-color: rgba(255, 122, 26, 0.4);
+  color: var(--ball-500);
+}
+.fortymm-theme .md-react__glyph {
+  color: var(--ball-500);
+}
+
+/* ---------- Share modal ---------- */
+.fortymm-theme .md-modal-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 13, 18, 0.78);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  animation: md-fade-in 200ms var(--ease-out);
+}
+.fortymm-theme .md-modal {
+  background: var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-radius: var(--r-xl);
+  width: 100%;
+  max-width: 460px;
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  animation: md-pop-in 240ms var(--ease-snap);
+}
+.fortymm-theme .md-modal__hd {
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.fortymm-theme .md-modal__title {
+  font: 700 18px var(--font-ui);
+  color: var(--fg-1);
+  letter-spacing: -0.01em;
+}
+.fortymm-theme .md-modal__body {
+  padding: 18px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.fortymm-theme .md-modal__preview {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.fortymm-theme .md-modal__preview .md-avatar {
+  width: 36px;
+  height: 36px;
+  font-size: 12px;
+  box-shadow: none;
+}
+.fortymm-theme .md-modal__preview-title {
+  font: 600 13px var(--font-ui);
+  color: var(--fg-1);
+}
+.fortymm-theme .md-modal__preview-sub {
+  font: 500 11px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.06em;
+  margin-top: 2px;
+}
+.fortymm-theme .md-modal__url-row {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+}
+.fortymm-theme .md-modal__url {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  height: 38px;
+  padding: 0 12px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-default);
+  border-radius: var(--r-sm);
+  color: var(--fg-1);
+  font: 500 13px var(--font-mono);
+  cursor: default;
+  user-select: all;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.fortymm-theme .md-modal__url-row .md-btn--primary {
+  width: 108px;
+  justify-content: center;
+}
+.fortymm-theme .md-modal__tiles {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+}
+.fortymm-theme .md-share-tile {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  padding: 14px 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  cursor: pointer;
+  color: var(--fg-1);
+  transition: all var(--dur-fast) var(--ease-out);
+}
+.fortymm-theme .md-share-tile:hover {
+  background: var(--bg-raised);
+  border-color: var(--chalk-500);
+}
+.fortymm-theme .md-share-tile__label {
+  font: 600 12px var(--font-ui);
+  color: var(--fg-1);
+}
+.fortymm-theme .md-share-tile__hint {
+  font: 500 10px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.1em;
+  margin-top: 2px;
+}
+.fortymm-theme .md-modal__note {
+  padding: 12px 14px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font: 400 12px/1.5 var(--font-ui);
+  color: var(--fg-3);
+}
+.fortymm-theme .md-modal__note .accent {
+  color: var(--ball-500);
+  margin-top: 2px;
+}
+@keyframes md-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes md-pop-in {
+  from { opacity: 0; transform: scale(0.96) translateY(8px); }
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* ---------- Footer ---------- */
+.fortymm-theme .md-footer {
+  margin-top: 60px;
+  padding-top: 28px;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+.fortymm-theme .md-footer__tagline {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font: 400 12px var(--font-ui);
+  color: var(--fg-3);
+}
+.fortymm-theme .md-footer__links {
+  display: flex;
+  gap: 18px;
+  font: 500 12px var(--font-ui);
+  color: var(--fg-3);
+}
+.fortymm-theme .md-footer__links a {
+  cursor: pointer;
+}
+
+/* ---------- Fade swap ---------- */
+.fortymm-theme .md-fade-swap {
+  animation: md-fade-up 320ms var(--ease-out);
+}
+@keyframes md-fade-up {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 880px) {
+  .fortymm-theme .md-col-2 {
+    grid-template-columns: 1fr;
+  }
+  .fortymm-theme .md-col-2__aside {
+    position: static;
+  }
+  .fortymm-theme .md-players {
+    grid-template-columns: 1fr;
+  }
+  .fortymm-theme .md-players__divider {
+    height: 1px;
+    width: auto;
+  }
+  .fortymm-theme .md-games__grid {
+    grid-template-columns: 96px repeat(5, 1fr) 60px;
+  }
+  .fortymm-theme .md-hero__score {
+    font-size: 84px;
+  }
+  .fortymm-theme .md-hero__name {
+    font-size: 22px;
+  }
+  .fortymm-theme .md-hero {
+    padding: 24px 22px 22px;
+  }
+}
+@media (max-width: 560px) {
+  .fortymm-theme .md-page {
+    padding: 0 16px;
+  }
+  .fortymm-theme .md-hero__row {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+  .fortymm-theme .md-hero__player--r {
+    align-items: flex-start;
+  }
+  .fortymm-theme .md-hero__player--r .md-hero__player-row {
+    flex-direction: row;
+  }
+  .fortymm-theme .md-hero__player-text--r {
+    text-align: left;
+  }
+  .fortymm-theme .md-hero__player--r .md-hero__meta {
+    justify-content: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fortymm-theme .md-fade-swap,
+  .fortymm-theme .md-modal,
+  .fortymm-theme .md-modal-scrim {
+    animation: none !important;
+  }
+}

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as MatchesIndexRouteImport } from './routes/matches/index'
 import { Route as AdminIndexRouteImport } from './routes/admin.index'
 import { Route as MatchesNewRouteImport } from './routes/matches/new'
+import { Route as MatchesMatchIdRouteImport } from './routes/matches.$matchId'
 import { Route as AdminUsersRouteImport } from './routes/admin.users'
 import { Route as AdminRolesRouteImport } from './routes/admin.roles'
 import { Route as AdminPermissionsRouteImport } from './routes/admin.permissions'
@@ -62,6 +63,11 @@ const MatchesNewRoute = MatchesNewRouteImport.update({
   path: '/matches/new',
   getParentRoute: () => rootRouteImport,
 } as any)
+const MatchesMatchIdRoute = MatchesMatchIdRouteImport.update({
+  id: '/matches/$matchId',
+  path: '/matches/$matchId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AdminUsersRoute = AdminUsersRouteImport.update({
   id: '/users',
   path: '/users',
@@ -79,9 +85,9 @@ const AdminPermissionsRoute = AdminPermissionsRouteImport.update({
 } as any)
 const MatchesMatchIdGamesGameIdScoresNewRoute =
   MatchesMatchIdGamesGameIdScoresNewRouteImport.update({
-    id: '/matches/$matchId/games/$gameId/scores/new',
-    path: '/matches/$matchId/games/$gameId/scores/new',
-    getParentRoute: () => rootRouteImport,
+    id: '/games/$gameId/scores/new',
+    path: '/games/$gameId/scores/new',
+    getParentRoute: () => MatchesMatchIdRoute,
   } as any)
 
 export interface FileRoutesByFullPath {
@@ -93,6 +99,7 @@ export interface FileRoutesByFullPath {
   '/admin/permissions': typeof AdminPermissionsRoute
   '/admin/roles': typeof AdminRolesRoute
   '/admin/users': typeof AdminUsersRoute
+  '/matches/$matchId': typeof MatchesMatchIdRouteWithChildren
   '/matches/new': typeof MatchesNewRoute
   '/admin/': typeof AdminIndexRoute
   '/matches/': typeof MatchesIndexRoute
@@ -106,6 +113,7 @@ export interface FileRoutesByTo {
   '/admin/permissions': typeof AdminPermissionsRoute
   '/admin/roles': typeof AdminRolesRoute
   '/admin/users': typeof AdminUsersRoute
+  '/matches/$matchId': typeof MatchesMatchIdRouteWithChildren
   '/matches/new': typeof MatchesNewRoute
   '/admin': typeof AdminIndexRoute
   '/matches': typeof MatchesIndexRoute
@@ -121,6 +129,7 @@ export interface FileRoutesById {
   '/admin/permissions': typeof AdminPermissionsRoute
   '/admin/roles': typeof AdminRolesRoute
   '/admin/users': typeof AdminUsersRoute
+  '/matches/$matchId': typeof MatchesMatchIdRouteWithChildren
   '/matches/new': typeof MatchesNewRoute
   '/admin/': typeof AdminIndexRoute
   '/matches/': typeof MatchesIndexRoute
@@ -137,6 +146,7 @@ export interface FileRouteTypes {
     | '/admin/permissions'
     | '/admin/roles'
     | '/admin/users'
+    | '/matches/$matchId'
     | '/matches/new'
     | '/admin/'
     | '/matches/'
@@ -150,6 +160,7 @@ export interface FileRouteTypes {
     | '/admin/permissions'
     | '/admin/roles'
     | '/admin/users'
+    | '/matches/$matchId'
     | '/matches/new'
     | '/admin'
     | '/matches'
@@ -164,6 +175,7 @@ export interface FileRouteTypes {
     | '/admin/permissions'
     | '/admin/roles'
     | '/admin/users'
+    | '/matches/$matchId'
     | '/matches/new'
     | '/admin/'
     | '/matches/'
@@ -176,9 +188,9 @@ export interface RootRouteChildren {
   DashboardRoute: typeof DashboardRoute
   DesignSystemRoute: typeof DesignSystemRoute
   SettingsRoute: typeof SettingsRoute
+  MatchesMatchIdRoute: typeof MatchesMatchIdRouteWithChildren
   MatchesNewRoute: typeof MatchesNewRoute
   MatchesIndexRoute: typeof MatchesIndexRoute
-  MatchesMatchIdGamesGameIdScoresNewRoute: typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -239,6 +251,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MatchesNewRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/matches/$matchId': {
+      id: '/matches/$matchId'
+      path: '/matches/$matchId'
+      fullPath: '/matches/$matchId'
+      preLoaderRoute: typeof MatchesMatchIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/admin/users': {
       id: '/admin/users'
       path: '/users'
@@ -262,10 +281,10 @@ declare module '@tanstack/react-router' {
     }
     '/matches/$matchId/games/$gameId/scores/new': {
       id: '/matches/$matchId/games/$gameId/scores/new'
-      path: '/matches/$matchId/games/$gameId/scores/new'
+      path: '/games/$gameId/scores/new'
       fullPath: '/matches/$matchId/games/$gameId/scores/new'
       preLoaderRoute: typeof MatchesMatchIdGamesGameIdScoresNewRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof MatchesMatchIdRoute
     }
   }
 }
@@ -286,16 +305,28 @@ const AdminRouteChildren: AdminRouteChildren = {
 
 const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
 
+interface MatchesMatchIdRouteChildren {
+  MatchesMatchIdGamesGameIdScoresNewRoute: typeof MatchesMatchIdGamesGameIdScoresNewRoute
+}
+
+const MatchesMatchIdRouteChildren: MatchesMatchIdRouteChildren = {
+  MatchesMatchIdGamesGameIdScoresNewRoute:
+    MatchesMatchIdGamesGameIdScoresNewRoute,
+}
+
+const MatchesMatchIdRouteWithChildren = MatchesMatchIdRoute._addFileChildren(
+  MatchesMatchIdRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AdminRoute: AdminRouteWithChildren,
   DashboardRoute: DashboardRoute,
   DesignSystemRoute: DesignSystemRoute,
   SettingsRoute: SettingsRoute,
+  MatchesMatchIdRoute: MatchesMatchIdRouteWithChildren,
   MatchesNewRoute: MatchesNewRoute,
   MatchesIndexRoute: MatchesIndexRoute,
-  MatchesMatchIdGamesGameIdScoresNewRoute:
-    MatchesMatchIdGamesGameIdScoresNewRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -17,10 +17,10 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as MatchesIndexRouteImport } from './routes/matches/index'
 import { Route as AdminIndexRouteImport } from './routes/admin.index'
 import { Route as MatchesNewRouteImport } from './routes/matches/new'
-import { Route as MatchesMatchIdRouteImport } from './routes/matches.$matchId'
 import { Route as AdminUsersRouteImport } from './routes/admin.users'
 import { Route as AdminRolesRouteImport } from './routes/admin.roles'
 import { Route as AdminPermissionsRouteImport } from './routes/admin.permissions'
+import { Route as MatchesMatchIdIndexRouteImport } from './routes/matches.$matchId.index'
 import { Route as MatchesMatchIdGamesGameIdScoresNewRouteImport } from './routes/matches.$matchId.games.$gameId.scores.new'
 
 const SettingsRoute = SettingsRouteImport.update({
@@ -63,11 +63,6 @@ const MatchesNewRoute = MatchesNewRouteImport.update({
   path: '/matches/new',
   getParentRoute: () => rootRouteImport,
 } as any)
-const MatchesMatchIdRoute = MatchesMatchIdRouteImport.update({
-  id: '/matches/$matchId',
-  path: '/matches/$matchId',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const AdminUsersRoute = AdminUsersRouteImport.update({
   id: '/users',
   path: '/users',
@@ -83,11 +78,16 @@ const AdminPermissionsRoute = AdminPermissionsRouteImport.update({
   path: '/permissions',
   getParentRoute: () => AdminRoute,
 } as any)
+const MatchesMatchIdIndexRoute = MatchesMatchIdIndexRouteImport.update({
+  id: '/matches/$matchId/',
+  path: '/matches/$matchId/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MatchesMatchIdGamesGameIdScoresNewRoute =
   MatchesMatchIdGamesGameIdScoresNewRouteImport.update({
-    id: '/games/$gameId/scores/new',
-    path: '/games/$gameId/scores/new',
-    getParentRoute: () => MatchesMatchIdRoute,
+    id: '/matches/$matchId/games/$gameId/scores/new',
+    path: '/matches/$matchId/games/$gameId/scores/new',
+    getParentRoute: () => rootRouteImport,
   } as any)
 
 export interface FileRoutesByFullPath {
@@ -99,10 +99,10 @@ export interface FileRoutesByFullPath {
   '/admin/permissions': typeof AdminPermissionsRoute
   '/admin/roles': typeof AdminRolesRoute
   '/admin/users': typeof AdminUsersRoute
-  '/matches/$matchId': typeof MatchesMatchIdRouteWithChildren
   '/matches/new': typeof MatchesNewRoute
   '/admin/': typeof AdminIndexRoute
   '/matches/': typeof MatchesIndexRoute
+  '/matches/$matchId/': typeof MatchesMatchIdIndexRoute
   '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 export interface FileRoutesByTo {
@@ -113,10 +113,10 @@ export interface FileRoutesByTo {
   '/admin/permissions': typeof AdminPermissionsRoute
   '/admin/roles': typeof AdminRolesRoute
   '/admin/users': typeof AdminUsersRoute
-  '/matches/$matchId': typeof MatchesMatchIdRouteWithChildren
   '/matches/new': typeof MatchesNewRoute
   '/admin': typeof AdminIndexRoute
   '/matches': typeof MatchesIndexRoute
+  '/matches/$matchId': typeof MatchesMatchIdIndexRoute
   '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 export interface FileRoutesById {
@@ -129,10 +129,10 @@ export interface FileRoutesById {
   '/admin/permissions': typeof AdminPermissionsRoute
   '/admin/roles': typeof AdminRolesRoute
   '/admin/users': typeof AdminUsersRoute
-  '/matches/$matchId': typeof MatchesMatchIdRouteWithChildren
   '/matches/new': typeof MatchesNewRoute
   '/admin/': typeof AdminIndexRoute
   '/matches/': typeof MatchesIndexRoute
+  '/matches/$matchId/': typeof MatchesMatchIdIndexRoute
   '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 export interface FileRouteTypes {
@@ -146,10 +146,10 @@ export interface FileRouteTypes {
     | '/admin/permissions'
     | '/admin/roles'
     | '/admin/users'
-    | '/matches/$matchId'
     | '/matches/new'
     | '/admin/'
     | '/matches/'
+    | '/matches/$matchId/'
     | '/matches/$matchId/games/$gameId/scores/new'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -160,10 +160,10 @@ export interface FileRouteTypes {
     | '/admin/permissions'
     | '/admin/roles'
     | '/admin/users'
-    | '/matches/$matchId'
     | '/matches/new'
     | '/admin'
     | '/matches'
+    | '/matches/$matchId'
     | '/matches/$matchId/games/$gameId/scores/new'
   id:
     | '__root__'
@@ -175,10 +175,10 @@ export interface FileRouteTypes {
     | '/admin/permissions'
     | '/admin/roles'
     | '/admin/users'
-    | '/matches/$matchId'
     | '/matches/new'
     | '/admin/'
     | '/matches/'
+    | '/matches/$matchId/'
     | '/matches/$matchId/games/$gameId/scores/new'
   fileRoutesById: FileRoutesById
 }
@@ -188,9 +188,10 @@ export interface RootRouteChildren {
   DashboardRoute: typeof DashboardRoute
   DesignSystemRoute: typeof DesignSystemRoute
   SettingsRoute: typeof SettingsRoute
-  MatchesMatchIdRoute: typeof MatchesMatchIdRouteWithChildren
   MatchesNewRoute: typeof MatchesNewRoute
   MatchesIndexRoute: typeof MatchesIndexRoute
+  MatchesMatchIdIndexRoute: typeof MatchesMatchIdIndexRoute
+  MatchesMatchIdGamesGameIdScoresNewRoute: typeof MatchesMatchIdGamesGameIdScoresNewRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -251,13 +252,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MatchesNewRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/matches/$matchId': {
-      id: '/matches/$matchId'
-      path: '/matches/$matchId'
-      fullPath: '/matches/$matchId'
-      preLoaderRoute: typeof MatchesMatchIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/admin/users': {
       id: '/admin/users'
       path: '/users'
@@ -279,12 +273,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminPermissionsRouteImport
       parentRoute: typeof AdminRoute
     }
+    '/matches/$matchId/': {
+      id: '/matches/$matchId/'
+      path: '/matches/$matchId'
+      fullPath: '/matches/$matchId/'
+      preLoaderRoute: typeof MatchesMatchIdIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/matches/$matchId/games/$gameId/scores/new': {
       id: '/matches/$matchId/games/$gameId/scores/new'
-      path: '/games/$gameId/scores/new'
+      path: '/matches/$matchId/games/$gameId/scores/new'
       fullPath: '/matches/$matchId/games/$gameId/scores/new'
       preLoaderRoute: typeof MatchesMatchIdGamesGameIdScoresNewRouteImport
-      parentRoute: typeof MatchesMatchIdRoute
+      parentRoute: typeof rootRouteImport
     }
   }
 }
@@ -305,28 +306,17 @@ const AdminRouteChildren: AdminRouteChildren = {
 
 const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
 
-interface MatchesMatchIdRouteChildren {
-  MatchesMatchIdGamesGameIdScoresNewRoute: typeof MatchesMatchIdGamesGameIdScoresNewRoute
-}
-
-const MatchesMatchIdRouteChildren: MatchesMatchIdRouteChildren = {
-  MatchesMatchIdGamesGameIdScoresNewRoute:
-    MatchesMatchIdGamesGameIdScoresNewRoute,
-}
-
-const MatchesMatchIdRouteWithChildren = MatchesMatchIdRoute._addFileChildren(
-  MatchesMatchIdRouteChildren,
-)
-
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AdminRoute: AdminRouteWithChildren,
   DashboardRoute: DashboardRoute,
   DesignSystemRoute: DesignSystemRoute,
   SettingsRoute: SettingsRoute,
-  MatchesMatchIdRoute: MatchesMatchIdRouteWithChildren,
   MatchesNewRoute: MatchesNewRoute,
   MatchesIndexRoute: MatchesIndexRoute,
+  MatchesMatchIdIndexRoute: MatchesMatchIdIndexRoute,
+  MatchesMatchIdGamesGameIdScoresNewRoute:
+    MatchesMatchIdGamesGameIdScoresNewRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/web-client/src/routes/matches.$matchId.index.tsx
+++ b/web-client/src/routes/matches.$matchId.index.tsx
@@ -15,7 +15,7 @@ import {
 import { AppShell } from '@/components/app-shell'
 import { cn } from '@/lib/utils'
 
-export const Route = createFileRoute('/matches/$matchId')({
+export const Route = createFileRoute('/matches/$matchId/')({
   component: MatchDetailsPage,
 })
 

--- a/web-client/src/routes/matches.$matchId.tsx
+++ b/web-client/src/routes/matches.$matchId.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent } from 'react'
+import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import {
   Check,
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react'
 
 import { AppShell } from '@/components/app-shell'
+import { cn } from '@/lib/utils'
 
 export const Route = createFileRoute('/matches/$matchId')({
   component: MatchDetailsPage,
@@ -21,8 +22,7 @@ export const Route = createFileRoute('/matches/$matchId')({
 type MatchState = 'live' | 'final' | 'upcoming'
 type Format = 'singles' | 'doubles'
 type Context = 'tournament' | 'casual'
-
-/* ---------- DATA (hard-coded from the design handoff) -------------------- */
+type Side = 'a' | 'b'
 
 const MATCH = {
   tournament: 'Spring Open 2026',
@@ -45,7 +45,7 @@ interface DoublesMember {
 }
 
 interface BasePlayer {
-  id: 'a' | 'b'
+  id: Side
   initials: string
   seed: number
   club: string
@@ -105,10 +105,10 @@ const DOUBLES_PLAYERS: Record<'a' | 'b', DoublesPlayer> = {
 
 interface Scoreline {
   games: Array<[number, number]>
-  winner: 'a' | 'b' | null
+  winner: Side | null
   summary: [number, number]
   currentGame?: number
-  serving?: 'a' | 'b'
+  serving?: Side
 }
 
 const SCORES_FINAL: Scoreline = { games: [[11, 6], [9, 11], [11, 8], [11, 9]], winner: 'a', summary: [3, 1] }
@@ -118,49 +118,67 @@ const DOUBLES_LIVE: Scoreline = { games: [[11, 9], [8, 11], [11, 7], [7, 5]], wi
 
 interface FormResult { r: 'W' | 'L'; score: string; opp: string; when: string }
 
-const RECENT_FORM: Record<string, FormResult[]> = {
-  a_singles: [
-    { r: 'W', score: '3–0', opp: 'Silva, R.', when: 'May 10 · R32' },
-    { r: 'W', score: '3–1', opp: 'Kim, H.', when: 'May 09 · R64' },
-    { r: 'W', score: '3–2', opp: 'Hansen, M.', when: 'Apr 21 · Cup' },
-    { r: 'L', score: '1–3', opp: 'Tanaka, Y.', when: 'Apr 06 · Reg.' },
-    { r: 'W', score: '3–0', opp: 'Ali, R.', when: 'Mar 29 · Club' },
-  ],
-  b_singles: [
-    { r: 'W', score: '3–2', opp: 'Dubois, C.', when: 'May 10 · R32' },
-    { r: 'W', score: '3–0', opp: 'Ahmed, I.', when: 'May 09 · R64' },
-    { r: 'L', score: '2–3', opp: 'Tran, L.', when: 'Apr 18 · Cup' },
-    { r: 'L', score: '0–3', opp: 'Müller, F.', when: 'Apr 03 · Reg.' },
-    { r: 'W', score: '3–1', opp: 'Park, J.', when: 'Mar 22 · Club' },
-  ],
-  a_doubles: [
-    { r: 'W', score: '3–0', opp: 'Müller/Rossi', when: 'May 10 · R32' },
-    { r: 'W', score: '3–1', opp: 'Ali/Park', when: 'May 09 · R64' },
-    { r: 'W', score: '3–2', opp: 'Hansen/Kim', when: 'Apr 21 · Cup' },
-    { r: 'L', score: '2–3', opp: 'Tanaka/Yoon', when: 'Apr 06 · Reg.' },
-    { r: 'W', score: '3–0', opp: 'Silva/Dubois', when: 'Mar 29 · Club' },
-  ],
-  b_doubles: [
-    { r: 'W', score: '3–2', opp: 'Chen/Wong', when: 'May 10 · R32' },
-    { r: 'L', score: '1–3', opp: 'Patel/Mehta', when: 'May 09 · R64' },
-    { r: 'L', score: '2–3', opp: 'Tran/Le', when: 'Apr 18 · Cup' },
-    { r: 'W', score: '3–0', opp: 'Doe/Roe', when: 'Apr 03 · Reg.' },
-    { r: 'W', score: '3–1', opp: 'Park/Yoon', when: 'Mar 22 · Club' },
-  ],
+const RECENT_FORM: Record<Format, Record<Side, FormResult[]>> = {
+  singles: {
+    a: [
+      { r: 'W', score: '3–0', opp: 'Silva, R.', when: 'May 10 · R32' },
+      { r: 'W', score: '3–1', opp: 'Kim, H.', when: 'May 09 · R64' },
+      { r: 'W', score: '3–2', opp: 'Hansen, M.', when: 'Apr 21 · Cup' },
+      { r: 'L', score: '1–3', opp: 'Tanaka, Y.', when: 'Apr 06 · Reg.' },
+      { r: 'W', score: '3–0', opp: 'Ali, R.', when: 'Mar 29 · Club' },
+    ],
+    b: [
+      { r: 'W', score: '3–2', opp: 'Dubois, C.', when: 'May 10 · R32' },
+      { r: 'W', score: '3–0', opp: 'Ahmed, I.', when: 'May 09 · R64' },
+      { r: 'L', score: '2–3', opp: 'Tran, L.', when: 'Apr 18 · Cup' },
+      { r: 'L', score: '0–3', opp: 'Müller, F.', when: 'Apr 03 · Reg.' },
+      { r: 'W', score: '3–1', opp: 'Park, J.', when: 'Mar 22 · Club' },
+    ],
+  },
+  doubles: {
+    a: [
+      { r: 'W', score: '3–0', opp: 'Müller/Rossi', when: 'May 10 · R32' },
+      { r: 'W', score: '3–1', opp: 'Ali/Park', when: 'May 09 · R64' },
+      { r: 'W', score: '3–2', opp: 'Hansen/Kim', when: 'Apr 21 · Cup' },
+      { r: 'L', score: '2–3', opp: 'Tanaka/Yoon', when: 'Apr 06 · Reg.' },
+      { r: 'W', score: '3–0', opp: 'Silva/Dubois', when: 'Mar 29 · Club' },
+    ],
+    b: [
+      { r: 'W', score: '3–2', opp: 'Chen/Wong', when: 'May 10 · R32' },
+      { r: 'L', score: '1–3', opp: 'Patel/Mehta', when: 'May 09 · R64' },
+      { r: 'L', score: '2–3', opp: 'Tran/Le', when: 'Apr 18 · Cup' },
+      { r: 'W', score: '3–0', opp: 'Doe/Roe', when: 'Apr 03 · Reg.' },
+      { r: 'W', score: '3–1', opp: 'Park/Yoon', when: 'Mar 22 · Club' },
+    ],
+  },
 }
 
-const RATING_HISTORY: Record<string, number[]> = {
-  a_singles: [2098, 2104, 2110, 2118, 2128, 2122, 2120, 2132, 2140, 2145],
-  b_singles: [2080, 2074, 2065, 2050, 2052, 2040, 2018, 2012, 2008, 2002],
-  a_doubles: [2042, 2050, 2058, 2062, 2058, 2068, 2074, 2078, 2084, 2092],
-  b_doubles: [2050, 2048, 2052, 2048, 2044, 2052, 2050, 2042, 2038, 2036],
+const RATING_HISTORY: Record<Format, Record<Side, number[]>> = {
+  singles: {
+    a: [2098, 2104, 2110, 2118, 2128, 2122, 2120, 2132, 2140, 2145],
+    b: [2080, 2074, 2065, 2050, 2052, 2040, 2018, 2012, 2008, 2002],
+  },
+  doubles: {
+    a: [2042, 2050, 2058, 2062, 2058, 2068, 2074, 2078, 2084, 2092],
+    b: [2050, 2048, 2052, 2048, 2044, 2052, 2050, 2042, 2038, 2036],
+  },
 }
 
-const CAREER: Record<string, { matches: number; winPct: number }> = {
-  a_singles: { matches: 184, winPct: 71 },
-  b_singles: { matches: 162, winPct: 62 },
-  a_doubles: { matches: 92, winPct: 68 },
-  b_doubles: { matches: 78, winPct: 55 },
+const CAREER: Record<Format, Record<Side, { matches: number; winPct: number }>> = {
+  singles: {
+    a: { matches: 184, winPct: 71 },
+    b: { matches: 162, winPct: 62 },
+  },
+  doubles: {
+    a: { matches: 92, winPct: 68 },
+    b: { matches: 78, winPct: 55 },
+  },
+}
+
+// Singles-only rating delta (a wins +12, b loses -12). Used by RatingRow.
+const SINGLES_RATING_DELTA: Record<Side, { rating: number; ratingNew: number; delta: number; history: number[] }> = {
+  a: { rating: 2145, ratingNew: 2157, delta: 12, history: [2098, 2110, 2128, 2120, 2145, 2157] },
+  b: { rating: 2002, ratingNew: 1990, delta: -12, history: [2080, 2065, 2050, 2018, 2002, 1990] },
 }
 
 interface H2HMatch {
@@ -168,7 +186,7 @@ interface H2HMatch {
   date: string
   round: string
   score: [number, number]
-  winner: 'a' | 'b'
+  winner: Side
   tonight?: boolean
 }
 
@@ -202,7 +220,6 @@ const COMMENTS_INIT: Comment[] = [
   { who: 'Patel, Meera', initials: 'MP', when: '35 min ago', body: 'Court 3 has the best view in the building. Fight me.', reacts: { ball: 24, fire: 11 }, yours: { ball: false, fire: true } },
 ]
 
-/* ---------- Shared bits --------------------------------------------------- */
 
 function Logo({ size = 26 }: { size?: number }) {
   return (
@@ -244,7 +261,6 @@ function Sparkline({ points, color = 'currentColor', width = 120, height = 32 }:
   )
 }
 
-/* ---------- Breadcrumb + tabs -------------------------------------------- */
 
 function Breadcrumb({ context }: { context: Context }) {
   if (context === 'casual') {
@@ -271,7 +287,6 @@ function Breadcrumb({ context }: { context: Context }) {
   )
 }
 
-/* ---------- Hero scoreboard ---------------------------------------------- */
 
 function PlayerSide({
   player,
@@ -298,7 +313,7 @@ function PlayerSide({
             {doublesPlayer.members.map((m, i) => (
               <div
                 key={i}
-                className={`md-avatar ${win ? 'md-avatar--win' : 'md-avatar--loss'}`}
+                className={cn('md-avatar', win ? 'md-avatar--win' : 'md-avatar--loss')}
                 style={{ zIndex: 2 - i }}
               >
                 {m.initials}
@@ -306,7 +321,7 @@ function PlayerSide({
             ))}
           </div>
         ) : (
-          <div className={`md-avatar md-hero__avatar-singles ${win ? 'md-avatar--win' : 'md-avatar--loss'}`}>
+          <div className={cn('md-avatar md-hero__avatar-singles', win ? 'md-avatar--win' : 'md-avatar--loss')}>
             {player.initials}
           </div>
         )}
@@ -321,7 +336,7 @@ function PlayerSide({
               </span>
             )}
           </div>
-          <div className={`md-hero__name ${win ? 'md-hero__name--win' : ''}`}>
+          <div className={cn('md-hero__name', win && 'md-hero__name--win')}>
             {isDoubles ? player.last : `${(player as SinglesPlayer).last}, ${(player as SinglesPlayer).first}`}
           </div>
           <div className="md-hero__club">{player.club}</div>
@@ -398,9 +413,9 @@ function HeroScoreboard({ state, format, context }: { state: MatchState; format:
           ) : (
             <>
               <div className="md-hero__score-row">
-                <div className={`md-hero__score md-hero__score--l ${winA ? 'md-hero__score--win' : ''}`}>{aTotal}</div>
+                <div className={cn('md-hero__score md-hero__score--l', winA && 'md-hero__score--win')}>{aTotal}</div>
                 <div className="md-hero__score-dash">—</div>
-                <div className={`md-hero__score md-hero__score--r ${winB ? 'md-hero__score--win' : ''}`}>{bTotal}</div>
+                <div className={cn('md-hero__score md-hero__score--r', winB && 'md-hero__score--win')}>{bTotal}</div>
               </div>
               <div className="md-hero__score-caption">
                 {isLive
@@ -418,83 +433,83 @@ function HeroScoreboard({ state, format, context }: { state: MatchState; format:
   )
 }
 
+const GAME_INDEXES = [0, 1, 2, 3, 4] as const
+
 function GameGrid({
   score,
   players,
   state,
 }: {
   score: Scoreline
-  players: Record<'a' | 'b', SinglesPlayer | DoublesPlayer>
+  players: Record<Side, SinglesPlayer | DoublesPlayer>
   state: MatchState
 }) {
-  const games = [0, 1, 2, 3, 4]
-  const isLive = state === 'live'
-
-  function nameOf(p: SinglesPlayer | DoublesPlayer): string {
-    return (p.last || '').split('/')[0].trim()
-  }
-
   return (
     <div className="md-games">
       <div className="md-games__grid">
         <div className="md-games__kicker">GAMES</div>
-        {games.map((i) => (
+        {GAME_INDEXES.map((i) => (
           <div key={`h-${i}`} className="md-games__col-label">G{i + 1}</div>
         ))}
         <div className="md-games__col-label">SETS</div>
 
-        <div className="md-games__player">
-          <span className="md-avatar md-avatar--win">{players.a.initials}</span>
-          <span className="md-games__player-name">{nameOf(players.a)}</span>
-        </div>
-        {games.map((i) => {
-          const g = score.games[i]
-          if (!g) return <div key={`a-${i}`} className="md-games__cell md-games__cell--empty">—</div>
-          const isLiveCell = isLive && score.currentGame === i + 1
-          return (
-            <div
-              key={`a-${i}`}
-              className={`md-games__cell ${g[0] > g[1] ? 'md-games__cell--win' : 'md-games__cell--loss'} ${isLiveCell ? 'md-games__cell--live' : ''}`}
-            >
-              {g[0]}
-            </div>
-          )
-        })}
-        <div className={`md-games__total ${score.winner === 'a' ? 'md-games__total--win' : ''}`}>
-          {score.summary[0]}
-        </div>
-
-        <div className="md-games__player">
-          <span className="md-avatar md-avatar--loss">{players.b.initials}</span>
-          <span className="md-games__player-name">{nameOf(players.b)}</span>
-        </div>
-        {games.map((i) => {
-          const g = score.games[i]
-          if (!g) return <div key={`b-${i}`} className="md-games__cell md-games__cell--empty">—</div>
-          const isLiveCell = isLive && score.currentGame === i + 1
-          return (
-            <div
-              key={`b-${i}`}
-              className={`md-games__cell ${g[1] > g[0] ? 'md-games__cell--win' : 'md-games__cell--loss'} ${isLiveCell ? 'md-games__cell--live' : ''}`}
-            >
-              {g[1]}
-            </div>
-          )
-        })}
-        <div className={`md-games__total ${score.winner === 'b' ? 'md-games__total--win' : ''}`}>
-          {score.summary[1]}
-        </div>
+        <GameGridSide side="a" score={score} player={players.a} state={state} />
+        <GameGridSide side="b" score={score} player={players.b} state={state} />
       </div>
     </div>
   )
 }
 
-/* ---------- Players & form card ----------------------------------------- */
+function GameGridSide({
+  side,
+  score,
+  player,
+  state,
+}: {
+  side: Side
+  score: Scoreline
+  player: SinglesPlayer | DoublesPlayer
+  state: MatchState
+}) {
+  const isLive = state === 'live'
+  const myIdx = side === 'a' ? 0 : 1
+  const oppIdx = side === 'a' ? 1 : 0
+  const name = (player.last || '').split('/')[0].trim()
+  return (
+    <>
+      <div className="md-games__player">
+        <span className={cn('md-avatar', side === 'a' ? 'md-avatar--win' : 'md-avatar--loss')}>
+          {player.initials}
+        </span>
+        <span className="md-games__player-name">{name}</span>
+      </div>
+      {GAME_INDEXES.map((i) => {
+        const g = score.games[i]
+        if (!g) return <div key={`${side}-${i}`} className="md-games__cell md-games__cell--empty">—</div>
+        const isLiveCell = isLive && score.currentGame === i + 1
+        return (
+          <div
+            key={`${side}-${i}`}
+            className={cn(
+              'md-games__cell',
+              g[myIdx] > g[oppIdx] ? 'md-games__cell--win' : 'md-games__cell--loss',
+              isLiveCell && 'md-games__cell--live',
+            )}
+          >
+            {g[myIdx]}
+          </div>
+        )
+      })}
+      <div className={cn('md-games__total', score.winner === side && 'md-games__total--win')}>
+        {score.summary[myIdx]}
+      </div>
+    </>
+  )
+}
+
 
 function PlayersCard({ state, format }: { state: MatchState; format: Format }) {
   const players = format === 'doubles' ? DOUBLES_PLAYERS : SINGLES_PLAYERS
-  const aKey = format === 'doubles' ? 'a_doubles' : 'a_singles'
-  const bKey = format === 'doubles' ? 'b_doubles' : 'b_singles'
 
   return (
     <div className="md-card">
@@ -503,9 +518,9 @@ function PlayersCard({ state, format }: { state: MatchState; format: Format }) {
         <span className="md-modal__preview-sub" style={{ marginTop: 0 }}>LAST 5 RESULTS</span>
       </div>
       <div className="md-players">
-        <PlayerProfile p={players.a} form={RECENT_FORM[aKey]} history={RATING_HISTORY[aKey]} career={CAREER[aKey]} format={format} won={state === 'final'} />
+        <PlayerProfile p={players.a} form={RECENT_FORM[format].a} history={RATING_HISTORY[format].a} career={CAREER[format].a} format={format} won={state === 'final'} />
         <div className="md-players__divider" />
-        <PlayerProfile p={players.b} form={RECENT_FORM[bKey]} history={RATING_HISTORY[bKey]} career={CAREER[bKey]} format={format} won={false} />
+        <PlayerProfile p={players.b} form={RECENT_FORM[format].b} history={RATING_HISTORY[format].b} career={CAREER[format].b} format={format} won={false} />
       </div>
     </div>
   )
@@ -539,7 +554,7 @@ function PlayerProfile({
             {doublesPlayer.members.map((m, i) => (
               <div
                 key={i}
-                className={`md-avatar ${won ? 'md-avatar--win' : 'md-avatar--loss'}`}
+                className={cn('md-avatar', won ? 'md-avatar--win' : 'md-avatar--loss')}
                 style={{ zIndex: 2 - i }}
               >
                 {m.initials}
@@ -547,7 +562,7 @@ function PlayerProfile({
             ))}
           </div>
         ) : (
-          <div className={`md-avatar ${won ? 'md-avatar--win' : 'md-avatar--loss'}`}>
+          <div className={cn('md-avatar', won ? 'md-avatar--win' : 'md-avatar--loss')}>
             {p.initials}
           </div>
         )}
@@ -590,7 +605,7 @@ function PlayerProfile({
                 <div className="md-form-row__opp">{m.opp}</div>
                 <div className="md-form-row__when">{m.when}</div>
               </div>
-              <span className={`md-form-row__score ${m.r === 'L' ? 'md-form-row__score--loss' : ''}`}>
+              <span className={cn('md-form-row__score', m.r === 'L' && 'md-form-row__score--loss')}>
                 {m.score}
               </span>
             </div>
@@ -605,7 +620,7 @@ function PlayerProfile({
         </div>
         <div>
           <div className="md-kicker">Win rate</div>
-          <div className={`md-profile__career-value ${career.winPct >= 60 ? 'md-profile__career-value--good' : ''}`}>
+          <div className={cn('md-profile__career-value', career.winPct >= 60 && 'md-profile__career-value--good')}>
             {career.winPct}%
           </div>
         </div>
@@ -614,7 +629,6 @@ function PlayerProfile({
   )
 }
 
-/* ---------- Sidebar cards ----------------------------------------------- */
 
 function MatchInfoCard({ context, format, state }: { context: Context; format: Format; state: MatchState }) {
   const rows: Array<[string, string]> = []
@@ -683,25 +697,24 @@ function RatingCard({ format, state, context }: { format: Format; state: MatchSt
       </div>
     )
   }
-  const isDoubles = format === 'doubles'
   return (
     <div className="md-card">
       <div className="md-card__hd"><h3>Rating change</h3></div>
       <div className="md-card__body" style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
-        <RatingRow p={players.a} win doubles={isDoubles} />
+        <RatingRow p={players.a} win format={format} />
         <hr className="md-rating-divider" />
-        <RatingRow p={players.b} win={false} doubles={isDoubles} />
+        <RatingRow p={players.b} win={false} format={format} />
       </div>
     </div>
   )
 }
 
-function RatingRow({ p, win, doubles }: { p: SinglesPlayer | DoublesPlayer; win: boolean; doubles: boolean }) {
-  if (doubles) {
+function RatingRow({ p, win, format }: { p: SinglesPlayer | DoublesPlayer; win: boolean; format: Format }) {
+  if (format === 'doubles') {
     const dp = p as DoublesPlayer
     return (
       <div className="md-rating-row">
-        <div className={`md-avatar ${win ? 'md-avatar--win' : 'md-avatar--loss'}`} style={{ width: 36, height: 36, fontSize: 12 }}>
+        <div className={cn('md-avatar', win ? 'md-avatar--win' : 'md-avatar--loss')} style={{ width: 36, height: 36, fontSize: 12 }}>
           {dp.initials}
         </div>
         <div className="md-rating-row__text">
@@ -710,23 +723,19 @@ function RatingRow({ p, win, doubles }: { p: SinglesPlayer | DoublesPlayer; win:
             {dp.rating}
           </div>
         </div>
-        <div className={`md-rating-row__delta-num ${dp.delta > 0 ? 'md-delta-up' : 'md-delta-down'}`}>
+        <div className={cn('md-rating-row__delta-num', dp.delta > 0 ? 'md-delta-up' : 'md-delta-down')}>
           {dp.ratingNew}
         </div>
       </div>
     )
   }
 
-  const isA = p.id === 'a'
-  const history = isA ? [2098, 2110, 2128, 2120, 2145, 2157] : [2080, 2065, 2050, 2018, 2002, 1990]
-  const rating = isA ? 2145 : 2002
-  const ratingNew = isA ? 2157 : 1990
-  const delta = isA ? 12 : -12
   const sp = p as SinglesPlayer
+  const { rating, ratingNew, delta, history } = SINGLES_RATING_DELTA[sp.id]
 
   return (
     <div className="md-rating-row">
-      <div className={`md-avatar ${win ? 'md-avatar--win' : 'md-avatar--loss'}`}>
+      <div className={cn('md-avatar', win ? 'md-avatar--win' : 'md-avatar--loss')}>
         {sp.initials}
       </div>
       <div className="md-rating-row__text">
@@ -739,7 +748,7 @@ function RatingRow({ p, win, doubles }: { p: SinglesPlayer | DoublesPlayer; win:
       </div>
       <div className="md-rating-row__delta">
         <Sparkline points={history} color={delta > 0 ? 'var(--serve-500)' : 'var(--loss)'} width={60} height={24} />
-        <span className={`md-rating-row__delta-num ${delta > 0 ? 'md-delta-up' : 'md-delta-down'}`}>
+        <span className={cn('md-rating-row__delta-num', delta > 0 ? 'md-delta-up' : 'md-delta-down')}>
           {delta > 0 ? '+' : ''}{delta}
         </span>
       </div>
@@ -783,10 +792,10 @@ function H2HCard({ format }: { format: Format }) {
             {H2H.matches.slice(0, 5).map((m) => (
               <div key={m.id} className="md-h2h__row">
                 <span className="md-h2h__date">{m.date.slice(2).replace(/-/g, '·')}</span>
-                <span className={`md-h2h__label ${m.tonight ? 'md-h2h__label--tonight' : ''}`}>
+                <span className={cn('md-h2h__label', m.tonight && 'md-h2h__label--tonight')}>
                   {m.tonight ? '● Tonight' : m.round}
                 </span>
-                <span className={`md-h2h__score ${m.winner === 'a' ? 'md-h2h__score--win' : ''}`}>
+                <span className={cn('md-h2h__score', m.winner === 'a' && 'md-h2h__score--win')}>
                   {m.score[0]}–{m.score[1]}
                 </span>
                 <span className={`md-h2h__result md-h2h__result--${m.winner === 'a' ? 'w' : 'l'}`}>
@@ -801,7 +810,6 @@ function H2HCard({ format }: { format: Format }) {
   )
 }
 
-/* ---------- Comments ---------------------------------------------------- */
 
 function CommentsCard({ state }: { state: MatchState }) {
   const [list, setList] = useState<Comment[]>(COMMENTS_INIT)
@@ -854,7 +862,6 @@ function CommentsCard({ state }: { state: MatchState }) {
             type="submit"
             className="md-btn md-btn--primary md-btn--sm"
             disabled={!draft.trim()}
-            style={{ opacity: draft.trim() ? 1 : 0.45 }}
           >
             Post
           </button>
@@ -870,10 +877,10 @@ function CommentsCard({ state }: { state: MatchState }) {
                 </div>
                 <div className="md-comment__body">{c.body}</div>
                 <div className="md-comment__reacts">
-                  <button type="button" className={`md-react ${c.yours.ball ? 'is-on' : ''}`} onClick={() => toggleReact(i, 'ball')}>
+                  <button type="button" className={cn('md-react', c.yours.ball && 'is-on')} onClick={() => toggleReact(i, 'ball')}>
                     <span className="md-react__glyph">●</span> {c.reacts.ball}
                   </button>
-                  <button type="button" className={`md-react ${c.yours.fire ? 'is-on' : ''}`} onClick={() => toggleReact(i, 'fire')}>
+                  <button type="button" className={cn('md-react', c.yours.fire && 'is-on')} onClick={() => toggleReact(i, 'fire')}>
                     <span className="md-react__glyph">★</span> {c.reacts.fire}
                   </button>
                 </div>
@@ -886,7 +893,21 @@ function CommentsCard({ state }: { state: MatchState }) {
   )
 }
 
-/* ---------- Share modal -------------------------------------------------- */
+
+const SHARE_SUMMARY: Record<MatchState, Record<Format, string>> = {
+  final: {
+    singles: 'Final · 3–1 · Nguyen def. Okafor',
+    doubles: 'Final · 3–2 · Nguyen/Patel def. Okafor/Tanaka',
+  },
+  live: {
+    singles: 'Live · 2–1 · G4 · Nguyen vs Okafor',
+    doubles: 'Live · 2–1 · G4 · Nguyen/Patel vs Okafor/Tanaka',
+  },
+  upcoming: {
+    singles: 'Upcoming · Nguyen vs Okafor',
+    doubles: 'Upcoming · Nguyen/Patel vs Okafor/Tanaka',
+  },
+}
 
 function ShareModal({
   open,
@@ -900,6 +921,7 @@ function ShareModal({
   format: Format
 }) {
   const [copied, setCopied] = useState(false)
+  const copyResetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const url = `https://fortymm.app/m/spring-open-2026/r16/14${format === 'doubles' ? '-d' : ''}`
 
   useEffect(() => {
@@ -910,6 +932,10 @@ function ShareModal({
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [open, onClose])
+
+  useEffect(() => () => {
+    if (copyResetTimer.current) clearTimeout(copyResetTimer.current)
+  }, [])
 
   if (!open) return null
 
@@ -925,21 +951,11 @@ function ShareModal({
       document.body.removeChild(ta)
     }
     setCopied(true)
-    setTimeout(() => setCopied(false), 2200)
+    if (copyResetTimer.current) clearTimeout(copyResetTimer.current)
+    copyResetTimer.current = setTimeout(() => setCopied(false), 2200)
   }
 
-  const summary =
-    state === 'final'
-      ? format === 'doubles'
-        ? 'Final · 3–2 · Nguyen/Patel def. Okafor/Tanaka'
-        : 'Final · 3–1 · Nguyen def. Okafor'
-      : state === 'live'
-        ? format === 'doubles'
-          ? 'Live · 2–1 · G4 · Nguyen/Patel vs Okafor/Tanaka'
-          : 'Live · 2–1 · G4 · Nguyen vs Okafor'
-        : format === 'doubles'
-          ? 'Upcoming · Nguyen/Patel vs Okafor/Tanaka'
-          : 'Upcoming · Nguyen vs Okafor'
+  const summary = SHARE_SUMMARY[state][format]
 
   return (
     <div className="md-modal-scrim" onClick={onClose}>
@@ -1005,21 +1021,25 @@ function ShareTile({ icon, label, hint }: { icon: React.ReactNode; label: string
   )
 }
 
-/* ---------- Page --------------------------------------------------------- */
+
+// The Live/Final/Upcoming tabs and Preview format/context toggles from the
+// design handoff aren't wired up yet; default the page to a finished singles
+// tournament match. Components downstream still branch on these values, so
+// re-introducing the toggles is a localized change.
+const DEFAULT_STATE: MatchState = 'final'
+const DEFAULT_FORMAT: Format = 'singles'
+const DEFAULT_CONTEXT: Context = 'tournament'
 
 function MatchDetailsPage() {
-  // Variant state is preserved so the components can render any of
-  // live/final/upcoming, singles/doubles, or tournament/casual — but the
-  // demo toggles that switched between them have been removed for now.
-  const [state, _setState] = useState<MatchState>('final')
-  const [format, _setFormat] = useState<Format>('singles')
-  const [context, _setContext] = useState<Context>('tournament')
   const [shareOpen, setShareOpen] = useState(false)
+  const state = DEFAULT_STATE
+  const format = DEFAULT_FORMAT
+  const context = DEFAULT_CONTEXT
 
   return (
     <AppShell>
       <div className="match-details">
-        <main className="md-page" style={{ padding: '32px 32px 80px' }}>
+        <main className="md-page md-page--y">
           <div className="md-header">
             <Breadcrumb context={context} />
             <div className="md-header__right">
@@ -1029,12 +1049,10 @@ function MatchDetailsPage() {
             </div>
           </div>
 
-          <div key={`hero-${state}-${format}-${context}`} className="md-fade-swap">
-            <HeroScoreboard state={state} format={format} context={context} />
-          </div>
+          <HeroScoreboard state={state} format={format} context={context} />
 
           <div className="md-col-2">
-            <div className="md-col-2__main" key={`main-${state}-${format}`}>
+            <div className="md-col-2__main">
               <PlayersCard state={state} format={format} />
               <CommentsCard state={state} />
             </div>

--- a/web-client/src/routes/matches.$matchId.tsx
+++ b/web-client/src/routes/matches.$matchId.tsx
@@ -1,0 +1,1066 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  Check,
+  ChevronRight,
+  Clock,
+  Copy,
+  Download,
+  Link2,
+  Send,
+  Share2,
+  X,
+} from 'lucide-react'
+
+import { AppShell } from '@/components/app-shell'
+
+export const Route = createFileRoute('/matches/$matchId')({
+  component: MatchDetailsPage,
+})
+
+type MatchState = 'live' | 'final' | 'upcoming'
+type Format = 'singles' | 'doubles'
+type Context = 'tournament' | 'casual'
+
+/* ---------- DATA (hard-coded from the design handoff) -------------------- */
+
+const MATCH = {
+  tournament: 'Spring Open 2026',
+  round: 'Round of 16',
+  matchNo: 14,
+  court: 'Court 3',
+  date: 'Sat · May 10, 2026',
+  startedAt: '19:42',
+  duration: '32:14',
+  format: 'Best of 5 · Games to 11',
+  referee: 'M. Larsson',
+  umpire: 'A. Doyle',
+  spectators: 184,
+}
+
+interface DoublesMember {
+  first: string
+  last: string
+  initials: string
+}
+
+interface BasePlayer {
+  id: 'a' | 'b'
+  initials: string
+  seed: number
+  club: string
+  country: string
+}
+
+interface SinglesPlayer extends BasePlayer {
+  first: string
+  last: string
+}
+
+interface DoublesPlayer extends BasePlayer {
+  last: string
+  members: DoublesMember[]
+  rating: string
+  ratingNew: string
+  delta: number
+}
+
+const SINGLES_PLAYERS: Record<'a' | 'b', SinglesPlayer> = {
+  a: { id: 'a', last: 'Nguyen', first: 'Thanh', initials: 'TN', seed: 1, club: 'Saigon TT', country: 'VN' },
+  b: { id: 'b', last: 'Okafor', first: 'Daniel', initials: 'DO', seed: 8, club: 'Lagos Spin', country: 'NG' },
+}
+
+const DOUBLES_PLAYERS: Record<'a' | 'b', DoublesPlayer> = {
+  a: {
+    id: 'a',
+    last: 'Nguyen / Patel',
+    initials: 'NP',
+    seed: 1,
+    rating: '2145 / 1998',
+    ratingNew: '+8 / +9',
+    delta: 8.5,
+    club: 'Saigon TT · Mumbai SC',
+    country: 'VN',
+    members: [
+      { first: 'Thanh', last: 'Nguyen', initials: 'TN' },
+      { first: 'Meera', last: 'Patel', initials: 'MP' },
+    ],
+  },
+  b: {
+    id: 'b',
+    last: 'Okafor / Tanaka',
+    initials: 'OT',
+    seed: 5,
+    rating: '2002 / 2070',
+    ratingNew: '−7 / −8',
+    delta: -7.5,
+    club: 'Lagos Spin · Osaka Loops',
+    country: 'NG',
+    members: [
+      { first: 'Daniel', last: 'Okafor', initials: 'DO' },
+      { first: 'Yuki', last: 'Tanaka', initials: 'YT' },
+    ],
+  },
+}
+
+interface Scoreline {
+  games: Array<[number, number]>
+  winner: 'a' | 'b' | null
+  summary: [number, number]
+  currentGame?: number
+  serving?: 'a' | 'b'
+}
+
+const SCORES_FINAL: Scoreline = { games: [[11, 6], [9, 11], [11, 8], [11, 9]], winner: 'a', summary: [3, 1] }
+const SCORES_LIVE: Scoreline = { games: [[11, 6], [9, 11], [11, 8], [9, 8]], winner: null, summary: [2, 1], currentGame: 4, serving: 'a' }
+const DOUBLES_FINAL: Scoreline = { games: [[11, 9], [8, 11], [11, 7], [9, 11], [11, 8]], winner: 'a', summary: [3, 2] }
+const DOUBLES_LIVE: Scoreline = { games: [[11, 9], [8, 11], [11, 7], [7, 5]], winner: null, summary: [2, 1], currentGame: 4, serving: 'b' }
+
+interface FormResult { r: 'W' | 'L'; score: string; opp: string; when: string }
+
+const RECENT_FORM: Record<string, FormResult[]> = {
+  a_singles: [
+    { r: 'W', score: '3–0', opp: 'Silva, R.', when: 'May 10 · R32' },
+    { r: 'W', score: '3–1', opp: 'Kim, H.', when: 'May 09 · R64' },
+    { r: 'W', score: '3–2', opp: 'Hansen, M.', when: 'Apr 21 · Cup' },
+    { r: 'L', score: '1–3', opp: 'Tanaka, Y.', when: 'Apr 06 · Reg.' },
+    { r: 'W', score: '3–0', opp: 'Ali, R.', when: 'Mar 29 · Club' },
+  ],
+  b_singles: [
+    { r: 'W', score: '3–2', opp: 'Dubois, C.', when: 'May 10 · R32' },
+    { r: 'W', score: '3–0', opp: 'Ahmed, I.', when: 'May 09 · R64' },
+    { r: 'L', score: '2–3', opp: 'Tran, L.', when: 'Apr 18 · Cup' },
+    { r: 'L', score: '0–3', opp: 'Müller, F.', when: 'Apr 03 · Reg.' },
+    { r: 'W', score: '3–1', opp: 'Park, J.', when: 'Mar 22 · Club' },
+  ],
+  a_doubles: [
+    { r: 'W', score: '3–0', opp: 'Müller/Rossi', when: 'May 10 · R32' },
+    { r: 'W', score: '3–1', opp: 'Ali/Park', when: 'May 09 · R64' },
+    { r: 'W', score: '3–2', opp: 'Hansen/Kim', when: 'Apr 21 · Cup' },
+    { r: 'L', score: '2–3', opp: 'Tanaka/Yoon', when: 'Apr 06 · Reg.' },
+    { r: 'W', score: '3–0', opp: 'Silva/Dubois', when: 'Mar 29 · Club' },
+  ],
+  b_doubles: [
+    { r: 'W', score: '3–2', opp: 'Chen/Wong', when: 'May 10 · R32' },
+    { r: 'L', score: '1–3', opp: 'Patel/Mehta', when: 'May 09 · R64' },
+    { r: 'L', score: '2–3', opp: 'Tran/Le', when: 'Apr 18 · Cup' },
+    { r: 'W', score: '3–0', opp: 'Doe/Roe', when: 'Apr 03 · Reg.' },
+    { r: 'W', score: '3–1', opp: 'Park/Yoon', when: 'Mar 22 · Club' },
+  ],
+}
+
+const RATING_HISTORY: Record<string, number[]> = {
+  a_singles: [2098, 2104, 2110, 2118, 2128, 2122, 2120, 2132, 2140, 2145],
+  b_singles: [2080, 2074, 2065, 2050, 2052, 2040, 2018, 2012, 2008, 2002],
+  a_doubles: [2042, 2050, 2058, 2062, 2058, 2068, 2074, 2078, 2084, 2092],
+  b_doubles: [2050, 2048, 2052, 2048, 2044, 2052, 2050, 2042, 2038, 2036],
+}
+
+const CAREER: Record<string, { matches: number; winPct: number }> = {
+  a_singles: { matches: 184, winPct: 71 },
+  b_singles: { matches: 162, winPct: 62 },
+  a_doubles: { matches: 92, winPct: 68 },
+  b_doubles: { matches: 78, winPct: 55 },
+}
+
+interface H2HMatch {
+  id: string
+  date: string
+  round: string
+  score: [number, number]
+  winner: 'a' | 'b'
+  tonight?: boolean
+}
+
+const H2H: { total: number; aWins: number; bWins: number; matches: H2HMatch[] } = {
+  total: 6,
+  aWins: 4,
+  bWins: 2,
+  matches: [
+    { id: 'spring-open-2026-r16', date: '2026-05-10', round: 'Spring Open · R16', score: [3, 1], winner: 'a', tonight: true },
+    { id: 'autumn-cup-2025-qf', date: '2025-11-22', round: 'Autumn Cup · QF', score: [3, 2], winner: 'a' },
+    { id: 'summer-slam-2025-f', date: '2025-08-04', round: 'Summer Slam · F', score: [1, 3], winner: 'b' },
+    { id: 'friendly-2025-03', date: '2025-03-17', round: 'Friendly · BO5', score: [3, 0], winner: 'a' },
+    { id: 'regional-2024-sf', date: '2024-10-08', round: 'Regional · SF', score: [2, 3], winner: 'b' },
+    { id: 'club-night-2024-06', date: '2024-06-21', round: 'Club night · BO3', score: [2, 1], winner: 'a' },
+  ],
+}
+
+interface Comment {
+  who: string
+  initials: string
+  when: string
+  body: string
+  reacts: { ball: number; fire: number }
+  yours: { ball: boolean; fire: boolean }
+}
+
+const COMMENTS_INIT: Comment[] = [
+  { who: 'Kim, Hyun', initials: 'KH', when: '2 min ago', body: 'What a comeback in G2 — that 9-11 swing was unreal. Nguyen looked rattled and then just locked in.', reacts: { ball: 12, fire: 4 }, yours: { ball: false, fire: false } },
+  { who: 'Park, Joon', initials: 'PJ', when: '12 min ago', body: 'His backhand block down the line on point 6 of G3 should be a poster.', reacts: { ball: 18, fire: 9 }, yours: { ball: true, fire: false } },
+  { who: 'Silva, Renata', initials: 'SR', when: '22 min ago', body: 'Watching from Toronto. GG, both. Daniel still played his heart out.', reacts: { ball: 6, fire: 2 }, yours: { ball: false, fire: false } },
+  { who: 'Patel, Meera', initials: 'MP', when: '35 min ago', body: 'Court 3 has the best view in the building. Fight me.', reacts: { ball: 24, fire: 11 }, yours: { ball: false, fire: true } },
+]
+
+/* ---------- Shared bits --------------------------------------------------- */
+
+function Logo({ size = 26 }: { size?: number }) {
+  return (
+    <div className="md-logo">
+      <svg width={size} height={size} viewBox="0 0 80 80" aria-hidden="true">
+        <defs>
+          <radialGradient id="md-logo-grad" cx="35%" cy="35%" r="65%">
+            <stop offset="0%" stopColor="#FFB57A" />
+            <stop offset="55%" stopColor="#FF7A1A" />
+            <stop offset="100%" stopColor="#B94700" />
+          </radialGradient>
+        </defs>
+        <circle cx="40" cy="40" r="36" fill="url(#md-logo-grad)" />
+        <ellipse cx="30" cy="28" rx="10" ry="6" fill="#FFF" fillOpacity="0.22" />
+      </svg>
+      <span className="md-logo__word" style={{ fontSize: size * 0.95 }}>
+        FORTYMM<span className="accent">.</span>
+      </span>
+    </div>
+  )
+}
+
+function FlagBadge({ code }: { code: string }) {
+  return <span className="md-hero__flag">{code}</span>
+}
+
+function Sparkline({ points, color = 'currentColor', width = 120, height = 32 }: { points: number[]; color?: string; width?: number; height?: number }) {
+  const min = Math.min(...points)
+  const max = Math.max(...points)
+  const span = Math.max(1, max - min)
+  const xs = points.map((_, i) => (i / (points.length - 1)) * width)
+  const ys = points.map((p) => height - ((p - min) / span) * (height - 4) - 2)
+  const d = xs.map((x, i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${ys[i].toFixed(1)}`).join(' ')
+  return (
+    <svg width={width} height={height} style={{ overflow: 'visible' }} aria-hidden="true">
+      <path d={d} fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx={xs[xs.length - 1]} cy={ys[ys.length - 1]} r={2.5} fill={color} />
+    </svg>
+  )
+}
+
+/* ---------- Breadcrumb + tabs -------------------------------------------- */
+
+function Breadcrumb({ context }: { context: Context }) {
+  if (context === 'casual') {
+    return (
+      <div className="md-breadcrumb">
+        <a>Saigon TT</a>
+        <span>›</span>
+        <span>Club night · May 10</span>
+        <span>›</span>
+        <span className="md-breadcrumb__current">Match #042</span>
+      </div>
+    )
+  }
+  return (
+    <div className="md-breadcrumb">
+      <a>Spring Open 2026</a>
+      <span>›</span>
+      <a>Day 2</a>
+      <span>›</span>
+      <a>Round of 16</a>
+      <span>›</span>
+      <span className="md-breadcrumb__current">Match #14</span>
+    </div>
+  )
+}
+
+/* ---------- Hero scoreboard ---------------------------------------------- */
+
+function PlayerSide({
+  player,
+  win,
+  side,
+  state,
+  serving,
+  format,
+}: {
+  player: SinglesPlayer | DoublesPlayer
+  win: boolean
+  side: 'l' | 'r'
+  state: MatchState
+  serving: 'a' | 'b' | undefined
+  format: Format
+}) {
+  const isDoubles = format === 'doubles'
+  const doublesPlayer = isDoubles ? (player as DoublesPlayer) : null
+  return (
+    <div className={`md-hero__player md-hero__player--${side}`}>
+      <div className="md-hero__player-row">
+        {doublesPlayer ? (
+          <div className={`md-hero__doubles-row md-hero__doubles-row--${side}`}>
+            {doublesPlayer.members.map((m, i) => (
+              <div
+                key={i}
+                className={`md-avatar ${win ? 'md-avatar--win' : 'md-avatar--loss'}`}
+                style={{ zIndex: 2 - i }}
+              >
+                {m.initials}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className={`md-avatar md-hero__avatar-singles ${win ? 'md-avatar--win' : 'md-avatar--loss'}`}>
+            {player.initials}
+          </div>
+        )}
+        <div className={`md-hero__player-text--${side}`}>
+          <div className="md-hero__meta">
+            <span className="md-hero__seed">[{player.seed}]</span>
+            <FlagBadge code={player.country} />
+            {state === 'live' && serving === player.id && (
+              <span className="md-hero__serving" title="Serving">
+                <span className="ball-dot ball-dot--live" />
+                SERVE
+              </span>
+            )}
+          </div>
+          <div className={`md-hero__name ${win ? 'md-hero__name--win' : ''}`}>
+            {isDoubles ? player.last : `${(player as SinglesPlayer).last}, ${(player as SinglesPlayer).first}`}
+          </div>
+          <div className="md-hero__club">{player.club}</div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function HeroScoreboard({ state, format, context }: { state: MatchState; format: Format; context: Context }) {
+  const players = format === 'doubles' ? DOUBLES_PLAYERS : SINGLES_PLAYERS
+  const score = state === 'live'
+    ? (format === 'doubles' ? DOUBLES_LIVE : SCORES_LIVE)
+    : (format === 'doubles' ? DOUBLES_FINAL : SCORES_FINAL)
+
+  const isLive = state === 'live'
+  const isUpcoming = state === 'upcoming'
+
+  const aTotal = isUpcoming ? 0 : score.summary[0]
+  const bTotal = isUpcoming ? 0 : score.summary[1]
+  const winA = score.winner === 'a'
+  const winB = score.winner === 'b'
+
+  return (
+    <section className="md-hero">
+      <div className="md-hero__grid-bg" aria-hidden="true" />
+
+      <div className="md-hero__strip">
+        <div className="md-hero__strip-l">
+          {isLive && (
+            <span className="md-chip md-chip--live">
+              <span className="dot" />
+              Live · Game {score.currentGame}
+            </span>
+          )}
+          {state === 'final' && (
+            <span className="md-chip md-chip--final">
+              <span className="dot" />
+              Final
+            </span>
+          )}
+          {isUpcoming && (
+            <span className="md-chip md-chip--upcoming">
+              <span className="dot" />
+              Starts in 2h 14m
+            </span>
+          )}
+          <span className="md-hero__strip-meta">
+            {context === 'casual' ? 'CLUB NIGHT · TUE' : `${MATCH.round.toUpperCase()} · ${MATCH.court.toUpperCase()}`}
+          </span>
+        </div>
+        <div className="md-hero__strip-r">
+          <span className="md-hero__strip-meta">
+            {format === 'doubles' ? 'DOUBLES' : 'SINGLES'} · BO5
+          </span>
+          {!isUpcoming && (
+            <span className="md-hero__strip-meta md-hero__strip-meta--with-icon">
+              <Clock size={13} strokeWidth={1.75} />
+              {MATCH.duration}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="md-hero__row">
+        <PlayerSide player={players.a} win={winA} side="l" state={state} serving={score.serving} format={format} />
+        <div className="md-hero__score-block">
+          {isUpcoming ? (
+            <>
+              <div className="md-hero__vs-label">VS</div>
+              <div className="md-hero__vs-dash">—</div>
+              <div className="md-hero__vs-label">{MATCH.startedAt} · {MATCH.date.replace('Sat · ', '')}</div>
+            </>
+          ) : (
+            <>
+              <div className="md-hero__score-row">
+                <div className={`md-hero__score md-hero__score--l ${winA ? 'md-hero__score--win' : ''}`}>{aTotal}</div>
+                <div className="md-hero__score-dash">—</div>
+                <div className={`md-hero__score md-hero__score--r ${winB ? 'md-hero__score--win' : ''}`}>{bTotal}</div>
+              </div>
+              <div className="md-hero__score-caption">
+                {isLive
+                  ? `IN PROGRESS · ${(score.games[(score.currentGame ?? 1) - 1] || []).join('–')}`
+                  : MATCH.date}
+              </div>
+            </>
+          )}
+        </div>
+        <PlayerSide player={players.b} win={winB} side="r" state={state} serving={score.serving} format={format} />
+      </div>
+
+      {!isUpcoming && <GameGrid score={score} players={players} state={state} />}
+    </section>
+  )
+}
+
+function GameGrid({
+  score,
+  players,
+  state,
+}: {
+  score: Scoreline
+  players: Record<'a' | 'b', SinglesPlayer | DoublesPlayer>
+  state: MatchState
+}) {
+  const games = [0, 1, 2, 3, 4]
+  const isLive = state === 'live'
+
+  function nameOf(p: SinglesPlayer | DoublesPlayer): string {
+    return (p.last || '').split('/')[0].trim()
+  }
+
+  return (
+    <div className="md-games">
+      <div className="md-games__grid">
+        <div className="md-games__kicker">GAMES</div>
+        {games.map((i) => (
+          <div key={`h-${i}`} className="md-games__col-label">G{i + 1}</div>
+        ))}
+        <div className="md-games__col-label">SETS</div>
+
+        <div className="md-games__player">
+          <span className="md-avatar md-avatar--win">{players.a.initials}</span>
+          <span className="md-games__player-name">{nameOf(players.a)}</span>
+        </div>
+        {games.map((i) => {
+          const g = score.games[i]
+          if (!g) return <div key={`a-${i}`} className="md-games__cell md-games__cell--empty">—</div>
+          const isLiveCell = isLive && score.currentGame === i + 1
+          return (
+            <div
+              key={`a-${i}`}
+              className={`md-games__cell ${g[0] > g[1] ? 'md-games__cell--win' : 'md-games__cell--loss'} ${isLiveCell ? 'md-games__cell--live' : ''}`}
+            >
+              {g[0]}
+            </div>
+          )
+        })}
+        <div className={`md-games__total ${score.winner === 'a' ? 'md-games__total--win' : ''}`}>
+          {score.summary[0]}
+        </div>
+
+        <div className="md-games__player">
+          <span className="md-avatar md-avatar--loss">{players.b.initials}</span>
+          <span className="md-games__player-name">{nameOf(players.b)}</span>
+        </div>
+        {games.map((i) => {
+          const g = score.games[i]
+          if (!g) return <div key={`b-${i}`} className="md-games__cell md-games__cell--empty">—</div>
+          const isLiveCell = isLive && score.currentGame === i + 1
+          return (
+            <div
+              key={`b-${i}`}
+              className={`md-games__cell ${g[1] > g[0] ? 'md-games__cell--win' : 'md-games__cell--loss'} ${isLiveCell ? 'md-games__cell--live' : ''}`}
+            >
+              {g[1]}
+            </div>
+          )
+        })}
+        <div className={`md-games__total ${score.winner === 'b' ? 'md-games__total--win' : ''}`}>
+          {score.summary[1]}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ---------- Players & form card ----------------------------------------- */
+
+function PlayersCard({ state, format }: { state: MatchState; format: Format }) {
+  const players = format === 'doubles' ? DOUBLES_PLAYERS : SINGLES_PLAYERS
+  const aKey = format === 'doubles' ? 'a_doubles' : 'a_singles'
+  const bKey = format === 'doubles' ? 'b_doubles' : 'b_singles'
+
+  return (
+    <div className="md-card">
+      <div className="md-card__hd">
+        <h3>{state === 'upcoming' ? 'Players' : 'Players & form'}</h3>
+        <span className="md-modal__preview-sub" style={{ marginTop: 0 }}>LAST 5 RESULTS</span>
+      </div>
+      <div className="md-players">
+        <PlayerProfile p={players.a} form={RECENT_FORM[aKey]} history={RATING_HISTORY[aKey]} career={CAREER[aKey]} format={format} won={state === 'final'} />
+        <div className="md-players__divider" />
+        <PlayerProfile p={players.b} form={RECENT_FORM[bKey]} history={RATING_HISTORY[bKey]} career={CAREER[bKey]} format={format} won={false} />
+      </div>
+    </div>
+  )
+}
+
+function PlayerProfile({
+  p,
+  form,
+  history,
+  career,
+  format,
+  won,
+}: {
+  p: SinglesPlayer | DoublesPlayer
+  form: FormResult[]
+  history: number[]
+  career: { matches: number; winPct: number }
+  format: Format
+  won: boolean
+}) {
+  const isDoubles = format === 'doubles'
+  const doublesPlayer = isDoubles ? (p as DoublesPlayer) : null
+  const wins = form.filter((f) => f.r === 'W').length
+  const sparkColor = won ? 'var(--serve-500)' : 'var(--fg-3)'
+
+  return (
+    <div className="md-profile">
+      <div className="md-profile__identity">
+        {doublesPlayer ? (
+          <div className="md-profile__doubles-avatars">
+            {doublesPlayer.members.map((m, i) => (
+              <div
+                key={i}
+                className={`md-avatar ${won ? 'md-avatar--win' : 'md-avatar--loss'}`}
+                style={{ zIndex: 2 - i }}
+              >
+                {m.initials}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className={`md-avatar ${won ? 'md-avatar--win' : 'md-avatar--loss'}`}>
+            {p.initials}
+          </div>
+        )}
+        <div className="md-profile__id-text">
+          <div className="md-profile__tag-row">
+            <span className="md-profile__seed">[{p.seed}]</span>
+            <FlagBadge code={p.country} />
+          </div>
+          <div className="md-profile__name">
+            {isDoubles ? p.last : `${(p as SinglesPlayer).last}, ${(p as SinglesPlayer).first}`}
+          </div>
+          <div className="md-profile__club">{p.club}</div>
+        </div>
+      </div>
+
+      <div className="md-profile__rating-box">
+        <div>
+          <div className="md-kicker">Rating</div>
+          <div className="md-profile__rating-value">
+            {history[history.length - 1]}
+            {doublesPlayer && (
+              <span className="dim"> · {doublesPlayer.members.map((m) => m.initials).join('/')}</span>
+            )}
+          </div>
+        </div>
+        <Sparkline points={history} color={sparkColor} width={88} height={32} />
+      </div>
+
+      <div>
+        <div className="md-kicker" style={{ marginBottom: 8 }}>
+          Recent form · {wins}–{5 - wins}
+        </div>
+        <div>
+          {form.map((m, i) => (
+            <div key={i} className="md-form-row">
+              <span className={`md-form-row__badge md-form-row__badge--${m.r === 'W' ? 'w' : 'l'}`}>
+                {m.r}
+              </span>
+              <div style={{ minWidth: 0 }}>
+                <div className="md-form-row__opp">{m.opp}</div>
+                <div className="md-form-row__when">{m.when}</div>
+              </div>
+              <span className={`md-form-row__score ${m.r === 'L' ? 'md-form-row__score--loss' : ''}`}>
+                {m.score}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="md-profile__career">
+        <div>
+          <div className="md-kicker">Career matches</div>
+          <div className="md-profile__career-value">{career.matches}</div>
+        </div>
+        <div>
+          <div className="md-kicker">Win rate</div>
+          <div className={`md-profile__career-value ${career.winPct >= 60 ? 'md-profile__career-value--good' : ''}`}>
+            {career.winPct}%
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ---------- Sidebar cards ----------------------------------------------- */
+
+function MatchInfoCard({ context, format, state }: { context: Context; format: Format; state: MatchState }) {
+  const rows: Array<[string, string]> = []
+  if (context !== 'casual') {
+    rows.push(['Tournament', MATCH.tournament])
+    rows.push(['Round', MATCH.round])
+    rows.push(['Match', `#${MATCH.matchNo}`])
+  } else {
+    rows.push(['Venue', 'Saigon TT — Hall B'])
+    rows.push(['League', 'Club night · Tue'])
+  }
+  rows.push(['Format', `${format === 'doubles' ? 'Doubles' : 'Singles'} · Best of 5 to 11`])
+  rows.push(['Court', MATCH.court])
+  rows.push(['Date', MATCH.date])
+  rows.push(['Started', state === 'upcoming' ? '—' : MATCH.startedAt])
+  if (state !== 'upcoming') rows.push(['Duration', MATCH.duration])
+  if (context !== 'casual') {
+    rows.push(['Referee', MATCH.referee])
+    rows.push(['Umpire', MATCH.umpire])
+  }
+  if (state !== 'upcoming') rows.push(['Spectators', `${MATCH.spectators}`])
+
+  return (
+    <div className="md-card">
+      <div className="md-card__hd"><h3>Match info</h3></div>
+      <div className="md-card__body">
+        {rows.map(([k, v], i) => (
+          <div key={i} className="md-info-row">
+            <span className="md-info-row__k">{k}</span>
+            <span className="md-info-row__v">{v}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function RatingCard({ format, state, context }: { format: Format; state: MatchState; context: Context }) {
+  if (context === 'casual') {
+    return (
+      <div className="md-card">
+        <div className="md-card__hd"><h3>Club rating</h3></div>
+        <div className="md-card__body">
+          <div style={{ font: '500 13px var(--font-ui)', color: 'var(--fg-3)', lineHeight: 1.5 }}>
+            Club nights don't affect official ratings — but we still track the wins.
+          </div>
+        </div>
+      </div>
+    )
+  }
+  const players = format === 'doubles' ? DOUBLES_PLAYERS : SINGLES_PLAYERS
+  if (state === 'upcoming') {
+    return (
+      <div className="md-card">
+        <div className="md-card__hd"><h3>At stake</h3></div>
+        <div className="md-card__body">
+          <div style={{ font: '500 13px var(--font-ui)', color: 'var(--fg-2)', lineHeight: 1.5 }}>
+            Projected swing:{' '}
+            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--ball-500)', fontWeight: 700 }}>±11 pts</span>{' '}
+            for the winner.
+            <br />
+            Winner advances to{' '}
+            <span style={{ color: 'var(--fg-1)', fontWeight: 600 }}>QF · Match #5</span>.
+          </div>
+        </div>
+      </div>
+    )
+  }
+  const isDoubles = format === 'doubles'
+  return (
+    <div className="md-card">
+      <div className="md-card__hd"><h3>Rating change</h3></div>
+      <div className="md-card__body" style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+        <RatingRow p={players.a} win doubles={isDoubles} />
+        <hr className="md-rating-divider" />
+        <RatingRow p={players.b} win={false} doubles={isDoubles} />
+      </div>
+    </div>
+  )
+}
+
+function RatingRow({ p, win, doubles }: { p: SinglesPlayer | DoublesPlayer; win: boolean; doubles: boolean }) {
+  if (doubles) {
+    const dp = p as DoublesPlayer
+    return (
+      <div className="md-rating-row">
+        <div className={`md-avatar ${win ? 'md-avatar--win' : 'md-avatar--loss'}`} style={{ width: 36, height: 36, fontSize: 12 }}>
+          {dp.initials}
+        </div>
+        <div className="md-rating-row__text">
+          <div className="md-rating-row__name">{dp.last}</div>
+          <div style={{ font: '500 11px var(--font-mono)', color: 'var(--fg-3)', letterSpacing: '0.06em', marginTop: 2 }}>
+            {dp.rating}
+          </div>
+        </div>
+        <div className={`md-rating-row__delta-num ${dp.delta > 0 ? 'md-delta-up' : 'md-delta-down'}`}>
+          {dp.ratingNew}
+        </div>
+      </div>
+    )
+  }
+
+  const isA = p.id === 'a'
+  const history = isA ? [2098, 2110, 2128, 2120, 2145, 2157] : [2080, 2065, 2050, 2018, 2002, 1990]
+  const rating = isA ? 2145 : 2002
+  const ratingNew = isA ? 2157 : 1990
+  const delta = isA ? 12 : -12
+  const sp = p as SinglesPlayer
+
+  return (
+    <div className="md-rating-row">
+      <div className={`md-avatar ${win ? 'md-avatar--win' : 'md-avatar--loss'}`}>
+        {sp.initials}
+      </div>
+      <div className="md-rating-row__text">
+        <div className="md-rating-row__name">{sp.last}, {sp.first}</div>
+        <div className="md-rating-row__numbers">
+          <span className="from">{rating}</span>
+          <ChevronRight size={11} strokeWidth={1.75} />
+          <span className="to">{ratingNew}</span>
+        </div>
+      </div>
+      <div className="md-rating-row__delta">
+        <Sparkline points={history} color={delta > 0 ? 'var(--serve-500)' : 'var(--loss)'} width={60} height={24} />
+        <span className={`md-rating-row__delta-num ${delta > 0 ? 'md-delta-up' : 'md-delta-down'}`}>
+          {delta > 0 ? '+' : ''}{delta}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function H2HCard({ format }: { format: Format }) {
+  const a = H2H.aWins
+  const b = H2H.bWins
+  const tot = H2H.total
+  const aPct = (a / tot) * 100
+  const bPct = (b / tot) * 100
+
+  return (
+    <div className="md-card">
+      <div className="md-card__hd">
+        <h3>Head to head</h3>
+        <span style={{ font: '500 11px var(--font-mono)', color: 'var(--fg-3)', letterSpacing: '0.12em' }}>
+          {tot} MEETINGS
+        </span>
+      </div>
+      <div className="md-card__body">
+        <div className="md-h2h">
+          <div className="md-h2h__counts">
+            <div style={{ textAlign: 'right' }}>
+              <div className="md-h2h__count md-h2h__count--win">{a}</div>
+              <div className="md-h2h__count-label">{format === 'doubles' ? 'NP' : 'Nguyen'}</div>
+            </div>
+            <span className="md-h2h__sep">—</span>
+            <div style={{ textAlign: 'left' }}>
+              <div className="md-h2h__count">{b}</div>
+              <div className="md-h2h__count-label">{format === 'doubles' ? 'OT' : 'Okafor'}</div>
+            </div>
+          </div>
+          <div className="md-h2h__bar">
+            <div style={{ width: `${aPct}%`, background: 'var(--serve-500)' }} />
+            <div style={{ width: `${bPct}%`, background: 'var(--ink-500)' }} />
+          </div>
+          <div>
+            {H2H.matches.slice(0, 5).map((m) => (
+              <div key={m.id} className="md-h2h__row">
+                <span className="md-h2h__date">{m.date.slice(2).replace(/-/g, '·')}</span>
+                <span className={`md-h2h__label ${m.tonight ? 'md-h2h__label--tonight' : ''}`}>
+                  {m.tonight ? '● Tonight' : m.round}
+                </span>
+                <span className={`md-h2h__score ${m.winner === 'a' ? 'md-h2h__score--win' : ''}`}>
+                  {m.score[0]}–{m.score[1]}
+                </span>
+                <span className={`md-h2h__result md-h2h__result--${m.winner === 'a' ? 'w' : 'l'}`}>
+                  {m.winner === 'a' ? 'W' : 'L'}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ---------- Comments ---------------------------------------------------- */
+
+function CommentsCard({ state }: { state: MatchState }) {
+  const [list, setList] = useState<Comment[]>(COMMENTS_INIT)
+  const [draft, setDraft] = useState('')
+
+  function toggleReact(idx: number, k: 'ball' | 'fire') {
+    setList((prev) =>
+      prev.map((c, i) => {
+        if (i !== idx) return c
+        const has = c.yours[k]
+        return {
+          ...c,
+          yours: { ...c.yours, [k]: !has },
+          reacts: { ...c.reacts, [k]: c.reacts[k] + (has ? -1 : 1) },
+        }
+      }),
+    )
+  }
+
+  function submit(e: FormEvent) {
+    e.preventDefault()
+    const text = draft.trim()
+    if (!text) return
+    setList((prev) => [
+      { who: 'You', initials: 'YO', when: 'just now', body: text, reacts: { ball: 0, fire: 0 }, yours: { ball: false, fire: false } },
+      ...prev,
+    ])
+    setDraft('')
+  }
+
+  return (
+    <div className="md-card">
+      <div className="md-card__hd">
+        <h3>Club chat</h3>
+        <span style={{ font: '500 11px var(--font-mono)', color: 'var(--fg-3)', letterSpacing: '0.12em' }}>
+          {list.length} POSTS
+        </span>
+      </div>
+      <div className="md-card__body">
+        <form className="md-comments__form" onSubmit={submit}>
+          <div className="md-avatar">YO</div>
+          <input
+            type="text"
+            className="md-input"
+            placeholder={state === 'upcoming' ? 'Place a pick. Trash talk. Kindly.' : 'Add a reaction…'}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="md-btn md-btn--primary md-btn--sm"
+            disabled={!draft.trim()}
+            style={{ opacity: draft.trim() ? 1 : 0.45 }}
+          >
+            Post
+          </button>
+        </form>
+        <div>
+          {list.map((c, i) => (
+            <div key={i} className="md-comment">
+              <div className="md-avatar">{c.initials}</div>
+              <div>
+                <div className="md-comment__meta">
+                  <span className="md-comment__who">{c.who}</span>
+                  <span className="md-comment__when">· {c.when}</span>
+                </div>
+                <div className="md-comment__body">{c.body}</div>
+                <div className="md-comment__reacts">
+                  <button type="button" className={`md-react ${c.yours.ball ? 'is-on' : ''}`} onClick={() => toggleReact(i, 'ball')}>
+                    <span className="md-react__glyph">●</span> {c.reacts.ball}
+                  </button>
+                  <button type="button" className={`md-react ${c.yours.fire ? 'is-on' : ''}`} onClick={() => toggleReact(i, 'fire')}>
+                    <span className="md-react__glyph">★</span> {c.reacts.fire}
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ---------- Share modal -------------------------------------------------- */
+
+function ShareModal({
+  open,
+  onClose,
+  state,
+  format,
+}: {
+  open: boolean
+  onClose: () => void
+  state: MatchState
+  format: Format
+}) {
+  const [copied, setCopied] = useState(false)
+  const url = `https://fortymm.app/m/spring-open-2026/r16/14${format === 'doubles' ? '-d' : ''}`
+
+  useEffect(() => {
+    if (!open) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(url)
+    } catch {
+      const ta = document.createElement('textarea')
+      ta.value = url
+      document.body.appendChild(ta)
+      ta.select()
+      document.execCommand('copy')
+      document.body.removeChild(ta)
+    }
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2200)
+  }
+
+  const summary =
+    state === 'final'
+      ? format === 'doubles'
+        ? 'Final · 3–2 · Nguyen/Patel def. Okafor/Tanaka'
+        : 'Final · 3–1 · Nguyen def. Okafor'
+      : state === 'live'
+        ? format === 'doubles'
+          ? 'Live · 2–1 · G4 · Nguyen/Patel vs Okafor/Tanaka'
+          : 'Live · 2–1 · G4 · Nguyen vs Okafor'
+        : format === 'doubles'
+          ? 'Upcoming · Nguyen/Patel vs Okafor/Tanaka'
+          : 'Upcoming · Nguyen vs Okafor'
+
+  return (
+    <div className="md-modal-scrim" onClick={onClose}>
+      <div className="md-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="md-modal__hd">
+          <div>
+            <div className="md-kicker">● Share match</div>
+            <div className="md-modal__title" style={{ marginTop: 4 }}>One link. Anyone can view.</div>
+          </div>
+          <button type="button" className="md-btn md-btn--ghost md-btn--icon md-btn--sm" onClick={onClose} aria-label="Close">
+            <X size={14} />
+          </button>
+        </div>
+        <div className="md-modal__body">
+          <div className="md-modal__preview">
+            <div className="md-avatar md-avatar--win">TN</div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div className="md-modal__preview-title">
+                {format === 'doubles' ? 'Nguyen/Patel vs Okafor/Tanaka' : 'Nguyen, T. vs Okafor, D.'}
+              </div>
+              <div className="md-modal__preview-sub">{summary}</div>
+            </div>
+          </div>
+
+          <div className="md-modal__url-row">
+            <div className="md-modal__url">{url}</div>
+            <button type="button" className="md-btn md-btn--primary" onClick={copy}>
+              {copied ? (
+                <><Check size={14} /> Copied</>
+              ) : (
+                <><Copy size={14} /> Copy</>
+              )}
+            </button>
+          </div>
+
+          <div className="md-modal__tiles">
+            <ShareTile icon={<Send size={16} />} label="Post on X" hint="@spring_open" />
+            <ShareTile icon={<Link2 size={16} />} label="Embed" hint="iframe" />
+            <ShareTile icon={<Download size={16} />} label="Save PNG" hint="Recap card" />
+          </div>
+
+          <div className="md-modal__note">
+            <span className="accent">●</span>
+            <div>
+              Public links don't require a FortyMM account. We never track who clicks them — share the URL like it's 2004.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ShareTile({ icon, label, hint }: { icon: React.ReactNode; label: string; hint: string }) {
+  return (
+    <button type="button" className="md-share-tile">
+      {icon}
+      <div style={{ textAlign: 'left' }}>
+        <div className="md-share-tile__label">{label}</div>
+        <div className="md-share-tile__hint">{hint}</div>
+      </div>
+    </button>
+  )
+}
+
+/* ---------- Page --------------------------------------------------------- */
+
+function MatchDetailsPage() {
+  // Variant state is preserved so the components can render any of
+  // live/final/upcoming, singles/doubles, or tournament/casual — but the
+  // demo toggles that switched between them have been removed for now.
+  const [state, _setState] = useState<MatchState>('final')
+  const [format, _setFormat] = useState<Format>('singles')
+  const [context, _setContext] = useState<Context>('tournament')
+  const [shareOpen, setShareOpen] = useState(false)
+
+  return (
+    <AppShell>
+      <div className="match-details">
+        <main className="md-page" style={{ padding: '32px 32px 80px' }}>
+          <div className="md-header">
+            <Breadcrumb context={context} />
+            <div className="md-header__right">
+              <button type="button" className="md-btn md-btn--ghost md-btn--sm" onClick={() => setShareOpen(true)}>
+                <Share2 size={14} /> Share
+              </button>
+            </div>
+          </div>
+
+          <div key={`hero-${state}-${format}-${context}`} className="md-fade-swap">
+            <HeroScoreboard state={state} format={format} context={context} />
+          </div>
+
+          <div className="md-col-2">
+            <div className="md-col-2__main" key={`main-${state}-${format}`}>
+              <PlayersCard state={state} format={format} />
+              <CommentsCard state={state} />
+            </div>
+            <aside className="md-col-2__aside">
+              <MatchInfoCard context={context} format={format} state={state} />
+              <RatingCard format={format} state={state} context={context} />
+              <H2HCard format={format} />
+            </aside>
+          </div>
+
+          <footer className="md-footer">
+            <div className="md-footer__tagline">
+              <Logo size={20} />
+              <span>The math is quiet. The rallies are loud.</span>
+            </div>
+            <div className="md-footer__links">
+              <a>Manifesto</a>
+              <a>Open source</a>
+              <a>Made by players</a>
+            </div>
+          </footer>
+        </main>
+
+        <ShareModal open={shareOpen} onClose={() => setShareOpen(false)} state={state} format={format} />
+      </div>
+    </AppShell>
+  )
+}
+

--- a/web-client/src/routes/matches/index.css
+++ b/web-client/src/routes/matches/index.css
@@ -189,6 +189,10 @@
 .match-list-page table.matches tbody tr:hover {
   background: var(--bg-hover);
 }
+.match-list-page table.matches tbody tr.is-clickable:focus-visible {
+  outline: 2px solid var(--ball-500);
+  outline-offset: -2px;
+}
 .match-list-page table.matches tbody tr.is-live td:first-child {
   box-shadow: inset 2px 0 0 var(--serve-500);
 }

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useMemo, useState } from 'react'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import {
   ChevronLeft,
   ChevronRight,
@@ -558,6 +558,11 @@ interface MatchTableProps {
 }
 
 function MatchTable({ rows, sort, setSort, onClear }: MatchTableProps) {
+  const navigate = useNavigate()
+  function openMatch(id: number) {
+    void navigate({ to: '/matches/$matchId', params: { matchId: String(id) } })
+  }
+
   if (rows.length === 0) {
     return (
       <div className="empty">
@@ -587,7 +592,20 @@ function MatchTable({ rows, sort, setSort, onClear }: MatchTableProps) {
       </thead>
       <tbody>
         {rows.map((m) => (
-          <tr key={m.id} className={m.status === 'live' ? 'is-live' : ''}>
+          <tr
+            key={m.id}
+            className={'is-clickable' + (m.status === 'live' ? ' is-live' : '')}
+            role="link"
+            tabIndex={0}
+            aria-label={`Open match M-${m.id}, ${m.a.name} vs ${m.b.name}`}
+            onClick={() => openMatch(m.id)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                openMatch(m.id)
+              }
+            }}
+          >
             <td className="id-cell">M-{m.id}</td>
             <td><ContextCell m={m} /></td>
             <td>

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 
 import { AppShell } from '@/components/app-shell'
+import { cn } from '@/lib/utils'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -594,7 +595,7 @@ function MatchTable({ rows, sort, setSort, onClear }: MatchTableProps) {
         {rows.map((m) => (
           <tr
             key={m.id}
-            className={'is-clickable' + (m.status === 'live' ? ' is-live' : '')}
+            className={cn('is-clickable', m.status === 'live' && 'is-live')}
             role="link"
             tabIndex={0}
             aria-label={`Open match M-${m.id}, ${m.a.name} vs ${m.b.name}`}


### PR DESCRIPTION
## Summary

- Add the **Match details** design handoff as a real route at `/matches/:matchId` (UI only — hard-coded mock data, no backend wiring).
- Make rows in the existing `/matches` list **clickable**: click or Enter navigates to the new details page, with the focus-visible outline already common to RBAC tables.
- Implementation: scoped under `.fortymm-theme .match-details` in `src/index.css` so the existing routes are untouched; renders inside the standard `AppShell`.

## Implementation notes

- The route file is named `matches.$matchId.index.tsx` (not `.tsx`) so that TanStack treats it as the leaf for `/matches/:matchId` instead of making it the parent layout for the nested `matches.$matchId.games.$gameId.scores.new` route. Score entry tests would otherwise fail because the wrapper has no `<Outlet />`.
- Variant rendering (`live` / `final` / `upcoming`, `singles` / `doubles`, `tournament` / `casual`) is preserved as default constants; the per-page toggles from the design handoff have been removed for now and can be re-introduced as a localized change.

## Test plan

- [x] `pytest` (76 passed)
- [x] `npm run test:run` — vitest unit tests
- [x] `npm run lint`
- [x] `npm run build` — tsc + vite
- [x] `npm run test:e2e` — 116 passed (incl. existing score-entry suite, after the index-route fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)