### PR TITLE
New match: clear stale 'rated needs opponent' error (#150)

### DIFF
--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -87,9 +87,11 @@ describe('NewMatchPage', () => {
     const user = userEvent.setup()
     renderNewMatch()
 
-    await user.click(
-      await screen.findByRole('button', { name: /start match/i }),
-    )
+    // The error only appears after a submit attempt — not on initial load.
+    await screen.findByRole('button', { name: /start match/i })
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /start match/i }))
     expect(await screen.findByRole('alert')).toHaveTextContent(
       /rated match needs an opponent/i,
     )

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -83,6 +83,25 @@ describe('NewMatchPage', () => {
     ).toBeInTheDocument()
   })
 
+  it('clears the stale rated-needs-opponent error after picking a guest (#150)', async () => {
+    const user = userEvent.setup()
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /start match/i }),
+    )
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /rated match needs an opponent/i,
+    )
+
+    // Adding a guest auto-unrates the match, so the error no longer applies —
+    // it must not linger and contradict "Guest matches are always unrated".
+    await user.click(
+      screen.getByRole('button', { name: /add guest opponent/i }),
+    )
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
   it('creates a match against a picked opponent and navigates to the dashboard', async () => {
     const user = userEvent.setup()
     let captured: unknown = null

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -115,33 +115,29 @@ function MatchCard() {
   const [opponent, setOpponent] = useState<Opponent | null>(null)
   const [bestOf, setBestOf] = useState(5)
   const [rated, setRated] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [apiError, setApiError] = useState<string | null>(null)
+  const [submitted, setSubmitted] = useState(false)
 
   const me = session?.data.user ?? null
 
-  // Changing the opponent or the rated toggle can flip the form from invalid
-  // back to valid, so clear any submit error eagerly — otherwise a stale
-  // "rated needs an opponent" message lingers after picking a guest (#150).
-  const chooseOpponent = (next: Opponent | null) => {
-    setOpponent(next)
-    setError(null)
-  }
-  const changeRated = (next: boolean) => {
-    setRated(next)
-    setError(null)
-  }
+  // Validation is derived from the live form state via the zod schema — never
+  // stored — so the message clears the instant the form turns valid (e.g. once
+  // a guest is picked, #150) instead of lingering. It only surfaces after the
+  // user has tried to submit; the async create failure is the only stored error.
+  const validation = matchFormSchema.safeParse({
+    opponentKind: opponent?.kind ?? null,
+    rated,
+    bestOf,
+  })
+  const validationError = validation.success
+    ? null
+    : (validation.error.issues[0]?.message ?? 'Check the match setup.')
+  const error = apiError ?? (submitted ? validationError : null)
 
   async function handleSubmit() {
-    const parsed = matchFormSchema.safeParse({
-      opponentKind: opponent?.kind ?? null,
-      rated,
-      bestOf,
-    })
-    if (!parsed.success) {
-      setError(parsed.error.issues[0]?.message ?? 'Check the match setup.')
-      return
-    }
-    setError(null)
+    setSubmitted(true)
+    if (validationError) return
+    setApiError(null)
 
     // Guest / "start without opponent" matches have a single side, so they
     // can never be rated regardless of the toggle.
@@ -154,7 +150,7 @@ function MatchCard() {
       })
       navigate(nextScoringDestination(created))
     } catch (err) {
-      setError(
+      setApiError(
         err instanceof ApiError
           ? (err.detail ?? err.message)
           : 'Could not start the match. Try again.',
@@ -187,23 +183,23 @@ function MatchCard() {
         {opponent ? (
           <SelectedOpponent
             opponent={opponent}
-            onChange={() => chooseOpponent(null)}
+            onChange={() => setOpponent(null)}
           />
         ) : (
           <OpponentPickerBoundary>
             <RecentPicker
-              onPick={(player) => chooseOpponent(registeredOpponent(player))}
+              onPick={(player) => setOpponent(registeredOpponent(player))}
             />
           </OpponentPickerBoundary>
         )}
 
         {!opponent && (
           <div className="nm-skip-row">
-            <button type="button" onClick={() => chooseOpponent(GUEST)}>
+            <button type="button" onClick={() => setOpponent(GUEST)}>
               Add guest opponent
             </button>
             <span className="sep">·</span>
-            <button type="button" onClick={() => chooseOpponent(OPPONENT_TBD)}>
+            <button type="button" onClick={() => setOpponent(OPPONENT_TBD)}>
               Start without opponent
             </button>
           </div>
@@ -212,7 +208,7 @@ function MatchCard() {
 
       <div className="nm-settings">
         <BestOfField bestOf={bestOf} setBestOf={setBestOf} />
-        <RatedField rated={rated} setRated={changeRated} opponent={opponent} />
+        <RatedField rated={rated} setRated={setRated} opponent={opponent} />
       </div>
 
       <SubmitRow

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -119,6 +119,18 @@ function MatchCard() {
 
   const me = session?.data.user ?? null
 
+  // Changing the opponent or the rated toggle can flip the form from invalid
+  // back to valid, so clear any submit error eagerly — otherwise a stale
+  // "rated needs an opponent" message lingers after picking a guest (#150).
+  const chooseOpponent = (next: Opponent | null) => {
+    setOpponent(next)
+    setError(null)
+  }
+  const changeRated = (next: boolean) => {
+    setRated(next)
+    setError(null)
+  }
+
   async function handleSubmit() {
     const parsed = matchFormSchema.safeParse({
       opponentKind: opponent?.kind ?? null,
@@ -175,23 +187,23 @@ function MatchCard() {
         {opponent ? (
           <SelectedOpponent
             opponent={opponent}
-            onChange={() => setOpponent(null)}
+            onChange={() => chooseOpponent(null)}
           />
         ) : (
           <OpponentPickerBoundary>
             <RecentPicker
-              onPick={(player) => setOpponent(registeredOpponent(player))}
+              onPick={(player) => chooseOpponent(registeredOpponent(player))}
             />
           </OpponentPickerBoundary>
         )}
 
         {!opponent && (
           <div className="nm-skip-row">
-            <button type="button" onClick={() => setOpponent(GUEST)}>
+            <button type="button" onClick={() => chooseOpponent(GUEST)}>
               Add guest opponent
             </button>
             <span className="sep">·</span>
-            <button type="button" onClick={() => setOpponent(OPPONENT_TBD)}>
+            <button type="button" onClick={() => chooseOpponent(OPPONENT_TBD)}>
               Start without opponent
             </button>
           </div>
@@ -200,7 +212,7 @@ function MatchCard() {
 
       <div className="nm-settings">
         <BestOfField bestOf={bestOf} setBestOf={setBestOf} />
-        <RatedField rated={rated} setRated={setRated} opponent={opponent} />
+        <RatedField rated={rated} setRated={changeRated} opponent={opponent} />
       </div>
 
       <SubmitRow


### PR DESCRIPTION
## Summary

On `/matches/new`, submitting a rated match with no opponent showed the inline error *"A rated match needs an opponent — pick one, or switch off Rated to play without one."* Picking **Add guest opponent** then left that error on screen — even though choosing a guest auto-unrates the match and the form now says *"Guest matches are always unrated."* The two messages contradicted each other.

## Fix

The error was stored in component state and only managed inside `handleSubmit`, so it lingered after the form became valid again. Instead, **derive the validation error from the existing `matchFormSchema` (zod) on every render** and gate its display on a `submitted` flag:

```ts
const validation = matchFormSchema.safeParse({ opponentKind: opponent?.kind ?? null, rated, bestOf })
const validationError = validation.success ? null : (validation.error.issues[0]?.message ?? 'Check the match setup.')
const error = apiError ?? (submitted ? validationError : null)
```

- Validation can no longer go stale — it recomputes when the opponent or Rated toggle changes, so picking a guest clears it immediately.
- It still only surfaces after a submit attempt (the `submitted` gate), preserving the current UX.
- Only the async create failure (`apiError`) stays in component state.

Kept this as zod-on-`useState` rather than a full react-hook-form + zodResolver conversion — the form uses custom controls (opponent picker, radio, toggle), so RHF would be a heavier refactor for no extra benefit here.

Closes #150.

## Test plan

- [x] New test: error appears only after submit, then clears once a guest is picked (no lingering contradiction).
- [x] `npm run test:run` — 87/87 pass
- [x] `npm run test:e2e` — 126/126 pass
- [x] `npm run lint` + `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)