### PR TITLE
Styled 404 page for unknown routes (#281)

### DIFF
--- a/web-client/src/components/not-found-page.test.tsx
+++ b/web-client/src/components/not-found-page.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, expect, it } from 'vitest'
+import { NotFoundPage } from './not-found-page'
+
+function renderAt(path: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute()
+  const dashboardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/dashboard',
+    component: () => <div>Dashboard route</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([dashboardRoute]),
+    history: createMemoryHistory({ initialEntries: [path] }),
+    defaultNotFoundComponent: NotFoundPage,
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('NotFoundPage', () => {
+  it('renders the 404 for an unknown route, echoing the requested path', async () => {
+    renderAt('/this-page-does-not-exist')
+
+    expect(
+      await screen.findByRole('heading', { name: /page not\s*found/i }),
+    ).toBeInTheDocument()
+    // The meta line echoes the path the user actually hit.
+    expect(
+      screen.getByText('/this-page-does-not-exist'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /back to dashboard/i }),
+    ).toHaveAttribute('href', '/dashboard')
+  })
+
+  it('recovers to the dashboard when the action is clicked', async () => {
+    const user = userEvent.setup()
+    renderAt('/nope')
+
+    await user.click(
+      await screen.findByRole('link', { name: /back to dashboard/i }),
+    )
+    expect(await screen.findByText('Dashboard route')).toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/not-found-page.tsx
+++ b/web-client/src/components/not-found-page.tsx
@@ -1,0 +1,93 @@
+import { Link, useRouterState } from '@tanstack/react-router'
+import { AppShell } from '@/components/app-shell'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Router-level catch-all for unknown URLs. Renders inside the app shell with
+ * the typographic treatment from the "Error and Empty States" design handoff:
+ * a mono eyebrow, a big Bebas headline, and a single recovery action.
+ */
+export function NotFoundPage() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  return (
+    <AppShell>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          justifyContent: 'center',
+          minHeight: '100%',
+          padding: '40px clamp(24px, 8vw, 80px)',
+          maxWidth: 920,
+        }}
+      >
+        <div
+          style={{
+            font: '600 11px var(--font-mono)',
+            letterSpacing: '0.2em',
+            color: 'var(--ball-500)',
+            textTransform: 'uppercase',
+            marginBottom: 20,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: 'currentColor',
+            }}
+          />
+          404
+        </div>
+        <h1
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 'clamp(80px, 11vw, 144px)',
+            lineHeight: 0.88,
+            letterSpacing: '0.01em',
+            color: 'var(--fg-1)',
+            margin: '0 0 24px',
+            textTransform: 'uppercase',
+            textWrap: 'balance',
+          }}
+        >
+          Page not
+          <br />
+          found.
+        </h1>
+        <p
+          style={{
+            font: '400 19px var(--font-ui)',
+            lineHeight: 1.45,
+            color: 'var(--fg-2)',
+            margin: '0 0 32px',
+            maxWidth: 560,
+          }}
+        >
+          That URL doesn&rsquo;t lead anywhere we know about. The page may have
+          moved, or the link might be off.
+        </p>
+        <div
+          aria-label="Requested path"
+          style={{
+            font: '500 12px var(--font-mono)',
+            color: 'var(--fg-3)',
+            letterSpacing: '0.08em',
+            marginBottom: 28,
+            wordBreak: 'break-all',
+          }}
+        >
+          {pathname}
+        </div>
+        <Button asChild>
+          <Link to="/dashboard">Back to dashboard</Link>
+        </Button>
+      </div>
+    </AppShell>
+  )
+}

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import './index.css'
 import { Toaster } from '@/components/ui/sonner'
+import { NotFoundPage } from '@/components/not-found-page'
 import { routeTree } from './routeTree.gen'
 
 const queryClient = new QueryClient({
@@ -15,7 +16,11 @@ const queryClient = new QueryClient({
     },
   },
 })
-const router = createRouter({ routeTree, context: { queryClient } })
+const router = createRouter({
+  routeTree,
+  context: { queryClient },
+  defaultNotFoundComponent: NotFoundPage,
+})
 
 declare module '@tanstack/react-router' {
   interface Register {


### PR DESCRIPTION
## Summary

Unknown URLs rendered a bare unstyled "Not Found" on a black background — no app shell, no branding, no way home. This adds a router-level catch-all (`defaultNotFoundComponent`) that renders a styled 404 inside the normal app shell, consistent with the graceful match-not-found treatment.

Built from the "Error and Empty States" design handoff (claude.ai/design): a mono `404` eyebrow, a big Bebas "Page not found." headline, the requested path echoed in mono, and a single recovery action. Recreated in-codebase using the existing design tokens (`--ball-500`, `--font-display`), `AppShell`, and shadcn `Button` rather than the prototype's raw HTML.

Two adaptations requested while reviewing the mock:
- **Dropped the tournament-specific copy** — the sub no longer references tournaments, and the meta line (a fake tournament path in the mock) now echoes the path the user actually hit.
- **Single "Back to dashboard" button** replacing the mock's "Back to overview" / "Search players" pair (no player-search page exists yet).

Closes #281.

## Implementation

- `web-client/src/components/not-found-page.tsx` — the `NotFoundPage` component (typographic layout inside `AppShell`; path via `useRouterState`; action is `<Button asChild><Link to="/dashboard">`).
- `web-client/src/main.tsx` — wires `defaultNotFoundComponent: NotFoundPage` into `createRouter`.

## Test plan

- [x] New test navigates to an unknown route and asserts the 404 renders, echoes the requested path, and the "Back to dashboard" link points to `/dashboard` and navigates there.
- [x] `npm run test:run` — 86/86 pass
- [x] `npm run test:e2e` — 126/126 pass
- [x] `npm run lint` + `npm run build` — clean
- [x] Verified live in the browser at an unknown route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)