### PR TITLE
Remove kebab "Row actions" placeholder from the matches list

### DIFF
--- a/web-client/src/routes/matches/index.css
+++ b/web-client/src/routes/matches/index.css
@@ -348,25 +348,6 @@
   color: var(--fg-2);
 }
 
-.match-list-page .row-action {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  width: 28px;
-  height: 28px;
-  border-radius: 6px;
-  color: var(--fg-3);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-    color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-.match-list-page .row-action:hover {
-  background: var(--bg-raised);
-  color: var(--fg-1);
-}
-
 /* ============ Context chips ============ */
 .match-list-page .ctx-chip {
   display: inline-flex;

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -6,7 +6,6 @@ import {
   ChevronsLeft,
   ChevronsRight,
   Inbox,
-  MoreHorizontal,
   Search,
   User,
   X,
@@ -395,15 +394,7 @@ function MatchRow({
               Score
             </Link>
           </Button>
-        ) : (
-          <button
-            type="button"
-            className="row-action"
-            aria-label="Row actions"
-          >
-            <MoreHorizontal size={16} strokeWidth={2} />
-          </button>
-        )}
+        ) : null}
       </td>
     </tr>
   )


### PR DESCRIPTION
## Summary
- Removes the per-row kebab `Row actions` button on `/matches`. The button had no `onClick` and opened no menu — it was a visual placeholder.
- Drops the now-unused `MoreHorizontal` import and the orphan `.row-action` CSS.
- Rows with an in-progress game still render the **Score** button; rows without render an empty action cell.

## Test plan
- [x] `npm run test:run` (vitest) — 93/93 pass
- [x] `npm run lint` — clean (one pre-existing warning in generated `mockServiceWorker.js`)
- [x] `npm run build` (tsc + vite) — passes
- [x] `npm run test:e2e` (Playwright) — 126/126 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)