### PR TITLE
Hide Turnstile widget until a challenge is required

### DIFF
--- a/web-client/src/components/turnstile.tsx
+++ b/web-client/src/components/turnstile.tsx
@@ -18,6 +18,7 @@ interface TurnstileApi {
       'expired-callback'?: () => void
       'error-callback'?: () => void
       theme?: 'light' | 'dark' | 'auto'
+      appearance?: 'always' | 'execute' | 'interaction-only'
     },
   ) => string
   reset: (widgetId?: string) => void
@@ -122,6 +123,7 @@ export function Turnstile({
           sitekey:
             import.meta.env.VITE_TURNSTILE_SITE_KEY ?? TURNSTILE_TEST_SITE_KEY,
           theme: 'dark',
+          appearance: 'interaction-only',
           callback: (token) => onTokenRef.current(token),
           'expired-callback': () => onExpireRef.current?.(),
           'error-callback': () => {


### PR DESCRIPTION
## Summary
- Set `appearance: 'interaction-only'` on the Turnstile render call so the widget is hidden by default; Cloudflare auto-issues a passing token for users it doesn't need to challenge, and only shows the iframe when a real challenge is required.
- Added `appearance` to the local `TurnstileApi` render-options type so the option typechecks.

## Notes
- Submit gating is unchanged — the same `callback` fires with a token whether or not UI was shown, so the existing `captchaToken`-gated button still enables.
- `settings.test.tsx` mocks `@/components/turnstile` entirely; no test changes needed.
- In dev/tests the widget will essentially never appear because the always-passes test site key (`1x00000000000000000000AA`) skips the challenge UI. To exercise the challenge path locally, temporarily flip to `appearance: 'always'` or use Cloudflare's always-challenges key `2x00000000000000000000AB`.

## Test plan
- [ ] Email-change form on `/settings` still submits successfully (token issued silently).
- [ ] If Cloudflare does issue a challenge, the widget renders inline in place of the (currently empty) 16px wrapper at `settings.tsx:983` — note layout may shift; tighten with `min-h` if it feels jarring.
- [ ] Script-load failure still shows the `turnstile-error` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)