### PR TITLE
Fix tie-score validation message for scores below 11

### DIFF
--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -196,11 +196,11 @@ class MatchGameScoreWrite(BaseModel):
     @model_validator(mode="after")
     def _table_tennis_rules(self):
         a, b = self.side_1_points, self.side_2_points
-        if a == b:
-            raise ValueError("A game cannot end in a tie.")
         winner, loser = max(a, b), min(a, b)
         if winner < 11:
             raise ValueError("The winning side must reach at least 11 points.")
+        if a == b:
+            raise ValueError("A game cannot end in a tie.")
         if winner == 11 and loser > 9:
             raise ValueError(
                 f"At 10–10 the game enters deuce; the winner must lead by 2. "

--- a/web-client/e2e/score-entry.spec.ts
+++ b/web-client/e2e/score-entry.spec.ts
@@ -133,10 +133,10 @@ function projectMatchDetails(seed: Seed) {
 }
 
 function validateScore(side1: number, side2: number): string | null {
-  if (side1 === side2) return 'A game cannot end in a tie.'
   const winner = Math.max(side1, side2)
   const loser = Math.min(side1, side2)
   if (winner < 11) return 'The winning side must reach at least 11 points.'
+  if (side1 === side2) return 'A game cannot end in a tie.'
   if (winner === 11 && loser > 9) {
     return `At 10–10 the game enters deuce; the winner must lead by 2. ${winner}–${loser} is not a legal final score.`
   }

--- a/web-client/src/lib/scoring.test.ts
+++ b/web-client/src/lib/scoring.test.ts
@@ -14,8 +14,9 @@ describe('illegalScoreReason', () => {
   })
 
   it.each([
-    [11, 11, /tie/i],
-    [0, 0, /tie/i],
+    [11, 11, /tie/i], // tied at/above 11 — the reaching-11 hint doesn't apply
+    [5, 5, /at least 11/i], // tied below 11 — point them at the 11 threshold
+    [0, 0, /at least 11/i],
     [8, 5, /at least 11/i],
     [10, 9, /at least 11/i],
     [11, 10, /deuce/i], // win-by-1 at deuce — the reported bug

--- a/web-client/src/lib/scoring.ts
+++ b/web-client/src/lib/scoring.ts
@@ -3,10 +3,10 @@
 // final score the server will reject with a 422. Returns the reason a score is
 // illegal, or null when it's a legal final score.
 export function illegalScoreReason(a: number, b: number): string | null {
-  if (a === b) return 'A game cannot end in a tie.'
   const winner = Math.max(a, b)
   const loser = Math.min(a, b)
   if (winner < 11) return 'The winning side must reach at least 11 points.'
+  if (a === b) return 'A game cannot end in a tie.'
   if (winner === 11 && loser > 9)
     return 'At 10–10 the game enters deuce — the winner must lead by 2.'
   if (winner > 11) {

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -618,10 +618,10 @@ export function validateScore(side1: number, side2: number): string | null {
   if (!Number.isInteger(side2) || side2 < 0 || side2 > 99) {
     return 'Each side must score between 0 and 99 points.'
   }
-  if (side1 === side2) return 'A game cannot end in a tie.'
   const winner = Math.max(side1, side2)
   const loser = Math.min(side1, side2)
   if (winner < 11) return 'The winning side must reach at least 11 points.'
+  if (side1 === side2) return 'A game cannot end in a tie.'
   if (winner === 11 && loser > 9) {
     return `At 10–10 the game enters deuce; the winner must lead by 2. ${winner}–${loser} is not a legal final score.`
   }


### PR DESCRIPTION
## What

A tied score like **5-5** reported _"A game cannot end in a tie."_ when the more useful reason is that neither side reached 11. This reorders the table-tennis rule checks so `winner < 11` is evaluated **before** the tie check.

- Tied **below** 11 (5-5, 0-0, 10-10) → "The winning side must reach at least 11 points."
- Tied **at/above** 11 (11-11, 12-12) → still "A game cannot end in a tie." (the reach-11 hint doesn't apply)
- All non-tied scores are unaffected.

## Where

Applied to all four mirrors of the rule so they stay in lock-step:

- `api/app/schemas/match.py` — server-side `MatchGameScoreWrite._table_tennis_rules`
- `web-client/src/lib/scoring.ts` — client validator
- `web-client/src/mocks/match-store.ts` — MSW mock
- `web-client/e2e/score-entry.spec.ts` — e2e mirror

Plus updated `web-client/src/lib/scoring.test.ts` (added a `5-5` case, corrected the `0-0` expectation).

## Notes

- Server still rejects the same scores with 422 — only the message text changes for tied-below-11. The OpenAPI schema is unchanged (`model_validator` logic doesn't serialize), so no `schema.d.ts` drift.

## Tests

pytest (299), mypy, vitest (93), web-client e2e (126), lint, build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)