### PR TITLE
Fix back-button data-integrity bug on score-entry

### DIFF
--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -355,23 +355,13 @@ describe('ScoreEntry — create', () => {
     )
   })
 
-  it('surfaces an edit-link affordance when the game is already scored (409)', async () => {
+  it('locks the page when a concurrent scorer beat us to it and the server 409s (race)', async () => {
+    // The cache says the game is un-scored, but between our GET and POST
+    // another participant scored it. The cache-first "already scored" case
+    // is caught proactively by the redirect (see the next test); this test
+    // covers the post-submit race where game.score is null in the cache.
     server.use(
-      http.get('*/v1/matches/m-1', () =>
-        HttpResponse.json(
-          inProgressMatch({
-            games: [
-              {
-                id: 'g-3',
-                game_number: 3,
-                score: score('s-3-existing', 11, 6),
-              },
-              { id: 'g-4', game_number: 4, score: null },
-            ],
-            current_game: { id: 'g-4', game_number: 4 },
-          }),
-        ),
-      ),
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
       http.post('*/v1/matches/m-1/games/g-3/scores', () =>
         HttpResponse.json(
           { detail: 'This game has already been scored.' },
@@ -388,13 +378,33 @@ describe('ScoreEntry — create', () => {
     await user.type(screen.getByRole('textbox', { name: 'nguyen.t score' }), '6')
     await user.click(screen.getByRole('button', { name: /save/i }))
 
-    const editLink = await screen.findByRole('link', {
-      name: /edit existing score/i,
-    })
-    expect(editLink).toHaveAttribute(
-      'href',
-      '/matches/m-1/games/g-3/scores/s-3-existing/edit',
+    expect(
+      await screen.findByText(/already been scored/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Back to match' }),
+    ).toHaveAttribute('href', '/matches/m-1')
+  })
+
+  it('redirects to the existing score\'s edit page when landing on /scores/new for an already-scored game', async () => {
+    // Simulates the browser-Back-after-save flow: the user advanced to game 3
+    // (scoring g-3), pressed Back to /games/g-1/scores/new, but g-1 already
+    // has a score on the server. Without the redirect the page would render
+    // empty inputs over a tally that already counts the win, and an enabled
+    // Save would either 409 or duplicate.
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
     )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameId: 'g-1' })
+
+    await waitFor(() =>
+      expect(screen.getByText('scoring-edit m-1 g-1 s-1')).toBeInTheDocument(),
+    )
+    // The /scores/new page must not have rendered its Save button.
+    expect(
+      screen.queryByRole('button', { name: /save/i }),
+    ).not.toBeInTheDocument()
   })
 
   it('disables the form and shows a back link when the match is no longer scorable (409)', async () => {

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -94,6 +94,19 @@ function ScoreEntryInner({
     return <Navigate {...matchDetailRoute(matchId)} />
   }
 
+  // Landing on /scores/new for a game that's already scored (e.g. browser
+  // Back after saving and advancing) would show empty inputs alongside the
+  // tally that already counts the win. Replace into the score's edit route
+  // so the form reflects reality and a Save can't create a duplicate.
+  if (mode.kind === 'create' && game.score) {
+    return (
+      <Navigate
+        {...scoringEditRoute(matchId, gameId, game.score.id)}
+        replace
+      />
+    )
+  }
+
   const mySideNumber = mySide.side_number === 2 ? 2 : 1
   const oppName = oppSide.players[0]?.username ?? 'Opponent'
   const meName = mySide.players[0]?.username ?? 'You'
@@ -198,17 +211,6 @@ function ScoreEntryInner({
         ? 'Save game & next →'
         : 'Save final game →'
 
-  // The "already scored" 409 only happens on the create route. The existing
-  // score id is in the cached payload, so we can offer a direct switch to its
-  // edit route.
-  const editLink =
-    mode.kind === 'create' &&
-    apiError?.status === 409 &&
-    apiError.detail?.includes('already been scored') &&
-    game.score
-      ? scoringEditRoute(matchId, gameId, game.score.id)
-      : null
-
   return (
     <AppShell>
       <div className="entry-wrap">
@@ -274,11 +276,6 @@ function ScoreEntryInner({
                 {lockedReason}
               </div>
               <div className="action-btns">
-                {editLink && (
-                  <Link {...editLink} className="btn ghost">
-                    Edit existing score
-                  </Link>
-                )}
                 <Link {...matchDetailRoute(matchId)} className="btn primary">
                   Back to match
                 </Link>


### PR DESCRIPTION
## Summary
- Browser-Back from Game N after saving lands on Game N-1's `/scores/new` with empty inputs over a tally that already counts the win — the Save button is active and would either 409 or create a duplicate.
- Add an early-return `<Navigate replace>` in `ScoreEntryInner` that redirects create-mode to the score's edit route whenever the cached match shows the game is already scored.
- Drop the now-unreachable 409 "Edit existing score" affordance (the proactive redirect catches the same case earlier); keep the 409 alert + Back-to-match link for the post-submit race where the cache is stale.

## Test plan
- [x] `npm run test:run` — 95/95 vitest pass, including the new redirect test and the rewritten race-condition test
- [x] `npm run lint` — clean
- [x] `npm run build` (tsc -b + vite build) — clean
- [x] `npm run test:e2e` — 126/126 Playwright pass
- [ ] Manual: start a Bo7 match, save Game 1, press browser Back — land on Game 1's edit page with the persisted score, not on an empty `/scores/new`

🤖 Generated with [Claude Code](https://claude.com/claude-code)