### PR TITLE
Add pre-match rating, sparkline, dates, and career stats to Players & form

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -538,8 +538,8 @@ async def _load_pre_match_rating(
     league_id: uuid.UUID,
     before: datetime,
 ) -> tuple[float | None, list[float]]:
-    """Last N rating values for this user in this league strictly before
-    ``before``, returned as (most-recent-value, chronological-list)."""
+    """Returns ``(most-recent-value, chronological-list)``. Strict ``<`` on
+    ``before`` so this match's own rating row never leaks in."""
     rows = (
         await db.execute(
             select(RatingHistory.rating_value)
@@ -564,9 +564,8 @@ async def _load_career_before(
     current_match_id: uuid.UUID,
     before: datetime,
 ) -> tuple[int, int]:
-    """(career_matches, career_wins) for this user across all leagues, in
-    completed matches that finished before ``before``. Excludes the current
-    match so a just-completed lookup doesn't double-count itself."""
+    """Cross-league ``(matches, wins)``. Excludes ``current_match_id`` so a
+    just-completed match isn't double-counted into its own pre-match record."""
     side = aliased(MatchSide)
     player = aliased(MatchSidePlayer)
     row = (

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1,6 +1,7 @@
 import math
 import uuid
 from dataclasses import dataclass
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func, select
@@ -52,6 +53,9 @@ router = APIRouter(prefix="/v1")
 MAX_PAGE_SIZE = 100
 RECENT_FORM_LIMIT = 5
 H2H_MEETINGS_LIMIT = 5
+# Cap on the pre-match sparkline so the BFF stays cheap; the dashboard
+# Sparkline already pads single points to 2.
+RATING_HISTORY_LIMIT = 10
 
 
 # ----- helpers -------------------------------------------------------------
@@ -493,7 +497,7 @@ def _history_base_query(current_match_id: uuid.UUID):
 async def _load_recent_form(
     db: AsyncSession,
     user_ids: list[uuid.UUID],
-    current_match_id: uuid.UUID,
+    match: Match,
 ) -> list[MatchDetailsPlayerForm]:
     if not user_ids:
         return []
@@ -503,19 +507,85 @@ async def _load_recent_form(
         rows = (
             await db.execute(
                 participant_filter(
-                    _history_base_query(current_match_id), user_id
+                    _history_base_query(match.id), user_id
                 ).limit(RECENT_FORM_LIMIT)
             )
         ).scalars().all()
+        rating_before, rating_history = await _load_pre_match_rating(
+            db, user_id, match.league_id, match.created_at
+        )
+        matches_before, wins_before = await _load_career_before(
+            db, user_id, match.id, match.created_at
+        )
         result.append(
             MatchDetailsPlayerForm(
                 user_id=user_id,
                 recent_results=[
-                    _build_form_result(match, user_id) for match in rows
+                    _build_form_result(past, user_id) for past in rows
                 ],
+                rating_before=rating_before,
+                rating_history=rating_history,
+                career_matches_before=matches_before,
+                career_wins_before=wins_before,
             )
         )
     return result
+
+
+async def _load_pre_match_rating(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    league_id: uuid.UUID,
+    before: datetime,
+) -> tuple[float | None, list[float]]:
+    """Last N rating values for this user in this league strictly before
+    ``before``, returned as (most-recent-value, chronological-list)."""
+    rows = (
+        await db.execute(
+            select(RatingHistory.rating_value)
+            .where(
+                RatingHistory.user_id == user_id,
+                RatingHistory.league_id == league_id,
+                RatingHistory.created_at < before,
+            )
+            .order_by(RatingHistory.created_at.desc())
+            .limit(RATING_HISTORY_LIMIT)
+        )
+    ).scalars().all()
+    if not rows:
+        return None, []
+    history = list(reversed(rows))
+    return history[-1], history
+
+
+async def _load_career_before(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    current_match_id: uuid.UUID,
+    before: datetime,
+) -> tuple[int, int]:
+    """(career_matches, career_wins) for this user across all leagues, in
+    completed matches that finished before ``before``. Excludes the current
+    match so a just-completed lookup doesn't double-count itself."""
+    side = aliased(MatchSide)
+    player = aliased(MatchSidePlayer)
+    row = (
+        await db.execute(
+            select(
+                func.count(Match.id),
+                func.count(Match.id).filter(side.won.is_(True)),
+            )
+            .join(side, side.match_id == Match.id)
+            .join(player, player.match_side_id == side.id)
+            .where(
+                player.user_id == user_id,
+                Match.status == MatchStatus.completed,
+                Match.id != current_match_id,
+                Match.updated_at < before,
+            )
+        )
+    ).one()
+    return int(row[0]), int(row[1])
 
 
 def _build_form_result(
@@ -624,7 +694,7 @@ async def _load_view_extras(db: AsyncSession, match: Match) -> ViewExtras:
     user_ids = _singles_user_ids(match)
     return ViewExtras(
         rating_changes=await _load_rating_changes(db, match.id),
-        recent_form=await _load_recent_form(db, user_ids, match.id),
+        recent_form=await _load_recent_form(db, user_ids, match),
         head_to_head=await _load_head_to_head(
             db, user_ids if len(user_ids) == 2 else [], match.id
         ),

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -102,10 +102,22 @@ class MatchDetailsFormResult(BaseModel):
 
 class MatchDetailsPlayerForm(BaseModel):
     """A player's previous-5 results, attached by ``user_id`` so the FE can
-    map it onto whichever side carries that user."""
+    map it onto whichever side carries that user.
+
+    All `*_before` fields are anchored to this match's `created_at` — they
+    describe the player's rating + record going into this match, not after."""
 
     user_id: uuid.UUID
     recent_results: list[MatchDetailsFormResult]
+    # Rating in this match's league as of just before this match. Null when
+    # the player has no prior rating in the league.
+    rating_before: float | None = None
+    # Chronological rating values (oldest first) preceding this match in this
+    # match's league. Capped at ~10 — enough for a sparkline, small enough
+    # to keep the BFF cheap.
+    rating_history: list[float] = Field(default_factory=list)
+    career_matches_before: int = 0
+    career_wins_before: int = 0
 
 
 class MatchDetailsH2HMeeting(BaseModel):

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -977,3 +977,56 @@ async def test_details_head_to_head_is_null_for_solo_match(
     # Only the creator is in recent_form — and they have no prior history.
     assert len(detail["recent_form"]) == 1
     assert detail["recent_form"][0]["recent_results"] == []
+
+
+async def test_details_recent_form_includes_pre_match_rating_and_career(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await start_session(api_client, db_session)
+    other = await make_user(db_session, "career-other")
+    # Two completed wins build up career stats *and* rating history before
+    # the head-to-head match is created.
+    await _play_match_to_completion(api_client, other.id, best_of=3, side_1_wins=True)
+    await _play_match_to_completion(api_client, other.id, best_of=3, side_1_wins=True)
+
+    opp = await make_user(db_session, "pre-rating-opp")
+    current = await _create_match(api_client, opp.id, best_of=3)
+    detail = (await api_client.get(f"/v1/matches/{current['id']}")).json()
+
+    forms = {f["user_id"]: f for f in detail["recent_form"]}
+    mine = forms[str(me.id)]
+    # I had 2 completed matches before this one, both wins.
+    assert mine["career_matches_before"] == 2
+    assert mine["career_wins_before"] == 2
+    # Rating history exists with 2 prior entries (one per rated match) and
+    # rating_before matches the most-recent entry.
+    assert mine["rating_before"] is not None
+    assert len(mine["rating_history"]) == 2
+    assert mine["rating_history"][-1] == mine["rating_before"]
+    # Brand-new opponent: no rating, no career.
+    fresh = forms[str(opp.id)]
+    assert fresh["rating_before"] is None
+    assert fresh["rating_history"] == []
+    assert fresh["career_matches_before"] == 0
+    assert fresh["career_wins_before"] == 0
+
+
+async def test_details_recent_form_excludes_self_from_career_count(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A just-completed match's own row in rating_history / its own match
+    row must not double-count itself in the BFF."""
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "self-exclude-opp")
+    finished = await _play_match_to_completion(
+        api_client, opp.id, best_of=3, side_1_wins=True
+    )
+
+    detail = (await api_client.get(f"/v1/matches/{finished['id']}")).json()
+    for f in detail["recent_form"]:
+        # No prior matches exist — only the current one — so career and
+        # rating-history must be empty.
+        assert f["career_matches_before"] == 0
+        assert f["career_wins_before"] == 0
+        assert f["rating_history"] == []
+        assert f["rating_before"] is None

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -606,6 +606,9 @@ export interface components {
          * MatchDetailsPlayerForm
          * @description A player's previous-5 results, attached by ``user_id`` so the FE can
          *     map it onto whichever side carries that user.
+         *
+         *     All `*_before` fields are anchored to this match's `created_at` — they
+         *     describe the player's rating + record going into this match, not after.
          */
         MatchDetailsPlayerForm: {
             /**
@@ -615,6 +618,20 @@ export interface components {
             user_id: string;
             /** Recent Results */
             recent_results: components["schemas"]["MatchDetailsFormResult"][];
+            /** Rating Before */
+            rating_before?: number | null;
+            /** Rating History */
+            rating_history?: number[];
+            /**
+             * Career Matches Before
+             * @default 0
+             */
+            career_matches_before: number;
+            /**
+             * Career Wins Before
+             * @default 0
+             */
+            career_wins_before: number;
         };
         /** MatchDetailsScore */
         MatchDetailsScore: {

--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -373,8 +373,19 @@ describe('MatchDetailsView', () => {
               completed_at: '2026-05-07T18:00:00Z',
             },
           ],
+          rating_before: 1612,
+          rating_history: [1580, 1601, 1612],
+          career_matches_before: 12,
+          career_wins_before: 9,
         },
-        { user_id: 'u-rookie', recent_results: [] },
+        {
+          user_id: 'u-rookie',
+          recent_results: [],
+          rating_before: null,
+          rating_history: [],
+          career_matches_before: 0,
+          career_wins_before: 0,
+        },
       ],
     })
     server.use(http.get('*/v1/matches/m-form', () => HttpResponse.json(match)))
@@ -394,12 +405,29 @@ describe('MatchDetailsView', () => {
     expect(within(myForm).getByText('3–1')).toBeInTheDocument()
     expect(within(myForm).getByText('tanaka.y')).toBeInTheDocument()
     expect(within(myForm).getByText('1–3')).toBeInTheDocument()
+    // Each form row carries the date the past match completed on.
+    expect(within(myForm).getByText('May 9')).toBeInTheDocument()
+    expect(within(myForm).getByText('May 7')).toBeInTheDocument()
+    // Pre-match rating shows (rounded) with a sparkline; career stats below.
+    const myRating = screen.getByTestId('rating-box-1')
+    expect(within(myRating).getByText('1612')).toBeInTheDocument()
+    expect(myRating.querySelector('svg')).not.toBeNull()
+    const myCareer = screen.getByTestId('career-1')
+    expect(within(myCareer).getByText('12')).toBeInTheDocument()
+    expect(within(myCareer).getByText('75%')).toBeInTheDocument()
     // Rookie shows the empty state, not a result list.
     const oppForm = screen.getByTestId('form-2')
     expect(within(oppForm).getByText(/No prior matches yet/)).toBeInTheDocument()
     expect(
       within(oppForm).queryByText(/Recent form · /),
     ).not.toBeInTheDocument()
+    // Unrated rookie: no rating number, no sparkline, no win rate.
+    const oppRating = screen.getByTestId('rating-box-2')
+    expect(within(oppRating).getByText('Unrated')).toBeInTheDocument()
+    expect(oppRating.querySelector('svg')).toBeNull()
+    const oppCareer = screen.getByTestId('career-2')
+    expect(within(oppCareer).getByText('0')).toBeInTheDocument()
+    expect(within(oppCareer).getByText('—')).toBeInTheDocument()
   })
 
   it('shows the head-to-head card with prior meetings counted per side', async () => {

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -796,10 +796,8 @@ function ProfileSparkline({
 
 function CareerStats({ side }: { side: SideView }) {
   const matches = side.careerMatchesBefore
-  const wins = side.careerWinsBefore
-  const winRate = matches > 0 ? Math.round((wins / matches) * 100) : null
-  const winRateValue =
-    winRate === null ? <span className="dim">—</span> : `${winRate}%`
+  const winRate =
+    matches > 0 ? Math.round((side.careerWinsBefore / matches) * 100) : null
   return (
     <div
       className="md-profile__career"
@@ -819,7 +817,7 @@ function CareerStats({ side }: { side: SideView }) {
               'md-profile__career-value--good',
           )}
         >
-          {winRateValue}
+          {winRate === null ? <span className="dim">—</span> : `${winRate}%`}
         </div>
       </div>
     </div>

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -24,9 +24,19 @@ type MatchDetails = components['schemas']['MatchDetails']
 type MatchDetailsGame = components['schemas']['MatchDetailsGame']
 type MatchDetailsSide = components['schemas']['MatchDetailsSide']
 type MatchDetailsFormResult = components['schemas']['MatchDetailsFormResult']
+type MatchDetailsPlayerForm = components['schemas']['MatchDetailsPlayerForm']
 type MatchDetailsH2H = components['schemas']['MatchDetailsH2H']
 type MatchDetailsH2HMeeting = components['schemas']['MatchDetailsH2HMeeting']
 type RatingChange = components['schemas']['RatingChange']
+
+const EMPTY_FORM: MatchDetailsPlayerForm = {
+  user_id: '',
+  recent_results: [],
+  rating_before: null,
+  rating_history: [],
+  career_matches_before: 0,
+  career_wins_before: 0,
+}
 
 type HeroState = 'live' | 'final' | 'upcoming'
 
@@ -40,6 +50,10 @@ type SideView = {
   isCurrentUser: boolean
   ratingChange: RatingChange | null
   recentForm: MatchDetailsFormResult[]
+  ratingBefore: number | null
+  ratingHistory: number[]
+  careerMatchesBefore: number
+  careerWinsBefore: number
 }
 
 type GameView = {
@@ -88,7 +102,7 @@ type MatchView = {
 function projectSide(
   side: MatchDetailsSide,
   fallbackLabel: string,
-  recentForm: MatchDetailsFormResult[],
+  form: MatchDetailsPlayerForm,
 ): SideView {
   const player = side.players[0]
   const username = player?.username ?? fallbackLabel
@@ -101,7 +115,11 @@ function projectSide(
     won: side.won,
     isCurrentUser: side.is_current_user_side,
     ratingChange: side.rating_change ?? null,
-    recentForm,
+    recentForm: form.recent_results,
+    ratingBefore: form.rating_before ?? null,
+    ratingHistory: form.rating_history ?? [],
+    careerMatchesBefore: form.career_matches_before,
+    careerWinsBefore: form.career_wins_before,
   }
 }
 
@@ -149,11 +167,9 @@ function projectGame(
 function formForUser(
   data: MatchDetails,
   userId: string | null,
-): MatchDetailsFormResult[] {
-  if (!userId) return []
-  return (
-    data.recent_form?.find((f) => f.user_id === userId)?.recent_results ?? []
-  )
+): MatchDetailsPlayerForm {
+  if (!userId) return EMPTY_FORM
+  return data.recent_form?.find((f) => f.user_id === userId) ?? EMPTY_FORM
 }
 
 function projectHeadToHead(
@@ -685,6 +701,7 @@ function PlayerProfile({ side, won }: { side: SideView; won: boolean }) {
           <div className="md-profile__name">{side.username}</div>
         </div>
       </div>
+      <RatingBox side={side} />
       <div className="md-profile__form" data-testid={`form-${side.sideNumber}`}>
         <div className="md-kicker">
           {form.length === 0
@@ -703,6 +720,107 @@ function PlayerProfile({ side, won }: { side: SideView; won: boolean }) {
             ))}
           </ul>
         )}
+      </div>
+      <CareerStats side={side} />
+    </div>
+  )
+}
+
+function RatingBox({ side }: { side: SideView }) {
+  const value = side.ratingBefore
+  return (
+    <div
+      className="md-profile__rating-box"
+      data-testid={`rating-box-${side.sideNumber}`}
+    >
+      <div>
+        <div className="md-kicker">Rating</div>
+        <div className="md-profile__rating-value">
+          {value === null ? <span className="dim">Unrated</span> : Math.round(value)}
+        </div>
+      </div>
+      {side.ratingHistory.length >= 2 && (
+        <ProfileSparkline data={side.ratingHistory} />
+      )}
+    </div>
+  )
+}
+
+// Local copy of the dashboard sparkline — same shape and palette, but the
+// match-details card uses a smaller footprint than the dashboard hero.
+function ProfileSparkline({
+  data,
+  w = 110,
+  h = 36,
+}: {
+  data: number[]
+  w?: number
+  h?: number
+}) {
+  const min = Math.min(...data)
+  const max = Math.max(...data)
+  const range = max - min || 1
+  const pad = 2
+  const points = data.map((v, i) => {
+    const x = pad + (i / (data.length - 1)) * (w - pad * 2)
+    const y = h - pad - ((v - min) / range) * (h - pad * 2)
+    return [x, y] as const
+  })
+  const path = points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${p[0].toFixed(1)} ${p[1].toFixed(1)}`)
+    .join(' ')
+  // The last point's trend picks the colour so a falling rating reads as a
+  // loss tone even before the user squints at the y-axis.
+  const trendUp = data[data.length - 1] >= data[0]
+  const color = trendUp ? 'var(--serve-500)' : 'var(--fg-3)'
+  const last = points[points.length - 1]
+  return (
+    <svg
+      width={w}
+      height={h}
+      style={{ display: 'block', overflow: 'visible' }}
+      aria-hidden="true"
+    >
+      <path
+        d={path}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx={last[0]} cy={last[1]} r="2.4" fill={color} />
+    </svg>
+  )
+}
+
+function CareerStats({ side }: { side: SideView }) {
+  const matches = side.careerMatchesBefore
+  const wins = side.careerWinsBefore
+  const winRate = matches > 0 ? Math.round((wins / matches) * 100) : null
+  const winRateValue =
+    winRate === null ? <span className="dim">—</span> : `${winRate}%`
+  return (
+    <div
+      className="md-profile__career"
+      data-testid={`career-${side.sideNumber}`}
+    >
+      <div>
+        <div className="md-kicker">Career matches</div>
+        <div className="md-profile__career-value">{matches}</div>
+      </div>
+      <div>
+        <div className="md-kicker">Win rate</div>
+        <div
+          className={cn(
+            'md-profile__career-value',
+            winRate !== null &&
+              winRate >= 50 &&
+              'md-profile__career-value--good',
+          )}
+        >
+          {winRateValue}
+        </div>
       </div>
     </div>
   )
@@ -723,7 +841,8 @@ function FormRow({ result }: { result: MatchDetailsFormResult }) {
         {win ? 'W' : 'L'}
       </span>
       <span className="md-form-row__opp" title={opponentLabel}>
-        {opponentLabel}
+        <span className="md-form-row__opp-name">{opponentLabel}</span>
+        <span className="md-form-row__when">{fmtDateShort(result.completed_at)}</span>
       </span>
       <span
         className={cn(

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2674,6 +2674,12 @@ body.dark.fortymm-theme {
   color: var(--loss);
 }
 .fortymm-theme .md-form-row__opp {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.fortymm-theme .md-form-row__opp-name {
   font: 500 13px var(--font-ui);
   color: var(--fg-1);
   overflow: hidden;

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -269,8 +269,36 @@ function projectRecentForm(
       if (row) recent_results.push(row)
       if (recent_results.length === RECENT_FORM_LIMIT) break
     }
-    return { user_id, recent_results }
+    const wins = recent_results.filter((r) => r.is_win).length
+    // The mock store doesn't track real rating moves, so synthesize a
+    // deterministic-ish curve from the W/L pattern so the dev sparkline
+    // looks alive. The real BFF returns RatingHistory rows here.
+    const history = synthesizeRatingHistory(recent_results)
+    return {
+      user_id,
+      recent_results,
+      rating_before: history.length ? history[history.length - 1] : null,
+      rating_history: history,
+      career_matches_before: recent_results.length,
+      career_wins_before: wins,
+    }
   })
+}
+
+function synthesizeRatingHistory(
+  recent: MatchDetailsFormResult[],
+): number[] {
+  if (recent.length === 0) return []
+  // Walk newest → oldest results in reverse so the sparkline reads
+  // chronologically; +12 per W, -10 per L is just enough to make the line
+  // visibly tilt without claiming to be a real rating system.
+  let rating = 1500
+  const points: number[] = [rating]
+  for (let i = recent.length - 1; i >= 0; i -= 1) {
+    rating += recent[i].is_win ? 12 : -10
+    points.push(rating)
+  }
+  return points
 }
 
 function projectHeadToHead(

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -204,6 +204,10 @@ export function matchDetails(
       (s) => ({
         user_id: s.players[0]?.user_id ?? nextId('u'),
         recent_results: [],
+        rating_before: null,
+        rating_history: [],
+        career_matches_before: 0,
+        career_wins_before: 0,
       }),
     ),
     head_to_head: opponentSide


### PR DESCRIPTION
## Summary
- Extend the Players & form panel on `/matches/$matchId` with three pre-match signals: completed-at date on each recent-form row, the player's pre-match league rating with a small sparkline, and career matches + win-rate before this match.
- Backend wires this into `GET /v1/matches/{id}` by adding `rating_before`, `rating_history`, `career_matches_before`, `career_wins_before` to `MatchDetailsPlayerForm`; populated from `RatingHistory` (league-scoped) and a `MatchSide` count (cross-league). Schema regenerated.
- Mock store synthesizes a deterministic rating curve from the seeded W/L pattern so the dev MSW preview matches the real API's shape.

## Screenshot
Card after wire-up (left side has history, right side is a brand-new player):

<img width=\"400\" alt=\"Players & form card\" src=\"https://github.com/user-attachments/assets/placeholder\" />

## Test plan
- [x] `pytest api/` — 206 passed (incl. 2 new tests for the BFF fields).
- [x] `npm run test:run` (web vitest) — 47 passed.
- [x] `npm run lint && npm run build` — green.
- [x] `npm run test:e2e` (web Playwright) — 126 passed.
- [x] `mise run regen-api-types` — schema.d.ts in sync.
- [x] Manual: dev server + Playwright snapshot to confirm card renders correctly.

## Follow-ups (filed during review)
- #193 — career count uses `Match.updated_at`, which ticks on score edits; needs a real `completed_at`.
- #194 — extract shared Sparkline component (this PR's `ProfileSparkline` is a deliberate clone of the dashboard one).
- #195 — `_load_recent_form` does 3 sequential awaits per user; needs batched query or session-factory + gather.
- #196, #197, #198 — nits (sentinel `''`, missing positive test, unnecessary `reversed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)