### PR TITLE
Enforce timezone-aware datetimes and singular-parent table naming in api

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1,0 +1,42 @@
+# api/CLAUDE.md
+
+Schema conventions for the FastAPI service. See the root `CLAUDE.md` for repo
+layout, commands, and architecture.
+
+## Datetimes are timezone-aware, always
+
+- **Migrations:** every `sa.Column(..., sa.DateTime(...), ...)` must use
+  `sa.DateTime(timezone=True)`. Bare `sa.DateTime()` is forbidden.
+- **Models:** every `Mapped[datetime]` column must explicitly pass
+  `DateTime(timezone=True)` to `mapped_column(...)`. Import `DateTime` from
+  `sqlalchemy`. SQLAlchemy's default is naïve — do not rely on it.
+- Pydantic / response schemas are exempt unless they emit a naïve datetime.
+
+## Table naming: `<singular_parent>_<plural_child>`
+
+- Use `user_tokens`, `user_roles`, `role_permissions`, `match_settings`,
+  `match_sides`, `match_side_players`, `match_games`.
+- Not `users_tokens`, `users_roles`, `roles_permissions`.
+- Class names stay singular and unchanged (`UserToken`, `UserRole`,
+  `RolePermission`).
+- Index / constraint names mirror the table name with the prefix scheme the
+  codebase already uses: `ix_`, `uq_`, `ck_`, `fk_`. So
+  `ix_user_tokens_user_id`, not `ix_users_tokens_user_id`.
+
+## Pre-deploy: edit migrations in place
+
+Until the first production deploy, fix schema mistakes by editing the
+existing migration file rather than adding an "alter" migration. Obliterate
+and re-run alembic against a fresh database to test.
+
+- **Revision ids (`0001`, `0002`, ...) and `down_revision` chains stay
+  frozen.** Filenames carry the revision id as a prefix — keep the prefix,
+  only change the descriptive suffix when a migration is renamed.
+- When renaming a table, update everything that references it: the model's
+  `__tablename__`, the migration's `create_table` / `drop_table` /
+  `ForeignKey` / index / constraint names, the migration filename and
+  docstring, and any test or app code that hardcodes the old name as a
+  string.
+
+Once we deploy, this license expires and schema changes go in new
+migrations.

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -32,11 +32,6 @@ and re-run alembic against a fresh database to test.
 - **Revision ids (`0001`, `0002`, ...) and `down_revision` chains stay
   frozen.** Filenames carry the revision id as a prefix — keep the prefix,
   only change the descriptive suffix when a migration is renamed.
-- When renaming a table, update everything that references it: the model's
-  `__tablename__`, the migration's `create_table` / `drop_table` /
-  `ForeignKey` / index / constraint names, the migration filename and
-  docstring, and any test or app code that hardcodes the old name as a
-  string.
-
-Once we deploy, this license expires and schema changes go in new
-migrations.
+- Renaming a table touches: the model's `__tablename__`, the migration's
+  create/drop/FK/index/constraint names, the migration filename and
+  docstring, and any hardcoded references in app or test code.

--- a/api/app/models/permission.py
+++ b/api/app/models/permission.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import String, func
+from sqlalchemy import DateTime, String, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -21,8 +21,11 @@ class Permission(Base):
     )
     description: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        server_default=func.now(), nullable=False
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        server_default=func.now(), onupdate=func.now(), nullable=False
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
     )

--- a/api/app/models/role.py
+++ b/api/app/models/role.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import String, func
+from sqlalchemy import DateTime, String, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -21,8 +21,11 @@ class Role(Base):
     )
     description: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        server_default=func.now(), nullable=False
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        server_default=func.now(), onupdate=func.now(), nullable=False
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
     )

--- a/api/app/models/role_permission.py
+++ b/api/app/models/role_permission.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import ForeignKey, func
+from sqlalchemy import DateTime, ForeignKey, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -9,7 +9,7 @@ from app.db import Base
 
 
 class RolePermission(Base):
-    __tablename__ = "roles_permissions"
+    __tablename__ = "role_permissions"
 
     role_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
@@ -22,5 +22,5 @@ class RolePermission(Base):
         primary_key=True,
     )
     created_at: Mapped[datetime] = mapped_column(
-        server_default=func.now(), nullable=False
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/api/app/models/user.py
+++ b/api/app/models/user.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import String, func
+from sqlalchemy import DateTime, String, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -20,8 +20,11 @@ class User(Base):
         String(255), unique=True, nullable=False, index=True
     )
     created_at: Mapped[datetime] = mapped_column(
-        server_default=func.now(), nullable=False
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        server_default=func.now(), onupdate=func.now(), nullable=False
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
     )

--- a/api/app/models/user_role.py
+++ b/api/app/models/user_role.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import ForeignKey, func
+from sqlalchemy import DateTime, ForeignKey, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -9,7 +9,7 @@ from app.db import Base
 
 
 class UserRole(Base):
-    __tablename__ = "users_roles"
+    __tablename__ = "user_roles"
 
     user_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
@@ -22,5 +22,5 @@ class UserRole(Base):
         primary_key=True,
     )
     created_at: Mapped[datetime] = mapped_column(
-        server_default=func.now(), nullable=False
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/api/app/models/user_token.py
+++ b/api/app/models/user_token.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import ForeignKey, LargeBinary, String, func
+from sqlalchemy import DateTime, ForeignKey, LargeBinary, String, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -10,7 +10,7 @@ from app.models.user import User
 
 
 class UserToken(Base):
-    __tablename__ = "users_tokens"
+    __tablename__ = "user_tokens"
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
@@ -27,7 +27,7 @@ class UserToken(Base):
         index=True,
     )
     created_at: Mapped[datetime] = mapped_column(
-        server_default=func.now(), nullable=False
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 
     user: Mapped[User] = relationship(User)

--- a/api/app/rbac.py
+++ b/api/app/rbac.py
@@ -391,7 +391,7 @@ async def set_user_roles(
     db: AsyncSession = Depends(get_session),
 ) -> RbacUserRead:
     # FOR UPDATE on the user row prevents racing PUTs from colliding on the
-    # users_roles primary key (delete-then-insert otherwise conflicts).
+    # user_roles primary key (delete-then-insert otherwise conflicts).
     locked = await db.execute(
         select(User).where(User.id == user_id).with_for_update()
     )

--- a/api/migrations/versions/20260510_0000_0001_create_users_table.py
+++ b/api/migrations/versions/20260510_0000_0001_create_users_table.py
@@ -25,13 +25,13 @@ def upgrade() -> None:
         sa.Column("username", sa.String(length=255), nullable=False),
         sa.Column(
             "created_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),
         sa.Column(
             "updated_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),

--- a/api/migrations/versions/20260511_0000_0002_create_user_tokens_table.py
+++ b/api/migrations/versions/20260511_0000_0002_create_user_tokens_table.py
@@ -1,4 +1,4 @@
-"""create users_tokens table
+"""create user_tokens table
 
 Revision ID: 0002
 Revises: 0001
@@ -20,7 +20,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     op.create_table(
-        "users_tokens",
+        "user_tokens",
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column("token", sa.LargeBinary(), nullable=False),
         sa.Column("context", sa.String(length=255), nullable=False),
@@ -33,16 +33,16 @@ def upgrade() -> None:
         ),
         sa.Column(
             "created_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),
     )
     op.create_index(
-        "ix_users_tokens_user_id", "users_tokens", ["user_id"]
+        "ix_user_tokens_user_id", "user_tokens", ["user_id"]
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_users_tokens_user_id", table_name="users_tokens")
-    op.drop_table("users_tokens")
+    op.drop_index("ix_user_tokens_user_id", table_name="user_tokens")
+    op.drop_table("user_tokens")

--- a/api/migrations/versions/20260512_0000_0003_create_rbac_tables.py
+++ b/api/migrations/versions/20260512_0000_0003_create_rbac_tables.py
@@ -26,13 +26,13 @@ def upgrade() -> None:
         sa.Column("description", sa.String(length=1024), nullable=True),
         sa.Column(
             "created_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),
         sa.Column(
             "updated_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),
@@ -47,13 +47,13 @@ def upgrade() -> None:
         sa.Column("description", sa.String(length=1024), nullable=True),
         sa.Column(
             "created_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),
         sa.Column(
             "updated_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),
@@ -62,7 +62,7 @@ def upgrade() -> None:
     op.create_index("ix_permissions_name", "permissions", ["name"])
 
     op.create_table(
-        "roles_permissions",
+        "role_permissions",
         sa.Column(
             "role_id",
             postgresql.UUID(as_uuid=True),
@@ -77,14 +77,14 @@ def upgrade() -> None:
         ),
         sa.Column(
             "created_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),
     )
 
     op.create_table(
-        "users_roles",
+        "user_roles",
         sa.Column(
             "user_id",
             postgresql.UUID(as_uuid=True),
@@ -99,7 +99,7 @@ def upgrade() -> None:
         ),
         sa.Column(
             "created_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),
@@ -107,8 +107,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_table("users_roles")
-    op.drop_table("roles_permissions")
+    op.drop_table("user_roles")
+    op.drop_table("role_permissions")
     op.drop_index("ix_permissions_name", table_name="permissions")
     op.drop_table("permissions")
     op.drop_index("ix_roles_name", table_name="roles")


### PR DESCRIPTION
## Summary
- Every `Mapped[datetime]` column and every `sa.DateTime(...)` in alembic migrations is now `DateTime(timezone=True)` — SQLAlchemy's naïve default is no longer relied on.
- Junction/child tables renamed to `<singular_parent>_<plural_child>` form: `users_tokens` → `user_tokens`, `users_roles` → `user_roles`, `roles_permissions` → `role_permissions` (tables, `__tablename__`, indexes, FK names, migration filename, one comment in `rbac.py`). Class names stay singular.
- Edited migrations 0001–0003 in place (pre-deploy); revision ids and `down_revision` chain unchanged.
- New `api/CLAUDE.md` records the two conventions plus the pre-deploy edit-in-place license so future agents pick them up automatically.

## Test plan
- [x] `grep -rn "sa.DateTime()" api/` → empty
- [x] `grep -rn "users_tokens\|roles_permissions\|users_roles" api/` → empty (besides anti-examples in `api/CLAUDE.md`)
- [x] `alembic downgrade base && alembic upgrade head` clean against a fresh Postgres; all 13 timestamp columns confirmed `timestamp with time zone`
- [x] `cd api && pytest` — 76 passed
- [x] `cd web-client && npm run test:run` — 17 passed
- [x] `cd web-client && npm run lint && npm run build` — clean
- [x] `cd web-client && npm run test:e2e` — 116 passed
- [x] OpenAPI drift check (`mise run regen-api-types` + `git diff schema.d.ts`) — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)