### PR TITLE
New match: gate recent-opponents query on session to fix cold-start 401 (#98)

### DIFF
--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -46,11 +46,14 @@ export function matchQueryKey(matchId: string) {
  * (backfilled with other registered players by the API). Errors are thrown so
  * the surrounding error boundary can render a retry affordance.
  */
-export function useRecentOpponents() {
+export function useRecentOpponents(options: { enabled?: boolean } = {}) {
   return useQuery({
     queryKey: RECENT_OPPONENTS_QUERY_KEY,
     queryFn: async (): Promise<Player[]> =>
       unwrap('load recent opponents', await api.GET('/v1/players/recent')),
+    // Gate on the session so a first-visit direct-load doesn't fire before the
+    // session cookie lands and 401 into the error boundary (#98).
+    enabled: options.enabled ?? true,
     staleTime: 1000 * 60 * 5,
     // Fail fast to the error boundary's explicit "Try again" button rather
     // than silently retrying behind the skeleton.

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -11,7 +11,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { delay, http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 import { server } from '@/mocks/server'
-import { matchDetails } from '@/test/factories'
+import { matchDetails, sessionResponse } from '@/test/factories'
 import { Route } from './new'
 
 // The page component isn't exported (route files should only export `Route`,
@@ -191,6 +191,41 @@ describe('NewMatchPage — recent opponents', () => {
     expect(
       screen.queryByRole('status', { name: /loading players/i }),
     ).not.toBeInTheDocument()
+  })
+
+  it('waits for the session before requesting recent opponents (no first-visit 401 race)', async () => {
+    const recentRequests: string[] = []
+    let releaseSession: (() => void) | null = null
+    server.use(
+      // Hold the session request open to simulate the cookie not having
+      // landed yet on a first-visit direct-load (#98).
+      http.get('*/v1/session', async () => {
+        await new Promise<void>((resolve) => {
+          releaseSession = resolve
+        })
+        return HttpResponse.json(sessionResponse())
+      }),
+      http.get('*/v1/players/recent', ({ request }) => {
+        recentRequests.push(request.url)
+        return HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }])
+      }),
+    )
+    renderNewMatch()
+
+    // While the session is unresolved the query is disabled: the skeleton
+    // holds and no players request is fired (so it can't 401).
+    expect(
+      await screen.findByRole('status', { name: /loading players/i }),
+    ).toBeInTheDocument()
+    await waitFor(() => expect(releaseSession).not.toBeNull())
+    expect(recentRequests).toHaveLength(0)
+
+    // Once the session resolves, the query runs and the real chips render.
+    releaseSession!()
+    expect(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    ).toBeInTheDocument()
+    expect(recentRequests.length).toBeGreaterThanOrEqual(1)
   })
 
   it('renders recent opponents in the order the endpoint returns them', async () => {

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -270,7 +270,14 @@ function RecentSkeleton() {
 
 function RecentPicker({ onPick }: { onPick: (player: Player) => void }) {
   const [showSearch, setShowSearch] = useState(false)
-  const { data: players = [], isLoading } = useRecentOpponents()
+  // Wait for the session before fetching players — otherwise a first-visit
+  // direct-load races the session cookie and 401s into the error boundary
+  // (#98). A disabled query stays `isPending`, so the skeleton holds until the
+  // session resolves rather than flashing the empty state.
+  const session = useSession()
+  const recent = useRecentOpponents({ enabled: session.isSuccess })
+  const players = recent.data ?? []
+  const isLoading = recent.isPending
 
   if (showSearch) return <TypeaheadPicker onPick={onPick} />
 


### PR DESCRIPTION
## Summary

A cookieless direct-load of `/matches/new` (e.g. the landing page's "Start playing" CTA on a first visit) fired `GET /v1/players/recent` **before** the auto-issued session cookie landed, so the request 401'd and churned the opponent picker's error boundary ("Couldn't load players") on every cold load.

This gates the recent-opponents query on `useSession().isSuccess`, the same pattern used by the matches list (#144) and the dashboard. The disabled query stays `isPending`, so the skeleton holds until the session resolves instead of flashing the empty state or hitting the boundary.

- `web-client/src/api/matches.ts`: `useRecentOpponents` accepts `{ enabled }`, passed through to the query.
- `web-client/src/routes/matches/new.tsx`: `RecentPicker` calls `useSession()`, passes `enabled: session.isSuccess`, and derives the loading flag from `recent.isPending`.

Closes #98.

## Verification

Reproduced on uat.fortymm.com first: a cookieless direct-load of `/matches/new` returned a 401 on `GET /api/v1/players/recent` and rendered the picker's "Couldn't load players" boundary. With this change the query waits for the session; happy path verified locally (recent-opponent chips render, no boundary).

## Test plan

- [x] New unit test holds `/v1/session` open and asserts **no** `/v1/players/recent` request fires (so it can't 401) while the skeleton holds, then chips render once the session resolves.
- [x] `npm run test:run` — 84/84 pass
- [x] `npm run test:e2e` — 126/126 pass
- [x] `npm run lint` + `npm run build` — clean

## Note

The latent "infinite skeleton if `/v1/session` itself errors" case applies here as it does to the matches list and dashboard; it's tracked separately in #292 (global error boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)