### PR TITLE
Add public /p/matches/$matchId share page

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from pyrate_limiter import Duration, Rate
 from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
@@ -30,6 +31,7 @@ from app.models import (
     UserLeagueRating,
 )
 from app.players import escape_like
+from app.rate_limiting import RedisRateLimiter
 from app.ratings import get_calculator, state_rating_value, validate_state
 from app.schemas.match import (
     STATUS_LABELS,
@@ -50,7 +52,7 @@ from app.schemas.match import (
     MatchListRow,
 )
 from app.schemas.rating import RatingChange
-from app.sessions import get_current_user
+from app.sessions import get_current_user, get_optional_user
 
 router = APIRouter(prefix="/v1")
 
@@ -173,7 +175,7 @@ def current_unscored_game(match: Match) -> MatchGame | None:
 
 def _serialize_details(
     match: Match,
-    current_user_id: uuid.UUID,
+    current_user_id: uuid.UUID | None,
     extras: "ViewExtras | None" = None,
 ) -> MatchDetails:
     extras = extras or _EMPTY_EXTRAS
@@ -207,7 +209,10 @@ def _serialize_details(
     )
 
     sides_sorted = sorted(match.sides, key=lambda s: s.side_number)
-    is_participant = _is_participant(match, current_user_id)
+    # Anonymous viewers on the public route are never participants.
+    is_participant = current_user_id is not None and _is_participant(
+        match, current_user_id
+    )
 
     return MatchDetails(
         id=match.id,
@@ -515,19 +520,48 @@ def _matches_to_csv(rows: list[MatchListRow]) -> str:
     return buf.getvalue()
 
 
-@router.get("/matches/{match_id}", response_model=MatchDetails)
+async def _match_details_ip_key(request: Request) -> str:
+    """Per-IP key for the public match-details endpoint — applies to both
+    anonymous and signed-in callers so an open URL can't be scraped from a
+    single source."""
+    client = request.client
+    ip = client.host if client else "unknown"
+    return f"match-details-ip:{ip}"
+
+
+# 60/min per IP: matches the public-player endpoint's limiter. Comfortably
+# above a human opening several shared match links in quick succession, well
+# below scrape volume.
+match_details_ip_rate_limit = RedisRateLimiter(
+    rates=[Rate(60, Duration.MINUTE)],
+    bucket_key="match-details-ip",
+    identifier=_match_details_ip_key,
+)
+
+
+@router.get(
+    "/matches/{match_id}",
+    response_model=MatchDetails,
+    dependencies=[Depends(match_details_ip_rate_limit)],
+)
 async def get_match(
     match_id: uuid.UUID,
-    current_user: User = Depends(get_current_user),
+    current_user: User | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_session),
 ) -> MatchDetails:
-    # Open to any signed-in viewer. The serializer flags whether the current
-    # user is on a side; write paths below still gate on participation.
+    """Open to anyone, signed in or not. The same endpoint backs both the
+    authed `/matches/$matchId` route and the public `/p/matches/$matchId`
+    share route — a signed-in caller gets is_current_user / can_score flags;
+    an anonymous caller gets the same view with those flags off. Per-IP
+    rate-limited (60/min) so an open URL can't be scraped from one source.
+
+    The serializer flags whether the current user is on a side; write paths
+    below still gate on participation via `get_current_user`."""
     match = await _load_match(db, match_id)
     if match is None:
         raise HTTPException(status_code=404, detail="Match not found.")
     extras = await _load_view_extras(db, match)
-    return _serialize_details(match, current_user.id, extras)
+    return _serialize_details(match, current_user.id if current_user else None, extras)
 
 
 # ----- score writes --------------------------------------------------------

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -277,9 +277,25 @@ async def get_session_endpoint(
     return await _build_session_response(db, user)
 
 
-async def get_current_user(
+async def get_optional_user(
     session_cookie: Annotated[str | None, Cookie(alias=SESSION_COOKIE_NAME)] = None,
     db: AsyncSession = Depends(get_session),
+) -> User | None:
+    """Resolve the user from the session cookie, returning ``None`` when no
+    valid session is present.
+
+    For endpoints that are open to anonymous callers but tailor their
+    response to a signed-in user when one is present (e.g. flagging the
+    current user's side in match details). Never mints a new session — that
+    behavior is reserved for ``GET /v1/session``.
+    """
+    if not session_cookie:
+        return None
+    return await _find_session_user(db, session_cookie)
+
+
+async def get_current_user(
+    user: Annotated[User | None, Depends(get_optional_user)],
 ) -> User:
     """Resolve the authenticated user from the session cookie.
 
@@ -287,7 +303,6 @@ async def get_current_user(
     endpoints that create or mutate data require an already-established
     session and respond ``401`` otherwise.
     """
-    user = await _find_session_user(db, session_cookie) if session_cookie else None
     if user is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -285,6 +285,52 @@ async def test_get_unknown_match_is_404(
     assert response.status_code == 404
 
 
+# ----- anonymous viewer ---------------------------------------------------
+
+
+async def test_get_match_is_open_to_anonymous_callers(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Same endpoint as the authed view backs the public `/p/matches/$id`
+    share route: anonymous callers get the same payload with no participant
+    flags and can_score=False."""
+    creator = await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "anon.viewer.opp")
+    created = await _create_match(api_client, opponent.id)
+
+    async with make_client() as client:
+        response = await client.get(f"/v1/matches/{created['id']}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == created["id"]
+    # An anonymous caller never gets a session minted just by viewing.
+    assert "session" not in response.cookies
+    # No current user → no participant flags, no Score CTA.
+    assert all(not s["is_current_user_side"] for s in body["sides"])
+    assert all(not p["is_current_user"] for s in body["sides"] for p in s["players"])
+    assert body["can_score"] is False
+    # The underlying players still appear on the two sides.
+    user_ids = {p["user_id"] for s in body["sides"] for p in s["players"]}
+    assert user_ids == {str(creator.id), str(opponent.id)}
+
+
+async def test_get_match_is_rate_limited_per_ip(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Per-IP rate limit (60/min) protects the endpoint from being scraped
+    from a single source, now that anonymous callers can hit it."""
+    await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "rl.match.opp")
+    created = await _create_match(api_client, opponent.id)
+
+    async with make_client() as client:
+        for i in range(60):
+            response = await client.get(f"/v1/matches/{created['id']}")
+            assert response.status_code == 200, (i, response.text)
+        over = await client.get(f"/v1/matches/{created['id']}")
+    assert over.status_code == 429
+
+
 # ----- list ---------------------------------------------------------------
 
 

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -334,7 +334,17 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get Match */
+        /**
+         * Get Match
+         * @description Open to anyone, signed in or not. The same endpoint backs both the
+         *     authed `/matches/$matchId` route and the public `/p/matches/$matchId`
+         *     share route — a signed-in caller gets is_current_user / can_score flags;
+         *     an anonymous caller gets the same view with those flags off. Per-IP
+         *     rate-limited (60/min) so an open URL can't be scraped from one source.
+         *
+         *     The serializer flags whether the current user is on a side; write paths
+         *     below still gate on participation via `get_current_user`.
+         */
         get: operations["get_match_v1_matches__match_id__get"];
         put?: never;
         post?: never;

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -261,31 +261,43 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
   }
 }
 
-export function MatchDetailsView({ matchId }: { matchId: string }) {
+export function MatchDetailsView({
+  matchId,
+  standalone = false,
+}: {
+  matchId: string
+  /** When true, render without AppShell — used by the public `/p/matches`
+   * route which has no signed-in user to drive the nav sidebar. Also
+   * suppresses the "Matches" breadcrumb crumb, which would 401 an anonymous
+   * viewer. */
+  standalone?: boolean
+}) {
   const { data, isLoading } = useMatch(matchId)
 
-  if (isLoading || !data) {
-    return (
-      <AppShell>
-        <MatchDetailsSkeleton />
-      </AppShell>
+  const body =
+    isLoading || !data ? (
+      <MatchDetailsSkeleton />
+    ) : (
+      <MatchDetailsPage
+        view={projectMatchView(data, matchId)}
+        matchId={matchId}
+        standalone={standalone}
+      />
     )
-  }
-
-  const view = projectMatchView(data, matchId)
-  return (
-    <AppShell>
-      <MatchDetailsPage view={view} matchId={matchId} />
-    </AppShell>
-  )
+  return standalone ? body : <AppShell>{body}</AppShell>
 }
 
 export function MatchDetailsError({
   error,
   reset,
+  standalone = false,
 }: {
   error: Error
   reset: () => void
+  /** Mirror of `MatchDetailsView`'s standalone — skip AppShell on the public
+   * route, and drop the "Back to matches" affordance (anonymous viewers
+   * can't reach /matches). */
+  standalone?: boolean
 }) {
   const router = useRouter()
   const status = error instanceof ApiError ? error.status : 0
@@ -297,29 +309,32 @@ export function MatchDetailsError({
   const message = notFound
     ? "We couldn't find that match."
     : 'Something went wrong loading this match.'
-  return (
-    <AppShell>
-      <div role="alert" className="md-error-state">
-        <div className="md-error-state__title">{message}</div>
-        {notFound ? (
+  const body = (
+    <div role="alert" className="md-error-state">
+      <div className="md-error-state__title">{message}</div>
+      {notFound ? (
+        // The public route has no /matches index to send anonymous viewers
+        // to; for them the 404 page stops at the message.
+        standalone ? null : (
           <Link to="/matches" className="md-btn md-btn--secondary">
             Back to matches
           </Link>
-        ) : (
-          <button
-            type="button"
-            className="md-btn md-btn--secondary"
-            onClick={() => {
-              reset()
-              router.invalidate()
-            }}
-          >
-            Try again
-          </button>
-        )}
-      </div>
-    </AppShell>
+        )
+      ) : (
+        <button
+          type="button"
+          className="md-btn md-btn--secondary"
+          onClick={() => {
+            reset()
+            router.invalidate()
+          }}
+        >
+          Try again
+        </button>
+      )}
+    </div>
   )
+  return standalone ? body : <AppShell>{body}</AppShell>
 }
 
 function MatchDetailsSkeleton() {
@@ -333,7 +348,15 @@ function MatchDetailsSkeleton() {
   )
 }
 
-function MatchDetailsPage({ view, matchId }: { view: MatchView; matchId: string }) {
+function MatchDetailsPage({
+  view,
+  matchId,
+  standalone,
+}: {
+  view: MatchView
+  matchId: string
+  standalone: boolean
+}) {
   const [shareOpen, setShareOpen] = useState(false)
   // Comments + share modal are still part of the design handoff but have no
   // real data behind them yet; gate them off and flip when each lands.
@@ -352,7 +375,7 @@ function MatchDetailsPage({ view, matchId }: { view: MatchView; matchId: string 
     <div className="match-details">
       <main className="md-page md-page--y">
         <div className="md-header">
-          <Breadcrumb matchId={matchId} />
+          <Breadcrumb matchId={matchId} standalone={standalone} />
           <div className="md-header__right">
             {view.scoreCta && (
               <Link
@@ -431,7 +454,24 @@ function Logo({ size = 26 }: { size?: number }) {
   )
 }
 
-function Breadcrumb({ matchId }: { matchId: string }) {
+function Breadcrumb({
+  matchId,
+  standalone,
+}: {
+  matchId: string
+  standalone: boolean
+}) {
+  // On the public route there's no /matches index for anonymous viewers, so
+  // collapse the breadcrumb to just the current match label.
+  if (standalone) {
+    return (
+      <div className="md-breadcrumb">
+        <span className="md-breadcrumb__current">
+          Match {matchId.slice(0, 6)}
+        </span>
+      </div>
+    )
+  }
   return (
     <div className="md-breadcrumb">
       <Link to="/matches">Matches</Link>

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as AdminRolesRouteImport } from './routes/admin.roles'
 import { Route as AdminPermissionsRouteImport } from './routes/admin.permissions'
 import { Route as MatchesMatchIdIndexRouteImport } from './routes/matches.$matchId.index'
 import { Route as PPlayersUsernameRouteImport } from './routes/p.players.$username'
+import { Route as PMatchesMatchIdRouteImport } from './routes/p.matches.$matchId'
 import { Route as MatchesMatchIdGamesGameIdScoresNewRouteImport } from './routes/matches.$matchId.games.$gameId.scores.new'
 import { Route as MatchesMatchIdGamesGameIdScoresScoreIdEditRouteImport } from './routes/matches.$matchId.games.$gameId.scores.$scoreId.edit'
 
@@ -138,6 +139,11 @@ const PPlayersUsernameRoute = PPlayersUsernameRouteImport.update({
   path: '/p/players/$username',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PMatchesMatchIdRoute = PMatchesMatchIdRouteImport.update({
+  id: '/p/matches/$matchId',
+  path: '/p/matches/$matchId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MatchesMatchIdGamesGameIdScoresNewRoute =
   MatchesMatchIdGamesGameIdScoresNewRouteImport.update({
     id: '/matches/$matchId/games/$gameId/scores/new',
@@ -171,6 +177,7 @@ export interface FileRoutesByFullPath {
   '/login/': typeof LoginIndexRoute
   '/matches/': typeof MatchesIndexRoute
   '/players/': typeof PlayersIndexRoute
+  '/p/matches/$matchId': typeof PMatchesMatchIdRoute
   '/p/players/$username': typeof PPlayersUsernameRoute
   '/matches/$matchId/': typeof MatchesMatchIdIndexRoute
   '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
@@ -195,6 +202,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginIndexRoute
   '/matches': typeof MatchesIndexRoute
   '/players': typeof PlayersIndexRoute
+  '/p/matches/$matchId': typeof PMatchesMatchIdRoute
   '/p/players/$username': typeof PPlayersUsernameRoute
   '/matches/$matchId': typeof MatchesMatchIdIndexRoute
   '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
@@ -221,6 +229,7 @@ export interface FileRoutesById {
   '/login/': typeof LoginIndexRoute
   '/matches/': typeof MatchesIndexRoute
   '/players/': typeof PlayersIndexRoute
+  '/p/matches/$matchId': typeof PMatchesMatchIdRoute
   '/p/players/$username': typeof PPlayersUsernameRoute
   '/matches/$matchId/': typeof MatchesMatchIdIndexRoute
   '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
@@ -248,6 +257,7 @@ export interface FileRouteTypes {
     | '/login/'
     | '/matches/'
     | '/players/'
+    | '/p/matches/$matchId'
     | '/p/players/$username'
     | '/matches/$matchId/'
     | '/matches/$matchId/games/$gameId/scores/new'
@@ -272,6 +282,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/matches'
     | '/players'
+    | '/p/matches/$matchId'
     | '/p/players/$username'
     | '/matches/$matchId'
     | '/matches/$matchId/games/$gameId/scores/new'
@@ -297,6 +308,7 @@ export interface FileRouteTypes {
     | '/login/'
     | '/matches/'
     | '/players/'
+    | '/p/matches/$matchId'
     | '/p/players/$username'
     | '/matches/$matchId/'
     | '/matches/$matchId/games/$gameId/scores/new'
@@ -319,6 +331,7 @@ export interface RootRouteChildren {
   LoginIndexRoute: typeof LoginIndexRoute
   MatchesIndexRoute: typeof MatchesIndexRoute
   PlayersIndexRoute: typeof PlayersIndexRoute
+  PMatchesMatchIdRoute: typeof PMatchesMatchIdRoute
   PPlayersUsernameRoute: typeof PPlayersUsernameRoute
   MatchesMatchIdIndexRoute: typeof MatchesMatchIdIndexRoute
   MatchesMatchIdGamesGameIdScoresNewRoute: typeof MatchesMatchIdGamesGameIdScoresNewRoute
@@ -474,6 +487,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PPlayersUsernameRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/p/matches/$matchId': {
+      id: '/p/matches/$matchId'
+      path: '/p/matches/$matchId'
+      fullPath: '/p/matches/$matchId'
+      preLoaderRoute: typeof PMatchesMatchIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/matches/$matchId/games/$gameId/scores/new': {
       id: '/matches/$matchId/games/$gameId/scores/new'
       path: '/matches/$matchId/games/$gameId/scores/new'
@@ -523,6 +543,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginIndexRoute: LoginIndexRoute,
   MatchesIndexRoute: MatchesIndexRoute,
   PlayersIndexRoute: PlayersIndexRoute,
+  PMatchesMatchIdRoute: PMatchesMatchIdRoute,
   PPlayersUsernameRoute: PPlayersUsernameRoute,
   MatchesMatchIdIndexRoute: MatchesMatchIdIndexRoute,
   MatchesMatchIdGamesGameIdScoresNewRoute:

--- a/web-client/src/routes/p.matches.$matchId.tsx
+++ b/web-client/src/routes/p.matches.$matchId.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  MatchDetailsError,
+  MatchDetailsView,
+} from '@/components/matches/match-details-page'
+import { pageTitle } from '@/lib/page-title'
+
+export const Route = createFileRoute('/p/matches/$matchId')({
+  head: () => ({
+    meta: [{ title: pageTitle('Match') }],
+  }),
+  component: PublicMatchDetailsRoute,
+  errorComponent: PublicMatchDetailsError,
+})
+
+function PublicMatchDetailsRoute() {
+  const { matchId } = Route.useParams()
+  return <MatchDetailsView matchId={matchId} standalone />
+}
+
+function PublicMatchDetailsError({
+  error,
+  reset,
+}: {
+  error: Error
+  reset: () => void
+}) {
+  return <MatchDetailsError error={error} reset={reset} standalone />
+}


### PR DESCRIPTION
## Summary
- Unifies the match-details endpoint: `/v1/matches/{match_id}` now accepts anonymous callers (new `get_optional_user` dep in `app/sessions.py`) and is IP-rate-limited at 60/min — same pattern as `/v1/players/{id}/matches`. No twin `/v1/p/matches/...` endpoint.
- Adds `/p/matches/$matchId` route that reuses `MatchDetailsView` via a new `standalone` prop (skips AppShell, collapses the "Matches >" breadcrumb anonymous viewers can't reach).
- `_serialize_details` now tolerates `current_user_id=None`: anonymous viewers get `is_current_user_side=False` everywhere and `can_score=False`.

## Test plan
- [x] api: pytest (318 passed) — includes 3 new tests covering anonymous viewer, rate limit, and 404
- [x] web-client: vitest (102 passed), eslint, tsc, vite build
- [x] web-client: Playwright (125 passed)
- [x] Manual: screenshotted /p/matches/{id} (renders without sidebar/topbar), /matches/{id} (authed unchanged), /p/matches/{bad-id} (404 path renders without "Back to matches" link)
- [x] OpenAPI schema regenerated; no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)