### PR TITLE
Drop the guest path; unify "No opponent" label across surfaces

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -321,9 +321,9 @@ async def create_match(
             detail="A rated match needs a registered opponent.",
         )
 
-    # Guest / "start without opponent" matches get a sentinel opponent side
-    # (no player) below, so they're scorable but can never affect ratings
-    # regardless of the requested flag.
+    # Solo matches (no opponent picked) get a player-less sentinel opponent
+    # side below, so they're scorable but can never affect ratings regardless
+    # of the requested flag.
     affects_rating = payload.rated and opponent is not None
 
     league = await resolve_league(db, payload.league_id)

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -23,10 +23,10 @@ STATUS_LABELS: dict[MatchStatus, str] = {
 class MatchCreate(BaseModel):
     """Request body for ``POST /v1/matches``.
 
-    ``opponent_user_id`` is optional: a match created without a registered
-    opponent (a guest, or "start without opponent") gets a player-less sentinel
-    opponent side — so it's still scorable — and is always unrated, since the
-    rating system needs two registered sides.
+    ``opponent_user_id`` is optional: a solo match (the client submits one
+    when the user starts without picking an opponent) gets a player-less
+    sentinel opponent side — so it's still scorable — and is always unrated,
+    since the rating system needs two registered sides.
 
     ``league_id`` is optional: when omitted the server binds the match to the
     default league (see ``app.leagues.get_default_league``).

--- a/web-client/e2e/match-creation.spec.ts
+++ b/web-client/e2e/match-creation.spec.ts
@@ -160,6 +160,7 @@ test.describe('New match — picking an opponent', () => {
     await expect(nm.ratedSwitch).not.toBeChecked()
 
     await nm.start()
+    await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
       { opponent_user_id: LINUS.id, best_of: 5, rated: false },
     ])

--- a/web-client/e2e/match-creation.spec.ts
+++ b/web-client/e2e/match-creation.spec.ts
@@ -35,8 +35,11 @@ test.describe('New match — page', () => {
     await expect(nm.heading).toBeVisible()
     await expect(nm.youName).toHaveText(CREATOR_USERNAME)
     await expect(nm.startButton).toBeEnabled()
-    // Rated is on by default before an opponent is chosen.
-    await expect(nm.ratedSwitch).toBeChecked()
+    // Rated defaults off so submitting without picking an opponent "just
+    // works" — the no-opponent match is unrated by definition. Picking a
+    // registered opponent unlocks the toggle but does not auto-flip it.
+    await expect(nm.ratedSwitch).not.toBeChecked()
+    await expect(nm.ratedSwitch).toBeDisabled()
   })
 
   test('lists the registered players in the picker', async ({ page }) => {
@@ -56,34 +59,37 @@ test.describe('New match — page', () => {
   })
 })
 
-test.describe('New match — validation', () => {
-  test('blocks a rated match with no opponent and sends no request', async ({
-    page,
-  }) => {
-    const nm = await NewMatchPage.open(page, { players: ROSTER })
-
-    await nm.start()
-
-    await expect(nm.error).toHaveText(/rated match needs an opponent/i)
-    await expect(page).toHaveURL(/\/matches\/new$/)
-    expect(nm.store.createdMatches).toHaveLength(0)
-  })
-})
-
 test.describe('New match — creating a match', () => {
-  test('creates a rated match against a registered opponent', async ({
+  test('creates an unrated match against a registered opponent by default', async ({
     page,
   }) => {
     const nm = await NewMatchPage.open(page, { players: ROSTER })
 
     await nm.pickPlayer(GRACE.username)
     await expect(nm.selectedOpponentName).toHaveText(GRACE.username)
-    await expect(nm.summaryTop).toContainText('You vs')
+    await expect(nm.summaryTop).toContainText('You')
     await nm.start()
 
     await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
-      { opponent_user_id: GRACE.id, best_of: 5, rated: true },
+      { opponent_user_id: GRACE.id, best_of: 5, rated: false },
+    ])
+  })
+
+  test('creates a rated match when Rated is toggled on', async ({ page }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.pickPlayer(ADA.username)
+    // Picking a registered opponent unlocks the Rated toggle; the user opts
+    // into rating explicitly per click.
+    await nm.toggleRated()
+    await expect(nm.ratedSwitch).toBeChecked()
+    await expect(nm.summarySub).toContainText('Rated')
+    await nm.start()
+
+    await expect(page).toHaveURL(SCORING_URL)
+    expect(nm.store.createdMatches).toEqual([
+      { opponent_user_id: ADA.id, best_of: 5, rated: true },
     ])
   })
 
@@ -98,24 +104,7 @@ test.describe('New match — creating a match', () => {
 
     await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
-      { opponent_user_id: ADA.id, best_of: 7, rated: true },
-    ])
-  })
-
-  test('creates an unrated match when Rated is toggled off', async ({
-    page,
-  }) => {
-    const nm = await NewMatchPage.open(page, { players: ROSTER })
-
-    await nm.pickPlayer(ADA.username)
-    await nm.toggleRated()
-    await expect(nm.ratedSwitch).not.toBeChecked()
-    await expect(nm.summarySub).toContainText('Unrated')
-    await nm.start()
-
-    await expect(page).toHaveURL(SCORING_URL)
-    expect(nm.store.createdMatches).toEqual([
-      { opponent_user_id: ADA.id, best_of: 5, rated: false },
+      { opponent_user_id: ADA.id, best_of: 7, rated: false },
     ])
   })
 
@@ -124,25 +113,8 @@ test.describe('New match — creating a match', () => {
   }) => {
     const nm = await NewMatchPage.open(page, { players: ROSTER })
 
-    await nm.startWithoutOpponent()
-    await nm.start()
-
-    await expect(page).toHaveURL(SCORING_URL)
-    expect(nm.store.createdMatches).toEqual([
-      { opponent_user_id: null, best_of: 5, rated: false },
-    ])
-  })
-
-  test('forces a guest match unrated regardless of the toggle', async ({
-    page,
-  }) => {
-    const nm = await NewMatchPage.open(page, { players: ROSTER })
-
-    await nm.addGuest()
-    // A guest can't be rated, so the switch is disabled and off.
-    await expect(nm.ratedSwitch).toBeDisabled()
-    await expect(nm.ratedSwitch).not.toBeChecked()
-    await expect(nm.summarySub).toContainText('Unrated')
+    // No opponent picked, no toggle flipped — Start match submits a solo,
+    // unrated match (the form's only no-opponent path now).
     await nm.start()
 
     await expect(page).toHaveURL(SCORING_URL)
@@ -166,7 +138,30 @@ test.describe('New match — picking an opponent', () => {
     await nm.start()
     await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
-      { opponent_user_id: LINUS.id, best_of: 5, rated: true },
+      { opponent_user_id: LINUS.id, best_of: 5, rated: false },
+    ])
+  })
+
+  test('resets the Rated toggle when the opponent is cleared', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    // Pick Ada, flip Rated on, then clear the opponent. The toggle must come
+    // back off — otherwise re-picking would silently submit a rated match
+    // the user didn't ask for, and the (now-disabled) toggle would offer no
+    // way to switch it back off.
+    await nm.pickPlayer(ADA.username)
+    await nm.toggleRated()
+    await expect(nm.ratedSwitch).toBeChecked()
+
+    await nm.changeOpponent()
+    await nm.pickPlayer(LINUS.username)
+    await expect(nm.ratedSwitch).not.toBeChecked()
+
+    await nm.start()
+    expect(nm.store.createdMatches).toEqual([
+      { opponent_user_id: LINUS.id, best_of: 5, rated: false },
     ])
   })
 
@@ -182,7 +177,7 @@ test.describe('New match — picking an opponent', () => {
 
     await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
-      { opponent_user_id: BARBARA.id, best_of: 5, rated: true },
+      { opponent_user_id: BARBARA.id, best_of: 5, rated: false },
     ])
   })
 })

--- a/web-client/e2e/opponent-picker.spec.ts
+++ b/web-client/e2e/opponent-picker.spec.ts
@@ -76,7 +76,7 @@ test.describe('Opponent picker — recent opponents', () => {
     await expect(nm.pickerError).toBeHidden()
   })
 
-  test('still lets the player add a guest after a failed recent load', async ({
+  test('still lets the player start a solo match after a failed recent load', async ({
     page,
   }) => {
     const nm = await NewMatchPage.open(page, {
@@ -85,9 +85,9 @@ test.describe('Opponent picker — recent opponents', () => {
     })
 
     await expect(nm.pickerError).toBeVisible()
-    // The skip row sits outside the picker boundary, so guest / no-opponent
-    // flows keep working even when the players request fails.
-    await nm.addGuest()
+    // The picker boundary swallows the failed players request but the form's
+    // Start button still works — submitting without picking creates a solo,
+    // unrated match.
     await nm.start()
 
     await expect(page).toHaveURL(SCORING_URL)
@@ -125,7 +125,7 @@ test.describe('Opponent picker — search', () => {
     await nm.start()
     await expect(page).toHaveURL(SCORING_URL)
     expect(nm.store.createdMatches).toEqual([
-      { opponent_user_id: MARGARET.id, best_of: 5, rated: true },
+      { opponent_user_id: MARGARET.id, best_of: 5, rated: false },
     ])
   })
 

--- a/web-client/e2e/page-objects/matches/new-match.page.ts
+++ b/web-client/e2e/page-objects/matches/new-match.page.ts
@@ -87,16 +87,6 @@ export class NewMatchPage {
     await this.playerChip(username).click()
   }
 
-  async addGuest(): Promise<void> {
-    await this.page.getByRole('button', { name: /add guest opponent/i }).click()
-  }
-
-  async startWithoutOpponent(): Promise<void> {
-    await this.page
-      .getByRole('button', { name: /start without opponent/i })
-      .click()
-  }
-
   async changeOpponent(): Promise<void> {
     await this.page.getByRole('button', { name: /^change$/i }).click()
   }

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -616,10 +616,10 @@ export interface components {
          * MatchCreate
          * @description Request body for ``POST /v1/matches``.
          *
-         *     ``opponent_user_id`` is optional: a match created without a registered
-         *     opponent (a guest, or "start without opponent") gets a player-less sentinel
-         *     opponent side — so it's still scorable — and is always unrated, since the
-         *     rating system needs two registered sides.
+         *     ``opponent_user_id`` is optional: a solo match (the client submits one
+         *     when the user starts without picking an opponent) gets a player-less
+         *     sentinel opponent side — so it's still scorable — and is always unrated,
+         *     since the rating system needs two registered sides.
          *
          *     ``league_id`` is optional: when omitted the server binds the match to the
          *     default league (see ``app.leagues.get_default_league``).

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
-import { ArrowRight, ChevronRight, Plus, X } from 'lucide-react'
+import { ArrowRight, ChevronRight, Plus, User as UserIcon, X } from 'lucide-react'
 import { useDashboard } from '@/api/dashboard'
 import type {
   DashboardRating,
@@ -13,7 +13,11 @@ import { Overline } from '@/components/overline'
 import { fmtDateShort, fmtLongDate } from '@/lib/dates'
 import { formatRatingDelta } from '@/lib/rating'
 
-const GUEST_OPPONENT = 'guest'
+// Used everywhere an opponent slot has no registered player — the form's
+// solo-match path produces this. Matches the label used on the match-details
+// hero and form-history rows so the same match reads identically wherever it
+// surfaces.
+const NO_OPPONENT_LABEL = 'No opponent'
 
 const C = {
   ink950: 'var(--ink-950)',
@@ -145,11 +149,43 @@ function Avatar({
   ring = false,
   ringColor = C.ball500,
 }: {
-  name: string
+  // `null` renders the dashed-circle "no opponent" placeholder. We never want
+  // a contrived monogram (e.g. "NO" for "No opponent") that looks like a real
+  // initials avatar — it should read unambiguously as "no player here".
+  name: string | null
   size?: number
   ring?: boolean
   ringColor?: string
 }) {
+  const baseStyle: CSSProperties = {
+    width: size,
+    height: size,
+    borderRadius: '50%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    boxShadow: ring
+      ? `0 0 0 2px ${C.ink950}, 0 0 0 ${size > 40 ? 3 : 2.5}px ${ringColor}`
+      : 'none',
+    flexShrink: 0,
+  }
+
+  if (name === null) {
+    return (
+      <div
+        aria-hidden="true"
+        style={{
+          ...baseStyle,
+          background: 'transparent',
+          border: `1px dashed ${C.ink500}`,
+          color: C.chalk500,
+        }}
+      >
+        <UserIcon size={Math.round(size * 0.45)} strokeWidth={1.75} />
+      </div>
+    )
+  }
+
   const initials = name
     .split(/[ -]/)
     .map((s) => s[0])
@@ -164,20 +200,11 @@ function Avatar({
   return (
     <div
       style={{
-        width: size,
-        height: size,
-        borderRadius: '50%',
+        ...baseStyle,
         background: bg,
         color: fg,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
         font: `600 ${Math.round(size * 0.42)}px ${UI}`,
         letterSpacing: '0.03em',
-        boxShadow: ring
-          ? `0 0 0 2px ${C.ink950}, 0 0 0 ${size > 40 ? 3 : 2.5}px ${ringColor}`
-          : 'none',
-        flexShrink: 0,
       }}
     >
       {initials}
@@ -481,7 +508,8 @@ function PageTitle({
 
 function ScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
   const accent = C.ball500
-  const opponent = banner.opponent_username ?? GUEST_OPPONENT
+  const opponent = banner.opponent_username
+  const headline = opponent ? `vs ${opponent}` : NO_OPPONENT_LABEL
   const scoringRoute = scoringNewRoute(banner.match_id, banner.current_game_id)
   return (
     <div
@@ -569,7 +597,7 @@ function ScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
                   lineHeight: 1.1,
                 }}
               >
-                vs {opponent}
+                {headline}
               </h1>
             </div>
           </div>
@@ -626,7 +654,8 @@ function ScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
 // uses an amber accent so a second pending match is impossible to miss
 // without dimming the priority of the headline match.
 function CompactScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
-  const opponent = banner.opponent_username ?? GUEST_OPPONENT
+  const opponent = banner.opponent_username
+  const headline = opponent ? `vs ${opponent}` : NO_OPPONENT_LABEL
   const scoringRoute = scoringNewRoute(banner.match_id, banner.current_game_id)
   return (
     <div
@@ -675,7 +704,7 @@ function CompactScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
             textOverflow: 'ellipsis',
           }}
         >
-          vs {opponent}
+          {headline}
         </div>
       </div>
       <Button
@@ -913,7 +942,8 @@ function RecentResultsCard({ rows }: { rows: DashboardRecentResult[] }) {
           </thead>
           <tbody>
             {rows.map((r, i) => {
-              const opponent = r.opponent_username ?? GUEST_OPPONENT
+              const opponent = r.opponent_username
+              const opponentLabel = opponent ?? NO_OPPONENT_LABEL
               const score = `${r.my_games_won}-${r.opponent_games_won}`
               return (
                 <tr
@@ -934,12 +964,13 @@ function RecentResultsCard({ rows }: { rows: DashboardRecentResult[] }) {
                       <Avatar name={opponent} size={24} />
                       <span
                         style={{
-                          color: C.chalk50,
+                          color: opponent ? C.chalk50 : C.chalk500,
+                          fontStyle: opponent ? 'normal' : 'italic',
                           fontWeight: 500,
                           whiteSpace: 'nowrap',
                         }}
                       >
-                        {opponent}
+                        {opponentLabel}
                       </span>
                     </div>
                   </td>

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -807,7 +807,7 @@ function NoOpponentProfile() {
         </div>
       </div>
       <div className="md-profile__empty">
-        This match has no second player.
+        Solo match — no second player.
       </div>
     </div>
   )

--- a/web-client/src/components/matches/opponent-picker-boundary.tsx
+++ b/web-client/src/components/matches/opponent-picker-boundary.tsx
@@ -15,8 +15,8 @@ function OpponentPickerError({ resetErrorBoundary }: FallbackProps) {
       <div className="body">
         <div className="t">Couldn’t load players</div>
         <div className="d">
-          Something went wrong reaching the server. You can still add a guest
-          or start without an opponent.
+          Something went wrong reaching the server. You can still start the
+          match without picking an opponent.
         </div>
       </div>
       <button

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react'
 import { Link, Navigate, useNavigate } from '@tanstack/react-router'
 import type { UseMutationResult } from '@tanstack/react-query'
+import { User as UserIcon } from 'lucide-react'
 import { ApiError } from '@/api/client'
 import {
   matchDetailRoute,
@@ -13,6 +14,11 @@ import {
 import { AppShell } from '@/components/app-shell'
 import { cn, initialsOf } from '@/lib/utils'
 import { illegalScoreReason } from '@/lib/scoring'
+
+// Mirror the canonical placeholder on the match-details hero and form-history
+// rows. Solo-match scoring used to surface an "OP" avatar via initialsOf('Opponent') —
+// indistinguishable from a real two-letter monogram.
+const NO_OPPONENT_LABEL = 'No opponent'
 
 export type ScoreMutation = UseMutationResult<
   MatchDetails,
@@ -81,8 +87,8 @@ function ScoreEntryInner({
 
   // The scoring screen is participant-only; spectators bounce back to the
   // read-only details page. The opponent side is always present — a real
-  // player, or the player-less "No opponent" sentinel — so its name falls back
-  // to "Opponent" below.
+  // player, or the player-less placeholder for solo matches (rendered as
+  // "No opponent" with a ghost avatar below).
   const mySide = data.sides.find((s) => s.is_current_user_side) ?? null
   const oppSide = data.sides.find((s) => !s.is_current_user_side) ?? null
   if (!mySide || !oppSide) {
@@ -95,10 +101,11 @@ function ScoreEntryInner({
   }
 
   const mySideNumber = mySide.side_number === 2 ? 2 : 1
-  const oppName = oppSide.players[0]?.username ?? 'Opponent'
+  const oppUsername = oppSide.players[0]?.username ?? null
+  const oppName = oppUsername ?? NO_OPPONENT_LABEL
   const meName = mySide.players[0]?.username ?? 'You'
   const meInitials = initialsOf(meName)
-  const oppInitials = initialsOf(oppName)
+  const oppHasPlayer = oppUsername !== null
 
   const bestOf = data.best_of
   const gameNumber = game.game_number
@@ -247,7 +254,7 @@ function ScoreEntryInner({
           <ScoreSide
             side="opp"
             name={oppName}
-            initials={oppInitials}
+            initials={oppHasPlayer ? initialsOf(oppName) : null}
             wins={oppWins}
             value={opp}
             inputRef={oppRef}
@@ -327,7 +334,9 @@ function ScoreSide({
 }: {
   side: 'me' | 'opp'
   name: string
-  initials: string
+  // `null` means there's no player on this side — render the ghost avatar
+  // (dashed circle + person icon) instead of a contrived monogram.
+  initials: string | null
   wins: number
   value: string
   inputRef: React.RefObject<HTMLInputElement | null>
@@ -337,7 +346,12 @@ function ScoreSide({
   onChange: (value: string) => void
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void
 }) {
-  const avatar = <div className="av">{initials}</div>
+  const noPlayer = initials === null
+  const avatar = (
+    <div className="av" aria-hidden={noPlayer || undefined}>
+      {noPlayer ? <UserIcon size={20} strokeWidth={1.75} /> : initials}
+    </div>
+  )
   const identity = (
     <div>
       <div className="nm">{name}</div>
@@ -348,7 +362,7 @@ function ScoreSide({
   )
 
   return (
-    <div className={cn('se-side', side)}>
+    <div className={cn('se-side', side, noPlayer && 'no-opponent')}>
       <div className={cn('se-head', side === 'opp' && 'right')}>
         {side === 'opp' && identity}
         {avatar}

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1582,7 +1582,7 @@ body.dark.fortymm-theme {
   color: #fff;
   box-shadow: 0 0 0 1px var(--ball-500);
 }
-.fortymm-theme .se-side.opp.guest .av {
+.fortymm-theme .se-side.opp.no-opponent .av {
   background: transparent;
   border: 1.5px dashed var(--ink-500);
   color: var(--fg-3);

--- a/web-client/src/routes/matches/new.css
+++ b/web-client/src/routes/matches/new.css
@@ -144,32 +144,6 @@
   text-transform: uppercase;
   color: var(--fg-muted);
 }
-.nm-skip-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-top: 12px;
-  font: 500 13px var(--font-ui);
-  color: var(--fg-3);
-}
-.nm-skip-row .sep {
-  color: var(--ink-500);
-}
-.nm-skip-row button {
-  padding: 0 0 1px;
-  background: none;
-  border: none;
-  border-bottom: 1px solid var(--ink-500);
-  font: inherit;
-  color: var(--fg-2);
-  cursor: pointer;
-  transition: color var(--dur-fast), border-color var(--dur-fast);
-}
-.nm-skip-row button:hover {
-  color: var(--ball-500);
-  border-color: var(--ball-500);
-}
-
 /* --- Typeahead picker --- */
 .nm-search {
   position: relative;
@@ -272,11 +246,6 @@
   font: 700 12px var(--font-ui);
   color: var(--fg-1);
 }
-.nm-item.guest .av {
-  background: transparent;
-  border: 1px dashed var(--ink-500);
-  color: var(--fg-3);
-}
 .nm-item .body {
   flex: 1;
   min-width: 0;
@@ -337,11 +306,6 @@
   background: var(--ink-700);
   font: 700 16px var(--font-ui);
   color: var(--fg-1);
-}
-.nm-selected.guest .av {
-  background: transparent;
-  border: 1px dashed var(--ink-500);
-  color: var(--fg-3);
 }
 .nm-selected .info {
   flex: 1;

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -131,6 +131,51 @@ describe('NewMatchPage', () => {
     })
   })
 
+  it('resets Rated to off when the opponent is cleared, so re-picking does not silently re-engage rating', async () => {
+    const user = userEvent.setup()
+    let captured: unknown = null
+    server.use(
+      http.get('*/v1/players/recent', () =>
+        HttpResponse.json([
+          { id: 'pl-1', username: 'ada.lovelace' },
+          { id: 'pl-2', username: 'grace.hopper' },
+        ]),
+      ),
+      http.post('*/v1/matches', async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json(pendingMatch(), { status: 201 })
+      }),
+    )
+    renderNewMatch()
+
+    // Pick Ada and turn Rated on.
+    await user.click(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    )
+    const ratedSwitch = () =>
+      screen.getByRole('switch', { name: /rated match/i })
+    await user.click(ratedSwitch())
+    expect(ratedSwitch()).toHaveAttribute('aria-checked', 'true')
+
+    // Unpick Ada — clearing the opponent must also clear the rated state, so
+    // re-picking doesn't quietly submit a rated match the user didn't ask for.
+    await user.click(screen.getByRole('button', { name: /^change$/i }))
+    await user.click(screen.getByRole('button', { name: /grace\.hopper/i }))
+    expect(ratedSwitch()).toHaveAttribute('aria-checked', 'false')
+
+    await user.click(screen.getByRole('button', { name: /start match/i }))
+    await waitFor(() =>
+      expect(
+        screen.getByText('Scoring route m-test game g-test'),
+      ).toBeInTheDocument(),
+    )
+    expect(captured).toEqual({
+      opponent_user_id: 'pl-2',
+      best_of: 5,
+      rated: false,
+    })
+  })
+
   it('surfaces the API error detail when match creation fails', async () => {
     const user = userEvent.setup()
     server.use(

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -65,45 +65,6 @@ function renderNewMatch() {
 }
 
 describe('NewMatchPage', () => {
-  it('blocks a rated match with no opponent and shows an inline error', async () => {
-    const user = userEvent.setup()
-    renderNewMatch()
-
-    // Rated is on by default and no opponent is picked yet.
-    await user.click(
-      await screen.findByRole('button', { name: /start match/i }),
-    )
-
-    expect(await screen.findByRole('alert')).toHaveTextContent(
-      /rated match needs an opponent/i,
-    )
-    // Still on the match page — nothing was submitted.
-    expect(
-      screen.getByRole('heading', { level: 1, name: /new match/i }),
-    ).toBeInTheDocument()
-  })
-
-  it('clears the stale rated-needs-opponent error after picking a guest (#150)', async () => {
-    const user = userEvent.setup()
-    renderNewMatch()
-
-    // The error only appears after a submit attempt — not on initial load.
-    await screen.findByRole('button', { name: /start match/i })
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: /start match/i }))
-    expect(await screen.findByRole('alert')).toHaveTextContent(
-      /rated match needs an opponent/i,
-    )
-
-    // Adding a guest auto-unrates the match, so the error no longer applies —
-    // it must not linger and contradict "Guest matches are always unrated".
-    await user.click(
-      screen.getByRole('button', { name: /add guest opponent/i }),
-    )
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-  })
-
   it('creates a match against a picked opponent and navigates to the dashboard', async () => {
     const user = userEvent.setup()
     let captured: unknown = null
@@ -124,6 +85,9 @@ describe('NewMatchPage', () => {
     await user.click(
       await screen.findByRole('button', { name: /ada\.lovelace/i }),
     )
+    // Picking an opponent unlocks the Rated toggle; turn it on so the match
+    // is submitted as rated.
+    await user.click(screen.getByRole('switch', { name: /rated match/i }))
     await user.click(screen.getByRole('button', { name: /start match/i }))
 
     await waitFor(() =>
@@ -149,17 +113,17 @@ describe('NewMatchPage', () => {
     )
     renderNewMatch()
 
+    // No opponent picked, no toggle flipped — Start match submits a solo,
+    // unrated match (the form defaults Rated off for this reason).
     await user.click(
-      await screen.findByRole('button', { name: /start without opponent/i }),
+      await screen.findByRole('button', { name: /start match/i }),
     )
-    await user.click(screen.getByRole('button', { name: /start match/i }))
 
     await waitFor(() =>
       expect(
         screen.getByText('Scoring route m-test game g-test'),
       ).toBeInTheDocument(),
     )
-    // Guest / TBD opponents can't be rated, so `rated` is forced false.
     expect(captured).toEqual({
       opponent_user_id: null,
       best_of: 5,

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -30,20 +30,13 @@ export const Route = createFileRoute('/matches/new')({
 /*  Opponent model                                                    */
 /* ------------------------------------------------------------------ */
 
-type OpponentKind = 'registered' | 'guest' | 'tbd'
-
 interface Opponent {
-  /** A real user id for `registered`; a sentinel string for guest / tbd. */
   id: string
-  kind: OpponentKind
   name: string
 }
 
-const GUEST: Opponent = { id: 'guest', kind: 'guest', name: 'Guest player' }
-const OPPONENT_TBD: Opponent = { id: 'tbd', kind: 'tbd', name: 'Opponent TBD' }
-
-function registeredOpponent(player: Player): Opponent {
-  return { id: player.id, kind: 'registered', name: player.username }
+function opponentFromPlayer(player: Player): Opponent {
+  return { id: player.id, name: player.username }
 }
 
 /** Two-letter monogram for an avatar bubble. */
@@ -56,31 +49,22 @@ function initialsOf(name: string): string {
   return letters.toUpperCase() || '?'
 }
 
-/** Whether a match against this opponent can count toward ratings. */
-function canRate(opponent: Opponent | null) {
-  return !opponent || opponent.kind === 'registered'
-}
-
 /* ------------------------------------------------------------------ */
 /*  Validation                                                        */
 /* ------------------------------------------------------------------ */
 
-// The backend independently enforces these rules; the client copy gives
-// immediate, inline feedback before a round-trip. The two refinements are
-// ordered so the rated-specific message wins when both would apply.
+// Rated matches need an opponent; the API enforces this independently. The
+// client toggle is disabled when no opponent is picked, so this only fires
+// in a near-impossible race — keep the refinement for defense in depth.
 const matchFormSchema = z
   .object({
-    opponentKind: z.enum(['registered', 'guest', 'tbd']).nullable(),
+    hasOpponent: z.boolean(),
     rated: z.boolean(),
     bestOf: z.number(),
   })
-  .refine((value) => !(value.rated && value.opponentKind === null), {
+  .refine((value) => !(value.rated && !value.hasOpponent), {
     message:
-      'A rated match needs an opponent — pick one, or switch off Rated to play without one.',
-    path: ['opponent'],
-  })
-  .refine((value) => value.opponentKind !== null, {
-    message: "Choose an opponent, or pick 'Start without opponent'.",
+      'A rated match needs an opponent — pick one, or switch off Rated.',
     path: ['opponent'],
   })
 
@@ -114,18 +98,16 @@ function MatchCard() {
 
   const [opponent, setOpponent] = useState<Opponent | null>(null)
   const [bestOf, setBestOf] = useState(5)
-  const [rated, setRated] = useState(true)
+  // Default off so submitting without picking an opponent "just works" —
+  // the no-opponent match is unrated by definition.
+  const [rated, setRated] = useState(false)
   const [apiError, setApiError] = useState<string | null>(null)
   const [submitted, setSubmitted] = useState(false)
 
   const me = session?.data.user ?? null
 
-  // Validation is derived from the live form state via the zod schema — never
-  // stored — so the message clears the instant the form turns valid (e.g. once
-  // a guest is picked, #150) instead of lingering. It only surfaces after the
-  // user has tried to submit; the async create failure is the only stored error.
   const validation = matchFormSchema.safeParse({
-    opponentKind: opponent?.kind ?? null,
+    hasOpponent: opponent !== null,
     rated,
     bestOf,
   })
@@ -139,15 +121,11 @@ function MatchCard() {
     if (validationError) return
     setApiError(null)
 
-    // Guest / "start without opponent" matches have no registered opponent, so
-    // they can never be rated regardless of the toggle (the API gives them a
-    // player-less sentinel opponent side instead).
-    const isRegistered = opponent?.kind === 'registered'
     try {
       const created = await createMatch.mutateAsync({
-        opponent_user_id: isRegistered ? opponent.id : null,
+        opponent_user_id: opponent?.id ?? null,
         best_of: bestOf,
-        rated: isRegistered && rated,
+        rated: opponent !== null && rated,
       })
       navigate(nextScoringDestination(created))
     } catch (err) {
@@ -172,13 +150,9 @@ function MatchCard() {
       <div className="nm-opp-block">
         <div className="nm-section-head">
           <span className="title">Opponent</span>
-          {opponent && (
-            <span className="hint">
-              {opponent.kind === 'registered'
-                ? 'Rated player'
-                : 'Guest · unrated'}
-            </span>
-          )}
+          <span className="hint">
+            {opponent ? 'Rated-eligible' : 'Optional · leave blank for a solo match'}
+          </span>
         </div>
 
         {opponent ? (
@@ -189,21 +163,9 @@ function MatchCard() {
         ) : (
           <OpponentPickerBoundary>
             <RecentPicker
-              onPick={(player) => setOpponent(registeredOpponent(player))}
+              onPick={(player) => setOpponent(opponentFromPlayer(player))}
             />
           </OpponentPickerBoundary>
-        )}
-
-        {!opponent && (
-          <div className="nm-skip-row">
-            <button type="button" onClick={() => setOpponent(GUEST)}>
-              Add guest opponent
-            </button>
-            <span className="sep">·</span>
-            <button type="button" onClick={() => setOpponent(OPPONENT_TBD)}>
-              Start without opponent
-            </button>
-          </div>
         )}
       </div>
 
@@ -236,19 +198,12 @@ function SelectedOpponent({
   opponent: Opponent
   onChange: () => void
 }) {
-  const guest = opponent.kind !== 'registered'
-  const tag =
-    opponent.kind === 'registered'
-      ? 'REGISTERED PLAYER'
-      : opponent.kind === 'guest'
-        ? 'UNRATED GUEST'
-        : 'TO BE DECIDED'
   return (
-    <div className={cn('nm-selected', guest && 'guest')}>
+    <div className="nm-selected">
       <div className="av">{initialsOf(opponent.name)}</div>
       <div className="info">
         <div className="name">{opponent.name}</div>
-        <div className="rating">{tag}</div>
+        <div className="rating">REGISTERED PLAYER</div>
       </div>
       <button type="button" className="change" onClick={onChange}>
         Change
@@ -308,7 +263,8 @@ function RecentPicker({ onPick }: { onPick: (player: Player) => void }) {
         <RecentSkeleton />
       ) : players.length === 0 ? (
         <div className="nm-no-match">
-          No other players yet. Add a guest, or start without an opponent.
+          No other players yet. Start the match without picking one for a
+          casual solo session.
         </div>
       ) : (
         <div className="nm-recent-grid">
@@ -516,27 +472,23 @@ function RatedField({
   setRated: (rated: boolean) => void
   opponent: Opponent | null
 }) {
-  const ratable = canRate(opponent)
+  const ratable = opponent !== null
   const effectiveRated = rated && ratable
 
   let description: string
   if (effectiveRated) {
-    description = opponent
-      ? 'Result will update both ratings.'
-      : 'Pick a registered opponent for this to count.'
+    description = 'Result will update both ratings.'
   } else if (ratable) {
-    description = opponent
-      ? 'No rating change. Still logged to history.'
-      : 'No rating change either way. Still logged to history.'
+    description = 'No rating change. Still logged to history.'
   } else {
-    description = 'Guest matches are always unrated.'
+    description = 'Pick an opponent to make this rated.'
   }
 
   return (
     <div>
       <div className="nm-field-label">
         Rated match
-        {!ratable && <span className="na">Guest · unavailable</span>}
+        {!ratable && <span className="na">No opponent · unavailable</span>}
       </div>
       <div className="nm-rated">
         <button
@@ -580,7 +532,7 @@ function SubmitRow({
   onSubmit: () => void
   onCancel: () => void
 }) {
-  const effectivelyRated = rated && opponent?.kind === 'registered'
+  const effectivelyRated = rated && opponent !== null
   const gamesToWin = Math.ceil(bestOf / 2)
   const lengthCopy =
     bestOf === 1 ? 'Single game' : `Best of ${bestOf} · first to ${gamesToWin}`
@@ -589,17 +541,13 @@ function SubmitRow({
     <div className="nm-summary">
       <div className="read">
         <div className="top">
-          {opponent?.kind === 'registered' ? (
+          {opponent ? (
             <>
               Ready: <b>You</b> vs <b>{opponent.name}</b>
             </>
-          ) : opponent ? (
-            <>
-              You vs <span className="opp-tbd">{opponent.name}</span>
-            </>
           ) : (
             <>
-              You vs <span className="opp-tbd">pick an opponent</span>
+              Ready: <b>You</b> <span className="opp-tbd">· solo match</span>
             </>
           )}
         </div>

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -158,7 +158,16 @@ function MatchCard() {
         {opponent ? (
           <SelectedOpponent
             opponent={opponent}
-            onChange={() => setOpponent(null)}
+            // Clearing the opponent must also clear `rated` — otherwise the
+            // toggle's "off" appearance (because `effectiveRated` is gated by
+            // `ratable`) hides a stored `true` that would either (a) trip the
+            // rated-needs-opponent refinement with a disabled toggle the user
+            // can't switch off, or (b) silently re-engage rating when a new
+            // opponent is picked.
+            onChange={() => {
+              setOpponent(null)
+              setRated(false)
+            }}
           />
         ) : (
           <OpponentPickerBoundary>

--- a/web-client/src/test/setup.ts
+++ b/web-client/src/test/setup.ts
@@ -1,7 +1,15 @@
 import '@testing-library/jest-dom/vitest'
+import { configure } from '@testing-library/dom'
 import { afterAll, afterEach, beforeAll } from 'vitest'
 import { resetMockMatches } from '../mocks/match-store'
 import { server } from '../mocks/server'
+
+// testing-library's 1s `findBy*` default is tight on CI: the first test in a
+// file pays the MSW + React-Query + jsdom warm-up cost (e.g. waiting for
+// `/v1/session` to resolve, then `/v1/players/recent` chips to render) and
+// occasionally lands at ~1.05s — flaky-by-design. Bump globally so warm-up
+// cost can't time out a fast assertion.
+configure({ asyncUtilTimeout: 5000 })
 
 // vitest's jsdom env on Node 26 doesn't expose localStorage. Production code
 // guards it with try/catch, but tests want to read/write it directly — give


### PR DESCRIPTION
## Summary
- Collapsed the "Add guest opponent" and "Start without opponent" buttons into a single flow on `/matches/new`: submitting without picking an opponent now creates a solo, unrated match (Rated defaults off, auto-enables when an opponent is picked).
- Unified the empty-opponent label to "No opponent" with a dashed-circle ghost avatar across the new-match form, score entry, dashboard banners, dashboard recent results, and match details — so the same solo match reads identically everywhere.
- Score entry no longer shows the "OP" initials fallback; dashboard recent matches no longer say "guest"; dashboard score banners no longer say "vs guest".

## Test plan
- [ ] `/matches/new`: no separate "Add guest opponent" / "Start without opponent" buttons; "Start match" works with nothing selected and creates an unrated solo match
- [ ] `/matches/new`: picking a registered opponent unlocks the Rated toggle (defaults off — flip it on for a rated match)
- [ ] Score entry for a solo match shows a dashed-circle ghost avatar + "No opponent" (not the "OP" monogram)
- [ ] Dashboard recent matches row for a solo match shows "No opponent" with a ghost avatar
- [ ] Dashboard score banners for a solo match show "No opponent" (not "vs guest")
- [ ] Match details hero / form-history strip for a solo match continue to show "No opponent"
- [ ] `npm run test:run`, `npm run lint`, `npm run build` in `web-client/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)