### PR TITLE
Gate RBAC admin surface on permissions and harden the API

### DIFF
--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -13,6 +13,7 @@ RUN apt-get update \
 COPY pyproject.toml ./
 COPY app ./app
 COPY migrations ./migrations
+COPY scripts ./scripts
 COPY alembic.ini ./alembic.ini
 
 RUN pip install -e '.[dev]'

--- a/api/app/rbac.py
+++ b/api/app/rbac.py
@@ -1,5 +1,6 @@
 import uuid
 from collections.abc import Sequence
+from typing import Awaitable, Callable
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import delete, func, select
@@ -19,8 +20,47 @@ from app.schemas.rbac import (
     RoleRead,
     RoleUpdate,
 )
+from app.sessions import get_current_user
 
-router = APIRouter(prefix="/v1")
+
+# ----- authorization -------------------------------------------------------
+
+
+# Reads and writes on every endpoint here require this permission. The
+# Administration overview page (which doesn't hit any RBAC route) needs
+# `administration.view` instead, but that gate is enforced client-side —
+# this router has no overview endpoint to protect.
+RBAC_PERMISSION = "authorization.manage"
+
+
+async def _user_has_permission(
+    db: AsyncSession, user_id: uuid.UUID, name: str
+) -> bool:
+    result = await db.execute(
+        select(Permission.id)
+        .join(RolePermission, RolePermission.permission_id == Permission.id)
+        .join(UserRole, UserRole.role_id == RolePermission.role_id)
+        .where(UserRole.user_id == user_id, Permission.name == name)
+        .limit(1)
+    )
+    return result.first() is not None
+
+
+def require_permission(name: str) -> Callable[..., Awaitable[User]]:
+    async def dep(
+        user: User = Depends(get_current_user),
+        db: AsyncSession = Depends(get_session),
+    ) -> User:
+        if not await _user_has_permission(db, user.id, name):
+            raise HTTPException(status_code=403, detail="forbidden")
+        return user
+
+    return dep
+
+
+_require_rbac = require_permission(RBAC_PERMISSION)
+
+router = APIRouter(prefix="/v1", dependencies=[Depends(_require_rbac)])
 
 
 # ----- helpers -------------------------------------------------------------
@@ -31,10 +71,13 @@ async def _load_role_permission_map(
 ) -> dict[uuid.UUID, list[uuid.UUID]]:
     if not role_ids:
         return {}
+    # Order by permission name so response payloads are stable across calls —
+    # tests and the UI assume the array is sorted.
     result = await db.execute(
-        select(RolePermission.role_id, RolePermission.permission_id).where(
-            RolePermission.role_id.in_(role_ids)
-        )
+        select(RolePermission.role_id, RolePermission.permission_id)
+        .join(Permission, Permission.id == RolePermission.permission_id)
+        .where(RolePermission.role_id.in_(role_ids))
+        .order_by(Permission.name)
     )
     grouped: dict[uuid.UUID, list[uuid.UUID]] = {rid: [] for rid in role_ids}
     for role_id, permission_id in result.all():
@@ -48,9 +91,10 @@ async def _load_user_role_map(
     if not user_ids:
         return {}
     result = await db.execute(
-        select(UserRole.user_id, UserRole.role_id).where(
-            UserRole.user_id.in_(user_ids)
-        )
+        select(UserRole.user_id, UserRole.role_id)
+        .join(Role, Role.id == UserRole.role_id)
+        .where(UserRole.user_id.in_(user_ids))
+        .order_by(Role.name)
     )
     grouped: dict[uuid.UUID, list[uuid.UUID]] = {uid: [] for uid in user_ids}
     for user_id, role_id in result.all():
@@ -130,6 +174,21 @@ async def _validate_permission_ids(
     return deduped
 
 
+async def _name_taken(
+    db: AsyncSession,
+    model: type,
+    name: str,
+    *,
+    exclude_id: uuid.UUID | None = None,
+) -> bool:
+    """Case-insensitive uniqueness check for `name` columns on Role/Permission/User."""
+    field = getattr(model, "name", None) or model.username  # type: ignore[attr-defined]
+    stmt = select(model.id).where(func.lower(field) == name.lower())
+    if exclude_id is not None:
+        stmt = stmt.where(model.id != exclude_id)
+    return (await db.execute(stmt.limit(1))).first() is not None
+
+
 async def _validate_role_ids(
     db: AsyncSession, role_ids: Sequence[uuid.UUID]
 ) -> list[uuid.UUID]:
@@ -167,6 +226,10 @@ async def create_permission(
     payload: PermissionCreate,
     db: AsyncSession = Depends(get_session),
 ) -> PermissionRead:
+    if await _name_taken(db, Permission, payload.name):
+        raise HTTPException(
+            status_code=409, detail="permission name already exists"
+        )
     perm = Permission(name=payload.name, description=payload.description)
     db.add(perm)
     try:
@@ -197,6 +260,14 @@ async def update_permission(
 ) -> PermissionRead:
     perm = await _get_permission_or_404(db, permission_id)
     data = payload.model_dump(exclude_unset=True)
+    if (
+        "name" in data
+        and data["name"]
+        and await _name_taken(db, Permission, data["name"], exclude_id=perm.id)
+    ):
+        raise HTTPException(
+            status_code=409, detail="permission name already exists"
+        )
     for key, value in data.items():
         setattr(perm, key, value)
     try:
@@ -246,6 +317,9 @@ async def create_role(
             status_code=400,
             detail="provide either template_id or permission_ids, not both",
         )
+
+    if await _name_taken(db, Role, payload.name):
+        raise HTTPException(status_code=409, detail="role name already exists")
 
     permission_ids: list[uuid.UUID] = []
     if payload.template_id is not None:
@@ -302,8 +376,17 @@ async def update_role(
 
     new_permission_ids: list[uuid.UUID] | None = None
     if "permission_ids" in data:
-        raw = data.pop("permission_ids") or []
-        new_permission_ids = await _validate_permission_ids(db, raw)
+        # Explicit `null` means "no change"; explicit `[]` means "clear all".
+        raw = data.pop("permission_ids")
+        if raw is not None:
+            new_permission_ids = await _validate_permission_ids(db, raw)
+
+    if (
+        "name" in data
+        and data["name"]
+        and await _name_taken(db, Role, data["name"], exclude_id=role.id)
+    ):
+        raise HTTPException(status_code=409, detail="role name already exists")
 
     for key, value in data.items():
         setattr(role, key, value)
@@ -364,6 +447,8 @@ async def create_user(
     payload: RbacUserCreate,
     db: AsyncSession = Depends(get_session),
 ) -> RbacUserRead:
+    if await _name_taken(db, User, payload.username):
+        raise HTTPException(status_code=409, detail="username already exists")
     user = User(username=payload.username)
     db.add(user)
     try:
@@ -408,8 +493,16 @@ async def set_user_roles(
 
 @router.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_user(
-    user_id: uuid.UUID, db: AsyncSession = Depends(get_session)
+    user_id: uuid.UUID,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
 ) -> Response:
+    if user_id == current_user.id:
+        # Defense in depth — the UI also disables this button. Without this
+        # guard, the workspace can be locked out by deleting the last admin.
+        raise HTTPException(
+            status_code=400, detail="you cannot delete your own account"
+        )
     user = await _get_user_or_404(db, user_id)
     await db.delete(user)
     await db.commit()

--- a/api/app/rbac.py
+++ b/api/app/rbac.py
@@ -71,8 +71,7 @@ async def _load_role_permission_map(
 ) -> dict[uuid.UUID, list[uuid.UUID]]:
     if not role_ids:
         return {}
-    # Order by permission name so response payloads are stable across calls —
-    # tests and the UI assume the array is sorted.
+    # Stable order: tests and the UI assume sorted permission_ids.
     result = await db.execute(
         select(RolePermission.role_id, RolePermission.permission_id)
         .join(Permission, Permission.id == RolePermission.permission_id)
@@ -176,16 +175,17 @@ async def _validate_permission_ids(
 
 async def _name_taken(
     db: AsyncSession,
-    model: type,
+    id_col,
+    name_col,
     name: str,
     *,
     exclude_id: uuid.UUID | None = None,
 ) -> bool:
-    """Case-insensitive uniqueness check for `name` columns on Role/Permission/User."""
-    field = getattr(model, "name", None) or model.username  # type: ignore[attr-defined]
-    stmt = select(model.id).where(func.lower(field) == name.lower())
+    """Case-insensitive uniqueness check. Pass the model's id + name columns
+    (e.g. `Role.id, Role.name` or `User.id, User.username`)."""
+    stmt = select(id_col).where(func.lower(name_col) == name.lower())
     if exclude_id is not None:
-        stmt = stmt.where(model.id != exclude_id)
+        stmt = stmt.where(id_col != exclude_id)
     return (await db.execute(stmt.limit(1))).first() is not None
 
 
@@ -226,7 +226,7 @@ async def create_permission(
     payload: PermissionCreate,
     db: AsyncSession = Depends(get_session),
 ) -> PermissionRead:
-    if await _name_taken(db, Permission, payload.name):
+    if await _name_taken(db, Permission.id, Permission.name, payload.name):
         raise HTTPException(
             status_code=409, detail="permission name already exists"
         )
@@ -263,7 +263,9 @@ async def update_permission(
     if (
         "name" in data
         and data["name"]
-        and await _name_taken(db, Permission, data["name"], exclude_id=perm.id)
+        and await _name_taken(
+            db, Permission.id, Permission.name, data["name"], exclude_id=perm.id
+        )
     ):
         raise HTTPException(
             status_code=409, detail="permission name already exists"
@@ -318,7 +320,7 @@ async def create_role(
             detail="provide either template_id or permission_ids, not both",
         )
 
-    if await _name_taken(db, Role, payload.name):
+    if await _name_taken(db, Role.id, Role.name, payload.name):
         raise HTTPException(status_code=409, detail="role name already exists")
 
     permission_ids: list[uuid.UUID] = []
@@ -384,7 +386,9 @@ async def update_role(
     if (
         "name" in data
         and data["name"]
-        and await _name_taken(db, Role, data["name"], exclude_id=role.id)
+        and await _name_taken(
+            db, Role.id, Role.name, data["name"], exclude_id=role.id
+        )
     ):
         raise HTTPException(status_code=409, detail="role name already exists")
 
@@ -447,7 +451,7 @@ async def create_user(
     payload: RbacUserCreate,
     db: AsyncSession = Depends(get_session),
 ) -> RbacUserRead:
-    if await _name_taken(db, User, payload.username):
+    if await _name_taken(db, User.id, User.username, payload.username):
         raise HTTPException(status_code=409, detail="username already exists")
     user = User(username=payload.username)
     db.add(user)

--- a/api/scripts/seed_rbac.py
+++ b/api/scripts/seed_rbac.py
@@ -1,96 +1,30 @@
-"""Seed the local dev database with demo RBAC data.
+"""Seed the RBAC bootstrap data this change introduces.
 
-DEV/UAT ONLY. This script is never auto-run — not by alembic, not by the
-container CMD, not by the API on startup. To seed, you must explicitly invoke
-it inside a running api container, e.g.:
-
-    docker compose -p fortymm-rbac exec api python scripts/seed_rbac.py
-
-It is idempotent: it bails out if any permissions already exist, so re-running
-won't duplicate data. Do NOT add this to production migrations or compose
-commands.
+Idempotent: re-runs insert only the rows that aren't already present. Safe to
+run against UAT/prod on every container boot — the dev and UAT compose files
+chain it into the api command after `alembic upgrade head`.
 """
 
 import asyncio
 
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.db import get_engine
-from app.models import Permission, Role, RolePermission, User, UserRole
-from sqlalchemy.ext.asyncio import async_sessionmaker
+from app.models import Permission, Role, RolePermission
 
 
 PERMISSIONS = [
-    ("tournament.view", "See tournament list and details."),
-    ("tournament.create", "Spin up a new tournament event."),
-    ("tournament.edit", "Rename, reschedule, change format."),
-    ("tournament.delete", "Permanently remove a tournament."),
-    ("tournament.publish", "Publish a tournament to the spectator view."),
-    ("draws.view", "View brackets and seeds."),
-    ("draws.generate", "Run the SMT solver to build a draw."),
-    ("draws.edit", "Re-seed or manually swap matchups."),
-    ("draws.publish", "Lock the draw and notify players."),
-    ("draws.lock", "Freeze a draw against further edits."),
-    ("courts.view", "See live court status."),
-    ("courts.assign", "Send the next match to a court."),
-    ("courts.score", "Tap in points during live play."),
-    ("courts.override", "Correct a posted score after the fact."),
-    ("players.view", "Browse the player directory."),
-    ("players.create", "Register a new player."),
-    ("players.edit", "Update contact info, club, rating cap."),
-    ("players.delete", "Soft-delete a player profile."),
-    ("players.merge", "Combine two player records."),
-    ("ratings.view", "See rating history and deltas."),
-    ("ratings.recalculate", "Re-run the rating engine."),
-    ("members.view", "See workspace members."),
-    ("members.add", "Add a user to the workspace."),
-    ("members.remove", "Remove a user from the workspace."),
-    ("roles.manage", "Create, edit, and delete roles."),
-    ("permissions.assign", "Attach permissions to roles."),
-    ("system.view", "See system status."),
-    ("system.configure", "Edit org-wide settings."),
-    ("system.export", "Download backups and reports."),
+    ("administration.view", "Open the Administration area and see the overview."),
+    ("authorization.manage", "Manage roles, permissions, and user role assignments."),
 ]
 
 ROLES = [
-    ("Owner", "Full control of the workspace. Granted to founding admins.", "ALL"),
     (
-        "Tournament Director",
-        "Runs events end-to-end. Cannot edit org-wide settings.",
-        [
-            "tournament.view", "tournament.create", "tournament.edit", "tournament.publish",
-            "draws.view", "draws.generate", "draws.edit", "draws.publish", "draws.lock",
-            "courts.view", "courts.assign", "courts.score", "courts.override",
-            "players.view", "players.create", "players.edit", "players.merge",
-            "ratings.view", "ratings.recalculate",
-            "members.view", "system.export",
-        ],
+        "Administrator",
+        "Sees the Administration area and manages roles, permissions, and user assignments.",
+        ["administration.view", "authorization.manage"],
     ),
-    ("Scorekeeper", "Taps in points at courtside. Read-only everywhere else.",
-     ["tournament.view", "draws.view", "courts.view", "courts.score", "players.view"]),
-    ("Umpire", "Calls matches. Can override scores after the fact.",
-     ["tournament.view", "draws.view", "courts.view", "courts.score", "courts.override", "players.view"]),
-    ("Club Admin", "Manages the player roster. No live scoring.",
-     ["tournament.view", "draws.view", "players.view", "players.create", "players.edit", "players.merge", "ratings.view", "members.view"]),
-    ("Read-only", "Sees everything, changes nothing.", "ALL_VIEW"),
-    ("Weekend Volunteer", "One-off scorer role for weekend tournaments.",
-     ["tournament.view", "draws.view", "courts.view", "courts.score", "players.view"]),
-]
-
-USERS = [
-    ("tim.nguyen", ["Owner"]),
-    ("alex.johansen", ["Tournament Director"]),
-    ("maya.okafor", ["Tournament Director", "Club Admin"]),
-    ("riley.park", ["Scorekeeper"]),
-    ("sam.patel", ["Scorekeeper", "Umpire"]),
-    ("lin.chen", ["Umpire"]),
-    ("robin.kim", ["Club Admin"]),
-    ("dean.silva", ["Read-only"]),
-    ("carlos.rossi", ["Read-only"]),
-    ("jamie.tran", ["Weekend Volunteer", "Umpire"]),
-    ("priya.desai", ["Scorekeeper"]),
-    ("marcus.webb", ["Weekend Volunteer"]),
-    ("eun.han", []),
 ]
 
 
@@ -98,49 +32,79 @@ async def seed() -> None:
     engine = get_engine()
     sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
     async with sessionmaker() as db:
-        existing = (await db.execute(select(Permission))).scalars().all()
-        if existing:
-            print(f"Already seeded ({len(existing)} permissions present); aborting.")
-            return
+        perms_by_name: dict[str, Permission] = {
+            p.name: p
+            for p in (
+                await db.execute(
+                    select(Permission).where(
+                        Permission.name.in_([n for n, _ in PERMISSIONS])
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        }
 
-        perms_by_name: dict[str, Permission] = {}
+        created_perms = 0
         for name, desc in PERMISSIONS:
+            if name in perms_by_name:
+                continue
             p = Permission(name=name, description=desc)
             db.add(p)
             perms_by_name[name] = p
+            created_perms += 1
+
+        roles_by_name: dict[str, Role] = {
+            r.name: r
+            for r in (
+                await db.execute(
+                    select(Role).where(Role.name.in_([n for n, _, _ in ROLES]))
+                )
+            )
+            .scalars()
+            .all()
+        }
+
+        created_roles = 0
+        for name, desc, _ in ROLES:
+            if name in roles_by_name:
+                continue
+            r = Role(name=name, description=desc)
+            db.add(r)
+            roles_by_name[name] = r
+            created_roles += 1
+
         await db.flush()
 
-        all_perm_ids = [p.id for p in perms_by_name.values()]
-        view_perm_ids = [p.id for n, p in perms_by_name.items() if n.endswith(".view")]
+        existing_links = {
+            (row.role_id, row.permission_id)
+            for row in (
+                await db.execute(
+                    select(RolePermission).where(
+                        RolePermission.role_id.in_(
+                            [r.id for r in roles_by_name.values()]
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        }
 
-        roles_by_name: dict[str, Role] = {}
-        for name, desc, perms in ROLES:
-            role = Role(name=name, description=desc)
-            db.add(role)
-            roles_by_name[name] = role
-        await db.flush()
-
-        for name, _desc, perms in ROLES:
+        added_links = 0
+        for name, _, perm_names in ROLES:
             role = roles_by_name[name]
-            if perms == "ALL":
-                pids = all_perm_ids
-            elif perms == "ALL_VIEW":
-                pids = view_perm_ids
-            else:
-                pids = [perms_by_name[pn].id for pn in perms]
-            for pid in pids:
-                db.add(RolePermission(role_id=role.id, permission_id=pid))
-
-        for username, role_names in USERS:
-            user = User(username=username)
-            db.add(user)
-            await db.flush()
-            for rn in role_names:
-                db.add(UserRole(user_id=user.id, role_id=roles_by_name[rn].id))
+            for pn in perm_names:
+                perm = perms_by_name[pn]
+                if (role.id, perm.id) in existing_links:
+                    continue
+                db.add(RolePermission(role_id=role.id, permission_id=perm.id))
+                added_links += 1
 
         await db.commit()
         print(
-            f"Seeded {len(PERMISSIONS)} permissions, {len(ROLES)} roles, {len(USERS)} users."
+            f"Seed complete: +{created_perms} permissions, "
+            f"+{created_roles} roles, +{added_links} role/permission links."
         )
 
 

--- a/api/tests/test_rbac.py
+++ b/api/tests/test_rbac.py
@@ -8,14 +8,40 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db import get_session
 from app.main import app
 from app.models import Permission, Role, RolePermission, User, UserRole
+from app.rbac import _require_rbac
+from app.sessions import get_current_user
 
 
 @pytest_asyncio.fixture
-async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
-    async def _override() -> AsyncIterator[AsyncSession]:
+async def admin_user(db_session: AsyncSession) -> User:
+    """A real DB user the rbac routes will see as `current_user`.
+
+    The router's authz gate is bypassed via dependency_overrides[_require_rbac]
+    so this user does NOT need a permission row attached — that keeps existing
+    list-endpoint tests with their "this DB starts empty" assumptions.
+    """
+    user = User(username="rbac-admin")
+    db_session.add(user)
+    await db_session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def api_client(
+    db_session: AsyncSession, admin_user: User
+) -> AsyncIterator[AsyncClient]:
+    async def _override_session() -> AsyncIterator[AsyncSession]:
         yield db_session
 
-    app.dependency_overrides[get_session] = _override
+    async def _override_user() -> User:
+        return admin_user
+
+    async def _bypass_rbac() -> User:
+        return admin_user
+
+    app.dependency_overrides[get_session] = _override_session
+    app.dependency_overrides[get_current_user] = _override_user
+    app.dependency_overrides[_require_rbac] = _bypass_rbac
     transport = ASGITransport(app=app)
     async with AsyncClient(
         transport=transport, base_url="https://testserver"
@@ -384,3 +410,130 @@ async def test_delete_user(api_client: AsyncClient, db_session: AsyncSession):
         )
     ).scalar_one_or_none()
     assert remaining is None
+
+
+async def test_delete_user_refuses_self(
+    api_client: AsyncClient, admin_user: User
+):
+    response = await api_client.delete(f"/v1/users/{admin_user.id}")
+    assert response.status_code == 400
+    assert "your own" in response.json()["detail"]
+
+
+# ----- regression: case-insensitive uniqueness ----------------------------
+#
+# Permission names are forced lowercase by PERMISSION_NAME_PATTERN, so the
+# case-insensitive _name_taken check is dead code for that model (it stays
+# in place for symmetry). Roles and usernames have no shape constraint and
+# are the realistic collision surfaces.
+
+
+async def test_role_name_collision_is_case_insensitive(api_client: AsyncClient):
+    await api_client.post("/v1/roles", json={"name": "Owner"})
+    second = await api_client.post("/v1/roles", json={"name": "owner"})
+    assert second.status_code == 409
+
+
+async def test_role_rename_collision_returns_409(api_client: AsyncClient):
+    a = (await api_client.post("/v1/roles", json={"name": "alpha"})).json()
+    (await api_client.post("/v1/roles", json={"name": "bravo"})).json()
+    patched = await api_client.patch(
+        f"/v1/roles/{a['id']}", json={"name": "Bravo"}
+    )
+    assert patched.status_code == 409
+
+
+async def test_username_collision_is_case_insensitive(api_client: AsyncClient):
+    await api_client.post("/v1/users", json={"username": "Dup"})
+    second = await api_client.post("/v1/users", json={"username": "DUP"})
+    assert second.status_code == 409
+
+
+# ----- regression: updated_at + null/[] semantics --------------------------
+
+
+async def test_update_role_permissions_only_bumps_updated_at(
+    api_client: AsyncClient,
+):
+    p = (
+        await api_client.post("/v1/permissions", json={"name": "perm.a"})
+    ).json()
+    role = (
+        await api_client.post(
+            "/v1/roles", json={"name": "alpha"}
+        )
+    ).json()
+    before = role["updated_at"]
+
+    patched = await api_client.patch(
+        f"/v1/roles/{role['id']}", json={"permission_ids": [p["id"]]}
+    )
+    after = patched.json()["updated_at"]
+    assert after > before
+
+
+async def test_update_role_null_permission_ids_keeps_existing(
+    api_client: AsyncClient,
+):
+    p = (
+        await api_client.post("/v1/permissions", json={"name": "perm.a"})
+    ).json()
+    role = (
+        await api_client.post(
+            "/v1/roles", json={"name": "alpha", "permission_ids": [p["id"]]}
+        )
+    ).json()
+
+    patched = await api_client.patch(
+        f"/v1/roles/{role['id']}", json={"permission_ids": None}
+    )
+    assert patched.status_code == 200
+    assert patched.json()["permission_ids"] == [p["id"]]
+
+
+# ----- regression: stable ordering ----------------------------------------
+
+
+async def test_list_roles_permission_ids_sorted_by_name(
+    api_client: AsyncClient,
+):
+    pb = (
+        await api_client.post("/v1/permissions", json={"name": "perm.b"})
+    ).json()
+    pa = (
+        await api_client.post("/v1/permissions", json={"name": "perm.a"})
+    ).json()
+    pc = (
+        await api_client.post("/v1/permissions", json={"name": "perm.c"})
+    ).json()
+
+    role = (
+        await api_client.post(
+            "/v1/roles",
+            json={
+                "name": "r",
+                # Intentionally out-of-order on the wire.
+                "permission_ids": [pb["id"], pa["id"], pc["id"]],
+            },
+        )
+    ).json()
+
+    listing = (await api_client.get("/v1/roles")).json()
+    fetched = next(r for r in listing if r["id"] == role["id"])
+    assert fetched["permission_ids"] == [pa["id"], pb["id"], pc["id"]]
+
+
+async def test_list_users_role_ids_sorted_by_role_name(
+    api_client: AsyncClient,
+):
+    rz = (await api_client.post("/v1/roles", json={"name": "zeta"})).json()
+    ra = (await api_client.post("/v1/roles", json={"name": "alpha"})).json()
+    user = (
+        await api_client.post("/v1/users", json={"username": "ordered"})
+    ).json()
+    await api_client.put(
+        f"/v1/users/{user['id']}/roles", json={"role_ids": [rz["id"], ra["id"]]}
+    )
+    listing = (await api_client.get("/v1/users")).json()
+    fetched = next(u for u in listing if u["id"] == user["id"])
+    assert fetched["role_ids"] == [ra["id"], rz["id"]]

--- a/api/tests/test_rbac_authz.py
+++ b/api/tests/test_rbac_authz.py
@@ -1,0 +1,138 @@
+"""Exercises the `_require_rbac` gate on every endpoint in app.rbac.
+
+The shared `api_client` fixture in test_rbac.py overrides `get_current_user`
+to return an admin; this file builds clients for users who *don't* have
+`authorization.manage` to confirm they are blocked.
+"""
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_session
+from app.main import app
+from app.models import Permission, Role, RolePermission, User, UserRole
+from app.sessions import get_current_user
+
+
+@pytest_asyncio.fixture
+async def plain_user(db_session: AsyncSession) -> User:
+    """A real user with zero permissions."""
+    user = User(username="no-perms")
+    db_session.add(user)
+    await db_session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def viewer_user(db_session: AsyncSession) -> User:
+    """A user with `administration.view` but NOT `authorization.manage`."""
+    user = User(username="viewer-only")
+    role = Role(name="viewer-role")
+    perm = Permission(name="administration.view")
+    db_session.add_all([user, role, perm])
+    await db_session.flush()
+    db_session.add_all(
+        [
+            UserRole(user_id=user.id, role_id=role.id),
+            RolePermission(role_id=role.id, permission_id=perm.id),
+        ]
+    )
+    await db_session.commit()
+    return user
+
+
+def _build_client(db_session: AsyncSession, user: User | None) -> AsyncClient:
+    async def _override_session() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    async def _override_user() -> User:
+        if user is None:
+            from fastapi import HTTPException, status
+
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="authentication required",
+            )
+        return user
+
+    app.dependency_overrides[get_session] = _override_session
+    app.dependency_overrides[get_current_user] = _override_user
+    return AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://testserver"
+    )
+
+
+@pytest_asyncio.fixture
+async def anon_client(
+    db_session: AsyncSession,
+) -> AsyncIterator[AsyncClient]:
+    async with _build_client(db_session, None) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def viewer_client(
+    db_session: AsyncSession, viewer_user: User
+) -> AsyncIterator[AsyncClient]:
+    async with _build_client(db_session, viewer_user) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def plain_client(
+    db_session: AsyncSession, plain_user: User
+) -> AsyncIterator[AsyncClient]:
+    async with _build_client(db_session, plain_user) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+# Every path-method pair the rbac router exposes. UUIDs are fine because the
+# auth gate runs before path-param validation.
+ENDPOINTS = [
+    ("GET", "/v1/permissions"),
+    ("POST", "/v1/permissions"),
+    ("GET", "/v1/permissions/00000000-0000-0000-0000-000000000000"),
+    ("PATCH", "/v1/permissions/00000000-0000-0000-0000-000000000000"),
+    ("DELETE", "/v1/permissions/00000000-0000-0000-0000-000000000000"),
+    ("GET", "/v1/roles"),
+    ("POST", "/v1/roles"),
+    ("GET", "/v1/roles/00000000-0000-0000-0000-000000000000"),
+    ("PATCH", "/v1/roles/00000000-0000-0000-0000-000000000000"),
+    ("DELETE", "/v1/roles/00000000-0000-0000-0000-000000000000"),
+    ("GET", "/v1/users"),
+    ("POST", "/v1/users"),
+    ("GET", "/v1/users/00000000-0000-0000-0000-000000000000"),
+    ("DELETE", "/v1/users/00000000-0000-0000-0000-000000000000"),
+    ("PUT", "/v1/users/00000000-0000-0000-0000-000000000000/roles"),
+]
+
+
+@pytest.mark.parametrize("method,path", ENDPOINTS)
+async def test_unauthenticated_blocked(
+    anon_client: AsyncClient, method: str, path: str
+):
+    response = await anon_client.request(method, path, json={})
+    assert response.status_code == 401, (method, path, response.text)
+
+
+@pytest.mark.parametrize("method,path", ENDPOINTS)
+async def test_user_without_authorization_manage_blocked(
+    plain_client: AsyncClient, method: str, path: str
+):
+    response = await plain_client.request(method, path, json={})
+    assert response.status_code == 403, (method, path, response.text)
+
+
+@pytest.mark.parametrize("method,path", ENDPOINTS)
+async def test_administration_view_alone_is_not_enough(
+    viewer_client: AsyncClient, method: str, path: str
+):
+    response = await viewer_client.request(method, path, json={})
+    assert response.status_code == 403, (method, path, response.text)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -44,6 +44,7 @@ services:
       - "8000:8000"
     command: >
       sh -c "alembic upgrade head &&
+             python scripts/seed_rbac.py &&
              uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
 
   worker:

--- a/web-client/e2e/nav-gating.spec.ts
+++ b/web-client/e2e/nav-gating.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Verifies the side-nav adapts to the current session's permissions:
+ *
+ *   - Administration entry hides entirely unless `administration.view`.
+ *   - Roles / Permissions / Users children show only with `authorization.manage`.
+ *   - When the only surviving child is "Overview", Administration renders as
+ *     a flat link with no sub-menu (matching the other top-level items).
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+interface SessionShape {
+  username?: string
+  permissions: string[]
+}
+
+async function withSession(page: Page, session: SessionShape) {
+  await page.route('**/v1/session', async (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          user: {
+            username: session.username ?? 'tester',
+            permissions: session.permissions,
+          },
+        },
+      }),
+    }),
+  )
+  // Generic catch-all so the dashboard (or any other AppShell page) doesn't
+  // surface unrelated 404s from missing API mocks.
+  await page.route('**/api/v1/**', async (route) => {
+    const path = new URL(route.request().url()).pathname
+    if (path.endsWith('/v1/session')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            user: {
+              username: session.username ?? 'tester',
+              permissions: session.permissions,
+            },
+          },
+        }),
+      })
+      return
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '[]',
+    })
+  })
+}
+
+function sidebar(page: Page) {
+  return page.locator('.app-shell__sidebar')
+}
+
+test.describe('Sidebar permission gating', () => {
+  test('hides Administration when user has neither admin permission', async ({ page }) => {
+    await withSession(page, { permissions: [] })
+    await page.goto('/dashboard')
+
+    const bar = sidebar(page)
+    await expect(bar.getByRole('link', { name: /Dashboard/i })).toBeVisible()
+    await expect(bar.getByRole('link', { name: /Administration/i })).toHaveCount(0)
+    await expect(bar.getByRole('link', { name: /^Roles$/ })).toHaveCount(0)
+    await expect(bar.getByRole('link', { name: /^Permissions$/ })).toHaveCount(0)
+    await expect(bar.getByRole('link', { name: /^Users$/ })).toHaveCount(0)
+  })
+
+  test('administration.view alone shows Administration as a flat link with no children', async ({ page }) => {
+    await withSession(page, { permissions: ['administration.view'] })
+    await page.goto('/dashboard')
+
+    const bar = sidebar(page)
+    await expect(bar.getByRole('link', { name: /Administration/i })).toBeVisible()
+    // No sub-nav children should render.
+    await expect(bar.locator('.app-shell__sub-nav-list')).toHaveCount(0)
+    await expect(bar.getByRole('link', { name: /^Roles$/ })).toHaveCount(0)
+    await expect(bar.getByRole('link', { name: /^Permissions$/ })).toHaveCount(0)
+    await expect(bar.getByRole('link', { name: /^Users$/ })).toHaveCount(0)
+  })
+
+  test('navigating to /admin shows the flat-link variant with no sub-nav', async ({ page }) => {
+    await withSession(page, { permissions: ['administration.view'] })
+    await page.goto('/admin')
+
+    const bar = sidebar(page)
+    await expect(bar.getByRole('link', { name: /Administration/i })).toBeVisible()
+    // Even on /admin, the Administration item should NOT expand into a sub-nav
+    // since the only allowed child IS the parent page.
+    await expect(bar.locator('.app-shell__sub-nav-list')).toHaveCount(0)
+  })
+
+  test('both permissions reveal full Roles / Permissions / Users sub-nav on /admin', async ({ page }) => {
+    await withSession(page, {
+      permissions: ['administration.view', 'authorization.manage'],
+    })
+    await page.goto('/admin')
+
+    const bar = sidebar(page)
+    await expect(bar.getByRole('link', { name: /Administration/i })).toBeVisible()
+    // Sub-nav should be present and contain all admin pages.
+    await expect(bar.locator('.app-shell__sub-nav-list')).toHaveCount(1)
+    await expect(bar.getByRole('link', { name: /^Overview$/ })).toBeVisible()
+    await expect(bar.getByRole('link', { name: /^Roles$/ })).toBeVisible()
+    await expect(bar.getByRole('link', { name: /^Permissions$/ })).toBeVisible()
+    await expect(bar.getByRole('link', { name: /^Users$/ })).toBeVisible()
+  })
+
+  test('authorization.manage without administration.view still hides Administration', async ({ page }) => {
+    // Defensive: the parent gate is administration.view; without it, you don't
+    // see Administration at all even if you could otherwise manage roles.
+    await withSession(page, { permissions: ['authorization.manage'] })
+    await page.goto('/dashboard')
+
+    const bar = sidebar(page)
+    await expect(bar.getByRole('link', { name: /Administration/i })).toHaveCount(0)
+  })
+})

--- a/web-client/e2e/nav-gating.spec.ts
+++ b/web-client/e2e/nav-gating.spec.ts
@@ -7,6 +7,7 @@
  *     a flat link with no sub-menu (matching the other top-level items).
  */
 import { test, expect, type Page } from '@playwright/test'
+import { PERM } from '../src/lib/permissions'
 
 interface SessionShape {
   username?: string
@@ -14,44 +15,25 @@ interface SessionShape {
 }
 
 async function withSession(page: Page, session: SessionShape) {
-  await page.route('**/v1/session', async (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        data: {
-          user: {
-            username: session.username ?? 'tester',
-            permissions: session.permissions,
-          },
-        },
-      }),
-    }),
-  )
-  // Generic catch-all so the dashboard (or any other AppShell page) doesn't
-  // surface unrelated 404s from missing API mocks.
+  const sessionBody = JSON.stringify({
+    data: {
+      user: {
+        username: session.username ?? 'tester',
+        permissions: session.permissions,
+      },
+    },
+  })
+  // The client hits `/api/v1/session` (see api/client.ts resolveBaseUrl) so
+  // the `**/api/v1/**` catch-all is the one that intercepts the session
+  // request — branch on it here, and serve `[]` for anything else the
+  // dashboard/AppShell happens to fetch.
   await page.route('**/api/v1/**', async (route) => {
     const path = new URL(route.request().url()).pathname
     if (path.endsWith('/v1/session')) {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          data: {
-            user: {
-              username: session.username ?? 'tester',
-              permissions: session.permissions,
-            },
-          },
-        }),
-      })
+      await route.fulfill({ status: 200, contentType: 'application/json', body: sessionBody })
       return
     }
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: '[]',
-    })
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
   })
 }
 
@@ -73,7 +55,7 @@ test.describe('Sidebar permission gating', () => {
   })
 
   test('administration.view alone shows Administration as a flat link with no children', async ({ page }) => {
-    await withSession(page, { permissions: ['administration.view'] })
+    await withSession(page, { permissions: [PERM.ADMIN_VIEW] })
     await page.goto('/dashboard')
 
     const bar = sidebar(page)
@@ -86,7 +68,7 @@ test.describe('Sidebar permission gating', () => {
   })
 
   test('navigating to /admin shows the flat-link variant with no sub-nav', async ({ page }) => {
-    await withSession(page, { permissions: ['administration.view'] })
+    await withSession(page, { permissions: [PERM.ADMIN_VIEW] })
     await page.goto('/admin')
 
     const bar = sidebar(page)
@@ -98,7 +80,7 @@ test.describe('Sidebar permission gating', () => {
 
   test('both permissions reveal full Roles / Permissions / Users sub-nav on /admin', async ({ page }) => {
     await withSession(page, {
-      permissions: ['administration.view', 'authorization.manage'],
+      permissions: [PERM.ADMIN_VIEW, PERM.AUTH_MANAGE],
     })
     await page.goto('/admin')
 
@@ -115,7 +97,7 @@ test.describe('Sidebar permission gating', () => {
   test('authorization.manage without administration.view still hides Administration', async ({ page }) => {
     // Defensive: the parent gate is administration.view; without it, you don't
     // see Administration at all even if you could otherwise manage roles.
-    await withSession(page, { permissions: ['authorization.manage'] })
+    await withSession(page, { permissions: [PERM.AUTH_MANAGE] })
     await page.goto('/dashboard')
 
     const bar = sidebar(page)

--- a/web-client/e2e/page-objects/rbac/rbac-store.ts
+++ b/web-client/e2e/page-objects/rbac/rbac-store.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page, Request as PWRequest, Route } from '@playwright/test'
+import { PERM } from '../../../src/lib/permissions'
 import { sessionResponse } from '../../../src/test/factories'
 import {
   createRbacState,
@@ -19,7 +20,7 @@ export type { Permission, RbacUser, Role, SeedSpec }
 const SESSION = sessionResponse({
   user: {
     username: 'rita.kovac',
-    permissions: ['administration.view', 'authorization.manage'],
+    permissions: [PERM.ADMIN_VIEW, PERM.AUTH_MANAGE],
   },
 })
 

--- a/web-client/e2e/page-objects/rbac/rbac-store.ts
+++ b/web-client/e2e/page-objects/rbac/rbac-store.ts
@@ -12,7 +12,16 @@ import {
 
 export type { Permission, RbacUser, Role, SeedSpec }
 
-const SESSION = sessionResponse({ user: { username: 'rita.kovac' } })
+// The default session carries both admin permissions so the existing RBAC
+// e2e tests see the full Roles/Permissions/Users sub-nav. Suites that need
+// a non-admin session should layer their own page.route('**/v1/session')
+// AFTER calling RbacStore.install() so it wins by recency.
+const SESSION = sessionResponse({
+  user: {
+    username: 'rita.kovac',
+    permissions: ['administration.view', 'authorization.manage'],
+  },
+})
 
 export interface FailureSpec {
   /** Matched against `${method} ${url}` — substring (string) or regex. */

--- a/web-client/e2e/page-objects/rbac/roles.page.ts
+++ b/web-client/e2e/page-objects/rbac/roles.page.ts
@@ -38,11 +38,17 @@ export class RolesPage extends RbacPage {
   }
   /** Detail title (h1 with role name) */
   detailTitle(name: string): Locator {
-    return this.page.locator('h1.rbac-inline-edit', { hasText: name }).first()
+    // Inline rename was replaced by a modal Edit dialog; the h1 is now plain.
+    return this.page.getByRole('heading', { level: 1, name }).first()
   }
-  /** Save / cancel inline edit input for the title */
-  titleInput(value: string): Locator {
-    return this.page.locator(`input[value="${value}"]`).first()
+  get editButton(): Locator {
+    return this.page.getByRole('button', { name: /^Edit$/ }).first()
+  }
+  get editNameInput(): Locator {
+    return this.page.getByLabel('Name', { exact: true })
+  }
+  get editSaveButton(): Locator {
+    return this.page.getByRole('button', { name: 'Save changes' })
   }
   get confirmDeleteButton(): Locator {
     return this.page.getByRole('button', { name: 'Delete role' })

--- a/web-client/e2e/rbac-roles.spec.ts
+++ b/web-client/e2e/rbac-roles.spec.ts
@@ -35,7 +35,7 @@ test.describe('Administration · Roles', () => {
     await expect(page.getByText('Admin').first()).toBeVisible()
     await expect(page.getByText('Scorekeeper').first()).toBeVisible()
     // Detail title for the first (alphabetical) role
-    await expect(page.locator('h1.rbac-inline-edit', { hasText: 'Admin' })).toBeVisible()
+    await expect(page.getByRole('heading', { level: 1, name: 'Admin' })).toBeVisible()
   })
 
   test('shows the empty state with a CTA when no roles exist', async ({ page }) => {
@@ -90,14 +90,15 @@ test.describe('Administration · Roles', () => {
     expect(store.getRole('r_score')!.permission_ids).toEqual(['p_cs'])
   })
 
-  test('inline-renaming a role to an existing name surfaces a 409 toast', async ({ page }) => {
+  test('renaming a role to an existing name surfaces an inline error', async ({ page }) => {
     const { pom, store } = await RolesPage.navigateTo(page, BASE_SEED)
     await pom.roleRow('Scorekeeper').click()
-    await pom.detailTitle('Scorekeeper').click()
-    const input = pom.titleInput('Scorekeeper')
-    await input.fill('Admin')
-    await input.press('Tab')
-    await expect(pom.toast()).toContainText(/role name already exists/i)
+    await pom.editButton.click()
+    await pom.editNameInput.fill('Admin')
+    await pom.editSaveButton.click()
+    // Client-side zod check catches it before any network call — surfaces
+    // under the field per web-client/CLAUDE.md, not as a toast.
+    await expect(page.getByText(/already exists/i)).toBeVisible()
     expect(store.getRole('r_score')!.name).toBe('Scorekeeper')
   })
 
@@ -107,7 +108,7 @@ test.describe('Administration · Roles', () => {
     await pom.newRoleNameInput.fill('Volunteer Scorer')
     await pom.newRoleDescriptionInput.fill('Weekend volunteers.')
     await pom.newRoleSubmit.click()
-    await expect(page.locator('h1.rbac-inline-edit', { hasText: 'Volunteer Scorer' })).toBeVisible()
+    await expect(page.getByRole('heading', { level: 1, name: 'Volunteer Scorer' })).toBeVisible()
     expect(store.listRoles().some((r) => r.name === 'Volunteer Scorer')).toBe(true)
   })
 

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -549,7 +549,9 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody?: never;
         responses: {
@@ -562,6 +564,15 @@ export interface operations {
                     "application/json": components["schemas"]["PermissionRead"][];
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     create_permission_v1_permissions_post: {
@@ -569,7 +580,9 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody: {
             content: {
@@ -604,7 +617,9 @@ export interface operations {
             path: {
                 permission_id: string;
             };
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody?: never;
         responses: {
@@ -635,7 +650,9 @@ export interface operations {
             path: {
                 permission_id: string;
             };
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody?: never;
         responses: {
@@ -664,7 +681,9 @@ export interface operations {
             path: {
                 permission_id: string;
             };
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody: {
             content: {
@@ -697,7 +716,9 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody?: never;
         responses: {
@@ -710,6 +731,15 @@ export interface operations {
                     "application/json": components["schemas"]["RoleRead"][];
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     create_role_v1_roles_post: {
@@ -717,7 +747,9 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody: {
             content: {
@@ -752,7 +784,9 @@ export interface operations {
             path: {
                 role_id: string;
             };
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody?: never;
         responses: {
@@ -783,7 +817,9 @@ export interface operations {
             path: {
                 role_id: string;
             };
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody?: never;
         responses: {
@@ -812,7 +848,9 @@ export interface operations {
             path: {
                 role_id: string;
             };
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody: {
             content: {
@@ -845,7 +883,9 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody?: never;
         responses: {
@@ -858,6 +898,15 @@ export interface operations {
                     "application/json": components["schemas"]["RbacUserRead"][];
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     create_user_v1_users_post: {
@@ -865,7 +914,9 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody: {
             content: {
@@ -900,7 +951,9 @@ export interface operations {
             path: {
                 user_id: string;
             };
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody?: never;
         responses: {
@@ -931,7 +984,9 @@ export interface operations {
             path: {
                 user_id: string;
             };
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody?: never;
         responses: {
@@ -960,7 +1015,9 @@ export interface operations {
             path: {
                 user_id: string;
             };
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody: {
             content: {

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -19,3 +19,9 @@ export function sessionQueryOptions() {
 export function useSession() {
   return useQuery(sessionQueryOptions())
 }
+
+/** True when the current session carries `name` in its permissions list. */
+export function useHasPermission(name: string): boolean {
+  const { data } = useSession()
+  return data?.data.user.permissions.includes(name) ?? false
+}

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
 import { Bell, Gauge, Globe, Key, Mail, MapPin, Shield, User, Users } from 'lucide-react'
 import { useSession } from '@/api/session'
+import { PERM } from '@/lib/permissions'
 import { UserMenu } from './user-menu'
 
 type NavChild = { label: string; to: string; hash?: string; icon: ReactNode; requires?: string }
@@ -97,7 +98,7 @@ const NAV_SECTIONS: NavSection[] = [
       {
         label: 'Administration',
         to: '/admin',
-        requires: 'administration.view',
+        requires: PERM.ADMIN_VIEW,
         icon: (
           <svg
             width="18"
@@ -115,20 +116,14 @@ const NAV_SECTIONS: NavSection[] = [
         ),
         children: [
           { label: 'Overview', to: '/admin', icon: <Gauge size={15} strokeWidth={1.75} /> },
-          { label: 'Roles', to: '/admin/roles', icon: <Shield size={15} strokeWidth={1.75} />, requires: 'authorization.manage' },
-          { label: 'Permissions', to: '/admin/permissions', icon: <Key size={15} strokeWidth={1.75} />, requires: 'authorization.manage' },
-          { label: 'Users', to: '/admin/users', icon: <Users size={15} strokeWidth={1.75} />, requires: 'authorization.manage' },
+          { label: 'Roles', to: '/admin/roles', icon: <Shield size={15} strokeWidth={1.75} />, requires: PERM.AUTH_MANAGE },
+          { label: 'Permissions', to: '/admin/permissions', icon: <Key size={15} strokeWidth={1.75} />, requires: PERM.AUTH_MANAGE },
+          { label: 'Users', to: '/admin/users', icon: <Users size={15} strokeWidth={1.75} />, requires: PERM.AUTH_MANAGE },
         ],
       },
     ],
   },
 ]
-
-function withoutChildren(item: NavItem): NavItem {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { children, ...flat } = item
-  return flat
-}
 
 /**
  * Drops items / children the user lacks permission for. When an item with
@@ -148,10 +143,11 @@ function filterNavByPermissions(
         if (!allowed(item.requires)) return []
         if (!item.children) return [item]
         const children = item.children.filter((c) => allowed(c.requires))
-        if (children.length === 0) return [withoutChildren(item)]
         const onlyOverview =
           children.length === 1 && children[0].to === item.to && !children[0].hash
-        if (onlyOverview) return [withoutChildren(item)]
+        if (children.length === 0 || onlyOverview) {
+          return [{ ...item, children: undefined }]
+        }
         return [{ ...item, children }]
       }),
     }))
@@ -165,14 +161,14 @@ interface AppShellProps {
 export function AppShell({ children }: AppShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const { data: session } = useSession()
+  const permissions = useSession().data?.data.user.permissions
+  // TanStack Query's default structuralSharing preserves array identity across
+  // background refetches when the data is unchanged, so depending on the
+  // permissions array (not the whole session) skips the rebuild on no-op
+  // refetches.
   const sections = useMemo(
-    () =>
-      filterNavByPermissions(
-        NAV_SECTIONS,
-        new Set(session?.data.user.permissions ?? []),
-      ),
-    [session],
+    () => filterNavByPermissions(NAV_SECTIONS, new Set(permissions ?? [])),
+    [permissions],
   )
   const activeHash = useRouterState({
     select: (s) => s.location.hash.replace(/^#/, ''),

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -1,13 +1,17 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
 import { Bell, Gauge, Globe, Key, Mail, MapPin, Shield, User, Users } from 'lucide-react'
+import { useSession } from '@/api/session'
 import { UserMenu } from './user-menu'
+
+type NavChild = { label: string; to: string; hash?: string; icon: ReactNode; requires?: string }
 
 type NavItem = {
   label: string
   icon: ReactNode
   to: string
-  children?: Array<{ label: string; to: string; hash?: string; icon: ReactNode }>
+  requires?: string
+  children?: NavChild[]
 }
 
 type NavSection = {
@@ -93,6 +97,7 @@ const NAV_SECTIONS: NavSection[] = [
       {
         label: 'Administration',
         to: '/admin',
+        requires: 'administration.view',
         icon: (
           <svg
             width="18"
@@ -110,14 +115,48 @@ const NAV_SECTIONS: NavSection[] = [
         ),
         children: [
           { label: 'Overview', to: '/admin', icon: <Gauge size={15} strokeWidth={1.75} /> },
-          { label: 'Roles', to: '/admin/roles', icon: <Shield size={15} strokeWidth={1.75} /> },
-          { label: 'Permissions', to: '/admin/permissions', icon: <Key size={15} strokeWidth={1.75} /> },
-          { label: 'Users', to: '/admin/users', icon: <Users size={15} strokeWidth={1.75} /> },
+          { label: 'Roles', to: '/admin/roles', icon: <Shield size={15} strokeWidth={1.75} />, requires: 'authorization.manage' },
+          { label: 'Permissions', to: '/admin/permissions', icon: <Key size={15} strokeWidth={1.75} />, requires: 'authorization.manage' },
+          { label: 'Users', to: '/admin/users', icon: <Users size={15} strokeWidth={1.75} />, requires: 'authorization.manage' },
         ],
       },
     ],
   },
 ]
+
+function withoutChildren(item: NavItem): NavItem {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { children, ...flat } = item
+  return flat
+}
+
+/**
+ * Drops items / children the user lacks permission for. When an item with
+ * children survives but every child that survives points back at the parent's
+ * `to` (i.e. only "Overview" is left), the children are stripped so the entry
+ * renders as a flat link instead of an expandable group.
+ */
+function filterNavByPermissions(
+  sections: NavSection[],
+  permissions: ReadonlySet<string>,
+): NavSection[] {
+  const allowed = (req?: string) => !req || permissions.has(req)
+  return sections
+    .map((section) => ({
+      ...section,
+      items: section.items.flatMap<NavItem>((item) => {
+        if (!allowed(item.requires)) return []
+        if (!item.children) return [item]
+        const children = item.children.filter((c) => allowed(c.requires))
+        if (children.length === 0) return [withoutChildren(item)]
+        const onlyOverview =
+          children.length === 1 && children[0].to === item.to && !children[0].hash
+        if (onlyOverview) return [withoutChildren(item)]
+        return [{ ...item, children }]
+      }),
+    }))
+    .filter((s) => s.items.length > 0)
+}
 
 interface AppShellProps {
   children: ReactNode
@@ -126,6 +165,15 @@ interface AppShellProps {
 export function AppShell({ children }: AppShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const { data: session } = useSession()
+  const sections = useMemo(
+    () =>
+      filterNavByPermissions(
+        NAV_SECTIONS,
+        new Set(session?.data.user.permissions ?? []),
+      ),
+    [session],
+  )
   const activeHash = useRouterState({
     select: (s) => s.location.hash.replace(/^#/, ''),
   })
@@ -194,7 +242,7 @@ export function AppShell({ children }: AppShellProps) {
         </div>
 
         <nav className="app-shell__nav">
-          {NAV_SECTIONS.map((section) => (
+          {sections.map((section) => (
             <div className="app-shell__nav-section" key={section.label}>
               <div className="app-shell__nav-label">{section.label}</div>
               <ul className="app-shell__nav-list">

--- a/web-client/src/components/rbac/admin-layout.tsx
+++ b/web-client/src/components/rbac/admin-layout.tsx
@@ -1,4 +1,5 @@
 import { useRouterState } from '@tanstack/react-router'
+import { useSession } from '@/api/session'
 import { Skeleton } from '@/components/ui/skeleton'
 import { usePermissions, useRbacUsers, useRoles } from './queries'
 
@@ -9,9 +10,11 @@ const TAB_LABELS: Record<string, string> = {
 }
 
 export function AdminBreadcrumbAndCounts() {
-  const usersQ = useRbacUsers()
-  const rolesQ = useRoles()
-  const permsQ = usePermissions()
+  const { data: session } = useSession()
+  // /v1/roles, /v1/permissions, /v1/users are all gated on authorization.manage,
+  // so administration.view-only users would 403 and trip the error boundary.
+  const canManageAuth =
+    session?.data.user.permissions.includes('authorization.manage') ?? false
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const current = TAB_LABELS[pathname] ?? 'Overview'
 
@@ -35,37 +38,46 @@ export function AdminBreadcrumbAndCounts() {
         <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg-1)' }}>{current}</span>
       </div>
       <div style={{ flex: 1 }} />
-      <div
+      {canManageAuth && <AdminCountsPill />}
+    </div>
+  )
+}
+
+function AdminCountsPill() {
+  const usersQ = useRbacUsers()
+  const rolesQ = useRoles()
+  const permsQ = usePermissions()
+  return (
+    <div
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '4px 12px',
+        borderRadius: 999,
+        background: 'var(--bg-card)',
+        border: '1px solid var(--border-subtle)',
+        fontSize: 11,
+        fontFamily: 'var(--font-mono)',
+        color: 'var(--fg-3)',
+        fontVariantNumeric: 'tabular-nums',
+      }}
+    >
+      <span
         style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 10,
-          padding: '4px 12px',
-          borderRadius: 999,
-          background: 'var(--bg-card)',
-          border: '1px solid var(--border-subtle)',
-          fontSize: 11,
-          fontFamily: 'var(--font-mono)',
-          color: 'var(--fg-3)',
-          fontVariantNumeric: 'tabular-nums',
+          width: 6,
+          height: 6,
+          borderRadius: '50%',
+          background: 'var(--serve-500)',
+          boxShadow: '0 0 6px var(--serve-500)',
+          animation: 'ball-pulse 1.4s ease-in-out infinite',
         }}
-      >
-        <span
-          style={{
-            width: 6,
-            height: 6,
-            borderRadius: '50%',
-            background: 'var(--serve-500)',
-            boxShadow: '0 0 6px var(--serve-500)',
-            animation: 'ball-pulse 1.4s ease-in-out infinite',
-          }}
-        />
-        <CountChip label="users" count={usersQ.data?.length} loading={usersQ.isLoading} />
-        <span style={{ color: 'var(--ink-500)' }}>·</span>
-        <CountChip label="roles" count={rolesQ.data?.length} loading={rolesQ.isLoading} />
-        <span style={{ color: 'var(--ink-500)' }}>·</span>
-        <CountChip label="perms" count={permsQ.data?.length} loading={permsQ.isLoading} />
-      </div>
+      />
+      <CountChip label="users" count={usersQ.data?.length} loading={usersQ.isLoading} />
+      <span style={{ color: 'var(--ink-500)' }}>·</span>
+      <CountChip label="roles" count={rolesQ.data?.length} loading={rolesQ.isLoading} />
+      <span style={{ color: 'var(--ink-500)' }}>·</span>
+      <CountChip label="perms" count={permsQ.data?.length} loading={permsQ.isLoading} />
     </div>
   )
 }

--- a/web-client/src/components/rbac/admin-layout.tsx
+++ b/web-client/src/components/rbac/admin-layout.tsx
@@ -1,5 +1,6 @@
 import { useRouterState } from '@tanstack/react-router'
-import { useSession } from '@/api/session'
+import { useHasPermission } from '@/api/session'
+import { PERM } from '@/lib/permissions'
 import { Skeleton } from '@/components/ui/skeleton'
 import { usePermissions, useRbacUsers, useRoles } from './queries'
 
@@ -10,11 +11,10 @@ const TAB_LABELS: Record<string, string> = {
 }
 
 export function AdminBreadcrumbAndCounts() {
-  const { data: session } = useSession()
-  // /v1/roles, /v1/permissions, /v1/users are all gated on authorization.manage,
-  // so administration.view-only users would 403 and trip the error boundary.
-  const canManageAuth =
-    session?.data.user.permissions.includes('authorization.manage') ?? false
+  // /v1/roles, /v1/permissions, /v1/users are all gated server-side on
+  // authorization.manage; without it the count fetches 403 and trip the
+  // error boundary, so skip the entire pill (and its hooks) instead.
+  const canManageAuth = useHasPermission(PERM.AUTH_MANAGE)
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const current = TAB_LABELS[pathname] ?? 'Overview'
 

--- a/web-client/src/components/rbac/error-fallback.tsx
+++ b/web-client/src/components/rbac/error-fallback.tsx
@@ -6,39 +6,8 @@ import {
 } from 'react-error-boundary'
 import { QueryErrorResetBoundary } from '@tanstack/react-query'
 import { ApiError } from '@/api/client'
+import { PERM } from '@/lib/permissions'
 import { Button } from '@/components/ui/button'
-
-function RbacErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
-  // 403s come from the authorization.manage gate — show a clearer message
-  // than "something went wrong" so unauthorized direct-navigation reads as
-  // intentional rather than broken.
-  if (error instanceof ApiError && error.status === 403) {
-    return (
-      <div role="alert" style={containerStyle}>
-        <div style={{ ...iconWrap, background: 'rgba(110, 130, 255, 0.12)' }}>
-          <Lock size={22} color="var(--info, #6e82ff)" strokeWidth={1.75} />
-        </div>
-        <div style={titleStyle}>You don't have access to this page</div>
-        <div style={detailStyle}>
-          Ask an administrator to grant you the{' '}
-          <code style={{ fontFamily: 'var(--font-mono)' }}>authorization.manage</code> permission.
-        </div>
-      </div>
-    )
-  }
-  return (
-    <div role="alert" style={containerStyle}>
-      <div style={{ ...iconWrap, background: 'rgba(255,77,109,0.12)' }}>
-        <AlertTriangle size={22} color="var(--loss)" strokeWidth={1.75} />
-      </div>
-      <div style={titleStyle}>Something went wrong loading this page</div>
-      <div style={{ ...detailStyle, fontFamily: 'var(--font-mono)', wordBreak: 'break-word' }}>
-        {error instanceof Error ? error.message : String(error)}
-      </div>
-      <Button onClick={resetErrorBoundary}>Try again</Button>
-    </div>
-  )
-}
 
 const containerStyle = {
   padding: '48px 24px',
@@ -61,6 +30,38 @@ const detailStyle = {
   color: 'var(--fg-3)',
   maxWidth: 420,
   margin: '0 auto 18px',
+}
+
+function RbacErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
+  // 403s come from the authorization.manage gate — show a clearer message
+  // than "something went wrong" so unauthorized direct-navigation reads as
+  // intentional rather than broken.
+  if (error instanceof ApiError && error.status === 403) {
+    return (
+      <div role="alert" style={containerStyle}>
+        <div style={{ ...iconWrap, background: 'rgba(110, 130, 255, 0.12)' }}>
+          <Lock size={22} color="var(--info, #6e82ff)" strokeWidth={1.75} />
+        </div>
+        <div style={titleStyle}>You don't have access to this page</div>
+        <div style={detailStyle}>
+          Ask an administrator to grant you the{' '}
+          <code style={{ fontFamily: 'var(--font-mono)' }}>{PERM.AUTH_MANAGE}</code> permission.
+        </div>
+      </div>
+    )
+  }
+  return (
+    <div role="alert" style={containerStyle}>
+      <div style={{ ...iconWrap, background: 'rgba(255,77,109,0.12)' }}>
+        <AlertTriangle size={22} color="var(--loss)" strokeWidth={1.75} />
+      </div>
+      <div style={titleStyle}>Something went wrong loading this page</div>
+      <div style={{ ...detailStyle, fontFamily: 'var(--font-mono)', wordBreak: 'break-word' }}>
+        {error instanceof Error ? error.message : String(error)}
+      </div>
+      <Button onClick={resetErrorBoundary}>Try again</Button>
+    </div>
+  )
 }
 
 export function RbacBoundary({ children }: { children: ReactNode }) {

--- a/web-client/src/components/rbac/error-fallback.tsx
+++ b/web-client/src/components/rbac/error-fallback.tsx
@@ -1,55 +1,66 @@
 import type { ReactNode } from 'react'
-import { AlertTriangle } from 'lucide-react'
+import { AlertTriangle, Lock } from 'lucide-react'
 import {
   ErrorBoundary,
   type FallbackProps,
 } from 'react-error-boundary'
 import { QueryErrorResetBoundary } from '@tanstack/react-query'
+import { ApiError } from '@/api/client'
 import { Button } from '@/components/ui/button'
 
 function RbacErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
+  // 403s come from the authorization.manage gate — show a clearer message
+  // than "something went wrong" so unauthorized direct-navigation reads as
+  // intentional rather than broken.
+  if (error instanceof ApiError && error.status === 403) {
+    return (
+      <div role="alert" style={containerStyle}>
+        <div style={{ ...iconWrap, background: 'rgba(110, 130, 255, 0.12)' }}>
+          <Lock size={22} color="var(--info, #6e82ff)" strokeWidth={1.75} />
+        </div>
+        <div style={titleStyle}>You don't have access to this page</div>
+        <div style={detailStyle}>
+          Ask an administrator to grant you the{' '}
+          <code style={{ fontFamily: 'var(--font-mono)' }}>authorization.manage</code> permission.
+        </div>
+      </div>
+    )
+  }
   return (
-    <div
-      role="alert"
-      style={{
-        padding: '48px 24px',
-        margin: '32px auto',
-        maxWidth: 560,
-        textAlign: 'center',
-        border: '1px solid rgba(255,77,109,0.4)',
-        background: 'rgba(255,77,109,0.05)',
-        borderRadius: 'var(--r-md, 10px)',
-      }}
-    >
-      <div
-        style={{
-          display: 'inline-flex',
-          padding: 14,
-          background: 'rgba(255,77,109,0.12)',
-          borderRadius: 999,
-          marginBottom: 14,
-        }}
-      >
+    <div role="alert" style={containerStyle}>
+      <div style={{ ...iconWrap, background: 'rgba(255,77,109,0.12)' }}>
         <AlertTriangle size={22} color="var(--loss)" strokeWidth={1.75} />
       </div>
-      <div style={{ fontSize: 16, fontWeight: 600, color: 'var(--fg-1)', marginBottom: 6 }}>
-        Something went wrong loading this page
-      </div>
-      <div
-        style={{
-          fontSize: 13,
-          color: 'var(--fg-3)',
-          maxWidth: 420,
-          margin: '0 auto 18px',
-          fontFamily: 'var(--font-mono)',
-          wordBreak: 'break-word',
-        }}
-      >
+      <div style={titleStyle}>Something went wrong loading this page</div>
+      <div style={{ ...detailStyle, fontFamily: 'var(--font-mono)', wordBreak: 'break-word' }}>
         {error instanceof Error ? error.message : String(error)}
       </div>
       <Button onClick={resetErrorBoundary}>Try again</Button>
     </div>
   )
+}
+
+const containerStyle = {
+  padding: '48px 24px',
+  margin: '32px auto',
+  maxWidth: 560,
+  textAlign: 'center' as const,
+  border: '1px solid rgba(255,77,109,0.4)',
+  background: 'rgba(255,77,109,0.05)',
+  borderRadius: 'var(--r-md, 10px)',
+}
+const iconWrap = {
+  display: 'inline-flex',
+  padding: 14,
+  borderRadius: 999,
+  marginBottom: 14,
+}
+const titleStyle = { fontSize: 16, fontWeight: 600, color: 'var(--fg-1)', marginBottom: 6 }
+const detailStyle = {
+  fontSize: 13,
+  color: 'var(--fg-3)',
+  maxWidth: 420,
+  margin: '0 auto 18px',
 }
 
 export function RbacBoundary({ children }: { children: ReactNode }) {

--- a/web-client/src/components/rbac/helpers.ts
+++ b/web-client/src/components/rbac/helpers.ts
@@ -73,13 +73,16 @@ export function initialsFor(name: string): string {
     .toUpperCase()
 }
 
+// Same cardinality as ROLE_PALETTE (7) so name → bucket maps consistently
+// between role pill colors and user avatars.
 const AVATAR_PALETTE: Array<[string, string]> = [
   ['#FF7A1A', '#fff'],
   ['#00E29A', '#0B0D12'],
   ['#6FB5FF', '#0B0D12'],
   ['#FFC43D', '#0B0D12'],
-  ['#FF4D6D', '#fff'],
   ['#A87BFF', '#fff'],
+  ['#FF4D6D', '#fff'],
+  ['#8CFFD4', '#0B0D12'],
 ]
 
 export function avatarColorsFor(name: string): [string, string] {

--- a/web-client/src/components/rbac/queries.ts
+++ b/web-client/src/components/rbac/queries.ts
@@ -134,8 +134,24 @@ export function useUpdateRole() {
           body: input.patch,
         }),
       ),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ROLES_KEY }),
-    onError: notifyError('update the role'),
+    // Optimistic update so permission checkboxes (toggled rapidly) flip
+    // instantly; restore the snapshot on error so the UI doesn't lie.
+    onMutate: async (input) => {
+      await qc.cancelQueries({ queryKey: ROLES_KEY })
+      const previous = qc.getQueryData<Role[]>(ROLES_KEY)
+      if (previous) {
+        qc.setQueryData<Role[]>(
+          ROLES_KEY,
+          previous.map((r) => (r.id === input.id ? { ...r, ...input.patch } : r)),
+        )
+      }
+      return { previous }
+    },
+    onError: (err, _input, ctx) => {
+      if (ctx?.previous) qc.setQueryData(ROLES_KEY, ctx.previous)
+      notifyError('update the role')(err)
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: ROLES_KEY }),
   })
 }
 
@@ -197,7 +213,26 @@ export function useSetUserRoles() {
           body: { role_ids: input.roleIds },
         }),
       ),
-    onSuccess: () => qc.invalidateQueries({ queryKey: USERS_KEY }),
-    onError: notifyError('save role assignments'),
+    // Optimistic so revoke-from-role-detail doesn't read a stale cached list
+    // when two revokes fire close together — both reads would otherwise see
+    // the pre-revoke role set and one revoke would be lost.
+    onMutate: async (input) => {
+      await qc.cancelQueries({ queryKey: USERS_KEY })
+      const previous = qc.getQueryData<RbacUser[]>(USERS_KEY)
+      if (previous) {
+        qc.setQueryData<RbacUser[]>(
+          USERS_KEY,
+          previous.map((u) =>
+            u.id === input.id ? { ...u, role_ids: input.roleIds } : u,
+          ),
+        )
+      }
+      return { previous }
+    },
+    onError: (err, _input, ctx) => {
+      if (ctx?.previous) qc.setQueryData(USERS_KEY, ctx.previous)
+      notifyError('save role assignments')(err)
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: USERS_KEY }),
   })
 }

--- a/web-client/src/components/rbac/roles-page.tsx
+++ b/web-client/src/components/rbac/roles-page.tsx
@@ -1,7 +1,21 @@
 import { useMemo, useState, type CSSProperties } from 'react'
-import { Check, Copy, Folder, Plus, Search, Shield, Trash2, Users, X } from 'lucide-react'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import { z } from 'zod'
+import { Check, Copy, Folder, Pencil, Plus, Search, Shield, Trash2, Users, X } from 'lucide-react'
+import { ApiError } from '@/api/client'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import {
@@ -153,7 +167,7 @@ export function RolesPage() {
 
       <div style={{ flex: 1, overflowY: 'auto', background: 'var(--bg-app)' }}>
         {selected ? (
-          <RoleDetail role={selected} permissions={permissions} users={users} onSelect={setSelectedId} />
+          <RoleDetail role={selected} roles={roles} permissions={permissions} users={users} onSelect={setSelectedId} />
         ) : (
           <div style={{ padding: 40, color: 'var(--fg-3)' }}>
             No role selected.{' '}
@@ -261,11 +275,13 @@ function RoleRow({
 
 function RoleDetail({
   role,
+  roles,
   permissions,
   users,
   onSelect,
 }: {
   role: Role
+  roles: Role[]
   permissions: Permission[]
   users: RbacUser[]
   onSelect: (id: string | null) => void
@@ -275,8 +291,7 @@ function RoleDetail({
   const createRole = useCreateRole()
   const setUserRoles = useSetUserRoles()
   const [tab, setTab] = useState<'permissions' | 'members'>('permissions')
-  const [editingName, setEditingName] = useState(false)
-  const [editingDesc, setEditingDesc] = useState(false)
+  const [editingDetails, setEditingDetails] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
 
   const accent = colorFor(role.name)
@@ -324,44 +339,10 @@ function RoleDetail({
             <Shield size={20} color={accent} strokeWidth={1.75} />
           </div>
           <div style={{ flex: 1, minWidth: 0 }}>
-            {editingName ? (
-              <Input
-                autoFocus
-                defaultValue={role.name}
-                onBlur={(e) => {
-                  updateRole.mutate({ id: role.id, patch: { name: e.target.value.trim() || role.name } })
-                  setEditingName(false)
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
-                  if (e.key === 'Escape') {
-                    ;(e.target as HTMLInputElement).value = role.name
-                    ;(e.target as HTMLInputElement).blur()
-                  }
-                }}
-                style={{ fontSize: 22, fontWeight: 700, height: 38, maxWidth: 420 }}
-              />
-            ) : (
-              <h1 onClick={() => setEditingName(true)} className="rbac-inline-edit" style={titleStyle}>
-                {role.name}
-              </h1>
-            )}
-            {editingDesc ? (
-              <Textarea
-                autoFocus
-                defaultValue={role.description || ''}
-                onBlur={(e) => {
-                  updateRole.mutate({ id: role.id, patch: { description: e.target.value.trim() } })
-                  setEditingDesc(false)
-                }}
-                placeholder="Describe what this role can do…"
-                style={{ maxWidth: 640, minHeight: 50, fontSize: 13 }}
-              />
-            ) : (
-              <div onClick={() => setEditingDesc(true)} className="rbac-inline-edit" style={descStyle(!!role.description)}>
-                {role.description || 'No description — click to add one'}
-              </div>
-            )}
+            <h1 style={titleStyle}>{role.name}</h1>
+            <div style={descStyle(!!role.description)}>
+              {role.description || 'No description'}
+            </div>
             <div style={{ display: 'flex', gap: 24, marginTop: 14, flexWrap: 'wrap' }}>
               <Stat label="Users" value={members.length} />
               <Stat label="Permissions" value={`${role.permission_ids.length} / ${permissions.length}`} />
@@ -371,6 +352,9 @@ function RoleDetail({
             </div>
           </div>
           <div style={{ display: 'flex', gap: 8 }}>
+            <Button variant="outline" size="sm" onClick={() => setEditingDetails(true)}>
+              <Pencil size={14} /> Edit
+            </Button>
             <Button
               variant="outline"
               size="sm"
@@ -447,7 +431,129 @@ function RoleDetail({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {editingDetails && (
+        <EditRoleModal
+          role={role}
+          existingNames={roles.filter((r) => r.id !== role.id).map((r) => r.name)}
+          onClose={() => setEditingDetails(false)}
+          onSubmit={async (values) => {
+            await updateRole.mutateAsync({
+              id: role.id,
+              patch: { name: values.name, description: values.description ?? '' },
+            })
+            setEditingDetails(false)
+          }}
+        />
+      )}
     </div>
+  )
+}
+
+function buildRoleEditSchema(existingNames: string[]) {
+  const taken = new Set(existingNames.map((n) => n.toLowerCase()))
+  return z.object({
+    name: z
+      .string()
+      .trim()
+      .min(1, { message: 'Name is required.' })
+      .max(255, { message: 'Name must be 255 characters or fewer.' })
+      .refine((v) => !taken.has(v.toLowerCase()), {
+        message: 'A role with this name already exists.',
+      }),
+    description: z
+      .string()
+      .trim()
+      .max(1024, { message: 'Description must be 1024 characters or fewer.' })
+      .optional(),
+  })
+}
+
+type RoleEditValues = z.infer<ReturnType<typeof buildRoleEditSchema>>
+
+function EditRoleModal({
+  role,
+  existingNames,
+  onClose,
+  onSubmit,
+}: {
+  role: Role
+  existingNames: string[]
+  onClose: () => void
+  onSubmit: (values: { name: string; description: string }) => Promise<void>
+}) {
+  const schema = useMemo(() => buildRoleEditSchema(existingNames), [existingNames])
+  const form = useForm<RoleEditValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { name: role.name, description: role.description ?? '' },
+    mode: 'onChange',
+  })
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    try {
+      await onSubmit({ name: values.name, description: values.description ?? '' })
+    } catch (err) {
+      if (err instanceof ApiError && (err.status === 409 || err.status === 422)) {
+        form.setError('name', {
+          type: 'server',
+          message: err.detail ?? 'Server rejected this name.',
+        })
+        return
+      }
+      toast.error("Couldn't update the role", {
+        description: err instanceof Error ? err.message : String(err),
+      })
+    }
+  })
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-h-[calc(100vh-2rem)] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Edit role</DialogTitle>
+          <DialogDescription>Rename this role or update its description.</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={handleSubmit} noValidate>
+            <div style={{ display: 'grid', gap: 16 }}>
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input autoFocus {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Textarea style={{ minHeight: 80 }} {...field} value={field.value ?? ''} />
+                    </FormControl>
+                    <FormDescription>What does this role let people do?</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <DialogFooter style={{ marginTop: 16 }}>
+              <Button type="button" variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button type="submit">Save changes</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   )
 }
 
@@ -792,9 +898,6 @@ const titleStyle: CSSProperties = {
   margin: '0 0 4px',
   cursor: 'text',
   display: 'inline-block',
-  padding: '2px 6px',
-  marginLeft: -6,
-  borderRadius: 6,
 }
 
 function descStyle(hasDescription: boolean): CSSProperties {
@@ -803,11 +906,8 @@ function descStyle(hasDescription: boolean): CSSProperties {
     color: hasDescription ? 'var(--fg-3)' : 'var(--fg-muted)',
     fontStyle: hasDescription ? 'normal' : 'italic',
     maxWidth: 640,
-    cursor: 'text',
-    padding: '4px 6px',
-    marginLeft: -6,
-    borderRadius: 6,
     lineHeight: 1.5,
+    marginTop: 4,
   }
 }
 

--- a/web-client/src/components/rbac/roles-page.tsx
+++ b/web-client/src/components/rbac/roles-page.tsx
@@ -57,8 +57,10 @@ export function RolesPage() {
   const { data: permissions = [] } = usePermissions()
   const { data: users = [] } = useRbacUsers()
   const createRole = useCreateRole()
+  const updateRole = useUpdateRole()
   const [search, setSearch] = useState('')
   const [creating, setCreating] = useState(false)
+  const [editing, setEditing] = useState<Role | null>(null)
   const [selectedId, setSelectedId] = useState<string | null>(null)
 
   const memberCounts = useMemo(() => {
@@ -167,7 +169,7 @@ export function RolesPage() {
 
       <div style={{ flex: 1, overflowY: 'auto', background: 'var(--bg-app)' }}>
         {selected ? (
-          <RoleDetail role={selected} roles={roles} permissions={permissions} users={users} onSelect={setSelectedId} />
+          <RoleDetail role={selected} permissions={permissions} users={users} onSelect={setSelectedId} onEdit={setEditing} />
         ) : (
           <div style={{ padding: 40, color: 'var(--fg-3)' }}>
             No role selected.{' '}
@@ -190,6 +192,20 @@ export function RolesPage() {
             })
             setSelectedId(created.id)
             setCreating(false)
+          }}
+        />
+      )}
+      {editing && (
+        <EditRoleModal
+          role={editing}
+          existingNames={roles.filter((r) => r.id !== editing.id).map((r) => r.name)}
+          onClose={() => setEditing(null)}
+          onSubmit={async (values) => {
+            await updateRole.mutateAsync({
+              id: editing.id,
+              patch: { name: values.name, description: values.description ?? '' },
+            })
+            setEditing(null)
           }}
         />
       )}
@@ -275,23 +291,22 @@ function RoleRow({
 
 function RoleDetail({
   role,
-  roles,
   permissions,
   users,
   onSelect,
+  onEdit,
 }: {
   role: Role
-  roles: Role[]
   permissions: Permission[]
   users: RbacUser[]
   onSelect: (id: string | null) => void
+  onEdit: (role: Role) => void
 }) {
   const updateRole = useUpdateRole()
   const deleteRole = useDeleteRole()
   const createRole = useCreateRole()
   const setUserRoles = useSetUserRoles()
   const [tab, setTab] = useState<'permissions' | 'members'>('permissions')
-  const [editingDetails, setEditingDetails] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
 
   const accent = colorFor(role.name)
@@ -352,7 +367,7 @@ function RoleDetail({
             </div>
           </div>
           <div style={{ display: 'flex', gap: 8 }}>
-            <Button variant="outline" size="sm" onClick={() => setEditingDetails(true)}>
+            <Button variant="outline" size="sm" onClick={() => onEdit(role)}>
               <Pencil size={14} /> Edit
             </Button>
             <Button
@@ -432,20 +447,6 @@ function RoleDetail({
         </AlertDialogContent>
       </AlertDialog>
 
-      {editingDetails && (
-        <EditRoleModal
-          role={role}
-          existingNames={roles.filter((r) => r.id !== role.id).map((r) => r.name)}
-          onClose={() => setEditingDetails(false)}
-          onSubmit={async (values) => {
-            await updateRole.mutateAsync({
-              id: role.id,
-              patch: { name: values.name, description: values.description ?? '' },
-            })
-            setEditingDetails(false)
-          }}
-        />
-      )}
     </div>
   )
 }
@@ -896,8 +897,6 @@ const titleStyle: CSSProperties = {
   fontWeight: 700,
   color: 'var(--fg-1)',
   margin: '0 0 4px',
-  cursor: 'text',
-  display: 'inline-block',
 }
 
 function descStyle(hasDescription: boolean): CSSProperties {

--- a/web-client/src/components/rbac/users-page.tsx
+++ b/web-client/src/components/rbac/users-page.tsx
@@ -577,7 +577,10 @@ function AddUserModal({
   const [username, setUsername] = useState('')
   const trimmed = username.trim()
   const taken = existingUsernames.some((u) => u.toLowerCase() === trimmed.toLowerCase())
-  const validShape = /^[a-z0-9._-]{2,}$/i.test(trimmed)
+  // Match the settings-page rule: separators allowed in the middle but not
+  // at the ends, length 2+. Settings.tsx is the canonical source.
+  const validShape =
+    /^[a-z0-9._-]{2,}$/i.test(trimmed) && !/^[._-]|[._-]$/.test(trimmed)
   const valid = trimmed && validShape && !taken
   const { hint, hintTone } = validateUsername({ trimmed, taken, validShape })
 

--- a/web-client/src/lib/permissions.ts
+++ b/web-client/src/lib/permissions.ts
@@ -1,0 +1,11 @@
+/**
+ * Server-defined permission names. Mirror api/scripts/seed_rbac.py — typos
+ * silently fail-open since both producer (FastAPI) and consumer (nav gating)
+ * compare on the string. Keep this enum the source of truth client-side.
+ */
+export const PERM = {
+  ADMIN_VIEW: 'administration.view',
+  AUTH_MANAGE: 'authorization.manage',
+} as const
+
+export type PermissionName = (typeof PERM)[keyof typeof PERM]


### PR DESCRIPTION
## Summary

- **Server authz:** every `app.rbac` endpoint is now gated on `authorization.manage` via a router-level `require_permission` dep. `DELETE /v1/users/{id}` refuses self-deletion. Name uniqueness is case-insensitive across roles, permissions, and usernames; `PATCH /v1/roles` with `permission_ids: null` is now a no-op (`[]` still clears). Permission/role ID arrays come back sorted by name.
- **Frontend nav:** the side-nav's Administration entry hides without `administration.view`, its Roles/Permissions/Users children hide without `authorization.manage`, and when only "Overview" survives the parent renders as a flat link instead of an expandable group. 403s get a distinct "no access" panel rather than the generic error fallback.
- **Role edit UX:** inline name/description editing replaced with an Edit dialog that surfaces 409/422s inline per `web-client/CLAUDE.md`. `useUpdateRole` and `useSetUserRoles` are optimistic so toggles flip instantly and concurrent revokes don't race on stale cache.
- **Seed + deploy wiring:** `seed_rbac.py` rewritten to just the new bootstrap (`administration.view`, `authorization.manage`, `Administrator` role), idempotent, and chained into the dev compose api command between `alembic upgrade head` and `uvicorn`. **UAT compose lives in a sibling worktree and needs the same one-line `&& python scripts/seed_rbac.py` insertion to get auto-seed on its boot.**

## Test plan

- [x] `cd api && pytest` — 129 passed (new authz parametrize + collision/regression suites)
- [x] `cd web-client && npm run test:run` — 17 passed
- [x] `cd web-client && npm run lint && npm run build` — clean
- [x] `cd web-client && PLAYWRIGHT_PORT=5187 npm run test:e2e` — 121 passed (new `nav-gating.spec.ts` covers four permission scenarios)
- [x] `mise run regen-api-types` — committed (schema picked up new session-cookie/401 declarations)
- [ ] Manual: visit `/dashboard` and `/admin` as `tim.nguyen` (Owner — has both perms via ALL), `ada.lovelace` (Administrator — same), an `administration.view`-only user, and a no-perm user
- [ ] Manual: deploy to UAT, confirm seed runs at boot (`docker compose -p fortymm-uat logs api | grep "Seed complete"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)