### PR TITLE
Make matches without an opponent scorable

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -241,14 +241,20 @@ def _serialize_details(
     )
 
 
-def _add_side(match: Match, side_number: int, player: User) -> None:
-    """Attach a single-player side to ``match``.
+def _add_side(match: Match, side_number: int, player: User | None) -> None:
+    """Attach a side to ``match``. ``player=None`` creates the sentinel
+    "no opponent" side — a real second side carrying no player — so an
+    opponent-less match still has two sides and is therefore scorable. It reads
+    as opponent-less wherever the code inspects ``side.players`` (serialization
+    renders the "No opponent" placeholder; rating updates skip player-less
+    sides).
 
     Wiring up the ``match`` relationship on both the side and the side-player
     is what populates their (non-null, denormalized) ``match_id`` columns on
     flush."""
     side = MatchSide(match=match, side_number=side_number)
-    side.players.append(MatchSidePlayer(match=match, user=player))
+    if player is not None:
+        side.players.append(MatchSidePlayer(match=match, user=player))
 
 
 # ----- list helpers --------------------------------------------------------
@@ -315,8 +321,9 @@ async def create_match(
             detail="A rated match needs a registered opponent.",
         )
 
-    # Guest / "start without opponent" matches have only the creator's side,
-    # so they can never affect ratings regardless of the requested flag.
+    # Guest / "start without opponent" matches get a sentinel opponent side
+    # (no player) below, so they're scorable but can never affect ratings
+    # regardless of the requested flag.
     affects_rating = payload.rated and opponent is not None
 
     league = await resolve_league(db, payload.league_id)
@@ -333,8 +340,9 @@ async def create_match(
         status=MatchStatus.in_progress,
     )
     _add_side(match, 1, current_user)
-    if opponent is not None:
-        _add_side(match, 2, opponent)
+    # Always create side 2. With no opponent it's a player-less sentinel side,
+    # which keeps the match scorable (two sides) while reading as "No opponent".
+    _add_side(match, 2, opponent)
     # The FE never creates a game — game 1 is written here so scoring routes
     # always have a real entity to deep-link into.
     match.games.append(MatchGame(game_number=1))

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -24,8 +24,9 @@ class MatchCreate(BaseModel):
     """Request body for ``POST /v1/matches``.
 
     ``opponent_user_id`` is optional: a match created without a registered
-    opponent (a guest, or "start without opponent") gets a single side and is
-    always unrated, since the rating system needs two registered sides.
+    opponent (a guest, or "start without opponent") gets a player-less sentinel
+    opponent side — so it's still scorable — and is always unrated, since the
+    rating system needs two registered sides.
 
     ``league_id`` is optional: when omitted the server binds the match to the
     default league (see ``app.leagues.get_default_league``).

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -93,7 +93,7 @@ async def test_create_unrated_match_with_opponent(
     assert len(body["sides"]) == 2
 
 
-async def test_create_match_without_opponent_has_a_single_side(
+async def test_create_match_without_opponent_has_a_sentinel_opponent_side(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     me = await start_session(api_client, db_session)
@@ -104,14 +104,51 @@ async def test_create_match_without_opponent_has_a_single_side(
     assert response.status_code == 201
     body = response.json()
     assert body["affects_rating"] is False
-    assert len(body["sides"]) == 1
-    assert body["sides"][0]["players"][0]["user_id"] == str(me.id)
-    # No opponent → nothing to score against, even though game 1 exists.
+    # Two sides: the creator, plus a player-less sentinel "No opponent" side.
+    sides = sorted(body["sides"], key=lambda s: s["side_number"])
+    assert [s["side_number"] for s in sides] == [1, 2]
+    assert sides[0]["players"][0]["user_id"] == str(me.id)
+    assert sides[1]["players"] == []
+    # The sentinel side makes the match scorable for its creator.
     assert body["current_game"] is not None
-    assert body["can_score"] is False
+    assert body["can_score"] is True
 
-    sides = (await db_session.execute(select(MatchSide))).scalars().all()
-    assert len(sides) == 1
+    rows = (await db_session.execute(select(MatchSide))).scalars().all()
+    assert len(rows) == 2
+
+
+async def test_match_without_opponent_can_be_scored_to_completion(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+
+    match = (
+        await api_client.post(
+            "/v1/matches", json={"best_of": 3, "rated": False}
+        )
+    ).json()
+    # The creator is side 1; the sentinel opponent is side 2.
+    after_g1 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+            json={"side_1_points": 11, "side_2_points": 4},
+        )
+    ).json()
+    assert after_g1["status"] == "in_progress"
+    game_2 = after_g1["games"][1]
+    after_g2 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/{game_2['id']}/scores",
+            json={"side_1_points": 11, "side_2_points": 7},
+        )
+    )
+    assert after_g2.status_code == 201
+    body = after_g2.json()
+    assert body["status"] == "completed"
+    sides = sorted(body["sides"], key=lambda s: s["side_number"])
+    assert [s["won"] for s in sides] == [True, False]
+    # No rating moved — a player-less opponent can't be rated against.
+    assert body["affects_rating"] is False
 
 
 async def test_rated_match_without_opponent_is_rejected(
@@ -729,7 +766,7 @@ async def test_scoring_an_unknown_game_404(
     assert response.json()["detail"] == "Game not found."
 
 
-async def test_cannot_score_match_without_opponent(
+async def test_can_score_match_without_opponent(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
@@ -742,8 +779,11 @@ async def test_cannot_score_match_without_opponent(
         f"/v1/matches/{created['id']}/games/{created['games'][0]['id']}/scores",
         json={"side_1_points": 11, "side_2_points": 4},
     )
-    assert response.status_code == 422
-    assert "opponent" in response.json()["detail"].lower()
+    # The sentinel opponent side makes the match scorable.
+    assert response.status_code == 201
+    body = response.json()
+    sides = sorted(body["sides"], key=lambda s: s["side_number"])
+    assert [s["games_won"] for s in sides] == [1, 0]
 
 
 # ----- league binding -----------------------------------------------------

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -617,8 +617,9 @@ export interface components {
          * @description Request body for ``POST /v1/matches``.
          *
          *     ``opponent_user_id`` is optional: a match created without a registered
-         *     opponent (a guest, or "start without opponent") gets a single side and is
-         *     always unrated, since the rating system needs two registered sides.
+         *     opponent (a guest, or "start without opponent") gets a player-less sentinel
+         *     opponent side — so it's still scorable — and is always unrated, since the
+         *     rating system needs two registered sides.
          *
          *     ``league_id`` is optional: when omitted the server binds the match to the
          *     default league (see ``app.leagues.get_default_league``).

--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -260,7 +260,8 @@ describe('MatchDetailsView', () => {
     ).toHaveAttribute('href', '/matches')
   })
 
-  it('renders solo matches (no opponent) with only the participant side', async () => {
+  it('renders no-opponent matches with a "No opponent" placeholder, still scorable', async () => {
+    const game1 = { id: 'g-solo-1', game_number: 1, score: null }
     const match = matchDetails({
       id: 'm-solo',
       sides: [
@@ -273,18 +274,26 @@ describe('MatchDetailsView', () => {
           won: null,
           is_current_user_side: true,
         },
+        // The sentinel opponent: a real side row with no player.
+        {
+          side_number: 2,
+          players: [],
+          games_won: 0,
+          won: null,
+          is_current_user_side: false,
+        },
       ],
-      games: [],
-      current_game: null,
-      can_score: false,
+      games: [game1],
+      current_game: { id: game1.id, game_number: 1 },
+      can_score: true,
     })
     server.use(
       http.get('*/v1/matches/m-solo', () => HttpResponse.json(match)),
     )
     const { container } = renderDetails('m-solo')
 
-    // The participant shows on the left; the empty opponent side renders a
-    // "No opponent" placeholder rather than a blank slot.
+    // The participant shows on the left; the player-less opponent side renders
+    // a "No opponent" placeholder rather than a blank slot.
     await waitFor(() =>
       expect(container.querySelectorAll('.md-hero__name').length).toBe(2),
     )
@@ -302,7 +311,11 @@ describe('MatchDetailsView', () => {
     expect(
       container.querySelector('.md-profile__name--ghost'),
     ).toHaveTextContent('No opponent')
-    // Did not bounce to the list — this replaced an earlier redirect.
+    // A no-opponent match is now scorable: the Score CTA is present.
+    expect(
+      await screen.findByRole('link', { name: 'Score' }),
+    ).toHaveAttribute('href', '/matches/m-solo/games/g-solo-1/scores/new')
+    // Did not bounce to the list.
     expect(screen.queryByText('matches-list')).not.toBeInTheDocument()
   })
 

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -52,6 +52,9 @@ type SideView = {
   sideNumber: number
   username: string
   userId: string | null
+  // A "no opponent" side: a real side row carrying no player. Rendered as the
+  // dashed-circle placeholder instead of an avatar/profile.
+  isGhost: boolean
   initials: string
   gamesWon: number
   won: boolean | null
@@ -113,11 +116,13 @@ function projectSide(
   form: MatchDetailsPlayerForm,
 ): SideView {
   const player = side.players[0]
+  const isGhost = side.players.length === 0
   const username = player?.username ?? fallbackLabel
   return {
     sideNumber: side.side_number,
     username,
     userId: player?.user_id ?? null,
+    isGhost,
     initials: initialsOf(username),
     gamesWon: side.games_won,
     won: side.won,
@@ -523,6 +528,7 @@ function HeroScoreboard({
 }
 
 function PlayerSide({ side, pos }: { side: SideView; pos: 'l' | 'r' }) {
+  if (side.isGhost) return <NoOpponentSide pos={pos} />
   const win = side.won === true
   return (
     <div className={`md-hero__player md-hero__player--${pos}`}>
@@ -630,10 +636,20 @@ function GameGridSide({
   return (
     <>
       <div className="md-games__player">
-        <span className={cn('md-avatar', won ? 'md-avatar--win' : 'md-avatar--loss')}>
-          {side.initials}
+        {side.isGhost ? (
+          <span className="md-avatar md-avatar--ghost" aria-hidden="true">
+            <User size={14} strokeWidth={1.75} />
+          </span>
+        ) : (
+          <span
+            className={cn('md-avatar', won ? 'md-avatar--win' : 'md-avatar--loss')}
+          >
+            {side.initials}
+          </span>
+        )}
+        <span className="md-games__player-name">
+          {side.isGhost ? NO_OPPONENT_LABEL : side.username}
         </span>
-        <span className="md-games__player-name">{side.username}</span>
       </div>
       {slots.map((g, i) => {
         if (!g) {
@@ -715,6 +731,7 @@ function PlayersCard({ view }: { view: MatchView }) {
 }
 
 function PlayerProfile({ side, won }: { side: SideView; won: boolean }) {
+  if (side.isGhost) return <NoOpponentProfile />
   const form = side.recentForm
   const wins = form.filter((r) => r.is_win).length
   const losses = form.length - wins

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -79,8 +79,10 @@ function ScoreEntryInner({
     )
   }
 
-  // The scoring screen is participant-only; spectators and solo-match owners
-  // (no opponent side) bounce back to the read-only details page.
+  // The scoring screen is participant-only; spectators bounce back to the
+  // read-only details page. The opponent side is always present — a real
+  // player, or the player-less "No opponent" sentinel — so its name falls back
+  // to "Opponent" below.
   const mySide = data.sides.find((s) => s.is_current_user_side) ?? null
   const oppSide = data.sides.find((s) => !s.is_current_user_side) ?? null
   if (!mySide || !oppSide) {

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -91,9 +91,8 @@ function applyScore(
   body: MatchScoreBody,
   options: { scoreId?: string } = {},
 ): Response {
-  if (seed.opponent === null) {
-    return detail("This match has no opponent and can't be scored.", 422)
-  }
+  // A no-opponent match is scorable against its player-less sentinel side
+  // (mirrors the API), so there's no opponent gate here.
   if (seed.status === 'disputed' || seed.status === 'voided') {
     return detail('This match is no longer scorable.', 409)
   }

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -116,7 +116,7 @@ export function reconcile(seed: SeedMatch): void {
   } else {
     seed.status = 'in_progress'
     seed.completed_at = null
-    if (currentUnscored(seed) === null && seed.opponent !== null) {
+    if (currentUnscored(seed) === null) {
       const nextNumber =
         seed.games.reduce((max, g) => Math.max(max, g.game_number), 0) + 1
       seed.games.push({
@@ -130,7 +130,9 @@ export function reconcile(seed: SeedMatch): void {
 
 function projectSides(seed: SeedMatch): {
   mySide: MatchDetailsSide
-  opponentSide: MatchDetailsSide | null
+  // Always present: a real opponent, or the player-less sentinel side that
+  // makes an opponent-less match scorable (mirrors the API).
+  opponentSide: MatchDetailsSide
 } {
   const { side1, side2 } = sideWinCounts(seed)
   const decided = seed.status === 'completed'
@@ -152,22 +154,23 @@ function projectSides(seed: SeedMatch): {
     is_current_user_side: true,
     rating_change: showRatingChange ? ratingChangeFor(seed.id, myWon) : null,
   }
-  const opponentSide: MatchDetailsSide | null = seed.opponent
-    ? {
-        side_number: 2,
-        players: [
+  const opponentSide: MatchDetailsSide = {
+    side_number: 2,
+    // No opponent → an empty (player-less) sentinel side.
+    players: seed.opponent
+      ? [
           {
             user_id: seed.opponent.id,
             username: seed.opponent.username,
             is_current_user: false,
           },
-        ],
-        games_won: side2,
-        won: decided ? !myWon : null,
-        is_current_user_side: false,
-        rating_change: showRatingChange ? ratingChangeFor(seed.id, !myWon) : null,
-      }
-    : null
+        ]
+      : [],
+    games_won: side2,
+    won: decided ? !myWon : null,
+    is_current_user_side: false,
+    rating_change: showRatingChange ? ratingChangeFor(seed.id, !myWon) : null,
+  }
   return { mySide, opponentSide }
 }
 
@@ -203,12 +206,12 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
     team_size: 1,
     affects_rating: seed.affects_rating,
     created_at: seed.created_at,
-    sides: opponentSide ? [mySide, opponentSide] : [mySide],
+    sides: [mySide, opponentSide],
     games,
     current_game: current
       ? { id: current.id, game_number: current.game_number }
       : null,
-    can_score: current !== null && opponentSide !== null,
+    can_score: current !== null,
     recent_form: projectRecentForm(seed, priors),
     head_to_head: projectHeadToHead(seed, priors),
   }
@@ -342,14 +345,13 @@ export function projectListRow(seed: SeedMatch): MatchListRow {
   const current = currentUnscored(seed)
   const scorable =
     (seed.status === 'pending' || seed.status === 'in_progress') &&
-    opponentSide !== null &&
     current !== null
   return {
     id: seed.id,
     status: seed.status,
     status_label: STATUS_LABELS[seed.status],
     league: MOCK_DEFAULT_LEAGUE,
-    sides: opponentSide ? [mySide, opponentSide] : [mySide],
+    sides: [mySide, opponentSide],
     best_of: seed.best_of,
     created_at: seed.created_at,
     current_game_id: scorable ? current.id : null,

--- a/web-client/src/routes/matches/index.css
+++ b/web-client/src/routes/matches/index.css
@@ -234,6 +234,18 @@
   gap: 8px;
   min-width: 0;
 }
+.match-list-page .player-avatar--ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  flex: none;
+  border-radius: 9999px;
+  background: transparent;
+  border: 1.5px dashed var(--border-subtle);
+  color: var(--fg-3);
+}
 .match-list-page .player-name {
   font-size: 14px;
   color: var(--fg-1);

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -8,6 +8,7 @@ import {
   Inbox,
   MoreHorizontal,
   Search,
+  User,
   X,
 } from 'lucide-react'
 
@@ -414,14 +415,22 @@ function sideLabel(side: MatchListRowSide | null): string {
 
 function PlayerChip({ side }: { side: MatchListRowSide | null }) {
   const name = sideLabel(side)
-  const isEmpty = side === null
+  // No opponent: a null side (legacy) or a player-less sentinel side. Both read
+  // as "No opponent" and get the dashed-circle placeholder.
+  const isEmpty = side === null || side.players.length === 0
   return (
     <div className="player">
-      <Avatar className="size-[26px]">
-        <AvatarFallback className="font-mono text-[11px] font-bold">
-          {isEmpty ? '?' : initialsOf(name)}
-        </AvatarFallback>
-      </Avatar>
+      {isEmpty ? (
+        <span className="player-avatar player-avatar--ghost" aria-hidden="true">
+          <User size={15} strokeWidth={1.75} />
+        </span>
+      ) : (
+        <Avatar className="size-[26px]">
+          <AvatarFallback className="font-mono text-[11px] font-bold">
+            {initialsOf(name)}
+          </AvatarFallback>
+        </Avatar>
+      )}
       <span
         className={cn(
           'player-name',

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -139,8 +139,9 @@ function MatchCard() {
     if (validationError) return
     setApiError(null)
 
-    // Guest / "start without opponent" matches have a single side, so they
-    // can never be rated regardless of the toggle.
+    // Guest / "start without opponent" matches have no registered opponent, so
+    // they can never be rated regardless of the toggle (the API gives them a
+    // player-less sentinel opponent side instead).
     const isRegistered = opponent?.kind === 'registered'
     try {
       const created = await createMatch.mutateAsync({

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -137,7 +137,9 @@ export function player(overrides: Partial<Player> = {}): Player {
  * agree on the canonical "rita.kovac vs faker-name" shape. */
 function defaultSides(opponentName: string | null): {
   mySide: MatchDetailsSide
-  opponentSide: MatchDetailsSide | null
+  // Always present: a real opponent, or the player-less sentinel "No opponent"
+  // side that keeps an opponent-less match scorable (mirrors the API).
+  opponentSide: MatchDetailsSide
 } {
   const mySide: MatchDetailsSide = {
     side_number: 1,
@@ -152,22 +154,23 @@ function defaultSides(opponentName: string | null): {
     won: null,
     is_current_user_side: true,
   }
-  const opponentSide: MatchDetailsSide | null =
-    opponentName === null
-      ? null
-      : {
-          side_number: 2,
-          players: [
+  const opponentSide: MatchDetailsSide = {
+    side_number: 2,
+    // No opponent → an empty (player-less) sentinel side.
+    players:
+      opponentName === null
+        ? []
+        : [
             {
               user_id: nextId('u'),
               username: opponentName,
               is_current_user: false,
             },
           ],
-          games_won: 0,
-          won: null,
-          is_current_user_side: false,
-        }
+    games_won: 0,
+    won: null,
+    is_current_user_side: false,
+  }
   return { mySide, opponentSide }
 }
 
@@ -199,28 +202,26 @@ export function matchDetails(
     team_size: 1,
     affects_rating: false,
     created_at: ISO,
-    sides: opponentSide ? [mySide, opponentSide] : [mySide],
+    sides: [mySide, opponentSide],
     games: [firstGame],
     current_game: { id: firstGame.id, game_number: 1 },
     can_score: true,
-    recent_form: (opponentSide ? [mySide, opponentSide] : [mySide]).map(
-      (s) => ({
-        user_id: s.players[0]?.user_id ?? nextId('u'),
+    recent_form: [mySide, opponentSide]
+      .filter((s) => s.players.length > 0)
+      .map((s) => ({
+        user_id: s.players[0].user_id,
         recent_results: [],
         rating_before: null,
         rating_history: [],
         career_matches_before: 0,
         career_wins_before: 0,
-      }),
-    ),
-    head_to_head: opponentSide
-      ? {
-          total_meetings: 0,
-          side_1_wins: 0,
-          side_2_wins: 0,
-          recent_meetings: [],
-        }
-      : null,
+      })),
+    head_to_head: {
+      total_meetings: 0,
+      side_1_wins: 0,
+      side_2_wins: 0,
+      recent_meetings: [],
+    },
     ...overrides,
   }
 }
@@ -243,11 +244,11 @@ export function matchListRow(
     status: 'in_progress',
     status_label: 'Live',
     league: MOCK_DEFAULT_LEAGUE,
-    sides: opponentSide ? [mySide, opponentSide] : [mySide],
+    sides: [mySide, opponentSide],
     best_of: 5,
     created_at: ISO,
-    current_game_id: opponentName === null ? null : nextId('g'),
-    can_score: opponentName !== null,
+    current_game_id: nextId('g'),
+    can_score: true,
     ...rest,
   }
 }


### PR DESCRIPTION
## What & why

Opponent-less matches couldn't be scored: a "start without opponent" / guest match was created with only the creator's side, and every scoring guard required two (`len(sides) >= 2`). So the Score affordance never appeared and the API rejected scores with 422.

This always creates **side 2** — as a **player-less sentinel "No opponent" side** when there's no registered opponent. That single change makes the match scorable while it still reads as opponent-less everywhere:

- `can_score` / `_enforce_scorable` now pass; creating a no-opponent match drops you straight on the scoring screen.
- Serialization renders the "No opponent" placeholder; rating updates skip the player-less side, so it stays unrated (`affects_rating` is still forced `False`).

## Frontend

- The match list, detail hero, game grid, and players card render the dashed-circle "unknown player" placeholder for a player-less side.
- That same icon is reused in the **match list at avatar size** (smaller version of the detail-page placeholder).
- The MSW dev store and test factories emit the same sentinel shape, and the MSW score handler no longer rejects no-opponent matches (it had diverged from the API).

## Tests / checks

- API `pytest`: 300 passed (replaced the obsolete "can't score / single side" tests with sentinel-shape + score-to-completion tests). `mypy --strict` clean.
- web-client `vitest`: 92 passed; Playwright e2e: 126 passed; lint + `tsc -b`/build clean.
- No request/response schema shape change; `schema.d.ts` regenerated for the updated `MatchCreate` docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)