### PR TITLE
Add alpha badge with warning popover to app shell header

### DIFF
--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -1,10 +1,27 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
-import { Gauge, Key, Settings, Shield, Users } from 'lucide-react'
+import {
+  ChevronDown,
+  Gauge,
+  Key,
+  Settings,
+  Shield,
+  TriangleAlert,
+  Users,
+} from 'lucide-react'
 import { useSession } from '@/api/session'
 import { cn } from '@/lib/utils'
 import { PERM } from '@/lib/permissions'
 import { UserMenu } from './user-menu'
+import { Badge } from '@/components/ui/badge'
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from '@/components/ui/popover'
 
 type NavChild = { label: string; to: string; icon: ReactNode; requires?: string }
 
@@ -305,6 +322,44 @@ export function AppShell({ children }: AppShellProps) {
           <div className="app-shell__spacer" />
 
           <div className="app-shell__actions">
+            <Popover>
+              <PopoverTrigger asChild>
+                <Badge
+                  variant="outline"
+                  role="button"
+                  aria-label="About the alpha release"
+                  className="cursor-pointer gap-1.5 border-amber-500/50 bg-amber-500/15 px-2.5 font-semibold tracking-wider text-amber-300 uppercase shadow-sm transition-colors hover:bg-amber-500/25 hover:text-amber-200 focus-visible:border-amber-400 focus-visible:ring-amber-400/50"
+                >
+                  <TriangleAlert />
+                  Alpha
+                  <ChevronDown className="opacity-60" />
+                </Badge>
+              </PopoverTrigger>
+              <PopoverContent
+                align="end"
+                className="w-80 gap-0 overflow-hidden p-0"
+              >
+                <PopoverHeader className="flex-row items-start gap-3 border-b border-border/60 bg-amber-500/10 p-3.5">
+                  <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-amber-500/20 text-amber-300">
+                    <TriangleAlert className="size-4" />
+                  </span>
+                  <span className="flex flex-col gap-0.5">
+                    <PopoverTitle>You're using an early alpha</PopoverTitle>
+                    <PopoverDescription className="text-xs leading-relaxed">
+                      FortyMM is under active development — expect rough edges.
+                    </PopoverDescription>
+                  </span>
+                </PopoverHeader>
+                <ul className="list-disc space-y-1.5 py-3.5 pr-3.5 pl-8 text-xs leading-relaxed text-muted-foreground">
+                  <li>Features may change or break without warning.</li>
+                  <li>Your data can be reset or lost at any time.</li>
+                  <li>Please don't rely on it for anything important yet.</li>
+                </ul>
+                <p className="border-t border-border/60 p-3.5 text-xs text-foreground">
+                  Thanks for helping us test it. 🏓
+                </p>
+              </PopoverContent>
+            </Popover>
             <UserMenu />
           </div>
         </header>

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -325,14 +325,15 @@ export function AppShell({ children }: AppShellProps) {
             <Popover>
               <PopoverTrigger asChild>
                 <Badge
+                  asChild
                   variant="outline"
-                  role="button"
-                  aria-label="About the alpha release"
                   className="cursor-pointer gap-1.5 border-amber-500/50 bg-amber-500/15 px-2.5 font-semibold tracking-wider text-amber-300 uppercase shadow-sm transition-colors hover:bg-amber-500/25 hover:text-amber-200 focus-visible:border-amber-400 focus-visible:ring-amber-400/50"
                 >
-                  <TriangleAlert />
-                  Alpha
-                  <ChevronDown className="opacity-60" />
+                  <button type="button" aria-label="About the alpha release">
+                    <TriangleAlert />
+                    Alpha
+                    <ChevronDown className="opacity-60" />
+                  </button>
                 </Badge>
               </PopoverTrigger>
               <PopoverContent


### PR DESCRIPTION
## Summary

Adds a clickable amber **Alpha** badge to the app-shell topbar, just left of the user menu. Clicking it opens a popover warning that the app is early, in-progress software.

- Vivid amber "danger" pill with a warning-triangle icon and a chevron-down affordance so it reads as clickable.
- Popover is structured into a header band (icon chip + title + summary), a bulleted body (features may break, data may be reset, don't rely on it yet), and a footer thanking testers.

## Testing

- `npm run test:run` — 65 passed
- `npm run lint` — 0 errors
- `npm run build` (tsc -b) — clean
- `npm run test:e2e` — 126 passed
- Visually verified the badge placement and popover via screenshot.

Frontend-only; no API or OpenAPI schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)