### PR TITLE
Show a "No opponent" placeholder on solo match details

### DIFF
--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -283,10 +283,25 @@ describe('MatchDetailsView', () => {
     )
     const { container } = renderDetails('m-solo')
 
+    // The participant shows on the left; the empty opponent side renders a
+    // "No opponent" placeholder rather than a blank slot.
     await waitFor(() =>
-      expect(container.querySelectorAll('.md-hero__name').length).toBe(1),
+      expect(container.querySelectorAll('.md-hero__name').length).toBe(2),
     )
-    expect(container.querySelector('.md-hero__name')).toHaveTextContent('me')
+    const heroNames = Array.from(
+      container.querySelectorAll('.md-hero__name'),
+    ).map((el) => el.textContent)
+    expect(heroNames).toEqual(['me', 'No opponent'])
+    // The placeholder is styled as a ghost (dashed avatar + muted name), not a
+    // real player.
+    expect(
+      container.querySelector('.md-hero__name--ghost'),
+    ).toHaveTextContent('No opponent')
+    expect(container.querySelector('.md-avatar--ghost')).toBeInTheDocument()
+    // The Players & form card mirrors it on the opponent side.
+    expect(
+      container.querySelector('.md-profile__name--ghost'),
+    ).toHaveTextContent('No opponent')
     // Did not bounce to the list — this replaced an earlier redirect.
     expect(screen.queryByText('matches-list')).not.toBeInTheDocument()
   })

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -9,6 +9,7 @@ import {
   Link2,
   Send,
   Share2,
+  User,
   X,
 } from 'lucide-react'
 
@@ -29,6 +30,12 @@ type MatchDetailsPlayerForm = components['schemas']['MatchDetailsPlayerForm']
 type MatchDetailsH2H = components['schemas']['MatchDetailsH2H']
 type MatchDetailsH2HMeeting = components['schemas']['MatchDetailsH2HMeeting']
 type RatingChange = components['schemas']['RatingChange']
+
+// A match with only the creator's side has no opponent and may never gain one
+// (solo / "start without opponent" matches). The empty side reads as this
+// rather than implying someone is on the way — mirrors the recent-form rows,
+// which already label a missing opponent "No opponent".
+const NO_OPPONENT_LABEL = 'No opponent'
 
 const EMPTY_FORM: MatchDetailsPlayerForm = {
   user_id: '',
@@ -501,7 +508,11 @@ function HeroScoreboard({
             </>
           )}
         </div>
-        {view.rightSide && <PlayerSide side={view.rightSide} pos="r" />}
+        {view.rightSide ? (
+          <PlayerSide side={view.rightSide} pos="r" />
+        ) : (
+          <NoOpponentSide pos="r" />
+        )}
       </div>
 
       {!isUpcoming && view.rightSide && (
@@ -527,6 +538,26 @@ function PlayerSide({ side, pos }: { side: SideView; pos: 'l' | 'r' }) {
         <div className={`md-hero__player-text--${pos}`}>
           <div className={cn('md-hero__name', win && 'md-hero__name--win')}>
             {side.username}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function NoOpponentSide({ pos }: { pos: 'l' | 'r' }) {
+  return (
+    <div className={`md-hero__player md-hero__player--${pos}`}>
+      <div className="md-hero__player-row">
+        <div
+          className="md-avatar md-avatar--ghost md-hero__avatar-singles"
+          aria-hidden="true"
+        >
+          <User size={26} strokeWidth={1.75} />
+        </div>
+        <div className={`md-hero__player-text--${pos}`}>
+          <div className="md-hero__name md-hero__name--ghost">
+            {NO_OPPONENT_LABEL}
           </div>
         </div>
       </div>
@@ -669,14 +700,14 @@ function PlayersCard({ view }: { view: MatchView }) {
       </div>
       <div className="md-players">
         <PlayerProfile side={view.leftSide} won={view.leftSide.won === true} />
-        {view.rightSide && (
-          <>
-            <div className="md-players__divider" />
-            <PlayerProfile
-              side={view.rightSide}
-              won={view.rightSide.won === true}
-            />
-          </>
+        <div className="md-players__divider" />
+        {view.rightSide ? (
+          <PlayerProfile
+            side={view.rightSide}
+            won={view.rightSide.won === true}
+          />
+        ) : (
+          <NoOpponentProfile />
         )}
       </div>
     </div>
@@ -718,6 +749,26 @@ function PlayerProfile({ side, won }: { side: SideView; won: boolean }) {
         )}
       </div>
       <CareerStats side={side} />
+    </div>
+  )
+}
+
+function NoOpponentProfile() {
+  return (
+    <div className="md-profile">
+      <div className="md-profile__identity">
+        <div className="md-avatar md-avatar--ghost" aria-hidden="true">
+          <User size={20} strokeWidth={1.75} />
+        </div>
+        <div className="md-profile__id-text">
+          <div className="md-profile__name md-profile__name--ghost">
+            {NO_OPPONENT_LABEL}
+          </div>
+        </div>
+      </div>
+      <div className="md-profile__empty">
+        This match has no second player.
+      </div>
     </div>
   )
 }

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2126,6 +2126,13 @@ body.dark.fortymm-theme {
   background: linear-gradient(135deg, #2a3040, #11141b);
   color: var(--fg-2);
 }
+/* Empty-seat placeholder: a dashed outline + muted glyph reads as "no player
+   here", distinct from a real (filled) avatar. */
+.fortymm-theme .md-avatar--ghost {
+  background: transparent;
+  border: 1.5px dashed var(--border-subtle);
+  color: var(--fg-3);
+}
 
 /* ---------- Hero scoreboard ---------- */
 .fortymm-theme .md-hero {
@@ -2247,6 +2254,10 @@ body.dark.fortymm-theme {
 }
 .fortymm-theme .md-hero__name--win {
   color: var(--serve-500);
+}
+.fortymm-theme .md-hero__name--ghost {
+  color: var(--fg-3);
+  font-weight: 600;
 }
 .fortymm-theme .md-hero__club {
   font: 500 12px var(--font-ui);
@@ -2541,6 +2552,10 @@ body.dark.fortymm-theme {
   color: var(--fg-1);
   letter-spacing: -0.005em;
   line-height: 1.2;
+}
+.fortymm-theme .md-profile__name--ghost {
+  color: var(--fg-3);
+  font-weight: 600;
 }
 .fortymm-theme .md-profile__club {
   font: 500 12px var(--font-ui);


### PR DESCRIPTION
## What

Solo / "start without opponent" matches have only the creator's side, so the match-details **hero scoreboard** and **Players & form** card left the opponent slot blank — the centered `0 – 0` looked orphaned.

This fills that slot with a placeholder: a dashed ghost avatar (person glyph) + muted **"No opponent"** label, right-aligned to mirror the real player. The Players & form card mirrors it with the same label plus "This match has no second player."

The wording reuses what the recent-form rows already show for a missing opponent (`opponent_username ?? 'No opponent'`), and deliberately reads as *no player* rather than *waiting for one* — a solo match may never gain an opponent.

I verified it live against a real no-opponent match in the dev (MSW) build: the hero right slot and the Players & form opponent column both render the ghost placeholder, while the rating/head-to-head/game-grid sections correctly stay hidden for a one-sided match.

## Scope

Purely additive presentational change — JSX + CSS + a vitest update. No `api/**` or `web-client/src/api/**` touched, so no OpenAPI schema drift.

## Tests

- `npm run test:run` → 92 passed (updated the existing solo-match test to assert the placeholder in both the hero and the Players & form card)
- `npm run lint` → clean (one pre-existing warning in generated `mockServiceWorker.js`)
- `npm run build` (tsc -b && vite build) → green
- `npm run test:e2e` → 126 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)