### PR TITLE
Redirect new-match flow to scoring page with real matchId

### DIFF
--- a/web-client/e2e/match-creation.spec.ts
+++ b/web-client/e2e/match-creation.spec.ts
@@ -2,6 +2,10 @@ import { expect, test } from '@playwright/test'
 import { NewMatchPage } from './page-objects/matches/new-match.page'
 import { CREATOR_USERNAME } from './page-objects/matches/match-store'
 
+// Successful match creation lands on the scoring page for game 1 of the new
+// match's id (the factory mints ids like `m-1`).
+const SCORING_URL = /\/matches\/[^/]+\/games\/1\/scores\/new$/
+
 // Stable, explicit ids so request-body assertions can name them.
 const ADA = { id: 'pl-ada', username: 'ada.lovelace' }
 const GRACE = { id: 'pl-grace', username: 'grace.hopper' }
@@ -76,7 +80,7 @@ test.describe('New match — creating a match', () => {
     await expect(nm.summaryTop).toContainText('You vs')
     await nm.start()
 
-    await expect(page).toHaveURL(/\/dashboard$/)
+    await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
       { opponent_user_id: GRACE.id, best_of: 5, rated: true },
     ])
@@ -91,7 +95,7 @@ test.describe('New match — creating a match', () => {
     await expect(nm.summarySub).toContainText('Best of 7 · first to 4')
     await nm.start()
 
-    await expect(page).toHaveURL(/\/dashboard$/)
+    await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
       { opponent_user_id: ADA.id, best_of: 7, rated: true },
     ])
@@ -108,7 +112,7 @@ test.describe('New match — creating a match', () => {
     await expect(nm.summarySub).toContainText('Unrated')
     await nm.start()
 
-    await expect(page).toHaveURL(/\/dashboard$/)
+    await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
       { opponent_user_id: ADA.id, best_of: 5, rated: false },
     ])
@@ -122,7 +126,7 @@ test.describe('New match — creating a match', () => {
     await nm.startWithoutOpponent()
     await nm.start()
 
-    await expect(page).toHaveURL(/\/dashboard$/)
+    await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
       { opponent_user_id: null, best_of: 5, rated: false },
     ])
@@ -140,7 +144,7 @@ test.describe('New match — creating a match', () => {
     await expect(nm.summarySub).toContainText('Unrated')
     await nm.start()
 
-    await expect(page).toHaveURL(/\/dashboard$/)
+    await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
       { opponent_user_id: null, best_of: 5, rated: false },
     ])
@@ -159,7 +163,7 @@ test.describe('New match — picking an opponent', () => {
     await expect(nm.selectedOpponentName).toHaveText(LINUS.username)
 
     await nm.start()
-    await expect(page).toHaveURL(/\/dashboard$/)
+    await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
       { opponent_user_id: LINUS.id, best_of: 5, rated: true },
     ])
@@ -175,7 +179,7 @@ test.describe('New match — picking an opponent', () => {
     await expect(nm.selectedOpponentName).toHaveText(BARBARA.username)
     await nm.start()
 
-    await expect(page).toHaveURL(/\/dashboard$/)
+    await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
       { opponent_user_id: BARBARA.id, best_of: 5, rated: true },
     ])
@@ -205,7 +209,7 @@ test.describe('New match — error handling', () => {
 
     // Only the first create was queued to fail — the retry goes through.
     await nm.start()
-    await expect(page).toHaveURL(/\/dashboard$/)
+    await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toHaveLength(2)
   })
 })

--- a/web-client/e2e/opponent-picker.spec.ts
+++ b/web-client/e2e/opponent-picker.spec.ts
@@ -9,6 +9,10 @@ const MARGARET = { id: 'pl-margaret', username: 'margaret.hamilton' }
 
 const ROSTER = [ADA, GRACE, LINUS, MARGARET]
 
+// Successful match creation lands on the scoring page for game 1 of the new
+// match's id (the factory mints ids like `m-1`).
+const SCORING_URL = /\/matches\/[^/]+\/games\/1\/scores\/new$/
+
 test.describe('Opponent picker — recent opponents', () => {
   test('shows a skeleton while recent opponents load, then the chips', async ({
     page,
@@ -85,7 +89,7 @@ test.describe('Opponent picker — recent opponents', () => {
     await nm.addGuest()
     await nm.start()
 
-    await expect(page).toHaveURL(/\/dashboard$/)
+    await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
       { opponent_user_id: null, best_of: 5, rated: false },
     ])
@@ -118,7 +122,7 @@ test.describe('Opponent picker — search', () => {
     expect(nm.store.searchQueries).toContain('hamilton')
 
     await nm.start()
-    await expect(page).toHaveURL(/\/dashboard$/)
+    await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
       { opponent_user_id: MARGARET.id, best_of: 5, rated: true },
     ])

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -36,8 +36,6 @@ function pendingMatch(): MatchRead {
   }
 }
 
-// NewMatchPage navigates to the scoring route on success and to /dashboard on
-// cancel, so the test router needs all three mounted.
 function renderNewMatch() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -36,8 +36,8 @@ function pendingMatch(): MatchRead {
   }
 }
 
-// NewMatchPage navigates to /dashboard on success, so the test router needs
-// both routes mounted.
+// NewMatchPage navigates to the scoring route on success and to /dashboard on
+// cancel, so the test router needs all three mounted.
 function renderNewMatch() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -53,8 +53,20 @@ function renderNewMatch() {
     path: '/dashboard',
     component: () => <div>Dashboard route</div>,
   })
+  const scoringRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches/$matchId/games/$gameId/scores/new',
+    component: () => {
+      const { matchId, gameId } = scoringRoute.useParams()
+      return <div>Scoring route {matchId} game {gameId}</div>
+    },
+  })
   const router = createRouter({
-    routeTree: rootRoute.addChildren([newMatchRoute, dashboardRoute]),
+    routeTree: rootRoute.addChildren([
+      newMatchRoute,
+      dashboardRoute,
+      scoringRoute,
+    ]),
     history: createMemoryHistory({ initialEntries: ['/matches/new'] }),
   })
   return render(
@@ -106,7 +118,9 @@ describe('NewMatchPage', () => {
     await user.click(screen.getByRole('button', { name: /start match/i }))
 
     await waitFor(() =>
-      expect(screen.getByText('Dashboard route')).toBeInTheDocument(),
+      expect(
+        screen.getByText('Scoring route m-test game 1'),
+      ).toBeInTheDocument(),
     )
     expect(captured).toEqual({
       opponent_user_id: 'pl-1',
@@ -132,7 +146,9 @@ describe('NewMatchPage', () => {
     await user.click(screen.getByRole('button', { name: /start match/i }))
 
     await waitFor(() =>
-      expect(screen.getByText('Dashboard route')).toBeInTheDocument(),
+      expect(
+        screen.getByText('Scoring route m-test game 1'),
+      ).toBeInTheDocument(),
     )
     // Guest / TBD opponents can't be rated, so `rated` is forced false.
     expect(captured).toEqual({

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -130,12 +130,15 @@ function MatchCard() {
     // can never be rated regardless of the toggle.
     const isRegistered = opponent?.kind === 'registered'
     try {
-      await createMatch.mutateAsync({
+      const created = await createMatch.mutateAsync({
         opponent_user_id: isRegistered ? opponent.id : null,
         best_of: bestOf,
         rated: isRegistered && rated,
       })
-      navigate({ to: '/dashboard' })
+      navigate({
+        to: '/matches/$matchId/games/$gameId/scores/new',
+        params: { matchId: created.id, gameId: '1' },
+      })
     } catch (err) {
       setError(
         err instanceof ApiError


### PR DESCRIPTION
## Summary
- After a successful `POST /v1/matches`, the new-match form navigates to `/matches/<id>/games/1/scores/new` instead of `/dashboard`, using the real match id from the API response and a hardcoded gameId of `'1'` (the scoring page is still a static stub).
- Updated unit (`new.test.tsx`) and e2e (`match-creation.spec.ts`, `opponent-picker.spec.ts`) assertions to expect the scoring URL.

## Test plan
- [x] `npm run test:run` (vitest) — 17/17
- [x] `npm run lint` + `npm run build` — clean
- [x] `PLAYWRIGHT_PORT=5179 npx playwright test` — 116/116
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)