### PR TITLE
Use the standard AppShell layout for score entry

### DIFF
--- a/web-client/e2e/page-objects/score-entry.page.ts
+++ b/web-client/e2e/page-objects/score-entry.page.ts
@@ -24,8 +24,6 @@ export const SEED = {
 export class ScoreEntryPage {
   public readonly page: Page
   public readonly heading: Locator
-  public readonly gameTag: Locator
-  public readonly metaLine: Locator
   public readonly meInput: Locator
   public readonly oppInput: Locator
   public readonly saveButton: Locator
@@ -52,8 +50,6 @@ export class ScoreEntryPage {
   constructor(page: Page, opponentUsername: string = SEED.opponentUsername) {
     this.page = page
     this.heading = page.getByRole('heading', { level: 2 })
-    this.gameTag = page.locator('.live-bar .tag')
-    this.metaLine = page.locator('.live-bar .meta')
     this.meInput = page.getByRole('textbox', { name: `${SEED.meUsername} score` })
     this.oppInput = page.getByRole('textbox', {
       name: `${opponentUsername} score`,

--- a/web-client/e2e/score-entry.spec.ts
+++ b/web-client/e2e/score-entry.spec.ts
@@ -216,10 +216,6 @@ test.describe('Score entry', () => {
     const scoreEntry = await ScoreEntryPage.navigateTo(page)
 
     await expect(scoreEntry.heading).toHaveText('Enter game 3 score.')
-    await expect(scoreEntry.gameTag).toContainText('GAME 03 OF 05')
-    await expect(scoreEntry.metaLine).toContainText(
-      'RATED · BEST OF 5 · FIRST TO 3',
-    )
     await expect(scoreEntry.meInput).toBeVisible()
     await expect(scoreEntry.oppInput).toBeVisible()
   })

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -376,9 +376,7 @@ describe('ScoreEntry — create', () => {
     expect(alert).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: 'rita.kovac score' })).toBeDisabled()
     expect(screen.getByRole('textbox', { name: 'nguyen.t score' })).toBeDisabled()
-    // The primary "Back to match" CTA replaces the save button. The live-bar
-    // link is the persistent "← Back to match" at the top — we want the new
-    // primary CTA below.
+    // The primary "Back to match" CTA replaces the save button.
     expect(
       screen.getByRole('link', { name: 'Back to match' }),
     ).toHaveAttribute('href', '/matches/m-1')

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -10,6 +10,7 @@ import {
   type MatchDetails,
   type MatchGameScoreWrite,
 } from '@/api/matches'
+import { AppShell } from '@/components/app-shell'
 import { cn, initialsOf } from '@/lib/utils'
 
 export type ScoreMutation = UseMutationResult<
@@ -71,11 +72,9 @@ function ScoreEntryInner({
 
   if (isLoading || !data) {
     return (
-      <div
-        className="fortymm-theme dark score-entry-screen"
-        aria-busy="true"
-        data-testid="score-entry-loading"
-      />
+      <AppShell>
+        <div aria-busy="true" data-testid="score-entry-loading" />
+      </AppShell>
     )
   }
 
@@ -99,7 +98,6 @@ function ScoreEntryInner({
   const oppInitials = initialsOf(oppName)
 
   const bestOf = data.best_of
-  const gamesToWin = data.games_to_win
   const gameNumber = game.game_number
 
   const meWins = mySide.games_won
@@ -173,8 +171,6 @@ function ScoreEntryInner({
     }
   }
 
-  const pad = (n: number) => String(n).padStart(2, '0')
-  const gameLabel = `GAME ${pad(gameNumber)} OF ${pad(bestOf)}`
   const inputsLocked = mutation.isPending || lockedReason !== null
   const isEdit = mode.kind === 'edit'
 
@@ -206,20 +202,7 @@ function ScoreEntryInner({
       : null
 
   return (
-    <div className="fortymm-theme dark score-entry-screen">
-      <div className="live-bar">
-        <Link {...matchDetailRoute(matchId)} className="back">
-          ← Back to match
-        </Link>
-        <span className="tag">
-          <span className="dot" /> {gameLabel}
-        </span>
-        <span className="meta">
-          {data.affects_rating ? 'RATED' : 'UNRATED'} · BEST OF {bestOf} ·
-          FIRST TO {gamesToWin}
-        </span>
-      </div>
-
+    <AppShell>
       <div className="entry-wrap">
         <div className="entry-head">
           <h2>{heading}</h2>
@@ -317,7 +300,7 @@ function ScoreEntryInner({
           mySideNumber={mySideNumber}
         />
       </div>
-    </div>
+    </AppShell>
   )
 }
 

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1375,7 +1375,6 @@ body.dark.fortymm-theme {
 /* =========================================================================
    Score entry — single-game score capture
    (route: /matches/:matchId/games/:gameId/scores/new)
-   Ported from the "Match Settings Page v2" design handoff (LiveScreen).
    ========================================================================= */
 /* ---------- Entry layout ---------- */
 .fortymm-theme .entry-wrap {

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1377,7 +1377,8 @@ body.dark.fortymm-theme {
    (route: /matches/:matchId/games/:gameId/scores/new)
    Ported from the "Match Settings Page v2" design handoff (LiveScreen).
    ========================================================================= */
-.fortymm-theme .score-entry-screen {
+/* ---------- Entry layout ---------- */
+.fortymm-theme .entry-wrap {
   /* Motion/shadow tokens the design defines at :root — kept local so the
      port stays faithful without expanding the shared token set. */
   --dur-fast: 120ms;
@@ -1385,70 +1386,6 @@ body.dark.fortymm-theme {
   --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
 
-  position: fixed;
-  inset: 0;
-  background: var(--ink-950);
-  color: var(--fg-1);
-  font-family: var(--font-ui);
-  z-index: 100;
-  display: flex;
-  flex-direction: column;
-  overflow: auto;
-}
-.fortymm-theme .score-entry-screen *,
-.fortymm-theme .score-entry-screen *::before,
-.fortymm-theme .score-entry-screen *::after {
-  box-sizing: border-box;
-}
-
-/* ---------- Top bar ---------- */
-.fortymm-theme .live-bar {
-  padding: 18px 40px;
-  display: flex;
-  align-items: center;
-  gap: 20px;
-  border-bottom: 1px solid var(--ink-600);
-}
-.fortymm-theme .live-bar .back {
-  background: transparent;
-  border: 1px solid var(--ink-500);
-  color: var(--fg-2);
-  height: 36px;
-  padding: 0 14px;
-  border-radius: 8px;
-  cursor: pointer;
-  font: 600 13px var(--font-ui);
-}
-.fortymm-theme .live-bar .back:hover {
-  background: var(--bg-hover);
-  color: var(--fg-1);
-}
-.fortymm-theme .live-bar .tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font: 700 11px var(--font-mono);
-  letter-spacing: 0.2em;
-  color: var(--ball-500);
-}
-.fortymm-theme .live-bar .tag .dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--ball-500);
-  box-shadow: 0 0 10px rgba(255, 122, 26, 0.7);
-  animation: ball-pulse 1.4s ease-in-out infinite;
-}
-.fortymm-theme .live-bar .meta {
-  font: 600 11px var(--font-mono);
-  letter-spacing: 0.14em;
-  color: var(--fg-3);
-  margin-left: auto;
-}
-
-/* ---------- Entry layout ---------- */
-.fortymm-theme .entry-wrap {
-  flex: 1;
   display: flex;
   flex-direction: column;
   max-width: 1180px;
@@ -1785,9 +1722,6 @@ body.dark.fortymm-theme {
 
 /* ---------- Responsive ---------- */
 @media (max-width: 820px) {
-  .fortymm-theme .live-bar {
-    padding: 14px 16px;
-  }
   .fortymm-theme .entry-wrap {
     padding: 20px 16px;
   }
@@ -1830,9 +1764,6 @@ body.dark.fortymm-theme {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .fortymm-theme .live-bar .tag .dot {
-    animation: none !important;
-  }
   .fortymm-theme .sl-cell {
     transition: none !important;
   }


### PR DESCRIPTION
## Summary
- Replaces the score-entry page's custom full-screen overlay (`score-entry-screen` + `live-bar` with back button, GAME tag, RATED/BEST OF meta) with the standard `AppShell` used elsewhere in the app.
- Drops the now-dead CSS (~73 lines), the unused `gameLabel`/`pad`/`gamesToWin` locals, and the e2e locators that targeted the removed bar.

## Heads up
The live-bar provided two affordances now removed: a one-click back link to the specific match, and ambient context (game number / RATED / BO / first-to). Navigation falls back to the sidebar's "Matches" link (goes to the list, not the match), and match metadata is no longer shown on this page. Happy to bring either back in a follow-up if desired.

## Test plan
- [x] `npm run test:run` — 46/46
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm run test:e2e` — 126/126
- [ ] Eyeball score entry on a live match and confirm sidebar nav works

🤖 Generated with [Claude Code](https://claude.com/claude-code)