### PR TITLE
Redirect / to /dashboard once the user has entered the app

### DIFF
--- a/web-client/src/lib/landing-redirect.ts
+++ b/web-client/src/lib/landing-redirect.ts
@@ -1,0 +1,18 @@
+export const APP_ENTERED_KEY = 'fortymm.app-entered'
+
+export function markAppEntered(): void {
+  try {
+    window.localStorage.setItem(APP_ENTERED_KEY, '1')
+  } catch {
+    // Safari private mode / disabled storage — best-effort, the redirect
+    // simply won't fire and the user sees the landing page next time.
+  }
+}
+
+export function hasAppEntered(): boolean {
+  try {
+    return window.localStorage.getItem(APP_ENTERED_KEY) === '1'
+  } catch {
+    return false
+  }
+}

--- a/web-client/src/routes/__root.tsx
+++ b/web-client/src/routes/__root.tsx
@@ -1,11 +1,14 @@
+import { useEffect } from 'react'
 import {
   HeadContent,
   Outlet,
   createRootRouteWithContext,
+  useRouterState,
 } from '@tanstack/react-router'
 import type { QueryClient } from '@tanstack/react-query'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { ServiceWorkerUpdater } from '@/components/service-worker-updater'
+import { markAppEntered } from '@/lib/landing-redirect'
 import { pageTitle } from '@/lib/page-title'
 
 export interface RouterContext {
@@ -20,6 +23,11 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 })
 
 function RootComponent() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  useEffect(() => {
+    if (pathname !== '/') markAppEntered()
+  }, [pathname])
+
   return (
     <>
       <HeadContent />

--- a/web-client/src/routes/index.test.tsx
+++ b/web-client/src/routes/index.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { APP_ENTERED_KEY } from '@/lib/landing-redirect'
+import { Route as IndexRoute } from './index'
+
+interface TestRouterContext {
+  queryClient: QueryClient
+}
+
+function renderAt(initialEntry: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRouteWithContext<TestRouterContext>()()
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: IndexRoute.options.component!,
+    beforeLoad: IndexRoute.options.beforeLoad,
+    validateSearch: IndexRoute.options.validateSearch,
+    loader: IndexRoute.options.loader,
+  })
+  const dashboardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/dashboard',
+    component: () => <div>Dashboard stub</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, dashboardRoute]),
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
+    context: { queryClient },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+async function expectLandingVisible() {
+  expect(
+    await screen.findByRole('heading', {
+      level: 1,
+      name: /play more\.\s*pay never\./i,
+    }),
+  ).toBeInTheDocument()
+}
+
+describe('/ route', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('renders the landing page when the user has not entered the app', async () => {
+    renderAt('/')
+    await expectLandingVisible()
+  })
+
+  it('redirects to /dashboard when the user has entered the app', async () => {
+    window.localStorage.setItem(APP_ENTERED_KEY, '1')
+    renderAt('/')
+    expect(await screen.findByText('Dashboard stub')).toBeInTheDocument()
+  })
+
+  it('shows the landing page when ?landing=1 is set, even after entering the app', async () => {
+    window.localStorage.setItem(APP_ENTERED_KEY, '1')
+    renderAt('/?landing=1')
+    await expectLandingVisible()
+  })
+})

--- a/web-client/src/routes/index.tsx
+++ b/web-client/src/routes/index.tsx
@@ -1,5 +1,6 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import { sessionQueryOptions } from '@/api/session'
+import { hasAppEntered } from '@/lib/landing-redirect'
 import { BRAND } from '@/lib/page-title'
 import App from '../App'
 
@@ -7,6 +8,13 @@ export const Route = createFileRoute('/')({
   head: () => ({
     meta: [{ title: `${BRAND} — table tennis, properly tracked` }],
   }),
+  validateSearch: (search: Record<string, unknown>) => ({
+    landing: 'landing' in search,
+  }),
+  beforeLoad: ({ search }) => {
+    if (search.landing) return
+    if (hasAppEntered()) throw redirect({ to: '/dashboard' })
+  },
   loader: ({ context: { queryClient } }) => {
     void queryClient.prefetchQuery(sessionQueryOptions())
   },

--- a/web-client/src/test/setup.ts
+++ b/web-client/src/test/setup.ts
@@ -3,6 +3,26 @@ import { afterAll, afterEach, beforeAll } from 'vitest'
 import { resetMockMatches } from '../mocks/match-store'
 import { server } from '../mocks/server'
 
+// vitest's jsdom env on Node 26 doesn't expose localStorage. Production code
+// guards it with try/catch, but tests want to read/write it directly — give
+// them a small in-memory shim.
+if (!window.localStorage) {
+  const store = new Map<string, string>()
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() {
+        return store.size
+      },
+    } satisfies Storage,
+  })
+}
+
 // jsdom doesn't implement matchMedia; responsive components (e.g. AppShell)
 // read it on mount, so provide an inert stub.
 if (!window.matchMedia) {


### PR DESCRIPTION
## Summary
- Sets a localStorage flag (`fortymm.app-entered`) from the root route whenever the user navigates anywhere outside `/`.
- The landing route's `beforeLoad` reads the flag and redirects to `/dashboard` on subsequent visits.
- `?landing=1` bypasses the redirect so the marketing page is still reachable from inside the app or via a shared link.

## Test plan
- [x] `npm run test:run` (vitest, 50 passing — 3 new in `routes/index.test.tsx`)
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:e2e` (Playwright, 126 passing)
- [x] `pytest` against api (204 passing — unrelated to this PR, sanity only)
- [x] Manual browser walkthrough: landing → `/matches/new` → flag set → `/` now redirects to `/dashboard`; `/?landing=1` still shows landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)