### PR TITLE
Render solo (no-opponent) matches on the match-detail page

### DIFF
--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -260,7 +260,7 @@ describe('MatchDetailsView', () => {
     ).toHaveAttribute('href', '/matches')
   })
 
-  it('redirects solo matches (no opponent) back to /matches', async () => {
+  it('renders solo matches (no opponent) with only the participant side', async () => {
     const match = matchDetails({
       id: 'm-solo',
       sides: [
@@ -281,11 +281,14 @@ describe('MatchDetailsView', () => {
     server.use(
       http.get('*/v1/matches/m-solo', () => HttpResponse.json(match)),
     )
-    renderDetails('m-solo')
+    const { container } = renderDetails('m-solo')
 
     await waitFor(() =>
-      expect(screen.getByText('matches-list')).toBeInTheDocument(),
+      expect(container.querySelectorAll('.md-hero__name').length).toBe(1),
     )
+    expect(container.querySelector('.md-hero__name')).toHaveTextContent('me')
+    // Did not bounce to the list — this replaced an earlier redirect.
+    expect(screen.queryByText('matches-list')).not.toBeInTheDocument()
   })
 
   it('renders for spectators (no current-user side) without a Score CTA', async () => {

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link, Navigate, useRouter } from '@tanstack/react-router'
+import { Link, useRouter } from '@tanstack/react-router'
 import {
   Check,
   ChevronRight,
@@ -254,12 +254,6 @@ export function MatchDetailsView({ matchId }: { matchId: string }) {
         <MatchDetailsSkeleton />
       </AppShell>
     )
-  }
-
-  if (data.sides.length < 2) {
-    // Solo matches aren't viewable on this page yet — the surface assumes
-    // two sides.
-    return <Navigate to="/matches" />
   }
 
   const view = projectMatchView(data, matchId)
@@ -675,12 +669,14 @@ function PlayersCard({ view }: { view: MatchView }) {
       </div>
       <div className="md-players">
         <PlayerProfile side={view.leftSide} won={view.leftSide.won === true} />
-        <div className="md-players__divider" />
         {view.rightSide && (
-          <PlayerProfile
-            side={view.rightSide}
-            won={view.rightSide.won === true}
-          />
+          <>
+            <div className="md-players__divider" />
+            <PlayerProfile
+              side={view.rightSide}
+              won={view.rightSide.won === true}
+            />
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
## What

A match with no opponent (a "solo" match, created via **Start without opponent**) has a single side. `MatchDetailsView` redirected any match with `sides.length < 2` straight back to `/matches`, so the matches-list row for a solo match was effectively a **dead link** — clicking it navigated to `/matches/{id}`, which instantly bounced back to the list.

This removes that stale guard so solo matches render on the detail page. The render tree already null-guards the opponent side throughout (`orderSides` returns `rightSide: … ?? null`; the hero, game grid, players card, rating card, and H2H card all guard with `?.`/`&&`), so the `sides.length < 2` redirect was the only thing blocking it.

Also gates the players-card divider on the opponent side so solo matches don't render a dangling divider with empty space beside it.

As a bonus this removes a pre-existing double-redirect: creating a solo match went new → scoring → detail → list; it now ends on the viewable detail page.

## Test plan

- Updated the unit test that asserted the redirect to instead assert a solo match renders one side and does not bounce to the list.
- Verified live in the browser: creating a solo match now lands on its detail page, and clicking the solo row from `/matches` opens it.
- web-client unit (92) ✅, lint ✅, build/typecheck ✅, web-client e2e (126) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)