### PR TITLE
Consume change-email tokens at confirm time

### DIFF
--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -16,6 +16,10 @@ class SessionUser(BaseModel):
     permissions: list[str]
     email: str | None = None
     confirmed_at: datetime | None = None
+    # Pending change address. Lives only on the change token until
+    # confirm_email consumes it; surfaced here so the FE can distinguish
+    # "verified for X with a pending move to Y" from plain "verified".
+    pending_email: str | None = None
 
 
 class SessionData(BaseModel):

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -44,6 +44,13 @@ def _email_change_context(old_email: str | None) -> str:
     return f"{EMAIL_CHANGE_CONTEXT_PREFIX}{old_email or ''}"
 
 
+def _old_email_from_context(context: str) -> str | None:
+    """Inverse of ``_email_change_context``: decode the prior email out
+    of a change token's context. ``change:`` (empty suffix) means there
+    was no prior confirmed address."""
+    return context[len(EMAIL_CHANGE_CONTEXT_PREFIX):] or None
+
+
 def _hash_cookie_for_key(cookie: str) -> str:
     """Hash the raw session cookie before putting it into a Redis key. The
     cookie is a bearer credential; if it lands in Redis verbatim (snapshots,
@@ -134,6 +141,7 @@ async def _find_session_user(db: AsyncSession, raw_token: str) -> User | None:
 
 async def _build_session_response(db: AsyncSession, user: User) -> SessionResponse:
     permissions = await _load_permissions(db, user.id)
+    pending = await _pending_change_token(db, user.id)
     return SessionResponse(
         data=SessionData(
             user=SessionUser(
@@ -141,6 +149,7 @@ async def _build_session_response(db: AsyncSession, user: User) -> SessionRespon
                 permissions=permissions,
                 email=user.email,
                 confirmed_at=user.confirmed_at,
+                pending_email=pending.sent_to if pending else None,
             )
         )
     )
@@ -273,14 +282,15 @@ async def _verify_captcha_or_400(captcha_token: str) -> None:
         )
 
 
-async def _existing_change_context(
+async def _pending_change_token(
     db: AsyncSession, user_id
-) -> str | None:
-    """Return the context of the user's pending email-change token, if any.
-    Lets ``resend`` preserve the original "change:" + old_email signature
-    instead of guessing once the user's row has been overwritten."""
+) -> UserToken | None:
+    """Return the user's pending email-change token, if any. Resend needs
+    both the prior ``context`` (audit trail) and ``sent_to`` (where to
+    re-deliver) — now that ``user.email`` no longer mirrors the pending
+    address, the token is the only source of truth for the resend target."""
     result = await db.execute(
-        select(UserToken.context)
+        select(UserToken)
         .where(
             UserToken.user_id == user_id,
             UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
@@ -363,12 +373,10 @@ async def set_email(
         # a "sent" toast but never receives an email.
         return await _build_session_response(db, current_user)
 
-    if current_user.email != email:
-        current_user.email = email
-
-    # Every successful set_email re-starts the confirmation handshake — the
-    # user must click the new link even if they re-submitted the same address.
-    current_user.confirmed_at = None
+    # Do not touch `current_user.email` or `current_user.confirmed_at` here.
+    # Until the user clicks the link, their confirmed address (and verified
+    # status) is whatever it was. The pending change lives only on the token
+    # — `confirm_email` is the single place that stamps the new email.
     raw_token = await _issue_confirmation_token(
         db, current_user, email, _email_change_context(old_email)
     )
@@ -421,30 +429,26 @@ async def resend_email_confirmation(
 ) -> SessionResponse:
     if payload.fmm_hp_token.strip():
         return await _build_session_response(db, current_user)
-    if not current_user.email:
+    # The pending change token is now the single source of truth for what
+    # to resend — confirmed users with no pending change have nothing to
+    # re-send, and unconfirmed users with no token are in the same boat.
+    pending = await _pending_change_token(db, current_user.id)
+    if pending is None or not pending.sent_to:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Add an email address before requesting a resend.",
-        )
-    if current_user.confirmed_at is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="This email is already confirmed.",
+            detail="No pending email change to resend.",
         )
     await _verify_captcha_or_400(payload.captcha_token)
 
-    # Reuse the prior token's context so the audit trail still records what
-    # the user was originally changing away from.
-    prior_context = await _existing_change_context(db, current_user.id)
     raw_token = await _issue_confirmation_token(
         db,
         current_user,
-        current_user.email,
-        prior_context or _email_change_context(None),
+        pending.sent_to,
+        pending.context,
     )
     try:
         job = _enqueue_confirmation_email(
-            current_user.email, raw_token, current_user.username
+            pending.sent_to, raw_token, current_user.username
         )
     except Exception:
         await db.rollback()
@@ -470,15 +474,13 @@ async def confirm_email(
     response: Response,
     db: AsyncSession = Depends(get_session),
 ) -> SessionResponse:
-    """Confirm the email-change handshake.
+    """Consume an email-change token: stamp the new email + confirmed_at.
 
-    The token in the email is itself the bearer credential — we don't
-    require the click to come from the same browser that requested it.
-    That lets users complete the flow on a mobile mail client even when
-    their desktop session cookie isn't available, and avoids minting an
-    orphan guest user on every cross-device click. The endpoint also
-    rotates the caller's session cookie to the token's owner so the
-    confirming browser ends up signed in as the right user.
+    Invariant: ``user.email`` holds the prior confirmed address; the new
+    address lives on ``token.sent_to``. This is the only place either
+    one flips. The token itself is the bearer credential, so the click
+    doesn't have to come from the original browser — we rotate the
+    caller's session cookie to the token's owner on success.
     """
     token_row = (
         await db.execute(
@@ -503,9 +505,13 @@ async def confirm_email(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="That confirmation link is invalid or expired.",
         )
-    if token_row.sent_to and token_row.sent_to != user.email:
-        # The user changed their email between request and click — the link
-        # no longer matches the intended address.
+
+    expected_old = _old_email_from_context(token_row.context)
+    if user.email != expected_old:
+        # The user's current address doesn't match the one this token was
+        # cut against. Could be: admin reset their email, or a stray token
+        # from a prior change leaked back in. Either way the token is no
+        # longer trustworthy — burn it and bail.
         await db.delete(token_row)
         await db.commit()
         raise HTTPException(
@@ -513,6 +519,7 @@ async def confirm_email(
             detail="That confirmation link no longer matches your email.",
         )
 
+    user.email = token_row.sent_to
     user.confirmed_at = datetime.now(timezone.utc)
     await db.delete(token_row)
     # Mint a fresh session for the token's owner so the confirming browser
@@ -526,6 +533,18 @@ async def confirm_email(
             token=_hash_token(raw_session),
         )
     )
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError:
+        # Another user confirmed the same address between this token being
+        # issued and the click. The unique constraint on ``users.email``
+        # caught it. Return the same opaque error as any other invalid
+        # link — telling the user "that address is now taken" would leak
+        # who owns it.
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That confirmation link is invalid or expired.",
+        )
     _set_session_cookie(response, raw_session)
     return await _build_session_response(db, user)

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -53,21 +53,27 @@ async def test_session_response_includes_email_fields(
     user = response.json()["data"]["user"]
     assert user["email"] is None
     assert user["confirmed_at"] is None
+    assert user["pending_email"] is None
 
 
-async def test_set_email_persists_and_enqueues_send(
+async def test_set_email_does_not_mutate_user_row(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
+    """`set_email` is pending-only: it issues a token and enqueues the
+    email but leaves ``user.email`` / ``user.confirmed_at`` untouched.
+    The new address lives on the token (``sent_to``) and is surfaced to
+    the frontend as ``pending_email`` until confirm consumes it."""
     user = await start_session(api_client, db_session)
     response = await _set_email(api_client)
     assert response.status_code == 202
 
     body_user = response.json()["data"]["user"]
-    assert body_user["email"] == "rita@example.com"
+    assert body_user["email"] is None
     assert body_user["confirmed_at"] is None
+    assert body_user["pending_email"] == "rita@example.com"
 
     await db_session.refresh(user)
-    assert user.email == "rita@example.com"
+    assert user.email is None
     assert user.confirmed_at is None
 
     tokens = (
@@ -95,11 +101,18 @@ async def test_set_email_requires_session(api_client: AsyncClient):
 async def test_set_email_normalizes_to_lowercase(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    user = await start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     response = await _set_email(api_client, email="MixedCase@Example.COM")
     assert response.status_code == 202
-    await db_session.refresh(user)
-    assert user.email == "mixedcase@example.com"
+    token = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+            )
+        )
+    ).scalar_one()
+    assert token.sent_to == "mixedcase@example.com"
+    assert response.json()["data"]["user"]["pending_email"] == "mixedcase@example.com"
 
 
 async def test_set_email_rejects_invalid_format(api_client: AsyncClient, db_session):
@@ -177,15 +190,16 @@ async def test_set_email_with_taken_address_is_enumeration_safe(
     assert fake_email_queue.finished_job_registry.count == 0
 
 
-async def test_token_context_records_old_email(
-    api_client: AsyncClient, db_session: AsyncSession
+async def test_token_context_records_confirmed_prior_email(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    """Tokens carry their pre-change address in their context so we have an
-    audit trail of what each one was changing FROM. First-time set leaves
-    the address empty."""
+    """Tokens carry the user's *confirmed* prior address in their context
+    so we have an audit trail of what each token was changing FROM. Until
+    a change has been confirmed there is no prior, so re-submitting before
+    confirming keeps the context as the still-empty prior."""
     await start_session(api_client, db_session)
 
-    # First-time set — no prior address.
+    # First-time set — no prior confirmed address.
     await _set_email(api_client, email="first@example.com")
     token = (
         await db_session.execute(
@@ -197,7 +211,9 @@ async def test_token_context_records_old_email(
     assert token.context == "change:"
     assert token.sent_to == "first@example.com"
 
-    # Change to a new address — the old one shows up in the context.
+    # Submit a different address before confirming the first. The prior
+    # confirmed email is still nothing, so the context doesn't change —
+    # only the latest pending sent_to does.
     await _set_email(api_client, email="second@example.com")
     token = (
         await db_session.execute(
@@ -206,8 +222,27 @@ async def test_token_context_records_old_email(
             )
         )
     ).scalar_one()
-    assert token.context == "change:first@example.com"
+    assert token.context == "change:"
     assert token.sent_to == "second@example.com"
+
+    # Now confirm "second" and submit a third. The context picks up the
+    # newly-confirmed prior.
+    raw_token = _all_send_tokens(fake_email_queue)[-1]
+    confirm = await api_client.post(
+        "/v1/me/email/confirm", json={"token": raw_token}
+    )
+    assert confirm.status_code == 200
+
+    await _set_email(api_client, email="third@example.com")
+    token = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+            )
+        )
+    ).scalar_one()
+    assert token.context == "change:second@example.com"
+    assert token.sent_to == "third@example.com"
 
 
 async def test_resend_preserves_original_change_context(
@@ -267,11 +302,41 @@ async def test_set_email_replaces_existing_unconfirmed_token(
     assert tokens[0].sent_to == "rita2@example.com"
 
 
-async def test_resubmitting_same_email_clears_confirmation(
+async def test_set_email_leaves_confirmed_user_confirmed_until_new_consumed(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    """Even when the address didn't change, calling set_email un-confirms
-    the user — they must click the fresh link to re-prove ownership."""
+    """A user who has already confirmed an email and submits a CHANGE
+    stays confirmed for their current address until they click the new
+    link. The new address only lives on the pending token meanwhile."""
+    user = await start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
+    await api_client.post(
+        "/v1/me/email/confirm", json={"token": raw_token}
+    )
+    await db_session.refresh(user)
+    assert user.email == "rita@example.com"
+    assert user.confirmed_at is not None
+    confirmed_first = user.confirmed_at
+
+    response = await _set_email(api_client, email="changed@example.com")
+    await db_session.refresh(user)
+    # Still confirmed for the prior address — the pending change hasn't
+    # been consumed yet.
+    assert user.email == "rita@example.com"
+    assert user.confirmed_at == confirmed_first
+
+    body_user = response.json()["data"]["user"]
+    assert body_user["email"] == "rita@example.com"
+    assert body_user["confirmed_at"] is not None
+    assert body_user["pending_email"] == "changed@example.com"
+
+
+async def test_resubmitting_same_email_leaves_confirmation_intact(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """Resubmitting the already-confirmed address doesn't un-confirm the
+    user. confirm_email will refresh confirmed_at when the new link is
+    clicked, but in the meantime the user stays verified."""
     user = await start_session(api_client, db_session)
     raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
     await api_client.post(
@@ -279,39 +344,12 @@ async def test_resubmitting_same_email_clears_confirmation(
     )
     await db_session.refresh(user)
     assert user.confirmed_at is not None
+    confirmed_first = user.confirmed_at
 
     await _set_email(api_client)  # same email as VALID_BODY
     await db_session.refresh(user)
-    assert user.confirmed_at is None
     assert user.email == "rita@example.com"
-
-
-async def test_changing_email_clears_confirmation(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    user = await start_session(api_client, db_session)
-    await _set_email(api_client)
-
-    # Confirm out-of-band to set confirmed_at.
-    token_row = (
-        await db_session.execute(
-            select(UserToken).where(
-                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
-            )
-        )
-    ).scalar_one()
-    # We don't know the raw token in this test, so simulate by changing email
-    # while user is confirmed.
-    user.confirmed_at = datetime.now(timezone.utc)
-    await db_session.delete(token_row)
-    await db_session.commit()
-    await db_session.refresh(user)
-    assert user.confirmed_at is not None
-
-    await _set_email(api_client, email="changed@example.com")
-    await db_session.refresh(user)
-    assert user.confirmed_at is None
-    assert user.email == "changed@example.com"
+    assert user.confirmed_at == confirmed_first
 
 
 # ---- confirm email --------------------------------------------------------
@@ -339,20 +377,32 @@ async def _capture_raw_token(
     return tokens[-1]
 
 
-async def test_confirm_email_sets_confirmed_at_and_invalidates_token(
+async def test_confirm_email_stamps_new_email_and_confirmed_at(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
+    """Consuming the token is where the new email *and* confirmed_at land
+    on the user row — set_email only stages the pending change on the
+    token. After confirm: email == token.sent_to, confirmed_at != null,
+    token is gone, pending_email goes back to null."""
     user = await start_session(api_client, db_session)
     raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
+
+    # Pre-condition: set_email did NOT touch the user row.
+    await db_session.refresh(user)
+    assert user.email is None
+    assert user.confirmed_at is None
 
     response = await api_client.post(
         "/v1/me/email/confirm", json={"token": raw_token}
     )
     assert response.status_code == 200
     body_user = response.json()["data"]["user"]
+    assert body_user["email"] == "rita@example.com"
     assert body_user["confirmed_at"] is not None
+    assert body_user["pending_email"] is None
 
     await db_session.refresh(user)
+    assert user.email == "rita@example.com"
     assert user.confirmed_at is not None
 
     # Token consumed.
@@ -370,6 +420,76 @@ async def test_confirm_email_sets_confirmed_at_and_invalidates_token(
         "/v1/me/email/confirm", json={"token": raw_token}
     )
     assert replay.status_code == 400
+
+
+async def test_confirm_rejects_when_current_email_diverges_from_token(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """The consume step verifies user.email matches the prior recorded in
+    the token's context. If something else modified the user's email out
+    of band (e.g. an admin reset) between request and click, the token
+    no longer matches their current state and we refuse rather than
+    silently overwriting."""
+    user = await start_session(api_client, db_session)
+    # Establish a confirmed prior so the next set encodes a non-empty old.
+    user.email = "original@example.com"
+    user.confirmed_at = datetime.now(timezone.utc)
+    await db_session.commit()
+
+    raw_token = await _capture_raw_token(
+        api_client, db_session, fake_email_queue, email="new@example.com"
+    )
+    # Token at this point: context = "change:original@example.com",
+    # sent_to = "new@example.com". Simulate an out-of-band edit that
+    # rewrites the user's confirmed email.
+    user.email = "admin-reset@example.com"
+    await db_session.commit()
+
+    response = await api_client.post(
+        "/v1/me/email/confirm", json={"token": raw_token}
+    )
+    assert response.status_code == 400
+
+    await db_session.refresh(user)
+    # Confirmed email is unchanged — the new address never landed.
+    assert user.email == "admin-reset@example.com"
+    # The stale token is burned so it can't be retried.
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+            )
+        )
+    ).scalars().all()
+    assert tokens == []
+
+
+async def test_confirm_rejects_when_new_email_is_now_taken(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """If someone else confirms the same address between this user's set
+    and their click, the unique constraint on users.email catches it at
+    commit time. Surface that as an opaque 'invalid or expired link' to
+    avoid leaking who owns the address."""
+    me = await start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(
+        api_client, db_session, fake_email_queue, email="contested@example.com"
+    )
+
+    # Another user grabs the same address while our token is in flight.
+    db_session.add(
+        User(username="winner", email="contested@example.com")
+    )
+    await db_session.commit()
+
+    response = await api_client.post(
+        "/v1/me/email/confirm", json={"token": raw_token}
+    )
+    assert response.status_code == 400
+
+    await db_session.refresh(me)
+    assert me.email is None
+    assert me.confirmed_at is None
 
 
 async def test_confirm_email_rejects_unknown_token(
@@ -404,11 +524,14 @@ async def test_confirm_email_works_from_a_different_browser(
         assert response.status_code == 200
         body_user = response.json()["data"]["user"]
         assert body_user["username"] == user_a.username
+        assert body_user["email"] == "rita@example.com"
         assert body_user["confirmed_at"] is not None
+        assert body_user["pending_email"] is None
         # Session cookie was minted/rotated to user A on the new browser.
         assert other_client.cookies.get("session")
 
     await db_session.refresh(user_a)
+    assert user_a.email == "rita@example.com"
     assert user_a.confirmed_at is not None
 
 
@@ -466,9 +589,11 @@ async def test_resend_issues_new_token(
     assert confirm.status_code == 400
 
 
-async def test_resend_requires_email_set(
+async def test_resend_requires_pending_change(
     api_client: AsyncClient, db_session: AsyncSession
 ):
+    """No pending token → nothing to resend. Users with no email set and
+    users whose change has already been consumed both hit this branch."""
     await start_session(api_client, db_session)
     response = await api_client.post(
         "/v1/me/email/resend",
@@ -477,9 +602,13 @@ async def test_resend_requires_email_set(
     assert response.status_code == 400
 
 
-async def test_resend_rejects_if_already_confirmed(
+async def test_resend_rejected_after_change_is_consumed(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
+    """Confirming the pending change deletes the token, so a subsequent
+    resend has nothing to re-send (400, not 409 — there's no "already
+    confirmed" state because resend operates on the token, not the user
+    row)."""
     user = await start_session(api_client, db_session)
     raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
     await api_client.post(
@@ -492,7 +621,41 @@ async def test_resend_rejects_if_already_confirmed(
         "/v1/me/email/resend",
         json={"captcha_token": "x", "fmm_hp_token": ""},
     )
-    assert response.status_code == 409
+    assert response.status_code == 400
+
+
+async def test_resend_after_set_targets_pending_address_not_confirmed(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """Once user.email no longer mirrors the pending address, resend
+    must derive the destination from the token's sent_to — otherwise it
+    would re-deliver to the confirmed (old) address."""
+    user = await start_session(api_client, db_session)
+    user.email = "current@example.com"
+    user.confirmed_at = datetime.now(timezone.utc)
+    await db_session.commit()
+
+    # Start a pending change.
+    await _set_email(api_client, email="next@example.com")
+    sends_after_set = _all_send_tokens(fake_email_queue)
+    assert sends_after_set, "set_email should have enqueued a send"
+
+    response = await api_client.post(
+        "/v1/me/email/resend",
+        json={"captcha_token": "x", "fmm_hp_token": ""},
+    )
+    assert response.status_code == 202
+
+    # The resend job's recipient is the pending address, not the
+    # confirmed one.
+    jobs = [
+        fake_email_queue.fetch_job(j_id)
+        for j_id in fake_email_queue.finished_job_registry.get_job_ids()
+    ]
+    jobs = [j for j in jobs if j is not None]
+    jobs.sort(key=lambda j: j.enqueued_at)
+    latest = jobs[-1]
+    assert latest.args[0] == "next@example.com"
 
 
 async def test_resend_honeypot_short_circuits(

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -83,15 +83,13 @@ export interface paths {
         put?: never;
         /**
          * Confirm Email
-         * @description Confirm the email-change handshake.
+         * @description Consume an email-change token: stamp the new email + confirmed_at.
          *
-         *     The token in the email is itself the bearer credential — we don't
-         *     require the click to come from the same browser that requested it.
-         *     That lets users complete the flow on a mobile mail client even when
-         *     their desktop session cookie isn't available, and avoids minting an
-         *     orphan guest user on every cross-device click. The endpoint also
-         *     rotates the caller's session cookie to the token's owner so the
-         *     confirming browser ends up signed in as the right user.
+         *     Invariant: ``user.email`` holds the prior confirmed address; the new
+         *     address lives on ``token.sent_to``. This is the only place either
+         *     one flips. The token itself is the bearer credential, so the click
+         *     doesn't have to come from the original browser — we rotate the
+         *     caller's session cookie to the token's owner on success.
          */
         post: operations["confirm_email_v1_me_email_confirm_post"];
         delete?: never;
@@ -975,6 +973,8 @@ export interface components {
             email?: string | null;
             /** Confirmed At */
             confirmed_at?: string | null;
+            /** Pending Email */
+            pending_email?: string | null;
         };
         /** SetEmailRequest */
         SetEmailRequest: {

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -155,8 +155,7 @@ export const handlers = [
       return detail('Invalid email.', 422)
     mockSession.data.user = {
       ...mockSession.data.user,
-      email: body.email.toLowerCase(),
-      confirmed_at: null,
+      pending_email: body.email.toLowerCase(),
     }
     return HttpResponse.json(mockSession, { status: 202 })
   }),
@@ -168,10 +167,8 @@ export const handlers = [
       } | undefined) ?? {}
     if (body.fmm_hp_token?.trim())
       return HttpResponse.json(mockSession, { status: 202 })
-    if (!mockSession.data.user.email)
-      return detail('Add an email address before requesting a resend.', 400)
-    if (mockSession.data.user.confirmed_at)
-      return detail('This email is already confirmed.', 409)
+    if (!mockSession.data.user.pending_email)
+      return detail('No pending email change to resend.', 400)
     if (!body.captcha_token) return detail('Captcha required.', 400)
     return HttpResponse.json(mockSession, { status: 202 })
   }),
@@ -179,11 +176,14 @@ export const handlers = [
     const body =
       ((await readJson(request)) as { token?: string } | undefined) ?? {}
     if (!body.token) return detail('Missing token.', 400)
-    if (!mockSession.data.user.email)
+    const pending = mockSession.data.user.pending_email
+    if (!pending)
       return detail('That confirmation link is invalid or expired.', 400)
     mockSession.data.user = {
       ...mockSession.data.user,
+      email: pending,
       confirmed_at: new Date().toISOString(),
+      pending_email: null,
     }
     return HttpResponse.json(mockSession)
   }),

--- a/web-client/src/routes/settings.test.tsx
+++ b/web-client/src/routes/settings.test.tsx
@@ -44,6 +44,7 @@ beforeEach(() => {
   // Reset the shared session between tests so honeypot/email checks start fresh.
   mockSession.data.user.email = null
   mockSession.data.user.confirmed_at = null
+  mockSession.data.user.pending_email = null
   mockSession.data.user.username = 'rita.kovac'
 })
 
@@ -98,7 +99,10 @@ describe('SettingsPage email section', () => {
     expect(
       await screen.findByText(/waiting for verification/i),
     ).toBeInTheDocument()
-    expect(mockSession.data.user.email).toBe('me@example.com')
+    // The pending address now lives on pending_email; the confirmed
+    // user.email stays null until consume runs.
+    expect(mockSession.data.user.pending_email).toBe('me@example.com')
+    expect(mockSession.data.user.email).toBeNull()
   })
 
   it("doesn't persist when the honeypot is filled", async () => {
@@ -120,8 +124,9 @@ describe('SettingsPage email section', () => {
     await user.click(submit)
 
     // The server responds as if it succeeded (status hidden from the bot)
-    // but the session never picked up the email.
+    // but nothing landed on the session.
     await waitFor(() => expect(mockSession.data.user.email).toBeNull())
+    expect(mockSession.data.user.pending_email).toBeNull()
   })
 
   it('requires the captcha before the submit button enables', async () => {

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -43,6 +43,17 @@ export const Route = createFileRoute('/settings')({
 
 type EmailStatus = 'guest' | 'pending' | 'verified'
 
+// A pending change outranks a prior verification — the user still has to
+// click the new link before we consider them settled on the new address.
+function deriveEmailStatus(args: {
+  pendingEmail: string | null
+  confirmedAt: string | null
+}): EmailStatus {
+  if (args.pendingEmail) return 'pending'
+  if (args.confirmedAt) return 'verified'
+  return 'guest'
+}
+
 interface Validation {
   ok: boolean
   err?: string
@@ -796,14 +807,19 @@ const HONEYPOT_STYLE: CSSProperties = {
 function EmailSection({
   email,
   confirmedAt,
+  pendingEmail,
 }: {
   email: string | null
   confirmedAt: string | null
+  pendingEmail: string | null
 }) {
   const toast = useToast()
   const setEmail = useSetEmail()
   const resendEmail = useResendEmailConfirmation()
-  const current = email ?? ''
+  // The pending address takes precedence — that's what the user most
+  // recently asked to use, and what the "Open the link we just sent to…"
+  // banner needs to display. Falls back to the confirmed address.
+  const current = pendingEmail ?? email ?? ''
   const [val, setVal] = useState(current)
   const [touched, setTouched] = useState(false)
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
@@ -827,11 +843,7 @@ function EmailSection({
   const dirty = val !== current
   const showErr = serverErr ?? (touched && !v.ok ? v.err : null)
 
-  const status: EmailStatus = confirmedAt
-    ? 'verified'
-    : email
-      ? 'pending'
-      : 'guest'
+  const status = deriveEmailStatus({ pendingEmail, confirmedAt })
 
   const resetCaptcha = () => {
     captchaRef.current?.reset()
@@ -878,7 +890,7 @@ function EmailSection({
     try {
       await resendEmail.mutateAsync({ captchaToken, honeypot })
       resetCaptcha()
-      toast(`Verification link re-sent to ${email}.`)
+      toast(`Verification link re-sent to ${current}.`)
     } catch (err) {
       resetCaptcha()
       toast(
@@ -916,7 +928,7 @@ function EmailSection({
             setTouched(false)
             setServerErr(null)
           }}
-          primaryLabel={email ? 'Update email' : 'Add email'}
+          primaryLabel={email || pendingEmail ? 'Update email' : 'Add email'}
         />
       }
     >
@@ -991,7 +1003,7 @@ function EmailSection({
         />
       </div>
 
-      {email && (
+      {current && (
         <div
           style={{
             marginTop: 16,
@@ -1042,7 +1054,10 @@ function EmailSection({
                 </div>
                 <div style={{ color: 'var(--fg-3)', marginTop: 2 }}>
                   Open the link we just sent to{' '}
-                  <span style={{ fontFamily: 'var(--font-mono)' }}>{email}</span>.
+                  <span style={{ fontFamily: 'var(--font-mono)' }}>
+                    {current}
+                  </span>
+                  .
                 </div>
               </>
             )}
@@ -1086,13 +1101,13 @@ function SettingsPage() {
   const sessionUsername = sessionUser?.username ?? ''
   const sessionEmail = sessionUser?.email ?? null
   const sessionConfirmedAt = sessionUser?.confirmed_at ?? null
+  const sessionPendingEmail = sessionUser?.pending_email ?? null
   const hash = useRouterState({ select: (s) => s.location.hash })
 
-  const effectiveStatus: EmailStatus = sessionConfirmedAt
-    ? 'verified'
-    : sessionEmail
-      ? 'pending'
-      : 'guest'
+  const effectiveStatus = deriveEmailStatus({
+    pendingEmail: sessionPendingEmail,
+    confirmedAt: sessionConfirmedAt,
+  })
   const claimed = effectiveStatus === 'verified'
 
   // Honor /settings#sec-* deep links from external nav.
@@ -1111,7 +1126,7 @@ function SettingsPage() {
 
               <ClaimBanner
                 status={effectiveStatus}
-                email={sessionEmail ?? ''}
+                email={sessionPendingEmail ?? sessionEmail ?? ''}
                 onJump={() => scrollToSection('sec-email')}
               />
 
@@ -1120,6 +1135,7 @@ function SettingsPage() {
                 <EmailSection
                   email={sessionEmail}
                   confirmedAt={sessionConfirmedAt}
+                  pendingEmail={sessionPendingEmail}
                 />
               </div>
 

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -69,6 +69,7 @@ export function sessionUser(overrides: Partial<SessionUser> = {}): SessionUser {
     permissions: [],
     email: null,
     confirmed_at: null,
+    pending_email: null,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary

- `set_email` is now **pending-only**: it issues a token (`sent_to=NEW`, `context="change:OLD"`) and enqueues delivery, but leaves `users.email` and `users.confirmed_at` untouched. The user remains verified for their prior address until they click the new link.
- `confirm_email` is the single place either column flips. It verifies `users.email == _old_email_from_context(token.context)` (i.e. the user's current confirmed address matches the prior recorded in the token), then stamps `user.email = token.sent_to` and `user.confirmed_at = now`. Stale-context tokens are burned; the unique-constraint race when another user grabs the same address first is caught at commit and surfaced as an opaque "invalid or expired link" (no enumeration).
- `resend_email_confirmation` now derives the destination from the pending token's `sent_to` rather than `users.email` (which no longer mirrors the pending change). No pending token → 400 "no pending email change."
- Expose `pending_email` on `SessionUser` so the FE can distinguish "verified for X with a pending move to Y" from plain "verified." A new `deriveEmailStatus({pendingEmail, confirmedAt})` helper centralises the precedence rule shared by `EmailSection` and the page-level `SettingsPage` banner.
- Token-context audit semantics now reflect the *confirmed* prior address: re-submitting before confirming keeps `context="change:"`, while changing again after a confirm picks up the newly-confirmed prior.

## Follow-ups flagged in review (not in this PR)

- `deriveEmailStatus` returns `'guest'` if `email` is set but both `pendingEmail` and `confirmedAt` are null. Unreachable via the normal API today; would surface if an admin ever clears `confirmed_at` while leaving `users.email`.
- Resend no longer 409s a confirmed user with a pending change. Rate limits (3/hr per session, 10/hr per IP) + `set_email`'s enumeration-safe collision path keep abuse contained to *unclaimed* addresses, but it's a behavior change worth knowing about.
- `_pending_change_token` uses `LIMIT 1` without `ORDER BY`. Currently safe because `_issue_confirmation_token` deletes prior change tokens upfront — a defensive `ORDER BY id DESC` would make resend/session deterministic if a future code path ever bypasses that helper.

## Test plan

- [x] `cd api && pytest` — 260 passed (new coverage: pending-only set_email, current-email/old-email check, taken-email race at confirm-commit, pending-aware resend target)
- [x] `cd web-client && npm run test:run` — 56 passed
- [x] `cd web-client && npm run lint && npm run build` — clean
- [x] `cd web-client && PLAYWRIGHT_PORT=15174 npm run test:e2e` — 126 passed
- [x] `mise run regen-api-types` — schema clean
- [ ] Manual: confirm a first-ever email, then change to a second address — verify the user stays verified for the first until clicking the new link, then both `email` and `confirmed_at` flip together
- [ ] Manual: change email, then change again before confirming — verify only the latest pending address is targeted by resend

🤖 Generated with [Claude Code](https://claude.com/claude-code)