### PR TITLE
Filter dashboard /matches deep-links to the current user

### DIFF
--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import {
   RouterProvider,
   createMemoryHistory,
@@ -155,7 +155,7 @@ describe('DashboardPage', () => {
     expect(link).toHaveAttribute('href', '/matches/new')
   })
 
-  it('Full history links to /matches', async () => {
+  it('Full history links to /matches filtered by the current user', async () => {
     server.use(
       http.get('*/v1/dashboard', () =>
         HttpResponse.json(dashboardResponse()),
@@ -164,7 +164,12 @@ describe('DashboardPage', () => {
     renderDashboard()
 
     const link = await screen.findByRole('link', { name: /full history/i })
-    expect(link).toHaveAttribute('href', '/matches')
+    // The link renders before the session query resolves; once the username
+    // lands the search params update, so poll the attribute rather than
+    // asserting it on first paint.
+    await waitFor(() =>
+      expect(link).toHaveAttribute('href', '/matches?q=rita.kovac'),
+    )
   })
 
   it('renders the rating card from the dashboard rating payload', async () => {
@@ -276,7 +281,7 @@ describe('DashboardPage', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('collapses 3+ pending matches into a "+N more pending" link to /matches', async () => {
+  it('collapses 3+ pending matches into a "+N more pending" link to the current user\'s live matches', async () => {
     server.use(
       http.get('*/v1/dashboard', () =>
         HttpResponse.json(
@@ -308,6 +313,6 @@ describe('DashboardPage', () => {
     const more = await screen.findByTestId('dashboard-score-banner-more')
     expect(more).toHaveTextContent('+2')
     expect(more).toHaveTextContent(/more pending/i)
-    expect(more).toHaveAttribute('href', '/matches')
+    expect(more).toHaveAttribute('href', '/matches?q=rita.kovac&status=live')
   })
 })

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -383,11 +383,13 @@ function SectionHeader({
   subtitle,
   action,
   actionTo,
+  actionSearch,
 }: {
   title: string
   subtitle?: string
   action?: string
   actionTo?: string
+  actionSearch?: Record<string, string | undefined>
 }) {
   return (
     <div style={{ display: 'flex', alignItems: 'baseline', marginBottom: 14, gap: 12 }}>
@@ -408,6 +410,7 @@ function SectionHeader({
       {action && actionTo && (
         <Link
           to={actionTo}
+          search={actionSearch}
           style={{
             font: `500 13px ${UI}`,
             color: C.chalk300,
@@ -722,11 +725,20 @@ function CompactScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
   )
 }
 
-// 3+ pending: a single quiet link that funnels the rest into /matches.
-function MorePendingLink({ count }: { count: number }) {
+// 3+ pending: a single quiet link that funnels the rest into /matches,
+// pre-filtered to the current user's live (in-progress) matches so the
+// destination opens straight on the same pile the pill is summarizing.
+function MorePendingLink({
+  count,
+  username,
+}: {
+  count: number
+  username?: string
+}) {
   return (
     <Link
       to="/matches"
+      search={{ q: username, status: 'live' }}
       data-testid="dashboard-score-banner-more"
       style={{
         display: 'inline-flex',
@@ -751,7 +763,13 @@ function MorePendingLink({ count }: { count: number }) {
   )
 }
 
-function ScoreBannerStack({ banners }: { banners: DashboardScoreBanner[] }) {
+function ScoreBannerStack({
+  banners,
+  username,
+}: {
+  banners: DashboardScoreBanner[]
+  username?: string
+}) {
   if (banners.length === 0) return null
   const [primary, secondary, ...rest] = banners
   return (
@@ -765,7 +783,9 @@ function ScoreBannerStack({ banners }: { banners: DashboardScoreBanner[] }) {
     >
       <ScoreBanner banner={primary} />
       {secondary && <CompactScoreBanner banner={secondary} />}
-      {rest.length > 0 && <MorePendingLink count={rest.length} />}
+      {rest.length > 0 && (
+        <MorePendingLink count={rest.length} username={username} />
+      )}
     </div>
   )
 }
@@ -1019,10 +1039,12 @@ function YourGameRow({
   rating,
   recent,
   isLoading,
+  username,
 }: {
   rating: DashboardRating | null
   recent: DashboardRecentResult[]
   isLoading: boolean
+  username?: string
 }) {
   return (
     <section style={{ marginBottom: 36 }}>
@@ -1035,6 +1057,7 @@ function YourGameRow({
         }
         action="Full history"
         actionTo="/matches"
+        actionSearch={{ q: username }}
       />
       <div
         style={{
@@ -1090,12 +1113,13 @@ export function DashboardPage() {
       {isLoading ? (
         <SkeletonCard label="Loading score banner" height={140} />
       ) : data?.score_banners?.length ? (
-        <ScoreBannerStack banners={data.score_banners} />
+        <ScoreBannerStack banners={data.score_banners} username={username} />
       ) : null}
       <YourGameRow
         rating={data?.rating ?? null}
         recent={data?.recent_results ?? []}
         isLoading={isLoading}
+        username={username}
       />
     </div>
   )

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -3,6 +3,7 @@ import type { components } from '@/api/schema'
 import { healthCheck, player, sessionResponse } from '@/test/factories'
 import {
   findMatch,
+  MOCK_CURRENT_USER,
   mockMatches,
   newMatchSeed,
   projectListRow,
@@ -40,6 +41,17 @@ export const mockRecentOpponents = mockPlayers.slice(0, 6)
 export { mockMatches }
 
 const state = createRbacState(DEMO_SEED)
+
+// Mirrors the API's `_player_username_filter`: substring-match against *any*
+// participant on the match, not just the opponent. Side 1 is always the mock
+// current user (see match-store), so without this the dashboard's new
+// `?q=<my-username>` deep-links match zero rows in MSW.
+function matchHasPlayerLike(m: SeedMatch, q: string): boolean {
+  return (
+    MOCK_CURRENT_USER.username.toLowerCase().includes(q) ||
+    (m.opponent?.username ?? '').toLowerCase().includes(q)
+  )
+}
 
 async function readJson(request: Request): Promise<unknown> {
   try {
@@ -266,9 +278,7 @@ export const handlers = [
     const q = url.searchParams.get('q')?.trim().toLowerCase() ?? ''
     let scoped = mockMatches.slice()
     if (q) {
-      scoped = scoped.filter((m) =>
-        (m.opponent?.username ?? '').toLowerCase().includes(q),
-      )
+      scoped = scoped.filter((m) => matchHasPlayerLike(m, q))
     }
     const filtered = statusFilter
       ? scoped.filter((m) => m.status === statusFilter)
@@ -325,9 +335,7 @@ export const handlers = [
 
     let scoped = mockMatches.slice()
     if (q) {
-      scoped = scoped.filter((m) =>
-        (m.opponent?.username ?? '').toLowerCase().includes(q),
-      )
+      scoped = scoped.filter((m) => matchHasPlayerLike(m, q))
     }
     const filtered = statusFilter
       ? scoped.filter((m) => m.status === statusFilter)

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -3,7 +3,6 @@ import type { components } from '@/api/schema'
 import { healthCheck, player, sessionResponse } from '@/test/factories'
 import {
   findMatch,
-  MOCK_CURRENT_USER,
   mockMatches,
   newMatchSeed,
   projectListRow,
@@ -45,10 +44,12 @@ const state = createRbacState(DEMO_SEED)
 // Mirrors the API's `_player_username_filter`: substring-match against *any*
 // participant on the match, not just the opponent. Side 1 is always the mock
 // current user (see match-store), so without this the dashboard's new
-// `?q=<my-username>` deep-links match zero rows in MSW.
+// `?q=<my-username>` deep-links match zero rows in MSW. Read the username
+// off `mockSession` so the filter follows PATCH /v1/me — otherwise renaming
+// yourself via /settings would silently stop matching your own matches.
 function matchHasPlayerLike(m: SeedMatch, q: string): boolean {
   return (
-    MOCK_CURRENT_USER.username.toLowerCase().includes(q) ||
+    mockSession.data.user.username.toLowerCase().includes(q) ||
     (m.opponent?.username ?? '').toLowerCase().includes(q)
   )
 }


### PR DESCRIPTION
## Summary

Two dashboard deep-links were dropping users into the unfiltered /matches list:

- **"Full history"** in the *Your game* section header — now carries `?q=<username>` so the list opens on the signed-in user's own history.
- **"+N more pending"** pill at the bottom of the score-banner stack — now carries `?q=<username>&status=live` so it lands on the same pile of in-progress matches the pill is summarizing.

Both reuse the existing URL filter contract on `/matches` (the `q` search input and the live status tab), so no API or schema changes were needed.

## Test plan

- [x] `npm run test:run` (101 passed)
- [x] `npm run lint`
- [x] `npx tsc -b`
- [x] `dashboard-page.test.tsx` updated: "Full history" link asserts `/matches?q=rita.kovac`, "+N more pending" link asserts `/matches?q=rita.kovac&status=live`


---
_Generated by [Claude Code](https://claude.ai/code/session_01X4Hd57im1YG4zJAZwbPLWj)_