### PR TITLE
ci: always run all workflows on PRs; unique job names

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -4,16 +4,13 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - 'api/**'
-      - '.github/workflows/api.yml'
 
 defaults:
   run:
     working-directory: api
 
 jobs:
-  test:
+  pytest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,17 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - 'e2e/**'
-      - 'web-client/**'
-      - 'api/**'
-      - 'nginx/**'
-      - 'docker-compose.dev.yml'
-      - 'docker-compose.e2e.yml'
-      - '.github/workflows/e2e.yml'
 
 jobs:
-  test:
+  compose-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/openapi-schema.yml
+++ b/.github/workflows/openapi-schema.yml
@@ -4,14 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - 'api/**'
-      - 'web-client/package.json'
-      - 'web-client/package-lock.json'
-      - 'web-client/.npmrc'
-      - 'web-client/src/api/**'
-      - 'mise.toml'
-      - '.github/workflows/openapi-schema.yml'
 
 jobs:
   verify:

--- a/.github/workflows/web-client-e2e.yml
+++ b/.github/workflows/web-client-e2e.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - 'web-client/**'
-      - '.github/workflows/web-client-e2e.yml'
 
 defaults:
   run:

--- a/.github/workflows/web-client.yml
+++ b/.github/workflows/web-client.yml
@@ -4,16 +4,13 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - 'web-client/**'
-      - '.github/workflows/web-client.yml'
 
 defaults:
   run:
     working-directory: web-client
 
 jobs:
-  test:
+  checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Removes `pull_request: paths:` filters from all 5 workflows so every PR runs every check.
- Renames three colliding job keys (`api/test`, `e2e/test`, `web-client/test`) to unique names (`pytest`, `compose-e2e`, `checks`) so branch protection can require each one individually.

Prep for enabling `required_status_checks` on `main`. With the existing path filters, required checks would hang forever on PRs that didn't touch the filtered paths (e.g. a web-client-only PR would never trigger \`api\` or \`openapi-schema\`).

## Trade-off

CI now runs ~5 min of jobs that would previously have been skipped on path-irrelevant PRs. Acceptable for a repo this size, and necessary to make required checks actually work.

## Test plan

- [x] yaml diff reviewed
- [ ] verify all 5 checks appear and pass on this PR (since we just removed path filters, every workflow should now trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)