### PR TITLE
Deep-link dashboard "Full history" to /matches

### DIFF
--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -33,6 +33,11 @@ function renderDashboard() {
     path: '/matches/new',
     component: () => <div>New match route</div>,
   })
+  const matchesRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches',
+    component: () => <div>Matches route</div>,
+  })
   const scoringRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/matches/$matchId/games/$gameId/scores/new',
@@ -49,6 +54,7 @@ function renderDashboard() {
     routeTree: rootRoute.addChildren([
       dashboardRoute,
       newMatchRoute,
+      matchesRoute,
       scoringRoute,
     ]),
     history: createMemoryHistory({ initialEntries: ['/dashboard'] }),
@@ -147,6 +153,18 @@ describe('DashboardPage', () => {
 
     const link = await screen.findByRole('link', { name: /log a match/i })
     expect(link).toHaveAttribute('href', '/matches/new')
+  })
+
+  it('Full history links to /matches', async () => {
+    server.use(
+      http.get('*/v1/dashboard', () =>
+        HttpResponse.json(dashboardResponse()),
+      ),
+    )
+    renderDashboard()
+
+    const link = await screen.findByRole('link', { name: /full history/i })
+    expect(link).toHaveAttribute('href', '/matches')
   })
 
   it('renders the rating card from the dashboard rating payload', async () => {

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -382,10 +382,12 @@ function SectionHeader({
   title,
   subtitle,
   action,
+  actionTo,
 }: {
   title: string
   subtitle?: string
   action?: string
+  actionTo?: string
 }) {
   return (
     <div style={{ display: 'flex', alignItems: 'baseline', marginBottom: 14, gap: 12 }}>
@@ -403,9 +405,9 @@ function SectionHeader({
         <span style={{ font: `400 13px ${UI}`, color: C.chalk500 }}>{subtitle}</span>
       )}
       <div style={{ flex: 1 }} />
-      {action && (
-        <a
-          href="#"
+      {action && actionTo && (
+        <Link
+          to={actionTo}
           style={{
             font: `500 13px ${UI}`,
             color: C.chalk300,
@@ -417,7 +419,7 @@ function SectionHeader({
         >
           {action}
           <ChevronRight size={12} strokeWidth={1.75} />
-        </a>
+        </Link>
       )}
     </div>
   )
@@ -1032,6 +1034,7 @@ function YourGameRow({
             : 'Last 30 days'
         }
         action="Full history"
+        actionTo="/matches"
       />
       <div
         style={{


### PR DESCRIPTION
## Summary
- The Your-game section's "Full history" affordance on the dashboard was a placeholder anchor (`href="#"`) since the dashboard shipped. Now wired through TanStack Router to `/matches` so it actually navigates to the match list.
- `SectionHeader` learned an `actionTo` prop; when supplied alongside `action`, the link renders as a real router `<Link>`.

## Test plan
- [x] `npm run test -- src/components/dashboard/dashboard-page.test.tsx` — added a test asserting the "Full history" link has `href="/matches"`.
- [x] `npm run lint`
- [x] `tsc -b`

https://claude.ai/code/session_01MT7yNryJM2XfFXXzmWmA7f

---
_Generated by [Claude Code](https://claude.ai/code/session_01MT7yNryJM2XfFXXzmWmA7f)_