### PR TITLE
Restyle Sonner action button to match the FortyMM kit

### DIFF
--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -443,6 +443,27 @@ body.dark.fortymm-theme {
   top: 8px;
   transform: none;
 }
+/* Action button — promoted to its own row as the toast's CTA. */
+[data-sonner-toast][data-styled='true'].cn-toast:has([data-button][data-action]) {
+  flex-wrap: wrap;
+  row-gap: 12px;
+}
+[data-sonner-toast][data-styled='true'].cn-toast:has([data-button][data-action]) [data-content] {
+  flex: 1 1 100%;
+}
+[data-sonner-toast][data-styled='true'].cn-toast [data-button][data-action] {
+  margin-left: auto;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  height: 36px;
+  padding: 0 16px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 500;
+}
+[data-sonner-toast][data-styled='true'].cn-toast [data-button][data-action]:hover {
+  background: var(--ball-400);
+}
 
 .fortymm-theme .ball-dot {
   display: inline-block;

--- a/web-client/src/routes/design-system.tsx
+++ b/web-client/src/routes/design-system.tsx
@@ -1379,7 +1379,7 @@ function FeedbackSection() {
         </div>
       </Showcase>
 
-      <Showcase title="Sonner / Toast" tag="3 variants">
+      <Showcase title="Sonner / Toast" tag="4 variants">
         <div className="flex flex-col gap-5">
           <div className="flex max-w-[420px] flex-col gap-3">
             <ToastCard
@@ -1432,6 +1432,20 @@ function FeedbackSection() {
               }
             >
               Trigger info
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                toast.info('A new version of FortyMM is ready.', {
+                  id: 'sw-update-available',
+                  description: 'Reload to get the latest update.',
+                  duration: Infinity,
+                  action: { label: 'Reload', onClick: () => {} },
+                })
+              }
+            >
+              Trigger reload
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Promote Sonner's action button to its own row inside the toast and restyle to the FortyMM primary (orange on ink-950) so the SW reload prompt's CTA reads with the same weight as buttons elsewhere in the app.
- Add a "Trigger reload" demo to the design-system showcase so the action-button treatment is documented alongside the success/error/info variants.

## Test plan
- [x] vitest (50/50)
- [x] eslint
- [x] tsc + vite build
- [x] web-client Playwright e2e (126/126, incl. existing design-system toast snapshots)
- [ ] Manually verify the SW reload toast on a real update prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)