### PR TITLE
Stop silently mutating the username input on /settings

### DIFF
--- a/web-client/src/routes/settings.test.tsx
+++ b/web-client/src/routes/settings.test.tsx
@@ -142,3 +142,49 @@ describe('SettingsPage email section', () => {
     expect(submit).toBeDisabled()
   })
 })
+
+describe('SettingsPage username section', () => {
+  it('preserves what the user typed without silently lowercasing or stripping spaces', async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    const input = (await screen.findByLabelText(/^username$/i)) as HTMLInputElement
+    await user.clear(input)
+    await user.type(input, 'Foo bar')
+
+    expect(input.value).toBe('Foo bar')
+    // Counter reflects the actual typed length, not a post-strip length.
+    const section = input.closest('section') as HTMLElement
+    expect(within(section).getByText('7/40')).toBeInTheDocument()
+  })
+
+  it('shows a clear inline error when uppercase is typed', async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    const input = await screen.findByLabelText(/^username$/i)
+    await user.clear(input)
+    await user.type(input, 'Foo')
+
+    const section = input.closest('section') as HTMLElement
+    expect(
+      within(section).getByText(/lowercase letters only/i),
+    ).toBeInTheDocument()
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+    expect(
+      within(section).getByRole('button', { name: /save changes/i }),
+    ).toBeDisabled()
+  })
+
+  it('shows a clear inline error when whitespace is typed', async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    const input = await screen.findByLabelText(/^username$/i)
+    await user.clear(input)
+    await user.type(input, 'foo bar')
+
+    const section = input.closest('section') as HTMLElement
+    expect(within(section).getByText(/no spaces/i)).toBeInTheDocument()
+  })
+})

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -74,8 +74,14 @@ const USERNAME_MAX = 40
 
 function validateUsername(u: string): Validation {
   if (!u) return { ok: false, err: 'Username is required.' }
-  if (u.length < USERNAME_MIN) return { ok: false, err: `At least ${USERNAME_MIN} characters.` }
+  // Surface the specific reason a username is invalid so the user knows what
+  // to fix — rather than a generic "allowed characters" hint that they have
+  // to decode against what they typed. Char checks come before length checks
+  // so "Fo" reads as "uppercase isn't allowed" rather than "too short".
+  if (/[A-Z]/.test(u)) return { ok: false, err: 'Lowercase letters only — no uppercase.' }
+  if (/\s/.test(u)) return { ok: false, err: 'No spaces — try a dot, hyphen or underscore instead.' }
   if (u.length > USERNAME_MAX) return { ok: false, err: `No more than ${USERNAME_MAX} characters.` }
+  if (u.length < USERNAME_MIN) return { ok: false, err: `At least ${USERNAME_MIN} characters.` }
   if (!USERNAME_RE.test(u))
     return {
       ok: false,
@@ -639,8 +645,13 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
 
   const clientV = useMemo(() => validateUsername(val), [val])
   const dirty = val !== currentUsername
+  // If the value contains a disallowed character (e.g. uppercase, whitespace,
+  // punctuation outside the allowed set), surface that immediately — the user
+  // just typed it and we want them to know it's not going through. Length
+  // errors stay gated on blur so we don't nag while they're still typing.
+  const hasInvalidChar = /[^a-z0-9._-]/.test(val)
   const displayedErr =
-    serverErr ?? (touched && !clientV.ok ? (clientV.err ?? null) : null)
+    serverErr ?? ((touched || hasInvalidChar) && !clientV.ok ? (clientV.err ?? null) : null)
 
   const onSave = async () => {
     if (!clientV.ok || !dirty) return
@@ -725,7 +736,7 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
             className={`fmm-input fmm-input--mono ${displayedErr ? 'fmm-input--err' : dirty && clientV.ok ? 'fmm-input--ok' : ''}`}
             value={val}
             onChange={(e) => {
-              setVal(e.target.value.toLowerCase().replace(/\s/g, ''))
+              setVal(e.target.value)
               if (serverErr) setServerErr(null)
             }}
             onBlur={() => setTouched(true)}
@@ -733,6 +744,7 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
             style={{ paddingLeft: 30 }}
             spellCheck={false}
             autoComplete="off"
+            autoCapitalize="none"
             aria-invalid={!!displayedErr || undefined}
           />
         </div>


### PR DESCRIPTION
## Summary

- The `/settings` username field used to run `e.target.value.toLowerCase().replace(/\s/g, '')` in `onChange`, so typing "Foo bar" silently became "foobar" and the character counter showed the post-strip length, masking the mutation.
- Now the input preserves what the user typed verbatim. `validateUsername` reorders checks so character-level errors take precedence over length errors and surfaces specific messages ("Lowercase letters only — no uppercase.", "No spaces — try a dot, hyphen or underscore instead.").
- A new `hasInvalidChar` predicate makes the inline error appear eagerly while disallowed characters are present; length errors stay gated on blur so we don't nag mid-typing. Added `autoCapitalize="none"` for mobile keyboards.

## Test plan

- [x] `npm run test:run` — 97/97 vitest passing, including 3 new cases asserting preserved value/counter, eager uppercase error + aria-invalid + disabled save, and eager whitespace error
- [x] `npm run lint` — clean (1 pre-existing warning in mockServiceWorker.js)
- [x] `npm run build` — tsc + vite build clean
- [x] `npm run test:e2e` — 126/126 Playwright passing
- [ ] Manual: type "Foo bar" into the username field at /settings — input stays "Foo bar", counter shows 7/40, inline error reads "Lowercase letters only — no uppercase.", Save button disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)