### PR TITLE
Add ruff + strict mypy gates to the API (replaces #311)

### DIFF
--- a/.claude/commands/land-the-plane.md
+++ b/.claude/commands/land-the-plane.md
@@ -24,7 +24,7 @@ Apply any fixes it identifies. When `simplify` produces edits, stage and commit 
 
 Run each suite the project ships. Use the project root as cwd. Run independent suites in parallel via separate Bash tool calls in one message. Skip any suite whose directory is absent.
 
-- **API (pytest):** `cd api && pytest` (matches CI in `.github/workflows/api.yml`; assumes `pip install -e '.[dev]'` has been run in `api/.venv`. If pytest isn't on PATH, use `api/.venv/bin/pytest`.)
+- **API (ruff + mypy + pytest):** from `api/`, run the same gates as CI (`.github/workflows/api.yml`) **in order** — `ruff check app tests`, `ruff format --check app tests`, `mypy` (strict; config in `pyproject.toml`), then `pytest`. Assumes `pip install -e '.[dev]'` has been run in `api/.venv`; if the tools aren't on PATH, prefix with `api/.venv/bin/` (e.g. `api/.venv/bin/mypy`). A ruff failure is usually auto-fixable (`ruff check --fix`, `ruff format`) — apply, then re-run; mypy/pytest failures stop the workflow.
 - **Web client unit tests (vitest):** `cd web-client && npm run test:run`
 - **Web client lint + typecheck/build:** `cd web-client && npm run lint && npm run build` (the `build` script is `tsc -b && vite build` — it's the only typecheck.)
 - **Web client e2e (Playwright):** `cd web-client && npm run test:e2e`. Playwright defaults to port 5174 which collides with the dev compose web-client; set `PLAYWRIGHT_PORT` to a free port when the dev compose stack is up.

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -23,6 +23,10 @@ jobs:
 
       - run: pip install -e '.[dev]'
 
+      - run: ruff check app tests
+
+      - run: ruff format --check app tests
+
       - run: mypy
 
       - run: pytest

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1,7 +1,23 @@
 # api/CLAUDE.md
 
-Schema conventions for the FastAPI service. See the root `CLAUDE.md` for repo
-layout, commands, and architecture.
+Conventions for the FastAPI service. See the root `CLAUDE.md` for repo layout,
+commands, and architecture.
+
+The two guiding principles for new code: **make illegal states
+unrepresentable**, and **type the I/O boundaries so errors are caught by the
+type checker, not at runtime**. The rules below are how those principles cash
+out in this codebase.
+
+## Verification
+
+`app/` is type-checked under `mypy --strict` and linted + formatted with
+`ruff`; CI (`.github/workflows/api.yml`) gates on all of them. After every
+change, run from `api/`:
+
+1. `ruff check app tests` — lint (auto-fix the trivial ones with `--fix`)
+2. `ruff format app tests` — format (CI runs `ruff format --check`)
+3. `mypy` — strict type check; settings live in `pyproject.toml`
+4. `pytest` — tests (needs Docker for testcontainers)
 
 ## Datetimes are timezone-aware, always
 
@@ -46,3 +62,169 @@ and re-run alembic against a fresh database to test.
 - Renaming a table touches: the model's `__tablename__`, the migration's
   create/drop/FK/index/constraint names, the migration filename and
   docstring, and any hardcoded references in app or test code.
+
+## Make illegal states unrepresentable
+
+The goal is that a value that compiles/validates cannot be in a contradictory
+state. Reach for the type system before reaching for a runtime check.
+
+- **No tri-state booleans for what is really a sum type.** `bool | None` to mean
+  {yes, no, unknown} — or two parallel `won: bool | None` flags that could both
+  be `True` — lets contradictions exist. Model the outcome once, as a closed
+  set of cases (an `Enum`, or a discriminated union of Pydantic models), so
+  "both sides won" can't be constructed. (Existing `MatchSide.won` is the
+  pattern we're moving away from, not toward.)
+
+- **Don't carry a field and its own derivation in the same model.** If
+  `status_label` is a pure function of `status`, don't store both on the
+  schema where they can drift — expose the derived value with a Pydantic
+  `@computed_field`, or send only the source and derive client-side. Never
+  hand-map with a raw dict index (`STATUS_LABELS[status]`): a missing key is a
+  runtime `KeyError`. If you must map an enum, do it in one place with an
+  exhaustive `match` that has no catch-all, so adding an enum member is a type
+  error until you handle it.
+
+- **Use `Literal` / `Enum` for small closed domains, not `int`/`str`.**
+  `best_of: Literal[1, 3, 5, 7]` beats `best_of: int` + a hand-written
+  validator: it self-documents in OpenAPI and is checked statically.
+  `side_number: Literal[1, 2]` beats `int`. Reserve `int`/`str` for genuinely
+  open domains.
+
+- **Distinct ID types, not bare `uuid.UUID` everywhere.** Define
+  `UserId = NewType("UserId", uuid.UUID)`, `MatchId`, etc., so the type checker
+  rejects passing a match id where a user id is expected. They are
+  interchangeable today and that is a latent class of bug.
+
+- **Prefer total functions; don't index into possibly-empty collections.**
+  `side.players[0]` assumes "singles" — an empty or doubles side is a
+  representable DB row that will `IndexError`. Either model the invariant
+  (`SinglesSide` vs `DoublesSide`, or a non-empty list) or handle the empty
+  case explicitly and return early.
+
+## Type the I/O boundaries
+
+Every edge where data enters or leaves the process — request bodies, response
+bodies, the database, JSONB columns, queue payloads — gets a precise type. The
+interior should never traffic in `Any` or untyped `dict`.
+
+- **`response_model` (or a typed return) on every route.** No endpoint returns
+  a bare `dict`. A handler that returns `{"email": ...}` needs a response model
+  (`class LoginAccepted(BaseModel): email: EmailStr`) so the generated TS client
+  gets a real shape.
+
+- **Request models reject the unexpected.** New request schemas set
+  `model_config = ConfigDict(extra="forbid")` — an unknown key is a client bug
+  worth a 422, not something to silently drop. Consider `strict=True` for
+  inbound types to disable lax coercion.
+
+- **Parse, don't validate — turn untyped blobs into typed objects at the
+  boundary.** JSONB columns are the main offender. `rating_state` flows around
+  as `dict[str, Any]` and is read with stringly-keyed access (`state["rating"]`,
+  `state.get("rd")`); a malformed row only fails deep in the call stack. Decode
+  JSONB into a Pydantic model (a discriminated union over the strategy key)
+  at read time, so the rest of the code holds a `Glicko2State` /`ManualState`
+  with real fields and `KeyError` is impossible. New code must not introduce
+  another `dict[str, Any]` that crosses more than one function.
+
+- **Don't use `assert x is not None` as control flow after a DB load.** A
+  loader typed `-> Match | None` forces the caller to handle the `None`; an
+  `assert` is stripped under `python -O` and is not a guarantee. If a path
+  genuinely cannot return `None` (you just committed the row), give it a
+  loader that returns a non-optional type and raises on absence, rather than
+  re-fetching and asserting.
+
+- **A `DateTime(timezone=True)` column should yield an aware datetime — don't
+  re-defend at every read.** If you find yourself writing
+  `if dt.tzinfo is None: dt = dt.replace(tzinfo=utc)`, the boundary contract is
+  wrong; fix it at the loader, not the call site.
+
+- **Annotate internal seams too.** Helper functions that take SQLAlchemy
+  constructs (`def participant_filter(query, current_user_id)`,
+  `name_taken(db, id_col, name_col, ...)`) still get full annotations. `mypy
+  --strict` should have nothing to infer.
+
+## Error handling
+
+- **Catch the specific exception, never a bare `except Exception`.** A blanket
+  catch swallows the `KeyError` / `AttributeError` bugs you'd rather see crash
+  loudly. Name what you expect (`IntegrityError`, `httpx.HTTPError`) and let the
+  rest propagate to the handler / middleware layer.
+- **Route handlers are `async def` by default.** The whole stack is async
+  (async SQLAlchemy, async deps); a sync handler blocks the event loop. Drop to
+  plain `def` only for genuinely CPU-bound work you've deliberately chosen to
+  offload.
+
+## Static checking is the enforcement
+
+The rules above are only real if a checker runs them. All of `app/` passes
+`mypy --strict` in CI today — keep it that way, with no `# type: ignore` unless
+the suppression carries a comment explaining why. If you reach for `Any`,
+`cast`, or `# type: ignore`, treat it as a smell to justify in review, not a
+default.
+
+## Module layout for new code
+
+- **Separate the HTTP layer from domain/data logic.** A route handler should
+  parse the request, call a service/query function, and shape the response —
+  not contain raw SQLAlchemy queries, serializers, and domain rules inline.
+  New domains get their query + domain logic in their own module rather than
+  growing a 900-line router.
+- **Don't import another router's internals.** Shared query/domain helpers
+  (e.g. participant filters, win-count helpers) belong in a service/domain
+  module that both routers import — routers should not depend on each other.
+- **Reusable dependencies** (`get_session`, `get_current_user`,
+  `require_permission`) and **configuration** (a single `pydantic-settings`
+  `Settings`, instead of scattered `os.environ.get(...)`) belong in shared
+  modules, not wherever they were first needed.
+
+## Service layer and dependency injection
+
+When a service has collaborators worth injecting, keep three layers distinct.
+
+- **Handler** declares what it needs and knows nothing about construction:
+  `service: MatchService = Depends(get_match_service)`. Never instantiate a
+  service in the handler body — that loses `app.dependency_overrides` for tests
+  and repeats the wiring in every handler.
+- **Provider** (`<domain>/dependencies.py`) is the single place that knows the
+  wiring. It takes collaborators as `Depends` and constructor-injects them;
+  service-to-service deps are just more `Depends` args here, and FastAPI
+  resolves the whole tree per request:
+
+  ```python
+  def get_match_service(
+      db: AsyncSession = Depends(get_session),
+      ratings: RatingCalculator = Depends(get_rating_calculator),
+  ) -> MatchService:
+      return MatchService(db, ratings)
+  ```
+
+- **Service** is a plain class with a plain `__init__` — no FastAPI imports, no
+  `Depends` in the constructor. Type collaborators as `Protocol` (like the
+  existing `RatingCalculator`), not concrete classes, so the seam is
+  substitutable and the checker verifies the wiring.
+
+Rules of thumb:
+
+- **Stateless service → just a module-level function** taking `db` as a param
+  (as `resolve_league` / `name_taken` already do). Reach for the
+  class-plus-provider only when there's a collaborator worth injecting.
+- **Never a module-level singleton** for anything holding the `AsyncSession`:
+  the session is request-scoped, so the service must be too.
+- **No two services may `Depends`/import each other.** A cycle means the shared
+  logic wants to be a third module.
+
+Because services are plain classes wired by a thin provider, they must be
+constructible without FastAPI anywhere — REPL, `scripts/`, tests. Outside a
+request you own the session lifecycle yourself (`get_session` only
+yields/closes it inside one):
+
+```python
+async with sessionmaker() as db:
+    service = MatchService(db, Glicko2Calculator())
+    ...
+```
+
+Unit-test services by constructing them with fakes directly; use
+`app.dependency_overrides[get_match_service]` for endpoint tests. If you can't
+build a service in the console without FastAPI running, something leaked — a
+`Depends` in the constructor, or a session-holding singleton.

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -1,6 +1,6 @@
 import uuid
 from collections.abc import Sequence
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Literal
 
 from fastapi import APIRouter, Depends
@@ -10,12 +10,14 @@ from sqlalchemy.orm import selectinload
 
 from app.db import get_session
 from app.matches import (
-    participant_filter,
     current_unscored_game,
     match_eager_options,
-    my_side as resolve_my_side,
     opponent_username,
+    participant_filter,
     side_win_counts,
+)
+from app.matches import (
+    my_side as resolve_my_side,
 )
 from app.models import (
     League,
@@ -111,13 +113,17 @@ async def _load_my_rating_changes(
     if not match_ids:
         return {}
     rows = (
-        await db.execute(
-            select(RatingHistory).where(
-                RatingHistory.match_id.in_(match_ids),
-                RatingHistory.user_id == user_id,
+        (
+            await db.execute(
+                select(RatingHistory).where(
+                    RatingHistory.match_id.in_(match_ids),
+                    RatingHistory.user_id == user_id,
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     changes: dict[uuid.UUID, RatingChange] = {}
     for row in rows:
         assert row.match_id is not None  # IN-filtered to non-null match_ids
@@ -167,9 +173,7 @@ def _build_recent_result(
     side_wins = side_win_counts(match)
     my_games_won = side_wins.get(mine.side_number, 0)
     opp_games_won = sum(
-        wins
-        for number, wins in side_wins.items()
-        if number != mine.side_number
+        wins for number, wins in side_wins.items() if number != mine.side_number
     )
     return DashboardRecentResult(
         match_id=match.id,
@@ -182,9 +186,7 @@ def _build_recent_result(
     )
 
 
-async def _build_rating(
-    db: AsyncSession, user_id: uuid.UUID
-) -> DashboardRating | None:
+async def _build_rating(db: AsyncSession, user_id: uuid.UUID) -> DashboardRating | None:
     """Resolve the user's headline rating row.
 
     Picks the default league's rating if there is one, otherwise the oldest
@@ -228,9 +230,7 @@ async def _resolve_user_rating(
     # and strategy so the caller can read is_automatic without an extra round
     # trip.
     options = (
-        selectinload(UserLeagueRating.league).selectinload(
-            League.rating_strategy
-        ),
+        selectinload(UserLeagueRating.league).selectinload(League.rating_strategy),
     )
     default = (
         await db.execute(
@@ -296,7 +296,7 @@ async def _league_percentile(
     ).one()
     if total <= 1:
         return None
-    return round(at_or_below / total * 100)
+    return round(int(at_or_below) / int(total) * 100)
 
 
 async def _spark_and_delta(
@@ -307,7 +307,7 @@ async def _spark_and_delta(
     DESC + reversing avoids the latent bug where ``LIMIT 30 ORDER BY ASC``
     would silently truncate today's points on a power user with >30 events in
     the window."""
-    cutoff = datetime.now(timezone.utc) - timedelta(days=SPARK_WINDOW_DAYS)
+    cutoff = datetime.now(UTC) - timedelta(days=SPARK_WINDOW_DAYS)
     rows = (
         await db.execute(
             select(
@@ -331,11 +331,7 @@ async def _spark_and_delta(
         if latest.previous_rating_value is not None
         else 0.0
     )
-    spark = [
-        float(r.rating_value)
-        for r in reversed(rows)
-        if r.created_at >= cutoff
-    ]
+    spark = [float(r.rating_value) for r in reversed(rows) if r.created_at >= cutoff]
     return spark, delta
 
 
@@ -346,22 +342,26 @@ async def _current_streak(
     wins or losses from the top. Returns None if the user has no completed
     matches."""
     rows = (
-        await db.execute(
-            select(MatchSide.won)
-            .join(Match, Match.id == MatchSide.match_id)
-            .join(
-                MatchSidePlayer,
-                MatchSidePlayer.match_side_id == MatchSide.id,
+        (
+            await db.execute(
+                select(MatchSide.won)
+                .join(Match, Match.id == MatchSide.match_id)
+                .join(
+                    MatchSidePlayer,
+                    MatchSidePlayer.match_side_id == MatchSide.id,
+                )
+                .where(
+                    MatchSidePlayer.user_id == user_id,
+                    Match.status == MatchStatus.completed,
+                    MatchSide.won.is_not(None),
+                )
+                .order_by(Match.updated_at.desc())
+                .limit(STREAK_SCAN_LIMIT)
             )
-            .where(
-                MatchSidePlayer.user_id == user_id,
-                Match.status == MatchStatus.completed,
-                MatchSide.won.is_not(None),
-            )
-            .order_by(Match.updated_at.desc())
-            .limit(STREAK_SCAN_LIMIT)
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     if not rows:
         return None
     head_kind: Literal["W", "L"] = "W" if rows[0] else "L"
@@ -386,7 +386,10 @@ def _strategy_stats(
         rd = _as_float(state.get("rd"))
         volatility = _as_float(state.get("volatility"))
         return [
-            DashboardRatingStat(label="RD", value=str(round(rd)) if rd is not None else "—"),
+            DashboardRatingStat(
+                label="RD",
+                value=str(round(rd)) if rd is not None else "—",
+            ),
             DashboardRatingStat(
                 label="Volatility",
                 value=f"{volatility:.3f}" if volatility is not None else "—",

--- a/api/app/leagues.py
+++ b/api/app/leagues.py
@@ -24,9 +24,7 @@ async def get_default_league(db: AsyncSession) -> League | None:
     return result.scalar_one_or_none()
 
 
-async def resolve_league(
-    db: AsyncSession, league_id: uuid.UUID | None
-) -> League:
+async def resolve_league(db: AsyncSession, league_id: uuid.UUID | None) -> League:
     """Resolve a league by id, falling back to the default. Raises 404 if a
     specific id is supplied but missing, 500 if no default is configured."""
     if league_id is not None:
@@ -42,9 +40,7 @@ async def resolve_league(
         return league
     default = await get_default_league(db)
     if default is None:
-        raise HTTPException(
-            status_code=500, detail="No default league configured."
-        )
+        raise HTTPException(status_code=500, detail="No default league configured.")
     return default
 
 
@@ -85,9 +81,7 @@ def seed_user_league_rating(
     return rating
 
 
-async def add_user_to_default_league(
-    db: AsyncSession, user_id: uuid.UUID
-) -> None:
+async def add_user_to_default_league(db: AsyncSession, user_id: uuid.UUID) -> None:
     """Add the user to the default league and seed their rating row.
 
     Does not commit; the caller controls the surrounding transaction. Seeding
@@ -97,8 +91,6 @@ async def add_user_to_default_league(
     """
     default = await get_default_league(db)
     if default is None:
-        raise RuntimeError(
-            "No default league configured. Run scripts/seed_leagues.py."
-        )
+        raise RuntimeError("No default league configured. Run scripts/seed_leagues.py.")
     db.add(LeagueMembership(league_id=default.id, user_id=user_id))
     seed_user_league_rating(db, default.id, user_id, default.rating_strategy)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import redis.asyncio as redis_asyncio
@@ -9,8 +10,6 @@ from fastapi_limiter import FastAPILimiter
 from pydantic import BaseModel
 from sqlalchemy import text
 
-log = logging.getLogger(__name__)
-
 from app import db, queue
 from app.dashboard import router as dashboard_router
 from app.matches import router as matches_router
@@ -18,9 +17,11 @@ from app.players import router as players_router
 from app.rbac import router as rbac_router
 from app.sessions import router as sessions_router
 
+log = logging.getLogger(__name__)
+
 
 @asynccontextmanager
-async def lifespan(_: FastAPI):
+async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
     connection = redis_asyncio.from_url(redis_url, encoding="utf-8")
     initialized = False
@@ -97,16 +98,14 @@ async def _check_database() -> ComponentHealth:
 def _check_solver() -> ComponentHealth:
     started = time.monotonic()
     try:
-        job = queue.get_queue().enqueue(
-            "app.solver.solve_hello_world", job_timeout=10
-        )
+        job = queue.get_queue().enqueue("app.solver.solve_hello_world", job_timeout=10)
     except Exception as exc:
         return ComponentHealth(healthy=False, error=str(exc) or exc.__class__.__name__)
 
     deadline = time.monotonic() + SOLVER_HEALTH_TIMEOUT
     while time.monotonic() < deadline:
         try:
-            job.refresh()
+            job.refresh()  # type: ignore[no-untyped-call]  # rq's Job.refresh is untyped
         except Exception as exc:
             return ComponentHealth(
                 healthy=False, error=str(exc) or exc.__class__.__name__

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -4,11 +4,13 @@ import math
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
-from sqlalchemy import func, select
+from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
+from sqlalchemy.sql.base import ExecutableOption
 
 from app.db import get_session
 from app.leagues import resolve_league
@@ -87,9 +89,7 @@ def _side_schema(
         ],
         games_won=side_wins.get(side.side_number, 0),
         won=side.won,
-        is_current_user_side=any(
-            p.user_id == current_user_id for p in side.players
-        ),
+        is_current_user_side=any(p.user_id == current_user_id for p in side.players),
         rating_change=rating_change,
     )
 
@@ -97,7 +97,7 @@ def _side_schema(
 # Shared eager-load chain. Used by every read path that returns a hierarchical
 # match — async SQLAlchemy can't lazy-load mid-request, so all four collections
 # are pulled up front.
-def match_eager_options():
+def match_eager_options() -> tuple[ExecutableOption, ...]:
     return (
         selectinload(Match.match_settings),
         selectinload(Match.league).selectinload(League.rating_strategy),
@@ -105,7 +105,7 @@ def match_eager_options():
     )
 
 
-def _match_history_options():
+def _match_history_options() -> tuple[ExecutableOption, ...]:
     """Subset of ``match_eager_options`` for paths that only need sides + scores
     (recent form, H2H): no match_settings, no league/rating-strategy."""
     return (
@@ -125,11 +125,7 @@ async def _load_match(db: AsyncSession, match_id: uuid.UUID) -> Match | None:
 
 def my_side(match: Match, user_id: uuid.UUID) -> MatchSide | None:
     return next(
-        (
-            s
-            for s in match.sides
-            if any(p.user_id == user_id for p in s.players)
-        ),
+        (s for s in match.sides if any(p.user_id == user_id for p in s.players)),
         None,
     )
 
@@ -138,9 +134,7 @@ def opponent_side(match: Match, user_id: uuid.UUID) -> MatchSide | None:
     mine = my_side(match, user_id)
     if mine is None:
         return None
-    return next(
-        (s for s in match.sides if s.side_number != mine.side_number), None
-    )
+    return next((s for s in match.sides if s.side_number != mine.side_number), None)
 
 
 def opponent_username(match: Match, user_id: uuid.UUID) -> str | None:
@@ -260,7 +254,9 @@ def _add_side(match: Match, side_number: int, player: User | None) -> None:
 # ----- list helpers --------------------------------------------------------
 
 
-def participant_filter(query, current_user_id: uuid.UUID):
+def participant_filter(
+    query: Select[tuple[Match]], current_user_id: uuid.UUID
+) -> Select[tuple[Match]]:
     me_in_match = (
         select(MatchSidePlayer.id)
         .where(
@@ -272,8 +268,13 @@ def participant_filter(query, current_user_id: uuid.UUID):
     return query.where(me_in_match)
 
 
-def _player_username_filter(query, q: str):
-    """Restrict to matches that have *any* player whose username matches ``q``."""
+def _player_username_filter[SelectT: Select[Any]](query: SelectT, q: str) -> SelectT:
+    """Restrict to matches that have *any* player whose username matches ``q``.
+
+    A row-narrowing filter preserves the ``Select``'s row shape, so it's
+    generic over whatever the caller is selecting (matches list vs. status
+    counts).
+    """
     pattern = f"%{escape_like(q.strip())}%"
     has_matching_player = (
         select(MatchSidePlayer.id)
@@ -308,9 +309,7 @@ async def create_match(
                 detail="You cannot start a match against yourself.",
             )
         opponent = (
-            await db.execute(
-                select(User).where(User.id == payload.opponent_user_id)
-            )
+            await db.execute(select(User).where(User.id == payload.opponent_user_id))
         ).scalar_one_or_none()
         if opponent is None:
             raise HTTPException(status_code=404, detail="Opponent not found.")
@@ -355,7 +354,9 @@ async def create_match(
     return _serialize_details(created, current_user.id)
 
 
-def _filtered_matches_query(q: str | None, status_: MatchStatus | None):
+def _filtered_matches_query(
+    q: str | None, status_: MatchStatus | None
+) -> Select[tuple[Match]]:
     """Shared base query for the matches list + CSV export (status + search)."""
     base = select(Match)
     if q:
@@ -383,9 +384,7 @@ async def export_matches_csv(
         .scalars()
         .all()
     )
-    csv_text = _matches_to_csv(
-        [_list_row(match, current_user.id) for match in matches]
-    )
+    csv_text = _matches_to_csv([_list_row(match, current_user.id) for match in matches])
     filename = f"fortymm-matches-{datetime.now(UTC).strftime('%Y-%m-%d')}.csv"
     return Response(
         content=csv_text,
@@ -459,10 +458,7 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
         status=match.status,
         status_label=STATUS_LABELS[match.status],
         league=MatchLeague(id=match.league.id, name=match.league.name),
-        sides=[
-            _side_schema(side, side_wins, current_user_id)
-            for side in sides_sorted
-        ],
+        sides=[_side_schema(side, side_wins, current_user_id) for side in sides_sorted],
         best_of=match.match_settings.best_of,
         created_at=match.created_at,
         current_game_id=current_game.id if can_score and current_game else None,
@@ -544,9 +540,7 @@ def _enforce_scorable(match: Match) -> None:
             detail="This match has no opponent and can't be scored.",
         )
     if match.status in {MatchStatus.disputed, MatchStatus.voided}:
-        raise HTTPException(
-            status_code=409, detail="This match is no longer scorable."
-        )
+        raise HTTPException(status_code=409, detail="This match is no longer scorable.")
 
 
 async def _load_rating_changes(
@@ -555,10 +549,14 @@ async def _load_rating_changes(
     """Returns ``user_id -> RatingChange`` for every rating row this match
     produced. Empty for matches that didn't move ratings."""
     rows = (
-        await db.execute(
-            select(RatingHistory).where(RatingHistory.match_id == match_id)
+        (
+            await db.execute(
+                select(RatingHistory).where(RatingHistory.match_id == match_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     return {row.user_id: RatingChange.from_history(row) for row in rows}
 
 
@@ -567,15 +565,13 @@ def _singles_user_ids(match: Match) -> list[uuid.UUID]:
     player are skipped — no doubles surface yet."""
     sides_in_order = sorted(match.sides, key=lambda s: s.side_number)
     return [
-        side.players[0].user_id
-        for side in sides_in_order
-        if len(side.players) == 1
+        side.players[0].user_id for side in sides_in_order if len(side.players) == 1
     ]
 
 
 def _history_base_query(
     current_match_id: uuid.UUID, before: datetime | None = None
-):
+) -> Select[tuple[Match]]:
     """Foundation for both recent-form and H2H lookups: completed matches
     other than this one, eagerly loading just the sides + games subtree.
 
@@ -607,13 +603,17 @@ async def _load_recent_form(
     result: list[MatchDetailsPlayerForm] = []
     for user_id in user_ids:
         rows = (
-            await db.execute(
-                participant_filter(
-                    _history_base_query(match.id, before=match.created_at),
-                    user_id,
-                ).limit(RECENT_FORM_LIMIT)
+            (
+                await db.execute(
+                    participant_filter(
+                        _history_base_query(match.id, before=match.created_at),
+                        user_id,
+                    ).limit(RECENT_FORM_LIMIT)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         rating_before, rating_history = await _load_pre_match_rating(
             db, user_id, match.league_id, match.created_at
         )
@@ -623,9 +623,7 @@ async def _load_recent_form(
         result.append(
             MatchDetailsPlayerForm(
                 user_id=user_id,
-                recent_results=[
-                    _build_form_result(past, user_id) for past in rows
-                ],
+                recent_results=[_build_form_result(past, user_id) for past in rows],
                 rating_before=rating_before,
                 rating_history=rating_history,
                 career_matches_before=matches_before,
@@ -644,17 +642,21 @@ async def _load_pre_match_rating(
     """Returns ``(most-recent-value, chronological-list)``. Strict ``<`` on
     ``before`` so this match's own rating row never leaks in."""
     rows = (
-        await db.execute(
-            select(RatingHistory.rating_value)
-            .where(
-                RatingHistory.user_id == user_id,
-                RatingHistory.league_id == league_id,
-                RatingHistory.created_at < before,
+        (
+            await db.execute(
+                select(RatingHistory.rating_value)
+                .where(
+                    RatingHistory.user_id == user_id,
+                    RatingHistory.league_id == league_id,
+                    RatingHistory.created_at < before,
+                )
+                .order_by(RatingHistory.created_at.desc())
+                .limit(RATING_HISTORY_LIMIT)
             )
-            .order_by(RatingHistory.created_at.desc())
-            .limit(RATING_HISTORY_LIMIT)
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     if not rows:
         return None, []
     history = list(reversed(rows))
@@ -690,16 +692,12 @@ async def _load_career_before(
     return int(row[0]), int(row[1])
 
 
-def _build_form_result(
-    past_match: Match, user_id: uuid.UUID
-) -> MatchDetailsFormResult:
+def _build_form_result(past_match: Match, user_id: uuid.UUID) -> MatchDetailsFormResult:
     mine = my_side(past_match, user_id)
     assert mine is not None  # participant_filter guarantees membership
     side_wins = side_win_counts(past_match)
     player_games = side_wins.get(mine.side_number, 0)
-    opp_games = sum(
-        wins for n, wins in side_wins.items() if n != mine.side_number
-    )
+    opp_games = sum(wins for n, wins in side_wins.items() if n != mine.side_number)
     return MatchDetailsFormResult(
         match_id=past_match.id,
         is_win=mine.won is True,
@@ -722,9 +720,7 @@ async def _load_head_to_head(
         participant_filter(_history_base_query(current_match_id), user_a),
         user_b,
     )
-    rows = (
-        await db.execute(rows_query.limit(H2H_MEETINGS_LIMIT))
-    ).scalars().all()
+    rows = (await db.execute(rows_query.limit(H2H_MEETINGS_LIMIT))).scalars().all()
 
     meetings: list[MatchDetailsH2HMeeting] = []
     for past in rows:
@@ -850,9 +846,7 @@ async def _apply_rating_update(db: AsyncSession, match: Match) -> None:
 
     already_applied = (
         await db.execute(
-            select(RatingHistory.id)
-            .where(RatingHistory.match_id == match.id)
-            .limit(1)
+            select(RatingHistory.id).where(RatingHistory.match_id == match.id).limit(1)
         )
     ).scalar_one_or_none()
     if already_applied is not None:
@@ -954,9 +948,7 @@ def _recompute_match(match: Match) -> None:
         for game in trailing_unscored:
             match.games.remove(game)
     elif not trailing_unscored:
-        next_number = (
-            max((g.game_number for g in games_sorted), default=0) + 1
-        )
+        next_number = max((g.game_number for g in games_sorted), default=0) + 1
         match.games.append(MatchGame(game_number=next_number))
 
 

--- a/api/app/models/league.py
+++ b/api/app/models/league.py
@@ -3,7 +3,17 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, String, Text, func, text
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    func,
+    text,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -71,6 +81,4 @@ class League(Base):
         cascade="all, delete-orphan",
         passive_deletes=True,
     )
-    rating_strategy: Mapped["RatingStrategy"] = relationship(
-        back_populates="leagues"
-    )
+    rating_strategy: Mapped["RatingStrategy"] = relationship(back_populates="leagues")

--- a/api/app/models/match_game_score.py
+++ b/api/app/models/match_game_score.py
@@ -26,9 +26,7 @@ class MatchGameScore(Base):
 
     __tablename__ = "match_game_scores"
     __table_args__ = (
-        UniqueConstraint(
-            "match_game_id", name="uq_match_game_scores_match_game_id"
-        ),
+        UniqueConstraint("match_game_id", name="uq_match_game_scores_match_game_id"),
         CheckConstraint(
             "side_1_points >= 0", name="ck_match_game_scores_side_1_points"
         ),

--- a/api/app/models/match_settings.py
+++ b/api/app/models/match_settings.py
@@ -3,7 +3,15 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, CheckConstraint, DateTime, Enum, SmallInteger, func, text
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Enum,
+    SmallInteger,
+    func,
+    text,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 

--- a/api/app/models/rating_history.py
+++ b/api/app/models/rating_history.py
@@ -75,9 +75,7 @@ class RatingHistory(Base):
     )
     rating_value: Mapped[float] = mapped_column(Float, nullable=False)
     rating_state: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
-    previous_rating_value: Mapped[float | None] = mapped_column(
-        Float, nullable=True
-    )
+    previous_rating_value: Mapped[float | None] = mapped_column(Float, nullable=True)
     source: Mapped[RatingHistorySource] = mapped_column(
         Enum(
             RatingHistorySource,
@@ -100,6 +98,4 @@ class RatingHistory(Base):
     user: Mapped["User"] = relationship(foreign_keys=[user_id])
     match: Mapped["Match | None"] = relationship()
     rating_strategy: Mapped["RatingStrategy"] = relationship()
-    created_by: Mapped["User | None"] = relationship(
-        foreign_keys=[created_by_user_id]
-    )
+    created_by: Mapped["User | None"] = relationship(foreign_keys=[created_by_user_id])

--- a/api/app/models/rating_strategy.py
+++ b/api/app/models/rating_strategy.py
@@ -30,12 +30,8 @@ class RatingStrategy(Base):
     name: Mapped[str] = mapped_column(String(128), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     state_schema: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
-    initial_state: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB, nullable=True
-    )
-    initial_rating_value: Mapped[float | None] = mapped_column(
-        Float, nullable=True
-    )
+    initial_state: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    initial_rating_value: Mapped[float | None] = mapped_column(Float, nullable=True)
     is_automatic: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false")
     )

--- a/api/app/models/user_league_rating.py
+++ b/api/app/models/user_league_rating.py
@@ -46,9 +46,7 @@ class UserLeagueRating(Base):
         nullable=False,
     )
     rating_value: Mapped[float | None] = mapped_column(Float, nullable=True)
-    rating_state: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB, nullable=True
-    )
+    rating_state: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/api/app/players.py
+++ b/api/app/players.py
@@ -116,9 +116,7 @@ async def list_recent_opponents(
         opponents.extend(backfill)
 
     league = await resolve_league(db, league_id)
-    ratings = await _load_player_ratings(
-        db, league.id, (user.id for user in opponents)
-    )
+    ratings = await _load_player_ratings(db, league.id, (user.id for user in opponents))
     return _serialize(opponents, ratings)
 
 
@@ -152,7 +150,5 @@ async def search_players(
     )
     users = result.scalars().all()
     league = await resolve_league(db, league_id)
-    ratings = await _load_player_ratings(
-        db, league.id, (user.id for user in users)
-    )
+    ratings = await _load_player_ratings(db, league.id, (user.id for user in users))
     return _serialize(users, ratings)

--- a/api/app/ratings/glicko2.py
+++ b/api/app/ratings/glicko2.py
@@ -3,6 +3,7 @@
 Each match is its own one-game rating period for both players — the simplest
 mapping that produces an update on every result.
 """
+
 import math
 from typing import Any
 

--- a/api/app/ratings/recompute.py
+++ b/api/app/ratings/recompute.py
@@ -12,6 +12,8 @@ retried call lands on the same result.
 """
 
 import uuid
+from datetime import datetime
+from typing import Any
 
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,6 +28,7 @@ from app.models import (
     MatchStatus,
     RatingHistory,
     RatingHistorySource,
+    RatingStrategy,
     UserLeagueRating,
 )
 from app.ratings.base import state_rating_value
@@ -97,9 +100,7 @@ async def recompute_league_ratings(
                     MatchSettings.affects_rating.is_(True),
                     MatchSettings.team_size == 1,
                 )
-                .options(
-                    selectinload(Match.sides).selectinload(MatchSide.players)
-                )
+                .options(selectinload(Match.sides).selectinload(MatchSide.players))
                 .order_by(Match.updated_at.asc(), Match.id.asc())
             )
         )
@@ -216,9 +217,9 @@ async def _seed_states(
     db: AsyncSession,
     league_id: uuid.UUID,
     user_ids: set[uuid.UUID],
-    t_start,
-    strategy,
-) -> dict[uuid.UUID, dict]:
+    t_start: datetime,
+    strategy: RatingStrategy,
+) -> dict[uuid.UUID, dict[str, Any]]:
     """Per-user rating state as of the moment just before ``t_start``: the
     user's most recent ``rating_history`` row in this league, or the
     strategy's initial state if they have none. Users with no history and no
@@ -247,7 +248,7 @@ async def _seed_states(
         select(subq.c.user_id, subq.c.rating_state).where(subq.c.rn == 1)
     )
 
-    states: dict[uuid.UUID, dict] = {
+    states: dict[uuid.UUID, dict[str, Any]] = {
         user_id: dict(state) for user_id, state in latest_per_user.all()
     }
     if strategy.initial_state is not None:

--- a/api/app/ratings/registry.py
+++ b/api/app/ratings/registry.py
@@ -1,7 +1,6 @@
 from app.ratings.base import RatingCalculator
 from app.ratings.glicko2 import CALCULATOR as GLICKO2_CALCULATOR
 
-
 STRATEGIES: dict[str, RatingCalculator] = {
     GLICKO2_CALCULATOR.key: GLICKO2_CALCULATOR,
 }

--- a/api/app/rbac.py
+++ b/api/app/rbac.py
@@ -1,6 +1,5 @@
 import uuid
-from collections.abc import Sequence
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import delete, func, select
@@ -10,7 +9,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db import get_session
 from app.leagues import add_user_to_default_league
 from app.models import Permission, Role, RolePermission, User, UserRole
-from app.uniqueness import name_taken
 from app.schemas.rbac import (
     PermissionCreate,
     PermissionRead,
@@ -23,7 +21,7 @@ from app.schemas.rbac import (
     RoleUpdate,
 )
 from app.sessions import get_current_user
-
+from app.uniqueness import name_taken
 
 # ----- authorization -------------------------------------------------------
 
@@ -35,9 +33,7 @@ from app.sessions import get_current_user
 RBAC_PERMISSION = "authorization.manage"
 
 
-async def _user_has_permission(
-    db: AsyncSession, user_id: uuid.UUID, name: str
-) -> bool:
+async def _user_has_permission(db: AsyncSession, user_id: uuid.UUID, name: str) -> bool:
     result = await db.execute(
         select(Permission.id)
         .join(RolePermission, RolePermission.permission_id == Permission.id)
@@ -162,9 +158,7 @@ async def _validate_permission_ids(
     deduped = list(dict.fromkeys(permission_ids))
     if not deduped:
         return []
-    result = await db.execute(
-        select(Permission.id).where(Permission.id.in_(deduped))
-    )
+    result = await db.execute(select(Permission.id).where(Permission.id.in_(deduped)))
     found = set(result.scalars().all())
     missing = [pid for pid in deduped if pid not in found]
     if missing:
@@ -213,9 +207,7 @@ async def create_permission(
     db: AsyncSession = Depends(get_session),
 ) -> PermissionRead:
     if await name_taken(db, Permission.id, Permission.name, payload.name):
-        raise HTTPException(
-            status_code=409, detail="Permission name already exists."
-        )
+        raise HTTPException(status_code=409, detail="Permission name already exists.")
     perm = Permission(name=payload.name, description=payload.description)
     db.add(perm)
     try:
@@ -224,7 +216,7 @@ async def create_permission(
         await db.rollback()
         raise HTTPException(
             status_code=409, detail="Permission name already exists."
-        )
+        ) from None
     await db.refresh(perm)
     return PermissionRead.model_validate(perm)
 
@@ -253,9 +245,7 @@ async def update_permission(
             db, Permission.id, Permission.name, data["name"], exclude_id=perm.id
         )
     ):
-        raise HTTPException(
-            status_code=409, detail="Permission name already exists."
-        )
+        raise HTTPException(status_code=409, detail="Permission name already exists.")
     for key, value in data.items():
         setattr(perm, key, value)
     try:
@@ -264,14 +254,12 @@ async def update_permission(
         await db.rollback()
         raise HTTPException(
             status_code=409, detail="Permission name already exists."
-        )
+        ) from None
     await db.refresh(perm)
     return PermissionRead.model_validate(perm)
 
 
-@router.delete(
-    "/permissions/{permission_id}", status_code=status.HTTP_204_NO_CONTENT
-)
+@router.delete("/permissions/{permission_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_permission(
     permission_id: uuid.UUID,
     db: AsyncSession = Depends(get_session),
@@ -293,9 +281,7 @@ async def list_roles(db: AsyncSession = Depends(get_session)) -> list[RoleRead]:
     return [_serialize_role(r, perm_map.get(r.id, [])) for r in roles]
 
 
-@router.post(
-    "/roles", response_model=RoleRead, status_code=status.HTTP_201_CREATED
-)
+@router.post("/roles", response_model=RoleRead, status_code=status.HTTP_201_CREATED)
 async def create_role(
     payload: RoleCreate,
     db: AsyncSession = Depends(get_session),
@@ -315,9 +301,7 @@ async def create_role(
         template_perms = await _load_role_permission_map(db, [template.id])
         permission_ids = template_perms.get(template.id, [])
     elif payload.permission_ids is not None:
-        permission_ids = await _validate_permission_ids(
-            db, payload.permission_ids
-        )
+        permission_ids = await _validate_permission_ids(db, payload.permission_ids)
 
     role = Role(name=payload.name, description=payload.description)
     db.add(role)
@@ -325,7 +309,9 @@ async def create_role(
         await db.flush()
     except IntegrityError:
         await db.rollback()
-        raise HTTPException(status_code=409, detail="Role name already exists.")
+        raise HTTPException(
+            status_code=409, detail="Role name already exists."
+        ) from None
 
     for pid in permission_ids:
         db.add(RolePermission(role_id=role.id, permission_id=pid))
@@ -353,9 +339,7 @@ async def update_role(
     # racing PATCHes (e.g. duplicated clicks) don't collide on the
     # role_permissions primary key when one deletes and re-inserts before the
     # other commits.
-    locked = await db.execute(
-        select(Role).where(Role.id == role_id).with_for_update()
-    )
+    locked = await db.execute(select(Role).where(Role.id == role_id).with_for_update())
     role = locked.scalar_one_or_none()
     if role is None:
         raise HTTPException(status_code=404, detail="Role not found.")
@@ -372,9 +356,7 @@ async def update_role(
     if (
         "name" in data
         and data["name"]
-        and await name_taken(
-            db, Role.id, Role.name, data["name"], exclude_id=role.id
-        )
+        and await name_taken(db, Role.id, Role.name, data["name"], exclude_id=role.id)
     ):
         raise HTTPException(status_code=409, detail="Role name already exists.")
 
@@ -385,7 +367,9 @@ async def update_role(
         await db.flush()
     except IntegrityError:
         await db.rollback()
-        raise HTTPException(status_code=409, detail="Role name already exists.")
+        raise HTTPException(
+            status_code=409, detail="Role name already exists."
+        ) from None
 
     if new_permission_ids is not None:
         await db.execute(
@@ -430,9 +414,7 @@ async def list_users(
     return [_serialize_user(u, role_map.get(u.id, [])) for u in users]
 
 
-@router.post(
-    "/users", response_model=RbacUserRead, status_code=status.HTTP_201_CREATED
-)
+@router.post("/users", response_model=RbacUserRead, status_code=status.HTTP_201_CREATED)
 async def create_user(
     payload: RbacUserCreate,
     db: AsyncSession = Depends(get_session),
@@ -447,7 +429,9 @@ async def create_user(
         await db.commit()
     except IntegrityError:
         await db.rollback()
-        raise HTTPException(status_code=409, detail="Username already exists.")
+        raise HTTPException(
+            status_code=409, detail="Username already exists."
+        ) from None
     await db.refresh(user)
     return _serialize_user(user, [])
 
@@ -469,9 +453,7 @@ async def set_user_roles(
 ) -> RbacUserRead:
     # FOR UPDATE on the user row prevents racing PUTs from colliding on the
     # user_roles primary key (delete-then-insert otherwise conflicts).
-    locked = await db.execute(
-        select(User).where(User.id == user_id).with_for_update()
-    )
+    locked = await db.execute(select(User).where(User.id == user_id).with_for_update())
     user = locked.scalar_one_or_none()
     if user is None:
         raise HTTPException(status_code=404, detail="User not found.")

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -195,7 +195,7 @@ class MatchGameScoreWrite(BaseModel):
     side_2_points: int = Field(ge=0, le=99)
 
     @model_validator(mode="after")
-    def _table_tennis_rules(self):
+    def _table_tennis_rules(self) -> "MatchGameScoreWrite":
         a, b = self.side_1_points, self.side_2_points
         winner, loser = max(a, b), min(a, b)
         if winner < 11:

--- a/api/app/schemas/rating.py
+++ b/api/app/schemas/rating.py
@@ -16,7 +16,7 @@ class RatingChange(BaseModel):
     delta: float
 
     @classmethod
-    def from_history(cls, row: "RatingHistory") -> "RatingChange":
+    def from_history(cls, row: RatingHistory) -> RatingChange:
         prev = row.previous_rating_value
         delta = row.rating_value - prev if prev is not None else 0.0
         return cls(before=prev, after=row.rating_value, delta=delta)

--- a/api/app/schemas/rbac.py
+++ b/api/app/schemas/rbac.py
@@ -18,9 +18,7 @@ class PermissionBase(BaseModel):
 class PermissionCreate(PermissionBase):
     # Pattern is enforced on write only — historical rows that predate this
     # constraint must still serialize cleanly through PermissionRead.
-    name: str = Field(
-        min_length=1, max_length=255, pattern=PERMISSION_NAME_PATTERN
-    )
+    name: str = Field(min_length=1, max_length=255, pattern=PERMISSION_NAME_PATTERN)
 
 
 class PermissionUpdate(BaseModel):

--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -75,5 +75,13 @@ class RequestLoginRequest(CaptchaProtectedRequest):
     email: EmailStr
 
 
+class LoginRequestAccepted(BaseModel):
+    """202 body for the magic-link request endpoint. Always echoes the
+    submitted address — identical whether or not it maps to a real account,
+    so the response leaks nothing about which addresses are registered."""
+
+    email: EmailStr
+
+
 class ConsumeLoginRequest(BaseModel):
     token: str = Field(min_length=1, max_length=512)

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -3,12 +3,13 @@ import logging
 import os
 import secrets
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
 from coolname import generate_slug
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
 from fastapi_limiter.depends import RateLimiter
+from rq.job import Job
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,6 +24,7 @@ from app.ratings.jobs import RECOMPUTE_AFTER_MERGE_JOB
 from app.schemas.session import (
     ConfirmEmailRequest,
     ConsumeLoginRequest,
+    LoginRequestAccepted,
     MergeSummary,
     RequestLoginRequest,
     ResendEmailRequest,
@@ -96,9 +98,7 @@ async def _email_ip_rate_limit_key(request: Request) -> str:
 #   - looser per-IP ceiling so an attacker can't trivially multiply their
 #     budget by rotating guest sessions (each `GET /v1/session` mints a new
 #     one for free).
-email_send_rate_limit = RateLimiter(
-    times=5, hours=1, identifier=_email_rate_limit_key
-)
+email_send_rate_limit = RateLimiter(times=5, hours=1, identifier=_email_rate_limit_key)
 email_send_ip_rate_limit = RateLimiter(
     times=20, hours=1, identifier=_email_ip_rate_limit_key
 )
@@ -132,9 +132,7 @@ def _hash_token(raw_token: str) -> bytes:
 async def _generate_username(db: AsyncSession) -> str:
     base = generate_slug(2)
     result = await db.execute(
-        select(User.username).where(
-            User.username.ilike(f"{base}%", escape="\\")
-        )
+        select(User.username).where(User.username.ilike(f"{base}%", escape="\\"))
     )
     taken = {u.lower() for u in result.scalars().all()}
     if base not in taken:
@@ -206,7 +204,7 @@ async def _maybe_merge_prior_session(
     return MergeSummary(matches_moved=summary.matches_moved)
 
 
-async def _load_permissions(db: AsyncSession, user_id) -> list[str]:
+async def _load_permissions(db: AsyncSession, user_id: uuid.UUID) -> list[str]:
     result = await db.execute(
         select(Permission.name)
         .join(RolePermission, RolePermission.permission_id == Permission.id)
@@ -254,9 +252,7 @@ def _set_session_cookie(response: Response, raw_token: str) -> None:
 @router.get("/v1/session", response_model=SessionResponse)
 async def get_session_endpoint(
     response: Response,
-    session_cookie: Annotated[
-        str | None, Cookie(alias=SESSION_COOKIE_NAME)
-    ] = None,
+    session_cookie: Annotated[str | None, Cookie(alias=SESSION_COOKIE_NAME)] = None,
     db: AsyncSession = Depends(get_session),
 ) -> SessionResponse:
     user: User | None = None
@@ -269,9 +265,7 @@ async def get_session_endpoint(
 
 
 async def get_current_user(
-    session_cookie: Annotated[
-        str | None, Cookie(alias=SESSION_COOKIE_NAME)
-    ] = None,
+    session_cookie: Annotated[str | None, Cookie(alias=SESSION_COOKIE_NAME)] = None,
     db: AsyncSession = Depends(get_session),
 ) -> User:
     """Resolve the authenticated user from the session cookie.
@@ -280,9 +274,7 @@ async def get_current_user(
     endpoints that create or mutate data require an already-established
     session and respond ``401`` otherwise.
     """
-    user = (
-        await _find_session_user(db, session_cookie) if session_cookie else None
-    )
+    user = await _find_session_user(db, session_cookie) if session_cookie else None
     if user is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -319,7 +311,7 @@ async def update_current_user(
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Username already taken.",
-            )
+            ) from None
         await db.refresh(current_user)
 
     return await _build_session_response(db, current_user)
@@ -334,7 +326,7 @@ async def _verify_captcha_or_400(captcha_token: str) -> None:
 
 
 async def _pending_change_token(
-    db: AsyncSession, user_id
+    db: AsyncSession, user_id: uuid.UUID
 ) -> UserToken | None:
     """Return the user's pending email-change token, if any. Resend needs
     both the prior ``context`` (audit trail) and ``sent_to`` (where to
@@ -378,7 +370,7 @@ async def _issue_confirmation_token(
 
 def _enqueue_email_job(
     job_func: str, to_email: str, raw_token: str, username: str
-):
+) -> Job:
     # result_ttl=60 / failure_ttl=300 shrinks the window during which the raw
     # token (pickled into the RQ job hash in Redis) is recoverable from a
     # snapshot or dashboard. Defaults are 8m / 1 year respectively.
@@ -392,13 +384,13 @@ def _enqueue_email_job(
     )
 
 
-def _enqueue_confirmation_email(to_email: str, raw_token: str, username: str):
+def _enqueue_confirmation_email(to_email: str, raw_token: str, username: str) -> Job:
     return _enqueue_email_job(
         "app.email.send_confirmation_email", to_email, raw_token, username
     )
 
 
-def _enqueue_login_email(to_email: str, raw_token: str, username: str):
+def _enqueue_login_email(to_email: str, raw_token: str, username: str) -> Job:
     return _enqueue_email_job(
         "app.email.send_login_email", to_email, raw_token, username
     )
@@ -471,16 +463,14 @@ async def set_email(
     # user silently un-verified with no link sent. If enqueue fails, rollback
     # restores in-memory + on-disk state.
     try:
-        job = _enqueue_confirmation_email(
-            email, raw_token, current_user.username
-        )
+        job = _enqueue_confirmation_email(email, raw_token, current_user.username)
     except Exception:
         await db.rollback()
         await db.refresh(current_user)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Email service unavailable. Try again in a moment.",
-        )
+        ) from None
 
     try:
         await db.commit()
@@ -538,7 +528,7 @@ async def resend_email_confirmation(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Email service unavailable. Try again in a moment.",
-        )
+        ) from None
     try:
         await db.commit()
     except Exception:
@@ -555,9 +545,7 @@ async def resend_email_confirmation(
 async def confirm_email(
     payload: ConfirmEmailRequest,
     response: Response,
-    session_cookie: Annotated[
-        str | None, Cookie(alias=SESSION_COOKIE_NAME)
-    ] = None,
+    session_cookie: Annotated[str | None, Cookie(alias=SESSION_COOKIE_NAME)] = None,
     db: AsyncSession = Depends(get_session),
 ) -> SessionResponse:
     """Consume an email-change token: stamp the new email + ``confirmed_at``.
@@ -619,7 +607,7 @@ async def confirm_email(
     raw_session = secrets.token_urlsafe(32)
     try:
         user.email = token_row.sent_to
-        user.confirmed_at = datetime.now(timezone.utc)
+        user.confirmed_at = datetime.now(UTC)
         await db.delete(token_row)
         merged = await _maybe_merge_prior_session(db, session_cookie, user)
         db.add(
@@ -635,7 +623,7 @@ async def confirm_email(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="That confirmation link is invalid or expired.",
-        )
+        ) from None
     if merged is not None and merged.matches_moved > 0:
         _enqueue_rating_recompute_after_merge(user.id)
     _set_session_cookie(response, raw_session)
@@ -645,6 +633,7 @@ async def confirm_email(
 @router.post(
     "/v1/login/request",
     status_code=status.HTTP_202_ACCEPTED,
+    response_model=LoginRequestAccepted,
     dependencies=[
         Depends(email_send_ip_rate_limit),
         Depends(email_send_rate_limit),
@@ -653,7 +642,7 @@ async def confirm_email(
 async def request_login_email(
     payload: RequestLoginRequest,
     db: AsyncSession = Depends(get_session),
-) -> dict:
+) -> LoginRequestAccepted:
     """Mint a magic-link sign-in token and email it.
 
     Always returns the same 202 shape regardless of whether the address
@@ -671,7 +660,7 @@ async def request_login_email(
     email = payload.email.lower()
 
     if payload.fmm_hp_token.strip():
-        return {"email": email}
+        return LoginRequestAccepted(email=email)
 
     await _verify_captcha_or_400(payload.captcha_token)
 
@@ -679,19 +668,17 @@ async def request_login_email(
         await db.execute(select(User).where(User.email == email))
     ).scalar_one_or_none()
     if user is None:
-        return {"email": email}
+        return LoginRequestAccepted(email=email)
 
     if user.confirmed_at is None:
         await _issue_and_send_confirmation_email(db, user, email)
-        return {"email": email}
+        return LoginRequestAccepted(email=email)
 
     await _issue_and_send_login_email(db, user, email)
-    return {"email": email}
+    return LoginRequestAccepted(email=email)
 
 
-async def _issue_and_send_login_email(
-    db: AsyncSession, user: User, email: str
-) -> None:
+async def _issue_and_send_login_email(db: AsyncSession, user: User, email: str) -> None:
     """Replace any live login token for this user with a fresh one and
     enqueue the sign-in email. Enqueue before commit so a Redis flap
     rolls the DB write back instead of stranding a tokenless user."""
@@ -717,7 +704,7 @@ async def _issue_and_send_login_email(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Email service unavailable. Try again in a moment.",
-        )
+        ) from None
     try:
         await db.commit()
     except Exception:
@@ -746,7 +733,7 @@ async def _issue_and_send_confirmation_email(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Email service unavailable. Try again in a moment.",
-        )
+        ) from None
     try:
         await db.commit()
     except Exception:
@@ -766,9 +753,7 @@ async def _issue_and_send_confirmation_email(
 async def consume_login_token(
     payload: ConsumeLoginRequest,
     response: Response,
-    session_cookie: Annotated[
-        str | None, Cookie(alias=SESSION_COOKIE_NAME)
-    ] = None,
+    session_cookie: Annotated[str | None, Cookie(alias=SESSION_COOKIE_NAME)] = None,
     db: AsyncSession = Depends(get_session),
 ) -> SessionResponse:
     """Verify a magic-link token and rotate the caller's session cookie.
@@ -794,8 +779,8 @@ async def consume_login_token(
 
     issued_at = token_row.created_at
     if issued_at.tzinfo is None:
-        issued_at = issued_at.replace(tzinfo=timezone.utc)
-    if datetime.now(timezone.utc) - issued_at > LOGIN_TOKEN_LIFETIME:
+        issued_at = issued_at.replace(tzinfo=UTC)
+    if datetime.now(UTC) - issued_at > LOGIN_TOKEN_LIFETIME:
         await db.delete(token_row)
         await db.commit()
         raise HTTPException(

--- a/api/app/uniqueness.py
+++ b/api/app/uniqueness.py
@@ -2,12 +2,13 @@ import uuid
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import InstrumentedAttribute
 
 
 async def name_taken(
     db: AsyncSession,
-    id_col,
-    name_col,
+    id_col: InstrumentedAttribute[uuid.UUID],
+    name_col: InstrumentedAttribute[str] | InstrumentedAttribute[str | None],
     name: str,
     *,
     exclude_id: uuid.UUID | None = None,

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "testcontainers[postgres]>=4.8",
     "mypy>=1.13",
     "types-jsonschema>=4.21",
+    "ruff>=0.8",
 ]
 
 [build-system]
@@ -43,12 +44,18 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"
 
+[tool.ruff]
+target-version = "py313"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+# B008: FastAPI relies on `Depends(...)` / `Query(...)` as argument defaults.
+ignore = ["B008"]
+
 [tool.mypy]
 python_version = "3.13"
 files = ["app"]
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_unused_configs = true
+strict = true
 
 # ortools ships incomplete inline types (it has a py.typed marker) — CpModel's
 # methods (NewIntVar, Add, …) are added dynamically, so mypy reports false

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -12,9 +12,7 @@ from app.main import app as fastapi_app
 from app.models import User
 
 
-async def start_session(
-    api_client: AsyncClient, db_session: AsyncSession
-) -> User:
+async def start_session(api_client: AsyncClient, db_session: AsyncSession) -> User:
     """Establish a session cookie on the client and return the signed-in user."""
     response = await api_client.get("/v1/session")
     assert response.status_code == 200

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -13,10 +13,10 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+import app.models  # noqa: F401  -- ensures models register on Base.metadata
 from app import queue as queue_module
 from app.db import Base, get_session
 from app.main import app as fastapi_app
-import app.models  # noqa: F401  -- ensures models register on Base.metadata
 from app.models import League, LeagueVisibility, RatingStrategy
 
 

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -1,9 +1,8 @@
 """Unit tests for the ephemeral→verified merge primitive in app.account_merge."""
 
 import hashlib
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
-import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,7 +38,7 @@ async def _make_verified(db: AsyncSession, email: str) -> User:
     user = User(
         username=email.split("@")[0],
         email=email,
-        confirmed_at=datetime.now(timezone.utc),
+        confirmed_at=datetime.now(UTC),
     )
     db.add(user)
     await db.commit()
@@ -47,9 +46,7 @@ async def _make_verified(db: AsyncSession, email: str) -> User:
     return user
 
 
-async def _record_match(
-    db: AsyncSession, creator: User, *players: User
-) -> Match:
+async def _record_match(db: AsyncSession, creator: User, *players: User) -> Match:
     league = await get_default_league(db)
     settings = MatchSettings(team_size=1, best_of=5, affects_rating=False)
     match = Match(
@@ -87,10 +84,14 @@ async def test_merge_repoints_match_side_players_and_creator(
     assert summary.matches_moved == 1
 
     players = (
-        await db_session.execute(
-            select(MatchSidePlayer).where(MatchSidePlayer.match_id == match.id)
+        (
+            await db_session.execute(
+                select(MatchSidePlayer).where(MatchSidePlayer.match_id == match.id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     user_ids = {p.user_id for p in players}
     assert user_ids == {verified.id, opponent.id}
 
@@ -117,19 +118,21 @@ async def test_merge_deletes_ephemeral_user_and_cascades_tokens(
     )
     await db_session.commit()
 
-    await merge_user(
-        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
-    )
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
     await db_session.commit()
 
     assert (
         await db_session.execute(select(User).where(User.id == ephemeral.id))
     ).scalar_one_or_none() is None
     leftover_tokens = (
-        await db_session.execute(
-            select(UserToken).where(UserToken.user_id == ephemeral.id)
+        (
+            await db_session.execute(
+                select(UserToken).where(UserToken.user_id == ephemeral.id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert leftover_tokens == []
 
 
@@ -140,19 +143,19 @@ async def test_merge_moves_league_membership_when_target_has_none(
     verified = await _make_verified(db_session, "rita@example.com")
     # verified is NOT in the default league yet
 
-    await merge_user(
-        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
-    )
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
     await db_session.commit()
 
     league = await get_default_league(db_session)
     memberships = (
-        await db_session.execute(
-            select(LeagueMembership).where(
-                LeagueMembership.league_id == league.id
+        (
+            await db_session.execute(
+                select(LeagueMembership).where(LeagueMembership.league_id == league.id)
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     user_ids = {m.user_id for m in memberships}
     assert verified.id in user_ids
     assert ephemeral.id not in user_ids
@@ -168,19 +171,19 @@ async def test_merge_skips_membership_when_target_already_a_member(
     await add_user_to_default_league(db_session, verified.id)
     await db_session.commit()
 
-    await merge_user(
-        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
-    )
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
     await db_session.commit()
 
     league = await get_default_league(db_session)
     memberships = (
-        await db_session.execute(
-            select(LeagueMembership).where(
-                LeagueMembership.league_id == league.id
+        (
+            await db_session.execute(
+                select(LeagueMembership).where(LeagueMembership.league_id == league.id)
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     user_ids = [m.user_id for m in memberships]
     assert user_ids == [verified.id]
 
@@ -208,9 +211,7 @@ async def test_merge_repoints_rating_history_created_by(
     db_session.add(row)
     await db_session.commit()
 
-    await merge_user(
-        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
-    )
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
     await db_session.commit()
 
     await db_session.refresh(row)
@@ -269,24 +270,26 @@ async def test_merge_with_user_league_rating_collision_drops_ephemeral(
     league = await get_default_league(db_session)
     # Sanity: both have a rating row pre-merge.
     pre = (
-        await db_session.execute(
-            select(UserLeagueRating).where(
-                UserLeagueRating.league_id == league.id
+        (
+            await db_session.execute(
+                select(UserLeagueRating).where(UserLeagueRating.league_id == league.id)
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert {r.user_id for r in pre} == {ephemeral.id, verified.id}
 
-    await merge_user(
-        db_session, from_user_id=ephemeral.id, to_user_id=verified.id
-    )
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
     await db_session.commit()
 
     rows = (
-        await db_session.execute(
-            select(UserLeagueRating).where(
-                UserLeagueRating.league_id == league.id
+        (
+            await db_session.execute(
+                select(UserLeagueRating).where(UserLeagueRating.league_id == league.id)
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert [r.user_id for r in rows] == [verified.id]

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import UTC
 
 from httpx import AsyncClient
 from sqlalchemy import select, text
@@ -17,9 +18,7 @@ from app.models import (
 from tests._helpers import make_client, make_user, start_session
 
 
-async def _create_match(
-    client: AsyncClient, opponent_id, best_of: int = 5
-) -> dict:
+async def _create_match(client: AsyncClient, opponent_id, best_of: int = 5) -> dict:
     response = await client.post(
         "/v1/matches",
         json={
@@ -259,9 +258,7 @@ async def test_dashboard_rating_percentile_against_league_peers(
     bottom of the leaderboard until they actually beat someone."""
     me = await start_session(api_client, db_session)
     default_league = (
-        await db_session.execute(
-            select(League).where(League.is_default.is_(True))
-        )
+        await db_session.execute(select(League).where(League.is_default.is_(True)))
     ).scalar_one()
     # Seed 4 peers at varying ratings without playing any matches against me.
     for name, value in [
@@ -271,9 +268,7 @@ async def test_dashboard_rating_percentile_against_league_peers(
         ("high", 1800.0),
     ]:
         peer = await make_user(db_session, name)
-        db_session.add(
-            LeagueMembership(league_id=default_league.id, user_id=peer.id)
-        )
+        db_session.add(LeagueMembership(league_id=default_league.id, user_id=peer.id))
         db_session.add(
             UserLeagueRating(
                 league_id=default_league.id,
@@ -296,13 +291,11 @@ async def test_dashboard_sparkline_returns_most_recent_points(
     """When the user has more rating-history rows than SPARK_MAX_POINTS in
     the 30-day window, the sparkline should be the *most recent* points in
     chronological order — not the oldest 30."""
-    from datetime import datetime, timedelta, timezone
+    from datetime import datetime, timedelta
 
     me = await start_session(api_client, db_session)
     default_league = (
-        await db_session.execute(
-            select(League).where(League.is_default.is_(True))
-        )
+        await db_session.execute(select(League).where(League.is_default.is_(True)))
     ).scalar_one()
     strategy = (
         await db_session.execute(
@@ -357,9 +350,7 @@ async def test_dashboard_rating_is_null_for_manual_league(
         )
     ).scalar_one()
     default = (
-        await db_session.execute(
-            select(League).where(League.is_default.is_(True))
-        )
+        await db_session.execute(select(League).where(League.is_default.is_(True)))
     ).scalar_one()
     default.rating_strategy_id = manual.id
     await db_session.commit()

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -305,7 +305,7 @@ async def test_dashboard_sparkline_returns_most_recent_points(
     # The signup seed event sits before any match, so push it back behind the
     # 40 rows below; otherwise it would be the most-recent point and skew the
     # truncation this test is checking.
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     await db_session.execute(
         text(
             "UPDATE rating_history SET created_at = :ts "

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -1,6 +1,6 @@
 import hashlib
 from collections.abc import AsyncIterator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 import pytest_asyncio
@@ -36,9 +36,7 @@ VALID_BODY = {
 }
 
 
-async def _set_email(
-    client: AsyncClient, **overrides
-) -> "httpx.Response":  # noqa: F821
+async def _set_email(client: AsyncClient, **overrides) -> "httpx.Response":  # noqa: F821
     body = {**VALID_BODY, **overrides}
     return await client.post("/v1/me/email", json=body)
 
@@ -76,12 +74,16 @@ async def test_set_email_is_pending_only(
     assert user.confirmed_at is None
 
     tokens = (
-        await db_session.execute(
-            select(UserToken).where(
-                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+        (
+            await db_session.execute(
+                select(UserToken).where(
+                    UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(tokens) == 1
     assert tokens[0].sent_to == "rita@example.com"
     assert tokens[0].user_id == user.id
@@ -124,9 +126,7 @@ async def test_set_email_honeypot_silently_succeeds(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
     user = await start_session(api_client, db_session)
-    response = await _set_email(
-        api_client, fmm_hp_token="https://spammer.example"
-    )
+    response = await _set_email(api_client, fmm_hp_token="https://spammer.example")
     # Same shape as a real success — gives the bot no signal.
     assert response.status_code == 202
 
@@ -134,10 +134,16 @@ async def test_set_email_honeypot_silently_succeeds(
     assert user.email is None  # nothing persisted
 
     tokens = (
-        await db_session.execute(select(UserToken).where(
-            UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
-        ))
-    ).scalars().all()
+        (
+            await db_session.execute(
+                select(UserToken).where(
+                    UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
     assert tokens == []
     assert fake_email_queue.finished_job_registry.count == 0
 
@@ -178,13 +184,17 @@ async def test_set_email_with_taken_address_is_enumeration_safe(
     assert me.confirmed_at is None
 
     tokens = (
-        await db_session.execute(
-            select(UserToken).where(
-                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
-                UserToken.user_id == me.id,
+        (
+            await db_session.execute(
+                select(UserToken).where(
+                    UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
+                    UserToken.user_id == me.id,
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert tokens == []
     assert fake_email_queue.finished_job_registry.count == 0
 
@@ -226,7 +236,7 @@ async def test_token_context_records_confirmed_prior_email(
     # Simulate confirmation, then change again — now the context picks up
     # the newly-confirmed prior address.
     user.email = "second@example.com"
-    user.confirmed_at = datetime.now(timezone.utc)
+    user.confirmed_at = datetime.now(UTC)
     await db_session.commit()
     await _set_email(api_client, email="third@example.com")
     token = (
@@ -249,7 +259,7 @@ async def test_resend_preserves_original_change_context(
     # Establish a confirmed prior email so the next set has something to
     # change FROM.
     user.email = "prior@example.com"
-    user.confirmed_at = datetime.now(timezone.utc)
+    user.confirmed_at = datetime.now(UTC)
     await db_session.commit()
 
     await _set_email(api_client, email="next@example.com")
@@ -287,12 +297,16 @@ async def test_set_email_replaces_existing_unconfirmed_token(
     await _set_email(api_client, email="rita2@example.com")
 
     tokens = (
-        await db_session.execute(
-            select(UserToken).where(
-                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+        (
+            await db_session.execute(
+                select(UserToken).where(
+                    UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(tokens) == 1
     assert tokens[0].sent_to == "rita2@example.com"
 
@@ -304,9 +318,7 @@ async def test_resubmitting_same_email_when_verified_is_a_noop(
     nothing to confirm — no token issued, no email sent, no state change."""
     user = await start_session(api_client, db_session)
     raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
-    await api_client.post(
-        "/v1/me/email/confirm", json={"token": raw_token}
-    )
+    await api_client.post("/v1/me/email/confirm", json={"token": raw_token})
     await db_session.refresh(user)
     assert user.confirmed_at is not None
     sent_count = fake_email_queue.finished_job_registry.count
@@ -324,12 +336,16 @@ async def test_resubmitting_same_email_when_verified_is_a_noop(
     assert fake_email_queue.finished_job_registry.count == sent_count
     # No pending token left behind either.
     tokens = (
-        await db_session.execute(
-            select(UserToken).where(
-                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+        (
+            await db_session.execute(
+                select(UserToken).where(
+                    UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert tokens == []
 
 
@@ -341,7 +357,7 @@ async def test_changing_email_preserves_prior_verification(
     the link from the new inbox."""
     user = await start_session(api_client, db_session)
     user.email = "prior@example.com"
-    user.confirmed_at = datetime.now(timezone.utc)
+    user.confirmed_at = datetime.now(UTC)
     await db_session.commit()
 
     response = await _set_email(api_client, email="changed@example.com")
@@ -396,9 +412,7 @@ async def test_confirm_email_sets_confirmed_at_and_invalidates_token(
     user = await start_session(api_client, db_session)
     raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
 
-    response = await api_client.post(
-        "/v1/me/email/confirm", json={"token": raw_token}
-    )
+    response = await api_client.post("/v1/me/email/confirm", json={"token": raw_token})
     assert response.status_code == 200
     body_user = response.json()["data"]["user"]
     assert body_user["email"] == "rita@example.com"
@@ -411,18 +425,20 @@ async def test_confirm_email_sets_confirmed_at_and_invalidates_token(
 
     # Token consumed.
     tokens = (
-        await db_session.execute(
-            select(UserToken).where(
-                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+        (
+            await db_session.execute(
+                select(UserToken).where(
+                    UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert tokens == []
 
     # Replaying the same token is rejected.
-    replay = await api_client.post(
-        "/v1/me/email/confirm", json={"token": raw_token}
-    )
+    replay = await api_client.post("/v1/me/email/confirm", json={"token": raw_token})
     assert replay.status_code == 400
 
 
@@ -446,9 +462,7 @@ async def test_confirm_email_works_from_a_different_browser(
     from tests._helpers import make_client
 
     user_a = await start_session(api_client, db_session)
-    raw_token = await _capture_raw_token(
-        api_client, db_session, fake_email_queue
-    )
+    raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
 
     async with make_client() as other_client:
         # User B opens the link in a separate browser with no session cookie.
@@ -475,7 +489,7 @@ async def test_confirm_email_rejects_when_user_email_no_longer_matches_token_con
     confirm must burn it and return the opaque "invalid or expired"."""
     user = await start_session(api_client, db_session)
     user.email = "prior@example.com"
-    user.confirmed_at = datetime.now(timezone.utc)
+    user.confirmed_at = datetime.now(UTC)
     await db_session.commit()
 
     raw_token = await _capture_raw_token(
@@ -487,18 +501,20 @@ async def test_confirm_email_rejects_when_user_email_no_longer_matches_token_con
     user.email = "different@example.com"
     await db_session.commit()
 
-    response = await api_client.post(
-        "/v1/me/email/confirm", json={"token": raw_token}
-    )
+    response = await api_client.post("/v1/me/email/confirm", json={"token": raw_token})
     assert response.status_code == 400
     # Token burned.
     tokens = (
-        await db_session.execute(
-            select(UserToken).where(
-                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+        (
+            await db_session.execute(
+                select(UserToken).where(
+                    UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert tokens == []
 
 
@@ -519,14 +535,12 @@ async def test_confirm_email_handles_address_race(
         User(
             username="other",
             email="contested@example.com",
-            confirmed_at=datetime.now(timezone.utc),
+            confirmed_at=datetime.now(UTC),
         )
     )
     await db_session.commit()
 
-    response = await api_client.post(
-        "/v1/me/email/confirm", json={"token": raw_token}
-    )
+    response = await api_client.post("/v1/me/email/confirm", json={"token": raw_token})
     assert response.status_code == 400
     await db_session.refresh(me)
     # Caller's row is untouched — the rollback preserved their prior state.
@@ -537,9 +551,7 @@ async def test_confirm_email_handles_address_race(
 async def test_confirm_email_does_not_require_session(api_client: AsyncClient):
     """Cookieless POST to /confirm-email is the cross-device mobile-mail
     case — it should return 400 (invalid token) not 401 (no session)."""
-    response = await api_client.post(
-        "/v1/me/email/confirm", json={"token": "anything"}
-    )
+    response = await api_client.post("/v1/me/email/confirm", json={"token": "anything"})
     assert response.status_code == 400
 
 
@@ -567,9 +579,7 @@ async def test_resend_issues_new_token(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
     await start_session(api_client, db_session)
-    first_token = await _capture_raw_token(
-        api_client, db_session, fake_email_queue
-    )
+    first_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
 
     response = await api_client.post(
         "/v1/me/email/resend",
@@ -582,9 +592,7 @@ async def test_resend_issues_new_token(
     new_token = tokens[-1]
     assert new_token != first_token
 
-    confirm = await api_client.post(
-        "/v1/me/email/confirm", json={"token": first_token}
-    )
+    confirm = await api_client.post("/v1/me/email/confirm", json={"token": first_token})
     assert confirm.status_code == 400
 
 
@@ -608,9 +616,7 @@ async def test_resend_400s_after_confirm_consumes_the_token(
     nothing left to send and returns 400 (not 409 like the old flow)."""
     user = await start_session(api_client, db_session)
     raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
-    await api_client.post(
-        "/v1/me/email/confirm", json={"token": raw_token}
-    )
+    await api_client.post("/v1/me/email/confirm", json={"token": raw_token})
     await db_session.refresh(user)
     assert user.confirmed_at is not None
 
@@ -759,7 +765,10 @@ def test_captcha_secret_default_only_in_dev(monkeypatch):
         captcha_module._secret_key()
 
     monkeypatch.setenv("APP_ENV", "dev")
-    assert captcha_module._secret_key() == captcha_module.TURNSTILE_TEST_SECRET_ALWAYS_PASSES
+    assert (
+        captcha_module._secret_key()
+        == captcha_module.TURNSTILE_TEST_SECRET_ALWAYS_PASSES
+    )
 
 
 async def test_captcha_fails_closed_when_misconfigured_in_prod(monkeypatch):

--- a/api/tests/test_leagues.py
+++ b/api/tests/test_leagues.py
@@ -51,9 +51,7 @@ async def test_session_creates_default_league_membership(
 ):
     await start_session(api_client, db_session)
 
-    memberships = (
-        await db_session.execute(select(LeagueMembership))
-    ).scalars().all()
+    memberships = (await db_session.execute(select(LeagueMembership))).scalars().all()
     assert len(memberships) == 1
     assert memberships[0].league_id == default_league.id
 

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -1,6 +1,6 @@
 import hashlib
 from collections.abc import AsyncIterator
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
@@ -53,7 +53,7 @@ async def _make_confirmed_user(db_session: AsyncSession, email: str) -> User:
     user = User(
         username=email.split("@")[0],
         email=email,
-        confirmed_at=datetime.now(timezone.utc),
+        confirmed_at=datetime.now(UTC),
     )
     db_session.add(user)
     await db_session.commit()
@@ -74,10 +74,14 @@ async def test_request_enqueues_email_and_persists_token(
     assert response.json() == {"email": "rita@example.com"}
 
     tokens = (
-        await db_session.execute(
-            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        (
+            await db_session.execute(
+                select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(tokens) == 1
     assert tokens[0].user_id == user.id
     assert tokens[0].sent_to == "rita@example.com"
@@ -97,10 +101,14 @@ async def test_request_normalizes_email_to_lowercase(
     assert response.status_code == 202
 
     tokens = (
-        await db_session.execute(
-            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        (
+            await db_session.execute(
+                select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(tokens) == 1
     assert tokens[0].user_id == user.id
     assert tokens[0].sent_to == "rita@example.com"
@@ -113,10 +121,14 @@ async def test_request_for_unknown_email_returns_202_without_sending(
     assert response.status_code == 202
 
     tokens = (
-        await db_session.execute(
-            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        (
+            await db_session.execute(
+                select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert tokens == []
     assert fake_email_queue.finished_job_registry.count == 0
 
@@ -136,19 +148,25 @@ async def test_request_for_unconfirmed_account_resends_confirmation(
     assert response.json() == {"email": "rita@example.com"}
 
     login_tokens = (
-        await db_session.execute(
-            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        (
+            await db_session.execute(
+                select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert login_tokens == []
 
     change_tokens = (
-        await db_session.execute(
-            select(UserToken).where(
-                UserToken.context.startswith("change:")
+        (
+            await db_session.execute(
+                select(UserToken).where(UserToken.context.startswith("change:"))
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(change_tokens) == 1
     assert change_tokens[0].sent_to == "rita@example.com"
     assert change_tokens[0].user_id == user.id
@@ -167,10 +185,14 @@ async def test_request_replaces_prior_login_token_for_same_user(
     assert second.status_code == 202
 
     tokens = (
-        await db_session.execute(
-            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        (
+            await db_session.execute(
+                select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(tokens) == 1
 
 
@@ -186,10 +208,14 @@ async def test_request_honeypot_silently_succeeds(
     assert response.status_code == 202
 
     tokens = (
-        await db_session.execute(
-            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        (
+            await db_session.execute(
+                select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert tokens == []
 
 
@@ -261,9 +287,7 @@ async def test_consume_rotates_cookie_and_returns_session(
     raw = "raw-login-token-rita"
     await _issue_login_token(db_session, user, raw)
 
-    response = await api_client.post(
-        "/v1/login/consume", json={"token": raw}
-    )
+    response = await api_client.post("/v1/login/consume", json={"token": raw})
     assert response.status_code == 200
 
     body_user = response.json()["data"]["user"]
@@ -277,16 +301,19 @@ async def test_consume_rotates_cookie_and_returns_session(
     assert new_cookie
 
     sessions = (
-        await db_session.execute(
-            select(UserToken).where(
-                UserToken.context == SESSION_TOKEN_CONTEXT,
-                UserToken.user_id == user.id,
+        (
+            await db_session.execute(
+                select(UserToken).where(
+                    UserToken.context == SESSION_TOKEN_CONTEXT,
+                    UserToken.user_id == user.id,
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert any(
-        t.token == hashlib.sha256(new_cookie.encode("utf-8")).digest()
-        for t in sessions
+        t.token == hashlib.sha256(new_cookie.encode("utf-8")).digest() for t in sessions
     )
 
 
@@ -301,17 +328,19 @@ async def test_consume_deletes_token_so_it_cannot_be_reused(
     assert first.status_code == 200
 
     second_client = make_client()
-    second = await second_client.post(
-        "/v1/login/consume", json={"token": raw}
-    )
+    second = await second_client.post("/v1/login/consume", json={"token": raw})
     assert second.status_code == 400
     await second_client.aclose()
 
     leftover = (
-        await db_session.execute(
-            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        (
+            await db_session.execute(
+                select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert leftover == []
 
 
@@ -322,19 +351,21 @@ async def test_consume_rejects_expired_token(
     raw = "raw-login-token-expired"
     token = await _issue_login_token(db_session, user, raw)
     # Backdate past the 15-minute TTL.
-    token.created_at = datetime.now(timezone.utc) - timedelta(minutes=20)
+    token.created_at = datetime.now(UTC) - timedelta(minutes=20)
     await db_session.commit()
 
-    response = await api_client.post(
-        "/v1/login/consume", json={"token": raw}
-    )
+    response = await api_client.post("/v1/login/consume", json={"token": raw})
     assert response.status_code == 400
 
     leftover = (
-        await db_session.execute(
-            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        (
+            await db_session.execute(
+                select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert leftover == []
 
 
@@ -357,16 +388,12 @@ async def test_consume_replaces_guest_session_with_owner_session(
     guest = await start_session(api_client, db_session)
     assert guest.id != user.id
 
-    response = await api_client.post(
-        "/v1/login/consume", json={"token": raw}
-    )
+    response = await api_client.post("/v1/login/consume", json={"token": raw})
     assert response.status_code == 200
     assert response.json()["data"]["user"]["username"] == "rita"
 
     new_cookie = response.cookies.get(SESSION_COOKIE_NAME)
-    me = await api_client.get(
-        "/v1/session", cookies={SESSION_COOKIE_NAME: new_cookie}
-    )
+    me = await api_client.get("/v1/session", cookies={SESSION_COOKIE_NAME: new_cookie})
     assert me.json()["data"]["user"]["username"] == "rita"
 
 
@@ -386,9 +413,7 @@ async def test_consume_does_not_accept_email_change_token(
     )
     await db_session.commit()
 
-    response = await api_client.post(
-        "/v1/login/consume", json={"token": raw}
-    )
+    response = await api_client.post("/v1/login/consume", json={"token": raw})
     assert response.status_code == 400
 
 
@@ -404,25 +429,25 @@ async def test_consume_rejects_link_after_user_changed_email(
     user.email = "rita-new@example.com"
     await db_session.commit()
 
-    response = await api_client.post(
-        "/v1/login/consume", json={"token": raw}
-    )
+    response = await api_client.post("/v1/login/consume", json={"token": raw})
     assert response.status_code == 400
 
     leftover = (
-        await db_session.execute(
-            select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+        (
+            await db_session.execute(
+                select(UserToken).where(UserToken.context == LOGIN_TOKEN_CONTEXT)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert leftover == []
 
 
 # ---- merge of ephemeral session on consume -------------------------------
 
 
-async def _record_singles_match(
-    db_session: AsyncSession, *players: User
-) -> Match:
+async def _record_singles_match(db_session: AsyncSession, *players: User) -> Match:
     league = await get_default_league(db_session)
     settings = MatchSettings(team_size=1, best_of=5, affects_rating=False)
     match = Match(
@@ -460,10 +485,14 @@ async def test_consume_merges_ephemeral_matches_into_verified_account(
     assert body["merged"] == {"matches_moved": 1}
 
     players = (
-        await db_session.execute(
-            select(MatchSidePlayer).where(MatchSidePlayer.match_id == match.id)
+        (
+            await db_session.execute(
+                select(MatchSidePlayer).where(MatchSidePlayer.match_id == match.id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert {p.user_id for p in players} == {rita.id, opponent.id}
 
     creator_id = (
@@ -505,17 +534,13 @@ async def test_consume_omits_merge_when_prior_session_is_verified(
     await _issue_login_token(db_session, sam, raw_sam)
 
     # Sign in as Sam first to establish a verified session, then "log in" as Rita.
-    sign_in_sam = await api_client.post(
-        "/v1/login/consume", json={"token": raw_sam}
-    )
+    sign_in_sam = await api_client.post("/v1/login/consume", json={"token": raw_sam})
     assert sign_in_sam.status_code == 200
 
     opponent = await make_user(db_session, "opponent-jay")
     sam_match = await _record_singles_match(db_session, sam, opponent)
 
-    response = await api_client.post(
-        "/v1/login/consume", json={"token": raw_rita}
-    )
+    response = await api_client.post("/v1/login/consume", json={"token": raw_rita})
     assert response.status_code == 200
     assert response.json().get("merged") is None
 

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -15,7 +15,6 @@ from app.models import (
 )
 from tests._helpers import make_client, make_user, start_session
 
-
 # ----- create -------------------------------------------------------------
 
 
@@ -98,9 +97,7 @@ async def test_create_match_without_opponent_has_a_sentinel_opponent_side(
 ):
     me = await start_session(api_client, db_session)
 
-    response = await api_client.post(
-        "/v1/matches", json={"best_of": 7, "rated": False}
-    )
+    response = await api_client.post("/v1/matches", json={"best_of": 7, "rated": False})
     assert response.status_code == 201
     body = response.json()
     assert body["affects_rating"] is False
@@ -156,9 +153,7 @@ async def test_rated_match_without_opponent_is_rejected(
 ):
     await start_session(api_client, db_session)
 
-    response = await api_client.post(
-        "/v1/matches", json={"best_of": 5, "rated": True}
-    )
+    response = await api_client.post("/v1/matches", json={"best_of": 5, "rated": True})
     assert response.status_code == 422
     assert "rated" in response.json()["detail"].lower()
     assert (await db_session.execute(select(Match))).first() is None
@@ -257,9 +252,7 @@ async def test_details_perspective_swaps_per_caller(
         theirs = (await other_client.get(f"/v1/matches/{created['id']}")).json()
 
     my_perspective = next(s for s in mine["sides"] if s["is_current_user_side"])
-    their_perspective = next(
-        s for s in theirs["sides"] if s["is_current_user_side"]
-    )
+    their_perspective = next(s for s in theirs["sides"] if s["is_current_user_side"])
     assert my_perspective["players"][0]["user_id"] == str(me.id)
     assert their_perspective["players"][0]["user_id"] == str(them.id)
     # The flag flips per caller, but the underlying side numbers are stable.
@@ -282,9 +275,7 @@ async def test_get_match_is_open_to_non_participants(
         # write affordance is suppressed regardless of game state.
         assert all(not s["is_current_user_side"] for s in body["sides"])
         assert all(
-            not p["is_current_user"]
-            for s in body["sides"]
-            for p in s["players"]
+            not p["is_current_user"] for s in body["sides"] for p in s["players"]
         )
         assert body["can_score"] is False
         del spectator
@@ -301,9 +292,7 @@ async def test_get_unknown_match_is_404(
 # ----- list ---------------------------------------------------------------
 
 
-async def test_list_matches_empty(
-    api_client: AsyncClient, db_session: AsyncSession
-):
+async def test_list_matches_empty(api_client: AsyncClient, db_session: AsyncSession):
     await start_session(api_client, db_session)
     response = await api_client.get("/v1/matches")
     assert response.status_code == 200
@@ -355,17 +344,13 @@ async def test_list_q_filter_matches_caller_username(
         # username should not pick this up.
         unrelated = await _create_match(other_client, bystander.id)
 
-    listing = (
-        await api_client.get("/v1/matches", params={"q": me.username})
-    ).json()
+    listing = (await api_client.get("/v1/matches", params={"q": me.username})).json()
     ids = {row["id"] for row in listing["items"]}
     assert mine["id"] in ids
     assert unrelated["id"] not in ids
 
 
-async def test_list_filter_by_status(
-    api_client: AsyncClient, db_session: AsyncSession
-):
+async def test_list_filter_by_status(api_client: AsyncClient, db_session: AsyncSession):
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     in_progress = await _create_match(api_client, opp.id, best_of=1)
@@ -394,37 +379,27 @@ async def test_list_q_filter_matches_any_player_username(
     await _create_match(api_client, alpha.id)
     await _create_match(api_client, bravo.id)
 
-    listing = (
-        await api_client.get("/v1/matches", params={"q": "alpha"})
-    ).json()
+    listing = (await api_client.get("/v1/matches", params={"q": "alpha"})).json()
     assert len(listing["items"]) == 1
     players = {
-        p["username"]
-        for side in listing["items"][0]["sides"]
-        for p in side["players"]
+        p["username"] for side in listing["items"][0]["sides"] for p in side["players"]
     }
     assert "alphabet" in players
     # status_counts honors q (one row total)
     assert sum(listing["status_counts"].values()) == 1
 
 
-async def test_list_pagination(
-    api_client: AsyncClient, db_session: AsyncSession
-):
+async def test_list_pagination(api_client: AsyncClient, db_session: AsyncSession):
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     for _ in range(3):
         await _create_match(api_client, opp.id)
 
     page_1 = (
-        await api_client.get(
-            "/v1/matches", params={"page": 1, "page_size": 2}
-        )
+        await api_client.get("/v1/matches", params={"page": 1, "page_size": 2})
     ).json()
     page_2 = (
-        await api_client.get(
-            "/v1/matches", params={"page": 2, "page_size": 2}
-        )
+        await api_client.get("/v1/matches", params={"page": 2, "page_size": 2})
     ).json()
     assert page_1["total"] == 3
     assert len(page_1["items"]) == 2
@@ -682,9 +657,7 @@ async def test_put_closes_match_earlier_and_deletes_trailing_unscored(
     # No orphan score rows or trailing games left behind in the DB.
     games = (await db_session.execute(select(MatchGame))).scalars().all()
     assert len(games) == 2
-    scores = (
-        await db_session.execute(select(MatchGameScore))
-    ).scalars().all()
+    scores = (await db_session.execute(select(MatchGameScore))).scalars().all()
     assert len(scores) == 2
 
 
@@ -771,9 +744,7 @@ async def test_can_score_match_without_opponent(
 ):
     await start_session(api_client, db_session)
     created = (
-        await api_client.post(
-            "/v1/matches", json={"best_of": 5, "rated": False}
-        )
+        await api_client.post("/v1/matches", json={"best_of": 5, "rated": False})
     ).json()
     response = await api_client.post(
         f"/v1/matches/{created['id']}/games/{created['games'][0]['id']}/scores",
@@ -795,9 +766,7 @@ async def test_create_match_without_league_id_uses_default_league(
     default_league: League,
 ):
     await start_session(api_client, db_session)
-    response = await api_client.post(
-        "/v1/matches", json={"best_of": 3, "rated": False}
-    )
+    response = await api_client.post("/v1/matches", json={"best_of": 3, "rated": False})
     assert response.status_code == 201
     body = response.json()
     assert body["league"]["id"] == str(default_league.id)
@@ -859,9 +828,7 @@ async def test_create_match_with_no_default_seeded_is_500(
     await db_session.delete(default_league)
     await db_session.commit()
 
-    response = await api_client.post(
-        "/v1/matches", json={"best_of": 3, "rated": False}
-    )
+    response = await api_client.post("/v1/matches", json={"best_of": 3, "rated": False})
     assert response.status_code == 500
 
 
@@ -958,9 +925,7 @@ async def test_details_recent_form_lists_each_player_previous_results(
     # I have 2 prior completed matches (1 W, 1 L) against third-party.
     mine = forms[str(me.id)]
     assert {r["is_win"] for r in mine["recent_results"]} == {True, False}
-    assert all(
-        r["opponent_username"] == "third-party" for r in mine["recent_results"]
-    )
+    assert all(r["opponent_username"] == "third-party" for r in mine["recent_results"])
     # Opp shows up in the form list with no prior completed matches.
     assert forms[str(opp.id)]["recent_results"] == []
 
@@ -1034,9 +999,7 @@ async def test_details_head_to_head_is_null_for_solo_match(
 ):
     await start_session(api_client, db_session)
     created = (
-        await api_client.post(
-            "/v1/matches", json={"best_of": 3, "rated": False}
-        )
+        await api_client.post("/v1/matches", json={"best_of": 3, "rated": False})
     ).json()
     detail = (await api_client.get(f"/v1/matches/{created['id']}")).json()
     assert detail["head_to_head"] is None

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -120,9 +120,7 @@ async def test_match_without_opponent_can_be_scored_to_completion(
     await start_session(api_client, db_session)
 
     match = (
-        await api_client.post(
-            "/v1/matches", json={"best_of": 3, "rated": False}
-        )
+        await api_client.post("/v1/matches", json={"best_of": 3, "rated": False})
     ).json()
     # The creator is side 1; the sentinel opponent is side 2.
     after_g1 = (
@@ -133,11 +131,9 @@ async def test_match_without_opponent_can_be_scored_to_completion(
     ).json()
     assert after_g1["status"] == "in_progress"
     game_2 = after_g1["games"][1]
-    after_g2 = (
-        await api_client.post(
-            f"/v1/matches/{match['id']}/games/{game_2['id']}/scores",
-            json={"side_1_points": 11, "side_2_points": 7},
-        )
+    after_g2 = await api_client.post(
+        f"/v1/matches/{match['id']}/games/{game_2['id']}/scores",
+        json={"side_1_points": 11, "side_2_points": 7},
     )
     assert after_g2.status_code == 201
     body = after_g2.json()

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -16,7 +16,7 @@ from app.models import (
 from tests._helpers import make_user, start_session
 
 # A fixed anchor so recency-ordering assertions don't depend on wall-clock time.
-BASE_TIME = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+BASE_TIME = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
 
 
 async def _record_match(
@@ -153,7 +153,7 @@ async def test_recent_opponents_is_empty_without_other_users(
 async def test_recent_opponents_respects_the_limit(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    me = await start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     for name in ("ana", "bo", "cy", "di"):
         await make_user(db_session, name)
 
@@ -206,9 +206,7 @@ async def test_search_excludes_the_current_user(
 ):
     me = await start_session(api_client, db_session)
 
-    response = await api_client.get(
-        "/v1/players/search", params={"q": me.username}
-    )
+    response = await api_client.get("/v1/players/search", params={"q": me.username})
     assert response.status_code == 200
     assert me.username not in _usernames(response)
 
@@ -230,9 +228,7 @@ async def test_search_with_no_match_returns_empty(
     await start_session(api_client, db_session)
     await make_user(db_session, "ada.lovelace")
 
-    response = await api_client.get(
-        "/v1/players/search", params={"q": "nobody-here"}
-    )
+    response = await api_client.get("/v1/players/search", params={"q": "nobody-here"})
     assert response.status_code == 200
     assert response.json() == []
 
@@ -289,9 +285,9 @@ async def test_search_orders_results_alphabetically(
 async def test_search_includes_rating_for_default_league(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    me = await start_session(api_client, db_session)
+    await start_session(api_client, db_session)
     rival = await make_user(db_session, "ratedrival")
-    unrated = await make_user(db_session, "freshface")
+    await make_user(db_session, "freshface")
 
     league = await get_default_league(db_session)
     db_session.add(

--- a/api/tests/test_rating_recompute.py
+++ b/api/tests/test_rating_recompute.py
@@ -1,7 +1,8 @@
 """Coverage for ``app.ratings.recompute`` — the forward-walking cascade
 algorithm that rebuilds ratings after a merge moves matches onto a user."""
+
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,7 +24,6 @@ from app.models import (
 )
 from app.ratings.recompute import recompute_league_ratings
 from tests._helpers import make_user
-
 
 # ----- fixtures + helpers -------------------------------------------------
 
@@ -56,9 +56,7 @@ async def _build_completed_match(
     completion timestamp. ``updated_at`` is what ``recompute_league_ratings``
     orders by, so we overwrite it via raw SQL to control the chronology
     without sleeping in tests."""
-    settings = MatchSettings(
-        team_size=1, best_of=1, affects_rating=affects_rating
-    )
+    settings = MatchSettings(team_size=1, best_of=1, affects_rating=affects_rating)
     match = Match(
         match_settings=settings,
         league=league,
@@ -76,10 +74,7 @@ async def _build_completed_match(
     await db.refresh(match)
 
     await db.execute(
-        text(
-            "UPDATE matches SET created_at = :ts, updated_at = :ts "
-            "WHERE id = :id"
-        ),
+        text("UPDATE matches SET created_at = :ts, updated_at = :ts WHERE id = :id"),
         {"ts": completed_at, "id": match.id},
     )
     await db.commit()
@@ -98,9 +93,7 @@ async def test_recompute_no_matches_is_noop(
 
     await recompute_league_ratings(db_session, league.id, {me.id})
 
-    rows = (
-        await db_session.execute(select(RatingHistory))
-    ).scalars().all()
+    rows = (await db_session.execute(select(RatingHistory))).scalars().all()
     assert rows == []
 
 
@@ -118,14 +111,12 @@ async def test_recompute_manual_strategy_is_noop(
     me = await make_user(db_session, "me")
     opp = await make_user(db_session, "opp")
     await _build_completed_match(
-        db_session, default, me, opp, datetime(2026, 5, 1, tzinfo=timezone.utc)
+        db_session, default, me, opp, datetime(2026, 5, 1, tzinfo=UTC)
     )
 
     await recompute_league_ratings(db_session, default.id, {me.id})
 
-    rows = (
-        await db_session.execute(select(RatingHistory))
-    ).scalars().all()
+    rows = (await db_session.execute(select(RatingHistory))).scalars().all()
     assert rows == []
 
 
@@ -148,10 +139,8 @@ async def test_recompute_cascade_propagates_through_shared_matches(
     for user in (a, b, c, d):
         await _seed_rating(db_session, league, user.id, strategy)
 
-    base = datetime(2026, 5, 1, tzinfo=timezone.utc)
-    m1 = await _build_completed_match(
-        db_session, league, a, b, base
-    )
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    m1 = await _build_completed_match(db_session, league, a, b, base)
     m2 = await _build_completed_match(
         db_session, league, b, c, base + timedelta(hours=1)
     )
@@ -163,12 +152,16 @@ async def test_recompute_cascade_propagates_through_shared_matches(
     await db_session.commit()
 
     rows = (
-        await db_session.execute(
-            select(RatingHistory).where(
-                RatingHistory.match_id.in_([m1.id, m2.id, m3.id])
+        (
+            await db_session.execute(
+                select(RatingHistory).where(
+                    RatingHistory.match_id.in_([m1.id, m2.id, m3.id])
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert {row.match_id for row in rows} == {m1.id, m2.id, m3.id}
     assert len(rows) == 6
 
@@ -205,7 +198,7 @@ async def test_recompute_leaves_unrelated_matches_alone(
     for user in (me, opp, x, y):
         await _seed_rating(db_session, league, user.id, strategy)
 
-    base = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    base = datetime(2026, 5, 1, tzinfo=UTC)
     my_match = await _build_completed_match(db_session, league, me, opp, base)
     unrelated = await _build_completed_match(
         db_session, league, x, y, base + timedelta(hours=1)
@@ -241,10 +234,14 @@ async def test_recompute_leaves_unrelated_matches_alone(
 
     # The seed user's match did produce its own history rows.
     mine = (
-        await db_session.execute(
-            select(RatingHistory).where(RatingHistory.match_id == my_match.id)
+        (
+            await db_session.execute(
+                select(RatingHistory).where(RatingHistory.match_id == my_match.id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert {row.user_id for row in mine} == {me.id, opp.id}
 
 
@@ -266,7 +263,7 @@ async def test_recompute_restores_user_to_last_pre_window_rating(
     for user in (me, opp, later_opp):
         await _seed_rating(db_session, league, user.id, strategy)
 
-    base = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    base = datetime(2026, 5, 1, tzinfo=UTC)
     # Pre-window: opp already played a match and sits at 1550 going in.
     pre_match = await _build_completed_match(
         db_session, league, opp, later_opp, base - timedelta(days=30)
@@ -285,9 +282,7 @@ async def test_recompute_restores_user_to_last_pre_window_rating(
     )
     await db_session.commit()
     await db_session.execute(
-        text(
-            "UPDATE rating_history SET created_at = :ts WHERE match_id = :id"
-        ),
+        text("UPDATE rating_history SET created_at = :ts WHERE match_id = :id"),
         {"ts": base - timedelta(days=30), "id": pre_match.id},
     )
     await db_session.commit()
@@ -325,32 +320,32 @@ async def test_recompute_is_idempotent(
         await _seed_rating(db_session, league, user.id, strategy)
 
     await _build_completed_match(
-        db_session, league, me, opp, datetime(2026, 5, 1, tzinfo=timezone.utc)
+        db_session, league, me, opp, datetime(2026, 5, 1, tzinfo=UTC)
     )
 
     await recompute_league_ratings(db_session, league.id, {me.id})
     await db_session.commit()
     first = {
         r.user_id: r.rating_value
-        for r in (
-            await db_session.execute(select(UserLeagueRating))
-        ).scalars().all()
+        for r in (await db_session.execute(select(UserLeagueRating))).scalars().all()
     }
 
     await recompute_league_ratings(db_session, league.id, {me.id})
     await db_session.commit()
     second = {
         r.user_id: r.rating_value
-        for r in (
-            await db_session.execute(select(UserLeagueRating))
-        ).scalars().all()
+        for r in (await db_session.execute(select(UserLeagueRating))).scalars().all()
     }
 
     assert first == second
     # And only one set of history rows survives.
     rows = (
-        await db_session.execute(
-            select(RatingHistory).where(RatingHistory.user_id == me.id)
+        (
+            await db_session.execute(
+                select(RatingHistory).where(RatingHistory.user_id == me.id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(rows) == 1

--- a/api/tests/test_ratings.py
+++ b/api/tests/test_ratings.py
@@ -223,12 +223,16 @@ async def test_unrated_match_does_not_move_ratings(
     # The session user has an `initial` seed row from joining the league, but
     # an unrated match must not produce any `match`-sourced history.
     rows = (
-        await db_session.execute(
-            select(RatingHistory).where(
-                RatingHistory.source == RatingHistorySource.match
+        (
+            await db_session.execute(
+                select(RatingHistory).where(
+                    RatingHistory.source == RatingHistorySource.match
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert rows == []
 
 

--- a/api/tests/test_ratings.py
+++ b/api/tests/test_ratings.py
@@ -1,5 +1,6 @@
 """Coverage for the rating system: strategies, calculator math, validation,
 and the match-completion hook."""
+
 import uuid
 
 import jsonschema
@@ -10,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import (
     League,
-    LeagueVisibility,
     RatingHistory,
     RatingHistorySource,
     RatingStrategy,
@@ -24,7 +24,6 @@ from app.ratings import (
 )
 from app.ratings.glicko2 import CALCULATOR as GLICKO2
 from tests._helpers import make_user, start_session
-
 
 # ----- strategy seeding ----------------------------------------------------
 
@@ -151,10 +150,16 @@ async def test_completing_a_rated_match_writes_rating_history(
 
     # Two history rows, one per player, both linked to this match.
     rows = (
-        await db_session.execute(
-            select(RatingHistory).where(RatingHistory.match_id == uuid.UUID(body["id"]))
+        (
+            await db_session.execute(
+                select(RatingHistory).where(
+                    RatingHistory.match_id == uuid.UUID(body["id"])
+                )
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(rows) == 2
     by_user = {row.user_id: row for row in rows}
     winner = by_user[me.id]
@@ -169,9 +174,7 @@ async def test_completing_a_rated_match_writes_rating_history(
     assert winner.rating_strategy_id == default_league.rating_strategy_id
 
     # Current rating rows are upserted in lockstep.
-    ratings = (
-        await db_session.execute(select(UserLeagueRating))
-    ).scalars().all()
+    ratings = (await db_session.execute(select(UserLeagueRating))).scalars().all()
     assert {r.user_id for r in ratings} == {me.id, opp.id}
     assert {r.league_id for r in ratings} == {default_league.id}
 
@@ -239,9 +242,7 @@ async def test_manual_strategy_league_skips_rating_updates(
     membership hook eagerly seeds them), but with the strategy's null
     ``initial_state`` — to be filled by a later external import."""
     default = (
-        await db_session.execute(
-            select(League).where(League.is_default.is_(True))
-        )
+        await db_session.execute(select(League).where(League.is_default.is_(True)))
     ).scalar_one()
     default.rating_strategy_id = rating_strategies["manual"].id
     await db_session.commit()
@@ -259,9 +260,7 @@ async def test_manual_strategy_league_skips_rating_updates(
     # row but with the manual strategy's null initial state. `rival` was
     # created via ``make_user`` which doesn't route through league membership,
     # so they have no row at all.
-    ratings = (
-        await db_session.execute(select(UserLeagueRating))
-    ).scalars().all()
+    ratings = (await db_session.execute(select(UserLeagueRating))).scalars().all()
     assert len(ratings) == 1
     assert ratings[0].user_id == me.id
     assert ratings[0].rating_value is None
@@ -286,10 +285,16 @@ async def test_rating_update_is_idempotent_across_score_edits(
     assert edited.status_code == 200
 
     rows = (
-        await db_session.execute(
-            select(RatingHistory).where(RatingHistory.match_id == uuid.UUID(body["id"]))
+        (
+            await db_session.execute(
+                select(RatingHistory).where(
+                    RatingHistory.match_id == uuid.UUID(body["id"])
+                )
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(rows) == 2  # still just the original pair
 
 

--- a/api/tests/test_rbac.py
+++ b/api/tests/test_rbac.py
@@ -75,23 +75,17 @@ async def test_create_and_list_permissions(
 
 async def test_create_permission_rejects_duplicate_name(api_client: AsyncClient):
     await api_client.post("/v1/permissions", json={"name": "perm.dup"})
-    second = await api_client.post(
-        "/v1/permissions", json={"name": "perm.dup"}
-    )
+    second = await api_client.post("/v1/permissions", json={"name": "perm.dup"})
     assert second.status_code == 409
 
 
 async def test_create_permission_rejects_undotted_name(api_client: AsyncClient):
-    response = await api_client.post(
-        "/v1/permissions", json={"name": "invalidname"}
-    )
+    response = await api_client.post("/v1/permissions", json={"name": "invalidname"})
     assert response.status_code == 422
 
 
 async def test_create_permission_rejects_malformed_name(api_client: AsyncClient):
-    response = await api_client.post(
-        "/v1/permissions", json={"name": "Has Spaces!"}
-    )
+    response = await api_client.post("/v1/permissions", json={"name": "Has Spaces!"})
     assert response.status_code == 422
 
 
@@ -100,9 +94,7 @@ async def test_create_permission_rejects_empty_name(api_client: AsyncClient):
     assert response.status_code == 422
 
 
-async def test_update_permission(
-    api_client: AsyncClient, db_session: AsyncSession
-):
+async def test_update_permission(api_client: AsyncClient, db_session: AsyncSession):
     created = (
         await api_client.post(
             "/v1/permissions",
@@ -122,9 +114,7 @@ async def test_update_permission(
 
 async def test_update_permission_rejects_undotted_name(api_client: AsyncClient):
     created = (
-        await api_client.post(
-            "/v1/permissions", json={"name": "perm.start"}
-        )
+        await api_client.post("/v1/permissions", json={"name": "perm.start"})
     ).json()
     response = await api_client.patch(
         f"/v1/permissions/{created['id']}", json={"name": "invalidname"}
@@ -132,9 +122,7 @@ async def test_update_permission_rejects_undotted_name(api_client: AsyncClient):
     assert response.status_code == 422
 
 
-async def test_delete_permission(
-    api_client: AsyncClient, db_session: AsyncSession
-):
+async def test_delete_permission(api_client: AsyncClient, db_session: AsyncSession):
     created = (
         await api_client.post("/v1/permissions", json={"name": "perm.doomed"})
     ).json()
@@ -157,12 +145,8 @@ async def test_get_permission_not_found(api_client: AsyncClient):
 async def test_create_role_with_explicit_permissions(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    p1 = (
-        await api_client.post("/v1/permissions", json={"name": "perm.a"})
-    ).json()
-    p2 = (
-        await api_client.post("/v1/permissions", json={"name": "perm.b"})
-    ).json()
+    p1 = (await api_client.post("/v1/permissions", json={"name": "perm.a"})).json()
+    p2 = (await api_client.post("/v1/permissions", json={"name": "perm.b"})).json()
 
     role_resp = await api_client.post(
         "/v1/roles",
@@ -176,21 +160,15 @@ async def test_create_role_with_explicit_permissions(
     body = role_resp.json()
     assert set(body["permission_ids"]) == {p1["id"], p2["id"]}
 
-    rp = (
-        await db_session.execute(select(RolePermission))
-    ).scalars().all()
+    rp = (await db_session.execute(select(RolePermission))).scalars().all()
     assert len(rp) == 2
 
 
 async def test_create_role_from_template_copies_permissions(
     api_client: AsyncClient,
 ):
-    p1 = (
-        await api_client.post("/v1/permissions", json={"name": "perm.a"})
-    ).json()
-    p2 = (
-        await api_client.post("/v1/permissions", json={"name": "perm.b"})
-    ).json()
+    p1 = (await api_client.post("/v1/permissions", json={"name": "perm.a"})).json()
+    p2 = (await api_client.post("/v1/permissions", json={"name": "perm.b"})).json()
     tmpl = (
         await api_client.post(
             "/v1/roles",
@@ -208,9 +186,7 @@ async def test_create_role_from_template_copies_permissions(
 async def test_create_role_rejects_template_and_permissions_together(
     api_client: AsyncClient,
 ):
-    tmpl = (
-        await api_client.post("/v1/roles", json={"name": "template"})
-    ).json()
+    tmpl = (await api_client.post("/v1/roles", json={"name": "template"})).json()
     response = await api_client.post(
         "/v1/roles",
         json={
@@ -236,9 +212,7 @@ async def test_create_role_rejects_unknown_permission(api_client: AsyncClient):
 async def test_list_roles_returns_permission_ids(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    p = (
-        await api_client.post("/v1/permissions", json={"name": "perm.a"})
-    ).json()
+    p = (await api_client.post("/v1/permissions", json={"name": "perm.a"})).json()
     await api_client.post(
         "/v1/roles", json={"name": "alpha", "permission_ids": [p["id"]]}
     )
@@ -252,15 +226,9 @@ async def test_list_roles_returns_permission_ids(
 
 
 async def test_update_role_replaces_permissions(api_client: AsyncClient):
-    p1 = (
-        await api_client.post("/v1/permissions", json={"name": "perm.a"})
-    ).json()
-    p2 = (
-        await api_client.post("/v1/permissions", json={"name": "perm.b"})
-    ).json()
-    p3 = (
-        await api_client.post("/v1/permissions", json={"name": "perm.c"})
-    ).json()
+    p1 = (await api_client.post("/v1/permissions", json={"name": "perm.a"})).json()
+    p2 = (await api_client.post("/v1/permissions", json={"name": "perm.b"})).json()
+    p3 = (await api_client.post("/v1/permissions", json={"name": "perm.c"})).json()
     role = (
         await api_client.post(
             "/v1/roles",
@@ -277,9 +245,7 @@ async def test_update_role_replaces_permissions(api_client: AsyncClient):
 
 
 async def test_update_role_clears_permissions(api_client: AsyncClient):
-    p = (
-        await api_client.post("/v1/permissions", json={"name": "perm.a"})
-    ).json()
+    p = (await api_client.post("/v1/permissions", json={"name": "perm.a"})).json()
     role = (
         await api_client.post(
             "/v1/roles", json={"name": "r", "permission_ids": [p["id"]]}
@@ -293,9 +259,7 @@ async def test_update_role_clears_permissions(api_client: AsyncClient):
 
 
 async def test_update_role_partial_keeps_permissions(api_client: AsyncClient):
-    p = (
-        await api_client.post("/v1/permissions", json={"name": "perm.a"})
-    ).json()
+    p = (await api_client.post("/v1/permissions", json={"name": "perm.a"})).json()
     role = (
         await api_client.post(
             "/v1/roles", json={"name": "r", "permission_ids": [p["id"]]}
@@ -314,9 +278,7 @@ async def test_delete_role_cascades_user_assignments(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     role = (await api_client.post("/v1/roles", json={"name": "doomed"})).json()
-    user = (
-        await api_client.post("/v1/users", json={"username": "alice"})
-    ).json()
+    user = (await api_client.post("/v1/users", json={"username": "alice"})).json()
     await api_client.put(
         f"/v1/users/{user['id']}/roles", json={"role_ids": [role["id"]]}
     )
@@ -324,9 +286,7 @@ async def test_delete_role_cascades_user_assignments(
     deleted = await api_client.delete(f"/v1/roles/{role['id']}")
     assert deleted.status_code == 204
 
-    remaining = (
-        await db_session.execute(select(UserRole))
-    ).scalars().all()
+    remaining = (await db_session.execute(select(UserRole))).scalars().all()
     assert remaining == []
 
 
@@ -353,9 +313,7 @@ async def test_create_user_rejects_duplicate(api_client: AsyncClient):
 async def test_set_user_roles_replaces_assignments(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    user = (
-        await api_client.post("/v1/users", json={"username": "alex"})
-    ).json()
+    user = (await api_client.post("/v1/users", json={"username": "alex"})).json()
     r1 = (await api_client.post("/v1/roles", json={"name": "one"})).json()
     r2 = (await api_client.post("/v1/roles", json={"name": "two"})).json()
 
@@ -399,22 +357,16 @@ async def test_list_users_includes_role_ids(
 
 
 async def test_delete_user(api_client: AsyncClient, db_session: AsyncSession):
-    user = (
-        await api_client.post("/v1/users", json={"username": "doomed"})
-    ).json()
+    user = (await api_client.post("/v1/users", json={"username": "doomed"})).json()
     deleted = await api_client.delete(f"/v1/users/{user['id']}")
     assert deleted.status_code == 204
     remaining = (
-        await db_session.execute(
-            select(User).where(User.username == "doomed")
-        )
+        await db_session.execute(select(User).where(User.username == "doomed"))
     ).scalar_one_or_none()
     assert remaining is None
 
 
-async def test_delete_user_refuses_self(
-    api_client: AsyncClient, admin_user: User
-):
+async def test_delete_user_refuses_self(api_client: AsyncClient, admin_user: User):
     response = await api_client.delete(f"/v1/users/{admin_user.id}")
     assert response.status_code == 400
     assert "your own" in response.json()["detail"]
@@ -437,9 +389,7 @@ async def test_role_name_collision_is_case_insensitive(api_client: AsyncClient):
 async def test_role_rename_collision_returns_409(api_client: AsyncClient):
     a = (await api_client.post("/v1/roles", json={"name": "alpha"})).json()
     (await api_client.post("/v1/roles", json={"name": "bravo"})).json()
-    patched = await api_client.patch(
-        f"/v1/roles/{a['id']}", json={"name": "Bravo"}
-    )
+    patched = await api_client.patch(f"/v1/roles/{a['id']}", json={"name": "Bravo"})
     assert patched.status_code == 409
 
 
@@ -455,14 +405,8 @@ async def test_username_collision_is_case_insensitive(api_client: AsyncClient):
 async def test_update_role_permissions_only_bumps_updated_at(
     api_client: AsyncClient,
 ):
-    p = (
-        await api_client.post("/v1/permissions", json={"name": "perm.a"})
-    ).json()
-    role = (
-        await api_client.post(
-            "/v1/roles", json={"name": "alpha"}
-        )
-    ).json()
+    p = (await api_client.post("/v1/permissions", json={"name": "perm.a"})).json()
+    role = (await api_client.post("/v1/roles", json={"name": "alpha"})).json()
     before = role["updated_at"]
 
     patched = await api_client.patch(
@@ -475,9 +419,7 @@ async def test_update_role_permissions_only_bumps_updated_at(
 async def test_update_role_null_permission_ids_keeps_existing(
     api_client: AsyncClient,
 ):
-    p = (
-        await api_client.post("/v1/permissions", json={"name": "perm.a"})
-    ).json()
+    p = (await api_client.post("/v1/permissions", json={"name": "perm.a"})).json()
     role = (
         await api_client.post(
             "/v1/roles", json={"name": "alpha", "permission_ids": [p["id"]]}
@@ -497,15 +439,9 @@ async def test_update_role_null_permission_ids_keeps_existing(
 async def test_list_roles_permission_ids_sorted_by_name(
     api_client: AsyncClient,
 ):
-    pb = (
-        await api_client.post("/v1/permissions", json={"name": "perm.b"})
-    ).json()
-    pa = (
-        await api_client.post("/v1/permissions", json={"name": "perm.a"})
-    ).json()
-    pc = (
-        await api_client.post("/v1/permissions", json={"name": "perm.c"})
-    ).json()
+    pb = (await api_client.post("/v1/permissions", json={"name": "perm.b"})).json()
+    pa = (await api_client.post("/v1/permissions", json={"name": "perm.a"})).json()
+    pc = (await api_client.post("/v1/permissions", json={"name": "perm.c"})).json()
 
     role = (
         await api_client.post(
@@ -528,9 +464,7 @@ async def test_list_users_role_ids_sorted_by_role_name(
 ):
     rz = (await api_client.post("/v1/roles", json={"name": "zeta"})).json()
     ra = (await api_client.post("/v1/roles", json={"name": "alpha"})).json()
-    user = (
-        await api_client.post("/v1/users", json={"username": "ordered"})
-    ).json()
+    user = (await api_client.post("/v1/users", json={"username": "ordered"})).json()
     await api_client.put(
         f"/v1/users/{user['id']}/roles", json={"role_ids": [rz["id"], ra["id"]]}
     )

--- a/api/tests/test_rbac_authz.py
+++ b/api/tests/test_rbac_authz.py
@@ -61,9 +61,7 @@ def _build_client(db_session: AsyncSession, user: User | None) -> AsyncClient:
 
     app.dependency_overrides[get_session] = _override_session
     app.dependency_overrides[get_current_user] = _override_user
-    return AsyncClient(
-        transport=ASGITransport(app=app), base_url="https://testserver"
-    )
+    return AsyncClient(transport=ASGITransport(app=app), base_url="https://testserver")
 
 
 @pytest_asyncio.fixture

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -55,8 +55,7 @@ async def test_creates_session_when_no_cookie(
     token = (
         await db_session.execute(
             select(UserToken).where(
-                UserToken.token
-                == hashlib.sha256(raw_token.encode("utf-8")).digest()
+                UserToken.token == hashlib.sha256(raw_token.encode("utf-8")).digest()
             )
         )
     ).scalar_one()
@@ -81,17 +80,13 @@ async def test_returns_existing_session_when_cookie_valid(
 
     tokens = (await db_session.execute(select(UserToken))).scalars().all()
     assert len(tokens) == 1
-    assert tokens[0].token == hashlib.sha256(
-        first_token.encode("utf-8")
-    ).digest()
+    assert tokens[0].token == hashlib.sha256(first_token.encode("utf-8")).digest()
 
 
 async def test_creates_new_session_when_cookie_invalid(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    api_client.cookies.set(
-        SESSION_COOKIE_NAME, "not-a-real-token", domain="testserver"
-    )
+    api_client.cookies.set(SESSION_COOKIE_NAME, "not-a-real-token", domain="testserver")
     response = await api_client.get("/v1/session")
     assert response.status_code == 200
 
@@ -101,9 +96,7 @@ async def test_creates_new_session_when_cookie_invalid(
 
     tokens = (await db_session.execute(select(UserToken))).scalars().all()
     assert len(tokens) == 1
-    assert tokens[0].token == hashlib.sha256(
-        new_token.encode("utf-8")
-    ).digest()
+    assert tokens[0].token == hashlib.sha256(new_token.encode("utf-8")).digest()
 
 
 async def test_token_is_stored_hashed_not_plaintext(
@@ -115,10 +108,7 @@ async def test_token_is_stored_hashed_not_plaintext(
     tokens = (await db_session.execute(select(UserToken))).scalars().all()
     assert len(tokens) == 1
     assert tokens[0].token != raw_token.encode("utf-8")
-    assert (
-        tokens[0].token
-        == hashlib.sha256(raw_token.encode("utf-8")).digest()
-    )
+    assert tokens[0].token == hashlib.sha256(raw_token.encode("utf-8")).digest()
 
 
 async def test_session_response_includes_user_permissions(
@@ -202,16 +192,12 @@ async def test_update_username_persists_and_returns_session(
     assert body["data"]["user"]["permissions"] == []
 
     user = (
-        await db_session.execute(
-            select(User).where(User.username == "new-name")
-        )
+        await db_session.execute(select(User).where(User.username == "new-name"))
     ).scalar_one()
     assert user.username == "new-name"
 
     # The old name is gone — no orphan row, single user updated in place.
-    stale = await db_session.execute(
-        select(User).where(User.username == original)
-    )
+    stale = await db_session.execute(select(User).where(User.username == original))
     assert stale.scalar_one_or_none() is None
 
 
@@ -259,9 +245,7 @@ async def test_update_username_rejects_taken_name_case_insensitive(
     db_session.add(User(username="Mixed-Case"))
     await db_session.commit()
 
-    response = await api_client.patch(
-        "/v1/me", json={"username": "mixed-case"}
-    )
+    response = await api_client.patch("/v1/me", json={"username": "mixed-case"})
     assert response.status_code == 409
 
 
@@ -276,9 +260,7 @@ async def test_update_username_concurrent_collision_returns_409(
         await other_client.get("/v1/session")
         ok = await api_client.patch("/v1/me", json={"username": "race-name"})
         assert ok.status_code == 200
-        dup = await other_client.patch(
-            "/v1/me", json={"username": "race-name"}
-        )
+        dup = await other_client.patch("/v1/me", json={"username": "race-name"})
         assert dup.status_code == 409
 
 
@@ -302,9 +284,7 @@ async def test_update_username_rejects_invalid_format(
     api_client: AsyncClient, bad_username: str
 ):
     await api_client.get("/v1/session")
-    response = await api_client.patch(
-        "/v1/me", json={"username": bad_username}
-    )
+    response = await api_client.patch("/v1/me", json={"username": bad_username})
     assert response.status_code == 422, (bad_username, response.text)
 
 
@@ -335,8 +315,6 @@ async def test_update_username_preserves_user_id_and_permissions(
     assert response.json()["data"]["user"]["permissions"] == ["match:create"]
 
     refreshed = (
-        await db_session.execute(
-            select(User).where(User.username == "renamed")
-        )
+        await db_session.execute(select(User).where(User.username == "renamed"))
     ).scalar_one()
     assert refreshed.id == original_id

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -613,6 +613,19 @@ export interface components {
             solver: components["schemas"]["ComponentHealth"];
         };
         /**
+         * LoginRequestAccepted
+         * @description 202 body for the magic-link request endpoint. Always echoes the
+         *     submitted address — identical whether or not it maps to a real account,
+         *     so the response leaks nothing about which addresses are registered.
+         */
+        LoginRequestAccepted: {
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
+        };
+        /**
          * MatchCreate
          * @description Request body for ``POST /v1/matches``.
          *
@@ -1324,9 +1337,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["LoginRequestAccepted"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## What

Re-cut of #311 against current `main` (which had drifted with 9 merges, including PR #304 that already added basic `mypy`). This adds the parts of #311 that were still unmerged and resolves the conflicts with PRs #305, #306, #309, #310, #315.

- **ruff + strict mypy gates on the API.** Adds ruff (`E,F,I,UP,B`; `B008` ignored for FastAPI `Depends`) and flips mypy to `strict` in `pyproject.toml`. CI (`api.yml`) now runs `ruff check`, `ruff format --check`, and `mypy` (strict) before `pytest`.
- **Brings `app/` and `tests/` into compliance:** real type annotations (no `Any`/blanket-ignore — one sanctioned ignore for rq's untyped `Job.refresh`), `from None` on exception-translation sites, and a one-time `ruff format` pass.
- **`POST /v1/login/request`** now returns a `LoginRequestAccepted` response model instead of a bare dict (per `api/CLAUDE.md`); `web-client/src/api/schema.d.ts` regenerated to match.
- **`api/CLAUDE.md`**: merges the type-safety / illegal-states / IO-boundary / service-layer guidance, adds a Verification checklist and an Error-handling section, drops the legacy carve-out note now that all of `app/` passes strict.
- **`/land-the-plane`**: Step 2 API check now mirrors CI (ruff + mypy before pytest).

## Conflicts resolved during the re-cut

- `api/app/leagues.py` — kept main's new `seed_user_league_rating` helper (from #306) and applied #311's formatting collapse to `add_user_to_default_league`'s signature.
- `api/app/matches.py` — kept main's `_history_base_query(..., before=...)` signature (from #305) and added the `-> Select[tuple[Match]]` return annotation from #311.
- `api/tests/test_dashboard.py` — kept the #306-introduced signup-seed pushback block, replaced its `datetime.now(timezone.utc)` with the module-level `UTC` alias (since #311 standardized on `UTC`).
- `api/tests/test_matches.py`, `api/tests/test_ratings.py` — re-ran `ruff format` to absorb drift from #309 / #310.

## Testing

Locally (in worktree):
- `ruff check app tests` — clean
- `ruff format --check app tests` — clean (68 files)
- `mypy` (strict) — Success: no issues found in 48 source files
- `pytest -q` — 300 passed
- `npm run lint` — clean (pre-existing MSW warning only)
- `npm run build` — clean
- `npm run test:run` — 101 passed (13 files)

Closes #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)