### PR TITLE
Matches list: gate query on session to fix first-visit 401 race (#144)

### DIFF
--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -102,7 +102,10 @@ export function useCreateMatch() {
  * current page rendered while the next page or filter resolves, so the table
  * doesn't flash empty between requests. Throws to the surrounding boundary.
  */
-export function useMatchList(params: MatchListParams) {
+export function useMatchList(
+  params: MatchListParams,
+  options: { enabled?: boolean } = {},
+) {
   return useQuery({
     queryKey: matchListQueryKey(params),
     queryFn: async (): Promise<MatchListResponse> =>
@@ -119,6 +122,9 @@ export function useMatchList(params: MatchListParams) {
           },
         }),
       ),
+    // Gate on the session so a first-visit direct-load doesn't fire before the
+    // session cookie lands and 401 into the error boundary (#144).
+    enabled: options.enabled ?? true,
     placeholderData: keepPreviousData,
     retry: false,
     throwOnError: true,

--- a/web-client/src/routes/matches/index.test.tsx
+++ b/web-client/src/routes/matches/index.test.tsx
@@ -11,7 +11,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 import { server } from '@/mocks/server'
-import { matchListResponse, matchListRow } from '@/test/factories'
+import {
+  matchListResponse,
+  matchListRow,
+  sessionResponse,
+} from '@/test/factories'
 import { Route } from './index'
 
 const MatchesPage = Route.options.component!
@@ -77,6 +81,44 @@ describe('MatchesPage', () => {
     // The Players column shows both sides — the current mock user (side 1)
     // appears alongside the opponent (side 2).
     expect(screen.getAllByText('rita.kovac').length).toBeGreaterThan(0)
+  })
+
+  it('waits for the session before requesting matches (no first-visit 401 race)', async () => {
+    const matchRequests: string[] = []
+    let releaseSession: (() => void) | null = null
+    server.use(
+      // Hold the session request open to simulate the cookie not having
+      // landed yet on a first-visit direct-load (#144).
+      http.get('*/v1/session', async () => {
+        await new Promise<void>((resolve) => {
+          releaseSession = resolve
+        })
+        return HttpResponse.json(sessionResponse())
+      }),
+      http.get('*/v1/matches', ({ request }) => {
+        matchRequests.push(request.url)
+        return HttpResponse.json(
+          matchListResponse({
+            items: [matchListRow({ opponent: 'nguyen.t' })],
+            total: 1,
+            status_counts: { pending: 1 },
+          }),
+        )
+      }),
+    )
+    renderMatchesPage()
+
+    // While the session is unresolved the query is disabled: the skeleton
+    // holds and no matches request is fired (so it can't 401).
+    const table = await screen.findByRole('table')
+    expect(table).toHaveAttribute('aria-busy', 'true')
+    await waitFor(() => expect(releaseSession).not.toBeNull())
+    expect(matchRequests).toHaveLength(0)
+
+    // Once the session resolves, the query runs and real rows render.
+    releaseSession!()
+    expect(await screen.findByText('nguyen.t')).toBeInTheDocument()
+    expect(matchRequests.length).toBeGreaterThanOrEqual(1)
   })
 
   it('paints the winning side green on a completed row', async () => {

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -18,6 +18,7 @@ import {
   type MatchStatus,
 } from '@/api/matches'
 import type { components } from '@/api/schema'
+import { useSession } from '@/api/session'
 import { AppShell } from '@/components/app-shell'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
@@ -115,7 +116,14 @@ function MatchesPage() {
     }),
     [apiStatus, debouncedQ, page],
   )
-  const { data, isLoading } = useMatchList(queryParams)
+  // Wait for the session before firing the matches query — otherwise a
+  // first-visit direct-load races the session cookie and 401s into the error
+  // boundary (#144). A disabled query stays `isPending`, so the skeleton holds
+  // until the session resolves rather than flashing the empty state.
+  const session = useSession()
+  const matchList = useMatchList(queryParams, { enabled: session.isSuccess })
+  const data = matchList.data
+  const isLoading = matchList.isPending
 
   const changeStatus = useCallback((next: 'all' | StatusKey) => {
     setStatus(next)


### PR DESCRIPTION
## Summary

A cookieless direct-load of `/matches` (a brand-new visitor navigating straight there) fired `GET /v1/matches` **before** the auto-issued session cookie landed, so the request 401'd and threw into the "Something went wrong! — authentication required" error boundary. The page only recovered on a manual reload.

This gates the matches query on `useSession().isSuccess`, mirroring the dashboard's `useDashboard({ enabled: session.isSuccess })`. The disabled query stays `isPending`, so the skeleton holds until the session resolves instead of flashing the empty state.

- `web-client/src/api/matches.ts`: `useMatchList` accepts `{ enabled }`, passed through to the query.
- `web-client/src/routes/matches/index.tsx`: calls `useSession()`, passes `enabled: session.isSuccess`, and derives the loading flag from `matchList.isPending`.

Closes #144.

## Verification

Reproduced on uat.fortymm.com first: a cookieless direct-load of `/matches` returned a 401 on `GET /api/v1/matches` and rendered the error boundary. With this change the query waits for the session.

## Test plan

- [x] New unit test holds `/v1/session` open and asserts **no** `/v1/matches` request fires (so it can't 401) while the skeleton holds, then rows render once the session resolves.
- [x] `npm run test:run` — 66/66 pass
- [x] `npm run test:e2e` — 126/126 pass
- [x] `npm run lint` + `npm run build` — clean

## Note

While validating, #146 (empty matches list shows perpetual skeletons) was found to be **already fixed** — `web-client/src/routes/matches/index.tsx` already gates skeletons on \`isLoading && rows.length === 0\` and renders a proper "No matches yet" empty state (confirmed on UAT). Recommend closing #146 separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)