### PR TITLE
Add Players & form, Head to head, and Rating change panels to match details

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1,10 +1,11 @@
 import math
 import uuid
+from dataclasses import dataclass
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import aliased, selectinload
 
 from app.db import get_session
 from app.leagues import resolve_league
@@ -94,6 +95,14 @@ def match_eager_options():
     return (
         selectinload(Match.match_settings),
         selectinload(Match.league).selectinload(League.rating_strategy),
+        *_match_history_options(),
+    )
+
+
+def _match_history_options():
+    """Subset of ``match_eager_options`` for paths that only need sides + scores
+    (recent form, H2H): no match_settings, no league/rating-strategy."""
+    return (
         selectinload(Match.sides)
         .selectinload(MatchSide.players)
         .selectinload(MatchSidePlayer.user),
@@ -165,10 +174,9 @@ def current_unscored_game(match: Match) -> MatchGame | None:
 def _serialize_details(
     match: Match,
     current_user_id: uuid.UUID,
-    rating_changes: dict[uuid.UUID, RatingChange] | None = None,
-    recent_form: list[MatchDetailsPlayerForm] | None = None,
-    head_to_head: MatchDetailsH2H | None = None,
+    extras: "ViewExtras | None" = None,
 ) -> MatchDetails:
+    extras = extras or _EMPTY_EXTRAS
     side_wins = side_win_counts(match)
 
     def _score_schema(score: MatchGameScore) -> MatchDetailsScore:
@@ -212,7 +220,7 @@ def _serialize_details(
         affects_rating=match.match_settings.affects_rating,
         created_at=match.created_at,
         sides=[
-            _side_schema(side, side_wins, current_user_id, rating_changes)
+            _side_schema(side, side_wins, current_user_id, extras.rating_changes)
             for side in sides_sorted
         ],
         games=games,
@@ -222,8 +230,8 @@ def _serialize_details(
         can_score=(
             current_game is not None and len(match.sides) >= 2 and is_participant
         ),
-        recent_form=recent_form or [],
-        head_to_head=head_to_head,
+        recent_form=extras.recent_form,
+        head_to_head=extras.head_to_head,
     )
 
 
@@ -425,8 +433,8 @@ async def get_match(
     match = await _load_match(db, match_id)
     if match is None:
         raise HTTPException(status_code=404, detail="Match not found.")
-    changes, form, h2h = await _load_view_extras(db, match)
-    return _serialize_details(match, current_user.id, changes, form, h2h)
+    extras = await _load_view_extras(db, match)
+    return _serialize_details(match, current_user.id, extras)
 
 
 # ----- score writes --------------------------------------------------------
@@ -458,9 +466,8 @@ async def _load_rating_changes(
 
 
 def _singles_user_ids(match: Match) -> list[uuid.UUID]:
-    """User IDs of singles players on this match, ordered by side number.
-    Skips any side that doesn't have exactly one player (no doubles surface
-    yet). Returns one entry for a solo match, two for a 1v1."""
+    """Singles player IDs, ordered by side number. Sides without exactly one
+    player are skipped — no doubles surface yet."""
     sides_in_order = sorted(match.sides, key=lambda s: s.side_number)
     return [
         side.players[0].user_id
@@ -469,17 +476,18 @@ def _singles_user_ids(match: Match) -> list[uuid.UUID]:
     ]
 
 
-def _both_singles_user_ids(match: Match) -> list[uuid.UUID]:
-    """Only returns IDs when both side 1 and side 2 exist with a single
-    player each — the surface for H2H comparisons."""
-    by_number = {s.side_number: s for s in match.sides}
-    side_one = by_number.get(1)
-    side_two = by_number.get(2)
-    if side_one is None or side_two is None:
-        return []
-    if len(side_one.players) != 1 or len(side_two.players) != 1:
-        return []
-    return [side_one.players[0].user_id, side_two.players[0].user_id]
+def _history_base_query(current_match_id: uuid.UUID):
+    """Foundation for both recent-form and H2H lookups: completed matches
+    other than this one, eagerly loading just the sides + games subtree."""
+    return (
+        select(Match)
+        .where(
+            Match.status == MatchStatus.completed,
+            Match.id != current_match_id,
+        )
+        .options(*_match_history_options())
+        .order_by(Match.updated_at.desc())
+    )
 
 
 async def _load_recent_form(
@@ -487,32 +495,16 @@ async def _load_recent_form(
     user_ids: list[uuid.UUID],
     current_match_id: uuid.UUID,
 ) -> list[MatchDetailsPlayerForm]:
-    """For each user, the last ``RECENT_FORM_LIMIT`` completed matches they
-    were on a side of (excluding the current match)."""
     if not user_ids:
         return []
 
     result: list[MatchDetailsPlayerForm] = []
     for user_id in user_ids:
-        my_in_match = (
-            select(MatchSidePlayer.user_id)
-            .where(
-                MatchSidePlayer.match_id == Match.id,
-                MatchSidePlayer.user_id == user_id,
-            )
-            .exists()
-        )
         rows = (
             await db.execute(
-                select(Match)
-                .where(
-                    Match.status == MatchStatus.completed,
-                    Match.id != current_match_id,
-                    my_in_match,
-                )
-                .options(*match_eager_options())
-                .order_by(Match.updated_at.desc())
-                .limit(RECENT_FORM_LIMIT)
+                participant_filter(
+                    _history_base_query(current_match_id), user_id
+                ).limit(RECENT_FORM_LIMIT)
             )
         ).scalars().all()
         result.append(
@@ -530,19 +522,18 @@ def _build_form_result(
     past_match: Match, user_id: uuid.UUID
 ) -> MatchDetailsFormResult:
     mine = my_side(past_match, user_id)
-    assert mine is not None  # selectinload + filter guarantees membership
+    assert mine is not None  # participant_filter guarantees membership
     side_wins = side_win_counts(past_match)
     player_games = side_wins.get(mine.side_number, 0)
     opp_games = sum(
         wins for n, wins in side_wins.items() if n != mine.side_number
     )
-    opp_user = opponent_username(past_match, user_id)
     return MatchDetailsFormResult(
         match_id=past_match.id,
         is_win=mine.won is True,
         player_games_won=player_games,
         opponent_games_won=opp_games,
-        opponent_username=opp_user,
+        opponent_username=opponent_username(past_match, user_id),
         completed_at=past_match.updated_at,
     )
 
@@ -552,64 +543,28 @@ async def _load_head_to_head(
     user_ids: list[uuid.UUID],
     current_match_id: uuid.UUID,
 ) -> MatchDetailsH2H | None:
-    """Past completed matches that pitted these two users against each other
-    on opposite sides. Counts and per-row games are framed against the
-    *current* match's side numbers (side 1 = ``user_ids[0]``)."""
     if len(user_ids) != 2:
         return None
     user_a, user_b = user_ids
-    a_in_match = (
-        select(MatchSidePlayer.user_id)
-        .where(
-            MatchSidePlayer.match_id == Match.id,
-            MatchSidePlayer.user_id == user_a,
-        )
-        .exists()
-    )
-    b_in_match = (
-        select(MatchSidePlayer.user_id)
-        .where(
-            MatchSidePlayer.match_id == Match.id,
-            MatchSidePlayer.user_id == user_b,
-        )
-        .exists()
+    rows_query = participant_filter(
+        participant_filter(_history_base_query(current_match_id), user_a),
+        user_b,
     )
     rows = (
-        await db.execute(
-            select(Match)
-            .where(
-                Match.status == MatchStatus.completed,
-                Match.id != current_match_id,
-                a_in_match,
-                b_in_match,
-            )
-            .options(*match_eager_options())
-            .order_by(Match.updated_at.desc())
-        )
+        await db.execute(rows_query.limit(H2H_MEETINGS_LIMIT))
     ).scalars().all()
 
     meetings: list[MatchDetailsH2HMeeting] = []
-    a_wins = 0
-    b_wins = 0
     for past in rows:
         past_a = my_side(past, user_a)
         past_b = my_side(past, user_b)
-        if past_a is None or past_b is None:
-            continue
-        # Skip same-side meetings (doubles): the H2H card is a singles concept.
-        if past_a.side_number == past_b.side_number:
-            continue
+        assert past_a is not None and past_b is not None
         side_wins = side_win_counts(past)
         a_games = side_wins.get(past_a.side_number, 0)
         b_games = side_wins.get(past_b.side_number, 0)
-        if past_a.won is True:
-            a_wins += 1
-            winner_side: int | None = 1
-        elif past_b.won is True:
-            b_wins += 1
-            winner_side = 2
-        else:
-            winner_side = None
+        winner_side: int | None = (
+            1 if past_a.won is True else 2 if past_b.won is True else None
+        )
         meetings.append(
             MatchDetailsH2HMeeting(
                 match_id=past.id,
@@ -620,28 +575,60 @@ async def _load_head_to_head(
             )
         )
 
+    # Full-history aggregates so the displayed window doesn't undercount a
+    # long rivalry. Driven from MatchSide.won so a future void/dispute that
+    # leaves `won` null naturally drops out of both totals.
+    a_side = aliased(MatchSide)
+    b_side = aliased(MatchSide)
+    a_player = aliased(MatchSidePlayer)
+    b_player = aliased(MatchSidePlayer)
+    counts_query = (
+        select(
+            func.count(Match.id),
+            func.count(Match.id).filter(a_side.won.is_(True)),
+            func.count(Match.id).filter(b_side.won.is_(True)),
+        )
+        .join(a_side, a_side.match_id == Match.id)
+        .join(a_player, a_player.match_side_id == a_side.id)
+        .join(b_side, b_side.match_id == Match.id)
+        .join(b_player, b_player.match_side_id == b_side.id)
+        .where(
+            Match.status == MatchStatus.completed,
+            Match.id != current_match_id,
+            a_player.user_id == user_a,
+            b_player.user_id == user_b,
+            a_side.id != b_side.id,
+        )
+    )
+    total, a_wins, b_wins = (await db.execute(counts_query)).one()
+
     return MatchDetailsH2H(
-        total_meetings=len(meetings),
+        total_meetings=total,
         side_1_wins=a_wins,
         side_2_wins=b_wins,
-        recent_meetings=meetings[:H2H_MEETINGS_LIMIT],
+        recent_meetings=meetings,
     )
 
 
-async def _load_view_extras(
-    db: AsyncSession, match: Match
-) -> tuple[
-    dict[uuid.UUID, RatingChange],
-    list[MatchDetailsPlayerForm],
-    MatchDetailsH2H | None,
-]:
-    """All the extra rollups the details page needs that don't ride on the
-    match row itself. One call site means consistent payload shape across
-    GET /matches/{id} and the score-write returns."""
-    changes = await _load_rating_changes(db, match.id)
-    form = await _load_recent_form(db, _singles_user_ids(match), match.id)
-    h2h = await _load_head_to_head(db, _both_singles_user_ids(match), match.id)
-    return changes, form, h2h
+@dataclass
+class ViewExtras:
+    rating_changes: dict[uuid.UUID, RatingChange]
+    recent_form: list[MatchDetailsPlayerForm]
+    head_to_head: MatchDetailsH2H | None
+
+
+_EMPTY_EXTRAS = ViewExtras(rating_changes={}, recent_form=[], head_to_head=None)
+
+
+async def _load_view_extras(db: AsyncSession, match: Match) -> ViewExtras:
+    user_ids = _singles_user_ids(match)
+    return ViewExtras(
+        rating_changes=await _load_rating_changes(db, match.id),
+        recent_form=await _load_recent_form(db, user_ids, match.id),
+        head_to_head=await _load_head_to_head(
+            db, user_ids if len(user_ids) == 2 else [], match.id
+        ),
+    )
 
 
 async def _get_or_create_user_league_rating(
@@ -846,8 +833,8 @@ async def create_game_score(
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None
-    changes, form, h2h = await _load_view_extras(db, reloaded)
-    return _serialize_details(reloaded, current_user.id, changes, form, h2h)
+    extras = await _load_view_extras(db, reloaded)
+    return _serialize_details(reloaded, current_user.id, extras)
 
 
 @router.put(
@@ -880,5 +867,5 @@ async def update_game_score(
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None
-    changes, form, h2h = await _load_view_extras(db, reloaded)
-    return _serialize_details(reloaded, current_user.id, changes, form, h2h)
+    extras = await _load_view_extras(db, reloaded)
+    return _serialize_details(reloaded, current_user.id, extras)

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -30,8 +30,12 @@ from app.schemas.match import (
     MatchCreate,
     MatchDetails,
     MatchDetailsCurrentGame,
+    MatchDetailsFormResult,
     MatchDetailsGame,
+    MatchDetailsH2H,
+    MatchDetailsH2HMeeting,
     MatchDetailsPlayer,
+    MatchDetailsPlayerForm,
     MatchDetailsScore,
     MatchDetailsSide,
     MatchGameScoreWrite,
@@ -45,6 +49,8 @@ from app.sessions import get_current_user
 router = APIRouter(prefix="/v1")
 
 MAX_PAGE_SIZE = 100
+RECENT_FORM_LIMIT = 5
+H2H_MEETINGS_LIMIT = 5
 
 
 # ----- helpers -------------------------------------------------------------
@@ -160,6 +166,8 @@ def _serialize_details(
     match: Match,
     current_user_id: uuid.UUID,
     rating_changes: dict[uuid.UUID, RatingChange] | None = None,
+    recent_form: list[MatchDetailsPlayerForm] | None = None,
+    head_to_head: MatchDetailsH2H | None = None,
 ) -> MatchDetails:
     side_wins = side_win_counts(match)
 
@@ -214,6 +222,8 @@ def _serialize_details(
         can_score=(
             current_game is not None and len(match.sides) >= 2 and is_participant
         ),
+        recent_form=recent_form or [],
+        head_to_head=head_to_head,
     )
 
 
@@ -415,8 +425,8 @@ async def get_match(
     match = await _load_match(db, match_id)
     if match is None:
         raise HTTPException(status_code=404, detail="Match not found.")
-    changes = await _load_rating_changes(db, match.id)
-    return _serialize_details(match, current_user.id, changes)
+    changes, form, h2h = await _load_view_extras(db, match)
+    return _serialize_details(match, current_user.id, changes, form, h2h)
 
 
 # ----- score writes --------------------------------------------------------
@@ -445,6 +455,193 @@ async def _load_rating_changes(
         )
     ).scalars().all()
     return {row.user_id: RatingChange.from_history(row) for row in rows}
+
+
+def _singles_user_ids(match: Match) -> list[uuid.UUID]:
+    """User IDs of singles players on this match, ordered by side number.
+    Skips any side that doesn't have exactly one player (no doubles surface
+    yet). Returns one entry for a solo match, two for a 1v1."""
+    sides_in_order = sorted(match.sides, key=lambda s: s.side_number)
+    return [
+        side.players[0].user_id
+        for side in sides_in_order
+        if len(side.players) == 1
+    ]
+
+
+def _both_singles_user_ids(match: Match) -> list[uuid.UUID]:
+    """Only returns IDs when both side 1 and side 2 exist with a single
+    player each — the surface for H2H comparisons."""
+    by_number = {s.side_number: s for s in match.sides}
+    side_one = by_number.get(1)
+    side_two = by_number.get(2)
+    if side_one is None or side_two is None:
+        return []
+    if len(side_one.players) != 1 or len(side_two.players) != 1:
+        return []
+    return [side_one.players[0].user_id, side_two.players[0].user_id]
+
+
+async def _load_recent_form(
+    db: AsyncSession,
+    user_ids: list[uuid.UUID],
+    current_match_id: uuid.UUID,
+) -> list[MatchDetailsPlayerForm]:
+    """For each user, the last ``RECENT_FORM_LIMIT`` completed matches they
+    were on a side of (excluding the current match)."""
+    if not user_ids:
+        return []
+
+    result: list[MatchDetailsPlayerForm] = []
+    for user_id in user_ids:
+        my_in_match = (
+            select(MatchSidePlayer.user_id)
+            .where(
+                MatchSidePlayer.match_id == Match.id,
+                MatchSidePlayer.user_id == user_id,
+            )
+            .exists()
+        )
+        rows = (
+            await db.execute(
+                select(Match)
+                .where(
+                    Match.status == MatchStatus.completed,
+                    Match.id != current_match_id,
+                    my_in_match,
+                )
+                .options(*match_eager_options())
+                .order_by(Match.updated_at.desc())
+                .limit(RECENT_FORM_LIMIT)
+            )
+        ).scalars().all()
+        result.append(
+            MatchDetailsPlayerForm(
+                user_id=user_id,
+                recent_results=[
+                    _build_form_result(match, user_id) for match in rows
+                ],
+            )
+        )
+    return result
+
+
+def _build_form_result(
+    past_match: Match, user_id: uuid.UUID
+) -> MatchDetailsFormResult:
+    mine = my_side(past_match, user_id)
+    assert mine is not None  # selectinload + filter guarantees membership
+    side_wins = side_win_counts(past_match)
+    player_games = side_wins.get(mine.side_number, 0)
+    opp_games = sum(
+        wins for n, wins in side_wins.items() if n != mine.side_number
+    )
+    opp_user = opponent_username(past_match, user_id)
+    return MatchDetailsFormResult(
+        match_id=past_match.id,
+        is_win=mine.won is True,
+        player_games_won=player_games,
+        opponent_games_won=opp_games,
+        opponent_username=opp_user,
+        completed_at=past_match.updated_at,
+    )
+
+
+async def _load_head_to_head(
+    db: AsyncSession,
+    user_ids: list[uuid.UUID],
+    current_match_id: uuid.UUID,
+) -> MatchDetailsH2H | None:
+    """Past completed matches that pitted these two users against each other
+    on opposite sides. Counts and per-row games are framed against the
+    *current* match's side numbers (side 1 = ``user_ids[0]``)."""
+    if len(user_ids) != 2:
+        return None
+    user_a, user_b = user_ids
+    a_in_match = (
+        select(MatchSidePlayer.user_id)
+        .where(
+            MatchSidePlayer.match_id == Match.id,
+            MatchSidePlayer.user_id == user_a,
+        )
+        .exists()
+    )
+    b_in_match = (
+        select(MatchSidePlayer.user_id)
+        .where(
+            MatchSidePlayer.match_id == Match.id,
+            MatchSidePlayer.user_id == user_b,
+        )
+        .exists()
+    )
+    rows = (
+        await db.execute(
+            select(Match)
+            .where(
+                Match.status == MatchStatus.completed,
+                Match.id != current_match_id,
+                a_in_match,
+                b_in_match,
+            )
+            .options(*match_eager_options())
+            .order_by(Match.updated_at.desc())
+        )
+    ).scalars().all()
+
+    meetings: list[MatchDetailsH2HMeeting] = []
+    a_wins = 0
+    b_wins = 0
+    for past in rows:
+        past_a = my_side(past, user_a)
+        past_b = my_side(past, user_b)
+        if past_a is None or past_b is None:
+            continue
+        # Skip same-side meetings (doubles): the H2H card is a singles concept.
+        if past_a.side_number == past_b.side_number:
+            continue
+        side_wins = side_win_counts(past)
+        a_games = side_wins.get(past_a.side_number, 0)
+        b_games = side_wins.get(past_b.side_number, 0)
+        if past_a.won is True:
+            a_wins += 1
+            winner_side: int | None = 1
+        elif past_b.won is True:
+            b_wins += 1
+            winner_side = 2
+        else:
+            winner_side = None
+        meetings.append(
+            MatchDetailsH2HMeeting(
+                match_id=past.id,
+                completed_at=past.updated_at,
+                side_1_games_won=a_games,
+                side_2_games_won=b_games,
+                winner_side_number=winner_side,
+            )
+        )
+
+    return MatchDetailsH2H(
+        total_meetings=len(meetings),
+        side_1_wins=a_wins,
+        side_2_wins=b_wins,
+        recent_meetings=meetings[:H2H_MEETINGS_LIMIT],
+    )
+
+
+async def _load_view_extras(
+    db: AsyncSession, match: Match
+) -> tuple[
+    dict[uuid.UUID, RatingChange],
+    list[MatchDetailsPlayerForm],
+    MatchDetailsH2H | None,
+]:
+    """All the extra rollups the details page needs that don't ride on the
+    match row itself. One call site means consistent payload shape across
+    GET /matches/{id} and the score-write returns."""
+    changes = await _load_rating_changes(db, match.id)
+    form = await _load_recent_form(db, _singles_user_ids(match), match.id)
+    h2h = await _load_head_to_head(db, _both_singles_user_ids(match), match.id)
+    return changes, form, h2h
 
 
 async def _get_or_create_user_league_rating(
@@ -649,8 +846,8 @@ async def create_game_score(
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None
-    changes = await _load_rating_changes(db, reloaded.id)
-    return _serialize_details(reloaded, current_user.id, changes)
+    changes, form, h2h = await _load_view_extras(db, reloaded)
+    return _serialize_details(reloaded, current_user.id, changes, form, h2h)
 
 
 @router.put(
@@ -683,5 +880,5 @@ async def update_game_score(
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None
-    changes = await _load_rating_changes(db, reloaded.id)
-    return _serialize_details(reloaded, current_user.id, changes)
+    changes, form, h2h = await _load_view_extras(db, reloaded)
+    return _serialize_details(reloaded, current_user.id, changes, form, h2h)

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -86,6 +86,51 @@ class MatchDetailsCurrentGame(BaseModel):
     game_number: int
 
 
+class MatchDetailsFormResult(BaseModel):
+    """One past completed match for the Players & form recent-results list.
+
+    Counts are framed from the cited *player's* perspective, not from a
+    side number in the past match."""
+
+    match_id: uuid.UUID
+    is_win: bool
+    player_games_won: int
+    opponent_games_won: int
+    opponent_username: str | None
+    completed_at: datetime
+
+
+class MatchDetailsPlayerForm(BaseModel):
+    """A player's previous-5 results, attached by ``user_id`` so the FE can
+    map it onto whichever side carries that user."""
+
+    user_id: uuid.UUID
+    recent_results: list[MatchDetailsFormResult]
+
+
+class MatchDetailsH2HMeeting(BaseModel):
+    """One past meeting between the two players in *this* match. Game counts
+    are aligned to this match's side numbers so the FE doesn't need to
+    re-map per row."""
+
+    match_id: uuid.UUID
+    completed_at: datetime
+    side_1_games_won: int
+    side_2_games_won: int
+    winner_side_number: int | None
+
+
+class MatchDetailsH2H(BaseModel):
+    """Head-to-head between this match's two singles players. Wins are
+    counted against this match's side numbers (not the side numbers of the
+    historical matches)."""
+
+    total_meetings: int
+    side_1_wins: int
+    side_2_wins: int
+    recent_meetings: list[MatchDetailsH2HMeeting]
+
+
 class MatchDetails(BaseModel):
     id: uuid.UUID
     status: MatchStatus
@@ -102,6 +147,13 @@ class MatchDetails(BaseModel):
     games: list[MatchDetailsGame]
     current_game: MatchDetailsCurrentGame | None
     can_score: bool
+    # Previous completed matches for each singles player on this match
+    # (excludes the current match). Empty entry means the player has no prior
+    # completed matches.
+    recent_form: list[MatchDetailsPlayerForm] = Field(default_factory=list)
+    # Past meetings between the two singles players. Null for solo matches
+    # or anything we can't reduce to two known players.
+    head_to_head: MatchDetailsH2H | None = None
 
 
 # ----- list (BFF for /matches) ---------------------------------------------

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -147,12 +147,7 @@ class MatchDetails(BaseModel):
     games: list[MatchDetailsGame]
     current_game: MatchDetailsCurrentGame | None
     can_score: bool
-    # Previous completed matches for each singles player on this match
-    # (excludes the current match). Empty entry means the player has no prior
-    # completed matches.
     recent_form: list[MatchDetailsPlayerForm] = Field(default_factory=list)
-    # Past meetings between the two singles players. Null for solo matches
-    # or anything we can't reduce to two known players.
     head_to_head: MatchDetailsH2H | None = None
 
 

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -849,3 +849,131 @@ async def test_list_and_get_match_include_league(
 
     listing = (await api_client.get("/v1/matches")).json()
     assert listing["items"][0]["league"]["id"] == str(default_league.id)
+
+
+# ----- recent form + head to head -----------------------------------------
+
+
+async def _play_match_to_completion(
+    client: AsyncClient,
+    opponent_id: uuid.UUID,
+    best_of: int,
+    side_1_wins: bool,
+) -> dict:
+    """Create a match and score it to completion. The chosen side wins the
+    minimum number of games needed to clinch. Returns the final payload."""
+    match = await _create_match(client, opponent_id, best_of=best_of)
+    needed = best_of // 2 + 1
+    body = match
+    for _ in range(needed):
+        current = body["current_game"]
+        assert current is not None
+        s1, s2 = (11, 5) if side_1_wins else (5, 11)
+        body = (
+            await client.post(
+                f"/v1/matches/{body['id']}/games/{current['id']}/scores",
+                json={"side_1_points": s1, "side_2_points": s2},
+            )
+        ).json()
+    assert body["status"] == "completed"
+    return body
+
+
+async def test_details_includes_empty_recent_form_for_first_meeting(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "first-rival")
+    created = await _create_match(api_client, opp.id, best_of=3)
+
+    detail = (await api_client.get(f"/v1/matches/{created['id']}")).json()
+    assert detail["head_to_head"] == {
+        "total_meetings": 0,
+        "side_1_wins": 0,
+        "side_2_wins": 0,
+        "recent_meetings": [],
+    }
+    # Both players are in recent_form, both with empty results lists.
+    forms = {f["user_id"]: f for f in detail["recent_form"]}
+    assert len(forms) == 2
+    for f in forms.values():
+        assert f["recent_results"] == []
+
+
+async def test_details_recent_form_lists_each_player_previous_results(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await start_session(api_client, db_session)
+    opp = await make_user(db_session, "form-rival")
+    # Play two finished matches with a third party so each side has its own
+    # prior history that's *not* a head-to-head meeting.
+    other = await make_user(db_session, "third-party")
+    await _play_match_to_completion(api_client, other.id, best_of=3, side_1_wins=True)
+    await _play_match_to_completion(api_client, other.id, best_of=3, side_1_wins=False)
+    # Now start a head-to-head match and ask for its details.
+    current = await _create_match(api_client, opp.id, best_of=3)
+    detail = (await api_client.get(f"/v1/matches/{current['id']}")).json()
+
+    forms = {f["user_id"]: f for f in detail["recent_form"]}
+    # I have 2 prior completed matches (1 W, 1 L) against third-party.
+    mine = forms[str(me.id)]
+    assert {r["is_win"] for r in mine["recent_results"]} == {True, False}
+    assert all(
+        r["opponent_username"] == "third-party" for r in mine["recent_results"]
+    )
+    # Opp shows up in the form list with no prior completed matches.
+    assert forms[str(opp.id)]["recent_results"] == []
+
+
+async def test_details_recent_form_excludes_the_current_match(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "exclude-rival")
+    # Play to completion against this opp, then look up that match's detail.
+    finished = await _play_match_to_completion(
+        api_client, opp.id, best_of=3, side_1_wins=True
+    )
+
+    detail = (await api_client.get(f"/v1/matches/{finished['id']}")).json()
+    forms = {f["user_id"]: f for f in detail["recent_form"]}
+    # The finished match itself must not appear in its own recent-form list.
+    for f in forms.values():
+        assert all(r["match_id"] != finished["id"] for r in f["recent_results"])
+
+
+async def test_details_head_to_head_counts_prior_meetings_per_side(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    rival = await make_user(db_session, "h2h-rival")
+    # Three completed prior meetings: I win two, lose one.
+    await _play_match_to_completion(api_client, rival.id, best_of=3, side_1_wins=True)
+    await _play_match_to_completion(api_client, rival.id, best_of=3, side_1_wins=True)
+    await _play_match_to_completion(api_client, rival.id, best_of=3, side_1_wins=False)
+    # New in-progress match — H2H counts only completed *prior* meetings.
+    current = await _create_match(api_client, rival.id, best_of=5)
+
+    detail = (await api_client.get(f"/v1/matches/{current['id']}")).json()
+    h2h = detail["head_to_head"]
+    assert h2h["total_meetings"] == 3
+    assert h2h["side_1_wins"] == 2  # me, on side 1 of the current match
+    assert h2h["side_2_wins"] == 1
+    # Most-recent meeting is the one I just lost.
+    assert h2h["recent_meetings"][0]["winner_side_number"] == 2
+
+
+async def test_details_head_to_head_is_null_for_solo_match(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    created = (
+        await api_client.post(
+            "/v1/matches", json={"best_of": 3, "rated": False}
+        )
+    ).json()
+    detail = (await api_client.get(f"/v1/matches/{created['id']}")).json()
+    assert detail["head_to_head"] is None
+    # Only the creator is in recent_form — and they have no prior history.
+    assert len(detail["recent_form"]) == 1
+    assert detail["recent_form"][0]["recent_results"] == []

--- a/web-client/.gitignore
+++ b/web-client/.gitignore
@@ -16,6 +16,7 @@ dist-ssr
 /test-results/
 /playwright-report/
 /playwright/.cache/
+/.playwright-cli/
 
 # Editor directories and files
 .vscode/*

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -498,6 +498,9 @@ export interface components {
             current_game: components["schemas"]["MatchDetailsCurrentGame"] | null;
             /** Can Score */
             can_score: boolean;
+            /** Recent Form */
+            recent_form?: components["schemas"]["MatchDetailsPlayerForm"][];
+            head_to_head?: components["schemas"]["MatchDetailsH2H"] | null;
         };
         /** MatchDetailsCurrentGame */
         MatchDetailsCurrentGame: {
@@ -508,6 +511,33 @@ export interface components {
             id: string;
             /** Game Number */
             game_number: number;
+        };
+        /**
+         * MatchDetailsFormResult
+         * @description One past completed match for the Players & form recent-results list.
+         *
+         *     Counts are framed from the cited *player's* perspective, not from a
+         *     side number in the past match.
+         */
+        MatchDetailsFormResult: {
+            /**
+             * Match Id
+             * Format: uuid
+             */
+            match_id: string;
+            /** Is Win */
+            is_win: boolean;
+            /** Player Games Won */
+            player_games_won: number;
+            /** Opponent Games Won */
+            opponent_games_won: number;
+            /** Opponent Username */
+            opponent_username: string | null;
+            /**
+             * Completed At
+             * Format: date-time
+             */
+            completed_at: string;
         };
         /** MatchDetailsGame */
         MatchDetailsGame: {
@@ -520,6 +550,46 @@ export interface components {
             game_number: number;
             score: components["schemas"]["MatchDetailsScore"] | null;
         };
+        /**
+         * MatchDetailsH2H
+         * @description Head-to-head between this match's two singles players. Wins are
+         *     counted against this match's side numbers (not the side numbers of the
+         *     historical matches).
+         */
+        MatchDetailsH2H: {
+            /** Total Meetings */
+            total_meetings: number;
+            /** Side 1 Wins */
+            side_1_wins: number;
+            /** Side 2 Wins */
+            side_2_wins: number;
+            /** Recent Meetings */
+            recent_meetings: components["schemas"]["MatchDetailsH2HMeeting"][];
+        };
+        /**
+         * MatchDetailsH2HMeeting
+         * @description One past meeting between the two players in *this* match. Game counts
+         *     are aligned to this match's side numbers so the FE doesn't need to
+         *     re-map per row.
+         */
+        MatchDetailsH2HMeeting: {
+            /**
+             * Match Id
+             * Format: uuid
+             */
+            match_id: string;
+            /**
+             * Completed At
+             * Format: date-time
+             */
+            completed_at: string;
+            /** Side 1 Games Won */
+            side_1_games_won: number;
+            /** Side 2 Games Won */
+            side_2_games_won: number;
+            /** Winner Side Number */
+            winner_side_number: number | null;
+        };
         /** MatchDetailsPlayer */
         MatchDetailsPlayer: {
             /**
@@ -531,6 +601,20 @@ export interface components {
             username: string;
             /** Is Current User */
             is_current_user: boolean;
+        };
+        /**
+         * MatchDetailsPlayerForm
+         * @description A player's previous-5 results, attached by ``user_id`` so the FE can
+         *     map it onto whichever side carries that user.
+         */
+        MatchDetailsPlayerForm: {
+            /**
+             * User Id
+             * Format: uuid
+             */
+            user_id: string;
+            /** Recent Results */
+            recent_results: components["schemas"]["MatchDetailsFormResult"][];
         };
         /** MatchDetailsScore */
         MatchDetailsScore: {

--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -324,4 +324,234 @@ describe('MatchDetailsView', () => {
     // Scored cells stay plain divs rather than edit links for spectators.
     expect(screen.queryByRole('link', { name: '11' })).not.toBeInTheDocument()
   })
+
+  it('shows recent form per side and an empty state for first-time players', async () => {
+    const match = matchDetails({
+      id: 'm-form',
+      status: 'in_progress',
+      sides: [
+        {
+          side_number: 1,
+          players: [
+            { user_id: 'u-me', username: 'me', is_current_user: true },
+          ],
+          games_won: 0,
+          won: null,
+          is_current_user_side: true,
+        },
+        {
+          side_number: 2,
+          players: [
+            { user_id: 'u-rookie', username: 'rookie', is_current_user: false },
+          ],
+          games_won: 0,
+          won: null,
+          is_current_user_side: false,
+        },
+      ],
+      games: [],
+      current_game: null,
+      can_score: false,
+      recent_form: [
+        {
+          user_id: 'u-me',
+          recent_results: [
+            {
+              match_id: 'm-prev-1',
+              is_win: true,
+              player_games_won: 3,
+              opponent_games_won: 1,
+              opponent_username: 'silva.r',
+              completed_at: '2026-05-09T18:00:00Z',
+            },
+            {
+              match_id: 'm-prev-2',
+              is_win: false,
+              player_games_won: 1,
+              opponent_games_won: 3,
+              opponent_username: 'tanaka.y',
+              completed_at: '2026-05-07T18:00:00Z',
+            },
+          ],
+        },
+        { user_id: 'u-rookie', recent_results: [] },
+      ],
+    })
+    server.use(http.get('*/v1/matches/m-form', () => HttpResponse.json(match)))
+
+    const { container } = renderDetails('m-form')
+
+    // Wait for the Players & form card title to render.
+    await waitFor(() =>
+      expect(container.querySelector('.md-card__hd h3')).toHaveTextContent(
+        'Players & form',
+      ),
+    )
+    // My side: 1 W and 1 L with the right opponent / score labels.
+    const myForm = screen.getByTestId('form-1')
+    expect(within(myForm).getByText('Recent form · 1–1')).toBeInTheDocument()
+    expect(within(myForm).getByText('silva.r')).toBeInTheDocument()
+    expect(within(myForm).getByText('3–1')).toBeInTheDocument()
+    expect(within(myForm).getByText('tanaka.y')).toBeInTheDocument()
+    expect(within(myForm).getByText('1–3')).toBeInTheDocument()
+    // Rookie shows the empty state, not a result list.
+    const oppForm = screen.getByTestId('form-2')
+    expect(within(oppForm).getByText(/No prior matches yet/)).toBeInTheDocument()
+    expect(
+      within(oppForm).queryByText(/Recent form · /),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the head-to-head card with prior meetings counted per side', async () => {
+    const match = matchDetails({
+      id: 'm-h2h',
+      status: 'in_progress',
+      sides: [
+        {
+          side_number: 1,
+          players: [
+            { user_id: 'u-me', username: 'me', is_current_user: true },
+          ],
+          games_won: 0,
+          won: null,
+          is_current_user_side: true,
+        },
+        {
+          side_number: 2,
+          players: [
+            { user_id: 'u-opp', username: 'opp', is_current_user: false },
+          ],
+          games_won: 0,
+          won: null,
+          is_current_user_side: false,
+        },
+      ],
+      games: [],
+      current_game: null,
+      can_score: false,
+      head_to_head: {
+        total_meetings: 3,
+        side_1_wins: 2,
+        side_2_wins: 1,
+        recent_meetings: [
+          {
+            match_id: 'm-h2h-3',
+            completed_at: '2026-05-08T18:00:00Z',
+            side_1_games_won: 1,
+            side_2_games_won: 3,
+            winner_side_number: 2,
+          },
+          {
+            match_id: 'm-h2h-2',
+            completed_at: '2026-04-30T18:00:00Z',
+            side_1_games_won: 3,
+            side_2_games_won: 0,
+            winner_side_number: 1,
+          },
+          {
+            match_id: 'm-h2h-1',
+            completed_at: '2026-04-12T18:00:00Z',
+            side_1_games_won: 3,
+            side_2_games_won: 2,
+            winner_side_number: 1,
+          },
+        ],
+      },
+    })
+    server.use(http.get('*/v1/matches/m-h2h', () => HttpResponse.json(match)))
+
+    const { container } = renderDetails('m-h2h')
+
+    await waitFor(() => {
+      const headings = Array.from(container.querySelectorAll('.md-card__hd h3'))
+      expect(headings.map((h) => h.textContent)).toContain('Head to head')
+    })
+    const h2hCard = container.querySelector('.md-h2h')!
+    expect(screen.getByText('3 MEETINGS')).toBeInTheDocument()
+    // Win counts: left = me = 2, right = opp = 1.
+    const counts = h2hCard.querySelectorAll('.md-h2h__count')
+    expect(counts[0]).toHaveTextContent('2')
+    expect(counts[1]).toHaveTextContent('1')
+    // Three rows, newest first; the loss row gets the L marker.
+    const rows = h2hCard.querySelectorAll('.md-h2h__row')
+    expect(rows).toHaveLength(3)
+    expect(rows[0].querySelector('.md-h2h__result--l')).not.toBeNull()
+    expect(rows[1].querySelector('.md-h2h__result--w')).not.toBeNull()
+  })
+
+  it('shows the rating change card when ratings moved', async () => {
+    const match = matchDetails({
+      id: 'm-rated',
+      status: 'completed',
+      status_label: 'Final',
+      affects_rating: true,
+      sides: [
+        {
+          side_number: 1,
+          players: [
+            { user_id: 'u-me', username: 'me', is_current_user: true },
+          ],
+          games_won: 3,
+          won: true,
+          is_current_user_side: true,
+          rating_change: { before: 1500, after: 1512, delta: 12 },
+        },
+        {
+          side_number: 2,
+          players: [
+            { user_id: 'u-opp', username: 'opp', is_current_user: false },
+          ],
+          games_won: 1,
+          won: false,
+          is_current_user_side: false,
+          rating_change: { before: 1500, after: 1488, delta: -12 },
+        },
+      ],
+      games: [],
+      current_game: null,
+      can_score: false,
+    })
+    server.use(http.get('*/v1/matches/m-rated', () => HttpResponse.json(match)))
+
+    const { container } = renderDetails('m-rated')
+
+    await waitFor(() => {
+      const headings = Array.from(container.querySelectorAll('.md-card__hd h3'))
+      expect(headings.map((h) => h.textContent)).toContain('Rating change')
+    })
+    const rows = container.querySelectorAll('.md-rating-row')
+    expect(rows).toHaveLength(2)
+    const [winnerRow, loserRow] = Array.from(rows)
+    expect(
+      winnerRow.querySelector('.md-rating-row__delta-num'),
+    ).toHaveTextContent('+12')
+    expect(
+      winnerRow.querySelector('.md-rating-row__delta-num'),
+    ).toHaveClass('md-delta-up')
+    expect(
+      loserRow.querySelector('.md-rating-row__delta-num'),
+    ).toHaveTextContent('-12')
+    expect(
+      loserRow.querySelector('.md-rating-row__delta-num'),
+    ).toHaveClass('md-delta-down')
+  })
+
+  it('hides the rating change card when no ratings have moved', async () => {
+    const match = matchDetails({
+      id: 'm-unrated',
+      status: 'completed',
+      affects_rating: false,
+    })
+    server.use(
+      http.get('*/v1/matches/m-unrated', () => HttpResponse.json(match)),
+    )
+
+    const { container } = renderDetails('m-unrated')
+
+    await waitFor(() =>
+      expect(container.querySelector('.md-card__hd h3')).toBeInTheDocument(),
+    )
+    const headings = Array.from(container.querySelectorAll('.md-card__hd h3'))
+    expect(headings.map((h) => h.textContent)).not.toContain('Rating change')
+  })
 })

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Link, Navigate, useRouter } from '@tanstack/react-router'
 import {
   Check,
+  ChevronRight,
   Clock,
   Copy,
   Download,
@@ -21,6 +22,9 @@ import { ApiError } from '@/api/client'
 type MatchDetails = components['schemas']['MatchDetails']
 type MatchDetailsGame = components['schemas']['MatchDetailsGame']
 type MatchDetailsSide = components['schemas']['MatchDetailsSide']
+type MatchDetailsFormResult = components['schemas']['MatchDetailsFormResult']
+type MatchDetailsH2H = components['schemas']['MatchDetailsH2H']
+type MatchDetailsH2HMeeting = components['schemas']['MatchDetailsH2HMeeting']
 type RatingChange = components['schemas']['RatingChange']
 
 type HeroState = 'live' | 'final' | 'upcoming'
@@ -28,11 +32,13 @@ type HeroState = 'live' | 'final' | 'upcoming'
 type SideView = {
   sideNumber: number
   username: string
+  userId: string | null
   initials: string
   gamesWon: number
   won: boolean | null
   isCurrentUser: boolean
   ratingChange: RatingChange | null
+  recentForm: MatchDetailsFormResult[]
 }
 
 type GameView = {
@@ -43,6 +49,23 @@ type GameView = {
   // The full score record for an edit-link affordance. Null when the game
   // hasn't been scored yet.
   scoreId: string | null
+}
+
+type H2HMeetingView = {
+  matchId: string
+  completedAt: string
+  leftGamesWon: number
+  rightGamesWon: number
+  // `null` when the prior meeting didn't have a definitive winner; otherwise
+  // the side number in *this* match that took it.
+  winnerSideNumber: number | null
+}
+
+type H2HView = {
+  totalMeetings: number
+  leftWins: number
+  rightWins: number
+  recentMeetings: H2HMeetingView[]
 }
 
 type MatchView = {
@@ -60,18 +83,26 @@ type MatchView = {
   currentGameNumber: number | null
   canScore: boolean
   scoreCta: { matchId: string; gameId: string } | null
+  headToHead: H2HView | null
 }
 
-function projectSide(side: MatchDetailsSide, fallbackLabel: string): SideView {
-  const username = side.players[0]?.username ?? fallbackLabel
+function projectSide(
+  side: MatchDetailsSide,
+  fallbackLabel: string,
+  recentForm: MatchDetailsFormResult[],
+): SideView {
+  const player = side.players[0]
+  const username = player?.username ?? fallbackLabel
   return {
     sideNumber: side.side_number,
     username,
+    userId: player?.user_id ?? null,
     initials: initialsOf(username),
     gamesWon: side.games_won,
     won: side.won,
     isCurrentUser: side.is_current_user_side,
     ratingChange: side.rating_change ?? null,
+    recentForm,
   }
 }
 
@@ -116,6 +147,50 @@ function projectGame(
   }
 }
 
+function formForUser(
+  data: MatchDetails,
+  userId: string | null,
+): MatchDetailsFormResult[] {
+  if (!userId) return []
+  return (
+    data.recent_form?.find((f) => f.user_id === userId)?.recent_results ?? []
+  )
+}
+
+function projectHeadToHead(
+  raw: MatchDetailsH2H | null | undefined,
+  leftSideNumber: number,
+): H2HView | null {
+  if (!raw) return null
+  const rightSideNumber = leftSideNumber === 1 ? 2 : 1
+  const leftWins = leftSideNumber === 1 ? raw.side_1_wins : raw.side_2_wins
+  const rightWins = leftSideNumber === 1 ? raw.side_2_wins : raw.side_1_wins
+  const recentMeetings: H2HMeetingView[] = raw.recent_meetings.map(
+    (m: MatchDetailsH2HMeeting) => ({
+      matchId: m.match_id,
+      completedAt: m.completed_at,
+      leftGamesWon:
+        leftSideNumber === 1 ? m.side_1_games_won : m.side_2_games_won,
+      rightGamesWon:
+        leftSideNumber === 1 ? m.side_2_games_won : m.side_1_games_won,
+      // Winner side number is already framed against *this* match's sides
+      // by the API; re-map only when the viewer perspective swaps left/right.
+      winnerSideNumber:
+        m.winner_side_number === null
+          ? null
+          : m.winner_side_number === leftSideNumber
+            ? leftSideNumber
+            : rightSideNumber,
+    }),
+  )
+  return {
+    totalMeetings: raw.total_meetings,
+    leftWins,
+    rightWins,
+    recentMeetings,
+  }
+}
+
 function projectMatchView(data: MatchDetails, matchId: string): MatchView {
   const state: HeroState =
     data.status === 'in_progress'
@@ -127,8 +202,18 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
   const viewerIsParticipant = leftSide.is_current_user_side
   const leftLabel = viewerIsParticipant ? 'You' : 'Side 1'
   const rightLabel = viewerIsParticipant ? 'Opponent' : 'Side 2'
-  const leftView = projectSide(leftSide, leftLabel)
-  const rightView = rightSide ? projectSide(rightSide, rightLabel) : null
+  const leftView = projectSide(
+    leftSide,
+    leftLabel,
+    formForUser(data, leftSide.players[0]?.user_id ?? null),
+  )
+  const rightView = rightSide
+    ? projectSide(
+        rightSide,
+        rightLabel,
+        formForUser(data, rightSide.players[0]?.user_id ?? null),
+      )
+    : null
   const games = data.games
     .slice()
     .sort((a, b) => a.game_number - b.game_number)
@@ -149,6 +234,7 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
     currentGameNumber: data.current_game?.game_number ?? null,
     canScore: data.can_score,
     scoreCta,
+    headToHead: projectHeadToHead(data.head_to_head, leftView.sideNumber),
   }
 }
 
@@ -222,10 +308,13 @@ function MatchDetailsSkeleton() {
 
 function MatchDetailsPage({ view, matchId }: { view: MatchView; matchId: string }) {
   const [shareOpen, setShareOpen] = useState(false)
-  // Rating sparklines, H2H, comments, and the share modal are part of the
-  // design handoff but have no real data behind them yet. The cards and their
-  // render sites are gated off; flip this once each one's data lands.
+  // Comments + share modal are still part of the design handoff but have no
+  // real data behind them yet; gate them off and flip when each lands.
   const showAuxCards = false
+  const showRatingCard =
+    view.rated &&
+    (view.leftSide.ratingChange !== null ||
+      (view.rightSide?.ratingChange ?? null) !== null)
 
   return (
     <div className="match-details">
@@ -262,8 +351,10 @@ function MatchDetailsPage({ view, matchId }: { view: MatchView; matchId: string 
           </div>
           <aside className="md-col-2__aside">
             <MatchInfoCard view={view} />
-            {showAuxCards && <RatingCard />}
-            {showAuxCards && <H2HCard />}
+            {showRatingCard && <RatingCard view={view} />}
+            {view.headToHead && (
+              <H2HCard view={view} h2h={view.headToHead} />
+            )}
           </aside>
         </div>
 
@@ -574,7 +665,8 @@ function PlayersCard({ view }: { view: MatchView }) {
   return (
     <div className="md-card">
       <div className="md-card__hd">
-        <h3>Players</h3>
+        <h3>Players &amp; form</h3>
+        <span className="md-card__hd-meta">LAST 5 RESULTS</span>
       </div>
       <div className="md-players">
         <PlayerProfile side={view.leftSide} won={view.leftSide.won === true} />
@@ -591,6 +683,9 @@ function PlayersCard({ view }: { view: MatchView }) {
 }
 
 function PlayerProfile({ side, won }: { side: SideView; won: boolean }) {
+  const form = side.recentForm
+  const wins = form.filter((r) => r.is_win).length
+  const losses = form.length - wins
   return (
     <div className="md-profile">
       <div className="md-profile__identity">
@@ -601,7 +696,55 @@ function PlayerProfile({ side, won }: { side: SideView; won: boolean }) {
           <div className="md-profile__name">{side.username}</div>
         </div>
       </div>
+      <div className="md-profile__form" data-testid={`form-${side.sideNumber}`}>
+        <div className="md-kicker">
+          {form.length === 0
+            ? 'Recent form'
+            : `Recent form · ${wins}–${losses}`}
+        </div>
+        {form.length === 0 ? (
+          <div className="md-profile__empty">
+            No prior matches yet — this is{' '}
+            {side.isCurrentUser ? 'your' : 'their'} first one.
+          </div>
+        ) : (
+          <ul className="md-profile__form-list">
+            {form.map((r) => (
+              <FormRow key={r.match_id} result={r} />
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
+  )
+}
+
+function FormRow({ result }: { result: MatchDetailsFormResult }) {
+  const win = result.is_win
+  const score = `${result.player_games_won}–${result.opponent_games_won}`
+  const opponentLabel = result.opponent_username ?? 'No opponent'
+  return (
+    <li className="md-form-row">
+      <span
+        className={cn(
+          'md-form-row__badge',
+          win ? 'md-form-row__badge--w' : 'md-form-row__badge--l',
+        )}
+      >
+        {win ? 'W' : 'L'}
+      </span>
+      <span className="md-form-row__opp" title={opponentLabel}>
+        {opponentLabel}
+      </span>
+      <span
+        className={cn(
+          'md-form-row__score',
+          !win && 'md-form-row__score--loss',
+        )}
+      >
+        {score}
+      </span>
+    </li>
   )
 }
 
@@ -626,12 +769,183 @@ function MatchInfoCard({ view }: { view: MatchView }) {
   )
 }
 
-function RatingCard() {
-  return null
+function RatingCard({ view }: { view: MatchView }) {
+  const sides = [view.leftSide, view.rightSide].filter(
+    (s): s is SideView => s !== null,
+  )
+  return (
+    <div className="md-card">
+      <div className="md-card__hd">
+        <h3>Rating change</h3>
+      </div>
+      <div className="md-card__body md-rating-card__body">
+        {sides.map((side, i) => (
+          <RatingRow key={side.sideNumber} side={side} isFirst={i === 0} />
+        ))}
+      </div>
+    </div>
+  )
 }
 
-function H2HCard() {
-  return null
+function RatingRow({ side, isFirst }: { side: SideView; isFirst: boolean }) {
+  const change = side.ratingChange
+  const won = side.won === true
+  const isPending = change === null
+  return (
+    <>
+      {!isFirst && <hr className="md-rating-divider" />}
+      <div className="md-rating-row">
+        <div
+          className={cn(
+            'md-avatar',
+            won ? 'md-avatar--win' : 'md-avatar--loss',
+          )}
+        >
+          {side.initials}
+        </div>
+        <div className="md-rating-row__text">
+          <div className="md-rating-row__name">{side.username}</div>
+          {change ? (
+            <div className="md-rating-row__numbers">
+              {change.before !== null && (
+                <span className="from">{Math.round(change.before)}</span>
+              )}
+              <ChevronRight size={11} strokeWidth={1.75} />
+              <span className="to">{Math.round(change.after)}</span>
+            </div>
+          ) : (
+            <div className="md-rating-row__numbers">
+              <span className="from">Rating updates when the match ends</span>
+            </div>
+          )}
+        </div>
+        {change && !isPending && (
+          <div className="md-rating-row__delta">
+            <span
+              className={cn(
+                'md-rating-row__delta-num',
+                change.delta >= 0 ? 'md-delta-up' : 'md-delta-down',
+              )}
+            >
+              {formatRatingDelta(change.delta)}
+            </span>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+function H2HCard({ view, h2h }: { view: MatchView; h2h: H2HView }) {
+  const leftLabel = view.leftSide.username
+  const rightLabel = view.rightSide?.username ?? 'Opponent'
+  const totalDecided = h2h.leftWins + h2h.rightWins
+  const leftPct = totalDecided > 0 ? (h2h.leftWins / totalDecided) * 100 : 0
+  const rightPct = totalDecided > 0 ? (h2h.rightWins / totalDecided) * 100 : 0
+  const hasMeetings = h2h.totalMeetings > 0
+  return (
+    <div className="md-card">
+      <div className="md-card__hd">
+        <h3>Head to head</h3>
+        <span className="md-card__hd-meta">
+          {h2h.totalMeetings} {h2h.totalMeetings === 1 ? 'MEETING' : 'MEETINGS'}
+        </span>
+      </div>
+      <div className="md-card__body md-h2h">
+        <div className="md-h2h__counts">
+          <div className="md-h2h__count-block md-h2h__count-block--l">
+            <div
+              className={cn(
+                'md-h2h__count',
+                h2h.leftWins > h2h.rightWins && 'md-h2h__count--win',
+              )}
+            >
+              {h2h.leftWins}
+            </div>
+            <div className="md-h2h__count-label">{leftLabel}</div>
+          </div>
+          <span className="md-h2h__sep">—</span>
+          <div className="md-h2h__count-block md-h2h__count-block--r">
+            <div
+              className={cn(
+                'md-h2h__count',
+                h2h.rightWins > h2h.leftWins && 'md-h2h__count--win',
+              )}
+            >
+              {h2h.rightWins}
+            </div>
+            <div className="md-h2h__count-label">{rightLabel}</div>
+          </div>
+        </div>
+        {hasMeetings ? (
+          <>
+            <div className="md-h2h__bar" aria-hidden="true">
+              <div
+                style={{
+                  width: `${leftPct}%`,
+                  background: 'var(--serve-500)',
+                }}
+              />
+              <div
+                style={{
+                  width: `${rightPct}%`,
+                  background: 'var(--ink-500)',
+                }}
+              />
+            </div>
+            <div>
+              {h2h.recentMeetings.map((m) => (
+                <H2HRow
+                  key={m.matchId}
+                  meeting={m}
+                  leftSideNumber={view.leftSide.sideNumber}
+                />
+              ))}
+            </div>
+          </>
+        ) : (
+          <div className="md-h2h__empty">
+            No prior meetings — this match is the start of the rivalry.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function H2HRow({
+  meeting,
+  leftSideNumber,
+}: {
+  meeting: H2HMeetingView
+  leftSideNumber: number
+}) {
+  const leftWon = meeting.winnerSideNumber === leftSideNumber
+  const scoreLabel = `${meeting.leftGamesWon}–${meeting.rightGamesWon}`
+  return (
+    <div className="md-h2h__row">
+      <span className="md-h2h__date">
+        {new Date(meeting.completedAt).toISOString().slice(0, 10)}
+      </span>
+      <span className="md-h2h__label">Match</span>
+      <span
+        className={cn(
+          'md-h2h__score',
+          leftWon && 'md-h2h__score--win',
+        )}
+      >
+        {scoreLabel}
+      </span>
+      <span
+        className={cn(
+          'md-h2h__result',
+          leftWon ? 'md-h2h__result--w' : 'md-h2h__result--l',
+        )}
+      >
+        {leftWon ? 'W' : 'L'}
+      </span>
+    </div>
+  )
 }
 
 function CommentsCard() {

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -14,6 +14,7 @@ import {
 
 import { AppShell } from '@/components/app-shell'
 import { cn, initialsOf } from '@/lib/utils'
+import { fmtDateShort } from '@/lib/dates'
 import { formatRatingDelta } from '@/lib/rating'
 import { scoringEditRoute, scoringNewRoute, useMatch } from '@/api/matches'
 import type { components } from '@/api/schema'
@@ -56,8 +57,6 @@ type H2HMeetingView = {
   completedAt: string
   leftGamesWon: number
   rightGamesWon: number
-  // `null` when the prior meeting didn't have a definitive winner; otherwise
-  // the side number in *this* match that took it.
   winnerSideNumber: number | null
 }
 
@@ -162,31 +161,22 @@ function projectHeadToHead(
   leftSideNumber: number,
 ): H2HView | null {
   if (!raw) return null
-  const rightSideNumber = leftSideNumber === 1 ? 2 : 1
-  const leftWins = leftSideNumber === 1 ? raw.side_1_wins : raw.side_2_wins
-  const rightWins = leftSideNumber === 1 ? raw.side_2_wins : raw.side_1_wins
+  const swap = leftSideNumber !== 1
   const recentMeetings: H2HMeetingView[] = raw.recent_meetings.map(
     (m: MatchDetailsH2HMeeting) => ({
       matchId: m.match_id,
       completedAt: m.completed_at,
-      leftGamesWon:
-        leftSideNumber === 1 ? m.side_1_games_won : m.side_2_games_won,
-      rightGamesWon:
-        leftSideNumber === 1 ? m.side_2_games_won : m.side_1_games_won,
-      // Winner side number is already framed against *this* match's sides
-      // by the API; re-map only when the viewer perspective swaps left/right.
-      winnerSideNumber:
-        m.winner_side_number === null
-          ? null
-          : m.winner_side_number === leftSideNumber
-            ? leftSideNumber
-            : rightSideNumber,
+      leftGamesWon: swap ? m.side_2_games_won : m.side_1_games_won,
+      rightGamesWon: swap ? m.side_1_games_won : m.side_2_games_won,
+      // API frames winner_side_number against *this* match's sides, which
+      // are also our left/right anchor — no remap needed.
+      winnerSideNumber: m.winner_side_number,
     }),
   )
   return {
     totalMeetings: raw.total_meetings,
-    leftWins,
-    rightWins,
+    leftWins: swap ? raw.side_2_wins : raw.side_1_wins,
+    rightWins: swap ? raw.side_1_wins : raw.side_2_wins,
     recentMeetings,
   }
 }
@@ -312,9 +302,8 @@ function MatchDetailsPage({ view, matchId }: { view: MatchView; matchId: string 
   // real data behind them yet; gate them off and flip when each lands.
   const showAuxCards = false
   const showRatingCard =
-    view.rated &&
-    (view.leftSide.ratingChange !== null ||
-      (view.rightSide?.ratingChange ?? null) !== null)
+    view.leftSide.ratingChange !== null ||
+    view.rightSide?.ratingChange != null
 
   return (
     <div className="match-details">
@@ -790,7 +779,6 @@ function RatingCard({ view }: { view: MatchView }) {
 function RatingRow({ side, isFirst }: { side: SideView; isFirst: boolean }) {
   const change = side.ratingChange
   const won = side.won === true
-  const isPending = change === null
   return (
     <>
       {!isFirst && <hr className="md-rating-divider" />}
@@ -819,7 +807,7 @@ function RatingRow({ side, isFirst }: { side: SideView; isFirst: boolean }) {
             </div>
           )}
         </div>
-        {change && !isPending && (
+        {change && (
           <div className="md-rating-row__delta">
             <span
               className={cn(
@@ -839,9 +827,6 @@ function RatingRow({ side, isFirst }: { side: SideView; isFirst: boolean }) {
 function H2HCard({ view, h2h }: { view: MatchView; h2h: H2HView }) {
   const leftLabel = view.leftSide.username
   const rightLabel = view.rightSide?.username ?? 'Opponent'
-  const totalDecided = h2h.leftWins + h2h.rightWins
-  const leftPct = totalDecided > 0 ? (h2h.leftWins / totalDecided) * 100 : 0
-  const rightPct = totalDecided > 0 ? (h2h.rightWins / totalDecided) * 100 : 0
   const hasMeetings = h2h.totalMeetings > 0
   return (
     <div className="md-card">
@@ -878,31 +863,7 @@ function H2HCard({ view, h2h }: { view: MatchView; h2h: H2HView }) {
           </div>
         </div>
         {hasMeetings ? (
-          <>
-            <div className="md-h2h__bar" aria-hidden="true">
-              <div
-                style={{
-                  width: `${leftPct}%`,
-                  background: 'var(--serve-500)',
-                }}
-              />
-              <div
-                style={{
-                  width: `${rightPct}%`,
-                  background: 'var(--ink-500)',
-                }}
-              />
-            </div>
-            <div>
-              {h2h.recentMeetings.map((m) => (
-                <H2HRow
-                  key={m.matchId}
-                  meeting={m}
-                  leftSideNumber={view.leftSide.sideNumber}
-                />
-              ))}
-            </div>
-          </>
+          <H2HMeetings h2h={h2h} leftSideNumber={view.leftSide.sideNumber} />
         ) : (
           <div className="md-h2h__empty">
             No prior meetings — this match is the start of the rivalry.
@@ -910,6 +871,31 @@ function H2HCard({ view, h2h }: { view: MatchView; h2h: H2HView }) {
         )}
       </div>
     </div>
+  )
+}
+
+function H2HMeetings({
+  h2h,
+  leftSideNumber,
+}: {
+  h2h: H2HView
+  leftSideNumber: number
+}) {
+  const totalDecided = h2h.leftWins + h2h.rightWins
+  const leftPct = totalDecided > 0 ? (h2h.leftWins / totalDecided) * 100 : 0
+  const rightPct = totalDecided > 0 ? (h2h.rightWins / totalDecided) * 100 : 0
+  return (
+    <>
+      <div className="md-h2h__bar" aria-hidden="true">
+        <div style={{ width: `${leftPct}%`, background: 'var(--serve-500)' }} />
+        <div style={{ width: `${rightPct}%`, background: 'var(--ink-500)' }} />
+      </div>
+      <div>
+        {h2h.recentMeetings.map((m) => (
+          <H2HRow key={m.matchId} meeting={m} leftSideNumber={leftSideNumber} />
+        ))}
+      </div>
+    </>
   )
 }
 
@@ -921,20 +907,14 @@ function H2HRow({
   leftSideNumber: number
 }) {
   const leftWon = meeting.winnerSideNumber === leftSideNumber
-  const scoreLabel = `${meeting.leftGamesWon}–${meeting.rightGamesWon}`
   return (
     <div className="md-h2h__row">
-      <span className="md-h2h__date">
-        {new Date(meeting.completedAt).toISOString().slice(0, 10)}
-      </span>
+      <span className="md-h2h__date">{fmtDateShort(meeting.completedAt)}</span>
       <span className="md-h2h__label">Match</span>
       <span
-        className={cn(
-          'md-h2h__score',
-          leftWon && 'md-h2h__score--win',
-        )}
+        className={cn('md-h2h__score', leftWon && 'md-h2h__score--win')}
       >
-        {scoreLabel}
+        {meeting.leftGamesWon}–{meeting.rightGamesWon}
       </span>
       <span
         className={cn(

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2155,6 +2155,16 @@ body.dark.fortymm-theme {
 .fortymm-theme .md-card__body {
   padding: 18px;
 }
+.fortymm-theme .md-card__hd-meta {
+  font: 500 11px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.12em;
+}
+.fortymm-theme .md-rating-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
 
 /* ---------- Avatar ---------- */
 .fortymm-theme .md-avatar {
@@ -2683,6 +2693,24 @@ body.dark.fortymm-theme {
 .fortymm-theme .md-form-row__score--loss {
   color: var(--fg-3);
 }
+.fortymm-theme .md-profile__form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.fortymm-theme .md-profile__form-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+.fortymm-theme .md-profile__empty {
+  font: 400 13px var(--font-ui);
+  color: var(--fg-3);
+  padding: 8px 0;
+  border-top: 1px dashed var(--border-subtle);
+}
 .fortymm-theme .md-profile__career {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -2796,6 +2824,12 @@ body.dark.fortymm-theme {
   align-items: center;
   gap: 12px;
 }
+.fortymm-theme .md-h2h__count-block--l {
+  text-align: right;
+}
+.fortymm-theme .md-h2h__count-block--r {
+  text-align: left;
+}
 .fortymm-theme .md-h2h__count {
   font: 700 28px var(--font-mono);
   font-variant-numeric: tabular-nums;
@@ -2871,6 +2905,10 @@ body.dark.fortymm-theme {
 }
 .fortymm-theme .md-h2h__result--l {
   color: var(--loss);
+}
+.fortymm-theme .md-h2h__empty {
+  font: 400 13px var(--font-ui);
+  color: var(--fg-3);
 }
 
 /* ---------- Comments ---------- */

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -4,6 +4,10 @@ type MatchStatus = components['schemas']['MatchStatus']
 type MatchDetails = components['schemas']['MatchDetails']
 type MatchDetailsSide = components['schemas']['MatchDetailsSide']
 type MatchDetailsGame = components['schemas']['MatchDetailsGame']
+type MatchDetailsPlayerForm = components['schemas']['MatchDetailsPlayerForm']
+type MatchDetailsFormResult = components['schemas']['MatchDetailsFormResult']
+type MatchDetailsH2H = components['schemas']['MatchDetailsH2H']
+type MatchDetailsH2HMeeting = components['schemas']['MatchDetailsH2HMeeting']
 type MatchListRow = components['schemas']['MatchListRow']
 type MatchLeague = components['schemas']['MatchLeague']
 type DashboardScoreBanner = components['schemas']['DashboardScoreBanner']
@@ -15,6 +19,8 @@ type RatingChange = components['schemas']['RatingChange']
 
 const MOCK_BASE_RATING = 1500
 const MOCK_RATING_DELTA = 8
+const RECENT_FORM_LIMIT = 5
+const H2H_LIMIT = 5
 
 function ratingChangeFor(seedId: string, won: boolean): RatingChange {
   // Deterministic so re-renders are stable.
@@ -202,6 +208,95 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
       ? { id: current.id, game_number: current.game_number }
       : null,
     can_score: current !== null && opponentSide !== null,
+    recent_form: projectRecentForm(seed),
+    head_to_head: projectHeadToHead(seed),
+  }
+}
+
+function priorCompleted(seed: SeedMatch): SeedMatch[] {
+  return mockMatches
+    .filter(
+      (m): m is SeedMatch & { completed_at: string } =>
+        m.status === 'completed' &&
+        m.completed_at !== null &&
+        m.id !== seed.id,
+    )
+    .sort((a, b) => b.completed_at.localeCompare(a.completed_at))
+}
+
+function recentResultsFor(
+  userId: string,
+  seeds: SeedMatch[],
+): MatchDetailsFormResult[] {
+  const results: MatchDetailsFormResult[] = []
+  for (const m of seeds) {
+    // The mock current-user always sits on side 1; everyone else's matches
+    // are inferred from `m.opponent.id`.
+    const onSide1 = userId === MOCK_CURRENT_USER.id
+    const onSide2 = m.opponent !== null && m.opponent.id === userId
+    if (!onSide1 && !onSide2) continue
+    const { side1, side2 } = sideWinCounts(m)
+    const won = onSide1 ? side1 > side2 : side2 > side1
+    const playerGames = onSide1 ? side1 : side2
+    const opponentGames = onSide1 ? side2 : side1
+    const opponentUsername = onSide1
+      ? (m.opponent?.username ?? null)
+      : MOCK_CURRENT_USER.username
+    results.push({
+      match_id: m.id,
+      is_win: won,
+      player_games_won: playerGames,
+      opponent_games_won: opponentGames,
+      opponent_username: opponentUsername,
+      completed_at: m.completed_at ?? m.created_at,
+    })
+    if (results.length === RECENT_FORM_LIMIT) break
+  }
+  return results
+}
+
+function projectRecentForm(seed: SeedMatch): MatchDetailsPlayerForm[] {
+  const completed = priorCompleted(seed)
+  const userIds = [
+    MOCK_CURRENT_USER.id,
+    ...(seed.opponent ? [seed.opponent.id] : []),
+  ]
+  return userIds.map((user_id) => ({
+    user_id,
+    recent_results: recentResultsFor(user_id, completed),
+  }))
+}
+
+function projectHeadToHead(seed: SeedMatch): MatchDetailsH2H | null {
+  if (seed.opponent === null) return null
+  const completed = priorCompleted(seed).filter(
+    (m) => m.opponent !== null && m.opponent.id === seed.opponent!.id,
+  )
+  const meetings: MatchDetailsH2HMeeting[] = []
+  let side1Wins = 0
+  let side2Wins = 0
+  for (const m of completed) {
+    const { side1, side2 } = sideWinCounts(m)
+    // In the seed model the current user is always on side 1 of every past
+    // match — same orientation as the current match — so per-row counts
+    // line up directly with this match's side numbers.
+    const winner: number | null =
+      side1 > side2 ? 1 : side2 > side1 ? 2 : null
+    if (winner === 1) side1Wins += 1
+    if (winner === 2) side2Wins += 1
+    meetings.push({
+      match_id: m.id,
+      completed_at: m.completed_at ?? m.created_at,
+      side_1_games_won: side1,
+      side_2_games_won: side2,
+      winner_side_number: winner,
+    })
+  }
+  return {
+    total_meetings: meetings.length,
+    side_1_wins: side1Wins,
+    side_2_wins: side2Wins,
+    recent_meetings: meetings.slice(0, H2H_LIMIT),
   }
 }
 

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -192,6 +192,7 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
     }))
 
   const current = currentUnscored(seed)
+  const priors = priorCompleted(seed)
   return {
     id: seed.id,
     status: seed.status,
@@ -208,8 +209,8 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
       ? { id: current.id, game_number: current.game_number }
       : null,
     can_score: current !== null && opponentSide !== null,
-    recent_form: projectRecentForm(seed),
-    head_to_head: projectHeadToHead(seed),
+    recent_form: projectRecentForm(seed, priors),
+    head_to_head: projectHeadToHead(seed, priors),
   }
 }
 
@@ -224,64 +225,72 @@ function priorCompleted(seed: SeedMatch): SeedMatch[] {
     .sort((a, b) => b.completed_at.localeCompare(a.completed_at))
 }
 
-function recentResultsFor(
-  userId: string,
-  seeds: SeedMatch[],
-): MatchDetailsFormResult[] {
-  const results: MatchDetailsFormResult[] = []
-  for (const m of seeds) {
-    // The mock current-user always sits on side 1; everyone else's matches
-    // are inferred from `m.opponent.id`.
-    const onSide1 = userId === MOCK_CURRENT_USER.id
-    const onSide2 = m.opponent !== null && m.opponent.id === userId
-    if (!onSide1 && !onSide2) continue
-    const { side1, side2 } = sideWinCounts(m)
-    const won = onSide1 ? side1 > side2 : side2 > side1
-    const playerGames = onSide1 ? side1 : side2
-    const opponentGames = onSide1 ? side2 : side1
-    const opponentUsername = onSide1
-      ? (m.opponent?.username ?? null)
-      : MOCK_CURRENT_USER.username
-    results.push({
-      match_id: m.id,
-      is_win: won,
-      player_games_won: playerGames,
-      opponent_games_won: opponentGames,
-      opponent_username: opponentUsername,
-      completed_at: m.completed_at ?? m.created_at,
-    })
-    if (results.length === RECENT_FORM_LIMIT) break
-  }
-  return results
+function winnerOf(seed: SeedMatch): 1 | 2 | null {
+  const { side1, side2 } = sideWinCounts(seed)
+  if (side1 > side2) return 1
+  if (side2 > side1) return 2
+  return null
 }
 
-function projectRecentForm(seed: SeedMatch): MatchDetailsPlayerForm[] {
-  const completed = priorCompleted(seed)
+function seedResultForUser(
+  userId: string,
+  m: SeedMatch,
+): MatchDetailsFormResult | null {
+  // The mock current-user always sits on side 1; everyone else's matches
+  // are inferred from `m.opponent.id`.
+  const onSide1 = userId === MOCK_CURRENT_USER.id
+  const onSide2 = m.opponent !== null && m.opponent.id === userId
+  if (!onSide1 && !onSide2) return null
+  const { side1, side2 } = sideWinCounts(m)
+  return {
+    match_id: m.id,
+    is_win: onSide1 ? side1 > side2 : side2 > side1,
+    player_games_won: onSide1 ? side1 : side2,
+    opponent_games_won: onSide1 ? side2 : side1,
+    opponent_username: onSide1
+      ? (m.opponent?.username ?? null)
+      : MOCK_CURRENT_USER.username,
+    completed_at: m.completed_at ?? m.created_at,
+  }
+}
+
+function projectRecentForm(
+  seed: SeedMatch,
+  priors: SeedMatch[],
+): MatchDetailsPlayerForm[] {
   const userIds = [
     MOCK_CURRENT_USER.id,
     ...(seed.opponent ? [seed.opponent.id] : []),
   ]
-  return userIds.map((user_id) => ({
-    user_id,
-    recent_results: recentResultsFor(user_id, completed),
-  }))
+  return userIds.map((user_id) => {
+    const recent_results: MatchDetailsFormResult[] = []
+    for (const m of priors) {
+      const row = seedResultForUser(user_id, m)
+      if (row) recent_results.push(row)
+      if (recent_results.length === RECENT_FORM_LIMIT) break
+    }
+    return { user_id, recent_results }
+  })
 }
 
-function projectHeadToHead(seed: SeedMatch): MatchDetailsH2H | null {
+function projectHeadToHead(
+  seed: SeedMatch,
+  priors: SeedMatch[],
+): MatchDetailsH2H | null {
   if (seed.opponent === null) return null
-  const completed = priorCompleted(seed).filter(
-    (m) => m.opponent !== null && m.opponent.id === seed.opponent!.id,
+  const opponentId = seed.opponent.id
+  const completed = priors.filter(
+    (m) => m.opponent !== null && m.opponent.id === opponentId,
   )
   const meetings: MatchDetailsH2HMeeting[] = []
   let side1Wins = 0
   let side2Wins = 0
+  // The mock current-user always sits on side 1 of every past match (same
+  // orientation as the current match), so per-row counts align with this
+  // match's side numbers without remapping.
   for (const m of completed) {
     const { side1, side2 } = sideWinCounts(m)
-    // In the seed model the current user is always on side 1 of every past
-    // match — same orientation as the current match — so per-row counts
-    // line up directly with this match's side numbers.
-    const winner: number | null =
-      side1 > side2 ? 1 : side2 > side1 ? 2 : null
+    const winner = winnerOf(m)
     if (winner === 1) side1Wins += 1
     if (winner === 2) side2Wins += 1
     meetings.push({

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -200,6 +200,20 @@ export function matchDetails(
     games: [firstGame],
     current_game: { id: firstGame.id, game_number: 1 },
     can_score: true,
+    recent_form: (opponentSide ? [mySide, opponentSide] : [mySide]).map(
+      (s) => ({
+        user_id: s.players[0]?.user_id ?? nextId('u'),
+        recent_results: [],
+      }),
+    ),
+    head_to_head: opponentSide
+      ? {
+          total_meetings: 0,
+          side_1_wins: 0,
+          side_2_wins: 0,
+          recent_meetings: [],
+        }
+      : null,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary
- Renames the Players panel to **Players & form** and shows each side's last 5 completed matches (W/L, opponent, score) with an empty state for first-time players.
- Adds a **Head to head** sidebar card with prior meetings between the two players, totals + recent rows + empty state.
- Adds a **Rating change** sidebar card (pre→post + signed delta) that renders only when the match has actually moved ratings.
- Extends `GET /v1/matches/{id}` and the score-write endpoints with `recent_form` and `head_to_head` rollups; new \`ViewExtras\` bundles them through \`_serialize_details\`.
- Lean eager-load options for history queries (no \`match_settings\` / \`league.rating_strategy\` per past row); SQL-side LIMITs on form + H2H rows; H2H totals/wins via a dedicated aggregate query so the displayed window can't undercount a long rivalry.

## Test plan
- [x] \`pytest\` — 204 passed
- [x] \`npm run test:run\` (web-client vitest) — 47 passed
- [x] \`npm run lint && npm run build\` — green
- [x] \`npm run test:e2e\` (web-client Playwright) — 126 passed
- [x] OpenAPI types regenerated — no drift
- [x] UI smoke-checked in dev (mock store): completed + in-progress matches render the three sections correctly, including empty states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)