### PR TITLE
Add tournament schedule simulator at /simulator

### DIFF
--- a/web-client/src/components/simulator/data.ts
+++ b/web-client/src/components/simulator/data.ts
@@ -570,7 +570,6 @@ function computeTotalIdle(matches: Match[]): number {
   return total
 }
 
-// Count total matches expected (across all events) for progress display
 export function totalExpectedMatches(cfg: Config): number {
   return cfg.events.reduce(
     (s, e) => s + (e.playerIds.length * (e.playerIds.length - 1)) / 2,
@@ -578,17 +577,33 @@ export function totalExpectedMatches(cfg: Config): number {
   )
 }
 
-// Color for event by index
 export function eventColor(eventIndex: number): string {
   return EVENT_COLORS[eventIndex % EVENT_COLORS.length]
 }
 
 export type ColorBy = 'event' | 'table' | 'player'
 
-// Compute color for matching `colorBy` setting
-export function colorForMatch(m: Match, cfg: Config, colorBy: ColorBy): string {
+// O(1) lookups built once per config, so render loops over 50+ matches don't
+// scan the events/tables/players arrays per match.
+export interface ConfigLookups {
+  eventById: Map<string, TournamentEvent>
+  eventIndexById: Map<string, number>
+  tableIndexById: Map<string, number>
+  playerById: Map<string, Player>
+}
+
+export function buildLookups(cfg: Config): ConfigLookups {
+  return {
+    eventById: new Map(cfg.events.map((e) => [e.id, e])),
+    eventIndexById: new Map(cfg.events.map((e, i) => [e.id, i])),
+    tableIndexById: new Map(cfg.tables.map((t, i) => [t.id, i])),
+    playerById: new Map(cfg.players.map((p) => [p.id, p])),
+  }
+}
+
+export function colorForMatch(m: Match, colorBy: ColorBy, lookups: ConfigLookups): string {
   if (colorBy === 'table') {
-    const i = cfg.tables.findIndex((t) => t.id === m.tableId)
+    const i = lookups.tableIndexById.get(m.tableId) ?? 0
     return EVENT_COLORS[(i + 2) % EVENT_COLORS.length]
   }
   if (colorBy === 'player') {
@@ -597,11 +612,38 @@ export function colorForMatch(m: Match, cfg: Config, colorBy: ColorBy): string {
       .reduce((acc, c) => (acc + c.charCodeAt(0)) % 1000, 0)
     return EVENT_COLORS[h % EVENT_COLORS.length]
   }
-  const i = cfg.events.findIndex((e) => e.id === m.eventId)
+  const i = lookups.eventIndexById.get(m.eventId) ?? 0
   return EVENT_COLORS[i % EVENT_COLORS.length]
 }
 
-// Initials helper
+// Which not-yet-completed match finishes first given the user's actual-duration
+// hypotheses. Single source of truth for "what advances next" — the schedule
+// panel highlight and the advance handlers must agree, including the
+// lowest-id tie-break.
+export function nextCompletion(
+  matches: Match[],
+  completedIds: Set<string>,
+  eventById: Map<string, TournamentEvent>,
+  durations: Record<string, number>,
+): { match: Match; actualDur: number } | null {
+  let best: Match | null = null
+  let bestT = Infinity
+  for (const m of matches) {
+    if (completedIds.has(m.id)) continue
+    const ev = eventById.get(m.eventId)
+    if (!ev) continue
+    const dur = durations[m.id] ?? ev.matchDurationMin
+    const t = m.plannedStart + dur
+    if (t < bestT || (t === bestT && (!best || m.id < best.id))) {
+      bestT = t
+      best = m
+    }
+  }
+  if (!best) return null
+  const ev = eventById.get(best.eventId)!
+  return { match: best, actualDur: durations[best.id] ?? ev.matchDurationMin }
+}
+
 export function initials(name: string): string {
   return name
     .split(/\s+/)

--- a/web-client/src/components/simulator/data.ts
+++ b/web-client/src/components/simulator/data.ts
@@ -1,0 +1,611 @@
+/* =====================================================================
+   data.ts — example config + helpers + fake CP-SAT-ish solver
+   Ported from the FortyMM design handoff (data.js).
+   ===================================================================== */
+
+export type EventFormat = 'round_robin'
+
+export interface Table {
+  id: string
+  name: string
+}
+
+export interface Player {
+  id: string
+  name: string
+  rating: number | null
+}
+
+export interface TournamentEvent {
+  id: string
+  name: string
+  matchDurationMin: number
+  restMin: number
+  format: EventFormat
+  playerIds: string[]
+}
+
+export interface TablePool {
+  id: string
+  eventId: string
+  tableIds: string[]
+  startMin: number
+  endMin: number
+}
+
+export interface Config {
+  name: string
+  startISO: string
+  endISO: string
+  tables: Table[]
+  players: Player[]
+  events: TournamentEvent[]
+  tablePools: TablePool[]
+}
+
+export interface Match {
+  id: string
+  eventId: string
+  p1: string
+  p2: string
+  tableId: string
+  plannedStart: number
+  plannedEnd: number
+  plannedDurationMin: number
+  completed: boolean
+  actualStart?: number
+  actualEnd?: number
+}
+
+export type SolveStatus = 'OPTIMAL' | 'FEASIBLE' | 'INFEASIBLE'
+
+export interface SolveError {
+  msg: string
+  ref: string
+  scope: ValidationScope
+}
+
+export interface Schedule {
+  status: SolveStatus
+  solveTimeMs: number
+  makespanMin: number
+  totalIdleMin: number
+  matches: Match[]
+  error?: SolveError
+}
+
+export interface Completion {
+  matchId: string
+  start: number
+  end: number
+  tableId: string
+}
+
+export interface SolveOptions {
+  completions?: Completion[]
+  previousSchedule?: Schedule | null
+  isInitial?: boolean
+  isPerturbed?: boolean
+}
+
+export type ValidationScope =
+  | 'tournament'
+  | 'tables'
+  | 'players'
+  | 'events'
+  | 'pools'
+
+export interface ValidationError {
+  scope: ValidationScope
+  ref?: string
+  field?: string
+  msg: string
+}
+
+export type ClockMode = '24h' | '12h' | 'from_start'
+
+// ----- ID helpers --------------------------------------------------------
+let __idc = 0
+export const nid = (p: string) => `${p}_${(++__idc).toString(36)}`
+
+// ----- Time helpers ------------------------------------------------------
+export const T0_ISO = '2026-06-13T08:00:00' // tournament t=0 anchor; sim "now" works in minutes
+export const TEND_ISO = '2026-06-13T19:00:00'
+export const minutesBetween = (aISO: string, bISO: string) =>
+  Math.round((+new Date(bISO) - +new Date(aISO)) / 60000)
+export const addMin = (iso: string, m: number) =>
+  new Date(new Date(iso).getTime() + m * 60000).toISOString()
+
+export function fmtClock(
+  minFromStart: number,
+  mode: ClockMode = '24h',
+  startISO: string = T0_ISO,
+): string {
+  const d = new Date(new Date(startISO).getTime() + minFromStart * 60000)
+  if (mode === 'from_start') {
+    const h = Math.floor(minFromStart / 60)
+    const m = Math.floor(minFromStart % 60)
+    return `+${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+  }
+  const hh = d.getHours()
+  const mm = d.getMinutes()
+  if (mode === '12h') {
+    const ampm = hh >= 12 ? 'PM' : 'AM'
+    const h12 = ((hh + 11) % 12) + 1
+    return `${h12}:${String(mm).padStart(2, '0')} ${ampm}`
+  }
+  return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`
+}
+
+// ----- Event color palette -----------------------------------------------
+// Hand-tuned on dark ink, distinct, never the brand orange (reserved for "now").
+export const EVENT_COLORS = [
+  '#FF7A1A', // ball orange — used for the most prominent event
+  '#6FB5FF', // info blue
+  '#00E29A', // serve green
+  '#C792EA', // violet
+  '#FFC43D', // warn yellow
+  '#FF7AA3', // pink
+  '#7AE7C7', // mint
+  '#FFA978', // peach
+]
+
+// ----- Example tournament -------------------------------------------------
+export function makeExampleConfig(): Config {
+  __idc = 0
+  const tables: Table[] = ['1', '2', '3', '4', '5', '6'].map((n) => ({
+    id: nid('tbl'),
+    name: `Table ${n}`,
+  }))
+
+  const PLAYER_NAMES: [string, number][] = [
+    ['Alex Nguyen', 1820],
+    ['Maria Chen', 2140],
+    ['Jordan Patel', 1670],
+    ['Sam Rivera', 1480],
+    ['Devon Park', 1980],
+    ['Casey Brooks', 1310],
+    ['Rin Tanaka', 2280],
+    ['Priya Shah', 1740],
+    ['Lukas Weber', 1560],
+    ['Naomi Cole', 1880],
+    ['Owen Murray', 1420],
+    ['Hana Sato', 2030],
+    ['Tobias Ng', 1620],
+    ['Elena Petrov', 1290],
+    ['Marcus Hill', 1950],
+    ['Yuki Mori', 2210],
+  ]
+  const players: Player[] = PLAYER_NAMES.map(([name, rating]) => ({
+    id: nid('plr'),
+    name,
+    rating,
+  }))
+
+  // ----- 3 events ------
+  // Rosters are largely disjoint so the example always solves.
+  const ev1: TournamentEvent = {
+    id: nid('ev'),
+    name: 'U2000 Singles',
+    matchDurationMin: 25,
+    restMin: 15,
+    format: 'round_robin',
+    playerIds: players
+      .filter((p) => (p.rating ?? 0) < 1800)
+      .slice(0, 8)
+      .map((p) => p.id),
+  }
+  const ev2: TournamentEvent = {
+    id: nid('ev'),
+    name: 'Open Singles',
+    matchDurationMin: 30,
+    restMin: 20,
+    format: 'round_robin',
+    playerIds: players
+      .filter((p) => (p.rating ?? 0) >= 1800)
+      .slice(0, 7)
+      .map((p) => p.id),
+  }
+  const ev3: TournamentEvent = {
+    id: nid('ev'),
+    name: 'Novice U1500',
+    matchDurationMin: 20,
+    restMin: 10,
+    format: 'round_robin',
+    playerIds: players
+      .filter((p) => (p.rating ?? 0) < 1500)
+      .slice(0, 4)
+      .map((p) => p.id),
+  }
+  const events = [ev1, ev2, ev3]
+
+  // ----- Table pools ------
+  // Spread across the day; events partly share/overlap. Day is 0-660 min (8:00-19:00).
+  const pools: TablePool[] = [
+    {
+      id: nid('pool'),
+      eventId: ev2.id,
+      tableIds: tables.slice(0, 6).map((t) => t.id),
+      startMin: 0,
+      endMin: 240,
+    },
+    {
+      id: nid('pool'),
+      eventId: ev2.id,
+      tableIds: tables.slice(0, 4).map((t) => t.id),
+      startMin: 270,
+      endMin: 540,
+    },
+    {
+      id: nid('pool'),
+      eventId: ev1.id,
+      tableIds: tables.slice(3, 6).map((t) => t.id),
+      startMin: 0,
+      endMin: 240,
+    },
+    {
+      id: nid('pool'),
+      eventId: ev1.id,
+      tableIds: tables.slice(2, 6).map((t) => t.id),
+      startMin: 270,
+      endMin: 600,
+    },
+    {
+      id: nid('pool'),
+      eventId: ev3.id,
+      tableIds: tables.slice(0, 3).map((t) => t.id),
+      startMin: 270,
+      endMin: 540,
+    },
+  ]
+
+  return {
+    name: 'Spring Open 2026',
+    startISO: T0_ISO,
+    endISO: TEND_ISO,
+    tables,
+    players,
+    events,
+    tablePools: pools,
+  }
+}
+
+// ----- Validation -------------------------------------------------------
+export function validateConfig(cfg: Config): ValidationError[] {
+  const errs: ValidationError[] = []
+  if (!cfg.name?.trim())
+    errs.push({ scope: 'tournament', field: 'name', msg: 'Tournament needs a name.' })
+  if (!cfg.startISO)
+    errs.push({ scope: 'tournament', field: 'startISO', msg: 'Start time required.' })
+  if (!cfg.endISO)
+    errs.push({ scope: 'tournament', field: 'endISO', msg: 'End time required.' })
+  if (cfg.startISO && cfg.endISO && new Date(cfg.endISO) <= new Date(cfg.startISO))
+    errs.push({ scope: 'tournament', field: 'endISO', msg: 'End must be after start.' })
+  if (cfg.tables.length === 0)
+    errs.push({ scope: 'tables', msg: 'At least one table required.' })
+  cfg.tables.forEach((t) => {
+    if (!t.name?.trim())
+      errs.push({ scope: 'tables', ref: t.id, field: 'name', msg: 'Table needs a name.' })
+  })
+  if (cfg.players.length < 2)
+    errs.push({ scope: 'players', msg: 'Need at least 2 players.' })
+  cfg.players.forEach((p) => {
+    if (!p.name?.trim())
+      errs.push({ scope: 'players', ref: p.id, field: 'name', msg: 'Player needs a name.' })
+    if (p.rating != null && (p.rating < 0 || p.rating > 3000 || !Number.isInteger(p.rating)))
+      errs.push({ scope: 'players', ref: p.id, field: 'rating', msg: 'Rating must be 0–3000.' })
+  })
+  if (cfg.events.length === 0)
+    errs.push({ scope: 'events', msg: 'Need at least one event.' })
+  cfg.events.forEach((e) => {
+    if (!e.name?.trim())
+      errs.push({ scope: 'events', ref: e.id, field: 'name', msg: 'Event needs a name.' })
+    if (!e.matchDurationMin || e.matchDurationMin <= 0)
+      errs.push({
+        scope: 'events',
+        ref: e.id,
+        field: 'matchDurationMin',
+        msg: 'Match duration required.',
+      })
+    else if (e.matchDurationMin % 5 !== 0)
+      errs.push({
+        scope: 'events',
+        ref: e.id,
+        field: 'matchDurationMin',
+        msg: 'Must be a multiple of 5.',
+      })
+    if (e.restMin == null || e.restMin < 0)
+      errs.push({ scope: 'events', ref: e.id, field: 'restMin', msg: 'Rest period required.' })
+    if (e.playerIds.length < 2)
+      errs.push({ scope: 'events', ref: e.id, field: 'playerIds', msg: 'Need at least 2 players.' })
+    if (!cfg.tablePools.some((p) => p.eventId === e.id))
+      errs.push({ scope: 'events', ref: e.id, field: 'pools', msg: 'No table pool covers this event.' })
+  })
+  cfg.tablePools.forEach((p) => {
+    if (!p.tableIds || p.tableIds.length === 0)
+      errs.push({ scope: 'pools', ref: p.id, field: 'tableIds', msg: 'Pool needs at least one table.' })
+    if (p.startMin >= p.endMin)
+      errs.push({ scope: 'pools', ref: p.id, field: 'endMin', msg: 'Pool end must be after start.' })
+  })
+  return errs
+}
+
+// ----- Round-robin pairs -------------------------------------------------
+// Circle-method ordering. For N players we use rounds where every player
+// plays once per round; the greedy then doesn't front-load any single
+// player and produces tightly-packed schedules.
+export function roundRobinPairs(playerIds: string[]): [string, string][] {
+  let arr = playerIds.slice()
+  if (arr.length < 2) return []
+  const hadOdd = arr.length % 2 === 1
+  if (hadOdd) arr.push('__BYE__')
+  const n = arr.length
+  const rounds: [string, string][][] = []
+  for (let r = 0; r < n - 1; r++) {
+    const round: [string, string][] = []
+    for (let i = 0; i < n / 2; i++) {
+      const a = arr[i],
+        b = arr[n - 1 - i]
+      if (a !== '__BYE__' && b !== '__BYE__') round.push([a, b])
+    }
+    rounds.push(round)
+    // Rotate: keep position 0 fixed, rotate everyone else
+    const fixed = arr[0]
+    const rest = arr.slice(1)
+    rest.unshift(rest.pop() as string)
+    arr = [fixed, ...rest]
+  }
+  const out: [string, string][] = []
+  rounds.forEach((r) => r.forEach((p) => out.push(p)))
+  return out
+}
+
+// ----- The fake solver ---------------------------------------------------
+// Greedy schedule packer with: pinned completions, player rest, table pool windows.
+export function solve(cfg: Config, options: SolveOptions = {}): Schedule {
+  const {
+    completions = [],
+    previousSchedule = null,
+    isInitial = false,
+    isPerturbed = false,
+  } = options
+  const evById = Object.fromEntries(cfg.events.map((e) => [e.id, e]))
+  const evIndex = Object.fromEntries(cfg.events.map((e, i) => [e.id, i]))
+  const tablePoolsByEvent: Record<string, TablePool[]> = {}
+  cfg.tablePools.forEach((p) => {
+    ;(tablePoolsByEvent[p.eventId] ||= []).push(p)
+  })
+  // Per-table availability is an array of [start,end] free slots
+  const dayEnd = minutesBetween(cfg.startISO, cfg.endISO)
+  const tableFree: Record<string, [number, number][]> = {}
+  cfg.tables.forEach((t) => {
+    tableFree[t.id] = [[0, dayEnd]]
+  })
+  // Per-player next-free time
+  const playerNextFree: Record<string, number> = {}
+  cfg.players.forEach((p) => {
+    playerNextFree[p.id] = 0
+  })
+
+  const completedIds = new Set(completions.map((c) => c.matchId))
+
+  // Build needed match list
+  const needed: { matchId: string; eventId: string; p1: string; p2: string }[] = []
+  cfg.events.forEach((ev) => {
+    const pairs = roundRobinPairs(ev.playerIds)
+    pairs.forEach(([a, b]) => {
+      const prev = previousSchedule?.matches?.find(
+        (m) =>
+          m.eventId === ev.id &&
+          ((m.p1 === a && m.p2 === b) || (m.p1 === b && m.p2 === a)),
+      )
+      needed.push({
+        matchId: prev?.id || nid('m'),
+        eventId: ev.id,
+        p1: a,
+        p2: b,
+      })
+    })
+  })
+
+  // Pin completed matches first (no scheduling — just block out table + player)
+  const matches: Match[] = []
+  for (const c of completions) {
+    const need = needed.find((n) => n.matchId === c.matchId)
+    if (!need) continue
+    const dur = c.end - c.start
+    matches.push({
+      id: need.matchId,
+      eventId: need.eventId,
+      p1: need.p1,
+      p2: need.p2,
+      tableId: c.tableId,
+      plannedStart: c.start,
+      plannedEnd: c.end,
+      plannedDurationMin: dur,
+      completed: true,
+      actualStart: c.start,
+      actualEnd: c.end,
+    })
+    blockTable(tableFree[c.tableId], c.start, c.end)
+    playerNextFree[need.p1] = Math.max(
+      playerNextFree[need.p1],
+      c.end + evById[need.eventId].restMin,
+    )
+    playerNextFree[need.p2] = Math.max(
+      playerNextFree[need.p2],
+      c.end + evById[need.eventId].restMin,
+    )
+  }
+
+  // Order remaining matches: by previous-schedule start (warm start), else event order
+  const pending = needed.filter((n) => !completedIds.has(n.matchId))
+  pending.sort((a, b) => {
+    const pa = previousSchedule?.matches?.find((m) => m.id === a.matchId)
+    const pb = previousSchedule?.matches?.find((m) => m.id === b.matchId)
+    if (pa && pb) return pa.plannedStart - pb.plannedStart
+    if (pa) return -1
+    if (pb) return 1
+    return evIndex[a.eventId] - evIndex[b.eventId]
+  })
+
+  for (const n of pending) {
+    const ev = evById[n.eventId]
+    const pools = tablePoolsByEvent[ev.id] || []
+    if (pools.length === 0) {
+      return {
+        status: 'INFEASIBLE',
+        solveTimeMs: 200,
+        makespanMin: 0,
+        totalIdleMin: 0,
+        matches: [],
+        error: { msg: `Event "${ev.name}" has no table pool.`, ref: ev.id, scope: 'events' },
+      }
+    }
+    const earliestPlayer = Math.max(playerNextFree[n.p1], playerNextFree[n.p2])
+
+    // Search for earliest fitting slot — prefer the same table as previous schedule when possible
+    const prevMatch = previousSchedule?.matches?.find((m) => m.id === n.matchId)
+    const preferredTable = prevMatch?.tableId
+    let best: { tableId: string; start: number; end: number } | null = null
+    for (const pool of pools) {
+      const candTables =
+        preferredTable && pool.tableIds.includes(preferredTable)
+          ? [preferredTable, ...pool.tableIds.filter((t) => t !== preferredTable)]
+          : pool.tableIds.slice()
+      for (const tid of candTables) {
+        for (const slot of tableFree[tid]) {
+          const s = Math.max(slot[0], pool.startMin, earliestPlayer)
+          const e = s + ev.matchDurationMin
+          if (e <= slot[1] && e <= pool.endMin) {
+            if (!best || s < best.start || (s === best.start && tid === preferredTable)) {
+              best = { tableId: tid, start: s, end: e }
+            }
+            break
+          }
+        }
+      }
+    }
+    if (!best) {
+      return {
+        status: 'INFEASIBLE',
+        solveTimeMs: 220,
+        makespanMin: 0,
+        totalIdleMin: 0,
+        matches: [],
+        error: {
+          msg: `Couldn't fit all matches for "${ev.name}" within its table pools.`,
+          ref: ev.id,
+          scope: 'events',
+        },
+      }
+    }
+    matches.push({
+      id: n.matchId,
+      eventId: n.eventId,
+      p1: n.p1,
+      p2: n.p2,
+      tableId: best.tableId,
+      plannedStart: best.start,
+      plannedEnd: best.end,
+      plannedDurationMin: ev.matchDurationMin,
+      completed: false,
+    })
+    blockTable(tableFree[best.tableId], best.start, best.end)
+    playerNextFree[n.p1] = best.end + ev.restMin
+    playerNextFree[n.p2] = best.end + ev.restMin
+  }
+
+  const makespanMin = Math.max(
+    ...matches.map((m) => (m.completed ? (m.actualEnd ?? 0) : m.plannedEnd)),
+    0,
+  )
+  const totalIdleMin = computeTotalIdle(matches)
+
+  // Solve time: synthetic. Initial is "slow", warm-start is fast.
+  let solveTimeMs: number
+  if (isInitial) solveTimeMs = Math.round(1500 + Math.random() * 1500)
+  else if (isPerturbed) solveTimeMs = Math.round(450 + Math.random() * 700)
+  else solveTimeMs = Math.round(180 + Math.random() * 280)
+
+  const status: SolveStatus =
+    pending.length <= 5 ? 'OPTIMAL' : Math.random() < 0.8 ? 'OPTIMAL' : 'FEASIBLE'
+
+  return { status, solveTimeMs, makespanMin, totalIdleMin, matches }
+}
+
+// Block a [s,e] interval out of a free-slot list (sorted, non-overlapping).
+function blockTable(slots: [number, number][], s: number, e: number): void {
+  for (let i = 0; i < slots.length; i++) {
+    const [a, b] = slots[i]
+    if (e <= a || s >= b) continue
+    // overlap
+    slots.splice(i, 1)
+    if (s > a) {
+      slots.splice(i, 0, [a, s])
+      i++
+    }
+    if (e < b) slots.splice(i, 0, [e, b])
+    return
+  }
+}
+
+function computeTotalIdle(matches: Match[]): number {
+  const byPlayer: Record<string, [number, number][]> = {}
+  matches.forEach((m) => {
+    const s = m.completed ? (m.actualStart ?? 0) : m.plannedStart
+    const e = m.completed ? (m.actualEnd ?? 0) : m.plannedEnd
+    ;[m.p1, m.p2].forEach((p) => {
+      ;(byPlayer[p] ||= []).push([s, e])
+    })
+  })
+  let total = 0
+  Object.values(byPlayer).forEach((arr) => {
+    arr.sort((a, b) => a[0] - b[0])
+    for (let i = 1; i < arr.length; i++) {
+      const gap = arr[i][0] - arr[i - 1][1]
+      if (gap > 0) total += gap
+    }
+  })
+  return total
+}
+
+// Count total matches expected (across all events) for progress display
+export function totalExpectedMatches(cfg: Config): number {
+  return cfg.events.reduce(
+    (s, e) => s + (e.playerIds.length * (e.playerIds.length - 1)) / 2,
+    0,
+  )
+}
+
+// Color for event by index
+export function eventColor(eventIndex: number): string {
+  return EVENT_COLORS[eventIndex % EVENT_COLORS.length]
+}
+
+export type ColorBy = 'event' | 'table' | 'player'
+
+// Compute color for matching `colorBy` setting
+export function colorForMatch(m: Match, cfg: Config, colorBy: ColorBy): string {
+  if (colorBy === 'table') {
+    const i = cfg.tables.findIndex((t) => t.id === m.tableId)
+    return EVENT_COLORS[(i + 2) % EVENT_COLORS.length]
+  }
+  if (colorBy === 'player') {
+    const h = (m.p1 + m.p2)
+      .split('')
+      .reduce((acc, c) => (acc + c.charCodeAt(0)) % 1000, 0)
+    return EVENT_COLORS[h % EVENT_COLORS.length]
+  }
+  const i = cfg.events.findIndex((e) => e.id === m.eventId)
+  return EVENT_COLORS[i % EVENT_COLORS.length]
+}
+
+// Initials helper
+export function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((w) => w[0]?.toUpperCase())
+    .join('')
+    .slice(0, 3)
+}

--- a/web-client/src/components/simulator/editor.tsx
+++ b/web-client/src/components/simulator/editor.tsx
@@ -355,6 +355,7 @@ export function Editor({
   setConfig,
   errors,
   onSolve,
+  onViewSchedule,
   onLoadExample,
   onReset,
   solving,
@@ -365,6 +366,7 @@ export function Editor({
   setConfig: (c: Config) => void
   errors: ValidationError[]
   onSolve: () => void
+  onViewSchedule: () => void
   onLoadExample: () => void
   onReset: () => void
   solving: boolean
@@ -942,10 +944,7 @@ export function Editor({
         </div>
         <div className="grow"></div>
         {schedule && !solving && (
-          <button
-            className="btn ghost"
-            onClick={() => window.dispatchEvent(new CustomEvent('sim-go-schedule'))}
-          >
+          <button className="btn ghost" onClick={onViewSchedule}>
             View current schedule <ArrowRight size={12} />
           </button>
         )}

--- a/web-client/src/components/simulator/editor.tsx
+++ b/web-client/src/components/simulator/editor.tsx
@@ -1,0 +1,966 @@
+/* =====================================================================
+   editor.tsx — Configuration editor screen
+   ===================================================================== */
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import {
+  AlertOctagon,
+  AlertTriangle,
+  ArrowRight,
+  CalendarRange,
+  Dice5,
+  ListChecks,
+  Loader2,
+  Play,
+  Plus,
+  Sparkles,
+  Table2,
+  Trash2,
+  Trophy,
+  Users,
+} from 'lucide-react'
+import {
+  eventColor,
+  minutesBetween,
+  nid,
+  totalExpectedMatches,
+  type Config,
+  type Player,
+  type Schedule,
+  type SolveError,
+  type TablePool,
+  type Table as TableT,
+  type ValidationError,
+  type ValidationScope,
+} from './data'
+
+// ---------- Reusable bits ----------
+function Field({
+  label,
+  children,
+  error,
+  help,
+  span = 4,
+}: {
+  label: string
+  children: ReactNode
+  error?: string | null
+  help?: string
+  span?: number
+}) {
+  return (
+    <div className="field" style={{ gridColumn: `span ${span}` }}>
+      <label>{label}</label>
+      {children}
+      {error && <div className="errmsg">{error}</div>}
+      {help && !error && <div className="help">{help}</div>}
+    </div>
+  )
+}
+
+function TextInput({
+  value,
+  onChange,
+  invalid,
+  ...rest
+}: {
+  value: string
+  onChange: (v: string) => void
+  invalid?: boolean
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'>) {
+  return (
+    <input
+      type="text"
+      value={value || ''}
+      onChange={(e) => onChange(e.target.value)}
+      className={invalid ? 'invalid' : ''}
+      {...rest}
+    />
+  )
+}
+
+function NumInput({
+  value,
+  onChange,
+  invalid,
+  step = 1,
+  ...rest
+}: {
+  value: number | null
+  onChange: (v: number | null) => void
+  invalid?: boolean
+  step?: number
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'step'>) {
+  return (
+    <input
+      type="number"
+      className={`mono ${invalid ? 'invalid' : ''}`}
+      value={value ?? ''}
+      step={step}
+      onChange={(e) => onChange(e.target.value === '' ? null : Number(e.target.value))}
+      {...rest}
+    />
+  )
+}
+
+function TimeInput({
+  valueISO,
+  onChange,
+  invalid,
+}: {
+  valueISO: string
+  onChange: (iso: string) => void
+  invalid?: boolean
+}) {
+  const v = useMemo(() => {
+    if (!valueISO) return ''
+    const d = new Date(valueISO)
+    return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+  }, [valueISO])
+  return (
+    <input
+      type="time"
+      className={`mono ${invalid ? 'invalid' : ''}`}
+      value={v}
+      onChange={(e) => {
+        const [h, m] = e.target.value.split(':').map(Number)
+        const d = new Date(valueISO)
+        d.setHours(h, m, 0, 0)
+        onChange(d.toISOString())
+      }}
+    />
+  )
+}
+
+// ---------- Player chip selector ----------
+function PlayerRoster({
+  allPlayers,
+  selectedIds,
+  onChange,
+}: {
+  allPlayers: Player[]
+  selectedIds: string[]
+  onChange: (ids: string[]) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const selectedSet = new Set(selectedIds)
+  const available = allPlayers.filter((p) => !selectedSet.has(p.id))
+  const selected = selectedIds
+    .map((id) => allPlayers.find((p) => p.id === id))
+    .filter((p): p is Player => Boolean(p))
+
+  useEffect(() => {
+    function onDoc(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [])
+
+  return (
+    <div style={{ position: 'relative' }} ref={ref}>
+      <div className="chipset">
+        {selected.map((p) => (
+          <span className="chip" key={p.id}>
+            {p.name}
+            {p.rating != null && <span className="rating">{p.rating}</span>}
+            <button onClick={() => onChange(selectedIds.filter((id) => id !== p.id))} title="Remove">
+              ×
+            </button>
+          </span>
+        ))}
+        <button className="add-chip" onClick={() => setOpen((o) => !o)}>
+          + Add player {selected.length > 0 ? `(${selected.length})` : ''}
+        </button>
+      </div>
+      {open && available.length > 0 && (
+        <div
+          style={{
+            position: 'absolute',
+            zIndex: 10,
+            top: '100%',
+            left: 0,
+            right: 0,
+            marginTop: 4,
+            maxHeight: 240,
+            overflow: 'auto',
+            background: 'var(--ink-900)',
+            border: '1px solid var(--border-default)',
+            borderRadius: 'var(--r-sm)',
+            boxShadow: 'var(--shadow-md)',
+            padding: 4,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              padding: '4px 8px',
+              color: 'var(--fg-3)',
+              fontSize: 11,
+            }}
+          >
+            <span>{available.length} available</span>
+            <button
+              className="btn ghost sm"
+              onClick={() => onChange([...selectedIds, ...available.map((a) => a.id)])}
+            >
+              Add all
+            </button>
+          </div>
+          {available.map((p) => (
+            <div
+              key={p.id}
+              onClick={() => onChange([...selectedIds, p.id])}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                padding: '5px 8px',
+                cursor: 'pointer',
+                borderRadius: 4,
+                fontSize: 12,
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg-hover)')}
+              onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+            >
+              <span>{p.name}</span>
+              <span style={{ color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>
+                {p.rating ?? '—'}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------- Table pool editor ----------
+function PoolEditor({
+  pool,
+  tables,
+  onChange,
+  onRemove,
+  dayEndMin,
+  invalidEnd,
+  invalidTables,
+}: {
+  pool: TablePool
+  tables: TableT[]
+  onChange: (p: TablePool) => void
+  onRemove: () => void
+  dayEndMin: number
+  invalidEnd?: boolean
+  invalidTables?: boolean
+}) {
+  const tSet = new Set(pool.tableIds)
+  return (
+    <div
+      style={{
+        border: '1px solid var(--border-subtle)',
+        background: 'var(--ink-900)',
+        borderRadius: 'var(--r-sm)',
+        padding: 12,
+        marginBottom: 8,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+        <div className="overline" style={{ fontSize: 10 }}>
+          Pool window
+        </div>
+        <div style={{ flex: 1 }}></div>
+        <button className="btn ghost sm" onClick={onRemove}>
+          Remove pool
+        </button>
+      </div>
+      <div className="fields">
+        <Field label="Start (min from start)" span={3}>
+          <NumInput
+            value={pool.startMin}
+            onChange={(v) => onChange({ ...pool, startMin: v ?? 0 })}
+            min={0}
+            step={5}
+            max={dayEndMin}
+          />
+        </Field>
+        <Field
+          label="End (min from start)"
+          span={3}
+          error={invalidEnd ? 'Must be after start' : null}
+        >
+          <NumInput
+            value={pool.endMin}
+            onChange={(v) => onChange({ ...pool, endMin: v ?? 0 })}
+            min={0}
+            step={5}
+            max={dayEndMin}
+            invalid={invalidEnd}
+          />
+        </Field>
+        <Field
+          label={`Tables (${pool.tableIds.length})`}
+          span={6}
+          error={invalidTables ? 'Need at least 1 table' : null}
+        >
+          <div className="chipset" style={{ minHeight: 32 }}>
+            {tables.map((t) => {
+              const active = tSet.has(t.id)
+              return (
+                <button
+                  key={t.id}
+                  onClick={() =>
+                    onChange({
+                      ...pool,
+                      tableIds: active
+                        ? pool.tableIds.filter((id) => id !== t.id)
+                        : [...pool.tableIds, t.id],
+                    })
+                  }
+                  className="chip"
+                  style={{
+                    cursor: 'pointer',
+                    background: active ? 'var(--ball-500)' : 'var(--ink-800)',
+                    color: active ? 'var(--fg-inverse)' : 'var(--fg-2)',
+                    border: 0,
+                    padding: '3px 10px',
+                    fontWeight: active ? 600 : 400,
+                  }}
+                >
+                  {t.name}
+                </button>
+              )
+            })}
+          </div>
+        </Field>
+      </div>
+    </div>
+  )
+}
+
+// ---------- Random player generator ----------
+const RAND_FIRST = ['Alex','Sam','Jordan','Casey','Riley','Morgan','Quinn','Avery','Cameron','Drew','Skyler','Reese','Hayden','Eden','Sage','Robin','Finley','River','Phoenix','Logan','Devon','Kai','Rowan','Ari','Nova','Wren','Sasha','Ezra','Indi','Marin']
+const RAND_LAST = ['Nguyen','Chen','Patel','Rivera','Park','Brooks','Tanaka','Shah','Weber','Cole','Murray','Sato','Ng','Petrov','Hill','Mori','Garcia','Kumar','Reyes','Walsh','Hoffman','Bauer','Sasaki','Klein','Mendez','Holt','Bell','Singh','Ayers']
+
+function randomPlayer(): Player {
+  const f = RAND_FIRST[Math.floor(Math.random() * RAND_FIRST.length)]
+  const l = RAND_LAST[Math.floor(Math.random() * RAND_LAST.length)]
+  const r = 1100 + Math.floor(Math.random() * 1300)
+  return { id: nid('plr'), name: `${f} ${l}`, rating: r }
+}
+
+// ---------- Editor main ----------
+export function Editor({
+  config,
+  setConfig,
+  errors,
+  onSolve,
+  onLoadExample,
+  onReset,
+  solving,
+  schedule,
+  infeasibleErr,
+}: {
+  config: Config
+  setConfig: (c: Config) => void
+  errors: ValidationError[]
+  onSolve: () => void
+  onLoadExample: () => void
+  onReset: () => void
+  solving: boolean
+  schedule: Schedule | null
+  infeasibleErr: SolveError | null
+}) {
+  const [activeSection, setActiveSection] = useState<ValidationScope>('tournament')
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const errorsByScope = useMemo(() => {
+    const out: Record<string, ValidationError[]> = {
+      tournament: [],
+      tables: [],
+      players: [],
+      events: [],
+      pools: [],
+    }
+    errors.forEach((e) => {
+      ;(out[e.scope] || (out[e.scope] = [])).push(e)
+    })
+    return out
+  }, [errors])
+  const fieldErr = (scope: ValidationScope, ref: string | undefined, field: string) =>
+    errors.find((e) => e.scope === scope && e.ref === ref && e.field === field)?.msg
+
+  const scrollTo = (id: ValidationScope) => {
+    setActiveSection(id)
+    const el = scrollRef.current?.querySelector<HTMLElement>(`#sec-${id}`)
+    if (el && scrollRef.current) {
+      scrollRef.current.scrollTo({ top: el.offsetTop - 12, behavior: 'smooth' })
+    }
+  }
+
+  // Update helpers
+  const upd = (patch: Partial<Config>) => setConfig({ ...config, ...patch })
+  const updTable = (id: string, patch: Partial<TableT>) =>
+    upd({ tables: config.tables.map((t) => (t.id === id ? { ...t, ...patch } : t)) })
+  const updPlayer = (id: string, patch: Partial<Player>) =>
+    upd({ players: config.players.map((p) => (p.id === id ? { ...p, ...patch } : p)) })
+  const updEvent = (id: string, patch: Partial<Config['events'][number]>) =>
+    upd({ events: config.events.map((e) => (e.id === id ? { ...e, ...patch } : e)) })
+  const updPool = (id: string, patch: Partial<TablePool>) =>
+    upd({ tablePools: config.tablePools.map((p) => (p.id === id ? { ...p, ...patch } : p)) })
+
+  const dayEndMin =
+    config.startISO && config.endISO ? minutesBetween(config.startISO, config.endISO) : 600
+
+  const expectedMatches = totalExpectedMatches(config)
+
+  const sideItems: [ValidationScope, string, ReactNode][] = [
+    ['tournament', 'Tournament', <Trophy size={14} key="i" />],
+    ['tables', 'Tables', <Table2 size={14} key="i" />],
+    ['players', 'Players', <Users size={14} key="i" />],
+    ['events', 'Events', <ListChecks size={14} key="i" />],
+    ['pools', 'Table pools', <CalendarRange size={14} key="i" />],
+  ]
+
+  return (
+    <div className="editor">
+      <aside className="side">
+        <h4>Configuration</h4>
+        {sideItems.map(([key, label, icon]) => {
+          const errN = errorsByScope[key]?.length || 0
+          let count: number | null = null
+          if (key === 'tables') count = config.tables.length
+          else if (key === 'players') count = config.players.length
+          else if (key === 'events') count = config.events.length
+          else if (key === 'pools') count = config.tablePools.length
+          return (
+            <a
+              key={key}
+              className={activeSection === key ? 'active' : ''}
+              onClick={() => scrollTo(key)}
+            >
+              {icon}
+              <span>{label}</span>
+              {errN > 0 ? (
+                <span className="err">{errN}</span>
+              ) : (
+                count != null && <span className="count">{count}</span>
+              )}
+            </a>
+          )
+        })}
+        <div className="actions">
+          <button className="btn" onClick={onLoadExample}>
+            <Sparkles size={14} />
+            Load example
+          </button>
+          <button className="btn ghost" onClick={onReset}>
+            Reset
+          </button>
+        </div>
+      </aside>
+
+      <div className="scroll" ref={scrollRef}>
+        {/* Summary banners */}
+        {infeasibleErr && (
+          <div className="banner error">
+            <AlertOctagon size={18} style={{ color: 'var(--loss)' }} />
+            <div className="grow">
+              <strong>Infeasible.</strong> {infeasibleErr.msg}
+            </div>
+          </div>
+        )}
+        {errors.length > 0 && (
+          <div className="banner warn">
+            <AlertTriangle size={18} style={{ color: 'var(--warn)' }} />
+            <div className="grow">
+              <strong>
+                {errors.length} {errors.length === 1 ? 'issue' : 'issues'} to fix before solving.
+              </strong>
+              <ul>
+                {errors.slice(0, 5).map((e, i) => (
+                  <li key={i}>
+                    <a onClick={() => scrollTo(e.scope)}>{e.scope}</a>
+                    {' — '}
+                    {e.msg}
+                  </li>
+                ))}
+                {errors.length > 5 && <li>…and {errors.length - 5} more</li>}
+              </ul>
+            </div>
+          </div>
+        )}
+
+        {/* ---- TOURNAMENT ---- */}
+        <section id="sec-tournament" className="card">
+          <header>
+            <h2>Tournament</h2>
+            <div className="hint">Name, date, window.</div>
+            <div className="grow"></div>
+          </header>
+          <div className="fields">
+            <Field label="Name" span={5} error={fieldErr('tournament', undefined, 'name')}>
+              <TextInput
+                value={config.name}
+                onChange={(v) => upd({ name: v })}
+                invalid={!!fieldErr('tournament', undefined, 'name')}
+                placeholder="e.g. Spring Open 2026"
+              />
+            </Field>
+            <Field label="Date" span={3}>
+              <input
+                type="date"
+                className="mono"
+                value={config.startISO?.slice(0, 10) || ''}
+                onChange={(e) => {
+                  const date = e.target.value
+                  if (!date) return
+                  const s = new Date(config.startISO)
+                  const en = new Date(config.endISO)
+                  const [y, M, d] = date.split('-').map(Number)
+                  s.setFullYear(y, M - 1, d)
+                  en.setFullYear(y, M - 1, d)
+                  upd({ startISO: s.toISOString(), endISO: en.toISOString() })
+                }}
+              />
+            </Field>
+            <Field label="Start" span={2}>
+              <TimeInput valueISO={config.startISO} onChange={(iso) => upd({ startISO: iso })} />
+            </Field>
+            <Field label="End" span={2} error={fieldErr('tournament', undefined, 'endISO')}>
+              <TimeInput
+                valueISO={config.endISO}
+                onChange={(iso) => upd({ endISO: iso })}
+                invalid={!!fieldErr('tournament', undefined, 'endISO')}
+              />
+            </Field>
+          </div>
+        </section>
+
+        {/* ---- TABLES ---- */}
+        <section id="sec-tables" className="card">
+          <header>
+            <h2>Tables</h2>
+            <div className="hint">
+              {config.tables.length} table{config.tables.length === 1 ? '' : 's'}.
+            </div>
+            <div className="grow"></div>
+            <button
+              className="btn sm"
+              onClick={() =>
+                upd({
+                  tables: [
+                    ...config.tables,
+                    { id: nid('tbl'), name: `Table ${config.tables.length + 1}` },
+                  ],
+                })
+              }
+            >
+              <Plus size={12} /> Add table
+            </button>
+          </header>
+          {config.tables.length === 0 ? (
+            <div className="empty">No tables yet. Add one above.</div>
+          ) : (
+            <table className="list">
+              <thead>
+                <tr>
+                  <th style={{ width: 40 }}>#</th>
+                  <th>Name</th>
+                  <th className="actions">&nbsp;</th>
+                </tr>
+              </thead>
+              <tbody>
+                {config.tables.map((t, i) => (
+                  <tr key={t.id}>
+                    <td className="mono">{i + 1}</td>
+                    <td>
+                      <input
+                        type="text"
+                        value={t.name || ''}
+                        onChange={(e) => updTable(t.id, { name: e.target.value })}
+                        className={fieldErr('tables', t.id, 'name') ? 'invalid' : ''}
+                      />
+                    </td>
+                    <td className="actions">
+                      <button
+                        className="btn ghost sm"
+                        onClick={() => upd({ tables: config.tables.filter((x) => x.id !== t.id) })}
+                      >
+                        <Trash2 size={12} />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+
+        {/* ---- PLAYERS ---- */}
+        <section id="sec-players" className="card">
+          <header>
+            <h2>Players</h2>
+            <div className="hint">
+              {config.players.length} player{config.players.length === 1 ? '' : 's'} · drop into events below.
+            </div>
+            <div className="grow"></div>
+            <button
+              className="btn sm"
+              onClick={() =>
+                upd({ players: [...config.players, { id: nid('plr'), name: '', rating: null }] })
+              }
+            >
+              <Plus size={12} /> Add player
+            </button>
+            <button
+              className="btn sm"
+              onClick={() => {
+                const adds = Array.from({ length: 8 }, () => randomPlayer())
+                upd({ players: [...config.players, ...adds] })
+              }}
+            >
+              <Dice5 size={12} /> + 8 random
+            </button>
+          </header>
+          {config.players.length === 0 ? (
+            <div className="empty">No players. Add some manually, or use “+ 8 random”.</div>
+          ) : (
+            <table className="list">
+              <thead>
+                <tr>
+                  <th style={{ width: 40 }}>#</th>
+                  <th>Name</th>
+                  <th style={{ width: 120 }}>USATT rating</th>
+                  <th>Events</th>
+                  <th className="actions">&nbsp;</th>
+                </tr>
+              </thead>
+              <tbody>
+                {config.players.map((p, i) => {
+                  const inEvents = config.events.filter((e) => e.playerIds.includes(p.id))
+                  return (
+                    <tr key={p.id}>
+                      <td className="mono">{String(i + 1).padStart(2, '0')}</td>
+                      <td>
+                        <input
+                          type="text"
+                          value={p.name || ''}
+                          onChange={(e) => updPlayer(p.id, { name: e.target.value })}
+                          className={fieldErr('players', p.id, 'name') ? 'invalid' : ''}
+                          placeholder="Player name"
+                        />
+                      </td>
+                      <td>
+                        <input
+                          type="number"
+                          className={'mono ' + (fieldErr('players', p.id, 'rating') ? 'invalid' : '')}
+                          value={p.rating ?? ''}
+                          onChange={(e) =>
+                            updPlayer(p.id, {
+                              rating: e.target.value === '' ? null : parseInt(e.target.value, 10),
+                            })
+                          }
+                          placeholder="—"
+                          min={0}
+                          max={3000}
+                        />
+                      </td>
+                      <td>
+                        <span style={{ fontSize: 11, color: 'var(--fg-3)' }}>
+                          {inEvents.length === 0 ? '—' : inEvents.map((e) => e.name).join(', ')}
+                        </span>
+                      </td>
+                      <td className="actions">
+                        <button
+                          className="btn ghost sm"
+                          onClick={() => {
+                            upd({
+                              players: config.players.filter((x) => x.id !== p.id),
+                              events: config.events.map((ev) => ({
+                                ...ev,
+                                playerIds: ev.playerIds.filter((id) => id !== p.id),
+                              })),
+                            })
+                          }}
+                        >
+                          <Trash2 size={12} />
+                        </button>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          )}
+        </section>
+
+        {/* ---- EVENTS ---- */}
+        <section id="sec-events" className="card">
+          <header>
+            <h2>Events</h2>
+            <div className="hint">
+              {config.events.length} event{config.events.length === 1 ? '' : 's'} ·{' '}
+              <span className="mono" style={{ fontFamily: 'var(--font-mono)', color: 'var(--fg-2)' }}>
+                {expectedMatches}
+              </span>{' '}
+              matches total
+            </div>
+            <div className="grow"></div>
+            <button
+              className="btn sm"
+              onClick={() =>
+                upd({
+                  events: [
+                    ...config.events,
+                    {
+                      id: nid('ev'),
+                      name: `Event ${config.events.length + 1}`,
+                      matchDurationMin: 25,
+                      restMin: 15,
+                      format: 'round_robin',
+                      playerIds: [],
+                    },
+                  ],
+                })
+              }
+            >
+              <Plus size={12} /> Add event
+            </button>
+          </header>
+          {config.events.length === 0 ? (
+            <div className="empty">No events yet.</div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              {config.events.map((ev, idx) => {
+                const matchCount = (ev.playerIds.length * (ev.playerIds.length - 1)) / 2
+                const color = eventColor(idx)
+                return (
+                  <div
+                    key={ev.id}
+                    style={{
+                      background: 'var(--ink-900)',
+                      border: '1px solid var(--border-subtle)',
+                      borderRadius: 'var(--r-sm)',
+                      padding: 14,
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+                      <span
+                        style={{
+                          display: 'inline-block',
+                          width: 10,
+                          height: 10,
+                          borderRadius: 2,
+                          background: color,
+                        }}
+                      ></span>
+                      <input
+                        type="text"
+                        value={ev.name}
+                        onChange={(e) => updEvent(ev.id, { name: e.target.value })}
+                        className={fieldErr('events', ev.id, 'name') ? 'invalid' : ''}
+                        style={{ fontSize: 14, fontWeight: 600, padding: '4px 8px', minWidth: 200 }}
+                      />
+                      <div style={{ flex: 1 }}></div>
+                      <span style={{ fontSize: 11, color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>
+                        {matchCount} matches
+                      </span>
+                      <button
+                        className="btn ghost sm"
+                        onClick={() =>
+                          upd({
+                            events: config.events.filter((e2) => e2.id !== ev.id),
+                            tablePools: config.tablePools.filter((p) => p.eventId !== ev.id),
+                          })
+                        }
+                      >
+                        <Trash2 size={12} />
+                      </button>
+                    </div>
+                    <div className="fields">
+                      <Field label="Format" span={3}>
+                        <select
+                          value={ev.format}
+                          onChange={(e) =>
+                            updEvent(ev.id, { format: e.target.value as Config['events'][number]['format'] })
+                          }
+                        >
+                          <option value="round_robin">Round robin</option>
+                        </select>
+                      </Field>
+                      <Field
+                        label="Match duration (min)"
+                        span={3}
+                        error={fieldErr('events', ev.id, 'matchDurationMin')}
+                        help="Multiples of 5"
+                      >
+                        <NumInput
+                          value={ev.matchDurationMin}
+                          onChange={(v) => updEvent(ev.id, { matchDurationMin: v ?? 0 })}
+                          step={5}
+                          min={5}
+                          max={120}
+                          invalid={!!fieldErr('events', ev.id, 'matchDurationMin')}
+                        />
+                      </Field>
+                      <Field label="Min rest (min)" span={3} error={fieldErr('events', ev.id, 'restMin')}>
+                        <NumInput
+                          value={ev.restMin}
+                          onChange={(v) => updEvent(ev.id, { restMin: v ?? 0 })}
+                          step={5}
+                          min={0}
+                          max={120}
+                          invalid={!!fieldErr('events', ev.id, 'restMin')}
+                        />
+                      </Field>
+                      <Field label="Players" span={3}>
+                        <div
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 6,
+                            fontFamily: 'var(--font-mono)',
+                            fontSize: 13,
+                            height: 30,
+                          }}
+                        >
+                          <span style={{ color: 'var(--fg-1)', fontWeight: 600 }}>
+                            {ev.playerIds.length}
+                          </span>
+                          <span style={{ color: 'var(--fg-3)' }}>·</span>
+                          <span style={{ color: 'var(--fg-3)' }}>{matchCount} matches</span>
+                        </div>
+                      </Field>
+                      <Field label="Roster" span={12} error={fieldErr('events', ev.id, 'playerIds')}>
+                        <PlayerRoster
+                          allPlayers={config.players}
+                          selectedIds={ev.playerIds}
+                          onChange={(ids) => updEvent(ev.id, { playerIds: ids })}
+                        />
+                      </Field>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </section>
+
+        {/* ---- TABLE POOLS ---- */}
+        <section id="sec-pools" className="card">
+          <header>
+            <h2>Table pools</h2>
+            <div className="hint">
+              Each pool ties tables to an event for a time window. An event can have multiple pools.
+            </div>
+            <div className="grow"></div>
+          </header>
+          {config.events.length === 0 ? (
+            <div className="empty">Add an event first.</div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              {config.events.map((ev, idx) => {
+                const evPools = config.tablePools.filter((p) => p.eventId === ev.id)
+                const color = eventColor(idx)
+                const noPoolErr = fieldErr('events', ev.id, 'pools')
+                return (
+                  <div key={ev.id}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+                      <span style={{ width: 10, height: 10, borderRadius: 2, background: color }}></span>
+                      <span style={{ fontWeight: 600, fontSize: 13 }}>{ev.name}</span>
+                      <span style={{ color: 'var(--fg-3)', fontSize: 11, fontFamily: 'var(--font-mono)' }}>
+                        {evPools.length} pool{evPools.length === 1 ? '' : 's'}
+                      </span>
+                      <div style={{ flex: 1 }}></div>
+                      <button
+                        className="btn sm"
+                        onClick={() =>
+                          upd({
+                            tablePools: [
+                              ...config.tablePools,
+                              {
+                                id: nid('pool'),
+                                eventId: ev.id,
+                                tableIds: config.tables
+                                  .slice(0, Math.min(3, config.tables.length))
+                                  .map((t) => t.id),
+                                startMin: 0,
+                                endMin: Math.min(240, dayEndMin),
+                              },
+                            ],
+                          })
+                        }
+                      >
+                        <Plus size={12} /> Add pool
+                      </button>
+                    </div>
+                    {noPoolErr && (
+                      <div
+                        style={{
+                          color: 'var(--loss)',
+                          fontSize: 12,
+                          fontFamily: 'var(--font-mono)',
+                          marginBottom: 8,
+                        }}
+                      >
+                        {noPoolErr}
+                      </div>
+                    )}
+                    {evPools.length === 0 ? (
+                      <div className="empty" style={{ padding: 12 }}>
+                        No pools yet.
+                      </div>
+                    ) : (
+                      evPools.map((pool) => (
+                        <PoolEditor
+                          key={pool.id}
+                          pool={pool}
+                          tables={config.tables}
+                          dayEndMin={dayEndMin}
+                          onChange={(p) => updPool(pool.id, p)}
+                          onRemove={() =>
+                            upd({ tablePools: config.tablePools.filter((p) => p.id !== pool.id) })
+                          }
+                          invalidEnd={!!fieldErr('pools', pool.id, 'endMin')}
+                          invalidTables={!!fieldErr('pools', pool.id, 'tableIds')}
+                        />
+                      ))
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </section>
+      </div>
+
+      <div className="footer">
+        <div className="summary">
+          {config.events.length} events · <span className="mono">{config.players.length}</span> players ·{' '}
+          <span className="mono">{config.tables.length}</span> tables ·{' '}
+          <span className="mono">{expectedMatches}</span> matches to schedule
+        </div>
+        <div className="grow"></div>
+        {schedule && !solving && (
+          <button
+            className="btn ghost"
+            onClick={() => window.dispatchEvent(new CustomEvent('sim-go-schedule'))}
+          >
+            View current schedule <ArrowRight size={12} />
+          </button>
+        )}
+        <button className="btn primary" disabled={errors.length > 0 || solving} onClick={onSolve}>
+          {solving ? (
+            <>
+              <Loader2 size={14} className="spin" /> Solving…
+            </>
+          ) : (
+            <>
+              <Play size={14} /> Solve
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web-client/src/components/simulator/schedule.tsx
+++ b/web-client/src/components/simulator/schedule.tsx
@@ -16,15 +16,19 @@ import {
   Users,
 } from 'lucide-react'
 import {
+  buildLookups,
   colorForMatch,
   eventColor,
   fmtClock,
   initials,
   minutesBetween,
+  nextCompletion,
   type ClockMode,
   type ColorBy,
   type Config,
+  type ConfigLookups,
   type Match,
+  type Player,
   type Schedule,
   type TournamentEvent,
 } from './data'
@@ -61,8 +65,8 @@ function pickTickStep(pxPerMin: number): number {
   return 120
 }
 
-function abbrevPlayer(config: Config, pid: string): string {
-  const p = config.players.find((pp) => pp.id === pid)
+function abbrevPlayer(playerById: Map<string, Player>, pid: string): string {
+  const p = playerById.get(pid)
   if (!p) return '?'
   const parts = p.name.split(/\s+/)
   if (parts.length === 1) return parts[0]
@@ -78,6 +82,7 @@ function GanttChart({
   config,
   schedule,
   sim,
+  lookups,
   density,
   colorBy,
   animateMoves,
@@ -89,6 +94,7 @@ function GanttChart({
   config: Config
   schedule: Schedule
   sim: SimState
+  lookups: ConfigLookups
   density: Density
   colorBy: ColorBy
   animateMoves: boolean
@@ -177,8 +183,8 @@ function GanttChart({
                   ></div>
                 ))}
               {(matchesByTable[t.id] || []).map((m) => {
-                const ev = config.events.find((e) => e.id === m.eventId)
-                const c = colorForMatch(m, config, colorBy)
+                const ev = lookups.eventById.get(m.eventId)
+                const c = colorForMatch(m, colorBy, lookups)
                 const start = m.completed ? (m.actualStart ?? 0) : m.plannedStart
                 const end = m.completed ? (m.actualEnd ?? 0) : m.plannedEnd
                 const w = (end - start) * pxPerMin
@@ -211,8 +217,8 @@ function GanttChart({
                     )}
                     {!tiny && (
                       <div className="match-players">
-                        {abbrevPlayer(config, m.p1)} <span style={{ opacity: 0.6 }}>vs</span>{' '}
-                        {abbrevPlayer(config, m.p2)}
+                        {abbrevPlayer(lookups.playerById, m.p1)} <span style={{ opacity: 0.6 }}>vs</span>{' '}
+                        {abbrevPlayer(lookups.playerById, m.p2)}
                       </div>
                     )}
                     {!narrow && (
@@ -238,6 +244,7 @@ function PlayerTimeline({
   config,
   schedule,
   sim,
+  lookups,
   density,
   colorBy,
   animateMoves,
@@ -250,6 +257,7 @@ function PlayerTimeline({
   config: Config
   schedule: Schedule
   sim: SimState
+  lookups: ConfigLookups
   density: Density
   colorBy: ColorBy
   animateMoves: boolean
@@ -338,7 +346,7 @@ function PlayerTimeline({
         </div>
 
         {sortedPlayers.map(({ id, idleTotal }, ri) => {
-          const p = config.players.find((pp) => pp.id === id)
+          const p = lookups.playerById.get(id)
           if (!p) return null
           const d = playerData[id]
           return (
@@ -396,8 +404,8 @@ function PlayerTimeline({
                     ></div>
                   ))}
                 {d.matches.map((m) => {
-                  const ev = config.events.find((e) => e.id === m.eventId)
-                  const c = colorForMatch(m, config, colorBy)
+                  const ev = lookups.eventById.get(m.eventId)
+                  const c = colorForMatch(m, colorBy, lookups)
                   const start = m.completed ? (m.actualStart ?? 0) : m.plannedStart
                   const end = m.completed ? (m.actualEnd ?? 0) : m.plannedEnd
                   const w = (end - start) * pxPerMin
@@ -429,10 +437,12 @@ function PlayerTimeline({
                           <Lock className="lock" />
                         </>
                       )}
-                      {!tiny && <div className="match-players">vs {abbrevPlayer(config, otherId)}</div>}
+                      {!tiny && (
+                        <div className="match-players">vs {abbrevPlayer(lookups.playerById, otherId)}</div>
+                      )}
                       {!narrow && (
                         <div className="match-meta">
-                          T{config.tables.findIndex((t) => t.id === m.tableId) + 1} ·{' '}
+                          T{(lookups.tableIndexById.get(m.tableId) ?? 0) + 1} ·{' '}
                           {m.completed ? (m.actualEnd ?? 0) - (m.actualStart ?? 0) : m.plannedDurationMin}m
                         </div>
                       )}
@@ -450,12 +460,12 @@ function PlayerTimeline({
 }
 
 // ---------- Hover tooltip ----------
-function MatchTip({ hover, config }: { hover: HoverInfo | null; config: Config }) {
+function MatchTip({ hover, lookups }: { hover: HoverInfo | null; lookups: ConfigLookups }) {
   if (!hover) return null
   const { match: m, event: ev, color, x, y } = hover
-  const p1 = config.players.find((p) => p.id === m.p1)
-  const p2 = config.players.find((p) => p.id === m.p2)
-  const tbl = config.tables.find((t) => t.id === m.tableId)
+  const p1 = lookups.playerById.get(m.p1)
+  const p2 = lookups.playerById.get(m.p2)
+  const tableNum = (lookups.tableIndexById.get(m.tableId) ?? 0) + 1
   const start = m.completed ? (m.actualStart ?? 0) : m.plannedStart
   const end = m.completed ? (m.actualEnd ?? 0) : m.plannedEnd
   const W = 260,
@@ -489,7 +499,7 @@ function MatchTip({ hover, config }: { hover: HoverInfo | null; config: Config }
       </div>
       <div className="rows">
         <span className="k">Table</span>
-        <span className="v">{tbl?.name}</span>
+        <span className="v">T{tableNum}</span>
         <span className="k">Start</span>
         <span className="v">
           {fmtClock(start, '24h')} <span style={{ color: 'var(--fg-3)' }}>+{start}m</span>
@@ -507,9 +517,9 @@ function MatchTip({ hover, config }: { hover: HoverInfo | null; config: Config }
 
 // ---------- Simulator panel ----------
 function SimPanel({
-  config,
   schedule,
   sim,
+  lookups,
   durations,
   setDurations,
   onAdvance,
@@ -521,9 +531,9 @@ function SimPanel({
   onSelectMatch,
   lastResolveMs,
 }: {
-  config: Config
   schedule: Schedule
   sim: SimState
+  lookups: ConfigLookups
   durations: Record<string, number>
   setDurations: (d: Record<string, number>) => void
   onAdvance: () => void
@@ -535,40 +545,43 @@ function SimPanel({
   onSelectMatch: (id: string) => void
   lastResolveMs: number | null
 }) {
-  const totalExpected = schedule?.matches.length || 0
-  const completedIds = new Set(sim.completions.map((c) => c.matchId))
-  const completed = schedule.matches.filter((m) => completedIds.has(m.id))
-  const pending = schedule.matches
-    .filter((m) => !completedIds.has(m.id))
-    .sort((a, b) => a.plannedStart - b.plannedStart)
-
-  completed.sort((a, b) => (b.actualEnd || 0) - (a.actualEnd || 0))
+  const totalExpected = schedule.matches.length
+  const completedIds = useMemo(
+    () => new Set(sim.completions.map((c) => c.matchId)),
+    [sim.completions],
+  )
+  const completed = useMemo(
+    () =>
+      schedule.matches
+        .filter((m) => completedIds.has(m.id))
+        .sort((a, b) => (b.actualEnd || 0) - (a.actualEnd || 0)),
+    [schedule.matches, completedIds],
+  )
+  const pending = useMemo(
+    () =>
+      schedule.matches
+        .filter((m) => !completedIds.has(m.id))
+        .sort((a, b) => a.plannedStart - b.plannedStart),
+    [schedule.matches, completedIds],
+  )
+  const next = useMemo(
+    () => nextCompletion(schedule.matches, completedIds, lookups.eventById, durations),
+    [schedule.matches, completedIds, lookups, durations],
+  )
+  const nextId = next?.match.id ?? null
 
   const onBulkPerturb = () => {
-    const next = { ...durations }
+    const updated = { ...durations }
     pending.forEach((m) => {
-      const ev = config.events.find((e) => e.id === m.eventId)!
-      const planned = ev.matchDurationMin
+      const ev = lookups.eventById.get(m.eventId)!
       const delta = Math.round((Math.random() * 20 - 10) / 5) * 5
-      next[m.id] = Math.max(5, planned + delta)
+      updated[m.id] = Math.max(5, ev.matchDurationMin + delta)
     })
-    setDurations(next)
+    setDurations(updated)
   }
 
-  const nextToComplete = useMemo(() => {
-    let best: Match | null = null,
-      bestT = Infinity
-    pending.forEach((m) => {
-      const ev = config.events.find((e) => e.id === m.eventId)!
-      const dur = durations[m.id] ?? ev.matchDurationMin
-      const t = m.plannedStart + dur
-      if (t < bestT) {
-        bestT = t
-        best = m
-      }
-    })
-    return best as Match | null
-  }, [pending, durations, config])
+  const tableNum = (m: Match) => (lookups.tableIndexById.get(m.tableId) ?? 0) + 1
+  const eventColorFor = (m: Match) => eventColor(lookups.eventIndexById.get(m.eventId) ?? 0)
 
   return (
     <div className="sim">
@@ -628,31 +641,29 @@ function SimPanel({
       </div>
 
       <div className="sim-list">
-        {pending.length > 0 && nextToComplete && (
+        {next && (
           <>
             <div className="sim-section-head">
               <ChevronRight size={12} style={{ color: 'var(--ball-500)' }} />
               Next to complete
             </div>
             {(() => {
-              const m = nextToComplete
-              const ev = config.events.find((e) => e.id === m.eventId)!
-              const dur = durations[m.id] ?? ev.matchDurationMin
-              const evIdx = config.events.findIndex((e) => e.id === m.eventId)
-              const c = eventColor(evIdx)
+              const m = next.match
+              const ev = lookups.eventById.get(m.eventId)!
+              const dur = next.actualDur
               const finishesAt = m.plannedStart + dur
               return (
                 <div
                   className={`sim-row ${selectedMatchId === m.id ? 'selected' : ''}`}
                   onClick={() => onSelectMatch(m.id)}
                 >
-                  <div className="colorbar" style={{ '--c': c } as React.CSSProperties}></div>
+                  <div className="colorbar" style={{ '--c': eventColorFor(m) } as React.CSSProperties}></div>
                   <div className="info">
                     <div className="players">
-                      {abbrevPlayer(config, m.p1)} vs {abbrevPlayer(config, m.p2)}
+                      {abbrevPlayer(lookups.playerById, m.p1)} vs {abbrevPlayer(lookups.playerById, m.p2)}
                     </div>
                     <div className="meta">
-                      T{config.tables.findIndex((t) => t.id === m.tableId) + 1}
+                      T{tableNum(m)}
                       {' · '}starts {fmtClock(m.plannedStart, '24h')}
                       {' · '}done {fmtClock(finishesAt, '24h')}
                     </div>
@@ -688,44 +699,44 @@ function SimPanel({
             No pending matches. Reset to replay.
           </div>
         )}
-        {pending.slice(nextToComplete ? 1 : 0).map((m) => {
-          const ev = config.events.find((e) => e.id === m.eventId)!
-          const evIdx = config.events.findIndex((e) => e.id === m.eventId)
-          const c = eventColor(evIdx)
-          const dur = durations[m.id] ?? ev.matchDurationMin
-          const changed = dur !== ev.matchDurationMin
-          return (
-            <div
-              key={m.id}
-              className={`sim-row ${selectedMatchId === m.id ? 'selected' : ''}`}
-              onClick={() => onSelectMatch(m.id)}
-            >
-              <div className="colorbar" style={{ '--c': c } as React.CSSProperties}></div>
-              <div className="info">
-                <div className="players">
-                  {abbrevPlayer(config, m.p1)} vs {abbrevPlayer(config, m.p2)}
+        {pending
+          .filter((m) => m.id !== nextId)
+          .map((m) => {
+            const ev = lookups.eventById.get(m.eventId)!
+            const dur = durations[m.id] ?? ev.matchDurationMin
+            const changed = dur !== ev.matchDurationMin
+            return (
+              <div
+                key={m.id}
+                className={`sim-row ${selectedMatchId === m.id ? 'selected' : ''}`}
+                onClick={() => onSelectMatch(m.id)}
+              >
+                <div className="colorbar" style={{ '--c': eventColorFor(m) } as React.CSSProperties}></div>
+                <div className="info">
+                  <div className="players">
+                    {abbrevPlayer(lookups.playerById, m.p1)} vs {abbrevPlayer(lookups.playerById, m.p2)}
+                  </div>
+                  <div className="meta">
+                    T{tableNum(m)} · {fmtClock(m.plannedStart, '24h')}
+                  </div>
                 </div>
-                <div className="meta">
-                  T{config.tables.findIndex((t) => t.id === m.tableId) + 1} · {fmtClock(m.plannedStart, '24h')}
+                <div className="dur" onClick={(e) => e.stopPropagation()}>
+                  <input
+                    type="number"
+                    className={changed ? 'changed' : ''}
+                    value={dur}
+                    step={5}
+                    min={5}
+                    onChange={(e) => {
+                      const v = Math.max(5, parseInt(e.target.value || '0', 10) || ev.matchDurationMin)
+                      setDurations({ ...durations, [m.id]: v })
+                    }}
+                  />
+                  <span className="unit">m</span>
                 </div>
               </div>
-              <div className="dur" onClick={(e) => e.stopPropagation()}>
-                <input
-                  type="number"
-                  className={changed ? 'changed' : ''}
-                  value={dur}
-                  step={5}
-                  min={5}
-                  onChange={(e) => {
-                    const v = Math.max(5, parseInt(e.target.value || '0', 10) || ev.matchDurationMin)
-                    setDurations({ ...durations, [m.id]: v })
-                  }}
-                />
-                <span className="unit">m</span>
-              </div>
-            </div>
-          )
-        })}
+            )
+          })}
 
         {completed.length > 0 && (
           <>
@@ -736,9 +747,7 @@ function SimPanel({
               <span style={{ fontSize: 10, color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>ACTUAL</span>
             </div>
             {completed.map((m) => {
-              const ev = config.events.find((e) => e.id === m.eventId)!
-              const evIdx = config.events.findIndex((e) => e.id === m.eventId)
-              const c = eventColor(evIdx)
+              const ev = lookups.eventById.get(m.eventId)!
               const actual = (m.actualEnd ?? 0) - (m.actualStart ?? 0)
               return (
                 <div
@@ -746,18 +755,20 @@ function SimPanel({
                   className={`sim-row completed ${selectedMatchId === m.id ? 'selected' : ''}`}
                   onClick={() => onSelectMatch(m.id)}
                 >
-                  <div className="colorbar" style={{ '--c': c, opacity: 0.5 } as React.CSSProperties}></div>
+                  <div
+                    className="colorbar"
+                    style={{ '--c': eventColorFor(m), opacity: 0.5 } as React.CSSProperties}
+                  ></div>
                   <div className="info">
                     <div className="players">
                       <Lock
                         size={10}
                         style={{ color: 'var(--fg-3)', marginRight: 4, verticalAlign: 'middle' }}
                       />
-                      {abbrevPlayer(config, m.p1)} vs {abbrevPlayer(config, m.p2)}
+                      {abbrevPlayer(lookups.playerById, m.p1)} vs {abbrevPlayer(lookups.playerById, m.p2)}
                     </div>
                     <div className="meta">
-                      T{config.tables.findIndex((t) => t.id === m.tableId) + 1} ·{' '}
-                      {fmtClock(m.actualStart ?? 0, '24h')}–{fmtClock(m.actualEnd ?? 0, '24h')}
+                      T{tableNum(m)} · {fmtClock(m.actualStart ?? 0, '24h')}–{fmtClock(m.actualEnd ?? 0, '24h')}
                     </div>
                   </div>
                   <div className="dur">
@@ -831,7 +842,8 @@ export function ScheduleView({
   const [hover, setHover] = useState<HoverInfo | null>(null)
   const vizRef = useRef<HTMLDivElement>(null)
 
-  const status = schedule?.status || '—'
+  const lookups = useMemo(() => buildLookups(config), [config])
+  const status = schedule.status
   const animateMoves = tweaks.animateMoves !== false
 
   useLayoutEffect(() => {
@@ -925,6 +937,7 @@ export function ScheduleView({
             config={config}
             schedule={schedule}
             sim={sim}
+            lookups={lookups}
             density={tweaks.density || 'comfortable'}
             colorBy={tweaks.colorBy || 'event'}
             animateMoves={animateMoves}
@@ -938,6 +951,7 @@ export function ScheduleView({
             config={config}
             schedule={schedule}
             sim={sim}
+            lookups={lookups}
             density={tweaks.density || 'comfortable'}
             colorBy={tweaks.colorBy || 'event'}
             animateMoves={animateMoves}
@@ -951,9 +965,9 @@ export function ScheduleView({
       </div>
 
       <SimPanel
-        config={config}
         schedule={schedule}
         sim={sim}
+        lookups={lookups}
         durations={durations}
         setDurations={setDurations}
         onAdvance={onAdvance}
@@ -966,7 +980,7 @@ export function ScheduleView({
         lastResolveMs={lastResolveMs}
       />
 
-      <MatchTip hover={hover} config={config} />
+      <MatchTip hover={hover} lookups={lookups} />
     </div>
   )
 }

--- a/web-client/src/components/simulator/schedule.tsx
+++ b/web-client/src/components/simulator/schedule.tsx
@@ -1,0 +1,972 @@
+/* =====================================================================
+   schedule.tsx — Schedule + simulator screen
+   ===================================================================== */
+import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  Check,
+  ChevronRight,
+  Dice5,
+  Eraser,
+  FastForward,
+  LayoutGrid,
+  Loader2,
+  Lock,
+  RotateCcw,
+  SkipForward,
+  Users,
+} from 'lucide-react'
+import {
+  colorForMatch,
+  eventColor,
+  fmtClock,
+  initials,
+  minutesBetween,
+  type ClockMode,
+  type ColorBy,
+  type Config,
+  type Match,
+  type Schedule,
+  type TournamentEvent,
+} from './data'
+
+export type Density = 'comfortable' | 'compact' | 'tight'
+
+export interface Tweaks {
+  density: Density
+  colorBy: ColorBy
+  clockMode: ClockMode
+  showIdle: boolean
+  animateMoves: boolean
+}
+
+export interface SimState {
+  completions: { matchId: string; start: number; end: number; tableId: string }[]
+  nowMin: number
+}
+
+interface HoverInfo {
+  match: Match
+  event: TournamentEvent | undefined
+  color: string
+  x: number
+  y: number
+}
+
+// ---------- Axis helpers ----------
+function pickTickStep(pxPerMin: number): number {
+  const choices = [5, 10, 15, 20, 30, 60, 90, 120]
+  for (const c of choices) {
+    if (c * pxPerMin >= 80) return c
+  }
+  return 120
+}
+
+function abbrevPlayer(config: Config, pid: string): string {
+  const p = config.players.find((pp) => pp.id === pid)
+  if (!p) return '?'
+  const parts = p.name.split(/\s+/)
+  if (parts.length === 1) return parts[0]
+  return `${parts[0]} ${parts[parts.length - 1][0]}.`
+}
+
+function densityMinorPx(density: Density): number {
+  return density === 'tight' ? 4 : density === 'compact' ? 6 : 8
+}
+
+// ---------- Gantt (tables on Y) ----------
+function GanttChart({
+  config,
+  schedule,
+  sim,
+  density,
+  colorBy,
+  animateMoves,
+  clockMode,
+  onSelectMatch,
+  selectedMatchId,
+  onHover,
+}: {
+  config: Config
+  schedule: Schedule
+  sim: SimState
+  density: Density
+  colorBy: ColorBy
+  animateMoves: boolean
+  clockMode: ClockMode
+  onSelectMatch: (id: string) => void
+  selectedMatchId: string | null
+  onHover: (h: HoverInfo | null) => void
+}) {
+  const minorPx = densityMinorPx(density)
+  const dayEnd = minutesBetween(config.startISO, config.endISO)
+  const pxPerMin = minorPx
+  const rowH = density === 'tight' ? 32 : density === 'compact' ? 36 : 44
+  const trackW = dayEnd * pxPerMin
+  const tickStep = pickTickStep(pxPerMin)
+
+  const tables = config.tables
+  const matchesByTable = useMemo(() => {
+    const m: Record<string, Match[]> = {}
+    tables.forEach((t) => {
+      m[t.id] = []
+    })
+    schedule.matches.forEach((mm) => {
+      if (m[mm.tableId]) m[mm.tableId].push(mm)
+    })
+    return m
+  }, [tables, schedule])
+
+  return (
+    <div
+      className="tl"
+      style={
+        {
+          '--minor-px': `${minorPx}px`,
+          '--row-h': `${rowH}px`,
+          minWidth: 140 + trackW + 16,
+        } as React.CSSProperties
+      }
+    >
+      <div className="tl-grid" style={{ gridTemplateColumns: `140px ${trackW}px` }}>
+        <div className="tl-row-label head">Table</div>
+        <div className="tl-axis">
+          <div className="tl-axis-track" style={{ width: trackW }}>
+            {Array.from({ length: Math.floor(dayEnd / tickStep) + 1 }).map((_, i) => {
+              const min = i * tickStep
+              return (
+                <div key={i} className="tl-axis-tick major" style={{ left: min * pxPerMin }}>
+                  {fmtClock(min, clockMode)}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {tables.map((t, ri) => (
+          <Fragment key={t.id}>
+            <div
+              className="tl-row-label"
+              style={{ height: rowH, borderBottom: '1px solid var(--ink-800)' }}
+            >
+              <span
+                style={{
+                  width: 22,
+                  height: 22,
+                  borderRadius: 4,
+                  background: 'var(--ink-800)',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 11,
+                  color: 'var(--fg-2)',
+                }}
+              >
+                {ri + 1}
+              </span>
+              <span>{t.name}</span>
+            </div>
+            <div className={`tl-row ${ri % 2 ? 'alt' : ''}`} style={{ position: 'relative' }}>
+              {config.tablePools
+                .filter((p) => p.tableIds.includes(t.id))
+                .map((p) => (
+                  <div
+                    key={p.id}
+                    className="tl-pool"
+                    style={{ left: p.startMin * pxPerMin, width: (p.endMin - p.startMin) * pxPerMin }}
+                  ></div>
+                ))}
+              {(matchesByTable[t.id] || []).map((m) => {
+                const ev = config.events.find((e) => e.id === m.eventId)
+                const c = colorForMatch(m, config, colorBy)
+                const start = m.completed ? (m.actualStart ?? 0) : m.plannedStart
+                const end = m.completed ? (m.actualEnd ?? 0) : m.plannedEnd
+                const w = (end - start) * pxPerMin
+                const narrow = w < 60
+                const tiny = w < 36
+                return (
+                  <div
+                    key={m.id}
+                    className={
+                      'match ' +
+                      (m.completed ? 'completed ' : '') +
+                      (selectedMatchId === m.id ? 'selected ' : '') +
+                      (narrow ? 'narrow ' : '') +
+                      (tiny ? 'tiny ' : '') +
+                      (animateMoves ? 'animated ' : '')
+                    }
+                    style={
+                      { left: start * pxPerMin, width: Math.max(8, w - 2), '--c': c } as React.CSSProperties
+                    }
+                    onClick={() => onSelectMatch(m.id)}
+                    onMouseEnter={(e) => onHover({ match: m, event: ev, color: c, x: e.clientX, y: e.clientY })}
+                    onMouseMove={(e) => onHover({ match: m, event: ev, color: c, x: e.clientX, y: e.clientY })}
+                    onMouseLeave={() => onHover(null)}
+                  >
+                    {m.completed && (
+                      <>
+                        <div className="match-tag" style={{ background: c }}></div>
+                        <Lock className="lock" />
+                      </>
+                    )}
+                    {!tiny && (
+                      <div className="match-players">
+                        {abbrevPlayer(config, m.p1)} <span style={{ opacity: 0.6 }}>vs</span>{' '}
+                        {abbrevPlayer(config, m.p2)}
+                      </div>
+                    )}
+                    {!narrow && (
+                      <div className="match-meta">
+                        {ev?.name?.slice(0, 16)} ·{' '}
+                        {m.completed ? (m.actualEnd ?? 0) - (m.actualStart ?? 0) : m.plannedDurationMin}m
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+              {sim.nowMin > 0 && <div className="tl-now" style={{ left: sim.nowMin * pxPerMin }}></div>}
+            </div>
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ---------- Player timeline (players on Y, idle gaps highlighted) ----------
+function PlayerTimeline({
+  config,
+  schedule,
+  sim,
+  density,
+  colorBy,
+  animateMoves,
+  clockMode,
+  showIdle,
+  onSelectMatch,
+  selectedMatchId,
+  onHover,
+}: {
+  config: Config
+  schedule: Schedule
+  sim: SimState
+  density: Density
+  colorBy: ColorBy
+  animateMoves: boolean
+  clockMode: ClockMode
+  showIdle: boolean
+  onSelectMatch: (id: string) => void
+  selectedMatchId: string | null
+  onHover: (h: HoverInfo | null) => void
+}) {
+  const minorPx = densityMinorPx(density)
+  const dayEnd = minutesBetween(config.startISO, config.endISO)
+  const pxPerMin = minorPx
+  const rowH = density === 'tight' ? 28 : density === 'compact' ? 32 : 38
+  const trackW = dayEnd * pxPerMin
+  const tickStep = pickTickStep(pxPerMin)
+
+  const activePlayerIds = useMemo(() => {
+    const s = new Set<string>()
+    config.events.forEach((e) => e.playerIds.forEach((id) => s.add(id)))
+    return Array.from(s)
+  }, [config.events])
+
+  const playerData = useMemo(() => {
+    const out: Record<string, { matches: Match[]; idle: [number, number][] }> = {}
+    activePlayerIds.forEach((id) => {
+      out[id] = { matches: [], idle: [] }
+    })
+    schedule.matches.forEach((m) => {
+      ;[m.p1, m.p2].forEach((pid) => {
+        if (out[pid]) out[pid].matches.push(m)
+      })
+    })
+    Object.values(out).forEach((d) => {
+      d.matches.sort((a, b) => a.plannedStart - b.plannedStart)
+      let prev: number | null = null
+      for (const m of d.matches) {
+        const s = m.completed ? (m.actualStart ?? 0) : m.plannedStart
+        if (prev != null && s - prev > 5) d.idle.push([prev, s])
+        prev = m.completed ? (m.actualEnd ?? 0) : m.plannedEnd
+      }
+    })
+    return out
+  }, [activePlayerIds, schedule])
+
+  const sortedPlayers = useMemo(() => {
+    return activePlayerIds
+      .map((id) => {
+        const d = playerData[id]
+        const total = d.matches.reduce(
+          (s, m) => s + (m.completed ? (m.actualEnd ?? 0) - (m.actualStart ?? 0) : m.plannedDurationMin),
+          0,
+        )
+        const idleTotal = d.idle.reduce((s, [a, b]) => s + (b - a), 0)
+        return { id, total, idleTotal }
+      })
+      .sort((a, b) => b.total - a.total)
+  }, [activePlayerIds, playerData])
+
+  return (
+    <div
+      className="tl"
+      style={
+        {
+          '--minor-px': `${minorPx}px`,
+          '--row-h': `${rowH}px`,
+          minWidth: 200 + trackW + 16,
+        } as React.CSSProperties
+      }
+    >
+      <div className="tl-grid" style={{ gridTemplateColumns: `200px ${trackW}px` }}>
+        <div className="tl-row-label head">
+          Player <span style={{ flex: 1 }}></span>
+          <span style={{ color: 'var(--fg-3)', textTransform: 'uppercase', fontSize: 10 }}>idle</span>
+        </div>
+        <div className="tl-axis">
+          <div className="tl-axis-track" style={{ width: trackW }}>
+            {Array.from({ length: Math.floor(dayEnd / tickStep) + 1 }).map((_, i) => {
+              const min = i * tickStep
+              return (
+                <div key={i} className="tl-axis-tick major" style={{ left: min * pxPerMin }}>
+                  {fmtClock(min, clockMode)}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {sortedPlayers.map(({ id, idleTotal }, ri) => {
+          const p = config.players.find((pp) => pp.id === id)
+          if (!p) return null
+          const d = playerData[id]
+          return (
+            <Fragment key={id}>
+              <div className="tl-row-label" style={{ height: rowH }}>
+                <span
+                  style={{
+                    width: 24,
+                    height: 24,
+                    borderRadius: 999,
+                    background: 'var(--ink-800)',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 10,
+                    color: 'var(--fg-2)',
+                  }}
+                >
+                  {initials(p.name)}
+                </span>
+                <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 }}>
+                  <span
+                    style={{
+                      fontSize: 12,
+                      color: 'var(--fg-1)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {p.name}
+                  </span>
+                  <span style={{ fontSize: 10, color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>
+                    {p.rating ?? '—'}
+                  </span>
+                </div>
+                <span
+                  style={{
+                    fontSize: 11,
+                    fontFamily: 'var(--font-mono)',
+                    color: idleTotal > 90 ? 'var(--warn)' : 'var(--fg-3)',
+                  }}
+                >
+                  {idleTotal}
+                </span>
+              </div>
+              <div className={`tl-row ${ri % 2 ? 'alt' : ''}`} style={{ position: 'relative' }}>
+                {showIdle &&
+                  d.idle.map(([s, e], i) => (
+                    <div
+                      key={i}
+                      className="idle-block"
+                      style={{ left: s * pxPerMin, width: (e - s) * pxPerMin }}
+                    ></div>
+                  ))}
+                {d.matches.map((m) => {
+                  const ev = config.events.find((e) => e.id === m.eventId)
+                  const c = colorForMatch(m, config, colorBy)
+                  const start = m.completed ? (m.actualStart ?? 0) : m.plannedStart
+                  const end = m.completed ? (m.actualEnd ?? 0) : m.plannedEnd
+                  const w = (end - start) * pxPerMin
+                  const narrow = w < 60
+                  const tiny = w < 36
+                  const otherId = m.p1 === id ? m.p2 : m.p1
+                  return (
+                    <div
+                      key={m.id}
+                      className={
+                        'match ' +
+                        (m.completed ? 'completed ' : '') +
+                        (selectedMatchId === m.id ? 'selected ' : '') +
+                        (narrow ? 'narrow ' : '') +
+                        (tiny ? 'tiny ' : '') +
+                        (animateMoves ? 'animated ' : '')
+                      }
+                      style={
+                        { left: start * pxPerMin, width: Math.max(8, w - 2), '--c': c } as React.CSSProperties
+                      }
+                      onClick={() => onSelectMatch(m.id)}
+                      onMouseEnter={(e) => onHover({ match: m, event: ev, color: c, x: e.clientX, y: e.clientY })}
+                      onMouseMove={(e) => onHover({ match: m, event: ev, color: c, x: e.clientX, y: e.clientY })}
+                      onMouseLeave={() => onHover(null)}
+                    >
+                      {m.completed && (
+                        <>
+                          <div className="match-tag" style={{ background: c }}></div>
+                          <Lock className="lock" />
+                        </>
+                      )}
+                      {!tiny && <div className="match-players">vs {abbrevPlayer(config, otherId)}</div>}
+                      {!narrow && (
+                        <div className="match-meta">
+                          T{config.tables.findIndex((t) => t.id === m.tableId) + 1} ·{' '}
+                          {m.completed ? (m.actualEnd ?? 0) - (m.actualStart ?? 0) : m.plannedDurationMin}m
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+                {sim.nowMin > 0 && <div className="tl-now" style={{ left: sim.nowMin * pxPerMin }}></div>}
+              </div>
+            </Fragment>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ---------- Hover tooltip ----------
+function MatchTip({ hover, config }: { hover: HoverInfo | null; config: Config }) {
+  if (!hover) return null
+  const { match: m, event: ev, color, x, y } = hover
+  const p1 = config.players.find((p) => p.id === m.p1)
+  const p2 = config.players.find((p) => p.id === m.p2)
+  const tbl = config.tables.find((t) => t.id === m.tableId)
+  const start = m.completed ? (m.actualStart ?? 0) : m.plannedStart
+  const end = m.completed ? (m.actualEnd ?? 0) : m.plannedEnd
+  const W = 260,
+    H = 160
+  let left = x + 14
+  let top = y + 14
+  if (left + W > window.innerWidth - 10) left = x - W - 14
+  if (top + H > window.innerHeight - 10) top = y - H - 14
+  return (
+    <div className="match-tip" style={{ left, top, minWidth: W }}>
+      <div className="heading">
+        <span className="dot" style={{ background: color }}></span>
+        <span className="ev">{ev?.name || '—'}</span>
+        {m.completed && (
+          <span
+            style={{
+              marginLeft: 'auto',
+              fontSize: 10,
+              color: 'var(--fg-3)',
+              fontFamily: 'var(--font-mono)',
+            }}
+          >
+            ✓ COMPLETED
+          </span>
+        )}
+      </div>
+      <div className="players">
+        <span>{p1?.name}</span>
+        <span className="v">vs</span>
+        <span>{p2?.name}</span>
+      </div>
+      <div className="rows">
+        <span className="k">Table</span>
+        <span className="v">{tbl?.name}</span>
+        <span className="k">Start</span>
+        <span className="v">
+          {fmtClock(start, '24h')} <span style={{ color: 'var(--fg-3)' }}>+{start}m</span>
+        </span>
+        <span className="k">End</span>
+        <span className="v">
+          {fmtClock(end, '24h')} <span style={{ color: 'var(--fg-3)' }}>+{end}m</span>
+        </span>
+        <span className="k">Duration</span>
+        <span className="v">{end - start} min</span>
+      </div>
+    </div>
+  )
+}
+
+// ---------- Simulator panel ----------
+function SimPanel({
+  config,
+  schedule,
+  sim,
+  durations,
+  setDurations,
+  onAdvance,
+  onAdvanceAll,
+  onResetSim,
+  onResetDurations,
+  autoAdvancing,
+  selectedMatchId,
+  onSelectMatch,
+  lastResolveMs,
+}: {
+  config: Config
+  schedule: Schedule
+  sim: SimState
+  durations: Record<string, number>
+  setDurations: (d: Record<string, number>) => void
+  onAdvance: () => void
+  onAdvanceAll: () => void
+  onResetSim: () => void
+  onResetDurations: () => void
+  autoAdvancing: boolean
+  selectedMatchId: string | null
+  onSelectMatch: (id: string) => void
+  lastResolveMs: number | null
+}) {
+  const totalExpected = schedule?.matches.length || 0
+  const completedIds = new Set(sim.completions.map((c) => c.matchId))
+  const completed = schedule.matches.filter((m) => completedIds.has(m.id))
+  const pending = schedule.matches
+    .filter((m) => !completedIds.has(m.id))
+    .sort((a, b) => a.plannedStart - b.plannedStart)
+
+  completed.sort((a, b) => (b.actualEnd || 0) - (a.actualEnd || 0))
+
+  const onBulkPerturb = () => {
+    const next = { ...durations }
+    pending.forEach((m) => {
+      const ev = config.events.find((e) => e.id === m.eventId)!
+      const planned = ev.matchDurationMin
+      const delta = Math.round((Math.random() * 20 - 10) / 5) * 5
+      next[m.id] = Math.max(5, planned + delta)
+    })
+    setDurations(next)
+  }
+
+  const nextToComplete = useMemo(() => {
+    let best: Match | null = null,
+      bestT = Infinity
+    pending.forEach((m) => {
+      const ev = config.events.find((e) => e.id === m.eventId)!
+      const dur = durations[m.id] ?? ev.matchDurationMin
+      const t = m.plannedStart + dur
+      if (t < bestT) {
+        bestT = t
+        best = m
+      }
+    })
+    return best as Match | null
+  }, [pending, durations, config])
+
+  return (
+    <div className="sim">
+      <div className="sim-header">
+        <h3>● Simulator</h3>
+        <div className="progress">
+          {completed.length}/{totalExpected}
+        </div>
+      </div>
+      <div className="sim-controls">
+        <button
+          className="btn primary full"
+          onClick={onAdvance}
+          disabled={pending.length === 0 || autoAdvancing}
+        >
+          {autoAdvancing ? (
+            <>
+              <Loader2 size={14} className="spin" /> Re-solving…
+            </>
+          ) : pending.length === 0 ? (
+            <>
+              <Check size={14} /> All matches complete
+            </>
+          ) : (
+            <>
+              <SkipForward size={14} /> Advance
+            </>
+          )}
+        </button>
+        <button className="btn" onClick={onAdvanceAll} disabled={pending.length === 0 || autoAdvancing}>
+          <FastForward size={14} /> To end
+        </button>
+        <button
+          className="btn ghost"
+          onClick={onBulkPerturb}
+          disabled={pending.length === 0}
+          title="Apply random ±10 min to all pending matches"
+        >
+          <Dice5 size={14} /> ± perturb
+        </button>
+        <button
+          className="btn ghost full"
+          onClick={onResetSim}
+          disabled={sim.completions.length === 0}
+          title="Clear completions and re-solve from scratch (keeps duration edits)"
+        >
+          <RotateCcw size={14} /> Reset simulation
+        </button>
+        <button
+          className="btn ghost full"
+          onClick={onResetDurations}
+          disabled={Object.keys(durations).length === 0}
+          title="Clear actual-duration overrides"
+        >
+          <Eraser size={14} /> Reset durations to planned
+        </button>
+      </div>
+
+      <div className="sim-list">
+        {pending.length > 0 && nextToComplete && (
+          <>
+            <div className="sim-section-head">
+              <ChevronRight size={12} style={{ color: 'var(--ball-500)' }} />
+              Next to complete
+            </div>
+            {(() => {
+              const m = nextToComplete
+              const ev = config.events.find((e) => e.id === m.eventId)!
+              const dur = durations[m.id] ?? ev.matchDurationMin
+              const evIdx = config.events.findIndex((e) => e.id === m.eventId)
+              const c = eventColor(evIdx)
+              const finishesAt = m.plannedStart + dur
+              return (
+                <div
+                  className={`sim-row ${selectedMatchId === m.id ? 'selected' : ''}`}
+                  onClick={() => onSelectMatch(m.id)}
+                >
+                  <div className="colorbar" style={{ '--c': c } as React.CSSProperties}></div>
+                  <div className="info">
+                    <div className="players">
+                      {abbrevPlayer(config, m.p1)} vs {abbrevPlayer(config, m.p2)}
+                    </div>
+                    <div className="meta">
+                      T{config.tables.findIndex((t) => t.id === m.tableId) + 1}
+                      {' · '}starts {fmtClock(m.plannedStart, '24h')}
+                      {' · '}done {fmtClock(finishesAt, '24h')}
+                    </div>
+                  </div>
+                  <div className="dur" onClick={(e) => e.stopPropagation()}>
+                    <input
+                      type="number"
+                      className={dur !== ev.matchDurationMin ? 'changed' : ''}
+                      value={dur}
+                      step={5}
+                      min={5}
+                      onChange={(e) => {
+                        const v = Math.max(5, parseInt(e.target.value || '0', 10) || ev.matchDurationMin)
+                        setDurations({ ...durations, [m.id]: v })
+                      }}
+                    />
+                    <span className="unit">m</span>
+                  </div>
+                </div>
+              )
+            })()}
+          </>
+        )}
+
+        <div className="sim-section-head">
+          <span>Pending</span>
+          <span className="count">{pending.length}</span>
+          <div className="grow"></div>
+          <span style={{ fontSize: 10, color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>DURATION</span>
+        </div>
+        {pending.length === 0 && (
+          <div style={{ padding: '12px 16px', color: 'var(--fg-3)', fontSize: 12 }}>
+            No pending matches. Reset to replay.
+          </div>
+        )}
+        {pending.slice(nextToComplete ? 1 : 0).map((m) => {
+          const ev = config.events.find((e) => e.id === m.eventId)!
+          const evIdx = config.events.findIndex((e) => e.id === m.eventId)
+          const c = eventColor(evIdx)
+          const dur = durations[m.id] ?? ev.matchDurationMin
+          const changed = dur !== ev.matchDurationMin
+          return (
+            <div
+              key={m.id}
+              className={`sim-row ${selectedMatchId === m.id ? 'selected' : ''}`}
+              onClick={() => onSelectMatch(m.id)}
+            >
+              <div className="colorbar" style={{ '--c': c } as React.CSSProperties}></div>
+              <div className="info">
+                <div className="players">
+                  {abbrevPlayer(config, m.p1)} vs {abbrevPlayer(config, m.p2)}
+                </div>
+                <div className="meta">
+                  T{config.tables.findIndex((t) => t.id === m.tableId) + 1} · {fmtClock(m.plannedStart, '24h')}
+                </div>
+              </div>
+              <div className="dur" onClick={(e) => e.stopPropagation()}>
+                <input
+                  type="number"
+                  className={changed ? 'changed' : ''}
+                  value={dur}
+                  step={5}
+                  min={5}
+                  onChange={(e) => {
+                    const v = Math.max(5, parseInt(e.target.value || '0', 10) || ev.matchDurationMin)
+                    setDurations({ ...durations, [m.id]: v })
+                  }}
+                />
+                <span className="unit">m</span>
+              </div>
+            </div>
+          )
+        })}
+
+        {completed.length > 0 && (
+          <>
+            <div className="sim-section-head">
+              <span>Completed</span>
+              <span className="count">{completed.length}</span>
+              <div className="grow"></div>
+              <span style={{ fontSize: 10, color: 'var(--fg-3)', fontFamily: 'var(--font-mono)' }}>ACTUAL</span>
+            </div>
+            {completed.map((m) => {
+              const ev = config.events.find((e) => e.id === m.eventId)!
+              const evIdx = config.events.findIndex((e) => e.id === m.eventId)
+              const c = eventColor(evIdx)
+              const actual = (m.actualEnd ?? 0) - (m.actualStart ?? 0)
+              return (
+                <div
+                  key={m.id}
+                  className={`sim-row completed ${selectedMatchId === m.id ? 'selected' : ''}`}
+                  onClick={() => onSelectMatch(m.id)}
+                >
+                  <div className="colorbar" style={{ '--c': c, opacity: 0.5 } as React.CSSProperties}></div>
+                  <div className="info">
+                    <div className="players">
+                      <Lock
+                        size={10}
+                        style={{ color: 'var(--fg-3)', marginRight: 4, verticalAlign: 'middle' }}
+                      />
+                      {abbrevPlayer(config, m.p1)} vs {abbrevPlayer(config, m.p2)}
+                    </div>
+                    <div className="meta">
+                      T{config.tables.findIndex((t) => t.id === m.tableId) + 1} ·{' '}
+                      {fmtClock(m.actualStart ?? 0, '24h')}–{fmtClock(m.actualEnd ?? 0, '24h')}
+                    </div>
+                  </div>
+                  <div className="dur">
+                    <span className="actual">{actual}m</span>
+                    {actual !== ev.matchDurationMin && (
+                      <span
+                        style={{
+                          fontSize: 10,
+                          fontFamily: 'var(--font-mono)',
+                          color: actual > ev.matchDurationMin ? 'var(--loss)' : 'var(--serve-500)',
+                        }}
+                      >
+                        {actual > ev.matchDurationMin ? '+' : ''}
+                        {actual - ev.matchDurationMin}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </>
+        )}
+      </div>
+
+      <div className="sim-footer">
+        <span>
+          Last resolve{' '}
+          <span className="mono" style={{ color: 'var(--fg-2)', fontFamily: 'var(--font-mono)' }}>
+            {lastResolveMs || '—'}ms
+          </span>
+        </span>
+        <div className="grow"></div>
+        <span>
+          <span className="kbd">↵</span> advance
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ---------- ScheduleView ----------
+export function ScheduleView({
+  config,
+  schedule,
+  sim,
+  durations,
+  setDurations,
+  onAdvance,
+  onAdvanceAll,
+  onResetSim,
+  onResetDurations,
+  autoAdvancing,
+  tweaks,
+  lastResolveMs,
+}: {
+  config: Config
+  schedule: Schedule
+  sim: SimState
+  durations: Record<string, number>
+  setDurations: (d: Record<string, number>) => void
+  onAdvance: () => void
+  onAdvanceAll: () => void
+  onResetSim: () => void
+  onResetDurations: () => void
+  autoAdvancing: boolean
+  tweaks: Tweaks
+  lastResolveMs: number | null
+}) {
+  const [view, setView] = useState<'players' | 'gantt'>('players')
+  const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null)
+  const [hover, setHover] = useState<HoverInfo | null>(null)
+  const vizRef = useRef<HTMLDivElement>(null)
+
+  const status = schedule?.status || '—'
+  const animateMoves = tweaks.animateMoves !== false
+
+  useLayoutEffect(() => {
+    if (!selectedMatchId || !vizRef.current) return
+    const el = vizRef.current.querySelector('.match.selected')
+    if (el) el.scrollIntoView({ block: 'nearest', inline: 'center', behavior: 'smooth' })
+  }, [selectedMatchId, view])
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const tag = (e.target as HTMLElement).tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        onAdvance()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onAdvance])
+
+  return (
+    <div className="schedule">
+      <div className="solve-strip">
+        <div className="stat-cell" style={{ minWidth: 110 }}>
+          <span className="label">Status</span>
+          <div>
+            <span className={`pill ${status.toLowerCase()}`}>
+              {status === 'OPTIMAL' ? '● OPTIMAL' : status === 'FEASIBLE' ? '○ FEASIBLE' : '✕ INFEASIBLE'}
+            </span>
+          </div>
+        </div>
+        <div className="stat-cell">
+          <span className="label">Solve</span>
+          <span className="value">
+            {schedule.solveTimeMs}
+            <span style={{ fontSize: 12, color: 'var(--fg-3)' }}>ms</span>
+          </span>
+        </div>
+        <div className="stat-cell">
+          <span className="label">Makespan</span>
+          <span className="value">
+            {schedule.makespanMin}
+            <span style={{ fontSize: 12, color: 'var(--fg-3)' }}>m</span>
+          </span>
+        </div>
+        <div className="stat-cell">
+          <span className="label">Idle (Σ)</span>
+          <span className="value">
+            {schedule.totalIdleMin}
+            <span style={{ fontSize: 12, color: 'var(--fg-3)' }}>m</span>
+          </span>
+        </div>
+        <div className="stat-cell">
+          <span className="label">Matches</span>
+          <span className="value">
+            <span style={{ color: 'var(--serve-500)' }}>{sim.completions.length}</span>
+            <span style={{ color: 'var(--fg-3)' }}>/{schedule.matches.length}</span>
+          </span>
+        </div>
+        <div className="grow"></div>
+        <div className="stat-cell sim-clock" style={{ borderRight: 0, alignItems: 'flex-end' }}>
+          <span className="label">Sim clock</span>
+          <span className="now">{fmtClock(sim.nowMin, tweaks.clockMode || '24h')}</span>
+        </div>
+      </div>
+
+      <div className="view-bar">
+        <div className="tabs">
+          <button className={view === 'players' ? 'active' : ''} onClick={() => setView('players')}>
+            <Users size={14} /> Player timeline
+          </button>
+          <button className={view === 'gantt' ? 'active' : ''} onClick={() => setView('gantt')}>
+            <LayoutGrid size={14} /> Gantt
+          </button>
+        </div>
+        <div className="grow"></div>
+        <div className="swatches">
+          {config.events.map((ev, i) => (
+            <span className="swatch" key={ev.id}>
+              <span className="sq" style={{ '--c': eventColor(i) } as React.CSSProperties}></span>
+              {ev.name}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="viz" ref={vizRef}>
+        {view === 'gantt' ? (
+          <GanttChart
+            config={config}
+            schedule={schedule}
+            sim={sim}
+            density={tweaks.density || 'comfortable'}
+            colorBy={tweaks.colorBy || 'event'}
+            animateMoves={animateMoves}
+            clockMode={tweaks.clockMode || '24h'}
+            selectedMatchId={selectedMatchId}
+            onSelectMatch={setSelectedMatchId}
+            onHover={setHover}
+          />
+        ) : (
+          <PlayerTimeline
+            config={config}
+            schedule={schedule}
+            sim={sim}
+            density={tweaks.density || 'comfortable'}
+            colorBy={tweaks.colorBy || 'event'}
+            animateMoves={animateMoves}
+            clockMode={tweaks.clockMode || '24h'}
+            showIdle={tweaks.showIdle !== false}
+            selectedMatchId={selectedMatchId}
+            onSelectMatch={setSelectedMatchId}
+            onHover={setHover}
+          />
+        )}
+      </div>
+
+      <SimPanel
+        config={config}
+        schedule={schedule}
+        sim={sim}
+        durations={durations}
+        setDurations={setDurations}
+        onAdvance={onAdvance}
+        onAdvanceAll={onAdvanceAll}
+        onResetSim={onResetSim}
+        onResetDurations={onResetDurations}
+        autoAdvancing={autoAdvancing}
+        selectedMatchId={selectedMatchId}
+        onSelectMatch={setSelectedMatchId}
+        lastResolveMs={lastResolveMs}
+      />
+
+      <MatchTip hover={hover} config={config} />
+    </div>
+  )
+}

--- a/web-client/src/components/simulator/simulator-app.tsx
+++ b/web-client/src/components/simulator/simulator-app.tsx
@@ -1,0 +1,510 @@
+/* =====================================================================
+   simulator-app.tsx — Top-level state, routing between editor/schedule,
+   solve loop. Ported from the FortyMM design handoff (app.jsx).
+   ===================================================================== */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { CalendarClock, Settings2, SlidersHorizontal } from 'lucide-react'
+import {
+  fmtClock,
+  makeExampleConfig,
+  minutesBetween,
+  solve,
+  totalExpectedMatches,
+  validateConfig,
+  TEND_ISO,
+  T0_ISO,
+  type ClockMode,
+  type ColorBy,
+  type Config,
+  type Schedule,
+  type SolveError,
+  type SolveOptions,
+} from './data'
+import { Editor } from './editor'
+import { ScheduleView, type Density, type SimState, type Tweaks } from './schedule'
+import './simulator.css'
+
+interface LogLine {
+  t: number
+  text: string
+}
+
+// ----- Solve overlay (simulated CP-SAT) ----------------------------------
+function SolveOverlay({
+  phase,
+  progress,
+  log,
+}: {
+  phase: string
+  progress: number
+  log: LogLine[]
+}) {
+  return (
+    <div className="solve-overlay">
+      <div className="panel">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <span className="ball-mark"></span>
+          <span className="title">{phase}</span>
+        </div>
+        <div className="bar">
+          <div className="fill" style={{ '--p': `${progress}%` } as React.CSSProperties}></div>
+        </div>
+        <div className="log">
+          {log.slice(-4).map((l, i) => (
+            <div key={i} className="line">
+              <span className="dim">[t={l.t.toFixed(1)}s]</span> {l.text}
+            </div>
+          ))}
+        </div>
+        <div className="sub">CP-SAT · branch-and-bound · warm-start hints from last solution</div>
+      </div>
+    </div>
+  )
+}
+
+// Synthesizes a fake "solve" with progress/log updates.
+function fakeSolveAsync(
+  cfg: Config,
+  opts: SolveOptions = {},
+  onProgress?: (p: number, text: string, t: number) => void,
+): Promise<Schedule> {
+  const isInitial = opts.isInitial
+  const totalMs = isInitial ? 1400 + Math.random() * 1100 : 300 + Math.random() * 250
+  return new Promise((resolve) => {
+    const start = performance.now()
+    const phases: [number, string][] = isInitial
+      ? [
+          [0.05, 'Reading config…'],
+          [0.1, 'Building constraint model…'],
+          [
+            0.2,
+            `Variables: ${totalExpectedMatches(cfg) * 6}, constraints: ${Math.round(
+              totalExpectedMatches(cfg) * 14,
+            )}`,
+          ],
+          [0.35, 'CP-SAT: presolving…'],
+          [0.55, 'Searching feasible region…'],
+          [0.75, 'Improving objective: minimizing makespan'],
+          [0.9, 'Improving objective: minimizing player idle'],
+          [1.0, 'Done.'],
+        ]
+      : [
+          [0.3, 'Pinning completed matches…'],
+          [0.7, 'Warm-start hints loaded; resolving…'],
+          [1.0, 'Done.'],
+        ]
+    let phaseIdx = 0
+    const tick = () => {
+      const elapsed = performance.now() - start
+      const p = Math.min(1, elapsed / totalMs)
+      while (phaseIdx < phases.length && phases[phaseIdx][0] <= p) {
+        onProgress?.(p * 100, phases[phaseIdx][1], elapsed / 1000)
+        phaseIdx++
+      }
+      if (p < 1) requestAnimationFrame(tick)
+      else {
+        const result = solve(cfg, opts)
+        result.solveTimeMs = Math.round(totalMs)
+        resolve(result)
+      }
+    }
+    requestAnimationFrame(tick)
+  })
+}
+
+const DEFAULT_TWEAKS: Tweaks = {
+  density: 'comfortable',
+  colorBy: 'event',
+  clockMode: '24h',
+  showIdle: true,
+  animateMoves: true,
+}
+
+// ----- Lightweight view-settings popover (replaces design-tool Tweaks) ----
+function SettingsPopover({
+  tweaks,
+  setTweak,
+}: {
+  tweaks: Tweaks
+  setTweak: <K extends keyof Tweaks>(key: K, value: Tweaks[K]) => void
+}) {
+  const seg = <K extends keyof Tweaks>(
+    key: K,
+    options: { value: Tweaks[K]; label: string }[],
+  ) => (
+    <div className="seg">
+      {options.map((o) => (
+        <button
+          key={String(o.value)}
+          className={tweaks[key] === o.value ? 'active' : ''}
+          onClick={() => setTweak(key, o.value)}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  )
+  const toggle = (key: 'showIdle' | 'animateMoves') => (
+    <button
+      className="switch"
+      data-on={tweaks[key] ? '1' : '0'}
+      role="switch"
+      aria-checked={tweaks[key]}
+      onClick={() => setTweak(key, !tweaks[key])}
+    >
+      <i />
+    </button>
+  )
+  return (
+    <div className="settings-pop">
+      <div className="sect">Layout</div>
+      <div className="row">
+        <span>Density</span>
+        {seg<'density'>('density', [
+          { value: 'comfortable' as Density, label: 'Comfy' },
+          { value: 'compact' as Density, label: 'Compact' },
+          { value: 'tight' as Density, label: 'Tight' },
+        ])}
+      </div>
+      <div className="row">
+        <span>Clock</span>
+        {seg<'clockMode'>('clockMode', [
+          { value: '24h' as ClockMode, label: '24h' },
+          { value: '12h' as ClockMode, label: '12h' },
+          { value: 'from_start' as ClockMode, label: '+min' },
+        ])}
+      </div>
+      <div className="sect">Schedule</div>
+      <div className="row">
+        <span>Color by</span>
+        {seg<'colorBy'>('colorBy', [
+          { value: 'event' as ColorBy, label: 'Event' },
+          { value: 'table' as ColorBy, label: 'Table' },
+          { value: 'player' as ColorBy, label: 'Pair' },
+        ])}
+      </div>
+      <div className="row">
+        <span>Idle hatches</span>
+        {toggle('showIdle')}
+      </div>
+      <div className="row">
+        <span>Animate re-solves</span>
+        {toggle('animateMoves')}
+      </div>
+    </div>
+  )
+}
+
+// ----- App ---------------------------------------------------------------
+export function SimulatorApp() {
+  const [tab, setTab] = useState<'editor' | 'schedule'>('editor')
+  const [config, setConfig] = useState<Config>(() => makeExampleConfig())
+  const [schedule, setSchedule] = useState<Schedule | null>(null)
+  const [solving, setSolving] = useState(false)
+  const [solvePhase, setSolvePhase] = useState('Solving…')
+  const [solveProgress, setSolveProgress] = useState(0)
+  const [solveLog, setSolveLog] = useState<LogLine[]>([])
+  const [infeasibleErr, setInfeasibleErr] = useState<SolveError | null>(null)
+  const [autoAdvancing, setAutoAdvancing] = useState(false)
+  const [lastResolveMs, setLastResolveMs] = useState<number | null>(null)
+  const [settingsOpen, setSettingsOpen] = useState(false)
+
+  // Sim state — never sent to backend except as completions
+  const [sim, setSim] = useState<SimState>({ completions: [], nowMin: 0 })
+  const [durations, setDurations] = useState<Record<string, number>>({})
+
+  const [tweaks, setTweaks] = useState<Tweaks>(DEFAULT_TWEAKS)
+  const setTweak = useCallback(
+    <K extends keyof Tweaks>(key: K, value: Tweaks[K]) =>
+      setTweaks((prev) => ({ ...prev, [key]: value })),
+    [],
+  )
+
+  const errors = useMemo(() => validateConfig(config), [config])
+
+  // Navigation between editor <-> schedule via custom events (from editor footer)
+  useEffect(() => {
+    const goSchedule = () => setTab('schedule')
+    const goEditor = () => setTab('editor')
+    window.addEventListener('sim-go-schedule', goSchedule)
+    window.addEventListener('sim-go-editor', goEditor)
+    return () => {
+      window.removeEventListener('sim-go-schedule', goSchedule)
+      window.removeEventListener('sim-go-editor', goEditor)
+    }
+  }, [])
+
+  // ---- Solve ----
+  const runSolve = useCallback(
+    async (opts: SolveOptions = {}) => {
+      setSolving(true)
+      setSolveProgress(0)
+      setSolveLog([])
+      setInfeasibleErr(null)
+      const onProg = (p: number, text: string, t: number) => {
+        setSolveProgress(p)
+        setSolvePhase(text)
+        setSolveLog((log) => [...log, { t, text }])
+      }
+      const result = await fakeSolveAsync(config, opts, onProg)
+      setSolving(false)
+      if (result.status === 'INFEASIBLE') {
+        setInfeasibleErr(result.error ?? null)
+        setSchedule(null)
+        setTab('editor')
+        return result
+      }
+      setSchedule(result)
+      setLastResolveMs(result.solveTimeMs)
+      return result
+    },
+    [config],
+  )
+
+  const onSolveInitial = useCallback(async () => {
+    setSim({ completions: [], nowMin: 0 })
+    setDurations({})
+    setSchedule(null)
+    const result = await runSolve({ isInitial: true })
+    if (result && result.status !== 'INFEASIBLE') setTab('schedule')
+  }, [runSolve])
+
+  // Watch for actual config changes (deep) — invalidate sim & schedule
+  const lastConfigSig = useRef('')
+  useEffect(() => {
+    const sig = JSON.stringify(config)
+    if (lastConfigSig.current && lastConfigSig.current !== sig) {
+      setSim({ completions: [], nowMin: 0 })
+      setDurations({})
+      setSchedule(null)
+    }
+    lastConfigSig.current = sig
+  }, [config])
+
+  // ---- Advance simulator ----
+  const advanceOnce = useCallback(async () => {
+    if (!schedule) return
+    const completedIds = new Set(sim.completions.map((c) => c.matchId))
+    const pending = schedule.matches.filter((m) => !completedIds.has(m.id))
+    if (pending.length === 0) return
+    let next: (typeof pending)[number] | null = null,
+      bestT = Infinity
+    for (const m of pending) {
+      const ev = config.events.find((e) => e.id === m.eventId)!
+      const actualDur = durations[m.id] ?? ev.matchDurationMin
+      const t = m.plannedStart + actualDur
+      if (t < bestT || (t === bestT && (!next || m.id < next.id))) {
+        bestT = t
+        next = m
+      }
+    }
+    if (!next) return
+    const ev = config.events.find((e) => e.id === next!.eventId)!
+    const actualDur = durations[next.id] ?? ev.matchDurationMin
+    const completion = {
+      matchId: next.id,
+      start: next.plannedStart,
+      end: next.plannedStart + actualDur,
+      tableId: next.tableId,
+    }
+    const newCompletions = [...sim.completions, completion]
+    const newNow = completion.end
+
+    setSolving(true)
+    setSolveLog([])
+    setSolveProgress(0)
+    setSolvePhase('Re-solving with pinned completions…')
+    const result = await fakeSolveAsync(
+      config,
+      {
+        completions: newCompletions,
+        previousSchedule: schedule,
+        isPerturbed: actualDur !== ev.matchDurationMin,
+      },
+      (p, text, t) => {
+        setSolveProgress(p)
+        setSolvePhase(text)
+        setSolveLog((log) => [...log, { t, text }])
+      },
+    )
+    setSolving(false)
+    if (result.status === 'INFEASIBLE') {
+      setInfeasibleErr(result.error ?? null)
+      setTab('editor')
+      return
+    }
+    setSchedule(result)
+    setSim({ completions: newCompletions, nowMin: newNow })
+    setLastResolveMs(result.solveTimeMs)
+  }, [schedule, sim, durations, config])
+
+  const advanceToEnd = useCallback(async () => {
+    if (!schedule) return
+    setAutoAdvancing(true)
+    const cfg = config
+    let s = schedule
+    let sm = sim
+    const durs = durations
+    for (;;) {
+      const completedIds = new Set(sm.completions.map((c) => c.matchId))
+      const pending = s.matches.filter((m) => !completedIds.has(m.id))
+      if (pending.length === 0) break
+      let next: (typeof pending)[number] | null = null,
+        bestT = Infinity
+      for (const m of pending) {
+        const ev = cfg.events.find((e) => e.id === m.eventId)!
+        const ad = durs[m.id] ?? ev.matchDurationMin
+        const t = m.plannedStart + ad
+        if (t < bestT || (t === bestT && (!next || m.id < next.id))) {
+          bestT = t
+          next = m
+        }
+      }
+      if (!next) break
+      const ev = cfg.events.find((e) => e.id === next!.eventId)!
+      const ad = durs[next.id] ?? ev.matchDurationMin
+      const comp = {
+        matchId: next.id,
+        start: next.plannedStart,
+        end: next.plannedStart + ad,
+        tableId: next.tableId,
+      }
+      const newCompletions = [...sm.completions, comp]
+      setSolving(true)
+      setSolveLog([])
+      setSolveProgress(0)
+      setSolvePhase('Auto-advancing…')
+      const t0 = performance.now()
+      const ttotal = 250 + Math.random() * 180
+      await new Promise<void>((r) => {
+        const tick = () => {
+          const p = Math.min(1, (performance.now() - t0) / ttotal)
+          setSolveProgress(p * 100)
+          if (p < 1) requestAnimationFrame(tick)
+          else r()
+        }
+        requestAnimationFrame(tick)
+      })
+      const result = solve(cfg, {
+        completions: newCompletions,
+        previousSchedule: s,
+        isPerturbed: false,
+      })
+      result.solveTimeMs = Math.round(ttotal)
+      if (result.status === 'INFEASIBLE') {
+        setSolving(false)
+        setAutoAdvancing(false)
+        setInfeasibleErr(result.error ?? null)
+        setTab('editor')
+        return
+      }
+      s = result
+      sm = { completions: newCompletions, nowMin: comp.end }
+      setSchedule(s)
+      setSim(sm)
+      setLastResolveMs(result.solveTimeMs)
+      setSolving(false)
+      await new Promise<void>((r) => setTimeout(r, 60))
+    }
+    setAutoAdvancing(false)
+  }, [schedule, sim, durations, config])
+
+  const onResetSim = useCallback(async () => {
+    setSim({ completions: [], nowMin: 0 })
+    await runSolve({ isInitial: false })
+  }, [runSolve])
+
+  const onResetDurations = useCallback(() => {
+    setDurations({})
+  }, [])
+
+  return (
+    <div className="sim-root">
+      <div className="app">
+        <div className="topbar">
+          <div className="brand">
+            <span className="ball-mark"></span>
+            FORTYMM
+            <span className="subtitle">Scheduler · Simulator</span>
+          </div>
+          <div className="tabs">
+            <button className={tab === 'editor' ? 'active' : ''} onClick={() => setTab('editor')}>
+              <Settings2 size={14} /> Editor
+            </button>
+            <button
+              className={tab === 'schedule' ? 'active' : ''}
+              disabled={!schedule}
+              onClick={() => setTab('schedule')}
+            >
+              <CalendarClock size={14} /> Schedule
+            </button>
+          </div>
+          <div className="grow"></div>
+          <div className="meta">
+            <span>{config.name}</span>
+            <span style={{ color: 'var(--ink-600)' }}>·</span>
+            <span className="mono" style={{ fontFamily: 'var(--font-mono)' }}>
+              {fmtClock(0, '24h', config.startISO)} →{' '}
+              {fmtClock(minutesBetween(config.startISO, config.endISO), '24h', config.startISO)}
+            </span>
+          </div>
+          <button
+            className="btn ghost icon-only"
+            title="View settings"
+            aria-label="View settings"
+            onClick={() => setSettingsOpen((o) => !o)}
+          >
+            <SlidersHorizontal size={16} />
+          </button>
+        </div>
+
+        {tab === 'editor' ? (
+          <Editor
+            config={config}
+            setConfig={setConfig}
+            errors={errors}
+            onSolve={onSolveInitial}
+            onLoadExample={() => setConfig(makeExampleConfig())}
+            onReset={() => {
+              setConfig({
+                name: '',
+                startISO: T0_ISO,
+                endISO: TEND_ISO,
+                tables: [],
+                players: [],
+                events: [],
+                tablePools: [],
+              })
+            }}
+            solving={solving}
+            schedule={schedule}
+            infeasibleErr={infeasibleErr}
+          />
+        ) : schedule ? (
+          <ScheduleView
+            config={config}
+            schedule={schedule}
+            sim={sim}
+            durations={durations}
+            setDurations={setDurations}
+            onAdvance={advanceOnce}
+            onAdvanceAll={advanceToEnd}
+            onResetSim={onResetSim}
+            onResetDurations={onResetDurations}
+            autoAdvancing={autoAdvancing}
+            tweaks={tweaks}
+            lastResolveMs={lastResolveMs}
+          />
+        ) : (
+          <div className="no-schedule">No schedule yet — go to the editor and solve.</div>
+        )}
+
+        {solving && !autoAdvancing && (
+          <SolveOverlay phase={solvePhase} progress={solveProgress} log={solveLog} />
+        )}
+
+        {settingsOpen && <SettingsPopover tweaks={tweaks} setTweak={setTweak} />}
+      </div>
+    </div>
+  )
+}

--- a/web-client/src/components/simulator/simulator-app.tsx
+++ b/web-client/src/components/simulator/simulator-app.tsx
@@ -2,12 +2,13 @@
    simulator-app.tsx — Top-level state, routing between editor/schedule,
    solve loop. Ported from the FortyMM design handoff (app.jsx).
    ===================================================================== */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { CalendarClock, Settings2, SlidersHorizontal } from 'lucide-react'
 import {
   fmtClock,
   makeExampleConfig,
   minutesBetween,
+  nextCompletion,
   solve,
   totalExpectedMatches,
   validateConfig,
@@ -19,6 +20,7 @@ import {
   type Schedule,
   type SolveError,
   type SolveOptions,
+  type TournamentEvent,
 } from './data'
 import { Editor } from './editor'
 import { ScheduleView, type Density, type SimState, type Tweaks } from './schedule'
@@ -222,16 +224,15 @@ export function SimulatorApp() {
 
   const errors = useMemo(() => validateConfig(config), [config])
 
-  // Navigation between editor <-> schedule via custom events (from editor footer)
-  useEffect(() => {
-    const goSchedule = () => setTab('schedule')
-    const goEditor = () => setTab('editor')
-    window.addEventListener('sim-go-schedule', goSchedule)
-    window.addEventListener('sim-go-editor', goEditor)
-    return () => {
-      window.removeEventListener('sim-go-schedule', goSchedule)
-      window.removeEventListener('sim-go-editor', goEditor)
-    }
+  // Any config change invalidates an in-flight simulation and the schedule it
+  // produced. Routing every config write (edits, load-example, reset) through
+  // here keeps that invariant without diffing the whole config each render.
+  const applyConfig = useCallback((next: Config) => {
+    setConfig(next)
+    setSim({ completions: [], nowMin: 0 })
+    setDurations({})
+    setSchedule(null)
+    setInfeasibleErr(null)
   }, [])
 
   // ---- Solve ----
@@ -269,38 +270,15 @@ export function SimulatorApp() {
     if (result && result.status !== 'INFEASIBLE') setTab('schedule')
   }, [runSolve])
 
-  // Watch for actual config changes (deep) — invalidate sim & schedule
-  const lastConfigSig = useRef('')
-  useEffect(() => {
-    const sig = JSON.stringify(config)
-    if (lastConfigSig.current && lastConfigSig.current !== sig) {
-      setSim({ completions: [], nowMin: 0 })
-      setDurations({})
-      setSchedule(null)
-    }
-    lastConfigSig.current = sig
-  }, [config])
-
   // ---- Advance simulator ----
   const advanceOnce = useCallback(async () => {
     if (!schedule) return
+    const eventById = new Map(config.events.map((e) => [e.id, e]))
     const completedIds = new Set(sim.completions.map((c) => c.matchId))
-    const pending = schedule.matches.filter((m) => !completedIds.has(m.id))
-    if (pending.length === 0) return
-    let next: (typeof pending)[number] | null = null,
-      bestT = Infinity
-    for (const m of pending) {
-      const ev = config.events.find((e) => e.id === m.eventId)!
-      const actualDur = durations[m.id] ?? ev.matchDurationMin
-      const t = m.plannedStart + actualDur
-      if (t < bestT || (t === bestT && (!next || m.id < next.id))) {
-        bestT = t
-        next = m
-      }
-    }
-    if (!next) return
-    const ev = config.events.find((e) => e.id === next!.eventId)!
-    const actualDur = durations[next.id] ?? ev.matchDurationMin
+    const picked = nextCompletion(schedule.matches, completedIds, eventById, durations)
+    if (!picked) return
+    const { match: next, actualDur } = picked
+    const ev = eventById.get(next.eventId)!
     const completion = {
       matchId: next.id,
       start: next.plannedStart,
@@ -342,27 +320,15 @@ export function SimulatorApp() {
     if (!schedule) return
     setAutoAdvancing(true)
     const cfg = config
+    const eventById = new Map<string, TournamentEvent>(cfg.events.map((e) => [e.id, e]))
     let s = schedule
     let sm = sim
     const durs = durations
     for (;;) {
       const completedIds = new Set(sm.completions.map((c) => c.matchId))
-      const pending = s.matches.filter((m) => !completedIds.has(m.id))
-      if (pending.length === 0) break
-      let next: (typeof pending)[number] | null = null,
-        bestT = Infinity
-      for (const m of pending) {
-        const ev = cfg.events.find((e) => e.id === m.eventId)!
-        const ad = durs[m.id] ?? ev.matchDurationMin
-        const t = m.plannedStart + ad
-        if (t < bestT || (t === bestT && (!next || m.id < next.id))) {
-          bestT = t
-          next = m
-        }
-      }
-      if (!next) break
-      const ev = cfg.events.find((e) => e.id === next!.eventId)!
-      const ad = durs[next.id] ?? ev.matchDurationMin
+      const picked = nextCompletion(s.matches, completedIds, eventById, durs)
+      if (!picked) break
+      const { match: next, actualDur: ad } = picked
       const comp = {
         matchId: next.id,
         start: next.plannedStart,
@@ -461,12 +427,13 @@ export function SimulatorApp() {
         {tab === 'editor' ? (
           <Editor
             config={config}
-            setConfig={setConfig}
+            setConfig={applyConfig}
             errors={errors}
             onSolve={onSolveInitial}
-            onLoadExample={() => setConfig(makeExampleConfig())}
-            onReset={() => {
-              setConfig({
+            onViewSchedule={() => setTab('schedule')}
+            onLoadExample={() => applyConfig(makeExampleConfig())}
+            onReset={() =>
+              applyConfig({
                 name: '',
                 startISO: T0_ISO,
                 endISO: TEND_ISO,
@@ -475,7 +442,7 @@ export function SimulatorApp() {
                 events: [],
                 tablePools: [],
               })
-            }}
+            }
             solving={solving}
             schedule={schedule}
             infeasibleErr={infeasibleErr}

--- a/web-client/src/components/simulator/simulator.css
+++ b/web-client/src/components/simulator/simulator.css
@@ -1,0 +1,1464 @@
+/* =====================================================================
+   Tournament Schedule Simulator — scoped styles
+   Ported from the FortyMM design handoff (styles.css + colors_and_type.css).
+   Everything is scoped under `.sim-root` so the dark, dense dev-tool theme
+   never leaks into the rest of the (light) app. Fonts are already loaded
+   globally in index.css.
+   ===================================================================== */
+
+.sim-root {
+  /* ---------- Palette: ink (backgrounds) ---------- */
+  --ink-950: #0b0d12;
+  --ink-900: #11141b;
+  --ink-800: #171b24;
+  --ink-700: #1f2430;
+  --ink-600: #2a3040;
+  --ink-500: #3a4152;
+  --ink-400: #535b6e;
+
+  /* ---------- Palette: chalk (foregrounds) ---------- */
+  --chalk-50: #f7f8fb;
+  --chalk-100: #e4e7ef;
+  --chalk-300: #a9b0c2;
+  --chalk-500: #6b7283;
+
+  /* ---------- Palette: ball (hero orange) ---------- */
+  --ball-50: #fff4ed;
+  --ball-200: #ffcfa8;
+  --ball-400: #ff9a4a;
+  --ball-500: #ff7a1a;
+  --ball-600: #e85e00;
+  --ball-700: #b94700;
+
+  /* ---------- Palette: serve (live cyan-green) ---------- */
+  --serve-300: #8cffd4;
+  --serve-500: #00e29a;
+  --serve-700: #009968;
+
+  /* ---------- Semantic: status ---------- */
+  --win: #00e29a;
+  --loss: #ff4d6d;
+  --warn: #ffc43d;
+  --info: #6fb5ff;
+
+  /* ---------- Semantic: foreground tokens ---------- */
+  --fg-1: var(--chalk-50);
+  --fg-2: var(--chalk-100);
+  --fg-3: var(--chalk-300);
+  --fg-muted: var(--chalk-500);
+  --fg-disabled: var(--ink-400);
+  --fg-accent: var(--ball-500);
+  --fg-accent-hover: var(--ball-400);
+  --fg-live: var(--serve-500);
+  --fg-inverse: var(--ink-950);
+
+  /* ---------- Semantic: background tokens ---------- */
+  --bg-app: var(--ink-950);
+  --bg-panel: var(--ink-900);
+  --bg-card: var(--ink-800);
+  --bg-raised: var(--ink-700);
+  --bg-hover: rgba(255, 255, 255, 0.04);
+  --bg-press: rgba(255, 255, 255, 0.02);
+  --bg-accent: var(--ball-500);
+  --bg-accent-hover: var(--ball-400);
+  --bg-accent-soft: rgba(255, 122, 26, 0.12);
+  --bg-live-soft: rgba(0, 226, 154, 0.14);
+
+  /* ---------- Borders ---------- */
+  --border-subtle: var(--ink-600);
+  --border-default: var(--ink-500);
+  --border-strong: var(--chalk-500);
+  --border-accent: var(--ball-500);
+
+  /* ---------- Radii ---------- */
+  --r-xs: 4px;
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+  --r-xl: 20px;
+  --r-pill: 999px;
+
+  /* ---------- Shadows ---------- */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.55);
+  --shadow-glow: 0 0 0 1px rgba(255, 122, 26, 0.35), 0 8px 24px rgba(255, 122, 26, 0.25);
+  --shadow-live-glow: 0 0 0 1px rgba(0, 226, 154, 0.4), 0 0 24px rgba(0, 226, 154, 0.3);
+  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+
+  /* ---------- Motion ---------- */
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --ease-snap: cubic-bezier(0.5, 1.6, 0.4, 1);
+  --dur-fast: 120ms;
+  --dur-base: 200ms;
+  --dur-slow: 360ms;
+
+  /* ---------- Type stacks ---------- */
+  --font-ui: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'Bebas Neue', 'Space Grotesk', sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* ---------- Type scale ---------- */
+  --text-xs: 11px;
+  --text-sm: 13px;
+  --text-base: 15px;
+  --text-md: 17px;
+  --text-lg: 20px;
+  --text-xl: 24px;
+  --text-2xl: 32px;
+
+  /* ---------- App shell: full-bleed fixed container ---------- */
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  background: var(--bg-app);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  button {
+    font-family: inherit;
+  }
+  input,
+  select,
+  textarea {
+    font-family: inherit;
+    color: var(--fg-1);
+    background: var(--ink-900);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-sm);
+    padding: 6px 8px;
+    font-size: var(--text-sm);
+    outline: none;
+    transition:
+      border-color var(--dur-fast) var(--ease-out),
+      box-shadow var(--dur-fast) var(--ease-out);
+  }
+  input:focus,
+  select:focus,
+  textarea:focus {
+    border-color: var(--ball-500);
+    box-shadow: 0 0 0 2px rgba(255, 122, 26, 0.18);
+  }
+  input[type='number']::-webkit-outer-spin-button,
+  input[type='number']::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  input.mono {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+  }
+
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: var(--ink-700);
+    border-radius: 999px;
+    border: 2px solid var(--bg-app);
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--ink-600);
+  }
+
+  /* ---------- App shell ---------- */
+  .app {
+    display: grid;
+    grid-template-rows: 48px 1fr;
+    height: 100%;
+  }
+  .topbar {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 0 16px;
+    background: var(--bg-panel);
+    border-bottom: 1px solid var(--border-subtle);
+    height: 48px;
+    user-select: none;
+  }
+  .topbar .brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-family: var(--font-display);
+    letter-spacing: 0.04em;
+    font-size: 18px;
+    color: var(--fg-1);
+  }
+  .topbar .brand .subtitle {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--fg-3);
+    border-left: 1px solid var(--border-subtle);
+    padding-left: 10px;
+    margin-left: 2px;
+    white-space: nowrap;
+  }
+  .topbar .grow {
+    flex: 1;
+  }
+  .topbar .meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    color: var(--fg-3);
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 380px;
+  }
+  .topbar .meta .mono {
+    color: var(--fg-2);
+  }
+
+  /* Tabs */
+  .tabs {
+    display: inline-flex;
+    background: var(--ink-900);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--r-sm);
+    padding: 2px;
+    gap: 2px;
+  }
+  .tabs button {
+    background: transparent;
+    border: 0;
+    padding: 4px 12px;
+    color: var(--fg-3);
+    font-size: 12px;
+    font-weight: 500;
+    border-radius: 4px;
+    cursor: pointer;
+    letter-spacing: 0.02em;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .tabs button:hover {
+    color: var(--fg-1);
+    background: var(--bg-hover);
+  }
+  .tabs button.active {
+    background: var(--bg-raised);
+    color: var(--fg-1);
+  }
+  .tabs button:disabled {
+    color: var(--fg-disabled);
+    cursor: not-allowed;
+  }
+
+  /* ---------- Buttons ---------- */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--ink-800);
+    color: var(--fg-1);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-sm);
+    padding: 6px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    letter-spacing: 0.01em;
+    transition:
+      background var(--dur-fast) var(--ease-out),
+      border-color var(--dur-fast) var(--ease-out),
+      transform var(--dur-fast) var(--ease-out);
+    height: 30px;
+    white-space: nowrap;
+  }
+  .btn:hover {
+    background: var(--ink-700);
+  }
+  .btn:active {
+    transform: scale(0.97);
+  }
+  .btn:disabled {
+    color: var(--fg-disabled);
+    background: var(--ink-900);
+    cursor: not-allowed;
+    border-color: var(--border-subtle);
+  }
+  .btn:disabled:hover {
+    background: var(--ink-900);
+  }
+  .btn.primary {
+    background: var(--ball-500);
+    color: var(--fg-inverse);
+    border-color: var(--ball-500);
+    font-weight: 600;
+  }
+  .btn.primary:hover {
+    background: var(--ball-400);
+    border-color: var(--ball-400);
+    box-shadow: var(--shadow-glow);
+  }
+  .btn.primary:disabled {
+    background: var(--ink-800);
+    color: var(--fg-disabled);
+    border-color: var(--border-subtle);
+    box-shadow: none;
+  }
+  .btn.ghost {
+    background: transparent;
+    border-color: transparent;
+    color: var(--fg-3);
+  }
+  .btn.ghost:hover {
+    color: var(--fg-1);
+    background: var(--bg-hover);
+  }
+  .btn.danger {
+    color: var(--loss);
+    border-color: var(--ink-600);
+  }
+  .btn.danger:hover {
+    background: rgba(255, 77, 109, 0.08);
+    border-color: var(--loss);
+  }
+  .btn.sm {
+    height: 24px;
+    padding: 2px 8px;
+    font-size: 11px;
+  }
+  .btn.icon-only {
+    padding: 0;
+    width: 30px;
+    justify-content: center;
+  }
+  .btn.icon-only.sm {
+    width: 24px;
+  }
+
+  /* ---------- Pills / chips ---------- */
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: var(--r-pill);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .pill.optimal {
+    background: rgba(0, 226, 154, 0.12);
+    color: var(--serve-500);
+  }
+  .pill.feasible {
+    background: rgba(255, 196, 61, 0.12);
+    color: var(--warn);
+  }
+  .pill.infeasible {
+    background: rgba(255, 77, 109, 0.12);
+    color: var(--loss);
+  }
+  .pill.idle {
+    background: var(--ink-800);
+    color: var(--fg-3);
+  }
+
+  /* ---------- Editor ---------- */
+  .editor {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    grid-template-rows: 1fr 56px;
+    height: 100%;
+    overflow: hidden;
+  }
+  .editor .side {
+    background: var(--bg-panel);
+    border-right: 1px solid var(--border-subtle);
+    grid-row: 1 / span 2;
+    display: flex;
+    flex-direction: column;
+  }
+  .editor .side h4 {
+    margin: 0;
+    padding: 16px 16px 8px;
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    color: var(--fg-3);
+    text-transform: uppercase;
+  }
+  .editor .side a {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    color: var(--fg-2);
+    font-size: 13px;
+    text-decoration: none;
+    cursor: pointer;
+    border-left: 2px solid transparent;
+  }
+  .editor .side a:hover {
+    color: var(--fg-1);
+    background: var(--bg-hover);
+  }
+  .editor .side a.active {
+    color: var(--fg-1);
+    border-left-color: var(--ball-500);
+    background: var(--bg-hover);
+  }
+  .editor .side a .count {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 11px;
+    color: var(--fg-3);
+  }
+  .editor .side a .err {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    background: rgba(255, 77, 109, 0.15);
+    color: var(--loss);
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 999px;
+  }
+  .editor .side .actions {
+    margin-top: auto;
+    padding: 12px;
+    border-top: 1px solid var(--border-subtle);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .editor .scroll {
+    overflow-y: auto;
+    padding: 24px 32px 80px;
+    scroll-padding-top: 24px;
+  }
+  .editor section.card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--r-md);
+    padding: 20px 24px;
+    margin-bottom: 16px;
+  }
+  .editor section.card > header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .editor section.card > header h2 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--fg-1);
+  }
+  .editor section.card > header .hint {
+    font-size: 12px;
+    color: var(--fg-3);
+  }
+  .editor section.card > header .grow {
+    flex: 1;
+  }
+  .editor .footer {
+    grid-column: 2;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 24px;
+    background: var(--bg-panel);
+    border-top: 1px solid var(--border-subtle);
+  }
+  .editor .footer .grow {
+    flex: 1;
+  }
+  .editor .footer .summary {
+    color: var(--fg-3);
+    font-size: 12px;
+  }
+  .editor .footer .summary .mono {
+    color: var(--fg-2);
+    font-family: var(--font-mono);
+  }
+
+  /* Field grids */
+  .fields {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: 12px;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .field label {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--fg-3);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .field .errmsg {
+    font-size: 11px;
+    color: var(--loss);
+    font-family: var(--font-mono);
+    margin-top: 2px;
+  }
+  .field input.invalid,
+  .field select.invalid {
+    border-color: var(--loss);
+    box-shadow: 0 0 0 2px rgba(255, 77, 109, 0.18);
+  }
+  .field .help {
+    font-size: 11px;
+    color: var(--fg-3);
+  }
+
+  /* Table-style list inside cards */
+  .list {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    font-size: 13px;
+  }
+  .list th {
+    text-align: left;
+    font-weight: 500;
+    color: var(--fg-3);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--border-subtle);
+    background: transparent;
+    font-family: var(--font-ui);
+  }
+  .list td {
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--ink-800);
+    color: var(--fg-2);
+    vertical-align: middle;
+  }
+  .list tr:last-child td {
+    border-bottom: 0;
+  }
+  .list td input {
+    width: 100%;
+    padding: 4px 8px;
+  }
+  .list td.mono {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--fg-2);
+  }
+  .list td.actions {
+    text-align: right;
+    width: 1%;
+    white-space: nowrap;
+  }
+
+  /* Chip select for player rosters */
+  .chipset {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px;
+    background: var(--ink-900);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-sm);
+    min-height: 40px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    padding: 3px 4px 3px 8px;
+    background: var(--ink-700);
+    color: var(--fg-1);
+    border-radius: var(--r-pill);
+    user-select: none;
+  }
+  .chip .rating {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--fg-3);
+    font-size: 11px;
+  }
+  .chip button {
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    color: var(--fg-3);
+    padding: 0;
+    width: 16px;
+    height: 16px;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .chip button:hover {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--fg-1);
+  }
+  .chipset .add-chip {
+    background: transparent;
+    border: 1px dashed var(--border-default);
+    color: var(--fg-3);
+    font-size: 12px;
+    padding: 2px 10px;
+    border-radius: var(--r-pill);
+    cursor: pointer;
+  }
+  .chipset .add-chip:hover {
+    color: var(--ball-500);
+    border-color: var(--ball-500);
+  }
+
+  /* Banner */
+  .banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border-radius: var(--r-sm);
+    margin-bottom: 16px;
+    font-size: 13px;
+    border: 1px solid;
+  }
+  .banner.error {
+    background: rgba(255, 77, 109, 0.08);
+    border-color: rgba(255, 77, 109, 0.3);
+    color: var(--fg-1);
+  }
+  .banner.warn {
+    background: rgba(255, 196, 61, 0.08);
+    border-color: rgba(255, 196, 61, 0.3);
+    color: var(--fg-1);
+  }
+  .banner.info {
+    background: var(--bg-accent-soft);
+    border-color: rgba(255, 122, 26, 0.3);
+    color: var(--fg-1);
+  }
+  .banner .grow {
+    flex: 1;
+  }
+  .banner ul {
+    margin: 4px 0 0;
+    padding-left: 18px;
+    color: var(--fg-2);
+    font-size: 12px;
+  }
+  .banner ul li {
+    margin: 2px 0;
+  }
+  .banner ul li a {
+    color: var(--ball-400);
+    text-decoration: underline dotted;
+    cursor: pointer;
+  }
+
+  /* Empty state in cards */
+  .empty {
+    text-align: center;
+    padding: 32px 12px;
+    color: var(--fg-3);
+    font-size: 13px;
+    border: 1px dashed var(--border-subtle);
+    border-radius: var(--r-sm);
+  }
+
+  .overline {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+
+  /* ---------- Schedule screen ---------- */
+  .schedule {
+    display: grid;
+    grid-template-columns: 1fr 360px;
+    grid-template-rows: 64px auto 1fr;
+    height: 100%;
+    overflow: hidden;
+  }
+  .solve-strip {
+    grid-column: 1 / span 2;
+    grid-row: 1;
+    display: flex;
+    align-items: center;
+    gap: 0;
+    padding: 10px 16px;
+    background: var(--bg-panel);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .solve-strip .stat-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 0 18px;
+    border-right: 1px solid var(--border-subtle);
+    min-width: 90px;
+  }
+  .solve-strip .stat-cell:first-child {
+    padding-left: 0;
+  }
+  .solve-strip .stat-cell:last-of-type {
+    border-right: 0;
+  }
+  .solve-strip .stat-cell .label {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  .solve-strip .stat-cell .value {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--fg-1);
+    font-size: 16px;
+    font-weight: 600;
+  }
+  .solve-strip .stat-cell .value.big {
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: 22px;
+    letter-spacing: 0.04em;
+  }
+  .solve-strip .grow {
+    flex: 1;
+  }
+  .solve-strip .sim-clock {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding-right: 12px;
+  }
+  .solve-strip .sim-clock .now {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 22px;
+    color: var(--ball-500);
+  }
+
+  .view-bar {
+    grid-column: 1;
+    grid-row: 2;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    background: var(--bg-app);
+    border-bottom: 1px solid var(--border-subtle);
+    border-right: 1px solid var(--border-subtle);
+  }
+  .view-bar .grow {
+    flex: 1;
+  }
+  .view-bar .swatches {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 11px;
+    color: var(--fg-3);
+  }
+  .view-bar .swatch {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .view-bar .swatch .sq {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    background: var(--c, var(--ink-600));
+  }
+
+  .viz {
+    grid-column: 1;
+    grid-row: 3;
+    overflow: auto;
+    background: var(--bg-app);
+    border-right: 1px solid var(--border-subtle);
+    position: relative;
+  }
+
+  /* ---------- Gantt + Player Timeline shared ---------- */
+  .tl {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    min-width: 100%;
+    position: relative;
+  }
+  .tl-grid {
+    position: relative;
+    display: grid;
+    grid-template-columns: 140px 1fr;
+  }
+  .tl-row-label {
+    position: sticky;
+    left: 0;
+    background: var(--bg-app);
+    border-right: 1px solid var(--border-subtle);
+    border-bottom: 1px solid var(--ink-800);
+    padding: 0 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    z-index: 2;
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+  .tl-row-label.head {
+    border-bottom: 1px solid var(--border-default);
+    background: var(--bg-panel);
+    color: var(--fg-3);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+    position: sticky;
+    left: 0;
+    z-index: 5;
+  }
+  .tl-axis {
+    position: sticky;
+    top: 0;
+    z-index: 4;
+    background: var(--bg-panel);
+    border-bottom: 1px solid var(--border-default);
+    height: 28px;
+  }
+  .tl-axis-track {
+    position: relative;
+    height: 100%;
+  }
+  .tl-axis-tick {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    border-left: 1px solid var(--ink-700);
+    padding-left: 4px;
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 10px;
+    color: var(--fg-3);
+    display: flex;
+    align-items: center;
+  }
+  .tl-axis-tick.major {
+    border-left-color: var(--border-default);
+    color: var(--fg-2);
+  }
+
+  .tl-row {
+    position: relative;
+    border-bottom: 1px solid var(--ink-800);
+    height: var(--row-h, 36px);
+    background: repeating-linear-gradient(
+      to right,
+      transparent 0,
+      transparent calc(var(--minor-px) - 1px),
+      rgba(255, 255, 255, 0.018) calc(var(--minor-px) - 1px),
+      rgba(255, 255, 255, 0.018) var(--minor-px)
+    );
+  }
+  .tl-row.alt {
+    background-color: rgba(255, 255, 255, 0.012);
+  }
+  .tl-row.head {
+    height: 28px;
+  }
+
+  .tl-now {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 0;
+    border-left: 1.5px solid var(--ball-500);
+    z-index: 6;
+    pointer-events: none;
+    box-shadow: 0 0 8px rgba(255, 122, 26, 0.5);
+  }
+  .tl-now::before {
+    content: '';
+    position: absolute;
+    top: -4px;
+    left: -5px;
+    width: 9px;
+    height: 9px;
+    background: var(--ball-500);
+    border-radius: 999px;
+    box-shadow: 0 0 10px rgba(255, 122, 26, 0.7);
+  }
+
+  .tl-pool {
+    position: absolute;
+    top: 4px;
+    bottom: 4px;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px dashed rgba(255, 255, 255, 0.06);
+    border-radius: var(--r-xs);
+    pointer-events: none;
+  }
+
+  /* Match blocks */
+  .match {
+    position: absolute;
+    top: 4px;
+    bottom: 4px;
+    background: var(--c, var(--ball-500));
+    color: var(--fg-inverse);
+    border-radius: var(--r-xs);
+    padding: 4px 6px;
+    font-size: 11px;
+    line-height: 1.2;
+    overflow: hidden;
+    cursor: pointer;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    transition:
+      filter var(--dur-fast) var(--ease-out),
+      transform var(--dur-fast) var(--ease-out),
+      box-shadow var(--dur-fast) var(--ease-out);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  .match:hover {
+    filter: brightness(1.15);
+    box-shadow: 0 0 0 1.5px rgba(255, 255, 255, 0.4);
+    z-index: 7;
+  }
+  .match.completed {
+    background: var(--ink-700);
+    color: var(--fg-3);
+    border-color: var(--ink-600);
+    filter: saturate(0.4);
+  }
+  .match.completed .match-tag {
+    background: var(--c, var(--ball-500));
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 3px;
+    filter: saturate(1);
+  }
+  .match.completed .lock {
+    position: absolute;
+    top: 3px;
+    right: 3px;
+    width: 12px;
+    height: 12px;
+    color: var(--fg-3);
+  }
+  .match.selected {
+    outline: 2px solid var(--ball-500);
+    outline-offset: 1px;
+    z-index: 8;
+  }
+  .match .match-players {
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .match .match-meta {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 10px;
+    opacity: 0.85;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .match.narrow .match-meta {
+    display: none;
+  }
+  .match.tiny .match-players {
+    font-size: 10px;
+  }
+
+  /* Idle / rest hatches on player timeline */
+  .idle-block {
+    position: absolute;
+    top: 8px;
+    bottom: 8px;
+    background: repeating-linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.025) 0,
+      rgba(255, 255, 255, 0.025) 4px,
+      transparent 4px,
+      transparent 8px
+    );
+    border-radius: var(--r-xs);
+    pointer-events: none;
+  }
+
+  /* ---------- Simulator panel ---------- */
+  .sim {
+    grid-column: 2;
+    grid-row: 2 / span 2;
+    background: var(--bg-panel);
+    border-left: 1px solid var(--border-subtle);
+    display: grid;
+    grid-template-rows: auto auto 1fr auto;
+    overflow: hidden;
+  }
+  .sim-header {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-subtle);
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .sim-header h3 {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .sim-header .progress {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--fg-3);
+  }
+  .sim-controls {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .sim-controls .btn {
+    width: 100%;
+    justify-content: center;
+  }
+  .sim-controls .full {
+    grid-column: 1 / span 2;
+  }
+  .sim-list {
+    overflow-y: auto;
+    padding: 8px 0 16px;
+  }
+  .sim-section-head {
+    padding: 12px 16px 6px;
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--fg-3);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .sim-section-head .count {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    background: var(--ink-800);
+    color: var(--fg-2);
+    padding: 1px 6px;
+    border-radius: 999px;
+    font-size: 10px;
+  }
+  .sim-section-head .grow {
+    flex: 1;
+  }
+  .sim-row {
+    display: grid;
+    grid-template-columns: 6px 1fr auto;
+    gap: 10px;
+    padding: 8px 16px 8px 12px;
+    cursor: pointer;
+    border-left: 2px solid transparent;
+    align-items: center;
+  }
+  .sim-row:hover {
+    background: var(--bg-hover);
+  }
+  .sim-row.selected {
+    background: var(--bg-accent-soft);
+    border-left-color: var(--ball-500);
+  }
+  .sim-row .colorbar {
+    width: 4px;
+    height: 28px;
+    background: var(--c, var(--ball-500));
+    border-radius: 2px;
+  }
+  .sim-row .info {
+    min-width: 0;
+  }
+  .sim-row .info .players {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--fg-1);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .sim-row .info .meta {
+    font-size: 11px;
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--fg-3);
+  }
+  .sim-row.completed .info .players {
+    color: var(--fg-3);
+  }
+  .sim-row .dur {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .sim-row .dur input {
+    width: 50px;
+    padding: 4px 6px;
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 12px;
+    text-align: right;
+  }
+  .sim-row .dur input.changed {
+    border-color: var(--warn);
+    box-shadow: 0 0 0 2px rgba(255, 196, 61, 0.12);
+  }
+  .sim-row .dur .unit {
+    font-size: 11px;
+    color: var(--fg-3);
+  }
+  .sim-row .dur .actual {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--fg-3);
+    font-size: 12px;
+  }
+  .sim-footer {
+    border-top: 1px solid var(--border-subtle);
+    padding: 10px 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    color: var(--fg-3);
+  }
+  .sim-footer .grow {
+    flex: 1;
+  }
+
+  /* Solve overlay */
+  .solve-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(11, 13, 18, 0.7);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+  }
+  .solve-overlay .panel {
+    background: var(--bg-card);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-lg);
+    padding: 32px 40px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    box-shadow: var(--shadow-lg);
+    min-width: 340px;
+  }
+  .solve-overlay .panel .title {
+    font-family: var(--font-display);
+    font-size: 22px;
+    letter-spacing: 0.06em;
+  }
+  .solve-overlay .panel .sub {
+    color: var(--fg-3);
+    font-size: 12px;
+  }
+  .solve-overlay .panel .bar {
+    width: 100%;
+    height: 4px;
+    background: var(--ink-800);
+    border-radius: 999px;
+    overflow: hidden;
+  }
+  .solve-overlay .panel .bar .fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--ball-500), var(--ball-400));
+    border-radius: 999px;
+    width: var(--p, 0%);
+    transition: width 200ms linear;
+  }
+  .solve-overlay .panel .log {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--fg-3);
+    text-align: left;
+    width: 100%;
+    min-height: 60px;
+    max-height: 100px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+  .solve-overlay .panel .log .line {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .solve-overlay .panel .log .line span.dim {
+    color: var(--fg-disabled);
+  }
+
+  /* Hover tooltip on a match */
+  .match-tip {
+    position: fixed;
+    z-index: 100;
+    background: var(--ink-900);
+    border: 1px solid var(--border-default);
+    box-shadow: var(--shadow-md);
+    border-radius: var(--r-md);
+    padding: 10px 12px;
+    font-size: 12px;
+    color: var(--fg-1);
+    min-width: 220px;
+    pointer-events: none;
+  }
+  .match-tip .heading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+  .match-tip .heading .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+  }
+  .match-tip .heading .ev {
+    font-size: 11px;
+    color: var(--fg-3);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .match-tip .players {
+    font-size: 14px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+  .match-tip .players .v {
+    color: var(--fg-3);
+    font-family: var(--font-mono);
+    font-size: 11px;
+  }
+  .match-tip .rows {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 4px 12px;
+    font-size: 11px;
+  }
+  .match-tip .rows .k {
+    color: var(--fg-3);
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.08em;
+  }
+  .match-tip .rows .v {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--fg-1);
+  }
+
+  /* Animation when match block moves on re-solve */
+  .match.animated {
+    transition:
+      left var(--dur-base) var(--ease-out),
+      width var(--dur-base) var(--ease-out),
+      top var(--dur-base) var(--ease-out);
+  }
+
+  /* Empty schedule state */
+  .no-schedule {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: var(--fg-3);
+    font-size: 13px;
+  }
+
+  /* Number stat highlights */
+  .delta-pos {
+    color: var(--loss);
+  }
+  .delta-neg {
+    color: var(--serve-500);
+  }
+  .delta-zero {
+    color: var(--fg-3);
+  }
+
+  /* Ball logo in topbar */
+  .ball-mark {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 30% 30%, var(--ball-400), var(--ball-600));
+    box-shadow: 0 0 10px rgba(255, 122, 26, 0.5);
+  }
+
+  /* Misc */
+  .kbd {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    background: var(--ink-800);
+    color: var(--fg-3);
+    border: 1px solid var(--border-subtle);
+    border-bottom-width: 2px;
+    border-radius: 4px;
+    padding: 1px 5px;
+    letter-spacing: 0.02em;
+  }
+
+  /* Spin keyframe for inline loaders */
+  .spin {
+    animation: sim-spin 1s linear infinite;
+  }
+
+  /* Lightweight view-settings popover (replaces design-tool Tweaks panel) */
+  .settings-pop {
+    position: absolute;
+    top: 44px;
+    right: 12px;
+    z-index: 60;
+    width: 240px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-md);
+    box-shadow: var(--shadow-lg);
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .settings-pop .sect {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--fg-3);
+    padding: 8px 6px 2px;
+  }
+  .settings-pop .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    font-size: 12px;
+    color: var(--fg-2);
+  }
+  .settings-pop .row > span:first-child {
+    flex: 1;
+  }
+  .seg {
+    display: inline-flex;
+    background: var(--ink-900);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--r-sm);
+    padding: 2px;
+    gap: 2px;
+  }
+  .seg button {
+    background: transparent;
+    border: 0;
+    color: var(--fg-3);
+    font-size: 11px;
+    font-weight: 500;
+    padding: 2px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .seg button.active {
+    background: var(--bg-raised);
+    color: var(--fg-1);
+  }
+  .switch {
+    width: 32px;
+    height: 18px;
+    border: 0;
+    border-radius: 999px;
+    background: var(--ink-600);
+    position: relative;
+    cursor: pointer;
+    padding: 0;
+    transition: background var(--dur-fast) var(--ease-out);
+  }
+  .switch[data-on='1'] {
+    background: var(--serve-500);
+  }
+  .switch i {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #fff;
+    transition: transform var(--dur-fast) var(--ease-out);
+  }
+  .switch[data-on='1'] i {
+    transform: translateX(14px);
+  }
+}
+
+@keyframes sim-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SimulatorRouteImport } from './routes/simulator'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as DesignSystemRouteImport } from './routes/design-system'
 import { Route as DashboardRouteImport } from './routes/dashboard'
@@ -29,6 +30,11 @@ import { Route as MatchesMatchIdIndexRouteImport } from './routes/matches.$match
 import { Route as MatchesMatchIdGamesGameIdScoresNewRouteImport } from './routes/matches.$matchId.games.$gameId.scores.new'
 import { Route as MatchesMatchIdGamesGameIdScoresScoreIdEditRouteImport } from './routes/matches.$matchId.games.$gameId.scores.$scoreId.edit'
 
+const SimulatorRoute = SimulatorRouteImport.update({
+  id: '/simulator',
+  path: '/simulator',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
@@ -134,6 +140,7 @@ export interface FileRoutesByFullPath {
   '/dashboard': typeof DashboardRoute
   '/design-system': typeof DesignSystemRoute
   '/settings': typeof SettingsRoute
+  '/simulator': typeof SimulatorRoute
   '/admin/permissions': typeof AdminPermissionsRoute
   '/admin/roles': typeof AdminRolesRoute
   '/admin/users': typeof AdminUsersRoute
@@ -154,6 +161,7 @@ export interface FileRoutesByTo {
   '/dashboard': typeof DashboardRoute
   '/design-system': typeof DesignSystemRoute
   '/settings': typeof SettingsRoute
+  '/simulator': typeof SimulatorRoute
   '/admin/permissions': typeof AdminPermissionsRoute
   '/admin/roles': typeof AdminRolesRoute
   '/admin/users': typeof AdminUsersRoute
@@ -176,6 +184,7 @@ export interface FileRoutesById {
   '/dashboard': typeof DashboardRoute
   '/design-system': typeof DesignSystemRoute
   '/settings': typeof SettingsRoute
+  '/simulator': typeof SimulatorRoute
   '/admin/permissions': typeof AdminPermissionsRoute
   '/admin/roles': typeof AdminRolesRoute
   '/admin/users': typeof AdminUsersRoute
@@ -199,6 +208,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/design-system'
     | '/settings'
+    | '/simulator'
     | '/admin/permissions'
     | '/admin/roles'
     | '/admin/users'
@@ -219,6 +229,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/design-system'
     | '/settings'
+    | '/simulator'
     | '/admin/permissions'
     | '/admin/roles'
     | '/admin/users'
@@ -240,6 +251,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/design-system'
     | '/settings'
+    | '/simulator'
     | '/admin/permissions'
     | '/admin/roles'
     | '/admin/users'
@@ -262,6 +274,7 @@ export interface RootRouteChildren {
   DashboardRoute: typeof DashboardRoute
   DesignSystemRoute: typeof DesignSystemRoute
   SettingsRoute: typeof SettingsRoute
+  SimulatorRoute: typeof SimulatorRoute
   LoginSentRoute: typeof LoginSentRoute
   LoginVerifyingRoute: typeof LoginVerifyingRoute
   LoginWelcomeRoute: typeof LoginWelcomeRoute
@@ -275,6 +288,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/simulator': {
+      id: '/simulator'
+      path: '/simulator'
+      fullPath: '/simulator'
+      preLoaderRoute: typeof SimulatorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/settings': {
       id: '/settings'
       path: '/settings'
@@ -434,6 +454,7 @@ const rootRouteChildren: RootRouteChildren = {
   DashboardRoute: DashboardRoute,
   DesignSystemRoute: DesignSystemRoute,
   SettingsRoute: SettingsRoute,
+  SimulatorRoute: SimulatorRoute,
   LoginSentRoute: LoginSentRoute,
   LoginVerifyingRoute: LoginVerifyingRoute,
   LoginWelcomeRoute: LoginWelcomeRoute,

--- a/web-client/src/routes/simulator.tsx
+++ b/web-client/src/routes/simulator.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SimulatorApp } from '@/components/simulator/simulator-app'
+import { pageTitle } from '@/lib/page-title'
+
+export const Route = createFileRoute('/simulator')({
+  head: () => ({
+    meta: [{ title: pageTitle('Scheduler simulator') }],
+  }),
+  component: SimulatorApp,
+})


### PR DESCRIPTION
## What

Adds a self-contained tournament-schedule simulator dev tool at **`/simulator`**, ported from the FortyMM design handoff. It has three parts:

- **Editor** — configure a tournament (name/window, tables, players, events with round-robin rosters, and table pools), with inline validation and "Load example" / "+8 random players" shortcuts.
- **Schedule** — a per-player timeline (idle gaps as hatches, busiest players first) and a Gantt (tables on Y), color-coded by event, with a top stat strip (status / solve ms / makespan / idle Σ / completed-of-total / sim clock).
- **Match-completion simulator** — step through a fake CP-SAT re-solve loop: edit "actual durations" for pending matches, **Advance** / **To end** / **± perturb** / **Reset**, watch completed matches lock in and the rest reshuffle.

Entirely client-side — no backend wiring yet. Faithfully recreates the prototype in the real stack: React 19, TanStack Router file-based route, TypeScript, lucide-react. The dark dev-tool theme and full FortyMM token set are scoped under `.sim-root` so nothing leaks into the rest of the app.

## Notes

- A `simplify` pass unified the three duplicated "find next match" scans into one `nextCompletion` (fixing a tie-break inconsistency and a pending-list `slice(1)` bug), added O(1) lookup maps so 50+ match blocks don't scan the events/tables/players arrays per render, memoized the sim lists, and replaced a window-CustomEvent navigation + per-keystroke `JSON.stringify(config)` with a prop and a config-write wrapper.
- Follow-ups left for a later pass (non-blocking): map-ify the solver's warm-start `previousSchedule.find` in `solve()`, and add a `data.test.ts` covering the pure logic (`solve`, `validateConfig`, `roundRobinPairs`, `nextCompletion`).

## Test plan

- `npm run test:run` — 92 passed
- `npm run lint` — 0 errors
- `npm run build` (tsc + vite) — ✅
- `npm run test:e2e` — 126 passed
- Manually verified in-browser: load example → solve → advance/step through completions → Gantt + player timeline + settings popover all render correctly, no console errors.

(API / root-e2e / OpenAPI-drift suites N/A — this branch only touches `web-client` with no API changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)