### PR TITLE
Let users edit their own username

### DIFF
--- a/api/app/rbac.py
+++ b/api/app/rbac.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db import get_session
 from app.leagues import add_user_to_default_league
 from app.models import Permission, Role, RolePermission, User, UserRole
+from app.uniqueness import name_taken
 from app.schemas.rbac import (
     PermissionCreate,
     PermissionRead,
@@ -174,22 +175,6 @@ async def _validate_permission_ids(
     return deduped
 
 
-async def _name_taken(
-    db: AsyncSession,
-    id_col,
-    name_col,
-    name: str,
-    *,
-    exclude_id: uuid.UUID | None = None,
-) -> bool:
-    """Case-insensitive uniqueness check. Pass the model's id + name columns
-    (e.g. `Role.id, Role.name` or `User.id, User.username`)."""
-    stmt = select(id_col).where(func.lower(name_col) == name.lower())
-    if exclude_id is not None:
-        stmt = stmt.where(id_col != exclude_id)
-    return (await db.execute(stmt.limit(1))).first() is not None
-
-
 async def _validate_role_ids(
     db: AsyncSession, role_ids: Sequence[uuid.UUID]
 ) -> list[uuid.UUID]:
@@ -227,7 +212,7 @@ async def create_permission(
     payload: PermissionCreate,
     db: AsyncSession = Depends(get_session),
 ) -> PermissionRead:
-    if await _name_taken(db, Permission.id, Permission.name, payload.name):
+    if await name_taken(db, Permission.id, Permission.name, payload.name):
         raise HTTPException(
             status_code=409, detail="Permission name already exists."
         )
@@ -264,7 +249,7 @@ async def update_permission(
     if (
         "name" in data
         and data["name"]
-        and await _name_taken(
+        and await name_taken(
             db, Permission.id, Permission.name, data["name"], exclude_id=perm.id
         )
     ):
@@ -321,7 +306,7 @@ async def create_role(
             detail="Provide either template_id or permission_ids, not both.",
         )
 
-    if await _name_taken(db, Role.id, Role.name, payload.name):
+    if await name_taken(db, Role.id, Role.name, payload.name):
         raise HTTPException(status_code=409, detail="Role name already exists.")
 
     permission_ids: list[uuid.UUID] = []
@@ -387,7 +372,7 @@ async def update_role(
     if (
         "name" in data
         and data["name"]
-        and await _name_taken(
+        and await name_taken(
             db, Role.id, Role.name, data["name"], exclude_id=role.id
         )
     ):
@@ -452,7 +437,7 @@ async def create_user(
     payload: RbacUserCreate,
     db: AsyncSession = Depends(get_session),
 ) -> RbacUserRead:
-    if await _name_taken(db, User.id, User.username, payload.username):
+    if await name_taken(db, User.id, User.username, payload.username):
         raise HTTPException(status_code=409, detail="Username already exists.")
     user = User(username=payload.username)
     db.add(user)

--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -1,4 +1,12 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+# Lowercase alphanumerics with optional dots/hyphens/underscores between them.
+# Must start and end with an alphanumeric so we don't store names that look
+# like punctuation. 40 chars admits the auto-generated `slug-slug-XXXXXXXX`
+# format with headroom while keeping display sane.
+USERNAME_PATTERN = r"^[a-z0-9](?:[a-z0-9._-]{1,38}[a-z0-9])?$"
+USERNAME_MIN_LENGTH = 3
+USERNAME_MAX_LENGTH = 40
 
 
 class SessionUser(BaseModel):
@@ -12,3 +20,11 @@ class SessionData(BaseModel):
 
 class SessionResponse(BaseModel):
     data: SessionData
+
+
+class UpdateCurrentUserRequest(BaseModel):
+    username: str = Field(
+        min_length=USERNAME_MIN_LENGTH,
+        max_length=USERNAME_MAX_LENGTH,
+        pattern=USERNAME_PATTERN,
+    )

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -6,13 +6,19 @@ from typing import Annotated
 
 from coolname import generate_slug
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, status
-from sqlalchemy import select
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
 from app.leagues import add_user_to_default_league
 from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
-from app.schemas.session import SessionData, SessionResponse, SessionUser
+from app.schemas.session import (
+    SessionData,
+    SessionResponse,
+    SessionUser,
+    UpdateCurrentUserRequest,
+)
 
 router = APIRouter()
 
@@ -135,3 +141,45 @@ async def get_current_user(
             detail="authentication required",
         )
     return user
+
+
+@router.patch("/v1/me", response_model=SessionResponse)
+async def update_current_user(
+    payload: UpdateCurrentUserRequest,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> SessionResponse:
+    # No-op if the user "changed" their name to what it already is — skip the
+    # uniqueness probe so a user can submit the form unchanged without seeing
+    # their own row trigger a 409.
+    if payload.username != current_user.username:
+        existing = await db.execute(
+            select(User.id).where(
+                func.lower(User.username) == payload.username.lower(),
+                User.id != current_user.id,
+            )
+        )
+        if existing.first() is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Username already taken.",
+            )
+        current_user.username = payload.username
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Username already taken.",
+            )
+        await db.refresh(current_user)
+
+    permissions = await _load_permissions(db, current_user.id)
+    return SessionResponse(
+        data=SessionData(
+            user=SessionUser(
+                username=current_user.username, permissions=permissions
+            )
+        )
+    )

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from coolname import generate_slug
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, status
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +19,7 @@ from app.schemas.session import (
     SessionUser,
     UpdateCurrentUserRequest,
 )
+from app.uniqueness import name_taken
 
 router = APIRouter()
 
@@ -149,17 +150,16 @@ async def update_current_user(
     db: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
 ) -> SessionResponse:
-    # No-op if the user "changed" their name to what it already is — skip the
-    # uniqueness probe so a user can submit the form unchanged without seeing
-    # their own row trigger a 409.
+    # Skip the uniqueness probe on a no-op submit so the user's own row
+    # doesn't trip a 409 against itself.
     if payload.username != current_user.username:
-        existing = await db.execute(
-            select(User.id).where(
-                func.lower(User.username) == payload.username.lower(),
-                User.id != current_user.id,
-            )
-        )
-        if existing.first() is not None:
+        if await name_taken(
+            db,
+            User.id,
+            User.username,
+            payload.username,
+            exclude_id=current_user.id,
+        ):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Username already taken.",

--- a/api/app/uniqueness.py
+++ b/api/app/uniqueness.py
@@ -1,0 +1,20 @@
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def name_taken(
+    db: AsyncSession,
+    id_col,
+    name_col,
+    name: str,
+    *,
+    exclude_id: uuid.UUID | None = None,
+) -> bool:
+    """Case-insensitive uniqueness check. Pass the model's id + name columns
+    (e.g. `Role.id, Role.name` or `User.id, User.username`)."""
+    stmt = select(id_col).where(func.lower(name_col) == name.lower())
+    if exclude_id is not None:
+        stmt = stmt.where(id_col != exclude_id)
+    return (await db.execute(stmt.limit(1))).first() is not None

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -1,6 +1,7 @@
 import hashlib
 from collections.abc import AsyncIterator
 
+import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
@@ -10,6 +11,7 @@ from app.db import get_session
 from app.main import app
 from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
 from app.sessions import SESSION_COOKIE_NAME, SESSION_TOKEN_CONTEXT
+from tests._helpers import make_client
 
 
 @pytest_asyncio.fixture
@@ -182,3 +184,166 @@ async def test_session_deduplicates_permissions_across_roles(
 
     second = await api_client.get("/v1/session")
     assert second.json()["data"]["user"]["permissions"] == ["puzzle:read"]
+
+
+# ---- PATCH /v1/me ---------------------------------------------------------
+
+
+async def test_update_username_persists_and_returns_session(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    first = await api_client.get("/v1/session")
+    original = first.json()["data"]["user"]["username"]
+
+    response = await api_client.patch("/v1/me", json={"username": "new-name"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["user"]["username"] == "new-name"
+    assert body["data"]["user"]["permissions"] == []
+
+    user = (
+        await db_session.execute(
+            select(User).where(User.username == "new-name")
+        )
+    ).scalar_one()
+    assert user.username == "new-name"
+
+    # The old name is gone — no orphan row, single user updated in place.
+    stale = await db_session.execute(
+        select(User).where(User.username == original)
+    )
+    assert stale.scalar_one_or_none() is None
+
+
+async def test_update_username_unchanged_is_noop(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    first = await api_client.get("/v1/session")
+    username = first.json()["data"]["user"]["username"]
+
+    response = await api_client.patch("/v1/me", json={"username": username})
+    assert response.status_code == 200
+    assert response.json()["data"]["user"]["username"] == username
+
+
+async def test_update_username_requires_session(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # No prior GET /v1/session — no cookie set, so PATCH must 401.
+    response = await api_client.patch("/v1/me", json={"username": "hopeful"})
+    assert response.status_code == 401
+
+
+async def test_update_username_rejects_taken_name(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    db_session.add(User(username="taken"))
+    await db_session.commit()
+
+    await api_client.get("/v1/session")
+    response = await api_client.patch("/v1/me", json={"username": "taken"})
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Username already taken."
+
+
+async def test_update_username_rejects_taken_name_case_insensitive(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    db_session.add(User(username="taken"))
+    await db_session.commit()
+
+    await api_client.get("/v1/session")
+    # Pattern only admits lowercase, but case-insensitive uniqueness still
+    # matters if the existing row was created (e.g. by an admin tool) with
+    # mixed case.
+    db_session.add(User(username="Mixed-Case"))
+    await db_session.commit()
+
+    response = await api_client.patch(
+        "/v1/me", json={"username": "mixed-case"}
+    )
+    assert response.status_code == 409
+
+
+async def test_update_username_concurrent_collision_returns_409(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Two clients claim the same name; the second commit raises IntegrityError
+    and we must translate that to 409 rather than 500."""
+    await api_client.get("/v1/session")
+
+    async with make_client() as other_client:
+        await other_client.get("/v1/session")
+        # Race the rename: client A patches first, then client B tries the
+        # same name. The pre-check on B sees no conflict (A hasn't committed
+        # yet from its own snapshot's perspective, but in practice the commit
+        # has already happened by the time we issue B's PATCH below). What
+        # this exercises is the IntegrityError path: we already verified the
+        # pre-check at unit level, so here we just confirm the second one
+        # gets 409 too.
+        ok = await api_client.patch("/v1/me", json={"username": "race-name"})
+        assert ok.status_code == 200
+        dup = await other_client.patch(
+            "/v1/me", json={"username": "race-name"}
+        )
+        assert dup.status_code == 409
+
+
+@pytest.mark.parametrize(
+    "bad_username",
+    [
+        "",  # empty
+        "ab",  # too short
+        "a" * 41,  # too long
+        "Capitalized",  # uppercase
+        "-leading-dash",
+        "trailing-dash-",
+        ".dot-start",
+        "dot-end.",
+        "has space",
+        "weird!chars",
+        "emoji-🏓",
+    ],
+)
+async def test_update_username_rejects_invalid_format(
+    api_client: AsyncClient, bad_username: str
+):
+    await api_client.get("/v1/session")
+    response = await api_client.patch(
+        "/v1/me", json={"username": bad_username}
+    )
+    assert response.status_code == 422, (bad_username, response.text)
+
+
+async def test_update_username_preserves_user_id_and_permissions(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    first = await api_client.get("/v1/session")
+    original = first.json()["data"]["user"]["username"]
+    user = (
+        await db_session.execute(select(User).where(User.username == original))
+    ).scalar_one()
+    original_id = user.id
+
+    role = Role(name="player")
+    perm = Permission(name="match:create")
+    db_session.add_all([role, perm])
+    await db_session.commit()
+    db_session.add_all(
+        [
+            UserRole(user_id=user.id, role_id=role.id),
+            RolePermission(role_id=role.id, permission_id=perm.id),
+        ]
+    )
+    await db_session.commit()
+
+    response = await api_client.patch("/v1/me", json={"username": "renamed"})
+    assert response.status_code == 200
+    assert response.json()["data"]["user"]["permissions"] == ["match:create"]
+
+    refreshed = (
+        await db_session.execute(
+            select(User).where(User.username == "renamed")
+        )
+    ).scalar_one()
+    assert refreshed.id == original_id

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -268,19 +268,12 @@ async def test_update_username_rejects_taken_name_case_insensitive(
 async def test_update_username_concurrent_collision_returns_409(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    """Two clients claim the same name; the second commit raises IntegrityError
-    and we must translate that to 409 rather than 500."""
+    """Two clients claim the same name back-to-back; the loser must get 409,
+    not a 500 from IntegrityError leaking through."""
     await api_client.get("/v1/session")
 
     async with make_client() as other_client:
         await other_client.get("/v1/session")
-        # Race the rename: client A patches first, then client B tries the
-        # same name. The pre-check on B sees no conflict (A hasn't committed
-        # yet from its own snapshot's perspective, but in practice the commit
-        # has already happened by the time we issue B's PATCH below). What
-        # this exercises is the IntegrityError path: we already verified the
-        # pre-check at unit level, so here we just confirm the second one
-        # gets 409 too.
         ok = await api_client.patch("/v1/me", json={"username": "race-name"})
         assert ok.status_code == 200
         dup = await other_client.patch(
@@ -292,10 +285,10 @@ async def test_update_username_concurrent_collision_returns_409(
 @pytest.mark.parametrize(
     "bad_username",
     [
-        "",  # empty
-        "ab",  # too short
-        "a" * 41,  # too long
-        "Capitalized",  # uppercase
+        "",
+        "ab",
+        "a" * 41,
+        "Capitalized",
         "-leading-dash",
         "trailing-dash-",
         ".dot-start",

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -21,6 +21,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update Current User */
+        patch: operations["update_current_user_v1_me_patch"];
+        trace?: never;
+    };
     "/v1/permissions": {
         parameters: {
             query?: never;
@@ -860,6 +877,11 @@ export interface components {
             /** Permissions */
             permissions: string[];
         };
+        /** UpdateCurrentUserRequest */
+        UpdateCurrentUserRequest: {
+            /** Username */
+            username: string;
+        };
         /** ValidationError */
         ValidationError: {
             /** Location */
@@ -892,6 +914,41 @@ export interface operations {
             };
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_current_user_v1_me_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateCurrentUserRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -1,4 +1,9 @@
-import { queryOptions, useQuery } from '@tanstack/react-query'
+import {
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
 import { api, unwrap } from './client'
 import type { components } from './schema'
 
@@ -24,4 +29,24 @@ export function useSession() {
 export function useHasPermission(name: string): boolean {
   const { data } = useSession()
   return data?.data.user.permissions.includes(name) ?? false
+}
+
+// The change-username dialog awaits this via mutateAsync so it can surface
+// 4xx errors (409 taken, 422 invalid) inline on the field rather than as a
+// toast. Non-dialog callers must handle errors themselves.
+export function useUpdateUsername() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (username: string): Promise<Session> =>
+      unwrap(
+        'update username',
+        await api.PATCH('/v1/me', { body: { username } }),
+      ),
+    onSuccess: (session) => {
+      // Seed the cache so the menu re-renders with the new name immediately,
+      // before invalidation triggers a refetch round-trip.
+      qc.setQueryData(SESSION_QUERY_KEY, session)
+      qc.invalidateQueries({ queryKey: SESSION_QUERY_KEY })
+    },
+  })
 }

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -31,9 +31,8 @@ export function useHasPermission(name: string): boolean {
   return data?.data.user.permissions.includes(name) ?? false
 }
 
-// The change-username dialog awaits this via mutateAsync so it can surface
-// 4xx errors (409 taken, 422 invalid) inline on the field rather than as a
-// toast. Non-dialog callers must handle errors themselves.
+// Callers that want inline 4xx error handling (e.g. ChangeUsernameDialog)
+// must await this via mutateAsync and catch ApiError themselves.
 export function useUpdateUsername() {
   const qc = useQueryClient()
   return useMutation({
@@ -43,10 +42,7 @@ export function useUpdateUsername() {
         await api.PATCH('/v1/me', { body: { username } }),
       ),
     onSuccess: (session) => {
-      // Seed the cache so the menu re-renders with the new name immediately,
-      // before invalidation triggers a refetch round-trip.
       qc.setQueryData(SESSION_QUERY_KEY, session)
-      qc.invalidateQueries({ queryKey: SESSION_QUERY_KEY })
     },
   })
 }

--- a/web-client/src/components/change-username-dialog.tsx
+++ b/web-client/src/components/change-username-dialog.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from 'react'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import { z } from 'zod'
+import { ApiError } from '@/api/client'
+import { useUpdateUsername } from '@/api/session'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+// Mirror api/app/schemas/session.py USERNAME_PATTERN. Client-side validation
+// is for fast feedback; the server still enforces the same rules.
+const USERNAME_RE = /^[a-z0-9](?:[a-z0-9._-]{1,38}[a-z0-9])?$/
+const USERNAME_MIN = 3
+const USERNAME_MAX = 40
+
+function buildSchema(currentUsername: string) {
+  return z.object({
+    username: z
+      .string()
+      .trim()
+      .min(USERNAME_MIN, { message: `At least ${USERNAME_MIN} characters.` })
+      .max(USERNAME_MAX, { message: `No more than ${USERNAME_MAX} characters.` })
+      .refine((v) => USERNAME_RE.test(v), {
+        message:
+          'Lowercase letters, numbers, dots, hyphens and underscores. Must start and end with a letter or number.',
+      })
+      .refine((v) => v !== currentUsername, {
+        message: "That's already your username.",
+      }),
+  })
+}
+
+type FormValues = z.infer<ReturnType<typeof buildSchema>>
+
+export function ChangeUsernameDialog({
+  open,
+  onOpenChange,
+  currentUsername,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  currentUsername: string
+}) {
+  const schema = useMemo(() => buildSchema(currentUsername), [currentUsername])
+  const updateUsername = useUpdateUsername()
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { username: currentUsername },
+    mode: 'onChange',
+  })
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    try {
+      await updateUsername.mutateAsync(values.username)
+      onOpenChange(false)
+      form.reset({ username: values.username })
+      toast.success('Username updated.')
+    } catch (err) {
+      if (err instanceof ApiError && (err.status === 409 || err.status === 422)) {
+        form.setError('username', {
+          type: 'server',
+          message: err.detail ?? 'Server rejected this username.',
+        })
+        return
+      }
+      toast.error("Couldn't update username", {
+        description: err instanceof Error ? err.message : String(err),
+      })
+    }
+  })
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) form.reset({ username: currentUsername })
+        onOpenChange(next)
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Change username</DialogTitle>
+          <DialogDescription>
+            This is how other players will find you. You can change it again later.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={handleSubmit} noValidate>
+            <FormField
+              control={form.control}
+              name="username"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Username</FormLabel>
+                  <FormControl>
+                    <Input
+                      autoFocus
+                      autoComplete="off"
+                      spellCheck={false}
+                      style={{ fontFamily: 'var(--font-mono)' }}
+                      {...field}
+                      onChange={(e) =>
+                        field.onChange(
+                          e.target.value.toLowerCase().replace(/\s/g, ''),
+                        )
+                      }
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    3–40 characters. Lowercase letters, numbers, dots, hyphens, underscores.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter style={{ marginTop: 16 }}>
+              <Button
+                variant="outline"
+                type="button"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={updateUsername.isPending}>
+                {updateUsername.isPending ? 'Saving…' : 'Save'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web-client/src/components/user-menu.test.tsx
+++ b/web-client/src/components/user-menu.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse, delay } from 'msw'
 import { describe, expect, it } from 'vitest'
@@ -13,6 +14,7 @@ function renderWithClient(ui: React.ReactElement) {
   const client = new QueryClient({
     defaultOptions: {
       queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
     },
   })
   return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
@@ -77,5 +79,126 @@ describe('UserMenu', () => {
     const nameEl = await screen.findByText(longName)
     expect(nameEl).toHaveClass('app-shell__user-name--truncate')
     expect(nameEl).toHaveAttribute('title', longName)
+  })
+})
+
+describe('UserMenu — change username', () => {
+  function sessionWith(username: string): SessionResponse {
+    return { data: { user: { username, permissions: [] } } }
+  }
+
+  it('opens the dialog and renames the user end-to-end', async () => {
+    let current = 'rita.kovac'
+    server.use(
+      http.get('*/v1/session', () => HttpResponse.json(sessionWith(current))),
+      http.patch('*/v1/me', async ({ request }) => {
+        const body = (await request.json()) as { username: string }
+        current = body.username
+        return HttpResponse.json(sessionWith(current))
+      }),
+    )
+
+    const user = userEvent.setup()
+    renderWithClient(<UserMenu />)
+
+    await screen.findByText('rita.kovac')
+    await user.click(screen.getByRole('button', { name: /user menu/i }))
+
+    const menuItem = await screen.findByRole('menuitem', {
+      name: /change username/i,
+    })
+    await user.click(menuItem)
+
+    const input = await screen.findByLabelText(/^username$/i)
+    await user.clear(input)
+    await user.type(input, 'new-name')
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+    expect(await screen.findByText('new-name')).toBeInTheDocument()
+  })
+
+  it('shows a 409 conflict inline on the field', async () => {
+    server.use(
+      http.get('*/v1/session', () =>
+        HttpResponse.json(sessionWith('rita.kovac')),
+      ),
+      http.patch('*/v1/me', () =>
+        HttpResponse.json({ detail: 'Username already taken.' }, { status: 409 }),
+      ),
+    )
+
+    const user = userEvent.setup()
+    renderWithClient(<UserMenu />)
+
+    await screen.findByText('rita.kovac')
+    await user.click(screen.getByRole('button', { name: /user menu/i }))
+    await user.click(
+      await screen.findByRole('menuitem', { name: /change username/i }),
+    )
+
+    const input = await screen.findByLabelText(/^username$/i)
+    await user.clear(input)
+    await user.type(input, 'taken')
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(
+      await screen.findByText('Username already taken.'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('blocks submission of client-invalid input without hitting the API', async () => {
+    let patchCalls = 0
+    server.use(
+      http.get('*/v1/session', () =>
+        HttpResponse.json(sessionWith('rita.kovac')),
+      ),
+      http.patch('*/v1/me', () => {
+        patchCalls++
+        return HttpResponse.json(sessionWith('whatever'))
+      }),
+    )
+
+    const user = userEvent.setup()
+    renderWithClient(<UserMenu />)
+
+    await screen.findByText('rita.kovac')
+    await user.click(screen.getByRole('button', { name: /user menu/i }))
+    await user.click(
+      await screen.findByRole('menuitem', { name: /change username/i }),
+    )
+
+    const input = await screen.findByLabelText(/^username$/i)
+    await user.clear(input)
+    await user.type(input, 'ab')
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(await screen.findByText(/at least 3 characters/i)).toBeInTheDocument()
+    expect(patchCalls).toBe(0)
+  })
+
+  it("flags submitting the same name as already-yours", async () => {
+    server.use(
+      http.get('*/v1/session', () =>
+        HttpResponse.json(sessionWith('rita.kovac')),
+      ),
+    )
+
+    const user = userEvent.setup()
+    renderWithClient(<UserMenu />)
+
+    await screen.findByText('rita.kovac')
+    await user.click(screen.getByRole('button', { name: /user menu/i }))
+    await user.click(
+      await screen.findByRole('menuitem', { name: /change username/i }),
+    )
+
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+    expect(
+      await screen.findByText(/already your username/i),
+    ).toBeInTheDocument()
   })
 })

--- a/web-client/src/components/user-menu.tsx
+++ b/web-client/src/components/user-menu.tsx
@@ -1,4 +1,12 @@
+import { useState } from 'react'
 import { useSession } from '@/api/session'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { ChangeUsernameDialog } from './change-username-dialog'
 
 function getInitials(username: string): string {
   const cleaned = username.replace(/[._-]+/g, ' ').trim()
@@ -10,6 +18,7 @@ function getInitials(username: string): string {
 
 export function UserMenu() {
   const { data, isLoading, isError } = useSession()
+  const [editing, setEditing] = useState(false)
 
   if (isLoading) {
     return (
@@ -27,20 +36,45 @@ export function UserMenu() {
 
   const username = !isError && data ? data.data.user.username : 'Guest'
   const initials = getInitials(username)
+  const signedIn = !isError && !!data
 
   return (
-    <button
-      type="button"
-      className="app-shell__user-menu"
-      aria-label="User menu"
-    >
-      <div className="app-shell__user-avatar">{initials}</div>
-      <div
-        className="app-shell__user-name app-shell__user-name--truncate"
-        title={username}
-      >
-        {username}
-      </div>
-    </button>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="app-shell__user-menu"
+            aria-label="User menu"
+          >
+            <div className="app-shell__user-avatar">{initials}</div>
+            <div
+              className="app-shell__user-name app-shell__user-name--truncate"
+              title={username}
+            >
+              {username}
+            </div>
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56">
+          <DropdownMenuItem
+            disabled={!signedIn}
+            onSelect={(e) => {
+              e.preventDefault()
+              setEditing(true)
+            }}
+          >
+            Change username
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {signedIn && (
+        <ChangeUsernameDialog
+          open={editing}
+          onOpenChange={setEditing}
+          currentUsername={username}
+        />
+      )}
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- New `PATCH /v1/me` endpoint lets the signed-in user rename themselves. Format validated server-side via a single `USERNAME_PATTERN` (lowercase alphanumerics with `._-` separators, 3–40 chars); uniqueness is case-insensitive with both a pre-check and an `IntegrityError` fallback to cover the TOCTOU race.
- User-menu becomes a dropdown with a "Change username" item that opens a shadcn Dialog (RHF + zod). 409/422 from the server surface inline on the field; non-4xx errors fall back to a toast.
- Extracted `_name_taken` from `app/rbac.py` into a new `app/uniqueness.py` module so `sessions.py` can reuse it without setting up a circular import with `rbac.py`.
- Removed a redundant `invalidateQueries` after `setQueryData` in `useUpdateUsername` — the mutation response already contains fresh server state.

## Test plan
- [x] `cd api && pytest` — 222 passed
- [x] `cd web-client && npm run test:run` — 51 passed
- [x] `cd web-client && npm run lint && npm run build` — clean (pre-existing warning unrelated)
- [x] `cd web-client && npm run test:e2e` — 126 passed
- [x] OpenAPI drift check — `schema.d.ts` committed in sync with the runtime `openapi.json`
- [x] Manual: rename happy path closes dialog and updates the user-menu in place; 409 inline error on collision; client-side regex blocks bad input before reaching the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)