### PR TITLE
Fix temporal framing on the match detail page

### DIFF
--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -307,7 +307,7 @@ describe('MatchDetailsView', () => {
       container.querySelector('.md-hero__name--ghost'),
     ).toHaveTextContent('No opponent')
     expect(container.querySelector('.md-avatar--ghost')).toBeInTheDocument()
-    // The Players & form card mirrors it on the opponent side.
+    // The Players snapshot card mirrors it on the opponent side.
     expect(
       container.querySelector('.md-profile__name--ghost'),
     ).toHaveTextContent('No opponent')
@@ -449,16 +449,20 @@ describe('MatchDetailsView', () => {
 
     const { container } = renderDetails('m-form')
 
-    // Wait for the Players & form card title to render.
+    // Wait for the Players snapshot card title to render. The header now
+    // carries the temporal frame so the per-field labels don't have to.
     await waitFor(() =>
       expect(container.querySelector('.md-card__hd h3')).toHaveTextContent(
-        'Players & form',
+        'Players · going into this match',
       ),
     )
     // My side: 1 W and 1 L with the right opponent / score labels.
     const myForm = screen.getByTestId('form-1')
+    expect(within(myForm).getByText('Form · 1–1')).toBeInTheDocument()
+    // The with-history half leads with a one-line "going in" summary, mirroring
+    // the empty half's "first one" sentence.
     expect(
-      within(myForm).getByText('Form before this match · 1–1'),
+      within(myForm).getByText('12 prior matches · 75% win rate going in'),
     ).toBeInTheDocument()
     expect(within(myForm).getByText('silva.r')).toBeInTheDocument()
     expect(within(myForm).getByText('3–1')).toBeInTheDocument()
@@ -477,9 +481,7 @@ describe('MatchDetailsView', () => {
     // Rookie shows the empty state, not a result list.
     const oppForm = screen.getByTestId('form-2')
     expect(within(oppForm).getByText(/No prior matches yet/)).toBeInTheDocument()
-    expect(
-      within(oppForm).queryByText(/Form before this match · /),
-    ).not.toBeInTheDocument()
+    expect(within(oppForm).queryByText(/Form · /)).not.toBeInTheDocument()
     // Unrated rookie: no rating number, no sparkline, no win rate.
     const oppRating = screen.getByTestId('rating-box-2')
     expect(within(oppRating).getByText('Unrated')).toBeInTheDocument()
@@ -604,7 +606,9 @@ describe('MatchDetailsView', () => {
 
     await waitFor(() => {
       const headings = Array.from(container.querySelectorAll('.md-card__hd h3'))
-      expect(headings.map((h) => h.textContent)).toContain('Rating change')
+      expect(headings.map((h) => h.textContent)).toContain(
+        'Result · rating change',
+      )
     })
     const rows = container.querySelectorAll('.md-rating-row')
     expect(rows).toHaveLength(2)
@@ -639,6 +643,57 @@ describe('MatchDetailsView', () => {
       expect(container.querySelector('.md-card__hd h3')).toBeInTheDocument(),
     )
     const headings = Array.from(container.querySelectorAll('.md-card__hd h3'))
-    expect(headings.map((h) => h.textContent)).not.toContain('Rating change')
+    expect(headings.map((h) => h.textContent)).not.toContain(
+      'Result · rating change',
+    )
+  })
+
+  it('hides the rating change card while the match is still live', async () => {
+    // A live match may carry seeded/projected ratings; surfacing them in a
+    // "result" card mid-match contradicts the pre-match snapshot panel, so the
+    // card stays hidden until the match is Final.
+    const match = matchDetails({
+      id: 'm-live-rated',
+      status: 'in_progress',
+      status_label: 'Live',
+      affects_rating: true,
+      sides: [
+        {
+          side_number: 1,
+          players: [{ user_id: 'u-me', username: 'me', is_current_user: true }],
+          games_won: 1,
+          won: null,
+          is_current_user_side: true,
+          rating_change: { before: 1500, after: 1512, delta: 12 },
+        },
+        {
+          side_number: 2,
+          players: [
+            { user_id: 'u-opp', username: 'opp', is_current_user: false },
+          ],
+          games_won: 0,
+          won: null,
+          is_current_user_side: false,
+          rating_change: { before: 1500, after: 1488, delta: -12 },
+        },
+      ],
+      games: [],
+      current_game: null,
+      can_score: false,
+    })
+    server.use(
+      http.get('*/v1/matches/m-live-rated', () => HttpResponse.json(match)),
+    )
+
+    const { container } = renderDetails('m-live-rated')
+
+    await waitFor(() =>
+      expect(container.querySelector('.md-card__hd h3')).toBeInTheDocument(),
+    )
+    const headings = Array.from(container.querySelectorAll('.md-card__hd h3'))
+    expect(headings.map((h) => h.textContent)).not.toContain(
+      'Result · rating change',
+    )
+    expect(container.querySelector('.md-rating-row')).toBeNull()
   })
 })

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -1007,7 +1007,7 @@ function RatingRow({ side, isFirst }: { side: SideView; isFirst: boolean }) {
             </div>
           ) : (
             <div className="md-rating-row__numbers">
-              <span className="from">No rating change</span>
+              <span className="from">Unrated player</span>
             </div>
           )}
         </div>

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -16,7 +16,7 @@ import {
 import { AppShell } from '@/components/app-shell'
 import { Overline } from '@/components/overline'
 import { cn, initialsOf } from '@/lib/utils'
-import { fmtDateShort } from '@/lib/dates'
+import { fmtDateShort, fmtDateTimeShort } from '@/lib/dates'
 import { formatRatingDelta } from '@/lib/rating'
 import { scoringEditRoute, scoringNewRoute, useMatch } from '@/api/matches'
 import type { components } from '@/api/schema'
@@ -98,6 +98,9 @@ type MatchView = {
   bestOf: number
   gamesToWin: number
   rated: boolean
+  // When the match was created — used to stamp the pre-match "snapshot" of
+  // player form/ratings with the moment those numbers were captured.
+  createdAt: string
   // Left/right are perspective-relative: when the current user is on a side
   // they're left (and `leftSide.isCurrentUser` is true); otherwise left = side
   // 1, right = side 2.
@@ -247,6 +250,7 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
     bestOf: data.best_of,
     gamesToWin: data.games_to_win,
     rated: data.affects_rating,
+    createdAt: data.created_at,
     leftSide: leftView,
     rightSide: rightView,
     games,
@@ -334,9 +338,15 @@ function MatchDetailsPage({ view, matchId }: { view: MatchView; matchId: string 
   // Comments + share modal are still part of the design handoff but have no
   // real data behind them yet; gate them off and flip when each lands.
   const showAuxCards = false
+  // Only an over-and-done match has a real rating change to show. A live match
+  // may carry seeded/projected ratings that look like a finished result — the
+  // snapshot panel already states the pre-match numbers, so a "result" card
+  // mid-match reads as a contradiction. Gate it to Final. (Flagged for design:
+  // a live "PROJECTED · IF … WINS" card could replace this later.)
   const showRatingCard =
-    view.leftSide.ratingChange !== null ||
-    view.rightSide?.ratingChange != null
+    view.state === 'final' &&
+    (view.leftSide.ratingChange !== null ||
+      view.rightSide?.ratingChange != null)
 
   return (
     <div className="match-details">
@@ -711,8 +721,10 @@ function PlayersCard({ view }: { view: MatchView }) {
   return (
     <div className="md-card">
       <div className="md-card__hd">
-        <Overline as="h3">Players &amp; form</Overline>
-        <span className="md-card__hd-meta">5 BEFORE THIS MATCH</span>
+        <Overline as="h3">Players · going into this match</Overline>
+        <span className="md-card__hd-meta">
+          SNAPSHOT · {fmtDateTimeShort(view.createdAt).toUpperCase()}
+        </span>
       </div>
       <div className="md-players">
         <PlayerProfile side={view.leftSide} won={view.leftSide.won === true} />
@@ -735,6 +747,16 @@ function PlayerProfile({ side, won }: { side: SideView; won: boolean }) {
   const form = side.recentForm
   const wins = form.filter((r) => r.is_win).length
   const losses = form.length - wins
+  // A one-line "going in" summary so the with-history half leads with a
+  // sentence, mirroring the empty half's "first one" line (no lone row list).
+  const careerMatches = side.careerMatchesBefore
+  const careerWinRate =
+    careerMatches > 0
+      ? Math.round((side.careerWinsBefore / careerMatches) * 100)
+      : null
+  const formSummary =
+    `${careerMatches} prior ${careerMatches === 1 ? 'match' : 'matches'}` +
+    (careerWinRate !== null ? ` · ${careerWinRate}% win rate going in` : '')
   return (
     <div className="md-profile">
       <div className="md-profile__identity">
@@ -748,9 +770,7 @@ function PlayerProfile({ side, won }: { side: SideView; won: boolean }) {
       <RatingBox side={side} />
       <div className="md-profile__form" data-testid={`form-${side.sideNumber}`}>
         <div className="md-kicker">
-          {form.length === 0
-            ? 'Form before this match'
-            : `Form before this match · ${wins}–${losses}`}
+          {form.length === 0 ? 'Form' : `Form · ${wins}–${losses}`}
         </div>
         {form.length === 0 ? (
           <div className="md-profile__empty">
@@ -758,11 +778,14 @@ function PlayerProfile({ side, won }: { side: SideView; won: boolean }) {
             {side.isCurrentUser ? 'your' : 'their'} first one.
           </div>
         ) : (
-          <ul className="md-profile__form-list">
-            {form.map((r) => (
-              <FormRow key={r.match_id} result={r} />
-            ))}
-          </ul>
+          <>
+            <div className="md-profile__form-summary">{formSummary}</div>
+            <ul className="md-profile__form-list">
+              {form.map((r) => (
+                <FormRow key={r.match_id} result={r} />
+              ))}
+            </ul>
+          </>
         )}
       </div>
       <CareerStats side={side} />
@@ -946,7 +969,7 @@ function RatingCard({ view }: { view: MatchView }) {
   return (
     <div className="md-card">
       <div className="md-card__hd">
-        <Overline as="h3">Rating change</Overline>
+        <Overline as="h3">Result · rating change</Overline>
       </div>
       <div className="md-card__body md-rating-card__body">
         {sides.map((side, i) => (
@@ -984,7 +1007,7 @@ function RatingRow({ side, isFirst }: { side: SideView; isFirst: boolean }) {
             </div>
           ) : (
             <div className="md-rating-row__numbers">
-              <span className="from">Rating updates when the match ends</span>
+              <span className="from">No rating change</span>
             </div>
           )}
         </div>

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2494,7 +2494,7 @@ body.dark.fortymm-theme {
   top: 88px;
 }
 
-/* ---------- Players & form card ---------- */
+/* ---------- Players snapshot (going into this match) card ---------- */
 .fortymm-theme .md-players {
   display: grid;
   grid-template-columns: 1fr 1px 1fr;
@@ -2659,6 +2659,14 @@ body.dark.fortymm-theme {
   font: 400 13px var(--font-ui);
   color: var(--fg-3);
   padding: 8px 0;
+  border-top: 1px dashed var(--border-subtle);
+}
+/* The "going in" one-liner above the form list — matches the empty state's
+   muted, dashed-rule treatment so both halves of the panel read symmetrically. */
+.fortymm-theme .md-profile__form-summary {
+  font: 400 13px var(--font-ui);
+  color: var(--fg-3);
+  padding: 8px 0 2px;
   border-top: 1px dashed var(--border-subtle);
 }
 .fortymm-theme .md-profile__career {

--- a/web-client/src/lib/dates.ts
+++ b/web-client/src/lib/dates.ts
@@ -23,6 +23,12 @@ export function fmtDateShort(iso: string | null | undefined): string {
   return format(parseApiDate(iso), 'MMM d')
 }
 
+/** Compact day + 24h time for a snapshot stamp — e.g. "12 May, 09:00". */
+export function fmtDateTimeShort(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  return format(parseApiDate(iso), 'd MMM, HH:mm')
+}
+
 export function fmtDateRel(iso: string | null | undefined): string {
   if (!iso) return '—'
   return formatDistanceToNowStrict(parseApiDate(iso), { addSuffix: true })


### PR DESCRIPTION
## Why

On the match detail page (`/matches/:id`), the **pre-match player snapshot** and the **post-match rating-change card** described different points in time but only one used temporal language, so the page read as self-contradicting — e.g. a player showing `Unrated / 0 career matches` right beside a rating that just moved 1500 → 1383 (−117). Both were correct (pre-match vs. post-match); nothing on the page said so.

## What changed (web-client only — labels, copy, small layout signals; no data touched)

- **Section header carries the frame:** `PLAYERS & FORM` → **`PLAYERS · GOING INTO THIS MATCH`**.
- **Dropped the per-field qualifier:** `FORM BEFORE THIS MATCH · 2–0` → **`FORM · 2–0`**.
- **Timestamp pill** replaces the static `5 BEFORE THIS MATCH` badge → **`SNAPSHOT · 22 MAY, 04:34`**, built from the match's `created_at` (new `fmtDateTimeShort` helper).
- **Result card labeled as the after-state:** `RATING CHANGE` → **`RESULT · RATING CHANGE`**.
- **Symmetric helper copy:** kept the empty half's "first one" sentence and gave the with-history half a matching one-liner — **`N prior matches · X% win rate going in`**.
- **Live matches:** the result card is now gated to `state === 'final'`, so a Live match no longer surfaces seeded/projected ratings that look like a finished result. The stale "Rating updates when the match ends" fallback row became **`No rating change`**.

## Flagged for design review

- **Step 7 decision:** chose *hide on Live* (faster) over a `PROJECTED · IF … WINS` card — a projected card could replace it later (noted in a code comment).
- **Optional `AS OF KICKOFF` chips** were skipped — the header frame + result-card label already resolve the contradiction in testing.
- The form kicker `Form · {W–L}` is recent-form, while the new summary line uses career totals — intentional (recent vs. career), worth a design eyeball.

## Testing

- vitest: 94/94 (incl. a new "hides the rating change card while the match is still live" test)
- lint + `tsc -b` + `vite build`: clean
- web-client Playwright e2e: 126/126
- Verified visually against Final and Live seed matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)