### PR TITLE
Simplify sidenav to four core entries

### DIFF
--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -6,7 +6,6 @@ import { UserMenu } from './user-menu'
 type NavItem = {
   label: string
   icon: ReactNode
-  badge?: { label: string; live?: boolean }
   active?: boolean
   to?: string
   children?: Array<{ label: string; to: string; hash?: string; icon: ReactNode }>
@@ -45,7 +44,6 @@ const NAV_SECTIONS: NavSection[] = [
       {
         label: 'Matches',
         to: '/matches',
-        badge: { label: '12', live: true },
         icon: (
           <svg
             width="18"
@@ -62,163 +60,11 @@ const NAV_SECTIONS: NavSection[] = [
           </svg>
         ),
       },
-      {
-        label: 'Brackets',
-        icon: (
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M3 6h18M3 12h18M3 18h18" />
-          </svg>
-        ),
-      },
-      {
-        label: 'Schedule',
-        icon: (
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <rect x="3" y="4" width="18" height="18" rx="2" />
-            <path d="M16 2v4M8 2v4M3 10h18" />
-          </svg>
-        ),
-      },
-      {
-        label: 'Tournaments',
-        badge: { label: '3' },
-        icon: (
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M6 2h12l-2 7H8z" />
-            <path d="M9 9v6a3 3 0 0 0 6 0V9" />
-            <path d="M5 22h14M10 18h4v4h-4z" />
-          </svg>
-        ),
-      },
-    ],
-  },
-  {
-    label: 'Manage',
-    items: [
-      {
-        label: 'Players',
-        badge: { label: '128' },
-        icon: (
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-            <circle cx="9" cy="7" r="4" />
-            <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
-          </svg>
-        ),
-      },
-      {
-        label: 'Courts',
-        icon: (
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <rect x="3" y="3" width="18" height="18" rx="2" />
-            <path d="M3 9h18M9 21V9" />
-          </svg>
-        ),
-      },
-      {
-        label: 'Stats & Rankings',
-        icon: (
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M3 3v18h18" />
-            <path d="M7 14l4-4 4 4 5-5" />
-          </svg>
-        ),
-      },
-      {
-        label: 'Achievements',
-        icon: (
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <circle cx="12" cy="8" r="6" />
-            <path d="M15.5 13.5L17 22l-5-3-5 3 1.5-8.5" />
-          </svg>
-        ),
-      },
     ],
   },
   {
     label: 'Workspace',
     items: [
-      {
-        label: 'Messages',
-        badge: { label: '5' },
-        icon: (
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-          </svg>
-        ),
-      },
       {
         label: 'Settings',
         to: '/settings',
@@ -377,15 +223,6 @@ export function AppShell({ children }: AppShellProps) {
                     <>
                       <span className="app-shell__nav-icon">{item.icon}</span>
                       {item.label}
-                      {item.badge ? (
-                        <span
-                          className={`app-shell__nav-badge${
-                            item.badge.live ? ' app-shell__nav-badge--live' : ''
-                          }`}
-                        >
-                          {item.badge.label}
-                        </span>
-                      ) : null}
                     </>
                   )
                   return (
@@ -436,30 +273,6 @@ export function AppShell({ children }: AppShellProps) {
             </div>
           ))}
         </nav>
-
-        <div className="app-shell__sidebar-footer">
-          <div className="app-shell__promo">
-            <div className="app-shell__promo-title">SPRING OPEN '26</div>
-            <div className="app-shell__promo-copy">
-              Registration closes in 6 days. 64 spots, double elim.
-            </div>
-            <a href="#" className="app-shell__promo-btn">
-              Register
-              <svg
-                width="12"
-                height="12"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M5 12h14M13 5l7 7-7 7" />
-              </svg>
-            </a>
-          </div>
-        </div>
       </aside>
 
       <div className="app-shell__main">

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -6,8 +6,7 @@ import { UserMenu } from './user-menu'
 type NavItem = {
   label: string
   icon: ReactNode
-  active?: boolean
-  to?: string
+  to: string
   children?: Array<{ label: string; to: string; hash?: string; icon: ReactNode }>
 }
 
@@ -130,11 +129,6 @@ export function AppShell({ children }: AppShellProps) {
   const activeHash = useRouterState({
     select: (s) => s.location.hash.replace(/^#/, ''),
   })
-  const [activeLabel, setActiveLabel] = useState(
-    () =>
-      NAV_SECTIONS.flatMap((s) => s.items).find((i) => i.active)?.label ??
-      'Dashboard',
-  )
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -161,16 +155,7 @@ export function AppShell({ children }: AppShellProps) {
     }
   }, [sidebarOpen])
 
-  function handleNavClick(e: React.MouseEvent<HTMLAnchorElement>, label: string) {
-    e.preventDefault()
-    setActiveLabel(label)
-    if (window.matchMedia('(max-width: 960px)').matches) {
-      setSidebarOpen(false)
-    }
-  }
-
-  function handleRouteNavClick(label: string) {
-    setActiveLabel(label)
+  function closeOnMobile() {
     if (window.matchMedia('(max-width: 960px)').matches) {
       setSidebarOpen(false)
     }
@@ -215,36 +200,19 @@ export function AppShell({ children }: AppShellProps) {
               <ul className="app-shell__nav-list">
                 {section.items.map((item) => {
                   const childActive = item.children?.some((c) => pathname === c.to) ?? false
-                  const isActive = item.to
-                    ? pathname === item.to || childActive
-                    : activeLabel === item.label
+                  const isActive = pathname === item.to || childActive
                   const linkClassName = `app-shell__nav-link${isActive && !item.children ? ' is-active' : ''}${item.children && childActive ? ' is-parent-active' : ''}`
-                  const inner = (
-                    <>
-                      <span className="app-shell__nav-icon">{item.icon}</span>
-                      {item.label}
-                    </>
-                  )
                   return (
                     <li key={item.label}>
-                      {item.to ? (
-                        <Link
-                          to={item.to}
-                          className={linkClassName}
-                          onClick={() => handleRouteNavClick(item.label)}
-                        >
-                          {inner}
-                        </Link>
-                      ) : (
-                        <a
-                          href="#"
-                          className={linkClassName}
-                          onClick={(e) => handleNavClick(e, item.label)}
-                        >
-                          {inner}
-                        </a>
-                      )}
-                      {item.children && (isActive || childActive) ? (
+                      <Link
+                        to={item.to}
+                        className={linkClassName}
+                        onClick={closeOnMobile}
+                      >
+                        <span className="app-shell__nav-icon">{item.icon}</span>
+                        {item.label}
+                      </Link>
+                      {item.children && isActive ? (
                         <ul className="app-shell__sub-nav-list">
                           {item.children.map((child) => {
                             const childIsActive =
@@ -256,7 +224,7 @@ export function AppShell({ children }: AppShellProps) {
                                   to={child.to}
                                   hash={child.hash}
                                   className={`app-shell__sub-nav-link${childIsActive ? ' is-active' : ''}`}
-                                  onClick={() => handleRouteNavClick(child.label)}
+                                  onClick={closeOnMobile}
                                 >
                                   <span className="app-shell__nav-icon">{child.icon}</span>
                                   {child.label}

--- a/web-client/src/components/user-menu.tsx
+++ b/web-client/src/components/user-menu.tsx
@@ -21,9 +21,6 @@ export function UserMenu() {
       >
         <div className="app-shell__user-avatar app-shell__skeleton app-shell__skeleton--avatar" />
         <div className="app-shell__user-name app-shell__skeleton app-shell__skeleton--name" />
-        <span className="app-shell__user-chev" aria-hidden="true">
-          <Chevron />
-        </span>
       </div>
     )
   }
@@ -44,26 +41,6 @@ export function UserMenu() {
       >
         {username}
       </div>
-      <span className="app-shell__user-chev" aria-hidden="true">
-        <Chevron />
-      </span>
     </button>
-  )
-}
-
-function Chevron() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M6 9l6 6 6-6" />
-    </svg>
   )
 }

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -642,12 +642,6 @@ body.dark.fortymm-theme {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.app-shell__user-chev {
-  color: var(--fg-3);
-  display: grid;
-  place-items: center;
-}
-
 .app-shell__user-menu--loading {
   cursor: default;
 }
@@ -791,35 +785,6 @@ body.dark.fortymm-theme {
   color: var(--fg-2);
 }
 
-.app-shell__nav-badge {
-  margin-left: auto;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--fg-3);
-  background: var(--bg-card);
-  border: 1px solid var(--border-subtle);
-  padding: 2px 6px;
-  border-radius: 999px;
-  line-height: 1;
-}
-.app-shell__nav-badge--live {
-  color: var(--ink-950);
-  background: var(--serve-500);
-  border-color: transparent;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-.app-shell__nav-badge--live::before {
-  content: '';
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--ink-950);
-  animation: ball-pulse 1.4s ease-in-out infinite;
-}
-
 .app-shell__nav-link.is-active {
   background: var(--bg-accent-soft);
   color: var(--ball-200);
@@ -911,54 +876,6 @@ body.dark.fortymm-theme {
   background: var(--bg-hover);
 }
 
-.app-shell__sidebar-footer {
-  border-top: 1px solid var(--border-subtle);
-  padding: 12px;
-}
-.app-shell__promo {
-  background: linear-gradient(
-    160deg,
-    rgba(255, 122, 26, 0.14),
-    rgba(255, 122, 26, 0.04) 60%,
-    transparent
-  );
-  border: 1px solid rgba(255, 122, 26, 0.25);
-  border-radius: 10px;
-  padding: 16px;
-}
-.app-shell__promo-title {
-  font-family: var(--font-display);
-  font-size: 18px;
-  letter-spacing: 0.04em;
-  color: var(--fg-1);
-  margin-bottom: 4px;
-}
-.app-shell__promo-copy {
-  font-size: 11px;
-  color: var(--fg-3);
-  line-height: 1.25;
-  margin-bottom: 12px;
-}
-.app-shell__promo-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  background: var(--ball-500);
-  color: var(--ink-950);
-  border: none;
-  border-radius: 6px;
-  font-family: var(--font-ui);
-  font-weight: 600;
-  font-size: 12px;
-  padding: 7px 12px;
-  cursor: pointer;
-  text-decoration: none;
-  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-.app-shell__promo-btn:hover {
-  background: var(--ball-400);
-}
-
 /* ---------- Main column ---------- */
 .app-shell__main {
   min-width: 0;
@@ -1041,9 +958,6 @@ body.dark.fortymm-theme {
   .app-shell__nav-link,
   .app-shell__user-menu {
     transition: none !important;
-  }
-  .app-shell__nav-badge--live::before {
-    animation: none !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- Trim sidenav to Dashboard / Matches / Settings / Administration — removed Brackets, Schedule, Tournaments, Players, Courts, Stats & Rankings, Achievements, and Messages.
- Drop the Matches live badge, the SPRING OPEN promo footer, and the chevron in the user menu.
- Delete the now-orphaned `nav-badge`, `user-chev`, `sidebar-footer`, and `promo*` CSS rules.

## Test plan
- [x] `tsc -b` clean
- [x] `vitest run` — 17/17 pass
- [x] `eslint` clean on touched files
- [ ] Eyeball sidenav at http://localhost:5176 (dev server up locally) — header, Dashboard/Matches/Settings/Administration, no badges/promo/chevron

🤖 Generated with [Claude Code](https://claude.com/claude-code)