### PR TITLE
Clean up match details header; fix H2H layout for long usernames

### DIFF
--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -542,9 +542,7 @@ function GameGrid({ view, matchId }: { view: MatchView; matchId: string }) {
     <div className="md-games">
       <div
         className="md-games__grid"
-        style={
-          { '--md-games-count': view.bestOf } as React.CSSProperties
-        }
+        style={{ '--md-games-count': view.bestOf } as React.CSSProperties}
       >
         <div className="md-games__kicker">GAMES</div>
         {slots.map((_, i) => (
@@ -737,8 +735,6 @@ function RatingBox({ side }: { side: SideView }) {
   )
 }
 
-// Local copy of the dashboard sparkline — same shape and palette, but the
-// match-details card uses a smaller footprint than the dashboard hero.
 function Sparkline({
   data,
   w = 110,

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -508,7 +508,6 @@ function HeroScoreboard({
 
 function PlayerSide({ side, pos }: { side: SideView; pos: 'l' | 'r' }) {
   const win = side.won === true
-  const change = side.ratingChange
   return (
     <div className={`md-hero__player md-hero__player--${pos}`}>
       <div className="md-hero__player-row">
@@ -524,19 +523,6 @@ function PlayerSide({ side, pos }: { side: SideView; pos: 'l' | 'r' }) {
           <div className={cn('md-hero__name', win && 'md-hero__name--win')}>
             {side.username}
           </div>
-          {change && (
-            <div
-              className={cn(
-                'md-hero__rating-delta',
-                change.delta >= 0
-                  ? 'md-hero__rating-delta--up'
-                  : 'md-hero__rating-delta--down',
-              )}
-              data-testid={`rating-delta-${pos}`}
-            >
-              {formatRatingDelta(change.delta)} rating
-            </div>
-          )}
         </div>
       </div>
     </div>
@@ -554,7 +540,12 @@ function GameGrid({ view, matchId }: { view: MatchView; matchId: string }) {
   const canEdit = view.leftSide.isCurrentUser
   return (
     <div className="md-games">
-      <div className="md-games__grid">
+      <div
+        className="md-games__grid"
+        style={
+          { '--md-games-count': view.bestOf } as React.CSSProperties
+        }
+      >
         <div className="md-games__kicker">GAMES</div>
         {slots.map((_, i) => (
           <div key={`h-${i}`} className="md-games__col-label">
@@ -740,7 +731,7 @@ function RatingBox({ side }: { side: SideView }) {
         </div>
       </div>
       {side.ratingHistory.length >= 2 && (
-        <ProfileSparkline data={side.ratingHistory} />
+        <Sparkline data={side.ratingHistory} />
       )}
     </div>
   )
@@ -748,14 +739,16 @@ function RatingBox({ side }: { side: SideView }) {
 
 // Local copy of the dashboard sparkline — same shape and palette, but the
 // match-details card uses a smaller footprint than the dashboard hero.
-function ProfileSparkline({
+function Sparkline({
   data,
   w = 110,
   h = 36,
+  downColor = 'var(--fg-3)',
 }: {
   data: number[]
   w?: number
   h?: number
+  downColor?: string
 }) {
   const min = Math.min(...data)
   const max = Math.max(...data)
@@ -772,7 +765,7 @@ function ProfileSparkline({
   // The last point's trend picks the colour so a falling rating reads as a
   // loss tone even before the user squints at the y-axis.
   const trendUp = data[data.length - 1] >= data[0]
-  const color = trendUp ? 'var(--serve-500)' : 'var(--fg-3)'
+  const color = trendUp ? 'var(--serve-500)' : downColor
   const last = points[points.length - 1]
   return (
     <svg
@@ -926,6 +919,10 @@ function RatingRow({ side, isFirst }: { side: SideView; isFirst: boolean }) {
         </div>
         {change && (
           <div className="md-rating-row__delta">
+            <RatingRowSparkline
+              history={side.ratingHistory}
+              change={change}
+            />
             <span
               className={cn(
                 'md-rating-row__delta-num',
@@ -939,6 +936,24 @@ function RatingRow({ side, isFirst }: { side: SideView; isFirst: boolean }) {
       </div>
     </>
   )
+}
+
+function RatingRowSparkline({
+  history,
+  change,
+}: {
+  history: number[]
+  change: RatingChange
+}) {
+  // history is anchored "before this match"; append the post-match value so the
+  // line lands on the new rating.
+  const series = [...history]
+  if (series.length === 0 && change.before !== null) {
+    series.push(change.before)
+  }
+  series.push(change.after)
+  if (series.length < 2) return null
+  return <Sparkline data={series} w={80} h={28} downColor="var(--loss)" />
 }
 
 function H2HCard({ view, h2h }: { view: MatchView; h2h: H2HView }) {

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -966,28 +966,30 @@ function H2HCard({ view, h2h }: { view: MatchView; h2h: H2HView }) {
       </div>
       <div className="md-card__body md-h2h">
         <div className="md-h2h__counts">
-          <div className="md-h2h__count-block md-h2h__count-block--l">
-            <div
-              className={cn(
-                'md-h2h__count',
-                h2h.leftWins > h2h.rightWins && 'md-h2h__count--win',
-              )}
-            >
-              {h2h.leftWins}
-            </div>
-            <div className="md-h2h__count-label">{leftLabel}</div>
+          <div className="md-h2h__count-label md-h2h__count-label--l">
+            {leftLabel}
+          </div>
+          <div
+            className={cn(
+              'md-h2h__count',
+              'md-h2h__count--l',
+              h2h.leftWins > h2h.rightWins && 'md-h2h__count--win',
+            )}
+          >
+            {h2h.leftWins}
           </div>
           <span className="md-h2h__sep">—</span>
-          <div className="md-h2h__count-block md-h2h__count-block--r">
-            <div
-              className={cn(
-                'md-h2h__count',
-                h2h.rightWins > h2h.leftWins && 'md-h2h__count--win',
-              )}
-            >
-              {h2h.rightWins}
-            </div>
-            <div className="md-h2h__count-label">{rightLabel}</div>
+          <div
+            className={cn(
+              'md-h2h__count',
+              'md-h2h__count--r',
+              h2h.rightWins > h2h.leftWins && 'md-h2h__count--win',
+            )}
+          >
+            {h2h.rightWins}
+          </div>
+          <div className="md-h2h__count-label md-h2h__count-label--r">
+            {rightLabel}
           </div>
         </div>
         {hasMeetings ? (

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2315,18 +2315,6 @@ body.dark.fortymm-theme {
   color: var(--fg-3);
   margin-top: 4px;
 }
-.fortymm-theme .md-hero__rating-delta {
-  font: 600 11px var(--font-mono);
-  margin-top: 6px;
-  letter-spacing: 0.04em;
-}
-.fortymm-theme .md-hero__rating-delta--up {
-  color: var(--serve-500);
-}
-.fortymm-theme .md-hero__rating-delta--down {
-  color: var(--loss);
-}
-
 .fortymm-theme .md-hero__doubles-row {
   display: flex;
 }
@@ -2466,7 +2454,10 @@ body.dark.fortymm-theme {
 }
 .fortymm-theme .md-games__grid {
   display: grid;
-  grid-template-columns: 130px repeat(5, 1fr) 90px;
+  grid-template-columns:
+    var(--md-games-kicker, 130px)
+    repeat(var(--md-games-count, 5), 1fr)
+    var(--md-games-total, 90px);
   gap: 8px;
   align-items: center;
 }
@@ -2799,10 +2790,10 @@ body.dark.fortymm-theme {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 2px;
+  gap: 4px;
 }
 .fortymm-theme .md-rating-row__delta-num {
-  font: 700 13px var(--font-mono);
+  font: 700 16px var(--font-mono);
   letter-spacing: 0.04em;
 }
 .fortymm-theme .md-delta-up {
@@ -3204,7 +3195,8 @@ body.dark.fortymm-theme {
     width: auto;
   }
   .fortymm-theme .md-games__grid {
-    grid-template-columns: 96px repeat(5, 1fr) 60px;
+    --md-games-kicker: 96px;
+    --md-games-total: 60px;
   }
   .fortymm-theme .md-hero__score {
     font-size: 84px;

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2819,29 +2819,46 @@ body.dark.fortymm-theme {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  gap: 12px;
-}
-.fortymm-theme .md-h2h__count-block--l {
-  text-align: right;
-}
-.fortymm-theme .md-h2h__count-block--r {
-  text-align: left;
+  column-gap: 12px;
+  row-gap: 4px;
 }
 .fortymm-theme .md-h2h__count {
+  grid-row: 1;
   font: 700 28px var(--font-mono);
   font-variant-numeric: tabular-nums;
   line-height: 1;
   color: var(--fg-1);
+  min-width: 0;
+}
+.fortymm-theme .md-h2h__count--l {
+  grid-column: 1;
+  text-align: right;
+}
+.fortymm-theme .md-h2h__count--r {
+  grid-column: 3;
+  text-align: left;
 }
 .fortymm-theme .md-h2h__count--win {
   color: var(--serve-500);
 }
 .fortymm-theme .md-h2h__count-label {
+  grid-row: 2;
   font: 500 11px var(--font-ui);
   color: var(--fg-3);
-  margin-top: 2px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.fortymm-theme .md-h2h__count-label--l {
+  grid-column: 1;
+  text-align: right;
+}
+.fortymm-theme .md-h2h__count-label--r {
+  grid-column: 3;
+  text-align: left;
 }
 .fortymm-theme .md-h2h__sep {
+  grid-row: 1;
+  grid-column: 2;
   font: 700 13px var(--font-mono);
   color: var(--fg-3);
 }


### PR DESCRIPTION
## Summary
- Hero card drops the inline rating-delta; the dedicated Rating Change card below now owns it.
- Games grid columns are driven by `--md-games-count` from `view.bestOf` (was hard-coded to 5).
- `ProfileSparkline` renamed to `Sparkline` and generalized with a `downColor` prop; the rating row now renders a small sparkline beside the delta.
- **H2H panel**: restructured the counts grid so scores + separator live on row 1 and labels on row 2, with explicit `grid-row` / `grid-column` placement. Labels get `min-width: 0` + `overflow-wrap: anywhere` so long usernames wrap inside their own column without misaligning the score row. DOM order is `leftLabel, leftCount, —, rightCount, rightLabel` for natural screen-reader reading.

Before (long usernames misaligned the scores) vs. after (scores stay aligned, labels wrap in-column):

## Test plan
- [x] `web-client` vitest — all green (incl. `match-details-page.test.tsx` 11/11)
- [x] `web-client` lint
- [x] `web-client` build (tsc + vite)
- [x] `web-client` Playwright e2e — 126/126 green
- [x] Manual: verified the H2H panel with both long and asymmetric usernames; scores and separator stay aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)