### PR TITLE
api: fix mypy errors and run mypy in CI

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -23,4 +23,6 @@ jobs:
 
       - run: pip install -e '.[dev]'
 
+      - run: mypy
+
       - run: pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ uvicorn app.main:app --reload                  # dev server on :8000
 rq worker solver --url "$REDIS_URL"            # required for /v1/health to pass
 alembic upgrade head                           # apply migrations
 alembic revision --autogenerate -m "..."       # new migration (autogen reads app.models)
+mypy                                           # static type check (config + paths in pyproject.toml)
 pytest                                         # all tests; testcontainers spins ephemeral Postgres
 pytest tests/test_session.py::test_x           # single test
 TEST_DATABASE_URL=postgresql+asyncpg://... pytest   # skip testcontainers, use existing Postgres

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -10,8 +10,9 @@ stale relative to the freshly-moved matches — the caller enqueues the
 
 import uuid
 from dataclasses import dataclass
+from typing import Any, cast
 
-from sqlalchemy import delete, text, update
+from sqlalchemy import CursorResult, delete, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Match, MatchSidePlayer, RatingHistory, User
@@ -130,4 +131,4 @@ async def _repoint_match_side_players(
         ),
         {"from_id": from_user_id, "to_id": to_user_id},
     )
-    return result.rowcount or 0
+    return cast("CursorResult[Any]", result).rowcount or 0

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -118,7 +118,11 @@ async def _load_my_rating_changes(
             )
         )
     ).scalars().all()
-    return {row.match_id: RatingChange.from_history(row) for row in rows}
+    return {
+        row.match_id: RatingChange.from_history(row)
+        for row in rows
+        if row.match_id is not None
+    }
 
 
 def _build_score_banners(
@@ -140,7 +144,7 @@ def _build_score_banners(
 
 
 def _build_next_match(
-    pending: list[Match], current_user_id: uuid.UUID
+    pending: Sequence[Match], current_user_id: uuid.UUID
 ) -> DashboardNextMatch | None:
     if not pending:
         return None

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -457,7 +457,9 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
         ],
         best_of=match.match_settings.best_of,
         created_at=match.created_at,
-        current_game_id=current_game.id if can_score else None,
+        current_game_id=(
+            current_game.id if can_score and current_game is not None else None
+        ),
         can_score=can_score,
     )
 

--- a/api/app/solver.py
+++ b/api/app/solver.py
@@ -3,9 +3,9 @@ from ortools.sat.python import cp_model
 
 def solve_hello_world() -> bool:
     model = cp_model.CpModel()
-    x = model.NewIntVar(0, 10, "x")
-    y = model.NewIntVar(0, 10, "y")
-    model.Add(x + y == 10)
+    x = model.new_int_var(0, 10, "x")
+    y = model.new_int_var(0, 10, "y")
+    model.add(x + y == 10)
     solver = cp_model.CpSolver()
-    status = solver.Solve(model)
+    status = solver.solve(model)
     return status in (cp_model.OPTIMAL, cp_model.FEASIBLE)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -26,6 +26,8 @@ dev = [
     "httpx>=0.27.0",
     "fakeredis[lua]>=2.20",
     "testcontainers[postgres]>=4.8",
+    "mypy>=1.13",
+    "types-jsonschema>=4.21",
 ]
 
 [build-system]
@@ -34,6 +36,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 include = ["app*"]
+
+[tool.mypy]
+python_version = "3.13"
+files = ["app"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Fixes all existing mypy errors in `api/` and wires `mypy` into the api CI workflow so type regressions are caught.

## Tooling
- Added `mypy>=1.13` and `types-jsonschema>=4.21` to the api dev dependencies.
- Added a `[tool.mypy]` section to `pyproject.toml` (`python_version = "3.13"`, `files = ["app"]`).
- Added a `mypy` step before `pytest` in `.github/workflows/api.yml`.
- Documented the `mypy` command in the root `CLAUDE.md`.

## Type fixes (8 errors across 5 files)
- **`app/solver.py`** — switched from the camelCase ortools API (`NewIntVar`/`Add`/`Solve`) to the statically-typed snake_case form (`new_int_var`/`add`/`solve`). The camelCase methods are added dynamically via `setattr`, so mypy can't see them. Behavior verified unchanged.
- **`app/account_merge.py`** — `cast` the `db.execute()` result to `CursorResult[Any]` to access `.rowcount`.
- **`app/matches.py`** — explicitly narrow `current_game is not None` before reading `.id`.
- **`app/dashboard.py`** — widen `_build_next_match` to `Sequence[Match]`; drop null `match_id` rows from the rating-changes dict comprehension (the column is nullable, though the query never returns nulls).

## Verification
- `mypy` → `Success: no issues found in 48 source files`
- Solver runs correctly with the snake_case API.
- All edited modules import cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)