### PR TITLE
Open /matches list to all users; replace Opponent column with Players column

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -385,10 +385,11 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
     side_wins = side_win_counts(match)
     sides_sorted = sorted(match.sides, key=lambda s: s.side_number)
     current_game = current_unscored_game(match)
-    scorable = (
+    can_score = (
         match.status in {MatchStatus.pending, MatchStatus.in_progress}
         and len(match.sides) >= 2
         and current_game is not None
+        and _is_participant(match, current_user_id)
     )
 
     return MatchListRow(
@@ -402,8 +403,9 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
         ],
         best_of=match.match_settings.best_of,
         created_at=match.created_at,
-        current_game_id=current_game.id if current_game else None,
-        can_score=scorable and _is_participant(match, current_user_id),
+        # Only surfaced to participants — spectators have no scoring affordance.
+        current_game_id=current_game.id if can_score else None,
+        can_score=can_score,
     )
 
 

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -403,7 +403,6 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
         ],
         best_of=match.match_settings.best_of,
         created_at=match.created_at,
-        # Only surfaced to participants — spectators have no scoring affordance.
         current_game_id=current_game.id if can_score else None,
         can_score=can_score,
     )

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -44,6 +44,29 @@ MAX_PAGE_SIZE = 100
 # ----- helpers -------------------------------------------------------------
 
 
+def _side_schema(
+    side: MatchSide,
+    side_wins: dict[int, int],
+    current_user_id: uuid.UUID,
+) -> MatchDetailsSide:
+    return MatchDetailsSide(
+        side_number=side.side_number,
+        players=[
+            MatchDetailsPlayer(
+                user_id=p.user_id,
+                username=p.user.username,
+                is_current_user=p.user_id == current_user_id,
+            )
+            for p in sorted(side.players, key=lambda p: p.user.username)
+        ],
+        games_won=side_wins.get(side.side_number, 0),
+        won=side.won,
+        is_current_user_side=any(
+            p.user_id == current_user_id for p in side.players
+        ),
+    )
+
+
 # Shared eager-load chain. Used by every read path that returns a hierarchical
 # match — async SQLAlchemy can't lazy-load mid-request, so all four collections
 # are pulled up front.
@@ -145,22 +168,6 @@ def _serialize_details(match: Match, current_user_id: uuid.UUID) -> MatchDetails
     side_wins = side_win_counts(match)
     my_number = mine.side_number
 
-    def _side_schema(side: MatchSide) -> MatchDetailsSide:
-        return MatchDetailsSide(
-            side_number=side.side_number,
-            players=[
-                MatchDetailsPlayer(
-                    user_id=p.user_id,
-                    username=p.user.username,
-                    is_current_user=p.user_id == current_user_id,
-                )
-                for p in sorted(side.players, key=lambda p: p.user.username)
-            ],
-            games_won=side_wins.get(side.side_number, 0),
-            won=side.won,
-            is_current_user_side=side.side_number == my_number,
-        )
-
     def _score_schema(score: MatchGameScore) -> MatchDetailsScore:
         my_points = (
             score.side_1_points if my_number == 1 else score.side_2_points
@@ -204,8 +211,10 @@ def _serialize_details(match: Match, current_user_id: uuid.UUID) -> MatchDetails
         team_size=match.match_settings.team_size,
         affects_rating=match.match_settings.affects_rating,
         created_at=match.created_at,
-        my_side=_side_schema(mine),
-        opponent_side=_side_schema(opp) if opp else None,
+        my_side=_side_schema(mine, side_wins, current_user_id),
+        opponent_side=(
+            _side_schema(opp, side_wins, current_user_id) if opp else None
+        ),
         games=games,
         current_game=current_game,
         can_score=current_game is not None and opp is not None,
@@ -237,19 +246,19 @@ def participant_filter(query, current_user_id: uuid.UUID):
     return query.where(me_in_match)
 
 
-def _opponent_username_filter(query, current_user_id: uuid.UUID, q: str):
+def _player_username_filter(query, q: str):
+    """Restrict to matches that have *any* player whose username matches ``q``."""
     pattern = f"%{escape_like(q.strip())}%"
-    has_matching_opponent = (
+    has_matching_player = (
         select(MatchSidePlayer.id)
         .join(User, User.id == MatchSidePlayer.user_id)
         .where(
             MatchSidePlayer.match_id == Match.id,
-            MatchSidePlayer.user_id != current_user_id,
             User.username.ilike(pattern, escape="\\"),
         )
         .exists()
     )
-    return query.where(has_matching_opponent)
+    return query.where(has_matching_player)
 
 
 # ----- endpoints -----------------------------------------------------------
@@ -327,9 +336,11 @@ async def list_matches(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> MatchListResponse:
-    base = participant_filter(select(Match), current_user.id)
+    # The list is open to every signed-in user. Writes still gate on
+    # `_is_participant` downstream.
+    base = select(Match)
     if q:
-        base = _opponent_username_filter(base, current_user.id, q)
+        base = _player_username_filter(base, q)
 
     paged = base if status_ is None else base.where(Match.status == status_)
 
@@ -349,13 +360,9 @@ async def list_matches(
     # status_counts honors `q` and ignores the status filter, so it's built
     # from `base`. `total` then falls out of the same aggregate — no separate
     # count round-trip needed.
-    counts_query = participant_filter(
-        select(Match.status, func.count(Match.id)), current_user.id
-    )
+    counts_query = select(Match.status, func.count(Match.id))
     if q:
-        counts_query = _opponent_username_filter(
-            counts_query, current_user.id, q
-        )
+        counts_query = _player_username_filter(counts_query, q)
     status_counts: dict[MatchStatus, int] = {s: 0 for s in MatchStatus}
     for status_value, count in (
         await db.execute(counts_query.group_by(Match.status))
@@ -375,39 +382,28 @@ async def list_matches(
 
 
 def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
-    mine = my_side(match, current_user_id)
-    assert mine is not None  # list query already filtered to participants
-    opp = opponent_side(match, current_user_id)
-
     side_wins = side_win_counts(match)
-    my_games_won = side_wins.get(mine.side_number, 0)
-    opp_games_won = side_wins.get(opp.side_number, 0) if opp else 0
-    opp_player = opp.players[0] if opp and opp.players else None
-
+    sides_sorted = sorted(match.sides, key=lambda s: s.side_number)
     current_game = current_unscored_game(match)
     scorable = (
         match.status in {MatchStatus.pending, MatchStatus.in_progress}
-        and opp is not None
+        and len(match.sides) >= 2
         and current_game is not None
     )
-
-    is_win: bool | None = None
-    if match.status == MatchStatus.completed and opp is not None:
-        is_win = my_games_won > opp_games_won
 
     return MatchListRow(
         id=match.id,
         status=match.status,
         status_label=STATUS_LABELS[match.status],
         league=MatchLeague(id=match.league.id, name=match.league.name),
-        opponent_username=opp_player.user.username if opp_player else None,
-        opponent_user_id=opp_player.user_id if opp_player else None,
-        my_games_won=my_games_won,
-        opponent_games_won=opp_games_won,
-        is_win=is_win,
+        sides=[
+            _side_schema(side, side_wins, current_user_id)
+            for side in sides_sorted
+        ],
         best_of=match.match_settings.best_of,
         created_at=match.created_at,
-        current_game_id=current_game.id if scorable else None,
+        current_game_id=current_game.id if current_game else None,
+        can_score=scorable and _is_participant(match, current_user_id),
     )
 
 

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -109,14 +109,11 @@ class MatchListRow(BaseModel):
     status: MatchStatus
     status_label: str
     league: MatchLeague
-    opponent_username: str | None
-    opponent_user_id: uuid.UUID | None
-    my_games_won: int
-    opponent_games_won: int
-    is_win: bool | None
+    sides: list[MatchDetailsSide]
     best_of: int
     created_at: datetime
     current_game_id: uuid.UUID | None
+    can_score: bool
 
 
 class MatchListResponse(BaseModel):

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -265,19 +265,30 @@ async def test_list_matches_empty(
     assert body["status_counts"]["completed"] == 0
 
 
-async def test_list_matches_scoped_to_current_user(
+async def test_list_matches_shows_every_match_on_the_system(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await start_session(api_client, db_session)
+    me = await start_session(api_client, db_session)
     async with make_client() as other_client:
         them = await start_session(other_client, db_session)
         bystander = await make_user(db_session, "bystander")
-        # A match between Bob and a bystander — should NOT appear in Alice's list.
-        await _create_match(other_client, bystander.id)
-        del them
+        # A match between two strangers — historically hidden, now visible.
+        other_match = await _create_match(other_client, bystander.id)
 
     response = await api_client.get("/v1/matches")
-    assert response.json()["items"] == []
+    body = response.json()
+    ids = {row["id"] for row in body["items"]}
+    assert other_match["id"] in ids
+    # The spectator sees both sides flagged neutrally — neither claims to be
+    # `is_current_user_side`, since `me` is not a participant.
+    row = next(r for r in body["items"] if r["id"] == other_match["id"])
+    assert [side["is_current_user_side"] for side in row["sides"]] == [
+        False,
+        False,
+    ]
+    usernames = {p["username"] for side in row["sides"] for p in side["players"]}
+    assert usernames == {them.username, bystander.username}
+    assert me.id  # silence "unused" warning — the spectator's identity matters
 
 
 async def test_list_filter_by_status(
@@ -302,7 +313,7 @@ async def test_list_filter_by_status(
     assert listing["status_counts"]["completed"] == 1
 
 
-async def test_list_q_filter_matches_opponent_username(
+async def test_list_q_filter_matches_any_player_username(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
@@ -315,7 +326,12 @@ async def test_list_q_filter_matches_opponent_username(
         await api_client.get("/v1/matches", params={"q": "alpha"})
     ).json()
     assert len(listing["items"]) == 1
-    assert listing["items"][0]["opponent_username"] == "alphabet"
+    players = {
+        p["username"]
+        for side in listing["items"][0]["sides"]
+        for p in side["players"]
+    }
+    assert "alphabet" in players
     # status_counts honors q (one row total)
     assert sum(listing["status_counts"].values()) == 1
 
@@ -354,7 +370,26 @@ async def test_list_row_carries_current_game_id_when_scorable(
     created = await _create_match(api_client, opp.id)
 
     listing = (await api_client.get("/v1/matches")).json()
-    assert listing["items"][0]["current_game_id"] == created["games"][0]["id"]
+    row = listing["items"][0]
+    assert row["current_game_id"] == created["games"][0]["id"]
+    assert row["can_score"] is True
+
+
+async def test_list_row_can_score_is_false_for_spectators(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # `current_game_id` still leaks to spectators (so the FE can deep-link),
+    # but `can_score` gates the Score CTA on participation.
+    await start_session(api_client, db_session)
+    async with make_client() as other_client:
+        await start_session(other_client, db_session)
+        bystander = await make_user(db_session, "bystander")
+        created = await _create_match(other_client, bystander.id)
+
+    listing = (await api_client.get("/v1/matches")).json()
+    row = next(r for r in listing["items"] if r["id"] == created["id"])
+    assert row["current_game_id"] is not None
+    assert row["can_score"] is False
 
 
 # ----- TT scoring rules ---------------------------------------------------

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -280,7 +280,7 @@ async def test_list_matches_shows_every_match_on_the_system(
     ids = {row["id"] for row in body["items"]}
     assert other_match["id"] in ids
     # The spectator sees both sides flagged neutrally — neither claims to be
-    # `is_current_user_side`, since `me` is not a participant.
+    # `is_current_user_side`, and `me` doesn't appear in any row's players.
     row = next(r for r in body["items"] if r["id"] == other_match["id"])
     assert [side["is_current_user_side"] for side in row["sides"]] == [
         False,
@@ -288,7 +288,28 @@ async def test_list_matches_shows_every_match_on_the_system(
     ]
     usernames = {p["username"] for side in row["sides"] for p in side["players"]}
     assert usernames == {them.username, bystander.username}
-    assert me.id  # silence "unused" warning — the spectator's identity matters
+    assert me.username not in usernames
+
+
+async def test_list_q_filter_matches_caller_username(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    mine = await _create_match(api_client, opp.id)
+    async with make_client() as other_client:
+        await start_session(other_client, db_session)
+        bystander = await make_user(db_session, "bystander")
+        # A match the caller is not in — searching for the caller's own
+        # username should not pick this up.
+        unrelated = await _create_match(other_client, bystander.id)
+
+    listing = (
+        await api_client.get("/v1/matches", params={"q": me.username})
+    ).json()
+    ids = {row["id"] for row in listing["items"]}
+    assert mine["id"] in ids
+    assert unrelated["id"] not in ids
 
 
 async def test_list_filter_by_status(
@@ -375,11 +396,11 @@ async def test_list_row_carries_current_game_id_when_scorable(
     assert row["can_score"] is True
 
 
-async def test_list_row_can_score_is_false_for_spectators(
+async def test_list_row_hides_scoring_affordance_from_spectators(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    # `current_game_id` still leaks to spectators (so the FE can deep-link),
-    # but `can_score` gates the Score CTA on participation.
+    # Spectators get neither `can_score` nor `current_game_id` — the scoring
+    # route 404s for them anyway, and the FE has no reason to deep-link.
     await start_session(api_client, db_session)
     async with make_client() as other_client:
         await start_session(other_client, db_session)
@@ -388,7 +409,7 @@ async def test_list_row_can_score_is_false_for_spectators(
 
     listing = (await api_client.get("/v1/matches")).json()
     row = next(r for r in listing["items"] if r["id"] == created["id"])
-    assert row["current_game_id"] is not None
+    assert row["current_game_id"] is None
     assert row["can_score"] is False
 
 

--- a/web-client/e2e/matches-list.spec.ts
+++ b/web-client/e2e/matches-list.spec.ts
@@ -11,28 +11,23 @@ const PAGE_SIZE = 25
 const SEED = [
   matchListRow({
     id: 'm-live-1',
-    opponent_username: 'nguyen.t',
+    opponent: 'nguyen.t',
     status: 'in_progress',
     status_label: 'Live',
-    my_games_won: 1,
-    opponent_games_won: 1,
     current_game_id: 'g-live-1-3',
   }),
   matchListRow({
     id: 'm-pending-1',
-    opponent_username: 'okafor.d',
+    opponent: 'okafor.d',
     status: 'pending',
     status_label: 'Scheduled',
     current_game_id: 'g-pending-1-1',
   }),
   matchListRow({
     id: 'm-final-1',
-    opponent_username: 'silva.r',
+    opponent: 'silva.r',
     status: 'completed',
     status_label: 'Final',
-    my_games_won: 3,
-    opponent_games_won: 1,
-    is_win: true,
     current_game_id: null,
   }),
 ]
@@ -125,7 +120,7 @@ test.describe('Matches list — pagination', () => {
     const many = Array.from({ length: 30 }, (_, i) =>
       matchListRow({
         id: `m-${i}`,
-        opponent_username: `opp-${i}`,
+        opponent: `opp-${i}`,
         status: 'pending',
       }),
     )

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -545,16 +545,8 @@ export interface components {
             /** Status Label */
             status_label: string;
             league: components["schemas"]["MatchLeague"];
-            /** Opponent Username */
-            opponent_username: string | null;
-            /** Opponent User Id */
-            opponent_user_id: string | null;
-            /** My Games Won */
-            my_games_won: number;
-            /** Opponent Games Won */
-            opponent_games_won: number;
-            /** Is Win */
-            is_win: boolean | null;
+            /** Sides */
+            sides: components["schemas"]["MatchDetailsSide"][];
             /** Best Of */
             best_of: number;
             /**
@@ -564,6 +556,8 @@ export interface components {
             created_at: string;
             /** Current Game Id */
             current_game_id: string | null;
+            /** Can Score */
+            can_score: boolean;
         };
         /**
          * MatchStatus

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -103,10 +103,12 @@ export function reconcile(seed: SeedMatch): void {
   }
 }
 
-export function projectMatchDetails(seed: SeedMatch): MatchDetails {
+function projectSides(seed: SeedMatch): {
+  mySide: MatchDetailsSide
+  opponentSide: MatchDetailsSide | null
+} {
   const { side1, side2 } = sideWinCounts(seed)
   const decided = seed.status === 'completed'
-
   const mySide: MatchDetailsSide = {
     side_number: 1,
     players: [
@@ -135,6 +137,11 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
         is_current_user_side: false,
       }
     : null
+  return { mySide, opponentSide }
+}
+
+export function projectMatchDetails(seed: SeedMatch): MatchDetails {
+  const { mySide, opponentSide } = projectSides(seed)
 
   const games: MatchDetailsGame[] = seed.games
     .slice()
@@ -174,54 +181,21 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
 }
 
 export function projectListRow(seed: SeedMatch): MatchListRow {
-  const { side1, side2 } = sideWinCounts(seed)
-  const decided = seed.status === 'completed'
+  const { mySide, opponentSide } = projectSides(seed)
   const current = currentUnscored(seed)
   const scorable =
     (seed.status === 'pending' || seed.status === 'in_progress') &&
-    seed.opponent !== null &&
+    opponentSide !== null &&
     current !== null
-
-  const sides: MatchDetailsSide[] = [
-    {
-      side_number: 1,
-      players: [
-        {
-          user_id: MOCK_CURRENT_USER.id,
-          username: MOCK_CURRENT_USER.username,
-          is_current_user: true,
-        },
-      ],
-      games_won: side1,
-      won: decided ? side1 > side2 : null,
-      is_current_user_side: true,
-    },
-  ]
-  if (seed.opponent) {
-    sides.push({
-      side_number: 2,
-      players: [
-        {
-          user_id: seed.opponent.id,
-          username: seed.opponent.username,
-          is_current_user: false,
-        },
-      ],
-      games_won: side2,
-      won: decided ? side2 > side1 : null,
-      is_current_user_side: false,
-    })
-  }
-
   return {
     id: seed.id,
     status: seed.status,
     status_label: STATUS_LABELS[seed.status],
     league: MOCK_DEFAULT_LEAGUE,
-    sides,
+    sides: opponentSide ? [mySide, opponentSide] : [mySide],
     best_of: seed.best_of,
     created_at: seed.created_at,
-    current_game_id: current ? current.id : null,
+    current_game_id: scorable ? current.id : null,
     can_score: scorable,
   }
 }

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -181,19 +181,48 @@ export function projectListRow(seed: SeedMatch): MatchListRow {
     (seed.status === 'pending' || seed.status === 'in_progress') &&
     seed.opponent !== null &&
     current !== null
+
+  const sides: MatchDetailsSide[] = [
+    {
+      side_number: 1,
+      players: [
+        {
+          user_id: MOCK_CURRENT_USER.id,
+          username: MOCK_CURRENT_USER.username,
+          is_current_user: true,
+        },
+      ],
+      games_won: side1,
+      won: decided ? side1 > side2 : null,
+      is_current_user_side: true,
+    },
+  ]
+  if (seed.opponent) {
+    sides.push({
+      side_number: 2,
+      players: [
+        {
+          user_id: seed.opponent.id,
+          username: seed.opponent.username,
+          is_current_user: false,
+        },
+      ],
+      games_won: side2,
+      won: decided ? side2 > side1 : null,
+      is_current_user_side: false,
+    })
+  }
+
   return {
     id: seed.id,
     status: seed.status,
     status_label: STATUS_LABELS[seed.status],
     league: MOCK_DEFAULT_LEAGUE,
-    opponent_username: seed.opponent?.username ?? null,
-    opponent_user_id: seed.opponent?.id ?? null,
-    my_games_won: side1,
-    opponent_games_won: side2,
-    is_win: decided && seed.opponent ? side1 > side2 : null,
+    sides,
     best_of: seed.best_of,
     created_at: seed.created_at,
-    current_game_id: scorable && current ? current.id : null,
+    current_game_id: current ? current.id : null,
+    can_score: scorable,
   }
 }
 

--- a/web-client/src/routes/matches/index.css
+++ b/web-client/src/routes/matches/index.css
@@ -242,9 +242,6 @@
   color: var(--serve-500);
   font-weight: 600;
 }
-.match-list-page .player-name.is-loser {
-  color: var(--fg-3);
-}
 .match-list-page .player-name.is-empty {
   color: var(--fg-3);
   font-style: italic;

--- a/web-client/src/routes/matches/index.css
+++ b/web-client/src/routes/matches/index.css
@@ -245,6 +245,22 @@
 .match-list-page .player-name.is-loser {
   color: var(--fg-3);
 }
+.match-list-page .player-name.is-empty {
+  color: var(--fg-3);
+  font-style: italic;
+}
+.match-list-page .players-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+.match-list-page .players-vs {
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
 .match-list-page .seed-tag {
   font-family: var(--font-mono);
   font-size: 10px;

--- a/web-client/src/routes/matches/index.test.tsx
+++ b/web-client/src/routes/matches/index.test.tsx
@@ -190,7 +190,7 @@ describe('MatchesPage', () => {
     await waitFor(() => expect(requests.length).toBeGreaterThanOrEqual(1))
     const requestsBeforeTyping = requests.length
 
-    await user.type(screen.getByPlaceholderText(/search opponents/i), 'ngu')
+    await user.type(screen.getByPlaceholderText(/search players/i), 'ngu')
 
     await waitFor(
       () => {

--- a/web-client/src/routes/matches/index.test.tsx
+++ b/web-client/src/routes/matches/index.test.tsx
@@ -74,6 +74,28 @@ describe('MatchesPage', () => {
     // Seed handler also yields silva.r (final win) and patel.m (final loss).
     expect(screen.getByText('silva.r')).toBeInTheDocument()
     expect(screen.getByText('patel.m')).toBeInTheDocument()
+    // The Players column shows both sides — the current mock user (side 1)
+    // appears alongside the opponent (side 2).
+    expect(screen.getAllByText('rita.kovac').length).toBeGreaterThan(0)
+  })
+
+  it('paints the winning side green on a completed row', async () => {
+    renderMatchesPage()
+    // Seed match m-completed-win-1 has side-1 (rita.kovac) winning vs silva.r.
+    const winner = await screen.findByText('silva.r')
+    // The losing side's name is rendered without is-winner; the winning side
+    // (the seed user) on that row carries it.
+    const rows = screen.getAllByRole('link')
+    const winnerRow = rows.find((r) =>
+      r.getAttribute('aria-label')?.includes('silva.r'),
+    )
+    expect(winnerRow).toBeDefined()
+    // The current user on side 1 won this row, so their name carries the
+    // winner color.
+    const winnerName = winnerRow!.querySelector('.player-name.is-winner')
+    expect(winnerName?.textContent).toBe('rita.kovac')
+    // And the opponent's name stays neutral.
+    expect(winner).not.toHaveClass('is-winner')
   })
 
   it('passes the API status when the player picks a status tab', async () => {
@@ -84,7 +106,7 @@ describe('MatchesPage', () => {
         requests.push(request.url)
         return HttpResponse.json(
           matchListResponse({
-            items: [matchListRow({ opponent_username: 'live.opp' })],
+            items: [matchListRow({ opponent: 'live.opp' })],
             status_counts: { pending: 1, in_progress: 1, completed: 1 },
             total: 1,
           }),
@@ -123,7 +145,7 @@ describe('MatchesPage', () => {
         const items = Array.from({ length: page === 1 ? 25 : 1 }, (_, i) =>
           matchListRow({
             id: `m-${page}-${i}`,
-            opponent_username: `p${page}-${i}`,
+            opponent: `p${page}-${i}`,
           }),
         )
         return HttpResponse.json(
@@ -157,7 +179,7 @@ describe('MatchesPage', () => {
         requests.push(request.url)
         return HttpResponse.json(
           matchListResponse({
-            items: [matchListRow({ opponent_username: 'nguyen.t' })],
+            items: [matchListRow({ opponent: 'nguyen.t' })],
             total: 1,
             status_counts: { pending: 1 },
           }),

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -18,8 +18,6 @@ import {
   type MatchStatus,
 } from '@/api/matches'
 import type { components } from '@/api/schema'
-
-type MatchListRowSide = components['schemas']['MatchDetailsSide']
 import { AppShell } from '@/components/app-shell'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
@@ -48,6 +46,8 @@ import {
 import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { cn, initialsOf } from '@/lib/utils'
 import './index.css'
+
+type MatchListRowSide = components['schemas']['MatchDetailsSide']
 
 export const Route = createFileRoute('/matches/')({
   component: MatchesPage,
@@ -212,7 +212,7 @@ function FilterRow({
         <Search className="ml-search-icon" size={16} strokeWidth={2} />
         <Input
           className="h-9 pl-9 pr-9"
-          placeholder="Search opponents…"
+          placeholder="Search players…"
           value={q}
           onChange={(e) => setQ(e.target.value)}
         />

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -17,6 +17,9 @@ import {
   type MatchListRow,
   type MatchStatus,
 } from '@/api/matches'
+import type { components } from '@/api/schema'
+
+type MatchListRowSide = components['schemas']['MatchDetailsSide']
 import { AppShell } from '@/components/app-shell'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
@@ -43,7 +46,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useDebouncedValue } from '@/lib/use-debounced-value'
-import { cn } from '@/lib/utils'
+import { cn, initialsOf } from '@/lib/utils'
 import './index.css'
 
 export const Route = createFileRoute('/matches/')({
@@ -336,7 +339,7 @@ function MatchTableHead() {
     <thead>
       <tr>
         <th style={{ width: 120 }}>Match</th>
-        <th>Opponent</th>
+        <th>Players</th>
         <th style={{ width: 120 }}>Score</th>
         <th style={{ width: 120 }}>Status</th>
         <th style={{ width: 140 }}>Started</th>
@@ -371,7 +374,8 @@ function MatchRow({
   navigate: NavigateFn
 }) {
   const tab = API_TO_TAB[row.status]
-  const opponentName = row.opponent_username ?? 'No opponent'
+  const side1 = row.sides.find((s) => s.side_number === 1) ?? row.sides[0]
+  const side2 = row.sides.find((s) => s.side_number === 2) ?? null
   const showScore =
     row.status === 'in_progress' || row.status === 'completed'
 
@@ -384,7 +388,7 @@ function MatchRow({
       className={cn('is-clickable', row.status === 'in_progress' && 'is-live')}
       role="link"
       tabIndex={0}
-      aria-label={`Open match against ${opponentName}`}
+      aria-label={`Open match: ${sideLabel(side1)} vs ${sideLabel(side2)}`}
       onClick={open}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -395,25 +399,14 @@ function MatchRow({
     >
       <td className="id-cell">M-{shortId(row.id)}</td>
       <td>
-        <div className="player">
-          <Avatar className="size-[26px]">
-            <AvatarFallback className="font-mono text-[11px] font-bold">
-              {initials(opponentName)}
-            </AvatarFallback>
-          </Avatar>
-          <span
-            className={cn(
-              'player-name',
-              row.is_win === true && 'is-winner',
-              row.is_win === false && 'is-loser',
-            )}
-          >
-            {opponentName}
-          </span>
+        <div className="players-cell">
+          <PlayerChip side={side1} />
+          <span className="players-vs">vs</span>
+          <PlayerChip side={side2} />
         </div>
       </td>
       <td>
-        <ScoreCell row={row} showScore={showScore} />
+        <ScoreCell side1={side1} side2={side2} showScore={showScore} />
       </td>
       <td>
         <StatusBadge tab={tab} label={row.status_label} />
@@ -422,7 +415,7 @@ function MatchRow({
         <TimeCell iso={row.created_at} />
       </td>
       <td onClick={(e) => e.stopPropagation()}>
-        {row.current_game_id ? (
+        {row.can_score && row.current_game_id ? (
           <Button asChild variant="default" size="sm">
             <Link {...scoringNewRoute(row.id, row.current_game_id)}>
               Score
@@ -442,17 +435,49 @@ function MatchRow({
   )
 }
 
+function sideLabel(side: MatchListRowSide | null): string {
+  if (side === null) return 'No opponent'
+  return side.players.map((p) => p.username).join(' & ') || 'No opponent'
+}
+
+function PlayerChip({ side }: { side: MatchListRowSide | null }) {
+  const name = sideLabel(side)
+  const isEmpty = side === null
+  return (
+    <div className="player">
+      <Avatar className="size-[26px]">
+        <AvatarFallback className="font-mono text-[11px] font-bold">
+          {isEmpty ? '?' : initialsOf(name)}
+        </AvatarFallback>
+      </Avatar>
+      <span
+        className={cn(
+          'player-name',
+          isEmpty && 'is-empty',
+          side?.won === true && 'is-winner',
+        )}
+      >
+        {name}
+      </span>
+    </div>
+  )
+}
+
 function ScoreCell({
-  row,
+  side1,
+  side2,
   showScore,
 }: {
-  row: MatchListRow
+  side1: MatchListRowSide
+  side2: MatchListRowSide | null
   showScore: boolean
 }) {
-  if (!showScore) return <span className="score-cell pending">—</span>
+  if (!showScore || side2 === null) {
+    return <span className="score-cell pending">—</span>
+  }
   return (
     <span className="score-cell games">
-      {row.my_games_won}–{row.opponent_games_won}
+      {side1.games_won}–{side2.games_won}
     </span>
   )
 }
@@ -487,15 +512,6 @@ function TimeCell({ iso }: { iso: string }) {
 
 function shortId(id: string): string {
   return id.slice(-6).toUpperCase().padStart(6, '0')
-}
-
-function initials(name: string): string {
-  const parts = name.split(/[^a-zA-Z0-9]+/).filter(Boolean)
-  const letters =
-    parts.length >= 2
-      ? parts[0][0] + parts[1][0]
-      : name.replace(/[^a-zA-Z0-9]/g, '').slice(0, 2)
-  return letters.toUpperCase() || '?'
 }
 
 type PageToken = number | 'ellipsis'

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -415,7 +415,7 @@ function MatchRow({
         <TimeCell iso={row.created_at} />
       </td>
       <td onClick={(e) => e.stopPropagation()}>
-        {row.can_score && row.current_game_id ? (
+        {row.current_game_id ? (
           <Button asChild variant="default" size="sm">
             <Link {...scoringNewRoute(row.id, row.current_game_id)}>
               Score
@@ -436,8 +436,7 @@ function MatchRow({
 }
 
 function sideLabel(side: MatchListRowSide | null): string {
-  if (side === null) return 'No opponent'
-  return side.players.map((p) => p.username).join(' & ') || 'No opponent'
+  return side?.players.map((p) => p.username).join(' & ') || 'No opponent'
 }
 
 function PlayerChip({ side }: { side: MatchListRowSide | null }) {

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -197,24 +197,58 @@ export function matchDetails(
 }
 
 /** Row-shaped projection for the /matches list. Defaults mirror a pending
- * 1v1 against a registered opponent with one trailing un-scored game. */
+ * 1v1 against a registered opponent with one trailing un-scored game. Pass
+ * `opponent` as a shorthand to set the side-2 player without spelling out
+ * `sides`. */
 export function matchListRow(
-  overrides: Partial<MatchListRow> = {},
+  overrides: Partial<MatchListRow> & { opponent?: string | null } = {},
 ): MatchListRow {
+  const { opponent, ...rest } = overrides
+  const opponentName =
+    opponent === undefined
+      ? faker.internet.username().toLowerCase()
+      : opponent
+  const sides: MatchDetailsSide[] = [
+    {
+      side_number: 1,
+      players: [
+        {
+          user_id: nextId('u'),
+          username: 'rita.kovac',
+          is_current_user: true,
+        },
+      ],
+      games_won: 0,
+      won: null,
+      is_current_user_side: true,
+    },
+  ]
+  if (opponentName !== null) {
+    sides.push({
+      side_number: 2,
+      players: [
+        {
+          user_id: nextId('u'),
+          username: opponentName,
+          is_current_user: false,
+        },
+      ],
+      games_won: 0,
+      won: null,
+      is_current_user_side: false,
+    })
+  }
   return {
     id: nextId('m'),
     status: 'pending',
     status_label: 'Scheduled',
     league: MOCK_DEFAULT_LEAGUE,
-    opponent_username: faker.internet.username().toLowerCase(),
-    opponent_user_id: nextId('u'),
-    my_games_won: 0,
-    opponent_games_won: 0,
-    is_win: null,
+    sides,
     best_of: 5,
     created_at: ISO,
     current_game_id: nextId('g'),
-    ...overrides,
+    can_score: opponentName !== null,
+    ...rest,
   }
 }
 

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -13,8 +13,6 @@ type Player = components['schemas']['PlayerRead']
 type MatchDetails = components['schemas']['MatchDetails']
 type MatchDetailsSide = components['schemas']['MatchDetailsSide']
 type MatchDetailsGame = components['schemas']['MatchDetailsGame']
-type MatchDetailsCurrentGame =
-  components['schemas']['MatchDetailsCurrentGame']
 type MatchListRow = components['schemas']['MatchListRow']
 type MatchListResponse = components['schemas']['MatchListResponse']
 type MatchStatus = components['schemas']['MatchStatus']
@@ -130,6 +128,45 @@ export function player(overrides: Partial<Player> = {}): Player {
   }
 }
 
+/** Build a default `[mySide, opponentSide]` pair (or `[mySide]` for solo
+ * matches). Shared by `matchDetails` and `matchListRow` so both factories
+ * agree on the canonical "rita.kovac vs faker-name" shape. */
+function defaultSides(opponentName: string | null): {
+  mySide: MatchDetailsSide
+  opponentSide: MatchDetailsSide | null
+} {
+  const mySide: MatchDetailsSide = {
+    side_number: 1,
+    players: [
+      {
+        user_id: nextId('u'),
+        username: 'rita.kovac',
+        is_current_user: true,
+      },
+    ],
+    games_won: 0,
+    won: null,
+    is_current_user_side: true,
+  }
+  const opponentSide: MatchDetailsSide | null =
+    opponentName === null
+      ? null
+      : {
+          side_number: 2,
+          players: [
+            {
+              user_id: nextId('u'),
+              username: opponentName,
+              is_current_user: false,
+            },
+          ],
+          games_won: 0,
+          won: null,
+          is_current_user_side: false,
+        }
+  return { mySide, opponentSide }
+}
+
 /**
  * `MatchDetails` factory. Defaults to a fresh `pending` 1v1 with the current
  * user on side 1, a single opponent on side 2, and game 1 unscored — the
@@ -140,42 +177,13 @@ export function matchDetails(
 ): MatchDetails {
   const id = overrides.id ?? nextId('m')
   const bestOf = overrides.best_of ?? 5
-  const currentUserId = nextId('u')
-  const opponentId = nextId('u')
-  const mySide: MatchDetailsSide = {
-    side_number: 1,
-    players: [
-      {
-        user_id: currentUserId,
-        username: 'rita.kovac',
-        is_current_user: true,
-      },
-    ],
-    games_won: 0,
-    won: null,
-    is_current_user_side: true,
-  }
-  const opponentSide: MatchDetailsSide = {
-    side_number: 2,
-    players: [
-      {
-        user_id: opponentId,
-        username: faker.internet.username().toLowerCase(),
-        is_current_user: false,
-      },
-    ],
-    games_won: 0,
-    won: null,
-    is_current_user_side: false,
-  }
+  const { mySide, opponentSide } = defaultSides(
+    faker.internet.username().toLowerCase(),
+  )
   const firstGame: MatchDetailsGame = {
     id: nextId('g'),
     game_number: 1,
     score: null,
-  }
-  const currentGame: MatchDetailsCurrentGame = {
-    id: firstGame.id,
-    game_number: 1,
   }
   return {
     id,
@@ -190,7 +198,7 @@ export function matchDetails(
     my_side: mySide,
     opponent_side: opponentSide,
     games: [firstGame],
-    current_game: currentGame,
+    current_game: { id: firstGame.id, game_number: 1 },
     can_score: true,
     ...overrides,
   }
@@ -208,45 +216,16 @@ export function matchListRow(
     opponent === undefined
       ? faker.internet.username().toLowerCase()
       : opponent
-  const sides: MatchDetailsSide[] = [
-    {
-      side_number: 1,
-      players: [
-        {
-          user_id: nextId('u'),
-          username: 'rita.kovac',
-          is_current_user: true,
-        },
-      ],
-      games_won: 0,
-      won: null,
-      is_current_user_side: true,
-    },
-  ]
-  if (opponentName !== null) {
-    sides.push({
-      side_number: 2,
-      players: [
-        {
-          user_id: nextId('u'),
-          username: opponentName,
-          is_current_user: false,
-        },
-      ],
-      games_won: 0,
-      won: null,
-      is_current_user_side: false,
-    })
-  }
+  const { mySide, opponentSide } = defaultSides(opponentName)
   return {
     id: nextId('m'),
     status: 'pending',
     status_label: 'Scheduled',
     league: MOCK_DEFAULT_LEAGUE,
-    sides,
+    sides: opponentSide ? [mySide, opponentSide] : [mySide],
     best_of: 5,
     created_at: ISO,
-    current_game_id: nextId('g'),
+    current_game_id: opponentName === null ? null : nextId('g'),
     can_score: opponentName !== null,
     ...rest,
   }


### PR DESCRIPTION
## Summary

Closes #165 (list portion). Opens `GET /v1/matches` so any signed-in user can browse every match on the system, not only the matches they participate in. Writes still gate on `_is_participant` downstream.

- **API**
  - Drops `participant_filter` from `list_matches` and from the `status_counts` aggregate.
  - `q` now matches any player on any side (was opponent-only).
  - `MatchListRow` swaps `opponent_username` / `opponent_user_id` / `my_games_won` / `opponent_games_won` / `is_win` for a side-neutral `sides[]` list, and adds `can_score`. `current_game_id` is non-null iff `can_score` (server contract).
  - `_side_schema` hoisted so list + details share one builder.
- **Web**
  - Opponent column → Players column ("side1 vs side2", winner side name in green).
  - Search placeholder "opponents…" → "players…" to match the new semantics.
  - Score CTA gated on `current_game_id` (implicitly `can_score` via the contract).
  - Aria-label is side-neutral.
- **Tests**
  - API: spectator path covered; `current_game_id is None` + `can_score is False` for spectators; `q=<my_username>` returns the caller's matches.
  - Web: Players column rendering + winner-side-green; existing 126 Playwright cases pass.

## What does NOT change

- `GET /v1/matches/{id}` is still 404 for non-participants. The detail-page open-up (also in #165) requires reworking `MatchDetails` (nullable `my_side`, flat `sides[]`) and touches the scoring routes — left as a follow-up PR.

## Test plan

- [x] API pytest (177/177)
- [x] Web client vitest (40/40)
- [x] Web client lint + tsc + vite build
- [x] Web client Playwright (126/126)
- [x] OpenAPI schema regenerated; committed in same PR; no drift
- [ ] Smoke /matches in a browser as a signed-in user with no matches — should see everyone's matches (not the historical empty state)
- [ ] Confirm a spectator clicking Score on a row they don't own still 404s (no regression in the write boundary)

## Follow-ups

Review surfaced three nits, filed as separate issues:

- #174 — `matchListRow` factory can produce contract-invalid rows (`current_game_id: null` + `can_score: true`).
- #175 — Row aria-label reads awkwardly for opponent-less matches.
- #176 — Mock `projectSides` hard-codes `is_current_user_side: true` on side 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)