### PR TITLE
Deep-link Matches filters to the URL

### DIFF
--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -13,6 +13,7 @@
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/react-query": "^5.100.9",
         "@tanstack/react-router": "^1.169.2",
+        "@tanstack/zod-adapter": "^1.167.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -5406,6 +5407,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/zod-adapter": {
+      "version": "1.167.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/zod-adapter/-/zod-adapter-1.167.0.tgz",
+      "integrity": "sha512-5Wlm5teSu+pz3KKhfa1ESsiOJXbvV6ITr1vKOQKi9yEdtozp6VefEzxzafLLida97mnL2tmauva/njokQrG5CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-router": ">=1.43.2",
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/react-query": "^5.100.9",
     "@tanstack/react-router": "^1.169.2",
+    "@tanstack/zod-adapter": "^1.167.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/web-client/src/routes/matches/index.test.tsx
+++ b/web-client/src/routes/matches/index.test.tsx
@@ -20,7 +20,7 @@ import { Route } from './index'
 
 const MatchesPage = Route.options.component!
 
-function renderMatchesPage() {
+function renderMatchesPage(initialEntry = '/matches') {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
@@ -29,6 +29,7 @@ function renderMatchesPage() {
     getParentRoute: () => rootRoute,
     path: '/matches',
     component: MatchesPage,
+    validateSearch: Route.options.validateSearch,
   })
   const matchDetailRoute = createRoute({
     getParentRoute: () => rootRoute,
@@ -55,13 +56,13 @@ function renderMatchesPage() {
       newMatchRoute,
       scoringRoute,
     ]),
-    history: createMemoryHistory({ initialEntries: ['/matches'] }),
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
   })
-  return render(
+  return { router, ...render(
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
     </QueryClientProvider>,
-  )
+  ) }
 }
 
 describe('MatchesPage', () => {
@@ -265,6 +266,85 @@ describe('MatchesPage', () => {
     await screen.findByText(/no matches yet/i)
     const pill = container.querySelector('.live-pill')
     expect(pill?.textContent?.replace(/\s+/g, ' ').trim()).toBe('0 LIVE')
+  })
+
+  it('hydrates filters from the URL on load (deep-link)', async () => {
+    const requests: string[] = []
+    server.use(
+      http.get('*/v1/matches', ({ request }) => {
+        requests.push(request.url)
+        return HttpResponse.json(
+          matchListResponse({
+            items: [matchListRow({ opponent: 'nguyen.t' })],
+            total: 1,
+            page: 2,
+            status_counts: { in_progress: 1 },
+          }),
+        )
+      }),
+    )
+    renderMatchesPage('/matches?q=ngu&status=live&page=2')
+
+    // The first fetch already carries the URL filters — no debounce delay
+    // on initial load because the params are the same value across renders.
+    await waitFor(() => expect(requests.length).toBeGreaterThanOrEqual(1))
+    const url = new URL(requests[requests.length - 1])
+    expect(url.searchParams.get('q')).toBe('ngu')
+    expect(url.searchParams.get('status')).toBe('in_progress')
+    expect(url.searchParams.get('page')).toBe('2')
+
+    // The search input reflects the URL value.
+    expect(screen.getByPlaceholderText(/search players/i)).toHaveValue('ngu')
+  })
+
+  it('shrugs off garbage search params via zod fallback', async () => {
+    const requests: string[] = []
+    server.use(
+      http.get('*/v1/matches', ({ request }) => {
+        requests.push(request.url)
+        return HttpResponse.json(
+          matchListResponse({
+            items: [matchListRow({ opponent: 'nguyen.t' })],
+            total: 1,
+            status_counts: { pending: 1 },
+          }),
+        )
+      }),
+    )
+    // ?status=garbage and ?page=NaN should not crash — both fall back to
+    // defaults and the page renders as if no filter were set.
+    renderMatchesPage('/matches?status=garbage&page=NaN')
+
+    await waitFor(() => expect(requests.length).toBeGreaterThanOrEqual(1))
+    const url = new URL(requests[0])
+    expect(url.searchParams.get('status')).toBeNull()
+    expect(url.searchParams.get('page')).toBe('1')
+  })
+
+  it('writes filter changes to the URL immediately, before the debounced fetch fires', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches', () =>
+        HttpResponse.json(
+          matchListResponse({
+            items: [matchListRow({ opponent: 'nguyen.t' })],
+            total: 1,
+            status_counts: { pending: 1 },
+          }),
+        ),
+      ),
+    )
+    const { router } = renderMatchesPage()
+    await screen.findByText('nguyen.t')
+
+    await user.type(screen.getByPlaceholderText(/search players/i), 'ngu')
+
+    // URL reflects every keystroke — no debounce on the persistence side.
+    await waitFor(() => {
+      expect(router.state.location.search).toEqual(
+        expect.objectContaining({ q: 'ngu' }),
+      )
+    })
   })
 
   it('Export CSV links straight to /v1/matches.csv with the active filter (#149)', async () => {

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -46,11 +46,13 @@ type MatchListRowSide = components['schemas']['MatchDetailsSide']
 type RowTab = 'scheduled' | 'live' | 'final'
 type StatusKey = RowTab
 
-// URL is the source of truth for filters. `.optional().catch(undefined)` keeps
-// junk query strings (`?status=garbage`, `?page=NaN`) from crashing the page —
-// invalid values silently drop back to defaults instead of throwing.
+// URL is the source of truth for filters. `.trim()` strips whitespace so a
+// junk query like `?q=%20%20%20` collapses to "no filter" instead of polluting
+// the URL forever. `.optional().catch(undefined)` keeps `?status=garbage` or
+// `?page=NaN` from crashing the page — invalid values silently drop back to
+// defaults instead of throwing.
 export const matchesSearchSchema = z.object({
-  q: z.string().min(1).optional().catch(undefined),
+  q: z.string().trim().min(1).optional().catch(undefined),
   status: z.enum(['scheduled', 'live', 'final']).optional().catch(undefined),
   page: z.coerce.number().int().min(2).optional().catch(undefined),
 })

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -171,11 +171,16 @@ function MatchesPage() {
     [setSearch],
   )
 
-  // Match the displayed rows — debounced q, live status — so the CSV the
-  // user downloads is the one they're looking at.
+  // CSV reflects what the user just typed (live, not debounced) — clicking
+  // Export right after typing should download the query you see, not the
+  // stale one the table is still showing.
   const exportHref = useMemo(
-    () => matchesCsvUrl({ status: apiStatus, q: debouncedQ || undefined }),
-    [apiStatus, debouncedQ],
+    () =>
+      matchesCsvUrl({
+        status: apiStatus,
+        q: q.trim() || undefined,
+      }),
+    [apiStatus, q],
   )
 
   const items = data?.items ?? []

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -43,8 +43,11 @@ import './index.css'
 
 type MatchListRowSide = components['schemas']['MatchDetailsSide']
 
-type RowTab = 'scheduled' | 'live' | 'final'
-type StatusKey = RowTab
+// Single source of truth for the filter-tab status values — the URL schema,
+// the row classification, and the tab list all derive from this tuple.
+const STATUS_KEYS = ['scheduled', 'live', 'final'] as const
+type StatusKey = (typeof STATUS_KEYS)[number]
+type RowTab = StatusKey
 
 // URL is the source of truth for filters. `.trim()` strips whitespace so a
 // junk query like `?q=%20%20%20` collapses to "no filter" instead of polluting
@@ -53,7 +56,7 @@ type StatusKey = RowTab
 // defaults instead of throwing.
 export const matchesSearchSchema = z.object({
   q: z.string().trim().min(1).optional().catch(undefined),
-  status: z.enum(['scheduled', 'live', 'final']).optional().catch(undefined),
+  status: z.enum(STATUS_KEYS).optional().catch(undefined),
   page: z.coerce.number().int().min(2).optional().catch(undefined),
 })
 

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
+import { zodValidator } from '@tanstack/zod-adapter'
 import {
   ChevronLeft,
   ChevronRight,
@@ -11,6 +12,7 @@ import {
   User,
   X,
 } from 'lucide-react'
+import { z } from 'zod'
 
 import {
   matchesCsvUrl,
@@ -41,15 +43,25 @@ import './index.css'
 
 type MatchListRowSide = components['schemas']['MatchDetailsSide']
 
+type RowTab = 'scheduled' | 'live' | 'final'
+type StatusKey = RowTab
+
+// URL is the source of truth for filters. `.optional().catch(undefined)` keeps
+// junk query strings (`?status=garbage`, `?page=NaN`) from crashing the page —
+// invalid values silently drop back to defaults instead of throwing.
+export const matchesSearchSchema = z.object({
+  q: z.string().min(1).optional().catch(undefined),
+  status: z.enum(['scheduled', 'live', 'final']).optional().catch(undefined),
+  page: z.coerce.number().int().min(2).optional().catch(undefined),
+})
+
 export const Route = createFileRoute('/matches/')({
   head: () => ({
     meta: [{ title: pageTitle('Matches') }],
   }),
+  validateSearch: zodValidator(matchesSearchSchema),
   component: MatchesPage,
 })
-
-type RowTab = 'scheduled' | 'live' | 'final'
-type StatusKey = RowTab
 
 const TAB_TO_API: Record<RowTab, MatchStatus> = {
   scheduled: 'pending',
@@ -84,23 +96,31 @@ const STATUS_TONE: Record<RowTab, string> = {
 type NavigateFn = ReturnType<typeof useNavigate>
 
 function MatchesPage() {
-  const [q, setQ] = useState('')
-  const [status, setStatus] = useState<'all' | StatusKey>('all')
-  const [page, setPage] = useState(1)
-  const debouncedQ = useDebouncedValue(q, 300).trim()
+  const urlSearch = Route.useSearch()
   const navigate = useNavigate()
 
-  const apiStatus = status === 'all' ? undefined : TAB_TO_API[status]
-  // Memoize the params bag so React Query's structural sharing — and any
-  // future React.memo on MatchTable — sees a stable reference.
+  const q = urlSearch.q ?? ''
+  const status: 'all' | StatusKey = urlSearch.status ?? 'all'
+  const page = urlSearch.page ?? 1
+
+  // Debounce the params that drive the backend call so a quick burst of
+  // keystrokes (or tab clicks) coalesces into a single fetch. The URL still
+  // updates immediately on every change — only the query is held back.
+  const liveParams = useMemo(
+    () => ({ q: q.trim(), status, page }),
+    [q, status, page],
+  )
+  const debounced = useDebouncedValue(liveParams, 300)
+  const apiStatus =
+    debounced.status === 'all' ? undefined : TAB_TO_API[debounced.status]
   const queryParams = useMemo(
     () => ({
       status: apiStatus,
-      q: debouncedQ || undefined,
-      page,
+      q: debounced.q || undefined,
+      page: debounced.page,
       page_size: PAGE_SIZE,
     }),
-    [apiStatus, debouncedQ, page],
+    [apiStatus, debounced.q, debounced.page],
   )
   // Wait for the session before firing the matches query — otherwise a
   // first-visit direct-load races the session cookie and 401s into the error
@@ -111,25 +131,59 @@ function MatchesPage() {
   const data = matchList.data
   const isLoading = matchList.isPending
 
-  const changeStatus = useCallback((next: 'all' | StatusKey) => {
-    setStatus(next)
-    setPage(1)
-  }, [])
-  const changeQuery = useCallback((next: string) => {
-    setQ(next)
-    setPage(1)
-  }, [])
-  const onClear = useCallback(() => {
-    setQ('')
-    setStatus('all')
-    setPage(1)
-  }, [])
+  // Rewrite the URL — `replace: true` keeps each keystroke from filling
+  // browser history. Defaults are stripped so the URL stays clean.
+  const setSearch = useCallback(
+    (patch: Partial<z.infer<typeof matchesSearchSchema>>) => {
+      void navigate({
+        to: '/matches',
+        replace: true,
+        search: (prev) => {
+          const merged = { ...prev, ...patch }
+          return {
+            q: merged.q && merged.q.length > 0 ? merged.q : undefined,
+            status: merged.status,
+            page: merged.page && merged.page > 1 ? merged.page : undefined,
+          }
+        },
+      })
+    },
+    [navigate],
+  )
 
-  // Link straight to the CSV endpoint for the active filters — the browser
-  // downloads it directly (no client-side fetch/buffering).
+  const changeStatus = useCallback(
+    (next: 'all' | StatusKey) => {
+      setSearch({
+        status: next === 'all' ? undefined : next,
+        page: undefined,
+      })
+    },
+    [setSearch],
+  )
+  const changeQuery = useCallback(
+    (next: string) => {
+      setSearch({ q: next || undefined, page: undefined })
+    },
+    [setSearch],
+  )
+  const onClear = useCallback(() => {
+    setSearch({ q: undefined, status: undefined, page: undefined })
+  }, [setSearch])
+  const setPage = useCallback(
+    (next: number) => {
+      setSearch({ page: next })
+    },
+    [setSearch],
+  )
+
+  // CSV reflects what the user typed (URL), not the debounced view.
   const exportHref = useMemo(
-    () => matchesCsvUrl({ status: apiStatus, q: debouncedQ || undefined }),
-    [apiStatus, debouncedQ],
+    () =>
+      matchesCsvUrl({
+        status: status === 'all' ? undefined : TAB_TO_API[status],
+        q: q.trim() || undefined,
+      }),
+    [status, q],
   )
 
   const items = data?.items ?? []

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -103,24 +103,19 @@ function MatchesPage() {
   const status: 'all' | StatusKey = urlSearch.status ?? 'all'
   const page = urlSearch.page ?? 1
 
-  // Debounce the params that drive the backend call so a quick burst of
-  // keystrokes (or tab clicks) coalesces into a single fetch. The URL still
-  // updates immediately on every change — only the query is held back.
-  const liveParams = useMemo(
-    () => ({ q: q.trim(), status, page }),
-    [q, status, page],
-  )
-  const debounced = useDebouncedValue(liveParams, 300)
-  const apiStatus =
-    debounced.status === 'all' ? undefined : TAB_TO_API[debounced.status]
+  // Debounce only the text search — tab and pagination clicks aren't a
+  // hammer risk and should fire immediately so the table doesn't lag the
+  // click by 300ms. The URL still updates synchronously on every change.
+  const debouncedQ = useDebouncedValue(q.trim(), 300)
+  const apiStatus = status === 'all' ? undefined : TAB_TO_API[status]
   const queryParams = useMemo(
     () => ({
       status: apiStatus,
-      q: debounced.q || undefined,
-      page: debounced.page,
+      q: debouncedQ || undefined,
+      page,
       page_size: PAGE_SIZE,
     }),
-    [apiStatus, debounced.q, debounced.page],
+    [apiStatus, debouncedQ, page],
   )
   // Wait for the session before firing the matches query — otherwise a
   // first-visit direct-load races the session cookie and 401s into the error
@@ -176,14 +171,11 @@ function MatchesPage() {
     [setSearch],
   )
 
-  // CSV reflects what the user typed (URL), not the debounced view.
+  // Match the displayed rows — debounced q, live status — so the CSV the
+  // user downloads is the one they're looking at.
   const exportHref = useMemo(
-    () =>
-      matchesCsvUrl({
-        status: status === 'all' ? undefined : TAB_TO_API[status],
-        q: q.trim() || undefined,
-      }),
-    [status, q],
+    () => matchesCsvUrl({ status: apiStatus, q: debouncedQ || undefined }),
+    [apiStatus, debouncedQ],
   )
 
   const items = data?.items ?? []


### PR DESCRIPTION
## Summary

- Persist the `/matches` filters (`q`, `status`, `page`) to the URL via `@tanstack/zod-adapter`, so reload and link-sharing preserve the active view.
- Each filter change writes to the URL synchronously (`replace: true`, so typing doesn't fill history); only the text search is debounced 300ms before the API call. Tab and pagination clicks fire immediately.
- Junk query strings (`?status=garbage`, `?page=NaN`, `?q=%20%20%20`) fall back silently via `.optional().catch(undefined)` and a `.trim()` on the search.
- CSV export href tracks the live (un-debounced) `q` — clicking Export right after typing downloads the query you just typed.
- `STATUS_KEYS` is the single source of truth for the tab/URL status vocabulary; both the `RowTab` type and the Zod enum derive from it.

## Test plan

- [x] vitest: 100/100 — three new tests cover deep-link hydration, garbage-param tolerance, and immediate URL writes
- [x] Playwright (matches-list): 4/4
- [x] lint + tsc + vite build clean
- [ ] Manual: deep-link a `/matches?q=ngu&status=live&page=2` URL and confirm rows render with the filter applied
- [ ] Manual: type in the search box, confirm URL updates per keystroke but only one API request fires after 300ms of quiet
- [ ] Manual: click a status tab — table refreshes immediately (no 300ms lag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)