### PR TITLE
Hide scoring big-input placeholder on focus

### DIFF
--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1627,6 +1627,10 @@ body.dark.fortymm-theme {
   font-weight: 400;
   -webkit-text-fill-color: var(--ink-500);
 }
+.fortymm-theme .big-input:focus::placeholder {
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
 .fortymm-theme .big-input:focus {
   color: var(--ball-500);
   -webkit-text-fill-color: var(--ball-500);


### PR DESCRIPTION
## Summary
- Add `.big-input:focus::placeholder { color: transparent }` (plus the `-webkit-text-fill-color` companion for Safari) so the placeholder hides while the cursor is in a scoring input.

## Test plan
- [x] `npm run test:run` (vitest, 101/101)
- [x] `npm run lint`
- [x] `npm run build` (tsc + vite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)