### PR TITLE
Stack multiple pending score banners on the dashboard

### DIFF
--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -63,12 +63,13 @@ async def get_dashboard(
         .order_by(Match.created_at.desc())
         .limit(1)
     )
+    # Oldest first — the most-urgent banner heads the stack, and the
+    # frontend collapses anything past the second into a "+N more" pill.
     in_progress_q = (
         participant_filter(select(Match), current_user.id)
         .where(Match.status == MatchStatus.in_progress)
         .options(*match_eager_options())
-        .order_by(Match.created_at.desc())
-        .limit(1)
+        .order_by(Match.created_at.asc())
     )
     completed_q = (
         participant_filter(select(Match), current_user.id)
@@ -86,7 +87,7 @@ async def get_dashboard(
         db, current_user.id, [m.id for m in completed]
     )
 
-    score_banner = _build_score_banner(in_progress, current_user.id)
+    score_banners = _build_score_banners(in_progress, current_user.id)
     next_match = _build_next_match(pending, current_user.id)
     recent_results = [
         _build_recent_result(match, current_user.id, rating_changes.get(match.id))
@@ -95,7 +96,7 @@ async def get_dashboard(
     rating = await _build_rating(db, current_user.id)
 
     return DashboardResponse(
-        score_banner=score_banner,
+        score_banners=score_banners,
         next_match=next_match,
         recent_results=recent_results,
         rating=rating,
@@ -120,20 +121,22 @@ async def _load_my_rating_changes(
     return {row.match_id: RatingChange.from_history(row) for row in rows}
 
 
-def _build_score_banner(
-    in_progress: list[Match], current_user_id: uuid.UUID
-) -> DashboardScoreBanner | None:
-    if not in_progress:
-        return None
-    match = in_progress[0]
-    current_game = current_unscored_game(match)
-    if current_game is None:
-        return None
-    return DashboardScoreBanner(
-        match_id=match.id,
-        opponent_username=opponent_username(match, current_user_id),
-        current_game_id=current_game.id,
-    )
+def _build_score_banners(
+    in_progress: Sequence[Match], current_user_id: uuid.UUID
+) -> list[DashboardScoreBanner]:
+    banners: list[DashboardScoreBanner] = []
+    for match in in_progress:
+        current_game = current_unscored_game(match)
+        if current_game is None:
+            continue
+        banners.append(
+            DashboardScoreBanner(
+                match_id=match.id,
+                opponent_username=opponent_username(match, current_user_id),
+                current_game_id=current_game.id,
+            )
+        )
+    return banners
 
 
 def _build_next_match(

--- a/api/app/schemas/dashboard.py
+++ b/api/app/schemas/dashboard.py
@@ -66,7 +66,7 @@ class DashboardRating(BaseModel):
 
 
 class DashboardResponse(BaseModel):
-    score_banner: DashboardScoreBanner | None
+    score_banners: list[DashboardScoreBanner]
     next_match: DashboardNextMatch | None
     recent_results: list[DashboardRecentResult]
     rating: DashboardRating | None = None

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -44,7 +44,7 @@ async def test_dashboard_empty_when_user_has_no_matches(
     response = await api_client.get("/v1/dashboard")
     assert response.status_code == 200
     body = response.json()
-    assert body["score_banner"] is None
+    assert body["score_banners"] == []
     assert body["next_match"] is None
     assert body["recent_results"] == []
     # A fresh signup is auto-joined to the default Glicko-2 league with
@@ -80,12 +80,42 @@ async def test_dashboard_returns_score_banner_for_in_progress_match(
     ).json()
 
     body = (await api_client.get("/v1/dashboard")).json()
-    assert body["score_banner"]["match_id"] == match["id"]
-    assert body["score_banner"]["opponent_username"] == "rival"
-    assert body["score_banner"]["current_game_id"] == after_g1["current_game"]["id"]
+    assert len(body["score_banners"]) == 1
+    banner = body["score_banners"][0]
+    assert banner["match_id"] == match["id"]
+    assert banner["opponent_username"] == "rival"
+    assert banner["current_game_id"] == after_g1["current_game"]["id"]
     # An in-progress match is not "pending" so the next_match slot is empty.
     assert body["next_match"] is None
     assert body["recent_results"] == []
+
+
+async def test_dashboard_returns_multiple_banners_oldest_first(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # Variant D: back-to-back tournament play means a player can have two (or
+    # more) matches sitting in_progress at once. The frontend stacks them, but
+    # only if the API returns them in priority order — oldest first, since the
+    # one that's been waiting longest is the most urgent to score.
+    await start_session(api_client, db_session)
+    opp_a = await make_user(db_session, "rival_a")
+    opp_b = await make_user(db_session, "rival_b")
+    opp_c = await make_user(db_session, "rival_c")
+    match_a = await _create_match(api_client, opp_a.id, best_of=5)
+    match_b = await _create_match(api_client, opp_b.id, best_of=5)
+    match_c = await _create_match(api_client, opp_c.id, best_of=5)
+
+    body = (await api_client.get("/v1/dashboard")).json()
+    assert [b["match_id"] for b in body["score_banners"]] == [
+        match_a["id"],
+        match_b["id"],
+        match_c["id"],
+    ]
+    assert [b["opponent_username"] for b in body["score_banners"]] == [
+        "rival_a",
+        "rival_b",
+        "rival_c",
+    ]
 
 
 async def test_dashboard_returns_next_match_for_pending_match(
@@ -101,7 +131,7 @@ async def test_dashboard_returns_next_match_for_pending_match(
     await db_session.commit()
 
     body = (await api_client.get("/v1/dashboard")).json()
-    assert body["score_banner"] is None
+    assert body["score_banners"] == []
     assert body["next_match"]["match_id"] == created["id"]
     assert body["next_match"]["opponent_username"] == "rival"
     assert body["next_match"]["best_of"] == 5
@@ -144,7 +174,7 @@ async def test_dashboard_scoped_to_current_user(
         await _create_match(other_client, bystander.id)
 
     body = (await api_client.get("/v1/dashboard")).json()
-    assert body["score_banner"] is None
+    assert body["score_banners"] == []
     assert body["next_match"] is None
     assert body["recent_results"] == []
     # Alice has her own seeded league row but no completed matches of her own

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -415,7 +415,8 @@ export interface components {
         };
         /** DashboardResponse */
         DashboardResponse: {
-            score_banner: components["schemas"]["DashboardScoreBanner"] | null;
+            /** Score Banners */
+            score_banners: components["schemas"]["DashboardScoreBanner"][];
             next_match: components["schemas"]["DashboardNextMatch"] | null;
             /** Recent Results */
             recent_results: components["schemas"]["DashboardRecentResult"][];

--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import {
   RouterProvider,
   createMemoryHistory,
@@ -76,11 +76,13 @@ describe('DashboardPage', () => {
       http.get('*/v1/dashboard', () =>
         HttpResponse.json(
           dashboardResponse({
-            score_banner: dashboardScoreBanner({
-              match_id: 'm-banner',
-              current_game_id: 'g-banner-1',
-              opponent_username: 'nguyen.t',
-            }),
+            score_banners: [
+              dashboardScoreBanner({
+                match_id: 'm-banner',
+                current_game_id: 'g-banner-1',
+                opponent_username: 'nguyen.t',
+              }),
+            ],
             next_match: dashboardNextMatch({
               match_id: 'm-next',
               opponent_username: 'okafor.d',
@@ -128,7 +130,7 @@ describe('DashboardPage', () => {
       http.get('*/v1/dashboard', () =>
         HttpResponse.json(
           dashboardResponse({
-            score_banner: null,
+            score_banners: [],
             next_match: null,
             recent_results: [],
           }),
@@ -205,11 +207,13 @@ describe('DashboardPage', () => {
       http.get('*/v1/dashboard', () =>
         HttpResponse.json(
           dashboardResponse({
-            score_banner: dashboardScoreBanner({
-              match_id: 'm-banner',
-              current_game_id: 'g-banner-1',
-              opponent_username: 'nguyen.t',
-            }),
+            score_banners: [
+              dashboardScoreBanner({
+                match_id: 'm-banner',
+                current_game_id: 'g-banner-1',
+                opponent_username: 'nguyen.t',
+              }),
+            ],
           }),
         ),
       ),
@@ -221,5 +225,78 @@ describe('DashboardPage', () => {
       'href',
       '/matches/m-banner/games/g-banner-1/scores/new',
     )
+  })
+
+  it('stacks a compact banner when a second match is pending scoring', async () => {
+    server.use(
+      http.get('*/v1/dashboard', () =>
+        HttpResponse.json(
+          dashboardResponse({
+            score_banners: [
+              dashboardScoreBanner({
+                match_id: 'm-primary',
+                current_game_id: 'g-primary',
+                opponent_username: 'nguyen.t',
+              }),
+              dashboardScoreBanner({
+                match_id: 'm-secondary',
+                current_game_id: 'g-secondary',
+                opponent_username: 'holm.s',
+              }),
+            ],
+          }),
+        ),
+      ),
+    )
+    renderDashboard()
+
+    expect(await screen.findByTestId('dashboard-score-banner')).toHaveTextContent(
+      'vs nguyen.t',
+    )
+    const compact = await screen.findByTestId('dashboard-score-banner-compact')
+    expect(compact).toHaveTextContent('vs holm.s')
+    expect(compact).toHaveTextContent(/also pending/i)
+    expect(within(compact).getByRole('link', { name: /enter score/i })).toHaveAttribute(
+      'href',
+      '/matches/m-secondary/games/g-secondary/scores/new',
+    )
+    expect(
+      screen.queryByTestId('dashboard-score-banner-more'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('collapses 3+ pending matches into a "+N more pending" link to /matches', async () => {
+    server.use(
+      http.get('*/v1/dashboard', () =>
+        HttpResponse.json(
+          dashboardResponse({
+            score_banners: [
+              dashboardScoreBanner({
+                match_id: 'm-1',
+                opponent_username: 'nguyen.t',
+              }),
+              dashboardScoreBanner({
+                match_id: 'm-2',
+                opponent_username: 'holm.s',
+              }),
+              dashboardScoreBanner({
+                match_id: 'm-3',
+                opponent_username: 'okafor.m',
+              }),
+              dashboardScoreBanner({
+                match_id: 'm-4',
+                opponent_username: 'silva.r',
+              }),
+            ],
+          }),
+        ),
+      ),
+    )
+    renderDashboard()
+
+    const more = await screen.findByTestId('dashboard-score-banner-more')
+    expect(more).toHaveTextContent('+2')
+    expect(more).toHaveTextContent(/more pending/i)
+    expect(more).toHaveAttribute('href', '/matches')
   })
 })

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -597,7 +597,6 @@ function ScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
         border: '1px solid rgba(255,122,26,0.42)',
         borderRadius: 14,
         overflow: 'hidden',
-        marginBottom: 32,
       }}
     >
       <div
@@ -725,6 +724,124 @@ function ScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
       >
         <X size={14} strokeWidth={1.75} />
       </button>
+    </div>
+  )
+}
+
+// Used when a player has more than one match waiting for their score. The
+// primary ScoreBanner above keeps the single hero-orange CTA; this strip
+// uses an amber accent so a second pending match is impossible to miss
+// without dimming the priority of the headline match.
+function CompactScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
+  const opponent = banner.opponent_username ?? GUEST_OPPONENT
+  const scoringRoute = scoringNewRoute(banner.match_id, banner.current_game_id)
+  return (
+    <div
+      data-testid="dashboard-score-banner-compact"
+      style={{
+        position: 'relative',
+        background: `linear-gradient(180deg, rgba(255,196,61,0.06) 0%, rgba(11,13,18,0) 100%), ${C.ink800}`,
+        border: '1px solid rgba(255,196,61,0.24)',
+        borderRadius: 12,
+        padding: '14px 18px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 16,
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: 2,
+          background: `linear-gradient(90deg, ${C.warn} 0%, ${C.warn} 50%, transparent 100%)`,
+        }}
+      />
+      <BallDot live color={C.warn} size={8} />
+      <Avatar name={opponent} size={36} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            font: `700 10px ${MONO}`,
+            color: C.warn,
+            letterSpacing: '0.16em',
+            marginBottom: 2,
+          }}
+        >
+          ALSO PENDING
+        </div>
+        <div
+          style={{
+            font: `600 15px ${UI}`,
+            color: C.chalk50,
+            lineHeight: 1.2,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          vs {opponent}
+        </div>
+      </div>
+      <Button
+        kind="secondary"
+        size="md"
+        iconRight={<ArrowRight size={14} strokeWidth={1.75} />}
+        style={{ borderColor: 'rgba(255,196,61,0.4)', color: C.warn }}
+        {...scoringRoute}
+      >
+        Enter score
+      </Button>
+    </div>
+  )
+}
+
+// 3+ pending: a single quiet link that funnels the rest into /matches.
+function MorePendingLink({ count }: { count: number }) {
+  return (
+    <Link
+      to="/matches"
+      data-testid="dashboard-score-banner-more"
+      style={{
+        display: 'inline-flex',
+        alignSelf: 'flex-start',
+        alignItems: 'center',
+        gap: 8,
+        padding: '6px 12px',
+        borderRadius: 999,
+        border: `1px solid ${C.ink500}`,
+        background: 'transparent',
+        font: `500 12px ${UI}`,
+        color: C.chalk300,
+        textDecoration: 'none',
+      }}
+    >
+      <Mono size={12} weight={600} color={C.chalk100}>
+        +{count}
+      </Mono>
+      more pending
+      <ChevronRight size={14} strokeWidth={1.75} />
+    </Link>
+  )
+}
+
+function ScoreBannerStack({ banners }: { banners: DashboardScoreBanner[] }) {
+  if (banners.length === 0) return null
+  const [primary, secondary, ...rest] = banners
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+        marginBottom: 32,
+      }}
+    >
+      <ScoreBanner banner={primary} />
+      {secondary && <CompactScoreBanner banner={secondary} />}
+      {rest.length > 0 && <MorePendingLink count={rest.length} />}
     </div>
   )
 }
@@ -1608,8 +1725,8 @@ export function DashboardPage() {
         <PageTitle greeting="Hi, Aimee" subtitle="3 things need your attention" />
         {isLoading ? (
           <SkeletonCard label="Loading score banner" height={140} />
-        ) : data?.score_banner ? (
-          <ScoreBanner banner={data.score_banner} />
+        ) : data?.score_banners?.length ? (
+          <ScoreBannerStack banners={data.score_banners} />
         ) : null}
         <UpNextRow
           match={data?.next_match ?? null}

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -238,8 +238,7 @@ export const handlers = [
   // ----- dashboard -------------------------------------------------------
   http.get('*/v1/dashboard', async () => {
     await delay(300)
-    const scoreBanner =
-      mockMatches.map(projectScoreBanner).find(notNull) ?? null
+    const scoreBanners = mockMatches.map(projectScoreBanner).filter(notNull)
     const nextMatch =
       mockMatches.map(projectNextMatch).find(notNull) ?? null
     const recentResults = mockMatches
@@ -248,7 +247,7 @@ export const handlers = [
       .sort((a, b) => b.completed_at.localeCompare(a.completed_at))
       .slice(0, 5)
     return HttpResponse.json({
-      score_banner: scoreBanner,
+      score_banners: scoreBanners,
       next_match: nextMatch,
       recent_results: recentResults,
       rating: projectRating(mockMatches),

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -281,7 +281,7 @@ export function dashboardResponse(
   overrides: Partial<DashboardResponse> = {},
 ): DashboardResponse {
   return {
-    score_banner: null,
+    score_banners: [],
     next_match: null,
     recent_results: [],
     rating: dashboardRating(),


### PR DESCRIPTION
## Summary

Implements **variant D** from the player-dashboard handoff: when a player has more than one match waiting for their score (back-to-back tournament play), the dashboard now stacks the banners instead of silently dropping the others.

- **API**: `DashboardResponse.score_banner` (singular) → `score_banners: list[DashboardScoreBanner]`. `/v1/dashboard` returns every in-progress match with an unscored game, ordered `created_at ASC` so the oldest (most urgent) heads the stack.
- **Web-client**: A new `ScoreBannerStack` renders three tiers:
  - 1 pending → full orange banner (unchanged from today)
  - 2 pending → primary + amber "ALSO PENDING" compact strip (`CompactScoreBanner`)
  - 3+ pending → also a `+N more pending` pill linking to `/matches`
- MSW dev handler, factory, and regenerated `schema.d.ts` updated for the new contract.

## Test plan

- [x] `pytest` — 225 passed (new `test_dashboard_returns_multiple_banners_oldest_first` covers ordering)
- [x] `npm run test:run` — 52 passed (new vitest specs cover the 1 / 2 / 3+ banner cases and the compact CTA href)
- [x] `npm run build` + `npm run lint` clean
- [x] Visually verified the 4-pending state in a browser via Playwright with a temporary seed; screenshot delivered in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)