### PR TITLE
Consolidate identity avatars behind a single UserAvatar component

### DIFF
--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -1,7 +1,8 @@
 import type { CSSProperties, ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
-import { ArrowRight, ChevronRight, Plus, User as UserIcon, X } from 'lucide-react'
+import { ArrowRight, ChevronRight, Plus, X } from 'lucide-react'
 import { useDashboard } from '@/api/dashboard'
+import { UserAvatar } from '@/components/ui/user-avatar'
 import type {
   DashboardRating,
   DashboardRecentResult,
@@ -143,74 +144,6 @@ function BallDot({
   )
 }
 
-function Avatar({
-  name,
-  size = 40,
-  ring = false,
-  ringColor = C.ball500,
-}: {
-  // `null` renders the dashed-circle "no opponent" placeholder. We never want
-  // a contrived monogram (e.g. "NO" for "No opponent") that looks like a real
-  // initials avatar — it should read unambiguously as "no player here".
-  name: string | null
-  size?: number
-  ring?: boolean
-  ringColor?: string
-}) {
-  const baseStyle: CSSProperties = {
-    width: size,
-    height: size,
-    borderRadius: '50%',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    boxShadow: ring
-      ? `0 0 0 2px ${C.ink950}, 0 0 0 ${size > 40 ? 3 : 2.5}px ${ringColor}`
-      : 'none',
-    flexShrink: 0,
-  }
-
-  if (name === null) {
-    return (
-      <div
-        aria-hidden="true"
-        style={{
-          ...baseStyle,
-          background: 'transparent',
-          border: `1px dashed ${C.ink500}`,
-          color: C.chalk500,
-        }}
-      >
-        <UserIcon size={Math.round(size * 0.45)} strokeWidth={1.75} />
-      </div>
-    )
-  }
-
-  const initials = name
-    .split(/[ -]/)
-    .map((s) => s[0])
-    .filter(Boolean)
-    .slice(0, 2)
-    .join('')
-    .toUpperCase()
-  let hue = 0
-  for (let i = 0; i < name.length; i++) hue = (hue * 31 + name.charCodeAt(i)) % 360
-  const bg = `hsl(${hue}, 28%, 28%)`
-  const fg = `hsl(${hue}, 60%, 78%)`
-  return (
-    <div
-      style={{
-        ...baseStyle,
-        background: bg,
-        color: fg,
-        font: `600 ${Math.round(size * 0.42)}px ${UI}`,
-        letterSpacing: '0.03em',
-      }}
-    >
-      {initials}
-    </div>
-  )
-}
 
 function Sparkline({
   data,
@@ -591,7 +524,7 @@ function ScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
               minWidth: 0,
             }}
           >
-            <Avatar name={opponent} size={64} ring ringColor={accent} />
+            <UserAvatar name={opponent} size={64} ring ringColor={accent} />
             <div style={{ minWidth: 0, flex: 1 }}>
               <h1
                 style={{
@@ -687,7 +620,7 @@ function CompactScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
         }}
       />
       <BallDot live color={C.warn} size={8} />
-      <Avatar name={opponent} size={36} />
+      <UserAvatar name={opponent} size={36} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
           style={{
@@ -983,7 +916,7 @@ function RecentResultsCard({ rows }: { rows: DashboardRecentResult[] }) {
                           boxShadow: `0 0 6px ${r.is_win ? 'rgba(0,226,154,0.5)' : 'rgba(255,77,109,0.5)'}`,
                         }}
                       />
-                      <Avatar name={opponent} size={24} />
+                      <UserAvatar name={opponent} size={24} />
                       <span
                         style={{
                           color: opponent ? C.chalk50 : C.chalk500,

--- a/web-client/src/components/ui/user-avatar.tsx
+++ b/web-client/src/components/ui/user-avatar.tsx
@@ -1,0 +1,104 @@
+import type { CSSProperties } from 'react'
+import { User as UserIcon } from 'lucide-react'
+
+import { cn, initialsOf } from '@/lib/utils'
+
+function hueFor(name: string): number {
+  let hue = 0
+  for (let i = 0; i < name.length; i += 1) {
+    hue = (hue * 31 + name.charCodeAt(i)) % 360
+  }
+  return hue
+}
+
+export interface UserAvatarProps {
+  /** Username. `null` renders the dashed-circle "no opponent" placeholder. */
+  name: string | null
+  /** Pixel diameter. */
+  size?: number
+  /** Outer ring (e.g. score-needed hero). */
+  ring?: boolean
+  /** Ring color when `ring` is true. Defaults to `--ball-500`. */
+  ringColor?: string
+  /** Neutral muted background instead of the per-user color — for non-claimed
+   *  or preview states where the username isn't a real identity yet. */
+  dim?: boolean
+  className?: string
+  style?: CSSProperties
+}
+
+export function UserAvatar({
+  name,
+  size = 32,
+  ring = false,
+  ringColor = 'var(--ball-500)',
+  dim = false,
+  className,
+  style,
+}: UserAvatarProps) {
+  const base: CSSProperties = {
+    width: size,
+    height: size,
+    borderRadius: '50%',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    fontFamily: 'var(--font-mono)',
+    fontWeight: 700,
+    fontSize: Math.round(size * 0.4),
+    letterSpacing: '0.02em',
+    boxShadow: ring
+      ? `0 0 0 2px var(--ink-950), 0 0 0 ${size > 40 ? 3 : 2.5}px ${ringColor}`
+      : undefined,
+  }
+
+  if (name === null) {
+    return (
+      <span
+        aria-hidden="true"
+        className={cn('user-avatar user-avatar--ghost', className)}
+        style={{
+          ...base,
+          background: 'transparent',
+          border: '1.5px dashed var(--ink-500)',
+          color: 'var(--fg-3)',
+          ...style,
+        }}
+      >
+        <UserIcon size={Math.round(size * 0.45)} strokeWidth={1.75} />
+      </span>
+    )
+  }
+
+  if (dim) {
+    return (
+      <span
+        className={cn('user-avatar user-avatar--dim', className)}
+        style={{
+          ...base,
+          background: 'var(--ink-700)',
+          color: 'var(--fg-3)',
+          ...style,
+        }}
+      >
+        {initialsOf(name)}
+      </span>
+    )
+  }
+
+  const hue = hueFor(name)
+  return (
+    <span
+      className={cn('user-avatar', className)}
+      style={{
+        ...base,
+        background: `hsl(${hue}, 28%, 28%)`,
+        color: `hsl(${hue}, 60%, 78%)`,
+        ...style,
+      }}
+    >
+      {initialsOf(name)}
+    </span>
+  )
+}

--- a/web-client/src/components/ui/user-avatar.tsx
+++ b/web-client/src/components/ui/user-avatar.tsx
@@ -11,6 +11,14 @@ function hueFor(name: string): number {
   return hue
 }
 
+// `initialsOf` returns '' for empty input and the literal ellipsis for '…' —
+// neither reads as a name. Coerce those to a stable '?' so transient/empty
+// states render a recognizable placeholder rather than a blank circle.
+function monogram(name: string): string {
+  const out = initialsOf(name).replace(/[^A-Z0-9]/gi, '')
+  return out || '?'
+}
+
 export interface UserAvatarProps {
   /** Username. `null` renders the dashed-circle "no opponent" placeholder. */
   name: string | null
@@ -74,6 +82,8 @@ export function UserAvatar({
   if (dim) {
     return (
       <span
+        role="img"
+        aria-label={name}
         className={cn('user-avatar user-avatar--dim', className)}
         style={{
           ...base,
@@ -82,7 +92,7 @@ export function UserAvatar({
           ...style,
         }}
       >
-        {initialsOf(name)}
+        {monogram(name)}
       </span>
     )
   }
@@ -90,6 +100,8 @@ export function UserAvatar({
   const hue = hueFor(name)
   return (
     <span
+      role="img"
+      aria-label={name}
       className={cn('user-avatar', className)}
       style={{
         ...base,
@@ -98,7 +110,7 @@ export function UserAvatar({
         ...style,
       }}
     >
-      {initialsOf(name)}
+      {monogram(name)}
     </span>
   )
 }

--- a/web-client/src/components/user-menu.tsx
+++ b/web-client/src/components/user-menu.tsx
@@ -1,12 +1,5 @@
 import { useSession } from '@/api/session'
-
-function getInitials(username: string): string {
-  const cleaned = username.replace(/[._-]+/g, ' ').trim()
-  const parts = cleaned.split(/\s+/).filter(Boolean)
-  if (parts.length === 0) return '??'
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
-  return (parts[0][0] + parts[1][0]).toUpperCase()
-}
+import { UserAvatar } from '@/components/ui/user-avatar'
 
 export function UserMenu() {
   const { data, isLoading, isError } = useSession()
@@ -26,7 +19,6 @@ export function UserMenu() {
   }
 
   const username = !isError && data ? data.data.user.username : 'Guest'
-  const initials = getInitials(username)
 
   return (
     <div
@@ -34,7 +26,7 @@ export function UserMenu() {
       data-testid="user-menu"
       aria-label={`Signed in as ${username}`}
     >
-      <div className="app-shell__user-avatar">{initials}</div>
+      <UserAvatar name={username} size={30} />
       <div
         className="app-shell__user-name app-shell__user-name--truncate"
         title={username}

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -23,7 +23,6 @@ import {
 import type { components } from '@/api/schema'
 import { useSession } from '@/api/session'
 import { AppShell } from '@/components/app-shell'
-import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -35,9 +34,10 @@ import {
   PaginationLink,
 } from '@/components/ui/pagination'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { UserAvatar } from '@/components/ui/user-avatar'
 import { pageTitle } from '@/lib/page-title'
 import { useDebouncedValue } from '@/lib/use-debounced-value'
-import { cn, initialsOf } from '@/lib/utils'
+import { cn } from '@/lib/utils'
 import './index.css'
 
 type MatchListRowSide = components['schemas']['MatchDetailsSide']
@@ -472,11 +472,7 @@ function PlayerChip({ side }: { side: MatchListRowSide | null }) {
           <User size={15} strokeWidth={1.75} />
         </span>
       ) : (
-        <Avatar className="size-[26px]">
-          <AvatarFallback className="font-mono text-[11px] font-bold">
-            {initialsOf(name)}
-          </AvatarFallback>
-        </Avatar>
+        <UserAvatar name={name} size={26} />
       )}
       <span
         className={cn(

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -14,6 +14,7 @@ import {
   type Player,
 } from '@/api/matches'
 import { OpponentPickerBoundary } from '@/components/matches/opponent-picker-boundary'
+import { UserAvatar } from '@/components/ui/user-avatar'
 import { pageTitle } from '@/lib/page-title'
 import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { cn } from '@/lib/utils'
@@ -37,16 +38,6 @@ interface Opponent {
 
 function opponentFromPlayer(player: Player): Opponent {
   return { id: player.id, name: player.username }
-}
-
-/** Two-letter monogram for an avatar bubble. */
-function initialsOf(name: string): string {
-  const parts = name.split(/[^a-zA-Z0-9]+/).filter(Boolean)
-  const letters =
-    parts.length >= 2
-      ? parts[0][0] + parts[1][0]
-      : name.replace(/[^a-zA-Z0-9]/g, '').slice(0, 2)
-  return letters.toUpperCase() || '?'
 }
 
 /* ------------------------------------------------------------------ */
@@ -140,7 +131,7 @@ function MatchCard() {
   return (
     <div className="nm-card">
       <div className="nm-you-strip">
-        <div className="av">{me ? initialsOf(me.username) : '··'}</div>
+        <UserAvatar name={me?.username ?? '…'} size={36} dim={!me} />
         <div className="block">
           <span className="lbl">You</span>
           <span className="name">{me?.username ?? 'Loading…'}</span>
@@ -209,7 +200,7 @@ function SelectedOpponent({
 }) {
   return (
     <div className="nm-selected">
-      <div className="av">{initialsOf(opponent.name)}</div>
+      <UserAvatar name={opponent.name} size={48} />
       <div className="info">
         <div className="name">{opponent.name}</div>
         <div className="rating">REGISTERED PLAYER</div>
@@ -284,7 +275,7 @@ function RecentPicker({ onPick }: { onPick: (player: Player) => void }) {
               className="nm-chip"
               onClick={() => onPick(p)}
             >
-              <div className="av">{initialsOf(p.username)}</div>
+              <UserAvatar name={p.username} size={32} />
               <div className="body">
                 <div className="n">{p.username}</div>
                 <div className="m">REGISTERED PLAYER</div>
@@ -378,7 +369,7 @@ function TypeaheadPicker({ onPick }: { onPick: (player: Player) => void }) {
         onMouseEnter={() => setActiveIdx(i)}
         onClick={() => onPick(p)}
       >
-        <div className="av">{initialsOf(p.username)}</div>
+        <UserAvatar name={p.username} size={36} />
         <div className="body">
           <div className="n">{p.username}</div>
           <div className="m">

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -25,6 +25,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { UserAvatar } from '@/components/ui/user-avatar'
 import {
   HONEYPOT_STYLE,
   validateEmail,
@@ -104,35 +105,6 @@ function relativeTime(ts: number): string {
 
 function Spinner() {
   return <span className="fmm-spinner" />
-}
-
-function Avatar({ name, size = 32, dim = false }: { name: string; size?: number; dim?: boolean }) {
-  const init =
-    (name || '?').replace(/[^a-z0-9]/gi, '').slice(0, 2).toUpperCase() || '?'
-  return (
-    <div
-      style={{
-        width: size,
-        height: size,
-        borderRadius: '50%',
-        background: dim
-          ? 'var(--ink-700)'
-          : 'linear-gradient(135deg, var(--ball-500), var(--ball-700))',
-        color: dim ? 'var(--fg-3)' : 'var(--ink-950)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        fontFamily: 'var(--font-mono)',
-        fontSize: Math.round(size * 0.36),
-        fontWeight: 700,
-        letterSpacing: '0.02em',
-        flexShrink: 0,
-        boxShadow: dim ? 'none' : '0 0 0 2px rgba(255,122,26,0.18)',
-      }}
-    >
-      {init}
-    </div>
-  )
 }
 
 const COMING_SOON_TRIGGER: CSSProperties = {
@@ -450,7 +422,7 @@ function PageHeader({
             flexShrink: 0,
           }}
         >
-          <Avatar name={username || '…'} size={26} dim={!claimed} />
+          <UserAvatar name={username || '…'} size={26} dim={!claimed} />
           <div
             style={{
               fontFamily: 'var(--font-mono)',
@@ -687,7 +659,7 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
           gap: 14,
         }}
       >
-        <Avatar name={val} size={36} dim={!clientV.ok} />
+        <UserAvatar name={val} size={36} dim={!clientV.ok} />
         <div style={{ flex: 1 }}>
           <div
             style={{


### PR DESCRIPTION
## Summary
- Fixes the inconsistency where the same username produced different initials (`brawny-moth` → "BM" in the topbar, "BR" in settings) and different colors (cyan gradient / orange gradient / shadcn gray / HSL-hash) across the topbar, settings, dashboard, matches list, and new-match flow.
- Introduces `web-client/src/components/ui/user-avatar.tsx` with one initials algorithm (canonical `initialsOf` from `lib/utils.ts`) and one deterministic per-username HSL color, and routes every identity-bearing avatar through it.
- Match-details win/loss and score-entry me/opp coloring stay put — they encode outcome and team, not identity, so they're intentionally out of scope.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` (tsc + vite) clean
- [x] `npm run test:run` — 101 vitest tests pass (including `user-menu` `getByText('MR')` for `maria.rossi`)
- [x] `npm run test:e2e` — 125 Playwright tests pass
- [x] API `ruff check` + `ruff format --check` + `mypy` + 300 pytest pass (no API files touched, run as a safety net)
- [ ] Eyeball the topbar, settings chip + preview, dashboard score-needed banner, and matches list to confirm the same username renders with the same monogram and hue everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)