### PR TITLE
Clean up match details header

### DIFF
--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -542,9 +542,7 @@ function GameGrid({ view, matchId }: { view: MatchView; matchId: string }) {
     <div className="md-games">
       <div
         className="md-games__grid"
-        style={
-          { '--md-games-count': view.bestOf } as React.CSSProperties
-        }
+        style={{ '--md-games-count': view.bestOf } as React.CSSProperties}
       >
         <div className="md-games__kicker">GAMES</div>
         {slots.map((_, i) => (
@@ -737,8 +735,6 @@ function RatingBox({ side }: { side: SideView }) {
   )
 }
 
-// Local copy of the dashboard sparkline — same shape and palette, but the
-// match-details card uses a smaller footprint than the dashboard hero.
 function Sparkline({
   data,
   w = 110,

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -508,7 +508,6 @@ function HeroScoreboard({
 
 function PlayerSide({ side, pos }: { side: SideView; pos: 'l' | 'r' }) {
   const win = side.won === true
-  const change = side.ratingChange
   return (
     <div className={`md-hero__player md-hero__player--${pos}`}>
       <div className="md-hero__player-row">
@@ -524,19 +523,6 @@ function PlayerSide({ side, pos }: { side: SideView; pos: 'l' | 'r' }) {
           <div className={cn('md-hero__name', win && 'md-hero__name--win')}>
             {side.username}
           </div>
-          {change && (
-            <div
-              className={cn(
-                'md-hero__rating-delta',
-                change.delta >= 0
-                  ? 'md-hero__rating-delta--up'
-                  : 'md-hero__rating-delta--down',
-              )}
-              data-testid={`rating-delta-${pos}`}
-            >
-              {formatRatingDelta(change.delta)} rating
-            </div>
-          )}
         </div>
       </div>
     </div>
@@ -554,7 +540,12 @@ function GameGrid({ view, matchId }: { view: MatchView; matchId: string }) {
   const canEdit = view.leftSide.isCurrentUser
   return (
     <div className="md-games">
-      <div className="md-games__grid">
+      <div
+        className="md-games__grid"
+        style={
+          { '--md-games-count': view.bestOf } as React.CSSProperties
+        }
+      >
         <div className="md-games__kicker">GAMES</div>
         {slots.map((_, i) => (
           <div key={`h-${i}`} className="md-games__col-label">
@@ -740,7 +731,7 @@ function RatingBox({ side }: { side: SideView }) {
         </div>
       </div>
       {side.ratingHistory.length >= 2 && (
-        <ProfileSparkline data={side.ratingHistory} />
+        <Sparkline data={side.ratingHistory} />
       )}
     </div>
   )
@@ -748,14 +739,16 @@ function RatingBox({ side }: { side: SideView }) {
 
 // Local copy of the dashboard sparkline — same shape and palette, but the
 // match-details card uses a smaller footprint than the dashboard hero.
-function ProfileSparkline({
+function Sparkline({
   data,
   w = 110,
   h = 36,
+  downColor = 'var(--fg-3)',
 }: {
   data: number[]
   w?: number
   h?: number
+  downColor?: string
 }) {
   const min = Math.min(...data)
   const max = Math.max(...data)
@@ -772,7 +765,7 @@ function ProfileSparkline({
   // The last point's trend picks the colour so a falling rating reads as a
   // loss tone even before the user squints at the y-axis.
   const trendUp = data[data.length - 1] >= data[0]
-  const color = trendUp ? 'var(--serve-500)' : 'var(--fg-3)'
+  const color = trendUp ? 'var(--serve-500)' : downColor
   const last = points[points.length - 1]
   return (
     <svg
@@ -926,6 +919,10 @@ function RatingRow({ side, isFirst }: { side: SideView; isFirst: boolean }) {
         </div>
         {change && (
           <div className="md-rating-row__delta">
+            <RatingRowSparkline
+              history={side.ratingHistory}
+              change={change}
+            />
             <span
               className={cn(
                 'md-rating-row__delta-num',
@@ -939,6 +936,24 @@ function RatingRow({ side, isFirst }: { side: SideView; isFirst: boolean }) {
       </div>
     </>
   )
+}
+
+function RatingRowSparkline({
+  history,
+  change,
+}: {
+  history: number[]
+  change: RatingChange
+}) {
+  // history is anchored "before this match"; append the post-match value so the
+  // line lands on the new rating.
+  const series = [...history]
+  if (series.length === 0 && change.before !== null) {
+    series.push(change.before)
+  }
+  series.push(change.after)
+  if (series.length < 2) return null
+  return <Sparkline data={series} w={80} h={28} downColor="var(--loss)" />
 }
 
 function H2HCard({ view, h2h }: { view: MatchView; h2h: H2HView }) {

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2315,18 +2315,6 @@ body.dark.fortymm-theme {
   color: var(--fg-3);
   margin-top: 4px;
 }
-.fortymm-theme .md-hero__rating-delta {
-  font: 600 11px var(--font-mono);
-  margin-top: 6px;
-  letter-spacing: 0.04em;
-}
-.fortymm-theme .md-hero__rating-delta--up {
-  color: var(--serve-500);
-}
-.fortymm-theme .md-hero__rating-delta--down {
-  color: var(--loss);
-}
-
 .fortymm-theme .md-hero__doubles-row {
   display: flex;
 }
@@ -2466,7 +2454,10 @@ body.dark.fortymm-theme {
 }
 .fortymm-theme .md-games__grid {
   display: grid;
-  grid-template-columns: 130px repeat(5, 1fr) 90px;
+  grid-template-columns:
+    var(--md-games-kicker, 130px)
+    repeat(var(--md-games-count, 5), 1fr)
+    var(--md-games-total, 90px);
   gap: 8px;
   align-items: center;
 }
@@ -2799,10 +2790,10 @@ body.dark.fortymm-theme {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 2px;
+  gap: 4px;
 }
 .fortymm-theme .md-rating-row__delta-num {
-  font: 700 13px var(--font-mono);
+  font: 700 16px var(--font-mono);
   letter-spacing: 0.04em;
 }
 .fortymm-theme .md-delta-up {
@@ -3204,7 +3195,8 @@ body.dark.fortymm-theme {
     width: auto;
   }
   .fortymm-theme .md-games__grid {
-    grid-template-columns: 96px repeat(5, 1fr) 60px;
+    --md-games-kicker: 96px;
+    --md-games-total: 60px;
   }
   .fortymm-theme .md-hero__score {
     font-size: 84px;


### PR DESCRIPTION
## Summary
- Fix the games grid breaking on best-of-1 matches — column count is now driven by `view.bestOf` through a CSS variable instead of a hardcoded `repeat(5, 1fr)`.
- Remove the rating delta from the hero (it stays in the dedicated rating change card).
- Add a sparkline of recent rating trajectory to each row of the rating change card (red on a loss, green on a win), with the post-match value appended to history so the line lands on the new rating.

## Test plan
- [x] `npm run test:run` — 54/54 vitest pass
- [x] `npm run lint` — clean
- [x] `npm run build` — typecheck + bundle succeed
- [ ] Manual: open a BO1 match details page; verify GAMES row renders as `GAMES | G1 | SETS` cleanly with both player rows aligned beneath
- [ ] Manual: open a completed rated match; verify each rating-change row shows a sparkline next to the delta, colored by direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)