### PR TITLE
Consume change-email tokens at confirm time (replaces #222)

### DIFF
--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -16,6 +16,11 @@ class SessionUser(BaseModel):
     permissions: list[str]
     email: str | None = None
     confirmed_at: datetime | None = None
+    # Pending change address. Lives only on the change token until
+    # ``confirm_email`` consumes it; surfaced here so the FE can show
+    # "verification sent to NEW" while ``email`` still reflects the
+    # user's confirmed prior address.
+    pending_email: str | None = None
 
 
 class SessionData(BaseModel):

--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -16,10 +16,6 @@ class SessionUser(BaseModel):
     permissions: list[str]
     email: str | None = None
     confirmed_at: datetime | None = None
-    # Pending change address. Lives only on the change token until
-    # ``confirm_email`` consumes it; surfaced here so the FE can show
-    # "verification sent to NEW" while ``email`` still reflects the
-    # user's confirmed prior address.
     pending_email: str | None = None
 
 

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -55,6 +55,13 @@ def _email_change_context(old_email: str | None) -> str:
     return f"{EMAIL_CHANGE_CONTEXT_PREFIX}{old_email or ''}"
 
 
+def _old_email_from_context(context: str) -> str | None:
+    """Inverse of ``_email_change_context``: decode the prior confirmed
+    address out of a change token's context. ``change:`` (empty suffix)
+    means there was no prior confirmed address."""
+    return context[len(EMAIL_CHANGE_CONTEXT_PREFIX):] or None
+
+
 def _hash_cookie_for_key(cookie: str) -> str:
     """Hash the raw session cookie before putting it into a Redis key. The
     cookie is a bearer credential; if it lands in Redis verbatim (snapshots,
@@ -162,6 +169,7 @@ async def _build_session_response(
     db: AsyncSession, user: User, merged: MergeSummary | None = None
 ) -> SessionResponse:
     permissions = await _load_permissions(db, user.id)
+    pending = await _pending_change_token(db, user.id)
     return SessionResponse(
         data=SessionData(
             user=SessionUser(
@@ -169,6 +177,7 @@ async def _build_session_response(
                 permissions=permissions,
                 email=user.email,
                 confirmed_at=user.confirmed_at,
+                pending_email=pending.sent_to if pending else None,
             )
         ),
         merged=merged,
@@ -326,21 +335,23 @@ async def _verify_captcha_or_400(captcha_token: str) -> None:
         )
 
 
-async def _existing_change_context(
+async def _pending_change_token(
     db: AsyncSession, user_id
-) -> str | None:
-    """Return the context of the user's pending email-change token, if any.
-    Lets ``resend`` preserve the original "change:" + old_email signature
-    instead of guessing once the user's row has been overwritten."""
+) -> UserToken | None:
+    """Return the user's pending email-change token, if any. Resend needs
+    both the prior ``context`` (audit trail) and ``sent_to`` (where to
+    re-deliver) — now that ``user.email`` no longer mirrors the pending
+    address, the token is the only source of truth for the resend target.
+    Also drives the ``pending_email`` field on the session response."""
     result = await db.execute(
-        select(UserToken.context)
+        select(UserToken)
         .where(
             UserToken.user_id == user_id,
             UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
         )
         .limit(1)
     )
-    return result.scalars().first()
+    return result.scalar_one_or_none()
 
 
 async def _issue_confirmation_token(
@@ -441,7 +452,11 @@ async def set_email(
 
     email = payload.email.lower()
     old_email = current_user.email
-    if current_user.email != email and await name_taken(
+    # Already-verified-for-this-address resubmits are a no-op: nothing to
+    # confirm, no email worth sending.
+    if old_email == email and current_user.confirmed_at is not None:
+        return await _build_session_response(db, current_user)
+    if old_email != email and await name_taken(
         db, User.id, User.email, email, exclude_id=current_user.id
     ):
         # Don't reveal that the email belongs to another user — that
@@ -452,12 +467,10 @@ async def set_email(
         # a "sent" toast but never receives an email.
         return await _build_session_response(db, current_user)
 
-    if current_user.email != email:
-        current_user.email = email
-
-    # Every successful set_email re-starts the confirmation handshake — the
-    # user must click the new link even if they re-submitted the same address.
-    current_user.confirmed_at = None
+    # The new address lives only on the token until ``confirm_email``
+    # consumes it. Do NOT mutate ``current_user.email`` or
+    # ``current_user.confirmed_at`` here — the user keeps their prior
+    # verified status until they click the link from the new inbox.
     raw_token = await _issue_confirmation_token(
         db, current_user, email, _email_change_context(old_email)
     )
@@ -510,30 +523,27 @@ async def resend_email_confirmation(
 ) -> SessionResponse:
     if payload.fmm_hp_token.strip():
         return await _build_session_response(db, current_user)
-    if not current_user.email:
+    # The pending change token is the single source of truth for what to
+    # resend — ``user.email`` no longer mirrors the pending address. No
+    # token means nothing to resend (the user is either verified with no
+    # change in flight, or hasn't started one yet).
+    pending = await _pending_change_token(db, current_user.id)
+    if pending is None or not pending.sent_to:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Add an email address before requesting a resend.",
-        )
-    if current_user.confirmed_at is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="This email is already confirmed.",
+            detail="No pending email change to resend.",
         )
     await _verify_captcha_or_400(payload.captcha_token)
 
-    # Reuse the prior token's context so the audit trail still records what
-    # the user was originally changing away from.
-    prior_context = await _existing_change_context(db, current_user.id)
     raw_token = await _issue_confirmation_token(
         db,
         current_user,
-        current_user.email,
-        prior_context or _email_change_context(None),
+        pending.sent_to,
+        pending.context,
     )
     try:
         job = _enqueue_confirmation_email(
-            current_user.email, raw_token, current_user.username
+            pending.sent_to, raw_token, current_user.username
         )
     except Exception:
         await db.rollback()
@@ -562,7 +572,11 @@ async def confirm_email(
     ] = None,
     db: AsyncSession = Depends(get_session),
 ) -> SessionResponse:
-    """Confirm the email-change handshake.
+    """Consume an email-change token: stamp the new email + ``confirmed_at``.
+
+    Invariant: ``user.email`` holds the prior confirmed address; the new
+    address lives on ``token.sent_to`` until this endpoint runs. This is
+    the single place either column flips.
 
     The token in the email is itself the bearer credential — we don't
     require the click to come from the same browser that requested it.
@@ -595,31 +609,49 @@ async def confirm_email(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="That confirmation link is invalid or expired.",
         )
-    if token_row.sent_to and token_row.sent_to != user.email:
-        # The user changed their email between request and click — the link
-        # no longer matches the intended address.
+    expected_old = _old_email_from_context(token_row.context)
+    if user.email != expected_old:
+        # The user's current confirmed address no longer matches the one
+        # this token was cut against — could be an admin reset, or a stale
+        # token from a prior change. Burn it and surface the generic
+        # "invalid or expired" so we don't leak any state to the caller.
         await db.delete(token_row)
         await db.commit()
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="That confirmation link no longer matches your email.",
+            detail="That confirmation link is invalid or expired.",
         )
 
-    user.confirmed_at = datetime.now(timezone.utc)
-    await db.delete(token_row)
-    merged = await _maybe_merge_prior_session(db, session_cookie, user)
-    # Mint a fresh session for the token's owner so the confirming browser
-    # is signed in as them — replaces whatever guest session this browser
-    # had (or hadn't) on arrival.
+    # Wrap from the email mutation through commit so a `users.email`
+    # autoflush triggered by a downstream query (e.g. inside
+    # ``_maybe_merge_prior_session``) is caught here, not propagated as a
+    # 500. Another user confirming the same address between this token
+    # being issued and this click trips the unique constraint — surface
+    # the opaque "invalid or expired" because "that address is now taken"
+    # would leak who owns it.
     raw_session = secrets.token_urlsafe(32)
-    db.add(
-        UserToken(
-            user_id=user.id,
-            context=SESSION_TOKEN_CONTEXT,
-            token=_hash_token(raw_session),
+    try:
+        user.email = token_row.sent_to
+        user.confirmed_at = datetime.now(timezone.utc)
+        await db.delete(token_row)
+        merged = await _maybe_merge_prior_session(db, session_cookie, user)
+        # Mint a fresh session for the token's owner so the confirming
+        # browser is signed in as them — replaces whatever guest session
+        # this browser had (or hadn't) on arrival.
+        db.add(
+            UserToken(
+                user_id=user.id,
+                context=SESSION_TOKEN_CONTEXT,
+                token=_hash_token(raw_session),
+            )
         )
-    )
-    await db.commit()
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That confirmation link is invalid or expired.",
+        )
     if merged is not None and merged.matches_moved > 0:
         _enqueue_rating_recompute_after_merge(user.id)
     _set_session_cookie(response, raw_session)
@@ -719,9 +751,9 @@ async def _issue_and_send_confirmation_email(
     """Re-issue this user's pending email-confirmation link. Preserves the
     prior change-token's context so the audit trail still records what the
     user was originally changing away from."""
-    prior_context = await _existing_change_context(db, user.id)
+    prior = await _pending_change_token(db, user.id)
     raw_token = await _issue_confirmation_token(
-        db, user, email, prior_context or _email_change_context(None)
+        db, user, email, prior.context if prior else _email_change_context(None)
     )
     try:
         job = _enqueue_confirmation_email(email, raw_token, user.username)

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -56,10 +56,8 @@ def _email_change_context(old_email: str | None) -> str:
 
 
 def _old_email_from_context(context: str) -> str | None:
-    """Inverse of ``_email_change_context``: decode the prior confirmed
-    address out of a change token's context. ``change:`` (empty suffix)
-    means there was no prior confirmed address."""
-    return context[len(EMAIL_CHANGE_CONTEXT_PREFIX):] or None
+    """Inverse of ``_email_change_context``."""
+    return context.removeprefix(EMAIL_CHANGE_CONTEXT_PREFIX) or None
 
 
 def _hash_cookie_for_key(cookie: str) -> str:
@@ -452,8 +450,6 @@ async def set_email(
 
     email = payload.email.lower()
     old_email = current_user.email
-    # Already-verified-for-this-address resubmits are a no-op: nothing to
-    # confirm, no email worth sending.
     if old_email == email and current_user.confirmed_at is not None:
         return await _build_session_response(db, current_user)
     if old_email != email and await name_taken(
@@ -467,10 +463,6 @@ async def set_email(
         # a "sent" toast but never receives an email.
         return await _build_session_response(db, current_user)
 
-    # The new address lives only on the token until ``confirm_email``
-    # consumes it. Do NOT mutate ``current_user.email`` or
-    # ``current_user.confirmed_at`` here — the user keeps their prior
-    # verified status until they click the link from the new inbox.
     raw_token = await _issue_confirmation_token(
         db, current_user, email, _email_change_context(old_email)
     )
@@ -523,10 +515,6 @@ async def resend_email_confirmation(
 ) -> SessionResponse:
     if payload.fmm_hp_token.strip():
         return await _build_session_response(db, current_user)
-    # The pending change token is the single source of truth for what to
-    # resend — ``user.email`` no longer mirrors the pending address. No
-    # token means nothing to resend (the user is either verified with no
-    # change in flight, or hasn't started one yet).
     pending = await _pending_change_token(db, current_user.id)
     if pending is None or not pending.sent_to:
         raise HTTPException(
@@ -622,22 +610,18 @@ async def confirm_email(
             detail="That confirmation link is invalid or expired.",
         )
 
-    # Wrap from the email mutation through commit so a `users.email`
-    # autoflush triggered by a downstream query (e.g. inside
-    # ``_maybe_merge_prior_session``) is caught here, not propagated as a
-    # 500. Another user confirming the same address between this token
-    # being issued and this click trips the unique constraint — surface
-    # the opaque "invalid or expired" because "that address is now taken"
-    # would leak who owns it.
+    # ``_maybe_merge_prior_session`` runs a query that triggers an
+    # autoflush of ``user.email`` before our explicit commit, so the
+    # users.email unique-constraint race (another user confirmed this
+    # address first) can surface anywhere in this block — not just at
+    # commit. Return the opaque "invalid or expired" so we don't leak
+    # who owns the address.
     raw_session = secrets.token_urlsafe(32)
     try:
         user.email = token_row.sent_to
         user.confirmed_at = datetime.now(timezone.utc)
         await db.delete(token_row)
         merged = await _maybe_merge_prior_session(db, session_cookie, user)
-        # Mint a fresh session for the token's owner so the confirming
-        # browser is signed in as them — replaces whatever guest session
-        # this browser had (or hadn't) on arrival.
         db.add(
             UserToken(
                 user_id=user.id,

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -53,21 +53,26 @@ async def test_session_response_includes_email_fields(
     user = response.json()["data"]["user"]
     assert user["email"] is None
     assert user["confirmed_at"] is None
+    assert user["pending_email"] is None
 
 
-async def test_set_email_persists_and_enqueues_send(
+async def test_set_email_is_pending_only(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
+    """``set_email`` issues a token and enqueues delivery but does not
+    mutate ``user.email`` or ``user.confirmed_at`` — the new address lives
+    only on the token until ``confirm_email`` consumes it."""
     user = await start_session(api_client, db_session)
     response = await _set_email(api_client)
     assert response.status_code == 202
 
     body_user = response.json()["data"]["user"]
-    assert body_user["email"] == "rita@example.com"
+    assert body_user["email"] is None
     assert body_user["confirmed_at"] is None
+    assert body_user["pending_email"] == "rita@example.com"
 
     await db_session.refresh(user)
-    assert user.email == "rita@example.com"
+    assert user.email is None
     assert user.confirmed_at is None
 
     tokens = (
@@ -95,11 +100,18 @@ async def test_set_email_requires_session(api_client: AsyncClient):
 async def test_set_email_normalizes_to_lowercase(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    user = await start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     response = await _set_email(api_client, email="MixedCase@Example.COM")
     assert response.status_code == 202
-    await db_session.refresh(user)
-    assert user.email == "mixedcase@example.com"
+    token = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+            )
+        )
+    ).scalar_one()
+    assert token.sent_to == "mixedcase@example.com"
+    assert response.json()["data"]["user"]["pending_email"] == "mixedcase@example.com"
 
 
 async def test_set_email_rejects_invalid_format(api_client: AsyncClient, db_session):
@@ -177,15 +189,16 @@ async def test_set_email_with_taken_address_is_enumeration_safe(
     assert fake_email_queue.finished_job_registry.count == 0
 
 
-async def test_token_context_records_old_email(
+async def test_token_context_records_confirmed_prior_email(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    """Tokens carry their pre-change address in their context so we have an
-    audit trail of what each one was changing FROM. First-time set leaves
-    the address empty."""
-    await start_session(api_client, db_session)
+    """Tokens carry the user's *confirmed* prior address in their context
+    so we have an audit trail of what each token was changing FROM.
+    Unconfirmed re-submits keep context=``change:`` because nothing was
+    ever verified to change FROM."""
+    user = await start_session(api_client, db_session)
 
-    # First-time set — no prior address.
+    # First-time set — no prior confirmed address.
     await _set_email(api_client, email="first@example.com")
     token = (
         await db_session.execute(
@@ -197,7 +210,8 @@ async def test_token_context_records_old_email(
     assert token.context == "change:"
     assert token.sent_to == "first@example.com"
 
-    # Change to a new address — the old one shows up in the context.
+    # Re-submit before confirming — the first address was never confirmed
+    # so the context still records no prior address.
     await _set_email(api_client, email="second@example.com")
     token = (
         await db_session.execute(
@@ -206,8 +220,24 @@ async def test_token_context_records_old_email(
             )
         )
     ).scalar_one()
-    assert token.context == "change:first@example.com"
+    assert token.context == "change:"
     assert token.sent_to == "second@example.com"
+
+    # Simulate confirmation, then change again — now the context picks up
+    # the newly-confirmed prior address.
+    user.email = "second@example.com"
+    user.confirmed_at = datetime.now(timezone.utc)
+    await db_session.commit()
+    await _set_email(api_client, email="third@example.com")
+    token = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+            )
+        )
+    ).scalar_one()
+    assert token.context == "change:second@example.com"
+    assert token.sent_to == "third@example.com"
 
 
 async def test_resend_preserves_original_change_context(
@@ -267,11 +297,11 @@ async def test_set_email_replaces_existing_unconfirmed_token(
     assert tokens[0].sent_to == "rita2@example.com"
 
 
-async def test_resubmitting_same_email_clears_confirmation(
+async def test_resubmitting_same_email_when_verified_is_a_noop(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    """Even when the address didn't change, calling set_email un-confirms
-    the user — they must click the fresh link to re-prove ownership."""
+    """Resubmitting the address the user is already verified for has
+    nothing to confirm — no token issued, no email sent, no state change."""
     user = await start_session(api_client, db_session)
     raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
     await api_client.post(
@@ -279,39 +309,60 @@ async def test_resubmitting_same_email_clears_confirmation(
     )
     await db_session.refresh(user)
     assert user.confirmed_at is not None
+    sent_count = fake_email_queue.finished_job_registry.count
 
-    await _set_email(api_client)  # same email as VALID_BODY
+    response = await _set_email(api_client)  # same email as VALID_BODY
+    assert response.status_code == 202
+    body_user = response.json()["data"]["user"]
+    assert body_user["pending_email"] is None
+    assert body_user["confirmed_at"] is not None
+
     await db_session.refresh(user)
-    assert user.confirmed_at is None
+    assert user.confirmed_at is not None
     assert user.email == "rita@example.com"
+    # No second email enqueued for the no-op resubmit.
+    assert fake_email_queue.finished_job_registry.count == sent_count
+    # No pending token left behind either.
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+            )
+        )
+    ).scalars().all()
+    assert tokens == []
 
 
-async def test_changing_email_clears_confirmation(
+async def test_changing_email_preserves_prior_verification(
     api_client: AsyncClient, db_session: AsyncSession
 ):
+    """Requesting a change to a NEW address must not un-verify the user —
+    they keep their verified state for the prior address until they click
+    the link from the new inbox."""
     user = await start_session(api_client, db_session)
-    await _set_email(api_client)
+    user.email = "prior@example.com"
+    user.confirmed_at = datetime.now(timezone.utc)
+    await db_session.commit()
 
-    # Confirm out-of-band to set confirmed_at.
-    token_row = (
+    response = await _set_email(api_client, email="changed@example.com")
+    assert response.status_code == 202
+    body_user = response.json()["data"]["user"]
+    assert body_user["email"] == "prior@example.com"
+    assert body_user["confirmed_at"] is not None
+    assert body_user["pending_email"] == "changed@example.com"
+
+    await db_session.refresh(user)
+    assert user.email == "prior@example.com"
+    assert user.confirmed_at is not None
+    token = (
         await db_session.execute(
             select(UserToken).where(
                 UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
             )
         )
     ).scalar_one()
-    # We don't know the raw token in this test, so simulate by changing email
-    # while user is confirmed.
-    user.confirmed_at = datetime.now(timezone.utc)
-    await db_session.delete(token_row)
-    await db_session.commit()
-    await db_session.refresh(user)
-    assert user.confirmed_at is not None
-
-    await _set_email(api_client, email="changed@example.com")
-    await db_session.refresh(user)
-    assert user.confirmed_at is None
-    assert user.email == "changed@example.com"
+    assert token.context == "change:prior@example.com"
+    assert token.sent_to == "changed@example.com"
 
 
 # ---- confirm email --------------------------------------------------------
@@ -350,9 +401,12 @@ async def test_confirm_email_sets_confirmed_at_and_invalidates_token(
     )
     assert response.status_code == 200
     body_user = response.json()["data"]["user"]
+    assert body_user["email"] == "rita@example.com"
     assert body_user["confirmed_at"] is not None
+    assert body_user["pending_email"] is None
 
     await db_session.refresh(user)
+    assert user.email == "rita@example.com"
     assert user.confirmed_at is not None
 
     # Token consumed.
@@ -412,6 +466,74 @@ async def test_confirm_email_works_from_a_different_browser(
     assert user_a.confirmed_at is not None
 
 
+async def test_confirm_email_rejects_when_user_email_no_longer_matches_token_context(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """The token's context records the user's confirmed prior address at
+    issue time. If the user's current ``email`` no longer matches that
+    (admin reset, stale token, etc.), the token is no longer trustworthy —
+    confirm must burn it and return the opaque "invalid or expired"."""
+    user = await start_session(api_client, db_session)
+    user.email = "prior@example.com"
+    user.confirmed_at = datetime.now(timezone.utc)
+    await db_session.commit()
+
+    raw_token = await _capture_raw_token(
+        api_client, db_session, fake_email_queue, email="next@example.com"
+    )
+
+    # Out-of-band reset of the user's email — context was cut against
+    # "prior@example.com" but now points elsewhere.
+    user.email = "different@example.com"
+    await db_session.commit()
+
+    response = await api_client.post(
+        "/v1/me/email/confirm", json={"token": raw_token}
+    )
+    assert response.status_code == 400
+    # Token burned.
+    tokens = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+            )
+        )
+    ).scalars().all()
+    assert tokens == []
+
+
+async def test_confirm_email_handles_address_race(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """If a second user grabs the same address between this user's token
+    being issued and the click, the commit hits the ``users.email`` unique
+    constraint. Surface the same opaque error as any other invalid link —
+    "that address is now taken" would leak who owns it."""
+    me = await start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(
+        api_client, db_session, fake_email_queue, email="contested@example.com"
+    )
+
+    # A different user confirms the same address first.
+    db_session.add(
+        User(
+            username="other",
+            email="contested@example.com",
+            confirmed_at=datetime.now(timezone.utc),
+        )
+    )
+    await db_session.commit()
+
+    response = await api_client.post(
+        "/v1/me/email/confirm", json={"token": raw_token}
+    )
+    assert response.status_code == 400
+    await db_session.refresh(me)
+    # Caller's row is untouched — the rollback preserved their prior state.
+    assert me.email is None
+    assert me.confirmed_at is None
+
+
 async def test_confirm_email_does_not_require_session(api_client: AsyncClient):
     """Cookieless POST to /confirm-email is the cross-device mobile-mail
     case — it should return 400 (invalid token) not 401 (no session)."""
@@ -466,9 +588,11 @@ async def test_resend_issues_new_token(
     assert confirm.status_code == 400
 
 
-async def test_resend_requires_email_set(
+async def test_resend_requires_pending_change(
     api_client: AsyncClient, db_session: AsyncSession
 ):
+    """No pending token → nothing to resend. Covers both the never-set and
+    the already-verified-with-no-change-in-flight cases."""
     await start_session(api_client, db_session)
     response = await api_client.post(
         "/v1/me/email/resend",
@@ -477,9 +601,11 @@ async def test_resend_requires_email_set(
     assert response.status_code == 400
 
 
-async def test_resend_rejects_if_already_confirmed(
+async def test_resend_400s_after_confirm_consumes_the_token(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
+    """Once the user confirms, the pending token is gone — resend has
+    nothing left to send and returns 400 (not 409 like the old flow)."""
     user = await start_session(api_client, db_session)
     raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
     await api_client.post(
@@ -492,7 +618,7 @@ async def test_resend_rejects_if_already_confirmed(
         "/v1/me/email/resend",
         json={"captcha_token": "x", "fmm_hp_token": ""},
     )
-    assert response.status_code == 409
+    assert response.status_code == 400
 
 
 async def test_resend_honeypot_short_circuits(

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -83,7 +83,11 @@ export interface paths {
         put?: never;
         /**
          * Confirm Email
-         * @description Confirm the email-change handshake.
+         * @description Consume an email-change token: stamp the new email + ``confirmed_at``.
+         *
+         *     Invariant: ``user.email`` holds the prior confirmed address; the new
+         *     address lives on ``token.sent_to`` until this endpoint runs. This is
+         *     the single place either column flips.
          *
          *     The token in the email is itself the bearer credential — we don't
          *     require the click to come from the same browser that requested it.
@@ -1063,6 +1067,8 @@ export interface components {
             email?: string | null;
             /** Confirmed At */
             confirmed_at?: string | null;
+            /** Pending Email */
+            pending_email?: string | null;
         };
         /** SetEmailRequest */
         SetEmailRequest: {

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -154,15 +154,12 @@ export const handlers = [
     if (!body.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(body.email))
       return detail('Invalid email.', 422)
     const next = body.email.toLowerCase()
-    // Already-verified-for-this-address resubmit is a no-op.
     if (
       mockSession.data.user.email === next &&
       mockSession.data.user.confirmed_at
     ) {
       return HttpResponse.json(mockSession, { status: 202 })
     }
-    // Pending-only: leave email + confirmed_at alone; surface the new
-    // address as pending_email until confirm consumes it.
     mockSession.data.user = {
       ...mockSession.data.user,
       pending_email: next,

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -153,10 +153,19 @@ export const handlers = [
     if (!body.captcha_token) return detail('Captcha required.', 400)
     if (!body.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(body.email))
       return detail('Invalid email.', 422)
+    const next = body.email.toLowerCase()
+    // Already-verified-for-this-address resubmit is a no-op.
+    if (
+      mockSession.data.user.email === next &&
+      mockSession.data.user.confirmed_at
+    ) {
+      return HttpResponse.json(mockSession, { status: 202 })
+    }
+    // Pending-only: leave email + confirmed_at alone; surface the new
+    // address as pending_email until confirm consumes it.
     mockSession.data.user = {
       ...mockSession.data.user,
-      email: body.email.toLowerCase(),
-      confirmed_at: null,
+      pending_email: next,
     }
     return HttpResponse.json(mockSession, { status: 202 })
   }),
@@ -168,10 +177,8 @@ export const handlers = [
       } | undefined) ?? {}
     if (body.fmm_hp_token?.trim())
       return HttpResponse.json(mockSession, { status: 202 })
-    if (!mockSession.data.user.email)
-      return detail('Add an email address before requesting a resend.', 400)
-    if (mockSession.data.user.confirmed_at)
-      return detail('This email is already confirmed.', 409)
+    if (!mockSession.data.user.pending_email)
+      return detail('No pending email change to resend.', 400)
     if (!body.captcha_token) return detail('Captcha required.', 400)
     return HttpResponse.json(mockSession, { status: 202 })
   }),
@@ -179,11 +186,13 @@ export const handlers = [
     const body =
       ((await readJson(request)) as { token?: string } | undefined) ?? {}
     if (!body.token) return detail('Missing token.', 400)
-    if (!mockSession.data.user.email)
+    if (!mockSession.data.user.pending_email)
       return detail('That confirmation link is invalid or expired.', 400)
     mockSession.data.user = {
       ...mockSession.data.user,
+      email: mockSession.data.user.pending_email,
       confirmed_at: new Date().toISOString(),
+      pending_email: null,
     }
     return HttpResponse.json(mockSession)
   }),

--- a/web-client/src/routes/settings.test.tsx
+++ b/web-client/src/routes/settings.test.tsx
@@ -44,6 +44,7 @@ beforeEach(() => {
   // Reset the shared session between tests so honeypot/email checks start fresh.
   mockSession.data.user.email = null
   mockSession.data.user.confirmed_at = null
+  mockSession.data.user.pending_email = null
   mockSession.data.user.username = 'rita.kovac'
 })
 
@@ -98,7 +99,11 @@ describe('SettingsPage email section', () => {
     expect(
       await screen.findByText(/waiting for verification/i),
     ).toBeInTheDocument()
-    expect(mockSession.data.user.email).toBe('me@example.com')
+    // The new address lives only on the pending field until the user
+    // clicks the confirmation link; ``email`` stays at the prior verified
+    // value (null here for a first-time set).
+    expect(mockSession.data.user.pending_email).toBe('me@example.com')
+    expect(mockSession.data.user.email).toBeNull()
   })
 
   it("doesn't persist when the honeypot is filled", async () => {
@@ -120,8 +125,10 @@ describe('SettingsPage email section', () => {
     await user.click(submit)
 
     // The server responds as if it succeeded (status hidden from the bot)
-    // but the session never picked up the email.
-    await waitFor(() => expect(mockSession.data.user.email).toBeNull())
+    // but the session never picked up the pending change.
+    await waitFor(() =>
+      expect(mockSession.data.user.pending_email).toBeNull(),
+    )
   })
 
   it('requires the captcha before the submit button enables', async () => {

--- a/web-client/src/routes/settings.test.tsx
+++ b/web-client/src/routes/settings.test.tsx
@@ -99,9 +99,6 @@ describe('SettingsPage email section', () => {
     expect(
       await screen.findByText(/waiting for verification/i),
     ).toBeInTheDocument()
-    // The new address lives only on the pending field until the user
-    // clicks the confirmation link; ``email`` stays at the prior verified
-    // value (null here for a first-time set).
     expect(mockSession.data.user.pending_email).toBe('me@example.com')
     expect(mockSession.data.user.email).toBeNull()
   })

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -778,15 +778,21 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
 function EmailSection({
   email,
   confirmedAt,
+  pendingEmail,
 }: {
   email: string | null
   confirmedAt: string | null
+  pendingEmail: string | null
 }) {
   const toast = useToast()
   const setEmail = useSetEmail()
   const resendEmail = useResendEmailConfirmation()
-  const current = email ?? ''
-  const [val, setVal] = useState(current)
+  // ``email`` reflects the user's *confirmed* address; the pending change
+  // (if any) lives on ``pendingEmail`` until the user clicks the link.
+  // Show pending state when either we have a pending change or we have no
+  // confirmed address at all.
+  const displayAddress = pendingEmail ?? email ?? ''
+  const [val, setVal] = useState(displayAddress)
   const [touched, setTouched] = useState(false)
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
   const [honeypot, setHoneypot] = useState('')
@@ -796,24 +802,26 @@ function EmailSection({
 
   // Reset the local input when the underlying session value changes (e.g. on
   // refetch after another tab confirmed). Avoid clobbering in-progress edits.
-  const lastSyncedRef = useRef(current)
+  const lastSyncedRef = useRef(displayAddress)
   useEffect(() => {
-    if (current === lastSyncedRef.current) return
-    lastSyncedRef.current = current
-    setVal(current)
+    if (displayAddress === lastSyncedRef.current) return
+    lastSyncedRef.current = displayAddress
+    setVal(displayAddress)
     setTouched(false)
     setServerErr(null)
-  }, [current])
+  }, [displayAddress])
 
   const v = useMemo(() => validateEmail(val), [val])
-  const dirty = val !== current
+  const dirty = val !== displayAddress
   const showErr = serverErr ?? (touched && !v.ok ? v.err : null)
 
-  const status: EmailStatus = confirmedAt
-    ? 'verified'
-    : email
-      ? 'pending'
-      : 'guest'
+  const status: EmailStatus = pendingEmail
+    ? 'pending'
+    : confirmedAt
+      ? 'verified'
+      : email
+        ? 'pending'
+        : 'guest'
 
   const resetCaptcha = () => {
     captchaRef.current?.reset()
@@ -860,7 +868,7 @@ function EmailSection({
     try {
       await resendEmail.mutateAsync({ captchaToken, honeypot })
       resetCaptcha()
-      toast(`Verification link re-sent to ${email}.`)
+      toast(`Verification link re-sent to ${pendingEmail ?? displayAddress}.`)
     } catch (err) {
       resetCaptcha()
       toast(
@@ -894,11 +902,11 @@ function EmailSection({
           savedAt={savedAt}
           onSave={onSave}
           onCancel={() => {
-            setVal(current)
+            setVal(displayAddress)
             setTouched(false)
             setServerErr(null)
           }}
-          primaryLabel={email ? 'Update email' : 'Add email'}
+          primaryLabel={email || pendingEmail ? 'Update email' : 'Add email'}
         />
       }
     >
@@ -973,7 +981,7 @@ function EmailSection({
         />
       </div>
 
-      {email && (
+      {(email || pendingEmail) && (
         <div
           style={{
             marginTop: 16,
@@ -1024,7 +1032,10 @@ function EmailSection({
                 </div>
                 <div style={{ color: 'var(--fg-3)', marginTop: 2 }}>
                   Open the link we just sent to{' '}
-                  <span style={{ fontFamily: 'var(--font-mono)' }}>{email}</span>.
+                  <span style={{ fontFamily: 'var(--font-mono)' }}>
+                    {pendingEmail ?? email}
+                  </span>
+                  .
                 </div>
               </>
             )}
@@ -1068,13 +1079,18 @@ function SettingsPage() {
   const sessionUsername = sessionUser?.username ?? ''
   const sessionEmail = sessionUser?.email ?? null
   const sessionConfirmedAt = sessionUser?.confirmed_at ?? null
+  const sessionPendingEmail = sessionUser?.pending_email ?? null
   const hash = useRouterState({ select: (s) => s.location.hash })
 
-  const effectiveStatus: EmailStatus = sessionConfirmedAt
-    ? 'verified'
-    : sessionEmail
-      ? 'pending'
-      : 'guest'
+  // Pending state wins for banner purposes (a verified user with a pending
+  // change still has something the FE needs to nudge them to complete).
+  const effectiveStatus: EmailStatus = sessionPendingEmail
+    ? 'pending'
+    : sessionConfirmedAt
+      ? 'verified'
+      : sessionEmail
+        ? 'pending'
+        : 'guest'
   const claimed = effectiveStatus === 'verified'
 
   // Honor /settings#sec-* deep links from external nav.
@@ -1093,7 +1109,7 @@ function SettingsPage() {
 
               <ClaimBanner
                 status={effectiveStatus}
-                email={sessionEmail ?? ''}
+                email={sessionPendingEmail ?? sessionEmail ?? ''}
                 onJump={() => scrollToSection('sec-email')}
               />
 
@@ -1102,6 +1118,7 @@ function SettingsPage() {
                 <EmailSection
                   email={sessionEmail}
                   confirmedAt={sessionConfirmedAt}
+                  pendingEmail={sessionPendingEmail}
                 />
               </div>
 

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -48,6 +48,23 @@ export const Route = createFileRoute('/settings')({
 
 type EmailStatus = 'guest' | 'pending' | 'verified'
 
+function deriveEmailStatus({
+  email,
+  confirmedAt,
+  pendingEmail,
+}: {
+  email: string | null
+  confirmedAt: string | null
+  pendingEmail: string | null
+}): EmailStatus {
+  // A pending change wins even when the user is already verified — the FE
+  // still has something to nudge them to complete.
+  if (pendingEmail) return 'pending'
+  if (confirmedAt) return 'verified'
+  if (email) return 'pending'
+  return 'guest'
+}
+
 // Mirrors api/app/schemas/session.py USERNAME_PATTERN. Client-side validation
 // is for fast feedback; the server still enforces the same rules and returns
 // 409 on duplicates.
@@ -787,11 +804,8 @@ function EmailSection({
   const toast = useToast()
   const setEmail = useSetEmail()
   const resendEmail = useResendEmailConfirmation()
-  // ``email`` reflects the user's *confirmed* address; the pending change
-  // (if any) lives on ``pendingEmail`` until the user clicks the link.
-  // Show pending state when either we have a pending change or we have no
-  // confirmed address at all.
   const displayAddress = pendingEmail ?? email ?? ''
+  const hasAddress = Boolean(email || pendingEmail)
   const [val, setVal] = useState(displayAddress)
   const [touched, setTouched] = useState(false)
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
@@ -815,13 +829,7 @@ function EmailSection({
   const dirty = val !== displayAddress
   const showErr = serverErr ?? (touched && !v.ok ? v.err : null)
 
-  const status: EmailStatus = pendingEmail
-    ? 'pending'
-    : confirmedAt
-      ? 'verified'
-      : email
-        ? 'pending'
-        : 'guest'
+  const status = deriveEmailStatus({ email, confirmedAt, pendingEmail })
 
   const resetCaptcha = () => {
     captchaRef.current?.reset()
@@ -868,7 +876,7 @@ function EmailSection({
     try {
       await resendEmail.mutateAsync({ captchaToken, honeypot })
       resetCaptcha()
-      toast(`Verification link re-sent to ${pendingEmail ?? displayAddress}.`)
+      toast(`Verification link re-sent to ${displayAddress}.`)
     } catch (err) {
       resetCaptcha()
       toast(
@@ -906,7 +914,7 @@ function EmailSection({
             setTouched(false)
             setServerErr(null)
           }}
-          primaryLabel={email || pendingEmail ? 'Update email' : 'Add email'}
+          primaryLabel={hasAddress ? 'Update email' : 'Add email'}
         />
       }
     >
@@ -981,7 +989,7 @@ function EmailSection({
         />
       </div>
 
-      {(email || pendingEmail) && (
+      {hasAddress && (
         <div
           style={{
             marginTop: 16,
@@ -1082,15 +1090,11 @@ function SettingsPage() {
   const sessionPendingEmail = sessionUser?.pending_email ?? null
   const hash = useRouterState({ select: (s) => s.location.hash })
 
-  // Pending state wins for banner purposes (a verified user with a pending
-  // change still has something the FE needs to nudge them to complete).
-  const effectiveStatus: EmailStatus = sessionPendingEmail
-    ? 'pending'
-    : sessionConfirmedAt
-      ? 'verified'
-      : sessionEmail
-        ? 'pending'
-        : 'guest'
+  const effectiveStatus = deriveEmailStatus({
+    email: sessionEmail,
+    confirmedAt: sessionConfirmedAt,
+    pendingEmail: sessionPendingEmail,
+  })
   const claimed = effectiveStatus === 'verified'
 
   // Honor /settings#sec-* deep links from external nav.

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -69,6 +69,7 @@ export function sessionUser(overrides: Partial<SessionUser> = {}): SessionUser {
     permissions: [],
     email: null,
     confirmed_at: null,
+    pending_email: null,
     ...overrides,
   }
 }


### PR DESCRIPTION
Re-cut of #222 onto current main — the original conflicted with the magic-link/login work (#225, #231) and was simpler to redo than rebase.

## Summary

- `set_email` is **pending-only**: it issues a token (`sent_to=NEW`, `context="change:OLD"`) and enqueues delivery, but leaves `users.email` and `users.confirmed_at` untouched. The user remains verified for their prior address until they click the new link.
- `confirm_email` is the single place either column flips. It verifies `users.email == _old_email_from_context(token.context)` (the user's current confirmed address matches the prior recorded in the token), then stamps `user.email = token.sent_to` + `confirmed_at = now`. The commit is wrapped to catch the `users.email` unique-constraint race when another user confirms the same address first — surfaces as the opaque "invalid or expired link" (no enumeration). Resubmitting the same address while already verified short-circuits to a no-op.
- `resend_email_confirmation` derives the destination from the pending token's `sent_to` rather than `users.email` (which no longer mirrors the pending change). No pending token → 400 "no pending email change to resend." Replaces the prior 409-on-confirmed branch (after confirm there's no pending token, so this is just 400).
- `pending_email` is exposed on `SessionUser` so the FE can distinguish "verified for X with a pending move to Y" from plain "verified." `EmailSection` and the page-level claim banner pull the pending address forward when present.
- Token-context audit semantics now reflect the *confirmed* prior address: re-submitting before confirming keeps `context="change:"`, while changing again after a confirm picks up the newly-confirmed prior.

## Notes for review

- `_existing_change_context` → `_pending_change_token` returning the full row, because resend needs both `context` and `sent_to`. The login-flow helper (`_issue_and_send_confirmation_email`) was updated to use `.context` from the same return value.
- The `IntegrityError` wrapper in `confirm_email` covers from the `user.email` mutation through commit, not just commit, because `_maybe_merge_prior_session` runs a query that triggers SQLAlchemy autoflush before the explicit commit — the unique-constraint violation surfaces there.
- I left the `request_login_email` "unconfirmed → resend confirmation" branch in place even though under the new invariant (`user.email` only set after confirm) it's unreachable through normal flows; ripping it out felt out of scope for this PR.

## Test plan

- [x] `cd api && pytest` — 295 passed
- [x] `cd web-client && npm run test:run` — 65 passed
- [x] `cd web-client && npm run lint && npm run build` — clean (1 pre-existing warning in `public/mockServiceWorker.js`)
- [x] `mise run regen-api-types` — schema regenerated, only `pending_email` added under `SessionUser`
- [ ] Manual: confirm a first-ever email, then change to a second address — verify the user stays verified for the first until clicking the new link, then both `email` and `confirmed_at` flip together
- [ ] Manual: change email, then change again before confirming — verify only the latest pending address is targeted by resend
- [ ] Manual: two-account race — both initiate change to the same address; first to confirm wins, second sees opaque "invalid or expired"

🤖 Generated with [Claude Code](https://claude.com/claude-code)