### PR TITLE
Drop hex suffix from autogenerated usernames

### DIFF
--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from coolname import generate_slug
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, status
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -35,11 +35,11 @@ def _hash_token(raw_token: str) -> bytes:
 async def _generate_username(db: AsyncSession) -> str:
     base = generate_slug(2)
     result = await db.execute(
-        select(func.lower(User.username)).where(
-            func.lower(User.username).like(f"{base}%")
+        select(User.username).where(
+            User.username.ilike(f"{base}%", escape="\\")
         )
     )
-    taken = set(result.scalars().all())
+    taken = {u.lower() for u in result.scalars().all()}
     if base not in taken:
         return base
     suffix = 2

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from coolname import generate_slug
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -32,8 +32,20 @@ def _hash_token(raw_token: str) -> bytes:
     return hashlib.sha256(raw_token.encode("utf-8")).digest()
 
 
-def _generate_username() -> str:
-    return f"{generate_slug(2)}-{secrets.token_hex(4)}"
+async def _generate_username(db: AsyncSession) -> str:
+    base = generate_slug(2)
+    result = await db.execute(
+        select(func.lower(User.username)).where(
+            func.lower(User.username).like(f"{base}%")
+        )
+    )
+    taken = set(result.scalars().all())
+    if base not in taken:
+        return base
+    suffix = 2
+    while f"{base}-{suffix}" in taken:
+        suffix += 1
+    return f"{base}-{suffix}"
 
 
 def _cookie_secure() -> bool:
@@ -68,7 +80,7 @@ async def _load_permissions(db: AsyncSession, user_id) -> list[str]:
 
 
 async def _create_session(db: AsyncSession) -> tuple[User, str]:
-    user = User(username=_generate_username())
+    user = User(username=await _generate_username(db))
     db.add(user)
     await db.flush()
 


### PR DESCRIPTION
## Summary
- Autogenerated usernames are now bare 2-word coolname slugs (e.g. `amiable-waxbill`) instead of `<slug>-<hex>` (e.g. `amiable-waxbill-3f2a`).
- On collision, the lowest free numeric suffix is appended: `amiable-waxbill-2`, `-3`, …
- Collision lookup uses `ilike` (case-insensitive, hits the existing btree index on `users.username`) to align with the editable-username uniqueness check in `app/uniqueness.py`.

## Notes
- Single-file change (`api/app/sessions.py`), internal helper only — no routes or schemas touched, so no OpenAPI drift.
- There's a small TOCTOU window where two parallel `/v1/session` first-hits could pick the same base slug and the second would raise `IntegrityError` on flush. Coolname has ~25M two-word combinations so the probability is low; adding a retry loop is a fine follow-up if it ever bites.
- Existing `tests/test_session.py` only asserts the username is non-empty, so it still passes. No positive test added for the suffix-on-collision path — also a fine follow-up.

## Test plan
- [x] `pytest` — 224/224 passing
- [x] `npm run test:run` (web vitest) — 50/50
- [x] `npm run lint` + `npm run build` (web)
- [x] `npm run test:e2e` (web Playwright) — 126/126
- [x] `npm test` in `e2e/` (root Playwright, full docker stack) — 4/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)