### PR TITLE
Use current host in settings profile URL preview

### DIFF
--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -690,7 +690,7 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
             letterSpacing: '0.08em',
           }}
         >
-          fortymm.app/p/{clientV.ok ? val : '—'}
+          {window.location.host}/p/users/{clientV.ok ? val : '—'}
         </span>
       </div>
     </SectionCard>


### PR DESCRIPTION
## Summary
- The username section on `/settings` showed a hard-coded `fortymm.app/p/{username}` preview that misnamed the host across dev/UAT/prod and used the wrong path.
- Replaced the static text with `{window.location.host}/p/users/{username}` so the preview tracks the live origin and the real profile route (`/p/users/$username`).

## Test plan
- [ ] Load `/settings` in dev — preview reads `localhost:<port>/p/users/<username>`
- [ ] Same on UAT / prod — preview reflects whatever hostname the user is on
- [ ] Invalid username still renders the `—` placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)