### PR TITLE
Dashboard: remove hardcoded greeting subtitle and mock date

### DIFF
--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -440,7 +440,7 @@ function PageTitle({
   subtitle,
 }: {
   greeting: string
-  subtitle: string
+  subtitle?: string
 }) {
   return (
     <div style={{ display: 'flex', alignItems: 'flex-end', marginBottom: 24, gap: 16 }}>
@@ -460,9 +460,11 @@ function PageTitle({
           {greeting}
           <span style={{ color: C.ball500 }}>.</span>
         </h1>
-        <div style={{ marginTop: 6, font: `400 14px ${UI}`, color: C.chalk300 }}>
-          {subtitle}
-        </div>
+        {subtitle && (
+          <div style={{ marginTop: 6, font: `400 14px ${UI}`, color: C.chalk300 }}>
+            {subtitle}
+          </div>
+        )}
       </div>
       <div style={{ flex: 1 }} />
       <Button
@@ -1050,7 +1052,7 @@ export function DashboardPage() {
         boxSizing: 'border-box',
       }}
     >
-      <PageTitle greeting={greeting} subtitle="3 things need your attention" />
+      <PageTitle greeting={greeting} />
       {isLoading ? (
         <SkeletonCard label="Loading score banner" height={140} />
       ) : data?.score_banners?.length ? (

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -10,7 +10,7 @@ import type {
 import { scoringNewRoute } from '@/api/matches'
 import { useSession } from '@/api/session'
 import { Overline } from '@/components/overline'
-import { fmtDateShort } from '@/lib/dates'
+import { fmtDateShort, fmtLongDate } from '@/lib/dates'
 import { formatRatingDelta } from '@/lib/rating'
 
 const GUEST_OPPONENT = 'guest'
@@ -446,7 +446,7 @@ function PageTitle({
     <div style={{ display: 'flex', alignItems: 'flex-end', marginBottom: 24, gap: 16 }}>
       <div>
         <Overline style={{ marginBottom: 8 }}>
-          Dashboard · Tuesday, April 22
+          Dashboard · {fmtLongDate()}
         </Overline>
         <h1
           style={{

--- a/web-client/src/lib/dates.test.ts
+++ b/web-client/src/lib/dates.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { fmtLongDate } from './dates'
+
+describe('fmtLongDate', () => {
+  it('formats a date as full weekday, month and day', () => {
+    // 2024-01-01 (local) is a Monday.
+    expect(fmtLongDate(new Date(2024, 0, 1))).toBe('Monday, January 1')
+    expect(fmtLongDate(new Date(2026, 3, 22))).toBe('Wednesday, April 22')
+  })
+
+  it('defaults to today', () => {
+    expect(fmtLongDate()).toBe(fmtLongDate(new Date()))
+  })
+})

--- a/web-client/src/lib/dates.ts
+++ b/web-client/src/lib/dates.ts
@@ -27,3 +27,8 @@ export function fmtDateRel(iso: string | null | undefined): string {
   if (!iso) return '—'
   return formatDistanceToNowStrict(parseApiDate(iso), { addSuffix: true })
 }
+
+/** Full weekday, month and day for a header — e.g. "Tuesday, April 22". */
+export function fmtLongDate(date: Date = new Date()): string {
+  return format(date, 'EEEE, MMMM d')
+}


### PR DESCRIPTION
## Summary

Two pieces of hardcoded mock copy in the dashboard `PageTitle` header, shown to every user with nothing behind them:

1. **"3 things need your attention"** subtitle — removed. `PageTitle`'s `subtitle` is now optional and only renders when provided; the dashboard no longer passes it, so the greeting (`Hi, @username.`) stands alone.
2. **"Dashboard · Tuesday, April 22"** overline — now shows today's real date. Added a `fmtLongDate(date = new Date())` helper to `lib/dates.ts` (date-fns `EEEE, MMMM d`, e.g. "Tuesday, April 22") and use it in the overline.

Both were flagged but left out of scope during the greeting fix (#279); related to the broader dashboard mock-data cleanup (#161).

## Test plan

- [x] New `fmtLongDate` unit test (deterministic dates: Mon 2024-01-01, Wed 2026-04-22; plus the today default).
- [x] `npm run test:run` — 89/89 pass
- [x] `npm run lint` + `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)