### PR TITLE
Set per-route page titles

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>web-client</title>
+    <title>FortyMM</title>
   </head>
   <body class="dark fortymm-theme">
     <div id="root"></div>

--- a/web-client/src/lib/page-title.ts
+++ b/web-client/src/lib/page-title.ts
@@ -1,0 +1,5 @@
+export const BRAND = 'FortyMM'
+
+export function pageTitle(label?: string): string {
+  return label ? `${label} · ${BRAND}` : BRAND
+}

--- a/web-client/src/routes/__root.tsx
+++ b/web-client/src/routes/__root.tsx
@@ -1,4 +1,8 @@
-import { Outlet, createRootRouteWithContext } from '@tanstack/react-router'
+import {
+  HeadContent,
+  Outlet,
+  createRootRouteWithContext,
+} from '@tanstack/react-router'
 import type { QueryClient } from '@tanstack/react-query'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { ServiceWorkerUpdater } from '@/components/service-worker-updater'
@@ -8,12 +12,16 @@ export interface RouterContext {
 }
 
 export const Route = createRootRouteWithContext<RouterContext>()({
+  head: () => ({
+    meta: [{ title: 'FortyMM' }],
+  }),
   component: RootComponent,
 })
 
 function RootComponent() {
   return (
     <>
+      <HeadContent />
       <Outlet />
       <ServiceWorkerUpdater />
       <TanStackRouterDevtools />

--- a/web-client/src/routes/__root.tsx
+++ b/web-client/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import {
 import type { QueryClient } from '@tanstack/react-query'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { ServiceWorkerUpdater } from '@/components/service-worker-updater'
+import { pageTitle } from '@/lib/page-title'
 
 export interface RouterContext {
   queryClient: QueryClient
@@ -13,7 +14,7 @@ export interface RouterContext {
 
 export const Route = createRootRouteWithContext<RouterContext>()({
   head: () => ({
-    meta: [{ title: 'FortyMM' }],
+    meta: [{ title: pageTitle() }],
   }),
   component: RootComponent,
 })

--- a/web-client/src/routes/admin.index.tsx
+++ b/web-client/src/routes/admin.index.tsx
@@ -2,6 +2,9 @@ import { createFileRoute } from '@tanstack/react-router'
 import { SystemHealth } from '@/components/system-health'
 
 export const Route = createFileRoute('/admin/')({
+  head: () => ({
+    meta: [{ title: 'Administration · FortyMM' }],
+  }),
   component: AdminOverview,
 })
 

--- a/web-client/src/routes/admin.index.tsx
+++ b/web-client/src/routes/admin.index.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { SystemHealth } from '@/components/system-health'
+import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute('/admin/')({
   head: () => ({
-    meta: [{ title: 'Administration · FortyMM' }],
+    meta: [{ title: pageTitle('Administration') }],
   }),
   component: AdminOverview,
 })

--- a/web-client/src/routes/admin.permissions.tsx
+++ b/web-client/src/routes/admin.permissions.tsx
@@ -2,5 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import { PermissionsPage } from '@/components/rbac/permissions-page'
 
 export const Route = createFileRoute('/admin/permissions')({
+  head: () => ({
+    meta: [{ title: 'Permissions · Admin · FortyMM' }],
+  }),
   component: PermissionsPage,
 })

--- a/web-client/src/routes/admin.permissions.tsx
+++ b/web-client/src/routes/admin.permissions.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { PermissionsPage } from '@/components/rbac/permissions-page'
+import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute('/admin/permissions')({
   head: () => ({
-    meta: [{ title: 'Permissions · Admin · FortyMM' }],
+    meta: [{ title: pageTitle('Permissions · Admin') }],
   }),
   component: PermissionsPage,
 })

--- a/web-client/src/routes/admin.roles.tsx
+++ b/web-client/src/routes/admin.roles.tsx
@@ -2,5 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import { RolesPage } from '@/components/rbac/roles-page'
 
 export const Route = createFileRoute('/admin/roles')({
+  head: () => ({
+    meta: [{ title: 'Roles · Admin · FortyMM' }],
+  }),
   component: RolesPage,
 })

--- a/web-client/src/routes/admin.roles.tsx
+++ b/web-client/src/routes/admin.roles.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { RolesPage } from '@/components/rbac/roles-page'
+import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute('/admin/roles')({
   head: () => ({
-    meta: [{ title: 'Roles · Admin · FortyMM' }],
+    meta: [{ title: pageTitle('Roles · Admin') }],
   }),
   component: RolesPage,
 })

--- a/web-client/src/routes/admin.users.tsx
+++ b/web-client/src/routes/admin.users.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { UsersPage } from '@/components/rbac/users-page'
+import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute('/admin/users')({
   head: () => ({
-    meta: [{ title: 'Users · Admin · FortyMM' }],
+    meta: [{ title: pageTitle('Users · Admin') }],
   }),
   component: UsersPage,
 })

--- a/web-client/src/routes/admin.users.tsx
+++ b/web-client/src/routes/admin.users.tsx
@@ -2,5 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import { UsersPage } from '@/components/rbac/users-page'
 
 export const Route = createFileRoute('/admin/users')({
+  head: () => ({
+    meta: [{ title: 'Users · Admin · FortyMM' }],
+  }),
   component: UsersPage,
 })

--- a/web-client/src/routes/dashboard.tsx
+++ b/web-client/src/routes/dashboard.tsx
@@ -3,6 +3,9 @@ import { AppShell } from '@/components/app-shell'
 import { DashboardPage } from '@/components/dashboard/dashboard-page'
 
 export const Route = createFileRoute('/dashboard')({
+  head: () => ({
+    meta: [{ title: 'Dashboard · FortyMM' }],
+  }),
   component: DashboardRoute,
 })
 

--- a/web-client/src/routes/dashboard.tsx
+++ b/web-client/src/routes/dashboard.tsx
@@ -1,10 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { AppShell } from '@/components/app-shell'
 import { DashboardPage } from '@/components/dashboard/dashboard-page'
+import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute('/dashboard')({
   head: () => ({
-    meta: [{ title: 'Dashboard · FortyMM' }],
+    meta: [{ title: pageTitle('Dashboard') }],
   }),
   component: DashboardRoute,
 })

--- a/web-client/src/routes/design-system.tsx
+++ b/web-client/src/routes/design-system.tsx
@@ -194,10 +194,11 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { Calendar } from '@/components/ui/calendar'
+import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute('/design-system')({
   head: () => ({
-    meta: [{ title: 'Design system · FortyMM' }],
+    meta: [{ title: pageTitle('Design system') }],
   }),
   component: DesignSystemPage,
 })

--- a/web-client/src/routes/design-system.tsx
+++ b/web-client/src/routes/design-system.tsx
@@ -196,6 +196,9 @@ import {
 import { Calendar } from '@/components/ui/calendar'
 
 export const Route = createFileRoute('/design-system')({
+  head: () => ({
+    meta: [{ title: 'Design system · FortyMM' }],
+  }),
   component: DesignSystemPage,
 })
 

--- a/web-client/src/routes/index.tsx
+++ b/web-client/src/routes/index.tsx
@@ -1,10 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { sessionQueryOptions } from '@/api/session'
+import { BRAND } from '@/lib/page-title'
 import App from '../App'
 
 export const Route = createFileRoute('/')({
   head: () => ({
-    meta: [{ title: 'FortyMM — table tennis, properly tracked' }],
+    meta: [{ title: `${BRAND} — table tennis, properly tracked` }],
   }),
   loader: ({ context: { queryClient } }) => {
     void queryClient.prefetchQuery(sessionQueryOptions())

--- a/web-client/src/routes/index.tsx
+++ b/web-client/src/routes/index.tsx
@@ -3,6 +3,9 @@ import { sessionQueryOptions } from '@/api/session'
 import App from '../App'
 
 export const Route = createFileRoute('/')({
+  head: () => ({
+    meta: [{ title: 'FortyMM — table tennis, properly tracked' }],
+  }),
   loader: ({ context: { queryClient } }) => {
     void queryClient.prefetchQuery(sessionQueryOptions())
   },

--- a/web-client/src/routes/matches.$matchId.games.$gameId.scores.$scoreId.edit.tsx
+++ b/web-client/src/routes/matches.$matchId.games.$gameId.scores.$scoreId.edit.tsx
@@ -1,12 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ScoreEntry } from '@/components/matches/score-entry'
 import { useUpdateScore } from '@/api/matches'
+import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute(
   '/matches/$matchId/games/$gameId/scores/$scoreId/edit',
 )({
   head: () => ({
-    meta: [{ title: 'Edit score · FortyMM' }],
+    meta: [{ title: pageTitle('Edit score') }],
   }),
   component: ScoreEditRoute,
 })

--- a/web-client/src/routes/matches.$matchId.games.$gameId.scores.$scoreId.edit.tsx
+++ b/web-client/src/routes/matches.$matchId.games.$gameId.scores.$scoreId.edit.tsx
@@ -5,6 +5,9 @@ import { useUpdateScore } from '@/api/matches'
 export const Route = createFileRoute(
   '/matches/$matchId/games/$gameId/scores/$scoreId/edit',
 )({
+  head: () => ({
+    meta: [{ title: 'Edit score · FortyMM' }],
+  }),
   component: ScoreEditRoute,
 })
 

--- a/web-client/src/routes/matches.$matchId.games.$gameId.scores.new.tsx
+++ b/web-client/src/routes/matches.$matchId.games.$gameId.scores.new.tsx
@@ -1,12 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ScoreEntry } from '@/components/matches/score-entry'
 import { useCreateScore } from '@/api/matches'
+import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute(
   '/matches/$matchId/games/$gameId/scores/new',
 )({
   head: () => ({
-    meta: [{ title: 'Enter score · FortyMM' }],
+    meta: [{ title: pageTitle('Enter score') }],
   }),
   component: ScoreCreateRoute,
 })

--- a/web-client/src/routes/matches.$matchId.games.$gameId.scores.new.tsx
+++ b/web-client/src/routes/matches.$matchId.games.$gameId.scores.new.tsx
@@ -5,6 +5,9 @@ import { useCreateScore } from '@/api/matches'
 export const Route = createFileRoute(
   '/matches/$matchId/games/$gameId/scores/new',
 )({
+  head: () => ({
+    meta: [{ title: 'Enter score · FortyMM' }],
+  }),
   component: ScoreCreateRoute,
 })
 

--- a/web-client/src/routes/matches.$matchId.index.tsx
+++ b/web-client/src/routes/matches.$matchId.index.tsx
@@ -3,10 +3,11 @@ import {
   MatchDetailsError,
   MatchDetailsView,
 } from '@/components/matches/match-details-page'
+import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute('/matches/$matchId/')({
   head: () => ({
-    meta: [{ title: 'Match · FortyMM' }],
+    meta: [{ title: pageTitle('Match') }],
   }),
   component: MatchDetailsRoute,
   errorComponent: MatchDetailsError,

--- a/web-client/src/routes/matches.$matchId.index.tsx
+++ b/web-client/src/routes/matches.$matchId.index.tsx
@@ -5,6 +5,9 @@ import {
 } from '@/components/matches/match-details-page'
 
 export const Route = createFileRoute('/matches/$matchId/')({
+  head: () => ({
+    meta: [{ title: 'Match · FortyMM' }],
+  }),
   component: MatchDetailsRoute,
   errorComponent: MatchDetailsError,
 })

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -50,6 +50,9 @@ import './index.css'
 type MatchListRowSide = components['schemas']['MatchDetailsSide']
 
 export const Route = createFileRoute('/matches/')({
+  head: () => ({
+    meta: [{ title: 'Matches · FortyMM' }],
+  }),
   component: MatchesPage,
 })
 

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -43,6 +43,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { pageTitle } from '@/lib/page-title'
 import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { cn, initialsOf } from '@/lib/utils'
 import './index.css'
@@ -51,7 +52,7 @@ type MatchListRowSide = components['schemas']['MatchDetailsSide']
 
 export const Route = createFileRoute('/matches/')({
   head: () => ({
-    meta: [{ title: 'Matches · FortyMM' }],
+    meta: [{ title: pageTitle('Matches') }],
   }),
   component: MatchesPage,
 })

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -14,13 +14,14 @@ import {
   type Player,
 } from '@/api/matches'
 import { OpponentPickerBoundary } from '@/components/matches/opponent-picker-boundary'
+import { pageTitle } from '@/lib/page-title'
 import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { cn } from '@/lib/utils'
 import './new.css'
 
 export const Route = createFileRoute('/matches/new')({
   head: () => ({
-    meta: [{ title: 'New match · FortyMM' }],
+    meta: [{ title: pageTitle('New match') }],
   }),
   component: NewMatchPage,
 })

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -19,6 +19,9 @@ import { cn } from '@/lib/utils'
 import './new.css'
 
 export const Route = createFileRoute('/matches/new')({
+  head: () => ({
+    meta: [{ title: 'New match · FortyMM' }],
+  }),
   component: NewMatchPage,
 })
 

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -14,11 +14,12 @@ import {
 import { createFileRoute, useRouterState } from '@tanstack/react-router'
 
 import { AppShell } from '@/components/app-shell'
+import { pageTitle } from '@/lib/page-title'
 import './settings.css'
 
 export const Route = createFileRoute('/settings')({
   head: () => ({
-    meta: [{ title: 'Settings · FortyMM' }],
+    meta: [{ title: pageTitle('Settings') }],
   }),
   component: SettingsPage,
 })

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -17,6 +17,9 @@ import { AppShell } from '@/components/app-shell'
 import './settings.css'
 
 export const Route = createFileRoute('/settings')({
+  head: () => ({
+    meta: [{ title: 'Settings · FortyMM' }],
+  }),
   component: SettingsPage,
 })
 


### PR DESCRIPTION
## Summary

- Replaces the static `web-client` document title with per-route titles via TanStack Router's `head` API + `<HeadContent />` in `__root.tsx`.
- Adds `src/lib/page-title.ts` with `BRAND` and `pageTitle(label?)` so the `· FortyMM` brand suffix lives in one place instead of being hand-typed at every route.
- `index.html` default title becomes `FortyMM` (covers the brief moment before the router resolves).

Sample titles after the change:
- `/` → `FortyMM — table tennis, properly tracked`
- `/dashboard` → `Dashboard · FortyMM`
- `/matches/new` → `New match · FortyMM`
- `/admin/users` → `Users · Admin · FortyMM`

## Test plan

- [x] \`npm run build\` (tsc + vite) — clean
- [x] \`npm run lint\` — clean (one pre-existing warning in mockServiceWorker.js)
- [x] \`npm run test:run\` (vitest) — 47/47
- [x] \`npm run test:e2e\` (Playwright) — 126/126
- [x] Verified live in a browser with playwright-cli that \`document.title\` matches expectations on \`/\`, \`/dashboard\`, \`/matches/new\`, \`/admin/users\`

## Follow-ups (not in this PR)

- \`/matches/\$matchId\` shows the generic \`Match · FortyMM\`. A loader-derived title (e.g. \`Alice vs Bob · FortyMM\`) would help when users have several match tabs open.
- \`pageTitle()\` currently takes a single pre-joined label string; admin sub-pages pass \`'Users · Admin'\` etc. A varargs signature (\`pageTitle('Users', 'Admin')\`) would compose more cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)