### PR TITLE
Match details: friendly not-found for malformed match IDs (#152)

### DIFF
--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -234,6 +234,32 @@ describe('MatchDetailsView', () => {
     expect(within(alert).getByText(/couldn.t find that match/i)).toBeInTheDocument()
   })
 
+  it('shows friendly not-found copy (not the raw API detail) for a malformed match id (#152)', async () => {
+    server.use(
+      http.get('*/v1/matches/garbage', () =>
+        HttpResponse.json(
+          {
+            detail:
+              'Input should be a valid UUID, invalid character: found `g` at 1',
+          },
+          { status: 422 },
+        ),
+      ),
+    )
+    renderDetails('garbage')
+
+    const alert = await screen.findByRole('alert')
+    expect(
+      within(alert).getByText(/couldn.t find that match/i),
+    ).toBeInTheDocument()
+    // The raw pydantic validation message must not leak to the user.
+    expect(within(alert).queryByText(/valid UUID/i)).not.toBeInTheDocument()
+    // Retrying the same broken URL is pointless — offer a way back to the list.
+    expect(
+      within(alert).getByRole('link', { name: /back to matches/i }),
+    ).toHaveAttribute('href', '/matches')
+  })
+
   it('redirects solo matches (no opponent) back to /matches', async () => {
     const match = matchDetails({
       id: 'm-solo',

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -279,24 +279,34 @@ export function MatchDetailsError({
 }) {
   const router = useRouter()
   const status = error instanceof ApiError ? error.status : 0
-  const message =
-    status === 404
-      ? "We couldn't find that match."
-      : error.message || "Something went wrong loading this match."
+  // Any client error (404 no-such-match, 422 malformed id, …) means there's no
+  // viewable match at this URL — show the friendly copy and never leak the raw
+  // API detail (e.g. the pydantic "Input should be a valid UUID" string, #152).
+  // Retrying the same URL won't help, so offer a way back to the list instead.
+  const notFound = status >= 400 && status < 500
+  const message = notFound
+    ? "We couldn't find that match."
+    : 'Something went wrong loading this match.'
   return (
     <AppShell>
       <div role="alert" className="md-error-state">
         <div className="md-error-state__title">{message}</div>
-        <button
-          type="button"
-          className="md-btn md-btn--secondary"
-          onClick={() => {
-            reset()
-            router.invalidate()
-          }}
-        >
-          Try again
-        </button>
+        {notFound ? (
+          <Link to="/matches" className="md-btn md-btn--secondary">
+            Back to matches
+          </Link>
+        ) : (
+          <button
+            type="button"
+            className="md-btn md-btn--secondary"
+            onClick={() => {
+              reset()
+              router.invalidate()
+            }}
+          >
+            Try again
+          </button>
+        )}
       </div>
     </AppShell>
   )


### PR DESCRIPTION
## Summary

Navigating to a malformed match URL (e.g. `/matches/garbage`) returned a **422** from the API, and the match-details error fallback rendered the raw pydantic detail verbatim — *"Input should be a valid UUID, invalid character: found `g` at 1"* — with a "Try again" button that just re-hit the same broken URL.

Now any client error (**4xx** — covers 404 no-such-match and 422 malformed id) shows the friendly *"We couldn't find that match."* and never surfaces the raw API detail. Since retrying a broken URL is pointless, that case offers a **"Back to matches"** link; "Try again" remains for transient / server (5xx / network) failures.

Closes #152.

## Implementation

`web-client/src/components/matches/match-details-page.tsx` — `MatchDetailsError` now derives `notFound = status >= 400 && status < 500`, picks the friendly vs generic message accordingly, and renders a `Link to="/matches"` for the not-found case instead of the retry button.

## Test plan

- [x] New test: a 422 malformed-id response shows the friendly copy, does **not** leak the pydantic message, and offers "Back to matches" → `/matches`.
- [x] Existing 404 error-fallback test still passes.
- [x] `npm run test:run` — 90/90 pass
- [x] `npm run test:e2e` — 126/126 pass
- [x] `npm run lint` + `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)