### PR TITLE
Scoring: validate legal final score client-side (#284)

### DIFF
--- a/web-client/e2e/score-entry.spec.ts
+++ b/web-client/e2e/score-entry.spec.ts
@@ -280,18 +280,17 @@ test.describe('Score entry', () => {
     await expect(scoreEntry.oppInput).toHaveValue('8')
   })
 
-  test('shows the TT-rule violation inline when the score is illegal', async ({
+  test('blocks an illegal score client-side with an inline hint', async ({
     page,
   }) => {
     const scoreEntry = await ScoreEntryPage.navigateTo(page)
 
-    // 11-10 isn't a legal final score — at 10-10 the game enters deuce.
+    // 11-10 isn't a legal final score — at 10-10 the game enters deuce. The
+    // client catches this so Save stays disabled and never round-trips.
     await scoreEntry.enterScores('11', '10')
-    await scoreEntry.saveButton.click()
 
-    await expect(scoreEntry.inlineError).toContainText(
-      /not a legal final score/i,
-    )
+    await expect(scoreEntry.saveButton).toBeDisabled()
+    await expect(scoreEntry.inlineError).toContainText(/deuce/i)
     await expect(scoreEntry.meInput).toHaveAttribute('aria-invalid', 'true')
     await expect(scoreEntry.oppInput).toHaveAttribute('aria-invalid', 'true')
   })

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -258,7 +258,53 @@ describe('ScoreEntry — create', () => {
     )
   })
 
-  it('renders the 422 detail inline and clears it when the user edits an input', async () => {
+  it('blocks an illegal final score client-side without hitting the server', async () => {
+    const user = userEvent.setup()
+    let posted = 0
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      http.post('*/v1/matches/m-1/games/g-3/scores', () => {
+        posted += 1
+        return HttpResponse.json(
+          inProgressMatch({
+            games: [
+              { id: 'g-3', game_number: 3, score: score('s-3', 11, 9) },
+              { id: 'g-4', game_number: 4, score: null },
+            ],
+            current_game: { id: 'g-4', game_number: 4 },
+          }),
+        )
+      }),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameId: 'g-3' })
+    const meInput = await screen.findByRole('textbox', { name: 'rita.kovac score' })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+
+    // 11–10 is illegal (win-by-1). The button stays disabled and an inline
+    // hint explains why — no request is made.
+    await user.type(meInput, '11')
+    await user.type(oppInput, '10')
+    const save = screen.getByRole('button', { name: /save/i })
+    expect(save).toBeDisabled()
+    expect(screen.getByRole('alert')).toHaveTextContent(/deuce/i)
+    expect(meInput).toHaveAttribute('aria-invalid', 'true')
+    expect(oppInput).toHaveAttribute('aria-invalid', 'true')
+
+    // Correcting to a legal score clears the hint and re-enables Save.
+    await user.clear(oppInput)
+    await user.type(oppInput, '9')
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(save).toBeEnabled()
+
+    await user.click(save)
+    await waitFor(() =>
+      expect(screen.getByText('scoring-new m-1 g-4')).toBeInTheDocument(),
+    )
+    expect(posted).toBe(1)
+  })
+
+  it('renders a server 422 detail inline and clears it when the user edits an input', async () => {
     const user = userEvent.setup()
     let calls = 0
     server.use(
@@ -266,18 +312,17 @@ describe('ScoreEntry — create', () => {
       http.post('*/v1/matches/m-1/games/g-3/scores', () => {
         calls += 1
         if (calls === 1) {
+          // A client-legal score the server still rejects (e.g. for match
+          // state the client doesn't model) — exercises the 422 render path.
           return HttpResponse.json(
-            {
-              detail:
-                'At 10–10 the game enters deuce; the winner must lead by 2. 11–10 is not a legal final score.',
-            },
+            { detail: 'This score was rejected by the server.' },
             { status: 422 },
           )
         }
         return HttpResponse.json(
           inProgressMatch({
             games: [
-              { id: 'g-3', game_number: 3, score: score('s-3', 12, 10) },
+              { id: 'g-3', game_number: 3, score: score('s-3', 11, 4) },
               { id: 'g-4', game_number: 4, score: null },
             ],
             current_game: { id: 'g-4', game_number: 4 },
@@ -291,11 +336,11 @@ describe('ScoreEntry — create', () => {
     const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
 
     await user.type(meInput, '11')
-    await user.type(oppInput, '10')
+    await user.type(oppInput, '4')
     await user.click(screen.getByRole('button', { name: /save/i }))
 
     const alert = await screen.findByRole('alert')
-    expect(alert).toHaveTextContent(/not a legal final score/i)
+    expect(alert).toHaveTextContent(/rejected by the server/i)
     expect(meInput).toHaveAttribute('aria-invalid', 'true')
     expect(oppInput).toHaveAttribute('aria-invalid', 'true')
 
@@ -303,7 +348,7 @@ describe('ScoreEntry — create', () => {
     await user.clear(meInput)
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
 
-    await user.type(meInput, '12')
+    await user.type(meInput, '11')
     await user.click(screen.getByRole('button', { name: /save/i }))
     await waitFor(() =>
       expect(screen.getByText('scoring-new m-1 g-4')).toBeInTheDocument(),
@@ -481,9 +526,13 @@ describe('ScoreEntry — edit', () => {
     const meInput = await screen.findByRole('textbox', {
       name: 'rita.kovac score',
     })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
     await waitFor(() => expect(meInput).toHaveValue('11'))
+    // Flip game 2 to a legal opponent win (9–11) so the edit re-opens the match.
     await user.clear(meInput)
     await user.type(meInput, '9')
+    await user.clear(oppInput)
+    await user.type(oppInput, '11')
     await user.click(screen.getByRole('button', { name: /save/i }))
 
     await waitFor(() =>

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -134,6 +134,8 @@ function ScoreEntryInner({
     : null
   const inputsValid = bothFilled && localScoreError === null
   const apiError = mutation.error instanceof ApiError ? mutation.error : null
+  const showScoreError =
+    localScoreError !== null || (apiError !== null && apiError.status === 422)
 
   // 409 from the API means the game is either already scored (create) or the
   // match isn't scorable. Both swap out the regular controls for a back-link.
@@ -228,10 +230,7 @@ function ScoreEntryInner({
             inputRef={meRef}
             autoFocus
             disabled={inputsLocked}
-            invalid={
-              localScoreError !== null ||
-              (apiError !== null && apiError.status === 422)
-            }
+            invalid={showScoreError}
             onChange={onMeChange}
             onKeyDown={(e) => handleKey(e, 'me')}
           />
@@ -251,16 +250,13 @@ function ScoreEntryInner({
             value={opp}
             inputRef={oppRef}
             disabled={inputsLocked}
-            invalid={
-              localScoreError !== null ||
-              (apiError !== null && apiError.status === 422)
-            }
+            invalid={showScoreError}
             onChange={onOppChange}
             onKeyDown={(e) => handleKey(e, 'opp')}
           />
         </div>
 
-        {(localScoreError || (apiError && apiError.status === 422)) && (
+        {showScoreError && (
           <p
             role="alert"
             className="mt-1.5 text-xs text-[color:var(--loss)]"

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/api/matches'
 import { AppShell } from '@/components/app-shell'
 import { cn, initialsOf } from '@/lib/utils'
+import { illegalScoreReason } from '@/lib/scoring'
 
 export type ScoreMutation = UseMutationResult<
   MatchDetails,
@@ -127,8 +128,11 @@ function ScoreEntryInner({
     if (mutation.error) mutation.reset()
   }
 
-  const inputsValid =
-    me !== '' && opp !== '' && Number(me) !== Number(opp)
+  const bothFilled = me !== '' && opp !== ''
+  const localScoreError = bothFilled
+    ? illegalScoreReason(Number(me), Number(opp))
+    : null
+  const inputsValid = bothFilled && localScoreError === null
   const apiError = mutation.error instanceof ApiError ? mutation.error : null
 
   // 409 from the API means the game is either already scored (create) or the
@@ -224,7 +228,10 @@ function ScoreEntryInner({
             inputRef={meRef}
             autoFocus
             disabled={inputsLocked}
-            invalid={apiError !== null && apiError.status === 422}
+            invalid={
+              localScoreError !== null ||
+              (apiError !== null && apiError.status === 422)
+            }
             onChange={onMeChange}
             onKeyDown={(e) => handleKey(e, 'me')}
           />
@@ -244,18 +251,21 @@ function ScoreEntryInner({
             value={opp}
             inputRef={oppRef}
             disabled={inputsLocked}
-            invalid={apiError !== null && apiError.status === 422}
+            invalid={
+              localScoreError !== null ||
+              (apiError !== null && apiError.status === 422)
+            }
             onChange={onOppChange}
             onKeyDown={(e) => handleKey(e, 'opp')}
           />
         </div>
 
-        {apiError && apiError.status === 422 && (
+        {(localScoreError || (apiError && apiError.status === 422)) && (
           <p
             role="alert"
             className="mt-1.5 text-xs text-[color:var(--loss)]"
           >
-            {apiError.detail ?? apiError.message}
+            {localScoreError ?? apiError?.detail ?? apiError?.message}
           </p>
         )}
 

--- a/web-client/src/lib/scoring.test.ts
+++ b/web-client/src/lib/scoring.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { illegalScoreReason } from './scoring'
+
+describe('illegalScoreReason', () => {
+  it.each([
+    [11, 9],
+    [11, 0],
+    [9, 11], // symmetric: order doesn't matter
+    [12, 10], // deuce won by exactly 2
+    [13, 11],
+    [20, 18],
+  ])('accepts the legal final score %i–%i', (a, b) => {
+    expect(illegalScoreReason(a, b)).toBeNull()
+  })
+
+  it.each([
+    [11, 11, /tie/i],
+    [0, 0, /tie/i],
+    [8, 5, /at least 11/i],
+    [10, 9, /at least 11/i],
+    [11, 10, /deuce/i], // win-by-1 at deuce — the reported bug
+    [10, 11, /deuce/i], // symmetric
+    [12, 9, /both sides reach 10/i], // past 11 without a deuce
+    [15, 10, /exactly 2/i], // deuce, but won by more than 2
+    [13, 10, /exactly 2/i],
+  ])('rejects the illegal score %i–%i', (a, b, pattern) => {
+    expect(illegalScoreReason(a, b)).toMatch(pattern)
+  })
+})

--- a/web-client/src/lib/scoring.ts
+++ b/web-client/src/lib/scoring.ts
@@ -1,0 +1,19 @@
+// Mirrors the server-side table-tennis rule in api/app/schemas/match.py
+// (MatchGameScoreWrite._table_tennis_rules) so the client doesn't submit a
+// final score the server will reject with a 422. Returns the reason a score is
+// illegal, or null when it's a legal final score.
+export function illegalScoreReason(a: number, b: number): string | null {
+  if (a === b) return 'A game cannot end in a tie.'
+  const winner = Math.max(a, b)
+  const loser = Math.min(a, b)
+  if (winner < 11) return 'The winning side must reach at least 11 points.'
+  if (winner === 11 && loser > 9)
+    return 'At 10–10 the game enters deuce — the winner must lead by 2.'
+  if (winner > 11) {
+    if (loser < 10)
+      return 'A game can only go past 11 once both sides reach 10.'
+    if (winner - loser !== 2)
+      return 'In a deuce game the winner leads by exactly 2 points.'
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

The score-entry form only blocked **ties** client-side, so an illegal win-by-1 score like **11–10** stayed submittable — it round-tripped to a `422`, logged a `Failed to load resource` console error, and surfaced the deuce rule only *after* the network call. Validation was inconsistent: `11–11` was caught locally, `11–10` wasn't.

This adds `illegalScoreReason` (`web-client/src/lib/scoring.ts`) mirroring the server-side table-tennis rule in `api/app/schemas/match.py`, and gates the Save button on it. Illegal scores now keep **Save disabled with an inline hint** (matching the `web-client/CLAUDE.md` form-error convention: `aria-invalid` + red `<p>`) instead of round-tripping. The server-side check remains the authority.

Closes #284.

## Verification

Reproduced the bug on uat.fortymm.com first, then verified the fix in a local browser: 11–10 now keeps Save disabled with the hint "At 10–10 the game enters deuce — the winner must lead by 2.", no POST, no console error; 11–9 re-enables Save.

## Test plan

- [x] Unit (`src/lib/scoring.test.ts`): 15 table-driven cases over every rule branch (tie, under-11, deuce win-by-1, past-11 cases, symmetry).
- [x] Integration (`score-entry.test.tsx`): 11–10 → Save disabled + hint + `aria-invalid` + zero POSTs; correcting to 11–9 → enabled + one POST. Repurposed the old 422 test to a client-valid score so the server-422 render path stays covered.
- [x] `npm run test:run` — 81/81 pass
- [x] `npm run test:e2e` — 126/126 pass (updated `score-entry.spec.ts` illegal-score test)
- [x] `npm run lint` + `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)