### PR TITLE
api: add mypy type-checking

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -23,19 +23,6 @@ jobs:
 
       - run: pip install -e '.[dev]'
 
-      - run: pytest
-
-  mypy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-          cache: pip
-          cache-dependency-path: api/pyproject.toml
-
-      - run: pip install -e '.[dev]'
-
       - run: mypy
+
+      - run: pytest

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -24,3 +24,18 @@ jobs:
       - run: pip install -e '.[dev]'
 
       - run: pytest
+
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: api/pyproject.toml
+
+      - run: pip install -e '.[dev]'
+
+      - run: mypy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ alembic revision --autogenerate -m "..."       # new migration (autogen reads ap
 pytest                                         # all tests; testcontainers spins ephemeral Postgres
 pytest tests/test_session.py::test_x           # single test
 TEST_DATABASE_URL=postgresql+asyncpg://... pytest   # skip testcontainers, use existing Postgres
+mypy                                           # type-check app/ (config in [tool.mypy], pyproject.toml)
 ```
 
 Web client (`cd web-client`):

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -10,8 +10,9 @@ stale relative to the freshly-moved matches — the caller enqueues the
 
 import uuid
 from dataclasses import dataclass
+from typing import Any, cast
 
-from sqlalchemy import delete, text, update
+from sqlalchemy import CursorResult, delete, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Match, MatchSidePlayer, RatingHistory, User
@@ -130,4 +131,4 @@ async def _repoint_match_side_players(
         ),
         {"from_id": from_user_id, "to_id": to_user_id},
     )
-    return result.rowcount or 0
+    return cast("CursorResult[Any]", result).rowcount or 0

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -131,4 +131,4 @@ async def _repoint_match_side_players(
         ),
         {"from_id": from_user_id, "to_id": to_user_id},
     )
-    return cast("CursorResult[Any]", result).rowcount or 0
+    return cast(CursorResult[Any], result).rowcount or 0

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -118,11 +118,11 @@ async def _load_my_rating_changes(
             )
         )
     ).scalars().all()
-    return {
-        row.match_id: RatingChange.from_history(row)
-        for row in rows
-        if row.match_id is not None
-    }
+    changes: dict[uuid.UUID, RatingChange] = {}
+    for row in rows:
+        assert row.match_id is not None  # IN-filtered to non-null match_ids
+        changes[row.match_id] = RatingChange.from_history(row)
+    return changes
 
 
 def _build_score_banners(

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -118,7 +118,11 @@ async def _load_my_rating_changes(
             )
         )
     ).scalars().all()
-    return {row.match_id: RatingChange.from_history(row) for row in rows}
+    return {
+        row.match_id: RatingChange.from_history(row)
+        for row in rows
+        if row.match_id is not None
+    }
 
 
 def _build_score_banners(
@@ -140,7 +144,7 @@ def _build_score_banners(
 
 
 def _build_next_match(
-    pending: list[Match], current_user_id: uuid.UUID
+    pending: Sequence[Match], current_user_id: uuid.UUID
 ) -> DashboardNextMatch | None:
     if not pending:
         return None

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -457,7 +457,7 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
         ],
         best_of=match.match_settings.best_of,
         created_at=match.created_at,
-        current_game_id=current_game.id if can_score else None,
+        current_game_id=current_game.id if can_score and current_game else None,
         can_score=can_score,
     )
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -50,10 +50,9 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unused_configs = true
 
-# ortools ships incomplete inline types — CpModel's methods (NewIntVar, Add, …)
-# are added dynamically, so mypy reports false attr-defined errors. Treat the
-# package as untyped instead of chasing those.
+# ortools ships incomplete inline types (it has a py.typed marker) — CpModel's
+# methods (NewIntVar, Add, …) are added dynamically, so mypy reports false
+# attr-defined errors. Skip following its imports so it's treated as untyped.
 [[tool.mypy.overrides]]
 module = "ortools.*"
 follow_imports = "skip"
-ignore_missing_imports = true

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -26,6 +26,8 @@ dev = [
     "httpx>=0.27.0",
     "fakeredis[lua]>=2.20",
     "testcontainers[postgres]>=4.8",
+    "mypy>=1.13",
+    "types-jsonschema>=4.21",
 ]
 
 [build-system]
@@ -40,3 +42,18 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"
+
+[tool.mypy]
+python_version = "3.13"
+files = ["app"]
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unused_configs = true
+
+# ortools ships incomplete inline types — CpModel's methods (NewIntVar, Add, …)
+# are added dynamically, so mypy reports false attr-defined errors. Treat the
+# package as untyped instead of chasing those.
+[[tool.mypy.overrides]]
+module = "ortools.*"
+follow_imports = "skip"
+ignore_missing_imports = true


### PR DESCRIPTION
## What

Introduces mypy type-checking to the `api/` service.

- Adds `mypy` + `types-jsonschema` dev deps and a non-strict `[tool.mypy]` config scoped to `app/`, with an `ortools.*` override (`follow_imports = "skip"`) since ortools ships a `py.typed` marker but its `CpModel` methods are added dynamically.
- Fixes the 7 real type errors this surfaced:
  - `account_merge.py`: cast Core UPDATE result to `CursorResult[Any]` to read `.rowcount` (`AsyncSession.execute` is typed `Result[Any]`).
  - `dashboard.py`: build the rating-changes dict with an `assert row.match_id is not None` loop (the `IN`-filter guarantees non-null) instead of a silent filter; widen `_build_next_match`'s `pending` param to `Sequence[Match]` (what `.scalars().all()` returns).
  - `matches.py`: add a `current_game` narrowing alongside the existing `can_score` gate (behavior unchanged — `can_score` still gates the field).
- Wires `mypy` into CI as a fast-fail step before `pytest` in `.github/workflows/api.yml` (no duplicate `pip install`).
- Documents the `mypy` command in `CLAUDE.md`.

Non-strict baseline chosen per `api/CLAUDE.md`'s "don't mass-rewrite working code" — `--strict` would have demanded ~26 `no-untyped-def` annotations on legacy modules.

## Testing

- `mypy` → green (48 source files)
- API pytest: 298 passed
- web-client vitest: 92 passed; lint clean; build/typecheck passed
- OpenAPI schema regenerated → no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)