### PR TITLE
Add public + authed user profile pages

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -16,6 +16,7 @@ from app.matches import router as matches_router
 from app.players import router as players_router
 from app.rbac import router as rbac_router
 from app.sessions import router as sessions_router
+from app.users import router as users_router
 
 log = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ app.include_router(rbac_router)
 app.include_router(matches_router)
 app.include_router(players_router)
 app.include_router(dashboard_router)
+app.include_router(users_router)
 
 SOLVER_HEALTH_TIMEOUT = 10.0
 

--- a/api/app/schemas/user.py
+++ b/api/app/schemas/user.py
@@ -18,3 +18,12 @@ class UserRead(UserBase):
     id: uuid.UUID
     created_at: datetime
     updated_at: datetime
+
+
+class UserProfile(BaseModel):
+    """Minimal user shape for profile pages — public-safe (no email)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    username: str

--- a/api/app/users.py
+++ b/api/app/users.py
@@ -1,6 +1,7 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi_limiter.depends import RateLimiter
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -10,6 +11,21 @@ from app.schemas.user import UserProfile
 from app.sessions import get_current_user
 
 router = APIRouter(prefix="/v1")
+
+
+async def _public_profile_ip_key(request: Request) -> str:
+    """Per-IP key for the unauthenticated profile endpoint — there is no
+    session cookie to bucket against, so IP is all we have."""
+    client = request.client
+    ip = client.host if client else "unknown"
+    return f"public-profile-ip:{ip}"
+
+
+# 60/min per IP: comfortably above a human browsing several profiles in quick
+# succession, well below the volume needed to scrape the user table.
+public_profile_ip_rate_limit = RateLimiter(
+    times=60, minutes=1, identifier=_public_profile_ip_key
+)
 
 
 @router.get("/users/{user_id}/profile", response_model=UserProfile)
@@ -28,7 +44,11 @@ async def get_user_by_id(
     return UserProfile.model_validate(user)
 
 
-@router.get("/p/users/{username}", response_model=UserProfile)
+@router.get(
+    "/p/users/{username}",
+    response_model=UserProfile,
+    dependencies=[Depends(public_profile_ip_rate_limit)],
+)
 async def get_public_user_by_username(
     username: str,
     db: AsyncSession = Depends(get_session),

--- a/api/app/users.py
+++ b/api/app/users.py
@@ -1,0 +1,43 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_session
+from app.models import User
+from app.schemas.user import UserProfile
+from app.sessions import get_current_user
+
+router = APIRouter(prefix="/v1")
+
+
+@router.get("/users/{user_id}/profile", response_model=UserProfile)
+async def get_user_by_id(
+    user_id: uuid.UUID,
+    _current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> UserProfile:
+    user = (
+        await db.execute(select(User).where(User.id == user_id))
+    ).scalar_one_or_none()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found."
+        )
+    return UserProfile.model_validate(user)
+
+
+@router.get("/p/users/{username}", response_model=UserProfile)
+async def get_public_user_by_username(
+    username: str,
+    db: AsyncSession = Depends(get_session),
+) -> UserProfile:
+    user = (
+        await db.execute(select(User).where(User.username == username))
+    ).scalar_one_or_none()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found."
+        )
+    return UserProfile.model_validate(user)

--- a/api/tests/test_users.py
+++ b/api/tests/test_users.py
@@ -58,3 +58,17 @@ async def test_public_user_by_username_404_when_missing(
     assert response.status_code == 404
     assert api_client is not None
     assert db_session is not None
+
+
+async def test_public_user_by_username_is_rate_limited_per_ip(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """After 60 requests in the same minute from one IP, the 61st returns 429."""
+    await make_user(db_session, "rl.target")
+    async with make_client() as client:
+        for i in range(60):
+            response = await client.get("/v1/p/users/rl.target")
+            assert response.status_code == 200, (i, response.text)
+        over = await client.get("/v1/p/users/rl.target")
+    assert over.status_code == 429
+    assert api_client is not None

--- a/api/tests/test_users.py
+++ b/api/tests/test_users.py
@@ -1,0 +1,60 @@
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests._helpers import make_client, make_user, start_session
+
+
+async def test_get_user_by_id_returns_profile_for_signed_in_caller(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    target = await make_user(db_session, "viewed.user")
+
+    response = await api_client.get(f"/v1/users/{target.id}/profile")
+
+    assert response.status_code == 200
+    assert response.json() == {"id": str(target.id), "username": "viewed.user"}
+
+
+async def test_get_user_by_id_requires_a_session(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    target = await make_user(db_session, "lookup.target")
+    # Fresh cookie-isolated client so no session cookie is in flight.
+    async with make_client() as client:
+        response = await client.get(f"/v1/users/{target.id}/profile")
+    assert response.status_code == 401
+    assert api_client is not None  # keeps the dep-override fixture active
+
+
+async def test_get_user_by_id_404_when_missing(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    response = await api_client.get(f"/v1/users/{uuid.uuid4()}/profile")
+    assert response.status_code == 404
+
+
+async def test_public_user_by_username_does_not_require_session(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    target = await make_user(db_session, "public.user")
+    async with make_client() as client:
+        response = await client.get("/v1/p/users/public.user")
+    assert response.status_code == 200
+    assert response.json() == {"id": str(target.id), "username": "public.user"}
+    # No session cookie should have been minted by the public endpoint.
+    assert "session" not in response.cookies
+    assert api_client is not None
+
+
+async def test_public_user_by_username_404_when_missing(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    async with make_client() as client:
+        response = await client.get("/v1/p/users/nobody.here")
+    assert response.status_code == 404
+    assert api_client is not None
+    assert db_session is not None

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -443,6 +443,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/users/{user_id}/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get User By Id */
+        get: operations["get_user_by_id_v1_users__user_id__profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/p/users/{username}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Public User By Username */
+        get: operations["get_public_user_by_username_v1_p_users__username__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/health": {
         parameters: {
             query?: never;
@@ -1122,6 +1156,19 @@ export interface components {
         };
         /** UpdateCurrentUserRequest */
         UpdateCurrentUserRequest: {
+            /** Username */
+            username: string;
+        };
+        /**
+         * UserProfile
+         * @description Minimal user shape for profile pages — public-safe (no email).
+         */
+        UserProfile: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
             /** Username */
             username: string;
         };
@@ -2188,6 +2235,70 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DashboardResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_user_by_id_v1_users__user_id__profile_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                user_id: string;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserProfile"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_public_user_by_username_v1_p_users__username__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                username: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserProfile"];
                 };
             };
             /** @description Validation Error */

--- a/web-client/src/api/users.ts
+++ b/web-client/src/api/users.ts
@@ -1,0 +1,39 @@
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import { api, unwrap } from './client'
+import type { components } from './schema'
+
+export type UserProfile = components['schemas']['UserProfile']
+
+export function userByIdQueryOptions(userId: string) {
+  return queryOptions({
+    queryKey: ['user', 'by-id', userId] as const,
+    queryFn: async (): Promise<UserProfile> =>
+      unwrap(
+        'load user',
+        await api.GET('/v1/users/{user_id}/profile', {
+          params: { path: { user_id: userId } },
+        }),
+      ),
+  })
+}
+
+export function useUserById(userId: string, options: { enabled?: boolean } = {}) {
+  return useQuery({ ...userByIdQueryOptions(userId), ...options })
+}
+
+export function publicUserByUsernameQueryOptions(username: string) {
+  return queryOptions({
+    queryKey: ['user', 'public', username] as const,
+    queryFn: async (): Promise<UserProfile> =>
+      unwrap(
+        'load public profile',
+        await api.GET('/v1/p/users/{username}', {
+          params: { path: { username } },
+        }),
+      ),
+  })
+}
+
+export function usePublicUserByUsername(username: string) {
+  return useQuery(publicUserByUsernameQueryOptions(username))
+}

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -144,6 +144,26 @@ export const handlers = [
     await delay(600)
     return HttpResponse.json(mockSession)
   }),
+  http.get('*/v1/users/:userId/profile', async ({ params }) => {
+    await delay(200)
+    const userId = String(params.userId)
+    const match = mockPlayers.find((p) => p.id === userId)
+    if (!match) return HttpResponse.json({ detail: 'User not found.' }, { status: 404 })
+    return HttpResponse.json({ id: match.id, username: match.username })
+  }),
+  http.get('*/v1/p/users/:username', async ({ params }) => {
+    await delay(200)
+    const username = String(params.username)
+    if (username === mockSession.data.user.username) {
+      return HttpResponse.json({
+        id: 'me_mock',
+        username: mockSession.data.user.username,
+      })
+    }
+    const match = mockPlayers.find((p) => p.username === username)
+    if (!match) return HttpResponse.json({ detail: 'User not found.' }, { status: 404 })
+    return HttpResponse.json({ id: match.id, username: match.username })
+  }),
   http.patch('*/v1/me', async ({ request }) => {
     const body = (await readJson(request)) as { username?: string } | undefined
     const next = body?.username?.trim() ?? ''

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as MatchesIndexRouteImport } from './routes/matches/index'
 import { Route as LoginIndexRouteImport } from './routes/login.index'
 import { Route as AdminIndexRouteImport } from './routes/admin.index'
+import { Route as UsersUserIdRouteImport } from './routes/users.$userId'
 import { Route as MatchesNewRouteImport } from './routes/matches/new'
 import { Route as LoginWelcomeRouteImport } from './routes/login.welcome'
 import { Route as LoginVerifyingRouteImport } from './routes/login.verifying'
@@ -27,6 +28,7 @@ import { Route as AdminUsersRouteImport } from './routes/admin.users'
 import { Route as AdminRolesRouteImport } from './routes/admin.roles'
 import { Route as AdminPermissionsRouteImport } from './routes/admin.permissions'
 import { Route as MatchesMatchIdIndexRouteImport } from './routes/matches.$matchId.index'
+import { Route as PUsersUsernameRouteImport } from './routes/p.users.$username'
 import { Route as MatchesMatchIdGamesGameIdScoresNewRouteImport } from './routes/matches.$matchId.games.$gameId.scores.new'
 import { Route as MatchesMatchIdGamesGameIdScoresScoreIdEditRouteImport } from './routes/matches.$matchId.games.$gameId.scores.$scoreId.edit'
 
@@ -80,6 +82,11 @@ const AdminIndexRoute = AdminIndexRouteImport.update({
   path: '/',
   getParentRoute: () => AdminRoute,
 } as any)
+const UsersUserIdRoute = UsersUserIdRouteImport.update({
+  id: '/users/$userId',
+  path: '/users/$userId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MatchesNewRoute = MatchesNewRouteImport.update({
   id: '/matches/new',
   path: '/matches/new',
@@ -120,6 +127,11 @@ const MatchesMatchIdIndexRoute = MatchesMatchIdIndexRouteImport.update({
   path: '/matches/$matchId/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PUsersUsernameRoute = PUsersUsernameRouteImport.update({
+  id: '/p/users/$username',
+  path: '/p/users/$username',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MatchesMatchIdGamesGameIdScoresNewRoute =
   MatchesMatchIdGamesGameIdScoresNewRouteImport.update({
     id: '/matches/$matchId/games/$gameId/scores/new',
@@ -148,9 +160,11 @@ export interface FileRoutesByFullPath {
   '/login/verifying': typeof LoginVerifyingRoute
   '/login/welcome': typeof LoginWelcomeRoute
   '/matches/new': typeof MatchesNewRoute
+  '/users/$userId': typeof UsersUserIdRoute
   '/admin/': typeof AdminIndexRoute
   '/login/': typeof LoginIndexRoute
   '/matches/': typeof MatchesIndexRoute
+  '/p/users/$username': typeof PUsersUsernameRoute
   '/matches/$matchId/': typeof MatchesMatchIdIndexRoute
   '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
   '/matches/$matchId/games/$gameId/scores/$scoreId/edit': typeof MatchesMatchIdGamesGameIdScoresScoreIdEditRoute
@@ -169,9 +183,11 @@ export interface FileRoutesByTo {
   '/login/verifying': typeof LoginVerifyingRoute
   '/login/welcome': typeof LoginWelcomeRoute
   '/matches/new': typeof MatchesNewRoute
+  '/users/$userId': typeof UsersUserIdRoute
   '/admin': typeof AdminIndexRoute
   '/login': typeof LoginIndexRoute
   '/matches': typeof MatchesIndexRoute
+  '/p/users/$username': typeof PUsersUsernameRoute
   '/matches/$matchId': typeof MatchesMatchIdIndexRoute
   '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
   '/matches/$matchId/games/$gameId/scores/$scoreId/edit': typeof MatchesMatchIdGamesGameIdScoresScoreIdEditRoute
@@ -192,9 +208,11 @@ export interface FileRoutesById {
   '/login/verifying': typeof LoginVerifyingRoute
   '/login/welcome': typeof LoginWelcomeRoute
   '/matches/new': typeof MatchesNewRoute
+  '/users/$userId': typeof UsersUserIdRoute
   '/admin/': typeof AdminIndexRoute
   '/login/': typeof LoginIndexRoute
   '/matches/': typeof MatchesIndexRoute
+  '/p/users/$username': typeof PUsersUsernameRoute
   '/matches/$matchId/': typeof MatchesMatchIdIndexRoute
   '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
   '/matches/$matchId/games/$gameId/scores/$scoreId/edit': typeof MatchesMatchIdGamesGameIdScoresScoreIdEditRoute
@@ -216,9 +234,11 @@ export interface FileRouteTypes {
     | '/login/verifying'
     | '/login/welcome'
     | '/matches/new'
+    | '/users/$userId'
     | '/admin/'
     | '/login/'
     | '/matches/'
+    | '/p/users/$username'
     | '/matches/$matchId/'
     | '/matches/$matchId/games/$gameId/scores/new'
     | '/matches/$matchId/games/$gameId/scores/$scoreId/edit'
@@ -237,9 +257,11 @@ export interface FileRouteTypes {
     | '/login/verifying'
     | '/login/welcome'
     | '/matches/new'
+    | '/users/$userId'
     | '/admin'
     | '/login'
     | '/matches'
+    | '/p/users/$username'
     | '/matches/$matchId'
     | '/matches/$matchId/games/$gameId/scores/new'
     | '/matches/$matchId/games/$gameId/scores/$scoreId/edit'
@@ -259,9 +281,11 @@ export interface FileRouteTypes {
     | '/login/verifying'
     | '/login/welcome'
     | '/matches/new'
+    | '/users/$userId'
     | '/admin/'
     | '/login/'
     | '/matches/'
+    | '/p/users/$username'
     | '/matches/$matchId/'
     | '/matches/$matchId/games/$gameId/scores/new'
     | '/matches/$matchId/games/$gameId/scores/$scoreId/edit'
@@ -279,8 +303,10 @@ export interface RootRouteChildren {
   LoginVerifyingRoute: typeof LoginVerifyingRoute
   LoginWelcomeRoute: typeof LoginWelcomeRoute
   MatchesNewRoute: typeof MatchesNewRoute
+  UsersUserIdRoute: typeof UsersUserIdRoute
   LoginIndexRoute: typeof LoginIndexRoute
   MatchesIndexRoute: typeof MatchesIndexRoute
+  PUsersUsernameRoute: typeof PUsersUsernameRoute
   MatchesMatchIdIndexRoute: typeof MatchesMatchIdIndexRoute
   MatchesMatchIdGamesGameIdScoresNewRoute: typeof MatchesMatchIdGamesGameIdScoresNewRoute
   MatchesMatchIdGamesGameIdScoresScoreIdEditRoute: typeof MatchesMatchIdGamesGameIdScoresScoreIdEditRoute
@@ -358,6 +384,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminIndexRouteImport
       parentRoute: typeof AdminRoute
     }
+    '/users/$userId': {
+      id: '/users/$userId'
+      path: '/users/$userId'
+      fullPath: '/users/$userId'
+      preLoaderRoute: typeof UsersUserIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/matches/new': {
       id: '/matches/new'
       path: '/matches/new'
@@ -414,6 +447,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MatchesMatchIdIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/p/users/$username': {
+      id: '/p/users/$username'
+      path: '/p/users/$username'
+      fullPath: '/p/users/$username'
+      preLoaderRoute: typeof PUsersUsernameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/matches/$matchId/games/$gameId/scores/new': {
       id: '/matches/$matchId/games/$gameId/scores/new'
       path: '/matches/$matchId/games/$gameId/scores/new'
@@ -459,8 +499,10 @@ const rootRouteChildren: RootRouteChildren = {
   LoginVerifyingRoute: LoginVerifyingRoute,
   LoginWelcomeRoute: LoginWelcomeRoute,
   MatchesNewRoute: MatchesNewRoute,
+  UsersUserIdRoute: UsersUserIdRoute,
   LoginIndexRoute: LoginIndexRoute,
   MatchesIndexRoute: MatchesIndexRoute,
+  PUsersUsernameRoute: PUsersUsernameRoute,
   MatchesMatchIdIndexRoute: MatchesMatchIdIndexRoute,
   MatchesMatchIdGamesGameIdScoresNewRoute:
     MatchesMatchIdGamesGameIdScoresNewRoute,

--- a/web-client/src/routes/p.users.$username.tsx
+++ b/web-client/src/routes/p.users.$username.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  publicUserByUsernameQueryOptions,
+  usePublicUserByUsername,
+} from '@/api/users'
+import { pageTitle } from '@/lib/page-title'
+
+export const Route = createFileRoute('/p/users/$username')({
+  head: () => ({
+    meta: [{ title: pageTitle('User') }],
+  }),
+  loader: ({ context: { queryClient }, params: { username } }) => {
+    void queryClient.prefetchQuery(publicUserByUsernameQueryOptions(username))
+  },
+  component: PublicUserRoute,
+})
+
+function PublicUserRoute() {
+  const { username } = Route.useParams()
+  const { data, isPending, isError } = usePublicUserByUsername(username)
+
+  return (
+    <div className="p-6">
+      {isPending && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {isError && <p className="text-sm text-[color:var(--loss)]">User not found.</p>}
+      {data && <h1 className="text-2xl font-semibold">{data.username}</h1>}
+    </div>
+  )
+}

--- a/web-client/src/routes/users.$userId.tsx
+++ b/web-client/src/routes/users.$userId.tsx
@@ -1,0 +1,31 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { sessionQueryOptions } from '@/api/session'
+import { useUserById, userByIdQueryOptions } from '@/api/users'
+import { AppShell } from '@/components/app-shell'
+import { pageTitle } from '@/lib/page-title'
+
+export const Route = createFileRoute('/users/$userId')({
+  head: () => ({
+    meta: [{ title: pageTitle('User') }],
+  }),
+  loader: ({ context: { queryClient }, params: { userId } }) => {
+    void queryClient.prefetchQuery(sessionQueryOptions())
+    void queryClient.prefetchQuery(userByIdQueryOptions(userId))
+  },
+  component: UserRoute,
+})
+
+function UserRoute() {
+  const { userId } = Route.useParams()
+  const { data, isPending, isError } = useUserById(userId)
+
+  return (
+    <AppShell>
+      <div className="p-6">
+        {isPending && <p className="text-sm text-muted-foreground">Loading…</p>}
+        {isError && <p className="text-sm text-[color:var(--loss)]">User not found.</p>}
+        {data && <h1 className="text-2xl font-semibold">{data.username}</h1>}
+      </div>
+    </AppShell>
+  )
+}

--- a/web-client/src/routes/users.$userId.tsx
+++ b/web-client/src/routes/users.$userId.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { sessionQueryOptions } from '@/api/session'
-import { useUserById, userByIdQueryOptions } from '@/api/users'
+import { sessionQueryOptions, useSession } from '@/api/session'
+import { useUserById } from '@/api/users'
 import { AppShell } from '@/components/app-shell'
 import { pageTitle } from '@/lib/page-title'
 
@@ -8,16 +8,21 @@ export const Route = createFileRoute('/users/$userId')({
   head: () => ({
     meta: [{ title: pageTitle('User') }],
   }),
-  loader: ({ context: { queryClient }, params: { userId } }) => {
+  // Don't prefetch the profile here — it requires a session cookie, and on a
+  // direct-load the session prefetch hasn't landed yet. The component fires
+  // the profile query once `session.isSuccess`. See #144.
+  loader: ({ context: { queryClient } }) => {
     void queryClient.prefetchQuery(sessionQueryOptions())
-    void queryClient.prefetchQuery(userByIdQueryOptions(userId))
   },
   component: UserRoute,
 })
 
 function UserRoute() {
   const { userId } = Route.useParams()
-  const { data, isPending, isError } = useUserById(userId)
+  const session = useSession()
+  const { data, isPending, isError } = useUserById(userId, {
+    enabled: session.isSuccess,
+  })
 
   return (
     <AppShell>


### PR DESCRIPTION
## Summary
- Adds `/users/$userId` (authed, AppShell-wrapped, currently renders just the username) backed by new `GET /v1/users/{user_id}/profile`. The bare `/v1/users/{user_id}` path is already owned by the rbac admin router.
- Adds `/p/users/$username` (public, no shell, no session minted) backed by new `GET /v1/p/users/{username}`. Rate-limited at 60/min per IP to cap username enumeration.
- New minimal `UserProfile` schema (id + username only) — won't leak email.
- Authed route gates its profile query on `session.isSuccess` to avoid the first-visit 401 race (#144).

## Test plan
- [x] `api/` pytest — 306 pass (5 new endpoint tests + 1 rate-limit test)
- [x] `web-client/` vitest — 101 pass
- [x] `web-client/` lint + tsc + vite build — clean
- [x] `web-client/` Playwright e2e — 125 pass
- [x] OpenAPI schema regenerated, no drift
- [ ] Manual: visit `/p/users/<existing>` while signed out — page renders, no `session` cookie set
- [ ] Manual: visit `/users/<id>` direct-load with no prior session — page shows username (not "User not found")

🤖 Generated with [Claude Code](https://claude.com/claude-code)