### PR TITLE
Show form from before the viewed match, not current form

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -565,10 +565,16 @@ def _singles_user_ids(match: Match) -> list[uuid.UUID]:
     ]
 
 
-def _history_base_query(current_match_id: uuid.UUID):
+def _history_base_query(
+    current_match_id: uuid.UUID, before: datetime | None = None
+):
     """Foundation for both recent-form and H2H lookups: completed matches
-    other than this one, eagerly loading just the sides + games subtree."""
-    return (
+    other than this one, eagerly loading just the sides + games subtree.
+
+    Pass ``before`` to restrict to matches completed before that instant, so a
+    match viewed in the past shows the form as it stood then rather than the
+    players' current form."""
+    query = (
         select(Match)
         .where(
             Match.status == MatchStatus.completed,
@@ -577,6 +583,9 @@ def _history_base_query(current_match_id: uuid.UUID):
         .options(*_match_history_options())
         .order_by(Match.updated_at.desc())
     )
+    if before is not None:
+        query = query.where(Match.updated_at < before)
+    return query
 
 
 async def _load_recent_form(
@@ -592,7 +601,8 @@ async def _load_recent_form(
         rows = (
             await db.execute(
                 participant_filter(
-                    _history_base_query(match.id), user_id
+                    _history_base_query(match.id, before=match.created_at),
+                    user_id,
                 ).limit(RECENT_FORM_LIMIT)
             )
         ).scalars().all()

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -942,6 +942,32 @@ async def test_details_recent_form_excludes_the_current_match(
         assert all(r["match_id"] != finished["id"] for r in f["recent_results"])
 
 
+async def test_details_recent_form_excludes_matches_after_this_one(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Viewing an older match shows form as it stood then: a match completed
+    before this one was created counts; one completed after it does not."""
+    me = await start_session(api_client, db_session)
+    opp = await make_user(db_session, "after-rival")
+    other = await make_user(db_session, "after-third-party")
+    # A match I finished *before* the viewed match is created.
+    earlier = await _play_match_to_completion(
+        api_client, other.id, best_of=3, side_1_wins=True
+    )
+    # The match we'll view (in progress, so it stays "current" in time).
+    current = await _create_match(api_client, opp.id, best_of=3)
+    # A match I finish *after* the viewed match was created.
+    later = await _play_match_to_completion(
+        api_client, other.id, best_of=3, side_1_wins=False
+    )
+
+    detail = (await api_client.get(f"/v1/matches/{current['id']}")).json()
+    forms = {f["user_id"]: f for f in detail["recent_form"]}
+    my_match_ids = {r["match_id"] for r in forms[str(me.id)]["recent_results"]}
+    assert earlier["id"] in my_match_ids
+    assert later["id"] not in my_match_ids
+
+
 async def test_details_head_to_head_counts_prior_meetings_per_side(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -429,7 +429,9 @@ describe('MatchDetailsView', () => {
     )
     // My side: 1 W and 1 L with the right opponent / score labels.
     const myForm = screen.getByTestId('form-1')
-    expect(within(myForm).getByText('Recent form · 1–1')).toBeInTheDocument()
+    expect(
+      within(myForm).getByText('Form before this match · 1–1'),
+    ).toBeInTheDocument()
     expect(within(myForm).getByText('silva.r')).toBeInTheDocument()
     expect(within(myForm).getByText('3–1')).toBeInTheDocument()
     expect(within(myForm).getByText('tanaka.y')).toBeInTheDocument()
@@ -448,7 +450,7 @@ describe('MatchDetailsView', () => {
     const oppForm = screen.getByTestId('form-2')
     expect(within(oppForm).getByText(/No prior matches yet/)).toBeInTheDocument()
     expect(
-      within(oppForm).queryByText(/Recent form · /),
+      within(oppForm).queryByText(/Form before this match · /),
     ).not.toBeInTheDocument()
     // Unrated rookie: no rating number, no sparkline, no win rate.
     const oppRating = screen.getByTestId('rating-box-2')

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -665,7 +665,7 @@ function PlayersCard({ view }: { view: MatchView }) {
     <div className="md-card">
       <div className="md-card__hd">
         <Overline as="h3">Players &amp; form</Overline>
-        <span className="md-card__hd-meta">LAST 5 RESULTS</span>
+        <span className="md-card__hd-meta">5 BEFORE THIS MATCH</span>
       </div>
       <div className="md-players">
         <PlayerProfile side={view.leftSide} won={view.leftSide.won === true} />
@@ -701,8 +701,8 @@ function PlayerProfile({ side, won }: { side: SideView; won: boolean }) {
       <div className="md-profile__form" data-testid={`form-${side.sideNumber}`}>
         <div className="md-kicker">
           {form.length === 0
-            ? 'Recent form'
-            : `Recent form · ${wins}–${losses}`}
+            ? 'Form before this match'
+            : `Form before this match · ${wins}–${losses}`}
         </div>
         {form.length === 0 ? (
           <div className="md-profile__empty">


### PR DESCRIPTION
## What

The match-details **Players & form** card showed each player's *globally most-recent* 5 completed matches, while the rating and career-stats columns beside it were computed *as-of the viewed match*. Opening an old match therefore mixed point-in-time stats with present-day form.

This clamps recent form to matches completed **before the viewed match was created**, matching the existing `_load_career_before` / `_load_pre_match_rating` cutoff, and updates the copy so the meaning is explicit.

## Changes

- `_history_base_query` takes an optional `before` cutoff; `_load_recent_form` passes `match.created_at`. H2H lookups call it without `before`, so their behavior is unchanged.
- Copy: `LAST 5 RESULTS` → `5 BEFORE THIS MATCH`; `Recent form` → `Form before this match`.
- New API test asserting a match completed after the viewed one is excluded while an earlier one is included; updated web-client copy assertions.

## Tests

- API: `pytest` — 299 passed
- web-client: `npm run test:run` — 92 passed; `lint` clean; `build` (tsc + vite) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)