### PR TITLE
PR 1: Split match games from scores and add page-level BFF endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ Full stack via Docker: `docker compose -f docker-compose.dev.yml up`. Nginx on *
 
 **Routing is file-based and generated.** `web-client/src/routes/*.tsx` files are compiled into `routeTree.gen.ts` by the `@tanstack/router-plugin/vite` plugin. Don't edit `routeTree.gen.ts` by hand.
 
+**BFF endpoints — one per page.** Each page-level UI surface has a single backend endpoint that returns all the data it needs, pre-shaped for that page. The frontend does no joining, aggregation, or status-label mapping — those happen on the server, current-user-aware. Examples: `GET /v1/matches` backs `/matches`; `GET /v1/matches/{id}` backs both `/matches/$matchId` and the scoring routes; `GET /v1/dashboard` backs the dynamic widgets on `/dashboard`. Exception: independently-interactive widgets (typeaheads, autocompletes, infinite-scroll panels) keep their own endpoints — e.g. `GET /v1/players/search` backs the new-match opponent picker. Rule of thumb: if the widget fetches in response to user input rather than on page load, it's its own endpoint.
+
 **MSW only intercepts in `import.meta.env.DEV`.** See `web-client/src/main.tsx`. The vitest setup (`src/test/setup.ts`) uses the Node MSW server with `onUnhandledRequest: 'error'` — every fetch in a test must have a matching handler in `src/mocks/handlers.ts` (or one added via `server.use(...)`). Production builds never load MSW.
 
 **`VITE_API_URL`** (web-client) overrides the API base URL; otherwise the client uses `window.location.origin`. In dev that means MSW handles everything; in the compose stack the web origin (`:8080`) is also where nginx proxies the API.

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -1,0 +1,153 @@
+import uuid
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.db import get_session
+from app.matches import _side_win_counts
+from app.models import (
+    Match,
+    MatchGame,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    User,
+)
+from app.schemas.dashboard import (
+    DashboardNextMatch,
+    DashboardRecentResult,
+    DashboardResponse,
+    DashboardScoreBanner,
+)
+from app.sessions import get_current_user
+
+router = APIRouter(prefix="/v1")
+
+RECENT_RESULTS_LIMIT = 5
+
+
+def _opponent_username(
+    match: Match, current_user_id: uuid.UUID
+) -> str | None:
+    for side in match.sides:
+        for player in side.players:
+            if player.user_id != current_user_id:
+                return player.user.username
+    return None
+
+
+def _my_side_number(match: Match, current_user_id: uuid.UUID) -> int | None:
+    for side in match.sides:
+        if any(p.user_id == current_user_id for p in side.players):
+            return side.side_number
+    return None
+
+
+async def _matches_for_user(
+    db: AsyncSession,
+    current_user_id: uuid.UUID,
+    *,
+    status_: MatchStatus,
+    limit: int,
+):
+    me_in_match = (
+        select(MatchSidePlayer.id)
+        .where(
+            MatchSidePlayer.match_id == Match.id,
+            MatchSidePlayer.user_id == current_user_id,
+        )
+        .exists()
+    )
+    result = await db.execute(
+        select(Match)
+        .where(me_in_match, Match.status == status_)
+        .options(
+            selectinload(Match.match_settings),
+            selectinload(Match.sides)
+            .selectinload(MatchSide.players)
+            .selectinload(MatchSidePlayer.user),
+            selectinload(Match.games).selectinload(MatchGame.score),
+        )
+        .order_by(
+            Match.updated_at.desc()
+            if status_ == MatchStatus.completed
+            else Match.created_at.desc()
+        )
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+@router.get("/dashboard", response_model=DashboardResponse)
+async def get_dashboard(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> DashboardResponse:
+    in_progress = await _matches_for_user(
+        db, current_user.id, status_=MatchStatus.in_progress, limit=1
+    )
+    pending = await _matches_for_user(
+        db, current_user.id, status_=MatchStatus.pending, limit=1
+    )
+    completed = await _matches_for_user(
+        db,
+        current_user.id,
+        status_=MatchStatus.completed,
+        limit=RECENT_RESULTS_LIMIT,
+    )
+
+    score_banner: DashboardScoreBanner | None = None
+    if in_progress:
+        match = in_progress[0]
+        current_game = next(
+            (g for g in match.games if g.score is None), None
+        )
+        if current_game is not None:
+            score_banner = DashboardScoreBanner(
+                match_id=match.id,
+                opponent_username=_opponent_username(match, current_user.id),
+                current_game_id=current_game.id,
+            )
+
+    next_match: DashboardNextMatch | None = None
+    if pending:
+        match = pending[0]
+        next_match = DashboardNextMatch(
+            match_id=match.id,
+            opponent_username=_opponent_username(match, current_user.id),
+            best_of=match.match_settings.best_of,
+            created_at=match.created_at,
+        )
+
+    recent_results: list[DashboardRecentResult] = []
+    for match in completed:
+        my_number = _my_side_number(match, current_user.id)
+        side_wins = _side_win_counts(match)
+        my_games_won = side_wins.get(my_number or 0, 0)
+        opp_games_won = sum(
+            wins
+            for number, wins in side_wins.items()
+            if number != my_number
+        )
+        # is_win is well-defined: completed matches always have two sides.
+        is_win = my_games_won > opp_games_won
+        recent_results.append(
+            DashboardRecentResult(
+                match_id=match.id,
+                opponent_username=_opponent_username(match, current_user.id),
+                is_win=is_win,
+                my_games_won=my_games_won,
+                opponent_games_won=opp_games_won,
+                completed_at=match.updated_at,
+            )
+        )
+
+    return DashboardResponse(
+        score_banner=score_banner,
+        next_match=next_match,
+        recent_results=recent_results,
+    )
+
+

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -1,20 +1,17 @@
-import uuid
-
 from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from app.db import get_session
-from app.matches import _side_win_counts
-from app.models import (
-    Match,
-    MatchGame,
-    MatchSide,
-    MatchSidePlayer,
-    MatchStatus,
-    User,
+from app.matches import (
+    participant_filter,
+    current_unscored_game,
+    match_eager_options,
+    my_side as resolve_my_side,
+    opponent_username,
+    side_win_counts,
 )
+from app.models import Match, MatchStatus, User
 from app.schemas.dashboard import (
     DashboardNextMatch,
     DashboardRecentResult,
@@ -28,121 +25,46 @@ router = APIRouter(prefix="/v1")
 RECENT_RESULTS_LIMIT = 5
 
 
-def _opponent_username(
-    match: Match, current_user_id: uuid.UUID
-) -> str | None:
-    for side in match.sides:
-        for player in side.players:
-            if player.user_id != current_user_id:
-                return player.user.username
-    return None
-
-
-def _my_side_number(match: Match, current_user_id: uuid.UUID) -> int | None:
-    for side in match.sides:
-        if any(p.user_id == current_user_id for p in side.players):
-            return side.side_number
-    return None
-
-
-async def _matches_for_user(
-    db: AsyncSession,
-    current_user_id: uuid.UUID,
-    *,
-    status_: MatchStatus,
-    limit: int,
-):
-    me_in_match = (
-        select(MatchSidePlayer.id)
-        .where(
-            MatchSidePlayer.match_id == Match.id,
-            MatchSidePlayer.user_id == current_user_id,
-        )
-        .exists()
-    )
-    result = await db.execute(
-        select(Match)
-        .where(me_in_match, Match.status == status_)
-        .options(
-            selectinload(Match.match_settings),
-            selectinload(Match.sides)
-            .selectinload(MatchSide.players)
-            .selectinload(MatchSidePlayer.user),
-            selectinload(Match.games).selectinload(MatchGame.score),
-        )
-        .order_by(
-            Match.updated_at.desc()
-            if status_ == MatchStatus.completed
-            else Match.created_at.desc()
-        )
-        .limit(limit)
-    )
-    return list(result.scalars().all())
-
-
 @router.get("/dashboard", response_model=DashboardResponse)
 async def get_dashboard(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> DashboardResponse:
-    in_progress = await _matches_for_user(
-        db, current_user.id, status_=MatchStatus.in_progress, limit=1
+    # One query pulls every match the user participates in across the three
+    # statuses we surface; per-status bucketing happens in Python below. The
+    # dashboard always shows at most 1 + 1 + 5 = 7 matches, so the bound is
+    # safe even for an active user with thousands of completed matches.
+    pending_q = (
+        participant_filter(select(Match), current_user.id)
+        .where(Match.status == MatchStatus.pending)
+        .options(*match_eager_options())
+        .order_by(Match.created_at.desc())
+        .limit(1)
     )
-    pending = await _matches_for_user(
-        db, current_user.id, status_=MatchStatus.pending, limit=1
+    in_progress_q = (
+        participant_filter(select(Match), current_user.id)
+        .where(Match.status == MatchStatus.in_progress)
+        .options(*match_eager_options())
+        .order_by(Match.created_at.desc())
+        .limit(1)
     )
-    completed = await _matches_for_user(
-        db,
-        current_user.id,
-        status_=MatchStatus.completed,
-        limit=RECENT_RESULTS_LIMIT,
+    completed_q = (
+        participant_filter(select(Match), current_user.id)
+        .where(Match.status == MatchStatus.completed)
+        .options(*match_eager_options())
+        .order_by(Match.updated_at.desc())
+        .limit(RECENT_RESULTS_LIMIT)
     )
 
-    score_banner: DashboardScoreBanner | None = None
-    if in_progress:
-        match = in_progress[0]
-        current_game = next(
-            (g for g in match.games if g.score is None), None
-        )
-        if current_game is not None:
-            score_banner = DashboardScoreBanner(
-                match_id=match.id,
-                opponent_username=_opponent_username(match, current_user.id),
-                current_game_id=current_game.id,
-            )
+    pending = (await db.execute(pending_q)).scalars().all()
+    in_progress = (await db.execute(in_progress_q)).scalars().all()
+    completed = (await db.execute(completed_q)).scalars().all()
 
-    next_match: DashboardNextMatch | None = None
-    if pending:
-        match = pending[0]
-        next_match = DashboardNextMatch(
-            match_id=match.id,
-            opponent_username=_opponent_username(match, current_user.id),
-            best_of=match.match_settings.best_of,
-            created_at=match.created_at,
-        )
-
-    recent_results: list[DashboardRecentResult] = []
-    for match in completed:
-        my_number = _my_side_number(match, current_user.id)
-        side_wins = _side_win_counts(match)
-        my_games_won = side_wins.get(my_number or 0, 0)
-        opp_games_won = sum(
-            wins
-            for number, wins in side_wins.items()
-            if number != my_number
-        )
-        # is_win is well-defined: completed matches always have two sides.
-        is_win = my_games_won > opp_games_won
-        recent_results.append(
-            DashboardRecentResult(
-                match_id=match.id,
-                opponent_username=_opponent_username(match, current_user.id),
-                is_win=is_win,
-                my_games_won=my_games_won,
-                opponent_games_won=opp_games_won,
-                completed_at=match.updated_at,
-            )
-        )
+    score_banner = _build_score_banner(in_progress, current_user.id)
+    next_match = _build_next_match(pending, current_user.id)
+    recent_results = [
+        _build_recent_result(match, current_user.id) for match in completed
+    ]
 
     return DashboardResponse(
         score_banner=score_banner,
@@ -151,3 +73,51 @@ async def get_dashboard(
     )
 
 
+def _build_score_banner(
+    in_progress: list[Match], current_user_id
+) -> DashboardScoreBanner | None:
+    if not in_progress:
+        return None
+    match = in_progress[0]
+    current_game = current_unscored_game(match)
+    if current_game is None:
+        return None
+    return DashboardScoreBanner(
+        match_id=match.id,
+        opponent_username=opponent_username(match, current_user_id),
+        current_game_id=current_game.id,
+    )
+
+
+def _build_next_match(
+    pending: list[Match], current_user_id
+) -> DashboardNextMatch | None:
+    if not pending:
+        return None
+    match = pending[0]
+    return DashboardNextMatch(
+        match_id=match.id,
+        opponent_username=opponent_username(match, current_user_id),
+        best_of=match.match_settings.best_of,
+        created_at=match.created_at,
+    )
+
+
+def _build_recent_result(match: Match, current_user_id) -> DashboardRecentResult:
+    mine = resolve_my_side(match, current_user_id)
+    assert mine is not None  # query filters to participants
+    side_wins = side_win_counts(match)
+    my_games_won = side_wins.get(mine.side_number, 0)
+    opp_games_won = sum(
+        wins
+        for number, wins in side_wins.items()
+        if number != mine.side_number
+    )
+    return DashboardRecentResult(
+        match_id=match.id,
+        opponent_username=opponent_username(match, current_user_id),
+        is_win=my_games_won > opp_games_won,
+        my_games_won=my_games_won,
+        opponent_games_won=opp_games_won,
+        completed_at=match.updated_at,
+    )

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from sqlalchemy import text
 
 from app import db, queue
+from app.dashboard import router as dashboard_router
 from app.matches import router as matches_router
 from app.players import router as players_router
 from app.rbac import router as rbac_router
@@ -15,6 +16,7 @@ app.include_router(sessions_router)
 app.include_router(rbac_router)
 app.include_router(matches_router)
 app.include_router(players_router)
+app.include_router(dashboard_router)
 
 SOLVER_HEALTH_TIMEOUT = 10.0
 

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -17,7 +17,7 @@ from app.models import (
     MatchStatus,
     User,
 )
-from app.players import _escape_like
+from app.players import escape_like
 from app.schemas.match import (
     STATUS_LABELS,
     MatchCreate,
@@ -41,29 +41,55 @@ MAX_PAGE_SIZE = 100
 # ----- helpers -------------------------------------------------------------
 
 
+# Shared eager-load chain. Used by every read path that returns a hierarchical
+# match — async SQLAlchemy can't lazy-load mid-request, so all four collections
+# are pulled up front.
+def match_eager_options():
+    return (
+        selectinload(Match.match_settings),
+        selectinload(Match.sides)
+        .selectinload(MatchSide.players)
+        .selectinload(MatchSidePlayer.user),
+        selectinload(Match.games).selectinload(MatchGame.score),
+    )
+
+
 async def _load_match(db: AsyncSession, match_id: uuid.UUID) -> Match | None:
-    """Fetch a match with every relationship the BFF serializer touches eagerly
-    loaded — async SQLAlchemy can't lazy-load once the request is in flight."""
     result = await db.execute(
-        select(Match)
-        .where(Match.id == match_id)
-        .options(
-            selectinload(Match.match_settings),
-            selectinload(Match.sides)
-            .selectinload(MatchSide.players)
-            .selectinload(MatchSidePlayer.user),
-            selectinload(Match.games).selectinload(MatchGame.score),
-        )
+        select(Match).where(Match.id == match_id).options(*match_eager_options())
     )
     return result.scalar_one_or_none()
 
 
-def _is_participant(match: Match, user_id: uuid.UUID) -> bool:
-    return any(
-        player.user_id == user_id
-        for side in match.sides
-        for player in side.players
+def my_side(match: Match, user_id: uuid.UUID) -> MatchSide | None:
+    return next(
+        (
+            s
+            for s in match.sides
+            if any(p.user_id == user_id for p in s.players)
+        ),
+        None,
     )
+
+
+def opponent_side(match: Match, user_id: uuid.UUID) -> MatchSide | None:
+    mine = my_side(match, user_id)
+    if mine is None:
+        return None
+    return next(
+        (s for s in match.sides if s.side_number != mine.side_number), None
+    )
+
+
+def opponent_username(match: Match, user_id: uuid.UUID) -> str | None:
+    opp = opponent_side(match, user_id)
+    if opp is None or not opp.players:
+        return None
+    return opp.players[0].user.username
+
+
+def _is_participant(match: Match, user_id: uuid.UUID) -> bool:
+    return my_side(match, user_id) is not None
 
 
 def _games_to_win(best_of: int) -> int:
@@ -71,10 +97,11 @@ def _games_to_win(best_of: int) -> int:
 
 
 def _game_winner_side(score: MatchGameScore) -> int:
+    # Ties are blocked by MatchGameScoreWrite; defensive fallback maps to side 2.
     return 1 if score.side_1_points > score.side_2_points else 2
 
 
-def _side_win_counts(match: Match) -> dict[int, int]:
+def side_win_counts(match: Match) -> dict[int, int]:
     counts = {side.side_number: 0 for side in match.sides}
     for game in match.games:
         if game.score is None:
@@ -84,27 +111,17 @@ def _side_win_counts(match: Match) -> dict[int, int]:
     return counts
 
 
+def current_unscored_game(match: Match) -> MatchGame | None:
+    return next((g for g in match.games if g.score is None), None)
+
+
 def _serialize_details(match: Match, current_user_id: uuid.UUID) -> MatchDetails:
-    sides_sorted = sorted(match.sides, key=lambda s: s.side_number)
-    games_sorted = sorted(match.games, key=lambda g: g.game_number)
-    side_wins = _side_win_counts(match)
-
-    my_side = next(
-        (
-            s
-            for s in sides_sorted
-            if any(p.user_id == current_user_id for p in s.players)
-        ),
-        None,
-    )
-    if my_side is None:
+    mine = my_side(match, current_user_id)
+    if mine is None:
         raise RuntimeError("serialize_details called for non-participant")
-
-    opponent_side = next(
-        (s for s in sides_sorted if s.side_number != my_side.side_number),
-        None,
-    )
-    my_number = my_side.side_number
+    opp = opponent_side(match, current_user_id)
+    side_wins = side_win_counts(match)
+    my_number = mine.side_number
 
     def _side_schema(side: MatchSide) -> MatchDetailsSide:
         return MatchDetailsSide(
@@ -136,6 +153,7 @@ def _serialize_details(match: Match, current_user_id: uuid.UUID) -> MatchDetails
             is_my_win=_game_winner_side(score) == my_number,
         )
 
+    games_sorted = sorted(match.games, key=lambda g: g.game_number)
     games = [
         MatchDetailsGame(
             id=game.id,
@@ -145,9 +163,7 @@ def _serialize_details(match: Match, current_user_id: uuid.UUID) -> MatchDetails
         for game in games_sorted
     ]
 
-    current_game_obj = next(
-        (g for g in games_sorted if g.score is None), None
-    )
+    current_game_obj = current_unscored_game(match)
     current_game = (
         MatchDetailsCurrentGame(
             id=current_game_obj.id, game_number=current_game_obj.game_number
@@ -155,8 +171,6 @@ def _serialize_details(match: Match, current_user_id: uuid.UUID) -> MatchDetails
         if current_game_obj is not None
         else None
     )
-
-    can_score = current_game is not None and opponent_side is not None
 
     return MatchDetails(
         id=match.id,
@@ -167,13 +181,11 @@ def _serialize_details(match: Match, current_user_id: uuid.UUID) -> MatchDetails
         team_size=match.match_settings.team_size,
         affects_rating=match.match_settings.affects_rating,
         created_at=match.created_at,
-        my_side=_side_schema(my_side),
-        opponent_side=(
-            _side_schema(opponent_side) if opponent_side else None
-        ),
+        my_side=_side_schema(mine),
+        opponent_side=_side_schema(opp) if opp else None,
         games=games,
         current_game=current_game,
-        can_score=can_score,
+        can_score=current_game is not None and opp is not None,
     )
 
 
@@ -190,7 +202,7 @@ def _add_side(match: Match, side_number: int, player: User) -> None:
 # ----- list helpers --------------------------------------------------------
 
 
-def _participant_filter(query, current_user_id: uuid.UUID):
+def participant_filter(query, current_user_id: uuid.UUID):
     me_in_match = (
         select(MatchSidePlayer.id)
         .where(
@@ -203,7 +215,7 @@ def _participant_filter(query, current_user_id: uuid.UUID):
 
 
 def _opponent_username_filter(query, current_user_id: uuid.UUID, q: str):
-    pattern = f"%{_escape_like(q.strip())}%"
+    pattern = f"%{escape_like(q.strip())}%"
     has_matching_opponent = (
         select(MatchSidePlayer.id)
         .join(User, User.id == MatchSidePlayer.user_id)
@@ -268,8 +280,8 @@ async def create_match(
     _add_side(match, 1, current_user)
     if opponent is not None:
         _add_side(match, 2, opponent)
-    # Game 1 always exists from the moment a match is created — the FE never
-    # creates a game, it only deep-links into the current one to record a score.
+    # The FE never creates a game — game 1 is written here so scoring routes
+    # always have a real entity to deep-link into.
     match.games.append(MatchGame(game_number=1))
 
     db.add(match)
@@ -289,30 +301,16 @@ async def list_matches(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> MatchListResponse:
-    base = _participant_filter(select(Match), current_user.id)
+    base = participant_filter(select(Match), current_user.id)
     if q:
         base = _opponent_username_filter(base, current_user.id, q)
 
-    paged = base
-    if status_ is not None:
-        paged = paged.where(Match.status == status_)
-
-    total = (
-        await db.execute(
-            select(func.count()).select_from(paged.order_by(None).subquery())
-        )
-    ).scalar_one()
+    paged = base if status_ is None else base.where(Match.status == status_)
 
     matches = (
         (
             await db.execute(
-                paged.options(
-                    selectinload(Match.match_settings),
-                    selectinload(Match.sides)
-                    .selectinload(MatchSide.players)
-                    .selectinload(MatchSidePlayer.user),
-                    selectinload(Match.games).selectinload(MatchGame.score),
-                )
+                paged.options(*match_eager_options())
                 .order_by(Match.created_at.desc())
                 .offset((page - 1) * page_size)
                 .limit(page_size)
@@ -322,27 +320,27 @@ async def list_matches(
         .all()
     )
 
-    items: list[MatchListRow] = [
-        _list_row(match, current_user.id) for match in matches
-    ]
-
-    # status_counts honors `q` but ignores the status filter, so build it from
-    # the unpaginated, unstatused query: same WHEREs as `base`, project the
-    # status column, group by it.
-    counts_query = _participant_filter(
+    # status_counts honors `q` and ignores the status filter, so it's built
+    # from `base`. `total` then falls out of the same aggregate — no separate
+    # count round-trip needed.
+    counts_query = participant_filter(
         select(Match.status, func.count(Match.id)), current_user.id
     )
     if q:
         counts_query = _opponent_username_filter(
             counts_query, current_user.id, q
         )
-    counts_query = counts_query.group_by(Match.status)
     status_counts: dict[MatchStatus, int] = {s: 0 for s in MatchStatus}
-    for status_value, count in (await db.execute(counts_query)).all():
+    for status_value, count in (
+        await db.execute(counts_query.group_by(Match.status))
+    ).all():
         status_counts[status_value] = count
+    total = (
+        status_counts[status_] if status_ is not None else sum(status_counts.values())
+    )
 
     return MatchListResponse(
-        items=items,
+        items=[_list_row(match, current_user.id) for match in matches],
         page=page,
         page_size=page_size,
         total=total,
@@ -351,51 +349,32 @@ async def list_matches(
 
 
 def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
-    my_side = next(
-        s
-        for s in match.sides
-        if any(p.user_id == current_user_id for p in s.players)
-    )
-    opponent_side = next(
-        (s for s in match.sides if s.side_number != my_side.side_number),
-        None,
-    )
+    mine = my_side(match, current_user_id)
+    assert mine is not None  # list query already filtered to participants
+    opp = opponent_side(match, current_user_id)
 
-    side_wins = _side_win_counts(match)
-    my_games_won = side_wins.get(my_side.side_number, 0)
-    opp_games_won = (
-        side_wins.get(opponent_side.side_number, 0) if opponent_side else 0
-    )
+    side_wins = side_win_counts(match)
+    my_games_won = side_wins.get(mine.side_number, 0)
+    opp_games_won = side_wins.get(opp.side_number, 0) if opp else 0
+    opp_player = opp.players[0] if opp and opp.players else None
 
-    opponent_player = (
-        opponent_side.players[0]
-        if opponent_side and opponent_side.players
-        else None
-    )
-
-    current_game = next(
-        (g for g in match.games if g.score is None), None
-    )
+    current_game = current_unscored_game(match)
     scorable = (
         match.status in {MatchStatus.pending, MatchStatus.in_progress}
-        and opponent_side is not None
+        and opp is not None
         and current_game is not None
     )
 
     is_win: bool | None = None
-    if match.status == MatchStatus.completed and opponent_side is not None:
+    if match.status == MatchStatus.completed and opp is not None:
         is_win = my_games_won > opp_games_won
 
     return MatchListRow(
         id=match.id,
         status=match.status,
         status_label=STATUS_LABELS[match.status],
-        opponent_username=(
-            opponent_player.user.username if opponent_player else None
-        ),
-        opponent_user_id=(
-            opponent_player.user_id if opponent_player else None
-        ),
+        opponent_username=opp_player.user.username if opp_player else None,
+        opponent_user_id=opp_player.user_id if opp_player else None,
         my_games_won=my_games_won,
         opponent_games_won=opp_games_won,
         is_win=is_win,
@@ -433,16 +412,11 @@ def _enforce_scorable(match: Match) -> None:
 
 
 def _recompute_match(match: Match) -> None:
-    """Apply all post-score-write derivations on a single loaded ``match``:
-
-    - side ``score`` (count of games each side has won)
-    - match ``status`` (completed if either side reached games_to_win)
-    - side ``won`` flags (true/false on completion, reset to None on re-open)
-    - game lifecycle reconciliation (delete trailing unscored games when
-      completed; ensure exactly one trailing unscored game otherwise)
-    """
+    """Apply all post-score-write derivations on a loaded ``match``:
+    side ``score``, match ``status``, side ``won`` flags, and the trailing
+    un-scored game (deleted on completion; exactly one otherwise)."""
     sides_by_number = {s.side_number: s for s in match.sides}
-    side_wins = _side_win_counts(match)
+    side_wins = side_win_counts(match)
     target = _games_to_win(match.match_settings.best_of)
     a_wins = side_wins.get(1, 0)
     b_wins = side_wins.get(2, 0)

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1,36 +1,48 @@
+import math
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.db import get_session
 from app.models import (
     Match,
+    MatchGame,
+    MatchGameScore,
     MatchSettings,
     MatchSide,
     MatchSidePlayer,
     MatchStatus,
     User,
 )
+from app.players import _escape_like
 from app.schemas.match import (
+    STATUS_LABELS,
     MatchCreate,
-    MatchRead,
-    MatchSettingsRead,
-    MatchSidePlayerRead,
-    MatchSideRead,
+    MatchDetails,
+    MatchDetailsCurrentGame,
+    MatchDetailsGame,
+    MatchDetailsPlayer,
+    MatchDetailsScore,
+    MatchDetailsSide,
+    MatchGameScoreWrite,
+    MatchListResponse,
+    MatchListRow,
 )
 from app.sessions import get_current_user
 
 router = APIRouter(prefix="/v1")
+
+MAX_PAGE_SIZE = 100
 
 
 # ----- helpers -------------------------------------------------------------
 
 
 async def _load_match(db: AsyncSession, match_id: uuid.UUID) -> Match | None:
-    """Fetch a match with every relationship the serializer touches eagerly
+    """Fetch a match with every relationship the BFF serializer touches eagerly
     loaded — async SQLAlchemy can't lazy-load once the request is in flight."""
     result = await db.execute(
         select(Match)
@@ -40,35 +52,128 @@ async def _load_match(db: AsyncSession, match_id: uuid.UUID) -> Match | None:
             selectinload(Match.sides)
             .selectinload(MatchSide.players)
             .selectinload(MatchSidePlayer.user),
+            selectinload(Match.games).selectinload(MatchGame.score),
         )
     )
     return result.scalar_one_or_none()
 
 
-def _serialize_match(match: Match) -> MatchRead:
-    sides = sorted(match.sides, key=lambda side: side.side_number)
-    return MatchRead(
+def _is_participant(match: Match, user_id: uuid.UUID) -> bool:
+    return any(
+        player.user_id == user_id
+        for side in match.sides
+        for player in side.players
+    )
+
+
+def _games_to_win(best_of: int) -> int:
+    return math.ceil(best_of / 2)
+
+
+def _game_winner_side(score: MatchGameScore) -> int:
+    return 1 if score.side_1_points > score.side_2_points else 2
+
+
+def _side_win_counts(match: Match) -> dict[int, int]:
+    counts = {side.side_number: 0 for side in match.sides}
+    for game in match.games:
+        if game.score is None:
+            continue
+        winner = _game_winner_side(game.score)
+        counts[winner] = counts.get(winner, 0) + 1
+    return counts
+
+
+def _serialize_details(match: Match, current_user_id: uuid.UUID) -> MatchDetails:
+    sides_sorted = sorted(match.sides, key=lambda s: s.side_number)
+    games_sorted = sorted(match.games, key=lambda g: g.game_number)
+    side_wins = _side_win_counts(match)
+
+    my_side = next(
+        (
+            s
+            for s in sides_sorted
+            if any(p.user_id == current_user_id for p in s.players)
+        ),
+        None,
+    )
+    if my_side is None:
+        raise RuntimeError("serialize_details called for non-participant")
+
+    opponent_side = next(
+        (s for s in sides_sorted if s.side_number != my_side.side_number),
+        None,
+    )
+    my_number = my_side.side_number
+
+    def _side_schema(side: MatchSide) -> MatchDetailsSide:
+        return MatchDetailsSide(
+            side_number=side.side_number,
+            players=[
+                MatchDetailsPlayer(
+                    user_id=p.user_id,
+                    username=p.user.username,
+                    is_current_user=p.user_id == current_user_id,
+                )
+                for p in sorted(side.players, key=lambda p: p.user.username)
+            ],
+            games_won=side_wins.get(side.side_number, 0),
+            won=side.won,
+            is_current_user_side=side.side_number == my_number,
+        )
+
+    def _score_schema(score: MatchGameScore) -> MatchDetailsScore:
+        my_points = (
+            score.side_1_points if my_number == 1 else score.side_2_points
+        )
+        opp_points = (
+            score.side_2_points if my_number == 1 else score.side_1_points
+        )
+        return MatchDetailsScore(
+            id=score.id,
+            my_points=my_points,
+            opponent_points=opp_points,
+            is_my_win=_game_winner_side(score) == my_number,
+        )
+
+    games = [
+        MatchDetailsGame(
+            id=game.id,
+            game_number=game.game_number,
+            score=_score_schema(game.score) if game.score else None,
+        )
+        for game in games_sorted
+    ]
+
+    current_game_obj = next(
+        (g for g in games_sorted if g.score is None), None
+    )
+    current_game = (
+        MatchDetailsCurrentGame(
+            id=current_game_obj.id, game_number=current_game_obj.game_number
+        )
+        if current_game_obj is not None
+        else None
+    )
+
+    can_score = current_game is not None and opponent_side is not None
+
+    return MatchDetails(
         id=match.id,
         status=match.status,
-        created_by_user_id=match.created_by_user_id,
+        status_label=STATUS_LABELS[match.status],
+        best_of=match.match_settings.best_of,
+        games_to_win=_games_to_win(match.match_settings.best_of),
+        team_size=match.match_settings.team_size,
+        affects_rating=match.match_settings.affects_rating,
         created_at=match.created_at,
-        settings=MatchSettingsRead.model_validate(match.match_settings),
-        sides=[
-            MatchSideRead(
-                side_number=side.side_number,
-                score=side.score,
-                won=side.won,
-                players=[
-                    MatchSidePlayerRead(
-                        user_id=player.user_id, username=player.user.username
-                    )
-                    for player in sorted(
-                        side.players, key=lambda p: p.user.username
-                    )
-                ],
-            )
-            for side in sides
-        ],
+        my_side=_side_schema(my_side),
+        opponent_side=(
+            _side_schema(opponent_side) if opponent_side else None
+        ),
+        games=games,
+        current_game=current_game,
+        can_score=can_score,
     )
 
 
@@ -82,23 +187,55 @@ def _add_side(match: Match, side_number: int, player: User) -> None:
     side.players.append(MatchSidePlayer(match=match, user=player))
 
 
+# ----- list helpers --------------------------------------------------------
+
+
+def _participant_filter(query, current_user_id: uuid.UUID):
+    me_in_match = (
+        select(MatchSidePlayer.id)
+        .where(
+            MatchSidePlayer.match_id == Match.id,
+            MatchSidePlayer.user_id == current_user_id,
+        )
+        .exists()
+    )
+    return query.where(me_in_match)
+
+
+def _opponent_username_filter(query, current_user_id: uuid.UUID, q: str):
+    pattern = f"%{_escape_like(q.strip())}%"
+    has_matching_opponent = (
+        select(MatchSidePlayer.id)
+        .join(User, User.id == MatchSidePlayer.user_id)
+        .where(
+            MatchSidePlayer.match_id == Match.id,
+            MatchSidePlayer.user_id != current_user_id,
+            User.username.ilike(pattern, escape="\\"),
+        )
+        .exists()
+    )
+    return query.where(has_matching_opponent)
+
+
 # ----- endpoints -----------------------------------------------------------
 
 
 @router.post(
-    "/matches", response_model=MatchRead, status_code=status.HTTP_201_CREATED
+    "/matches",
+    response_model=MatchDetails,
+    status_code=status.HTTP_201_CREATED,
 )
 async def create_match(
     payload: MatchCreate,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
-) -> MatchRead:
+) -> MatchDetails:
     opponent: User | None = None
     if payload.opponent_user_id is not None:
         if payload.opponent_user_id == current_user.id:
             raise HTTPException(
                 status_code=422,
-                detail="you cannot start a match against yourself",
+                detail="You cannot start a match against yourself.",
             )
         opponent = (
             await db.execute(
@@ -106,12 +243,12 @@ async def create_match(
             )
         ).scalar_one_or_none()
         if opponent is None:
-            raise HTTPException(status_code=404, detail="opponent not found")
+            raise HTTPException(status_code=404, detail="Opponent not found.")
 
     if payload.rated and opponent is None:
         raise HTTPException(
             status_code=422,
-            detail="a rated match needs a registered opponent",
+            detail="A rated match needs a registered opponent.",
         )
 
     # Guest / "start without opponent" matches have only the creator's side,
@@ -131,21 +268,292 @@ async def create_match(
     _add_side(match, 1, current_user)
     if opponent is not None:
         _add_side(match, 2, opponent)
+    # Game 1 always exists from the moment a match is created — the FE never
+    # creates a game, it only deep-links into the current one to record a score.
+    match.games.append(MatchGame(game_number=1))
 
     db.add(match)
     await db.commit()
 
     created = await _load_match(db, match.id)
-    assert created is not None  # just committed; the row exists
-    return _serialize_match(created)
+    assert created is not None
+    return _serialize_details(created, current_user.id)
 
 
-@router.get("/matches/{match_id}", response_model=MatchRead)
+@router.get("/matches", response_model=MatchListResponse)
+async def list_matches(
+    status_: MatchStatus | None = Query(default=None, alias="status"),
+    q: str | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=25, ge=1, le=MAX_PAGE_SIZE),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> MatchListResponse:
+    base = _participant_filter(select(Match), current_user.id)
+    if q:
+        base = _opponent_username_filter(base, current_user.id, q)
+
+    paged = base
+    if status_ is not None:
+        paged = paged.where(Match.status == status_)
+
+    total = (
+        await db.execute(
+            select(func.count()).select_from(paged.order_by(None).subquery())
+        )
+    ).scalar_one()
+
+    matches = (
+        (
+            await db.execute(
+                paged.options(
+                    selectinload(Match.match_settings),
+                    selectinload(Match.sides)
+                    .selectinload(MatchSide.players)
+                    .selectinload(MatchSidePlayer.user),
+                    selectinload(Match.games).selectinload(MatchGame.score),
+                )
+                .order_by(Match.created_at.desc())
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    items: list[MatchListRow] = [
+        _list_row(match, current_user.id) for match in matches
+    ]
+
+    # status_counts honors `q` but ignores the status filter, so build it from
+    # the unpaginated, unstatused query: same WHEREs as `base`, project the
+    # status column, group by it.
+    counts_query = _participant_filter(
+        select(Match.status, func.count(Match.id)), current_user.id
+    )
+    if q:
+        counts_query = _opponent_username_filter(
+            counts_query, current_user.id, q
+        )
+    counts_query = counts_query.group_by(Match.status)
+    status_counts: dict[MatchStatus, int] = {s: 0 for s in MatchStatus}
+    for status_value, count in (await db.execute(counts_query)).all():
+        status_counts[status_value] = count
+
+    return MatchListResponse(
+        items=items,
+        page=page,
+        page_size=page_size,
+        total=total,
+        status_counts=status_counts,
+    )
+
+
+def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
+    my_side = next(
+        s
+        for s in match.sides
+        if any(p.user_id == current_user_id for p in s.players)
+    )
+    opponent_side = next(
+        (s for s in match.sides if s.side_number != my_side.side_number),
+        None,
+    )
+
+    side_wins = _side_win_counts(match)
+    my_games_won = side_wins.get(my_side.side_number, 0)
+    opp_games_won = (
+        side_wins.get(opponent_side.side_number, 0) if opponent_side else 0
+    )
+
+    opponent_player = (
+        opponent_side.players[0]
+        if opponent_side and opponent_side.players
+        else None
+    )
+
+    current_game = next(
+        (g for g in match.games if g.score is None), None
+    )
+    scorable = (
+        match.status in {MatchStatus.pending, MatchStatus.in_progress}
+        and opponent_side is not None
+        and current_game is not None
+    )
+
+    is_win: bool | None = None
+    if match.status == MatchStatus.completed and opponent_side is not None:
+        is_win = my_games_won > opp_games_won
+
+    return MatchListRow(
+        id=match.id,
+        status=match.status,
+        status_label=STATUS_LABELS[match.status],
+        opponent_username=(
+            opponent_player.user.username if opponent_player else None
+        ),
+        opponent_user_id=(
+            opponent_player.user_id if opponent_player else None
+        ),
+        my_games_won=my_games_won,
+        opponent_games_won=opp_games_won,
+        is_win=is_win,
+        best_of=match.match_settings.best_of,
+        created_at=match.created_at,
+        current_game_id=current_game.id if scorable else None,
+    )
+
+
+@router.get("/matches/{match_id}", response_model=MatchDetails)
 async def get_match(
     match_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
-) -> MatchRead:
+) -> MatchDetails:
     match = await _load_match(db, match_id)
-    if match is None:
-        raise HTTPException(status_code=404, detail="match not found")
-    return _serialize_match(match)
+    if match is None or not _is_participant(match, current_user.id):
+        raise HTTPException(status_code=404, detail="Match not found.")
+    return _serialize_details(match, current_user.id)
+
+
+# ----- score writes --------------------------------------------------------
+
+
+def _enforce_scorable(match: Match) -> None:
+    if len(match.sides) < 2:
+        raise HTTPException(
+            status_code=422,
+            detail="This match has no opponent and can't be scored.",
+        )
+    if match.status in {MatchStatus.disputed, MatchStatus.voided}:
+        raise HTTPException(
+            status_code=409, detail="This match is no longer scorable."
+        )
+
+
+def _recompute_match(match: Match) -> None:
+    """Apply all post-score-write derivations on a single loaded ``match``:
+
+    - side ``score`` (count of games each side has won)
+    - match ``status`` (completed if either side reached games_to_win)
+    - side ``won`` flags (true/false on completion, reset to None on re-open)
+    - game lifecycle reconciliation (delete trailing unscored games when
+      completed; ensure exactly one trailing unscored game otherwise)
+    """
+    sides_by_number = {s.side_number: s for s in match.sides}
+    side_wins = _side_win_counts(match)
+    target = _games_to_win(match.match_settings.best_of)
+    a_wins = side_wins.get(1, 0)
+    b_wins = side_wins.get(2, 0)
+
+    for side in match.sides:
+        side.score = side_wins.get(side.side_number, 0)
+
+    decided = a_wins >= target or b_wins >= target
+    side_one = sides_by_number.get(1)
+    side_two = sides_by_number.get(2)
+
+    if decided:
+        match.status = MatchStatus.completed
+        if side_one is not None:
+            side_one.won = a_wins > b_wins
+        if side_two is not None:
+            side_two.won = b_wins > a_wins
+    else:
+        has_scored = a_wins > 0 or b_wins > 0
+        match.status = (
+            MatchStatus.in_progress if has_scored else MatchStatus.pending
+        )
+        for side in match.sides:
+            side.won = None
+
+    games_sorted = sorted(match.games, key=lambda g: g.game_number)
+    trailing_unscored = [g for g in games_sorted if g.score is None]
+    if decided:
+        for game in trailing_unscored:
+            match.games.remove(game)
+    elif not trailing_unscored:
+        next_number = (
+            max((g.game_number for g in games_sorted), default=0) + 1
+        )
+        match.games.append(MatchGame(game_number=next_number))
+
+
+async def _load_match_for_scoring(
+    db: AsyncSession,
+    match_id: uuid.UUID,
+    current_user_id: uuid.UUID,
+) -> Match:
+    match = await _load_match(db, match_id)
+    if match is None or not _is_participant(match, current_user_id):
+        raise HTTPException(status_code=404, detail="Match not found.")
+    return match
+
+
+@router.post(
+    "/matches/{match_id}/games/{game_id}/scores",
+    response_model=MatchDetails,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_game_score(
+    match_id: uuid.UUID,
+    game_id: uuid.UUID,
+    payload: MatchGameScoreWrite,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> MatchDetails:
+    match = await _load_match_for_scoring(db, match_id, current_user.id)
+    _enforce_scorable(match)
+
+    game = next((g for g in match.games if g.id == game_id), None)
+    if game is None:
+        raise HTTPException(status_code=404, detail="Game not found.")
+    if game.score is not None:
+        raise HTTPException(
+            status_code=409, detail="This game has already been scored."
+        )
+
+    game.score = MatchGameScore(
+        side_1_points=payload.side_1_points,
+        side_2_points=payload.side_2_points,
+    )
+
+    _recompute_match(match)
+    await db.commit()
+
+    reloaded = await _load_match(db, match.id)
+    assert reloaded is not None
+    return _serialize_details(reloaded, current_user.id)
+
+
+@router.put(
+    "/matches/{match_id}/games/{game_id}/scores/{score_id}",
+    response_model=MatchDetails,
+)
+async def update_game_score(
+    match_id: uuid.UUID,
+    game_id: uuid.UUID,
+    score_id: uuid.UUID,
+    payload: MatchGameScoreWrite,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> MatchDetails:
+    match = await _load_match_for_scoring(db, match_id, current_user.id)
+    _enforce_scorable(match)
+
+    game = next((g for g in match.games if g.id == game_id), None)
+    if game is None:
+        raise HTTPException(status_code=404, detail="Game not found.")
+    if game.score is None or game.score.id != score_id:
+        raise HTTPException(status_code=404, detail="Score not found.")
+
+    game.score.side_1_points = payload.side_1_points
+    game.score.side_2_points = payload.side_2_points
+
+    _recompute_match(match)
+    await db.commit()
+
+    reloaded = await _load_match(db, match.id)
+    assert reloaded is not None
+    return _serialize_details(reloaded, current_user.id)

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.match import Match, MatchStatus
 from app.models.match_game import MatchGame
+from app.models.match_game_score import MatchGameScore
 from app.models.match_settings import MatchSettings, VerificationPolicy
 from app.models.match_side import MatchSide
 from app.models.match_side_player import MatchSidePlayer
@@ -13,6 +14,7 @@ from app.models.user_token import UserToken
 __all__ = [
     "Match",
     "MatchGame",
+    "MatchGameScore",
     "MatchSettings",
     "MatchSide",
     "MatchSidePlayer",

--- a/api/app/models/match.py
+++ b/api/app/models/match.py
@@ -35,7 +35,16 @@ class Match(Base):
             "created_by_user_id",
             text("created_at DESC"),
         ),
-        Index("ix_matches_status", "status"),
+        Index(
+            "ix_matches_status_created_at",
+            "status",
+            text("created_at DESC"),
+        ),
+        Index(
+            "ix_matches_status_updated_at",
+            "status",
+            text("updated_at DESC"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/api/app/models/match_game.py
+++ b/api/app/models/match_game.py
@@ -1,12 +1,15 @@
 import uuid
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import (
     CheckConstraint,
+    DateTime,
     ForeignKey,
     Index,
     SmallInteger,
     UniqueConstraint,
+    func,
     text,
 )
 from sqlalchemy.dialects.postgresql import UUID
@@ -16,10 +19,12 @@ from app.db import Base
 
 if TYPE_CHECKING:
     from app.models.match import Match
+    from app.models.match_game_score import MatchGameScore
 
 
 class MatchGame(Base):
-    """Per-game scores within a match. Each row is one game."""
+    """Lifecycle row for one game inside a match. The score is a separate row
+    that exists only once the game has been completed and reported."""
 
     __tablename__ = "match_games"
     __table_args__ = (
@@ -27,8 +32,6 @@ class MatchGame(Base):
             "match_id", "game_number", name="uq_match_games_match_id_game_number"
         ),
         CheckConstraint("game_number >= 1", name="ck_match_games_game_number"),
-        CheckConstraint("side_1_points >= 0", name="ck_match_games_side_1_points"),
-        CheckConstraint("side_2_points >= 0", name="ck_match_games_side_2_points"),
         Index("ix_match_games_match_id", "match_id"),
     )
 
@@ -43,7 +46,20 @@ class MatchGame(Base):
         nullable=False,
     )
     game_number: Mapped[int] = mapped_column(SmallInteger, nullable=False)
-    side_1_points: Mapped[int] = mapped_column(SmallInteger, nullable=False)
-    side_2_points: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
 
     match: Mapped["Match"] = relationship(back_populates="games")
+    score: Mapped["MatchGameScore | None"] = relationship(
+        back_populates="match_game",
+        uselist=False,
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )

--- a/api/app/models/match_game_score.py
+++ b/api/app/models/match_game_score.py
@@ -1,0 +1,62 @@
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    SmallInteger,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.match_game import MatchGame
+
+
+class MatchGameScore(Base):
+    """Per-game point totals. Inserted when a game finishes; updated when an
+    already-scored game is corrected."""
+
+    __tablename__ = "match_game_scores"
+    __table_args__ = (
+        UniqueConstraint(
+            "match_game_id", name="uq_match_game_scores_match_game_id"
+        ),
+        CheckConstraint(
+            "side_1_points >= 0", name="ck_match_game_scores_side_1_points"
+        ),
+        CheckConstraint(
+            "side_2_points >= 0", name="ck_match_game_scores_side_2_points"
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    match_game_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("match_games.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    side_1_points: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    side_2_points: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    match_game: Mapped["MatchGame"] = relationship(back_populates="score")

--- a/api/app/players.py
+++ b/api/app/players.py
@@ -23,7 +23,7 @@ def _serialize(users: Iterable[User]) -> list[PlayerRead]:
     return [PlayerRead.model_validate(user) for user in users]
 
 
-def _escape_like(term: str) -> str:
+def escape_like(term: str) -> str:
     """Escape LIKE wildcards so a query of ``%`` matches a literal percent
     sign rather than every username."""
     return term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
@@ -108,7 +108,7 @@ async def search_players(
     if not term:
         return []
 
-    pattern = f"%{_escape_like(term)}%"
+    pattern = f"%{escape_like(term)}%"
     result = await db.execute(
         select(User)
         .where(

--- a/api/app/rbac.py
+++ b/api/app/rbac.py
@@ -52,7 +52,7 @@ def require_permission(name: str) -> Callable[..., Awaitable[User]]:
         db: AsyncSession = Depends(get_session),
     ) -> User:
         if not await _user_has_permission(db, user.id, name):
-            raise HTTPException(status_code=403, detail="forbidden")
+            raise HTTPException(status_code=403, detail="Forbidden.")
         return user
 
     return dep
@@ -130,7 +130,7 @@ async def _get_role_or_404(db: AsyncSession, role_id: uuid.UUID) -> Role:
         await db.execute(select(Role).where(Role.id == role_id))
     ).scalar_one_or_none()
     if role is None:
-        raise HTTPException(status_code=404, detail="role not found")
+        raise HTTPException(status_code=404, detail="Role not found.")
     return role
 
 
@@ -141,7 +141,7 @@ async def _get_permission_or_404(
         await db.execute(select(Permission).where(Permission.id == permission_id))
     ).scalar_one_or_none()
     if perm is None:
-        raise HTTPException(status_code=404, detail="permission not found")
+        raise HTTPException(status_code=404, detail="Permission not found.")
     return perm
 
 
@@ -150,7 +150,7 @@ async def _get_user_or_404(db: AsyncSession, user_id: uuid.UUID) -> User:
         await db.execute(select(User).where(User.id == user_id))
     ).scalar_one_or_none()
     if user is None:
-        raise HTTPException(status_code=404, detail="user not found")
+        raise HTTPException(status_code=404, detail="User not found.")
     return user
 
 
@@ -168,7 +168,7 @@ async def _validate_permission_ids(
     if missing:
         raise HTTPException(
             status_code=400,
-            detail=f"unknown permission ids: {', '.join(str(m) for m in missing)}",
+            detail=f"Unknown permission ids: {', '.join(str(m) for m in missing)}.",
         )
     return deduped
 
@@ -201,7 +201,7 @@ async def _validate_role_ids(
     if missing:
         raise HTTPException(
             status_code=400,
-            detail=f"unknown role ids: {', '.join(str(m) for m in missing)}",
+            detail=f"Unknown role ids: {', '.join(str(m) for m in missing)}.",
         )
     return deduped
 
@@ -228,7 +228,7 @@ async def create_permission(
 ) -> PermissionRead:
     if await _name_taken(db, Permission.id, Permission.name, payload.name):
         raise HTTPException(
-            status_code=409, detail="permission name already exists"
+            status_code=409, detail="Permission name already exists."
         )
     perm = Permission(name=payload.name, description=payload.description)
     db.add(perm)
@@ -237,7 +237,7 @@ async def create_permission(
     except IntegrityError:
         await db.rollback()
         raise HTTPException(
-            status_code=409, detail="permission name already exists"
+            status_code=409, detail="Permission name already exists."
         )
     await db.refresh(perm)
     return PermissionRead.model_validate(perm)
@@ -268,7 +268,7 @@ async def update_permission(
         )
     ):
         raise HTTPException(
-            status_code=409, detail="permission name already exists"
+            status_code=409, detail="Permission name already exists."
         )
     for key, value in data.items():
         setattr(perm, key, value)
@@ -277,7 +277,7 @@ async def update_permission(
     except IntegrityError:
         await db.rollback()
         raise HTTPException(
-            status_code=409, detail="permission name already exists"
+            status_code=409, detail="Permission name already exists."
         )
     await db.refresh(perm)
     return PermissionRead.model_validate(perm)
@@ -317,11 +317,11 @@ async def create_role(
     if payload.template_id is not None and payload.permission_ids is not None:
         raise HTTPException(
             status_code=400,
-            detail="provide either template_id or permission_ids, not both",
+            detail="Provide either template_id or permission_ids, not both.",
         )
 
     if await _name_taken(db, Role.id, Role.name, payload.name):
-        raise HTTPException(status_code=409, detail="role name already exists")
+        raise HTTPException(status_code=409, detail="Role name already exists.")
 
     permission_ids: list[uuid.UUID] = []
     if payload.template_id is not None:
@@ -339,7 +339,7 @@ async def create_role(
         await db.flush()
     except IntegrityError:
         await db.rollback()
-        raise HTTPException(status_code=409, detail="role name already exists")
+        raise HTTPException(status_code=409, detail="Role name already exists.")
 
     for pid in permission_ids:
         db.add(RolePermission(role_id=role.id, permission_id=pid))
@@ -372,7 +372,7 @@ async def update_role(
     )
     role = locked.scalar_one_or_none()
     if role is None:
-        raise HTTPException(status_code=404, detail="role not found")
+        raise HTTPException(status_code=404, detail="Role not found.")
 
     data = payload.model_dump(exclude_unset=True)
 
@@ -390,7 +390,7 @@ async def update_role(
             db, Role.id, Role.name, data["name"], exclude_id=role.id
         )
     ):
-        raise HTTPException(status_code=409, detail="role name already exists")
+        raise HTTPException(status_code=409, detail="Role name already exists.")
 
     for key, value in data.items():
         setattr(role, key, value)
@@ -399,7 +399,7 @@ async def update_role(
         await db.flush()
     except IntegrityError:
         await db.rollback()
-        raise HTTPException(status_code=409, detail="role name already exists")
+        raise HTTPException(status_code=409, detail="Role name already exists.")
 
     if new_permission_ids is not None:
         await db.execute(
@@ -452,14 +452,14 @@ async def create_user(
     db: AsyncSession = Depends(get_session),
 ) -> RbacUserRead:
     if await _name_taken(db, User.id, User.username, payload.username):
-        raise HTTPException(status_code=409, detail="username already exists")
+        raise HTTPException(status_code=409, detail="Username already exists.")
     user = User(username=payload.username)
     db.add(user)
     try:
         await db.commit()
     except IntegrityError:
         await db.rollback()
-        raise HTTPException(status_code=409, detail="username already exists")
+        raise HTTPException(status_code=409, detail="Username already exists.")
     await db.refresh(user)
     return _serialize_user(user, [])
 
@@ -486,7 +486,7 @@ async def set_user_roles(
     )
     user = locked.scalar_one_or_none()
     if user is None:
-        raise HTTPException(status_code=404, detail="user not found")
+        raise HTTPException(status_code=404, detail="User not found.")
     role_ids = await _validate_role_ids(db, payload.role_ids)
     await db.execute(delete(UserRole).where(UserRole.user_id == user.id))
     for rid in role_ids:
@@ -505,7 +505,7 @@ async def delete_user(
         # Defense in depth — the UI also disables this button. Without this
         # guard, the workspace can be locked out by deleting the last admin.
         raise HTTPException(
-            status_code=400, detail="you cannot delete your own account"
+            status_code=400, detail="You cannot delete your own account."
         )
     user = await _get_user_or_404(db, user_id)
     await db.delete(user)

--- a/api/app/schemas/dashboard.py
+++ b/api/app/schemas/dashboard.py
@@ -1,0 +1,32 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class DashboardScoreBanner(BaseModel):
+    match_id: uuid.UUID
+    opponent_username: str | None
+    current_game_id: uuid.UUID
+
+
+class DashboardNextMatch(BaseModel):
+    match_id: uuid.UUID
+    opponent_username: str | None
+    best_of: int
+    created_at: datetime
+
+
+class DashboardRecentResult(BaseModel):
+    match_id: uuid.UUID
+    opponent_username: str | None
+    is_win: bool
+    my_games_won: int
+    opponent_games_won: int
+    completed_at: datetime
+
+
+class DashboardResponse(BaseModel):
+    score_banner: DashboardScoreBanner | None
+    next_match: DashboardNextMatch | None
+    recent_results: list[DashboardRecentResult]

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -1,14 +1,22 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.models.match import MatchStatus
-from app.models.match_settings import VerificationPolicy
 
 # Match lengths the client offers. All odd so one side can always reach a
 # strict majority of games; the DB additionally enforces "odd and >= 1".
 ALLOWED_BEST_OF = (1, 3, 5, 7)
+
+# Maps the internal status enum to the label the BFF sends to clients.
+STATUS_LABELS: dict[MatchStatus, str] = {
+    MatchStatus.pending: "Scheduled",
+    MatchStatus.in_progress: "Live",
+    MatchStatus.completed: "Final",
+    MatchStatus.disputed: "Disputed",
+    MatchStatus.voided: "Voided",
+}
 
 
 class MatchCreate(BaseModel):
@@ -32,31 +40,111 @@ class MatchCreate(BaseModel):
         return value
 
 
-class MatchSidePlayerRead(BaseModel):
+# ----- details (BFF for /matches/$id and the scoring routes) ---------------
+
+
+class MatchDetailsPlayer(BaseModel):
     user_id: uuid.UUID
     username: str
+    is_current_user: bool
 
 
-class MatchSideRead(BaseModel):
+class MatchDetailsSide(BaseModel):
     side_number: int
-    score: int
+    players: list[MatchDetailsPlayer]
+    games_won: int
     won: bool | None
-    players: list[MatchSidePlayerRead]
+    is_current_user_side: bool
 
 
-class MatchSettingsRead(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    team_size: int
-    best_of: int
-    affects_rating: bool
-    verification_policy: VerificationPolicy
+class MatchDetailsScore(BaseModel):
+    id: uuid.UUID
+    my_points: int
+    opponent_points: int
+    is_my_win: bool
 
 
-class MatchRead(BaseModel):
+class MatchDetailsGame(BaseModel):
+    id: uuid.UUID
+    game_number: int
+    score: MatchDetailsScore | None
+
+
+class MatchDetailsCurrentGame(BaseModel):
+    id: uuid.UUID
+    game_number: int
+
+
+class MatchDetails(BaseModel):
     id: uuid.UUID
     status: MatchStatus
-    created_by_user_id: uuid.UUID
+    status_label: str
+    best_of: int
+    games_to_win: int
+    team_size: int
+    affects_rating: bool
     created_at: datetime
-    settings: MatchSettingsRead
-    sides: list[MatchSideRead]
+    my_side: MatchDetailsSide
+    opponent_side: MatchDetailsSide | None
+    games: list[MatchDetailsGame]
+    current_game: MatchDetailsCurrentGame | None
+    can_score: bool
+
+
+# ----- list (BFF for /matches) ---------------------------------------------
+
+
+class MatchListRow(BaseModel):
+    id: uuid.UUID
+    status: MatchStatus
+    status_label: str
+    opponent_username: str | None
+    opponent_user_id: uuid.UUID | None
+    my_games_won: int
+    opponent_games_won: int
+    is_win: bool | None
+    best_of: int
+    created_at: datetime
+    current_game_id: uuid.UUID | None
+
+
+class MatchListResponse(BaseModel):
+    items: list[MatchListRow]
+    page: int
+    page_size: int
+    total: int
+    status_counts: dict[MatchStatus, int]
+
+
+# ----- score write (POST/PUT body) -----------------------------------------
+
+
+class MatchGameScoreWrite(BaseModel):
+    side_1_points: int = Field(ge=0, le=99)
+    side_2_points: int = Field(ge=0, le=99)
+
+    @model_validator(mode="after")
+    def _table_tennis_rules(self):
+        a, b = self.side_1_points, self.side_2_points
+        if a == b:
+            raise ValueError("A game cannot end in a tie.")
+        winner, loser = max(a, b), min(a, b)
+        if winner < 11:
+            raise ValueError("The winning side must reach at least 11 points.")
+        if winner == 11 and loser > 9:
+            raise ValueError(
+                f"At 10–10 the game enters deuce; the winner must lead by 2. "
+                f"{winner}–{loser} is not a legal final score."
+            )
+        if winner > 11:
+            if loser < 10:
+                raise ValueError(
+                    f"A game can only go past 11 points after both sides reach 10. "
+                    f"{winner}–{loser} is not a legal final score."
+                )
+            if winner - loser != 2:
+                raise ValueError(
+                    f"In a deuce game the winner leads by exactly 2 points. "
+                    f"{winner}–{loser} is not a legal final score."
+                )
+        return self

--- a/api/migrations/versions/20260514_0000_0004_create_match_tables.py
+++ b/api/migrations/versions/20260514_0000_0004_create_match_tables.py
@@ -224,23 +224,67 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("game_number", sa.SmallInteger(), nullable=False),
-        sa.Column("side_1_points", sa.SmallInteger(), nullable=False),
-        sa.Column("side_2_points", sa.SmallInteger(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
         sa.UniqueConstraint(
             "match_id", "game_number", name="uq_match_games_match_id_game_number"
         ),
         sa.CheckConstraint("game_number >= 1", name="ck_match_games_game_number"),
-        sa.CheckConstraint(
-            "side_1_points >= 0", name="ck_match_games_side_1_points"
-        ),
-        sa.CheckConstraint(
-            "side_2_points >= 0", name="ck_match_games_side_2_points"
-        ),
     )
     op.create_index("ix_match_games_match_id", "match_games", ["match_id"])
 
+    op.create_table(
+        "match_game_scores",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "match_game_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("match_games.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("side_1_points", sa.SmallInteger(), nullable=False),
+        sa.Column("side_2_points", sa.SmallInteger(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "match_game_id", name="uq_match_game_scores_match_game_id"
+        ),
+        sa.CheckConstraint(
+            "side_1_points >= 0", name="ck_match_game_scores_side_1_points"
+        ),
+        sa.CheckConstraint(
+            "side_2_points >= 0", name="ck_match_game_scores_side_2_points"
+        ),
+    )
+
 
 def downgrade() -> None:
+    op.drop_table("match_game_scores")
     op.drop_table("match_games")
     op.drop_table("match_side_players")
     op.drop_table("match_sides")

--- a/api/migrations/versions/20260514_0000_0004_create_match_tables.py
+++ b/api/migrations/versions/20260514_0000_0004_create_match_tables.py
@@ -131,7 +131,20 @@ def upgrade() -> None:
         "matches",
         ["created_by_user_id", sa.text("created_at DESC")],
     )
-    op.create_index("ix_matches_status", "matches", ["status"])
+    # Supports the /v1/matches list page's status-filtered, recent-first scan
+    # and the dashboard's per-status LIMIT 1 queries (pending/in_progress).
+    op.create_index(
+        "ix_matches_status_created_at",
+        "matches",
+        ["status", sa.text("created_at DESC")],
+    )
+    # Supports the dashboard's "last 5 completed" view, which orders by
+    # updated_at (no dedicated completed_at column).
+    op.create_index(
+        "ix_matches_status_updated_at",
+        "matches",
+        ["status", sa.text("updated_at DESC")],
+    )
 
     op.create_table(
         "match_sides",

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -4,10 +4,11 @@ The leading underscore keeps pytest from auto-collecting this as a test module;
 fixtures still belong in ``conftest.py``.
 """
 
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.main import app as fastapi_app
 from app.models import User
 
 
@@ -29,3 +30,17 @@ async def make_user(db_session: AsyncSession, username: str) -> User:
     await db_session.commit()
     await db_session.refresh(user)
     return user
+
+
+def make_client() -> AsyncClient:
+    """Build a second cookie-isolated client bound to the same test app.
+
+    Useful when a test needs two distinct users (each one calls
+    ``start_session`` on their own client) sharing the same ``db_session``
+    fixture override — which the primary ``api_client`` fixture has already
+    installed by the time this helper runs.
+    """
+    return AsyncClient(
+        transport=ASGITransport(app=fastapi_app),
+        base_url="https://testserver",
+    )

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -1,0 +1,113 @@
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests._helpers import make_client, make_user, start_session
+
+
+async def _create_match(
+    client: AsyncClient, opponent_id, best_of: int = 5
+) -> dict:
+    response = await client.post(
+        "/v1/matches",
+        json={
+            "opponent_user_id": str(opponent_id),
+            "best_of": best_of,
+            "rated": True,
+        },
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+async def test_dashboard_requires_a_session(api_client: AsyncClient):
+    response = await api_client.get("/v1/dashboard")
+    assert response.status_code == 401
+
+
+async def test_dashboard_empty_when_user_has_no_matches(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    response = await api_client.get("/v1/dashboard")
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "score_banner": None,
+        "next_match": None,
+        "recent_results": [],
+    }
+
+
+async def test_dashboard_returns_score_banner_for_in_progress_match(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=5)
+    after_g1 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+            json={"side_1_points": 11, "side_2_points": 4},
+        )
+    ).json()
+
+    body = (await api_client.get("/v1/dashboard")).json()
+    assert body["score_banner"]["match_id"] == match["id"]
+    assert body["score_banner"]["opponent_username"] == "rival"
+    assert body["score_banner"]["current_game_id"] == after_g1["current_game"]["id"]
+    # An in-progress match is not "pending" so the next_match slot is empty.
+    assert body["next_match"] is None
+    assert body["recent_results"] == []
+
+
+async def test_dashboard_returns_next_match_for_pending_match(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    created = await _create_match(api_client, opp.id, best_of=5)
+
+    body = (await api_client.get("/v1/dashboard")).json()
+    assert body["score_banner"] is None
+    assert body["next_match"]["match_id"] == created["id"]
+    assert body["next_match"]["opponent_username"] == "rival"
+    assert body["next_match"]["best_of"] == 5
+
+
+async def test_dashboard_returns_recent_results_for_completed_matches(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=1)
+    await api_client.post(
+        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+        json={"side_1_points": 11, "side_2_points": 4},
+    )
+
+    body = (await api_client.get("/v1/dashboard")).json()
+    assert len(body["recent_results"]) == 1
+    result = body["recent_results"][0]
+    assert result["match_id"] == match["id"]
+    assert result["opponent_username"] == "rival"
+    assert result["is_win"] is True
+    assert result["my_games_won"] == 1
+    assert result["opponent_games_won"] == 0
+
+
+async def test_dashboard_scoped_to_current_user(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    async with make_client() as other_client:
+        await start_session(other_client, db_session)
+        bystander = await make_user(db_session, "bystander")
+        # A match between Bob and a bystander should not show up for Alice.
+        await _create_match(other_client, bystander.id)
+
+    body = (await api_client.get("/v1/dashboard")).json()
+    assert body == {
+        "score_banner": None,
+        "next_match": None,
+        "recent_results": [],
+    }

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1,11 +1,15 @@
 import uuid
 
+import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Match, MatchSide
-from tests._helpers import make_user, start_session
+from app.models import Match, MatchGame, MatchGameScore, MatchSide
+from tests._helpers import make_client, make_user, start_session
+
+
+# ----- create -------------------------------------------------------------
 
 
 async def test_create_match_requires_a_session(api_client: AsyncClient):
@@ -30,18 +34,36 @@ async def test_create_rated_match_with_registered_opponent(
     assert response.status_code == 201
     body = response.json()
     assert body["status"] == "pending"
-    assert body["created_by_user_id"] == str(me.id)
-    assert body["settings"]["best_of"] == 5
-    assert body["settings"]["team_size"] == 1
-    assert body["settings"]["affects_rating"] is True
+    assert body["status_label"] == "Scheduled"
+    assert body["best_of"] == 5
+    assert body["games_to_win"] == 3
+    assert body["team_size"] == 1
+    assert body["affects_rating"] is True
 
-    sides = sorted(body["sides"], key=lambda side: side["side_number"])
-    assert [side["side_number"] for side in sides] == [1, 2]
-    assert sides[0]["players"][0]["user_id"] == str(me.id)
-    assert sides[1]["players"][0]["user_id"] == str(opponent.id)
+    assert body["my_side"]["side_number"] == 1
+    assert body["my_side"]["is_current_user_side"] is True
+    assert body["my_side"]["players"][0]["user_id"] == str(me.id)
+    assert body["my_side"]["players"][0]["is_current_user"] is True
+    assert body["my_side"]["games_won"] == 0
+
+    assert body["opponent_side"]["side_number"] == 2
+    assert body["opponent_side"]["is_current_user_side"] is False
+    assert body["opponent_side"]["players"][0]["user_id"] == str(opponent.id)
+    assert body["opponent_side"]["players"][0]["is_current_user"] is False
+
+    # Game 1 always exists from the moment a match is created.
+    assert len(body["games"]) == 1
+    assert body["games"][0]["game_number"] == 1
+    assert body["games"][0]["score"] is None
+    assert body["current_game"]["id"] == body["games"][0]["id"]
+    assert body["current_game"]["game_number"] == 1
+    assert body["can_score"] is True
 
     match = (await db_session.execute(select(Match))).scalar_one()
     assert str(match.id) == body["id"]
+    games = (await db_session.execute(select(MatchGame))).scalars().all()
+    assert len(games) == 1
+    assert games[0].game_number == 1
 
 
 async def test_create_unrated_match_with_opponent(
@@ -60,11 +82,11 @@ async def test_create_unrated_match_with_opponent(
     )
     assert response.status_code == 201
     body = response.json()
-    assert body["settings"]["affects_rating"] is False
-    assert len(body["sides"]) == 2
+    assert body["affects_rating"] is False
+    assert body["opponent_side"] is not None
 
 
-async def test_create_match_without_opponent_has_a_single_side(
+async def test_create_match_without_opponent_has_no_opponent_side(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     me = await start_session(api_client, db_session)
@@ -74,10 +96,12 @@ async def test_create_match_without_opponent_has_a_single_side(
     )
     assert response.status_code == 201
     body = response.json()
-    assert body["settings"]["affects_rating"] is False
-    assert len(body["sides"]) == 1
-    assert body["sides"][0]["side_number"] == 1
-    assert body["sides"][0]["players"][0]["user_id"] == str(me.id)
+    assert body["affects_rating"] is False
+    assert body["my_side"]["players"][0]["user_id"] == str(me.id)
+    assert body["opponent_side"] is None
+    # No opponent → nothing to score against, even though game 1 exists.
+    assert body["current_game"] is not None
+    assert body["can_score"] is False
 
     sides = (await db_session.execute(select(MatchSide))).scalars().all()
     assert len(sides) == 1
@@ -143,27 +167,507 @@ async def test_even_best_of_is_rejected(
     assert response.status_code == 422
 
 
-async def test_get_match_returns_the_created_match(
+# ----- details ------------------------------------------------------------
+
+
+async def _create_match(
+    client: AsyncClient, opponent_id: uuid.UUID, best_of: int = 5
+) -> dict:
+    response = await client.post(
+        "/v1/matches",
+        json={
+            "opponent_user_id": str(opponent_id),
+            "best_of": best_of,
+            "rated": True,
+        },
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+async def test_get_match_returns_current_user_view(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await start_session(api_client, db_session)
+    me = await start_session(api_client, db_session)
     opponent = await make_user(db_session, "rival")
-    created = (
-        await api_client.post(
-            "/v1/matches",
-            json={
-                "opponent_user_id": str(opponent.id),
-                "best_of": 5,
-                "rated": True,
-            },
-        )
-    ).json()
+    created = await _create_match(api_client, opponent.id)
 
     response = await api_client.get(f"/v1/matches/{created['id']}")
     assert response.status_code == 200
-    assert response.json() == created
+    body = response.json()
+    assert body["my_side"]["players"][0]["user_id"] == str(me.id)
+    assert body["opponent_side"]["players"][0]["user_id"] == str(opponent.id)
 
 
-async def test_get_unknown_match_is_404(api_client: AsyncClient):
+async def test_details_perspective_swaps_per_caller(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await start_session(api_client, db_session)
+    async with make_client() as other_client:
+        them = await start_session(other_client, db_session)
+        created = await _create_match(api_client, them.id)
+
+        mine = (await api_client.get(f"/v1/matches/{created['id']}")).json()
+        theirs = (await other_client.get(f"/v1/matches/{created['id']}")).json()
+
+    assert mine["my_side"]["players"][0]["user_id"] == str(me.id)
+    assert theirs["my_side"]["players"][0]["user_id"] == str(them.id)
+    # The two sides flip without changing which underlying row is which.
+    assert mine["my_side"]["side_number"] == theirs["opponent_side"]["side_number"]
+    assert mine["opponent_side"]["side_number"] == theirs["my_side"]["side_number"]
+
+
+async def test_get_match_404_for_non_participant(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    async with make_client() as other_client:
+        them = await start_session(other_client, db_session)
+        bystander = await make_user(db_session, "bystander")
+        created = await _create_match(other_client, bystander.id)
+        del them
+
+        response = await api_client.get(f"/v1/matches/{created['id']}")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Match not found."
+
+
+async def test_get_unknown_match_is_404(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
     response = await api_client.get(f"/v1/matches/{uuid.uuid4()}")
     assert response.status_code == 404
+
+
+# ----- list ---------------------------------------------------------------
+
+
+async def test_list_matches_empty(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    response = await api_client.get("/v1/matches")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"] == []
+    assert body["total"] == 0
+    assert body["page"] == 1
+    assert body["page_size"] == 25
+    assert body["status_counts"]["pending"] == 0
+    assert body["status_counts"]["completed"] == 0
+
+
+async def test_list_matches_scoped_to_current_user(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    async with make_client() as other_client:
+        them = await start_session(other_client, db_session)
+        bystander = await make_user(db_session, "bystander")
+        # A match between Bob and a bystander — should NOT appear in Alice's list.
+        await _create_match(other_client, bystander.id)
+        del them
+
+    response = await api_client.get("/v1/matches")
+    assert response.json()["items"] == []
+
+
+async def test_list_filter_by_status(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    pending = await _create_match(api_client, opp.id, best_of=1)
+    # Score game 1 to flip a separate match to completed.
+    completed_match = await _create_match(api_client, opp.id, best_of=1)
+    score_resp = await api_client.post(
+        f"/v1/matches/{completed_match['id']}/games/{completed_match['games'][0]['id']}/scores",
+        json={"side_1_points": 11, "side_2_points": 5},
+    )
+    assert score_resp.status_code == 201
+
+    listing = (
+        await api_client.get("/v1/matches", params={"status": "pending"})
+    ).json()
+    assert [row["id"] for row in listing["items"]] == [pending["id"]]
+    assert listing["status_counts"]["pending"] == 1
+    assert listing["status_counts"]["completed"] == 1
+
+
+async def test_list_q_filter_matches_opponent_username(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    alpha = await make_user(db_session, "alphabet")
+    bravo = await make_user(db_session, "bravo")
+    await _create_match(api_client, alpha.id)
+    await _create_match(api_client, bravo.id)
+
+    listing = (
+        await api_client.get("/v1/matches", params={"q": "alpha"})
+    ).json()
+    assert len(listing["items"]) == 1
+    assert listing["items"][0]["opponent_username"] == "alphabet"
+    # status_counts honors q (one row total)
+    assert sum(listing["status_counts"].values()) == 1
+
+
+async def test_list_pagination(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    for _ in range(3):
+        await _create_match(api_client, opp.id)
+
+    page_1 = (
+        await api_client.get(
+            "/v1/matches", params={"page": 1, "page_size": 2}
+        )
+    ).json()
+    page_2 = (
+        await api_client.get(
+            "/v1/matches", params={"page": 2, "page_size": 2}
+        )
+    ).json()
+    assert page_1["total"] == 3
+    assert len(page_1["items"]) == 2
+    assert len(page_2["items"]) == 1
+    assert {row["id"] for row in page_1["items"]} & {
+        row["id"] for row in page_2["items"]
+    } == set()
+
+
+async def test_list_row_carries_current_game_id_when_scorable(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    created = await _create_match(api_client, opp.id)
+
+    listing = (await api_client.get("/v1/matches")).json()
+    assert listing["items"][0]["current_game_id"] == created["games"][0]["id"]
+
+
+# ----- TT scoring rules ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "side_1,side_2,is_valid",
+    [
+        (11, 0, True),
+        (11, 9, True),
+        (12, 10, True),
+        (13, 11, True),
+        (11, 10, False),  # at deuce, must lead by 2
+        (13, 10, False),  # past 11 only legal when both reach 10
+        (12, 9, False),
+        (10, 5, False),  # winner didn't reach 11
+        (0, 0, False),
+        (11, 11, False),
+        (100, 0, False),  # caps at 99
+    ],
+)
+async def test_table_tennis_scoring_rules(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    side_1: int,
+    side_2: int,
+    is_valid: bool,
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=5)
+
+    response = await api_client.post(
+        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+        json={"side_1_points": side_1, "side_2_points": side_2},
+    )
+    if is_valid:
+        assert response.status_code == 201
+    else:
+        assert response.status_code == 422
+
+
+# ----- score lifecycle ----------------------------------------------------
+
+
+async def test_scoring_game_1_flips_pending_to_in_progress_and_adds_game_2(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=5)
+
+    response = await api_client.post(
+        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+        json={"side_1_points": 11, "side_2_points": 4},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["status"] == "in_progress"
+    assert body["status_label"] == "Live"
+    assert body["my_side"]["games_won"] == 1
+    assert body["opponent_side"]["games_won"] == 0
+
+    # Game 2 has been opened.
+    assert len(body["games"]) == 2
+    assert body["games"][1]["game_number"] == 2
+    assert body["games"][1]["score"] is None
+    assert body["current_game"]["game_number"] == 2
+
+
+async def test_deciding_game_flips_to_completed_with_no_trailing_unscored(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=3)
+
+    # Win game 1, win game 2 → match completed (best of 3, need 2).
+    after_g1 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+            json={"side_1_points": 11, "side_2_points": 4},
+        )
+    ).json()
+    game_2 = after_g1["games"][1]
+    after_g2 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/{game_2['id']}/scores",
+            json={"side_1_points": 11, "side_2_points": 7},
+        )
+    ).json()
+
+    assert after_g2["status"] == "completed"
+    assert after_g2["status_label"] == "Final"
+    assert len(after_g2["games"]) == 2  # no trailing unscored game
+    assert after_g2["current_game"] is None
+    assert after_g2["my_side"]["won"] is True
+    assert after_g2["opponent_side"]["won"] is False
+    assert after_g2["can_score"] is False
+
+
+async def test_post_score_409_when_game_already_scored(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=5)
+    game_id = match["games"][0]["id"]
+    await api_client.post(
+        f"/v1/matches/{match['id']}/games/{game_id}/scores",
+        json={"side_1_points": 11, "side_2_points": 4},
+    )
+
+    second = await api_client.post(
+        f"/v1/matches/{match['id']}/games/{game_id}/scores",
+        json={"side_1_points": 11, "side_2_points": 5},
+    )
+    assert second.status_code == 409
+    assert second.json()["detail"] == "This game has already been scored."
+
+
+async def test_put_edits_a_past_games_score(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=5)
+    game_1 = match["games"][0]
+    after_g1 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/{game_1['id']}/scores",
+            json={"side_1_points": 11, "side_2_points": 4},
+        )
+    ).json()
+    score_id = after_g1["games"][0]["score"]["id"]
+
+    edited = await api_client.put(
+        f"/v1/matches/{match['id']}/games/{game_1['id']}/scores/{score_id}",
+        json={"side_1_points": 5, "side_2_points": 11},
+    )
+    assert edited.status_code == 200
+    body = edited.json()
+    assert body["my_side"]["games_won"] == 0
+    assert body["opponent_side"]["games_won"] == 1
+    # Status stays in_progress; game 2 stays open.
+    assert body["status"] == "in_progress"
+
+
+async def test_put_reopens_a_completed_match(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=3)
+    after_g1 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+            json={"side_1_points": 11, "side_2_points": 4},
+        )
+    ).json()
+    game_2 = after_g1["games"][1]
+    after_g2 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/{game_2['id']}/scores",
+            json={"side_1_points": 11, "side_2_points": 7},
+        )
+    ).json()
+    assert after_g2["status"] == "completed"
+
+    # Flip game 2 so the opponent wins it → only game 1 has been won by me, 1-1.
+    g2_score_id = after_g2["games"][1]["score"]["id"]
+    reopened = await api_client.put(
+        f"/v1/matches/{match['id']}/games/{game_2['id']}/scores/{g2_score_id}",
+        json={"side_1_points": 7, "side_2_points": 11},
+    )
+    assert reopened.status_code == 200
+    body = reopened.json()
+    assert body["status"] == "in_progress"
+    assert body["my_side"]["won"] is None
+    assert body["opponent_side"]["won"] is None
+    # Game 3 has been opened by reconciliation.
+    assert len(body["games"]) == 3
+    assert body["games"][2]["score"] is None
+    assert body["current_game"]["game_number"] == 3
+
+
+async def test_put_closes_match_earlier_and_deletes_trailing_unscored(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=3)
+
+    # Game 1: opponent wins. Game 2: I win. Now 1-1 with game 3 open.
+    after_g1 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+            json={"side_1_points": 5, "side_2_points": 11},
+        )
+    ).json()
+    game_2 = after_g1["games"][1]
+    after_g2 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/{game_2['id']}/scores",
+            json={"side_1_points": 11, "side_2_points": 4},
+        )
+    ).json()
+    assert after_g2["status"] == "in_progress"
+    assert len(after_g2["games"]) == 3  # game 3 open
+
+    # Edit game 1 so I win it instead → 2-0 → match completed, game 3 deleted.
+    g1_score_id = after_g2["games"][0]["score"]["id"]
+    edited = await api_client.put(
+        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores/{g1_score_id}",
+        json={"side_1_points": 11, "side_2_points": 6},
+    )
+    body = edited.json()
+    assert body["status"] == "completed"
+    assert len(body["games"]) == 2
+    assert body["current_game"] is None
+
+    # No orphan score rows or trailing games left behind in the DB.
+    games = (await db_session.execute(select(MatchGame))).scalars().all()
+    assert len(games) == 2
+    scores = (
+        await db_session.execute(select(MatchGameScore))
+    ).scalars().all()
+    assert len(scores) == 2
+
+
+async def test_put_404_for_unknown_score_id(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=5)
+    game_id = match["games"][0]["id"]
+    await api_client.post(
+        f"/v1/matches/{match['id']}/games/{game_id}/scores",
+        json={"side_1_points": 11, "side_2_points": 4},
+    )
+
+    response = await api_client.put(
+        f"/v1/matches/{match['id']}/games/{game_id}/scores/{uuid.uuid4()}",
+        json={"side_1_points": 11, "side_2_points": 5},
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Score not found."
+
+
+async def test_put_404_for_mismatched_game_and_score(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=5)
+    after_g1 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+            json={"side_1_points": 11, "side_2_points": 4},
+        )
+    ).json()
+    score_id = after_g1["games"][0]["score"]["id"]
+    other_game_id = after_g1["games"][1]["id"]
+
+    response = await api_client.put(
+        f"/v1/matches/{match['id']}/games/{other_game_id}/scores/{score_id}",
+        json={"side_1_points": 11, "side_2_points": 5},
+    )
+    assert response.status_code == 404
+
+
+async def test_non_participant_cannot_score(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    async with make_client() as other_client:
+        them = await start_session(other_client, db_session)
+        bystander = await make_user(db_session, "bystander")
+        created = await _create_match(other_client, bystander.id)
+        del them
+
+        post = await api_client.post(
+            f"/v1/matches/{created['id']}/games/{created['games'][0]['id']}/scores",
+            json={"side_1_points": 11, "side_2_points": 4},
+        )
+        assert post.status_code == 404
+        put = await api_client.put(
+            f"/v1/matches/{created['id']}/games/{created['games'][0]['id']}/scores/{uuid.uuid4()}",
+            json={"side_1_points": 11, "side_2_points": 4},
+        )
+        assert put.status_code == 404
+
+
+async def test_scoring_an_unknown_game_404(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=5)
+    response = await api_client.post(
+        f"/v1/matches/{match['id']}/games/{uuid.uuid4()}/scores",
+        json={"side_1_points": 11, "side_2_points": 4},
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Game not found."
+
+
+async def test_cannot_score_match_without_opponent(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    created = (
+        await api_client.post(
+            "/v1/matches", json={"best_of": 5, "rated": False}
+        )
+    ).json()
+    response = await api_client.post(
+        f"/v1/matches/{created['id']}/games/{created['games'][0]['id']}/scores",
+        json={"side_1_points": 11, "side_2_points": 4},
+    )
+    assert response.status_code == 422
+    assert "opponent" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary

- Split `match_games` (lifecycle: id, match_id, game_number, timestamps) from new `match_game_scores` (one-to-one, deletable on cascade). Server owns the game lifecycle: game 1 is created with the match, and every score write reconciles the trailing un-scored game so `current_game.id` on a details response is always a real, deep-linkable entity.
- Three BFF endpoints: `GET /v1/matches` (paged list with status filter, opponent username search, per-row aggregates, `status_counts`), `GET /v1/matches/{id}` (current-user-relative `MatchDetails` replacing the old flat `MatchRead`), `GET /v1/dashboard` (score banner, next match, last 5 results). Plus `POST` / `PUT` score endpoints with TT-rule validation and post-write recomputation of side totals, match status, won flags, and the next game.
- Adds composite indexes `(status, created_at DESC)` and `(status, updated_at DESC)` on `matches` to support the new query patterns.
- Codifies the one-endpoint-per-page BFF convention in root `CLAUDE.md`. Audits `matches.py` + `rbac.py` error strings to sentence case with terminal punctuation.

Note: `web-client/src/api/schema.d.ts` is intentionally **not** regenerated here — PR 2 (FE plumbing) owns that, so the `openapi-schema` CI workflow will fail on this PR by design.

## Test plan

- [x] `cd api && pytest` (165/165 passing — adds parametrized TT-rule coverage, full match lifecycle, list pagination/filter/scoping, dashboard scoping)
- [x] `cd web-client && npm run lint` (clean — only the pre-existing `mockServiceWorker.js` warning)
- [x] `cd web-client && npm run build` (tsc + vite both clean)
- [x] `cd web-client && npm run test:run` (17/17 vitest passing — no FE changes in this PR)
- [ ] Expected to fail: `openapi-schema` CI workflow until PR 2 regenerates `schema.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)