### PR TITLE
Magic-link login flow (UI + API)

### DIFF
--- a/api/app/email.py
+++ b/api/app/email.py
@@ -44,6 +44,17 @@ def _confirm_url(raw_token: str) -> str:
     return f"{base}/confirm-email?{query}"
 
 
+def _login_url(raw_token: str) -> str:
+    base = _app_base_url()
+    if base is None:
+        raise RuntimeError(
+            "APP_BASE_URL must be set outside FORTYMM_DEV — refusing to "
+            "render an unclickable localhost URL into a sign-in email."
+        )
+    query = urlencode({"token": raw_token})
+    return f"{base}/login/verifying?{query}"
+
+
 def _smtp_configured() -> bool:
     return bool(os.environ.get("SMTP_HOST"))
 
@@ -91,6 +102,41 @@ def send_confirmation_email(to_email: str, raw_token: str, username: str) -> Non
             extra={"to": to_email, "url": confirm_url},
         )
         print(f"[email] confirmation link for {to_email}: {confirm_url}")
+        return
+
+    message = EmailMessage()
+    message["Subject"] = subject
+    message["From"] = from_addr
+    message["To"] = to_email
+    message.set_content(body)
+    _send_via_smtp(message)
+
+
+def send_login_email(to_email: str, raw_token: str, username: str) -> None:
+    """Render and deliver the magic-link sign-in email. Invoked by the RQ worker."""
+    login_url = _login_url(raw_token)
+    from_addr = os.environ.get("EMAIL_FROM", "noreply@fortymm.local")
+    subject = "Your FortyMM sign-in link"
+    body = (
+        f"Hi @{username},\n\n"
+        "Click the link below to sign in to FortyMM. The link is good for "
+        "15 minutes and only works once.\n\n"
+        f"{login_url}\n\n"
+        "If you didn't ask to sign in, you can ignore this email — nobody "
+        "can use the link without your inbox.\n"
+    )
+
+    if not _smtp_configured():
+        if not _dev_mode():
+            raise RuntimeError(
+                "SMTP is not configured and FORTYMM_DEV is not set — "
+                "refusing to silently drop a sign-in email."
+            )
+        log.info(
+            "email_login_link",
+            extra={"to": to_email, "url": login_url},
+        )
+        print(f"[email] sign-in link for {to_email}: {login_url}")
         return
 
     message = EmailMessage()

--- a/api/app/email.py
+++ b/api/app/email.py
@@ -73,75 +73,72 @@ def _send_via_smtp(message: EmailMessage) -> None:
         smtp.send_message(message)
 
 
-def send_confirmation_email(to_email: str, raw_token: str, username: str) -> None:
-    """Render and deliver the confirmation email. Invoked by the RQ worker."""
-    confirm_url = _confirm_url(raw_token)
-    from_addr = os.environ.get("EMAIL_FROM", "noreply@fortymm.local")
-    subject = "Confirm your FortyMM email"
-    body = (
-        f"Hi @{username},\n\n"
-        "Click the link below to confirm your email address and claim your "
-        "FortyMM account.\n\n"
-        f"{confirm_url}\n\n"
-        "If you didn't request this, you can ignore this email.\n"
-    )
-
+def _deliver(
+    *,
+    to_email: str,
+    subject: str,
+    body: str,
+    log_event: str,
+    log_url: str,
+    dev_label: str,
+) -> None:
+    """Deliver an email via SMTP, or print + log it in dev. The ``log_event``
+    and ``log_url`` are kept in dev logs only (gated on FORTYMM_DEV) so a
+    prod deploy that forgets SMTP doesn't write bearer tokens to centralized
+    logs. Outside dev, missing SMTP raises so RQ moves the job to
+    ``failed_job_registry`` for an operator to notice."""
     if not _smtp_configured():
         if not _dev_mode():
-            # No SMTP and not dev — this is a deploy bug, not a workflow.
-            # Raising lands the job in failed_job_registry so it's visible.
             raise RuntimeError(
                 "SMTP is not configured and FORTYMM_DEV is not set — "
-                "refusing to silently drop a confirmation email."
+                f"refusing to silently drop a {dev_label} email."
             )
-        # Dev mode: log + print the link so `rq worker email` shows it.
-        # Gated on FORTYMM_DEV (not on missing SMTP) so a prod deploy that
-        # forgets SMTP doesn't write bearer tokens to centralized logs.
-        log.info(
-            "email_confirmation_link",
-            extra={"to": to_email, "url": confirm_url},
-        )
-        print(f"[email] confirmation link for {to_email}: {confirm_url}")
+        log.info(log_event, extra={"to": to_email, "url": log_url})
+        print(f"[email] {dev_label} link for {to_email}: {log_url}")
         return
 
     message = EmailMessage()
     message["Subject"] = subject
-    message["From"] = from_addr
+    message["From"] = os.environ.get("EMAIL_FROM", "noreply@fortymm.local")
     message["To"] = to_email
     message.set_content(body)
     _send_via_smtp(message)
+
+
+def send_confirmation_email(to_email: str, raw_token: str, username: str) -> None:
+    """Render and deliver the confirmation email. Invoked by the RQ worker."""
+    confirm_url = _confirm_url(raw_token)
+    _deliver(
+        to_email=to_email,
+        subject="Confirm your FortyMM email",
+        body=(
+            f"Hi @{username},\n\n"
+            "Click the link below to confirm your email address and claim your "
+            "FortyMM account.\n\n"
+            f"{confirm_url}\n\n"
+            "If you didn't request this, you can ignore this email.\n"
+        ),
+        log_event="email_confirmation_link",
+        log_url=confirm_url,
+        dev_label="confirmation",
+    )
 
 
 def send_login_email(to_email: str, raw_token: str, username: str) -> None:
     """Render and deliver the magic-link sign-in email. Invoked by the RQ worker."""
     login_url = _login_url(raw_token)
-    from_addr = os.environ.get("EMAIL_FROM", "noreply@fortymm.local")
-    subject = "Your FortyMM sign-in link"
-    body = (
-        f"Hi @{username},\n\n"
-        "Click the link below to sign in to FortyMM. The link is good for "
-        "15 minutes and only works once.\n\n"
-        f"{login_url}\n\n"
-        "If you didn't ask to sign in, you can ignore this email — nobody "
-        "can use the link without your inbox.\n"
+    _deliver(
+        to_email=to_email,
+        subject="Your FortyMM sign-in link",
+        body=(
+            f"Hi @{username},\n\n"
+            "Click the link below to sign in to FortyMM. The link is good for "
+            "15 minutes and only works once.\n\n"
+            f"{login_url}\n\n"
+            "If you didn't ask to sign in, you can ignore this email — nobody "
+            "can use the link without your inbox.\n"
+        ),
+        log_event="email_login_link",
+        log_url=login_url,
+        dev_label="sign-in",
     )
-
-    if not _smtp_configured():
-        if not _dev_mode():
-            raise RuntimeError(
-                "SMTP is not configured and FORTYMM_DEV is not set — "
-                "refusing to silently drop a sign-in email."
-            )
-        log.info(
-            "email_login_link",
-            extra={"to": to_email, "url": login_url},
-        )
-        print(f"[email] sign-in link for {to_email}: {login_url}")
-        return
-
-    message = EmailMessage()
-    message["Subject"] = subject
-    message["From"] = from_addr
-    message["To"] = to_email
-    message.set_content(body)
-    _send_via_smtp(message)

--- a/api/app/models/user_token.py
+++ b/api/app/models/user_token.py
@@ -17,7 +17,7 @@ class UserToken(Base):
         primary_key=True,
         default=uuid.uuid4,
     )
-    token: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    token: Mapped[bytes] = mapped_column(LargeBinary, nullable=False, index=True)
     context: Mapped[str] = mapped_column(String(255), nullable=False)
     sent_to: Mapped[str | None] = mapped_column(String(255), nullable=True)
     user_id: Mapped[uuid.UUID] = mapped_column(

--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -59,3 +59,11 @@ class ResendEmailRequest(CaptchaProtectedRequest):
 
 class ConfirmEmailRequest(BaseModel):
     token: str = Field(min_length=1, max_length=512)
+
+
+class RequestLoginRequest(CaptchaProtectedRequest):
+    email: EmailStr
+
+
+class ConsumeLoginRequest(BaseModel):
+    token: str = Field(min_length=1, max_length=512)

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -98,6 +98,21 @@ email_resend_ip_rate_limit = RateLimiter(
 )
 
 
+async def _login_consume_ip_rate_limit_key(request: Request) -> str:
+    """Separate per-IP key for /v1/login/consume so failed verification
+    bursts don't burn the email-send IP budget for legitimate sign-ins
+    from the same network."""
+    return f"login-consume-ip:{_client_ip(request)}"
+
+
+# Permissive ceiling on /v1/login/consume — the bearer token is 256 bits
+# of entropy, so this is defense-in-depth against floods rather than a
+# realistic brute-force barrier.
+login_consume_ip_rate_limit = RateLimiter(
+    times=60, hours=1, identifier=_login_consume_ip_rate_limit_key
+)
+
+
 def _hash_token(raw_token: str) -> bytes:
     return hashlib.sha256(raw_token.encode("utf-8")).digest()
 
@@ -563,32 +578,45 @@ async def request_login_email(
 ) -> dict:
     """Mint a magic-link sign-in token and email it.
 
-    Always returns 202 regardless of whether the address belongs to a
-    confirmed account. Differential responses here would let an attacker
-    enumerate accounts by cycling guest sessions for fresh rate-limit
-    budgets, the same enumeration vector the email-change flow guards
-    against.
+    Always returns the same 202 shape regardless of whether the address
+    belongs to a known account. Differential responses would let an
+    attacker enumerate the user base by cycling guest sessions for fresh
+    rate-limit budgets — the same enumeration vector the email-change flow
+    guards against.
+
+    Accounts whose email hasn't been confirmed yet get the confirmation
+    link re-sent instead of a sign-in link. The login token would let
+    someone sign in without proving control of the inbox; the confirmation
+    link clears that hurdle and (per ``confirm_email``) rotates them into
+    a session anyway.
     """
+    email = payload.email.lower()
+
     if payload.fmm_hp_token.strip():
-        return {"email": payload.email}
+        return {"email": email}
 
     await _verify_captcha_or_400(payload.captcha_token)
 
-    email = payload.email.lower()
     user = (
-        await db.execute(
-            select(User).where(
-                User.email == email, User.confirmed_at.is_not(None)
-            )
-        )
+        await db.execute(select(User).where(User.email == email))
     ).scalar_one_or_none()
     if user is None:
-        # Unknown email or unconfirmed account — return the same shape as the
-        # success path so the response can't be used to probe membership.
         return {"email": email}
 
-    # One live login token per user — clicking "resend" or re-submitting the
-    # form invalidates the prior link.
+    if user.confirmed_at is None:
+        await _issue_and_send_confirmation_email(db, user, email)
+        return {"email": email}
+
+    await _issue_and_send_login_email(db, user, email)
+    return {"email": email}
+
+
+async def _issue_and_send_login_email(
+    db: AsyncSession, user: User, email: str
+) -> None:
+    """Replace any live login token for this user with a fresh one and
+    enqueue the sign-in email. Enqueue before commit so a Redis flap
+    rolls the DB write back instead of stranding a tokenless user."""
     await db.execute(
         delete(UserToken).where(
             UserToken.user_id == user.id,
@@ -604,7 +632,6 @@ async def request_login_email(
             sent_to=email,
         )
     )
-
     try:
         job = _enqueue_login_email(email, raw_token, user.username)
     except Exception:
@@ -613,7 +640,6 @@ async def request_login_email(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Email service unavailable. Try again in a moment.",
         )
-
     try:
         await db.commit()
     except Exception:
@@ -623,10 +649,42 @@ async def request_login_email(
         except Exception:
             pass
         raise
-    return {"email": email}
 
 
-@router.post("/v1/login/consume", response_model=SessionResponse)
+async def _issue_and_send_confirmation_email(
+    db: AsyncSession, user: User, email: str
+) -> None:
+    """Re-issue this user's pending email-confirmation link. Preserves the
+    prior change-token's context so the audit trail still records what the
+    user was originally changing away from."""
+    prior_context = await _existing_change_context(db, user.id)
+    raw_token = await _issue_confirmation_token(
+        db, user, email, prior_context or _email_change_context(None)
+    )
+    try:
+        job = _enqueue_confirmation_email(email, raw_token, user.username)
+    except Exception:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Email service unavailable. Try again in a moment.",
+        )
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        try:
+            job.cancel()
+        except Exception:
+            pass
+        raise
+
+
+@router.post(
+    "/v1/login/consume",
+    response_model=SessionResponse,
+    dependencies=[Depends(login_consume_ip_rate_limit)],
+)
 async def consume_login_token(
     payload: ConsumeLoginRequest,
     response: Response,
@@ -673,6 +731,17 @@ async def consume_login_token(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="That sign-in link is invalid or expired.",
+        )
+
+    # If the user changed their email between request and click, the link no
+    # longer matches the inbox that proved control — reject so the new owner
+    # of the old address can't ride an in-flight link.
+    if token_row.sent_to and token_row.sent_to != user.email:
+        await db.delete(token_row)
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That sign-in link no longer matches your email.",
         )
 
     # Single-use: delete the link the moment we accept it.

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -18,6 +18,8 @@ from app.leagues import add_user_to_default_league
 from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
 from app.schemas.session import (
     ConfirmEmailRequest,
+    ConsumeLoginRequest,
+    RequestLoginRequest,
     ResendEmailRequest,
     SessionData,
     SessionResponse,
@@ -36,6 +38,8 @@ SESSION_TOKEN_CONTEXT = "session"
 # us an audit trail of what each token was changing away from. Look up
 # pending tokens by `context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)`.
 EMAIL_CHANGE_CONTEXT_PREFIX = "change:"
+LOGIN_TOKEN_CONTEXT = "login"
+LOGIN_TOKEN_LIFETIME = timedelta(minutes=15)
 SESSION_LIFETIME = timedelta(days=30)
 EMAIL_TAKEN_DETAIL = "That email is already in use."
 
@@ -518,6 +522,158 @@ async def confirm_email(
     # Mint a fresh session for the token's owner so the confirming browser
     # is signed in as them — replaces whatever guest session this browser
     # had (or hadn't) on arrival.
+    raw_session = secrets.token_urlsafe(32)
+    db.add(
+        UserToken(
+            user_id=user.id,
+            context=SESSION_TOKEN_CONTEXT,
+            token=_hash_token(raw_session),
+        )
+    )
+    await db.commit()
+    _set_session_cookie(response, raw_session)
+    return await _build_session_response(db, user)
+
+
+def _enqueue_login_email(to_email: str, raw_token: str, username: str):
+    return queue_module.get_email_queue().enqueue(
+        "app.email.send_login_email",
+        to_email,
+        raw_token,
+        username,
+        result_ttl=60,
+        failure_ttl=300,
+    )
+
+
+@router.post(
+    "/v1/login/request",
+    status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[
+        Depends(email_send_ip_rate_limit),
+        Depends(email_send_rate_limit),
+    ],
+)
+async def request_login_email(
+    payload: RequestLoginRequest,
+    db: AsyncSession = Depends(get_session),
+) -> dict:
+    """Mint a magic-link sign-in token and email it.
+
+    Always returns 202 regardless of whether the address belongs to a
+    confirmed account. Differential responses here would let an attacker
+    enumerate accounts by cycling guest sessions for fresh rate-limit
+    budgets, the same enumeration vector the email-change flow guards
+    against.
+    """
+    if payload.fmm_hp_token.strip():
+        return {"email": payload.email}
+
+    await _verify_captcha_or_400(payload.captcha_token)
+
+    email = payload.email.lower()
+    user = (
+        await db.execute(
+            select(User).where(
+                User.email == email, User.confirmed_at.is_not(None)
+            )
+        )
+    ).scalar_one_or_none()
+    if user is None:
+        # Unknown email or unconfirmed account — return the same shape as the
+        # success path so the response can't be used to probe membership.
+        return {"email": email}
+
+    # One live login token per user — clicking "resend" or re-submitting the
+    # form invalidates the prior link.
+    await db.execute(
+        delete(UserToken).where(
+            UserToken.user_id == user.id,
+            UserToken.context == LOGIN_TOKEN_CONTEXT,
+        )
+    )
+    raw_token = secrets.token_urlsafe(32)
+    db.add(
+        UserToken(
+            user_id=user.id,
+            context=LOGIN_TOKEN_CONTEXT,
+            token=_hash_token(raw_token),
+            sent_to=email,
+        )
+    )
+
+    try:
+        job = _enqueue_login_email(email, raw_token, user.username)
+    except Exception:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Email service unavailable. Try again in a moment.",
+        )
+
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        try:
+            job.cancel()
+        except Exception:
+            pass
+        raise
+    return {"email": email}
+
+
+@router.post("/v1/login/consume", response_model=SessionResponse)
+async def consume_login_token(
+    payload: ConsumeLoginRequest,
+    response: Response,
+    db: AsyncSession = Depends(get_session),
+) -> SessionResponse:
+    """Verify a magic-link token and rotate the caller's session cookie.
+
+    The token is itself the bearer credential, so the click is accepted from
+    any browser — the inbox proves ownership of the email. The endpoint
+    rotates the caller's session cookie to the token's owner regardless of
+    which guest session (if any) the browser arrived with.
+    """
+    token_row = (
+        await db.execute(
+            select(UserToken).where(
+                UserToken.token == _hash_token(payload.token),
+                UserToken.context == LOGIN_TOKEN_CONTEXT,
+            )
+        )
+    ).scalar_one_or_none()
+    if token_row is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That sign-in link is invalid or expired.",
+        )
+
+    issued_at = token_row.created_at
+    if issued_at.tzinfo is None:
+        issued_at = issued_at.replace(tzinfo=timezone.utc)
+    if datetime.now(timezone.utc) - issued_at > LOGIN_TOKEN_LIFETIME:
+        await db.delete(token_row)
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That sign-in link is invalid or expired.",
+        )
+
+    user = (
+        await db.execute(select(User).where(User.id == token_row.user_id))
+    ).scalar_one_or_none()
+    if user is None:
+        await db.delete(token_row)
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That sign-in link is invalid or expired.",
+        )
+
+    # Single-use: delete the link the moment we accept it.
+    await db.delete(token_row)
     raw_session = secrets.token_urlsafe(32)
     db.add(
         UserToken(

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -318,17 +318,31 @@ async def _issue_confirmation_token(
     return raw_token
 
 
-def _enqueue_confirmation_email(to_email: str, raw_token: str, username: str):
+def _enqueue_email_job(
+    job_func: str, to_email: str, raw_token: str, username: str
+):
     # result_ttl=60 / failure_ttl=300 shrinks the window during which the raw
     # token (pickled into the RQ job hash in Redis) is recoverable from a
     # snapshot or dashboard. Defaults are 8m / 1 year respectively.
     return queue_module.get_email_queue().enqueue(
-        "app.email.send_confirmation_email",
+        job_func,
         to_email,
         raw_token,
         username,
         result_ttl=60,
         failure_ttl=300,
+    )
+
+
+def _enqueue_confirmation_email(to_email: str, raw_token: str, username: str):
+    return _enqueue_email_job(
+        "app.email.send_confirmation_email", to_email, raw_token, username
+    )
+
+
+def _enqueue_login_email(to_email: str, raw_token: str, username: str):
+    return _enqueue_email_job(
+        "app.email.send_login_email", to_email, raw_token, username
     )
 
 
@@ -533,17 +547,6 @@ async def confirm_email(
     await db.commit()
     _set_session_cookie(response, raw_session)
     return await _build_session_response(db, user)
-
-
-def _enqueue_login_email(to_email: str, raw_token: str, username: str):
-    return queue_module.get_email_queue().enqueue(
-        "app.email.send_login_email",
-        to_email,
-        raw_token,
-        username,
-        result_ttl=60,
-        failure_ttl=300,
-    )
 
 
 @router.post(

--- a/api/migrations/versions/20260511_0000_0002_create_user_tokens_table.py
+++ b/api/migrations/versions/20260511_0000_0002_create_user_tokens_table.py
@@ -41,8 +41,15 @@ def upgrade() -> None:
     op.create_index(
         "ix_user_tokens_user_id", "user_tokens", ["user_id"]
     )
+    # Every cookie validation and every magic-link click looks up tokens by
+    # (token, context). Without this index Postgres falls back to a seq scan
+    # on user_tokens, which gets expensive once any session table grows.
+    op.create_index(
+        "ix_user_tokens_token", "user_tokens", ["token"]
+    )
 
 
 def downgrade() -> None:
+    op.drop_index("ix_user_tokens_token", table_name="user_tokens")
     op.drop_index("ix_user_tokens_user_id", table_name="user_tokens")
     op.drop_table("user_tokens")

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -111,28 +111,39 @@ async def test_request_for_unknown_email_returns_202_without_sending(
     assert fake_email_queue.finished_job_registry.count == 0
 
 
-async def test_request_for_unconfirmed_account_returns_202_without_sending(
+async def test_request_for_unconfirmed_account_resends_confirmation(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    db_session.add(
-        User(
-            username="pending",
-            email="rita@example.com",
-            confirmed_at=None,
-        )
-    )
+    """An account whose email isn't confirmed yet gets the confirmation
+    link re-sent instead of a sign-in link, so the user has a path
+    forward. Response shape stays identical for enumeration safety."""
+    user = User(username="pending", email="rita@example.com", confirmed_at=None)
+    db_session.add(user)
     await db_session.commit()
 
     response = await api_client.post("/v1/login/request", json=REQUEST_BODY)
     assert response.status_code == 202
+    assert response.json() == {"email": "rita@example.com"}
 
-    tokens = (
+    login_tokens = (
         await db_session.execute(
             select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
         )
     ).scalars().all()
-    assert tokens == []
-    assert fake_email_queue.finished_job_registry.count == 0
+    assert login_tokens == []
+
+    change_tokens = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith("change:")
+            )
+        )
+    ).scalars().all()
+    assert len(change_tokens) == 1
+    assert change_tokens[0].sent_to == "rita@example.com"
+    assert change_tokens[0].user_id == user.id
+
+    assert fake_email_queue.finished_job_registry.count == 1
 
 
 async def test_request_replaces_prior_login_token_for_same_user(
@@ -170,6 +181,25 @@ async def test_request_honeypot_silently_succeeds(
         )
     ).scalars().all()
     assert tokens == []
+
+
+async def test_request_honeypot_response_matches_success_path(api_client: AsyncClient):
+    """Honeypot 202 must echo the lowercased email so bots can't diff
+    honeypot vs success responses to detect the trap."""
+    honeypot = await api_client.post(
+        "/v1/login/request",
+        json={
+            **REQUEST_BODY,
+            "email": "Rita@Example.COM",
+            "fmm_hp_token": "https://spammer.example",
+        },
+    )
+    success = await api_client.post(
+        "/v1/login/request",
+        json={**REQUEST_BODY, "email": "Rita@Example.COM"},
+    )
+    assert honeypot.status_code == success.status_code == 202
+    assert honeypot.json() == success.json()
 
 
 async def test_request_rejects_bad_captcha(
@@ -350,3 +380,28 @@ async def test_consume_does_not_accept_email_change_token(
         "/v1/login/consume", json={"token": raw}
     )
     assert response.status_code == 400
+
+
+async def test_consume_rejects_link_after_user_changed_email(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """An in-flight login link to address X must not sign the user in if
+    they've since pointed their account at address Y."""
+    user = await _make_confirmed_user(db_session, "rita@example.com")
+    raw = "raw-login-token-stale"
+    await _issue_login_token(db_session, user, raw)
+
+    user.email = "rita-new@example.com"
+    await db_session.commit()
+
+    response = await api_client.post(
+        "/v1/login/consume", json={"token": raw}
+    )
+    assert response.status_code == 400
+
+    leftover = (
+        await db_session.execute(
+            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        )
+    ).scalars().all()
+    assert leftover == []

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -1,0 +1,352 @@
+import hashlib
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta, timezone
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_session
+from app.main import app
+from app.models import User, UserToken
+from app.sessions import (
+    LOGIN_TOKEN_CONTEXT,
+    SESSION_COOKIE_NAME,
+    SESSION_TOKEN_CONTEXT,
+)
+from tests._helpers import make_client, start_session
+
+
+@pytest_asyncio.fixture
+async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    app.dependency_overrides[get_session] = _override
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="https://testserver"
+    ) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+REQUEST_BODY = {
+    "email": "rita@example.com",
+    "captcha_token": "test-token",
+    "fmm_hp_token": "",
+}
+
+
+async def _make_confirmed_user(db_session: AsyncSession, email: str) -> User:
+    user = User(
+        username=email.split("@")[0],
+        email=email,
+        confirmed_at=datetime.now(timezone.utc),
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+# ---- request endpoint ----------------------------------------------------
+
+
+async def test_request_enqueues_email_and_persists_token(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    user = await _make_confirmed_user(db_session, "rita@example.com")
+
+    response = await api_client.post("/v1/login/request", json=REQUEST_BODY)
+    assert response.status_code == 202
+    assert response.json() == {"email": "rita@example.com"}
+
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        )
+    ).scalars().all()
+    assert len(tokens) == 1
+    assert tokens[0].user_id == user.id
+    assert tokens[0].sent_to == "rita@example.com"
+
+    assert fake_email_queue.finished_job_registry.count == 1
+
+
+async def test_request_normalizes_email_to_lowercase(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    user = await _make_confirmed_user(db_session, "rita@example.com")
+
+    response = await api_client.post(
+        "/v1/login/request",
+        json={**REQUEST_BODY, "email": "Rita@Example.COM"},
+    )
+    assert response.status_code == 202
+
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        )
+    ).scalars().all()
+    assert len(tokens) == 1
+    assert tokens[0].user_id == user.id
+    assert tokens[0].sent_to == "rita@example.com"
+
+
+async def test_request_for_unknown_email_returns_202_without_sending(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    response = await api_client.post("/v1/login/request", json=REQUEST_BODY)
+    assert response.status_code == 202
+
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        )
+    ).scalars().all()
+    assert tokens == []
+    assert fake_email_queue.finished_job_registry.count == 0
+
+
+async def test_request_for_unconfirmed_account_returns_202_without_sending(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    db_session.add(
+        User(
+            username="pending",
+            email="rita@example.com",
+            confirmed_at=None,
+        )
+    )
+    await db_session.commit()
+
+    response = await api_client.post("/v1/login/request", json=REQUEST_BODY)
+    assert response.status_code == 202
+
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        )
+    ).scalars().all()
+    assert tokens == []
+    assert fake_email_queue.finished_job_registry.count == 0
+
+
+async def test_request_replaces_prior_login_token_for_same_user(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    await _make_confirmed_user(db_session, "rita@example.com")
+
+    first = await api_client.post("/v1/login/request", json=REQUEST_BODY)
+    second = await api_client.post("/v1/login/request", json=REQUEST_BODY)
+    assert first.status_code == 202
+    assert second.status_code == 202
+
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        )
+    ).scalars().all()
+    assert len(tokens) == 1
+
+
+async def test_request_honeypot_silently_succeeds(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    await _make_confirmed_user(db_session, "rita@example.com")
+
+    response = await api_client.post(
+        "/v1/login/request",
+        json={**REQUEST_BODY, "fmm_hp_token": "https://spammer.example"},
+    )
+    assert response.status_code == 202
+
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        )
+    ).scalars().all()
+    assert tokens == []
+
+
+async def test_request_rejects_bad_captcha(
+    api_client: AsyncClient, db_session: AsyncSession, monkeypatch
+):
+    await _make_confirmed_user(db_session, "rita@example.com")
+
+    async def _always_fail(token):  # noqa: ARG001
+        return False
+
+    from app import captcha as captcha_module
+
+    monkeypatch.setattr(captcha_module, "verify_captcha", _always_fail)
+
+    response = await api_client.post("/v1/login/request", json=REQUEST_BODY)
+    assert response.status_code == 400
+
+
+async def test_request_rejects_invalid_email_format(api_client: AsyncClient):
+    response = await api_client.post(
+        "/v1/login/request",
+        json={**REQUEST_BODY, "email": "not-an-email"},
+    )
+    assert response.status_code == 422
+
+
+# ---- consume endpoint ----------------------------------------------------
+
+
+async def _issue_login_token(
+    db_session: AsyncSession, user: User, raw_token: str
+) -> UserToken:
+    token = UserToken(
+        user_id=user.id,
+        context=LOGIN_TOKEN_CONTEXT,
+        token=hashlib.sha256(raw_token.encode("utf-8")).digest(),
+        sent_to=user.email,
+    )
+    db_session.add(token)
+    await db_session.commit()
+    await db_session.refresh(token)
+    return token
+
+
+async def test_consume_rotates_cookie_and_returns_session(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    user = await _make_confirmed_user(db_session, "rita@example.com")
+    raw = "raw-login-token-rita"
+    await _issue_login_token(db_session, user, raw)
+
+    response = await api_client.post(
+        "/v1/login/consume", json={"token": raw}
+    )
+    assert response.status_code == 200
+
+    body_user = response.json()["data"]["user"]
+    assert body_user["username"] == "rita"
+    assert body_user["email"] == "rita@example.com"
+
+    cookie_header = response.headers.get("set-cookie", "").lower()
+    assert "httponly" in cookie_header
+    assert "samesite=lax" in cookie_header
+    new_cookie = response.cookies.get(SESSION_COOKIE_NAME)
+    assert new_cookie
+
+    sessions = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context == SESSION_TOKEN_CONTEXT,
+                UserToken.user_id == user.id,
+            )
+        )
+    ).scalars().all()
+    assert any(
+        t.token == hashlib.sha256(new_cookie.encode("utf-8")).digest()
+        for t in sessions
+    )
+
+
+async def test_consume_deletes_token_so_it_cannot_be_reused(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    user = await _make_confirmed_user(db_session, "rita@example.com")
+    raw = "raw-login-token-once"
+    await _issue_login_token(db_session, user, raw)
+
+    first = await api_client.post("/v1/login/consume", json={"token": raw})
+    assert first.status_code == 200
+
+    second_client = make_client()
+    second = await second_client.post(
+        "/v1/login/consume", json={"token": raw}
+    )
+    assert second.status_code == 400
+    await second_client.aclose()
+
+    leftover = (
+        await db_session.execute(
+            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        )
+    ).scalars().all()
+    assert leftover == []
+
+
+async def test_consume_rejects_expired_token(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    user = await _make_confirmed_user(db_session, "rita@example.com")
+    raw = "raw-login-token-expired"
+    token = await _issue_login_token(db_session, user, raw)
+    # Backdate past the 15-minute TTL.
+    token.created_at = datetime.now(timezone.utc) - timedelta(minutes=20)
+    await db_session.commit()
+
+    response = await api_client.post(
+        "/v1/login/consume", json={"token": raw}
+    )
+    assert response.status_code == 400
+
+    leftover = (
+        await db_session.execute(
+            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        )
+    ).scalars().all()
+    assert leftover == []
+
+
+async def test_consume_rejects_unknown_token(api_client: AsyncClient):
+    response = await api_client.post(
+        "/v1/login/consume", json={"token": "not-a-real-token"}
+    )
+    assert response.status_code == 400
+
+
+async def test_consume_replaces_guest_session_with_owner_session(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    user = await _make_confirmed_user(db_session, "rita@example.com")
+    raw = "raw-login-token-rotate"
+    await _issue_login_token(db_session, user, raw)
+
+    # Establish a guest session first — the consuming browser starts as
+    # someone else.
+    guest = await start_session(api_client, db_session)
+    assert guest.id != user.id
+
+    response = await api_client.post(
+        "/v1/login/consume", json={"token": raw}
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["user"]["username"] == "rita"
+
+    new_cookie = response.cookies.get(SESSION_COOKIE_NAME)
+    me = await api_client.get(
+        "/v1/session", cookies={SESSION_COOKIE_NAME: new_cookie}
+    )
+    assert me.json()["data"]["user"]["username"] == "rita"
+
+
+async def test_consume_does_not_accept_email_change_token(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    user = await _make_confirmed_user(db_session, "rita@example.com")
+    # Mint a change token rather than a login token.
+    raw = "raw-change-token"
+    db_session.add(
+        UserToken(
+            user_id=user.id,
+            context="change:",
+            token=hashlib.sha256(raw.encode("utf-8")).digest(),
+            sent_to=user.email,
+        )
+    )
+    await db_session.commit()
+
+    response = await api_client.post(
+        "/v1/login/consume", json={"token": raw}
+    )
+    assert response.status_code == 400

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -66,7 +66,13 @@ function Nav() {
         <a className="nav-link" href="#faq">FAQ</a>
       </div>
       <div style={{ flex: 1 }} />
-      <a className="nav-link" href="#">Sign in</a>
+      <Link
+        className="nav-link"
+        to="/login"
+        search={{ error: undefined, email: undefined }}
+      >
+        Sign in
+      </Link>
       <Link className="btn btn-primary" to="/matches/new">
         <span className="btn-dot" />
         Start playing

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -113,11 +113,17 @@ export interface paths {
          * Request Login Email
          * @description Mint a magic-link sign-in token and email it.
          *
-         *     Always returns 202 regardless of whether the address belongs to a
-         *     confirmed account. Differential responses here would let an attacker
-         *     enumerate accounts by cycling guest sessions for fresh rate-limit
-         *     budgets, the same enumeration vector the email-change flow guards
-         *     against.
+         *     Always returns the same 202 shape regardless of whether the address
+         *     belongs to a known account. Differential responses would let an
+         *     attacker enumerate the user base by cycling guest sessions for fresh
+         *     rate-limit budgets — the same enumeration vector the email-change flow
+         *     guards against.
+         *
+         *     Accounts whose email hasn't been confirmed yet get the confirmation
+         *     link re-sent instead of a sign-in link. The login token would let
+         *     someone sign in without proving control of the inbox; the confirmation
+         *     link clears that hurdle and (per ``confirm_email``) rotates them into
+         *     a session anyway.
          */
         post: operations["request_login_email_v1_login_request_post"];
         delete?: never;

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -100,6 +100,57 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/login/request": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Request Login Email
+         * @description Mint a magic-link sign-in token and email it.
+         *
+         *     Always returns 202 regardless of whether the address belongs to a
+         *     confirmed account. Differential responses here would let an attacker
+         *     enumerate accounts by cycling guest sessions for fresh rate-limit
+         *     budgets, the same enumeration vector the email-change flow guards
+         *     against.
+         */
+        post: operations["request_login_email_v1_login_request_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/login/consume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Consume Login Token
+         * @description Verify a magic-link token and rotate the caller's session cookie.
+         *
+         *     The token is itself the bearer credential, so the click is accepted from
+         *     any browser — the inbox proves ownership of the email. The endpoint
+         *     rotates the caller's session cookie to the token's owner regardless of
+         *     which guest session (if any) the browser arrived with.
+         */
+        post: operations["consume_login_token_v1_login_consume_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/permissions": {
         parameters: {
             query?: never;
@@ -393,6 +444,11 @@ export interface components {
         };
         /** ConfirmEmailRequest */
         ConfirmEmailRequest: {
+            /** Token */
+            token: string;
+        };
+        /** ConsumeLoginRequest */
+        ConsumeLoginRequest: {
             /** Token */
             token: string;
         };
@@ -903,6 +959,21 @@ export interface components {
             /** Role Ids */
             role_ids: string[];
         };
+        /** RequestLoginRequest */
+        RequestLoginRequest: {
+            /** Captcha Token */
+            captcha_token: string;
+            /**
+             * Fmm Hp Token
+             * @default
+             */
+            fmm_hp_token: string;
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
+        };
         /** ResendEmailRequest */
         ResendEmailRequest: {
             /** Captcha Token */
@@ -1164,6 +1235,74 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["ConfirmEmailRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    request_login_email_v1_login_request_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RequestLoginRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    consume_login_token_v1_login_consume_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConsumeLoginRequest"];
             };
         };
         responses: {

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -114,3 +114,43 @@ export function useConfirmEmail() {
     },
   })
 }
+
+export interface RequestLoginInput {
+  email: string
+  captchaToken: string
+  honeypot?: string
+}
+
+export function useRequestLogin() {
+  return useMutation({
+    mutationFn: async ({
+      email,
+      captchaToken,
+      honeypot = '',
+    }: RequestLoginInput) =>
+      unwrap(
+        'request sign-in link',
+        await api.POST('/v1/login/request', {
+          body: {
+            email,
+            captcha_token: captchaToken,
+            fmm_hp_token: honeypot,
+          },
+        }),
+      ),
+  })
+}
+
+export function useConsumeLoginToken() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (token: string): Promise<Session> =>
+      unwrap(
+        'sign in',
+        await api.POST('/v1/login/consume', { body: { token } }),
+      ),
+    onSuccess: (session) => {
+      qc.setQueryData(SESSION_QUERY_KEY, session)
+    },
+  })
+}

--- a/web-client/src/components/login/login-screens.tsx
+++ b/web-client/src/components/login/login-screens.tsx
@@ -2,23 +2,9 @@ import { useRef, useState } from 'react'
 import type { CSSProperties, FormEvent, ReactNode } from 'react'
 
 import { Turnstile, type TurnstileHandle } from '@/components/turnstile'
+import { HONEYPOT_STYLE, isValidEmail } from '@/lib/form-helpers'
 
 import './login.css'
-
-// Off-screen but still focusable so AT users hear "Leave this empty" — bots
-// pattern-match every visible field, then fill blanks anyway. Honeypots work
-// by being targeted by automation, not by being invisible to humans.
-const HONEYPOT_STYLE: CSSProperties = {
-  position: 'absolute',
-  left: '-9999px',
-  width: 1,
-  height: 1,
-  opacity: 0,
-}
-
-function isValidEmail(value: string): boolean {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(value)
-}
 
 /* ─── Brand atoms ───────────────────────────────────────────────────── */
 
@@ -303,11 +289,13 @@ function EmailField({
   onChange,
   state = 'valid',
   autoFocus,
+  readOnly = false,
 }: {
   value: string
-  onChange: (next: string) => void
+  onChange?: (next: string) => void
   state?: 'valid' | 'error'
   autoFocus?: boolean
+  readOnly?: boolean
 }) {
   const error = state === 'error'
   return (
@@ -347,7 +335,8 @@ function EmailField({
         autoComplete="email"
         autoFocus={autoFocus}
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        readOnly={readOnly}
+        onChange={readOnly ? undefined : (e) => onChange?.(e.target.value)}
         placeholder="you@yourclub.com"
         aria-label="Email address"
         aria-invalid={error || undefined}
@@ -1453,7 +1442,7 @@ export function ScreenEmailSendFailed({
           subtitle="Our email gateway isn’t answering. Not your fault. Give it a minute and try again — we’re already on it."
           accent="var(--loss)"
         >
-          <EmailField value={email} onChange={() => undefined} state="error" />
+          <EmailField value={email} state="error" readOnly />
 
           <InlineError
             code="ERR_MAIL_PROVIDER"

--- a/web-client/src/components/login/login-screens.tsx
+++ b/web-client/src/components/login/login-screens.tsx
@@ -1,6 +1,24 @@
-import type { CSSProperties, ReactNode } from 'react'
+import { useRef, useState } from 'react'
+import type { CSSProperties, FormEvent, ReactNode } from 'react'
+
+import { Turnstile, type TurnstileHandle } from '@/components/turnstile'
 
 import './login.css'
+
+// Off-screen but still focusable so AT users hear "Leave this empty" — bots
+// pattern-match every visible field, then fill blanks anyway. Honeypots work
+// by being targeted by automation, not by being invisible to humans.
+const HONEYPOT_STYLE: CSSProperties = {
+  position: 'absolute',
+  left: '-9999px',
+  width: 1,
+  height: 1,
+  opacity: 0,
+}
+
+function isValidEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(value)
+}
 
 /* ─── Brand atoms ───────────────────────────────────────────────────── */
 
@@ -281,11 +299,15 @@ function StepDots({ active }: { active: number }) {
 /* ─── Form parts ────────────────────────────────────────────────────── */
 
 function EmailField({
-  defaultValue = '',
+  value,
+  onChange,
   state = 'valid',
+  autoFocus,
 }: {
-  defaultValue?: string
+  value: string
+  onChange: (next: string) => void
   state?: 'valid' | 'error'
+  autoFocus?: boolean
 }) {
   const error = state === 'error'
   return (
@@ -322,7 +344,10 @@ function EmailField({
       </span>
       <input
         type="email"
-        defaultValue={defaultValue}
+        autoComplete="email"
+        autoFocus={autoFocus}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
         placeholder="you@yourclub.com"
         aria-label="Email address"
         aria-invalid={error || undefined}
@@ -482,7 +507,13 @@ function SolverLog({ lines }: { lines: SolverLine[] }) {
   )
 }
 
-function SuccessReceipt() {
+function SuccessReceipt({
+  username,
+  email,
+}: {
+  username: string
+  email: string | null
+}) {
   return (
     <div
       style={{
@@ -521,22 +552,19 @@ function SuccessReceipt() {
               marginTop: 4,
             }}
           >
-            Tomás Fischer · Club 37 · seed 14
+            @{username}
           </div>
         </div>
       </div>
-      <div style={receiptDiv} />
-      <div style={receiptRow}>
-        <span style={receiptK}>Rating</span>
-        <span style={{ ...receiptV, color: 'var(--serve-500)' }}>
-          1842 ▲ +12
-        </span>
-      </div>
-      <div style={receiptDiv} />
-      <div style={receiptRow}>
-        <span style={receiptK}>Next match</span>
-        <span style={receiptV}>Tonight · 19:30 · Court 2</span>
-      </div>
+      {email && (
+        <>
+          <div style={receiptDiv} />
+          <div style={receiptRow}>
+            <span style={receiptK}>Email</span>
+            <span style={receiptV}>{email}</span>
+          </div>
+        </>
+      )}
     </div>
   )
 }
@@ -682,7 +710,7 @@ function BounceReceipt({ email }: { email: string }) {
   )
 }
 
-function ErrorReceipt({ code }: { code: string }) {
+function ErrorReceipt({ code, detail }: { code: string; detail?: string }) {
   return (
     <div
       style={{
@@ -711,37 +739,22 @@ function ErrorReceipt({ code }: { code: string }) {
               letterSpacing: '0.18em',
             }}
           >
-            ● TOKEN REJECTED
+            ● {code}
           </div>
-          <div
-            style={{
-              fontFamily: 'var(--font-ui)',
-              fontSize: 14,
-              fontWeight: 500,
-              color: 'var(--fg-1)',
-              marginTop: 4,
-            }}
-          >
-            {code}
-          </div>
+          {detail && (
+            <div
+              style={{
+                fontFamily: 'var(--font-ui)',
+                fontSize: 14,
+                fontWeight: 500,
+                color: 'var(--fg-1)',
+                marginTop: 4,
+              }}
+            >
+              {detail}
+            </div>
+          )}
         </div>
-      </div>
-      <div style={receiptDiv} />
-      <div style={receiptRow}>
-        <span style={receiptK}>Issued</span>
-        <span style={{ ...receiptV, color: 'var(--fg-2)' }}>18 min ago</span>
-      </div>
-      <div style={receiptDiv} />
-      <div style={receiptRow}>
-        <span style={receiptK}>Expired</span>
-        <span style={{ ...receiptV, color: 'var(--loss)' }}>
-          3 min ago · ttl 15m
-        </span>
-      </div>
-      <div style={receiptDiv} />
-      <div style={receiptRow}>
-        <span style={receiptK}>For</span>
-        <span style={receiptV}>tomas.fischer@club37.de</span>
       </div>
     </div>
   )
@@ -1076,7 +1089,47 @@ const logCard: CSSProperties = {
 
 /* ─── Screens ───────────────────────────────────────────────────────── */
 
-export function ScreenEmail() {
+export interface ScreenEmailProps {
+  initialEmail?: string
+  submitting?: boolean
+  errorMessage?: string | null
+  onSubmit: (input: {
+    email: string
+    captchaToken: string
+    honeypot: string
+  }) => void
+}
+
+export function ScreenEmail({
+  initialEmail = '',
+  submitting = false,
+  errorMessage = null,
+  onSubmit,
+}: ScreenEmailProps) {
+  const [email, setEmail] = useState(initialEmail)
+  const [touched, setTouched] = useState(false)
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null)
+  const [honeypot, setHoneypot] = useState('')
+  const [localError, setLocalError] = useState<string | null>(null)
+  const captchaRef = useRef<TurnstileHandle | null>(null)
+
+  const valid = isValidEmail(email)
+  const showError = errorMessage ?? localError ?? (touched && !valid
+    ? "That doesn't look like a valid email."
+    : null)
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setTouched(true)
+    if (!valid) return
+    if (!captchaToken) {
+      setLocalError('Complete the check above so we know you’re not a bot.')
+      return
+    }
+    setLocalError(null)
+    onSubmit({ email: email.trim(), captchaToken, honeypot })
+  }
+
   return (
     <Shell
       left={
@@ -1093,8 +1146,66 @@ export function ScreenEmail() {
           title="Your email"
           subtitle="Drop your email. We send a one-tap link — open it and you’re in. We never made a password, so we can’t lose yours."
         >
-          <EmailField defaultValue="" />
-          <button style={btnPrimary}>Send the link</button>
+          <form
+            onSubmit={handleSubmit}
+            style={{ display: 'flex', flexDirection: 'column', gap: 18 }}
+            noValidate
+          >
+            <EmailField
+              value={email}
+              onChange={(next) => {
+                setEmail(next)
+                if (localError) setLocalError(null)
+              }}
+              state={showError ? 'error' : 'valid'}
+              autoFocus
+            />
+            {showError && (
+              <p className="fmm-help fmm-help--err" role="alert">
+                {showError}
+              </p>
+            )}
+
+            <div style={HONEYPOT_STYLE} aria-hidden="true">
+              <label htmlFor="login-fmm-hp">Leave this empty</label>
+              <input
+                id="login-fmm-hp"
+                name="fmm_hp_token"
+                type="text"
+                tabIndex={-1}
+                autoComplete="off"
+                value={honeypot}
+                onChange={(e) => setHoneypot(e.target.value)}
+                data-testid="login-honeypot"
+              />
+            </div>
+
+            <div>
+              <Turnstile
+                handleRef={(h) => {
+                  captchaRef.current = h
+                }}
+                onToken={(token) => {
+                  setCaptchaToken(token)
+                  if (localError) setLocalError(null)
+                }}
+                onExpire={() => setCaptchaToken(null)}
+                onError={() => setCaptchaToken(null)}
+              />
+            </div>
+
+            <button
+              type="submit"
+              style={{
+                ...btnPrimary,
+                opacity: submitting ? 0.7 : 1,
+                cursor: submitting ? 'wait' : 'pointer',
+              }}
+              disabled={submitting}
+            >
+              {submitting ? 'Sending the link…' : 'Send the link'}
+            </button>
+          </form>
           <Divider label="OR" />
           <div style={fineprint}>
             New here? Same flow — we’ll create your account when you confirm.
@@ -1111,8 +1222,21 @@ export function ScreenEmail() {
   )
 }
 
-export function ScreenSent() {
-  const email = 'tomas.fischer@club37.de'
+export interface ScreenSentProps {
+  email: string
+  onResend?: () => void
+  onStartOver?: () => void
+  resending?: boolean
+  resendMessage?: string | null
+}
+
+export function ScreenSent({
+  email,
+  onResend,
+  onStartOver,
+  resending = false,
+  resendMessage = null,
+}: ScreenSentProps) {
   return (
     <Shell
       left={
@@ -1138,15 +1262,56 @@ export function ScreenSent() {
           <EmailReceipt email={email} />
 
           <div style={{ display: 'flex', gap: 10, marginTop: 4 }}>
-            <button style={{ ...btnPrimary, flex: 1 }}>Open inbox</button>
-            <button style={btnGhost}>Resend</button>
+            <button
+              type="button"
+              style={{
+                ...btnGhost,
+                flex: 1,
+                opacity: resending ? 0.7 : 1,
+                cursor: resending ? 'wait' : 'pointer',
+              }}
+              onClick={onResend}
+              disabled={resending || !onResend}
+            >
+              {resending ? 'Resending…' : 'Resend'}
+            </button>
+            <button
+              type="button"
+              style={btnGhost}
+              onClick={onStartOver}
+              disabled={!onStartOver}
+            >
+              Start over
+            </button>
           </div>
+
+          {resendMessage && (
+            <p
+              className="fmm-help fmm-help--ok"
+              role="status"
+              style={{ marginTop: 6 }}
+            >
+              {resendMessage}
+            </p>
+          )}
 
           <div style={{ ...fineprint, marginTop: 10 }}>
             No link? Check spam. Or hit resend, we don’t mind.
             <br />
             <span style={{ color: 'var(--fg-muted)' }}>
-              Wrong address? <a href="#" role="button" style={linkInline}>Start over</a>.
+              Wrong address?{' '}
+              <a
+                href="#"
+                role="button"
+                style={linkInline}
+                onClick={(e) => {
+                  e.preventDefault()
+                  onStartOver?.()
+                }}
+              >
+                Start over
+              </a>
+              .
             </span>
           </div>
 
@@ -1182,14 +1347,24 @@ export function ScreenVerify() {
   )
 }
 
-export function ScreenSuccess() {
+export interface ScreenSuccessProps {
+  username?: string
+  email?: string | null
+  redirectTo?: string
+}
+
+export function ScreenSuccess({
+  username = '',
+  email = null,
+  redirectTo = '/dashboard',
+}: ScreenSuccessProps) {
   return (
     <Shell
       left={
         <HeroCol
           eyebrow="● You’re in"
-          h1a="Welcome back,"
-          h1b="Tomás."
+          h1a="Welcome back"
+          h1b={username ? `@${username}.` : '.'}
         />
       }
       right={
@@ -1200,15 +1375,20 @@ export function ScreenSuccess() {
           subtitle="Warming up the courts."
           accent="var(--serve-500)"
         >
-          <SuccessReceipt />
-          <RedirectStrip dest="/dashboard" />
+          <SuccessReceipt username={username} email={email} />
+          <RedirectStrip dest={redirectTo} />
         </FormCol>
       }
     />
   )
 }
 
-export function ScreenError() {
+export interface ScreenErrorProps {
+  detail?: string
+  onRequestNew?: () => void
+}
+
+export function ScreenError({ detail, onRequestNew }: ScreenErrorProps) {
   return (
     <Shell
       left={
@@ -1226,8 +1406,15 @@ export function ScreenError() {
           subtitle="Your link expired or was already used. Links are good for 15 minutes and one tap — strict for a reason. We’ll send a fresh one."
           accent="var(--loss)"
         >
-          <ErrorReceipt code="ERR_TOKEN_EXPIRED" />
-          <button style={btnPrimary}>Hit me with a new link</button>
+          <ErrorReceipt code="ERR_TOKEN_EXPIRED" detail={detail} />
+          <button
+            type="button"
+            style={btnPrimary}
+            onClick={onRequestNew}
+            disabled={!onRequestNew}
+          >
+            Hit me with a new link
+          </button>
           <div style={{ ...fineprint, marginTop: 6 }}>
             Still stuck? <a href="#" role="button" style={linkInline}>Email support</a> — we read every
             one.
@@ -1238,7 +1425,17 @@ export function ScreenError() {
   )
 }
 
-export function ScreenEmailSendFailed() {
+export interface ScreenEmailSendFailedProps {
+  email?: string
+  detail?: string
+  onTryAgain?: () => void
+}
+
+export function ScreenEmailSendFailed({
+  email = '',
+  detail,
+  onTryAgain,
+}: ScreenEmailSendFailedProps) {
   return (
     <Shell
       left={
@@ -1256,31 +1453,31 @@ export function ScreenEmailSendFailed() {
           subtitle="Our email gateway isn’t answering. Not your fault. Give it a minute and try again — we’re already on it."
           accent="var(--loss)"
         >
-          <EmailField defaultValue="tomas.fischer@club37.de" state="error" />
+          <EmailField value={email} onChange={() => undefined} state="error" />
 
           <InlineError
-            code="ERR_MAIL_PROVIDER_5XX"
-            title="Mail gateway returned 503"
-            detail="Postmark · upstream timed out after 8s. Status: degraded."
-            statusUrl="status.fortymm.com"
+            code="ERR_MAIL_PROVIDER"
+            title="Email service unavailable"
+            detail={
+              detail ??
+              'Our mail provider didn’t answer. Give it a minute and try again.'
+            }
           />
 
           <div style={{ display: 'flex', gap: 10 }}>
-            <button style={{ ...btnPrimary, flex: 1 }}>Try again</button>
-            <button style={btnGhost}>Try magic-code instead</button>
+            <button
+              type="button"
+              style={{ ...btnPrimary, flex: 1 }}
+              onClick={onTryAgain}
+              disabled={!onTryAgain}
+            >
+              Try again
+            </button>
           </div>
 
           <div style={fineprint}>
-            We auto-retry in{' '}
-            <span
-              style={{ color: 'var(--fg-1)', fontFamily: 'var(--font-mono)' }}
-            >
-              00:14
-            </span>
-            .
-            <br />
             <span style={{ color: 'var(--fg-muted)' }}>
-              Still broken in 5 min? <a href="#" role="button" style={linkInline}>Email support</a> or
+              Still broken? <a href="#" role="button" style={linkInline}>Email support</a> or
               check <a href="#" role="button" style={linkInline}>status.fortymm.com</a>.
             </span>
           </div>
@@ -1290,8 +1487,19 @@ export function ScreenEmailSendFailed() {
   )
 }
 
-export function ScreenSentBounced() {
-  const email = 'tomas.fischr@club37.de'
+export interface ScreenSentBouncedProps {
+  email: string
+  onChangeEmail?: () => void
+  onRetry?: () => void
+  retrying?: boolean
+}
+
+export function ScreenSentBounced({
+  email,
+  onChangeEmail,
+  onRetry,
+  retrying = false,
+}: ScreenSentBouncedProps) {
   return (
     <Shell
       left={
@@ -1312,10 +1520,22 @@ export function ScreenSentBounced() {
           <BounceReceipt email={email} />
 
           <div style={{ display: 'flex', gap: 10 }}>
-            <button style={{ ...btnPrimary, flex: 1 }}>
+            <button
+              type="button"
+              style={{ ...btnPrimary, flex: 1 }}
+              onClick={onChangeEmail}
+              disabled={!onChangeEmail}
+            >
               Use a different email
             </button>
-            <button style={btnGhost}>Retry same address</button>
+            <button
+              type="button"
+              style={btnGhost}
+              onClick={onRetry}
+              disabled={retrying || !onRetry}
+            >
+              {retrying ? 'Retrying…' : 'Retry same address'}
+            </button>
           </div>
 
           <div style={fineprint}>
@@ -1332,7 +1552,17 @@ export function ScreenSentBounced() {
   )
 }
 
-export function ScreenVerifyNetError() {
+export interface ScreenVerifyNetErrorProps {
+  onRetry?: () => void
+  onSendNewLink?: () => void
+  retrying?: boolean
+}
+
+export function ScreenVerifyNetError({
+  onRetry,
+  onSendNewLink,
+  retrying = false,
+}: ScreenVerifyNetErrorProps) {
   return (
     <Shell
       left={
@@ -1353,17 +1583,28 @@ export function ScreenVerifyNetError() {
           <InlineError
             code="ERR_NETWORK_UNREACHABLE"
             title="auth.fortymm.com is unreachable"
-            detail="3 attempts · timed out after 12s. Your device looks online; our edge node may be down."
-            statusUrl="status.fortymm.com"
+            detail="The server didn’t answer. Your device looks online; our edge node may be down."
           />
 
           <SolverLog lines={FAILED_VERIFY_LOG} />
 
           <div style={{ display: 'flex', gap: 10 }}>
-            <button style={{ ...btnPrimary, flex: 1 }}>
-              Retry verification
+            <button
+              type="button"
+              style={{ ...btnPrimary, flex: 1 }}
+              onClick={onRetry}
+              disabled={retrying || !onRetry}
+            >
+              {retrying ? 'Retrying…' : 'Retry verification'}
             </button>
-            <button style={btnGhost}>Send a new link</button>
+            <button
+              type="button"
+              style={btnGhost}
+              onClick={onSendNewLink}
+              disabled={!onSendNewLink}
+            >
+              Send a new link
+            </button>
           </div>
         </FormCol>
       }

--- a/web-client/src/components/login/login-screens.tsx
+++ b/web-client/src/components/login/login-screens.tsx
@@ -562,12 +562,10 @@ function InlineError({
   code,
   title,
   detail,
-  statusUrl,
 }: {
   code: string
   title: string
   detail: string
-  statusUrl?: string
 }) {
   return (
     <div
@@ -623,12 +621,6 @@ function InlineError({
         }}
       >
         {detail}
-        {statusUrl && (
-          <>
-            {' '}
-            <a href="#" role="button" style={linkInline}>{statusUrl}</a>
-          </>
-        )}
       </div>
     </div>
   )
@@ -1024,6 +1016,32 @@ const linkInline: CSSProperties = {
   cursor: 'pointer',
 }
 
+// Reset for <button> elements that should render as inline text-link. Lets
+// app actions live in <button> (correct semantics, no scroll-jump, no `#`
+// in history) while still looking like the underlined links around them.
+const linkButtonStyle: CSSProperties = {
+  ...linkInline,
+  appearance: 'none',
+  background: 'transparent',
+  border: 'none',
+  padding: 0,
+  font: 'inherit',
+}
+
+function LinkButton({
+  onClick,
+  children,
+}: {
+  onClick?: () => void
+  children: ReactNode
+}) {
+  return (
+    <button type="button" style={linkButtonStyle} onClick={onClick}>
+      {children}
+    </button>
+  )
+}
+
 const mono: CSSProperties = {
   fontFamily: 'var(--font-mono)',
   color: 'var(--ball-500)',
@@ -1201,8 +1219,8 @@ export function ScreenEmail({
             <br />
             <span style={{ color: 'var(--fg-muted)' }}>
               By signing in you agree to play fair. That’s it.{' '}
-              <a href="#" role="button" style={linkInline}>House rules</a> ·{' '}
-              <a href="#" role="button" style={linkInline}>Privacy</a>
+              <LinkButton>House rules</LinkButton> ·{' '}
+              <LinkButton>Privacy</LinkButton>
             </span>
           </div>
         </FormCol>
@@ -1289,18 +1307,7 @@ export function ScreenSent({
             <br />
             <span style={{ color: 'var(--fg-muted)' }}>
               Wrong address?{' '}
-              <a
-                href="#"
-                role="button"
-                style={linkInline}
-                onClick={(e) => {
-                  e.preventDefault()
-                  onStartOver?.()
-                }}
-              >
-                Start over
-              </a>
-              .
+              <LinkButton onClick={onStartOver}>Start over</LinkButton>.
             </span>
           </div>
 
@@ -1405,8 +1412,11 @@ export function ScreenError({ detail, onRequestNew }: ScreenErrorProps) {
             Hit me with a new link
           </button>
           <div style={{ ...fineprint, marginTop: 6 }}>
-            Still stuck? <a href="#" role="button" style={linkInline}>Email support</a> — we read every
-            one.
+            Still stuck?{' '}
+            <a href="mailto:support@fortymm.com" style={linkInline}>
+              Email support
+            </a>{' '}
+            — we read every one.
           </div>
         </FormCol>
       }
@@ -1466,8 +1476,20 @@ export function ScreenEmailSendFailed({
 
           <div style={fineprint}>
             <span style={{ color: 'var(--fg-muted)' }}>
-              Still broken? <a href="#" role="button" style={linkInline}>Email support</a> or
-              check <a href="#" role="button" style={linkInline}>status.fortymm.com</a>.
+              Still broken?{' '}
+              <a href="mailto:support@fortymm.com" style={linkInline}>
+                Email support
+              </a>{' '}
+              or check{' '}
+              <a
+                href="https://status.fortymm.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={linkInline}
+              >
+                status.fortymm.com
+              </a>
+              .
             </span>
           </div>
         </FormCol>
@@ -1528,11 +1550,15 @@ export function ScreenSentBounced({
           </div>
 
           <div style={fineprint}>
-            Did you mean <a href="#" role="button" style={linkInline}>tomas.fischer@club37.de</a>?
+            Did you mean{' '}
+            <LinkButton onClick={onChangeEmail}>tomas.fischer@club37.de</LinkButton>?
             <br />
             <span style={{ color: 'var(--fg-muted)' }}>
               If your address is right, it might be on a blocklist.{' '}
-              <a href="#" role="button" style={linkInline}>Tell us</a>.
+              <a href="mailto:support@fortymm.com" style={linkInline}>
+                Tell us
+              </a>
+              .
             </span>
           </div>
         </FormCol>

--- a/web-client/src/lib/form-helpers.ts
+++ b/web-client/src/lib/form-helpers.ts
@@ -1,0 +1,30 @@
+import type { CSSProperties } from 'react'
+
+// Off-screen but still focusable so AT users hear "Leave this empty" — bots
+// pattern-match every visible field, then fill blanks anyway. Honeypots work
+// by being targeted by automation, not by being invisible to humans.
+export const HONEYPOT_STYLE: CSSProperties = {
+  position: 'absolute',
+  left: '-9999px',
+  width: 1,
+  height: 1,
+  opacity: 0,
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/
+
+export interface Validation {
+  ok: boolean
+  err?: string
+}
+
+export function validateEmail(e: string): Validation {
+  if (!e) return { ok: false, err: 'Email is required to claim your account.' }
+  if (!EMAIL_RE.test(e))
+    return { ok: false, err: "That doesn't look like a valid email." }
+  return { ok: true }
+}
+
+export function isValidEmail(e: string): boolean {
+  return EMAIL_RE.test(e)
+}

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -187,6 +187,41 @@ export const handlers = [
     }
     return HttpResponse.json(mockSession)
   }),
+  http.post('*/v1/login/request', async ({ request }) => {
+    const body =
+      ((await readJson(request)) as {
+        email?: string
+        captcha_token?: string
+        fmm_hp_token?: string
+      } | undefined) ?? {}
+    if (body.fmm_hp_token?.trim())
+      return HttpResponse.json({ email: body.email ?? '' }, { status: 202 })
+    if (!body.captcha_token) return detail('Captcha required.', 400)
+    if (!body.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(body.email))
+      return detail('Invalid email.', 422)
+    // Always 202 — the mock matches the API's enumeration-safe shape.
+    return HttpResponse.json(
+      { email: body.email.toLowerCase() },
+      { status: 202 },
+    )
+  }),
+  http.post('*/v1/login/consume', async ({ request }) => {
+    const body =
+      ((await readJson(request)) as { token?: string } | undefined) ?? {}
+    if (!body.token) return detail('Missing token.', 400)
+    // The dev-mode magic token "expired" is a deliberate hook for letting
+    // designers test the failure screen end-to-end without rewriting
+    // handlers — anything else succeeds.
+    if (body.token === 'expired')
+      return detail('That sign-in link is invalid or expired.', 400)
+    mockSession.data.user = {
+      ...mockSession.data.user,
+      email: mockSession.data.user.email ?? 'rita@example.com',
+      confirmed_at:
+        mockSession.data.user.confirmed_at ?? new Date().toISOString(),
+    }
+    return HttpResponse.json(mockSession)
+  }),
   http.get('*/v1/players/recent', async () => {
     await delay(300)
     return HttpResponse.json(mockRecentOpponents)

--- a/web-client/src/routes/login.index.tsx
+++ b/web-client/src/routes/login.index.tsx
@@ -1,5 +1,8 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
+import { ApiError } from '@/api/client'
+import { useRequestLogin } from '@/api/session'
 import {
   ScreenEmail,
   ScreenEmailSendFailed,
@@ -12,12 +15,60 @@ export const Route = createFileRoute('/login/')({
   }),
   validateSearch: (search: Record<string, unknown>) => ({
     error: search.error === 'send-failed' ? ('send-failed' as const) : undefined,
+    email: typeof search.email === 'string' ? search.email : undefined,
   }),
   component: LoginPage,
 })
 
 function LoginPage() {
-  const { error } = Route.useSearch()
-  if (error === 'send-failed') return <ScreenEmailSendFailed />
-  return <ScreenEmail />
+  const { error, email: initialEmail } = Route.useSearch()
+  const navigate = useNavigate()
+  const requestLogin = useRequestLogin()
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  if (error === 'send-failed') {
+    return (
+      <ScreenEmailSendFailed
+        email={initialEmail ?? ''}
+        detail={serverError ?? undefined}
+        onTryAgain={() =>
+          navigate({
+            to: '/login',
+            search: { error: undefined, email: initialEmail },
+          })
+        }
+      />
+    )
+  }
+
+  return (
+    <ScreenEmail
+      initialEmail={initialEmail ?? ''}
+      submitting={requestLogin.isPending}
+      errorMessage={serverError}
+      onSubmit={async ({ email, captchaToken, honeypot }) => {
+        setServerError(null)
+        try {
+          await requestLogin.mutateAsync({ email, captchaToken, honeypot })
+          navigate({
+            to: '/login/sent',
+            search: { email, error: undefined },
+          })
+        } catch (err) {
+          if (err instanceof ApiError) {
+            if (err.status >= 500 || err.status === 0) {
+              navigate({
+                to: '/login',
+                search: { error: 'send-failed', email },
+              })
+              return
+            }
+            setServerError(err.detail ?? 'Something went wrong. Try again.')
+            return
+          }
+          setServerError('Something went wrong. Try again.')
+        }
+      }}
+    />
+  )
 }

--- a/web-client/src/routes/login.sent.tsx
+++ b/web-client/src/routes/login.sent.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
 import { ScreenSent, ScreenSentBounced } from '@/components/login/login-screens'
 import { pageTitle } from '@/lib/page-title'
@@ -9,12 +9,34 @@ export const Route = createFileRoute('/login/sent')({
   }),
   validateSearch: (search: Record<string, unknown>) => ({
     error: search.error === 'bounce' ? ('bounce' as const) : undefined,
+    email: typeof search.email === 'string' ? search.email : '',
   }),
   component: LoginSentPage,
 })
 
 function LoginSentPage() {
-  const { error } = Route.useSearch()
-  if (error === 'bounce') return <ScreenSentBounced />
-  return <ScreenSent />
+  const { error, email } = Route.useSearch()
+  const navigate = useNavigate()
+
+  // Both "resend" and "start over" route back to /login with the email
+  // prefilled. The captcha can't replay across page loads, so we have to
+  // get the user through the challenge again to send a new link.
+  const back = () => {
+    navigate({
+      to: '/login',
+      search: { email: email || undefined, error: undefined },
+    })
+  }
+
+  if (error === 'bounce') {
+    return <ScreenSentBounced email={email} onChangeEmail={back} onRetry={back} />
+  }
+
+  return (
+    <ScreenSent
+      email={email || 'your inbox'}
+      onStartOver={back}
+      onResend={back}
+    />
+  )
 }

--- a/web-client/src/routes/login.test.tsx
+++ b/web-client/src/routes/login.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it, vi } from 'vitest'
+import { server } from '@/mocks/server'
+import { mockSession } from '@/mocks/handlers'
+import { Route as LoginIndexRoute } from './login.index'
+import { Route as LoginSentRoute } from './login.sent'
+import { Route as LoginVerifyingRoute } from './login.verifying'
+import { Route as LoginWelcomeRoute } from './login.welcome'
+
+interface TestRouterContext {
+  queryClient: QueryClient
+}
+
+// Replace the real Turnstile widget with a fake that hands a token to the
+// form on mount — the production component loads a Cloudflare script that
+// jsdom can't execute.
+vi.mock('@/components/turnstile', () => ({
+  Turnstile: ({ onToken }: { onToken: (token: string) => void }) => {
+    onToken('fake-captcha-token')
+    return <div data-testid="fake-turnstile" />
+  },
+}))
+
+function renderAt(initialEntry: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const rootRoute = createRootRouteWithContext<TestRouterContext>()()
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/login',
+    component: LoginIndexRoute.options.component!,
+    validateSearch: LoginIndexRoute.options.validateSearch,
+  })
+  const sentRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/login/sent',
+    component: LoginSentRoute.options.component!,
+    validateSearch: LoginSentRoute.options.validateSearch,
+  })
+  const verifyingRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/login/verifying',
+    component: LoginVerifyingRoute.options.component!,
+    validateSearch: LoginVerifyingRoute.options.validateSearch,
+  })
+  const welcomeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/login/welcome',
+    component: LoginWelcomeRoute.options.component!,
+  })
+  const dashboardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/dashboard',
+    component: () => <div>Dashboard stub</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([
+      indexRoute,
+      sentRoute,
+      verifyingRoute,
+      welcomeRoute,
+      dashboardRoute,
+    ]),
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
+    context: { queryClient },
+  })
+  return {
+    router,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    ),
+  }
+}
+
+describe('/login flow', () => {
+  it('submits the email and navigates to /login/sent on success', async () => {
+    const user = userEvent.setup()
+    const { router } = renderAt('/login')
+
+    const input = await screen.findByLabelText('Email address')
+    await user.type(input, 'rita@example.com')
+    await user.click(screen.getByRole('button', { name: /send the link/i }))
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/login/sent')
+    })
+    expect(router.state.location.search).toMatchObject({
+      email: 'rita@example.com',
+    })
+  })
+
+  it('keeps the user on /login and surfaces an inline error for bad emails', async () => {
+    const user = userEvent.setup()
+    const { router } = renderAt('/login')
+
+    const input = await screen.findByLabelText('Email address')
+    await user.type(input, 'definitely-not-an-email')
+    await user.click(screen.getByRole('button', { name: /send the link/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /that doesn.t look like a valid email/i,
+    )
+    expect(router.state.location.pathname).toBe('/login')
+  })
+
+  it('routes back to /login when /v1/login/request fails with a 5xx', async () => {
+    server.use(
+      http.post('*/v1/login/request', () =>
+        HttpResponse.json({ detail: 'Email down.' }, { status: 503 }),
+      ),
+    )
+    const user = userEvent.setup()
+    const { router } = renderAt('/login')
+
+    const input = await screen.findByLabelText('Email address')
+    await user.type(input, 'rita@example.com')
+    await user.click(screen.getByRole('button', { name: /send the link/i }))
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({
+        error: 'send-failed',
+      })
+    })
+    expect(
+      await screen.findByRole('heading', { name: /couldn.t send/i }),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('/login/verifying flow', () => {
+  it('consumes the token and routes to /login/welcome on success', async () => {
+    const { router } = renderAt('/login/verifying?token=good-token')
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/login/welcome')
+    })
+    expect(
+      await screen.findByRole('heading', { name: /welcome back/i }),
+    ).toBeInTheDocument()
+    // The session query data should now reflect a confirmed account.
+    expect(mockSession.data.user.email).toBeTruthy()
+  })
+
+  it('routes to ?error=expired when the API rejects the token', async () => {
+    const { router } = renderAt('/login/verifying?token=expired')
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({ error: 'expired' })
+    })
+    expect(
+      await screen.findByRole('heading', { name: /this link can.t be used/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('routes to ?error=net when the API is unreachable', async () => {
+    server.use(
+      http.post('*/v1/login/consume', () =>
+        HttpResponse.json({ detail: 'down' }, { status: 503 }),
+      ),
+    )
+    const { router } = renderAt('/login/verifying?token=anything')
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({ error: 'net' })
+    })
+    expect(
+      await screen.findByRole('heading', { name: /couldn.t reach/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the missing-token screen when no token is supplied', async () => {
+    renderAt('/login/verifying')
+    expect(
+      await screen.findByRole('heading', { name: /this link can.t be used/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/this link is missing its token/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/web-client/src/routes/login.verifying.tsx
+++ b/web-client/src/routes/login.verifying.tsx
@@ -1,5 +1,9 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { useEffect, useRef, useState } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
 
+import { api, ApiError, unwrap } from '@/api/client'
+import { SESSION_QUERY_KEY, type Session } from '@/api/session'
 import {
   ScreenError,
   ScreenVerify,
@@ -8,6 +12,11 @@ import {
 import { pageTitle } from '@/lib/page-title'
 
 type VerifyError = 'expired' | 'net'
+type ConsumeState =
+  | { status: 'idle' }
+  | { status: 'pending' }
+  | { status: 'success' }
+  | { status: 'error'; error: unknown }
 
 export const Route = createFileRoute('/login/verifying')({
   head: () => ({
@@ -16,6 +25,7 @@ export const Route = createFileRoute('/login/verifying')({
   validateSearch: (search: Record<string, unknown>) => {
     const e = search.error
     return {
+      token: typeof search.token === 'string' ? search.token : '',
       error: e === 'expired' || e === 'net' ? (e as VerifyError) : undefined,
     }
   },
@@ -23,8 +33,100 @@ export const Route = createFileRoute('/login/verifying')({
 })
 
 function LoginVerifyingPage() {
-  const { error } = Route.useSearch()
-  if (error === 'expired') return <ScreenError />
-  if (error === 'net') return <ScreenVerifyNetError />
+  const { token, error } = Route.useSearch()
+  const navigate = useNavigate()
+  const qc = useQueryClient()
+  const [state, setState] = useState<ConsumeState>({ status: 'idle' })
+  const fired = useRef(false)
+
+  // Fire the consume exactly once across mounts and pick up the result on
+  // whichever render observes it. We intentionally don't cancel from the
+  // effect cleanup: StrictMode's simulated unmount fires the cleanup before
+  // the response arrives, and a second mount whose effect early-returns
+  // would then never learn the outcome.
+  useEffect(() => {
+    if (fired.current || !token || error) return
+    fired.current = true
+    setState({ status: 'pending' })
+    ;(async () => {
+      try {
+        const result = await api.POST('/v1/login/consume', { body: { token } })
+        const session = unwrap('sign in', result) as Session
+        qc.setQueryData(SESSION_QUERY_KEY, session)
+        setState({ status: 'success' })
+      } catch (err) {
+        setState({ status: 'error', error: err })
+      }
+    })()
+  }, [token, error, qc])
+
+  useEffect(() => {
+    if (state.status === 'success') {
+      navigate({ to: '/login/welcome' })
+    } else if (state.status === 'error') {
+      const err = state.error
+      if (err instanceof ApiError && err.status >= 400 && err.status < 500) {
+        navigate({
+          to: '/login/verifying',
+          search: { token: '', error: 'expired' },
+        })
+      } else {
+        navigate({
+          to: '/login/verifying',
+          search: { token, error: 'net' },
+        })
+      }
+    }
+  }, [state, navigate, token])
+
+  if (!token && !error) {
+    return (
+      <ScreenError
+        detail="This link is missing its token."
+        onRequestNew={() =>
+          navigate({
+            to: '/login',
+            search: { error: undefined, email: undefined },
+          })
+        }
+      />
+    )
+  }
+
+  if (error === 'expired') {
+    return (
+      <ScreenError
+        onRequestNew={() =>
+          navigate({
+            to: '/login',
+            search: { error: undefined, email: undefined },
+          })
+        }
+      />
+    )
+  }
+
+  if (error === 'net') {
+    return (
+      <ScreenVerifyNetError
+        retrying={state.status === 'pending'}
+        onRetry={() => {
+          fired.current = false
+          setState({ status: 'idle' })
+          navigate({
+            to: '/login/verifying',
+            search: { token, error: undefined },
+          })
+        }}
+        onSendNewLink={() =>
+          navigate({
+            to: '/login',
+            search: { error: undefined, email: undefined },
+          })
+        }
+      />
+    )
+  }
+
   return <ScreenVerify />
 }

--- a/web-client/src/routes/login.welcome.tsx
+++ b/web-client/src/routes/login.welcome.tsx
@@ -1,11 +1,35 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { useEffect } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
+import { useSession } from '@/api/session'
 import { ScreenSuccess } from '@/components/login/login-screens'
 import { pageTitle } from '@/lib/page-title'
+
+// Long enough for the success card to register, short enough that the user
+// doesn't feel stuck. Matches the "2s" copy in the redirect strip.
+const REDIRECT_DELAY_MS = 2000
 
 export const Route = createFileRoute('/login/welcome')({
   head: () => ({
     meta: [{ title: pageTitle('Signed in') }],
   }),
-  component: ScreenSuccess,
+  component: LoginWelcomePage,
 })
+
+function LoginWelcomePage() {
+  const navigate = useNavigate()
+  const { data } = useSession()
+  const user = data?.data.user
+
+  useEffect(() => {
+    const id = setTimeout(() => navigate({ to: '/dashboard' }), REDIRECT_DELAY_MS)
+    return () => clearTimeout(id)
+  }, [navigate])
+
+  return (
+    <ScreenSuccess
+      username={user?.username ?? ''}
+      email={user?.email ?? null}
+    />
+  )
+}

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -27,6 +27,11 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import {
+  HONEYPOT_STYLE,
+  validateEmail,
+  type Validation,
+} from '@/lib/form-helpers'
 import { pageTitle } from '@/lib/page-title'
 import './settings.css'
 
@@ -42,11 +47,6 @@ export const Route = createFileRoute('/settings')({
 /* ------------------------------------------------------------------ */
 
 type EmailStatus = 'guest' | 'pending' | 'verified'
-
-interface Validation {
-  ok: boolean
-  err?: string
-}
 
 // Mirrors api/app/schemas/session.py USERNAME_PATTERN. Client-side validation
 // is for fast feedback; the server still enforces the same rules and returns
@@ -64,13 +64,6 @@ function validateUsername(u: string): Validation {
       ok: false,
       err: 'Lowercase letters, numbers, dots, hyphens and underscores. Must start and end with a letter or number.',
     }
-  return { ok: true }
-}
-
-function validateEmail(e: string): Validation {
-  if (!e) return { ok: false, err: 'Email is required to claim your account.' }
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(e))
-    return { ok: false, err: "That doesn't look like a valid email." }
   return { ok: true }
 }
 
@@ -781,17 +774,6 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
 /* ------------------------------------------------------------------ */
 /*  02 — Email (required to claim)                                    */
 /* ------------------------------------------------------------------ */
-
-// Off-screen but still focusable so AT users hear "Leave this empty" — bots
-// pattern-match every visible field, then fill blanks anyway. Honeypots work
-// by being targeted by automation, not by being invisible to humans.
-const HONEYPOT_STYLE: CSSProperties = {
-  position: 'absolute',
-  left: '-9999px',
-  width: 1,
-  height: 1,
-  opacity: 0,
-}
 
 function EmailSection({
   email,


### PR DESCRIPTION
## Summary

- Wires the magic-link sign-in flow end-to-end: `POST /v1/login/request` mints a 15-minute, single-use token and emails it; `POST /v1/login/consume` verifies the click, deletes the token, and rotates the caller's session cookie to the token's owner.
- Adds the four login screens (`/login`, `/login/sent`, `/login/verifying`, `/login/welcome`) with Turnstile + honeypot, plus MSW handlers so the dev/test loop works without a real backend.
- Hardens the flow: enumeration-safe 202s with byte-identical honeypot/success responses, `sent_to == user.email` guard on consume so a stale link can't sign in a user who's changed their address, per-IP rate limit on consume, and unconfirmed accounts get the confirmation link re-sent instead of a silent drop.
- Indexes `user_tokens.token` (edited migration 0002 in place per the pre-deploy convention) since every cookie validation and every magic-link click looks up tokens by hash.
- Refactors out two shared helpers: `_enqueue_email_job` / `_deliver` in `api/app/email.py` so the confirmation and sign-in code paths share their SMTP+dev fallback, and `web-client/src/lib/form-helpers.ts` with `HONEYPOT_STYLE` + `validateEmail` so the login form and settings email panel share one definition.

## Test plan
- [x] `cd api && pytest` — 273 passed (14 new login tests covering: request enqueues, normalization, unknown / unconfirmed emails, prior-token replacement, honeypot, captcha, format validation, consume success, single-use, expiry, unknown-token rejection, cookie rotation over a guest session, change-token rejection, and the post-email-change stale-link rejection)
- [x] `cd web-client && npm run test:run` — 63 passed (7 new login route tests)
- [x] `cd web-client && npm run lint && npm run build` — clean
- [x] `cd web-client && npm run test:e2e` — 126 passed
- [x] OpenAPI schema regenerated and in sync
- [x] Manual walkthrough in browser: `/ → Sign in → /login → submit → /login/sent → /login/verifying?token=... → /login/welcome → /dashboard`, plus the `?token=expired` failure path

🤖 Generated with [Claude Code](https://claude.com/claude-code)