### PR TITLE
Matches list: show single-digit live count, not zero-padded "00" (#282)

### DIFF
--- a/web-client/src/routes/matches/index.test.tsx
+++ b/web-client/src/routes/matches/index.test.tsx
@@ -244,4 +244,24 @@ describe('MatchesPage', () => {
     // Three keystrokes should coalesce into one debounced fetch.
     expect(requests.length - requestsBeforeTyping).toBe(1)
   })
+
+  it('renders a single-digit live count, not a zero-padded "00" (#282)', async () => {
+    server.use(
+      http.get('*/v1/matches', () =>
+        HttpResponse.json(
+          matchListResponse({
+            items: [],
+            total: 0,
+            status_counts: { in_progress: 0 },
+          }),
+        ),
+      ),
+    )
+    const { container } = renderMatchesPage()
+
+    // Wait for the load to settle (empty result → empty state).
+    await screen.findByText(/no matches yet/i)
+    const pill = container.querySelector('.live-pill')
+    expect(pill?.textContent?.replace(/\s+/g, ' ').trim()).toBe('0 LIVE')
+  })
 })

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -184,7 +184,7 @@ function ActionBar({ liveCount }: { liveCount: number }) {
       </div>
       <span className="live-pill">
         <span className="live-dot" />
-        {String(liveCount).padStart(2, '0')} LIVE
+        {liveCount} LIVE
       </span>
       <div className="filter-spacer" />
       <Button variant="ghost" size="sm">


### PR DESCRIPTION
## Summary

The live-count pill in the `/matches` header zero-padded the count to two digits via `String(liveCount).padStart(2, '0')`, so zero live matches rendered as a confusing **"00 LIVE"**. Drop the padding so it reads **"0 LIVE"** (and the true count otherwise) — consistent with how the status-tab counts render.

Closes #282.

## Test plan

- [x] New test asserts the live pill reads exactly `"0 LIVE"` (not `"00 LIVE"`) on an empty result.
- [x] `npm run test:run` — 91/91 pass
- [x] `npm run test:e2e` — 126/126 pass
- [x] `npm run lint` + `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)