### PR TITLE
Public per-player matches; bundle first page into profile response

### DIFF
--- a/api/app/players.py
+++ b/api/app/players.py
@@ -21,6 +21,7 @@ from app.models import (
     UserLeagueRating,
 )
 from app.schemas.player import (
+    PlayerDetail,
     PlayerListResponse,
     PlayerMatchListResponse,
     PlayerMatchOpponent,
@@ -392,43 +393,58 @@ async def _summarize_one_player(
     return summaries[0]
 
 
-@router.get("/players/{player_id}", response_model=PlayerSummary)
+async def _player_detail(
+    db: AsyncSession, user: User, league_id: uuid.UUID
+) -> PlayerDetail:
+    """Shared body for both `/v1/players/{id}` and
+    `/v1/p/players/{username}` — bundles the hero summary with the first
+    page of matches so the profile page paints in one round trip. The FE
+    seeds the matches-query cache from the embedded ``matches`` field;
+    page 2+ falls through to `/v1/players/{id}/matches`."""
+    summary = await _summarize_one_player(db, user, league_id)
+    matches = await _paginated_player_matches(
+        db, user.id, page=1, page_size=LIST_DEFAULT_PAGE_SIZE
+    )
+    return PlayerDetail(**summary.model_dump(), matches=matches)
+
+
+@router.get("/players/{player_id}", response_model=PlayerDetail)
 async def get_player(
     player_id: uuid.UUID,
     league_id: uuid.UUID | None = Query(default=None),
     _current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
-) -> PlayerSummary:
-    """Authed profile hero for `/players/$userId`. Same shape as a list row
-    so the FE can reuse the cache key after navigating from the list."""
+) -> PlayerDetail:
+    """Authed profile bundle for `/players/$userId` — hero + first page of
+    matches in one response."""
     user = await _load_player_by_id(db, player_id)
     if user is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Player not found."
         )
     league = await resolve_league(db, league_id)
-    return await _summarize_one_player(db, user, league.id)
+    return await _player_detail(db, user, league.id)
 
 
 @router.get(
     "/p/players/{username}",
-    response_model=PlayerSummary,
+    response_model=PlayerDetail,
     dependencies=[Depends(public_player_ip_rate_limit)],
 )
 async def get_public_player(
     username: str,
     league_id: uuid.UUID | None = Query(default=None),
     db: AsyncSession = Depends(get_session),
-) -> PlayerSummary:
-    """Public profile hero for `/p/players/$username` — no session required,
-    rate-limited per-IP to keep the user table from being scraped."""
+) -> PlayerDetail:
+    """Public profile bundle for `/p/players/$username` — same shape as
+    the authed endpoint. No session required, rate-limited per-IP."""
     user = await _load_player_by_username(db, username)
     if user is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Player not found."
         )
     league = await resolve_league(db, league_id)
-    return await _summarize_one_player(db, user, league.id)
+    return await _player_detail(db, user, league.id)
 
 
 def _player_matches_eager() -> tuple[ExecutableOption, ...]:
@@ -505,23 +521,16 @@ def _serialize_player_match(match: Match, player_id: uuid.UUID) -> PlayerMatchRo
     )
 
 
-@router.get("/players/{player_id}/matches", response_model=PlayerMatchListResponse)
-async def list_player_matches(
+async def _paginated_player_matches(
+    db: AsyncSession,
     player_id: uuid.UUID,
-    page: int = Query(default=1, ge=1),
-    page_size: int = Query(default=LIST_DEFAULT_PAGE_SIZE, ge=1, le=LIST_MAX_PAGE_SIZE),
-    _current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_session),
+    page: int,
+    page_size: int,
 ) -> PlayerMatchListResponse:
-    """Paginated per-player match history backing the profile-page match
-    table. Newest-first by ``created_at``. Sets are projected from the
-    player's perspective so the FE renders them without flipping sides."""
-    user = await _load_player_by_id(db, player_id)
-    if user is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Player not found."
-        )
-
+    """Shared body for both `/v1/players/{id}/matches` and
+    `/v1/p/players/{username}/matches`. The two endpoints differ only in
+    how they resolve the player; the matches list shape, ordering, and
+    perspective flip are identical."""
     participant = (
         select(MatchSidePlayer.id)
         .where(
@@ -530,11 +539,9 @@ async def list_player_matches(
         )
         .exists()
     )
-
     total = (
         await db.execute(select(func.count()).select_from(Match).where(participant))
     ).scalar_one()
-
     matches = list(
         (
             await db.execute(
@@ -549,8 +556,37 @@ async def list_player_matches(
         .scalars()
         .all()
     )
-
     items = [_serialize_player_match(match, player_id) for match in matches]
     return PlayerMatchListResponse(
         items=items, page=page, page_size=page_size, total=total
     )
+
+
+@router.get(
+    "/players/{player_id}/matches",
+    response_model=PlayerMatchListResponse,
+    dependencies=[Depends(public_player_ip_rate_limit)],
+)
+async def list_player_matches(
+    player_id: uuid.UUID,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=LIST_DEFAULT_PAGE_SIZE, ge=1, le=LIST_MAX_PAGE_SIZE),
+    db: AsyncSession = Depends(get_session),
+) -> PlayerMatchListResponse:
+    """Paginated per-player match history backing the profile-page match
+    table on BOTH the authed (`/players/$userId`) and public
+    (`/p/players/$username`) surfaces — the public page has already
+    resolved username → id via `/v1/p/players/{username}`, so it has the
+    id to hit this endpoint with.
+
+    Public — no session required, IP-rate-limited (60/min) so the match
+    history can't be scraped from a single source. Newest-first by
+    ``created_at``. Sets are projected from the player's perspective so
+    the FE renders them without flipping sides.
+    """
+    user = await _load_player_by_id(db, player_id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Player not found."
+        )
+    return await _paginated_player_matches(db, player_id, page, page_size)

--- a/api/app/schemas/player.py
+++ b/api/app/schemas/player.py
@@ -90,3 +90,17 @@ class PlayerMatchListResponse(BaseModel):
     page: int
     page_size: int
     total: int
+
+
+class PlayerDetail(PlayerSummary):
+    """Profile-page bundle: the hero (`PlayerSummary` fields) plus the
+    first page of matches inline. Saves a round trip on initial load —
+    `GET /v1/players/{id}` (and the public `/v1/p/players/{username}`
+    variant) returns this so the profile page paints with one request.
+
+    Pagination beyond page 1 still hits `GET /v1/players/{id}/matches`
+    directly; the FE seeds page 1's cache from this `matches` field via
+    TanStack Query's `initialData`.
+    """
+
+    matches: PlayerMatchListResponse

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -446,9 +446,11 @@ async def test_list_players_pagination_respects_page_and_page_size(
     assert page1_ids.isdisjoint(page2_ids)
 
 
-async def test_get_player_returns_summary(
+async def test_get_player_returns_summary_with_embedded_matches(
     api_client: AsyncClient, db_session: AsyncSession
 ):
+    """The profile bundle includes the hero summary PLUS the first page
+    of matches inline so the FE paints in one round trip."""
     await start_session(api_client, db_session)
     target = await make_user(db_session, "the.player")
     opponent = await make_user(db_session, "an.opponent")
@@ -466,6 +468,12 @@ async def test_get_player_returns_summary(
     assert body["losses"] == 1
     # Form is newest-first → most recent L, then W.
     assert body["form"] == "LW"
+    # Matches bundle: page 1 with both matches (newest-first by created_at).
+    assert body["matches"]["page"] == 1
+    assert body["matches"]["total"] == 2
+    assert body["matches"]["items"][0]["result"] == "L"
+    assert body["matches"]["items"][0]["opponent"]["username"] == "an.opponent"
+    assert body["matches"]["items"][1]["result"] == "W"
 
 
 async def test_get_player_requires_a_session(
@@ -491,7 +499,11 @@ async def test_get_player_404_when_missing(
 async def test_get_public_player_does_not_require_session(
     api_client: AsyncClient, db_session: AsyncSession
 ):
+    """Public profile bundle: same shape as the authed variant — hero
+    summary + first-page matches inline."""
     target = await make_user(db_session, "public.player")
+    opponent = await make_user(db_session, "public.opp")
+    await _record_match_with_winner(db_session, target, opponent, created_at=BASE_TIME)
     async with make_client() as client:
         response = await client.get("/v1/p/players/public.player")
     assert response.status_code == 200
@@ -499,6 +511,9 @@ async def test_get_public_player_does_not_require_session(
     assert body["id"] == str(target.id)
     assert body["username"] == "public.player"
     assert "session" not in response.cookies
+    # Embedded matches let the public profile paint in one request.
+    assert body["matches"]["total"] == 1
+    assert body["matches"]["items"][0]["opponent"]["username"] == "public.opp"
     assert api_client is not None
 
 
@@ -577,3 +592,39 @@ async def test_list_player_matches_404_when_player_missing(
     await start_session(api_client, db_session)
     response = await api_client.get(f"/v1/players/{_uuid.uuid4()}/matches")
     assert response.status_code == 404
+
+
+async def test_list_player_matches_does_not_require_a_session(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The matches endpoint is public — both the authed
+    `/players/$userId` page and the public `/p/players/$username` page
+    hit it with the same id (the public page resolves username → id via
+    `/v1/p/players/{username}` first). Rate-limited per-IP for both."""
+    target = await make_user(db_session, "anon.viewer.target")
+    opp = await make_user(db_session, "anon.viewer.opp")
+    await _record_match_with_winner(db_session, target, opp, created_at=BASE_TIME)
+    async with make_client() as client:
+        response = await client.get(f"/v1/players/{target.id}/matches")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["items"][0]["result"] == "W"
+    assert body["items"][0]["opponent"]["username"] == "anon.viewer.opp"
+    assert "session" not in response.cookies
+    assert api_client is not None
+
+
+async def test_list_player_matches_is_rate_limited_per_ip(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Per-IP rate limit (60/min) keeps the matches endpoint from being
+    scraped from a single source, even though it's now public."""
+    target = await make_user(db_session, "rl.matches.target")
+    async with make_client() as client:
+        for i in range(60):
+            response = await client.get(f"/v1/players/{target.id}/matches")
+            assert response.status_code == 200, (i, response.text)
+        over = await client.get(f"/v1/players/{target.id}/matches")
+    assert over.status_code == 429
+    assert api_client is not None

--- a/web-client/src/api/players.ts
+++ b/web-client/src/api/players.ts
@@ -4,6 +4,7 @@ import { api, unwrap } from './client'
 import type { components } from './schema'
 
 export type PlayerSummary = components['schemas']['PlayerSummary']
+export type PlayerDetail = components['schemas']['PlayerDetail']
 export type PlayerListResponse = components['schemas']['PlayerListResponse']
 export type PlayerMatchRow = components['schemas']['PlayerMatchRow']
 export type PlayerMatchListResponse =
@@ -78,12 +79,14 @@ export function usePlayerList(
   })
 }
 
-/** Authed profile-page hero. Cache key matches `playerQueryKey(id)` so the
- * cache primed by the list page can serve this view instantly. */
+/** Authed profile-page bundle — hero summary + first page of matches in one
+ * request. The FE seeds page 1 of the matches-query cache from
+ * `response.matches` via TanStack Query's `initialData` so the profile
+ * page paints in a single round trip. */
 export function playerByIdQueryOptions(playerId: string) {
   return queryOptions({
     queryKey: playerQueryKey(playerId),
-    queryFn: async (): Promise<PlayerSummary> =>
+    queryFn: async (): Promise<PlayerDetail> =>
       unwrap(
         'load player',
         await api.GET('/v1/players/{player_id}', {
@@ -102,12 +105,12 @@ export function usePlayerById(
   return useQuery({ ...playerByIdQueryOptions(playerId), ...options })
 }
 
-/** Public profile-page hero — same shape as the authed view, just keyed by
- * username and unauthenticated. */
+/** Public profile-page bundle — same shape as the authed view, just keyed
+ * by username. */
 export function publicPlayerByUsernameQueryOptions(username: string) {
   return queryOptions({
     queryKey: publicPlayerQueryKey(username),
-    queryFn: async (): Promise<PlayerSummary> =>
+    queryFn: async (): Promise<PlayerDetail> =>
       unwrap(
         'load public player',
         await api.GET('/v1/p/players/{username}', {
@@ -124,7 +127,11 @@ export function usePublicPlayerByUsername(username: string) {
 }
 
 /** Per-player paginated match list — pre-shaped from the player's
- * perspective so the FE doesn't have to flip set scores.
+ * perspective so the FE doesn't have to flip set scores. The backend
+ * endpoint is public (no session required) and IP-rate-limited, so this
+ * single hook serves BOTH the authed `/players/$userId` and the public
+ * `/p/players/$username` routes — they both already have the id by the
+ * time they call it.
  *
  * Intentionally NOT `throwOnError`: the profile page renders an inline
  * "Couldn't load matches · Try again" affordance for transient failures
@@ -133,7 +140,16 @@ export function usePublicPlayerByUsername(username: string) {
 export function usePlayerMatches(
   playerId: string,
   params: PlayerMatchListParams,
-  options: { enabled?: boolean } = {},
+  options: {
+    enabled?: boolean
+    /** Hydrate the cache with a previously-fetched page (e.g. the
+     * first-page matches embedded in the `PlayerDetail` profile
+     * response). Caller is responsible for only passing this for the
+     * matching page+page_size — the cache key includes them. When
+     * provided, the query skips the initial fetch and renders straight
+     * from this value. */
+    initialData?: PlayerMatchListResponse
+  } = {},
 ) {
   return useQuery({
     queryKey: playerMatchesQueryKey(playerId, params),
@@ -149,6 +165,16 @@ export function usePlayerMatches(
       ),
     enabled: options.enabled ?? true,
     placeholderData: keepPreviousData,
+    initialData: options.initialData,
+    // Stamp the seeded data with "just fetched" — the matches were embedded
+    // in the profile response in this same render cycle, so they're as
+    // fresh as a real fetch would be. Without this, TanStack would use
+    // `initialDataUpdatedAt: 0` (epoch) and the data would always be
+    // considered stale, triggering a background refetch on mount even
+    // within the QueryClient's 30s default `staleTime` (see main.tsx).
+    // Function form so the impurity (`Date.now()`) is deferred out of the
+    // hook's render — TanStack Query invokes it lazily.
+    initialDataUpdatedAt: options.initialData ? () => Date.now() : undefined,
     retry: false,
   })
 }

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -460,8 +460,8 @@ export interface paths {
         };
         /**
          * Get Player
-         * @description Authed profile hero for `/players/$userId`. Same shape as a list row
-         *     so the FE can reuse the cache key after navigating from the list.
+         * @description Authed profile bundle for `/players/$userId` — hero + first page of
+         *     matches in one response.
          */
         get: operations["get_player_v1_players__player_id__get"];
         put?: never;
@@ -481,8 +481,8 @@ export interface paths {
         };
         /**
          * Get Public Player
-         * @description Public profile hero for `/p/players/$username` — no session required,
-         *     rate-limited per-IP to keep the user table from being scraped.
+         * @description Public profile bundle for `/p/players/$username` — same shape as
+         *     the authed endpoint. No session required, rate-limited per-IP.
          */
         get: operations["get_public_player_v1_p_players__username__get"];
         put?: never;
@@ -503,8 +503,15 @@ export interface paths {
         /**
          * List Player Matches
          * @description Paginated per-player match history backing the profile-page match
-         *     table. Newest-first by ``created_at``. Sets are projected from the
-         *     player's perspective so the FE renders them without flipping sides.
+         *     table on BOTH the authed (`/players/$userId`) and public
+         *     (`/p/players/$username`) surfaces — the public page has already
+         *     resolved username → id via `/v1/p/players/{username}`, so it has the
+         *     id to hit this endpoint with.
+         *
+         *     Public — no session required, IP-rate-limited (60/min) so the match
+         *     history can't be scraped from a single source. Newest-first by
+         *     ``created_at``. Sets are projected from the player's perspective so
+         *     the FE renders them without flipping sides.
          */
         get: operations["list_player_matches_v1_players__player_id__matches_get"];
         put?: never;
@@ -1043,6 +1050,44 @@ export interface components {
             name?: string | null;
             /** Description */
             description?: string | null;
+        };
+        /**
+         * PlayerDetail
+         * @description Profile-page bundle: the hero (`PlayerSummary` fields) plus the
+         *     first page of matches inline. Saves a round trip on initial load —
+         *     `GET /v1/players/{id}` (and the public `/v1/p/players/{username}`
+         *     variant) returns this so the profile page paints with one request.
+         *
+         *     Pagination beyond page 1 still hits `GET /v1/players/{id}/matches`
+         *     directly; the FE seeds page 1's cache from this `matches` field via
+         *     TanStack Query's `initialData`.
+         */
+        PlayerDetail: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Username */
+            username: string;
+            /** Rating */
+            rating?: number | null;
+            /**
+             * Wins
+             * @default 0
+             */
+            wins: number;
+            /**
+             * Losses
+             * @default 0
+             */
+            losses: number;
+            /**
+             * Form
+             * @default
+             */
+            form: string;
+            matches: components["schemas"]["PlayerMatchListResponse"];
         };
         /**
          * PlayerListResponse
@@ -2425,7 +2470,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PlayerSummary"];
+                    "application/json": components["schemas"]["PlayerDetail"];
                 };
             };
             /** @description Validation Error */
@@ -2458,7 +2503,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PlayerSummary"];
+                    "application/json": components["schemas"]["PlayerDetail"];
                 };
             };
             /** @description Validation Error */
@@ -2482,9 +2527,7 @@ export interface operations {
             path: {
                 player_id: string;
             };
-            cookie?: {
-                session?: string | null;
-            };
+            cookie?: never;
         };
         requestBody?: never;
         responses: {

--- a/web-client/src/components/players/player-profile.tsx
+++ b/web-client/src/components/players/player-profile.tsx
@@ -7,8 +7,9 @@ import {
 
 import {
   usePlayerMatches,
+  type PlayerDetail,
+  type PlayerMatchListResponse,
   type PlayerMatchRow,
-  type PlayerSummary,
 } from '@/api/players'
 import { Button } from '@/components/ui/button'
 import {
@@ -34,8 +35,9 @@ import './player-profile.css'
  * the body so a transient match-fetch failure doesn't blank the whole page.
  */
 export interface PlayerProfileProps {
-  /** The loaded player, or null while the route's profile query is pending. */
-  player: PlayerSummary | null
+  /** The loaded player + bundled first-page matches, or null while the
+   * route's profile query is pending. */
+  player: PlayerDetail | null
   /** True while the route's profile query is pending — drives the hero
    * skeleton. */
   isPending: boolean
@@ -66,19 +68,17 @@ export function PlayerProfile({
   const rootClass =
     'player-profile dark fortymm-theme' +
     (standalone ? ' player-profile--standalone' : '')
-  // The matches endpoint (`/v1/players/{id}/matches`) requires a session, so
-  // the public route can't fetch it — a 401 would `throwOnError` straight to
-  // the route-level errorComponent and blank the whole profile with a
-  // misleading "Player not found" message. Hide the section there; the
-  // authed route still renders it.
-  const showMatches = player !== null && !standalone
   return (
     <div className={rootClass}>
       <Hero player={player} isPending={isPending} />
       <div className="player-profile__body">
-        {showMatches && (
+        {player && (
           <MatchesSection
             playerId={player.id}
+            // Bundled first-page matches from the profile endpoint —
+            // MatchesSection hydrates page 1 from this so we don't make
+            // a second request on initial load.
+            initialMatches={player.matches}
             asLinks={matchesAreLinks}
             page={page}
             onPageChange={onPageChange}
@@ -93,7 +93,9 @@ function Hero({
   player,
   isPending,
 }: {
-  player: PlayerSummary | null
+  // Only reads the PlayerSummary fields (id/username/rating/wins/losses);
+  // the embedded `matches` on PlayerDetail is consumed by MatchesSection.
+  player: PlayerDetail | null
   isPending: boolean
 }) {
   if (isPending || player === null) {
@@ -176,19 +178,27 @@ function Hero({
 
 function MatchesSection({
   playerId,
+  initialMatches,
   asLinks,
   page,
   onPageChange,
 }: {
   playerId: string
+  /** First-page matches from the profile bundle. Used as `initialData`
+   * for page 1 so the section paints synchronously on initial load.
+   * Page 2+ fetches normally — the bundled response only carries the
+   * first page, and its `page_size` agrees with the FE PAGE_SIZE
+   * (both default to 25). */
+  initialMatches: PlayerMatchListResponse
   asLinks: boolean
   page: number
   onPageChange: (next: number) => void
 }) {
-  const { data, isPending, isError, refetch } = usePlayerMatches(playerId, {
-    page,
-    page_size: PAGE_SIZE,
-  })
+  const { data, isPending, isError, refetch } = usePlayerMatches(
+    playerId,
+    { page, page_size: PAGE_SIZE },
+    { initialData: page === 1 ? initialMatches : undefined },
+  )
   const rows = data?.items ?? []
   const total = data?.total ?? 0
 

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -144,6 +144,56 @@ function summarizePlayer(p: {
   }
 }
 
+/** Mirrors the backend's `LIST_DEFAULT_PAGE_SIZE` in `api/app/players.py`
+ * and the FE's `PAGE_SIZE` in `player-profile.tsx`. If those drift, the
+ * FE's `initialData` cache-key won't match the bundle's `page_size` and
+ * we'll waste a second fetch on mount — the whole point of bundling. */
+const BUNDLED_MATCHES_PAGE_SIZE = 25
+
+/** PlayerDetail = PlayerSummary + first-page matches. Both profile
+ * endpoints (`/v1/players/{id}` and `/v1/p/players/{username}`) return
+ * this so the FE paints the profile page in one round trip; pagination
+ * beyond page 1 falls through to `/v1/players/{id}/matches`. */
+function playerDetail(p: {
+  id: string
+  username: string
+  rating?: number | null
+}) {
+  const summary = summarizePlayer(p)
+  const rows = projectPlayerMatches({ id: p.id, username: p.username })
+  return {
+    ...summary,
+    matches: {
+      items: rows.slice(0, BUNDLED_MATCHES_PAGE_SIZE),
+      page: 1,
+      page_size: BUNDLED_MATCHES_PAGE_SIZE,
+      total: rows.length,
+    },
+  }
+}
+
+/** Shared by the authed and public per-player-matches handlers — projects
+ * the player's matches and slices to the requested page. */
+function paginatedMatches(
+  player: { id: string; username: string },
+  request: Request,
+) {
+  const url = new URL(request.url)
+  const page = Math.max(1, Number(url.searchParams.get('page') ?? '1'))
+  const pageSize = Math.max(
+    1,
+    Number(url.searchParams.get('page_size') ?? '25'),
+  )
+  const rows = projectPlayerMatches(player)
+  const start = (page - 1) * pageSize
+  return HttpResponse.json({
+    items: rows.slice(start, start + pageSize),
+    page,
+    page_size: pageSize,
+    total: rows.length,
+  })
+}
+
 function projectPlayerMatches(player: {
   id: string
   username: string
@@ -354,7 +404,7 @@ export const handlers = [
         { status: 404 },
       )
     }
-    return HttpResponse.json(summarizePlayer(player))
+    return HttpResponse.json(playerDetail(player))
   }),
   http.get('*/v1/p/players/:username', async ({ params }) => {
     await delay(200)
@@ -366,7 +416,7 @@ export const handlers = [
         { status: 404 },
       )
     }
-    return HttpResponse.json(summarizePlayer(player))
+    return HttpResponse.json(playerDetail(player))
   }),
   http.get('*/v1/players/:playerId/matches', async ({ params, request }) => {
     await delay(300)
@@ -378,20 +428,7 @@ export const handlers = [
         { status: 404 },
       )
     }
-    const url = new URL(request.url)
-    const page = Math.max(1, Number(url.searchParams.get('page') ?? '1'))
-    const pageSize = Math.max(
-      1,
-      Number(url.searchParams.get('page_size') ?? '25'),
-    )
-    const rows = projectPlayerMatches(player)
-    const start = (page - 1) * pageSize
-    return HttpResponse.json({
-      items: rows.slice(start, start + pageSize),
-      page,
-      page_size: pageSize,
-      total: rows.length,
-    })
+    return paginatedMatches(player, request)
   }),
   http.patch('*/v1/me', async ({ request }) => {
     const body = (await readJson(request)) as { username?: string } | undefined


### PR DESCRIPTION
Two related shifts so the public profile page can show matches without
a second round trip, and so both the authed and public profile pages
render the same React tree through the same hooks + endpoint.

**Public matches endpoint:**
- `GET /v1/players/{id}/matches` is now public (no `get_current_user`
  dep) and IP-rate-limited (60/min, matches `/v1/p/players/{username}`).
  Both the authed `/players/$userId` route and the public
  `/p/players/$username` route hit it — the public route already has
  the id from its `/v1/p/players/{username}` profile lookup.
- One MatchesSection in `PlayerProfile`; no authed/public split.
- Authed test renamed to assert does-not-require-session; added 429
  rate-limit test.

**First-page matches embedded in profile response:**
- New `PlayerDetail` schema extends `PlayerSummary` with
  `matches: PlayerMatchListResponse`.
- `GET /v1/players/{id}` and `GET /v1/p/players/{username}` now return
  `PlayerDetail` — first page (page=1, page_size=25) embedded inline so
  the profile page paints in a single round trip.
- `usePlayerMatches` accepts an `initialData` option; `MatchesSection`
  passes `page === 1 ? player.matches : undefined` so page 1 hydrates
  from the bundle and page 2+ falls through to the standalone matches
  endpoint normally.
- `initialDataUpdatedAt: () => Date.now()` stamps the seeded data
  "just-fetched" so the global 30s `staleTime` (main.tsx) doesn't waste
  a refetch on mount.
- MSW handlers updated: both profile mocks now return PlayerDetail with
  the first 25 matches inline. Shared `BUNDLED_MATCHES_PAGE_SIZE`
  constant aligns with FE PAGE_SIZE and backend LIST_DEFAULT_PAGE_SIZE.

Verified in browser: `/players/u-me` fires ONE `GET /v1/players/u-me`
on initial load (no follow-up matches request); navigating to page 2
correctly fires `GET /v1/players/u-me/matches?page=2`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>