### PR TITLE
Add league model and bind matches to a default league

### DIFF
--- a/api/app/leagues.py
+++ b/api/app/leagues.py
@@ -1,0 +1,27 @@
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import League, LeagueMembership
+
+
+async def get_default_league(db: AsyncSession) -> League | None:
+    result = await db.execute(select(League).where(League.is_default.is_(True)))
+    return result.scalar_one_or_none()
+
+
+async def add_user_to_default_league(
+    db: AsyncSession, user_id: uuid.UUID
+) -> None:
+    """Add the user to the default league.
+
+    Does not commit; the caller controls the surrounding transaction. Callers
+    invoke this on a freshly-created user, so the uniq pair never collides.
+    """
+    default = await get_default_league(db)
+    if default is None:
+        raise RuntimeError(
+            "No default league configured. Run scripts/seed_leagues.py."
+        )
+    db.add(LeagueMembership(league_id=default.id, user_id=user_id))

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -7,7 +7,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.db import get_session
+from app.leagues import get_default_league
 from app.models import (
+    League,
     Match,
     MatchGame,
     MatchGameScore,
@@ -28,6 +30,7 @@ from app.schemas.match import (
     MatchDetailsScore,
     MatchDetailsSide,
     MatchGameScoreWrite,
+    MatchLeague,
     MatchListResponse,
     MatchListRow,
 )
@@ -47,6 +50,7 @@ MAX_PAGE_SIZE = 100
 def match_eager_options():
     return (
         selectinload(Match.match_settings),
+        selectinload(Match.league),
         selectinload(Match.sides)
         .selectinload(MatchSide.players)
         .selectinload(MatchSidePlayer.user),
@@ -59,6 +63,24 @@ async def _load_match(db: AsyncSession, match_id: uuid.UUID) -> Match | None:
         select(Match).where(Match.id == match_id).options(*match_eager_options())
     )
     return result.scalar_one_or_none()
+
+
+async def _resolve_league(
+    db: AsyncSession, league_id: uuid.UUID | None
+) -> League:
+    if league_id is not None:
+        league = (
+            await db.execute(select(League).where(League.id == league_id))
+        ).scalar_one_or_none()
+        if league is None:
+            raise HTTPException(status_code=404, detail="League not found.")
+        return league
+    default = await get_default_league(db)
+    if default is None:
+        raise HTTPException(
+            status_code=500, detail="No default league configured."
+        )
+    return default
 
 
 def my_side(match: Match, user_id: uuid.UUID) -> MatchSide | None:
@@ -176,6 +198,7 @@ def _serialize_details(match: Match, current_user_id: uuid.UUID) -> MatchDetails
         id=match.id,
         status=match.status,
         status_label=STATUS_LABELS[match.status],
+        league=MatchLeague(id=match.league.id, name=match.league.name),
         best_of=match.match_settings.best_of,
         games_to_win=_games_to_win(match.match_settings.best_of),
         team_size=match.match_settings.team_size,
@@ -267,6 +290,8 @@ async def create_match(
     # so they can never affect ratings regardless of the requested flag.
     affects_rating = payload.rated and opponent is not None
 
+    league = await _resolve_league(db, payload.league_id)
+
     settings = MatchSettings(
         team_size=1,
         best_of=payload.best_of,
@@ -274,6 +299,7 @@ async def create_match(
     )
     match = Match(
         match_settings=settings,
+        league=league,
         created_by_user_id=current_user.id,
         status=MatchStatus.pending,
     )
@@ -373,6 +399,7 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
         id=match.id,
         status=match.status,
         status_label=STATUS_LABELS[match.status],
+        league=MatchLeague(id=match.league.id, name=match.league.name),
         opponent_username=opp_player.user.username if opp_player else None,
         opponent_user_id=opp_player.user_id if opp_player else None,
         my_games_won=my_games_won,

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -1,3 +1,5 @@
+from app.models.league import League, LeagueVisibility
+from app.models.league_membership import LeagueMembership
 from app.models.match import Match, MatchStatus
 from app.models.match_game import MatchGame
 from app.models.match_game_score import MatchGameScore
@@ -12,6 +14,9 @@ from app.models.user_role import UserRole
 from app.models.user_token import UserToken
 
 __all__ = [
+    "League",
+    "LeagueMembership",
+    "LeagueVisibility",
     "Match",
     "MatchGame",
     "MatchGameScore",

--- a/api/app/models/league.py
+++ b/api/app/models/league.py
@@ -1,0 +1,66 @@
+import enum
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, DateTime, Enum, Index, String, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.league_membership import LeagueMembership
+    from app.models.match import Match
+
+
+class LeagueVisibility(enum.Enum):
+    public = "public"
+    private = "private"
+
+
+class League(Base):
+    __tablename__ = "leagues"
+    __table_args__ = (
+        # Partial unique index: at most one row may have is_default=true.
+        Index(
+            "uq_leagues_one_default",
+            "is_default",
+            unique=True,
+            postgresql_where=text("is_default"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    name: Mapped[str] = mapped_column(
+        String(255), unique=True, nullable=False, index=True
+    )
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    visibility: Mapped[LeagueVisibility] = mapped_column(
+        Enum(LeagueVisibility, name="league_visibility"),
+        nullable=False,
+        server_default=LeagueVisibility.public.value,
+    )
+    is_default: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    matches: Mapped[list["Match"]] = relationship(back_populates="league")
+    memberships: Mapped[list["LeagueMembership"]] = relationship(
+        back_populates="league",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )

--- a/api/app/models/league_membership.py
+++ b/api/app/models/league_membership.py
@@ -1,0 +1,53 @@
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Index, UniqueConstraint, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.league import League
+    from app.models.user import User
+
+
+class LeagueMembership(Base):
+    __tablename__ = "league_memberships"
+    __table_args__ = (
+        UniqueConstraint(
+            "league_id",
+            "user_id",
+            name="uq_league_memberships_league_id_user_id",
+        ),
+        Index("ix_league_memberships_user_id", "user_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    league_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("leagues.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    league: Mapped["League"] = relationship(back_populates="memberships")
+    user: Mapped["User"] = relationship("User")

--- a/api/app/models/match.py
+++ b/api/app/models/match.py
@@ -11,6 +11,7 @@ from app.db import Base
 from app.models.match_settings import MatchSettings
 
 if TYPE_CHECKING:
+    from app.models.league import League
     from app.models.match_game import MatchGame
     from app.models.match_side import MatchSide
     from app.models.match_side_player import MatchSidePlayer
@@ -45,6 +46,7 @@ class Match(Base):
             "status",
             text("updated_at DESC"),
         ),
+        Index("ix_matches_league_id", "league_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -55,6 +57,11 @@ class Match(Base):
     match_settings_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("match_settings.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    league_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("leagues.id", ondelete="RESTRICT"),
         nullable=False,
     )
     status: Mapped[MatchStatus] = mapped_column(
@@ -78,6 +85,7 @@ class Match(Base):
     )
 
     match_settings: Mapped[MatchSettings] = relationship(back_populates="matches")
+    league: Mapped["League"] = relationship(back_populates="matches")
     created_by: Mapped["User"] = relationship("User")
     sides: Mapped[list["MatchSide"]] = relationship(
         back_populates="match",

--- a/api/app/rbac.py
+++ b/api/app/rbac.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
+from app.leagues import add_user_to_default_league
 from app.models import Permission, Role, RolePermission, User, UserRole
 from app.schemas.rbac import (
     PermissionCreate,
@@ -456,6 +457,8 @@ async def create_user(
     user = User(username=payload.username)
     db.add(user)
     try:
+        await db.flush()
+        await add_user_to_default_league(db, user.id)
         await db.commit()
     except IntegrityError:
         await db.rollback()

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -25,9 +25,13 @@ class MatchCreate(BaseModel):
     ``opponent_user_id`` is optional: a match created without a registered
     opponent (a guest, or "start without opponent") gets a single side and is
     always unrated, since the rating system needs two registered sides.
+
+    ``league_id`` is optional: when omitted the server binds the match to the
+    default league (see ``app.leagues.get_default_league``).
     """
 
     opponent_user_id: uuid.UUID | None = None
+    league_id: uuid.UUID | None = None
     best_of: int = Field(description="Total games to play; one of 1, 3, 5, 7.")
     rated: bool = True
 
@@ -41,6 +45,11 @@ class MatchCreate(BaseModel):
 
 
 # ----- details (BFF for /matches/$id and the scoring routes) ---------------
+
+
+class MatchLeague(BaseModel):
+    id: uuid.UUID
+    name: str
 
 
 class MatchDetailsPlayer(BaseModel):
@@ -79,6 +88,7 @@ class MatchDetails(BaseModel):
     id: uuid.UUID
     status: MatchStatus
     status_label: str
+    league: MatchLeague
     best_of: int
     games_to_win: int
     team_size: int
@@ -98,6 +108,7 @@ class MatchListRow(BaseModel):
     id: uuid.UUID
     status: MatchStatus
     status_label: str
+    league: MatchLeague
     opponent_username: str | None
     opponent_user_id: uuid.UUID | None
     my_games_won: int

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
+from app.leagues import add_user_to_default_league
 from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
 from app.schemas.session import SessionData, SessionResponse, SessionUser
 
@@ -63,6 +64,8 @@ async def _create_session(db: AsyncSession) -> tuple[User, str]:
     user = User(username=_generate_username())
     db.add(user)
     await db.flush()
+
+    await add_user_to_default_league(db, user.id)
 
     raw_token = secrets.token_urlsafe(32)
     db.add(

--- a/api/migrations/versions/20260516_0000_0005_create_leagues_tables.py
+++ b/api/migrations/versions/20260516_0000_0005_create_leagues_tables.py
@@ -1,0 +1,146 @@
+"""create leagues tables
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-05-16 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0005"
+down_revision: Union[str, None] = "0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+league_visibility_enum = postgresql.ENUM(
+    "public",
+    "private",
+    name="league_visibility",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    league_visibility_enum.create(bind, checkfirst=True)
+
+    op.create_table(
+        "leagues",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "visibility",
+            league_visibility_enum,
+            nullable=False,
+            server_default="public",
+        ),
+        sa.Column(
+            "is_default",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_leagues_name", "leagues", ["name"], unique=True)
+    # Partial unique index: at most one league row may have is_default=true.
+    op.create_index(
+        "uq_leagues_one_default",
+        "leagues",
+        ["is_default"],
+        unique=True,
+        postgresql_where=sa.text("is_default"),
+    )
+
+    op.create_table(
+        "league_memberships",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "league_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("leagues.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "league_id",
+            "user_id",
+            name="uq_league_memberships_league_id_user_id",
+        ),
+    )
+    op.create_index(
+        "ix_league_memberships_user_id", "league_memberships", ["user_id"]
+    )
+
+    op.add_column(
+        "matches",
+        sa.Column(
+            "league_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("leagues.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_matches_league_id", "matches", ["league_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_matches_league_id", table_name="matches")
+    op.drop_column("matches", "league_id")
+
+    op.drop_index(
+        "ix_league_memberships_user_id", table_name="league_memberships"
+    )
+    op.drop_table("league_memberships")
+
+    op.drop_index("uq_leagues_one_default", table_name="leagues")
+    op.drop_index("ix_leagues_name", table_name="leagues")
+    op.drop_table("leagues")
+
+    bind = op.get_bind()
+    league_visibility_enum.drop(bind, checkfirst=True)

--- a/api/migrations/versions/20260516_0000_0005_create_leagues_tables.py
+++ b/api/migrations/versions/20260516_0000_0005_create_leagues_tables.py
@@ -4,6 +4,9 @@ Revision ID: 0005
 Revises: 0004
 Create Date: 2026-05-16 00:00:00.000000
 
+Note: adds ``matches.league_id`` as NOT NULL with no backfill, so this only
+applies cleanly against a fresh / empty matches table. Per the pre-deploy
+convention in api/CLAUDE.md, the assumption holds.
 """
 from typing import Sequence, Union
 

--- a/api/scripts/seed_leagues.py
+++ b/api/scripts/seed_leagues.py
@@ -1,0 +1,55 @@
+"""Seed (or update) the default league.
+
+Idempotent: re-runs locate the row by ``is_default=true`` and overwrite its
+``name``, ``description``, and ``visibility`` from the constants below.
+Editing the constants and redeploying is the supported way to rename or
+re-describe the default league. Safe to run on every container boot.
+"""
+
+import asyncio
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.db import get_engine
+from app.leagues import get_default_league
+from app.models import League, LeagueVisibility
+
+
+DEFAULT_LEAGUE_NAME = "FortyMM"
+DEFAULT_LEAGUE_DESCRIPTION = "The headline FortyMM league."
+DEFAULT_LEAGUE_VISIBILITY = LeagueVisibility.public
+
+
+async def upsert_default_league(db: AsyncSession) -> str:
+    """Insert or update the default league in ``db``.
+
+    Returns ``"created"`` or ``"updated"`` for caller logging. Caller commits.
+    """
+    existing = await get_default_league(db)
+    if existing is None:
+        db.add(
+            League(
+                name=DEFAULT_LEAGUE_NAME,
+                description=DEFAULT_LEAGUE_DESCRIPTION,
+                visibility=DEFAULT_LEAGUE_VISIBILITY,
+                is_default=True,
+            )
+        )
+        return "created"
+    existing.name = DEFAULT_LEAGUE_NAME
+    existing.description = DEFAULT_LEAGUE_DESCRIPTION
+    existing.visibility = DEFAULT_LEAGUE_VISIBILITY
+    return "updated"
+
+
+async def seed() -> None:
+    engine = get_engine()
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    async with sessionmaker() as db:
+        action = await upsert_default_league(db)
+        await db.commit()
+        print(f"Seed complete: default league {action} ({DEFAULT_LEAGUE_NAME}).")
+
+
+if __name__ == "__main__":
+    asyncio.run(seed())

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -17,6 +17,7 @@ from app import queue as queue_module
 from app.db import Base, get_session
 from app.main import app as fastapi_app
 import app.models  # noqa: F401  -- ensures models register on Base.metadata
+from app.models import League, LeagueVisibility
 
 
 @pytest.fixture(autouse=True)
@@ -60,6 +61,25 @@ async def db_session(engine: AsyncEngine) -> AsyncIterator[AsyncSession]:
     async with engine.begin() as conn:
         for table in reversed(Base.metadata.sorted_tables):
             await conn.execute(table.delete())
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def default_league(db_session: AsyncSession) -> League:
+    """Seed a default league so user-creation paths can attach memberships.
+
+    Autouse so tests don't have to remember to opt in. Tests that want to
+    exercise the "no default league" branch can ``await db_session.delete(...)``
+    this row before triggering the path under test.
+    """
+    league = League(
+        name="FortyMM",
+        description="Test default league.",
+        visibility=LeagueVisibility.public,
+        is_default=True,
+    )
+    db_session.add(league)
+    await db_session.commit()
+    return league
 
 
 @pytest_asyncio.fixture

--- a/api/tests/test_leagues.py
+++ b/api/tests/test_leagues.py
@@ -1,0 +1,93 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import League, LeagueMembership, LeagueVisibility, User
+from scripts import seed_leagues
+from tests._helpers import start_session
+
+
+async def test_default_league_unique_partial_index(
+    db_session: AsyncSession, default_league: League
+):
+    """At most one league row may have ``is_default=true``."""
+    db_session.add(
+        League(
+            name="Pretender",
+            description="Tries to also be default.",
+            visibility=LeagueVisibility.public,
+            is_default=True,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+async def test_membership_unique_per_pair(
+    db_session: AsyncSession, default_league: League
+):
+    user = User(username="dupe-member")
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add_all(
+        [
+            LeagueMembership(league_id=default_league.id, user_id=user.id),
+            LeagueMembership(league_id=default_league.id, user_id=user.id),
+        ]
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+async def test_session_creates_default_league_membership(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    default_league: League,
+):
+    await start_session(api_client, db_session)
+
+    memberships = (
+        await db_session.execute(select(LeagueMembership))
+    ).scalars().all()
+    assert len(memberships) == 1
+    assert memberships[0].league_id == default_league.id
+
+
+async def test_seed_creates_default_when_missing(
+    db_session: AsyncSession, default_league: League
+):
+    # Wipe the autouse default so the seed has to create one.
+    await db_session.delete(default_league)
+    await db_session.commit()
+
+    action = await seed_leagues.upsert_default_league(db_session)
+    await db_session.commit()
+    assert action == "created"
+
+    leagues = (await db_session.execute(select(League))).scalars().all()
+    assert len(leagues) == 1
+    assert leagues[0].name == seed_leagues.DEFAULT_LEAGUE_NAME
+    assert leagues[0].is_default is True
+    assert leagues[0].visibility == seed_leagues.DEFAULT_LEAGUE_VISIBILITY
+
+
+async def test_seed_updates_existing_default_in_place(
+    db_session: AsyncSession, default_league: League
+):
+    original_id = default_league.id
+    # Pre-condition: the autouse fixture inserts with description != seed value.
+    assert default_league.description != seed_leagues.DEFAULT_LEAGUE_DESCRIPTION
+
+    action = await seed_leagues.upsert_default_league(db_session)
+    await db_session.commit()
+    assert action == "updated"
+
+    leagues = (await db_session.execute(select(League))).scalars().all()
+    assert len(leagues) == 1
+    assert leagues[0].id == original_id
+    assert leagues[0].name == seed_leagues.DEFAULT_LEAGUE_NAME
+    assert leagues[0].description == seed_leagues.DEFAULT_LEAGUE_DESCRIPTION

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -5,7 +5,14 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Match, MatchGame, MatchGameScore, MatchSide
+from app.models import (
+    League,
+    LeagueVisibility,
+    Match,
+    MatchGame,
+    MatchGameScore,
+    MatchSide,
+)
 from tests._helpers import make_client, make_user, start_session
 
 
@@ -671,3 +678,107 @@ async def test_cannot_score_match_without_opponent(
     )
     assert response.status_code == 422
     assert "opponent" in response.json()["detail"].lower()
+
+
+# ----- league binding -----------------------------------------------------
+
+
+async def test_create_match_without_league_id_uses_default_league(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    default_league: League,
+):
+    await start_session(api_client, db_session)
+    response = await api_client.post(
+        "/v1/matches", json={"best_of": 3, "rated": False}
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["league"]["id"] == str(default_league.id)
+    assert body["league"]["name"] == default_league.name
+
+
+async def test_create_match_with_explicit_league_id_uses_that_league(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    default_league: League,
+):
+    other = League(
+        name="Side League",
+        description="Not the default.",
+        visibility=LeagueVisibility.private,
+    )
+    db_session.add(other)
+    await db_session.commit()
+    await db_session.refresh(other)
+
+    await start_session(api_client, db_session)
+    response = await api_client.post(
+        "/v1/matches",
+        json={"best_of": 3, "rated": False, "league_id": str(other.id)},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["league"]["id"] == str(other.id)
+    assert body["league"]["name"] == "Side League"
+
+
+async def test_create_match_with_unknown_league_id_is_404(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    default_league: League,
+):
+    await start_session(api_client, db_session)
+    response = await api_client.post(
+        "/v1/matches",
+        json={
+            "best_of": 3,
+            "rated": False,
+            "league_id": str(uuid.uuid4()),
+        },
+    )
+    assert response.status_code == 404
+    assert "league" in response.json()["detail"].lower()
+
+
+async def test_create_match_with_no_default_seeded_is_500(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    default_league: League,
+):
+    await start_session(api_client, db_session)
+    # Remove the autouse default after the session has already attached a
+    # membership; the create-match call should now have no fallback to land on.
+    await db_session.delete(default_league)
+    await db_session.commit()
+
+    response = await api_client.post(
+        "/v1/matches", json={"best_of": 3, "rated": False}
+    )
+    assert response.status_code == 500
+
+
+async def test_list_and_get_match_include_league(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    default_league: League,
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "league-rival")
+    created = (
+        await api_client.post(
+            "/v1/matches",
+            json={
+                "opponent_user_id": str(opp.id),
+                "best_of": 3,
+                "rated": True,
+            },
+        )
+    ).json()
+
+    detail = (await api_client.get(f"/v1/matches/{created['id']}")).json()
+    assert detail["league"]["id"] == str(default_league.id)
+    assert detail["league"]["name"] == default_league.name
+
+    listing = (await api_client.get("/v1/matches")).json()
+    assert listing["items"][0]["league"]["id"] == str(default_league.id)

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -4,6 +4,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import (
+    League,
     Match,
     MatchSettings,
     MatchSide,
@@ -19,6 +20,7 @@ BASE_TIME = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
 async def _record_match(
     db_session: AsyncSession,
+    league: League,
     *players: User,
     created_at: datetime,
 ) -> Match:
@@ -27,6 +29,7 @@ async def _record_match(
     settings = MatchSettings(team_size=1, best_of=5, affects_rating=False)
     match = Match(
         match_settings=settings,
+        league=league,
         created_by_user_id=players[0].id,
         status=MatchStatus.completed,
         created_at=created_at,
@@ -52,7 +55,7 @@ async def test_recent_opponents_requires_a_session(api_client: AsyncClient):
 
 
 async def test_recent_opponents_orders_by_most_recent_match(
-    api_client: AsyncClient, db_session: AsyncSession
+    api_client: AsyncClient, db_session: AsyncSession, default_league: League
 ):
     me = await start_session(api_client, db_session)
     ana = await make_user(db_session, "ana")
@@ -60,9 +63,9 @@ async def test_recent_opponents_orders_by_most_recent_match(
     cy = await make_user(db_session, "cy")
 
     # Played ana longest ago, then cy, then bo most recently.
-    await _record_match(db_session, me, ana, created_at=BASE_TIME - timedelta(days=3))
-    await _record_match(db_session, me, cy, created_at=BASE_TIME - timedelta(days=2))
-    await _record_match(db_session, me, bo, created_at=BASE_TIME - timedelta(days=1))
+    await _record_match(db_session, default_league, me, ana, created_at=BASE_TIME - timedelta(days=3))
+    await _record_match(db_session, default_league, me, cy, created_at=BASE_TIME - timedelta(days=2))
+    await _record_match(db_session, default_league, me, bo, created_at=BASE_TIME - timedelta(days=1))
 
     response = await api_client.get("/v1/players/recent")
     assert response.status_code == 200
@@ -70,16 +73,16 @@ async def test_recent_opponents_orders_by_most_recent_match(
 
 
 async def test_recent_opponents_dedupes_repeated_opponents(
-    api_client: AsyncClient, db_session: AsyncSession
+    api_client: AsyncClient, db_session: AsyncSession, default_league: League
 ):
     me = await start_session(api_client, db_session)
     ana = await make_user(db_session, "ana")
     bo = await make_user(db_session, "bo")
 
     # ana appears twice; her most recent match is newer than the bo match.
-    await _record_match(db_session, me, ana, created_at=BASE_TIME - timedelta(days=5))
-    await _record_match(db_session, me, bo, created_at=BASE_TIME - timedelta(days=3))
-    await _record_match(db_session, me, ana, created_at=BASE_TIME - timedelta(days=1))
+    await _record_match(db_session, default_league, me, ana, created_at=BASE_TIME - timedelta(days=5))
+    await _record_match(db_session, default_league, me, bo, created_at=BASE_TIME - timedelta(days=3))
+    await _record_match(db_session, default_league, me, ana, created_at=BASE_TIME - timedelta(days=1))
 
     response = await api_client.get("/v1/players/recent")
     assert response.status_code == 200
@@ -87,14 +90,14 @@ async def test_recent_opponents_dedupes_repeated_opponents(
 
 
 async def test_recent_opponents_backfills_with_other_players(
-    api_client: AsyncClient, db_session: AsyncSession
+    api_client: AsyncClient, db_session: AsyncSession, default_league: League
 ):
     me = await start_session(api_client, db_session)
     rival = await make_user(db_session, "rival")
     await make_user(db_session, "zoe")
     await make_user(db_session, "amy")
 
-    await _record_match(db_session, me, rival, created_at=BASE_TIME)
+    await _record_match(db_session, default_league, me, rival, created_at=BASE_TIME)
 
     response = await api_client.get("/v1/players/recent")
     assert response.status_code == 200
@@ -118,11 +121,11 @@ async def test_recent_opponents_for_a_new_player_is_a_non_empty_default(
 
 
 async def test_recent_opponents_excludes_the_current_user(
-    api_client: AsyncClient, db_session: AsyncSession
+    api_client: AsyncClient, db_session: AsyncSession, default_league: League
 ):
     me = await start_session(api_client, db_session)
     rival = await make_user(db_session, "rival")
-    await _record_match(db_session, me, rival, created_at=BASE_TIME)
+    await _record_match(db_session, default_league, me, rival, created_at=BASE_TIME)
 
     response = await api_client.get("/v1/players/recent")
     assert response.status_code == 200

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -3,8 +3,8 @@ from datetime import datetime, timedelta, timezone
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.leagues import get_default_league
 from app.models import (
-    League,
     Match,
     MatchSettings,
     MatchSide,
@@ -20,13 +20,13 @@ BASE_TIME = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
 async def _record_match(
     db_session: AsyncSession,
-    league: League,
     *players: User,
     created_at: datetime,
 ) -> Match:
     """Persist a singles match between ``players`` stamped with an explicit
     ``created_at`` so recency-ordering tests stay deterministic."""
     settings = MatchSettings(team_size=1, best_of=5, affects_rating=False)
+    league = await get_default_league(db_session)
     match = Match(
         match_settings=settings,
         league=league,
@@ -55,7 +55,7 @@ async def test_recent_opponents_requires_a_session(api_client: AsyncClient):
 
 
 async def test_recent_opponents_orders_by_most_recent_match(
-    api_client: AsyncClient, db_session: AsyncSession, default_league: League
+    api_client: AsyncClient, db_session: AsyncSession
 ):
     me = await start_session(api_client, db_session)
     ana = await make_user(db_session, "ana")
@@ -63,9 +63,9 @@ async def test_recent_opponents_orders_by_most_recent_match(
     cy = await make_user(db_session, "cy")
 
     # Played ana longest ago, then cy, then bo most recently.
-    await _record_match(db_session, default_league, me, ana, created_at=BASE_TIME - timedelta(days=3))
-    await _record_match(db_session, default_league, me, cy, created_at=BASE_TIME - timedelta(days=2))
-    await _record_match(db_session, default_league, me, bo, created_at=BASE_TIME - timedelta(days=1))
+    await _record_match(db_session, me, ana, created_at=BASE_TIME - timedelta(days=3))
+    await _record_match(db_session, me, cy, created_at=BASE_TIME - timedelta(days=2))
+    await _record_match(db_session, me, bo, created_at=BASE_TIME - timedelta(days=1))
 
     response = await api_client.get("/v1/players/recent")
     assert response.status_code == 200
@@ -73,16 +73,16 @@ async def test_recent_opponents_orders_by_most_recent_match(
 
 
 async def test_recent_opponents_dedupes_repeated_opponents(
-    api_client: AsyncClient, db_session: AsyncSession, default_league: League
+    api_client: AsyncClient, db_session: AsyncSession
 ):
     me = await start_session(api_client, db_session)
     ana = await make_user(db_session, "ana")
     bo = await make_user(db_session, "bo")
 
     # ana appears twice; her most recent match is newer than the bo match.
-    await _record_match(db_session, default_league, me, ana, created_at=BASE_TIME - timedelta(days=5))
-    await _record_match(db_session, default_league, me, bo, created_at=BASE_TIME - timedelta(days=3))
-    await _record_match(db_session, default_league, me, ana, created_at=BASE_TIME - timedelta(days=1))
+    await _record_match(db_session, me, ana, created_at=BASE_TIME - timedelta(days=5))
+    await _record_match(db_session, me, bo, created_at=BASE_TIME - timedelta(days=3))
+    await _record_match(db_session, me, ana, created_at=BASE_TIME - timedelta(days=1))
 
     response = await api_client.get("/v1/players/recent")
     assert response.status_code == 200
@@ -90,14 +90,14 @@ async def test_recent_opponents_dedupes_repeated_opponents(
 
 
 async def test_recent_opponents_backfills_with_other_players(
-    api_client: AsyncClient, db_session: AsyncSession, default_league: League
+    api_client: AsyncClient, db_session: AsyncSession
 ):
     me = await start_session(api_client, db_session)
     rival = await make_user(db_session, "rival")
     await make_user(db_session, "zoe")
     await make_user(db_session, "amy")
 
-    await _record_match(db_session, default_league, me, rival, created_at=BASE_TIME)
+    await _record_match(db_session, me, rival, created_at=BASE_TIME)
 
     response = await api_client.get("/v1/players/recent")
     assert response.status_code == 200
@@ -121,11 +121,11 @@ async def test_recent_opponents_for_a_new_player_is_a_non_empty_default(
 
 
 async def test_recent_opponents_excludes_the_current_user(
-    api_client: AsyncClient, db_session: AsyncSession, default_league: League
+    api_client: AsyncClient, db_session: AsyncSession
 ):
     me = await start_session(api_client, db_session)
     rival = await make_user(db_session, "rival")
-    await _record_match(db_session, default_league, me, rival, created_at=BASE_TIME)
+    await _record_match(db_session, me, rival, created_at=BASE_TIME)
 
     response = await api_client.get("/v1/players/recent")
     assert response.status_code == 200

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,6 +45,7 @@ services:
     command: >
       sh -c "alembic upgrade head &&
              python scripts/seed_rbac.py &&
+             python scripts/seed_leagues.py &&
              uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
 
   worker:

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -390,10 +390,15 @@ export interface components {
          *     ``opponent_user_id`` is optional: a match created without a registered
          *     opponent (a guest, or "start without opponent") gets a single side and is
          *     always unrated, since the rating system needs two registered sides.
+         *
+         *     ``league_id`` is optional: when omitted the server binds the match to the
+         *     default league (see ``app.leagues.get_default_league``).
          */
         MatchCreate: {
             /** Opponent User Id */
             opponent_user_id?: string | null;
+            /** League Id */
+            league_id?: string | null;
             /**
              * Best Of
              * @description Total games to play; one of 1, 3, 5, 7.
@@ -415,6 +420,7 @@ export interface components {
             status: components["schemas"]["MatchStatus"];
             /** Status Label */
             status_label: string;
+            league: components["schemas"]["MatchLeague"];
             /** Best Of */
             best_of: number;
             /** Games To Win */
@@ -503,6 +509,16 @@ export interface components {
             /** Side 2 Points */
             side_2_points: number;
         };
+        /** MatchLeague */
+        MatchLeague: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Name */
+            name: string;
+        };
         /** MatchListResponse */
         MatchListResponse: {
             /** Items */
@@ -528,6 +544,7 @@ export interface components {
             status: components["schemas"]["MatchStatus"];
             /** Status Label */
             status_label: string;
+            league: components["schemas"]["MatchLeague"];
             /** Opponent Username */
             opponent_username: string | null;
             /** Opponent User Id */

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -5,6 +5,7 @@ type MatchDetails = components['schemas']['MatchDetails']
 type MatchDetailsSide = components['schemas']['MatchDetailsSide']
 type MatchDetailsGame = components['schemas']['MatchDetailsGame']
 type MatchListRow = components['schemas']['MatchListRow']
+type MatchLeague = components['schemas']['MatchLeague']
 type DashboardScoreBanner = components['schemas']['DashboardScoreBanner']
 type DashboardNextMatch = components['schemas']['DashboardNextMatch']
 type DashboardRecentResult = components['schemas']['DashboardRecentResult']
@@ -13,6 +14,13 @@ type DashboardRecentResult = components['schemas']['DashboardRecentResult']
 // is on side 1, so `is_current_user_side` and `my_games_won` line up with
 // what the dev session would actually see.
 export const MOCK_CURRENT_USER = { id: 'u-me', username: 'rita.kovac' }
+
+// The seeded default league every mock match belongs to. Mirrors the
+// FortyMM row scripts/seed_leagues.py inserts on real boot.
+export const MOCK_DEFAULT_LEAGUE: MatchLeague = {
+  id: 'lg-fortymm',
+  name: 'FortyMM',
+}
 
 const STATUS_LABELS: Record<MatchStatus, string> = {
   pending: 'Scheduled',
@@ -149,6 +157,7 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
     id: seed.id,
     status: seed.status,
     status_label: STATUS_LABELS[seed.status],
+    league: MOCK_DEFAULT_LEAGUE,
     best_of: seed.best_of,
     games_to_win: gamesToWin(seed.best_of),
     team_size: 1,
@@ -176,6 +185,7 @@ export function projectListRow(seed: SeedMatch): MatchListRow {
     id: seed.id,
     status: seed.status,
     status_label: STATUS_LABELS[seed.status],
+    league: MOCK_DEFAULT_LEAGUE,
     opponent_username: seed.opponent?.username ?? null,
     opponent_user_id: seed.opponent?.id ?? null,
     my_games_won: side1,

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker'
 import type { components } from '@/api/schema'
+import { MOCK_DEFAULT_LEAGUE } from '@/mocks/match-store'
 
 type ComponentHealth = components['schemas']['ComponentHealth']
 type HealthResponse = components['schemas']['HealthResponse']
@@ -14,15 +15,9 @@ type MatchDetailsSide = components['schemas']['MatchDetailsSide']
 type MatchDetailsGame = components['schemas']['MatchDetailsGame']
 type MatchDetailsCurrentGame =
   components['schemas']['MatchDetailsCurrentGame']
-type MatchLeague = components['schemas']['MatchLeague']
 type MatchListRow = components['schemas']['MatchListRow']
 type MatchListResponse = components['schemas']['MatchListResponse']
 type MatchStatus = components['schemas']['MatchStatus']
-
-const DEFAULT_MATCH_LEAGUE: MatchLeague = {
-  id: 'lg-fortymm',
-  name: 'FortyMM',
-}
 type DashboardResponse = components['schemas']['DashboardResponse']
 type DashboardScoreBanner = components['schemas']['DashboardScoreBanner']
 type DashboardNextMatch = components['schemas']['DashboardNextMatch']
@@ -186,7 +181,7 @@ export function matchDetails(
     id,
     status: 'pending',
     status_label: 'Scheduled',
-    league: DEFAULT_MATCH_LEAGUE,
+    league: MOCK_DEFAULT_LEAGUE,
     best_of: bestOf,
     games_to_win: Math.ceil(bestOf / 2),
     team_size: 1,
@@ -210,7 +205,7 @@ export function matchListRow(
     id: nextId('m'),
     status: 'pending',
     status_label: 'Scheduled',
-    league: DEFAULT_MATCH_LEAGUE,
+    league: MOCK_DEFAULT_LEAGUE,
     opponent_username: faker.internet.username().toLowerCase(),
     opponent_user_id: nextId('u'),
     my_games_won: 0,

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -14,9 +14,15 @@ type MatchDetailsSide = components['schemas']['MatchDetailsSide']
 type MatchDetailsGame = components['schemas']['MatchDetailsGame']
 type MatchDetailsCurrentGame =
   components['schemas']['MatchDetailsCurrentGame']
+type MatchLeague = components['schemas']['MatchLeague']
 type MatchListRow = components['schemas']['MatchListRow']
 type MatchListResponse = components['schemas']['MatchListResponse']
 type MatchStatus = components['schemas']['MatchStatus']
+
+const DEFAULT_MATCH_LEAGUE: MatchLeague = {
+  id: 'lg-fortymm',
+  name: 'FortyMM',
+}
 type DashboardResponse = components['schemas']['DashboardResponse']
 type DashboardScoreBanner = components['schemas']['DashboardScoreBanner']
 type DashboardNextMatch = components['schemas']['DashboardNextMatch']
@@ -180,6 +186,7 @@ export function matchDetails(
     id,
     status: 'pending',
     status_label: 'Scheduled',
+    league: DEFAULT_MATCH_LEAGUE,
     best_of: bestOf,
     games_to_win: Math.ceil(bestOf / 2),
     team_size: 1,
@@ -203,6 +210,7 @@ export function matchListRow(
     id: nextId('m'),
     status: 'pending',
     status_label: 'Scheduled',
+    league: DEFAULT_MATCH_LEAGUE,
     opponent_username: faker.internet.username().toLowerCase(),
     opponent_user_id: nextId('u'),
     my_games_won: 0,


### PR DESCRIPTION
## Summary

- New `League` (name, description, `visibility` public/private, timestamps, `is_default`) with a partial unique index so at most one row can be the default.
- New `LeagueMembership` join table; every new user is auto-added to the default league via `app.leagues.add_user_to_default_league`, called from both `GET /v1/session` (ephemeral session bootstrap) and `POST /v1/users` (admin create).
- `matches.league_id` is NOT NULL with an FK to `leagues`. `POST /v1/matches` accepts an optional `league_id`; when omitted the server binds the match to the default league. `GET /v1/matches` and `GET /v1/matches/{id}` now include `league: { id, name }` in their BFF payloads.
- New idempotent `scripts/seed_leagues.py` (mirrors `scripts/seed_rbac.py`) — wired into the `api` service boot in `docker-compose.dev.yml` after `seed_rbac.py`. Editing the constants at the top of the script and redeploying upserts the default league in place.
- `web-client/src/api/schema.d.ts` regenerated. MSW handlers and test factories include a mock default league so projected match responses match the new schema.

## Test plan

- [x] `pytest` in `api/` — 175 passed (added `tests/test_leagues.py` covering the partial unique index, membership uniqueness, session-creates-membership, seed insert + update; extended `tests/test_matches.py` with league-binding cases — default fallback, explicit valid id, unknown id 404, missing default 500, league in list/detail payloads)
- [x] `alembic upgrade head` then `downgrade 0004` then `upgrade head` against a fresh Postgres — all clean
- [x] Ran `scripts/seed_leagues.py` twice — first time `created`, second time `updated`, single row preserved
- [x] `npm run lint`, `npm run build`, `npm run test:run` in `web-client/` — all green


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZCkQamTivf1FgwBXo5qmV)_