### PR TITLE
Fix scoring copy when a typed score would clinch the match (bug #12)

### DIFF
--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -258,6 +258,62 @@ describe('ScoreEntry — create', () => {
     )
   })
 
+  it('flips Save copy to "finish the match" when the typed score would clinch early', async () => {
+    // Bo5, 2-0 on the board, entering G3. A 11-3 win here clinches at 3-0,
+    // so the messaging must not promise a non-existent G4. (Bug #12.)
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          inProgressMatch({
+            sides: participantSides({ meWins: 2, oppWins: 0 }),
+            games: [
+              { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
+              { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
+              { id: 'g-3', game_number: 3, score: null },
+            ],
+            current_game: { id: 'g-3', game_number: 3 },
+          }),
+        ),
+      ),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameId: 'g-3' })
+    const meInput = await screen.findByRole('textbox', { name: 'rita.kovac score' })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+
+    // Pre-typing the message is still the generic "continue to game 4" hint.
+    expect(
+      screen.getByText(/save this game to continue to game 4/i),
+    ).toBeInTheDocument()
+
+    await user.type(meInput, '11')
+    await user.type(oppInput, '3')
+
+    expect(
+      screen.getByText(/save to finish the match/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(/continue to game 4/i),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /save & finish match/i }),
+    ).toBeInTheDocument()
+
+    // A non-clinching score (opponent wins G3, taking the match to 2-1)
+    // restores the "continue to game 4" hint.
+    await user.clear(meInput)
+    await user.type(meInput, '5')
+    await user.clear(oppInput)
+    await user.type(oppInput, '11')
+    expect(
+      screen.getByText(/save this game to continue to game 4/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /save game & next/i }),
+    ).toBeInTheDocument()
+  })
+
   it('blocks an illegal final score client-side without hitting the server', async () => {
     const user = userEvent.setup()
     let posted = 0

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -202,21 +202,33 @@ function ScoreEntryInner({
   const inputsLocked = mutation.isPending || lockedReason !== null
   const isEdit = mode.kind === 'edit'
 
+  // A typed, legal score that pushes either side to games_to_win clinches the
+  // match — even if more games would otherwise remain (e.g. 3-0 in a Bo5).
+  const gamesToWin = data.games_to_win
+  const willClinch =
+    inputsValid &&
+    (Number(me) > Number(opp)
+      ? meWins + 1 >= gamesToWin
+      : oppWins + 1 >= gamesToWin)
+  const isFinalGame = willClinch || gameNumber === bestOf
+
   const heading = isEdit
     ? `Edit game ${gameNumber} score.`
     : `Enter game ${gameNumber} score.`
   const subtitle = isEdit
     ? 'Save updates the score for this game.'
-    : gameNumber < bestOf
-      ? `Save this game to continue to game ${gameNumber + 1}.`
-      : 'Final game. Save to finish the match.'
+    : willClinch
+      ? 'Save to finish the match.'
+      : gameNumber < bestOf
+        ? `Save this game to continue to game ${gameNumber + 1}.`
+        : 'Final game. Save to finish the match.'
   const saveLabel = mutation.isPending
     ? 'Saving…'
     : isEdit
       ? 'Save changes →'
-      : gameNumber < bestOf
-        ? 'Save game & next →'
-        : 'Save final game →'
+      : isFinalGame
+        ? 'Save & finish match →'
+        : 'Save game & next →'
 
   return (
     <AppShell>


### PR DESCRIPTION
## Summary
- Bug #12: in a Bo5 leading 2-0 on G3, entering 11-3 was a match-clinching score, but the UI still read "Save this game to continue to game 4." with a "Save game & next →" button.
- Compute `willClinch` from the typed score vs `data.games_to_win`; when true, subtitle becomes "Save to finish the match." and button becomes "Save & finish match →" (the latter wording signals the match-locking nature of the save).
- Non-clinching scores still get the existing "continue to game N" / "Save game & next →" copy.

## Test plan
- [x] vitest: 102/102 pass, including a new `score-entry.test.tsx` case that asserts both the clinch path (11-3 → "finish match") and the non-clinch reset (5-11 → "continue to game 4").
- [x] web-client Playwright: 125/125 pass.
- [x] eslint + `tsc -b && vite build` clean.
- [ ] API pytest skipped — PR is frontend copy only, no `api/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)