### PR TITLE
Seed an initial rating-history event when a user joins a league

### DIFF
--- a/api/app/leagues.py
+++ b/api/app/leagues.py
@@ -5,7 +5,14 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models import League, LeagueMembership, UserLeagueRating
+from app.models import (
+    League,
+    LeagueMembership,
+    RatingHistory,
+    RatingHistorySource,
+    RatingStrategy,
+    UserLeagueRating,
+)
 
 
 async def get_default_league(db: AsyncSession) -> League | None:
@@ -41,6 +48,43 @@ async def resolve_league(
     return default
 
 
+def seed_user_league_rating(
+    db: AsyncSession,
+    league_id: uuid.UUID,
+    user_id: uuid.UUID,
+    strategy: RatingStrategy,
+) -> UserLeagueRating:
+    """Seed a member's current rating row and, for strategies that supply an
+    initial rating, an ``initial`` rating-history event recording that
+    baseline.
+
+    The history event matters because per-match views read a player's
+    pre-match rating from ``rating_history`` (not ``user_league_ratings``); a
+    seeded value with no matching history row reads as "Unrated" until the
+    player's first rated match. Manual-strategy leagues get a null rating row
+    and no event — their baseline arrives via import.
+
+    Adds rows to the session without flushing or committing; the caller owns
+    the surrounding transaction.
+    """
+    rating = UserLeagueRating.seed_for_strategy(league_id, user_id, strategy)
+    db.add(rating)
+    if strategy.initial_rating_value is not None and strategy.initial_state is not None:
+        db.add(
+            RatingHistory(
+                league_id=league_id,
+                user_id=user_id,
+                match_id=None,
+                rating_strategy_id=strategy.id,
+                rating_value=strategy.initial_rating_value,
+                rating_state=dict(strategy.initial_state),
+                previous_rating_value=None,
+                source=RatingHistorySource.initial,
+            )
+        )
+    return rating
+
+
 async def add_user_to_default_league(
     db: AsyncSession, user_id: uuid.UUID
 ) -> None:
@@ -57,8 +101,4 @@ async def add_user_to_default_league(
             "No default league configured. Run scripts/seed_leagues.py."
         )
     db.add(LeagueMembership(league_id=default.id, user_id=user_id))
-    db.add(
-        UserLeagueRating.seed_for_strategy(
-            default.id, user_id, default.rating_strategy
-        )
-    )
+    seed_user_league_rating(db, default.id, user_id, default.rating_strategy)

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -1,7 +1,7 @@
 import uuid
 
 from httpx import AsyncClient
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import (
@@ -49,7 +49,7 @@ async def test_dashboard_empty_when_user_has_no_matches(
     assert body["recent_results"] == []
     # A fresh signup is auto-joined to the default Glicko-2 league with
     # initial state, so the rating widget lights up immediately with peak ==
-    # current and a null streak / empty sparkline.
+    # current, a null streak, and a sparkline holding the lone seed point.
     rating = body["rating"]
     assert rating is not None
     assert rating["league_name"] == "FortyMM"
@@ -58,7 +58,7 @@ async def test_dashboard_empty_when_user_has_no_matches(
     assert rating["delta"] == 0.0
     assert rating["peak"] == 1500.0
     assert rating["percentile"] is None  # alone in the league
-    assert rating["spark_data"] == []
+    assert rating["spark_data"] == [1500.0]  # the initial seed event
     assert rating["streak"] is None
     assert rating["stats"] == [
         {"label": "RD", "value": "350"},
@@ -212,7 +212,8 @@ async def test_dashboard_rating_reflects_completed_match(
     assert rating["current"] > 1500.0
     assert rating["delta"] > 0
     assert rating["peak"] == rating["current"]
-    assert rating["spark_data"] == [rating["current"]]
+    # Seed point first, then the post-match value.
+    assert rating["spark_data"] == [1500.0, rating["current"]]
     assert rating["streak"] == {"kind": "W", "n": 1}
     rd_stat = next(s for s in rating["stats"] if s["label"] == "RD")
     assert int(rd_stat["value"]) < 350
@@ -230,7 +231,8 @@ async def test_dashboard_streak_counts_consecutive_results(
 
     rating = (await api_client.get("/v1/dashboard")).json()["rating"]
     assert rating["streak"] == {"kind": "L", "n": 1}
-    assert len(rating["spark_data"]) == 3
+    # The seed event plus three match results.
+    assert len(rating["spark_data"]) == 4
 
 
 async def test_dashboard_rating_peak_holds_after_loss(
@@ -307,9 +309,19 @@ async def test_dashboard_sparkline_returns_most_recent_points(
             select(RatingStrategy).where(RatingStrategy.key == "glicko2")
         )
     ).scalar_one()
+    # The signup seed event sits before any match, so push it back behind the
+    # 40 rows below; otherwise it would be the most-recent point and skew the
+    # truncation this test is checking.
+    now = datetime.now(timezone.utc)
+    await db_session.execute(
+        text(
+            "UPDATE rating_history SET created_at = :ts "
+            "WHERE user_id = :uid AND source = 'initial'"
+        ),
+        {"ts": now - timedelta(hours=41), "uid": me.id},
+    )
     # 40 history rows spaced 1 hour apart, all within the 30-day window;
     # rating climbs monotonically so we can read the order off the values.
-    now = datetime.now(timezone.utc)
     for i in range(40):
         db_session.add(
             RatingHistory(

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -998,10 +998,10 @@ async def test_details_recent_form_includes_pre_match_rating_and_career(
     # I had 2 completed matches before this one, both wins.
     assert mine["career_matches_before"] == 2
     assert mine["career_wins_before"] == 2
-    # Rating history exists with 2 prior entries (one per rated match) and
-    # rating_before matches the most-recent entry.
+    # Rating history exists with 3 prior entries (the league-join seed plus
+    # one per rated match) and rating_before matches the most-recent entry.
     assert mine["rating_before"] is not None
-    assert len(mine["rating_history"]) == 2
+    assert len(mine["rating_history"]) == 3
     assert mine["rating_history"][-1] == mine["rating_before"]
     # Brand-new opponent: no rating, no career.
     fresh = forms[str(opp.id)]
@@ -1015,21 +1015,35 @@ async def test_details_recent_form_excludes_self_from_career_count(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     """A just-completed match's own row in rating_history / its own match
-    row must not double-count itself in the BFF."""
-    await start_session(api_client, db_session)
+    row must not double-count itself in the BFF. The session user still shows
+    their league-join seed (recorded before the match), but none of the
+    match's own freshly-written rating rows leak into the pre-match view."""
+    me = await start_session(api_client, db_session)
     opp = await make_user(db_session, "self-exclude-opp")
     finished = await _play_match_to_completion(
         api_client, opp.id, best_of=3, side_1_wins=True
     )
 
     detail = (await api_client.get(f"/v1/matches/{finished['id']}")).json()
-    for f in detail["recent_form"]:
-        # No prior matches exist — only the current one — so career and
-        # rating-history must be empty.
+    forms = {f["user_id"]: f for f in detail["recent_form"]}
+    # No prior matches exist — only the current one — so career counts are 0
+    # for both players.
+    for f in forms.values():
         assert f["career_matches_before"] == 0
         assert f["career_wins_before"] == 0
-        assert f["rating_history"] == []
-        assert f["rating_before"] is None
+
+    # The session user joined the league at signup, so their pre-match rating
+    # is the seeded baseline; the match's own rating rows are excluded.
+    mine = forms[str(me.id)]
+    assert mine["rating_before"] == 1500.0
+    assert mine["rating_history"] == [1500.0]
+
+    # The opponent came in via make_user (no league join) and is only seeded
+    # when the match completes — after match creation — so they have no
+    # pre-match history.
+    opp_form = forms[str(opp.id)]
+    assert opp_form["rating_before"] is None
+    assert opp_form["rating_history"] == []
 
 
 async def test_list_matches_csv_export(

--- a/api/tests/test_ratings.py
+++ b/api/tests/test_ratings.py
@@ -217,7 +217,15 @@ async def test_unrated_match_does_not_move_ratings(
     for side in body["sides"]:
         assert side["rating_change"] is None
 
-    rows = (await db_session.execute(select(RatingHistory))).scalars().all()
+    # The session user has an `initial` seed row from joining the league, but
+    # an unrated match must not produce any `match`-sourced history.
+    rows = (
+        await db_session.execute(
+            select(RatingHistory).where(
+                RatingHistory.source == RatingHistorySource.match
+            )
+        )
+    ).scalars().all()
     assert rows == []
 
 


### PR DESCRIPTION
## Problem

On the match-details page, the **Players & Form** "RATING" box showed **Unrated** for fresh players, while the **Rating Change** card showed `1500 → …`. The two disagreed because they read from different places:

- "Rating Change" seeds from `user_league_ratings` (1500 on join).
- "Players & Form" reads a player's pre-match rating from `rating_history` (`_load_pre_match_rating`), which had **no row** at signup → `null` → "Unrated".

## Fix

Write an `initial`-source `RatingHistory` event **at user-creation time** — when the user joins the default league (`add_user_to_default_league`, called from session creation). Extracted into a `seed_user_league_rating` helper alongside the existing `UserLeagueRating` seeding.

- Only for strategies that supply an initial rating; **manual** leagues (no initial rating) get no event, matching their existing "null until import" behavior.
- **No migration** — the `rating_history` table and the `initial` enum value already exist; this only inserts a data row at runtime.
- Account-merge needs no change: the ephemeral user's seed row cascade-deletes on merge (`user_id` FK is `ON DELETE CASCADE`), and the verified user keeps their own.

## Behavior

- Match-details **"RATING" box**: shows `1500` instead of "Unrated" for new players (their seed event predates the match they create).
- Match-details **sparkline**: still needs ≥2 points, so it appears once a player has played at least one match (seed + result).
- **Dashboard** rating widget sparkline: includes the seed point from day one.

> Note: only affects users created from now on — existing dev-DB users have no retroactive seed event, so wipe/reseed to verify (per the pre-deploy convention).

## Tests

- Full API suite passes (**298**). Updated 7 tests whose expectations changed now that a fresh user legitimately has one rating point (e.g. a new signup's `spark_data` is `[1500.0]`; first-match `rating_before` is `1500.0`).
- `mypy` clean on the changed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)