### PR TITLE
Recompute ratings in background after account merge

### DIFF
--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -4,8 +4,8 @@ confirmation (``/v1/me/email/confirm``) when the browser arrived with a
 different ephemeral session than the target account.
 
 Leaves the verified user's ``user_league_ratings`` and ``rating_history``
-stale relative to the freshly-moved matches — rebuilding those is the
-caller's problem and must happen separately.
+stale relative to the freshly-moved matches — the caller enqueues the
+``app.ratings.jobs.recompute_after_merge`` background job to reconcile.
 """
 
 import uuid

--- a/api/app/queue.py
+++ b/api/app/queue.py
@@ -5,6 +5,7 @@ from rq import Queue
 
 SOLVER_QUEUE = "solver"
 EMAIL_QUEUE = "email"
+RATINGS_QUEUE = "ratings"
 
 
 def _connection() -> Redis:
@@ -18,3 +19,7 @@ def get_queue() -> Queue:
 
 def get_email_queue() -> Queue:
     return Queue(EMAIL_QUEUE, connection=_connection())
+
+
+def get_ratings_queue() -> Queue:
+    return Queue(RATINGS_QUEUE, connection=_connection())

--- a/api/app/ratings/jobs.py
+++ b/api/app/ratings/jobs.py
@@ -1,0 +1,63 @@
+"""Background jobs for rating recomputation. Invoked by RQ workers.
+
+The recompute itself is async (it uses ``app.ratings.recompute``), but RQ
+workers are sync processes, so each entry point is a thin ``asyncio.run``
+wrapper that opens its own ``async_sessionmaker`` from ``app.db.get_engine``.
+"""
+
+import asyncio
+import logging
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.db import get_engine
+from app.models import Match, MatchSettings, MatchSidePlayer, MatchStatus
+from app.ratings.recompute import recompute_league_ratings
+
+log = logging.getLogger(__name__)
+
+
+def recompute_after_merge(user_id: str) -> None:
+    """RQ entry point. Re-runs the rating cascade in every league where
+    ``user_id`` has at least one completed rated match — i.e. every league
+    whose timeline could have been disturbed by the just-completed merge.
+
+    Idempotent: the recompute reads current state and rewrites it deterministically,
+    so a retried job lands on the same result.
+    """
+    asyncio.run(_recompute_after_merge(uuid.UUID(user_id)))
+
+
+async def _recompute_after_merge(user_id: uuid.UUID) -> None:
+    sessionmaker = async_sessionmaker(get_engine(), expire_on_commit=False)
+    async with sessionmaker() as session:
+        league_ids = (
+            (
+                await session.execute(
+                    select(Match.league_id)
+                    .join(
+                        MatchSidePlayer,
+                        MatchSidePlayer.match_id == Match.id,
+                    )
+                    .join(
+                        MatchSettings,
+                        MatchSettings.id == Match.match_settings_id,
+                    )
+                    .where(
+                        MatchSidePlayer.user_id == user_id,
+                        Match.status == MatchStatus.completed,
+                        MatchSettings.affects_rating.is_(True),
+                    )
+                    .distinct()
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if not league_ids:
+            return
+        for league_id in league_ids:
+            await recompute_league_ratings(session, league_id, {user_id})
+        await session.commit()

--- a/api/app/ratings/jobs.py
+++ b/api/app/ratings/jobs.py
@@ -18,14 +18,13 @@ from app.ratings.recompute import recompute_league_ratings
 
 log = logging.getLogger(__name__)
 
+RECOMPUTE_AFTER_MERGE_JOB = "app.ratings.jobs.recompute_after_merge"
+
 
 def recompute_after_merge(user_id: str) -> None:
     """RQ entry point. Re-runs the rating cascade in every league where
     ``user_id`` has at least one completed rated match — i.e. every league
     whose timeline could have been disturbed by the just-completed merge.
-
-    Idempotent: the recompute reads current state and rewrites it deterministically,
-    so a retried job lands on the same result.
     """
     asyncio.run(_recompute_after_merge(uuid.UUID(user_id)))
 

--- a/api/app/ratings/recompute.py
+++ b/api/app/ratings/recompute.py
@@ -1,0 +1,251 @@
+"""Rebuild ``rating_history`` and ``user_league_ratings`` after data changes
+upstream of the rating timeline (e.g. an ephemeral→verified account merge
+moved matches onto a user). Operates one league at a time.
+
+The cascade: if user A's rating changes for match M1, and A then played B in
+match M2 > M1, B's post-M2 rating is also stale; anyone B played after M2
+is stale too. We walk forward chronologically from the earliest affected
+match, growing the affected-users set as we discover them.
+"""
+
+import uuid
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models import (
+    League,
+    Match,
+    MatchSettings,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    RatingHistory,
+    RatingHistorySource,
+    UserLeagueRating,
+)
+from app.ratings.base import state_rating_value
+from app.ratings.registry import get_calculator
+from app.ratings.validation import validate_state
+
+
+async def recompute_league_ratings(
+    db: AsyncSession,
+    league_id: uuid.UUID,
+    seed_user_ids: set[uuid.UUID],
+) -> None:
+    """Rebuild rating state for ``league_id`` starting from the earliest
+    completed rated match involving any of ``seed_user_ids``.
+
+    Walks forward in time, propagating staleness through shared matches:
+    once a user's rating is recomputed, every later match they played becomes
+    a recompute. Manual / non-automatic strategies are no-ops. No-op when
+    the seed users have no rated completed matches in this league.
+
+    Runs inside the caller's transaction — does not commit.
+    """
+    league = (
+        await db.execute(
+            select(League)
+            .where(League.id == league_id)
+            .options(selectinload(League.rating_strategy))
+        )
+    ).scalar_one_or_none()
+    if league is None:
+        return
+    strategy = league.rating_strategy
+    if not strategy.is_automatic:
+        return
+    calculator = get_calculator(strategy.key)
+    if calculator is None:
+        return
+
+    # Earliest match (by updated_at) involving a seed user. updated_at is set
+    # when the match completes, which is the moment ratings move.
+    t_start = (
+        await db.execute(
+            select(Match.updated_at)
+            .join(MatchSidePlayer, MatchSidePlayer.match_id == Match.id)
+            .join(MatchSettings, MatchSettings.id == Match.match_settings_id)
+            .where(
+                Match.league_id == league_id,
+                Match.status == MatchStatus.completed,
+                MatchSettings.affects_rating.is_(True),
+                MatchSettings.team_size == 1,
+                MatchSidePlayer.user_id.in_(seed_user_ids),
+            )
+            .order_by(Match.updated_at.asc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if t_start is None:
+        return
+
+    matches = (
+        (
+            await db.execute(
+                select(Match)
+                .join(MatchSettings, MatchSettings.id == Match.match_settings_id)
+                .where(
+                    Match.league_id == league_id,
+                    Match.status == MatchStatus.completed,
+                    Match.updated_at >= t_start,
+                    MatchSettings.affects_rating.is_(True),
+                    MatchSettings.team_size == 1,
+                )
+                .options(
+                    selectinload(Match.sides).selectinload(MatchSide.players)
+                )
+                .order_by(Match.updated_at.asc(), Match.id.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    affected_users: set[uuid.UUID] = set(seed_user_ids)
+    affected_matches: list[Match] = []
+    for match in matches:
+        winning_side = next((s for s in match.sides if s.won is True), None)
+        losing_side = next((s for s in match.sides if s.won is False), None)
+        if (
+            winning_side is None
+            or losing_side is None
+            or not winning_side.players
+            or not losing_side.players
+        ):
+            # Defensive: completed matches always have a winner + loser side,
+            # but skipping a malformed row beats raising mid-cascade.
+            continue
+        participants = {
+            winning_side.players[0].user_id,
+            losing_side.players[0].user_id,
+        }
+        if affected_users & participants:
+            affected_users |= participants
+            affected_matches.append(match)
+
+    if not affected_matches:
+        return
+
+    affected_match_ids = [m.id for m in affected_matches]
+    await db.execute(
+        delete(RatingHistory).where(
+            RatingHistory.league_id == league_id,
+            RatingHistory.match_id.in_(affected_match_ids),
+        )
+    )
+
+    states_by_user: dict[uuid.UUID, dict] = {}
+    for user_id in affected_users:
+        last_pre = (
+            await db.execute(
+                select(RatingHistory)
+                .where(
+                    RatingHistory.league_id == league_id,
+                    RatingHistory.user_id == user_id,
+                    RatingHistory.created_at < t_start,
+                )
+                .order_by(RatingHistory.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if last_pre is not None:
+            states_by_user[user_id] = dict(last_pre.rating_state)
+        elif strategy.initial_state is not None:
+            states_by_user[user_id] = dict(strategy.initial_state)
+        # else: no seed state — skip below.
+
+    ratings = (
+        (
+            await db.execute(
+                select(UserLeagueRating).where(
+                    UserLeagueRating.league_id == league_id,
+                    UserLeagueRating.user_id.in_(affected_users),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    rating_by_user = {r.user_id: r for r in ratings}
+
+    for user_id in affected_users:
+        state = states_by_user.get(user_id)
+        if state is None:
+            continue
+        value = state_rating_value(state)
+        ulr = rating_by_user.get(user_id)
+        if ulr is None:
+            ulr = UserLeagueRating(
+                league_id=league_id,
+                user_id=user_id,
+                rating_state=state,
+                rating_value=value,
+            )
+            db.add(ulr)
+            rating_by_user[user_id] = ulr
+        else:
+            ulr.rating_state = state
+            ulr.rating_value = value
+
+    for match in affected_matches:
+        winning_side = next(s for s in match.sides if s.won is True)
+        losing_side = next(s for s in match.sides if s.won is False)
+        winner_id = winning_side.players[0].user_id
+        loser_id = losing_side.players[0].user_id
+        if winner_id not in states_by_user or loser_id not in states_by_user:
+            continue
+
+        prev_winner_value = state_rating_value(states_by_user[winner_id])
+        prev_loser_value = state_rating_value(states_by_user[loser_id])
+
+        new_winner_state, new_loser_state = calculator.update_singles(
+            states_by_user[winner_id], states_by_user[loser_id]
+        )
+        validate_state(new_winner_state, strategy)
+        validate_state(new_loser_state, strategy)
+
+        states_by_user[winner_id] = new_winner_state
+        states_by_user[loser_id] = new_loser_state
+
+        new_winner_value = state_rating_value(new_winner_state)
+        new_loser_value = state_rating_value(new_loser_state)
+
+        # Stamp the rewritten history rows with the match's completion time
+        # so the chronological ordering used by ``_load_pre_match_rating`` and
+        # the dashboard sparkline survives the rebuild.
+        db.add(
+            RatingHistory(
+                league_id=league_id,
+                user_id=winner_id,
+                match_id=match.id,
+                rating_strategy_id=strategy.id,
+                rating_value=new_winner_value,
+                rating_state=new_winner_state,
+                previous_rating_value=prev_winner_value,
+                source=RatingHistorySource.match,
+                created_at=match.updated_at,
+            )
+        )
+        db.add(
+            RatingHistory(
+                league_id=league_id,
+                user_id=loser_id,
+                match_id=match.id,
+                rating_strategy_id=strategy.id,
+                rating_value=new_loser_value,
+                rating_state=new_loser_state,
+                previous_rating_value=prev_loser_value,
+                source=RatingHistorySource.match,
+                created_at=match.updated_at,
+            )
+        )
+
+        rating_by_user[winner_id].rating_state = new_winner_state
+        rating_by_user[winner_id].rating_value = new_winner_value
+        rating_by_user[loser_id].rating_state = new_loser_state
+        rating_by_user[loser_id].rating_value = new_loser_value
+
+    await db.flush()

--- a/api/app/ratings/recompute.py
+++ b/api/app/ratings/recompute.py
@@ -6,11 +6,14 @@ The cascade: if user A's rating changes for match M1, and A then played B in
 match M2 > M1, B's post-M2 rating is also stale; anyone B played after M2
 is stale too. We walk forward chronologically from the earliest affected
 match, growing the affected-users set as we discover them.
+
+Idempotent: reads current state and rewrites it deterministically, so a
+retried call lands on the same result.
 """
 
 import uuid
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -61,8 +64,8 @@ async def recompute_league_ratings(
     if calculator is None:
         return
 
-    # Earliest match (by updated_at) involving a seed user. updated_at is set
-    # when the match completes, which is the moment ratings move.
+    # updated_at is set when the match completes, which is the moment
+    # ratings move — and what we order the replay by.
     t_start = (
         await db.execute(
             select(Match.updated_at)
@@ -107,17 +110,8 @@ async def recompute_league_ratings(
     affected_users: set[uuid.UUID] = set(seed_user_ids)
     affected_matches: list[Match] = []
     for match in matches:
-        winning_side = next((s for s in match.sides if s.won is True), None)
-        losing_side = next((s for s in match.sides if s.won is False), None)
-        if (
-            winning_side is None
-            or losing_side is None
-            or not winning_side.players
-            or not losing_side.players
-        ):
-            # Defensive: completed matches always have a winner + loser side,
-            # but skipping a malformed row beats raising mid-cascade.
-            continue
+        winning_side = next(s for s in match.sides if s.won is True)
+        losing_side = next(s for s in match.sides if s.won is False)
         participants = {
             winning_side.players[0].user_id,
             losing_side.players[0].user_id,
@@ -137,25 +131,9 @@ async def recompute_league_ratings(
         )
     )
 
-    states_by_user: dict[uuid.UUID, dict] = {}
-    for user_id in affected_users:
-        last_pre = (
-            await db.execute(
-                select(RatingHistory)
-                .where(
-                    RatingHistory.league_id == league_id,
-                    RatingHistory.user_id == user_id,
-                    RatingHistory.created_at < t_start,
-                )
-                .order_by(RatingHistory.created_at.desc())
-                .limit(1)
-            )
-        ).scalar_one_or_none()
-        if last_pre is not None:
-            states_by_user[user_id] = dict(last_pre.rating_state)
-        elif strategy.initial_state is not None:
-            states_by_user[user_id] = dict(strategy.initial_state)
-        # else: no seed state — skip below.
+    states_by_user = await _seed_states(
+        db, league_id, affected_users, t_start, strategy
+    )
 
     ratings = (
         (
@@ -210,42 +188,69 @@ async def recompute_league_ratings(
         states_by_user[winner_id] = new_winner_state
         states_by_user[loser_id] = new_loser_state
 
-        new_winner_value = state_rating_value(new_winner_state)
-        new_loser_value = state_rating_value(new_loser_state)
-
-        # Stamp the rewritten history rows with the match's completion time
-        # so the chronological ordering used by ``_load_pre_match_rating`` and
-        # the dashboard sparkline survives the rebuild.
-        db.add(
-            RatingHistory(
-                league_id=league_id,
-                user_id=winner_id,
-                match_id=match.id,
-                rating_strategy_id=strategy.id,
-                rating_value=new_winner_value,
-                rating_state=new_winner_state,
-                previous_rating_value=prev_winner_value,
-                source=RatingHistorySource.match,
-                created_at=match.updated_at,
+        for user_id, new_state, prev_value in (
+            (winner_id, new_winner_state, prev_winner_value),
+            (loser_id, new_loser_state, prev_loser_value),
+        ):
+            new_value = state_rating_value(new_state)
+            db.add(
+                RatingHistory(
+                    league_id=league_id,
+                    user_id=user_id,
+                    match_id=match.id,
+                    rating_strategy_id=strategy.id,
+                    rating_value=new_value,
+                    rating_state=new_state,
+                    previous_rating_value=prev_value,
+                    source=RatingHistorySource.match,
+                    created_at=match.updated_at,
+                )
             )
-        )
-        db.add(
-            RatingHistory(
-                league_id=league_id,
-                user_id=loser_id,
-                match_id=match.id,
-                rating_strategy_id=strategy.id,
-                rating_value=new_loser_value,
-                rating_state=new_loser_state,
-                previous_rating_value=prev_loser_value,
-                source=RatingHistorySource.match,
-                created_at=match.updated_at,
-            )
-        )
-
-        rating_by_user[winner_id].rating_state = new_winner_state
-        rating_by_user[winner_id].rating_value = new_winner_value
-        rating_by_user[loser_id].rating_state = new_loser_state
-        rating_by_user[loser_id].rating_value = new_loser_value
+            rating_by_user[user_id].rating_state = new_state
+            rating_by_user[user_id].rating_value = new_value
 
     await db.flush()
+
+
+async def _seed_states(
+    db: AsyncSession,
+    league_id: uuid.UUID,
+    user_ids: set[uuid.UUID],
+    t_start,
+    strategy,
+) -> dict[uuid.UUID, dict]:
+    """Per-user rating state as of the moment just before ``t_start``: the
+    user's most recent ``rating_history`` row in this league, or the
+    strategy's initial state if they have none. Users with no history and no
+    initial state (e.g. manual strategy with no seed) are omitted.
+
+    A window function gets all users in one round trip — N affected users
+    would otherwise be N queries."""
+    row_number = func.row_number().over(
+        partition_by=RatingHistory.user_id,
+        order_by=RatingHistory.created_at.desc(),
+    )
+    subq = (
+        select(
+            RatingHistory.user_id,
+            RatingHistory.rating_state,
+            row_number.label("rn"),
+        )
+        .where(
+            RatingHistory.league_id == league_id,
+            RatingHistory.user_id.in_(user_ids),
+            RatingHistory.created_at < t_start,
+        )
+        .subquery()
+    )
+    latest_per_user = await db.execute(
+        select(subq.c.user_id, subq.c.rating_state).where(subq.c.rn == 1)
+    )
+
+    states: dict[uuid.UUID, dict] = {
+        user_id: dict(state) for user_id, state in latest_per_user.all()
+    }
+    if strategy.initial_state is not None:
+        for user_id in user_ids:
+            states.setdefault(user_id, dict(strategy.initial_state))
+    return states

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import os
 import secrets
 from datetime import datetime, timedelta, timezone
@@ -30,6 +31,8 @@ from app.schemas.session import (
     UpdateCurrentUserRequest,
 )
 from app.uniqueness import name_taken
+
+log = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -390,6 +393,28 @@ def _enqueue_login_email(to_email: str, raw_token: str, username: str):
     )
 
 
+def _enqueue_rating_recompute_after_merge(user_id) -> None:
+    """Fire-and-forget the rating recompute for ``user_id`` after a merge.
+
+    Called after the merge has already committed — a Redis flap here can't
+    leave the DB inconsistent because the merge stands on its own. We
+    log+swallow enqueue failures rather than fail the sign-in: the recompute
+    is recoverable (re-run by admin tool or re-fire on next login), but a
+    failed sign-in here is user-visible breakage."""
+    try:
+        queue_module.get_ratings_queue().enqueue(
+            "app.ratings.jobs.recompute_after_merge",
+            str(user_id),
+            result_ttl=60,
+            failure_ttl=86400,
+        )
+    except Exception:
+        log.exception(
+            "Failed to enqueue rating recompute after merge",
+            extra={"user_id": str(user_id)},
+        )
+
+
 @router.post(
     "/v1/me/email",
     response_model=SessionResponse,
@@ -593,6 +618,8 @@ async def confirm_email(
         )
     )
     await db.commit()
+    if merged is not None and merged.matches_moved > 0:
+        _enqueue_rating_recompute_after_merge(user.id)
     _set_session_cookie(response, raw_session)
     return await _build_session_response(db, user, merged=merged)
 
@@ -792,5 +819,7 @@ async def consume_login_token(
         )
     )
     await db.commit()
+    if merged is not None and merged.matches_moved > 0:
+        _enqueue_rating_recompute_after_merge(user.id)
     _set_session_cookie(response, raw_session)
     return await _build_session_response(db, user, merged=merged)

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import os
 import secrets
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Annotated
 
@@ -18,6 +19,7 @@ from app.account_merge import merge_user
 from app.db import get_session
 from app.leagues import add_user_to_default_league
 from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
+from app.ratings.jobs import RECOMPUTE_AFTER_MERGE_JOB
 from app.schemas.session import (
     ConfirmEmailRequest,
     ConsumeLoginRequest,
@@ -393,7 +395,7 @@ def _enqueue_login_email(to_email: str, raw_token: str, username: str):
     )
 
 
-def _enqueue_rating_recompute_after_merge(user_id) -> None:
+def _enqueue_rating_recompute_after_merge(user_id: uuid.UUID) -> None:
     """Fire-and-forget the rating recompute for ``user_id`` after a merge.
 
     Called after the merge has already committed — a Redis flap here can't
@@ -403,7 +405,7 @@ def _enqueue_rating_recompute_after_merge(user_id) -> None:
     failed sign-in here is user-visible breakage."""
     try:
         queue_module.get_ratings_queue().enqueue(
-            "app.ratings.jobs.recompute_after_merge",
+            RECOMPUTE_AFTER_MERGE_JOB,
             str(user_id),
             result_ttl=60,
             failure_ttl=86400,

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -29,6 +29,20 @@ def fake_solver_queue(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def fake_ratings_queue(monkeypatch):
+    """Async-style RQ queue against fakeredis: enqueues are recorded but the
+    job body never runs. The recompute job opens its own DB engine via
+    ``app.db.get_engine()`` which would not point at the testcontainers
+    database; we test the recompute algorithm by calling
+    ``app.ratings.recompute.recompute_league_ratings`` directly, and use this
+    fixture only to assert that callers enqueued the job."""
+    connection = fakeredis.FakeStrictRedis()
+    q = Queue(queue_module.RATINGS_QUEUE, connection=connection, is_async=True)
+    monkeypatch.setattr(queue_module, "get_ratings_queue", lambda: q)
+    return q
+
+
+@pytest.fixture(autouse=True)
 def fake_email_queue(monkeypatch):
     """Sync RQ queue against fakeredis so enqueued jobs execute inline.
 

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -19,6 +19,7 @@ from app.models import (
     User,
     UserToken,
 )
+from app.ratings.jobs import RECOMPUTE_AFTER_MERGE_JOB
 from app.sessions import (
     LOGIN_TOKEN_CONTEXT,
     SESSION_COOKIE_NAME,
@@ -553,7 +554,7 @@ async def test_consume_enqueues_rating_recompute_when_matches_moved(
     jobs = fake_ratings_queue.get_jobs()
     assert len(jobs) == 1
     job = jobs[0]
-    assert job.func_name == "app.ratings.jobs.recompute_after_merge"
+    assert job.func_name == RECOMPUTE_AFTER_MERGE_JOB
     assert job.args == (str(rita.id),)
 
 

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -528,3 +528,62 @@ async def test_consume_omits_merge_when_prior_session_is_verified(
     assert (
         await db_session.execute(select(User).where(User.id == sam.id))
     ).scalar_one() is not None
+
+
+# ---- rating recompute enqueue on merge -----------------------------------
+
+
+async def test_consume_enqueues_rating_recompute_when_matches_moved(
+    api_client: AsyncClient, db_session: AsyncSession, fake_ratings_queue
+):
+    """The merge moved a match — kick off the background rating recompute so
+    the surviving user's ratings catch up to their new match history."""
+    rita = await _make_confirmed_user(db_session, "rita@example.com")
+    raw = "raw-login-token-recompute"
+    await _issue_login_token(db_session, rita, raw)
+
+    guest = await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "opponent-jay")
+    await _record_singles_match(db_session, guest, opponent)
+
+    response = await api_client.post("/v1/login/consume", json={"token": raw})
+    assert response.status_code == 200
+    assert response.json()["merged"] == {"matches_moved": 1}
+
+    jobs = fake_ratings_queue.get_jobs()
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job.func_name == "app.ratings.jobs.recompute_after_merge"
+    assert job.args == (str(rita.id),)
+
+
+async def test_consume_skips_recompute_when_no_matches_moved(
+    api_client: AsyncClient, db_session: AsyncSession, fake_ratings_queue
+):
+    """No matches → no work to do. Don't burn an RQ slot."""
+    rita = await _make_confirmed_user(db_session, "rita@example.com")
+    raw = "raw-login-token-no-matches"
+    await _issue_login_token(db_session, rita, raw)
+
+    # Ephemeral session exists but never played anything.
+    await start_session(api_client, db_session)
+
+    response = await api_client.post("/v1/login/consume", json={"token": raw})
+    assert response.status_code == 200
+    assert response.json()["merged"] == {"matches_moved": 0}
+    assert fake_ratings_queue.get_jobs() == []
+
+
+async def test_consume_skips_recompute_when_no_prior_session(
+    api_client: AsyncClient, db_session: AsyncSession, fake_ratings_queue
+):
+    """Cookieless consume — no merge happens, so no recompute either."""
+    rita = await _make_confirmed_user(db_session, "rita@example.com")
+    raw = "raw-login-token-cookieless"
+    await _issue_login_token(db_session, rita, raw)
+
+    async with make_client() as fresh:
+        response = await fresh.post("/v1/login/consume", json={"token": raw})
+    assert response.status_code == 200
+    assert response.json().get("merged") is None
+    assert fake_ratings_queue.get_jobs() == []

--- a/api/tests/test_rating_recompute.py
+++ b/api/tests/test_rating_recompute.py
@@ -1,0 +1,361 @@
+"""Coverage for ``app.ratings.recompute`` — the forward-walking cascade
+algorithm that rebuilds ratings after a merge moves matches onto a user."""
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.leagues import get_default_league
+from app.models import (
+    League,
+    Match,
+    MatchGame,
+    MatchGameScore,
+    MatchSettings,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    RatingHistory,
+    RatingHistorySource,
+    RatingStrategy,
+    UserLeagueRating,
+)
+from app.ratings.recompute import recompute_league_ratings
+from tests._helpers import make_user
+
+
+# ----- fixtures + helpers -------------------------------------------------
+
+
+async def _seed_rating(
+    db: AsyncSession,
+    league: League,
+    user_id: uuid.UUID,
+    strategy: RatingStrategy,
+) -> UserLeagueRating:
+    """Stand up a fresh ``UserLeagueRating`` row seeded from the strategy.
+    The default-league fixture only attaches the session user; tests build
+    extra users by hand and need their rating rows wired up explicitly."""
+    rating = UserLeagueRating.seed_for_strategy(league.id, user_id, strategy)
+    db.add(rating)
+    await db.commit()
+    await db.refresh(rating)
+    return rating
+
+
+async def _build_completed_match(
+    db: AsyncSession,
+    league: League,
+    winner,
+    loser,
+    completed_at: datetime,
+    affects_rating: bool = True,
+) -> Match:
+    """Persist a singles match with a single 11-4 game and a fixed
+    completion timestamp. ``updated_at`` is what ``recompute_league_ratings``
+    orders by, so we overwrite it via raw SQL to control the chronology
+    without sleeping in tests."""
+    settings = MatchSettings(
+        team_size=1, best_of=1, affects_rating=affects_rating
+    )
+    match = Match(
+        match_settings=settings,
+        league=league,
+        created_by_user_id=winner.id,
+        status=MatchStatus.completed,
+    )
+    side1 = MatchSide(match=match, side_number=1, won=True, score=1)
+    side1.players.append(MatchSidePlayer(match=match, user=winner))
+    side2 = MatchSide(match=match, side_number=2, won=False, score=0)
+    side2.players.append(MatchSidePlayer(match=match, user=loser))
+    game = MatchGame(match=match, game_number=1)
+    game.score = MatchGameScore(side_1_points=11, side_2_points=4)
+    db.add(match)
+    await db.commit()
+    await db.refresh(match)
+
+    await db.execute(
+        text(
+            "UPDATE matches SET created_at = :ts, updated_at = :ts "
+            "WHERE id = :id"
+        ),
+        {"ts": completed_at, "id": match.id},
+    )
+    await db.commit()
+    await db.refresh(match)
+    return match
+
+
+# ----- no-op cases --------------------------------------------------------
+
+
+async def test_recompute_no_matches_is_noop(
+    db_session: AsyncSession,
+):
+    league = await get_default_league(db_session)
+    me = await make_user(db_session, "loner")
+
+    await recompute_league_ratings(db_session, league.id, {me.id})
+
+    rows = (
+        await db_session.execute(select(RatingHistory))
+    ).scalars().all()
+    assert rows == []
+
+
+async def test_recompute_manual_strategy_is_noop(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """A manual league skips the cascade even when the user has matches —
+    the calculator is None, there's nothing to recompute."""
+    default = await get_default_league(db_session)
+    default.rating_strategy_id = rating_strategies["manual"].id
+    await db_session.commit()
+    await db_session.refresh(default)
+
+    me = await make_user(db_session, "me")
+    opp = await make_user(db_session, "opp")
+    await _build_completed_match(
+        db_session, default, me, opp, datetime(2026, 5, 1, tzinfo=timezone.utc)
+    )
+
+    await recompute_league_ratings(db_session, default.id, {me.id})
+
+    rows = (
+        await db_session.execute(select(RatingHistory))
+    ).scalars().all()
+    assert rows == []
+
+
+# ----- cascade graph ------------------------------------------------------
+
+
+async def test_recompute_cascade_propagates_through_shared_matches(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """A→B at T1, B→C at T2, C→D at T3. Seed = {A}. The cascade pulls in B
+    (via T1), C (via T2), and D (via T3) — all three matches get new
+    history rows."""
+    league = await get_default_league(db_session)
+    strategy = rating_strategies["glicko2"]
+    a = await make_user(db_session, "alpha")
+    b = await make_user(db_session, "bravo")
+    c = await make_user(db_session, "charlie")
+    d = await make_user(db_session, "delta")
+    for user in (a, b, c, d):
+        await _seed_rating(db_session, league, user.id, strategy)
+
+    base = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    m1 = await _build_completed_match(
+        db_session, league, a, b, base
+    )
+    m2 = await _build_completed_match(
+        db_session, league, b, c, base + timedelta(hours=1)
+    )
+    m3 = await _build_completed_match(
+        db_session, league, c, d, base + timedelta(hours=2)
+    )
+
+    await recompute_league_ratings(db_session, league.id, {a.id})
+    await db_session.commit()
+
+    # Two rating_history rows per recomputed match — one per side.
+    rows = (
+        await db_session.execute(
+            select(RatingHistory).where(
+                RatingHistory.match_id.in_([m1.id, m2.id, m3.id])
+            )
+        )
+    ).scalars().all()
+    assert {row.match_id for row in rows} == {m1.id, m2.id, m3.id}
+    assert len(rows) == 6
+
+    # Stamped with the match's completion time, not wall-clock-now.
+    by_match = {m.id: m for m in (m1, m2, m3)}
+    for row in rows:
+        assert row.created_at == by_match[row.match_id].updated_at
+
+    # The current rating rows reflect the rebuilt state.
+    a_rating = (
+        await db_session.execute(
+            select(UserLeagueRating).where(UserLeagueRating.user_id == a.id)
+        )
+    ).scalar_one()
+    d_rating = (
+        await db_session.execute(
+            select(UserLeagueRating).where(UserLeagueRating.user_id == d.id)
+        )
+    ).scalar_one()
+    # A won m1 against a peer → up from 1500. D lost m3 to a since-updated C →
+    # below 1500.
+    assert a_rating.rating_value > 1500.0
+    assert d_rating.rating_value < 1500.0
+
+
+async def test_recompute_leaves_unrelated_matches_alone(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """X→Y is independent of the seed user's match. The cascade walks past
+    it without rewriting its history."""
+    league = await get_default_league(db_session)
+    strategy = rating_strategies["glicko2"]
+    me = await make_user(db_session, "me")
+    opp = await make_user(db_session, "opp")
+    x = await make_user(db_session, "ex")
+    y = await make_user(db_session, "why")
+    for user in (me, opp, x, y):
+        await _seed_rating(db_session, league, user.id, strategy)
+
+    base = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    my_match = await _build_completed_match(db_session, league, me, opp, base)
+    unrelated = await _build_completed_match(
+        db_session, league, x, y, base + timedelta(hours=1)
+    )
+
+    # Pre-seed a rating_history row for the unrelated match so we can prove
+    # it's untouched. Source isn't `match` so it falls outside the wipe
+    # filter — but we use match-sourced rows to mirror real data.
+    pre_existing = RatingHistory(
+        league_id=league.id,
+        user_id=x.id,
+        match_id=unrelated.id,
+        rating_strategy_id=strategy.id,
+        rating_value=1234.5,
+        rating_state={"rating": 1234.5, "rd": 200.0, "volatility": 0.06},
+        source=RatingHistorySource.match,
+    )
+    db_session.add(pre_existing)
+    await db_session.commit()
+    await db_session.refresh(pre_existing)
+    pre_id = pre_existing.id
+
+    await recompute_league_ratings(db_session, league.id, {me.id})
+    await db_session.commit()
+
+    # The pre-seeded row survives unchanged.
+    surviving = (
+        await db_session.execute(
+            select(RatingHistory).where(RatingHistory.id == pre_id)
+        )
+    ).scalar_one()
+    assert surviving.rating_value == 1234.5
+
+    # The seed user's match did produce its own history rows.
+    mine = (
+        await db_session.execute(
+            select(RatingHistory).where(RatingHistory.match_id == my_match.id)
+        )
+    ).scalars().all()
+    assert {row.user_id for row in mine} == {me.id, opp.id}
+
+
+# ----- pre-window state ---------------------------------------------------
+
+
+async def test_recompute_restores_user_to_last_pre_window_rating(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """An older history row before T_start is the baseline the recompute
+    walks forward from — not the strategy's seed value. This guards against
+    silently wiping a player back to 1500 every time a peer merges."""
+    league = await get_default_league(db_session)
+    strategy = rating_strategies["glicko2"]
+    me = await make_user(db_session, "me")
+    opp = await make_user(db_session, "opp")
+    later_opp = await make_user(db_session, "later-opp")
+    for user in (me, opp, later_opp):
+        await _seed_rating(db_session, league, user.id, strategy)
+
+    base = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    # Pre-window: opp already played a match and sits at 1550 going in.
+    pre_match = await _build_completed_match(
+        db_session, league, opp, later_opp, base - timedelta(days=30)
+    )
+    db_session.add(
+        RatingHistory(
+            league_id=league.id,
+            user_id=opp.id,
+            match_id=pre_match.id,
+            rating_strategy_id=strategy.id,
+            rating_value=1550.0,
+            rating_state={"rating": 1550.0, "rd": 300.0, "volatility": 0.06},
+            source=RatingHistorySource.match,
+            previous_rating_value=1500.0,
+        )
+    )
+    await db_session.commit()
+    await db_session.execute(
+        text(
+            "UPDATE rating_history SET created_at = :ts WHERE match_id = :id"
+        ),
+        {"ts": base - timedelta(days=30), "id": pre_match.id},
+    )
+    await db_session.commit()
+
+    # Window match: me beats opp. The recompute should seed opp from 1550,
+    # not from 1500.
+    in_window = await _build_completed_match(db_session, league, me, opp, base)
+
+    await recompute_league_ratings(db_session, league.id, {me.id})
+    await db_session.commit()
+
+    opp_row = (
+        await db_session.execute(
+            select(RatingHistory).where(
+                RatingHistory.match_id == in_window.id,
+                RatingHistory.user_id == opp.id,
+            )
+        )
+    ).scalar_one()
+    assert opp_row.previous_rating_value == 1550.0
+
+
+# ----- idempotency --------------------------------------------------------
+
+
+async def test_recompute_is_idempotent(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    league = await get_default_league(db_session)
+    strategy = rating_strategies["glicko2"]
+    me = await make_user(db_session, "me")
+    opp = await make_user(db_session, "opp")
+    for user in (me, opp):
+        await _seed_rating(db_session, league, user.id, strategy)
+
+    await _build_completed_match(
+        db_session, league, me, opp, datetime(2026, 5, 1, tzinfo=timezone.utc)
+    )
+
+    await recompute_league_ratings(db_session, league.id, {me.id})
+    await db_session.commit()
+    first = {
+        r.user_id: r.rating_value
+        for r in (
+            await db_session.execute(select(UserLeagueRating))
+        ).scalars().all()
+    }
+
+    await recompute_league_ratings(db_session, league.id, {me.id})
+    await db_session.commit()
+    second = {
+        r.user_id: r.rating_value
+        for r in (
+            await db_session.execute(select(UserLeagueRating))
+        ).scalars().all()
+    }
+
+    assert first == second
+    # And only one set of history rows survives.
+    rows = (
+        await db_session.execute(
+            select(RatingHistory).where(RatingHistory.user_id == me.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1

--- a/api/tests/test_rating_recompute.py
+++ b/api/tests/test_rating_recompute.py
@@ -162,7 +162,6 @@ async def test_recompute_cascade_propagates_through_shared_matches(
     await recompute_league_ratings(db_session, league.id, {a.id})
     await db_session.commit()
 
-    # Two rating_history rows per recomputed match — one per side.
     rows = (
         await db_session.execute(
             select(RatingHistory).where(
@@ -173,12 +172,10 @@ async def test_recompute_cascade_propagates_through_shared_matches(
     assert {row.match_id for row in rows} == {m1.id, m2.id, m3.id}
     assert len(rows) == 6
 
-    # Stamped with the match's completion time, not wall-clock-now.
     by_match = {m.id: m for m in (m1, m2, m3)}
     for row in rows:
         assert row.created_at == by_match[row.match_id].updated_at
 
-    # The current rating rows reflect the rebuilt state.
     a_rating = (
         await db_session.execute(
             select(UserLeagueRating).where(UserLeagueRating.user_id == a.id)
@@ -189,8 +186,6 @@ async def test_recompute_cascade_propagates_through_shared_matches(
             select(UserLeagueRating).where(UserLeagueRating.user_id == d.id)
         )
     ).scalar_one()
-    # A won m1 against a peer → up from 1500. D lost m3 to a since-updated C →
-    # below 1500.
     assert a_rating.rating_value > 1500.0
     assert d_rating.rating_value < 1500.0
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -60,7 +60,7 @@ services:
         condition: service_healthy
     volumes:
       - ./api:/app
-    command: rq worker --url redis://redis:6379/0 solver
+    command: rq worker --url redis://redis:6379/0 solver email ratings
 
   web-client:
     build:


### PR DESCRIPTION
## Summary

- After the ephemeral→verified account merge re-points matches onto a surviving user, their `user_league_ratings` and `rating_history` are stale relative to the freshly-moved matches. This adds a forward-walking cascade recompute that runs as a background job on a new `ratings` RQ queue.
- The cascade: find the earliest completed-rated match involving the merged user, walk forward chronologically, grow the affected-users set when an affected user appears on a match, replay only those matches. Skips work entirely when the user has no rated completed matches in a league.
- Enqueued post-commit from `confirm_email` and `consume_login_token` only when `matches_moved > 0`. The dev-compose worker now drains `solver email ratings` so the job actually runs locally.

Follow-ups filed: #244 #245 #246 #247 #248.

## Test plan

- [x] `pytest` — 293 passed (6 new recompute unit tests + 3 enqueue integration tests).
- [x] `npm run lint && npm run build && npm run test:run` in `web-client` — green.
- [x] `npm run test:e2e` in `web-client` — 126 passed.
- [ ] Skipped root `e2e/` — no UI changes; requires docker stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)