### PR TITLE
Enable Dependabot for pip, npm, GitHub Actions, and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /api
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /web-client
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      web-client-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /e2e
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      e2e-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      root-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: /api
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: docker
+    directory: /web-client
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering all ecosystems in the repo: pip (`api/`), npm (`web-client/`, `e2e/`, root), GitHub Actions, and Docker (`api/Dockerfile.dev`, `web-client/Dockerfile.dev`).
- Weekly cadence with minor+patch updates grouped per ecosystem to keep PR volume manageable; majors stay separate for deliberate review.
- Conservative `open-pull-requests-limit` per ecosystem (3–5).

## Notes
- Expect a flurry of PRs on first run after merge (existing drift across the lockfiles).
- No `ignore` blocks for tight-pinned majors (React 19, Tailwind 4, TanStack Router, Vite, FastAPI, SQLAlchemy) — major bumps will arrive as their own PRs; close-with-reason if undesired.

## Test plan
- [ ] Merge and confirm Dependabot opens initial round of PRs within ~24h.
- [ ] Verify groups land as single PRs (not one per dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)