### PR TITLE
Start new matches in Live status, not Scheduled

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -301,7 +301,7 @@ async def create_match(
         match_settings=settings,
         league=league,
         created_by_user_id=current_user.id,
-        status=MatchStatus.pending,
+        status=MatchStatus.in_progress,
     )
     _add_side(match, 1, current_user)
     if opponent is not None:
@@ -462,10 +462,7 @@ def _recompute_match(match: Match) -> None:
         if side_two is not None:
             side_two.won = b_wins > a_wins
     else:
-        has_scored = a_wins > 0 or b_wins > 0
-        match.status = (
-            MatchStatus.in_progress if has_scored else MatchStatus.pending
-        )
+        match.status = MatchStatus.in_progress
         for side in match.sides:
             side.won = None
 

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -1,6 +1,10 @@
+import uuid
+
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models import Match, MatchStatus
 from tests._helpers import make_client, make_user, start_session
 
 
@@ -66,6 +70,16 @@ async def test_dashboard_returns_next_match_for_pending_match(
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     created = await _create_match(api_client, opp.id, best_of=5)
+    # New matches start in_progress; force pending here to cover the widget
+    # (the legacy "scheduled" branch is dormant in production but the API
+    # endpoint still surfaces such rows if they exist).
+    db_match = (
+        await db_session.execute(
+            select(Match).where(Match.id == uuid.UUID(created["id"]))
+        )
+    ).scalar_one()
+    db_match.status = MatchStatus.pending
+    await db_session.commit()
 
     body = (await api_client.get("/v1/dashboard")).json()
     assert body["score_banner"] is None

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -1,7 +1,6 @@
 import uuid
 
 from httpx import AsyncClient
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Match, MatchStatus
@@ -70,14 +69,9 @@ async def test_dashboard_returns_next_match_for_pending_match(
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     created = await _create_match(api_client, opp.id, best_of=5)
-    # New matches start in_progress; force pending here to cover the widget
-    # (the legacy "scheduled" branch is dormant in production but the API
-    # endpoint still surfaces such rows if they exist).
-    db_match = (
-        await db_session.execute(
-            select(Match).where(Match.id == uuid.UUID(created["id"]))
-        )
-    ).scalar_one()
+    # Backfill to pending — the API no longer creates pending rows.
+    db_match = await db_session.get(Match, uuid.UUID(created["id"]))
+    assert db_match is not None
     db_match.status = MatchStatus.pending
     await db_session.commit()
 

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -406,7 +406,6 @@ async def test_scoring_game_1_keeps_in_progress_and_adds_game_2(
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     match = await _create_match(api_client, opp.id, best_of=5)
-    assert match["status"] == "in_progress"
 
     response = await api_client.post(
         f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -40,8 +40,8 @@ async def test_create_rated_match_with_registered_opponent(
     )
     assert response.status_code == 201
     body = response.json()
-    assert body["status"] == "pending"
-    assert body["status_label"] == "Scheduled"
+    assert body["status"] == "in_progress"
+    assert body["status_label"] == "Live"
     assert body["best_of"] == 5
     assert body["games_to_win"] == 3
     assert body["team_size"] == 1
@@ -285,7 +285,7 @@ async def test_list_filter_by_status(
 ):
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
-    pending = await _create_match(api_client, opp.id, best_of=1)
+    in_progress = await _create_match(api_client, opp.id, best_of=1)
     # Score game 1 to flip a separate match to completed.
     completed_match = await _create_match(api_client, opp.id, best_of=1)
     score_resp = await api_client.post(
@@ -295,10 +295,10 @@ async def test_list_filter_by_status(
     assert score_resp.status_code == 201
 
     listing = (
-        await api_client.get("/v1/matches", params={"status": "pending"})
+        await api_client.get("/v1/matches", params={"status": "in_progress"})
     ).json()
-    assert [row["id"] for row in listing["items"]] == [pending["id"]]
-    assert listing["status_counts"]["pending"] == 1
+    assert [row["id"] for row in listing["items"]] == [in_progress["id"]]
+    assert listing["status_counts"]["in_progress"] == 1
     assert listing["status_counts"]["completed"] == 1
 
 
@@ -400,12 +400,13 @@ async def test_table_tennis_scoring_rules(
 # ----- score lifecycle ----------------------------------------------------
 
 
-async def test_scoring_game_1_flips_pending_to_in_progress_and_adds_game_2(
+async def test_scoring_game_1_keeps_in_progress_and_adds_game_2(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     match = await _create_match(api_client, opp.id, best_of=5)
+    assert match["status"] == "in_progress"
 
     response = await api_client.post(
         f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -80,7 +80,6 @@ export function reconcile(seed: SeedMatch): void {
   const { side1, side2 } = sideWinCounts(seed)
   const target = gamesToWin(seed.best_of)
   const decided = side1 >= target || side2 >= target
-  const anyScored = side1 > 0 || side2 > 0
 
   if (decided) {
     seed.status = 'completed'
@@ -89,7 +88,7 @@ export function reconcile(seed: SeedMatch): void {
     if (seed.completed_at === null) seed.completed_at = new Date().toISOString()
     seed.games = seed.games.filter((g) => g.score !== null)
   } else {
-    seed.status = anyScored ? 'in_progress' : 'pending'
+    seed.status = 'in_progress'
     seed.completed_at = null
     if (currentUnscored(seed) === null && seed.opponent !== null) {
       const nextNumber =
@@ -407,7 +406,7 @@ export function newMatchSeed(input: {
   const id = `m-${Date.now().toString(36)}`
   const seed: SeedMatch = {
     id,
-    status: 'pending',
+    status: 'in_progress',
     best_of: input.bestOf,
     // A solo match (no opponent) can never affect ratings, mirroring the API.
     affects_rating: input.rated && input.opponent !== null,

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -131,9 +131,9 @@ export function player(overrides: Partial<Player> = {}): Player {
 }
 
 /**
- * `MatchDetails` factory. Defaults to a fresh `pending` 1v1 with the current
- * user on side 1, a single opponent on side 2, and game 1 unscored — the
- * shape the BFF returns straight after `POST /v1/matches`.
+ * `MatchDetails` factory. Defaults to a fresh `in_progress` 1v1 with the
+ * current user on side 1, a single opponent on side 2, and game 1 unscored
+ * — the shape the BFF returns straight after `POST /v1/matches`.
  */
 export function matchDetails(
   overrides: Partial<MatchDetails> = {},
@@ -179,8 +179,8 @@ export function matchDetails(
   }
   return {
     id,
-    status: 'pending',
-    status_label: 'Scheduled',
+    status: 'in_progress',
+    status_label: 'Live',
     league: MOCK_DEFAULT_LEAGUE,
     best_of: bestOf,
     games_to_win: Math.ceil(bestOf / 2),
@@ -196,15 +196,16 @@ export function matchDetails(
   }
 }
 
-/** Row-shaped projection for the /matches list. Defaults mirror a pending
- * 1v1 against a registered opponent with one trailing un-scored game. */
+/** Row-shaped projection for the /matches list. Defaults mirror an
+ * in_progress 1v1 against a registered opponent with one trailing
+ * un-scored game. */
 export function matchListRow(
   overrides: Partial<MatchListRow> = {},
 ): MatchListRow {
   return {
     id: nextId('m'),
-    status: 'pending',
-    status_label: 'Scheduled',
+    status: 'in_progress',
+    status_label: 'Live',
     league: MOCK_DEFAULT_LEAGUE,
     opponent_username: faker.internet.username().toLowerCase(),
     opponent_user_id: nextId('u'),


### PR DESCRIPTION
## Summary
- `POST /v1/matches` now creates matches as `MatchStatus.in_progress` so casual play is immediately interactive instead of sitting in the "Scheduled" pending state that the matches list can't open (#145, #147).
- `_recompute_match` no longer reverts to `pending` when no game has been won; an undecided match stays Live.
- Mock store, test factories, and assertions updated to match.

## Follow-ups noted (not blockers)
- Dashboard `next_match` widget queries `MatchStatus.pending` on every load; with this change no production rows land there. Consider hiding/removing until scheduling lands.
- #145 and #147 (pending-row UX gaps) become much rarer but stay latent for any historical pending rows.

## Test plan
- [x] API pytest — 175/175
- [x] web-client vitest — 39/39
- [x] web-client lint + tsc + vite build — clean
- [x] web-client Playwright — 126/126
- [x] OpenAPI schema — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)