### PR TITLE
PR 2: Wire web-client to the match BFF endpoints

### DIFF
--- a/web-client/e2e/page-objects/matches/match-store.ts
+++ b/web-client/e2e/page-objects/matches/match-store.ts
@@ -1,6 +1,6 @@
 import type { Page, Request as PWRequest, Route } from '@playwright/test'
 import type { components } from '../../../src/api/schema'
-import { matchResponse, sessionResponse } from '../../../src/test/factories'
+import { matchDetails, sessionResponse } from '../../../src/test/factories'
 
 type Player = components['schemas']['PlayerRead']
 type MatchCreate = components['schemas']['MatchCreate']
@@ -148,11 +148,38 @@ export class MatchStore {
     return this.json(
       route,
       201,
-      matchResponse({
-        creatorUsername: this.creatorUsername,
-        opponent,
-        bestOf: body.best_of,
-        rated: body.rated,
+      matchDetails({
+        best_of: body.best_of,
+        games_to_win: Math.ceil(body.best_of / 2),
+        affects_rating: body.rated && opponent !== null,
+        my_side: {
+          side_number: 1,
+          players: [
+            {
+              user_id: 'u-me',
+              username: this.creatorUsername,
+              is_current_user: true,
+            },
+          ],
+          games_won: 0,
+          won: null,
+          is_current_user_side: true,
+        },
+        opponent_side: opponent
+          ? {
+              side_number: 2,
+              players: [
+                {
+                  user_id: opponent.id,
+                  username: opponent.username,
+                  is_current_user: false,
+                },
+              ],
+              games_won: 0,
+              won: null,
+              is_current_user_side: false,
+            }
+          : null,
       }),
     )
   }

--- a/web-client/src/api/dashboard.ts
+++ b/web-client/src/api/dashboard.ts
@@ -11,10 +11,7 @@ export type DashboardRecentResult =
 
 export const DASHBOARD_QUERY_KEY = ['dashboard'] as const
 
-/**
- * Dashboard BFF: the score banner, next match, and recent results in one
- * round-trip. Errors are thrown so the route's boundary can render a retry.
- */
+/** Throws on failure so the dashboard route's boundary can render a retry. */
 export function useDashboard() {
   return useQuery({
     queryKey: DASHBOARD_QUERY_KEY,

--- a/web-client/src/api/dashboard.ts
+++ b/web-client/src/api/dashboard.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query'
+import { api, unwrap } from './client'
+import type { components } from './schema'
+
+export type DashboardResponse = components['schemas']['DashboardResponse']
+export type DashboardScoreBanner =
+  components['schemas']['DashboardScoreBanner']
+export type DashboardNextMatch = components['schemas']['DashboardNextMatch']
+export type DashboardRecentResult =
+  components['schemas']['DashboardRecentResult']
+
+export const DASHBOARD_QUERY_KEY = ['dashboard'] as const
+
+/**
+ * Dashboard BFF: the score banner, next match, and recent results in one
+ * round-trip. Errors are thrown so the route's boundary can render a retry.
+ */
+export function useDashboard() {
+  return useQuery({
+    queryKey: DASHBOARD_QUERY_KEY,
+    queryFn: async (): Promise<DashboardResponse> =>
+      unwrap('load dashboard', await api.GET('/v1/dashboard')),
+    retry: false,
+    throwOnError: true,
+  })
+}

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -1,10 +1,27 @@
-import { useMutation, useQuery } from '@tanstack/react-query'
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
 import { api, unwrap } from './client'
+import { DASHBOARD_QUERY_KEY } from './dashboard'
 import type { components } from './schema'
 
 export type Player = components['schemas']['PlayerRead']
-export type Match = components['schemas']['MatchRead']
 export type MatchCreate = components['schemas']['MatchCreate']
+export type MatchDetails = components['schemas']['MatchDetails']
+export type MatchListResponse = components['schemas']['MatchListResponse']
+export type MatchListRow = components['schemas']['MatchListRow']
+export type MatchGameScoreWrite = components['schemas']['MatchGameScoreWrite']
+export type MatchStatus = components['schemas']['MatchStatus']
+
+export type MatchListParams = {
+  status?: MatchStatus
+  q?: string
+  page: number
+  page_size: number
+}
 
 export const RECENT_OPPONENTS_QUERY_KEY = ['players', 'recent'] as const
 
@@ -12,6 +29,17 @@ export const RECENT_OPPONENTS_QUERY_KEY = ['players', 'recent'] as const
  * cached independently and `enabled` can gate the empty-term case. */
 export function playerSearchQueryKey(term: string) {
   return ['players', 'search', term] as const
+}
+
+/** Query key for the paginated /matches list. The whole params bag is the
+ * key so two different filters keep separate cache slots. */
+export function matchListQueryKey(params: MatchListParams) {
+  return ['matches', 'list', params] as const
+}
+
+/** Query key for a single match's details (BFF response). */
+export function matchQueryKey(matchId: string) {
+  return ['matches', 'detail', matchId] as const
 }
 
 /**
@@ -65,7 +93,140 @@ export function usePlayerSearch(term: string) {
  */
 export function useCreateMatch() {
   return useMutation({
-    mutationFn: async (input: MatchCreate): Promise<Match> =>
+    mutationFn: async (input: MatchCreate): Promise<MatchDetails> =>
       unwrap('create match', await api.POST('/v1/matches', { body: input })),
   })
+}
+
+/**
+ * Paginated /matches list. `placeholderData: keepPreviousData` keeps the
+ * current page rendered while the next page or filter resolves, so the table
+ * doesn't flash empty between requests. Throws to the surrounding boundary.
+ */
+export function useMatchList(params: MatchListParams) {
+  return useQuery({
+    queryKey: matchListQueryKey(params),
+    queryFn: async (): Promise<MatchListResponse> =>
+      unwrap(
+        'load matches',
+        await api.GET('/v1/matches', {
+          params: {
+            query: {
+              status: params.status,
+              q: params.q,
+              page: params.page,
+              page_size: params.page_size,
+            },
+          },
+        }),
+      ),
+    placeholderData: keepPreviousData,
+    retry: false,
+    throwOnError: true,
+  })
+}
+
+/**
+ * Single match details (BFF for /matches/$id and the scoring routes).
+ * Throws to the surrounding boundary on failure.
+ */
+export function useMatch(matchId: string) {
+  return useQuery({
+    queryKey: matchQueryKey(matchId),
+    queryFn: async (): Promise<MatchDetails> =>
+      unwrap(
+        'load match',
+        await api.GET('/v1/matches/{match_id}', {
+          params: { path: { match_id: matchId } },
+        }),
+      ),
+    retry: false,
+    throwOnError: true,
+  })
+}
+
+/** Cache work shared by both score mutations: prime the detail cache from the
+ * mutation response and invalidate the list / dashboard so they re-read the
+ * derived status, scoreboard, and next-up state. */
+function applyScoreMutationCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  matchId: string,
+  data: MatchDetails,
+) {
+  queryClient.setQueryData<MatchDetails>(matchQueryKey(matchId), data)
+  queryClient.invalidateQueries({ queryKey: ['matches', 'list'] })
+  queryClient.invalidateQueries({ queryKey: DASHBOARD_QUERY_KEY })
+}
+
+/**
+ * Writes the first score for a game. The scoring route surfaces errors
+ * inline, so `throwOnError` is intentionally omitted — callers branch on
+ * `mutation.error`.
+ */
+export function useCreateScore(matchId: string, gameId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: MatchGameScoreWrite): Promise<MatchDetails> =>
+      unwrap(
+        'submit score',
+        await api.POST('/v1/matches/{match_id}/games/{game_id}/scores', {
+          params: { path: { match_id: matchId, game_id: gameId } },
+          body: input,
+        }),
+      ),
+    onSuccess: (data) => applyScoreMutationCache(queryClient, matchId, data),
+  })
+}
+
+/**
+ * Edits an existing score. Same cache work and same no-throw posture as
+ * `useCreateScore` — the edit route handles errors inline.
+ */
+export function useUpdateScore(
+  matchId: string,
+  gameId: string,
+  scoreId: string,
+) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: MatchGameScoreWrite): Promise<MatchDetails> =>
+      unwrap(
+        'update score',
+        await api.PUT(
+          '/v1/matches/{match_id}/games/{game_id}/scores/{score_id}',
+          {
+            params: {
+              path: {
+                match_id: matchId,
+                game_id: gameId,
+                score_id: scoreId,
+              },
+            },
+            body: input,
+          },
+        ),
+      ),
+    onSuccess: (data) => applyScoreMutationCache(queryClient, matchId, data),
+  })
+}
+
+// URL helpers used by every scoring CTA so the route shape lives in one place.
+// `as const` preserves the literal `to` for TanStack Router's typed navigation.
+
+export function scoringNewRoute(matchId: string, gameId: string) {
+  return {
+    to: '/matches/$matchId/games/$gameId/scores/new' as const,
+    params: { matchId, gameId },
+  }
+}
+
+export function scoringEditRoute(
+  matchId: string,
+  gameId: string,
+  scoreId: string,
+) {
+  return {
+    to: '/matches/$matchId/games/$gameId/scores/$scoreId/edit' as const,
+    params: { matchId, gameId, scoreId },
+  }
 }

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -37,7 +37,6 @@ export function matchListQueryKey(params: MatchListParams) {
   return ['matches', 'list', params] as const
 }
 
-/** Query key for a single match's details (BFF response). */
 export function matchQueryKey(matchId: string) {
   return ['matches', 'detail', matchId] as const
 }
@@ -126,10 +125,7 @@ export function useMatchList(params: MatchListParams) {
   })
 }
 
-/**
- * Single match details (BFF for /matches/$id and the scoring routes).
- * Throws to the surrounding boundary on failure.
- */
+/** Throws on failure so the surrounding boundary can render a retry. */
 export function useMatch(matchId: string) {
   return useQuery({
     queryKey: matchQueryKey(matchId),
@@ -210,8 +206,8 @@ export function useUpdateScore(
   })
 }
 
-// URL helpers used by every scoring CTA so the route shape lives in one place.
-// `as const` preserves the literal `to` for TanStack Router's typed navigation.
+// `as const` on `to` preserves the literal so TanStack Router's typed
+// navigation can validate it against the route tree.
 
 export function scoringNewRoute(matchId: string, gameId: string) {
   return {

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -155,7 +155,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** List Matches */
+        get: operations["list_matches_v1_matches_get"];
         put?: never;
         /** Create Match */
         post: operations["create_match_v1_matches_post"];
@@ -175,6 +176,40 @@ export interface paths {
         /** Get Match */
         get: operations["get_match_v1_matches__match_id__get"];
         put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/matches/{match_id}/games/{game_id}/scores": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Game Score */
+        post: operations["create_game_score_v1_matches__match_id__games__game_id__scores_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/matches/{match_id}/games/{game_id}/scores/{score_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update Game Score */
+        put: operations["update_game_score_v1_matches__match_id__games__game_id__scores__score_id__put"];
         post?: never;
         delete?: never;
         options?: never;
@@ -230,6 +265,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/dashboard": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Dashboard */
+        get: operations["get_dashboard_v1_dashboard_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/health": {
         parameters: {
             query?: never;
@@ -259,6 +311,66 @@ export interface components {
             latency_ms?: number | null;
             /** Error */
             error?: string | null;
+        };
+        /** DashboardNextMatch */
+        DashboardNextMatch: {
+            /**
+             * Match Id
+             * Format: uuid
+             */
+            match_id: string;
+            /** Opponent Username */
+            opponent_username: string | null;
+            /** Best Of */
+            best_of: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
+        /** DashboardRecentResult */
+        DashboardRecentResult: {
+            /**
+             * Match Id
+             * Format: uuid
+             */
+            match_id: string;
+            /** Opponent Username */
+            opponent_username: string | null;
+            /** Is Win */
+            is_win: boolean;
+            /** My Games Won */
+            my_games_won: number;
+            /** Opponent Games Won */
+            opponent_games_won: number;
+            /**
+             * Completed At
+             * Format: date-time
+             */
+            completed_at: string;
+        };
+        /** DashboardResponse */
+        DashboardResponse: {
+            score_banner: components["schemas"]["DashboardScoreBanner"] | null;
+            next_match: components["schemas"]["DashboardNextMatch"] | null;
+            /** Recent Results */
+            recent_results: components["schemas"]["DashboardRecentResult"][];
+        };
+        /** DashboardScoreBanner */
+        DashboardScoreBanner: {
+            /**
+             * Match Id
+             * Format: uuid
+             */
+            match_id: string;
+            /** Opponent Username */
+            opponent_username: string | null;
+            /**
+             * Current Game Id
+             * Format: uuid
+             */
+            current_game_id: string;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -293,40 +405,60 @@ export interface components {
              */
             rated: boolean;
         };
-        /** MatchRead */
-        MatchRead: {
+        /** MatchDetails */
+        MatchDetails: {
             /**
              * Id
              * Format: uuid
              */
             id: string;
             status: components["schemas"]["MatchStatus"];
-            /**
-             * Created By User Id
-             * Format: uuid
-             */
-            created_by_user_id: string;
+            /** Status Label */
+            status_label: string;
+            /** Best Of */
+            best_of: number;
+            /** Games To Win */
+            games_to_win: number;
+            /** Team Size */
+            team_size: number;
+            /** Affects Rating */
+            affects_rating: boolean;
             /**
              * Created At
              * Format: date-time
              */
             created_at: string;
-            settings: components["schemas"]["MatchSettingsRead"];
-            /** Sides */
-            sides: components["schemas"]["MatchSideRead"][];
+            my_side: components["schemas"]["MatchDetailsSide"];
+            opponent_side: components["schemas"]["MatchDetailsSide"] | null;
+            /** Games */
+            games: components["schemas"]["MatchDetailsGame"][];
+            current_game: components["schemas"]["MatchDetailsCurrentGame"] | null;
+            /** Can Score */
+            can_score: boolean;
         };
-        /** MatchSettingsRead */
-        MatchSettingsRead: {
-            /** Team Size */
-            team_size: number;
-            /** Best Of */
-            best_of: number;
-            /** Affects Rating */
-            affects_rating: boolean;
-            verification_policy: components["schemas"]["VerificationPolicy"];
+        /** MatchDetailsCurrentGame */
+        MatchDetailsCurrentGame: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Game Number */
+            game_number: number;
         };
-        /** MatchSidePlayerRead */
-        MatchSidePlayerRead: {
+        /** MatchDetailsGame */
+        MatchDetailsGame: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Game Number */
+            game_number: number;
+            score: components["schemas"]["MatchDetailsScore"] | null;
+        };
+        /** MatchDetailsPlayer */
+        MatchDetailsPlayer: {
             /**
              * User Id
              * Format: uuid
@@ -334,17 +466,87 @@ export interface components {
             user_id: string;
             /** Username */
             username: string;
+            /** Is Current User */
+            is_current_user: boolean;
         };
-        /** MatchSideRead */
-        MatchSideRead: {
+        /** MatchDetailsScore */
+        MatchDetailsScore: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** My Points */
+            my_points: number;
+            /** Opponent Points */
+            opponent_points: number;
+            /** Is My Win */
+            is_my_win: boolean;
+        };
+        /** MatchDetailsSide */
+        MatchDetailsSide: {
             /** Side Number */
             side_number: number;
-            /** Score */
-            score: number;
+            /** Players */
+            players: components["schemas"]["MatchDetailsPlayer"][];
+            /** Games Won */
+            games_won: number;
             /** Won */
             won: boolean | null;
-            /** Players */
-            players: components["schemas"]["MatchSidePlayerRead"][];
+            /** Is Current User Side */
+            is_current_user_side: boolean;
+        };
+        /** MatchGameScoreWrite */
+        MatchGameScoreWrite: {
+            /** Side 1 Points */
+            side_1_points: number;
+            /** Side 2 Points */
+            side_2_points: number;
+        };
+        /** MatchListResponse */
+        MatchListResponse: {
+            /** Items */
+            items: components["schemas"]["MatchListRow"][];
+            /** Page */
+            page: number;
+            /** Page Size */
+            page_size: number;
+            /** Total */
+            total: number;
+            /** Status Counts */
+            status_counts: {
+                [key: string]: number;
+            };
+        };
+        /** MatchListRow */
+        MatchListRow: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            status: components["schemas"]["MatchStatus"];
+            /** Status Label */
+            status_label: string;
+            /** Opponent Username */
+            opponent_username: string | null;
+            /** Opponent User Id */
+            opponent_user_id: string | null;
+            /** My Games Won */
+            my_games_won: number;
+            /** Opponent Games Won */
+            opponent_games_won: number;
+            /** Is Win */
+            is_win: boolean | null;
+            /** Best Of */
+            best_of: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Current Game Id */
+            current_game_id: string | null;
         };
         /**
          * MatchStatus
@@ -499,11 +701,6 @@ export interface components {
             /** Context */
             ctx?: Record<string, never>;
         };
-        /**
-         * VerificationPolicy
-         * @enum {string}
-         */
-        VerificationPolicy: "none" | "self_report" | "opponent_confirms" | "all_players_confirm";
     };
     responses: never;
     parameters: never;
@@ -1045,6 +1242,42 @@ export interface operations {
             };
         };
     };
+    list_matches_v1_matches_get: {
+        parameters: {
+            query?: {
+                status?: components["schemas"]["MatchStatus"] | null;
+                q?: string | null;
+                page?: number;
+                page_size?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     create_match_v1_matches_post: {
         parameters: {
             query?: never;
@@ -1066,7 +1299,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["MatchRead"];
+                    "application/json": components["schemas"]["MatchDetails"];
                 };
             };
             /** @description Validation Error */
@@ -1087,7 +1320,9 @@ export interface operations {
             path: {
                 match_id: string;
             };
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody?: never;
         responses: {
@@ -1097,7 +1332,84 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["MatchRead"];
+                    "application/json": components["schemas"]["MatchDetails"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_game_score_v1_matches__match_id__games__game_id__scores_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                match_id: string;
+                game_id: string;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MatchGameScoreWrite"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchDetails"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_game_score_v1_matches__match_id__games__game_id__scores__score_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                match_id: string;
+                game_id: string;
+                score_id: string;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MatchGameScoreWrite"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchDetails"];
                 };
             };
             /** @description Validation Error */
@@ -1166,6 +1478,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PlayerRead"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_dashboard_v1_dashboard_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DashboardResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -1,11 +1,20 @@
 import { delay, http, HttpResponse } from 'msw'
 import type { components } from '@/api/schema'
+import { healthCheck, player, sessionResponse } from '@/test/factories'
 import {
-  healthCheck,
-  matchResponse,
-  player,
-  sessionResponse,
-} from '@/test/factories'
+  findMatch,
+  mockMatches,
+  newMatchSeed,
+  projectListRow,
+  projectMatchDetails,
+  projectNextMatch,
+  projectRecentResult,
+  projectScoreBanner,
+  reconcile,
+  statusCountsOf,
+  validateScore,
+  type SeedMatch,
+} from './match-store'
 import { createRbacState, dispatchRbac } from './rbac-engine'
 import { DEMO_SEED } from './rbac-store'
 
@@ -25,6 +34,9 @@ export const mockPlayers = [
 // The recent-opponents endpoint is capped at six chips; the dev/test mock just
 // serves the first slice in roster order.
 export const mockRecentOpponents = mockPlayers.slice(0, 6)
+
+// Re-exported so consumers can import the store from one place.
+export { mockMatches }
 
 const state = createRbacState(DEMO_SEED)
 
@@ -62,6 +74,54 @@ const RBAC_PATHS = [
   '*/v1/users/:id/roles',
 ]
 
+type MatchCreateBody = components['schemas']['MatchCreate']
+type MatchScoreBody = components['schemas']['MatchGameScoreWrite']
+
+function detail(message: string, status = 422) {
+  return HttpResponse.json({ detail: message }, { status })
+}
+
+/** Apply a score write to an existing game, recompute the seed, and return
+ * the projected MatchDetails. Validates against the same TT rules the API
+ * enforces so the FE inline-error tests see the same messages. */
+function applyScore(
+  seed: SeedMatch,
+  gameId: string,
+  body: MatchScoreBody,
+  options: { scoreId?: string } = {},
+): Response {
+  if (seed.opponent === null) {
+    return detail("This match has no opponent and can't be scored.", 422)
+  }
+  if (seed.status === 'disputed' || seed.status === 'voided') {
+    return detail('This match is no longer scorable.', 409)
+  }
+  const game = seed.games.find((g) => g.id === gameId)
+  if (!game) return detail('Game not found.', 404)
+  if (options.scoreId !== undefined) {
+    if (game.score === null || game.score.id !== options.scoreId) {
+      return detail('Score not found.', 404)
+    }
+  } else if (game.score !== null) {
+    return detail('This game has already been scored.', 409)
+  }
+
+  const message = validateScore(body.side_1_points, body.side_2_points)
+  if (message) return detail(message, 422)
+
+  game.score = {
+    id: options.scoreId ?? `s-${seed.id}-${game.game_number}-${Date.now().toString(36)}`,
+    side_1_points: body.side_1_points,
+    side_2_points: body.side_2_points,
+  }
+  reconcile(seed)
+  return HttpResponse.json(projectMatchDetails(seed))
+}
+
+function notNull<T>(value: T | null): value is T {
+  return value !== null
+}
+
 export const handlers = [
   http.get('*/v1/health', async () => {
     await delay(400)
@@ -85,22 +145,107 @@ export const handlers = [
         .slice(0, 10),
     )
   }),
+
+  // ----- matches ---------------------------------------------------------
   http.post('*/v1/matches', async ({ request }) => {
     await delay(400)
-    const body = (await readJson(request)) as components['schemas']['MatchCreate']
-    const opponent = body.opponent_user_id
-      ? (mockPlayers.find((p) => p.id === body.opponent_user_id) ?? null)
-      : null
-    return HttpResponse.json(
-      matchResponse({
-        creatorUsername: mockSession.data.user.username,
-        opponent,
-        bestOf: body.best_of,
-        rated: body.rated,
-      }),
-      { status: 201 },
-    )
+    const body = (await readJson(request)) as MatchCreateBody
+    let opponent: { id: string; username: string } | null = null
+    if (body.opponent_user_id) {
+      const found = mockPlayers.find((p) => p.id === body.opponent_user_id)
+      opponent = found ? { id: found.id, username: found.username } : null
+    }
+    const seed = newMatchSeed({
+      bestOf: body.best_of,
+      rated: body.rated,
+      opponent,
+    })
+    mockMatches.unshift(seed)
+    return HttpResponse.json(projectMatchDetails(seed), { status: 201 })
   }),
+
+  http.get('*/v1/matches', async ({ request }) => {
+    await delay(250)
+    const url = new URL(request.url)
+    const statusFilter = url.searchParams.get('status') ?? null
+    const q = url.searchParams.get('q')?.trim().toLowerCase() ?? ''
+    const page = Math.max(1, Number(url.searchParams.get('page') ?? '1'))
+    const pageSize = Math.max(
+      1,
+      Number(url.searchParams.get('page_size') ?? '25'),
+    )
+
+    let scoped = mockMatches.slice()
+    if (q) {
+      scoped = scoped.filter((m) =>
+        (m.opponent?.username ?? '').toLowerCase().includes(q),
+      )
+    }
+    const filtered = statusFilter
+      ? scoped.filter((m) => m.status === statusFilter)
+      : scoped
+
+    const start = (page - 1) * pageSize
+    const slice = filtered.slice(start, start + pageSize)
+    return HttpResponse.json({
+      items: slice.map(projectListRow),
+      page,
+      page_size: pageSize,
+      total: filtered.length,
+      status_counts: statusCountsOf(scoped),
+    })
+  }),
+
+  http.get('*/v1/matches/:matchId', async ({ params }) => {
+    await delay(200)
+    const seed = findMatch(String(params.matchId))
+    if (!seed) return detail('Match not found.', 404)
+    return HttpResponse.json(projectMatchDetails(seed))
+  }),
+
+  http.post(
+    '*/v1/matches/:matchId/games/:gameId/scores',
+    async ({ params, request }) => {
+      await delay(250)
+      const seed = findMatch(String(params.matchId))
+      if (!seed) return detail('Match not found.', 404)
+      const body = (await readJson(request)) as MatchScoreBody
+      return applyScore(seed, String(params.gameId), body)
+    },
+  ),
+
+  http.put(
+    '*/v1/matches/:matchId/games/:gameId/scores/:scoreId',
+    async ({ params, request }) => {
+      await delay(250)
+      const seed = findMatch(String(params.matchId))
+      if (!seed) return detail('Match not found.', 404)
+      const body = (await readJson(request)) as MatchScoreBody
+      return applyScore(seed, String(params.gameId), body, {
+        scoreId: String(params.scoreId),
+      })
+    },
+  ),
+
+  // ----- dashboard -------------------------------------------------------
+  http.get('*/v1/dashboard', async () => {
+    await delay(300)
+    const scoreBanner =
+      mockMatches.map(projectScoreBanner).find(notNull) ?? null
+    const nextMatch =
+      mockMatches.map(projectNextMatch).find(notNull) ?? null
+    const recentResults = mockMatches
+      .map(projectRecentResult)
+      .filter(notNull)
+      .sort((a, b) => b.completed_at.localeCompare(a.completed_at))
+      .slice(0, 5)
+    return HttpResponse.json({
+      score_banner: scoreBanner,
+      next_match: nextMatch,
+      recent_results: recentResults,
+    })
+  }),
+
   ...RBAC_PATHS.flatMap((path) => [
     http.get(path, rbacHandler),
     http.post(path, rbacHandler),

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -1,0 +1,400 @@
+import type { components } from '@/api/schema'
+
+type MatchStatus = components['schemas']['MatchStatus']
+type MatchDetails = components['schemas']['MatchDetails']
+type MatchDetailsSide = components['schemas']['MatchDetailsSide']
+type MatchDetailsGame = components['schemas']['MatchDetailsGame']
+type MatchListRow = components['schemas']['MatchListRow']
+type DashboardScoreBanner = components['schemas']['DashboardScoreBanner']
+type DashboardNextMatch = components['schemas']['DashboardNextMatch']
+type DashboardRecentResult = components['schemas']['DashboardRecentResult']
+
+// The mock-session user — handlers project every seed match as if this user
+// is on side 1, so `is_current_user_side` and `my_games_won` line up with
+// what the dev session would actually see.
+export const MOCK_CURRENT_USER = { id: 'u-me', username: 'rita.kovac' }
+
+const STATUS_LABELS: Record<MatchStatus, string> = {
+  pending: 'Scheduled',
+  in_progress: 'Live',
+  completed: 'Final',
+  disputed: 'Disputed',
+  voided: 'Voided',
+}
+
+const ALL_STATUSES: MatchStatus[] = [
+  'pending',
+  'in_progress',
+  'completed',
+  'disputed',
+  'voided',
+]
+
+export type SeedGame = {
+  id: string
+  game_number: number
+  score: { id: string; side_1_points: number; side_2_points: number } | null
+}
+
+export type SeedMatch = {
+  id: string
+  status: MatchStatus
+  best_of: number
+  affects_rating: boolean
+  created_at: string
+  completed_at: string | null
+  opponent: { id: string; username: string } | null
+  games: SeedGame[]
+}
+
+function gamesToWin(bestOf: number): number {
+  return Math.ceil(bestOf / 2)
+}
+
+function sideWinCounts(seed: SeedMatch): { side1: number; side2: number } {
+  let s1 = 0
+  let s2 = 0
+  for (const g of seed.games) {
+    if (!g.score) continue
+    if (g.score.side_1_points > g.score.side_2_points) s1 += 1
+    else if (g.score.side_2_points > g.score.side_1_points) s2 += 1
+  }
+  return { side1: s1, side2: s2 }
+}
+
+function currentUnscored(seed: SeedMatch): SeedGame | null {
+  return seed.games.find((g) => g.score === null) ?? null
+}
+
+/** Mirrors the API's `_recompute_match`: derive status / side `won`, drop any
+ * trailing unscored game on completion, append one when still in progress. */
+export function reconcile(seed: SeedMatch): void {
+  const { side1, side2 } = sideWinCounts(seed)
+  const target = gamesToWin(seed.best_of)
+  const decided = side1 >= target || side2 >= target
+  const anyScored = side1 > 0 || side2 > 0
+
+  if (decided) {
+    seed.status = 'completed'
+    if (seed.completed_at === null) seed.completed_at = '2026-05-12T09:30:00Z'
+    seed.games = seed.games.filter((g) => g.score !== null)
+  } else {
+    seed.status = anyScored ? 'in_progress' : 'pending'
+    seed.completed_at = null
+    if (currentUnscored(seed) === null && seed.opponent !== null) {
+      const nextNumber =
+        seed.games.reduce((max, g) => Math.max(max, g.game_number), 0) + 1
+      seed.games.push({
+        id: `g-${seed.id}-${nextNumber}`,
+        game_number: nextNumber,
+        score: null,
+      })
+    }
+  }
+}
+
+export function projectMatchDetails(seed: SeedMatch): MatchDetails {
+  const { side1, side2 } = sideWinCounts(seed)
+  const decided = seed.status === 'completed'
+
+  const mySide: MatchDetailsSide = {
+    side_number: 1,
+    players: [
+      {
+        user_id: MOCK_CURRENT_USER.id,
+        username: MOCK_CURRENT_USER.username,
+        is_current_user: true,
+      },
+    ],
+    games_won: side1,
+    won: decided ? side1 > side2 : null,
+    is_current_user_side: true,
+  }
+  const opponentSide: MatchDetailsSide | null = seed.opponent
+    ? {
+        side_number: 2,
+        players: [
+          {
+            user_id: seed.opponent.id,
+            username: seed.opponent.username,
+            is_current_user: false,
+          },
+        ],
+        games_won: side2,
+        won: decided ? side2 > side1 : null,
+        is_current_user_side: false,
+      }
+    : null
+
+  const games: MatchDetailsGame[] = seed.games
+    .slice()
+    .sort((a, b) => a.game_number - b.game_number)
+    .map((g) => ({
+      id: g.id,
+      game_number: g.game_number,
+      score: g.score
+        ? {
+            id: g.score.id,
+            my_points: g.score.side_1_points,
+            opponent_points: g.score.side_2_points,
+            is_my_win: g.score.side_1_points > g.score.side_2_points,
+          }
+        : null,
+    }))
+
+  const current = currentUnscored(seed)
+  return {
+    id: seed.id,
+    status: seed.status,
+    status_label: STATUS_LABELS[seed.status],
+    best_of: seed.best_of,
+    games_to_win: gamesToWin(seed.best_of),
+    team_size: 1,
+    affects_rating: seed.affects_rating,
+    created_at: seed.created_at,
+    my_side: mySide,
+    opponent_side: opponentSide,
+    games,
+    current_game: current
+      ? { id: current.id, game_number: current.game_number }
+      : null,
+    can_score: current !== null && opponentSide !== null,
+  }
+}
+
+export function projectListRow(seed: SeedMatch): MatchListRow {
+  const { side1, side2 } = sideWinCounts(seed)
+  const decided = seed.status === 'completed'
+  const current = currentUnscored(seed)
+  const scorable =
+    (seed.status === 'pending' || seed.status === 'in_progress') &&
+    seed.opponent !== null &&
+    current !== null
+  return {
+    id: seed.id,
+    status: seed.status,
+    status_label: STATUS_LABELS[seed.status],
+    opponent_username: seed.opponent?.username ?? null,
+    opponent_user_id: seed.opponent?.id ?? null,
+    my_games_won: side1,
+    opponent_games_won: side2,
+    is_win: decided && seed.opponent ? side1 > side2 : null,
+    best_of: seed.best_of,
+    created_at: seed.created_at,
+    current_game_id: scorable && current ? current.id : null,
+  }
+}
+
+export function projectScoreBanner(seed: SeedMatch): DashboardScoreBanner | null {
+  const current = currentUnscored(seed)
+  if (seed.status !== 'in_progress' || current === null) return null
+  return {
+    match_id: seed.id,
+    opponent_username: seed.opponent?.username ?? null,
+    current_game_id: current.id,
+  }
+}
+
+export function projectNextMatch(seed: SeedMatch): DashboardNextMatch | null {
+  if (seed.status !== 'pending') return null
+  return {
+    match_id: seed.id,
+    opponent_username: seed.opponent?.username ?? null,
+    best_of: seed.best_of,
+    created_at: seed.created_at,
+  }
+}
+
+export function projectRecentResult(seed: SeedMatch): DashboardRecentResult | null {
+  if (seed.status !== 'completed' || seed.opponent === null) return null
+  const { side1, side2 } = sideWinCounts(seed)
+  return {
+    match_id: seed.id,
+    opponent_username: seed.opponent.username,
+    is_win: side1 > side2,
+    my_games_won: side1,
+    opponent_games_won: side2,
+    completed_at: seed.completed_at ?? seed.created_at,
+  }
+}
+
+/** Single source of truth for the per-status histogram returned alongside
+ * the paginated list — the FE renders pill counts from this. */
+export function statusCountsOf(seeds: SeedMatch[]): Record<string, number> {
+  const counts: Record<string, number> = Object.fromEntries(
+    ALL_STATUSES.map((s) => [s, 0]),
+  )
+  for (const s of seeds) counts[s.status] = (counts[s.status] ?? 0) + 1
+  return counts
+}
+
+/** Seed snapshot used at module load. `m-2207` is the deterministic
+ * in-progress match the score-entry e2e hard-codes into its URL. */
+export function buildInitialSeeds(): SeedMatch[] {
+  return [
+    {
+      id: 'm-pending-1',
+      status: 'pending',
+      best_of: 5,
+      affects_rating: true,
+      created_at: '2026-05-14T17:00:00Z',
+      completed_at: null,
+      opponent: { id: 'pl-okafor', username: 'okafor.d' },
+      games: [
+        { id: 'g-pending-1-1', game_number: 1, score: null },
+      ],
+    },
+    {
+      id: 'm-2207',
+      status: 'in_progress',
+      best_of: 5,
+      affects_rating: true,
+      created_at: '2026-05-12T19:00:00Z',
+      completed_at: null,
+      opponent: { id: 'pl-nguyen', username: 'nguyen.t' },
+      games: [
+        {
+          id: 'g-2207-1',
+          game_number: 1,
+          score: { id: 's-2207-1', side_1_points: 11, side_2_points: 8 },
+        },
+        {
+          id: 'g-2207-2',
+          game_number: 2,
+          score: { id: 's-2207-2', side_1_points: 9, side_2_points: 11 },
+        },
+        { id: 'g-2207-3', game_number: 3, score: null },
+      ],
+    },
+    {
+      id: 'm-completed-win-1',
+      status: 'completed',
+      best_of: 5,
+      affects_rating: true,
+      created_at: '2026-05-10T18:00:00Z',
+      completed_at: '2026-05-10T18:42:00Z',
+      opponent: { id: 'pl-silva', username: 'silva.r' },
+      games: [
+        {
+          id: 'g-cw-1-1',
+          game_number: 1,
+          score: { id: 's-cw-1-1', side_1_points: 11, side_2_points: 7 },
+        },
+        {
+          id: 'g-cw-1-2',
+          game_number: 2,
+          score: { id: 's-cw-1-2', side_1_points: 11, side_2_points: 9 },
+        },
+        {
+          id: 'g-cw-1-3',
+          game_number: 3,
+          score: { id: 's-cw-1-3', side_1_points: 8, side_2_points: 11 },
+        },
+        {
+          id: 'g-cw-1-4',
+          game_number: 4,
+          score: { id: 's-cw-1-4', side_1_points: 12, side_2_points: 10 },
+        },
+      ],
+    },
+    {
+      id: 'm-completed-loss-1',
+      status: 'completed',
+      best_of: 3,
+      affects_rating: true,
+      created_at: '2026-05-08T20:00:00Z',
+      completed_at: '2026-05-08T20:25:00Z',
+      opponent: { id: 'pl-patel', username: 'patel.m' },
+      games: [
+        {
+          id: 'g-cl-1-1',
+          game_number: 1,
+          score: { id: 's-cl-1-1', side_1_points: 6, side_2_points: 11 },
+        },
+        {
+          id: 'g-cl-1-2',
+          game_number: 2,
+          score: { id: 's-cl-1-2', side_1_points: 9, side_2_points: 11 },
+        },
+      ],
+    },
+    {
+      id: 'm-completed-win-2',
+      status: 'completed',
+      best_of: 3,
+      affects_rating: true,
+      created_at: '2026-05-06T19:00:00Z',
+      completed_at: '2026-05-06T19:20:00Z',
+      opponent: { id: 'pl-chen', username: 'chen.w' },
+      games: [
+        {
+          id: 'g-cw-2-1',
+          game_number: 1,
+          score: { id: 's-cw-2-1', side_1_points: 11, side_2_points: 4 },
+        },
+        {
+          id: 'g-cw-2-2',
+          game_number: 2,
+          score: { id: 's-cw-2-2', side_1_points: 11, side_2_points: 6 },
+        },
+      ],
+    },
+  ]
+}
+
+/** Module-level store: a fresh snapshot is built on module load. Re-seeding
+ * across HMR isn't a goal — Vite will simply rebuild the array. */
+export const mockMatches: SeedMatch[] = buildInitialSeeds()
+
+export function findMatch(matchId: string): SeedMatch | undefined {
+  return mockMatches.find((m) => m.id === matchId)
+}
+
+/** Mirrors `MatchGameScoreWrite` model validation on the API. Returns the
+ * same human-readable message the FE shows so error-display tests can rely
+ * on it. */
+export function validateScore(side1: number, side2: number): string | null {
+  if (!Number.isInteger(side1) || side1 < 0 || side1 > 99) {
+    return 'Each side must score between 0 and 99 points.'
+  }
+  if (!Number.isInteger(side2) || side2 < 0 || side2 > 99) {
+    return 'Each side must score between 0 and 99 points.'
+  }
+  if (side1 === side2) return 'A game cannot end in a tie.'
+  const winner = Math.max(side1, side2)
+  const loser = Math.min(side1, side2)
+  if (winner < 11) return 'The winning side must reach at least 11 points.'
+  if (winner === 11 && loser > 9) {
+    return `At 10–10 the game enters deuce; the winner must lead by 2. ${winner}–${loser} is not a legal final score.`
+  }
+  if (winner > 11) {
+    if (loser < 10) {
+      return `A game can only go past 11 points after both sides reach 10. ${winner}–${loser} is not a legal final score.`
+    }
+    if (winner - loser !== 2) {
+      return `In a deuce game the winner leads by exactly 2 points. ${winner}–${loser} is not a legal final score.`
+    }
+  }
+  return null
+}
+
+/** Hardcoded current-user id used by `POST /v1/matches` to populate side 1. */
+export function newMatchSeed(input: {
+  bestOf: number
+  rated: boolean
+  opponent: { id: string; username: string } | null
+}): SeedMatch {
+  const id = `m-${Date.now().toString(36)}`
+  const seed: SeedMatch = {
+    id,
+    status: 'pending',
+    best_of: input.bestOf,
+    // A solo match (no opponent) can never affect ratings, mirroring the API.
+    affects_rating: input.rated && input.opponent !== null,
+    created_at: new Date().toISOString(),
+    completed_at: null,
+    opponent: input.opponent,
+    games: [{ id: `g-${id}-1`, game_number: 1, score: null }],
+  }
+  return seed
+}

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -76,7 +76,9 @@ export function reconcile(seed: SeedMatch): void {
 
   if (decided) {
     seed.status = 'completed'
-    if (seed.completed_at === null) seed.completed_at = '2026-05-12T09:30:00Z'
+    // Runtime-completed matches need a fresh timestamp so dashboard's
+    // recent-results sort puts them ahead of pre-seeded older matches.
+    if (seed.completed_at === null) seed.completed_at = new Date().toISOString()
     seed.games = seed.games.filter((g) => g.score !== null)
   } else {
     seed.status = anyScored ? 'in_progress' : 'pending'
@@ -345,6 +347,14 @@ export function buildInitialSeeds(): SeedMatch[] {
 /** Module-level store: a fresh snapshot is built on module load. Re-seeding
  * across HMR isn't a goal — Vite will simply rebuild the array. */
 export const mockMatches: SeedMatch[] = buildInitialSeeds()
+
+/** Restore the seed snapshot. Tests call this in `afterEach` so a test that
+ * mutates the store (via `POST /v1/matches` or a score write through the
+ * global handler) can't pollute the next test. */
+export function resetMockMatches(): void {
+  mockMatches.length = 0
+  mockMatches.push(...buildInitialSeeds())
+}
 
 export function findMatch(matchId: string): SeedMatch | undefined {
   return mockMatches.find((m) => m.id === matchId)

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -10,30 +10,16 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { delay, http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
-import type { components } from '@/api/schema'
 import { server } from '@/mocks/server'
+import { matchDetails } from '@/test/factories'
 import { Route } from './new'
-
-type MatchRead = components['schemas']['MatchRead']
 
 // The page component isn't exported (route files should only export `Route`,
 // so the router plugin can code-split them) — pull it off the route instead.
 const NewMatchPage = Route.options.component!
 
-function pendingMatch(): MatchRead {
-  return {
-    id: 'm-test',
-    status: 'pending',
-    created_by_user_id: 'u-test',
-    created_at: '2026-05-14T00:00:00Z',
-    settings: {
-      team_size: 1,
-      best_of: 5,
-      affects_rating: false,
-      verification_policy: 'none',
-    },
-    sides: [],
-  }
+function pendingMatch() {
+  return matchDetails({ id: 'm-test' })
 }
 
 function renderNewMatch() {

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -9,7 +9,18 @@ type Permission = components['schemas']['PermissionRead']
 type Role = components['schemas']['RoleRead']
 type RbacUser = components['schemas']['RbacUserRead']
 type Player = components['schemas']['PlayerRead']
-type MatchRead = components['schemas']['MatchRead']
+type MatchDetails = components['schemas']['MatchDetails']
+type MatchDetailsSide = components['schemas']['MatchDetailsSide']
+type MatchDetailsGame = components['schemas']['MatchDetailsGame']
+type MatchDetailsCurrentGame =
+  components['schemas']['MatchDetailsCurrentGame']
+type MatchListRow = components['schemas']['MatchListRow']
+type MatchListResponse = components['schemas']['MatchListResponse']
+type MatchStatus = components['schemas']['MatchStatus']
+type DashboardResponse = components['schemas']['DashboardResponse']
+type DashboardScoreBanner = components['schemas']['DashboardScoreBanner']
+type DashboardNextMatch = components['schemas']['DashboardNextMatch']
+type DashboardRecentResult = components['schemas']['DashboardRecentResult']
 
 function fastCheck(overrides: Partial<ComponentHealth> = {}): ComponentHealth {
   return {
@@ -119,47 +130,163 @@ export function player(overrides: Partial<Player> = {}): Player {
 }
 
 /**
- * Builds a `MatchRead` the way the API would for a `POST /v1/matches` body:
- * the creator always gets side 1, a registered opponent gets side 2, and
- * guest / no-opponent matches stay single-sided and unrated.
+ * `MatchDetails` factory. Defaults to a fresh `pending` 1v1 with the current
+ * user on side 1, a single opponent on side 2, and game 1 unscored — the
+ * shape the BFF returns straight after `POST /v1/matches`.
  */
-export function matchResponse(input: {
-  creatorUsername: string
-  opponent: Player | null
-  bestOf: number
-  rated: boolean
-}): MatchRead {
-  const creatorId = nextId('u')
-  const affectsRating = input.rated && input.opponent !== null
-  const sides: MatchRead['sides'] = [
-    {
-      side_number: 1,
-      score: 0,
-      won: null,
-      players: [{ user_id: creatorId, username: input.creatorUsername }],
-    },
-  ]
-  if (input.opponent) {
-    sides.push({
-      side_number: 2,
-      score: 0,
-      won: null,
-      players: [
-        { user_id: input.opponent.id, username: input.opponent.username },
-      ],
-    })
+export function matchDetails(
+  overrides: Partial<MatchDetails> = {},
+): MatchDetails {
+  const id = overrides.id ?? nextId('m')
+  const bestOf = overrides.best_of ?? 5
+  const currentUserId = nextId('u')
+  const opponentId = nextId('u')
+  const mySide: MatchDetailsSide = {
+    side_number: 1,
+    players: [
+      {
+        user_id: currentUserId,
+        username: 'rita.kovac',
+        is_current_user: true,
+      },
+    ],
+    games_won: 0,
+    won: null,
+    is_current_user_side: true,
   }
+  const opponentSide: MatchDetailsSide = {
+    side_number: 2,
+    players: [
+      {
+        user_id: opponentId,
+        username: faker.internet.username().toLowerCase(),
+        is_current_user: false,
+      },
+    ],
+    games_won: 0,
+    won: null,
+    is_current_user_side: false,
+  }
+  const firstGame: MatchDetailsGame = {
+    id: nextId('g'),
+    game_number: 1,
+    score: null,
+  }
+  const currentGame: MatchDetailsCurrentGame = {
+    id: firstGame.id,
+    game_number: 1,
+  }
+  return {
+    id,
+    status: 'pending',
+    status_label: 'Scheduled',
+    best_of: bestOf,
+    games_to_win: Math.ceil(bestOf / 2),
+    team_size: 1,
+    affects_rating: false,
+    created_at: ISO,
+    my_side: mySide,
+    opponent_side: opponentSide,
+    games: [firstGame],
+    current_game: currentGame,
+    can_score: true,
+    ...overrides,
+  }
+}
+
+/** Row-shaped projection for the /matches list. Defaults mirror a pending
+ * 1v1 against a registered opponent with one trailing un-scored game. */
+export function matchListRow(
+  overrides: Partial<MatchListRow> = {},
+): MatchListRow {
   return {
     id: nextId('m'),
     status: 'pending',
-    created_by_user_id: creatorId,
+    status_label: 'Scheduled',
+    opponent_username: faker.internet.username().toLowerCase(),
+    opponent_user_id: nextId('u'),
+    my_games_won: 0,
+    opponent_games_won: 0,
+    is_win: null,
+    best_of: 5,
     created_at: ISO,
-    settings: {
-      team_size: 1,
-      best_of: input.bestOf,
-      affects_rating: affectsRating,
-      verification_policy: 'none',
-    },
-    sides,
+    current_game_id: nextId('g'),
+    ...overrides,
+  }
+}
+
+const ALL_STATUSES: MatchStatus[] = [
+  'pending',
+  'in_progress',
+  'completed',
+  'disputed',
+  'voided',
+]
+
+export function matchListResponse(
+  overrides: Partial<MatchListResponse> = {},
+): MatchListResponse {
+  const items = overrides.items ?? []
+  const baseCounts: Record<string, number> = Object.fromEntries(
+    ALL_STATUSES.map((s) => [s, 0]),
+  )
+  for (const item of items) {
+    baseCounts[item.status] = (baseCounts[item.status] ?? 0) + 1
+  }
+  return {
+    items,
+    page: 1,
+    page_size: 25,
+    total: items.length,
+    status_counts: baseCounts,
+    ...overrides,
+  }
+}
+
+export function dashboardResponse(
+  overrides: Partial<DashboardResponse> = {},
+): DashboardResponse {
+  return {
+    score_banner: null,
+    next_match: null,
+    recent_results: [],
+    ...overrides,
+  }
+}
+
+export function dashboardScoreBanner(
+  overrides: Partial<DashboardScoreBanner> = {},
+): DashboardScoreBanner {
+  return {
+    match_id: nextId('m'),
+    opponent_username: faker.internet.username().toLowerCase(),
+    current_game_id: nextId('g'),
+    ...overrides,
+  }
+}
+
+export function dashboardNextMatch(
+  overrides: Partial<DashboardNextMatch> = {},
+): DashboardNextMatch {
+  return {
+    match_id: nextId('m'),
+    opponent_username: faker.internet.username().toLowerCase(),
+    best_of: 5,
+    created_at: ISO,
+    ...overrides,
+  }
+}
+
+export function dashboardRecentResult(
+  overrides: Partial<DashboardRecentResult> = {},
+): DashboardRecentResult {
+  return {
+    match_id: nextId('m'),
+    opponent_username: faker.internet.username().toLowerCase(),
+    is_win: true,
+    my_games_won: 3,
+    opponent_games_won: 1,
+    completed_at: ISO,
+    ...overrides,
   }
 }

--- a/web-client/src/test/setup.ts
+++ b/web-client/src/test/setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { afterAll, afterEach, beforeAll } from 'vitest'
+import { resetMockMatches } from '../mocks/match-store'
 import { server } from '../mocks/server'
 
 // jsdom doesn't implement matchMedia; responsive components (e.g. AppShell)
@@ -19,5 +20,8 @@ if (!window.matchMedia) {
 }
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  resetMockMatches()
+})
 afterAll(() => server.close())


### PR DESCRIPTION
## Summary

PR 2 of the match-flow wiring effort (PR 1 → #135 landed the backend). No
UI changes — just the data layer that PRs 3/4/5 will consume.

- Regenerates `schema.d.ts` against PR 1's new BFF (MatchDetails,
  MatchListResponse, MatchGameScoreWrite, DashboardResponse).
- `web-client/src/api/matches.ts` — `useMatchList` (keepPreviousData),
  `useMatch`, `useCreateScore` / `useUpdateScore` (cache-prime on
  success + invalidate list/dashboard, no `throwOnError` so the
  scoring route can render inline errors), and `scoringNewRoute` /
  `scoringEditRoute` URL helpers. `useCreateMatch` now returns
  `MatchDetails`.
- New `web-client/src/api/dashboard.ts` — `useDashboard` +
  `DASHBOARD_QUERY_KEY` (the key score mutations invalidate).
- `web-client/src/test/factories.ts` — replaces the old
  `MatchRead`-shaped `matchResponse` with `matchDetails`,
  `matchListRow`, `matchListResponse`, `dashboardResponse` (plus
  banner / next-match / recent-result factories).
- `web-client/src/mocks/match-store.ts` — stateful seed + projection
  helpers shared across the four match handlers; mirrors the API's
  `_recompute_match` (trailing-game reconcile) and TT-rule validation
  so MSW returns the same 422 messages the API does. Seeds a
  deterministic `m-2207` match the existing `score-entry.spec.ts`
  hard-codes, plus pending / completed coverage for PR 3 & PR 5.
- `web-client/src/mocks/handlers.ts` — six new stateful handlers
  (`POST /v1/matches`, `GET /v1/matches`, `GET /v1/matches/:id`,
  `POST/PUT .../scores`, `GET /v1/dashboard`).

## Test plan

- [x] `cd web-client && npm run lint` — clean (one pre-existing
      vendored mockServiceWorker.js warning, unchanged)
- [x] `npm run test:run` — 17/17 pass (existing `matches/new.test.tsx`
      now uses the new `matchDetails` factory)
- [x] `npm run build` — `tsc -b && vite build` clean
- [ ] `npm run test:e2e` — verify the score-entry spec still finds
      `m-2207` once it picks up the new MSW seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)