### PR TITLE
Push the Career matches block to the bottom of the Players card

### DIFF
--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2681,6 +2681,7 @@ body.dark.fortymm-theme {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
+  margin-top: auto;
   padding-top: 14px;
   border-top: 1px solid var(--border-subtle);
 }


### PR DESCRIPTION
## Summary
- Add `margin-top: auto` to `.md-profile__career` so the Career matches / Win rate block bottom-aligns inside each player's flex column.
- The grid stretches both halves to equal height already; this just makes the shorter half stop floating up under a short form list.

## Test plan
- [x] `npm run test:run` (vitest)
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:e2e` (Playwright, 125/125)
- [ ] Eyeball at narrow widths to confirm the stacked-grid layout still looks fine (no regression — change becomes a no-op there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)