### PR TITLE
Vertically center text in score-entry action buttons

### DIFF
--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1716,6 +1716,9 @@ body.dark.fortymm-theme {
   gap: 10px;
 }
 .fortymm-theme .action-btns .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: var(--ink-700);
   border: 1px solid var(--ink-500);
   color: var(--fg-1);
@@ -1724,6 +1727,7 @@ body.dark.fortymm-theme {
   height: 46px;
   border-radius: 10px;
   cursor: pointer;
+  text-decoration: none;
 }
 .fortymm-theme .action-btns .btn:hover {
   border-color: var(--fg-3);


### PR DESCRIPTION
## Summary
- `.fortymm-theme .action-btns .btn` sized buttons with `height: 46px` + `padding: 0 20px` but didn't set `display`, so the "Back to match" `<Link>` (an `<a>`) rendered with text pinned to the top of the box.
- Adds `display: inline-flex` + centering + `text-decoration: none` so the rule works for both the save `<button>` and the back-to-match anchor.

## Test plan
- [x] vitest (102/102)
- [x] eslint
- [x] tsc -b && vite build
- [x] web-client Playwright (125/125)
- [x] Manually verified before/after on `/matches/m-2207/games/g-2207-3/scores/new` with playwright-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)