### PR TITLE
Track per-league, per-user ratings with audit history

### DIFF
--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -1,3 +1,6 @@
+import uuid
+from collections.abc import Sequence
+
 from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,13 +14,14 @@ from app.matches import (
     opponent_username,
     side_win_counts,
 )
-from app.models import Match, MatchStatus, User
+from app.models import Match, MatchStatus, RatingHistory, User
 from app.schemas.dashboard import (
     DashboardNextMatch,
     DashboardRecentResult,
     DashboardResponse,
     DashboardScoreBanner,
 )
+from app.schemas.rating import RatingChange
 from app.sessions import get_current_user
 
 router = APIRouter(prefix="/v1")
@@ -60,10 +64,15 @@ async def get_dashboard(
     in_progress = (await db.execute(in_progress_q)).scalars().all()
     completed = (await db.execute(completed_q)).scalars().all()
 
+    rating_changes = await _load_my_rating_changes(
+        db, current_user.id, [m.id for m in completed]
+    )
+
     score_banner = _build_score_banner(in_progress, current_user.id)
     next_match = _build_next_match(pending, current_user.id)
     recent_results = [
-        _build_recent_result(match, current_user.id) for match in completed
+        _build_recent_result(match, current_user.id, rating_changes.get(match.id))
+        for match in completed
     ]
 
     return DashboardResponse(
@@ -73,8 +82,26 @@ async def get_dashboard(
     )
 
 
+async def _load_my_rating_changes(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    match_ids: Sequence[uuid.UUID],
+) -> dict[uuid.UUID, RatingChange]:
+    if not match_ids:
+        return {}
+    rows = (
+        await db.execute(
+            select(RatingHistory).where(
+                RatingHistory.match_id.in_(match_ids),
+                RatingHistory.user_id == user_id,
+            )
+        )
+    ).scalars().all()
+    return {row.match_id: RatingChange.from_history(row) for row in rows}
+
+
 def _build_score_banner(
-    in_progress: list[Match], current_user_id
+    in_progress: list[Match], current_user_id: uuid.UUID
 ) -> DashboardScoreBanner | None:
     if not in_progress:
         return None
@@ -90,7 +117,7 @@ def _build_score_banner(
 
 
 def _build_next_match(
-    pending: list[Match], current_user_id
+    pending: list[Match], current_user_id: uuid.UUID
 ) -> DashboardNextMatch | None:
     if not pending:
         return None
@@ -103,7 +130,11 @@ def _build_next_match(
     )
 
 
-def _build_recent_result(match: Match, current_user_id) -> DashboardRecentResult:
+def _build_recent_result(
+    match: Match,
+    current_user_id: uuid.UUID,
+    my_rating_change: RatingChange | None,
+) -> DashboardRecentResult:
     mine = resolve_my_side(match, current_user_id)
     assert mine is not None  # query filters to participants
     side_wins = side_win_counts(match)
@@ -120,4 +151,5 @@ def _build_recent_result(match: Match, current_user_id) -> DashboardRecentResult
         my_games_won=my_games_won,
         opponent_games_won=opp_games_won,
         completed_at=match.updated_at,
+        my_rating_change=my_rating_change,
     )

--- a/api/app/leagues.py
+++ b/api/app/leagues.py
@@ -1,23 +1,55 @@
 import uuid
 
+from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
-from app.models import League, LeagueMembership
+from app.models import League, LeagueMembership, UserLeagueRating
 
 
 async def get_default_league(db: AsyncSession) -> League | None:
-    result = await db.execute(select(League).where(League.is_default.is_(True)))
+    result = await db.execute(
+        select(League)
+        .where(League.is_default.is_(True))
+        .options(selectinload(League.rating_strategy))
+    )
     return result.scalar_one_or_none()
+
+
+async def resolve_league(
+    db: AsyncSession, league_id: uuid.UUID | None
+) -> League:
+    """Resolve a league by id, falling back to the default. Raises 404 if a
+    specific id is supplied but missing, 500 if no default is configured."""
+    if league_id is not None:
+        league = (
+            await db.execute(
+                select(League)
+                .where(League.id == league_id)
+                .options(selectinload(League.rating_strategy))
+            )
+        ).scalar_one_or_none()
+        if league is None:
+            raise HTTPException(status_code=404, detail="League not found.")
+        return league
+    default = await get_default_league(db)
+    if default is None:
+        raise HTTPException(
+            status_code=500, detail="No default league configured."
+        )
+    return default
 
 
 async def add_user_to_default_league(
     db: AsyncSession, user_id: uuid.UUID
 ) -> None:
-    """Add the user to the default league.
+    """Add the user to the default league and seed their rating row.
 
-    Does not commit; the caller controls the surrounding transaction. Callers
-    invoke this on a freshly-created user, so the uniq pair never collides.
+    Does not commit; the caller controls the surrounding transaction. Seeding
+    eagerly (rather than on first match) means new users appear on
+    leaderboards and in player search from day one. Manual-strategy leagues
+    get a null rating row, waiting for an external import to fill it in.
     """
     default = await get_default_league(db)
     if default is None:
@@ -25,3 +57,8 @@ async def add_user_to_default_league(
             "No default league configured. Run scripts/seed_leagues.py."
         )
     db.add(LeagueMembership(league_id=default.id, user_id=user_id))
+    db.add(
+        UserLeagueRating.seed_for_strategy(
+            default.id, user_id, default.rating_strategy
+        )
+    )

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.db import get_session
-from app.leagues import get_default_league
+from app.leagues import resolve_league
 from app.models import (
     League,
     Match,
@@ -17,9 +17,14 @@ from app.models import (
     MatchSide,
     MatchSidePlayer,
     MatchStatus,
+    RatingHistory,
+    RatingHistorySource,
+    RatingStrategy,
     User,
+    UserLeagueRating,
 )
 from app.players import escape_like
+from app.ratings import get_calculator, state_rating_value, validate_state
 from app.schemas.match import (
     STATUS_LABELS,
     MatchCreate,
@@ -34,6 +39,7 @@ from app.schemas.match import (
     MatchListResponse,
     MatchListRow,
 )
+from app.schemas.rating import RatingChange
 from app.sessions import get_current_user
 
 router = APIRouter(prefix="/v1")
@@ -48,7 +54,14 @@ def _side_schema(
     side: MatchSide,
     side_wins: dict[int, int],
     current_user_id: uuid.UUID,
+    rating_changes: dict[uuid.UUID, RatingChange] | None = None,
 ) -> MatchDetailsSide:
+    # Singles only for v1: each side has at most one rated player.
+    rating_change = (
+        rating_changes.get(side.players[0].user_id)
+        if rating_changes and side.players
+        else None
+    )
     return MatchDetailsSide(
         side_number=side.side_number,
         players=[
@@ -64,6 +77,7 @@ def _side_schema(
         is_current_user_side=any(
             p.user_id == current_user_id for p in side.players
         ),
+        rating_change=rating_change,
     )
 
 
@@ -73,7 +87,7 @@ def _side_schema(
 def match_eager_options():
     return (
         selectinload(Match.match_settings),
-        selectinload(Match.league),
+        selectinload(Match.league).selectinload(League.rating_strategy),
         selectinload(Match.sides)
         .selectinload(MatchSide.players)
         .selectinload(MatchSidePlayer.user),
@@ -86,24 +100,6 @@ async def _load_match(db: AsyncSession, match_id: uuid.UUID) -> Match | None:
         select(Match).where(Match.id == match_id).options(*match_eager_options())
     )
     return result.scalar_one_or_none()
-
-
-async def _resolve_league(
-    db: AsyncSession, league_id: uuid.UUID | None
-) -> League:
-    if league_id is not None:
-        league = (
-            await db.execute(select(League).where(League.id == league_id))
-        ).scalar_one_or_none()
-        if league is None:
-            raise HTTPException(status_code=404, detail="League not found.")
-        return league
-    default = await get_default_league(db)
-    if default is None:
-        raise HTTPException(
-            status_code=500, detail="No default league configured."
-        )
-    return default
 
 
 def my_side(match: Match, user_id: uuid.UUID) -> MatchSide | None:
@@ -160,7 +156,11 @@ def current_unscored_game(match: Match) -> MatchGame | None:
     return next((g for g in match.games if g.score is None), None)
 
 
-def _serialize_details(match: Match, current_user_id: uuid.UUID) -> MatchDetails:
+def _serialize_details(
+    match: Match,
+    current_user_id: uuid.UUID,
+    rating_changes: dict[uuid.UUID, RatingChange] | None = None,
+) -> MatchDetails:
     mine = my_side(match, current_user_id)
     if mine is None:
         raise RuntimeError("serialize_details called for non-participant")
@@ -211,9 +211,11 @@ def _serialize_details(match: Match, current_user_id: uuid.UUID) -> MatchDetails
         team_size=match.match_settings.team_size,
         affects_rating=match.match_settings.affects_rating,
         created_at=match.created_at,
-        my_side=_side_schema(mine, side_wins, current_user_id),
+        my_side=_side_schema(mine, side_wins, current_user_id, rating_changes),
         opponent_side=(
-            _side_schema(opp, side_wins, current_user_id) if opp else None
+            _side_schema(opp, side_wins, current_user_id, rating_changes)
+            if opp
+            else None
         ),
         games=games,
         current_game=current_game,
@@ -299,7 +301,7 @@ async def create_match(
     # so they can never affect ratings regardless of the requested flag.
     affects_rating = payload.rated and opponent is not None
 
-    league = await _resolve_league(db, payload.league_id)
+    league = await resolve_league(db, payload.league_id)
 
     settings = MatchSettings(
         team_size=1,
@@ -417,7 +419,8 @@ async def get_match(
     match = await _load_match(db, match_id)
     if match is None or not _is_participant(match, current_user.id):
         raise HTTPException(status_code=404, detail="Match not found.")
-    return _serialize_details(match, current_user.id)
+    changes = await _load_rating_changes(db, match.id)
+    return _serialize_details(match, current_user.id, changes)
 
 
 # ----- score writes --------------------------------------------------------
@@ -433,6 +436,136 @@ def _enforce_scorable(match: Match) -> None:
         raise HTTPException(
             status_code=409, detail="This match is no longer scorable."
         )
+
+
+async def _load_rating_changes(
+    db: AsyncSession, match_id: uuid.UUID
+) -> dict[uuid.UUID, RatingChange]:
+    """Returns ``user_id -> RatingChange`` for every rating row this match
+    produced. Empty for matches that didn't move ratings."""
+    rows = (
+        await db.execute(
+            select(RatingHistory).where(RatingHistory.match_id == match_id)
+        )
+    ).scalars().all()
+    return {row.user_id: RatingChange.from_history(row) for row in rows}
+
+
+async def _get_or_create_user_league_rating(
+    db: AsyncSession,
+    league_id: uuid.UUID,
+    user_id: uuid.UUID,
+    strategy: RatingStrategy,
+) -> UserLeagueRating:
+    existing = (
+        await db.execute(
+            select(UserLeagueRating).where(
+                UserLeagueRating.league_id == league_id,
+                UserLeagueRating.user_id == user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
+    rating = UserLeagueRating.seed_for_strategy(league_id, user_id, strategy)
+    db.add(rating)
+    await db.flush()
+    return rating
+
+
+async def _apply_rating_update(db: AsyncSession, match: Match) -> None:
+    """When ``match`` has just transitioned to completed and its league runs an
+    automatic rating strategy, compute the singles update and persist a
+    ``rating_history`` row + bump ``user_league_ratings`` for each side.
+
+    Idempotent on subsequent score edits: if any history row already exists for
+    this match, we skip. Re-applying ratings after a score correction is its own
+    feature (tied to dispute/void flows, which aren't wired up yet)."""
+    if match.status != MatchStatus.completed:
+        return
+    if not match.match_settings.affects_rating:
+        return
+    if match.match_settings.team_size != 1:
+        return
+
+    league = match.league
+    strategy = league.rating_strategy
+    if not strategy.is_automatic:
+        return
+    calculator = get_calculator(strategy.key)
+    if calculator is None:
+        return
+
+    already_applied = (
+        await db.execute(
+            select(RatingHistory.id)
+            .where(RatingHistory.match_id == match.id)
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if already_applied is not None:
+        return
+
+    winning_side = next((s for s in match.sides if s.won is True), None)
+    losing_side = next((s for s in match.sides if s.won is False), None)
+    if winning_side is None or losing_side is None:
+        return
+    if not winning_side.players or not losing_side.players:
+        return
+
+    winner_player = winning_side.players[0]
+    loser_player = losing_side.players[0]
+
+    winner_rating = await _get_or_create_user_league_rating(
+        db, league.id, winner_player.user_id, strategy
+    )
+    loser_rating = await _get_or_create_user_league_rating(
+        db, league.id, loser_player.user_id, strategy
+    )
+    if winner_rating.rating_state is None or loser_rating.rating_state is None:
+        return
+
+    prev_winner_value = winner_rating.rating_value
+    prev_loser_value = loser_rating.rating_value
+
+    new_winner_state, new_loser_state = calculator.update_singles(
+        winner_rating.rating_state, loser_rating.rating_state
+    )
+    validate_state(new_winner_state, strategy)
+    validate_state(new_loser_state, strategy)
+
+    new_winner_value = state_rating_value(new_winner_state)
+    new_loser_value = state_rating_value(new_loser_state)
+
+    winner_rating.rating_state = new_winner_state
+    winner_rating.rating_value = new_winner_value
+    loser_rating.rating_state = new_loser_state
+    loser_rating.rating_value = new_loser_value
+
+    db.add(
+        RatingHistory(
+            league_id=league.id,
+            user_id=winner_player.user_id,
+            match_id=match.id,
+            rating_strategy_id=strategy.id,
+            rating_value=new_winner_value,
+            rating_state=new_winner_state,
+            previous_rating_value=prev_winner_value,
+            source=RatingHistorySource.match,
+        )
+    )
+    db.add(
+        RatingHistory(
+            league_id=league.id,
+            user_id=loser_player.user_id,
+            match_id=match.id,
+            rating_strategy_id=strategy.id,
+            rating_value=new_loser_value,
+            rating_state=new_loser_state,
+            previous_rating_value=prev_loser_value,
+            source=RatingHistorySource.match,
+        )
+    )
 
 
 def _recompute_match(match: Match) -> None:
@@ -515,11 +648,13 @@ async def create_game_score(
     )
 
     _recompute_match(match)
+    await _apply_rating_update(db, match)
     await db.commit()
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None
-    return _serialize_details(reloaded, current_user.id)
+    changes = await _load_rating_changes(db, reloaded.id)
+    return _serialize_details(reloaded, current_user.id, changes)
 
 
 @router.put(
@@ -547,8 +682,10 @@ async def update_game_score(
     game.score.side_2_points = payload.side_2_points
 
     _recompute_match(match)
+    await _apply_rating_update(db, match)
     await db.commit()
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None
-    return _serialize_details(reloaded, current_user.id)
+    changes = await _load_rating_changes(db, reloaded.id)
+    return _serialize_details(reloaded, current_user.id, changes)

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -7,9 +7,12 @@ from app.models.match_settings import MatchSettings, VerificationPolicy
 from app.models.match_side import MatchSide
 from app.models.match_side_player import MatchSidePlayer
 from app.models.permission import Permission
+from app.models.rating_history import RatingHistory, RatingHistorySource
+from app.models.rating_strategy import RatingStrategy
 from app.models.role import Role
 from app.models.role_permission import RolePermission
 from app.models.user import User
+from app.models.user_league_rating import UserLeagueRating
 from app.models.user_role import UserRole
 from app.models.user_token import UserToken
 
@@ -25,9 +28,13 @@ __all__ = [
     "MatchSidePlayer",
     "MatchStatus",
     "Permission",
+    "RatingHistory",
+    "RatingHistorySource",
+    "RatingStrategy",
     "Role",
     "RolePermission",
     "User",
+    "UserLeagueRating",
     "UserRole",
     "UserToken",
     "VerificationPolicy",

--- a/api/app/models/league.py
+++ b/api/app/models/league.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, Enum, Index, String, Text, func, text
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, String, Text, func, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -12,6 +12,7 @@ from app.db import Base
 if TYPE_CHECKING:
     from app.models.league_membership import LeagueMembership
     from app.models.match import Match
+    from app.models.rating_strategy import RatingStrategy
 
 
 class LeagueVisibility(enum.Enum):
@@ -48,6 +49,12 @@ class League(Base):
     is_default: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false")
     )
+    rating_strategy_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("rating_strategies.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -63,4 +70,7 @@ class League(Base):
         back_populates="league",
         cascade="all, delete-orphan",
         passive_deletes=True,
+    )
+    rating_strategy: Mapped["RatingStrategy"] = relationship(
+        back_populates="leagues"
     )

--- a/api/app/models/rating_history.py
+++ b/api/app/models/rating_history.py
@@ -1,0 +1,105 @@
+import enum
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import (
+    DateTime,
+    Enum,
+    Float,
+    ForeignKey,
+    Index,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.league import League
+    from app.models.match import Match
+    from app.models.rating_strategy import RatingStrategy
+    from app.models.user import User
+
+
+class RatingHistorySource(enum.Enum):
+    match = "match"
+    manual = "manual"
+    import_ = "import"
+    initial = "initial"
+
+
+class RatingHistory(Base):
+    """Append-only audit of every rating change. ``match_id`` is nullable so
+    manual overrides, external imports, and seeded initial values are
+    first-class history rows."""
+
+    __tablename__ = "rating_history"
+    __table_args__ = (
+        Index(
+            "ix_rating_history_league_id_user_id_created_at",
+            "league_id",
+            "user_id",
+            text("created_at DESC"),
+        ),
+        Index("ix_rating_history_match_id", "match_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    league_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("leagues.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    match_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("matches.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    rating_strategy_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("rating_strategies.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    rating_value: Mapped[float] = mapped_column(Float, nullable=False)
+    rating_state: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    previous_rating_value: Mapped[float | None] = mapped_column(
+        Float, nullable=True
+    )
+    source: Mapped[RatingHistorySource] = mapped_column(
+        Enum(
+            RatingHistorySource,
+            name="rating_history_source",
+            values_callable=lambda enum_cls: [m.value for m in enum_cls],
+        ),
+        nullable=False,
+    )
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    league: Mapped["League"] = relationship()
+    user: Mapped["User"] = relationship(foreign_keys=[user_id])
+    match: Mapped["Match | None"] = relationship()
+    rating_strategy: Mapped["RatingStrategy"] = relationship()
+    created_by: Mapped["User | None"] = relationship(
+        foreign_keys=[created_by_user_id]
+    )

--- a/api/app/models/rating_strategy.py
+++ b/api/app/models/rating_strategy.py
@@ -1,0 +1,52 @@
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import Boolean, DateTime, Float, String, Text, func, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.league import League
+
+
+class RatingStrategy(Base):
+    """A rating algorithm definition: the JSON Schema describing the shape of
+    ``rating_state``, an initial state for new players, and a flag indicating
+    whether match completion triggers an automatic recompute."""
+
+    __tablename__ = "rating_strategies"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    key: Mapped[str] = mapped_column(
+        String(64), unique=True, nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    state_schema: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    initial_state: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    initial_rating_value: Mapped[float | None] = mapped_column(
+        Float, nullable=True
+    )
+    is_automatic: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    leagues: Mapped[list["League"]] = relationship(back_populates="rating_strategy")

--- a/api/app/models/user_league_rating.py
+++ b/api/app/models/user_league_rating.py
@@ -1,0 +1,81 @@
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import DateTime, Float, ForeignKey, Index, UniqueConstraint, func, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.league import League
+    from app.models.rating_strategy import RatingStrategy
+    from app.models.user import User
+
+
+class UserLeagueRating(Base):
+    """Current rating per (user, league). Nullable values support manual leagues
+    where a member exists but no externally-supplied rating has been imported yet."""
+
+    __tablename__ = "user_league_ratings"
+    __table_args__ = (
+        # The unique index already provides a btree on (league_id, user_id),
+        # which covers any league-scoped lookup.
+        UniqueConstraint(
+            "league_id",
+            "user_id",
+            name="uq_user_league_ratings_league_id_user_id",
+        ),
+        Index("ix_user_league_ratings_user_id", "user_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    league_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("leagues.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    rating_value: Mapped[float | None] = mapped_column(Float, nullable=True)
+    rating_state: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    league: Mapped["League"] = relationship()
+    user: Mapped["User"] = relationship()
+
+    @classmethod
+    def seed_for_strategy(
+        cls,
+        league_id: uuid.UUID,
+        user_id: uuid.UUID,
+        strategy: "RatingStrategy",
+    ) -> "UserLeagueRating":
+        return cls(
+            league_id=league_id,
+            user_id=user_id,
+            rating_value=strategy.initial_rating_value,
+            rating_state=(
+                dict(strategy.initial_state)
+                if strategy.initial_state is not None
+                else None
+            ),
+        )

--- a/api/app/players.py
+++ b/api/app/players.py
@@ -1,4 +1,5 @@
-from collections.abc import Iterable
+import uuid
+from collections.abc import Iterable, Mapping
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import and_, func, select
@@ -6,7 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.db import get_session
-from app.models import Match, MatchSidePlayer, User
+from app.leagues import resolve_league
+from app.models import Match, MatchSidePlayer, User, UserLeagueRating
 from app.schemas.player import PlayerRead
 from app.sessions import get_current_user
 
@@ -19,8 +21,32 @@ SEARCH_DEFAULT_LIMIT = 10
 MAX_LIMIT = 50
 
 
-def _serialize(users: Iterable[User]) -> list[PlayerRead]:
-    return [PlayerRead.model_validate(user) for user in users]
+def _serialize(
+    users: Iterable[User],
+    ratings: Mapping[uuid.UUID, float | None] | None = None,
+) -> list[PlayerRead]:
+    ratings = ratings or {}
+    return [
+        PlayerRead(id=user.id, username=user.username, rating=ratings.get(user.id))
+        for user in users
+    ]
+
+
+async def _load_player_ratings(
+    db: AsyncSession, league_id: uuid.UUID, user_ids: Iterable[uuid.UUID]
+) -> dict[uuid.UUID, float | None]:
+    ids = list(user_ids)
+    if not ids:
+        return {}
+    rows = (
+        await db.execute(
+            select(UserLeagueRating.user_id, UserLeagueRating.rating_value).where(
+                UserLeagueRating.league_id == league_id,
+                UserLeagueRating.user_id.in_(ids),
+            )
+        )
+    ).all()
+    return {user_id: rating for user_id, rating in rows}
 
 
 def escape_like(term: str) -> str:
@@ -32,6 +58,7 @@ def escape_like(term: str) -> str:
 @router.get("/players/recent", response_model=list[PlayerRead])
 async def list_recent_opponents(
     limit: int = Query(RECENT_DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    league_id: uuid.UUID | None = Query(default=None),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> list[PlayerRead]:
@@ -88,13 +115,18 @@ async def list_recent_opponents(
         )
         opponents.extend(backfill)
 
-    return _serialize(opponents)
+    league = await resolve_league(db, league_id)
+    ratings = await _load_player_ratings(
+        db, league.id, (user.id for user in opponents)
+    )
+    return _serialize(opponents, ratings)
 
 
 @router.get("/players/search", response_model=list[PlayerRead])
 async def search_players(
     q: str = Query(..., description="Username substring to match against."),
     limit: int = Query(SEARCH_DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    league_id: uuid.UUID | None = Query(default=None),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> list[PlayerRead]:
@@ -118,4 +150,9 @@ async def search_players(
         .order_by(User.username)
         .limit(limit)
     )
-    return _serialize(result.scalars().all())
+    users = result.scalars().all()
+    league = await resolve_league(db, league_id)
+    ratings = await _load_player_ratings(
+        db, league.id, (user.id for user in users)
+    )
+    return _serialize(users, ratings)

--- a/api/app/ratings/__init__.py
+++ b/api/app/ratings/__init__.py
@@ -1,0 +1,11 @@
+from app.ratings.base import RatingCalculator, state_rating_value
+from app.ratings.registry import STRATEGIES, get_calculator
+from app.ratings.validation import validate_state
+
+__all__ = [
+    "RatingCalculator",
+    "STRATEGIES",
+    "get_calculator",
+    "state_rating_value",
+    "validate_state",
+]

--- a/api/app/ratings/base.py
+++ b/api/app/ratings/base.py
@@ -1,0 +1,27 @@
+from typing import Any, Protocol
+
+
+class RatingCalculator(Protocol):
+    """A strategy that knows how to update player ratings after a singles match.
+
+    The hook in ``app.matches`` only calls singles for v1 — doubles is unwired
+    on the match-creation side (team_size hardcoded to 1). Add a doubles method
+    when that opens up.
+    """
+
+    key: str
+
+    def update_singles(
+        self,
+        winner_state: dict[str, Any],
+        loser_state: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Return ``(new_winner_state, new_loser_state)``."""
+        ...
+
+
+def state_rating_value(state: dict[str, Any]) -> float:
+    """Every strategy's ``rating_state`` stores its sortable numeric rating
+    under the ``rating`` key — Glicko-2 stores ``{rating, rd, volatility}``,
+    manual stores ``{rating}``. This is the column we use for leaderboards."""
+    return float(state["rating"])

--- a/api/app/ratings/glicko2.py
+++ b/api/app/ratings/glicko2.py
@@ -1,0 +1,95 @@
+"""Vendored Glicko-2 implementation. Reference: Glickman 2013.
+
+Each match is its own one-game rating period for both players — the simplest
+mapping that produces an update on every result.
+"""
+import math
+from typing import Any
+
+TAU = 0.5  # system constant, dampens volatility changes
+SCALE = 173.7178  # Glicko-2 conversion factor
+EPSILON = 1e-6
+
+
+def _g(phi: float) -> float:
+    return 1.0 / math.sqrt(1.0 + 3.0 * phi * phi / (math.pi * math.pi))
+
+
+def _e(mu: float, mu_j: float, phi_j: float) -> float:
+    return 1.0 / (1.0 + math.exp(-_g(phi_j) * (mu - mu_j)))
+
+
+def _new_volatility(phi: float, v: float, delta: float, sigma: float) -> float:
+    """Illinois algorithm for the new volatility (Glickman 2013, step 5)."""
+    a = math.log(sigma * sigma)
+
+    def f(x: float) -> float:
+        ex = math.exp(x)
+        num = ex * (delta * delta - phi * phi - v - ex)
+        den = 2.0 * (phi * phi + v + ex) ** 2
+        return num / den - (x - a) / (TAU * TAU)
+
+    A = a
+    if delta * delta > phi * phi + v:
+        B = math.log(delta * delta - phi * phi - v)
+    else:
+        k = 1
+        while f(a - k * TAU) < 0:
+            k += 1
+        B = a - k * TAU
+
+    fA = f(A)
+    fB = f(B)
+    while abs(B - A) > EPSILON:
+        C = A + (A - B) * fA / (fB - fA)
+        fC = f(C)
+        if fC * fB <= 0:
+            A, fA = B, fB
+        else:
+            fA = fA / 2.0
+        B, fB = C, fC
+    return math.exp(A / 2.0)
+
+
+def _update_one(
+    player: dict[str, Any], opp: dict[str, Any], score: float
+) -> dict[str, Any]:
+    mu = (player["rating"] - 1500.0) / SCALE
+    phi = player["rd"] / SCALE
+    sigma = player["volatility"]
+
+    mu_j = (opp["rating"] - 1500.0) / SCALE
+    phi_j = opp["rd"] / SCALE
+    g_j = _g(phi_j)
+    e_j = _e(mu, mu_j, phi_j)
+
+    v = 1.0 / (g_j * g_j * e_j * (1.0 - e_j))
+    sum_term = g_j * (score - e_j)
+    delta = v * sum_term
+
+    new_sigma = _new_volatility(phi, v, delta, sigma)
+    phi_star = math.sqrt(phi * phi + new_sigma * new_sigma)
+    new_phi = 1.0 / math.sqrt(1.0 / (phi_star * phi_star) + 1.0 / v)
+    new_mu = mu + new_phi * new_phi * sum_term
+
+    return {
+        "rating": SCALE * new_mu + 1500.0,
+        "rd": SCALE * new_phi,
+        "volatility": new_sigma,
+    }
+
+
+class Glicko2Calculator:
+    key = "glicko2"
+
+    def update_singles(
+        self,
+        winner_state: dict[str, Any],
+        loser_state: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        new_winner = _update_one(winner_state, loser_state, 1.0)
+        new_loser = _update_one(loser_state, winner_state, 0.0)
+        return new_winner, new_loser
+
+
+CALCULATOR = Glicko2Calculator()

--- a/api/app/ratings/registry.py
+++ b/api/app/ratings/registry.py
@@ -1,0 +1,11 @@
+from app.ratings.base import RatingCalculator
+from app.ratings.glicko2 import CALCULATOR as GLICKO2_CALCULATOR
+
+
+STRATEGIES: dict[str, RatingCalculator] = {
+    GLICKO2_CALCULATOR.key: GLICKO2_CALCULATOR,
+}
+
+
+def get_calculator(key: str) -> RatingCalculator | None:
+    return STRATEGIES.get(key)

--- a/api/app/ratings/validation.py
+++ b/api/app/ratings/validation.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+import jsonschema
+
+from app.models import RatingStrategy
+
+
+def validate_state(state: dict[str, Any], strategy: RatingStrategy) -> None:
+    """Validate a ``rating_state`` dict against its strategy's stored JSON Schema.
+
+    Raises :class:`jsonschema.ValidationError` on mismatch.
+    """
+    jsonschema.validate(instance=state, schema=strategy.state_schema)

--- a/api/app/schemas/dashboard.py
+++ b/api/app/schemas/dashboard.py
@@ -3,6 +3,8 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
+from app.schemas.rating import RatingChange
+
 
 class DashboardScoreBanner(BaseModel):
     match_id: uuid.UUID
@@ -24,6 +26,7 @@ class DashboardRecentResult(BaseModel):
     my_games_won: int
     opponent_games_won: int
     completed_at: datetime
+    my_rating_change: RatingChange | None = None
 
 
 class DashboardResponse(BaseModel):

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.models.match import MatchStatus
+from app.schemas.rating import RatingChange
 
 # Match lengths the client offers. All odd so one side can always reach a
 # strict majority of games; the DB additionally enforces "odd and >= 1".
@@ -64,6 +65,7 @@ class MatchDetailsSide(BaseModel):
     games_won: int
     won: bool | None
     is_current_user_side: bool
+    rating_change: RatingChange | None = None
 
 
 class MatchDetailsScore(BaseModel):

--- a/api/app/schemas/player.py
+++ b/api/app/schemas/player.py
@@ -1,12 +1,16 @@
 import uuid
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
 
 class PlayerRead(BaseModel):
-    """A user the current player can pick as a match opponent."""
+    """A user the current player can pick as a match opponent.
 
-    model_config = ConfigDict(from_attributes=True)
+    ``rating`` is the player's current ``rating_value`` in the league the
+    request was scoped to (defaulting to the default league) — None if they
+    haven't yet played a rated match in that league or, for manual-strategy
+    leagues, haven't been imported."""
 
     id: uuid.UUID
     username: str
+    rating: float | None = None

--- a/api/app/schemas/rating.py
+++ b/api/app/schemas/rating.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from app.models.rating_history import RatingHistory
+
+
+class RatingChange(BaseModel):
+    """A user's rating delta on a single completed match."""
+
+    before: float | None
+    after: float
+    delta: float
+
+    @classmethod
+    def from_history(cls, row: "RatingHistory") -> "RatingChange":
+        prev = row.previous_rating_value
+        delta = row.rating_value - prev if prev is not None else 0.0
+        return cls(before=prev, after=row.rating_value, delta=delta)

--- a/api/migrations/versions/20260516_0000_0005_create_leagues_tables.py
+++ b/api/migrations/versions/20260516_0000_0005_create_leagues_tables.py
@@ -1,13 +1,14 @@
-"""create leagues tables
+"""create leagues + rating strategies tables
 
 Revision ID: 0005
 Revises: 0004
 Create Date: 2026-05-16 00:00:00.000000
 
-Note: adds ``matches.league_id`` as NOT NULL with no backfill, so this only
-applies cleanly against a fresh / empty matches table. Per the pre-deploy
-convention in api/CLAUDE.md, the assumption holds.
+Per the pre-deploy convention in api/CLAUDE.md, edits to this migration
+happen in place. ``matches.league_id`` and ``leagues.rating_strategy_id``
+are both NOT NULL with no backfill — assumes a fresh / empty DB.
 """
+import uuid
 from typing import Sequence, Union
 
 from alembic import op
@@ -29,9 +30,109 @@ league_visibility_enum = postgresql.ENUM(
 )
 
 
+GLICKO2_STRATEGY_ID = uuid.UUID("11111111-1111-1111-1111-111111110001")
+MANUAL_STRATEGY_ID = uuid.UUID("11111111-1111-1111-1111-111111110002")
+
+GLICKO2_STATE_SCHEMA = {
+    "type": "object",
+    "required": ["rating", "rd", "volatility"],
+    "properties": {
+        "rating": {"type": "number"},
+        "rd": {"type": "number"},
+        "volatility": {"type": "number"},
+    },
+    "additionalProperties": False,
+}
+GLICKO2_INITIAL_STATE = {"rating": 1500.0, "rd": 350.0, "volatility": 0.06}
+
+MANUAL_STATE_SCHEMA = {
+    "type": "object",
+    "required": ["rating"],
+    "properties": {"rating": {"type": "number"}},
+    "additionalProperties": False,
+}
+
+
 def upgrade() -> None:
     bind = op.get_bind()
     league_visibility_enum.create(bind, checkfirst=True)
+
+    rating_strategies = op.create_table(
+        "rating_strategies",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("key", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "state_schema",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column(
+            "initial_state",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("initial_rating_value", sa.Float(), nullable=True),
+        sa.Column(
+            "is_automatic",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_rating_strategies_key", "rating_strategies", ["key"], unique=True
+    )
+
+    op.bulk_insert(
+        rating_strategies,
+        [
+            {
+                "id": GLICKO2_STRATEGY_ID,
+                "key": "glicko2",
+                "name": "Glicko-2",
+                "description": (
+                    "Glicko-2 — tracks both skill (rating) and uncertainty (RD + volatility). "
+                    "Updated automatically on each rated match."
+                ),
+                "state_schema": GLICKO2_STATE_SCHEMA,
+                "initial_state": GLICKO2_INITIAL_STATE,
+                "initial_rating_value": 1500.0,
+                "is_automatic": True,
+            },
+            {
+                "id": MANUAL_STRATEGY_ID,
+                "key": "manual",
+                "name": "Manual / external",
+                "description": (
+                    "Ratings supplied externally (e.g. USATT) or by admin entry. "
+                    "Match completion does not change ratings in a manual league."
+                ),
+                "state_schema": MANUAL_STATE_SCHEMA,
+                "initial_state": None,
+                "initial_rating_value": None,
+                "is_automatic": False,
+            },
+        ],
+    )
 
     op.create_table(
         "leagues",
@@ -56,6 +157,12 @@ def upgrade() -> None:
             server_default=sa.text("false"),
         ),
         sa.Column(
+            "rating_strategy_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("rating_strategies.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
             server_default=sa.func.now(),
@@ -69,6 +176,9 @@ def upgrade() -> None:
         ),
     )
     op.create_index("ix_leagues_name", "leagues", ["name"], unique=True)
+    op.create_index(
+        "ix_leagues_rating_strategy_id", "leagues", ["rating_strategy_id"]
+    )
     # Partial unique index: at most one league row may have is_default=true.
     op.create_index(
         "uq_leagues_one_default",
@@ -142,8 +252,12 @@ def downgrade() -> None:
     op.drop_table("league_memberships")
 
     op.drop_index("uq_leagues_one_default", table_name="leagues")
+    op.drop_index("ix_leagues_rating_strategy_id", table_name="leagues")
     op.drop_index("ix_leagues_name", table_name="leagues")
     op.drop_table("leagues")
+
+    op.drop_index("ix_rating_strategies_key", table_name="rating_strategies")
+    op.drop_table("rating_strategies")
 
     bind = op.get_bind()
     league_visibility_enum.drop(bind, checkfirst=True)

--- a/api/migrations/versions/20260516_0001_0006_create_rating_state_tables.py
+++ b/api/migrations/versions/20260516_0001_0006_create_rating_state_tables.py
@@ -1,0 +1,161 @@
+"""create rating state tables (user_league_ratings + rating_history)
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-16 00:01:00.000000
+
+Per the pre-deploy convention in api/CLAUDE.md, edits to this migration
+happen in place. No backfill — assumes a fresh / empty DB.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0006"
+down_revision: Union[str, None] = "0005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+rating_history_source_enum = postgresql.ENUM(
+    "match",
+    "manual",
+    "import",
+    "initial",
+    name="rating_history_source",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rating_history_source_enum.create(bind, checkfirst=True)
+
+    op.create_table(
+        "user_league_ratings",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "league_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("leagues.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("rating_value", sa.Float(), nullable=True),
+        sa.Column(
+            "rating_state",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "league_id",
+            "user_id",
+            name="uq_user_league_ratings_league_id_user_id",
+        ),
+    )
+    op.create_index(
+        "ix_user_league_ratings_user_id", "user_league_ratings", ["user_id"]
+    )
+
+    op.create_table(
+        "rating_history",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "league_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("leagues.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "match_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("matches.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "rating_strategy_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("rating_strategies.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("rating_value", sa.Float(), nullable=False),
+        sa.Column(
+            "rating_state",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("previous_rating_value", sa.Float(), nullable=True),
+        sa.Column("source", rating_history_source_enum, nullable=False),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_rating_history_league_id_user_id_created_at",
+        "rating_history",
+        ["league_id", "user_id", sa.text("created_at DESC")],
+    )
+    op.create_index("ix_rating_history_match_id", "rating_history", ["match_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_rating_history_match_id", table_name="rating_history")
+    op.drop_index(
+        "ix_rating_history_league_id_user_id_created_at",
+        table_name="rating_history",
+    )
+    op.drop_table("rating_history")
+
+    op.drop_index(
+        "ix_user_league_ratings_user_id", table_name="user_league_ratings"
+    )
+    op.drop_table("user_league_ratings")
+
+    bind = op.get_bind()
+    rating_history_source_enum.drop(bind, checkfirst=True)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "asyncpg>=0.30",
     "alembic>=1.14",
     "coolname>=2.2",
+    "jsonschema>=4.21",
 ]
 
 [project.optional-dependencies]

--- a/api/scripts/seed_leagues.py
+++ b/api/scripts/seed_leagues.py
@@ -8,16 +8,18 @@ re-describe the default league. Safe to run on every container boot.
 
 import asyncio
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.db import get_engine
 from app.leagues import get_default_league
-from app.models import League, LeagueVisibility
+from app.models import League, LeagueVisibility, RatingStrategy
 
 
 DEFAULT_LEAGUE_NAME = "FortyMM"
 DEFAULT_LEAGUE_DESCRIPTION = "The headline FortyMM league."
 DEFAULT_LEAGUE_VISIBILITY = LeagueVisibility.public
+DEFAULT_LEAGUE_RATING_STRATEGY_KEY = "glicko2"
 
 
 async def upsert_default_league(db: AsyncSession) -> str:
@@ -25,6 +27,14 @@ async def upsert_default_league(db: AsyncSession) -> str:
 
     Returns ``"created"`` or ``"updated"`` for caller logging. Caller commits.
     """
+    strategy = (
+        await db.execute(
+            select(RatingStrategy).where(
+                RatingStrategy.key == DEFAULT_LEAGUE_RATING_STRATEGY_KEY
+            )
+        )
+    ).scalar_one()
+
     existing = await get_default_league(db)
     if existing is None:
         db.add(
@@ -33,12 +43,14 @@ async def upsert_default_league(db: AsyncSession) -> str:
                 description=DEFAULT_LEAGUE_DESCRIPTION,
                 visibility=DEFAULT_LEAGUE_VISIBILITY,
                 is_default=True,
+                rating_strategy_id=strategy.id,
             )
         )
         return "created"
     existing.name = DEFAULT_LEAGUE_NAME
     existing.description = DEFAULT_LEAGUE_DESCRIPTION
     existing.visibility = DEFAULT_LEAGUE_VISIBILITY
+    existing.rating_strategy_id = strategy.id
     return "updated"
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -17,7 +17,7 @@ from app import queue as queue_module
 from app.db import Base, get_session
 from app.main import app as fastapi_app
 import app.models  # noqa: F401  -- ensures models register on Base.metadata
-from app.models import League, LeagueVisibility
+from app.models import League, LeagueVisibility, RatingStrategy
 
 
 @pytest.fixture(autouse=True)
@@ -63,8 +63,57 @@ async def db_session(engine: AsyncEngine) -> AsyncIterator[AsyncSession]:
             await conn.execute(table.delete())
 
 
+GLICKO2_STATE_SCHEMA = {
+    "type": "object",
+    "required": ["rating", "rd", "volatility"],
+    "properties": {
+        "rating": {"type": "number"},
+        "rd": {"type": "number"},
+        "volatility": {"type": "number"},
+    },
+    "additionalProperties": False,
+}
+MANUAL_STATE_SCHEMA = {
+    "type": "object",
+    "required": ["rating"],
+    "properties": {"rating": {"type": "number"}},
+    "additionalProperties": False,
+}
+
+
 @pytest_asyncio.fixture(autouse=True)
-async def default_league(db_session: AsyncSession) -> League:
+async def rating_strategies(db_session: AsyncSession) -> dict[str, RatingStrategy]:
+    """Seed the canonical rating strategies. Migration 0005 inserts these in
+    real deployments; tests build via ``Base.metadata.create_all`` so we
+    re-seed here for every test."""
+    glicko2 = RatingStrategy(
+        key="glicko2",
+        name="Glicko-2",
+        description="Glicko-2.",
+        state_schema=GLICKO2_STATE_SCHEMA,
+        initial_state={"rating": 1500.0, "rd": 350.0, "volatility": 0.06},
+        initial_rating_value=1500.0,
+        is_automatic=True,
+    )
+    manual = RatingStrategy(
+        key="manual",
+        name="Manual / external",
+        description="Ratings supplied externally.",
+        state_schema=MANUAL_STATE_SCHEMA,
+        initial_state=None,
+        initial_rating_value=None,
+        is_automatic=False,
+    )
+    db_session.add_all([glicko2, manual])
+    await db_session.commit()
+    return {"glicko2": glicko2, "manual": manual}
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def default_league(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+) -> League:
     """Seed a default league so user-creation paths can attach memberships.
 
     Autouse so tests don't have to remember to opt in. Tests that want to
@@ -76,6 +125,7 @@ async def default_league(db_session: AsyncSession) -> League:
         description="Test default league.",
         visibility=LeagueVisibility.public,
         is_default=True,
+        rating_strategy_id=rating_strategies["glicko2"].id,
     )
     db_session.add(league)
     await db_session.commit()

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -101,6 +101,11 @@ async def test_dashboard_returns_recent_results_for_completed_matches(
     assert result["is_win"] is True
     assert result["my_games_won"] == 1
     assert result["opponent_games_won"] == 0
+    change = result["my_rating_change"]
+    assert change is not None
+    assert change["before"] == 1500.0
+    assert change["after"] > 1500.0
+    assert change["delta"] > 0
 
 
 async def test_dashboard_scoped_to_current_user(

--- a/api/tests/test_leagues.py
+++ b/api/tests/test_leagues.py
@@ -19,6 +19,7 @@ async def test_default_league_unique_partial_index(
             description="Tries to also be default.",
             visibility=LeagueVisibility.public,
             is_default=True,
+            rating_strategy_id=default_league.rating_strategy_id,
         )
     )
     with pytest.raises(IntegrityError):

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -763,6 +763,7 @@ async def test_create_match_with_explicit_league_id_uses_that_league(
         name="Side League",
         description="Not the default.",
         visibility=LeagueVisibility.private,
+        rating_strategy_id=default_league.rating_strategy_id,
     )
     db_session.add(other)
     await db_session.commit()

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -11,6 +11,7 @@ from app.models import (
     MatchSidePlayer,
     MatchStatus,
     User,
+    UserLeagueRating,
 )
 from tests._helpers import make_user, start_session
 
@@ -44,6 +45,13 @@ async def _record_match(
 
 def _usernames(response) -> list[str]:
     return [player["username"] for player in response.json()]
+
+
+def _rating_for(response, username: str):
+    for player in response.json():
+        if player["username"] == username:
+            return player["rating"]
+    raise KeyError(username)
 
 
 # ----- recent opponents ----------------------------------------------------
@@ -273,3 +281,32 @@ async def test_search_orders_results_alphabetically(
         "match.bob",
         "match.charlie",
     ]
+
+
+# ----- rating field --------------------------------------------------------
+
+
+async def test_search_includes_rating_for_default_league(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await start_session(api_client, db_session)
+    rival = await make_user(db_session, "ratedrival")
+    unrated = await make_user(db_session, "freshface")
+
+    league = await get_default_league(db_session)
+    db_session.add(
+        UserLeagueRating(
+            league_id=league.id,
+            user_id=rival.id,
+            rating_value=1750.0,
+            rating_state={"rating": 1750.0, "rd": 200.0, "volatility": 0.06},
+        )
+    )
+    await db_session.commit()
+
+    response = await api_client.get("/v1/players/search", params={"q": "face"})
+    assert response.status_code == 200
+    assert _rating_for(response, "freshface") is None
+
+    response = await api_client.get("/v1/players/search", params={"q": "rival"})
+    assert _rating_for(response, "ratedrival") == 1750.0

--- a/api/tests/test_ratings.py
+++ b/api/tests/test_ratings.py
@@ -1,0 +1,341 @@
+"""Coverage for the rating system: strategies, calculator math, validation,
+and the match-completion hook."""
+import uuid
+
+import jsonschema
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    League,
+    LeagueVisibility,
+    RatingHistory,
+    RatingHistorySource,
+    RatingStrategy,
+    UserLeagueRating,
+)
+from app.ratings import (
+    STRATEGIES,
+    get_calculator,
+    state_rating_value,
+    validate_state,
+)
+from app.ratings.glicko2 import CALCULATOR as GLICKO2
+from tests._helpers import make_user, start_session
+
+
+# ----- strategy seeding ----------------------------------------------------
+
+
+async def test_rating_strategies_are_seeded(
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """The conftest fixture mirrors the migration's seed inserts. Two
+    canonical strategies are present and shaped correctly."""
+    assert set(rating_strategies) == {"glicko2", "manual"}
+
+    glicko2 = rating_strategies["glicko2"]
+    assert glicko2.is_automatic is True
+    assert glicko2.initial_rating_value == 1500.0
+    assert glicko2.initial_state == {"rating": 1500.0, "rd": 350.0, "volatility": 0.06}
+
+    manual = rating_strategies["manual"]
+    assert manual.is_automatic is False
+    assert manual.initial_state is None
+    assert manual.initial_rating_value is None
+
+
+def test_registry_only_contains_automatic_strategies():
+    """``manual`` has no calculator — the hook treats it as a no-op."""
+    assert "glicko2" in STRATEGIES
+    assert "manual" not in STRATEGIES
+    assert get_calculator("manual") is None
+
+
+# ----- Glicko-2 calculator -------------------------------------------------
+
+
+def test_glicko2_winner_gains_loser_loses():
+    """Two evenly-rated default players: the winner gains, the loser loses
+    a roughly symmetric amount, and both RDs shrink (we learned something)."""
+    initial = {"rating": 1500.0, "rd": 350.0, "volatility": 0.06}
+    new_winner, new_loser = GLICKO2.update_singles(initial, dict(initial))
+
+    assert new_winner["rating"] > 1500.0
+    assert new_loser["rating"] < 1500.0
+    assert new_winner["rd"] < initial["rd"]
+    assert new_loser["rd"] < initial["rd"]
+    # Symmetric matchup → symmetric magnitude.
+    assert abs((new_winner["rating"] - 1500) + (new_loser["rating"] - 1500)) < 0.01
+
+
+def test_glicko2_upset_moves_more_than_expected_win():
+    """Beating a much higher-rated opponent shifts ratings further than
+    beating a peer — the Glicko-2 information gain is larger."""
+    initial = {"rating": 1500.0, "rd": 200.0, "volatility": 0.06}
+    expected_winner, _ = GLICKO2.update_singles(initial, dict(initial))
+    upset_winner, _ = GLICKO2.update_singles(
+        {"rating": 1300.0, "rd": 200.0, "volatility": 0.06},
+        {"rating": 1700.0, "rd": 200.0, "volatility": 0.06},
+    )
+    assert (upset_winner["rating"] - 1300.0) > (expected_winner["rating"] - 1500.0)
+
+
+def test_state_rating_value_reads_the_rating_key():
+    assert state_rating_value({"rating": 1234.5, "rd": 100.0}) == 1234.5
+
+
+# ----- validation ----------------------------------------------------------
+
+
+def test_validate_state_accepts_initial_states(
+    rating_strategies: dict[str, RatingStrategy],
+):
+    glicko2 = rating_strategies["glicko2"]
+    validate_state(glicko2.initial_state, glicko2)  # type: ignore[arg-type]
+    # Manual schema accepts a bare {rating} payload.
+    validate_state({"rating": 1750.0}, rating_strategies["manual"])
+
+
+def test_validate_state_rejects_missing_required_key(
+    rating_strategies: dict[str, RatingStrategy],
+):
+    with pytest.raises(jsonschema.ValidationError):
+        validate_state({"rating": 1500.0}, rating_strategies["glicko2"])
+
+
+def test_validate_state_rejects_extra_keys(
+    rating_strategies: dict[str, RatingStrategy],
+):
+    with pytest.raises(jsonschema.ValidationError):
+        validate_state(
+            {"rating": 1500.0, "rd": 350.0, "volatility": 0.06, "extra": 1},
+            rating_strategies["glicko2"],
+        )
+
+
+# ----- hook: end-to-end through the score endpoint -------------------------
+
+
+async def _score_to_completion(
+    client: AsyncClient, opponent_id: uuid.UUID, best_of: int = 1
+) -> dict:
+    create = await client.post(
+        "/v1/matches",
+        json={
+            "opponent_user_id": str(opponent_id),
+            "best_of": best_of,
+            "rated": True,
+        },
+    )
+    assert create.status_code == 201
+    match = create.json()
+    score = await client.post(
+        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+        json={"side_1_points": 11, "side_2_points": 4},
+    )
+    assert score.status_code == 201
+    return score.json()
+
+
+async def test_completing_a_rated_match_writes_rating_history(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    default_league: League,
+):
+    me = await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    body = await _score_to_completion(api_client, opp.id)
+
+    # Two history rows, one per player, both linked to this match.
+    rows = (
+        await db_session.execute(
+            select(RatingHistory).where(RatingHistory.match_id == uuid.UUID(body["id"]))
+        )
+    ).scalars().all()
+    assert len(rows) == 2
+    by_user = {row.user_id: row for row in rows}
+    winner = by_user[me.id]
+    loser = by_user[opp.id]
+
+    assert winner.source == RatingHistorySource.match
+    assert loser.source == RatingHistorySource.match
+    assert winner.previous_rating_value == 1500.0
+    assert loser.previous_rating_value == 1500.0
+    assert winner.rating_value > 1500.0
+    assert loser.rating_value < 1500.0
+    assert winner.rating_strategy_id == default_league.rating_strategy_id
+
+    # Current rating rows are upserted in lockstep.
+    ratings = (
+        await db_session.execute(select(UserLeagueRating))
+    ).scalars().all()
+    assert {r.user_id for r in ratings} == {me.id, opp.id}
+    assert {r.league_id for r in ratings} == {default_league.id}
+
+
+async def test_match_details_response_carries_rating_change(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    body = await _score_to_completion(api_client, opp.id)
+
+    my_change = body["my_side"]["rating_change"]
+    opp_change = body["opponent_side"]["rating_change"]
+    assert my_change is not None
+    assert opp_change is not None
+    assert my_change["before"] == 1500.0
+    assert my_change["after"] > 1500.0
+    assert my_change["delta"] == pytest.approx(my_change["after"] - 1500.0)
+    assert opp_change["delta"] < 0
+
+
+async def test_unrated_match_does_not_move_ratings(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    create = await api_client.post(
+        "/v1/matches",
+        json={
+            "opponent_user_id": str(opp.id),
+            "best_of": 1,
+            "rated": False,
+        },
+    )
+    match = create.json()
+    score = await api_client.post(
+        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+        json={"side_1_points": 11, "side_2_points": 4},
+    )
+    body = score.json()
+    assert body["my_side"]["rating_change"] is None
+    assert body["opponent_side"]["rating_change"] is None
+
+    rows = (await db_session.execute(select(RatingHistory))).scalars().all()
+    assert rows == []
+
+
+async def test_manual_strategy_league_skips_rating_updates(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """Replace the default league's strategy with ``manual`` and confirm the
+    hook quietly skips. New members still get rating rows on join (the league
+    membership hook eagerly seeds them), but with the strategy's null
+    ``initial_state`` — to be filled by a later external import."""
+    default = (
+        await db_session.execute(
+            select(League).where(League.is_default.is_(True))
+        )
+    ).scalar_one()
+    default.rating_strategy_id = rating_strategies["manual"].id
+    await db_session.commit()
+
+    me = await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    body = await _score_to_completion(api_client, opp.id)
+    assert body["my_side"]["rating_change"] is None
+
+    rows = (await db_session.execute(select(RatingHistory))).scalars().all()
+    assert rows == []
+
+    # `me` joined the (now manual) default league via the session hook → has a
+    # row but with the manual strategy's null initial state. `rival` was
+    # created via ``make_user`` which doesn't route through league membership,
+    # so they have no row at all.
+    ratings = (
+        await db_session.execute(select(UserLeagueRating))
+    ).scalars().all()
+    assert len(ratings) == 1
+    assert ratings[0].user_id == me.id
+    assert ratings[0].rating_value is None
+    assert ratings[0].rating_state is None
+
+
+async def test_rating_update_is_idempotent_across_score_edits(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Editing a score on an already-completed match doesn't write a second
+    set of history rows. Re-application across edits is its own feature
+    (tied to dispute/void flows) and explicitly out of scope for v1."""
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    body = await _score_to_completion(api_client, opp.id)
+    score_id = body["games"][0]["score"]["id"]
+
+    edited = await api_client.put(
+        f"/v1/matches/{body['id']}/games/{body['games'][0]['id']}/scores/{score_id}",
+        json={"side_1_points": 11, "side_2_points": 5},
+    )
+    assert edited.status_code == 200
+
+    rows = (
+        await db_session.execute(
+            select(RatingHistory).where(RatingHistory.match_id == uuid.UUID(body["id"]))
+        )
+    ).scalars().all()
+    assert len(rows) == 2  # still just the original pair
+
+
+async def test_new_session_seeds_rating_for_default_league(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    default_league: League,
+):
+    """Starting a session creates the user, attaches them to the default
+    league, and seeds a rating row with the strategy's initial values — so
+    new players have a visible rating from day one without having to play
+    a match first."""
+    me = await start_session(api_client, db_session)
+
+    rating = (
+        await db_session.execute(
+            select(UserLeagueRating).where(
+                UserLeagueRating.user_id == me.id,
+                UserLeagueRating.league_id == default_league.id,
+            )
+        )
+    ).scalar_one()
+    assert rating.rating_value == 1500.0
+    assert rating.rating_state == {"rating": 1500.0, "rd": 350.0, "volatility": 0.06}
+
+
+async def test_manual_history_row_with_null_match_round_trips(
+    db_session: AsyncSession,
+    default_league: League,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """A manual override / external import path can write a history row with
+    no match link and a non-null ``created_by_user_id`` + ``note``."""
+    admin = await make_user(db_session, "admin")
+    player = await make_user(db_session, "player")
+
+    row = RatingHistory(
+        league_id=default_league.id,
+        user_id=player.id,
+        match_id=None,
+        rating_strategy_id=rating_strategies["manual"].id,
+        rating_value=1850.0,
+        rating_state={"rating": 1850.0},
+        previous_rating_value=None,
+        source=RatingHistorySource.import_,
+        note="USATT 2026-04 batch",
+        created_by_user_id=admin.id,
+    )
+    db_session.add(row)
+    await db_session.commit()
+
+    reloaded = (
+        await db_session.execute(
+            select(RatingHistory).where(RatingHistory.user_id == player.id)
+        )
+    ).scalar_one()
+    assert reloaded.match_id is None
+    assert reloaded.source == RatingHistorySource.import_
+    assert reloaded.note == "USATT 2026-04 batch"
+    assert reloaded.created_by_user_id == admin.id

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -349,6 +349,7 @@ export interface components {
              * Format: date-time
              */
             completed_at: string;
+            my_rating_change?: components["schemas"]["RatingChange"] | null;
         };
         /** DashboardResponse */
         DashboardResponse: {
@@ -501,6 +502,7 @@ export interface components {
             won: boolean | null;
             /** Is Current User Side */
             is_current_user_side: boolean;
+            rating_change?: components["schemas"]["RatingChange"] | null;
         };
         /** MatchGameScoreWrite */
         MatchGameScoreWrite: {
@@ -603,6 +605,11 @@ export interface components {
         /**
          * PlayerRead
          * @description A user the current player can pick as a match opponent.
+         *
+         *     ``rating`` is the player's current ``rating_value`` in the league the
+         *     request was scoped to (defaulting to the default league) — None if they
+         *     haven't yet played a rated match in that league or, for manual-strategy
+         *     leagues, haven't been imported.
          */
         PlayerRead: {
             /**
@@ -612,6 +619,20 @@ export interface components {
             id: string;
             /** Username */
             username: string;
+            /** Rating */
+            rating?: number | null;
+        };
+        /**
+         * RatingChange
+         * @description A user's rating delta on a single completed match.
+         */
+        RatingChange: {
+            /** Before */
+            before: number | null;
+            /** After */
+            after: number;
+            /** Delta */
+            delta: number;
         };
         /** RbacUserCreate */
         RbacUserCreate: {
@@ -1438,6 +1459,7 @@ export interface operations {
         parameters: {
             query?: {
                 limit?: number;
+                league_id?: string | null;
             };
             header?: never;
             path?: never;
@@ -1473,6 +1495,7 @@ export interface operations {
                 /** @description Username substring to match against. */
                 q: string;
                 limit?: number;
+                league_id?: string | null;
             };
             header?: never;
             path?: never;

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -25,6 +25,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { fmtDateRel, fmtDateShort } from '@/lib/dates'
+import { formatRatingDelta } from '@/lib/rating'
 
 const GUEST_OPPONENT = 'guest'
 
@@ -1117,6 +1118,9 @@ function RecentResultsCard({ rows }: { rows: DashboardRecentResult[] }) {
               <th style={{ textAlign: 'right', padding: '10px 8px 8px', fontWeight: 600 }}>
                 Score
               </th>
+              <th style={{ textAlign: 'right', padding: '10px 8px 8px', fontWeight: 600 }}>
+                Δ
+              </th>
               <th style={{ textAlign: 'right', padding: '10px 18px 8px', fontWeight: 600 }}>
                 When
               </th>
@@ -1158,6 +1162,25 @@ function RecentResultsCard({ rows }: { rows: DashboardRecentResult[] }) {
                     <Mono size={13} weight={500} color={r.is_win ? C.serve500 : C.loss}>
                       {score}
                     </Mono>
+                  </td>
+                  <td style={{ padding: '11px 8px', textAlign: 'right' }}>
+                    {r.my_rating_change ? (
+                      <Mono
+                        size={12}
+                        weight={500}
+                        color={
+                          r.my_rating_change.delta >= 0
+                            ? C.serve500
+                            : C.loss
+                        }
+                      >
+                        {formatRatingDelta(r.my_rating_change.delta)}
+                      </Mono>
+                    ) : (
+                      <Mono size={12} color={C.chalk500}>
+                        —
+                      </Mono>
+                    )}
                   </td>
                   <td style={{ padding: '11px 18px', textAlign: 'right' }}>
                     <Mono size={11} color={C.chalk500}>

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -13,6 +13,7 @@ import {
 
 import { AppShell } from '@/components/app-shell'
 import { cn, initialsOf } from '@/lib/utils'
+import { formatRatingDelta } from '@/lib/rating'
 import { scoringEditRoute, scoringNewRoute, useMatch } from '@/api/matches'
 import type { components } from '@/api/schema'
 import { ApiError } from '@/api/client'
@@ -20,6 +21,7 @@ import { ApiError } from '@/api/client'
 type MatchDetails = components['schemas']['MatchDetails']
 type MatchDetailsGame = components['schemas']['MatchDetailsGame']
 type MatchDetailsSide = components['schemas']['MatchDetailsSide']
+type RatingChange = components['schemas']['RatingChange']
 
 type HeroState = 'live' | 'final' | 'upcoming'
 
@@ -28,6 +30,7 @@ type SideView = {
   initials: string
   gamesWon: number
   won: boolean | null
+  ratingChange: RatingChange | null
 }
 
 type GameView = {
@@ -61,6 +64,7 @@ function projectSide(side: MatchDetailsSide, fallbackLabel: string): SideView {
     initials: initialsOf(username),
     gamesWon: side.games_won,
     won: side.won,
+    ratingChange: side.rating_change ?? null,
   }
 }
 
@@ -375,6 +379,7 @@ function HeroScoreboard({
 
 function PlayerSide({ side, pos }: { side: SideView; pos: 'l' | 'r' }) {
   const win = side.won === true
+  const change = side.ratingChange
   return (
     <div className={`md-hero__player md-hero__player--${pos}`}>
       <div className="md-hero__player-row">
@@ -390,6 +395,19 @@ function PlayerSide({ side, pos }: { side: SideView; pos: 'l' | 'r' }) {
           <div className={cn('md-hero__name', win && 'md-hero__name--win')}>
             {side.username}
           </div>
+          {change && (
+            <div
+              className={cn(
+                'md-hero__rating-delta',
+                change.delta >= 0
+                  ? 'md-hero__rating-delta--up'
+                  : 'md-hero__rating-delta--down',
+              )}
+              data-testid={`rating-delta-${pos}`}
+            >
+              {formatRatingDelta(change.delta)} rating
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2305,6 +2305,17 @@ body.dark.fortymm-theme {
   color: var(--fg-3);
   margin-top: 4px;
 }
+.fortymm-theme .md-hero__rating-delta {
+  font: 600 11px var(--font-mono);
+  margin-top: 6px;
+  letter-spacing: 0.04em;
+}
+.fortymm-theme .md-hero__rating-delta--up {
+  color: var(--serve-500);
+}
+.fortymm-theme .md-hero__rating-delta--down {
+  color: var(--loss);
+}
 
 .fortymm-theme .md-hero__doubles-row {
   display: flex;

--- a/web-client/src/lib/rating.ts
+++ b/web-client/src/lib/rating.ts
@@ -1,0 +1,5 @@
+export function formatRatingDelta(delta: number): string {
+  const rounded = Math.round(delta)
+  const sign = rounded > 0 ? '+' : ''
+  return `${sign}${rounded}`
+}

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -22,13 +22,13 @@ export const mockSession = sessionResponse({ user: { username: 'rita.kovac' } })
 export const mockHealthy = healthCheck()
 
 export const mockPlayers = [
-  player({ username: 'nguyen.t' }),
-  player({ username: 'okafor.d' }),
-  player({ username: 'silva.r' }),
-  player({ username: 'patel.m' }),
-  player({ username: 'johansen.a' }),
-  player({ username: 'chen.w' }),
-  player({ username: 'park.j' }),
+  player({ username: 'nguyen.t', rating: 1842 }),
+  player({ username: 'okafor.d', rating: 1721 }),
+  player({ username: 'silva.r', rating: 1605 }),
+  player({ username: 'patel.m', rating: 1933 }),
+  player({ username: 'johansen.a', rating: 1488 }),
+  player({ username: 'chen.w', rating: 1547 }),
+  player({ username: 'park.j', rating: null }),
 ]
 
 // The recent-opponents endpoint is capped at six chips; the dev/test mock just

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -9,6 +9,24 @@ type MatchLeague = components['schemas']['MatchLeague']
 type DashboardScoreBanner = components['schemas']['DashboardScoreBanner']
 type DashboardNextMatch = components['schemas']['DashboardNextMatch']
 type DashboardRecentResult = components['schemas']['DashboardRecentResult']
+type RatingChange = components['schemas']['RatingChange']
+
+const MOCK_BASE_RATING = 1500
+const MOCK_RATING_DELTA = 8
+
+function ratingChangeFor(seedId: string, won: boolean): RatingChange {
+  // Deterministic so re-renders are stable.
+  let h = 0
+  for (let i = 0; i < seedId.length; i += 1) h = (h * 31 + seedId.charCodeAt(i)) | 0
+  const jitter = Math.abs(h) % 7
+  const magnitude = MOCK_RATING_DELTA + jitter
+  const signed = won ? magnitude : -magnitude
+  return {
+    before: MOCK_BASE_RATING,
+    after: MOCK_BASE_RATING + signed,
+    delta: signed,
+  }
+}
 
 // The mock-session user — handlers project every seed match as if this user
 // is on side 1, so `is_current_user_side` and `my_games_won` line up with
@@ -108,6 +126,10 @@ function projectSides(seed: SeedMatch): {
 } {
   const { side1, side2 } = sideWinCounts(seed)
   const decided = seed.status === 'completed'
+
+  const showRatingChange = decided && seed.affects_rating && seed.opponent !== null
+  const myWon = side1 > side2
+
   const mySide: MatchDetailsSide = {
     side_number: 1,
     players: [
@@ -118,8 +140,9 @@ function projectSides(seed: SeedMatch): {
       },
     ],
     games_won: side1,
-    won: decided ? side1 > side2 : null,
+    won: decided ? myWon : null,
     is_current_user_side: true,
+    rating_change: showRatingChange ? ratingChangeFor(seed.id, myWon) : null,
   }
   const opponentSide: MatchDetailsSide | null = seed.opponent
     ? {
@@ -132,8 +155,9 @@ function projectSides(seed: SeedMatch): {
           },
         ],
         games_won: side2,
-        won: decided ? side2 > side1 : null,
+        won: decided ? !myWon : null,
         is_current_user_side: false,
+        rating_change: showRatingChange ? ratingChangeFor(seed.id, !myWon) : null,
       }
     : null
   return { mySide, opponentSide }
@@ -222,13 +246,15 @@ export function projectNextMatch(seed: SeedMatch): DashboardNextMatch | null {
 export function projectRecentResult(seed: SeedMatch): DashboardRecentResult | null {
   if (seed.status !== 'completed' || seed.opponent === null) return null
   const { side1, side2 } = sideWinCounts(seed)
+  const won = side1 > side2
   return {
     match_id: seed.id,
     opponent_username: seed.opponent.username,
-    is_win: side1 > side2,
+    is_win: won,
     my_games_won: side1,
     opponent_games_won: side2,
     completed_at: seed.completed_at ?? seed.created_at,
+    my_rating_change: seed.affects_rating ? ratingChangeFor(seed.id, won) : null,
   }
 }
 

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -396,7 +396,11 @@ function TypeaheadPicker({ onPick }: { onPick: (player: Player) => void }) {
         <div className="av">{initialsOf(p.username)}</div>
         <div className="body">
           <div className="n">{p.username}</div>
-          <div className="m">REGISTERED PLAYER</div>
+          <div className="m">
+            {p.rating != null
+              ? `RATING ${Math.round(p.rating)}`
+              : 'REGISTERED PLAYER'}
+          </div>
         </div>
       </button>
     ))


### PR DESCRIPTION
## Summary
- Adds `rating_strategies` (seeded with `glicko2` + `manual`), `user_league_ratings` (current per user/league), and `rating_history` (append-only audit, nullable `match_id` for manual overrides + external imports).
- Match completion runs the league's calculator (vendored Glicko-2 in `app/ratings/`), validates the new state against the strategy's stored JSON Schema, then writes a history row + bumps the current rating — all in the same transaction. Manual leagues skip the calculator path.
- New users get a seeded rating row at league-membership time so they appear on leaderboards and in the opponent picker from day one.
- BFF exposes `rating_change` on `MatchDetailsSide`, `my_rating_change` on `DashboardRecentResult`, and `rating` on `PlayerRead` (player search/recent take an optional `league_id`).
- Frontend renders the delta in the match-details hero, the dashboard recent-results table, and the new-match opponent picker.

Migration 0005 is edited in place (pre-deploy convention) to add `rating_strategies` + seed + the NOT NULL `leagues.rating_strategy_id` FK. New rating-state tables ship in 0006.

## Test plan
- [x] API: `cd api && pytest` — 191 passed
- [x] Web vitest: `cd web-client && npm run test:run` — 39 passed
- [x] Web lint + build: `cd web-client && npm run lint && npm run build` — clean
- [x] Web e2e: `cd web-client && npm run test:e2e` — 126 passed
- [x] Migration round-trip: alembic upgrade head → downgrade base → upgrade head, against a fresh testcontainers Postgres
- [x] `mise run regen-api-types` — committed schema matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)