### PR TITLE
Email setup: CAPTCHA, honeypot, rate-limited confirmation flow

### DIFF
--- a/api/app/captcha.py
+++ b/api/app/captcha.py
@@ -1,0 +1,34 @@
+"""Cloudflare Turnstile verification.
+
+Defaults to Cloudflare's documented "always passes" test secret key, so dev
+and tests work without any setup. Set ``TURNSTILE_SECRET_KEY`` to a real key
+in production. The matching site key for tests/dev is ``1x00000000000000000000AA``.
+"""
+
+import os
+
+import httpx
+
+TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+TURNSTILE_TEST_SECRET_ALWAYS_PASSES = "1x0000000000000000000000000000000AA"
+
+
+def _secret_key() -> str:
+    return os.environ.get("TURNSTILE_SECRET_KEY", TURNSTILE_TEST_SECRET_ALWAYS_PASSES)
+
+
+async def verify_captcha(token: str | None) -> bool:
+    if not token:
+        return False
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(
+                TURNSTILE_VERIFY_URL,
+                data={"secret": _secret_key(), "response": token},
+            )
+        if resp.status_code != 200:
+            return False
+        body = resp.json()
+    except (httpx.HTTPError, ValueError):
+        return False
+    return bool(body.get("success"))

--- a/api/app/captcha.py
+++ b/api/app/captcha.py
@@ -1,8 +1,11 @@
 """Cloudflare Turnstile verification.
 
-Defaults to Cloudflare's documented "always passes" test secret key, so dev
-and tests work without any setup. Set ``TURNSTILE_SECRET_KEY`` to a real key
-in production. The matching site key for tests/dev is ``1x00000000000000000000AA``.
+Defaults to Cloudflare's documented "always passes" test secret key in
+dev/test, so the local loop works without any setup. In any other
+``APP_ENV`` (``staging``, ``production``, etc.) ``TURNSTILE_SECRET_KEY``
+must be set explicitly — otherwise verification raises at startup-equivalent
+time (first call) rather than silently fail-opening on every request. The
+matching site key for the dev test secret is ``1x00000000000000000000AA``.
 """
 
 import os
@@ -11,20 +14,39 @@ import httpx
 
 TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
 TURNSTILE_TEST_SECRET_ALWAYS_PASSES = "1x0000000000000000000000000000000AA"
+DEV_ENVS = frozenset({"dev", "development", "test", "testing", "local"})
+
+
+def _app_env() -> str:
+    return os.environ.get("APP_ENV", "dev").lower()
 
 
 def _secret_key() -> str:
-    return os.environ.get("TURNSTILE_SECRET_KEY", TURNSTILE_TEST_SECRET_ALWAYS_PASSES)
+    key = os.environ.get("TURNSTILE_SECRET_KEY")
+    if key:
+        return key
+    if _app_env() in DEV_ENVS:
+        return TURNSTILE_TEST_SECRET_ALWAYS_PASSES
+    raise RuntimeError(
+        "TURNSTILE_SECRET_KEY must be set when APP_ENV is not dev/test — "
+        "refusing to fall back to the always-passes test key in a non-dev "
+        "environment."
+    )
 
 
 async def verify_captcha(token: str | None) -> bool:
     if not token:
         return False
     try:
+        secret = _secret_key()
+    except RuntimeError:
+        # Fail closed rather than silently disabling abuse protection.
+        return False
+    try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.post(
                 TURNSTILE_VERIFY_URL,
-                data={"secret": _secret_key(), "response": token},
+                data={"secret": secret, "response": token},
             )
         if resp.status_code != 200:
             return False

--- a/api/app/email.py
+++ b/api/app/email.py
@@ -1,0 +1,70 @@
+"""Email delivery — background job + dev-friendly default backend.
+
+The web app enqueues ``send_confirmation_email`` on the ``email`` RQ queue;
+the worker process imports this module and calls the job target. Until SMTP
+credentials are wired in, the backend logs the link so dev/UAT can copy it
+from worker output.
+"""
+
+import logging
+import os
+import smtplib
+from email.message import EmailMessage
+from urllib.parse import urlencode
+
+log = logging.getLogger(__name__)
+
+
+def _confirm_url(raw_token: str) -> str:
+    base = os.environ.get("APP_BASE_URL", "http://localhost:5173").rstrip("/")
+    query = urlencode({"token": raw_token})
+    return f"{base}/confirm-email?{query}"
+
+
+def _smtp_configured() -> bool:
+    return bool(os.environ.get("SMTP_HOST"))
+
+
+def _send_via_smtp(message: EmailMessage) -> None:
+    host = os.environ["SMTP_HOST"]
+    port = int(os.environ.get("SMTP_PORT", "587"))
+    user = os.environ.get("SMTP_USERNAME")
+    password = os.environ.get("SMTP_PASSWORD")
+    use_tls = os.environ.get("SMTP_USE_TLS", "true").lower() != "false"
+    with smtplib.SMTP(host, port) as smtp:
+        if use_tls:
+            smtp.starttls()
+        if user and password:
+            smtp.login(user, password)
+        smtp.send_message(message)
+
+
+def send_confirmation_email(to_email: str, raw_token: str, username: str) -> None:
+    """Render and deliver the confirmation email. Invoked by the RQ worker."""
+    confirm_url = _confirm_url(raw_token)
+    from_addr = os.environ.get("EMAIL_FROM", "noreply@fortymm.local")
+    subject = "Confirm your FortyMM email"
+    body = (
+        f"Hi @{username},\n\n"
+        "Click the link below to confirm your email address and claim your "
+        "FortyMM account.\n\n"
+        f"{confirm_url}\n\n"
+        "If you didn't request this, you can ignore this email.\n"
+    )
+
+    if not _smtp_configured():
+        log.info(
+            "email_confirmation_link",
+            extra={"to": to_email, "url": confirm_url},
+        )
+        # Print so dev users running `rq worker email` see the link in stdout
+        # without configuring a logging format.
+        print(f"[email] confirmation link for {to_email}: {confirm_url}")
+        return
+
+    message = EmailMessage()
+    message["Subject"] = subject
+    message["From"] = from_addr
+    message["To"] = to_email
+    message.set_content(body)
+    _send_via_smtp(message)

--- a/api/app/email.py
+++ b/api/app/email.py
@@ -1,9 +1,11 @@
 """Email delivery — background job + dev-friendly default backend.
 
 The web app enqueues ``send_confirmation_email`` on the ``email`` RQ queue;
-the worker process imports this module and calls the job target. Until SMTP
-credentials are wired in, the backend logs the link so dev/UAT can copy it
-from worker output.
+the worker process imports this module and calls the job target. In dev
+(``FORTYMM_DEV=1``) the worker prints the confirmation link to stdout so
+the local loop works without SMTP. In any other environment, missing SMTP
+configuration is treated as a misconfiguration and the job raises so RQ
+moves it to ``failed_job_registry`` for an operator to notice.
 """
 
 import logging
@@ -15,8 +17,29 @@ from urllib.parse import urlencode
 log = logging.getLogger(__name__)
 
 
+def _dev_mode() -> bool:
+    return os.environ.get("FORTYMM_DEV", "").lower() in {"1", "true", "yes"}
+
+
+def _app_base_url() -> str | None:
+    base = os.environ.get("APP_BASE_URL")
+    if base:
+        return base.rstrip("/")
+    if _dev_mode():
+        return "http://localhost:5173"
+    return None
+
+
 def _confirm_url(raw_token: str) -> str:
-    base = os.environ.get("APP_BASE_URL", "http://localhost:5173").rstrip("/")
+    base = _app_base_url()
+    if base is None:
+        # Refuse to render a localhost URL into a real outbound email — that
+        # was the failure mode that motivated this guard. Caller is expected
+        # to catch and surface as a deploy misconfiguration.
+        raise RuntimeError(
+            "APP_BASE_URL must be set outside FORTYMM_DEV — refusing to "
+            "render an unclickable localhost URL into a confirmation email."
+        )
     query = urlencode({"token": raw_token})
     return f"{base}/confirm-email?{query}"
 
@@ -53,12 +76,20 @@ def send_confirmation_email(to_email: str, raw_token: str, username: str) -> Non
     )
 
     if not _smtp_configured():
+        if not _dev_mode():
+            # No SMTP and not dev — this is a deploy bug, not a workflow.
+            # Raising lands the job in failed_job_registry so it's visible.
+            raise RuntimeError(
+                "SMTP is not configured and FORTYMM_DEV is not set — "
+                "refusing to silently drop a confirmation email."
+            )
+        # Dev mode: log + print the link so `rq worker email` shows it.
+        # Gated on FORTYMM_DEV (not on missing SMTP) so a prod deploy that
+        # forgets SMTP doesn't write bearer tokens to centralized logs.
         log.info(
             "email_confirmation_link",
             extra={"to": to_email, "url": confirm_url},
         )
-        # Print so dev users running `rq worker email` see the link in stdout
-        # without configuring a logging format.
         print(f"[email] confirmation link for {to_email}: {confirm_url}")
         return
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,6 +1,10 @@
+import os
 import time
+from contextlib import asynccontextmanager
 
+import redis.asyncio as redis_asyncio
 from fastapi import FastAPI
+from fastapi_limiter import FastAPILimiter
 from pydantic import BaseModel
 from sqlalchemy import text
 
@@ -11,7 +15,19 @@ from app.players import router as players_router
 from app.rbac import router as rbac_router
 from app.sessions import router as sessions_router
 
-app = FastAPI(title="FortyMM API")
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    connection = redis_asyncio.from_url(redis_url, encoding="utf-8")
+    await FastAPILimiter.init(connection)
+    try:
+        yield
+    finally:
+        await FastAPILimiter.close()
+
+
+app = FastAPI(title="FortyMM API", lifespan=lifespan)
 app.include_router(sessions_router)
 app.include_router(rbac_router)
 app.include_router(matches_router)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 from contextlib import asynccontextmanager
@@ -7,6 +8,8 @@ from fastapi import FastAPI
 from fastapi_limiter import FastAPILimiter
 from pydantic import BaseModel
 from sqlalchemy import text
+
+log = logging.getLogger(__name__)
 
 from app import db, queue
 from app.dashboard import router as dashboard_router
@@ -20,11 +23,21 @@ from app.sessions import router as sessions_router
 async def lifespan(_: FastAPI):
     redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
     connection = redis_asyncio.from_url(redis_url, encoding="utf-8")
-    await FastAPILimiter.init(connection)
+    initialized = False
+    try:
+        await FastAPILimiter.init(connection)
+        initialized = True
+    except Exception as exc:
+        # Don't block startup if Redis is unreachable — offline tooling
+        # (regen-api-types, ad-hoc local runs) still needs /openapi.json
+        # and the unprotected routes. Rate-limited endpoints will 500 on
+        # first request until Redis comes back.
+        log.warning("Rate limiter disabled — Redis unreachable: %s", exc)
     try:
         yield
     finally:
-        await FastAPILimiter.close()
+        if initialized:
+            await FastAPILimiter.close()
         await connection.aclose()
 
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -25,6 +25,7 @@ async def lifespan(_: FastAPI):
         yield
     finally:
         await FastAPILimiter.close()
+        await connection.aclose()
 
 
 app = FastAPI(title="FortyMM API", lifespan=lifespan)

--- a/api/app/models/user.py
+++ b/api/app/models/user.py
@@ -19,6 +19,12 @@ class User(Base):
     username: Mapped[str] = mapped_column(
         String(255), unique=True, nullable=False, index=True
     )
+    email: Mapped[str | None] = mapped_column(
+        String(320), unique=True, nullable=True, index=True
+    )
+    confirmed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/api/app/queue.py
+++ b/api/app/queue.py
@@ -4,8 +4,17 @@ from redis import Redis
 from rq import Queue
 
 SOLVER_QUEUE = "solver"
+EMAIL_QUEUE = "email"
+
+
+def _connection() -> Redis:
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    return Redis.from_url(redis_url)
 
 
 def get_queue() -> Queue:
-    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
-    return Queue(SOLVER_QUEUE, connection=Redis.from_url(redis_url))
+    return Queue(SOLVER_QUEUE, connection=_connection())
+
+
+def get_email_queue() -> Queue:
+    return Queue(EMAIL_QUEUE, connection=_connection())

--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -34,19 +34,23 @@ class UpdateCurrentUserRequest(BaseModel):
     )
 
 
-class SetEmailRequest(BaseModel):
-    email: EmailStr
+class CaptchaProtectedRequest(BaseModel):
+    """Base for endpoints gated by Cloudflare Turnstile + an off-screen
+    honeypot. ``website`` is the honeypot — bots fill every field; humans
+    never see it. Endpoints short-circuit as if successful when it's filled,
+    so the bot doesn't learn the field is a trap."""
+
     captcha_token: str = Field(min_length=1, max_length=4096)
-    # Honeypot — bots fill in every field; humans never see this one because
-    # the FE keeps it visually hidden. Any non-empty value short-circuits the
-    # request as if it succeeded (so bots don't learn the field is a trap).
     website: str = Field(default="", max_length=512)
+
+
+class SetEmailRequest(CaptchaProtectedRequest):
+    email: EmailStr
+
+
+class ResendEmailRequest(CaptchaProtectedRequest):
+    pass
 
 
 class ConfirmEmailRequest(BaseModel):
     token: str = Field(min_length=1, max_length=512)
-
-
-class ResendEmailRequest(BaseModel):
-    captcha_token: str = Field(min_length=1, max_length=4096)
-    website: str = Field(default="", max_length=512)

--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -36,12 +36,17 @@ class UpdateCurrentUserRequest(BaseModel):
 
 class CaptchaProtectedRequest(BaseModel):
     """Base for endpoints gated by Cloudflare Turnstile + an off-screen
-    honeypot. ``website`` is the honeypot — bots fill every field; humans
-    never see it. Endpoints short-circuit as if successful when it's filled,
-    so the bot doesn't learn the field is a trap."""
+    honeypot. ``fmm_hp_token`` is the honeypot — bots fill every field;
+    humans never see it. Endpoints short-circuit as if successful when it's
+    filled, so the bot doesn't learn the field is a trap.
+
+    The field name deliberately avoids canonical identity-profile names
+    (``website``, ``address``, ``phone``) because password managers and
+    browser autofillers ignore ``autocomplete=off`` for those and would
+    splash a real user's saved value into the trap."""
 
     captcha_token: str = Field(min_length=1, max_length=4096)
-    website: str = Field(default="", max_length=512)
+    fmm_hp_token: str = Field(default="", max_length=512)
 
 
 class SetEmailRequest(CaptchaProtectedRequest):

--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, Field
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr, Field
 
 # Lowercase alphanumerics with optional dots/hyphens/underscores between them.
 # Must start and end with an alphanumeric so we don't store names that look
@@ -12,6 +14,8 @@ USERNAME_MAX_LENGTH = 40
 class SessionUser(BaseModel):
     username: str
     permissions: list[str]
+    email: str | None = None
+    confirmed_at: datetime | None = None
 
 
 class SessionData(BaseModel):
@@ -28,3 +32,21 @@ class UpdateCurrentUserRequest(BaseModel):
         max_length=USERNAME_MAX_LENGTH,
         pattern=USERNAME_PATTERN,
     )
+
+
+class SetEmailRequest(BaseModel):
+    email: EmailStr
+    captcha_token: str = Field(min_length=1, max_length=4096)
+    # Honeypot — bots fill in every field; humans never see this one because
+    # the FE keeps it visually hidden. Any non-empty value short-circuits the
+    # request as if it succeeded (so bots don't learn the field is a trap).
+    website: str = Field(default="", max_length=512)
+
+
+class ConfirmEmailRequest(BaseModel):
+    token: str = Field(min_length=1, max_length=512)
+
+
+class ResendEmailRequest(BaseModel):
+    captcha_token: str = Field(min_length=1, max_length=4096)
+    website: str = Field(default="", max_length=512)

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -1,7 +1,7 @@
 import hashlib
 import os
 import secrets
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Annotated
 
 from coolname import generate_slug
@@ -10,13 +10,18 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app import captcha as captcha_module
+from app import queue as queue_module
 from app.db import get_session
 from app.leagues import add_user_to_default_league
 from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
 from app.schemas.session import (
+    ConfirmEmailRequest,
+    ResendEmailRequest,
     SessionData,
     SessionResponse,
     SessionUser,
+    SetEmailRequest,
     UpdateCurrentUserRequest,
 )
 from app.uniqueness import name_taken
@@ -25,6 +30,7 @@ router = APIRouter()
 
 SESSION_COOKIE_NAME = "session"
 SESSION_TOKEN_CONTEXT = "session"
+EMAIL_CONFIRMATION_TOKEN_CONTEXT = "email_confirmation"
 SESSION_LIFETIME = timedelta(days=30)
 
 
@@ -64,6 +70,20 @@ async def _find_session_user(db: AsyncSession, raw_token: str) -> User | None:
         return None
     user_result = await db.execute(select(User).where(User.id == token.user_id))
     return user_result.scalar_one_or_none()
+
+
+async def _build_session_response(db: AsyncSession, user: User) -> SessionResponse:
+    permissions = await _load_permissions(db, user.id)
+    return SessionResponse(
+        data=SessionData(
+            user=SessionUser(
+                username=user.username,
+                permissions=permissions,
+                email=user.email,
+                confirmed_at=user.confirmed_at,
+            )
+        )
+    )
 
 
 async def _load_permissions(db: AsyncSession, user_id) -> list[str]:
@@ -125,12 +145,7 @@ async def get_session_endpoint(
     if user is None:
         user, raw_token = await _create_session(db)
         _set_session_cookie(response, raw_token)
-    permissions = await _load_permissions(db, user.id)
-    return SessionResponse(
-        data=SessionData(
-            user=SessionUser(username=user.username, permissions=permissions)
-        )
-    )
+    return await _build_session_response(db, user)
 
 
 async def get_current_user(
@@ -187,11 +202,176 @@ async def update_current_user(
             )
         await db.refresh(current_user)
 
-    permissions = await _load_permissions(db, current_user.id)
-    return SessionResponse(
-        data=SessionData(
-            user=SessionUser(
-                username=current_user.username, permissions=permissions
+    return await _build_session_response(db, current_user)
+
+
+async def _verify_captcha_or_400(captcha_token: str) -> None:
+    if not await captcha_module.verify_captcha(captcha_token):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Captcha verification failed. Please try again.",
+        )
+
+
+async def _delete_email_tokens(db: AsyncSession, user_id) -> None:
+    existing = (
+        await db.execute(
+            select(UserToken).where(
+                UserToken.user_id == user_id,
+                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT,
             )
         )
+    ).scalars().all()
+    for token in existing:
+        await db.delete(token)
+
+
+async def _issue_confirmation_token(
+    db: AsyncSession, user: User, email: str
+) -> str:
+    """Generate, hash, and persist a fresh confirmation token. Returns the
+    raw token (only ever in memory) so the caller can hand it to the email
+    sender."""
+    await _delete_email_tokens(db, user.id)
+    raw_token = secrets.token_urlsafe(32)
+    db.add(
+        UserToken(
+            user_id=user.id,
+            context=EMAIL_CONFIRMATION_TOKEN_CONTEXT,
+            token=_hash_token(raw_token),
+            sent_to=email,
+        )
     )
+    return raw_token
+
+
+def _enqueue_confirmation_email(
+    to_email: str, raw_token: str, username: str
+) -> None:
+    queue_module.get_email_queue().enqueue(
+        "app.email.send_confirmation_email",
+        to_email,
+        raw_token,
+        username,
+    )
+
+
+@router.post(
+    "/v1/me/email",
+    response_model=SessionResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def set_email(
+    payload: SetEmailRequest,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> SessionResponse:
+    # Honeypot: silently succeed without doing anything. Bots fill it; humans
+    # never see it. We respond as if all is well so the bot doesn't learn the
+    # field is a trap.
+    if payload.website.strip():
+        return await _build_session_response(db, current_user)
+
+    await _verify_captcha_or_400(payload.captcha_token)
+
+    email = payload.email.lower()
+    if current_user.email != email:
+        # Case-insensitive uniqueness — emails are stored lowercased.
+        taken = (
+            await db.execute(
+                select(User.id).where(
+                    User.email == email, User.id != current_user.id
+                )
+            )
+        ).first()
+        if taken:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="That email is already in use.",
+            )
+        current_user.email = email
+        # Changing the email un-confirms; user must click the new link.
+        current_user.confirmed_at = None
+
+    raw_token = await _issue_confirmation_token(db, current_user, email)
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="That email is already in use.",
+        )
+    await db.refresh(current_user)
+    _enqueue_confirmation_email(email, raw_token, current_user.username)
+    return await _build_session_response(db, current_user)
+
+
+@router.post(
+    "/v1/me/email/resend",
+    response_model=SessionResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def resend_email_confirmation(
+    payload: ResendEmailRequest,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> SessionResponse:
+    if payload.website.strip():
+        return await _build_session_response(db, current_user)
+    if not current_user.email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Add an email address before requesting a resend.",
+        )
+    if current_user.confirmed_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This email is already confirmed.",
+        )
+    await _verify_captcha_or_400(payload.captcha_token)
+
+    raw_token = await _issue_confirmation_token(
+        db, current_user, current_user.email
+    )
+    await db.commit()
+    _enqueue_confirmation_email(
+        current_user.email, raw_token, current_user.username
+    )
+    return await _build_session_response(db, current_user)
+
+
+@router.post("/v1/me/email/confirm", response_model=SessionResponse)
+async def confirm_email(
+    payload: ConfirmEmailRequest,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> SessionResponse:
+    token_row = (
+        await db.execute(
+            select(UserToken).where(
+                UserToken.token == _hash_token(payload.token),
+                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT,
+            )
+        )
+    ).scalar_one_or_none()
+    if token_row is None or token_row.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That confirmation link is invalid or expired.",
+        )
+    # Defensive: the email on the user may have been changed since the link
+    # was sent. If so, the link no longer matches the intended address.
+    if token_row.sent_to and token_row.sent_to != current_user.email:
+        await db.delete(token_row)
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That confirmation link no longer matches your email.",
+        )
+
+    current_user.confirmed_at = datetime.now(timezone.utc)
+    await db.delete(token_row)
+    await db.commit()
+    await db.refresh(current_user)
+    return await _build_session_response(db, current_user)

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -5,7 +5,8 @@ from datetime import datetime, timedelta, timezone
 from typing import Annotated
 
 from coolname import generate_slug
-from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
+from fastapi_limiter.depends import RateLimiter
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,6 +34,29 @@ SESSION_TOKEN_CONTEXT = "session"
 EMAIL_CONFIRMATION_TOKEN_CONTEXT = "email_confirmation"
 SESSION_LIFETIME = timedelta(days=30)
 EMAIL_TAKEN_DETAIL = "That email is already in use."
+
+
+async def _email_rate_limit_key(request: Request) -> str:
+    """Key the email-send limiters by session cookie so legitimate users
+    behind a shared NAT aren't punished for each other's submissions. Fall
+    back to client IP for cookie-less requests (those will 401 downstream
+    anyway, but the limiter still gets to count the attempt)."""
+    cookie = request.cookies.get(SESSION_COOKIE_NAME)
+    if cookie:
+        return f"session:{cookie}"
+    client = request.client
+    return f"ip:{client.host if client else 'unknown'}"
+
+
+# Limits chosen to allow normal flows (edit email, immediate resend on typo)
+# while making bulk abuse uneconomical. Resend is tighter since users have an
+# explicit no-cost path via re-submitting `set_email`.
+email_send_rate_limit = RateLimiter(
+    times=5, hours=1, identifier=_email_rate_limit_key
+)
+email_resend_rate_limit = RateLimiter(
+    times=3, hours=1, identifier=_email_rate_limit_key
+)
 
 
 def _hash_token(raw_token: str) -> bytes:
@@ -253,6 +277,7 @@ def _enqueue_confirmation_email(
     "/v1/me/email",
     response_model=SessionResponse,
     status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[Depends(email_send_rate_limit)],
 )
 async def set_email(
     payload: SetEmailRequest,
@@ -277,9 +302,10 @@ async def set_email(
                 detail=EMAIL_TAKEN_DETAIL,
             )
         current_user.email = email
-        # Changing the email un-confirms; user must click the new link.
-        current_user.confirmed_at = None
 
+    # Every successful set_email re-starts the confirmation handshake — the
+    # user must click the new link even if they re-submitted the same address.
+    current_user.confirmed_at = None
     raw_token = await _issue_confirmation_token(db, current_user, email)
     try:
         await db.commit()
@@ -297,6 +323,7 @@ async def set_email(
     "/v1/me/email/resend",
     response_model=SessionResponse,
     status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[Depends(email_resend_rate_limit)],
 )
 async def resend_email_confirmation(
     payload: ResendEmailRequest,

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -31,9 +31,17 @@ router = APIRouter()
 
 SESSION_COOKIE_NAME = "session"
 SESSION_TOKEN_CONTEXT = "session"
-EMAIL_CONFIRMATION_TOKEN_CONTEXT = "email_confirmation"
+# Email-change confirmation tokens carry the *prior* address in their context
+# (e.g. "change:old@example.com", or "change:" on first-ever set). This gives
+# us an audit trail of what each token was changing away from. Look up
+# pending tokens by `context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)`.
+EMAIL_CHANGE_CONTEXT_PREFIX = "change:"
 SESSION_LIFETIME = timedelta(days=30)
 EMAIL_TAKEN_DETAIL = "That email is already in use."
+
+
+def _email_change_context(old_email: str | None) -> str:
+    return f"{EMAIL_CHANGE_CONTEXT_PREFIX}{old_email or ''}"
 
 
 async def _email_rate_limit_key(request: Request) -> str:
@@ -238,25 +246,40 @@ async def _verify_captcha_or_400(captcha_token: str) -> None:
         )
 
 
+async def _existing_change_context(
+    db: AsyncSession, user_id
+) -> str | None:
+    """Return the context of the user's pending email-change token, if any.
+    Lets ``resend`` preserve the original "change:" + old_email signature
+    instead of guessing once the user's row has been overwritten."""
+    result = await db.execute(
+        select(UserToken.context).where(
+            UserToken.user_id == user_id,
+            UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
+        )
+    )
+    return result.scalars().first()
+
+
 async def _issue_confirmation_token(
-    db: AsyncSession, user: User, email: str
+    db: AsyncSession, user: User, sent_to: str, context: str
 ) -> str:
-    """Generate, hash, and persist a fresh confirmation token. Returns the
-    raw token (only ever in memory) so the caller can hand it to the email
-    sender."""
+    """Generate, hash, and persist a fresh confirmation token, rotating any
+    prior change token for this user. Returns the raw token (only ever in
+    memory) so the caller can hand it to the email sender."""
     await db.execute(
         delete(UserToken).where(
             UserToken.user_id == user.id,
-            UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT,
+            UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
         )
     )
     raw_token = secrets.token_urlsafe(32)
     db.add(
         UserToken(
             user_id=user.id,
-            context=EMAIL_CONFIRMATION_TOKEN_CONTEXT,
+            context=context,
             token=_hash_token(raw_token),
-            sent_to=email,
+            sent_to=sent_to,
         )
     )
     return raw_token
@@ -293,6 +316,7 @@ async def set_email(
     await _verify_captcha_or_400(payload.captcha_token)
 
     email = payload.email.lower()
+    old_email = current_user.email
     if current_user.email != email:
         if await name_taken(
             db, User.id, User.email, email, exclude_id=current_user.id
@@ -306,7 +330,9 @@ async def set_email(
     # Every successful set_email re-starts the confirmation handshake — the
     # user must click the new link even if they re-submitted the same address.
     current_user.confirmed_at = None
-    raw_token = await _issue_confirmation_token(db, current_user, email)
+    raw_token = await _issue_confirmation_token(
+        db, current_user, email, _email_change_context(old_email)
+    )
     try:
         await db.commit()
     except IntegrityError:
@@ -344,8 +370,14 @@ async def resend_email_confirmation(
         )
     await _verify_captcha_or_400(payload.captcha_token)
 
+    # Reuse the prior token's context so the audit trail still records what
+    # the user was originally changing away from.
+    prior_context = await _existing_change_context(db, current_user.id)
     raw_token = await _issue_confirmation_token(
-        db, current_user, current_user.email
+        db,
+        current_user,
+        current_user.email,
+        prior_context or _email_change_context(None),
     )
     await db.commit()
     _enqueue_confirmation_email(
@@ -364,7 +396,7 @@ async def confirm_email(
         await db.execute(
             select(UserToken).where(
                 UserToken.token == _hash_token(payload.token),
-                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT,
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
             )
         )
     ).scalar_one_or_none()

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -253,10 +253,12 @@ async def _existing_change_context(
     Lets ``resend`` preserve the original "change:" + old_email signature
     instead of guessing once the user's row has been overwritten."""
     result = await db.execute(
-        select(UserToken.context).where(
+        select(UserToken.context)
+        .where(
             UserToken.user_id == user_id,
             UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
         )
+        .limit(1)
     )
     return result.scalars().first()
 

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from coolname import generate_slug
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, status
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -32,6 +32,7 @@ SESSION_COOKIE_NAME = "session"
 SESSION_TOKEN_CONTEXT = "session"
 EMAIL_CONFIRMATION_TOKEN_CONTEXT = "email_confirmation"
 SESSION_LIFETIME = timedelta(days=30)
+EMAIL_TAKEN_DETAIL = "That email is already in use."
 
 
 def _hash_token(raw_token: str) -> bytes:
@@ -213,26 +214,18 @@ async def _verify_captcha_or_400(captcha_token: str) -> None:
         )
 
 
-async def _delete_email_tokens(db: AsyncSession, user_id) -> None:
-    existing = (
-        await db.execute(
-            select(UserToken).where(
-                UserToken.user_id == user_id,
-                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT,
-            )
-        )
-    ).scalars().all()
-    for token in existing:
-        await db.delete(token)
-
-
 async def _issue_confirmation_token(
     db: AsyncSession, user: User, email: str
 ) -> str:
     """Generate, hash, and persist a fresh confirmation token. Returns the
     raw token (only ever in memory) so the caller can hand it to the email
     sender."""
-    await _delete_email_tokens(db, user.id)
+    await db.execute(
+        delete(UserToken).where(
+            UserToken.user_id == user.id,
+            UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT,
+        )
+    )
     raw_token = secrets.token_urlsafe(32)
     db.add(
         UserToken(
@@ -276,18 +269,12 @@ async def set_email(
 
     email = payload.email.lower()
     if current_user.email != email:
-        # Case-insensitive uniqueness — emails are stored lowercased.
-        taken = (
-            await db.execute(
-                select(User.id).where(
-                    User.email == email, User.id != current_user.id
-                )
-            )
-        ).first()
-        if taken:
+        if await name_taken(
+            db, User.id, User.email, email, exclude_id=current_user.id
+        ):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail="That email is already in use.",
+                detail=EMAIL_TAKEN_DETAIL,
             )
         current_user.email = email
         # Changing the email un-confirms; user must click the new link.
@@ -300,9 +287,8 @@ async def set_email(
         await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="That email is already in use.",
+            detail=EMAIL_TAKEN_DETAIL,
         )
-    await db.refresh(current_user)
     _enqueue_confirmation_email(email, raw_token, current_user.username)
     return await _build_session_response(db, current_user)
 
@@ -373,5 +359,4 @@ async def confirm_email(
     current_user.confirmed_at = datetime.now(timezone.utc)
     await db.delete(token_row)
     await db.commit()
-    await db.refresh(current_user)
     return await _build_session_response(db, current_user)

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -44,26 +44,53 @@ def _email_change_context(old_email: str | None) -> str:
     return f"{EMAIL_CHANGE_CONTEXT_PREFIX}{old_email or ''}"
 
 
+def _hash_cookie_for_key(cookie: str) -> str:
+    """Hash the raw session cookie before putting it into a Redis key. The
+    cookie is a bearer credential; if it lands in Redis verbatim (snapshots,
+    MONITOR, redis_exporter metric labels) anyone with read-only access can
+    impersonate the user."""
+    return hashlib.sha256(cookie.encode("utf-8")).hexdigest()
+
+
+def _client_ip(request: Request) -> str:
+    client = request.client
+    return client.host if client else "unknown"
+
+
 async def _email_rate_limit_key(request: Request) -> str:
-    """Key the email-send limiters by session cookie so legitimate users
-    behind a shared NAT aren't punished for each other's submissions. Fall
-    back to client IP for cookie-less requests (those will 401 downstream
-    anyway, but the limiter still gets to count the attempt)."""
+    """Key the email-send limiters by hashed session cookie so legitimate
+    users behind a shared NAT aren't penalised collectively. Fall back to
+    client IP for cookie-less requests (those will 401 downstream anyway,
+    but the limiter still counts the attempt)."""
     cookie = request.cookies.get(SESSION_COOKIE_NAME)
     if cookie:
-        return f"session:{cookie}"
-    client = request.client
-    return f"ip:{client.host if client else 'unknown'}"
+        return f"session:{_hash_cookie_for_key(cookie)}"
+    return f"ip:{_client_ip(request)}"
 
 
-# Limits chosen to allow normal flows (edit email, immediate resend on typo)
-# while making bulk abuse uneconomical. Resend is tighter since users have an
-# explicit no-cost path via re-submitting `set_email`.
+async def _email_ip_rate_limit_key(request: Request) -> str:
+    """Per-IP key for the looser ceiling that catches attackers cycling
+    fresh `/v1/session` cookies to bypass the per-session limit."""
+    return f"email-ip:{_client_ip(request)}"
+
+
+# Two-tier limit on the email-sending endpoints:
+#   - tight per-session caps so a single user doesn't bulk-spam themselves
+#     into a state where bounce-tracking matters,
+#   - looser per-IP ceiling so an attacker can't trivially multiply their
+#     budget by rotating guest sessions (each `GET /v1/session` mints a new
+#     one for free).
 email_send_rate_limit = RateLimiter(
     times=5, hours=1, identifier=_email_rate_limit_key
 )
+email_send_ip_rate_limit = RateLimiter(
+    times=20, hours=1, identifier=_email_ip_rate_limit_key
+)
 email_resend_rate_limit = RateLimiter(
     times=3, hours=1, identifier=_email_rate_limit_key
+)
+email_resend_ip_rate_limit = RateLimiter(
+    times=10, hours=1, identifier=_email_ip_rate_limit_key
 )
 
 
@@ -287,14 +314,17 @@ async def _issue_confirmation_token(
     return raw_token
 
 
-def _enqueue_confirmation_email(
-    to_email: str, raw_token: str, username: str
-) -> None:
-    queue_module.get_email_queue().enqueue(
+def _enqueue_confirmation_email(to_email: str, raw_token: str, username: str):
+    # result_ttl=60 / failure_ttl=300 shrinks the window during which the raw
+    # token (pickled into the RQ job hash in Redis) is recoverable from a
+    # snapshot or dashboard. Defaults are 8m / 1 year respectively.
+    return queue_module.get_email_queue().enqueue(
         "app.email.send_confirmation_email",
         to_email,
         raw_token,
         username,
+        result_ttl=60,
+        failure_ttl=300,
     )
 
 
@@ -302,7 +332,10 @@ def _enqueue_confirmation_email(
     "/v1/me/email",
     response_model=SessionResponse,
     status_code=status.HTTP_202_ACCEPTED,
-    dependencies=[Depends(email_send_rate_limit)],
+    dependencies=[
+        Depends(email_send_ip_rate_limit),
+        Depends(email_send_rate_limit),
+    ],
 )
 async def set_email(
     payload: SetEmailRequest,
@@ -312,21 +345,25 @@ async def set_email(
     # Honeypot: silently succeed without doing anything. Bots fill it; humans
     # never see it. We respond as if all is well so the bot doesn't learn the
     # field is a trap.
-    if payload.website.strip():
+    if payload.fmm_hp_token.strip():
         return await _build_session_response(db, current_user)
 
     await _verify_captcha_or_400(payload.captcha_token)
 
     email = payload.email.lower()
     old_email = current_user.email
+    if current_user.email != email and await name_taken(
+        db, User.id, User.email, email, exclude_id=current_user.id
+    ):
+        # Don't reveal that the email belongs to another user — that
+        # differential lets attackers enumerate the user base by cycling
+        # `GET /v1/session` for fresh rate-limit buckets. Return the same
+        # 202 + unchanged session shape as the success path. The legitimate
+        # owner is unaffected; the typo-on-someone-else's-address case sees
+        # a "sent" toast but never receives an email.
+        return await _build_session_response(db, current_user)
+
     if current_user.email != email:
-        if await name_taken(
-            db, User.id, User.email, email, exclude_id=current_user.id
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=EMAIL_TAKEN_DETAIL,
-            )
         current_user.email = email
 
     # Every successful set_email re-starts the confirmation handshake — the
@@ -335,15 +372,36 @@ async def set_email(
     raw_token = await _issue_confirmation_token(
         db, current_user, email, _email_change_context(old_email)
     )
+
+    # Enqueue BEFORE commit so a Redis flap can't leave a previously-verified
+    # user silently un-verified with no link sent. If enqueue fails, rollback
+    # restores in-memory + on-disk state.
+    try:
+        job = _enqueue_confirmation_email(
+            email, raw_token, current_user.username
+        )
+    except Exception:
+        await db.rollback()
+        await db.refresh(current_user)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Email service unavailable. Try again in a moment.",
+        )
+
     try:
         await db.commit()
     except IntegrityError:
+        # Race with another user claiming the same address between our
+        # `name_taken` probe and our commit. Cancel the now-orphan job and
+        # return the same enumeration-safe 202 as the up-front collision.
         await db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=EMAIL_TAKEN_DETAIL,
-        )
-    _enqueue_confirmation_email(email, raw_token, current_user.username)
+        try:
+            job.cancel()
+        except Exception:
+            pass
+        await db.refresh(current_user)
+        return await _build_session_response(db, current_user)
+
     return await _build_session_response(db, current_user)
 
 
@@ -351,14 +409,17 @@ async def set_email(
     "/v1/me/email/resend",
     response_model=SessionResponse,
     status_code=status.HTTP_202_ACCEPTED,
-    dependencies=[Depends(email_resend_rate_limit)],
+    dependencies=[
+        Depends(email_resend_ip_rate_limit),
+        Depends(email_resend_rate_limit),
+    ],
 )
 async def resend_email_confirmation(
     payload: ResendEmailRequest,
     db: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
 ) -> SessionResponse:
-    if payload.website.strip():
+    if payload.fmm_hp_token.strip():
         return await _build_session_response(db, current_user)
     if not current_user.email:
         raise HTTPException(
@@ -381,19 +442,44 @@ async def resend_email_confirmation(
         current_user.email,
         prior_context or _email_change_context(None),
     )
-    await db.commit()
-    _enqueue_confirmation_email(
-        current_user.email, raw_token, current_user.username
-    )
+    try:
+        job = _enqueue_confirmation_email(
+            current_user.email, raw_token, current_user.username
+        )
+    except Exception:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Email service unavailable. Try again in a moment.",
+        )
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        try:
+            job.cancel()
+        except Exception:
+            pass
+        raise
     return await _build_session_response(db, current_user)
 
 
 @router.post("/v1/me/email/confirm", response_model=SessionResponse)
 async def confirm_email(
     payload: ConfirmEmailRequest,
+    response: Response,
     db: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_current_user),
 ) -> SessionResponse:
+    """Confirm the email-change handshake.
+
+    The token in the email is itself the bearer credential — we don't
+    require the click to come from the same browser that requested it.
+    That lets users complete the flow on a mobile mail client even when
+    their desktop session cookie isn't available, and avoids minting an
+    orphan guest user on every cross-device click. The endpoint also
+    rotates the caller's session cookie to the token's owner so the
+    confirming browser ends up signed in as the right user.
+    """
     token_row = (
         await db.execute(
             select(UserToken).where(
@@ -402,14 +488,24 @@ async def confirm_email(
             )
         )
     ).scalar_one_or_none()
-    if token_row is None or token_row.user_id != current_user.id:
+    if token_row is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="That confirmation link is invalid or expired.",
         )
-    # Defensive: the email on the user may have been changed since the link
-    # was sent. If so, the link no longer matches the intended address.
-    if token_row.sent_to and token_row.sent_to != current_user.email:
+    user = (
+        await db.execute(select(User).where(User.id == token_row.user_id))
+    ).scalar_one_or_none()
+    if user is None:
+        await db.delete(token_row)
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That confirmation link is invalid or expired.",
+        )
+    if token_row.sent_to and token_row.sent_to != user.email:
+        # The user changed their email between request and click — the link
+        # no longer matches the intended address.
         await db.delete(token_row)
         await db.commit()
         raise HTTPException(
@@ -417,7 +513,19 @@ async def confirm_email(
             detail="That confirmation link no longer matches your email.",
         )
 
-    current_user.confirmed_at = datetime.now(timezone.utc)
+    user.confirmed_at = datetime.now(timezone.utc)
     await db.delete(token_row)
+    # Mint a fresh session for the token's owner so the confirming browser
+    # is signed in as them — replaces whatever guest session this browser
+    # had (or hadn't) on arrival.
+    raw_session = secrets.token_urlsafe(32)
+    db.add(
+        UserToken(
+            user_id=user.id,
+            context=SESSION_TOKEN_CONTEXT,
+            token=_hash_token(raw_session),
+        )
+    )
     await db.commit()
-    return await _build_session_response(db, current_user)
+    _set_session_cookie(response, raw_session)
+    return await _build_session_response(db, user)

--- a/api/migrations/versions/20260510_0000_0001_create_users_table.py
+++ b/api/migrations/versions/20260510_0000_0001_create_users_table.py
@@ -23,6 +23,12 @@ def upgrade() -> None:
         "users",
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column("username", sa.String(length=255), nullable=False),
+        sa.Column("email", sa.String(length=320), nullable=True),
+        sa.Column(
+            "confirmed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -36,10 +42,13 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.UniqueConstraint("username", name="uq_users_username"),
+        sa.UniqueConstraint("email", name="uq_users_email"),
     )
     op.create_index("ix_users_username", "users", ["username"])
+    op.create_index("ix_users_email", "users", ["email"])
 
 
 def downgrade() -> None:
+    op.drop_index("ix_users_email", table_name="users")
     op.drop_index("ix_users_username", table_name="users")
     op.drop_table("users")

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "alembic>=1.14",
     "coolname>=2.2",
     "jsonschema>=4.21",
+    "pydantic[email]>=2.0",
+    "httpx>=0.27.0",
 ]
 
 [project.optional-dependencies]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "jsonschema>=4.21",
     "pydantic[email]>=2.0",
     "httpx>=0.27.0",
+    "fastapi-limiter>=0.1.6,<0.2",
 ]
 
 [project.optional-dependencies]
@@ -23,7 +24,7 @@ dev = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.24",
     "httpx>=0.27.0",
-    "fakeredis>=2.20",
+    "fakeredis[lua]>=2.20",
     "testcontainers[postgres]>=4.8",
 ]
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -28,6 +28,34 @@ def fake_solver_queue(monkeypatch):
     return q
 
 
+@pytest.fixture(autouse=True)
+def fake_email_queue(monkeypatch):
+    """Sync RQ queue against fakeredis so enqueued jobs execute inline.
+
+    Tests can assert against the queue's ``finished_job_registry`` or peek
+    at recorded jobs via ``q.get_jobs()`` before they run by toggling
+    ``is_async`` if they need to inspect enqueue arguments without
+    triggering the email send.
+    """
+    connection = fakeredis.FakeStrictRedis()
+    q = Queue(queue_module.EMAIL_QUEUE, connection=connection, is_async=False)
+    monkeypatch.setattr(queue_module, "get_email_queue", lambda: q)
+    return q
+
+
+@pytest.fixture(autouse=True)
+def stub_captcha(monkeypatch):
+    """Pretend Cloudflare Turnstile said yes. Tests that want the failure
+    path override the patched function with ``monkeypatch.setattr``."""
+
+    async def _always_pass(token):  # noqa: ARG001
+        return True
+
+    from app import captcha as captcha_module
+
+    monkeypatch.setattr(captcha_module, "verify_captcha", _always_pass)
+
+
 @pytest.fixture(scope="session")
 def postgres_url() -> Iterator[str]:
     override = os.environ.get("TEST_DATABASE_URL")

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -36,10 +36,14 @@ def fake_email_queue(monkeypatch):
     at recorded jobs via ``q.get_jobs()`` before they run by toggling
     ``is_async`` if they need to inspect enqueue arguments without
     triggering the email send.
+
+    Also forces dev mode so ``send_confirmation_email`` runs the
+    log+print path instead of raising on missing SMTP.
     """
     connection = fakeredis.FakeStrictRedis()
     q = Queue(queue_module.EMAIL_QUEUE, connection=connection, is_async=False)
     monkeypatch.setattr(queue_module, "get_email_queue", lambda: q)
+    monkeypatch.setenv("FORTYMM_DEV", "1")
     return q
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -56,11 +56,11 @@ def stub_captcha(monkeypatch):
     monkeypatch.setattr(captcha_module, "verify_captcha", _always_pass)
 
 
-@pytest_asyncio.fixture(autouse=True)
-async def rate_limiter_fakeredis():
-    """Initialise FastAPILimiter against an in-memory fakeredis per test so
-    the rate-limit counters start clean. The httpx ASGITransport used by the
-    test client doesn't fire the app's lifespan, so we init here directly."""
+@pytest_asyncio.fixture(scope="session")
+async def _rate_limiter_redis():
+    """One fakeredis-backed FastAPILimiter for the whole test session — the
+    httpx ASGITransport never fires the app's lifespan, so we init here.
+    Per-test counter resets happen in ``rate_limiter_fakeredis`` below."""
     import fakeredis.aioredis
     from fastapi_limiter import FastAPILimiter
 
@@ -71,6 +71,13 @@ async def rate_limiter_fakeredis():
     finally:
         await FastAPILimiter.close()
         await fake.aclose()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def rate_limiter_fakeredis(_rate_limiter_redis):
+    """Flush rate-limit counters between tests so each starts clean."""
+    await _rate_limiter_redis.flushall()
+    return _rate_limiter_redis
 
 
 @pytest.fixture(scope="session")

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -56,6 +56,23 @@ def stub_captcha(monkeypatch):
     monkeypatch.setattr(captcha_module, "verify_captcha", _always_pass)
 
 
+@pytest_asyncio.fixture(autouse=True)
+async def rate_limiter_fakeredis():
+    """Initialise FastAPILimiter against an in-memory fakeredis per test so
+    the rate-limit counters start clean. The httpx ASGITransport used by the
+    test client doesn't fire the app's lifespan, so we init here directly."""
+    import fakeredis.aioredis
+    from fastapi_limiter import FastAPILimiter
+
+    fake = fakeredis.aioredis.FakeRedis(encoding="utf-8")
+    await FastAPILimiter.init(fake)
+    try:
+        yield fake
+    finally:
+        await FastAPILimiter.close()
+        await fake.aclose()
+
+
 @pytest.fixture(scope="session")
 def postgres_url() -> Iterator[str]:
     override = os.environ.get("TEST_DATABASE_URL")

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -1,5 +1,6 @@
 import hashlib
 from collections.abc import AsyncIterator
+from datetime import datetime, timezone
 
 import pytest
 import pytest_asyncio
@@ -196,7 +197,6 @@ async def test_resend_preserves_original_change_context(
     # Establish a confirmed prior email so the next set has something to
     # change FROM.
     user.email = "prior@example.com"
-    from datetime import datetime, timezone
     user.confirmed_at = datetime.now(timezone.utc)
     await db_session.commit()
 
@@ -280,7 +280,6 @@ async def test_changing_email_clears_confirmation(
     ).scalar_one()
     # We don't know the raw token in this test, so simulate by changing email
     # while user is confirmed.
-    from datetime import datetime, timezone
     user.confirmed_at = datetime.now(timezone.utc)
     await db_session.delete(token_row)
     await db_session.commit()

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -11,6 +11,7 @@ from app.db import get_session
 from app.main import app
 from app.models import User, UserToken
 from app.sessions import EMAIL_CONFIRMATION_TOKEN_CONTEXT
+from tests._helpers import start_session
 
 
 @pytest_asyncio.fixture
@@ -32,15 +33,6 @@ VALID_BODY = {
     "captcha_token": "test-token",
     "website": "",
 }
-
-
-async def _start_session(client: AsyncClient, db: AsyncSession) -> User:
-    response = await client.get("/v1/session")
-    assert response.status_code == 200
-    username = response.json()["data"]["user"]["username"]
-    return (
-        await db.execute(select(User).where(User.username == username))
-    ).scalar_one()
 
 
 async def _set_email(
@@ -65,7 +57,7 @@ async def test_session_response_includes_email_fields(
 async def test_set_email_persists_and_enqueues_send(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    user = await _start_session(api_client, db_session)
+    user = await start_session(api_client, db_session)
     response = await _set_email(api_client)
     assert response.status_code == 202
 
@@ -102,7 +94,7 @@ async def test_set_email_requires_session(api_client: AsyncClient):
 async def test_set_email_normalizes_to_lowercase(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    user = await _start_session(api_client, db_session)
+    user = await start_session(api_client, db_session)
     response = await _set_email(api_client, email="MixedCase@Example.COM")
     assert response.status_code == 202
     await db_session.refresh(user)
@@ -110,7 +102,7 @@ async def test_set_email_normalizes_to_lowercase(
 
 
 async def test_set_email_rejects_invalid_format(api_client: AsyncClient, db_session):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     response = await _set_email(api_client, email="not-an-email")
     assert response.status_code == 422
 
@@ -118,7 +110,7 @@ async def test_set_email_rejects_invalid_format(api_client: AsyncClient, db_sess
 async def test_set_email_honeypot_silently_succeeds(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    user = await _start_session(api_client, db_session)
+    user = await start_session(api_client, db_session)
     response = await _set_email(api_client, website="https://spammer.example")
     # Same shape as a real success — gives the bot no signal.
     assert response.status_code == 202
@@ -138,7 +130,7 @@ async def test_set_email_honeypot_silently_succeeds(
 async def test_set_email_rejects_failed_captcha(
     api_client: AsyncClient, db_session: AsyncSession, monkeypatch
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
 
     async def _fail(token):  # noqa: ARG001
         return False
@@ -156,7 +148,7 @@ async def test_set_email_rejects_duplicate(
 ):
     db_session.add(User(username="other", email="taken@example.com"))
     await db_session.commit()
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
 
     response = await _set_email(api_client, email="taken@example.com")
     assert response.status_code == 409
@@ -165,7 +157,7 @@ async def test_set_email_rejects_duplicate(
 async def test_set_email_replaces_existing_unconfirmed_token(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     await _set_email(api_client)
     await _set_email(api_client, email="rita2@example.com")
 
@@ -183,7 +175,7 @@ async def test_set_email_replaces_existing_unconfirmed_token(
 async def test_changing_email_clears_confirmation(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    user = await _start_session(api_client, db_session)
+    user = await start_session(api_client, db_session)
     await _set_email(api_client)
 
     # Confirm out-of-band to set confirmed_at.
@@ -237,7 +229,7 @@ async def _capture_raw_token(
 async def test_confirm_email_sets_confirmed_at_and_invalidates_token(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    user = await _start_session(api_client, db_session)
+    user = await start_session(api_client, db_session)
     raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
 
     response = await api_client.post(
@@ -270,7 +262,7 @@ async def test_confirm_email_sets_confirmed_at_and_invalidates_token(
 async def test_confirm_email_rejects_unknown_token(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     response = await api_client.post(
         "/v1/me/email/confirm", json={"token": "totally-bogus"}
     )
@@ -284,12 +276,12 @@ async def test_confirm_email_rejects_other_users_token(
     from tests._helpers import make_client
 
     # User A sets an email and we capture their token.
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
 
     # User B has a fresh session — submitting A's token must 400.
     async with make_client() as other_client:
-        await _start_session(other_client, db_session)
+        await start_session(other_client, db_session)
         response = await other_client.post(
             "/v1/me/email/confirm", json={"token": raw_token}
         )
@@ -306,7 +298,7 @@ async def test_confirm_email_requires_session(api_client: AsyncClient):
 async def test_token_is_stored_hashed_not_plaintext(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
 
     token_row = (
@@ -326,7 +318,7 @@ async def test_token_is_stored_hashed_not_plaintext(
 async def test_resend_issues_new_token(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     first_token = await _capture_raw_token(
         api_client, db_session, fake_email_queue
     )
@@ -351,7 +343,7 @@ async def test_resend_issues_new_token(
 async def test_resend_requires_email_set(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     response = await api_client.post(
         "/v1/me/email/resend",
         json={"captcha_token": "x", "website": ""},
@@ -362,7 +354,7 @@ async def test_resend_requires_email_set(
 async def test_resend_rejects_if_already_confirmed(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    user = await _start_session(api_client, db_session)
+    user = await start_session(api_client, db_session)
     raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
     await api_client.post(
         "/v1/me/email/confirm", json={"token": raw_token}
@@ -380,7 +372,7 @@ async def test_resend_rejects_if_already_confirmed(
 async def test_resend_honeypot_short_circuits(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    await _start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     await _set_email(api_client)
     job_count_before = fake_email_queue.finished_job_registry.count
 

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -172,6 +172,25 @@ async def test_set_email_replaces_existing_unconfirmed_token(
     assert tokens[0].sent_to == "rita2@example.com"
 
 
+async def test_resubmitting_same_email_clears_confirmation(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """Even when the address didn't change, calling set_email un-confirms
+    the user — they must click the fresh link to re-prove ownership."""
+    user = await start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
+    await api_client.post(
+        "/v1/me/email/confirm", json={"token": raw_token}
+    )
+    await db_session.refresh(user)
+    assert user.confirmed_at is not None
+
+    await _set_email(api_client)  # same email as VALID_BODY
+    await db_session.refresh(user)
+    assert user.confirmed_at is None
+    assert user.email == "rita@example.com"
+
+
 async def test_changing_email_clears_confirmation(
     api_client: AsyncClient, db_session: AsyncSession
 ):
@@ -382,3 +401,64 @@ async def test_resend_honeypot_short_circuits(
     )
     assert response.status_code == 202
     assert fake_email_queue.finished_job_registry.count == job_count_before
+
+
+# ---- rate limiting --------------------------------------------------------
+
+
+async def test_set_email_rate_limited(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """After 5 successful submits in the same session window, a 6th 429s."""
+    await start_session(api_client, db_session)
+    for i in range(5):
+        response = await _set_email(api_client, email=f"rita{i}@example.com")
+        assert response.status_code == 202, (i, response.text)
+
+    over = await _set_email(api_client, email="rita-final@example.com")
+    assert over.status_code == 429
+
+
+async def test_set_email_rate_limit_is_per_session(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Another user with a fresh session isn't penalised by the first's burst."""
+    from tests._helpers import make_client
+
+    await start_session(api_client, db_session)
+    for _ in range(5):
+        assert (await _set_email(api_client)).status_code == 202
+    assert (await _set_email(api_client)).status_code == 429
+
+    async with make_client() as other_client:
+        await start_session(other_client, db_session)
+        response = await other_client.post(
+            "/v1/me/email",
+            json={
+                "email": "other@example.com",
+                "captcha_token": "x",
+                "website": "",
+            },
+        )
+        assert response.status_code == 202
+
+
+async def test_resend_rate_limited(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """The resend endpoint allows 3 sends per session window; the 4th 429s."""
+    await start_session(api_client, db_session)
+    await _set_email(api_client)  # establishes an unconfirmed email
+
+    for i in range(3):
+        response = await api_client.post(
+            "/v1/me/email/resend",
+            json={"captcha_token": "x", "website": ""},
+        )
+        assert response.status_code == 202, (i, response.text)
+
+    over = await api_client.post(
+        "/v1/me/email/resend",
+        json={"captcha_token": "x", "website": ""},
+    )
+    assert over.status_code == 429

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -1,0 +1,392 @@
+import hashlib
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_session
+from app.main import app
+from app.models import User, UserToken
+from app.sessions import EMAIL_CONFIRMATION_TOKEN_CONTEXT
+
+
+@pytest_asyncio.fixture
+async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    app.dependency_overrides[get_session] = _override
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="https://testserver"
+    ) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+VALID_BODY = {
+    "email": "rita@example.com",
+    "captcha_token": "test-token",
+    "website": "",
+}
+
+
+async def _start_session(client: AsyncClient, db: AsyncSession) -> User:
+    response = await client.get("/v1/session")
+    assert response.status_code == 200
+    username = response.json()["data"]["user"]["username"]
+    return (
+        await db.execute(select(User).where(User.username == username))
+    ).scalar_one()
+
+
+async def _set_email(
+    client: AsyncClient, **overrides
+) -> "httpx.Response":  # noqa: F821
+    body = {**VALID_BODY, **overrides}
+    return await client.post("/v1/me/email", json=body)
+
+
+# ---- set email ------------------------------------------------------------
+
+
+async def test_session_response_includes_email_fields(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    response = await api_client.get("/v1/session")
+    user = response.json()["data"]["user"]
+    assert user["email"] is None
+    assert user["confirmed_at"] is None
+
+
+async def test_set_email_persists_and_enqueues_send(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    user = await _start_session(api_client, db_session)
+    response = await _set_email(api_client)
+    assert response.status_code == 202
+
+    body_user = response.json()["data"]["user"]
+    assert body_user["email"] == "rita@example.com"
+    assert body_user["confirmed_at"] is None
+
+    await db_session.refresh(user)
+    assert user.email == "rita@example.com"
+    assert user.confirmed_at is None
+
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT
+            )
+        )
+    ).scalars().all()
+    assert len(tokens) == 1
+    assert tokens[0].sent_to == "rita@example.com"
+    assert tokens[0].user_id == user.id
+    # Token stored hashed.
+    assert tokens[0].token != b"rita@example.com"
+
+    finished = fake_email_queue.finished_job_registry
+    assert finished.count == 1
+
+
+async def test_set_email_requires_session(api_client: AsyncClient):
+    response = await _set_email(api_client)
+    assert response.status_code == 401
+
+
+async def test_set_email_normalizes_to_lowercase(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    user = await _start_session(api_client, db_session)
+    response = await _set_email(api_client, email="MixedCase@Example.COM")
+    assert response.status_code == 202
+    await db_session.refresh(user)
+    assert user.email == "mixedcase@example.com"
+
+
+async def test_set_email_rejects_invalid_format(api_client: AsyncClient, db_session):
+    await _start_session(api_client, db_session)
+    response = await _set_email(api_client, email="not-an-email")
+    assert response.status_code == 422
+
+
+async def test_set_email_honeypot_silently_succeeds(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    user = await _start_session(api_client, db_session)
+    response = await _set_email(api_client, website="https://spammer.example")
+    # Same shape as a real success — gives the bot no signal.
+    assert response.status_code == 202
+
+    await db_session.refresh(user)
+    assert user.email is None  # nothing persisted
+
+    tokens = (
+        await db_session.execute(select(UserToken).where(
+            UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT
+        ))
+    ).scalars().all()
+    assert tokens == []
+    assert fake_email_queue.finished_job_registry.count == 0
+
+
+async def test_set_email_rejects_failed_captcha(
+    api_client: AsyncClient, db_session: AsyncSession, monkeypatch
+):
+    await _start_session(api_client, db_session)
+
+    async def _fail(token):  # noqa: ARG001
+        return False
+
+    from app import captcha as captcha_module
+
+    monkeypatch.setattr(captcha_module, "verify_captcha", _fail)
+    response = await _set_email(api_client)
+    assert response.status_code == 400
+    assert "Captcha" in response.json()["detail"]
+
+
+async def test_set_email_rejects_duplicate(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    db_session.add(User(username="other", email="taken@example.com"))
+    await db_session.commit()
+    await _start_session(api_client, db_session)
+
+    response = await _set_email(api_client, email="taken@example.com")
+    assert response.status_code == 409
+
+
+async def test_set_email_replaces_existing_unconfirmed_token(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    await _set_email(api_client)
+    await _set_email(api_client, email="rita2@example.com")
+
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT
+            )
+        )
+    ).scalars().all()
+    assert len(tokens) == 1
+    assert tokens[0].sent_to == "rita2@example.com"
+
+
+async def test_changing_email_clears_confirmation(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    user = await _start_session(api_client, db_session)
+    await _set_email(api_client)
+
+    # Confirm out-of-band to set confirmed_at.
+    token_row = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT
+            )
+        )
+    ).scalar_one()
+    # We don't know the raw token in this test, so simulate by changing email
+    # while user is confirmed.
+    from datetime import datetime, timezone
+    user.confirmed_at = datetime.now(timezone.utc)
+    await db_session.delete(token_row)
+    await db_session.commit()
+    await db_session.refresh(user)
+    assert user.confirmed_at is not None
+
+    await _set_email(api_client, email="changed@example.com")
+    await db_session.refresh(user)
+    assert user.confirmed_at is None
+    assert user.email == "changed@example.com"
+
+
+# ---- confirm email --------------------------------------------------------
+
+
+def _all_send_tokens(fake_email_queue) -> list[str]:
+    """Return every raw token handed to a finished email send job, ordered
+    by enqueue time (oldest first)."""
+    jobs = [
+        fake_email_queue.fetch_job(job_id)
+        for job_id in fake_email_queue.finished_job_registry.get_job_ids()
+    ]
+    jobs = [j for j in jobs if j is not None]
+    jobs.sort(key=lambda j: j.enqueued_at)
+    return [j.args[1] for j in jobs]
+
+
+async def _capture_raw_token(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue, **overrides
+) -> str:
+    """Set an email and pull the raw token out of the enqueued job args."""
+    await _set_email(api_client, **overrides)
+    tokens = _all_send_tokens(fake_email_queue)
+    assert tokens, "expected at least one finished email job"
+    return tokens[-1]
+
+
+async def test_confirm_email_sets_confirmed_at_and_invalidates_token(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    user = await _start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
+
+    response = await api_client.post(
+        "/v1/me/email/confirm", json={"token": raw_token}
+    )
+    assert response.status_code == 200
+    body_user = response.json()["data"]["user"]
+    assert body_user["confirmed_at"] is not None
+
+    await db_session.refresh(user)
+    assert user.confirmed_at is not None
+
+    # Token consumed.
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT
+            )
+        )
+    ).scalars().all()
+    assert tokens == []
+
+    # Replaying the same token is rejected.
+    replay = await api_client.post(
+        "/v1/me/email/confirm", json={"token": raw_token}
+    )
+    assert replay.status_code == 400
+
+
+async def test_confirm_email_rejects_unknown_token(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    response = await api_client.post(
+        "/v1/me/email/confirm", json={"token": "totally-bogus"}
+    )
+    assert response.status_code == 400
+
+
+async def test_confirm_email_rejects_other_users_token(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """A confirmation link issued to user A must not confirm user B."""
+    from tests._helpers import make_client
+
+    # User A sets an email and we capture their token.
+    await _start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
+
+    # User B has a fresh session — submitting A's token must 400.
+    async with make_client() as other_client:
+        await _start_session(other_client, db_session)
+        response = await other_client.post(
+            "/v1/me/email/confirm", json={"token": raw_token}
+        )
+        assert response.status_code == 400
+
+
+async def test_confirm_email_requires_session(api_client: AsyncClient):
+    response = await api_client.post(
+        "/v1/me/email/confirm", json={"token": "anything"}
+    )
+    assert response.status_code == 401
+
+
+async def test_token_is_stored_hashed_not_plaintext(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    await _start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
+
+    token_row = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT
+            )
+        )
+    ).scalar_one()
+    assert token_row.token == hashlib.sha256(raw_token.encode("utf-8")).digest()
+    assert token_row.token != raw_token.encode("utf-8")
+
+
+# ---- resend ---------------------------------------------------------------
+
+
+async def test_resend_issues_new_token(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    await _start_session(api_client, db_session)
+    first_token = await _capture_raw_token(
+        api_client, db_session, fake_email_queue
+    )
+
+    response = await api_client.post(
+        "/v1/me/email/resend",
+        json={"captcha_token": "x", "website": ""},
+    )
+    assert response.status_code == 202
+
+    # Old token must be gone; new token must be different.
+    tokens = _all_send_tokens(fake_email_queue)
+    new_token = tokens[-1]
+    assert new_token != first_token
+
+    confirm = await api_client.post(
+        "/v1/me/email/confirm", json={"token": first_token}
+    )
+    assert confirm.status_code == 400
+
+
+async def test_resend_requires_email_set(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await _start_session(api_client, db_session)
+    response = await api_client.post(
+        "/v1/me/email/resend",
+        json={"captcha_token": "x", "website": ""},
+    )
+    assert response.status_code == 400
+
+
+async def test_resend_rejects_if_already_confirmed(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    user = await _start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
+    await api_client.post(
+        "/v1/me/email/confirm", json={"token": raw_token}
+    )
+    await db_session.refresh(user)
+    assert user.confirmed_at is not None
+
+    response = await api_client.post(
+        "/v1/me/email/resend",
+        json={"captcha_token": "x", "website": ""},
+    )
+    assert response.status_code == 409
+
+
+async def test_resend_honeypot_short_circuits(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    await _start_session(api_client, db_session)
+    await _set_email(api_client)
+    job_count_before = fake_email_queue.finished_job_registry.count
+
+    response = await api_client.post(
+        "/v1/me/email/resend",
+        json={"captcha_token": "x", "website": "spam"},
+    )
+    assert response.status_code == 202
+    assert fake_email_queue.finished_job_registry.count == job_count_before

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db import get_session
 from app.main import app
 from app.models import User, UserToken
-from app.sessions import EMAIL_CONFIRMATION_TOKEN_CONTEXT
+from app.sessions import EMAIL_CHANGE_CONTEXT_PREFIX
 from tests._helpers import start_session
 
 
@@ -72,7 +72,7 @@ async def test_set_email_persists_and_enqueues_send(
     tokens = (
         await db_session.execute(
             select(UserToken).where(
-                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
             )
         )
     ).scalars().all()
@@ -120,7 +120,7 @@ async def test_set_email_honeypot_silently_succeeds(
 
     tokens = (
         await db_session.execute(select(UserToken).where(
-            UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT
+            UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
         ))
     ).scalars().all()
     assert tokens == []
@@ -154,6 +154,79 @@ async def test_set_email_rejects_duplicate(
     assert response.status_code == 409
 
 
+async def test_token_context_records_old_email(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Tokens carry their pre-change address in their context so we have an
+    audit trail of what each one was changing FROM. First-time set leaves
+    the address empty."""
+    await start_session(api_client, db_session)
+
+    # First-time set — no prior address.
+    await _set_email(api_client, email="first@example.com")
+    token = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+            )
+        )
+    ).scalar_one()
+    assert token.context == "change:"
+    assert token.sent_to == "first@example.com"
+
+    # Change to a new address — the old one shows up in the context.
+    await _set_email(api_client, email="second@example.com")
+    token = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+            )
+        )
+    ).scalar_one()
+    assert token.context == "change:first@example.com"
+    assert token.sent_to == "second@example.com"
+
+
+async def test_resend_preserves_original_change_context(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Resend should keep the original 'change:OLD' context so the audit
+    trail still reflects what the user was changing away from."""
+    user = await start_session(api_client, db_session)
+    # Establish a confirmed prior email so the next set has something to
+    # change FROM.
+    user.email = "prior@example.com"
+    from datetime import datetime, timezone
+    user.confirmed_at = datetime.now(timezone.utc)
+    await db_session.commit()
+
+    await _set_email(api_client, email="next@example.com")
+    first = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+            )
+        )
+    ).scalar_one()
+    assert first.context == "change:prior@example.com"
+
+    await api_client.post(
+        "/v1/me/email/resend",
+        json={"captcha_token": "x", "website": ""},
+    )
+    after = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+            )
+        )
+    ).scalar_one()
+    assert after.context == "change:prior@example.com"
+    assert after.sent_to == "next@example.com"
+    # Token rotated.
+    assert after.token != first.token
+
+
 async def test_set_email_replaces_existing_unconfirmed_token(
     api_client: AsyncClient, db_session: AsyncSession
 ):
@@ -164,7 +237,7 @@ async def test_set_email_replaces_existing_unconfirmed_token(
     tokens = (
         await db_session.execute(
             select(UserToken).where(
-                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
             )
         )
     ).scalars().all()
@@ -201,7 +274,7 @@ async def test_changing_email_clears_confirmation(
     token_row = (
         await db_session.execute(
             select(UserToken).where(
-                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
             )
         )
     ).scalar_one()
@@ -265,7 +338,7 @@ async def test_confirm_email_sets_confirmed_at_and_invalidates_token(
     tokens = (
         await db_session.execute(
             select(UserToken).where(
-                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
             )
         )
     ).scalars().all()
@@ -323,7 +396,7 @@ async def test_token_is_stored_hashed_not_plaintext(
     token_row = (
         await db_session.execute(
             select(UserToken).where(
-                UserToken.context == EMAIL_CONFIRMATION_TOKEN_CONTEXT
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
             )
         )
     ).scalar_one()

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -32,7 +32,7 @@ async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
 VALID_BODY = {
     "email": "rita@example.com",
     "captcha_token": "test-token",
-    "website": "",
+    "fmm_hp_token": "",
 }
 
 
@@ -112,7 +112,9 @@ async def test_set_email_honeypot_silently_succeeds(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
     user = await start_session(api_client, db_session)
-    response = await _set_email(api_client, website="https://spammer.example")
+    response = await _set_email(
+        api_client, fmm_hp_token="https://spammer.example"
+    )
     # Same shape as a real success — gives the bot no signal.
     assert response.status_code == 202
 
@@ -144,15 +146,35 @@ async def test_set_email_rejects_failed_captcha(
     assert "Captcha" in response.json()["detail"]
 
 
-async def test_set_email_rejects_duplicate(
-    api_client: AsyncClient, db_session: AsyncSession
+async def test_set_email_with_taken_address_is_enumeration_safe(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
+    """Submitting an address belonging to someone else must look identical
+    to a no-op success — same 202, same session response shape, no token
+    issued, no email enqueued. Returning 409 would let an attacker cycle
+    fresh `/v1/session` cookies to enumerate the user base."""
     db_session.add(User(username="other", email="taken@example.com"))
     await db_session.commit()
-    await start_session(api_client, db_session)
+    me = await start_session(api_client, db_session)
 
     response = await _set_email(api_client, email="taken@example.com")
-    assert response.status_code == 409
+    assert response.status_code == 202
+
+    await db_session.refresh(me)
+    # Caller's own row is untouched.
+    assert me.email is None
+    assert me.confirmed_at is None
+
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
+                UserToken.user_id == me.id,
+            )
+        )
+    ).scalars().all()
+    assert tokens == []
+    assert fake_email_queue.finished_job_registry.count == 0
 
 
 async def test_token_context_records_old_email(
@@ -212,7 +234,7 @@ async def test_resend_preserves_original_change_context(
 
     await api_client.post(
         "/v1/me/email/resend",
-        json={"captcha_token": "x", "website": ""},
+        json={"captcha_token": "x", "fmm_hp_token": ""},
     )
     after = (
         await db_session.execute(
@@ -360,30 +382,43 @@ async def test_confirm_email_rejects_unknown_token(
     assert response.status_code == 400
 
 
-async def test_confirm_email_rejects_other_users_token(
+async def test_confirm_email_works_from_a_different_browser(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    """A confirmation link issued to user A must not confirm user B."""
+    """The token is itself a bearer credential — clicking the link in any
+    browser must confirm the change. The endpoint rotates the caller's
+    session cookie to the token's owner so they end up signed in as the
+    right user."""
     from tests._helpers import make_client
 
-    # User A sets an email and we capture their token.
-    await start_session(api_client, db_session)
-    raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
+    user_a = await start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(
+        api_client, db_session, fake_email_queue
+    )
 
-    # User B has a fresh session — submitting A's token must 400.
     async with make_client() as other_client:
-        await start_session(other_client, db_session)
+        # User B opens the link in a separate browser with no session cookie.
         response = await other_client.post(
             "/v1/me/email/confirm", json={"token": raw_token}
         )
-        assert response.status_code == 400
+        assert response.status_code == 200
+        body_user = response.json()["data"]["user"]
+        assert body_user["username"] == user_a.username
+        assert body_user["confirmed_at"] is not None
+        # Session cookie was minted/rotated to user A on the new browser.
+        assert other_client.cookies.get("session")
+
+    await db_session.refresh(user_a)
+    assert user_a.confirmed_at is not None
 
 
-async def test_confirm_email_requires_session(api_client: AsyncClient):
+async def test_confirm_email_does_not_require_session(api_client: AsyncClient):
+    """Cookieless POST to /confirm-email is the cross-device mobile-mail
+    case — it should return 400 (invalid token) not 401 (no session)."""
     response = await api_client.post(
         "/v1/me/email/confirm", json={"token": "anything"}
     )
-    assert response.status_code == 401
+    assert response.status_code == 400
 
 
 async def test_token_is_stored_hashed_not_plaintext(
@@ -416,7 +451,7 @@ async def test_resend_issues_new_token(
 
     response = await api_client.post(
         "/v1/me/email/resend",
-        json={"captcha_token": "x", "website": ""},
+        json={"captcha_token": "x", "fmm_hp_token": ""},
     )
     assert response.status_code == 202
 
@@ -437,7 +472,7 @@ async def test_resend_requires_email_set(
     await start_session(api_client, db_session)
     response = await api_client.post(
         "/v1/me/email/resend",
-        json={"captcha_token": "x", "website": ""},
+        json={"captcha_token": "x", "fmm_hp_token": ""},
     )
     assert response.status_code == 400
 
@@ -455,7 +490,7 @@ async def test_resend_rejects_if_already_confirmed(
 
     response = await api_client.post(
         "/v1/me/email/resend",
-        json={"captcha_token": "x", "website": ""},
+        json={"captcha_token": "x", "fmm_hp_token": ""},
     )
     assert response.status_code == 409
 
@@ -469,7 +504,7 @@ async def test_resend_honeypot_short_circuits(
 
     response = await api_client.post(
         "/v1/me/email/resend",
-        json={"captcha_token": "x", "website": "spam"},
+        json={"captcha_token": "x", "fmm_hp_token": "spam"},
     )
     assert response.status_code == 202
     assert fake_email_queue.finished_job_registry.count == job_count_before
@@ -509,7 +544,7 @@ async def test_set_email_rate_limit_is_per_session(
             json={
                 "email": "other@example.com",
                 "captcha_token": "x",
-                "website": "",
+                "fmm_hp_token": "",
             },
         )
         assert response.status_code == 202
@@ -525,12 +560,111 @@ async def test_resend_rate_limited(
     for i in range(3):
         response = await api_client.post(
             "/v1/me/email/resend",
-            json={"captcha_token": "x", "website": ""},
+            json={"captcha_token": "x", "fmm_hp_token": ""},
         )
         assert response.status_code == 202, (i, response.text)
 
     over = await api_client.post(
         "/v1/me/email/resend",
-        json={"captcha_token": "x", "website": ""},
+        json={"captcha_token": "x", "fmm_hp_token": ""},
     )
     assert over.status_code == 429
+
+
+async def test_set_email_ip_limit_catches_session_cycling(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """An attacker who cycles `/v1/session` for fresh per-session buckets
+    is still caught by the looser per-IP ceiling."""
+    from tests._helpers import make_client
+
+    # Burn through the per-session cap on the primary client.
+    await start_session(api_client, db_session)
+    for _ in range(5):
+        assert (await _set_email(api_client)).status_code == 202
+
+    # Rotate through fresh sessions; each gets its own 5/hr session bucket,
+    # but the per-IP bucket is shared. After 20 total IP hits, the next 429s.
+    total = 5
+    for _ in range(20):
+        if total >= 20:
+            break
+        async with make_client() as fresh:
+            await start_session(fresh, db_session)
+            resp = await _set_email(fresh, email=f"r{total}@example.com")
+            assert resp.status_code == 202, (total, resp.text)
+            total += 1
+
+    async with make_client() as fresh:
+        await start_session(fresh, db_session)
+        resp = await _set_email(fresh, email="overflow@example.com")
+        assert resp.status_code == 429
+
+
+async def test_rate_limit_key_hashes_session_cookie(
+    api_client: AsyncClient, db_session: AsyncSession, rate_limiter_fakeredis
+):
+    """The session cookie is a bearer credential — it must never land in
+    Redis verbatim, where read-only access would let anyone impersonate
+    the user."""
+    await start_session(api_client, db_session)
+    raw_cookie = api_client.cookies.get("session")
+    assert raw_cookie
+
+    await _set_email(api_client)
+
+    keys = await rate_limiter_fakeredis.keys("*")
+    decoded = [k.decode() if isinstance(k, bytes) else k for k in keys]
+    for key in decoded:
+        assert raw_cookie not in key, (
+            f"raw session cookie leaked into Redis key: {key!r}"
+        )
+
+
+# ---- captcha + email config guards ---------------------------------------
+
+
+def test_captcha_secret_default_only_in_dev(monkeypatch):
+    from app import captcha as captcha_module
+
+    monkeypatch.delenv("TURNSTILE_SECRET_KEY", raising=False)
+    monkeypatch.setenv("APP_ENV", "production")
+    with pytest.raises(RuntimeError, match="TURNSTILE_SECRET_KEY"):
+        captcha_module._secret_key()
+
+    monkeypatch.setenv("APP_ENV", "dev")
+    assert captcha_module._secret_key() == captcha_module.TURNSTILE_TEST_SECRET_ALWAYS_PASSES
+
+
+async def test_captcha_fails_closed_when_misconfigured_in_prod(monkeypatch):
+    # Restore the real verifier (autouse `stub_captcha` swaps it out).
+    import importlib
+
+    from app import captcha as captcha_module
+
+    importlib.reload(captcha_module)
+
+    monkeypatch.delenv("TURNSTILE_SECRET_KEY", raising=False)
+    monkeypatch.setenv("APP_ENV", "production")
+    # Even with a non-empty token, verification refuses rather than
+    # silently passing via the test secret.
+    assert await captcha_module.verify_captcha("any-token") is False
+
+
+def test_email_refuses_to_send_without_app_base_url(monkeypatch):
+    from app import email as email_module
+
+    monkeypatch.delenv("APP_BASE_URL", raising=False)
+    monkeypatch.delenv("FORTYMM_DEV", raising=False)
+    with pytest.raises(RuntimeError, match="APP_BASE_URL"):
+        email_module._confirm_url("token")
+
+
+def test_email_refuses_to_send_when_smtp_unset_outside_dev(monkeypatch):
+    from app import email as email_module
+
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    monkeypatch.delenv("FORTYMM_DEV", raising=False)
+    monkeypatch.setenv("APP_BASE_URL", "https://example.com")
+    with pytest.raises(RuntimeError, match="SMTP"):
+        email_module.send_confirmation_email("a@b.com", "tok", "user")

--- a/api/tests/test_user_model.py
+++ b/api/tests/test_user_model.py
@@ -29,3 +29,18 @@ async def test_username_is_required(db_session: AsyncSession):
     db_session.add(User(username=None))  # type: ignore[arg-type]
     with pytest.raises(IntegrityError):
         await db_session.commit()
+
+
+async def test_email_defaults_to_null_and_is_unique(db_session: AsyncSession):
+    u = User(username="claire")
+    db_session.add(u)
+    await db_session.commit()
+    await db_session.refresh(u)
+    assert u.email is None
+    assert u.confirmed_at is None
+
+    db_session.add(User(username="dave", email="dup@example.com"))
+    await db_session.commit()
+    db_session.add(User(username="erin", email="dup@example.com"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -81,7 +81,18 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Confirm Email */
+        /**
+         * Confirm Email
+         * @description Confirm the email-change handshake.
+         *
+         *     The token in the email is itself the bearer credential — we don't
+         *     require the click to come from the same browser that requested it.
+         *     That lets users complete the flow on a mobile mail client even when
+         *     their desktop session cookie isn't available, and avoids minting an
+         *     orphan guest user on every cross-device click. The endpoint also
+         *     rotates the caller's session cookie to the token's owner so the
+         *     confirming browser ends up signed in as the right user.
+         */
         post: operations["confirm_email_v1_me_email_confirm_post"];
         delete?: never;
         options?: never;
@@ -897,10 +908,10 @@ export interface components {
             /** Captcha Token */
             captcha_token: string;
             /**
-             * Website
+             * Fmm Hp Token
              * @default
              */
-            website: string;
+            fmm_hp_token: string;
         };
         /** RoleCreate */
         RoleCreate: {
@@ -970,10 +981,10 @@ export interface components {
             /** Captcha Token */
             captcha_token: string;
             /**
-             * Website
+             * Fmm Hp Token
              * @default
              */
-            website: string;
+            fmm_hp_token: string;
             /**
              * Email
              * Format: email
@@ -1148,9 +1159,7 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
-            cookie?: {
-                session?: string | null;
-            };
+            cookie?: never;
         };
         requestBody: {
             content: {

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -967,11 +967,6 @@ export interface components {
         };
         /** SetEmailRequest */
         SetEmailRequest: {
-            /**
-             * Email
-             * Format: email
-             */
-            email: string;
             /** Captcha Token */
             captcha_token: string;
             /**
@@ -979,6 +974,11 @@ export interface components {
              * @default
              */
             website: string;
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
         };
         /** UpdateCurrentUserRequest */
         UpdateCurrentUserRequest: {

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -38,6 +38,57 @@ export interface paths {
         patch: operations["update_current_user_v1_me_patch"];
         trace?: never;
     };
+    "/v1/me/email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Set Email */
+        post: operations["set_email_v1_me_email_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/me/email/resend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Resend Email Confirmation */
+        post: operations["resend_email_confirmation_v1_me_email_resend_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/me/email/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Confirm Email */
+        post: operations["confirm_email_v1_me_email_confirm_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/permissions": {
         parameters: {
             query?: never;
@@ -328,6 +379,11 @@ export interface components {
             latency_ms?: number | null;
             /** Error */
             error?: string | null;
+        };
+        /** ConfirmEmailRequest */
+        ConfirmEmailRequest: {
+            /** Token */
+            token: string;
         };
         /** DashboardNextMatch */
         DashboardNextMatch: {
@@ -836,6 +892,16 @@ export interface components {
             /** Role Ids */
             role_ids: string[];
         };
+        /** ResendEmailRequest */
+        ResendEmailRequest: {
+            /** Captcha Token */
+            captcha_token: string;
+            /**
+             * Website
+             * @default
+             */
+            website: string;
+        };
         /** RoleCreate */
         RoleCreate: {
             /** Name */
@@ -894,6 +960,25 @@ export interface components {
             username: string;
             /** Permissions */
             permissions: string[];
+            /** Email */
+            email?: string | null;
+            /** Confirmed At */
+            confirmed_at?: string | null;
+        };
+        /** SetEmailRequest */
+        SetEmailRequest: {
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
+            /** Captcha Token */
+            captcha_token: string;
+            /**
+             * Website
+             * @default
+             */
+            website: string;
         };
         /** UpdateCurrentUserRequest */
         UpdateCurrentUserRequest: {
@@ -965,6 +1050,111 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["UpdateCurrentUserRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_email_v1_me_email_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetEmailRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resend_email_confirmation_v1_me_email_resend_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResendEmailRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    confirm_email_v1_me_email_confirm_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmEmailRequest"];
             };
         };
         responses: {

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -50,7 +50,9 @@ export function useUpdateUsername() {
 export interface SetEmailInput {
   email: string
   captchaToken: string
-  website?: string
+  // Honeypot — the form must include this field on the wire even when
+  // empty so the server's bot-check semantics match the FE form shape.
+  honeypot?: string
 }
 
 export function useSetEmail() {
@@ -59,7 +61,7 @@ export function useSetEmail() {
     mutationFn: async ({
       email,
       captchaToken,
-      website = '',
+      honeypot = '',
     }: SetEmailInput): Promise<Session> =>
       unwrap(
         'set email',
@@ -67,7 +69,7 @@ export function useSetEmail() {
           body: {
             email,
             captcha_token: captchaToken,
-            website,
+            fmm_hp_token: honeypot,
           },
         }),
       ),
@@ -82,15 +84,15 @@ export function useResendEmailConfirmation() {
   return useMutation({
     mutationFn: async ({
       captchaToken,
-      website = '',
+      honeypot = '',
     }: {
       captchaToken: string
-      website?: string
+      honeypot?: string
     }): Promise<Session> =>
       unwrap(
         'resend confirmation',
         await api.POST('/v1/me/email/resend', {
-          body: { captcha_token: captchaToken, website },
+          body: { captcha_token: captchaToken, fmm_hp_token: honeypot },
         }),
       ),
     onSuccess: (session) => {

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -46,3 +46,69 @@ export function useUpdateUsername() {
     },
   })
 }
+
+export interface SetEmailInput {
+  email: string
+  captchaToken: string
+  website?: string
+}
+
+export function useSetEmail() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async ({
+      email,
+      captchaToken,
+      website = '',
+    }: SetEmailInput): Promise<Session> =>
+      unwrap(
+        'set email',
+        await api.POST('/v1/me/email', {
+          body: {
+            email,
+            captcha_token: captchaToken,
+            website,
+          },
+        }),
+      ),
+    onSuccess: (session) => {
+      qc.setQueryData(SESSION_QUERY_KEY, session)
+    },
+  })
+}
+
+export function useResendEmailConfirmation() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async ({
+      captchaToken,
+      website = '',
+    }: {
+      captchaToken: string
+      website?: string
+    }): Promise<Session> =>
+      unwrap(
+        'resend confirmation',
+        await api.POST('/v1/me/email/resend', {
+          body: { captcha_token: captchaToken, website },
+        }),
+      ),
+    onSuccess: (session) => {
+      qc.setQueryData(SESSION_QUERY_KEY, session)
+    },
+  })
+}
+
+export function useConfirmEmail() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (token: string): Promise<Session> =>
+      unwrap(
+        'confirm email',
+        await api.POST('/v1/me/email/confirm', { body: { token } }),
+      ),
+    onSuccess: (session) => {
+      qc.setQueryData(SESSION_QUERY_KEY, session)
+    },
+  })
+}

--- a/web-client/src/components/turnstile.tsx
+++ b/web-client/src/components/turnstile.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Cloudflare Turnstile widget. Defaults to the documented always-passes test
+ * site key (`1x00000000000000000000AA`) so dev and tests work with no setup;
+ * production should set `VITE_TURNSTILE_SITE_KEY`.
+ */
+const TURNSTILE_TEST_SITE_KEY = '1x00000000000000000000AA'
+const TURNSTILE_SCRIPT_SRC =
+  'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+
+interface TurnstileApi {
+  render: (
+    container: HTMLElement,
+    options: {
+      sitekey: string
+      callback?: (token: string) => void
+      'expired-callback'?: () => void
+      'error-callback'?: () => void
+      theme?: 'light' | 'dark' | 'auto'
+    },
+  ) => string
+  reset: (widgetId?: string) => void
+  remove: (widgetId: string) => void
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi
+  }
+}
+
+let scriptPromise: Promise<TurnstileApi> | null = null
+
+function loadTurnstile(): Promise<TurnstileApi> {
+  if (typeof window === 'undefined') return Promise.reject(new Error('no-window'))
+  if (window.turnstile) return Promise.resolve(window.turnstile)
+  if (scriptPromise) return scriptPromise
+
+  scriptPromise = new Promise((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${TURNSTILE_SCRIPT_SRC}"]`,
+    )
+    if (existing) {
+      existing.addEventListener('load', () => {
+        if (window.turnstile) resolve(window.turnstile)
+        else reject(new Error('turnstile-missing-after-load'))
+      })
+      existing.addEventListener('error', () => reject(new Error('script-load-failed')))
+      return
+    }
+    const script = document.createElement('script')
+    script.src = TURNSTILE_SCRIPT_SRC
+    script.async = true
+    script.defer = true
+    script.onload = () => {
+      if (window.turnstile) resolve(window.turnstile)
+      else reject(new Error('turnstile-missing-after-load'))
+    }
+    script.onerror = () => reject(new Error('script-load-failed'))
+    document.head.appendChild(script)
+  })
+  return scriptPromise
+}
+
+export interface TurnstileHandle {
+  reset: () => void
+}
+
+export function Turnstile({
+  onToken,
+  onExpire,
+  onError,
+  handleRef,
+}: {
+  onToken: (token: string) => void
+  onExpire?: () => void
+  onError?: () => void
+  handleRef?: (handle: TurnstileHandle | null) => void
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const widgetIdRef = useRef<string | null>(null)
+  const apiRef = useRef<TurnstileApi | null>(null)
+  const [failed, setFailed] = useState(false)
+
+  // Hold the latest callbacks in refs so we can render the widget once and
+  // not have its callbacks go stale across re-renders.
+  const onTokenRef = useRef(onToken)
+  const onExpireRef = useRef(onExpire)
+  const onErrorRef = useRef(onError)
+  useEffect(() => {
+    onTokenRef.current = onToken
+    onExpireRef.current = onExpire
+    onErrorRef.current = onError
+  })
+
+  useEffect(() => {
+    let cancelled = false
+    loadTurnstile()
+      .then((api) => {
+        if (cancelled || !containerRef.current) return
+        apiRef.current = api
+        widgetIdRef.current = api.render(containerRef.current, {
+          sitekey:
+            import.meta.env.VITE_TURNSTILE_SITE_KEY ?? TURNSTILE_TEST_SITE_KEY,
+          theme: 'dark',
+          callback: (token) => onTokenRef.current(token),
+          'expired-callback': () => onExpireRef.current?.(),
+          'error-callback': () => {
+            onErrorRef.current?.()
+          },
+        })
+        handleRef?.({
+          reset: () => {
+            if (apiRef.current && widgetIdRef.current) {
+              apiRef.current.reset(widgetIdRef.current)
+            }
+          },
+        })
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true)
+      })
+
+    return () => {
+      cancelled = true
+      if (apiRef.current && widgetIdRef.current) {
+        try {
+          apiRef.current.remove(widgetIdRef.current)
+        } catch {
+          // ignore — widget may have already torn down
+        }
+      }
+      widgetIdRef.current = null
+      handleRef?.(null)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  if (failed) {
+    return (
+      <p
+        className="fmm-help fmm-help--err"
+        role="alert"
+        data-testid="turnstile-error"
+      >
+        Couldn't load CAPTCHA. Check your network and reload.
+      </p>
+    )
+  }
+
+  return <div ref={containerRef} data-testid="turnstile-widget" />
+}

--- a/web-client/src/components/turnstile.tsx
+++ b/web-client/src/components/turnstile.tsx
@@ -37,19 +37,27 @@ function loadTurnstile(): Promise<TurnstileApi> {
   if (window.turnstile) return Promise.resolve(window.turnstile)
   if (scriptPromise) return scriptPromise
 
+  // Track the tag we own so we can remove it on failure. `load`/`error`
+  // are one-shot — if we ever inherit a stale tag whose events already
+  // fired, attaching new listeners would never resolve, so we replace it.
+  let ownedScript: HTMLScriptElement | null = null
+
   scriptPromise = new Promise<TurnstileApi>((resolve, reject) => {
     const existing = document.querySelector<HTMLScriptElement>(
       `script[src="${TURNSTILE_SCRIPT_SRC}"]`,
     )
     if (existing) {
-      existing.addEventListener('load', () => {
-        if (window.turnstile) resolve(window.turnstile)
-        else reject(new Error('turnstile-missing-after-load'))
-      })
-      existing.addEventListener('error', () => reject(new Error('script-load-failed')))
-      return
+      // If turnstile already loaded successfully, we're done.
+      if (window.turnstile) {
+        resolve(window.turnstile)
+        return
+      }
+      // Otherwise the existing tag is a leftover from a failed load whose
+      // events have already fired and won't fire again. Drop it.
+      existing.remove()
     }
     const script = document.createElement('script')
+    ownedScript = script
     script.src = TURNSTILE_SCRIPT_SRC
     script.async = true
     script.defer = true
@@ -60,10 +68,15 @@ function loadTurnstile(): Promise<TurnstileApi> {
     script.onerror = () => reject(new Error('script-load-failed'))
     document.head.appendChild(script)
   })
-  // Clear the cached promise on failure so a transient network error
-  // doesn't poison every future mount in this tab.
+  // On failure, clear the cached promise AND drop the stale <script> tag
+  // so the next mount installs a fresh one. Without removing the tag, the
+  // existing-tag branch above would inherit a node whose one-shot load
+  // event already fired, deadlocking the new promise forever.
   scriptPromise.catch(() => {
     scriptPromise = null
+    if (ownedScript && ownedScript.parentNode) {
+      ownedScript.parentNode.removeChild(ownedScript)
+    }
   })
   return scriptPromise
 }

--- a/web-client/src/components/turnstile.tsx
+++ b/web-client/src/components/turnstile.tsx
@@ -37,7 +37,7 @@ function loadTurnstile(): Promise<TurnstileApi> {
   if (window.turnstile) return Promise.resolve(window.turnstile)
   if (scriptPromise) return scriptPromise
 
-  scriptPromise = new Promise((resolve, reject) => {
+  scriptPromise = new Promise<TurnstileApi>((resolve, reject) => {
     const existing = document.querySelector<HTMLScriptElement>(
       `script[src="${TURNSTILE_SCRIPT_SRC}"]`,
     )
@@ -59,6 +59,11 @@ function loadTurnstile(): Promise<TurnstileApi> {
     }
     script.onerror = () => reject(new Error('script-load-failed'))
     document.head.appendChild(script)
+  })
+  // Clear the cached promise on failure so a transient network error
+  // doesn't poison every future mount in this tab.
+  scriptPromise.catch(() => {
+    scriptPromise = null
   })
   return scriptPromise
 }

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -139,6 +139,54 @@ export const handlers = [
     mockSession.data.user = { ...mockSession.data.user, username: next }
     return HttpResponse.json(mockSession)
   }),
+  http.post('*/v1/me/email', async ({ request }) => {
+    const body =
+      ((await readJson(request)) as {
+        email?: string
+        captcha_token?: string
+        website?: string
+      } | undefined) ?? {}
+    // Honeypot win condition: behave like success without persisting.
+    if (body.website?.trim()) {
+      return HttpResponse.json(mockSession, { status: 202 })
+    }
+    if (!body.captcha_token) return detail('Captcha required.', 400)
+    if (!body.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(body.email))
+      return detail('Invalid email.', 422)
+    mockSession.data.user = {
+      ...mockSession.data.user,
+      email: body.email.toLowerCase(),
+      confirmed_at: null,
+    }
+    return HttpResponse.json(mockSession, { status: 202 })
+  }),
+  http.post('*/v1/me/email/resend', async ({ request }) => {
+    const body =
+      ((await readJson(request)) as {
+        captcha_token?: string
+        website?: string
+      } | undefined) ?? {}
+    if (body.website?.trim())
+      return HttpResponse.json(mockSession, { status: 202 })
+    if (!mockSession.data.user.email)
+      return detail('Add an email address before requesting a resend.', 400)
+    if (mockSession.data.user.confirmed_at)
+      return detail('This email is already confirmed.', 409)
+    if (!body.captcha_token) return detail('Captcha required.', 400)
+    return HttpResponse.json(mockSession, { status: 202 })
+  }),
+  http.post('*/v1/me/email/confirm', async ({ request }) => {
+    const body =
+      ((await readJson(request)) as { token?: string } | undefined) ?? {}
+    if (!body.token) return detail('Missing token.', 400)
+    if (!mockSession.data.user.email)
+      return detail('That confirmation link is invalid or expired.', 400)
+    mockSession.data.user = {
+      ...mockSession.data.user,
+      confirmed_at: new Date().toISOString(),
+    }
+    return HttpResponse.json(mockSession)
+  }),
   http.get('*/v1/players/recent', async () => {
     await delay(300)
     return HttpResponse.json(mockRecentOpponents)

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -144,10 +144,10 @@ export const handlers = [
       ((await readJson(request)) as {
         email?: string
         captcha_token?: string
-        website?: string
+        fmm_hp_token?: string
       } | undefined) ?? {}
     // Honeypot win condition: behave like success without persisting.
-    if (body.website?.trim()) {
+    if (body.fmm_hp_token?.trim()) {
       return HttpResponse.json(mockSession, { status: 202 })
     }
     if (!body.captcha_token) return detail('Captcha required.', 400)
@@ -164,9 +164,9 @@ export const handlers = [
     const body =
       ((await readJson(request)) as {
         captcha_token?: string
-        website?: string
+        fmm_hp_token?: string
       } | undefined) ?? {}
-    if (body.website?.trim())
+    if (body.fmm_hp_token?.trim())
       return HttpResponse.json(mockSession, { status: 202 })
     if (!mockSession.data.user.email)
       return detail('Add an email address before requesting a resend.', 400)

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as DesignSystemRouteImport } from './routes/design-system'
 import { Route as DashboardRouteImport } from './routes/dashboard'
+import { Route as ConfirmEmailRouteImport } from './routes/confirm-email'
 import { Route as AdminRouteImport } from './routes/admin'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as MatchesIndexRouteImport } from './routes/matches/index'
@@ -37,6 +38,11 @@ const DesignSystemRoute = DesignSystemRouteImport.update({
 const DashboardRoute = DashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ConfirmEmailRoute = ConfirmEmailRouteImport.update({
+  id: '/confirm-email',
+  path: '/confirm-email',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AdminRoute = AdminRouteImport.update({
@@ -100,6 +106,7 @@ const MatchesMatchIdGamesGameIdScoresScoreIdEditRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/admin': typeof AdminRouteWithChildren
+  '/confirm-email': typeof ConfirmEmailRoute
   '/dashboard': typeof DashboardRoute
   '/design-system': typeof DesignSystemRoute
   '/settings': typeof SettingsRoute
@@ -115,6 +122,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/confirm-email': typeof ConfirmEmailRoute
   '/dashboard': typeof DashboardRoute
   '/design-system': typeof DesignSystemRoute
   '/settings': typeof SettingsRoute
@@ -132,6 +140,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/admin': typeof AdminRouteWithChildren
+  '/confirm-email': typeof ConfirmEmailRoute
   '/dashboard': typeof DashboardRoute
   '/design-system': typeof DesignSystemRoute
   '/settings': typeof SettingsRoute
@@ -150,6 +159,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/admin'
+    | '/confirm-email'
     | '/dashboard'
     | '/design-system'
     | '/settings'
@@ -165,6 +175,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/confirm-email'
     | '/dashboard'
     | '/design-system'
     | '/settings'
@@ -181,6 +192,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/admin'
+    | '/confirm-email'
     | '/dashboard'
     | '/design-system'
     | '/settings'
@@ -198,6 +210,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AdminRoute: typeof AdminRouteWithChildren
+  ConfirmEmailRoute: typeof ConfirmEmailRoute
   DashboardRoute: typeof DashboardRoute
   DesignSystemRoute: typeof DesignSystemRoute
   SettingsRoute: typeof SettingsRoute
@@ -229,6 +242,13 @@ declare module '@tanstack/react-router' {
       path: '/dashboard'
       fullPath: '/dashboard'
       preLoaderRoute: typeof DashboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/confirm-email': {
+      id: '/confirm-email'
+      path: '/confirm-email'
+      fullPath: '/confirm-email'
+      preLoaderRoute: typeof ConfirmEmailRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/admin': {
@@ -330,6 +350,7 @@ const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AdminRoute: AdminRouteWithChildren,
+  ConfirmEmailRoute: ConfirmEmailRoute,
   DashboardRoute: DashboardRoute,
   DesignSystemRoute: DesignSystemRoute,
   SettingsRoute: SettingsRoute,

--- a/web-client/src/routes/confirm-email.tsx
+++ b/web-client/src/routes/confirm-email.tsx
@@ -3,7 +3,6 @@ import { Link, createFileRoute } from '@tanstack/react-router'
 
 import { ApiError } from '@/api/client'
 import { useConfirmEmail } from '@/api/session'
-import { AppShell } from '@/components/app-shell'
 import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute('/confirm-email')({
@@ -42,58 +41,63 @@ function ConfirmEmailPage() {
         ? confirm.error.detail
         : 'Confirmation failed.'
 
+  // Intentionally NOT wrapped in <AppShell> — AppShell calls useSession()
+  // on mount, and `GET /v1/session` auto-mints a guest user for cookieless
+  // requests. Clicking the link on a device that doesn't share cookies
+  // with the requesting browser (mobile mail, in-app webview) would leak
+  // one orphan user + session-token row per click. The confirm endpoint
+  // itself rotates the cookie to the token's owner, so the user lands on
+  // the dashboard signed in as themselves.
   return (
-    <AppShell>
-      <div
+    <div
+      style={{
+        maxWidth: 520,
+        margin: '64px auto',
+        padding: 24,
+        textAlign: 'center',
+      }}
+    >
+      <h1
         style={{
-          maxWidth: 520,
-          margin: '64px auto',
-          padding: 24,
-          textAlign: 'center',
+          fontFamily: 'var(--font-display)',
+          fontSize: 40,
+          margin: '0 0 12px',
         }}
       >
-        <h1
-          style={{
-            fontFamily: 'var(--font-display)',
-            fontSize: 40,
-            margin: '0 0 12px',
-          }}
-        >
-          {status === 'ok' ? 'You’re in.' : 'Confirming your email…'}
-        </h1>
-        {status === 'confirming' && (
-          <p style={{ color: 'var(--fg-3)' }}>Hang tight, this only takes a second.</p>
-        )}
-        {status === 'ok' && (
-          <>
-            <p style={{ color: 'var(--fg-2)' }}>
-              Your email is verified. Your FortyMM account is now yours to keep.
-            </p>
-            <Link
-              to="/dashboard"
-              className="fmm-btn fmm-btn--primary"
-              style={{ marginTop: 24 }}
-            >
-              Go to dashboard
-            </Link>
-          </>
-        )}
-        {(status === 'error' || status === 'missing-token') && (
-          <>
-            <p className="fmm-help fmm-help--err" role="alert">
-              {errorMsg}
-            </p>
-            <Link
-              to="/settings"
-              hash="sec-email"
-              className="fmm-btn fmm-btn--quiet"
-              style={{ marginTop: 24 }}
-            >
-              Back to settings
-            </Link>
-          </>
-        )}
-      </div>
-    </AppShell>
+        {status === 'ok' ? 'You’re in.' : 'Confirming your email…'}
+      </h1>
+      {status === 'confirming' && (
+        <p style={{ color: 'var(--fg-3)' }}>Hang tight, this only takes a second.</p>
+      )}
+      {status === 'ok' && (
+        <>
+          <p style={{ color: 'var(--fg-2)' }}>
+            Your email is verified. Your FortyMM account is now yours to keep.
+          </p>
+          <Link
+            to="/dashboard"
+            className="fmm-btn fmm-btn--primary"
+            style={{ marginTop: 24 }}
+          >
+            Go to dashboard
+          </Link>
+        </>
+      )}
+      {(status === 'error' || status === 'missing-token') && (
+        <>
+          <p className="fmm-help fmm-help--err" role="alert">
+            {errorMsg}
+          </p>
+          <Link
+            to="/settings"
+            hash="sec-email"
+            className="fmm-btn fmm-btn--quiet"
+            style={{ marginTop: 24 }}
+          >
+            Back to settings
+          </Link>
+        </>
+      )}
+    </div>
   )
 }

--- a/web-client/src/routes/confirm-email.tsx
+++ b/web-client/src/routes/confirm-email.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef } from 'react'
+import { Link, createFileRoute } from '@tanstack/react-router'
+
+import { ApiError } from '@/api/client'
+import { useConfirmEmail } from '@/api/session'
+import { AppShell } from '@/components/app-shell'
+import { pageTitle } from '@/lib/page-title'
+
+export const Route = createFileRoute('/confirm-email')({
+  head: () => ({
+    meta: [{ title: pageTitle('Confirm email') }],
+  }),
+  validateSearch: (search: Record<string, unknown>) => ({
+    token: typeof search.token === 'string' ? search.token : '',
+  }),
+  component: ConfirmEmailPage,
+})
+
+function ConfirmEmailPage() {
+  const { token } = Route.useSearch()
+  const confirm = useConfirmEmail()
+  const fired = useRef(false)
+
+  useEffect(() => {
+    if (fired.current || !token) return
+    fired.current = true
+    confirm.mutate(token)
+  }, [token, confirm])
+
+  const status: 'missing-token' | 'confirming' | 'ok' | 'error' = !token
+    ? 'missing-token'
+    : confirm.isSuccess
+      ? 'ok'
+      : confirm.isError
+        ? 'error'
+        : 'confirming'
+
+  const errorMsg =
+    status === 'missing-token'
+      ? 'This link is missing its token.'
+      : confirm.error instanceof ApiError && confirm.error.detail
+        ? confirm.error.detail
+        : 'Confirmation failed.'
+
+  return (
+    <AppShell>
+      <div
+        style={{
+          maxWidth: 520,
+          margin: '64px auto',
+          padding: 24,
+          textAlign: 'center',
+        }}
+      >
+        <h1
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 40,
+            margin: '0 0 12px',
+          }}
+        >
+          {status === 'ok' ? 'You’re in.' : 'Confirming your email…'}
+        </h1>
+        {status === 'confirming' && (
+          <p style={{ color: 'var(--fg-3)' }}>Hang tight, this only takes a second.</p>
+        )}
+        {status === 'ok' && (
+          <>
+            <p style={{ color: 'var(--fg-2)' }}>
+              Your email is verified. Your FortyMM account is now yours to keep.
+            </p>
+            <Link
+              to="/dashboard"
+              className="fmm-btn fmm-btn--primary"
+              style={{ marginTop: 24 }}
+            >
+              Go to dashboard
+            </Link>
+          </>
+        )}
+        {(status === 'error' || status === 'missing-token') && (
+          <>
+            <p className="fmm-help fmm-help--err" role="alert">
+              {errorMsg}
+            </p>
+            <Link
+              to="/settings"
+              hash="sec-email"
+              className="fmm-btn fmm-btn--quiet"
+              style={{ marginTop: 24 }}
+            >
+              Back to settings
+            </Link>
+          </>
+        )}
+      </div>
+    </AppShell>
+  )
+}

--- a/web-client/src/routes/settings.test.tsx
+++ b/web-client/src/routes/settings.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { mockSession } from '@/mocks/handlers'
+
+// The real Turnstile widget loads a remote script that jsdom can't run.
+// Replace it with a stub that hands back a token on click, so the form
+// submit path is testable.
+vi.mock('@/components/turnstile', () => ({
+  Turnstile: ({ onToken }: { onToken: (t: string) => void }) => (
+    <button
+      type="button"
+      data-testid="captcha-stub"
+      onClick={() => onToken('stub-token')}
+    >
+      Complete captcha
+    </button>
+  ),
+}))
+
+// Stub IntersectionObserver — radix-ui components used inside AppShell
+// instantiate it on mount and jsdom does not ship one.
+beforeEach(() => {
+  const g = globalThis as { IntersectionObserver?: unknown }
+  if (!g.IntersectionObserver) {
+    g.IntersectionObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return []
+      }
+    }
+  }
+  // Reset the shared session between tests so honeypot/email checks start fresh.
+  mockSession.data.user.email = null
+  mockSession.data.user.confirmed_at = null
+  mockSession.data.user.username = 'rita.kovac'
+})
+
+async function renderSettings() {
+  const { Route } = await import('./settings')
+  const SettingsPage = Route.options.component!
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  const rootRoute = createRootRoute()
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/settings',
+    component: SettingsPage,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([settingsRoute]),
+    history: createMemoryHistory({ initialEntries: ['/settings'] }),
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('SettingsPage email section', () => {
+  it('shows the guest claim banner until an email is set', async () => {
+    await renderSettings()
+    expect(await screen.findByText(/playing as a guest/i)).toBeInTheDocument()
+  })
+
+  it('persists a submitted email and re-renders as pending', async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    const section = (await screen.findByLabelText(/^email$/i)).closest(
+      'section',
+    ) as HTMLElement
+    const emailInput = within(section).getByLabelText(/^email$/i)
+    await user.type(emailInput, 'me@example.com')
+    await user.click(within(section).getByTestId('captcha-stub'))
+
+    const submit = within(section).getByRole('button', { name: /add email/i })
+    await waitFor(() => expect(submit).toBeEnabled())
+    await user.click(submit)
+
+    expect(
+      await screen.findByText(/waiting for verification/i),
+    ).toBeInTheDocument()
+    expect(mockSession.data.user.email).toBe('me@example.com')
+  })
+
+  it("doesn't persist when the honeypot is filled", async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    const section = (await screen.findByLabelText(/^email$/i)).closest(
+      'section',
+    ) as HTMLElement
+    const emailInput = within(section).getByLabelText(/^email$/i)
+    await user.type(emailInput, 'me@example.com')
+    // Spammer fills the honeypot. Humans never touch it.
+    const honeypot = within(section).getByTestId('email-honeypot')
+    await user.type(honeypot, 'spammer.example')
+    await user.click(within(section).getByTestId('captcha-stub'))
+
+    const submit = within(section).getByRole('button', { name: /add email/i })
+    await waitFor(() => expect(submit).toBeEnabled())
+    await user.click(submit)
+
+    // The server responds as if it succeeded (status hidden from the bot)
+    // but the session never picked up the email.
+    await waitFor(() => expect(mockSession.data.user.email).toBeNull())
+  })
+
+  it('requires the captcha before the submit button enables', async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    const section = (await screen.findByLabelText(/^email$/i)).closest(
+      'section',
+    ) as HTMLElement
+    const emailInput = within(section).getByLabelText(/^email$/i)
+    await user.type(emailInput, 'me@example.com')
+
+    const submit = within(section).getByRole('button', { name: /add email/i })
+    expect(submit).toBeDisabled()
+  })
+})

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -7,16 +7,20 @@ import {
   useRef,
   useState,
   type CSSProperties,
-  type Dispatch,
   type ReactNode,
-  type SetStateAction,
 } from 'react'
 import { createFileRoute, useRouterState } from '@tanstack/react-router'
-import { Check, Mail, Trash2 } from 'lucide-react'
+import { Check, Mail } from 'lucide-react'
 
 import { ApiError } from '@/api/client'
-import { useSession, useUpdateUsername } from '@/api/session'
+import {
+  useResendEmailConfirmation,
+  useSession,
+  useSetEmail,
+  useUpdateUsername,
+} from '@/api/session'
 import { AppShell } from '@/components/app-shell'
+import { Turnstile, type TurnstileHandle } from '@/components/turnstile'
 import {
   Tooltip,
   TooltipContent,
@@ -38,15 +42,6 @@ export const Route = createFileRoute('/settings')({
 /* ------------------------------------------------------------------ */
 
 type EmailStatus = 'guest' | 'pending' | 'verified'
-
-interface User {
-  email: string
-  emailVerified: boolean
-  _lastSaved: {
-    email: number | null
-    verified: number | null
-  }
-}
 
 interface Validation {
   ok: boolean
@@ -88,16 +83,6 @@ function relativeTime(ts: number): string {
   return `${Math.floor(diff / 86400)}d ago`
 }
 
-function initialUser(): User {
-  return {
-    email: '',
-    emailVerified: false,
-    _lastSaved: {
-      email: null,
-      verified: null,
-    },
-  }
-}
 
 /* ------------------------------------------------------------------ */
 /*  Toasts                                                            */
@@ -813,68 +798,112 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
 /*  02 — Email (required to claim)                                    */
 /* ------------------------------------------------------------------ */
 
+// Off-screen but still focusable so AT users hear "Leave this empty" — bots
+// pattern-match every visible field, then fill blanks anyway. Honeypots work
+// by being targeted by automation, not by being invisible to humans.
+const HONEYPOT_STYLE: CSSProperties = {
+  position: 'absolute',
+  left: '-9999px',
+  width: 1,
+  height: 1,
+  opacity: 0,
+}
+
 function EmailSection({
-  user,
-  setUser,
+  email,
+  confirmedAt,
 }: {
-  user: User
-  setUser: Dispatch<SetStateAction<User>>
+  email: string | null
+  confirmedAt: string | null
 }) {
   const toast = useToast()
-  const [val, setVal] = useState(user.email)
+  const setEmail = useSetEmail()
+  const resendEmail = useResendEmailConfirmation()
+  const current = email ?? ''
+  const [val, setVal] = useState(current)
   const [touched, setTouched] = useState(false)
-  const [saving, setSaving] = useState(false)
-  const [verifying, setVerifying] = useState(false)
-  const [savedAt, setSavedAt] = useState<number | null>(user._lastSaved.email)
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null)
+  const [website, setWebsite] = useState('')
+  const [serverErr, setServerErr] = useState<string | null>(null)
+  const [savedAt, setSavedAt] = useState<number | null>(null)
+  const captchaRef = useRef<TurnstileHandle | null>(null)
+
+  // Reset the local input when the underlying session value changes (e.g. on
+  // refetch after another tab confirmed). Avoid clobbering in-progress edits.
+  const lastSyncedRef = useRef(current)
+  useEffect(() => {
+    if (current === lastSyncedRef.current) return
+    lastSyncedRef.current = current
+    setVal(current)
+    setTouched(false)
+    setServerErr(null)
+  }, [current])
 
   const v = useMemo(() => validateEmail(val), [val])
-  const dirty = val !== user.email
-  const showErr = touched && !v.ok
+  const dirty = val !== current
+  const showErr = serverErr ?? (touched && !v.ok ? v.err : null)
 
-  const status: EmailStatus = user.emailVerified
+  const status: EmailStatus = confirmedAt
     ? 'verified'
-    : user.email
+    : email
       ? 'pending'
       : 'guest'
 
+  const resetCaptcha = () => {
+    captchaRef.current?.reset()
+    setCaptchaToken(null)
+  }
+
   const onSave = async () => {
-    if (!v.ok) return
-    setSaving(true)
-    await new Promise((r) => setTimeout(r, 700))
-    const now = Date.now()
-    setUser((u) => ({
-      ...u,
-      email: val,
-      emailVerified: false, // re-verify on any change
-      _lastSaved: { ...u._lastSaved, email: now },
-    }))
-    setSavedAt(now)
-    setSaving(false)
-    setTouched(false)
-    toast(`Verification link sent to ${val}.`)
+    if (!v.ok || !dirty) return
+    if (!captchaToken) {
+      setServerErr('Please complete the CAPTCHA above.')
+      return
+    }
+    setServerErr(null)
+    try {
+      await setEmail.mutateAsync({
+        email: val,
+        captchaToken,
+        website,
+      })
+      setSavedAt(Date.now())
+      setTouched(false)
+      resetCaptcha()
+      toast(`Verification link sent to ${val}.`)
+    } catch (err) {
+      resetCaptcha()
+      if (err instanceof ApiError && err.status && err.status < 500) {
+        setServerErr(err.detail ?? 'Server rejected this email.')
+        return
+      }
+      toast(
+        err instanceof Error
+          ? `Couldn't update email: ${err.message}`
+          : "Couldn't update email.",
+        { kind: 'err' },
+      )
+    }
   }
 
-  const onVerify = async () => {
-    setVerifying(true)
-    await new Promise((r) => setTimeout(r, 900))
-    setUser((u) => ({
-      ...u,
-      emailVerified: true,
-      _lastSaved: { ...u._lastSaved, verified: Date.now() },
-    }))
-    setVerifying(false)
-    toast('Email verified. Account claimed.')
-  }
-
-  const onResend = () => {
-    toast(`Verification link re-sent to ${user.email}.`)
-  }
-
-  const onRemove = () => {
-    setUser((u) => ({ ...u, email: '', emailVerified: false }))
-    setVal('')
-    setSavedAt(null)
-    toast("Email removed. You're back to a guest session.", { kind: 'err' })
+  const onResend = async () => {
+    if (!captchaToken) {
+      toast('Complete the CAPTCHA, then click Resend.', { kind: 'err' })
+      return
+    }
+    try {
+      await resendEmail.mutateAsync({ captchaToken, website })
+      resetCaptcha()
+      toast(`Verification link re-sent to ${email}.`)
+    } catch (err) {
+      resetCaptcha()
+      toast(
+        err instanceof ApiError && err.detail
+          ? err.detail
+          : "Couldn't resend confirmation.",
+        { kind: 'err' },
+      )
+    }
   }
 
   return (
@@ -894,15 +923,16 @@ function EmailSection({
       footer={
         <SaveBar
           dirty={dirty}
-          valid={v.ok}
-          saving={saving}
+          valid={v.ok && !!captchaToken}
+          saving={setEmail.isPending}
           savedAt={savedAt}
           onSave={onSave}
           onCancel={() => {
-            setVal(user.email)
+            setVal(current)
             setTouched(false)
+            setServerErr(null)
           }}
-          primaryLabel={user.email ? 'Update email' : 'Add email'}
+          primaryLabel={email ? 'Update email' : 'Add email'}
         />
       }
     >
@@ -914,7 +944,7 @@ function EmailSection({
             ? "Verified. You can change it any time — we'll send a fresh link."
             : "We'll send a link to verify it's yours. No marketing, ever."
         }
-        error={showErr ? v.err : null}
+        error={showErr ?? null}
       >
         <div style={{ position: 'relative' }}>
           <span
@@ -934,19 +964,47 @@ function EmailSection({
             type="email"
             className={`fmm-input fmm-input--mono ${showErr ? 'fmm-input--err' : status === 'verified' && !dirty ? 'fmm-input--ok' : ''}`}
             value={val}
-            onChange={(e) => setVal(e.target.value.trim())}
+            onChange={(e) => {
+              setVal(e.target.value.trim())
+              if (serverErr) setServerErr(null)
+            }}
             onBlur={() => setTouched(true)}
             placeholder="you@example.com"
             style={{ paddingLeft: 38 }}
             spellCheck={false}
             autoComplete="email"
-            aria-invalid={showErr || undefined}
+            aria-invalid={!!showErr || undefined}
           />
         </div>
       </Field>
 
-      {/* Verification state strip */}
-      {user.email && (
+      {/* Honeypot — invisible to humans, magnet for bots. */}
+      <div style={HONEYPOT_STYLE} aria-hidden="true">
+        <label htmlFor="email-website">Website</label>
+        <input
+          id="email-website"
+          type="text"
+          name="website"
+          tabIndex={-1}
+          autoComplete="off"
+          value={website}
+          onChange={(e) => setWebsite(e.target.value)}
+          data-testid="email-honeypot"
+        />
+      </div>
+
+      <div style={{ marginTop: 16 }}>
+        <Turnstile
+          handleRef={(h) => {
+            captchaRef.current = h
+          }}
+          onToken={(t) => setCaptchaToken(t)}
+          onExpire={() => setCaptchaToken(null)}
+          onError={() => setCaptchaToken(null)}
+        />
+      </div>
+
+      {email && (
         <div
           style={{
             marginTop: 16,
@@ -986,8 +1044,8 @@ function EmailSection({
               <>
                 <div style={{ fontWeight: 600, color: 'var(--fg-1)' }}>Account claimed.</div>
                 <div style={{ color: 'var(--fg-3)', marginTop: 2 }}>
-                  Verified {relativeTime(user._lastSaved.verified ?? 0)}. You can sign in from
-                  anywhere.
+                  Verified {relativeTime(new Date(confirmedAt!).getTime())}. You can sign in
+                  from anywhere.
                 </div>
               </>
             ) : (
@@ -996,49 +1054,28 @@ function EmailSection({
                   Waiting for verification.
                 </div>
                 <div style={{ color: 'var(--fg-3)', marginTop: 2 }}>
-                  Open the link in your inbox. Or — for the demo — click verify.
+                  Open the link we just sent to{' '}
+                  <span style={{ fontFamily: 'var(--font-mono)' }}>{email}</span>.
                 </div>
               </>
             )}
           </div>
           {status === 'pending' && (
-            <>
-              <button
-                type="button"
-                className="fmm-btn fmm-btn--quiet fmm-btn--sm"
-                onClick={onResend}
-              >
-                Resend
-              </button>
-              <button
-                type="button"
-                className="fmm-btn fmm-btn--primary fmm-btn--sm"
-                onClick={onVerify}
-                disabled={verifying}
-              >
-                {verifying ? (
-                  <>
-                    <Spinner />
-                    Verifying…
-                  </>
-                ) : (
-                  'Verify'
-                )}
-              </button>
-            </>
+            <button
+              type="button"
+              className="fmm-btn fmm-btn--quiet fmm-btn--sm"
+              onClick={onResend}
+              disabled={resendEmail.isPending || !captchaToken}
+            >
+              {resendEmail.isPending ? (
+                <>
+                  <Spinner /> Resending…
+                </>
+              ) : (
+                'Resend'
+              )}
+            </button>
           )}
-        </div>
-      )}
-
-      {user.email && (
-        <div style={{ marginTop: 16, display: 'flex', justifyContent: 'flex-end' }}>
-          <button
-            type="button"
-            className="fmm-btn fmm-btn--danger fmm-btn--sm"
-            onClick={onRemove}
-          >
-            <Trash2 size={14} /> Remove email
-          </button>
         </div>
       )}
     </SectionCard>
@@ -1058,13 +1095,15 @@ function scrollToSection(id: string) {
 
 function SettingsPage() {
   const session = useSession()
-  const sessionUsername = session.data?.data.user.username ?? ''
-  const [user, setUser] = useState<User>(initialUser)
+  const sessionUser = session.data?.data.user
+  const sessionUsername = sessionUser?.username ?? ''
+  const sessionEmail = sessionUser?.email ?? null
+  const sessionConfirmedAt = sessionUser?.confirmed_at ?? null
   const hash = useRouterState({ select: (s) => s.location.hash })
 
-  const effectiveStatus: EmailStatus = user.emailVerified
+  const effectiveStatus: EmailStatus = sessionConfirmedAt
     ? 'verified'
-    : user.email
+    : sessionEmail
       ? 'pending'
       : 'guest'
   const claimed = effectiveStatus === 'verified'
@@ -1083,19 +1122,18 @@ function SettingsPage() {
             <div className="fmm-main-inner">
               <PageHeader username={sessionUsername} claimed={claimed} />
 
-              <ComingSoon>
-                <ClaimBanner
-                  status={effectiveStatus}
-                  email={user.email}
-                  onJump={() => scrollToSection('sec-email')}
-                />
-              </ComingSoon>
+              <ClaimBanner
+                status={effectiveStatus}
+                email={sessionEmail ?? ''}
+                onJump={() => scrollToSection('sec-email')}
+              />
 
               <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
                 <UsernameSection currentUsername={sessionUsername} />
-                <ComingSoon>
-                  <EmailSection user={user} setUser={setUser} />
-                </ComingSoon>
+                <EmailSection
+                  email={sessionEmail}
+                  confirmedAt={sessionConfirmedAt}
+                />
               </div>
 
               <ComingSoon>

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -1040,11 +1040,11 @@ function EmailSection({
             />
           )}
           <div style={{ flex: 1, fontSize: 'var(--text-sm)', color: 'var(--fg-2)' }}>
-            {status === 'verified' ? (
+            {status === 'verified' && confirmedAt ? (
               <>
                 <div style={{ fontWeight: 600, color: 'var(--fg-1)' }}>Account claimed.</div>
                 <div style={{ color: 'var(--fg-3)', marginTop: 2 }}>
-                  Verified {relativeTime(new Date(confirmedAt!).getTime())}. You can sign in
+                  Verified {relativeTime(new Date(confirmedAt).getTime())}. You can sign in
                   from anywhere.
                 </div>
               </>

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -549,7 +549,6 @@ function ClaimBanner({
   email: string
   onJump: () => void
 }) {
-  const toast = useToast()
   if (status === 'verified') return null
   const guest = status === 'guest'
   return (
@@ -591,28 +590,13 @@ function ClaimBanner({
             </>
           )}
         </div>
-        {guest ? (
-          <button type="button" className="fmm-btn fmm-btn--primary fmm-btn--sm" onClick={onJump}>
-            Add email
-          </button>
-        ) : (
-          <>
-            <button
-              type="button"
-              className="fmm-btn fmm-btn--quiet fmm-btn--sm"
-              onClick={() => toast(`Verification link re-sent to ${email}.`)}
-            >
-              Resend
-            </button>
-            <button
-              type="button"
-              className="fmm-btn fmm-btn--ghost fmm-btn--sm"
-              onClick={onJump}
-            >
-              Verify now
-            </button>
-          </>
-        )}
+        <button
+          type="button"
+          className={`fmm-btn fmm-btn--${guest ? 'primary' : 'ghost'} fmm-btn--sm`}
+          onClick={onJump}
+        >
+          {guest ? 'Add email' : 'Verify now'}
+        </button>
       </div>
     </div>
   )
@@ -823,7 +807,7 @@ function EmailSection({
   const [val, setVal] = useState(current)
   const [touched, setTouched] = useState(false)
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
-  const [website, setWebsite] = useState('')
+  const [honeypot, setHoneypot] = useState('')
   const [serverErr, setServerErr] = useState<string | null>(null)
   const [savedAt, setSavedAt] = useState<number | null>(null)
   const captchaRef = useRef<TurnstileHandle | null>(null)
@@ -865,7 +849,7 @@ function EmailSection({
       await setEmail.mutateAsync({
         email: val,
         captchaToken,
-        website,
+        honeypot,
       })
       setSavedAt(Date.now())
       setTouched(false)
@@ -892,7 +876,7 @@ function EmailSection({
       return
     }
     try {
-      await resendEmail.mutateAsync({ captchaToken, website })
+      await resendEmail.mutateAsync({ captchaToken, honeypot })
       resetCaptcha()
       toast(`Verification link re-sent to ${email}.`)
     } catch (err) {
@@ -978,17 +962,20 @@ function EmailSection({
         </div>
       </Field>
 
-      {/* Honeypot — invisible to humans, magnet for bots. */}
+      {/* Honeypot. The field name deliberately avoids identity-profile
+          names ("website", "address") because Chrome / 1Password / Bitwarden
+          ignore autoComplete="off" for those and would splash real users'
+          saved data into the trap. */}
       <div style={HONEYPOT_STYLE} aria-hidden="true">
-        <label htmlFor="email-website">Website</label>
+        <label htmlFor="email-fmm-hp">Leave this empty</label>
         <input
-          id="email-website"
+          id="email-fmm-hp"
           type="text"
-          name="website"
+          name="fmm_hp_token"
           tabIndex={-1}
           autoComplete="off"
-          value={website}
-          onChange={(e) => setWebsite(e.target.value)}
+          value={honeypot}
+          onChange={(e) => setHoneypot(e.target.value)}
           data-testid="email-honeypot"
         />
       </div>

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -67,6 +67,8 @@ export function sessionUser(overrides: Partial<SessionUser> = {}): SessionUser {
   return {
     username: faker.internet.username().toLowerCase(),
     permissions: [],
+    email: null,
+    confirmed_at: null,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary

- Users can claim their account by adding an email from `/settings`. Submissions are gated by **Cloudflare Turnstile** + a hidden **honeypot**; an RQ worker on the new `email` queue delivers the confirmation link; clicking it hits `/confirm-email`, which stamps `users.confirmed_at`.
- Backend adds `users.email` + `users.confirmed_at` (migration 0001 edited in place since the app is undeployed), three endpoints (`POST /v1/me/email`, `/email/resend`, `/email/confirm`), sha-256-hashed confirmation tokens stored on the existing `user_tokens` table with context `"change:" + old_email` so each token records what it's changing FROM (empty after `:` on first-ever set; resend preserves the prior context).
- Email-sending endpoints are **rate-limited via `fastapi-limiter`** keyed on session cookie — 5/hour for `set_email`, 3/hour for `resend`. Limiter degrades gracefully when Redis is unreachable so offline tooling (regen-api-types) still serves `/openapi.json`.
- Frontend rewires the existing settings `EmailSection` to call the real API, adds a lazy-loaded `<Turnstile>` widget (defaults to the documented test site key), and adds a `/confirm-email` route.

## Configuration

- `TURNSTILE_SECRET_KEY` / `VITE_TURNSTILE_SITE_KEY` — both default to Cloudflare's always-passes test keys so dev/tests work with no setup
- `SMTP_HOST` / `SMTP_PORT` / `SMTP_USERNAME` / `SMTP_PASSWORD` / `EMAIL_FROM` — without these, the worker just logs/prints the link
- `APP_BASE_URL` — link base in the confirmation email (defaults to `http://localhost:5173`)
- New worker needed: `rq worker email --url \"\$REDIS_URL\"` in addition to the existing `solver` worker

## Follow-ups flagged in review

- Add a \`RATE_LIMITER_REQUIRED\` env var so prod crash-loops rather than silently fail-opening if Redis is down at startup
- Add a partial unique index on \`user_tokens(user_id) WHERE context LIKE 'change:%'\` to enforce the one-token-per-user invariant at the DB level
- Token TTL — confirmation tokens have no expiry; consider 24h

## Test plan

- [x] \`cd api && pytest\` — 251 pass
- [x] \`cd web-client && npm run test:run\` — 56 pass
- [x] \`cd web-client && npm run lint && npm run build\` — clean
- [x] \`cd web-client && PLAYWRIGHT_PORT=5176 npm run test:e2e\` — 126 pass
- [x] \`mise run regen-api-types\` — schema clean
- [ ] Manual: hit \`/settings\`, add an email, confirm the worker logs the link, click it, land on \`/confirm-email\`, verify session shows \`confirmed_at\` populated
- [ ] Manual: submit 6 emails in a row, confirm the 6th 429s
- [ ] Manual: change email to a new address, confirm \`confirmed_at\` clears and a fresh token is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)