### PR TITLE
Merge ephemeral session into verified account on sign-in

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -23,6 +23,17 @@ layout, commands, and architecture.
   codebase already uses: `ix_`, `uq_`, `ck_`, `fk_`. So
   `ix_user_tokens_user_id`, not `ix_users_tokens_user_id`.
 
+## New `users.id` foreign keys must update the account-merge service
+
+When you add a model (or column) with a foreign key to `users.id`, also update
+the ephemeral→verified account-merge logic to handle the new FK — re-point it
+to the surviving user, or rely on `ON DELETE CASCADE` and let the ephemeral
+user's deletion clean it up. Grep for `merge_user` to find it.
+
+Skipping this means a merged user silently leaves orphan rows, or a `RESTRICT`
+FK blocks the final ephemeral-user delete and the whole merge transaction
+fails.
+
 ## Pre-deploy: edit migrations in place
 
 Until the first production deploy, fix schema mistakes by editing the

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -1,12 +1,11 @@
 """Re-point ownership from an ephemeral user to a verified user, then delete
-the ephemeral user. Used when a browser holding an anonymous session signs in
-(``/v1/login/consume``) or confirms an email (``/v1/me/email/confirm``) for a
-different account.
+the ephemeral user. Called from sign-in (``/v1/login/consume``) and email
+confirmation (``/v1/me/email/confirm``) when the browser arrived with a
+different ephemeral session than the target account.
 
-Rating recompute is intentionally out of scope: after a merge the verified
-user's ``user_league_ratings`` and ``rating_history`` are stale w.r.t. the
-freshly-moved matches and need rebuilding from the merged match list. That
-lives in a follow-up — see CLAUDE.md.
+Leaves the verified user's ``user_league_ratings`` and ``rating_history``
+stale relative to the freshly-moved matches — rebuilding those is the
+caller's problem and must happen separately.
 """
 
 import uuid
@@ -58,8 +57,8 @@ async def merge_user(
     # user_league_ratings / league_memberships both have UNIQUE(league_id,
     # user_id). Re-point only where the verified user has no row in that
     # league; the leftover ephemeral rows cascade-delete with the user below.
-    # Rating recompute (next ticket) reconciles against the merged matches —
-    # don't try to merge JSONB state here.
+    # Don't try to merge JSONB rating state — a rating recompute against the
+    # merged match list is the only correct reconciliation.
     await db.execute(
         text(
             """

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -1,0 +1,134 @@
+"""Re-point ownership from an ephemeral user to a verified user, then delete
+the ephemeral user. Used when a browser holding an anonymous session signs in
+(``/v1/login/consume``) or confirms an email (``/v1/me/email/confirm``) for a
+different account.
+
+Rating recompute is intentionally out of scope: after a merge the verified
+user's ``user_league_ratings`` and ``rating_history`` are stale w.r.t. the
+freshly-moved matches and need rebuilding from the merged match list. That
+lives in a follow-up — see CLAUDE.md.
+"""
+
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import delete, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Match, MatchSidePlayer, RatingHistory, User
+
+
+@dataclass(frozen=True)
+class MergeSummary:
+    matches_moved: int
+
+
+async def merge_user(
+    db: AsyncSession,
+    *,
+    from_user_id: uuid.UUID,
+    to_user_id: uuid.UUID,
+) -> MergeSummary:
+    """Re-point ``from_user_id``'s data onto ``to_user_id`` and delete the
+    ephemeral row. Runs inside the caller's transaction — does not commit.
+
+    Caller invariants:
+      * ``from_user_id`` is ephemeral (``confirmed_at IS NULL``).
+      * ``to_user_id`` already exists.
+      * ``from_user_id != to_user_id``.
+    """
+    matches_moved = await _repoint_match_side_players(
+        db, from_user_id=from_user_id, to_user_id=to_user_id
+    )
+
+    await db.execute(
+        update(Match)
+        .where(Match.created_by_user_id == from_user_id)
+        .values(created_by_user_id=to_user_id)
+    )
+
+    # Preserve the audit trail by re-pointing rather than letting the FK's
+    # ON DELETE SET NULL null it out when the ephemeral user is deleted.
+    await db.execute(
+        update(RatingHistory)
+        .where(RatingHistory.created_by_user_id == from_user_id)
+        .values(created_by_user_id=to_user_id)
+    )
+
+    # user_league_ratings / league_memberships both have UNIQUE(league_id,
+    # user_id). Re-point only where the verified user has no row in that
+    # league; the leftover ephemeral rows cascade-delete with the user below.
+    # Rating recompute (next ticket) reconciles against the merged matches —
+    # don't try to merge JSONB state here.
+    await db.execute(
+        text(
+            """
+            UPDATE user_league_ratings AS ulr
+            SET user_id = :to_id
+            WHERE ulr.user_id = :from_id
+              AND NOT EXISTS (
+                SELECT 1 FROM user_league_ratings other
+                WHERE other.user_id = :to_id
+                  AND other.league_id = ulr.league_id
+              )
+            """
+        ),
+        {"from_id": from_user_id, "to_id": to_user_id},
+    )
+    await db.execute(
+        text(
+            """
+            UPDATE league_memberships AS lm
+            SET user_id = :to_id
+            WHERE lm.user_id = :from_id
+              AND NOT EXISTS (
+                SELECT 1 FROM league_memberships other
+                WHERE other.user_id = :to_id
+                  AND other.league_id = lm.league_id
+              )
+            """
+        ),
+        {"from_id": from_user_id, "to_id": to_user_id},
+    )
+
+    # match_side_players is RESTRICT, so any rows that didn't re-point would
+    # block the final user delete. Re-point should always cover them; this is
+    # a belt-and-braces drop in case the impossible collision ever fires.
+    await db.execute(
+        delete(MatchSidePlayer).where(MatchSidePlayer.user_id == from_user_id)
+    )
+
+    # CASCADE cleans up user_tokens, user_roles, rating_history (user_id), and
+    # any user_league_ratings / league_memberships rows that didn't re-point.
+    await db.execute(delete(User).where(User.id == from_user_id))
+    await db.flush()
+
+    return MergeSummary(matches_moved=matches_moved)
+
+
+async def _repoint_match_side_players(
+    db: AsyncSession,
+    *,
+    from_user_id: uuid.UUID,
+    to_user_id: uuid.UUID,
+) -> int:
+    """Re-point match_side_players from ephemeral → verified. Returns the row
+    count, which equals the number of matches moved because UNIQUE(match_id,
+    user_id) caps it at one row per match. NOT EXISTS skips the impossible-
+    but-defendable case where both users are already on the same match."""
+    result = await db.execute(
+        text(
+            """
+            UPDATE match_side_players AS msp
+            SET user_id = :to_id
+            WHERE msp.user_id = :from_id
+              AND NOT EXISTS (
+                SELECT 1 FROM match_side_players other
+                WHERE other.user_id = :to_id
+                  AND other.match_id = msp.match_id
+              )
+            """
+        ),
+        {"from_id": from_user_id, "to_id": to_user_id},
+    )
+    return result.rowcount or 0

--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -22,8 +22,17 @@ class SessionData(BaseModel):
     user: SessionUser
 
 
+class MergeSummary(BaseModel):
+    """Reported by sign-in / email-confirm responses when the call merged the
+    caller's ephemeral session into a different (verified) account. Drives the
+    "we brought your N matches with you" toast."""
+
+    matches_moved: int
+
+
 class SessionResponse(BaseModel):
     data: SessionData
+    merged: MergeSummary | None = None
 
 
 class UpdateCurrentUserRequest(BaseModel):

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -13,12 +13,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import captcha as captcha_module
 from app import queue as queue_module
+from app.account_merge import merge_user
 from app.db import get_session
 from app.leagues import add_user_to_default_league
 from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
 from app.schemas.session import (
     ConfirmEmailRequest,
     ConsumeLoginRequest,
+    MergeSummary,
     RequestLoginRequest,
     ResendEmailRequest,
     SessionData,
@@ -151,7 +153,9 @@ async def _find_session_user(db: AsyncSession, raw_token: str) -> User | None:
     return user_result.scalar_one_or_none()
 
 
-async def _build_session_response(db: AsyncSession, user: User) -> SessionResponse:
+async def _build_session_response(
+    db: AsyncSession, user: User, merged: MergeSummary | None = None
+) -> SessionResponse:
     permissions = await _load_permissions(db, user.id)
     return SessionResponse(
         data=SessionData(
@@ -161,8 +165,33 @@ async def _build_session_response(db: AsyncSession, user: User) -> SessionRespon
                 email=user.email,
                 confirmed_at=user.confirmed_at,
             )
-        )
+        ),
+        merged=merged,
     )
+
+
+async def _maybe_merge_prior_session(
+    db: AsyncSession, session_cookie: str | None, target_user: User
+) -> MergeSummary | None:
+    """If the browser arrived with a session cookie identifying a *different*
+    ephemeral user than ``target_user``, fold that user's data into the target
+    and return a summary. Otherwise return None.
+
+    Only runs for ephemeral prior users (``confirmed_at IS NULL``) — a verified
+    prior session means two real accounts share a browser, and silently
+    siphoning data out of one would be data loss.
+    """
+    if not session_cookie:
+        return None
+    prior_user = await _find_session_user(db, session_cookie)
+    if prior_user is None or prior_user.id == target_user.id:
+        return None
+    if prior_user.confirmed_at is not None:
+        return None
+    summary = await merge_user(
+        db, from_user_id=prior_user.id, to_user_id=target_user.id
+    )
+    return MergeSummary(matches_moved=summary.matches_moved)
 
 
 async def _load_permissions(db: AsyncSession, user_id) -> list[str]:
@@ -501,6 +530,9 @@ async def resend_email_confirmation(
 async def confirm_email(
     payload: ConfirmEmailRequest,
     response: Response,
+    session_cookie: Annotated[
+        str | None, Cookie(alias=SESSION_COOKIE_NAME)
+    ] = None,
     db: AsyncSession = Depends(get_session),
 ) -> SessionResponse:
     """Confirm the email-change handshake.
@@ -548,6 +580,7 @@ async def confirm_email(
 
     user.confirmed_at = datetime.now(timezone.utc)
     await db.delete(token_row)
+    merged = await _maybe_merge_prior_session(db, session_cookie, user)
     # Mint a fresh session for the token's owner so the confirming browser
     # is signed in as them — replaces whatever guest session this browser
     # had (or hadn't) on arrival.
@@ -561,7 +594,7 @@ async def confirm_email(
     )
     await db.commit()
     _set_session_cookie(response, raw_session)
-    return await _build_session_response(db, user)
+    return await _build_session_response(db, user, merged=merged)
 
 
 @router.post(
@@ -688,6 +721,9 @@ async def _issue_and_send_confirmation_email(
 async def consume_login_token(
     payload: ConsumeLoginRequest,
     response: Response,
+    session_cookie: Annotated[
+        str | None, Cookie(alias=SESSION_COOKIE_NAME)
+    ] = None,
     db: AsyncSession = Depends(get_session),
 ) -> SessionResponse:
     """Verify a magic-link token and rotate the caller's session cookie.
@@ -746,6 +782,7 @@ async def consume_login_token(
 
     # Single-use: delete the link the moment we accept it.
     await db.delete(token_row)
+    merged = await _maybe_merge_prior_session(db, session_cookie, user)
     raw_session = secrets.token_urlsafe(32)
     db.add(
         UserToken(
@@ -756,4 +793,4 @@ async def consume_login_token(
     )
     await db.commit()
     _set_session_cookie(response, raw_session)
-    return await _build_session_response(db, user)
+    return await _build_session_response(db, user, merged=merged)

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -22,6 +22,7 @@ from app.models import (
     UserLeagueRating,
     UserToken,
 )
+from app.sessions import SESSION_TOKEN_CONTEXT
 
 
 async def _make_ephemeral(db: AsyncSession, username: str) -> User:
@@ -110,7 +111,7 @@ async def test_merge_deletes_ephemeral_user_and_cascades_tokens(
     db_session.add(
         UserToken(
             user_id=ephemeral.id,
-            context="session",
+            context=SESSION_TOKEN_CONTEXT,
             token=hashlib.sha256(b"raw").digest(),
         )
     )

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -1,0 +1,291 @@
+"""Unit tests for the ephemeral→verified merge primitive in app.account_merge."""
+
+import hashlib
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.account_merge import merge_user
+from app.leagues import add_user_to_default_league, get_default_league
+from app.models import (
+    LeagueMembership,
+    Match,
+    MatchSettings,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    RatingHistory,
+    RatingHistorySource,
+    User,
+    UserLeagueRating,
+    UserToken,
+)
+
+
+async def _make_ephemeral(db: AsyncSession, username: str) -> User:
+    user = User(username=username)
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    await add_user_to_default_league(db, user.id)
+    await db.commit()
+    return user
+
+
+async def _make_verified(db: AsyncSession, email: str) -> User:
+    user = User(
+        username=email.split("@")[0],
+        email=email,
+        confirmed_at=datetime.now(timezone.utc),
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _record_match(
+    db: AsyncSession, creator: User, *players: User
+) -> Match:
+    league = await get_default_league(db)
+    settings = MatchSettings(team_size=1, best_of=5, affects_rating=False)
+    match = Match(
+        match_settings=settings,
+        league=league,
+        created_by_user_id=creator.id,
+        status=MatchStatus.completed,
+    )
+    for side_number, player in enumerate(players, start=1):
+        side = MatchSide(match=match, side_number=side_number)
+        side.players.append(MatchSidePlayer(match=match, user=player))
+    db.add(match)
+    await db.commit()
+    await db.refresh(match)
+    return match
+
+
+# ----- happy path ---------------------------------------------------------
+
+
+async def test_merge_repoints_match_side_players_and_creator(
+    db_session: AsyncSession,
+):
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    opponent = await _make_ephemeral(db_session, "spinning-otter")
+
+    match = await _record_match(db_session, ephemeral, ephemeral, opponent)
+
+    summary = await merge_user(
+        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
+    )
+    await db_session.commit()
+
+    assert summary.matches_moved == 1
+
+    players = (
+        await db_session.execute(
+            select(MatchSidePlayer).where(MatchSidePlayer.match_id == match.id)
+        )
+    ).scalars().all()
+    user_ids = {p.user_id for p in players}
+    assert user_ids == {verified.id, opponent.id}
+
+    creator_id = (
+        await db_session.execute(
+            select(Match.created_by_user_id).where(Match.id == match.id)
+        )
+    ).scalar_one()
+    assert creator_id == verified.id
+
+
+async def test_merge_deletes_ephemeral_user_and_cascades_tokens(
+    db_session: AsyncSession,
+):
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+
+    db_session.add(
+        UserToken(
+            user_id=ephemeral.id,
+            context="session",
+            token=hashlib.sha256(b"raw").digest(),
+        )
+    )
+    await db_session.commit()
+
+    await merge_user(
+        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
+    )
+    await db_session.commit()
+
+    assert (
+        await db_session.execute(select(User).where(User.id == ephemeral.id))
+    ).scalar_one_or_none() is None
+    leftover_tokens = (
+        await db_session.execute(
+            select(UserToken).where(UserToken.user_id == ephemeral.id)
+        )
+    ).scalars().all()
+    assert leftover_tokens == []
+
+
+async def test_merge_moves_league_membership_when_target_has_none(
+    db_session: AsyncSession,
+):
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    # verified is NOT in the default league yet
+
+    await merge_user(
+        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
+    )
+    await db_session.commit()
+
+    league = await get_default_league(db_session)
+    memberships = (
+        await db_session.execute(
+            select(LeagueMembership).where(
+                LeagueMembership.league_id == league.id
+            )
+        )
+    ).scalars().all()
+    user_ids = {m.user_id for m in memberships}
+    assert verified.id in user_ids
+    assert ephemeral.id not in user_ids
+
+
+async def test_merge_skips_membership_when_target_already_a_member(
+    db_session: AsyncSession,
+):
+    """UNIQUE(league_id, user_id) means we must NOT EXISTS-guard the re-point.
+    The ephemeral row gets cascade-deleted with the user."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    await add_user_to_default_league(db_session, verified.id)
+    await db_session.commit()
+
+    await merge_user(
+        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
+    )
+    await db_session.commit()
+
+    league = await get_default_league(db_session)
+    memberships = (
+        await db_session.execute(
+            select(LeagueMembership).where(
+                LeagueMembership.league_id == league.id
+            )
+        )
+    ).scalars().all()
+    user_ids = [m.user_id for m in memberships]
+    assert user_ids == [verified.id]
+
+
+async def test_merge_repoints_rating_history_created_by(
+    db_session: AsyncSession,
+    rating_strategies: dict,
+):
+    """`rating_history.created_by_user_id` is SET NULL on delete; the merge
+    re-points it so the audit trail still records who acted."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    league = await get_default_league(db_session)
+
+    row = RatingHistory(
+        league_id=league.id,
+        user_id=verified.id,
+        rating_strategy_id=rating_strategies["glicko2"].id,
+        rating_value=1500.0,
+        rating_state={"rating": 1500.0, "rd": 350.0, "volatility": 0.06},
+        source=RatingHistorySource.manual,
+        created_by_user_id=ephemeral.id,
+        note="moderator override",
+    )
+    db_session.add(row)
+    await db_session.commit()
+
+    await merge_user(
+        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
+    )
+    await db_session.commit()
+
+    await db_session.refresh(row)
+    assert row.created_by_user_id == verified.id
+
+
+# ----- counts -------------------------------------------------------------
+
+
+async def test_merge_summary_counts_distinct_matches(
+    db_session: AsyncSession,
+):
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    opp1 = await _make_ephemeral(db_session, "opp-one")
+    opp2 = await _make_ephemeral(db_session, "opp-two")
+
+    await _record_match(db_session, ephemeral, ephemeral, opp1)
+    await _record_match(db_session, ephemeral, ephemeral, opp2)
+
+    summary = await merge_user(
+        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
+    )
+    await db_session.commit()
+    assert summary.matches_moved == 2
+
+
+async def test_merge_summary_zero_when_ephemeral_played_nothing(
+    db_session: AsyncSession,
+):
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    summary = await merge_user(
+        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
+    )
+    await db_session.commit()
+    assert summary.matches_moved == 0
+
+
+# ----- skip cases handled by the endpoint guard ---------------------------
+# (`merge_user` itself doesn't check verified-ness or same-id — those are
+# the caller's responsibility, enforced in sessions._maybe_merge_prior_session.)
+
+
+async def test_merge_with_user_league_rating_collision_drops_ephemeral(
+    db_session: AsyncSession,
+):
+    """When both users have a UserLeagueRating in the same league (both got
+    seeded into the default league), the NOT EXISTS guard skips the re-point
+    and the ephemeral row cascade-deletes with the user."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    await add_user_to_default_league(db_session, verified.id)
+    await db_session.commit()
+
+    league = await get_default_league(db_session)
+    # Sanity: both have a rating row pre-merge.
+    pre = (
+        await db_session.execute(
+            select(UserLeagueRating).where(
+                UserLeagueRating.league_id == league.id
+            )
+        )
+    ).scalars().all()
+    assert {r.user_id for r in pre} == {ephemeral.id, verified.id}
+
+    await merge_user(
+        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
+    )
+    await db_session.commit()
+
+    rows = (
+        await db_session.execute(
+            select(UserLeagueRating).where(
+                UserLeagueRating.league_id == league.id
+            )
+        )
+    ).scalars().all()
+    assert [r.user_id for r in rows] == [verified.id]

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -8,14 +8,23 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
+from app.leagues import get_default_league
 from app.main import app
-from app.models import User, UserToken
+from app.models import (
+    Match,
+    MatchSettings,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    User,
+    UserToken,
+)
 from app.sessions import (
     LOGIN_TOKEN_CONTEXT,
     SESSION_COOKIE_NAME,
     SESSION_TOKEN_CONTEXT,
 )
-from tests._helpers import make_client, start_session
+from tests._helpers import make_client, make_user, start_session
 
 
 @pytest_asyncio.fixture
@@ -405,3 +414,117 @@ async def test_consume_rejects_link_after_user_changed_email(
         )
     ).scalars().all()
     assert leftover == []
+
+
+# ---- merge of ephemeral session on consume -------------------------------
+
+
+async def _record_singles_match(
+    db_session: AsyncSession, *players: User
+) -> Match:
+    league = await get_default_league(db_session)
+    settings = MatchSettings(team_size=1, best_of=5, affects_rating=False)
+    match = Match(
+        match_settings=settings,
+        league=league,
+        created_by_user_id=players[0].id,
+        status=MatchStatus.completed,
+    )
+    for side_number, player in enumerate(players, start=1):
+        side = MatchSide(match=match, side_number=side_number)
+        side.players.append(MatchSidePlayer(match=match, user=player))
+    db_session.add(match)
+    await db_session.commit()
+    return match
+
+
+async def test_consume_merges_ephemeral_matches_into_verified_account(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """When the consuming browser arrived with an ephemeral session that
+    already played a match, that match should follow the user into their
+    verified account and the response should report the merge."""
+    rita = await _make_confirmed_user(db_session, "rita@example.com")
+    raw = "raw-login-token-merge"
+    await _issue_login_token(db_session, rita, raw)
+
+    guest = await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "opponent-jay")
+    match = await _record_singles_match(db_session, guest, opponent)
+
+    response = await api_client.post("/v1/login/consume", json={"token": raw})
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["merged"] == {"matches_moved": 1}
+
+    players = (
+        await db_session.execute(
+            select(MatchSidePlayer).where(MatchSidePlayer.match_id == match.id)
+        )
+    ).scalars().all()
+    assert {p.user_id for p in players} == {rita.id, opponent.id}
+
+    creator_id = (
+        await db_session.execute(
+            select(Match.created_by_user_id).where(Match.id == match.id)
+        )
+    ).scalar_one()
+    assert creator_id == rita.id
+
+    assert (
+        await db_session.execute(select(User).where(User.id == guest.id))
+    ).scalar_one_or_none() is None
+
+
+async def test_consume_omits_merge_when_no_prior_session(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Cookieless consume — there's no ephemeral session to merge from."""
+    rita = await _make_confirmed_user(db_session, "rita@example.com")
+    raw = "raw-login-token-fresh-browser"
+    await _issue_login_token(db_session, rita, raw)
+
+    async with make_client() as fresh:
+        response = await fresh.post("/v1/login/consume", json={"token": raw})
+    assert response.status_code == 200
+    assert response.json().get("merged") is None
+
+
+async def test_consume_omits_merge_when_prior_session_is_verified(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Two verified accounts sharing a browser — silently siphoning one
+    user's data into the other would be data loss. The merge must skip."""
+    rita = await _make_confirmed_user(db_session, "rita@example.com")
+    sam = await _make_confirmed_user(db_session, "sam@example.com")
+    raw_rita = "raw-login-rita"
+    raw_sam = "raw-login-sam"
+    await _issue_login_token(db_session, rita, raw_rita)
+    await _issue_login_token(db_session, sam, raw_sam)
+
+    # Sign in as Sam first to establish a verified session, then "log in" as Rita.
+    sign_in_sam = await api_client.post(
+        "/v1/login/consume", json={"token": raw_sam}
+    )
+    assert sign_in_sam.status_code == 200
+
+    opponent = await make_user(db_session, "opponent-jay")
+    sam_match = await _record_singles_match(db_session, sam, opponent)
+
+    response = await api_client.post(
+        "/v1/login/consume", json={"token": raw_rita}
+    )
+    assert response.status_code == 200
+    assert response.json().get("merged") is None
+
+    # Sam still owns the match.
+    creator_id = (
+        await db_session.execute(
+            select(Match.created_by_user_id).where(Match.id == sam_match.id)
+        )
+    ).scalar_one()
+    assert creator_id == sam.id
+    assert (
+        await db_session.execute(select(User).where(User.id == sam.id))
+    ).scalar_one() is not None

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -870,6 +870,16 @@ export interface components {
          * @enum {string}
          */
         MatchStatus: "pending" | "in_progress" | "completed" | "disputed" | "voided";
+        /**
+         * MergeSummary
+         * @description Reported by sign-in / email-confirm responses when the call merged the
+         *     caller's ephemeral session into a different (verified) account. Drives the
+         *     "we brought your N matches with you" toast.
+         */
+        MergeSummary: {
+            /** Matches Moved */
+            matches_moved: number;
+        };
         /** PermissionCreate */
         PermissionCreate: {
             /** Name */
@@ -1041,6 +1051,7 @@ export interface components {
         /** SessionResponse */
         SessionResponse: {
             data: components["schemas"]["SessionData"];
+            merged?: components["schemas"]["MergeSummary"] | null;
         };
         /** SessionUser */
         SessionUser: {
@@ -1236,7 +1247,9 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody: {
             content: {
@@ -1304,7 +1317,9 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody: {
             content: {

--- a/web-client/src/routes/confirm-email.tsx
+++ b/web-client/src/routes/confirm-email.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { Link, createFileRoute } from '@tanstack/react-router'
+import { toast } from 'sonner'
 
 import { ApiError } from '@/api/client'
 import { useConfirmEmail } from '@/api/session'
@@ -25,6 +26,20 @@ function ConfirmEmailPage() {
     fired.current = true
     confirm.mutate(token)
   }, [token, confirm])
+
+  const toasted = useRef(false)
+  useEffect(() => {
+    if (toasted.current || !confirm.data) return
+    const moved = confirm.data.merged?.matches_moved ?? 0
+    if (moved > 0) {
+      toasted.current = true
+      toast.success(
+        moved === 1
+          ? 'We brought your 1 match with you.'
+          : `We brought your ${moved} matches with you.`,
+      )
+    }
+  }, [confirm.data])
 
   const status: 'missing-token' | 'confirming' | 'ok' | 'error' = !token
     ? 'missing-token'

--- a/web-client/src/routes/confirm-email.tsx
+++ b/web-client/src/routes/confirm-email.tsx
@@ -27,19 +27,17 @@ function ConfirmEmailPage() {
     confirm.mutate(token)
   }, [token, confirm])
 
-  const toasted = useRef(false)
   useEffect(() => {
-    if (toasted.current || !confirm.data) return
-    const moved = confirm.data.merged?.matches_moved ?? 0
+    if (!confirm.isSuccess) return
+    const moved = confirm.data?.merged?.matches_moved ?? 0
     if (moved > 0) {
-      toasted.current = true
       toast.success(
         moved === 1
           ? 'We brought your 1 match with you.'
           : `We brought your ${moved} matches with you.`,
       )
     }
-  }, [confirm.data])
+  }, [confirm.isSuccess, confirm.data])
 
   const status: 'missing-token' | 'confirming' | 'ok' | 'error' = !token
     ? 'missing-token'

--- a/web-client/src/routes/login.test.tsx
+++ b/web-client/src/routes/login.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
+import { toast } from 'sonner'
 import { describe, expect, it, vi } from 'vitest'
 import { server } from '@/mocks/server'
 import { mockSession } from '@/mocks/handlers'
@@ -30,6 +31,14 @@ vi.mock('@/components/turnstile', () => ({
     return <div data-testid="fake-turnstile" />
   },
 }))
+
+vi.mock('sonner', async () => {
+  const actual = await vi.importActual<typeof import('sonner')>('sonner')
+  return {
+    ...actual,
+    toast: { ...actual.toast, success: vi.fn() },
+  }
+})
 
 function renderAt(initialEntry: string) {
   const queryClient = new QueryClient({
@@ -189,5 +198,34 @@ describe('/login/verifying flow', () => {
     expect(
       screen.getByText(/this link is missing its token/i),
     ).toBeInTheDocument()
+  })
+
+  it('toasts the merged-matches count when consume reports a merge', async () => {
+    server.use(
+      http.post('*/v1/login/consume', () =>
+        HttpResponse.json({
+          ...mockSession,
+          merged: { matches_moved: 3 },
+        }),
+      ),
+    )
+    renderAt('/login/verifying?token=good-token-with-merge')
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        'We brought your 3 matches with you.',
+      )
+    })
+  })
+
+  it('does not toast when the consume response carries no merge', async () => {
+    vi.mocked(toast.success).mockClear()
+    renderAt('/login/verifying?token=good-token-no-merge')
+
+    await waitFor(() => {
+      // wait for the consume mutation to settle
+      expect(screen.queryByRole('heading', { name: /welcome back/i })).toBeInTheDocument()
+    })
+    expect(toast.success).not.toHaveBeenCalled()
   })
 })

--- a/web-client/src/routes/login.verifying.tsx
+++ b/web-client/src/routes/login.verifying.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 
 import { api, ApiError, unwrap } from '@/api/client'
 import { SESSION_QUERY_KEY, type Session } from '@/api/session'
@@ -53,6 +54,14 @@ function LoginVerifyingPage() {
         const result = await api.POST('/v1/login/consume', { body: { token } })
         const session = unwrap('sign in', result) as Session
         qc.setQueryData(SESSION_QUERY_KEY, session)
+        const movedMatches = session.merged?.matches_moved ?? 0
+        if (movedMatches > 0) {
+          toast.success(
+            movedMatches === 1
+              ? 'We brought your 1 match with you.'
+              : `We brought your ${movedMatches} matches with you.`,
+          )
+        }
         setState({ status: 'success' })
       } catch (err) {
         setState({ status: 'error', error: err })


### PR DESCRIPTION
## Summary

- On `/v1/login/consume` and `/v1/me/email/confirm`, if the browser arrives with an ephemeral session cookie that resolves to a different user than the token's target, re-point that ephemeral user's matches, league memberships, league ratings, and rating-history audit entries onto the target account, then delete the ephemeral user. Verified prior users are skipped (guards against data-theft between two real accounts sharing a browser).
- New service `app/account_merge.py` runs the whole merge inside the existing request transaction; CASCADE handles `user_tokens` / `user_roles` / leftover rating + membership rows.
- Frontend toasts "We brought your N matches with you" on the verifying screen and the cross-device confirm screen.
- `api/CLAUDE.md` updated with a rule that new `users.id` FKs must update `merge_user`, so future model additions don't silently leak orphans.

**Deferred to a follow-up:** rating recomputation. After a merge the verified user's `user_league_ratings` and `rating_history(user_id)` are stale relative to the freshly-moved matches and need rebuilding from the merged match list.

## Test plan

- [x] `pytest` — 284/284, including 8 new unit tests in `test_account_merge.py` and 3 new integration tests in `test_login.py`
- [x] `npm run test:run` — 65/65, including 2 new vitest cases asserting the toast fires/skips
- [x] `npm run lint && npm run build` — clean
- [x] `npm run test:e2e` (web-client Playwright) — 126/126
- [x] `mise run regen-api-types` — schema in sync (no drift)
- [ ] Manual smoke: sign in via magic link with an ephemeral session that has played at least one match — confirm the toast and that the match shows up under the verified account

🤖 Generated with [Claude Code](https://claude.com/claude-code)