### PR TITLE
Restore the topbar username pill as display-only

### DIFF
--- a/e2e/page-objects/dashboard-page/user-menu.page.ts
+++ b/e2e/page-objects/dashboard-page/user-menu.page.ts
@@ -1,0 +1,11 @@
+import { Locator, Page } from '@playwright/test';
+
+export class UserMenuPage {
+    public readonly skeleton: Locator;
+    public readonly menu: Locator;
+
+    constructor(page: Page) {
+        this.skeleton = page.getByTestId('user-menu-skeleton');
+        this.menu = page.getByTestId('user-menu');
+    }
+}

--- a/e2e/page-objects/dashboard.page.ts
+++ b/e2e/page-objects/dashboard.page.ts
@@ -1,8 +1,15 @@
 import { Page } from "@playwright/test";
+import { UserMenuPage } from "./dashboard-page/user-menu.page";
 
 export class DashboardPage {
+    public readonly userMenu: UserMenuPage;
+
     static async navigateTo(page: Page): Promise<DashboardPage> {
         await page.goto('/dashboard');
-        return new DashboardPage();
+        return new DashboardPage(page);
+    }
+
+    constructor(page: Page) {
+        this.userMenu = new UserMenuPage(page);
     }
 }

--- a/e2e/tests/dashboard-session.spec.ts
+++ b/e2e/tests/dashboard-session.spec.ts
@@ -3,11 +3,10 @@ import { DashboardPage } from '../page-objects/dashboard.page';
 
 test.describe('Dashboard', () => {
     test('issues a session to a first-time visitor', async ({ page, context }) => {
-        const sessionResponse = page.waitForResponse((response) =>
-            response.url().includes('/v1/session') && response.request().method() === 'GET',
-        );
-        await DashboardPage.navigateTo(page);
-        await sessionResponse;
+        const dashboard = await DashboardPage.navigateTo(page);
+
+        await expect(dashboard.userMenu.skeleton).not.toBeVisible();
+        await expect(dashboard.userMenu.menu).not.toContainText('Guest');
 
         const cookies = await context.cookies();
         const session = cookies.find((cookie) => cookie.name === 'session');

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -15,6 +15,7 @@ import {
 import { useSession } from '@/api/session'
 import { cn } from '@/lib/utils'
 import { PERM } from '@/lib/permissions'
+import { UserMenu } from './user-menu'
 
 type NavChild = { label: string; to: string; hash?: string; icon: ReactNode; requires?: string }
 
@@ -333,6 +334,10 @@ export function AppShell({ children }: AppShellProps) {
           </a>
 
           <div className="app-shell__spacer" />
+
+          <div className="app-shell__actions">
+            <UserMenu />
+          </div>
         </header>
 
         <main className="app-shell__content">{children}</main>

--- a/web-client/src/components/user-menu.test.tsx
+++ b/web-client/src/components/user-menu.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse, delay } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { server } from '@/mocks/server'
+import { mockSession } from '@/mocks/handlers'
+import type { components } from '@/api/schema'
+import { UserMenu } from './user-menu'
+
+type SessionResponse = components['schemas']['SessionResponse']
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+describe('UserMenu', () => {
+  it('shows a loading skeleton while the session is fetching', async () => {
+    server.use(
+      http.get('*/v1/session', async () => {
+        await delay(50)
+        return HttpResponse.json(mockSession)
+      }),
+    )
+
+    renderWithClient(<UserMenu />)
+
+    expect(screen.getByTestId('user-menu-skeleton')).toBeInTheDocument()
+    expect(screen.getByLabelText('Loading user menu')).toHaveAttribute(
+      'aria-busy',
+      'true',
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('user-menu-skeleton')).not.toBeInTheDocument()
+    })
+  })
+
+  it("displays the user's username once the session resolves", async () => {
+    renderWithClient(<UserMenu />)
+
+    expect(
+      await screen.findByText(mockSession.data.user.username),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('user-menu')).toHaveAttribute(
+      'aria-label',
+      `Signed in as ${mockSession.data.user.username}`,
+    )
+  })
+
+  it('renders avatar initials derived from the username', async () => {
+    const typed: SessionResponse = {
+      data: { user: { username: 'maria.rossi', permissions: [] } },
+    }
+    server.use(
+      http.get('*/v1/session', () => HttpResponse.json(typed)),
+    )
+
+    renderWithClient(<UserMenu />)
+
+    expect(await screen.findByText('maria.rossi')).toBeInTheDocument()
+    expect(screen.getByText('MR')).toBeInTheDocument()
+  })
+
+  it('truncates very long usernames via class and exposes full name as a tooltip', async () => {
+    const longName = 'a-really-extraordinarily-long-username-that-should-truncate'
+    const typed: SessionResponse = {
+      data: { user: { username: longName, permissions: [] } },
+    }
+    server.use(
+      http.get('*/v1/session', () => HttpResponse.json(typed)),
+    )
+
+    renderWithClient(<UserMenu />)
+
+    const nameEl = await screen.findByText(longName)
+    expect(nameEl).toHaveClass('app-shell__user-name--truncate')
+    expect(nameEl).toHaveAttribute('title', longName)
+  })
+})

--- a/web-client/src/components/user-menu.tsx
+++ b/web-client/src/components/user-menu.tsx
@@ -1,0 +1,46 @@
+import { useSession } from '@/api/session'
+
+function getInitials(username: string): string {
+  const cleaned = username.replace(/[._-]+/g, ' ').trim()
+  const parts = cleaned.split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return '??'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[1][0]).toUpperCase()
+}
+
+export function UserMenu() {
+  const { data, isLoading, isError } = useSession()
+
+  if (isLoading) {
+    return (
+      <div
+        className="app-shell__user-menu app-shell__user-menu--loading"
+        aria-busy="true"
+        aria-label="Loading user menu"
+        data-testid="user-menu-skeleton"
+      >
+        <div className="app-shell__user-avatar app-shell__skeleton app-shell__skeleton--avatar" />
+        <div className="app-shell__user-name app-shell__skeleton app-shell__skeleton--name" />
+      </div>
+    )
+  }
+
+  const username = !isError && data ? data.data.user.username : 'Guest'
+  const initials = getInitials(username)
+
+  return (
+    <div
+      className="app-shell__user-menu"
+      data-testid="user-menu"
+      aria-label={`Signed in as ${username}`}
+    >
+      <div className="app-shell__user-avatar">{initials}</div>
+      <div
+        className="app-shell__user-name app-shell__user-name--truncate"
+        title={username}
+      >
+        {username}
+      </div>
+    </div>
+  )
+}

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -611,6 +611,82 @@ body.dark.fortymm-theme {
   flex: 1;
 }
 
+.app-shell__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.app-shell__user-menu {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px 4px 4px;
+  height: 40px;
+  border-radius: 999px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  color: var(--fg-1);
+}
+.app-shell__user-avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #2a6fdb, #00e29a);
+  color: var(--ink-950);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 12px;
+}
+.app-shell__user-name {
+  font-size: 13px;
+  font-weight: 500;
+}
+.app-shell__user-name--truncate {
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.app-shell__skeleton {
+  position: relative;
+  overflow: hidden;
+  background: var(--bg-raised);
+}
+.app-shell__skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.06) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: app-shell-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+.app-shell__skeleton--avatar {
+  background: var(--bg-raised);
+}
+.app-shell__skeleton--name {
+  width: 96px;
+  height: 12px;
+  border-radius: 4px;
+}
+@keyframes app-shell-skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .app-shell__skeleton::after {
+    animation: none;
+  }
+}
+
 /* ---------- Sidebar ---------- */
 .app-shell__sidebar {
   position: sticky;
@@ -862,6 +938,13 @@ body.dark.fortymm-theme {
   }
   .app-shell__sidebar-close {
     display: inline-flex;
+  }
+
+  .app-shell__user-name {
+    display: none;
+  }
+  .app-shell__user-menu {
+    padding: 4px;
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #205, which removed the topbar UserMenu wholesale. We wanted to keep the little avatar+name pill (so signed-in identity is visible from every page) but *not* the dropdown-on-click. Username editing stays on the settings page.

- Bring back `UserMenu` as a non-interactive `<div>` — no `DropdownMenu`, no `ChangeUsernameDialog`, no `cursor: pointer` / `:hover` affordance
- Add `aria-label="Signed in as <name>"` for screen readers
- Restore the supporting CSS (`.app-shell__actions`, `.app-shell__user-menu*`, `.app-shell__skeleton*`, mobile responsive name-hiding)
- Restore the e2e `UserMenuPage` helper and the two dashboard-session assertions (they double as an implicit wait for the session fetch, fixing the race that needed the explicit `waitForResponse` in #205)

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` (tsc + vite) clean
- [x] `npm run test:run` — 50/50 pass (4 restored UserMenu tests cover skeleton, display, initials, truncation)
- [x] Manual smoke: pill renders avatar+name; click does nothing (no menu, no navigation); element is `<div>` with `cursor: auto` and no `role`

🤖 Generated with [Claude Code](https://claude.com/claude-code)