### PR TITLE
Dashboard: greet the signed-in user by username (#279)

### DIFF
--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -107,6 +107,19 @@ describe('DashboardPage', () => {
     expect(table).toHaveTextContent('1-3')
   })
 
+  it('greets the signed-in user by their username', async () => {
+    server.use(
+      http.get('*/v1/dashboard', () =>
+        HttpResponse.json(dashboardResponse()),
+      ),
+    )
+    renderDashboard()
+
+    expect(
+      await screen.findByRole('heading', { name: /Hi, @rita\.kovac/ }),
+    ).toBeInTheDocument()
+  })
+
   it('omits the score banner when none is active and shows the empty recent-results card', async () => {
     server.use(
       http.get('*/v1/dashboard', () =>

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -1038,6 +1038,8 @@ export function DashboardPage() {
   const dashboard = useDashboard({ enabled: session.isSuccess })
   const isLoading = dashboard.isPending
   const data = dashboard.data
+  const username = session.data?.data.user.username
+  const greeting = username ? `Hi, @${username}` : 'Hi'
   return (
     <div
       style={{
@@ -1048,7 +1050,7 @@ export function DashboardPage() {
         boxSizing: 'border-box',
       }}
     >
-      <PageTitle greeting="Hi, Aimee" subtitle="3 things need your attention" />
+      <PageTitle greeting={greeting} subtitle="3 things need your attention" />
       {isLoading ? (
         <SkeletonCard label="Loading score banner" height={140} />
       ) : data?.score_banners?.length ? (


### PR DESCRIPTION
## Summary

The dashboard greeting was hardcoded to **"Hi, Aimee"** for every signed-in user. This renders the user's own username instead — `Hi, @<username>` — derived from the session the page already loads.

- Matches the `@`-prefixed handle style used on the login confirmation screen (`login-screens.tsx`).
- While the session is still loading, shows a bare `Hi` so no placeholder name flashes (per the issue's loading-state requirement).
- The `subtitle` ("3 things need your attention") remains hardcoded — explicitly out of scope per #279.

Closes #279.

## Test plan

- [x] Added a vitest case asserting the heading renders `Hi, @rita.kovac` for the default mock session.
- [x] `npm run test:run` — 66/66 pass
- [x] `npm run lint` — clean (one pre-existing unrelated warning)
- [x] `npm run build` (tsc + vite) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)