### PR TITLE
PR 3: Wire /matches list to the match list BFF

### DIFF
--- a/web-client/e2e/matches-list.spec.ts
+++ b/web-client/e2e/matches-list.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test, type Page, type Route } from '@playwright/test'
+import {
+  matchListResponse,
+  matchListRow,
+  sessionResponse,
+} from '../src/test/factories'
+
+const SESSION = sessionResponse({ user: { username: 'rita.kovac' } })
+
+/** Three seeded matches across statuses, plus a "Score" CTA on the live row.
+ *  Each row exists in `mock` because the API filters by `status` server-side;
+ *  the page never has to filter client-side. */
+const SEED = [
+  matchListRow({
+    id: 'm-live-1',
+    opponent_username: 'nguyen.t',
+    status: 'in_progress',
+    status_label: 'Live',
+    my_games_won: 1,
+    opponent_games_won: 1,
+    current_game_id: 'g-live-1-3',
+  }),
+  matchListRow({
+    id: 'm-pending-1',
+    opponent_username: 'okafor.d',
+    status: 'pending',
+    status_label: 'Scheduled',
+    current_game_id: 'g-pending-1-1',
+  }),
+  matchListRow({
+    id: 'm-final-1',
+    opponent_username: 'silva.r',
+    status: 'completed',
+    status_label: 'Final',
+    my_games_won: 3,
+    opponent_games_won: 1,
+    is_win: true,
+    current_game_id: null,
+  }),
+]
+
+/** Mount a `GET /v1/matches` stub that filters seeded rows by the requested
+ *  status and paginates them. Records every request so specs can assert the
+ *  client sent the right query string. */
+async function installListMock(page: Page, rows = SEED, pageSize = 25) {
+  const requests: URL[] = []
+  await page.route('**/api/v1/**', (route: Route) => {
+    const url = new URL(route.request().url())
+    const path = url.pathname.replace(/^\/api/, '')
+    if (path === '/v1/session') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SESSION),
+      })
+    }
+    if (path === '/v1/matches' && route.request().method() === 'GET') {
+      requests.push(url)
+      const status = url.searchParams.get('status')
+      const pageNum = Number(url.searchParams.get('page') ?? '1')
+      const filtered = status ? rows.filter((r) => r.status === status) : rows
+      const start = (pageNum - 1) * pageSize
+      const slice = filtered.slice(start, start + pageSize)
+      const counts: Record<string, number> = {
+        pending: rows.filter((r) => r.status === 'pending').length,
+        in_progress: rows.filter((r) => r.status === 'in_progress').length,
+        completed: rows.filter((r) => r.status === 'completed').length,
+        disputed: 0,
+        voided: 0,
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          matchListResponse({
+            items: slice,
+            total: filtered.length,
+            page: pageNum,
+            page_size: pageSize,
+            status_counts: counts,
+          }),
+        ),
+      })
+    }
+    return route.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: JSON.stringify({ detail: `unmocked ${route.request().method()} ${path}` }),
+    })
+  })
+  return requests
+}
+
+test.describe('Matches list', () => {
+  test('renders the seeded matches', async ({ page }) => {
+    await installListMock(page)
+    await page.goto('/matches')
+
+    await expect(page.getByText('nguyen.t')).toBeVisible()
+    await expect(page.getByText('okafor.d')).toBeVisible()
+    await expect(page.getByText('silva.r')).toBeVisible()
+  })
+
+  test('filters down to the live tab', async ({ page }) => {
+    await installListMock(page)
+    await page.goto('/matches')
+    // Wait for the initial render so the tab interactions land after data.
+    await expect(page.getByText('nguyen.t')).toBeVisible()
+
+    await page.getByRole('tab', { name: /^live/i }).click()
+
+    await expect(page.getByText('nguyen.t')).toBeVisible()
+    await expect(page.getByText('okafor.d')).not.toBeVisible()
+    await expect(page.getByText('silva.r')).not.toBeVisible()
+  })
+
+  test('opens the match details page when a row is clicked', async ({ page }) => {
+    await installListMock(page)
+    await page.goto('/matches')
+
+    // The details page itself isn't mocked here — asserting the URL change is
+    // enough to prove the row navigated.
+    await page.getByText('nguyen.t').click()
+    await expect(page).toHaveURL(/\/matches\/m-live-1$/)
+  })
+
+  test('shows the pagination footer when total exceeds page size', async ({
+    page,
+  }) => {
+    const many = Array.from({ length: 30 }, (_, i) =>
+      matchListRow({
+        id: `m-${i}`,
+        opponent_username: `opp-${i}`,
+        status: 'pending',
+      }),
+    )
+    await installListMock(page, many)
+    await page.goto('/matches')
+
+    // Showing 1–25 of 30 — confirms the footer rendered with the API total.
+    await expect(page.getByText(/Showing/i)).toContainText('1–25')
+    await expect(page.getByText(/Showing/i)).toContainText('30')
+    await expect(page.getByRole('button', { name: /next page/i })).toBeEnabled()
+  })
+})

--- a/web-client/e2e/matches-list.spec.ts
+++ b/web-client/e2e/matches-list.spec.ts
@@ -6,10 +6,8 @@ import {
 } from '../src/test/factories'
 
 const SESSION = sessionResponse({ user: { username: 'rita.kovac' } })
+const PAGE_SIZE = 25
 
-/** Three seeded matches across statuses, plus a "Score" CTA on the live row.
- *  Each row exists in `mock` because the API filters by `status` server-side;
- *  the page never has to filter client-side. */
 const SEED = [
   matchListRow({
     id: 'm-live-1',
@@ -39,11 +37,10 @@ const SEED = [
   }),
 ]
 
-/** Mount a `GET /v1/matches` stub that filters seeded rows by the requested
- *  status and paginates them. Records every request so specs can assert the
- *  client sent the right query string. */
-async function installListMock(page: Page, rows = SEED, pageSize = 25) {
-  const requests: URL[] = []
+// `status_counts` is computed off the unfiltered `rows` so tab badges reflect
+// the full histogram regardless of which status the request asked for; `total`
+// uses the filtered set so the footer matches the visible page.
+async function installListMock(page: Page, rows = SEED) {
   await page.route('**/api/v1/**', (route: Route) => {
     const url = new URL(route.request().url())
     const path = url.pathname.replace(/^\/api/, '')
@@ -55,12 +52,11 @@ async function installListMock(page: Page, rows = SEED, pageSize = 25) {
       })
     }
     if (path === '/v1/matches' && route.request().method() === 'GET') {
-      requests.push(url)
       const status = url.searchParams.get('status')
       const pageNum = Number(url.searchParams.get('page') ?? '1')
       const filtered = status ? rows.filter((r) => r.status === status) : rows
-      const start = (pageNum - 1) * pageSize
-      const slice = filtered.slice(start, start + pageSize)
+      const start = (pageNum - 1) * PAGE_SIZE
+      const slice = filtered.slice(start, start + PAGE_SIZE)
       const counts: Record<string, number> = {
         pending: rows.filter((r) => r.status === 'pending').length,
         in_progress: rows.filter((r) => r.status === 'in_progress').length,
@@ -76,7 +72,7 @@ async function installListMock(page: Page, rows = SEED, pageSize = 25) {
             items: slice,
             total: filtered.length,
             page: pageNum,
-            page_size: pageSize,
+            page_size: PAGE_SIZE,
             status_counts: counts,
           }),
         ),
@@ -88,12 +84,14 @@ async function installListMock(page: Page, rows = SEED, pageSize = 25) {
       body: JSON.stringify({ detail: `unmocked ${route.request().method()} ${path}` }),
     })
   })
-  return requests
 }
 
 test.describe('Matches list', () => {
-  test('renders the seeded matches', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await installListMock(page)
+  })
+
+  test('renders the seeded matches', async ({ page }) => {
     await page.goto('/matches')
 
     await expect(page.getByText('nguyen.t')).toBeVisible()
@@ -102,28 +100,25 @@ test.describe('Matches list', () => {
   })
 
   test('filters down to the live tab', async ({ page }) => {
-    await installListMock(page)
     await page.goto('/matches')
-    // Wait for the initial render so the tab interactions land after data.
     await expect(page.getByText('nguyen.t')).toBeVisible()
 
     await page.getByRole('tab', { name: /^live/i }).click()
 
     await expect(page.getByText('nguyen.t')).toBeVisible()
-    await expect(page.getByText('okafor.d')).not.toBeVisible()
-    await expect(page.getByText('silva.r')).not.toBeVisible()
+    await expect(page.getByText('okafor.d')).toHaveCount(0)
+    await expect(page.getByText('silva.r')).toHaveCount(0)
   })
 
   test('opens the match details page when a row is clicked', async ({ page }) => {
-    await installListMock(page)
     await page.goto('/matches')
 
-    // The details page itself isn't mocked here — asserting the URL change is
-    // enough to prove the row navigated.
     await page.getByText('nguyen.t').click()
     await expect(page).toHaveURL(/\/matches\/m-live-1$/)
   })
+})
 
+test.describe('Matches list — pagination', () => {
   test('shows the pagination footer when total exceeds page size', async ({
     page,
   }) => {
@@ -137,7 +132,6 @@ test.describe('Matches list', () => {
     await installListMock(page, many)
     await page.goto('/matches')
 
-    // Showing 1–25 of 30 — confirms the footer rendered with the API total.
     await expect(page.getByText(/Showing/i)).toContainText('1–25')
     await expect(page.getByText(/Showing/i)).toContainText('30')
     await expect(page.getByRole('button', { name: /next page/i })).toBeEnabled()

--- a/web-client/src/routes/matches/index.css
+++ b/web-client/src/routes/matches/index.css
@@ -384,7 +384,6 @@
   font-family: var(--font-mono);
 }
 
-/* ============ Skeleton rows ============ */
 .match-list-page table.matches tbody tr.skeleton-row {
   cursor: default;
 }

--- a/web-client/src/routes/matches/index.css
+++ b/web-client/src/routes/matches/index.css
@@ -384,6 +384,30 @@
   font-family: var(--font-mono);
 }
 
+/* ============ Skeleton rows ============ */
+.match-list-page table.matches tbody tr.skeleton-row {
+  cursor: default;
+}
+.match-list-page table.matches tbody tr.skeleton-row td {
+  padding: 18px 16px;
+}
+.match-list-page .skeleton-line {
+  height: 14px;
+  border-radius: 4px;
+  background: linear-gradient(
+    90deg,
+    var(--bg-raised) 0%,
+    var(--bg-hover) 50%,
+    var(--bg-raised) 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.4s ease-in-out infinite;
+}
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
 /* ============ Empty state ============ */
 .match-list-page .empty {
   padding: 80px 24px;

--- a/web-client/src/routes/matches/index.test.tsx
+++ b/web-client/src/routes/matches/index.test.tsx
@@ -14,7 +14,6 @@ import { server } from '@/mocks/server'
 import { matchListResponse, matchListRow } from '@/test/factories'
 import { Route } from './index'
 
-// Route files only export `Route`; pull the component off it to mount.
 const MatchesPage = Route.options.component!
 
 function renderMatchesPage() {
@@ -63,16 +62,18 @@ function renderMatchesPage() {
 
 describe('MatchesPage', () => {
   it('shows skeleton rows while loading, then real rows', async () => {
-    // The default MSW handler serves seeded matches, which are enough to
-    // prove the loading → loaded transition.
     renderMatchesPage()
 
     const skeletonTable = await screen.findByRole('table')
     expect(skeletonTable).toHaveAttribute('aria-busy', 'true')
 
-    // Once the request resolves the seeded `nguyen.t` opponent shows up.
     expect(await screen.findByText('nguyen.t')).toBeInTheDocument()
-    expect(screen.getByRole('table')).not.toHaveAttribute('aria-busy', 'true')
+    // The aria-busy attribute is dropped (not flipped to "false") once the
+    // skeleton table unmounts, so assert on its absence.
+    expect(screen.getByRole('table')).not.toHaveAttribute('aria-busy')
+    // Seed handler also yields silva.r (final win) and patel.m (final loss).
+    expect(screen.getByText('silva.r')).toBeInTheDocument()
+    expect(screen.getByText('patel.m')).toBeInTheDocument()
   })
 
   it('passes the API status when the player picks a status tab', async () => {
@@ -92,7 +93,6 @@ describe('MatchesPage', () => {
     )
     renderMatchesPage()
 
-    // Wait for the first (status=all) request to land.
     await waitFor(() => expect(requests.length).toBeGreaterThanOrEqual(1))
     const firstUrl = new URL(requests[0])
     expect(firstUrl.searchParams.get('status')).toBeNull()
@@ -109,9 +109,7 @@ describe('MatchesPage', () => {
     renderMatchesPage()
     const called = await screen.findByRole('tab', { name: /called/i })
     expect(called).toBeDisabled()
-    // The tab renders no badge, so the only digits in its label come from
-    // accidentally-included counts. There should be none.
-    expect(called.textContent?.trim()).toBe('Called')
+    expect(called).toHaveAccessibleName('Called')
   })
 
   it('moves to the next page when the player clicks Next', async () => {
@@ -121,7 +119,7 @@ describe('MatchesPage', () => {
       http.get('*/v1/matches', ({ request }) => {
         requests.push(request.url)
         const page = Number(new URL(request.url).searchParams.get('page') ?? '1')
-        // 26 items total, so page 2 exists and the Next button activates.
+        // 26 items total — page 2 exists, so Next activates.
         const items = Array.from({ length: page === 1 ? 25 : 1 }, (_, i) =>
           matchListRow({
             id: `m-${page}-${i}`,
@@ -170,8 +168,6 @@ describe('MatchesPage', () => {
     await waitFor(() => expect(requests.length).toBeGreaterThanOrEqual(1))
     const requestsBeforeTyping = requests.length
 
-    // Three keystrokes in quick succession should coalesce into one request
-    // after the debounce window, not three.
     await user.type(screen.getByPlaceholderText(/search opponents/i), 'ngu')
 
     await waitFor(
@@ -181,17 +177,7 @@ describe('MatchesPage', () => {
       },
       { timeout: 1000 },
     )
-    // One request for the final settled term, not one per keystroke.
-    expect(requests.length - requestsBeforeTyping).toBeLessThanOrEqual(2)
-  })
-
-  it('renders the seeded matches end-to-end against MSW', async () => {
-    renderMatchesPage()
-
-    // The default MSW seeds include nguyen.t (live), silva.r (final win),
-    // patel.m (final loss). All three should render in the initial page.
-    expect(await screen.findByText('nguyen.t')).toBeInTheDocument()
-    expect(screen.getByText('silva.r')).toBeInTheDocument()
-    expect(screen.getByText('patel.m')).toBeInTheDocument()
+    // Three keystrokes should coalesce into one debounced fetch.
+    expect(requests.length - requestsBeforeTyping).toBe(1)
   })
 })

--- a/web-client/src/routes/matches/index.test.tsx
+++ b/web-client/src/routes/matches/index.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { server } from '@/mocks/server'
+import { matchListResponse, matchListRow } from '@/test/factories'
+import { Route } from './index'
+
+// Route files only export `Route`; pull the component off it to mount.
+const MatchesPage = Route.options.component!
+
+function renderMatchesPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute()
+  const matchesRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches',
+    component: MatchesPage,
+  })
+  const matchDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches/$matchId',
+    component: () => {
+      const { matchId } = matchDetailRoute.useParams()
+      return <div>Match detail {matchId}</div>
+    },
+  })
+  const newMatchRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches/new',
+    component: () => <div>New match route</div>,
+  })
+  const scoringRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches/$matchId/games/$gameId/scores/new',
+    component: () => <div>Scoring</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([
+      matchesRoute,
+      matchDetailRoute,
+      newMatchRoute,
+      scoringRoute,
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/matches'] }),
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('MatchesPage', () => {
+  it('shows skeleton rows while loading, then real rows', async () => {
+    // The default MSW handler serves seeded matches, which are enough to
+    // prove the loading → loaded transition.
+    renderMatchesPage()
+
+    const skeletonTable = await screen.findByRole('table')
+    expect(skeletonTable).toHaveAttribute('aria-busy', 'true')
+
+    // Once the request resolves the seeded `nguyen.t` opponent shows up.
+    expect(await screen.findByText('nguyen.t')).toBeInTheDocument()
+    expect(screen.getByRole('table')).not.toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('passes the API status when the player picks a status tab', async () => {
+    const user = userEvent.setup()
+    const requests: string[] = []
+    server.use(
+      http.get('*/v1/matches', ({ request }) => {
+        requests.push(request.url)
+        return HttpResponse.json(
+          matchListResponse({
+            items: [matchListRow({ opponent_username: 'live.opp' })],
+            status_counts: { pending: 1, in_progress: 1, completed: 1 },
+            total: 1,
+          }),
+        )
+      }),
+    )
+    renderMatchesPage()
+
+    // Wait for the first (status=all) request to land.
+    await waitFor(() => expect(requests.length).toBeGreaterThanOrEqual(1))
+    const firstUrl = new URL(requests[0])
+    expect(firstUrl.searchParams.get('status')).toBeNull()
+
+    await user.click(screen.getByRole('tab', { name: /live/i }))
+
+    await waitFor(() => {
+      const last = new URL(requests[requests.length - 1])
+      expect(last.searchParams.get('status')).toBe('in_progress')
+    })
+  })
+
+  it('keeps the "called" tab disabled with no count', async () => {
+    renderMatchesPage()
+    const called = await screen.findByRole('tab', { name: /called/i })
+    expect(called).toBeDisabled()
+    // The tab renders no badge, so the only digits in its label come from
+    // accidentally-included counts. There should be none.
+    expect(called.textContent?.trim()).toBe('Called')
+  })
+
+  it('moves to the next page when the player clicks Next', async () => {
+    const user = userEvent.setup()
+    const requests: string[] = []
+    server.use(
+      http.get('*/v1/matches', ({ request }) => {
+        requests.push(request.url)
+        const page = Number(new URL(request.url).searchParams.get('page') ?? '1')
+        // 26 items total, so page 2 exists and the Next button activates.
+        const items = Array.from({ length: page === 1 ? 25 : 1 }, (_, i) =>
+          matchListRow({
+            id: `m-${page}-${i}`,
+            opponent_username: `p${page}-${i}`,
+          }),
+        )
+        return HttpResponse.json(
+          matchListResponse({
+            items,
+            total: 26,
+            page,
+            status_counts: { pending: 26 },
+          }),
+        )
+      }),
+    )
+    renderMatchesPage()
+
+    await screen.findByText('p1-0')
+
+    await user.click(screen.getByRole('button', { name: /next page/i }))
+
+    await waitFor(() => {
+      const last = new URL(requests[requests.length - 1])
+      expect(last.searchParams.get('page')).toBe('2')
+    })
+    await screen.findByText('p2-0')
+  })
+
+  it('debounces the search input', async () => {
+    const user = userEvent.setup()
+    const requests: string[] = []
+    server.use(
+      http.get('*/v1/matches', ({ request }) => {
+        requests.push(request.url)
+        return HttpResponse.json(
+          matchListResponse({
+            items: [matchListRow({ opponent_username: 'nguyen.t' })],
+            total: 1,
+            status_counts: { pending: 1 },
+          }),
+        )
+      }),
+    )
+    renderMatchesPage()
+    await waitFor(() => expect(requests.length).toBeGreaterThanOrEqual(1))
+    const requestsBeforeTyping = requests.length
+
+    // Three keystrokes in quick succession should coalesce into one request
+    // after the debounce window, not three.
+    await user.type(screen.getByPlaceholderText(/search opponents/i), 'ngu')
+
+    await waitFor(
+      () => {
+        const last = new URL(requests[requests.length - 1])
+        expect(last.searchParams.get('q')).toBe('ngu')
+      },
+      { timeout: 1000 },
+    )
+    // One request for the final settled term, not one per keystroke.
+    expect(requests.length - requestsBeforeTyping).toBeLessThanOrEqual(2)
+  })
+
+  it('renders the seeded matches end-to-end against MSW', async () => {
+    renderMatchesPage()
+
+    // The default MSW seeds include nguyen.t (live), silva.r (final win),
+    // patel.m (final loss). All three should render in the initial page.
+    expect(await screen.findByText('nguyen.t')).toBeInTheDocument()
+    expect(screen.getByText('silva.r')).toBeInTheDocument()
+    expect(screen.getByText('patel.m')).toBeInTheDocument()
+  })
+})

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -1,5 +1,5 @@
-import { Fragment, useMemo, useState } from 'react'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
 import {
   ChevronLeft,
   ChevronRight,
@@ -11,8 +11,13 @@ import {
   X,
 } from 'lucide-react'
 
+import {
+  scoringNewRoute,
+  useMatchList,
+  type MatchListRow,
+  type MatchStatus,
+} from '@/api/matches'
 import { AppShell } from '@/components/app-shell'
-import { cn } from '@/lib/utils'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -27,287 +32,39 @@ import {
 import {
   Select,
   SelectContent,
-  SelectItem,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { useDebouncedValue } from '@/lib/use-debounced-value'
+import { cn } from '@/lib/utils'
 import './index.css'
 
 export const Route = createFileRoute('/matches/')({
   component: MatchesPage,
 })
 
-type ContextKey = 'tournament' | 'club' | 'casual' | 'ladder'
 type StatusKey = 'live' | 'final' | 'called' | 'scheduled'
-type Winner = 'a' | 'b' | null
-type Player = { name: string; seed: number }
 
-interface Match {
-  id: number
-  context: ContextKey
-  contextLabel: string
-  round: string | null
-  roundOrder: number
-  court: number | null
-  a: Player
-  b: Player
-  status: StatusKey
-  games: [number, number][]
-  aGames: number
-  bGames: number
-  winner: Winner
-  time: Date
-  bestOf: number
+// UI tabs ↔ API status. `called` has no backend concept yet — the tab stays
+// visible (disabled) so the navigation shape is stable as features land.
+const TAB_TO_API: Record<Exclude<StatusKey, 'called'>, MatchStatus> = {
+  scheduled: 'pending',
+  live: 'in_progress',
+  final: 'completed',
 }
-
-const PLAYERS: [string, number][] = [
-  ['Nguyen, T.', 1], ['Silva, R.', 2], ['Okafor, D.', 3], ['Johansen, A.', 4],
-  ['Tran, L.', 5], ['Patel, M.', 6], ['Chen, W.', 7], ['Park, J.', 8],
-  ['Kim, H.', 9], ['Ali, R.', 10], ['Rossi, G.', 11], ['Dubois, C.', 12],
-  ['Garcia, P.', 13], ['Müller, F.', 14], ['Tanaka, K.', 15], ['Yamamoto, S.', 16],
-  ['Ahmadi, B.', 17], ['Schmidt, L.', 18], ['Ivanova, N.', 19], ['Petrov, M.', 20],
-  ['Hassan, Y.', 21], ['O’Brien, P.', 22], ['Andersson, E.', 23], ['Lopez, R.', 24],
-  ['Becker, T.', 25], ['Cohen, D.', 26], ['Fernandez, J.', 27], ['Gupta, A.', 28],
-  ['Holm, V.', 29], ['Iwasaki, R.', 30], ['Jansen, K.', 31], ['Khan, S.', 32],
-  ['Lee, M.', 33], ['Moreau, A.', 34], ['Novak, J.', 35], ['Owens, B.', 36],
-  ['Pham, Q.', 37], ['Quinn, R.', 38], ['Reyes, T.', 39], ['Sato, H.', 40],
-  ['Torres, M.', 41], ['Ueda, K.', 42], ['Vargas, P.', 43], ['Wang, X.', 44],
-  ['Xu, L.', 45], ['Yusupov, F.', 46], ['Zhao, M.', 47], ['Abbas, N.', 48],
-  ['Brun, T.', 49], ['Costa, E.', 50], ['Diallo, S.', 51], ['Eriksen, J.', 52],
-  ['Fischer, M.', 53], ['Gomez, H.', 54], ['Hartmann, P.', 55], ['Inoue, R.', 56],
-  ['Jakobsen, A.', 57], ['Klein, S.', 58], ['Lindgren, O.', 59], ['Mancini, G.', 60],
-  ['Nakamura, T.', 61], ['Olsen, K.', 62], ['Pavlov, D.', 63], ['Rahman, M.', 64],
-]
-
-const AVATAR_PALETTE: [string, string][] = [
-  ['#3A4152', '#E4E7EF'], ['#1F2430', '#FFCFA8'], ['#171B24', '#8CFFD4'],
-  ['#11141B', '#FF9A4A'], ['#2A3040', '#A9B0C2'], ['#1F2430', '#6FB5FF'],
-]
-
-function avatarColors(seed: number): [string, string] {
-  return AVATAR_PALETTE[(seed - 1) % AVATAR_PALETTE.length]
-}
-
-function initials(name: string): string {
-  const [last, first] = name.split(',').map((s) => s.trim())
-  return ((first || '')[0] || '') + (last[0] || '')
-}
-
-const CONTEXTS: Record<ContextKey, { label: string; short: string }> = {
-  tournament: { label: 'Tournament', short: 'Tournament' },
-  club: { label: 'Club night', short: 'Club' },
-  casual: { label: 'Casual', short: 'Casual' },
-  ladder: { label: 'Ladder', short: 'Ladder' },
-}
-
-const TOURNAMENTS = ['Spring Open', 'City Cup', 'River League']
-const CLUBS = ['Riverside TT', 'East Side Pong', 'Downtown Paddle']
-
-const MOCK_TODAY_MS = new Date('2026-05-16T00:00:00').getTime()
-
-const ROUND_DEFS = [
-  { code: 'R64', label: 'Round of 64', order: 1 },
-  { code: 'R32', label: 'Round of 32', order: 2 },
-  { code: 'R16', label: 'Round of 16', order: 3 },
-  { code: 'QF', label: 'Quarterfinal', order: 4 },
-  { code: 'SF', label: 'Semifinal', order: 5 },
-  { code: 'F', label: 'Final', order: 6 },
-] as const
-
-function buildMatches(): Match[] {
-  let s = 17
-  const rnd = () => (s = (s * 9301 + 49297) % 233280) / 233280
-  const pickPlayers = (): [[string, number], [string, number]] => {
-    const aIdx = Math.floor(rnd() * PLAYERS.length)
-    let bIdx = Math.floor(rnd() * PLAYERS.length)
-    while (bIdx === aIdx) bIdx = Math.floor(rnd() * PLAYERS.length)
-    return [PLAYERS[aIdx], PLAYERS[bIdx]]
-  }
-
-  const start = new Date('2026-05-16T09:00:00')
-  const out: Match[] = []
-  let id = 1001
-
-  const tName = TOURNAMENTS[0]
-  ROUND_DEFS.forEach((r) => {
-    const counts: Record<string, number> = {
-      R64: 16, R32: 10, R16: 8, QF: 4, SF: 2, F: 1,
-    }
-    const n = counts[r.code]
-    for (let i = 0; i < n; i++) {
-      const [a, b] = pickPlayers()
-      const minute = (r.order - 1) * 110 + i * 16 + Math.floor(rnd() * 6)
-      const when = new Date(start.getTime() + minute * 60000)
-      let status: StatusKey
-      if (r.order <= 2) status = 'final'
-      else if (r.order === 3)
-        status = rnd() < 0.7 ? 'final' : rnd() < 0.5 ? 'live' : 'called'
-      else if (r.order === 4)
-        status = rnd() < 0.4 ? 'final' : rnd() < 0.55 ? 'live' : 'scheduled'
-      else status = rnd() < 0.5 ? 'scheduled' : 'called'
-      out.push(
-        buildMatch({
-          id: id++, rnd,
-          context: 'tournament', contextLabel: tName,
-          round: r.code, roundOrder: r.order,
-          court: 1 + Math.floor(rnd() * 8),
-          a, b, status, time: when, bestOf: 7,
-        }),
-      )
-    }
-  })
-
-  for (let i = 0; i < 14; i++) {
-    const [a, b] = pickPlayers()
-    const dayOffset = (i % 3) - 2
-    const evening = new Date(
-      start.getTime() +
-        dayOffset * 86400000 +
-        (12 * 60 + Math.floor(rnd() * 180)) * 60000,
-    )
-    const status: StatusKey = i < 2 ? 'live' : 'final'
-    out.push(
-      buildMatch({
-        id: id++, rnd,
-        context: 'club', contextLabel: CLUBS[i % CLUBS.length],
-        round: null, roundOrder: 0,
-        court: 1 + Math.floor(rnd() * 4),
-        a, b, status, time: evening, bestOf: 5,
-      }),
-    )
-  }
-
-  for (let i = 0; i < 16; i++) {
-    const [a, b] = pickPlayers()
-    const dayOffset = -Math.floor(rnd() * 7)
-    const when = new Date(
-      start.getTime() + dayOffset * 86400000 + Math.floor(rnd() * 720) * 60000,
-    )
-    out.push(
-      buildMatch({
-        id: id++, rnd,
-        context: 'casual', contextLabel: 'Casual',
-        round: null, roundOrder: 0, court: null,
-        a, b, status: 'final', time: when, bestOf: 3,
-      }),
-    )
-  }
-
-  for (let i = 0; i < 8; i++) {
-    const [a, b] = pickPlayers()
-    const dayOffset = -Math.floor(rnd() * 14)
-    const when = new Date(
-      start.getTime() + dayOffset * 86400000 + Math.floor(rnd() * 720) * 60000,
-    )
-    const status: StatusKey = i === 0 ? 'scheduled' : 'final'
-    out.push(
-      buildMatch({
-        id: id++, rnd,
-        context: 'ladder', contextLabel: 'Club ladder',
-        round: null, roundOrder: 0, court: null,
-        a, b, status, time: when, bestOf: 5,
-      }),
-    )
-  }
-
-  return out
-}
-
-interface BuildMatchInput {
-  id: number
-  rnd: () => number
-  context: ContextKey
-  contextLabel: string
-  round: string | null
-  roundOrder: number
-  court: number | null
-  a: [string, number]
-  b: [string, number]
-  status: StatusKey
-  time: Date
-  bestOf: number
-}
-
-function buildMatch(input: BuildMatchInput): Match {
-  const { id, rnd, context, contextLabel, round, roundOrder, court, a, b, status, time, bestOf } = input
-  const target = Math.ceil(bestOf / 2)
-  const games: [number, number][] = []
-  let aGames = 0
-  let bGames = 0
-  if (status === 'final') {
-    const aWins = rnd() < 0.55
-    while (aGames < target && bGames < target) {
-      if (rnd() < (aWins ? 0.6 : 0.4)) aGames++
-      else bGames++
-    }
-    const total = aGames + bGames
-    for (let g = 0; g < total; g++) {
-      const aIsGameWinner = rnd() < (aWins ? 0.6 : 0.4)
-      const winnerScore = 11 + Math.floor(rnd() * 3)
-      const loserScore = Math.max(0, winnerScore - 2 - Math.floor(rnd() * 8))
-      games.push(aIsGameWinner ? [winnerScore, loserScore] : [loserScore, winnerScore])
-    }
-  } else if (status === 'live') {
-    const done = Math.min(target - 1, 1 + Math.floor(rnd() * (target - 1)))
-    for (let g = 0; g < done; g++) {
-      const aIsGameWinner = rnd() < 0.5
-      const winnerScore = 11 + Math.floor(rnd() * 3)
-      const loserScore = Math.max(0, winnerScore - 2 - Math.floor(rnd() * 8))
-      games.push(aIsGameWinner ? [winnerScore, loserScore] : [loserScore, winnerScore])
-      if (aIsGameWinner) aGames++
-      else bGames++
-    }
-    games.push([Math.floor(rnd() * 11), Math.floor(rnd() * 11)])
-  }
-  const winner: Winner = status === 'final' ? (aGames > bGames ? 'a' : 'b') : null
-  return {
-    id, context, contextLabel, round, roundOrder, court,
-    a: { name: a[0], seed: a[1] },
-    b: { name: b[0], seed: b[1] },
-    status, games, aGames, bGames, winner, time, bestOf,
-  }
-}
-
-interface Counts {
-  total: number
-  live: number
-  called: number
-  scheduled: number
-  final: number
-}
-
-function ActionBar({ liveCount }: { liveCount: number }) {
-  return (
-    <div className="action-bar">
-      <div className="action-bar-title">Matches</div>
-      <div className="action-bar-crumb">Across tournaments, club nights, ladder &amp; casual</div>
-      <span className="live-pill">
-        <span className="live-dot" />
-        {String(liveCount).padStart(2, '0')} LIVE
-      </span>
-      <div className="filter-spacer" />
-      <Button variant="ghost" size="sm">Export CSV</Button>
-      <Button variant="default" size="sm">+ New match</Button>
-    </div>
-  )
-}
-
-interface FilterRowProps {
-  q: string
-  setQ: (v: string) => void
-  status: 'all' | StatusKey
-  setStatus: (v: 'all' | StatusKey) => void
-  context: 'all' | ContextKey
-  setContext: (v: 'all' | ContextKey) => void
-  round: string
-  setRound: (v: string) => void
-  court: string
-  setCourt: (v: string) => void
-  counts: Counts
-  courtOptions: number[]
-  onClear: () => void
-  anyFilter: boolean
+const API_TO_TAB: Record<MatchStatus, StatusKey | null> = {
+  pending: 'scheduled',
+  in_progress: 'live',
+  completed: 'final',
+  disputed: null,
+  voided: null,
 }
 
 const STATUS_TABS: { value: 'all' | StatusKey; label: string; live?: boolean }[] = [
@@ -318,19 +75,133 @@ const STATUS_TABS: { value: 'all' | StatusKey; label: string; live?: boolean }[]
   { value: 'final', label: 'Final' },
 ]
 
-function FilterRow(props: FilterRowProps) {
-  const {
-    q, setQ, status, setStatus, context, setContext, round, setRound, court, setCourt,
-    counts, courtOptions, onClear, anyFilter,
-  } = props
-  const statusCount = (v: 'all' | StatusKey) => (v === 'all' ? counts.total : counts[v])
+const PAGE_SIZE = 25
+
+// Pill tones keyed by UI tab; the visible text comes from the API's
+// `status_label` so the FE doesn't redefine copy.
+const STATUS_TONE: Record<StatusKey, string> = {
+  live: 'status-tone-live',
+  final: 'status-tone-final',
+  called: 'status-tone-called',
+  scheduled: 'status-tone-scheduled',
+}
+
+function MatchesPage() {
+  const [q, setQ] = useState('')
+  const [status, setStatus] = useState<'all' | StatusKey>('all')
+  const [page, setPage] = useState(1)
+  const debouncedQ = useDebouncedValue(q, 300).trim()
+
+  const apiStatus = status === 'all' || status === 'called'
+    ? undefined
+    : TAB_TO_API[status]
+  const { data, isLoading } = useMatchList({
+    status: apiStatus,
+    q: debouncedQ || undefined,
+    page,
+    page_size: PAGE_SIZE,
+  })
+
+  function changeStatus(next: 'all' | StatusKey) {
+    setStatus(next)
+    setPage(1)
+  }
+  function changeQuery(next: string) {
+    setQ(next)
+    setPage(1)
+  }
+
+  const items = data?.items ?? []
+  const total = data?.total ?? 0
+  const liveCount = data?.status_counts?.in_progress ?? 0
+
+  return (
+    <AppShell>
+      <TooltipProvider>
+        <div className="match-list-page">
+          <ActionBar liveCount={liveCount} />
+          <FilterRow
+            q={q}
+            setQ={changeQuery}
+            status={status}
+            setStatus={changeStatus}
+            statusCounts={data?.status_counts}
+          />
+          <div className="table-wrap">
+            <MatchTable
+              rows={items}
+              isLoading={isLoading}
+              onClear={() => {
+                changeQuery('')
+                changeStatus('all')
+              }}
+            />
+          </div>
+          <PaginationFooter
+            page={page}
+            setPage={setPage}
+            total={total}
+            pageSize={PAGE_SIZE}
+          />
+        </div>
+      </TooltipProvider>
+    </AppShell>
+  )
+}
+
+function ActionBar({ liveCount }: { liveCount: number }) {
+  return (
+    <div className="action-bar">
+      <div className="action-bar-title">Matches</div>
+      <div className="action-bar-crumb">
+        Across tournaments, club nights, ladder &amp; casual
+      </div>
+      <span className="live-pill">
+        <span className="live-dot" />
+        {String(liveCount).padStart(2, '0')} LIVE
+      </span>
+      <div className="filter-spacer" />
+      <Button variant="ghost" size="sm">
+        Export CSV
+      </Button>
+      <Button asChild variant="default" size="sm">
+        <Link to="/matches/new">+ New match</Link>
+      </Button>
+    </div>
+  )
+}
+
+function FilterRow({
+  q,
+  setQ,
+  status,
+  setStatus,
+  statusCounts,
+}: {
+  q: string
+  setQ: (v: string) => void
+  status: 'all' | StatusKey
+  setStatus: (v: 'all' | StatusKey) => void
+  statusCounts?: Record<string, number>
+}) {
+  function tabCount(value: 'all' | StatusKey): number | null {
+    if (value === 'called') return null
+    if (!statusCounts) return 0
+    if (value === 'all') {
+      // Backend total counts every status the user participates in, so derive
+      // the "all" count from the same histogram the tabs render from.
+      return Object.values(statusCounts).reduce((a, b) => a + b, 0)
+    }
+    const apiStatus = TAB_TO_API[value]
+    return statusCounts[apiStatus] ?? 0
+  }
   return (
     <div className="filter-row">
       <div className="ml-search">
         <Search className="ml-search-icon" size={16} strokeWidth={2} />
         <Input
           className="h-9 pl-9 pr-9"
-          placeholder="Search players or match #…"
+          placeholder="Search opponents…"
           value={q}
           onChange={(e) => setQ(e.target.value)}
         />
@@ -346,231 +217,93 @@ function FilterRow(props: FilterRowProps) {
         )}
       </div>
 
-      <Tabs value={status} onValueChange={(v) => setStatus(v as 'all' | StatusKey)}>
+      <Tabs
+        value={status}
+        onValueChange={(v) => setStatus(v as 'all' | StatusKey)}
+      >
         <TabsList>
-          {STATUS_TABS.map((t) => (
-            <TabsTrigger key={t.value} value={t.value} className="gap-1.5">
-              {t.live && <span className="live-dot" />}
-              {t.label}
-              <span className="seg-count">{statusCount(t.value)}</span>
-            </TabsTrigger>
-          ))}
+          {STATUS_TABS.map((t) => {
+            const count = tabCount(t.value)
+            const disabled = t.value === 'called'
+            return (
+              <TabsTrigger
+                key={t.value}
+                value={t.value}
+                className="gap-1.5"
+                disabled={disabled}
+              >
+                {t.live && <span className="live-dot" />}
+                {t.label}
+                {count !== null && <span className="seg-count">{count}</span>}
+              </TabsTrigger>
+            )
+          })}
         </TabsList>
       </Tabs>
 
       <div className="filter-spacer" />
 
-      <span className="filter-label">Context</span>
-      <Select value={context} onValueChange={(v) => setContext(v as 'all' | ContextKey)}>
-        <SelectTrigger className="h-9 min-w-[140px]">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All contexts</SelectItem>
-          {(Object.entries(CONTEXTS) as [ContextKey, { label: string }][]).map(([k, v]) => (
-            <SelectItem key={k} value={k}>{v.label}</SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      <span className="filter-label">Round</span>
-      <Select value={round} onValueChange={setRound}>
-        <SelectTrigger className="h-9 min-w-[140px]">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All rounds</SelectItem>
-          {ROUND_DEFS.map((r) => (
-            <SelectItem key={r.code} value={r.code}>{r.label}</SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      <span className="filter-label">Court</span>
-      <Select value={court} onValueChange={setCourt}>
-        <SelectTrigger className="h-9 min-w-[120px]">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All courts</SelectItem>
-          {courtOptions.map((c) => (
-            <SelectItem key={c} value={String(c)}>Court {c}</SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      {anyFilter && (
-        <Button variant="ghost" size="sm" onClick={onClear}>Clear filters</Button>
-      )}
+      <ComingSoonSelect label="Context" placeholder="All contexts" />
+      <ComingSoonSelect label="Round" placeholder="All rounds" />
+      <ComingSoonSelect label="Court" placeholder="All courts" />
     </div>
   )
 }
 
-function PlayerAvatar({ name, seed }: { name: string; seed: number }) {
-  const [bg, fg] = avatarColors(seed)
-  return (
-    <Avatar className="size-[26px]">
-      <AvatarFallback
-        className="font-mono text-[11px] font-bold"
-        style={{ background: bg, color: fg }}
-      >
-        {initials(name)}
-      </AvatarFallback>
-    </Avatar>
-  )
-}
-
-function ContextCell({ m }: { m: Match }) {
-  return (
-    <div className={'ctx-chip ctx-' + m.context}>
-      <span className="ctx-dot" />
-      <div>
-        <div>{CONTEXTS[m.context].short}</div>
-        <div className="ctx-meta">{m.contextLabel}</div>
-      </div>
-    </div>
-  )
-}
-
-function PlayerCell({ a, b, winner, status }: { a: Player; b: Player; winner: Winner; status: StatusKey }) {
-  const aClass =
-    'player-name' + (status === 'final' ? (winner === 'a' ? ' is-winner' : ' is-loser') : '')
-  const bClass =
-    'player-name' + (status === 'final' ? (winner === 'b' ? ' is-winner' : ' is-loser') : '')
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
-      <div className="player">
-        <PlayerAvatar name={a.name} seed={a.seed} />
-        <span className={aClass}>{a.name}</span>
-        <span className="seed-tag">#{a.seed}</span>
-      </div>
-      <span className="vs">vs</span>
-      <div className="player">
-        <PlayerAvatar name={b.name} seed={b.seed} />
-        <span className={bClass}>{b.name}</span>
-        <span className="seed-tag">#{b.seed}</span>
-      </div>
-    </div>
-  )
-}
-
-function ScoreCell({ m }: { m: Match }) {
-  if (m.status === 'scheduled' || m.status === 'called') {
-    return <span className="score-cell pending">—</span>
-  }
-  if (m.status === 'live') {
-    const last = m.games[m.games.length - 1]
-    return (
-      <span className="score-cell">
-        <span className="games">{m.aGames}–{m.bGames}</span>
-        {last && (
-          <span className="score-meta">({last[0]}–{last[1]})</span>
-        )}
-      </span>
-    )
-  }
-  const winnerIdx = m.winner === 'a' ? 0 : 1
-  return (
-    <span className="score-cell games">
-      {m.games.map((g, i) => {
-        const lost = g[winnerIdx] < g[1 - winnerIdx]
-        return (
-          <Fragment key={i}>
-            <span className={lost ? 'lost' : ''}>{g[0]}–{g[1]}</span>
-            {i < m.games.length - 1 && <span className="score-sep">·</span>}
-          </Fragment>
-        )
-      })}
-    </span>
-  )
-}
-
-const STATUS_BADGE: Record<StatusKey, { label: string; className: string }> = {
-  live: { label: 'Live', className: 'status-tone-live' },
-  final: { label: 'Final', className: 'status-tone-final' },
-  called: { label: 'Called', className: 'status-tone-called' },
-  scheduled: { label: 'Scheduled', className: 'status-tone-scheduled' },
-}
-
-function StatusBadge({ status }: { status: StatusKey }) {
-  const meta = STATUS_BADGE[status]
-  return (
-    <Badge variant="secondary" className={`status-pill ${meta.className}`}>
-      {status === 'live' && <span className="live-dot" />}
-      {meta.label}
-    </Badge>
-  )
-}
-
-function TimeCell({ t }: { t: Date }) {
-  const hh = String(t.getHours()).padStart(2, '0')
-  const mm = String(t.getMinutes()).padStart(2, '0')
-  const dayMs = new Date(t.getFullYear(), t.getMonth(), t.getDate()).getTime()
-  const diffDays = Math.round((MOCK_TODAY_MS - dayMs) / 86400000)
-  let when: string
-  if (diffDays === 0) when = `${hh}:${mm}`
-  else if (diffDays === 1) when = `yest ${hh}:${mm}`
-  else if (diffDays > 1) when = `${diffDays}d ago`
-  else when = `+${-diffDays}d`
-  return (
-    <span className="time-cell">
-      <span className="strong">{when}</span>
-    </span>
-  )
-}
-
-type SortKey = 'id' | 'context' | 'round' | 'court' | 'score' | 'status' | 'time'
-type SortState = { key: SortKey; dir: 'asc' | 'desc' }
-
-interface SortHeaderProps {
-  id: SortKey
+function ComingSoonSelect({
+  label,
+  placeholder,
+}: {
   label: string
-  sort: SortState
-  setSort: (v: SortState) => void
-  width?: number
-}
-
-function SortHeader({ id, label, sort, setSort, width }: SortHeaderProps) {
-  const isSorted = sort.key === id
-  const dir = isSorted ? sort.dir : null
+  placeholder: string
+}) {
   return (
-    <th
-      className={'sortable' + (isSorted ? ' is-sorted' : '')}
-      onClick={() =>
-        setSort(
-          sort.key === id
-            ? { key: id, dir: sort.dir === 'asc' ? 'desc' : 'asc' }
-            : { key: id, dir: 'asc' },
-        )
-      }
-      style={{ width }}
-    >
-      {label}
-      <span className="sort-arrow">{dir === 'asc' ? '↑' : '↓'}</span>
-    </th>
+    <>
+      <span className="filter-label">{label}</span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {/* Wrap the disabled trigger so the tooltip still receives hover. */}
+          <span>
+            <Select disabled>
+              <SelectTrigger className="h-9 min-w-[120px]" disabled>
+                <SelectValue placeholder={placeholder} />
+              </SelectTrigger>
+              <SelectContent />
+            </Select>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>coming soon</TooltipContent>
+      </Tooltip>
+    </>
   )
 }
 
-interface MatchTableProps {
-  rows: Match[]
-  sort: SortState
-  setSort: (v: SortState) => void
+function MatchTable({
+  rows,
+  isLoading,
+  onClear,
+}: {
+  rows: MatchListRow[]
+  isLoading: boolean
   onClear: () => void
-}
-
-function MatchTable({ rows, sort, setSort, onClear }: MatchTableProps) {
-  const navigate = useNavigate()
-  function openMatch(id: number) {
-    void navigate({ to: '/matches/$matchId', params: { matchId: String(id) } })
-  }
-
+}) {
+  if (isLoading && rows.length === 0) return <SkeletonRows />
   if (rows.length === 0) {
     return (
       <div className="empty">
-        <div className="empty-icon"><Inbox size={56} strokeWidth={1.5} /></div>
-        <div className="empty-title">No matches match these filters</div>
-        <div className="empty-sub">Try widening the context, round, or court — or clear the search.</div>
-        <Button variant="ghost" size="sm" className="empty-clear" onClick={onClear}>
+        <div className="empty-icon">
+          <Inbox size={56} strokeWidth={1.5} />
+        </div>
+        <div className="empty-title">No matches yet</div>
+        <div className="empty-sub">
+          Start a new match or clear the filters to see your history.
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="empty-clear"
+          onClick={onClear}
+        >
           Clear filters
         </Button>
       </div>
@@ -580,66 +313,176 @@ function MatchTable({ rows, sort, setSort, onClear }: MatchTableProps) {
     <table className="matches">
       <thead>
         <tr>
-          <SortHeader id="id" label="#" sort={sort} setSort={setSort} width={84} />
-          <SortHeader id="context" label="Context" sort={sort} setSort={setSort} width={130} />
-          <SortHeader id="round" label="Round" sort={sort} setSort={setSort} width={90} />
-          <SortHeader id="court" label="Court" sort={sort} setSort={setSort} width={70} />
-          <th>Players</th>
-          <SortHeader id="score" label="Score" sort={sort} setSort={setSort} width={220} />
-          <SortHeader id="status" label="Status" sort={sort} setSort={setSort} width={120} />
-          <SortHeader id="time" label="Time" sort={sort} setSort={setSort} width={100} />
-          <th style={{ width: 36 }} />
+          <th style={{ width: 120 }}>Match</th>
+          <th>Opponent</th>
+          <th style={{ width: 120 }}>Score</th>
+          <th style={{ width: 120 }}>Status</th>
+          <th style={{ width: 140 }}>Started</th>
+          <th style={{ width: 56 }} />
         </tr>
       </thead>
       <tbody>
-        {rows.map((m) => (
-          <tr
-            key={m.id}
-            className={cn('is-clickable', m.status === 'live' && 'is-live')}
-            role="link"
-            tabIndex={0}
-            aria-label={`Open match M-${m.id}, ${m.a.name} vs ${m.b.name}`}
-            onClick={() => openMatch(m.id)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault()
-                openMatch(m.id)
-              }
-            }}
-          >
-            <td className="id-cell">M-{m.id}</td>
-            <td><ContextCell m={m} /></td>
-            <td>
-              {m.round ? (
-                <span className={'round-chip' + (m.round === 'F' || m.round === 'SF' ? ' is-final' : '')}>
-                  {m.round}
-                </span>
-              ) : (
-                <span className="cell-na">—</span>
-              )}
-            </td>
-            <td className="court-cell">
-              {m.court != null ? `C${m.court}` : <span className="cell-na">—</span>}
-            </td>
-            <td><PlayerCell a={m.a} b={m.b} winner={m.winner} status={m.status} /></td>
-            <td><ScoreCell m={m} /></td>
-            <td><StatusBadge status={m.status} /></td>
-            <td><TimeCell t={m.time} /></td>
-            <td>
-              <button
-                type="button"
-                className="row-action"
-                onClick={(e) => e.stopPropagation()}
-                aria-label="Row actions"
-              >
-                <MoreHorizontal size={16} strokeWidth={2} />
-              </button>
+        {rows.map((row) => (
+          <MatchRow key={row.id} row={row} />
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function SkeletonRows() {
+  return (
+    <table className="matches" aria-busy="true">
+      <thead>
+        <tr>
+          <th style={{ width: 120 }}>Match</th>
+          <th>Opponent</th>
+          <th style={{ width: 120 }}>Score</th>
+          <th style={{ width: 120 }}>Status</th>
+          <th style={{ width: 140 }}>Started</th>
+          <th style={{ width: 56 }} />
+        </tr>
+      </thead>
+      <tbody>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <tr key={i} className="skeleton-row" aria-hidden="true">
+            <td colSpan={6}>
+              <div className="skeleton-line" />
             </td>
           </tr>
         ))}
       </tbody>
     </table>
   )
+}
+
+function MatchRow({ row }: { row: MatchListRow }) {
+  const navigate = useNavigate()
+  const tab = API_TO_TAB[row.status] ?? 'scheduled'
+  const opponentName = row.opponent_username ?? 'No opponent'
+  const showScore =
+    row.status === 'in_progress' || row.status === 'completed'
+
+  function open() {
+    void navigate({ to: '/matches/$matchId', params: { matchId: row.id } })
+  }
+
+  return (
+    <tr
+      className={cn('is-clickable', row.status === 'in_progress' && 'is-live')}
+      role="link"
+      tabIndex={0}
+      aria-label={`Open match against ${opponentName}`}
+      onClick={open}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          open()
+        }
+      }}
+    >
+      <td className="id-cell">M-{row.id.slice(-6).toUpperCase()}</td>
+      <td>
+        <div className="player">
+          <Avatar className="size-[26px]">
+            <AvatarFallback className="font-mono text-[11px] font-bold">
+              {initials(opponentName)}
+            </AvatarFallback>
+          </Avatar>
+          <span
+            className={cn(
+              'player-name',
+              row.is_win === true && 'is-winner',
+              row.is_win === false && 'is-loser',
+            )}
+          >
+            {opponentName}
+          </span>
+        </div>
+      </td>
+      <td>
+        <ScoreCell row={row} showScore={showScore} />
+      </td>
+      <td>
+        <StatusBadge status={tab} label={row.status_label} />
+      </td>
+      <td>
+        <TimeCell iso={row.created_at} />
+      </td>
+      <td onClick={(e) => e.stopPropagation()}>
+        {row.current_game_id ? (
+          <Button asChild variant="default" size="sm">
+            <Link {...scoringNewRoute(row.id, row.current_game_id)}>
+              Score
+            </Link>
+          </Button>
+        ) : (
+          <button
+            type="button"
+            className="row-action"
+            aria-label="Row actions"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <MoreHorizontal size={16} strokeWidth={2} />
+          </button>
+        )}
+      </td>
+    </tr>
+  )
+}
+
+function ScoreCell({
+  row,
+  showScore,
+}: {
+  row: MatchListRow
+  showScore: boolean
+}) {
+  if (!showScore) return <span className="score-cell pending">—</span>
+  return (
+    <span className="score-cell games">
+      {row.my_games_won}–{row.opponent_games_won}
+    </span>
+  )
+}
+
+function StatusBadge({ status, label }: { status: StatusKey; label: string }) {
+  return (
+    <Badge variant="secondary" className={`status-pill ${STATUS_TONE[status]}`}>
+      {status === 'live' && <span className="live-dot" />}
+      {label}
+    </Badge>
+  )
+}
+
+function TimeCell({ iso }: { iso: string }) {
+  const created = new Date(iso)
+  const now = new Date()
+  const diffMs = now.getTime() - created.getTime()
+  const dayMs = 86400000
+  const days = Math.floor(diffMs / dayMs)
+  let when: string
+  if (days === 0) {
+    const hh = String(created.getHours()).padStart(2, '0')
+    const mm = String(created.getMinutes()).padStart(2, '0')
+    when = `${hh}:${mm}`
+  } else if (days === 1) when = 'yesterday'
+  else if (days < 30) when = `${days}d ago`
+  else when = created.toLocaleDateString()
+  return (
+    <span className="time-cell">
+      <span className="strong">{when}</span>
+    </span>
+  )
+}
+
+function initials(name: string): string {
+  const parts = name.split(/[^a-zA-Z0-9]+/).filter(Boolean)
+  const letters =
+    parts.length >= 2
+      ? parts[0][0] + parts[1][0]
+      : name.replace(/[^a-zA-Z0-9]/g, '').slice(0, 2)
+  return letters.toUpperCase() || '?'
 }
 
 type PageToken = number | 'ellipsis'
@@ -657,49 +500,31 @@ function paginationRange(current: number, total: number): PageToken[] {
   return range
 }
 
-interface PaginationProps {
+function PaginationFooter({
+  page,
+  setPage,
+  total,
+  pageSize,
+}: {
   page: number
   setPage: (n: number) => void
   total: number
   pageSize: number
-  setPageSize: (n: number) => void
-  filteredCount: number
-}
-
-function PaginationFooter(props: PaginationProps) {
-  const { page, setPage, total, pageSize, setPageSize, filteredCount } = props
-  const first = filteredCount === 0 ? 0 : (page - 1) * pageSize + 1
-  const last = Math.min(filteredCount, page * pageSize)
-  const tokens = paginationRange(page, total || 1)
+}) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize))
+  const first = total === 0 ? 0 : (page - 1) * pageSize + 1
+  const last = Math.min(total, page * pageSize)
+  const tokens = paginationRange(page, totalPages)
   const atFirst = page <= 1
-  const atLast = page >= total
+  const atLast = page >= totalPages
 
   return (
     <div className="footer">
       <div className="footer-info">
         Showing <span className="mono">{first}–{last}</span> of{' '}
-        <span className="mono">{filteredCount}</span> matches
+        <span className="mono">{total}</span> matches
       </div>
       <div className="footer-spacer" />
-      <div className="page-size">
-        Rows per page
-        <Select
-          value={String(pageSize)}
-          onValueChange={(v) => {
-            setPageSize(Number(v))
-            setPage(1)
-          }}
-        >
-          <SelectTrigger size="sm" className="min-w-[64px]">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {[10, 15, 25, 50].map((n) => (
-              <SelectItem key={n} value={String(n)}>{n}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
       <Pagination className="mx-0 w-auto justify-end">
         <PaginationContent>
           <PaginationItem>
@@ -760,7 +585,7 @@ function PaginationFooter(props: PaginationProps) {
               variant="ghost"
               size="icon-sm"
               disabled={atLast}
-              onClick={() => setPage(total)}
+              onClick={() => setPage(totalPages)}
               aria-label="Last page"
             >
               <ChevronsRight size={14} strokeWidth={2.4} />
@@ -769,137 +594,5 @@ function PaginationFooter(props: PaginationProps) {
         </PaginationContent>
       </Pagination>
     </div>
-  )
-}
-
-const ALL_MATCHES = buildMatches()
-
-const STATUS_ORDER: Record<StatusKey, number> = { live: 0, called: 1, scheduled: 2, final: 3 }
-const CONTEXT_ORDER: Record<ContextKey, number> = { tournament: 0, club: 1, ladder: 2, casual: 3 }
-
-const COUNTS: Counts = (() => {
-  const out: Counts = { total: ALL_MATCHES.length, live: 0, called: 0, scheduled: 0, final: 0 }
-  ALL_MATCHES.forEach((m) => {
-    out[m.status]++
-  })
-  return out
-})()
-
-const COURT_OPTIONS = (() => {
-  const s = new Set<number>()
-  ALL_MATCHES.forEach((m) => {
-    if (m.court != null) s.add(m.court)
-  })
-  return [...s].sort((a, b) => a - b)
-})()
-
-function MatchesPage() {
-  const [q, setQ] = useState('')
-  const [status, setStatus] = useState<'all' | StatusKey>('all')
-  const [context, setContext] = useState<'all' | ContextKey>('all')
-  const [round, setRound] = useState<string>('all')
-  const [court, setCourt] = useState<string>('all')
-  const [sort, setSort] = useState<SortState>({ key: 'time', dir: 'desc' })
-  const [page, setPage] = useState(1)
-  const [pageSize, setPageSize] = useState(15)
-
-  const filterSig = `${q}|${status}|${context}|${round}|${court}`
-  const [lastFilterSig, setLastFilterSig] = useState(filterSig)
-  if (lastFilterSig !== filterSig) {
-    setLastFilterSig(filterSig)
-    setPage(1)
-  }
-
-  const filtered = useMemo(() => {
-    const ql = q.trim().toLowerCase()
-    return ALL_MATCHES.filter((m) => {
-      if (status !== 'all' && m.status !== status) return false
-      if (context !== 'all' && m.context !== context) return false
-      if (round !== 'all' && m.round !== round) return false
-      if (court !== 'all' && String(m.court) !== String(court)) return false
-      if (ql) {
-        const hay = `${m.a.name} ${m.b.name} m-${m.id} ${m.contextLabel}`.toLowerCase()
-        if (!hay.includes(ql)) return false
-      }
-      return true
-    })
-  }, [q, status, context, round, court])
-
-  const sorted = useMemo(() => {
-    const arr = filtered.slice()
-    const dirMul = sort.dir === 'asc' ? 1 : -1
-    arr.sort((a, b) => {
-      switch (sort.key) {
-        case 'id':
-          return (a.id - b.id) * dirMul
-        case 'context':
-          return (
-            (CONTEXT_ORDER[a.context] - CONTEXT_ORDER[b.context]) * dirMul ||
-            a.contextLabel.localeCompare(b.contextLabel)
-          )
-        case 'round':
-          return ((a.roundOrder || 99) - (b.roundOrder || 99)) * dirMul || a.id - b.id
-        case 'court':
-          return (
-            ((a.court ?? 99) - (b.court ?? 99)) * dirMul || a.time.getTime() - b.time.getTime()
-          )
-        case 'status':
-          return (
-            (STATUS_ORDER[a.status] - STATUS_ORDER[b.status]) * dirMul ||
-            a.time.getTime() - b.time.getTime()
-          )
-        case 'score':
-          return ((a.aGames + a.bGames) - (b.aGames + b.bGames)) * dirMul
-        case 'time':
-        default:
-          return (a.time.getTime() - b.time.getTime()) * dirMul
-      }
-    })
-    return arr
-  }, [filtered, sort])
-
-  const total = Math.max(1, Math.ceil(sorted.length / pageSize))
-  const pageRows = sorted.slice((page - 1) * pageSize, page * pageSize)
-
-  const onClear = () => {
-    setQ('')
-    setStatus('all')
-    setContext('all')
-    setRound('all')
-    setCourt('all')
-  }
-  const anyFilter =
-    q !== '' || status !== 'all' || context !== 'all' || round !== 'all' || court !== 'all'
-
-  return (
-    <AppShell>
-      <div className="match-list-page">
-        <ActionBar liveCount={COUNTS.live} />
-        <FilterRow
-          q={q} setQ={setQ}
-          status={status} setStatus={setStatus}
-          context={context} setContext={setContext}
-          round={round} setRound={setRound}
-          court={court} setCourt={setCourt}
-          counts={COUNTS}
-          courtOptions={COURT_OPTIONS}
-          onClear={onClear}
-          anyFilter={anyFilter}
-        />
-        <div className="table-wrap">
-          <MatchTable
-            rows={pageRows}
-            sort={sort} setSort={setSort}
-            onClear={onClear}
-          />
-        </div>
-        <PaginationFooter
-          page={page} setPage={setPage}
-          total={total}
-          pageSize={pageSize} setPageSize={setPageSize}
-          filteredCount={sorted.length}
-        />
-      </div>
-    </AppShell>
   )
 }

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
 import {
   ChevronLeft,
@@ -50,21 +50,24 @@ export const Route = createFileRoute('/matches/')({
   component: MatchesPage,
 })
 
-type StatusKey = 'live' | 'final' | 'called' | 'scheduled'
+type RowTab = 'scheduled' | 'live' | 'final'
+type StatusKey = RowTab | 'called'
 
-// UI tabs ↔ API status. `called` has no backend concept yet — the tab stays
-// visible (disabled) so the navigation shape is stable as features land.
-const TAB_TO_API: Record<Exclude<StatusKey, 'called'>, MatchStatus> = {
+// `called` has no backend concept yet — the tab stays visible (disabled) so
+// the nav shape is stable as features land.
+const TAB_TO_API: Record<RowTab, MatchStatus> = {
   scheduled: 'pending',
   live: 'in_progress',
   final: 'completed',
 }
-const API_TO_TAB: Record<MatchStatus, StatusKey | null> = {
+// Terminal statuses (disputed, voided) fall back to the `final` tone — they
+// share final's "no further action" semantics, not scheduled's pending one.
+const API_TO_TAB: Record<MatchStatus, RowTab> = {
   pending: 'scheduled',
   in_progress: 'live',
   completed: 'final',
-  disputed: null,
-  voided: null,
+  disputed: 'final',
+  voided: 'final',
 }
 
 const STATUS_TABS: { value: 'all' | StatusKey; label: string; live?: boolean }[] = [
@@ -77,39 +80,49 @@ const STATUS_TABS: { value: 'all' | StatusKey; label: string; live?: boolean }[]
 
 const PAGE_SIZE = 25
 
-// Pill tones keyed by UI tab; the visible text comes from the API's
-// `status_label` so the FE doesn't redefine copy.
-const STATUS_TONE: Record<StatusKey, string> = {
+const STATUS_TONE: Record<RowTab, string> = {
   live: 'status-tone-live',
   final: 'status-tone-final',
-  called: 'status-tone-called',
   scheduled: 'status-tone-scheduled',
 }
+
+type NavigateFn = ReturnType<typeof useNavigate>
 
 function MatchesPage() {
   const [q, setQ] = useState('')
   const [status, setStatus] = useState<'all' | StatusKey>('all')
   const [page, setPage] = useState(1)
   const debouncedQ = useDebouncedValue(q, 300).trim()
+  const navigate = useNavigate()
 
-  const apiStatus = status === 'all' || status === 'called'
-    ? undefined
-    : TAB_TO_API[status]
-  const { data, isLoading } = useMatchList({
-    status: apiStatus,
-    q: debouncedQ || undefined,
-    page,
-    page_size: PAGE_SIZE,
-  })
+  const apiStatus =
+    status === 'all' || status === 'called' ? undefined : TAB_TO_API[status]
+  // Memoize the params bag so React Query's structural sharing — and any
+  // future React.memo on MatchTable — sees a stable reference.
+  const queryParams = useMemo(
+    () => ({
+      status: apiStatus,
+      q: debouncedQ || undefined,
+      page,
+      page_size: PAGE_SIZE,
+    }),
+    [apiStatus, debouncedQ, page],
+  )
+  const { data, isLoading } = useMatchList(queryParams)
 
-  function changeStatus(next: 'all' | StatusKey) {
+  const changeStatus = useCallback((next: 'all' | StatusKey) => {
     setStatus(next)
     setPage(1)
-  }
-  function changeQuery(next: string) {
+  }, [])
+  const changeQuery = useCallback((next: string) => {
     setQ(next)
     setPage(1)
-  }
+  }, [])
+  const onClear = useCallback(() => {
+    setQ('')
+    setStatus('all')
+    setPage(1)
+  }, [])
 
   const items = data?.items ?? []
   const total = data?.total ?? 0
@@ -131,10 +144,8 @@ function MatchesPage() {
             <MatchTable
               rows={items}
               isLoading={isLoading}
-              onClear={() => {
-                changeQuery('')
-                changeStatus('all')
-              }}
+              onClear={onClear}
+              navigate={navigate}
             />
           </div>
           <PaginationFooter
@@ -186,14 +197,11 @@ function FilterRow({
 }) {
   function tabCount(value: 'all' | StatusKey): number | null {
     if (value === 'called') return null
-    if (!statusCounts) return 0
+    if (!statusCounts) return null
     if (value === 'all') {
-      // Backend total counts every status the user participates in, so derive
-      // the "all" count from the same histogram the tabs render from.
       return Object.values(statusCounts).reduce((a, b) => a + b, 0)
     }
-    const apiStatus = TAB_TO_API[value]
-    return statusCounts[apiStatus] ?? 0
+    return statusCounts[TAB_TO_API[value]] ?? 0
   }
   return (
     <div className="filter-row">
@@ -224,13 +232,12 @@ function FilterRow({
         <TabsList>
           {STATUS_TABS.map((t) => {
             const count = tabCount(t.value)
-            const disabled = t.value === 'called'
             return (
               <TabsTrigger
                 key={t.value}
                 value={t.value}
                 className="gap-1.5"
-                disabled={disabled}
+                disabled={t.value === 'called'}
               >
                 {t.live && <span className="live-dot" />}
                 {t.label}
@@ -261,8 +268,9 @@ function ComingSoonSelect({
     <>
       <span className="filter-label">{label}</span>
       <Tooltip>
+        {/* Span wrapper: disabled triggers don't dispatch pointer events, so
+            the tooltip needs an enabled element to attach to. */}
         <TooltipTrigger asChild>
-          {/* Wrap the disabled trigger so the tooltip still receives hover. */}
           <span>
             <Select disabled>
               <SelectTrigger className="h-9 min-w-[120px]" disabled>
@@ -282,10 +290,12 @@ function MatchTable({
   rows,
   isLoading,
   onClear,
+  navigate,
 }: {
   rows: MatchListRow[]
   isLoading: boolean
   onClear: () => void
+  navigate: NavigateFn
 }) {
   if (isLoading && rows.length === 0) return <SkeletonRows />
   if (rows.length === 0) {
@@ -311,38 +321,35 @@ function MatchTable({
   }
   return (
     <table className="matches">
-      <thead>
-        <tr>
-          <th style={{ width: 120 }}>Match</th>
-          <th>Opponent</th>
-          <th style={{ width: 120 }}>Score</th>
-          <th style={{ width: 120 }}>Status</th>
-          <th style={{ width: 140 }}>Started</th>
-          <th style={{ width: 56 }} />
-        </tr>
-      </thead>
+      <MatchTableHead />
       <tbody>
         {rows.map((row) => (
-          <MatchRow key={row.id} row={row} />
+          <MatchRow key={row.id} row={row} navigate={navigate} />
         ))}
       </tbody>
     </table>
   )
 }
 
+function MatchTableHead() {
+  return (
+    <thead>
+      <tr>
+        <th style={{ width: 120 }}>Match</th>
+        <th>Opponent</th>
+        <th style={{ width: 120 }}>Score</th>
+        <th style={{ width: 120 }}>Status</th>
+        <th style={{ width: 140 }}>Started</th>
+        <th style={{ width: 56 }} />
+      </tr>
+    </thead>
+  )
+}
+
 function SkeletonRows() {
   return (
     <table className="matches" aria-busy="true">
-      <thead>
-        <tr>
-          <th style={{ width: 120 }}>Match</th>
-          <th>Opponent</th>
-          <th style={{ width: 120 }}>Score</th>
-          <th style={{ width: 120 }}>Status</th>
-          <th style={{ width: 140 }}>Started</th>
-          <th style={{ width: 56 }} />
-        </tr>
-      </thead>
+      <MatchTableHead />
       <tbody>
         {Array.from({ length: 6 }).map((_, i) => (
           <tr key={i} className="skeleton-row" aria-hidden="true">
@@ -356,9 +363,14 @@ function SkeletonRows() {
   )
 }
 
-function MatchRow({ row }: { row: MatchListRow }) {
-  const navigate = useNavigate()
-  const tab = API_TO_TAB[row.status] ?? 'scheduled'
+function MatchRow({
+  row,
+  navigate,
+}: {
+  row: MatchListRow
+  navigate: NavigateFn
+}) {
+  const tab = API_TO_TAB[row.status]
   const opponentName = row.opponent_username ?? 'No opponent'
   const showScore =
     row.status === 'in_progress' || row.status === 'completed'
@@ -381,7 +393,7 @@ function MatchRow({ row }: { row: MatchListRow }) {
         }
       }}
     >
-      <td className="id-cell">M-{row.id.slice(-6).toUpperCase()}</td>
+      <td className="id-cell">M-{shortId(row.id)}</td>
       <td>
         <div className="player">
           <Avatar className="size-[26px]">
@@ -404,7 +416,7 @@ function MatchRow({ row }: { row: MatchListRow }) {
         <ScoreCell row={row} showScore={showScore} />
       </td>
       <td>
-        <StatusBadge status={tab} label={row.status_label} />
+        <StatusBadge tab={tab} label={row.status_label} />
       </td>
       <td>
         <TimeCell iso={row.created_at} />
@@ -421,7 +433,6 @@ function MatchRow({ row }: { row: MatchListRow }) {
             type="button"
             className="row-action"
             aria-label="Row actions"
-            onClick={(e) => e.stopPropagation()}
           >
             <MoreHorizontal size={16} strokeWidth={2} />
           </button>
@@ -446,10 +457,10 @@ function ScoreCell({
   )
 }
 
-function StatusBadge({ status, label }: { status: StatusKey; label: string }) {
+function StatusBadge({ tab, label }: { tab: RowTab; label: string }) {
   return (
-    <Badge variant="secondary" className={`status-pill ${STATUS_TONE[status]}`}>
-      {status === 'live' && <span className="live-dot" />}
+    <Badge variant="secondary" className={`status-pill ${STATUS_TONE[tab]}`}>
+      {tab === 'live' && <span className="live-dot" />}
       {label}
     </Badge>
   )
@@ -458,9 +469,7 @@ function StatusBadge({ status, label }: { status: StatusKey; label: string }) {
 function TimeCell({ iso }: { iso: string }) {
   const created = new Date(iso)
   const now = new Date()
-  const diffMs = now.getTime() - created.getTime()
-  const dayMs = 86400000
-  const days = Math.floor(diffMs / dayMs)
+  const days = Math.floor((now.getTime() - created.getTime()) / 86400000)
   let when: string
   if (days === 0) {
     const hh = String(created.getHours()).padStart(2, '0')
@@ -474,6 +483,10 @@ function TimeCell({ iso }: { iso: string }) {
       <span className="strong">{when}</span>
     </span>
   )
+}
+
+function shortId(id: string): string {
+  return id.slice(-6).toUpperCase().padStart(6, '0')
 }
 
 function initials(name: string): string {


### PR DESCRIPTION
## Summary
- Rewires `web-client/src/routes/matches/index.tsx` onto `useMatchList`, deleting the PRNG-seeded mock list and the synthesized context / round / court / seed fields.
- Status tabs map to the API enum (scheduled ↔ pending, live ↔ in_progress, final ↔ completed); the `called` tab stays visible but disabled until the backend models that state. Context, Round, and Court selects are disabled with a "coming soon" tooltip.
- Search debounces 300 ms into the request, pagination drives `page` directly from `data.total`, and each row's Score CTA renders only when the row has a scorable current game. `+ New match` now links to `/matches/new`.

## Test plan
- [ ] `cd web-client && npm run lint` — no errors.
- [ ] `cd web-client && npm run test:run` — 23 passed (4 files), incl. the new `src/routes/matches/index.test.tsx`.
- [ ] `cd web-client && npm run build` — tsc + vite build clean.
- [ ] `cd web-client && PLAYWRIGHT_PORT=<free port> npm run test:e2e` — 125 passed, incl. the new `e2e/matches-list.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)