### PR TITLE
Check for SW updates on visibility change + every 15 min

### DIFF
--- a/web-client/src/components/service-worker-updater.tsx
+++ b/web-client/src/components/service-worker-updater.tsx
@@ -3,27 +3,51 @@ import { useRegisterSW } from 'virtual:pwa-register/react'
 import { toast } from 'sonner'
 
 const TOAST_ID = 'sw-update-available'
+const UPDATE_INTERVAL_MS = 15 * 60 * 1000
+// Floor between successive update() calls so rapid tab switching doesn't spam
+// the network. Browsers throttle setInterval in hidden tabs, but
+// visibilitychange has no such guarantee.
+const MIN_UPDATE_GAP_MS = 60 * 1000
 
 export function ServiceWorkerUpdater() {
+  const registrationRef = useRef<ServiceWorkerRegistration | null>(null)
+  const lastUpdateRef = useRef(0)
+  const shownRef = useRef(false)
+
   const {
     needRefresh: [needRefresh, setNeedRefresh],
     updateServiceWorker,
   } = useRegisterSW({
     onRegisteredSW(_swUrl, registration) {
       if (!registration) return
-      const hourMs = 60 * 60 * 1000
-      setInterval(() => {
-        if (!registration.installing && navigator.onLine) {
-          registration.update()
-        }
-      }, hourMs)
+      registrationRef.current = registration
     },
     onRegisterError(error) {
       console.error('Service worker registration failed', error)
     },
   })
 
-  const shownRef = useRef(false)
+  useEffect(() => {
+    const checkForUpdates = () => {
+      const registration = registrationRef.current
+      if (!registration || registration.installing || !navigator.onLine) return
+      const now = Date.now()
+      if (now - lastUpdateRef.current < MIN_UPDATE_GAP_MS) return
+      lastUpdateRef.current = now
+      void registration.update()
+    }
+
+    const interval = setInterval(checkForUpdates, UPDATE_INTERVAL_MS)
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') checkForUpdates()
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [])
 
   useEffect(() => {
     if (!needRefresh || shownRef.current) return


### PR DESCRIPTION
## Summary

- Replace the 1-hour-only SW update polling cadence in `service-worker-updater.tsx` with the typical React-SPA combo: `visibilitychange` trigger + a 15-minute interval.
- Add a 60-second leading-edge throttle so rapid tab switching doesn't spam `registration.update()`. Browsers throttle `setInterval` in hidden tabs but make no such guarantee for `visibilitychange`.
- Move the interval/listener wiring into a `useEffect` with proper cleanup; stash the registration in a ref so the empty-deps effect can pick it up after `useRegisterSW` resolves asynchronously.

## Test plan

- [x] `npm run test:run` — vitest 46/46
- [x] `npm run lint && npm run build` — clean; PWA `sw.js` generated
- [x] `PLAYWRIGHT_PORT=5175 npm run test:e2e` — 126/126
- [ ] Manual: after a deploy, open the app, hide the tab briefly, return — the "new version ready" toast should appear without waiting an hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)