### PR TITLE
Decouple per-game scoring from match finalization

### DIFF
--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import selectinload
 
 from app.db import get_session
 from app.matches import (
-    current_unscored_game,
+    current_game_number,
     match_eager_options,
     opponent_username,
     participant_filter,
@@ -136,14 +136,14 @@ def _build_score_banners(
 ) -> list[DashboardScoreBanner]:
     banners: list[DashboardScoreBanner] = []
     for match in in_progress:
-        current_game = current_unscored_game(match)
-        if current_game is None:
+        next_number = current_game_number(match)
+        if next_number is None:
             continue
         banners.append(
             DashboardScoreBanner(
                 match_id=match.id,
                 opponent_username=opponent_username(match, current_user_id),
-                current_game_id=current_game.id,
+                current_game_number=next_number,
             )
         )
     return banners

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -4,9 +4,18 @@ import math
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from pyrate_limiter import Duration, Rate
 from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -50,6 +59,8 @@ from app.schemas.match import (
     MatchLeague,
     MatchListResponse,
     MatchListRow,
+    MatchResultsGameWrite,
+    MatchResultsWrite,
 )
 from app.schemas.rating import RatingChange
 from app.sessions import get_current_user, get_optional_user
@@ -169,8 +180,22 @@ def side_win_counts(match: Match) -> dict[int, int]:
     return counts
 
 
-def current_unscored_game(match: Match) -> MatchGame | None:
-    return next((g for g in match.games if g.score is None), None)
+def current_game_number(match: Match) -> int | None:
+    """The next un-scored game number for an in-progress match. ``None`` once
+    every game in ``1..best_of`` has a saved score, or when the match isn't
+    in progress (finalized / disputed / voided / settings missing).
+
+    Game rows are created lazily by the score-write endpoints, so the next
+    game to score may not have a ``MatchGame`` row yet — this helper exposes
+    the number rather than an object so deeplinks work either way."""
+    if match.status != MatchStatus.in_progress:
+        return None
+    best_of = match.match_settings.best_of
+    scored = {g.game_number for g in match.games if g.score is not None}
+    for n in range(1, best_of + 1):
+        if n not in scored:
+            return n
+    return None
 
 
 def _serialize_details(
@@ -199,12 +224,10 @@ def _serialize_details(
         for game in games_sorted
     ]
 
-    current_game_obj = current_unscored_game(match)
+    next_number = current_game_number(match)
     current_game = (
-        MatchDetailsCurrentGame(
-            id=current_game_obj.id, game_number=current_game_obj.game_number
-        )
-        if current_game_obj is not None
+        MatchDetailsCurrentGame(game_number=next_number)
+        if next_number is not None
         else None
     )
 
@@ -234,6 +257,12 @@ def _serialize_details(
         # non-participants in the score endpoints below.
         can_score=(
             current_game is not None and len(match.sides) >= 2 and is_participant
+        ),
+        # True iff the saved games already form a decided, validly-ordered
+        # match — the FE flips the scoring page's submit button label to
+        # "Finalize match" when this is true.
+        can_finalize=(
+            is_participant and len(match.sides) >= 2 and _can_finalize(match)
         ),
         recent_form=extras.recent_form,
         head_to_head=extras.head_to_head,
@@ -347,9 +376,9 @@ async def create_match(
     # Always create side 2. With no opponent it's a player-less sentinel side,
     # which keeps the match scorable (two sides) while reading as "No opponent".
     _add_side(match, 2, opponent)
-    # The FE never creates a game — game 1 is written here so scoring routes
-    # always have a real entity to deep-link into.
-    match.games.append(MatchGame(game_number=1))
+    # Games are no longer pre-created at match-create time — they're written
+    # lazily by ``POST .../games/{n}/scores/new`` keyed on the game number, so
+    # the FE can deep-link to any 1..best_of without us guessing.
 
     db.add(match)
     await db.commit()
@@ -450,11 +479,11 @@ async def list_matches(
 def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
     side_wins = side_win_counts(match)
     sides_sorted = sorted(match.sides, key=lambda s: s.side_number)
-    current_game = current_unscored_game(match)
+    next_number = current_game_number(match)
     can_score = (
         match.status in {MatchStatus.pending, MatchStatus.in_progress}
         and len(match.sides) >= 2
-        and current_game is not None
+        and next_number is not None
         and _is_participant(match, current_user_id)
     )
 
@@ -466,7 +495,7 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
         sides=[_side_schema(side, side_wins, current_user_id) for side in sides_sorted],
         best_of=match.match_settings.best_of,
         created_at=match.created_at,
-        current_game_id=current_game.id if can_score and current_game else None,
+        current_game_number=next_number if can_score else None,
         can_score=can_score,
     )
 
@@ -573,7 +602,14 @@ def _enforce_scorable(match: Match) -> None:
             status_code=422,
             detail="This match has no opponent and can't be scored.",
         )
-    if match.status in {MatchStatus.disputed, MatchStatus.voided}:
+    # ``completed`` lives here too — once a match is finalized via
+    # ``POST /v1/matches/{id}/results`` it's read-only. The 409 covers the
+    # per-game write endpoints *and* the re-finalize attempt.
+    if match.status in {
+        MatchStatus.completed,
+        MatchStatus.disputed,
+        MatchStatus.voided,
+    }:
         raise HTTPException(status_code=409, detail="This match is no longer scorable.")
 
 
@@ -948,42 +984,117 @@ async def _apply_rating_update(db: AsyncSession, match: Match) -> None:
     )
 
 
-def _recompute_match(match: Match) -> None:
-    """Apply all post-score-write derivations on a loaded ``match``:
-    side ``score``, match ``status``, side ``won`` flags, and the trailing
-    un-scored game (deleted on completion; exactly one otherwise)."""
-    sides_by_number = {s.side_number: s for s in match.sides}
-    side_wins = side_win_counts(match)
-    target = _games_to_win(match.match_settings.best_of)
-    a_wins = side_wins.get(1, 0)
-    b_wins = side_wins.get(2, 0)
+# ----- finalize-payload validation + apply --------------------------------
 
+
+def _validate_finalize_games(games: list[MatchResultsGameWrite], best_of: int) -> int:
+    """Cross-game invariants for a finalize payload. Per-game point legality
+    is already enforced by ``MatchResultsGameWrite``. Returns the decided side
+    number (1 or 2); raises ``ValueError`` with a human-readable detail on any
+    failure (the route handler maps that to 422)."""
+    if not games:
+        raise ValueError("A match needs at least one game to finalize.")
+
+    numbers = [g.game_number for g in games]
+    if any(n > best_of for n in numbers):
+        raise ValueError(f"Each game_number must be ≤ best_of ({best_of}).")
+    if len(set(numbers)) != len(numbers):
+        raise ValueError("Duplicate game_number in payload.")
+    if sorted(numbers) != list(range(1, len(numbers) + 1)):
+        raise ValueError("Games must be numbered 1..N consecutively with no gaps.")
+
+    target = _games_to_win(best_of)
+    games_in_order = sorted(games, key=lambda g: g.game_number)
+    wins: dict[int, int] = {1: 0, 2: 0}
+    decided_at: int | None = None
+    decided_side: int | None = None
+    for g in games_in_order:
+        winner = 1 if g.side_1_points > g.side_2_points else 2
+        wins[winner] += 1
+        if decided_side is None and wins[winner] >= target:
+            decided_side = winner
+            decided_at = g.game_number
+
+    if decided_side is None or decided_at is None:
+        raise ValueError(
+            f"No side reached {target} game wins — the match isn't decided."
+        )
+    if decided_at != games_in_order[-1].game_number:
+        raise ValueError(
+            "Scored games extend past the deciding game; "
+            "drop any games after the decider."
+        )
+    return decided_side
+
+
+def _games_payload_from_match(match: Match) -> list[MatchResultsGameWrite]:
+    """Recast currently-saved scores as a finalize payload, so ``_can_finalize``
+    can reuse ``_validate_finalize_games`` instead of duplicating its rules."""
+    return [
+        MatchResultsGameWrite(
+            game_number=g.game_number,
+            side_1_points=g.score.side_1_points,
+            side_2_points=g.score.side_2_points,
+        )
+        for g in match.games
+        if g.score is not None
+    ]
+
+
+def _can_finalize(match: Match) -> bool:
+    """Whether ``POST /v1/matches/{id}/results`` would succeed on the
+    currently-saved scores (ignoring authorization). Drives the FE's
+    ``can_finalize`` flag and the submit button's adaptive label."""
+    if match.status != MatchStatus.in_progress:
+        return False
+    try:
+        _validate_finalize_games(
+            _games_payload_from_match(match), match.match_settings.best_of
+        )
+    except ValueError:
+        return False
+    return True
+
+
+async def _apply_finalized_match(
+    db: AsyncSession,
+    match: Match,
+    payload: MatchResultsWrite,
+    decided_side: int,
+) -> None:
+    """Replace ``match.games`` (and the attached score rows) with the canonical
+    payload and mark the match completed. The caller commits."""
+    # ``Match.games`` cascades ``all, delete-orphan``; clearing the collection
+    # marks each existing MatchGame (and via MatchGame.score's own cascade,
+    # the MatchGameScore) for delete. We must flush the deletes before
+    # inserting new games at the same numbers, otherwise the
+    # ``uq_match_games_match_id_game_number`` constraint trips during
+    # autoflush.
+    match.games.clear()
+    await db.flush()
+
+    for game in sorted(payload.games, key=lambda g: g.game_number):
+        match.games.append(
+            MatchGame(
+                game_number=game.game_number,
+                score=MatchGameScore(
+                    side_1_points=game.side_1_points,
+                    side_2_points=game.side_2_points,
+                ),
+            )
+        )
+
+    new_wins: dict[int, int] = {1: 0, 2: 0}
+    for g in payload.games:
+        new_wins[1 if g.side_1_points > g.side_2_points else 2] += 1
     for side in match.sides:
-        side.score = side_wins.get(side.side_number, 0)
+        side.score = new_wins.get(side.side_number, 0)
+        side.won = side.side_number == decided_side
 
-    decided = a_wins >= target or b_wins >= target
-    side_one = sides_by_number.get(1)
-    side_two = sides_by_number.get(2)
+    match.status = MatchStatus.completed
 
-    if decided:
-        match.status = MatchStatus.completed
-        if side_one is not None:
-            side_one.won = a_wins > b_wins
-        if side_two is not None:
-            side_two.won = b_wins > a_wins
-    else:
-        match.status = MatchStatus.in_progress
-        for side in match.sides:
-            side.won = None
 
-    games_sorted = sorted(match.games, key=lambda g: g.game_number)
-    trailing_unscored = [g for g in games_sorted if g.score is None]
-    if decided:
-        for game in trailing_unscored:
-            match.games.remove(game)
-    elif not trailing_unscored:
-        next_number = max((g.game_number for g in games_sorted), default=0) + 1
-        match.games.append(MatchGame(game_number=next_number))
+# ----- scoring endpoints ---------------------------------------------------
 
 
 async def _load_match_for_scoring(
@@ -997,25 +1108,42 @@ async def _load_match_for_scoring(
     return match
 
 
+# Per-game endpoints are addressed by ``game_number``: a game row may not
+# exist yet (the FE deeplinks straight into ``/games/N/scores/new``). The
+# create handler lookups-or-inserts the MatchGame; update and delete operate
+# on an existing score. All three are pure "save / clear scratchpad state" —
+# they never touch match.status, side wins, side.won, or ratings. The single
+# canonical commit happens in ``finalize_match`` below.
+
+
 @router.post(
-    "/matches/{match_id}/games/{game_id}/scores",
+    "/matches/{match_id}/games/{game_number}/scores/new",
     response_model=MatchDetails,
     status_code=status.HTTP_201_CREATED,
 )
 async def create_game_score(
     match_id: uuid.UUID,
-    game_id: uuid.UUID,
     payload: MatchGameScoreWrite,
+    game_number: Annotated[int, Path(ge=1, le=7)],
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> MatchDetails:
     match = await _load_match_for_scoring(db, match_id, current_user.id)
     _enforce_scorable(match)
+    if game_number > match.match_settings.best_of:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"This match is best of {match.match_settings.best_of}; "
+                f"game {game_number} can't exist."
+            ),
+        )
 
-    game = next((g for g in match.games if g.id == game_id), None)
+    game = next((g for g in match.games if g.game_number == game_number), None)
     if game is None:
-        raise HTTPException(status_code=404, detail="Game not found.")
-    if game.score is not None:
+        game = MatchGame(game_number=game_number)
+        match.games.append(game)
+    elif game.score is not None:
         raise HTTPException(
             status_code=409, detail="This game has already been scored."
         )
@@ -1025,8 +1153,6 @@ async def create_game_score(
         side_2_points=payload.side_2_points,
     )
 
-    _recompute_match(match)
-    await _apply_rating_update(db, match)
     await db.commit()
 
     reloaded = await _load_match(db, match.id)
@@ -1036,30 +1162,90 @@ async def create_game_score(
 
 
 @router.put(
-    "/matches/{match_id}/games/{game_id}/scores/{score_id}",
+    "/matches/{match_id}/games/{game_number}/scores",
     response_model=MatchDetails,
 )
 async def update_game_score(
     match_id: uuid.UUID,
-    game_id: uuid.UUID,
-    score_id: uuid.UUID,
     payload: MatchGameScoreWrite,
+    game_number: Annotated[int, Path(ge=1, le=7)],
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> MatchDetails:
     match = await _load_match_for_scoring(db, match_id, current_user.id)
     _enforce_scorable(match)
 
-    game = next((g for g in match.games if g.id == game_id), None)
-    if game is None:
-        raise HTTPException(status_code=404, detail="Game not found.")
-    if game.score is None or game.score.id != score_id:
+    game = next((g for g in match.games if g.game_number == game_number), None)
+    if game is None or game.score is None:
         raise HTTPException(status_code=404, detail="Score not found.")
 
     game.score.side_1_points = payload.side_1_points
     game.score.side_2_points = payload.side_2_points
 
-    _recompute_match(match)
+    await db.commit()
+
+    reloaded = await _load_match(db, match.id)
+    assert reloaded is not None
+    extras = await _load_view_extras(db, reloaded)
+    return _serialize_details(reloaded, current_user.id, extras)
+
+
+@router.delete(
+    "/matches/{match_id}/games/{game_number}/scores",
+    response_model=MatchDetails,
+)
+async def delete_game_score(
+    match_id: uuid.UUID,
+    game_number: Annotated[int, Path(ge=1, le=7)],
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> MatchDetails:
+    match = await _load_match_for_scoring(db, match_id, current_user.id)
+    _enforce_scorable(match)
+
+    game = next((g for g in match.games if g.game_number == game_number), None)
+    if game is None or game.score is None:
+        raise HTTPException(status_code=404, detail="Score not found.")
+
+    # Drop the score; the MatchGame stays so a subsequent POST .../scores/new
+    # for the same number just attaches a fresh score row to the existing game.
+    # delete-orphan on ``MatchGame.score`` removes the row on flush.
+    game.score = None
+
+    await db.commit()
+
+    reloaded = await _load_match(db, match.id)
+    assert reloaded is not None
+    extras = await _load_view_extras(db, reloaded)
+    return _serialize_details(reloaded, current_user.id, extras)
+
+
+@router.post(
+    "/matches/{match_id}/results",
+    response_model=MatchDetails,
+    status_code=status.HTTP_201_CREATED,
+)
+async def finalize_match(
+    match_id: uuid.UUID,
+    payload: MatchResultsWrite,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> MatchDetails:
+    """Take the request body as canon. Any previously-saved per-game scores
+    on this match are discarded; the payload's games (validated as a complete,
+    decided match) become the match's games + scores. Then we mark completed
+    and apply the rating update — exactly once."""
+    match = await _load_match_for_scoring(db, match_id, current_user.id)
+    _enforce_scorable(match)
+
+    try:
+        decided_side = _validate_finalize_games(
+            payload.games, match.match_settings.best_of
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    await _apply_finalized_match(db, match, payload, decided_side)
     await _apply_rating_update(db, match)
     await db.commit()
 

--- a/api/app/schemas/dashboard.py
+++ b/api/app/schemas/dashboard.py
@@ -10,7 +10,10 @@ from app.schemas.rating import RatingChange
 class DashboardScoreBanner(BaseModel):
     match_id: uuid.UUID
     opponent_username: str | None
-    current_game_id: uuid.UUID
+    # The next game to score (1..best_of). Game rows are created lazily by the
+    # score-write endpoints, so the dashboard surfaces the number — the FE
+    # builds the deeplink ``/matches/{id}/games/{n}/scores/new`` from it.
+    current_game_number: int
 
 
 class DashboardNextMatch(BaseModel):

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.models.match import MatchStatus
 from app.schemas.rating import RatingChange
@@ -83,7 +83,9 @@ class MatchDetailsGame(BaseModel):
 
 
 class MatchDetailsCurrentGame(BaseModel):
-    id: uuid.UUID
+    # The next game to score: lowest 1..best_of with no saved score. The row
+    # may not exist in `match_games` yet — game rows are created lazily on the
+    # first score write. Use ``game_number`` (not an id) for deeplinks.
     game_number: int
 
 
@@ -160,6 +162,11 @@ class MatchDetails(BaseModel):
     games: list[MatchDetailsGame]
     current_game: MatchDetailsCurrentGame | None
     can_score: bool
+    # True when the saved games form a decided, validly-ordered match and the
+    # current user is a participant on an in-progress match. The FE uses this
+    # to swap the scoring page's submit-button label and target endpoint
+    # between "save game" and "finalize match".
+    can_finalize: bool
     recent_form: list[MatchDetailsPlayerForm] = Field(default_factory=list)
     head_to_head: MatchDetailsH2H | None = None
 
@@ -175,7 +182,10 @@ class MatchListRow(BaseModel):
     sides: list[MatchDetailsSide]
     best_of: int
     created_at: datetime
-    current_game_id: uuid.UUID | None
+    # Game rows are created lazily on the first score write, so the deeplink
+    # target may not have an id yet. The list passes the game number; the FE
+    # builds the route from (match_id, current_game_number).
+    current_game_number: int | None
     can_score: bool
 
 
@@ -190,32 +200,76 @@ class MatchListResponse(BaseModel):
 # ----- score write (POST/PUT body) -----------------------------------------
 
 
+def validate_game_score(side_1_points: int, side_2_points: int) -> None:
+    """Table-tennis rules for a single completed game. Raises ``ValueError`` —
+    callers wrap as needed for Pydantic (`model_validator`) or as the
+    422 detail on a route handler.
+
+    Used both by the per-game score-write schema (one row at a time) and the
+    finalize-payload validator (per-game inside a full match)."""
+    a, b = side_1_points, side_2_points
+    winner, loser = max(a, b), min(a, b)
+    if winner < 11:
+        raise ValueError("The winning side must reach at least 11 points.")
+    if a == b:
+        raise ValueError("A game cannot end in a tie.")
+    if winner == 11 and loser > 9:
+        raise ValueError(
+            f"At 10–10 the game enters deuce; the winner must lead by 2. "
+            f"{winner}–{loser} is not a legal final score."
+        )
+    if winner > 11:
+        if loser < 10:
+            raise ValueError(
+                f"A game can only go past 11 points after both sides reach 10. "
+                f"{winner}–{loser} is not a legal final score."
+            )
+        if winner - loser != 2:
+            raise ValueError(
+                f"In a deuce game the winner leads by exactly 2 points. "
+                f"{winner}–{loser} is not a legal final score."
+            )
+
+
 class MatchGameScoreWrite(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     side_1_points: int = Field(ge=0, le=99)
     side_2_points: int = Field(ge=0, le=99)
 
     @model_validator(mode="after")
     def _table_tennis_rules(self) -> "MatchGameScoreWrite":
-        a, b = self.side_1_points, self.side_2_points
-        winner, loser = max(a, b), min(a, b)
-        if winner < 11:
-            raise ValueError("The winning side must reach at least 11 points.")
-        if a == b:
-            raise ValueError("A game cannot end in a tie.")
-        if winner == 11 and loser > 9:
-            raise ValueError(
-                f"At 10–10 the game enters deuce; the winner must lead by 2. "
-                f"{winner}–{loser} is not a legal final score."
-            )
-        if winner > 11:
-            if loser < 10:
-                raise ValueError(
-                    f"A game can only go past 11 points after both sides reach 10. "
-                    f"{winner}–{loser} is not a legal final score."
-                )
-            if winner - loser != 2:
-                raise ValueError(
-                    f"In a deuce game the winner leads by exactly 2 points. "
-                    f"{winner}–{loser} is not a legal final score."
-                )
+        validate_game_score(self.side_1_points, self.side_2_points)
         return self
+
+
+# ----- finalize body (POST /v1/matches/{id}/results) -----------------------
+
+
+class MatchResultsGameWrite(BaseModel):
+    """One game inside a finalize-the-match payload. Per-game point legality
+    is checked here; cross-game checks (contiguous numbering, decided result,
+    no scores past the decider) live in the handler against the full list."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Best-of caps at 7 (see ``ALLOWED_BEST_OF``); the handler additionally
+    # rejects any number greater than the match's own ``best_of``.
+    game_number: int = Field(ge=1, le=7)
+    side_1_points: int = Field(ge=0, le=99)
+    side_2_points: int = Field(ge=0, le=99)
+
+    @model_validator(mode="after")
+    def _table_tennis_rules(self) -> "MatchResultsGameWrite":
+        validate_game_score(self.side_1_points, self.side_2_points)
+        return self
+
+
+class MatchResultsWrite(BaseModel):
+    """Request body for ``POST /v1/matches/{match_id}/results``. The list is
+    canon: the handler deletes every existing game + score on the match and
+    re-inserts these rows. No merge."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    games: list[MatchResultsGameWrite] = Field(min_length=1)

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -71,19 +71,18 @@ async def test_dashboard_returns_score_banner_for_in_progress_match(
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     match = await _create_match(api_client, opp.id, best_of=5)
-    after_g1 = (
-        await api_client.post(
-            f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
-            json={"side_1_points": 11, "side_2_points": 4},
-        )
-    ).json()
+    await api_client.post(
+        f"/v1/matches/{match['id']}/games/1/scores/new",
+        json={"side_1_points": 11, "side_2_points": 4},
+    )
 
     body = (await api_client.get("/v1/dashboard")).json()
     assert len(body["score_banners"]) == 1
     banner = body["score_banners"][0]
     assert banner["match_id"] == match["id"]
     assert banner["opponent_username"] == "rival"
-    assert banner["current_game_id"] == after_g1["current_game"]["id"]
+    # Game rows are created lazily; the dashboard deeplinks by game number.
+    assert banner["current_game_number"] == 2
     # An in-progress match is not "pending" so the next_match slot is empty.
     assert body["next_match"] is None
     assert body["recent_results"] == []
@@ -143,8 +142,12 @@ async def test_dashboard_returns_recent_results_for_completed_matches(
     opp = await make_user(db_session, "rival")
     match = await _create_match(api_client, opp.id, best_of=1)
     await api_client.post(
-        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
-        json={"side_1_points": 11, "side_2_points": 4},
+        f"/v1/matches/{match['id']}/results",
+        json={
+            "games": [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+            ]
+        },
     )
 
     body = (await api_client.get("/v1/dashboard")).json()
@@ -190,11 +193,20 @@ async def _play_match(
     i_win: bool,
     best_of: int = 1,
 ) -> dict:
+    """Create a match, fast-forward through a deciding result via /results
+    (the per-game scratchpad endpoints don't finalize anymore — see the
+    decouple-scoring refactor)."""
     match = await _create_match(client, opponent_id, best_of=best_of)
     s1, s2 = (11, 4) if i_win else (4, 11)
+    games_to_win = best_of // 2 + 1
     await client.post(
-        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
-        json={"side_1_points": s1, "side_2_points": s2},
+        f"/v1/matches/{match['id']}/results",
+        json={
+            "games": [
+                {"game_number": n, "side_1_points": s1, "side_2_points": s2}
+                for n in range(1, games_to_win + 1)
+            ]
+        },
     )
     return match
 

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -57,19 +57,17 @@ async def test_create_rated_match_with_registered_opponent(
     assert opp_side["players"][0]["user_id"] == str(opponent.id)
     assert opp_side["players"][0]["is_current_user"] is False
 
-    # Game 1 always exists from the moment a match is created.
-    assert len(body["games"]) == 1
-    assert body["games"][0]["game_number"] == 1
-    assert body["games"][0]["score"] is None
-    assert body["current_game"]["id"] == body["games"][0]["id"]
+    # Games are written lazily by the score-write endpoints — a freshly
+    # created match has no game rows yet, only the deeplink target.
+    assert body["games"] == []
     assert body["current_game"]["game_number"] == 1
     assert body["can_score"] is True
+    assert body["can_finalize"] is False
 
     match = (await db_session.execute(select(Match))).scalar_one()
     assert str(match.id) == body["id"]
     games = (await db_session.execute(select(MatchGame))).scalars().all()
-    assert len(games) == 1
-    assert games[0].game_number == 1
+    assert games == []
 
 
 async def test_create_unrated_match_with_opponent(
@@ -106,9 +104,11 @@ async def test_create_match_without_opponent_has_a_sentinel_opponent_side(
     assert [s["side_number"] for s in sides] == [1, 2]
     assert sides[0]["players"][0]["user_id"] == str(me.id)
     assert sides[1]["players"] == []
-    # The sentinel side makes the match scorable for its creator.
-    assert body["current_game"] is not None
+    # The sentinel side makes the match scorable for its creator. The first
+    # game number is still surfaced even though no MatchGame row exists yet.
+    assert body["current_game"] == {"game_number": 1}
     assert body["can_score"] is True
+    assert body["can_finalize"] is False
 
     rows = (await db_session.execute(select(MatchSide))).scalars().all()
     assert len(rows) == 2
@@ -122,26 +122,46 @@ async def test_match_without_opponent_can_be_scored_to_completion(
     match = (
         await api_client.post("/v1/matches", json={"best_of": 3, "rated": False})
     ).json()
-    # The creator is side 1; the sentinel opponent is side 2.
+    # Per-game scratchpad writes leave status untouched — the match isn't
+    # decided until POST /results.
     after_g1 = (
         await api_client.post(
-            f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+            f"/v1/matches/{match['id']}/games/1/scores/new",
             json={"side_1_points": 11, "side_2_points": 4},
         )
     ).json()
     assert after_g1["status"] == "in_progress"
-    game_2 = after_g1["games"][1]
-    after_g2 = await api_client.post(
-        f"/v1/matches/{match['id']}/games/{game_2['id']}/scores",
-        json={"side_1_points": 11, "side_2_points": 7},
+    assert after_g1["can_finalize"] is False
+    after_g2 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/2/scores/new",
+            json={"side_1_points": 11, "side_2_points": 7},
+        )
+    ).json()
+    assert after_g2["status"] == "in_progress"
+    # Two same-winner games in a best-of-3 → the saved scores form a decided
+    # match, so the FE's submit button will swap to "Finalize match".
+    assert after_g2["can_finalize"] is True
+
+    finalized = await api_client.post(
+        f"/v1/matches/{match['id']}/results",
+        json={
+            "games": [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
+            ]
+        },
     )
-    assert after_g2.status_code == 201
-    body = after_g2.json()
+    assert finalized.status_code == 201
+    body = finalized.json()
     assert body["status"] == "completed"
     sides = sorted(body["sides"], key=lambda s: s["side_number"])
     assert [s["won"] for s in sides] == [True, False]
     # No rating moved — a player-less opponent can't be rated against.
     assert body["affects_rating"] is False
+    assert body["current_game"] is None
+    assert body["can_score"] is False
+    assert body["can_finalize"] is False
 
 
 async def test_rated_match_without_opponent_is_rejected(
@@ -396,11 +416,15 @@ async def test_list_filter_by_status(api_client: AsyncClient, db_session: AsyncS
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     in_progress = await _create_match(api_client, opp.id, best_of=1)
-    # Score game 1 to flip a separate match to completed.
+    # Finalize a separate match to flip it to completed.
     completed_match = await _create_match(api_client, opp.id, best_of=1)
     score_resp = await api_client.post(
-        f"/v1/matches/{completed_match['id']}/games/{completed_match['games'][0]['id']}/scores",
-        json={"side_1_points": 11, "side_2_points": 5},
+        f"/v1/matches/{completed_match['id']}/results",
+        json={
+            "games": [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 5},
+            ]
+        },
     )
     assert score_resp.status_code == 201
 
@@ -451,23 +475,26 @@ async def test_list_pagination(api_client: AsyncClient, db_session: AsyncSession
     } == set()
 
 
-async def test_list_row_carries_current_game_id_when_scorable(
+async def test_list_row_carries_current_game_number_when_scorable(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
-    created = await _create_match(api_client, opp.id)
+    await _create_match(api_client, opp.id)
 
     listing = (await api_client.get("/v1/matches")).json()
     row = listing["items"][0]
-    assert row["current_game_id"] == created["games"][0]["id"]
+    # No games scored yet, so the next un-scored game is game 1. Game rows
+    # don't exist until the first POST .../scores/new, so the listing surfaces
+    # the number, not an id.
+    assert row["current_game_number"] == 1
     assert row["can_score"] is True
 
 
 async def test_list_row_hides_scoring_affordance_from_spectators(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    # Spectators get neither `can_score` nor `current_game_id` — the scoring
+    # Spectators get neither `can_score` nor `current_game_number` — the scoring
     # route 404s for them anyway, and the FE has no reason to deep-link.
     await start_session(api_client, db_session)
     async with make_client() as other_client:
@@ -477,7 +504,7 @@ async def test_list_row_hides_scoring_affordance_from_spectators(
 
     listing = (await api_client.get("/v1/matches")).json()
     row = next(r for r in listing["items"] if r["id"] == created["id"])
-    assert row["current_game_id"] is None
+    assert row["current_game_number"] is None
     assert row["can_score"] is False
 
 
@@ -512,7 +539,7 @@ async def test_table_tennis_scoring_rules(
     match = await _create_match(api_client, opp.id, best_of=5)
 
     response = await api_client.post(
-        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+        f"/v1/matches/{match['id']}/games/1/scores/new",
         json={"side_1_points": side_1, "side_2_points": side_2},
     )
     if is_valid:
@@ -521,10 +548,10 @@ async def test_table_tennis_scoring_rules(
         assert response.status_code == 422
 
 
-# ----- score lifecycle ----------------------------------------------------
+# ----- per-game score endpoints (scratchpad state) ------------------------
 
 
-async def test_scoring_game_1_keeps_in_progress_and_adds_game_2(
+async def test_score_create_lazily_inserts_the_game_row(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
@@ -532,222 +559,173 @@ async def test_scoring_game_1_keeps_in_progress_and_adds_game_2(
     match = await _create_match(api_client, opp.id, best_of=5)
 
     response = await api_client.post(
-        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
+        f"/v1/matches/{match['id']}/games/1/scores/new",
         json={"side_1_points": 11, "side_2_points": 4},
     )
     assert response.status_code == 201
     body = response.json()
+    # Match status, side wins, and side.won are untouched by per-game writes —
+    # finalization lives entirely in POST /results.
     assert body["status"] == "in_progress"
-    assert body["status_label"] == "Live"
     assert [s["games_won"] for s in body["sides"]] == [1, 0]
+    assert all(s["won"] is None for s in body["sides"])
+    # No trailing un-scored game auto-appended: only game 1 exists.
+    assert [g["game_number"] for g in body["games"]] == [1]
+    assert body["games"][0]["score"]["side_1_points"] == 11
+    # current_game advances to the next un-scored slot (lazy — no row yet).
+    assert body["current_game"] == {"game_number": 2}
+    assert body["can_score"] is True
+    assert body["can_finalize"] is False
 
-    # Game 2 has been opened.
-    assert len(body["games"]) == 2
-    assert body["games"][1]["game_number"] == 2
-    assert body["games"][1]["score"] is None
-    assert body["current_game"]["game_number"] == 2
-
-
-async def test_deciding_game_flips_to_completed_with_no_trailing_unscored(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    match = await _create_match(api_client, opp.id, best_of=3)
-
-    # Win game 1, win game 2 → match completed (best of 3, need 2).
-    after_g1 = (
-        await api_client.post(
-            f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
-            json={"side_1_points": 11, "side_2_points": 4},
-        )
-    ).json()
-    game_2 = after_g1["games"][1]
-    after_g2 = (
-        await api_client.post(
-            f"/v1/matches/{match['id']}/games/{game_2['id']}/scores",
-            json={"side_1_points": 11, "side_2_points": 7},
-        )
-    ).json()
-
-    assert after_g2["status"] == "completed"
-    assert after_g2["status_label"] == "Final"
-    assert len(after_g2["games"]) == 2  # no trailing unscored game
-    assert after_g2["current_game"] is None
-    assert [s["won"] for s in after_g2["sides"]] == [True, False]
-    assert after_g2["can_score"] is False
+    games = (await db_session.execute(select(MatchGame))).scalars().all()
+    assert len(games) == 1
 
 
-async def test_post_score_409_when_game_already_scored(
+async def test_score_create_409_when_game_already_scored(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     match = await _create_match(api_client, opp.id, best_of=5)
-    game_id = match["games"][0]["id"]
     await api_client.post(
-        f"/v1/matches/{match['id']}/games/{game_id}/scores",
+        f"/v1/matches/{match['id']}/games/1/scores/new",
         json={"side_1_points": 11, "side_2_points": 4},
     )
 
     second = await api_client.post(
-        f"/v1/matches/{match['id']}/games/{game_id}/scores",
+        f"/v1/matches/{match['id']}/games/1/scores/new",
         json={"side_1_points": 11, "side_2_points": 5},
     )
     assert second.status_code == 409
     assert second.json()["detail"] == "This game has already been scored."
 
 
-async def test_put_edits_a_past_games_score(
+async def test_score_create_422_when_game_number_exceeds_best_of(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=3)
+
+    response = await api_client.post(
+        f"/v1/matches/{match['id']}/games/4/scores/new",
+        json={"side_1_points": 11, "side_2_points": 4},
+    )
+    assert response.status_code == 422
+    assert "best of 3" in response.json()["detail"]
+
+
+async def test_score_create_accepts_gaps(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # The per-game endpoints are pure scratchpad — gaps are fine. Contiguity
+    # is enforced only when finalizing via POST /results.
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=5)
+
+    # Score game 3 before game 1 or 2 — the FE can let users enter games in
+    # any order.
+    response = await api_client.post(
+        f"/v1/matches/{match['id']}/games/3/scores/new",
+        json={"side_1_points": 11, "side_2_points": 9},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert [g["game_number"] for g in body["games"]] == [3]
+    # current_game falls back to the lowest unscored slot — game 1.
+    assert body["current_game"] == {"game_number": 1}
+    assert body["can_finalize"] is False
+
+
+async def test_score_update_overwrites_in_place(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     match = await _create_match(api_client, opp.id, best_of=5)
-    game_1 = match["games"][0]
-    after_g1 = (
-        await api_client.post(
-            f"/v1/matches/{match['id']}/games/{game_1['id']}/scores",
-            json={"side_1_points": 11, "side_2_points": 4},
-        )
-    ).json()
-    score_id = after_g1["games"][0]["score"]["id"]
+    await api_client.post(
+        f"/v1/matches/{match['id']}/games/1/scores/new",
+        json={"side_1_points": 11, "side_2_points": 4},
+    )
 
     edited = await api_client.put(
-        f"/v1/matches/{match['id']}/games/{game_1['id']}/scores/{score_id}",
+        f"/v1/matches/{match['id']}/games/1/scores",
         json={"side_1_points": 5, "side_2_points": 11},
     )
     assert edited.status_code == 200
     body = edited.json()
+    # Side wins flip, but status / won / current_game stay untouched —
+    # nothing about the match is finalized just because a score changed.
     assert [s["games_won"] for s in body["sides"]] == [0, 1]
-    # Status stays in_progress; game 2 stays open.
-    assert body["status"] == "in_progress"
-
-
-async def test_put_reopens_a_completed_match(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    match = await _create_match(api_client, opp.id, best_of=3)
-    after_g1 = (
-        await api_client.post(
-            f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
-            json={"side_1_points": 11, "side_2_points": 4},
-        )
-    ).json()
-    game_2 = after_g1["games"][1]
-    after_g2 = (
-        await api_client.post(
-            f"/v1/matches/{match['id']}/games/{game_2['id']}/scores",
-            json={"side_1_points": 11, "side_2_points": 7},
-        )
-    ).json()
-    assert after_g2["status"] == "completed"
-
-    # Flip game 2 so the opponent wins it → only game 1 has been won by me, 1-1.
-    g2_score_id = after_g2["games"][1]["score"]["id"]
-    reopened = await api_client.put(
-        f"/v1/matches/{match['id']}/games/{game_2['id']}/scores/{g2_score_id}",
-        json={"side_1_points": 7, "side_2_points": 11},
-    )
-    assert reopened.status_code == 200
-    body = reopened.json()
     assert body["status"] == "in_progress"
     assert all(s["won"] is None for s in body["sides"])
-    # Game 3 has been opened by reconciliation.
-    assert len(body["games"]) == 3
-    assert body["games"][2]["score"] is None
-    assert body["current_game"]["game_number"] == 3
+    assert body["current_game"] == {"game_number": 2}
+    # No new game row was created.
+    assert [g["game_number"] for g in body["games"]] == [1]
 
 
-async def test_put_closes_match_earlier_and_deletes_trailing_unscored(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    match = await _create_match(api_client, opp.id, best_of=3)
-
-    # Game 1: opponent wins. Game 2: I win. Now 1-1 with game 3 open.
-    after_g1 = (
-        await api_client.post(
-            f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
-            json={"side_1_points": 5, "side_2_points": 11},
-        )
-    ).json()
-    game_2 = after_g1["games"][1]
-    after_g2 = (
-        await api_client.post(
-            f"/v1/matches/{match['id']}/games/{game_2['id']}/scores",
-            json={"side_1_points": 11, "side_2_points": 4},
-        )
-    ).json()
-    assert after_g2["status"] == "in_progress"
-    assert len(after_g2["games"]) == 3  # game 3 open
-
-    # Edit game 1 so I win it instead → 2-0 → match completed, game 3 deleted.
-    g1_score_id = after_g2["games"][0]["score"]["id"]
-    edited = await api_client.put(
-        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores/{g1_score_id}",
-        json={"side_1_points": 11, "side_2_points": 6},
-    )
-    body = edited.json()
-    assert body["status"] == "completed"
-    assert len(body["games"]) == 2
-    assert body["current_game"] is None
-
-    # No orphan score rows or trailing games left behind in the DB.
-    games = (await db_session.execute(select(MatchGame))).scalars().all()
-    assert len(games) == 2
-    scores = (await db_session.execute(select(MatchGameScore))).scalars().all()
-    assert len(scores) == 2
-
-
-async def test_put_404_for_unknown_score_id(
+async def test_score_update_404_when_no_saved_score(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     match = await _create_match(api_client, opp.id, best_of=5)
-    game_id = match["games"][0]["id"]
-    await api_client.post(
-        f"/v1/matches/{match['id']}/games/{game_id}/scores",
-        json={"side_1_points": 11, "side_2_points": 4},
-    )
 
     response = await api_client.put(
-        f"/v1/matches/{match['id']}/games/{game_id}/scores/{uuid.uuid4()}",
+        f"/v1/matches/{match['id']}/games/1/scores",
         json={"side_1_points": 11, "side_2_points": 5},
     )
     assert response.status_code == 404
     assert response.json()["detail"] == "Score not found."
 
 
-async def test_put_404_for_mismatched_game_and_score(
+async def test_score_delete_clears_the_score_and_keeps_the_game(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     match = await _create_match(api_client, opp.id, best_of=5)
-    after_g1 = (
-        await api_client.post(
-            f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
-            json={"side_1_points": 11, "side_2_points": 4},
-        )
-    ).json()
-    score_id = after_g1["games"][0]["score"]["id"]
-    other_game_id = after_g1["games"][1]["id"]
-
-    response = await api_client.put(
-        f"/v1/matches/{match['id']}/games/{other_game_id}/scores/{score_id}",
-        json={"side_1_points": 11, "side_2_points": 5},
+    await api_client.post(
+        f"/v1/matches/{match['id']}/games/1/scores/new",
+        json={"side_1_points": 11, "side_2_points": 4},
     )
+
+    cleared = await api_client.delete(f"/v1/matches/{match['id']}/games/1/scores")
+    assert cleared.status_code == 200
+    body = cleared.json()
+    assert [s["games_won"] for s in body["sides"]] == [0, 0]
+    assert body["current_game"] == {"game_number": 1}
+
+    # A fresh POST .../scores/new at the same game number succeeds — the
+    # game row stays in place, just with no score attached.
+    again = await api_client.post(
+        f"/v1/matches/{match['id']}/games/1/scores/new",
+        json={"side_1_points": 11, "side_2_points": 9},
+    )
+    assert again.status_code == 201
+
+    scores = (await db_session.execute(select(MatchGameScore))).scalars().all()
+    assert len(scores) == 1
+    assert scores[0].side_2_points == 9
+
+
+async def test_score_delete_404_when_no_saved_score(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=5)
+
+    response = await api_client.delete(f"/v1/matches/{match['id']}/games/2/scores")
     assert response.status_code == 404
 
 
 async def test_non_participant_cannot_score(
     api_client: AsyncClient, db_session: AsyncSession
 ):
+    # 404 (not 403) — non-participants don't get to learn that the match
+    # exists from a write path.
     await start_session(api_client, db_session)
     async with make_client() as other_client:
         them = await start_session(other_client, db_session)
@@ -756,29 +734,27 @@ async def test_non_participant_cannot_score(
         del them
 
         post = await api_client.post(
-            f"/v1/matches/{created['id']}/games/{created['games'][0]['id']}/scores",
+            f"/v1/matches/{created['id']}/games/1/scores/new",
             json={"side_1_points": 11, "side_2_points": 4},
         )
         assert post.status_code == 404
         put = await api_client.put(
-            f"/v1/matches/{created['id']}/games/{created['games'][0]['id']}/scores/{uuid.uuid4()}",
+            f"/v1/matches/{created['id']}/games/1/scores",
             json={"side_1_points": 11, "side_2_points": 4},
         )
         assert put.status_code == 404
-
-
-async def test_scoring_an_unknown_game_404(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    match = await _create_match(api_client, opp.id, best_of=5)
-    response = await api_client.post(
-        f"/v1/matches/{match['id']}/games/{uuid.uuid4()}/scores",
-        json={"side_1_points": 11, "side_2_points": 4},
-    )
-    assert response.status_code == 404
-    assert response.json()["detail"] == "Game not found."
+        delete = await api_client.delete(f"/v1/matches/{created['id']}/games/1/scores")
+        assert delete.status_code == 404
+        results = await api_client.post(
+            f"/v1/matches/{created['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                    {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
+                ]
+            },
+        )
+        assert results.status_code == 404
 
 
 async def test_can_score_match_without_opponent(
@@ -789,7 +765,7 @@ async def test_can_score_match_without_opponent(
         await api_client.post("/v1/matches", json={"best_of": 5, "rated": False})
     ).json()
     response = await api_client.post(
-        f"/v1/matches/{created['id']}/games/{created['games'][0]['id']}/scores",
+        f"/v1/matches/{created['id']}/games/1/scores/new",
         json={"side_1_points": 11, "side_2_points": 4},
     )
     # The sentinel opponent side makes the match scorable.
@@ -797,6 +773,228 @@ async def test_can_score_match_without_opponent(
     body = response.json()
     sides = sorted(body["sides"], key=lambda s: s["side_number"])
     assert [s["games_won"] for s in sides] == [1, 0]
+
+
+# ----- finalize (POST /v1/matches/{id}/results) ---------------------------
+
+
+async def test_finalize_replaces_scores_and_marks_completed(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=3)
+
+    # Pre-finalize, the FE has scratched in a totally different game 1 score.
+    # The /results payload is canon — it should win.
+    await api_client.post(
+        f"/v1/matches/{match['id']}/games/1/scores/new",
+        json={"side_1_points": 5, "side_2_points": 11},
+    )
+
+    response = await api_client.post(
+        f"/v1/matches/{match['id']}/results",
+        json={
+            "games": [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
+            ]
+        },
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["status"] == "completed"
+    assert body["status_label"] == "Final"
+    assert body["current_game"] is None
+    assert body["can_score"] is False
+    assert body["can_finalize"] is False
+    sides = sorted(body["sides"], key=lambda s: s["side_number"])
+    assert [s["games_won"] for s in sides] == [2, 0]
+    assert [s["won"] for s in sides] == [True, False]
+    # Games + scores reflect the payload, not the scratchpad.
+    games = sorted(body["games"], key=lambda g: g["game_number"])
+    assert [g["game_number"] for g in games] == [1, 2]
+    assert games[0]["score"]["side_1_points"] == 11
+    assert games[0]["score"]["side_2_points"] == 4
+
+    # DB-side sanity: no orphan score rows from the obliterated scratchpad.
+    game_rows = (await db_session.execute(select(MatchGame))).scalars().all()
+    score_rows = (await db_session.execute(select(MatchGameScore))).scalars().all()
+    assert len(game_rows) == 2
+    assert len(score_rows) == 2
+
+
+async def test_finalize_409_when_already_completed(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=3)
+
+    payload = {
+        "games": [
+            {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+            {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
+        ]
+    }
+    first = await api_client.post(f"/v1/matches/{match['id']}/results", json=payload)
+    assert first.status_code == 201
+
+    second = await api_client.post(f"/v1/matches/{match['id']}/results", json=payload)
+    assert second.status_code == 409
+
+
+async def test_score_endpoints_409_once_match_is_completed(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=3)
+    await api_client.post(
+        f"/v1/matches/{match['id']}/results",
+        json={
+            "games": [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
+            ]
+        },
+    )
+
+    # Every write path returns 409 once the match is finalized.
+    post = await api_client.post(
+        f"/v1/matches/{match['id']}/games/1/scores/new",
+        json={"side_1_points": 8, "side_2_points": 11},
+    )
+    assert post.status_code == 409
+    put = await api_client.put(
+        f"/v1/matches/{match['id']}/games/1/scores",
+        json={"side_1_points": 8, "side_2_points": 11},
+    )
+    assert put.status_code == 409
+    delete = await api_client.delete(f"/v1/matches/{match['id']}/games/1/scores")
+    assert delete.status_code == 409
+
+
+@pytest.mark.parametrize(
+    "games,reason_contains",
+    [
+        # Gap — games 1 and 3 with no game 2.
+        (
+            [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                {"game_number": 3, "side_1_points": 11, "side_2_points": 7},
+            ],
+            "consecutively",
+        ),
+        # Duplicate game numbers.
+        (
+            [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 7},
+            ],
+            "Duplicate",
+        ),
+        # Undecided — 1-1 in best-of-3 (need 2 wins).
+        (
+            [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                {"game_number": 2, "side_1_points": 4, "side_2_points": 11},
+            ],
+            "decided",
+        ),
+        # Scored games past the decider — won 2-0 in game 2 but a game 3 is
+        # also reported.
+        (
+            [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
+                {"game_number": 3, "side_1_points": 11, "side_2_points": 9},
+            ],
+            "past the deciding game",
+        ),
+        # game_number > best_of.
+        (
+            [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
+                {"game_number": 3, "side_1_points": 11, "side_2_points": 9},
+                {"game_number": 4, "side_1_points": 11, "side_2_points": 9},
+            ],
+            "best_of",
+        ),
+    ],
+)
+async def test_finalize_422_on_invalid_payload(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    games: list[dict[str, int]],
+    reason_contains: str,
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=3)
+
+    response = await api_client.post(
+        f"/v1/matches/{match['id']}/results", json={"games": games}
+    )
+    assert response.status_code == 422
+    assert reason_contains in response.json()["detail"]
+
+
+async def test_finalize_422_on_illegal_per_game_score(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # An individual game with an illegal score (11-10, no win-by-2) trips
+    # the per-game validator inside MatchResultsGameWrite.
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=3)
+
+    response = await api_client.post(
+        f"/v1/matches/{match['id']}/results",
+        json={
+            "games": [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                {"game_number": 2, "side_1_points": 11, "side_2_points": 10},
+            ]
+        },
+    )
+    assert response.status_code == 422
+
+
+async def test_can_finalize_flag_tracks_saved_scores(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=3)
+
+    after_g1 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/1/scores/new",
+            json={"side_1_points": 11, "side_2_points": 4},
+        )
+    ).json()
+    # One game in — not enough to decide a best-of-3.
+    assert after_g1["can_finalize"] is False
+
+    after_g2 = (
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/2/scores/new",
+            json={"side_1_points": 11, "side_2_points": 7},
+        )
+    ).json()
+    # Same winner in both — match is decided.
+    assert after_g2["can_finalize"] is True
+
+    # Splitting g1/g2 leaves the match 1-1: undecided.
+    edited = (
+        await api_client.put(
+            f"/v1/matches/{match['id']}/games/2/scores",
+            json={"side_1_points": 5, "side_2_points": 11},
+        )
+    ).json()
+    assert edited["can_finalize"] is False
 
 
 # ----- league binding -----------------------------------------------------
@@ -909,21 +1107,21 @@ async def _play_match_to_completion(
     best_of: int,
     side_1_wins: bool,
 ) -> dict:
-    """Create a match and score it to completion. The chosen side wins the
-    minimum number of games needed to clinch. Returns the final payload."""
+    """Create a match and finalize it. The chosen side wins the minimum
+    number of games needed to clinch. Returns the final payload."""
     match = await _create_match(client, opponent_id, best_of=best_of)
     needed = best_of // 2 + 1
-    body = match
-    for _ in range(needed):
-        current = body["current_game"]
-        assert current is not None
-        s1, s2 = (11, 5) if side_1_wins else (5, 11)
-        body = (
-            await client.post(
-                f"/v1/matches/{body['id']}/games/{current['id']}/scores",
-                json={"side_1_points": s1, "side_2_points": s2},
-            )
-        ).json()
+    s1, s2 = (11, 5) if side_1_wins else (5, 11)
+    response = await client.post(
+        f"/v1/matches/{match['id']}/results",
+        json={
+            "games": [
+                {"game_number": n, "side_1_points": s1, "side_2_points": s2}
+                for n in range(1, needed + 1)
+            ]
+        },
+    )
+    body = response.json()
     assert body["status"] == "completed"
     return body
 

--- a/api/tests/test_ratings.py
+++ b/api/tests/test_ratings.py
@@ -121,6 +121,9 @@ def test_validate_state_rejects_extra_keys(
 async def _score_to_completion(
     client: AsyncClient, opponent_id: uuid.UUID, best_of: int = 1
 ) -> dict:
+    """Create a rated match and finalize it — current_user (side 1) wins.
+    Per-game endpoints are scratchpad-only post the decouple-scoring refactor,
+    so completion only happens via POST /results."""
     create = await client.post(
         "/v1/matches",
         json={
@@ -131,12 +134,18 @@ async def _score_to_completion(
     )
     assert create.status_code == 201
     match = create.json()
-    score = await client.post(
-        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
-        json={"side_1_points": 11, "side_2_points": 4},
+    needed = best_of // 2 + 1
+    finalize = await client.post(
+        f"/v1/matches/{match['id']}/results",
+        json={
+            "games": [
+                {"game_number": n, "side_1_points": 11, "side_2_points": 4}
+                for n in range(1, needed + 1)
+            ]
+        },
     )
-    assert score.status_code == 201
-    return score.json()
+    assert finalize.status_code == 201
+    return finalize.json()
 
 
 async def test_completing_a_rated_match_writes_rating_history(
@@ -212,11 +221,15 @@ async def test_unrated_match_does_not_move_ratings(
         },
     )
     match = create.json()
-    score = await api_client.post(
-        f"/v1/matches/{match['id']}/games/{match['games'][0]['id']}/scores",
-        json={"side_1_points": 11, "side_2_points": 4},
+    finalize = await api_client.post(
+        f"/v1/matches/{match['id']}/results",
+        json={
+            "games": [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+            ]
+        },
     )
-    body = score.json()
+    body = finalize.json()
     for side in body["sides"]:
         assert side["rating_change"] is None
 
@@ -271,22 +284,32 @@ async def test_manual_strategy_league_skips_rating_updates(
     assert ratings[0].rating_state is None
 
 
-async def test_rating_update_is_idempotent_across_score_edits(
+async def test_finalized_match_rejects_score_edits_and_keeps_rating_history(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    """Editing a score on an already-completed match doesn't write a second
-    set of history rows. Re-application across edits is its own feature
-    (tied to dispute/void flows) and explicitly out of scope for v1."""
+    """Once a match is finalized, every write path 409s — there's no way to
+    silently re-apply (or duplicate) the rating update. Re-applying ratings
+    after a correction is its own feature (tied to dispute/void flows),
+    explicitly out of scope for v1."""
     await start_session(api_client, db_session)
     opp = await make_user(db_session, "rival")
     body = await _score_to_completion(api_client, opp.id)
-    score_id = body["games"][0]["score"]["id"]
 
-    edited = await api_client.put(
-        f"/v1/matches/{body['id']}/games/{body['games'][0]['id']}/scores/{score_id}",
+    # Every score-write path is locked once the match is finalized.
+    put = await api_client.put(
+        f"/v1/matches/{body['id']}/games/1/scores",
         json={"side_1_points": 11, "side_2_points": 5},
     )
-    assert edited.status_code == 200
+    assert put.status_code == 409
+    re_finalize = await api_client.post(
+        f"/v1/matches/{body['id']}/results",
+        json={
+            "games": [
+                {"game_number": 1, "side_1_points": 11, "side_2_points": 5},
+            ]
+        },
+    )
+    assert re_finalize.status_code == 409
 
     rows = (
         (
@@ -299,7 +322,7 @@ async def test_rating_update_is_idempotent_across_score_edits(
         .scalars()
         .all()
     )
-    assert len(rows) == 2  # still just the original pair
+    assert len(rows) == 2  # still just the original pair from finalize
 
 
 async def test_new_session_seeds_rating_for_default_league(

--- a/web-client/e2e/matches-list.spec.ts
+++ b/web-client/e2e/matches-list.spec.ts
@@ -14,21 +14,21 @@ const SEED = [
     opponent: 'nguyen.t',
     status: 'in_progress',
     status_label: 'Live',
-    current_game_id: 'g-live-1-3',
+    current_game_number: 3,
   }),
   matchListRow({
     id: 'm-pending-1',
     opponent: 'okafor.d',
     status: 'pending',
     status_label: 'Scheduled',
-    current_game_id: 'g-pending-1-1',
+    current_game_number: 1,
   }),
   matchListRow({
     id: 'm-final-1',
     opponent: 'silva.r',
     status: 'completed',
     status_label: 'Final',
-    current_game_id: null,
+    current_game_number: null,
   }),
 ]
 

--- a/web-client/e2e/page-objects/score-entry.page.ts
+++ b/web-client/e2e/page-objects/score-entry.page.ts
@@ -2,9 +2,9 @@ import { Locator, Page } from '@playwright/test'
 
 type NavigateOptions = {
   matchId?: string
-  gameId?: string
-  // When provided, navigates to the edit route instead of the create route.
-  scoreId?: string
+  gameNumber?: number
+  // When true, navigates to the edit route instead of the create route.
+  edit?: boolean
   // Pin the opponent username so the input aria-label resolves. The default
   // tracks the seed for `m-2207`.
   opponentUsername?: string
@@ -14,9 +14,10 @@ type NavigateOptions = {
 // Hard-coded here so the e2e doesn't have to reach into the mock module.
 export const SEED = {
   matchId: 'm-2207',
-  game3Id: 'g-2207-3',
-  game1Id: 'g-2207-1',
-  score1Id: 's-2207-1',
+  // After the decouple-scoring refactor games 1 + 2 are scratchpad scores;
+  // game 3 is the next un-scored slot. All addressing is by game number.
+  nextGameNumber: 3,
+  scoredGameNumber: 1,
   opponentUsername: 'nguyen.t',
   meUsername: 'rita.kovac',
 } as const
@@ -35,14 +36,14 @@ export class ScoreEntryPage {
     page: Page,
     {
       matchId = SEED.matchId,
-      gameId = SEED.game3Id,
-      scoreId,
+      gameNumber = SEED.nextGameNumber,
+      edit = false,
       opponentUsername = SEED.opponentUsername,
     }: NavigateOptions = {},
   ): Promise<ScoreEntryPage> {
-    const url = scoreId
-      ? `/matches/${matchId}/games/${gameId}/scores/${scoreId}/edit`
-      : `/matches/${matchId}/games/${gameId}/scores/new`
+    const url = edit
+      ? `/matches/${matchId}/games/${gameNumber}/scores/edit`
+      : `/matches/${matchId}/games/${gameNumber}/scores/new`
     await page.goto(url)
     return new ScoreEntryPage(page, opponentUsername)
   }

--- a/web-client/e2e/score-entry.spec.ts
+++ b/web-client/e2e/score-entry.spec.ts
@@ -13,8 +13,9 @@ type Seed = {
 }
 
 // The seed shape exercised by the score-entry e2e. Mirrors `m-2207` from
-// `src/mocks/match-store.ts` (1-1 mid-match, game 3 unscored) so the asserts
-// can rely on the same stable ids.
+// `src/mocks/match-store.ts` (1-1 mid-match) so the asserts can rely on the
+// same stable id. Per the decouple-scoring refactor, only scored games have
+// rows — the next un-scored slot is exposed via current_game.game_number.
 function buildSeed(): Seed {
   return {
     id: SEED.matchId,
@@ -33,7 +34,6 @@ function buildSeed(): Seed {
         game_number: 2,
         score: { id: 's-2207-2', side_1_points: 9, side_2_points: 11 },
       },
-      { id: SEED.game3Id, game_number: 3, score: null },
     ],
   }
 }
@@ -53,22 +53,41 @@ function sideWins(seed: Seed): { s1: number; s2: number } {
   return { s1, s2 }
 }
 
-// Mirrors the API/MSW reconcile invariant: trail with one un-scored game iff
-// the match is still in progress; drop trailing un-scored game on completion.
-function reconcile(seed: Seed): void {
-  const { s1, s2 } = sideWins(seed)
+function currentGameNumber(seed: Seed): number | null {
+  if (seed.status !== 'in_progress') return null
+  const scored = new Set(
+    seed.games.filter((g) => g.score !== null).map((g) => g.game_number),
+  )
+  for (let n = 1; n <= seed.best_of; n += 1) {
+    if (!scored.has(n)) return n
+  }
+  return null
+}
+
+function canFinalizeSeed(seed: Seed): boolean {
+  if (seed.status !== 'in_progress') return false
+  const scored = seed.games.filter((g) => g.score !== null)
+  if (scored.length === 0) return false
+  const numbers = scored.map((g) => g.game_number).sort((a, b) => a - b)
+  if (numbers[numbers.length - 1] > seed.best_of) return false
+  for (let i = 0; i < numbers.length; i += 1) {
+    if (numbers[i] !== i + 1) return false
+  }
   const target = gamesToWin(seed.best_of)
-  if (s1 >= target || s2 >= target) {
-    seed.status = 'completed'
-    seed.games = seed.games.filter((g) => g.score !== null)
-    return
+  const { s1, s2 } = sideWins(seed)
+  if (s1 < target && s2 < target) return false
+  const ordered = scored.slice().sort((a, b) => a.game_number - b.game_number)
+  let wins1 = 0
+  let wins2 = 0
+  let decidedAt: number | null = null
+  for (const g of ordered) {
+    if (g.score!.side_1_points > g.score!.side_2_points) wins1 += 1
+    else wins2 += 1
+    if (decidedAt === null && (wins1 >= target || wins2 >= target)) {
+      decidedAt = g.game_number
+    }
   }
-  seed.status = s1 > 0 || s2 > 0 ? 'in_progress' : 'pending'
-  const trailing = seed.games.find((g) => g.score === null)
-  if (!trailing) {
-    const next = seed.games.reduce((m, g) => Math.max(m, g.game_number), 0) + 1
-    seed.games.push({ id: `g-${seed.id}-${next}`, game_number: next, score: null })
-  }
+  return decidedAt === ordered[ordered.length - 1].game_number
 }
 
 function projectMatchDetails(seed: Seed) {
@@ -90,11 +109,17 @@ function projectMatchDetails(seed: Seed) {
           }
         : null,
     }))
-  const current = seed.games.find((g) => g.score === null) ?? null
+  const nextNumber = currentGameNumber(seed)
   return {
     id: seed.id,
     status: seed.status,
-    status_label: { in_progress: 'Live', pending: 'Scheduled', completed: 'Final', disputed: 'Disputed', voided: 'Voided' }[seed.status],
+    status_label: {
+      in_progress: 'Live',
+      pending: 'Scheduled',
+      completed: 'Final',
+      disputed: 'Disputed',
+      voided: 'Voided',
+    }[seed.status],
     best_of: seed.best_of,
     games_to_win: gamesToWin(seed.best_of),
     team_size: 1,
@@ -125,10 +150,9 @@ function projectMatchDetails(seed: Seed) {
       },
     ],
     games,
-    current_game: current
-      ? { id: current.id, game_number: current.game_number }
-      : null,
-    can_score: current !== null,
+    current_game: nextNumber !== null ? { game_number: nextNumber } : null,
+    can_score: nextNumber !== null,
+    can_finalize: canFinalizeSeed(seed),
   }
 }
 
@@ -167,42 +191,92 @@ async function installApiMocks(page: Page, seed: Seed): Promise<void> {
   await page.route(`**/api/v1/matches/${seed.id}`, (route) =>
     route.fulfill(json(projectMatchDetails(seed))),
   )
+
+  // Per-game scratchpad endpoints (create/update/delete), addressed by game
+  // number. No status / side-wins side effects — only the scratchpad rows
+  // change.
   await page.route(
     new RegExp(
-      `/api/v1/matches/${seed.id}/games/[^/]+/scores(/[^/]+)?$`,
+      `/api/v1/matches/${seed.id}/games/(\\d+)/scores(?:/new)?$`,
     ),
     async (route) => {
+      const method = route.request().method()
       const url = new URL(route.request().url())
       const parts = url.pathname.split('/')
-      // .../matches/{id}/games/{gameId}/scores[/{scoreId}]
       const gamesIdx = parts.indexOf('games')
-      const gameId = parts[gamesIdx + 1]
-      const scoreId =
-        parts[gamesIdx + 3] === 'scores' && parts[gamesIdx + 4]
-          ? parts[gamesIdx + 4]
-          : null
+      const gameNumber = Number(parts[gamesIdx + 1])
+      const isCreate = parts[parts.length - 1] === 'new'
+
+      const upsertGame = () => {
+        let game = seed.games.find((g) => g.game_number === gameNumber)
+        if (!game) {
+          game = {
+            id: `g-${seed.id}-${gameNumber}`,
+            game_number: gameNumber,
+            score: null,
+          }
+          seed.games.push(game)
+        }
+        return game
+      }
+
+      if (method === 'DELETE') {
+        const game = seed.games.find((g) => g.game_number === gameNumber)
+        if (!game || game.score === null) {
+          return route.fulfill(json({ detail: 'Score not found.' }, 404))
+        }
+        game.score = null
+        return route.fulfill(json(projectMatchDetails(seed)))
+      }
+
       const body = JSON.parse(route.request().postData() ?? '{}') as {
         side_1_points: number
         side_2_points: number
       }
-      const game = seed.games.find((g) => g.id === gameId)
-      if (!game) {
-        return route.fulfill(json({ detail: 'Game not found.' }, 404))
+
+      if (method === 'POST' && isCreate) {
+        if (gameNumber > seed.best_of) {
+          return route.fulfill(
+            json(
+              {
+                detail: `This match is best of ${seed.best_of}; game ${gameNumber} can't exist.`,
+              },
+              422,
+            ),
+          )
+        }
+        const game = upsertGame()
+        if (game.score !== null) {
+          return route.fulfill(
+            json({ detail: 'This game has already been scored.' }, 409),
+          )
+        }
+        const message = validateScore(body.side_1_points, body.side_2_points)
+        if (message) return route.fulfill(json({ detail: message }, 422))
+        game.score = {
+          id: `s-${seed.id}-${gameNumber}`,
+          side_1_points: body.side_1_points,
+          side_2_points: body.side_2_points,
+        }
+        return route.fulfill(json(projectMatchDetails(seed), 201))
       }
-      if (scoreId === null && game.score !== null) {
-        return route.fulfill(
-          json({ detail: 'This game has already been scored.' }, 409),
-        )
+
+      if (method === 'PUT') {
+        const game = seed.games.find((g) => g.game_number === gameNumber)
+        if (!game || game.score === null) {
+          return route.fulfill(json({ detail: 'Score not found.' }, 404))
+        }
+        const message = validateScore(body.side_1_points, body.side_2_points)
+        if (message) return route.fulfill(json({ detail: message }, 422))
+        game.score = {
+          id: game.score.id,
+          side_1_points: body.side_1_points,
+          side_2_points: body.side_2_points,
+        }
+        return route.fulfill(json(projectMatchDetails(seed)))
       }
-      const message = validateScore(body.side_1_points, body.side_2_points)
-      if (message) return route.fulfill(json({ detail: message }, 422))
-      game.score = {
-        id: scoreId ?? `s-${seed.id}-${game.game_number}`,
-        side_1_points: body.side_1_points,
-        side_2_points: body.side_2_points,
-      }
-      reconcile(seed)
-      return route.fulfill(json(projectMatchDetails(seed)))
+
+      return route.fulfill(json({ detail: 'Method not allowed.' }, 405))
     },
   )
 }
@@ -241,12 +315,9 @@ test.describe('Score entry', () => {
     await scoreEntry.enterScores('11', '7')
     await scoreEntry.saveButton.click()
 
-    // The reconcile step appends a new trailing game whose id is derived
-    // from `${seed.id}-${gameNumber}` — same scheme the API/MSW use.
+    // After saving game 3, the next un-scored slot is game 4 (best-of-5).
     await expect(page).toHaveURL(
-      new RegExp(
-        `/matches/${SEED.matchId}/games/g-${SEED.matchId}-4/scores/new$`,
-      ),
+      new RegExp(`/matches/${SEED.matchId}/games/4/scores/new$`),
     )
     await expect(scoreEntry.heading).toHaveText('Enter game 4 score.')
   })
@@ -271,9 +342,7 @@ test.describe('Score entry', () => {
     await scoreEntry.cell(1).click()
 
     await expect(page).toHaveURL(
-      new RegExp(
-        `/matches/${SEED.matchId}/games/${SEED.game1Id}/scores/${SEED.score1Id}/edit$`,
-      ),
+      new RegExp(`/matches/${SEED.matchId}/games/1/scores/edit$`),
     )
     await expect(scoreEntry.heading).toHaveText('Edit game 1 score.')
     await expect(scoreEntry.meInput).toHaveValue('11')

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -14,6 +14,8 @@ export type MatchDetails = components['schemas']['MatchDetails']
 export type MatchListResponse = components['schemas']['MatchListResponse']
 export type MatchListRow = components['schemas']['MatchListRow']
 export type MatchGameScoreWrite = components['schemas']['MatchGameScoreWrite']
+export type MatchResultsWrite = components['schemas']['MatchResultsWrite']
+export type MatchResultsGameWrite = components['schemas']['MatchResultsGameWrite']
 export type MatchStatus = components['schemas']['MatchStatus']
 
 export type MatchListParams = {
@@ -180,52 +182,97 @@ function applyScoreMutationCache(
 }
 
 /**
- * Writes the first score for a game. The scoring route surfaces errors
- * inline, so `throwOnError` is intentionally omitted — callers branch on
- * `mutation.error`.
+ * Writes the first score for a game (lazily inserting the MatchGame row).
+ * Fire-and-forget: per-game writes are scratchpad-only — the canonical commit
+ * lives in `POST .../results`, which obliterates and replaces the saved
+ * scores. So we don't surface errors on these mutations.
  */
-export function useCreateScore(matchId: string, gameId: string) {
+export function useCreateScore(matchId: string, gameNumber: number) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (input: MatchGameScoreWrite): Promise<MatchDetails> =>
       unwrap(
         'submit score',
-        await api.POST('/v1/matches/{match_id}/games/{game_id}/scores', {
-          params: { path: { match_id: matchId, game_id: gameId } },
-          body: input,
-        }),
+        await api.POST(
+          '/v1/matches/{match_id}/games/{game_number}/scores/new',
+          {
+            params: {
+              path: { match_id: matchId, game_number: gameNumber },
+            },
+            body: input,
+          },
+        ),
       ),
     onSuccess: (data) => applyScoreMutationCache(queryClient, matchId, data),
   })
 }
 
 /**
- * Edits an existing score. Same cache work and same no-throw posture as
- * `useCreateScore` — the edit route handles errors inline.
+ * Edits the saved score for a game. Same scratchpad-write posture as
+ * `useCreateScore`.
  */
-export function useUpdateScore(
-  matchId: string,
-  gameId: string,
-  scoreId: string,
-) {
+export function useUpdateScore(matchId: string, gameNumber: number) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (input: MatchGameScoreWrite): Promise<MatchDetails> =>
       unwrap(
         'update score',
         await api.PUT(
-          '/v1/matches/{match_id}/games/{game_id}/scores/{score_id}',
+          '/v1/matches/{match_id}/games/{game_number}/scores',
           {
             params: {
-              path: {
-                match_id: matchId,
-                game_id: gameId,
-                score_id: scoreId,
-              },
+              path: { match_id: matchId, game_number: gameNumber },
             },
             body: input,
           },
         ),
+      ),
+    onSuccess: (data) => applyScoreMutationCache(queryClient, matchId, data),
+  })
+}
+
+/**
+ * Clears the saved score for a game. Same scratchpad-write posture — failures
+ * heal at finalize (the canonical /results POST is the source of truth).
+ */
+export function useDeleteScore(matchId: string, gameNumber: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (): Promise<MatchDetails> =>
+      unwrap(
+        'clear score',
+        await api.DELETE(
+          '/v1/matches/{match_id}/games/{game_number}/scores',
+          {
+            params: {
+              path: { match_id: matchId, game_number: gameNumber },
+            },
+          },
+        ),
+      ),
+    onSuccess: (data) => applyScoreMutationCache(queryClient, matchId, data),
+  })
+}
+
+/**
+ * Finalizes the match. The payload is canon — the server obliterates any
+ * scratchpad-saved games + scores, inserts these, validates the match as a
+ * decided whole, and applies the rating update. Unlike the per-game writes,
+ * this one's errors matter: pass `throwOnError`-style handling at the call
+ * site so the user can see what went wrong (most often a 422 if local
+ * validation drifted out of sync, or a 409 if the match is already
+ * finalized).
+ */
+export function useFinalizeMatch(matchId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: MatchResultsWrite): Promise<MatchDetails> =>
+      unwrap(
+        'finalize match',
+        await api.POST('/v1/matches/{match_id}/results', {
+          params: { path: { match_id: matchId } },
+          body: input,
+        }),
       ),
     onSuccess: (data) => applyScoreMutationCache(queryClient, matchId, data),
   })
@@ -241,31 +288,27 @@ export function matchDetailRoute(matchId: string) {
   }
 }
 
-export function scoringNewRoute(matchId: string, gameId: string) {
+export function scoringNewRoute(matchId: string, gameNumber: number) {
   return {
-    to: '/matches/$matchId/games/$gameId/scores/new' as const,
-    params: { matchId, gameId },
+    to: '/matches/$matchId/games/$gameNumber/scores/new' as const,
+    params: { matchId, gameNumber: String(gameNumber) },
   }
 }
 
-export function scoringEditRoute(
-  matchId: string,
-  gameId: string,
-  scoreId: string,
-) {
+export function scoringEditRoute(matchId: string, gameNumber: number) {
   return {
-    to: '/matches/$matchId/games/$gameId/scores/$scoreId/edit' as const,
-    params: { matchId, gameId, scoreId },
+    to: '/matches/$matchId/games/$gameNumber/scores/edit' as const,
+    params: { matchId, gameNumber: String(gameNumber) },
   }
 }
 
-/** Where to land after writing a match — score the trailing un-scored game,
- * or fall back to the match details page when the match is decided (per the
- * invariant `current_game !== null iff status !== completed`). */
+/** Where to land after writing a per-game score — the next un-scored slot, or
+ * the match detail page when there's no next game (match finalized, or every
+ * game has a saved score). */
 export function nextScoringDestination(
   match: Pick<MatchDetails, 'id' | 'current_game'>,
 ) {
   return match.current_game
-    ? scoringNewRoute(match.id, match.current_game.id)
+    ? scoringNewRoute(match.id, match.current_game.game_number)
     : matchDetailRoute(match.id)
 }

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -354,7 +354,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/matches/{match_id}/games/{game_id}/scores": {
+    "/v1/matches/{match_id}/games/{game_number}/scores/new": {
         parameters: {
             query?: never;
             header?: never;
@@ -364,14 +364,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** Create Game Score */
-        post: operations["create_game_score_v1_matches__match_id__games__game_id__scores_post"];
+        post: operations["create_game_score_v1_matches__match_id__games__game_number__scores_new_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/matches/{match_id}/games/{game_id}/scores/{score_id}": {
+    "/v1/matches/{match_id}/games/{game_number}/scores": {
         parameters: {
             query?: never;
             header?: never;
@@ -380,8 +380,32 @@ export interface paths {
         };
         get?: never;
         /** Update Game Score */
-        put: operations["update_game_score_v1_matches__match_id__games__game_id__scores__score_id__put"];
+        put: operations["update_game_score_v1_matches__match_id__games__game_number__scores_put"];
         post?: never;
+        /** Delete Game Score */
+        delete: operations["delete_game_score_v1_matches__match_id__games__game_number__scores_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/matches/{match_id}/results": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Finalize Match
+         * @description Take the request body as canon. Any previously-saved per-game scores
+         *     on this match are discarded; the payload's games (validated as a complete,
+         *     decided match) become the match's games + scores. Then we mark completed
+         *     and apply the rating update — exactly once.
+         */
+        post: operations["finalize_match_v1_matches__match_id__results_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -691,11 +715,8 @@ export interface components {
             match_id: string;
             /** Opponent Username */
             opponent_username: string | null;
-            /**
-             * Current Game Id
-             * Format: uuid
-             */
-            current_game_id: string;
+            /** Current Game Number */
+            current_game_number: number;
         };
         /** DashboardStreak */
         DashboardStreak: {
@@ -790,17 +811,14 @@ export interface components {
             current_game: components["schemas"]["MatchDetailsCurrentGame"] | null;
             /** Can Score */
             can_score: boolean;
+            /** Can Finalize */
+            can_finalize: boolean;
             /** Recent Form */
             recent_form?: components["schemas"]["MatchDetailsPlayerForm"][];
             head_to_head?: components["schemas"]["MatchDetailsH2H"] | null;
         };
         /** MatchDetailsCurrentGame */
         MatchDetailsCurrentGame: {
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
             /** Game Number */
             game_number: number;
         };
@@ -1005,10 +1023,34 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
-            /** Current Game Id */
-            current_game_id: string | null;
+            /** Current Game Number */
+            current_game_number: number | null;
             /** Can Score */
             can_score: boolean;
+        };
+        /**
+         * MatchResultsGameWrite
+         * @description One game inside a finalize-the-match payload. Per-game point legality
+         *     is checked here; cross-game checks (contiguous numbering, decided result,
+         *     no scores past the decider) live in the handler against the full list.
+         */
+        MatchResultsGameWrite: {
+            /** Game Number */
+            game_number: number;
+            /** Side 1 Points */
+            side_1_points: number;
+            /** Side 2 Points */
+            side_2_points: number;
+        };
+        /**
+         * MatchResultsWrite
+         * @description Request body for ``POST /v1/matches/{match_id}/results``. The list is
+         *     canon: the handler deletes every existing game + score on the match and
+         *     re-inserts these rows. No merge.
+         */
+        MatchResultsWrite: {
+            /** Games */
+            games: components["schemas"]["MatchResultsGameWrite"][];
         };
         /**
          * MatchStatus
@@ -2276,13 +2318,13 @@ export interface operations {
             };
         };
     };
-    create_game_score_v1_matches__match_id__games__game_id__scores_post: {
+    create_game_score_v1_matches__match_id__games__game_number__scores_new_post: {
         parameters: {
             query?: never;
             header?: never;
             path: {
                 match_id: string;
-                game_id: string;
+                game_number: number;
             };
             cookie?: {
                 session?: string | null;
@@ -2314,14 +2356,13 @@ export interface operations {
             };
         };
     };
-    update_game_score_v1_matches__match_id__games__game_id__scores__score_id__put: {
+    update_game_score_v1_matches__match_id__games__game_number__scores_put: {
         parameters: {
             query?: never;
             header?: never;
             path: {
                 match_id: string;
-                game_id: string;
-                score_id: string;
+                game_number: number;
             };
             cookie?: {
                 session?: string | null;
@@ -2335,6 +2376,77 @@ export interface operations {
         responses: {
             /** @description Successful Response */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchDetails"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_game_score_v1_matches__match_id__games__game_number__scores_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                match_id: string;
+                game_number: number;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchDetails"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    finalize_match_v1_matches__match_id__results_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                match_id: string;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MatchResultsWrite"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -75,7 +75,7 @@ describe('DashboardPage', () => {
             score_banners: [
               dashboardScoreBanner({
                 match_id: 'm-banner',
-                current_game_id: 'g-banner-1',
+                current_game_number: 1,
                 opponent_username: 'nguyen.t',
               }),
             ],
@@ -226,7 +226,7 @@ describe('DashboardPage', () => {
             score_banners: [
               dashboardScoreBanner({
                 match_id: 'm-banner',
-                current_game_id: 'g-banner-1',
+                current_game_number: 1,
                 opponent_username: 'nguyen.t',
               }),
             ],
@@ -239,7 +239,7 @@ describe('DashboardPage', () => {
     const link = await screen.findByRole('link', { name: /enter final score/i })
     expect(link).toHaveAttribute(
       'href',
-      '/matches/m-banner/games/g-banner-1/scores/new',
+      '/matches/m-banner/games/1/scores/new',
     )
   })
 
@@ -251,12 +251,12 @@ describe('DashboardPage', () => {
             score_banners: [
               dashboardScoreBanner({
                 match_id: 'm-primary',
-                current_game_id: 'g-primary',
+                current_game_number: 1,
                 opponent_username: 'nguyen.t',
               }),
               dashboardScoreBanner({
                 match_id: 'm-secondary',
-                current_game_id: 'g-secondary',
+                current_game_number: 1,
                 opponent_username: 'holm.s',
               }),
             ],
@@ -274,7 +274,7 @@ describe('DashboardPage', () => {
     expect(compact).toHaveTextContent(/also pending/i)
     expect(within(compact).getByRole('link', { name: /enter score/i })).toHaveAttribute(
       'href',
-      '/matches/m-secondary/games/g-secondary/scores/new',
+      '/matches/m-secondary/games/1/scores/new',
     )
     expect(
       screen.queryByTestId('dashboard-score-banner-more'),

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -448,7 +448,10 @@ function ScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
   const accent = C.ball500
   const opponent = banner.opponent_username
   const headline = opponent ? `vs ${opponent}` : NO_OPPONENT_LABEL
-  const scoringRoute = scoringNewRoute(banner.match_id, banner.current_game_id)
+  const scoringRoute = scoringNewRoute(
+    banner.match_id,
+    banner.current_game_number,
+  )
   return (
     <div
       data-testid="dashboard-score-banner"
@@ -594,7 +597,10 @@ function ScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
 function CompactScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
   const opponent = banner.opponent_username
   const headline = opponent ? `vs ${opponent}` : NO_OPPONENT_LABEL
-  const scoringRoute = scoringNewRoute(banner.match_id, banner.current_game_id)
+  const scoringRoute = scoringNewRoute(
+    banner.match_id,
+    banner.current_game_number,
+  )
   return (
     <div
       data-testid="dashboard-score-banner-compact"

--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -31,12 +31,12 @@ function renderDetails(matchId: string) {
   // <Link>s in the page resolve at render time.
   const scoringNew = createRoute({
     getParentRoute: () => rootRoute,
-    path: '/matches/$matchId/games/$gameId/scores/new',
+    path: '/matches/$matchId/games/$gameNumber/scores/new',
     component: () => <div>scoring-new</div>,
   })
   const scoringEdit = createRoute({
     getParentRoute: () => rootRoute,
-    path: '/matches/$matchId/games/$gameId/scores/$scoreId/edit',
+    path: '/matches/$matchId/games/$gameNumber/scores/edit',
     component: () => <div>scoring-edit</div>,
   })
   const matchesList = createRoute({
@@ -125,7 +125,7 @@ describe('MatchDetailsView', () => {
       status: 'pending',
       status_label: 'Scheduled',
       games: [game1],
-      current_game: { id: 'g-1', game_number: 1 },
+      current_game: { game_number: 1 },
       can_score: true,
     })
     server.use(
@@ -137,7 +137,7 @@ describe('MatchDetailsView', () => {
     const scoreLink = await screen.findByRole('link', { name: 'Score' })
     expect(scoreLink).toHaveAttribute(
       'href',
-      '/matches/m-2/games/g-1/scores/new',
+      '/matches/m-2/games/1/scores/new',
     )
   })
 
@@ -164,7 +164,7 @@ describe('MatchDetailsView', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('links each scored game cell on my row to its scores/$scoreId/edit route', async () => {
+  it('links each scored game cell on my row to its scores/edit route', async () => {
     const match = matchDetails({
       id: 'm-4',
       status: 'in_progress',
@@ -204,7 +204,7 @@ describe('MatchDetailsView', () => {
         },
         { id: 'g-2', game_number: 2, score: null },
       ],
-      current_game: { id: 'g-2', game_number: 2 },
+      current_game: { game_number: 2 },
       can_score: true,
     })
     server.use(
@@ -214,11 +214,11 @@ describe('MatchDetailsView', () => {
     renderDetails('m-4')
 
     await screen.findByRole('link', { name: 'Score' })
-    // The first-game cell on my row is a link to the edit route for s-1.
+    // The first-game cell on my row is a link to the edit route for game 1.
     const editLink = screen.getByRole('link', { name: '11' })
     expect(editLink).toHaveAttribute(
       'href',
-      '/matches/m-4/games/g-1/scores/s-1/edit',
+      '/matches/m-4/games/1/scores/edit',
     )
   })
 
@@ -284,7 +284,7 @@ describe('MatchDetailsView', () => {
         },
       ],
       games: [game1],
-      current_game: { id: game1.id, game_number: 1 },
+      current_game: { game_number: 1 },
       can_score: true,
     })
     server.use(
@@ -314,7 +314,7 @@ describe('MatchDetailsView', () => {
     // A no-opponent match is now scorable: the Score CTA is present.
     expect(
       await screen.findByRole('link', { name: 'Score' }),
-    ).toHaveAttribute('href', '/matches/m-solo/games/g-solo-1/scores/new')
+    ).toHaveAttribute('href', '/matches/m-solo/games/1/scores/new')
     // Did not bounce to the list.
     expect(screen.queryByText('matches-list')).not.toBeInTheDocument()
   })
@@ -357,7 +357,7 @@ describe('MatchDetailsView', () => {
         },
         { id: 'g-2', game_number: 2, score: null },
       ],
-      current_game: { id: 'g-2', game_number: 2 },
+      current_game: { game_number: 2 },
       // BFF returns false for non-participants regardless of game state.
       can_score: false,
     })

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -109,7 +109,7 @@ type MatchView = {
   games: GameView[]
   currentGameNumber: number | null
   canScore: boolean
-  scoreCta: { matchId: string; gameId: string } | null
+  scoreCta: { matchId: string; gameNumber: number } | null
   headToHead: H2HView | null
 }
 
@@ -242,7 +242,7 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
     .map((g) => projectGame(g, leftView.sideNumber))
   const scoreCta =
     data.can_score && data.current_game
-      ? { matchId, gameId: data.current_game.id }
+      ? { matchId, gameNumber: data.current_game.game_number }
       : null
   return {
     state,
@@ -379,7 +379,10 @@ function MatchDetailsPage({
           <div className="md-header__right">
             {view.scoreCta && (
               <Link
-                {...scoringNewRoute(view.scoreCta.matchId, view.scoreCta.gameId)}
+                {...scoringNewRoute(
+                  view.scoreCta.matchId,
+                  view.scoreCta.gameNumber,
+                )}
                 className="md-btn md-btn--primary md-btn--sm"
               >
                 Score
@@ -728,9 +731,7 @@ function GameGridSide({
         const value =
           rowSide === 'left' ? g.score.leftPoints : g.score.rightPoints
         const editTo =
-          canEdit && g.scoreId
-            ? scoringEditRoute(matchId, g.id, g.scoreId)
-            : null
+          canEdit && g.scoreId ? scoringEditRoute(matchId, g.gameNumber) : null
         const className = cn(
           'md-games__cell',
           cellWin ? 'md-games__cell--win' : 'md-games__cell--loss',

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -12,7 +12,6 @@ import { http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 import { server } from '@/mocks/server'
 import { matchDetails } from '@/test/factories'
-import { useCreateScore, useUpdateScore } from '@/api/matches'
 import type { components } from '@/api/schema'
 import { ScoreEntry } from './score-entry'
 
@@ -67,8 +66,8 @@ function score(
 }
 
 type RouteSpec =
-  | { kind: 'create'; matchId: string; gameId: string }
-  | { kind: 'edit'; matchId: string; gameId: string; scoreId: string }
+  | { kind: 'create'; matchId: string; gameNumber: number }
+  | { kind: 'edit'; matchId: string; gameNumber: number }
 
 function renderScoreEntry(spec: RouteSpec, options: { path?: string } = {}) {
   const queryClient = new QueryClient({
@@ -79,48 +78,35 @@ function renderScoreEntry(spec: RouteSpec, options: { path?: string } = {}) {
     getParentRoute: () => rootRoute,
     path: '/entry',
     component: function Entry() {
-      // Mount the mutation hook inside the route component so it lives in the
-      // same QueryClient as the cached match data.
-      if (spec.kind === 'create') {
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const mutation = useCreateScore(spec.matchId, spec.gameId)
-        return (
-          <ScoreEntry
-            matchId={spec.matchId}
-            gameId={spec.gameId}
-            mode={{ kind: 'create' }}
-            mutation={mutation}
-          />
-        )
-      }
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const mutation = useUpdateScore(spec.matchId, spec.gameId, spec.scoreId)
       return (
         <ScoreEntry
           matchId={spec.matchId}
-          gameId={spec.gameId}
-          mode={{ kind: 'edit', scoreId: spec.scoreId }}
-          mutation={mutation}
+          gameNumber={spec.gameNumber}
+          mode={{ kind: spec.kind }}
         />
       )
     },
   })
   const scoringNew = createRoute({
     getParentRoute: () => rootRoute,
-    path: '/matches/$matchId/games/$gameId/scores/new',
+    path: '/matches/$matchId/games/$gameNumber/scores/new',
     component: function Stub() {
       const params = scoringNew.useParams()
-      return <div>scoring-new {params.matchId} {params.gameId}</div>
+      return (
+        <div>
+          scoring-new {params.matchId} {params.gameNumber}
+        </div>
+      )
     },
   })
   const scoringEdit = createRoute({
     getParentRoute: () => rootRoute,
-    path: '/matches/$matchId/games/$gameId/scores/$scoreId/edit',
+    path: '/matches/$matchId/games/$gameNumber/scores/edit',
     component: function Stub() {
       const params = scoringEdit.useParams()
       return (
         <div>
-          scoring-edit {params.matchId} {params.gameId} {params.scoreId}
+          scoring-edit {params.matchId} {params.gameNumber}
         </div>
       )
     },
@@ -129,9 +115,8 @@ function renderScoreEntry(spec: RouteSpec, options: { path?: string } = {}) {
     getParentRoute: () => rootRoute,
     path: '/matches/$matchId',
     component: function Stub() {
-      // Hard-code the rendered match id — the route's inferred params type
-      // narrows to `never` once sibling routes share the `$matchId` prefix,
-      // and the test only needs the literal id to assert on.
+      // Hard-code the rendered match id — sibling routes' `$matchId` prefix
+      // narrows params to `never`, and the test only needs the literal id.
       return <div>match-page {spec.matchId}</div>
     },
   })
@@ -152,7 +137,7 @@ function renderScoreEntry(spec: RouteSpec, options: { path?: string } = {}) {
 }
 
 function inProgressMatch(overrides: Parameters<typeof matchDetails>[0] = {}) {
-  // 3 games: 1-2 scored, 3 current.
+  // Best-of-5, 1-1 on the board, game 3 next up.
   return matchDetails({
     id: 'm-1',
     status: 'in_progress',
@@ -164,104 +149,64 @@ function inProgressMatch(overrides: Parameters<typeof matchDetails>[0] = {}) {
     games: [
       { id: 'g-1', game_number: 1, score: score('s-1', 11, 8) },
       { id: 'g-2', game_number: 2, score: score('s-2', 9, 11) },
-      { id: 'g-3', game_number: 3, score: null },
     ],
-    current_game: { id: 'g-3', game_number: 3 },
+    current_game: { game_number: 3 },
     can_score: true,
+    can_finalize: false,
     ...overrides,
   })
 }
 
 describe('ScoreEntry — create', () => {
-  it('POSTs the score and navigates to the new current_game on success', async () => {
+  it('POSTs the score (fire-and-forget) and lands on the next un-scored game', async () => {
     const user = userEvent.setup()
     let captured: unknown = null
     server.use(
       http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
       http.post(
-        '*/v1/matches/m-1/games/g-3/scores',
+        '*/v1/matches/m-1/games/3/scores/new',
         async ({ request }) => {
           captured = await request.json()
-          // After scoring game 3, an unscored game 4 is reconciled in.
-          const next = inProgressMatch({
-            sides: participantSides({ meWins: 2, oppWins: 1 }),
-            games: [
-              { id: 'g-1', game_number: 1, score: score('s-1', 11, 8) },
-              { id: 'g-2', game_number: 2, score: score('s-2', 9, 11) },
-              { id: 'g-3', game_number: 3, score: score('s-3', 11, 4) },
-              { id: 'g-4', game_number: 4, score: null },
-            ],
-            current_game: { id: 'g-4', game_number: 4 },
-          })
-          return HttpResponse.json(next)
+          return HttpResponse.json(
+            inProgressMatch({
+              sides: participantSides({ meWins: 2, oppWins: 1 }),
+              games: [
+                { id: 'g-1', game_number: 1, score: score('s-1', 11, 8) },
+                { id: 'g-2', game_number: 2, score: score('s-2', 9, 11) },
+                { id: 'g-3', game_number: 3, score: score('s-3', 11, 4) },
+              ],
+              current_game: { game_number: 4 },
+            }),
+          )
         },
       ),
     )
 
-    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameId: 'g-3' })
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
 
     await screen.findByRole('heading', { name: /enter game 3 score/i })
-    await user.type(screen.getByRole('textbox', { name: 'rita.kovac score' }), '11')
-    await user.type(screen.getByRole('textbox', { name: 'nguyen.t score' }), '4')
-    await user.click(screen.getByRole('button', { name: /save/i }))
+    await user.type(
+      screen.getByRole('textbox', { name: 'rita.kovac score' }),
+      '11',
+    )
+    await user.type(
+      screen.getByRole('textbox', { name: 'nguyen.t score' }),
+      '4',
+    )
+    await user.click(screen.getByRole('button', { name: /save game & next/i }))
 
     await waitFor(() =>
-      expect(
-        screen.getByText('scoring-new m-1 g-4'),
-      ).toBeInTheDocument(),
+      expect(screen.getByText('scoring-new m-1 4')).toBeInTheDocument(),
     )
     expect(captured).toEqual({ side_1_points: 11, side_2_points: 4 })
   })
 
-  it('navigates to the match page when the deciding game closes out the match', async () => {
+  it('flips the submit button to "Finalize match" when this score would decide the match', async () => {
+    // Bo5, 2-0 on the board, entering G3. An 11-3 win clinches at 3-0, so
+    // the single submit button should POST /results (atomically saving +
+    // finalizing) instead of /scores/new.
     const user = userEvent.setup()
-    server.use(
-      http.get('*/v1/matches/m-1', () =>
-        HttpResponse.json(
-          inProgressMatch({
-            // Already 2-1 leading; this game decides it.
-            sides: participantSides({ meWins: 2, oppWins: 1 }),
-            games: [
-              { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
-              { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
-              { id: 'g-3', game_number: 3, score: score('s-3', 5, 11) },
-              { id: 'g-4', game_number: 4, score: null },
-            ],
-            current_game: { id: 'g-4', game_number: 4 },
-          }),
-        ),
-      ),
-      http.post('*/v1/matches/m-1/games/g-4/scores', () => {
-        const done = inProgressMatch({
-          status: 'completed',
-          status_label: 'Final',
-          sides: participantSides({ meWins: 3, oppWins: 1, meWon: true }),
-          games: [
-            { id: 'g-4', game_number: 4, score: score('s-4', 11, 7) },
-          ],
-          current_game: null,
-          can_score: false,
-        })
-        return HttpResponse.json(done)
-      }),
-    )
-
-    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameId: 'g-4' })
-
-    await screen.findByRole('heading', { name: /enter game 4 score/i })
-    await user.type(screen.getByRole('textbox', { name: 'rita.kovac score' }), '11')
-    await user.type(screen.getByRole('textbox', { name: 'nguyen.t score' }), '7')
-    await user.click(screen.getByRole('button', { name: /save/i }))
-
-    await waitFor(() =>
-      expect(screen.getByText('match-page m-1')).toBeInTheDocument(),
-    )
-  })
-
-  it('flips Save copy to "finish the match" when the typed score would clinch early', async () => {
-    // Bo5, 2-0 on the board, entering G3. A 11-3 win here clinches at 3-0,
-    // so the messaging must not promise a non-existent G4. (Bug #12.)
-    const user = userEvent.setup()
+    let finalizedBody: unknown = null
     server.use(
       http.get('*/v1/matches/m-1', () =>
         HttpResponse.json(
@@ -270,48 +215,69 @@ describe('ScoreEntry — create', () => {
             games: [
               { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
               { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
-              { id: 'g-3', game_number: 3, score: null },
             ],
-            current_game: { id: 'g-3', game_number: 3 },
+            current_game: { game_number: 3 },
           }),
         ),
       ),
+      http.post('*/v1/matches/m-1/results', async ({ request }) => {
+        finalizedBody = await request.json()
+        return HttpResponse.json(
+          matchDetails({
+            id: 'm-1',
+            status: 'completed',
+            status_label: 'Final',
+            best_of: 5,
+            games_to_win: 3,
+            sides: participantSides({ meWins: 3, oppWins: 0, meWon: true }),
+            games: [
+              { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
+              { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
+              { id: 'g-3', game_number: 3, score: score('s-3', 11, 3) },
+            ],
+            current_game: null,
+            can_score: false,
+            can_finalize: false,
+          }),
+          { status: 201 },
+        )
+      }),
     )
 
-    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameId: 'g-3' })
-    const meInput = await screen.findByRole('textbox', { name: 'rita.kovac score' })
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
     const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
 
-    // Pre-typing the message is still the generic "continue to game 4" hint.
+    // Pre-typing the button is the generic save-and-continue label.
     expect(
-      screen.getByText(/save this game to continue to game 4/i),
+      screen.getByRole('button', { name: /save game & next/i }),
     ).toBeInTheDocument()
 
     await user.type(meInput, '11')
     await user.type(oppInput, '3')
 
+    // The same button morphs into "Finalize match" because saving this score
+    // would complete a decided best-of-5.
+    const finalizeBtn = screen.getByRole('button', { name: /finalize match/i })
+    expect(finalizeBtn).toBeInTheDocument()
     expect(
-      screen.getByText(/save to finish the match/i),
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByText(/continue to game 4/i),
+      screen.queryByRole('button', { name: /save game & next/i }),
     ).not.toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: /save & finish match/i }),
-    ).toBeInTheDocument()
 
-    // A non-clinching score (opponent wins G3, taking the match to 2-1)
-    // restores the "continue to game 4" hint.
-    await user.clear(meInput)
-    await user.type(meInput, '5')
-    await user.clear(oppInput)
-    await user.type(oppInput, '11')
-    expect(
-      screen.getByText(/save this game to continue to game 4/i),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: /save game & next/i }),
-    ).toBeInTheDocument()
+    await user.click(finalizeBtn)
+
+    await waitFor(() =>
+      expect(screen.getByText('match-page m-1')).toBeInTheDocument(),
+    )
+    expect(finalizedBody).toEqual({
+      games: [
+        { game_number: 1, side_1_points: 11, side_2_points: 4 },
+        { game_number: 2, side_1_points: 11, side_2_points: 6 },
+        { game_number: 3, side_1_points: 11, side_2_points: 3 },
+      ],
+    })
   })
 
   it('blocks an illegal final score client-side without hitting the server', async () => {
@@ -319,26 +285,20 @@ describe('ScoreEntry — create', () => {
     let posted = 0
     server.use(
       http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
-      http.post('*/v1/matches/m-1/games/g-3/scores', () => {
+      http.post('*/v1/matches/m-1/games/3/scores/new', () => {
         posted += 1
-        return HttpResponse.json(
-          inProgressMatch({
-            games: [
-              { id: 'g-3', game_number: 3, score: score('s-3', 11, 9) },
-              { id: 'g-4', game_number: 4, score: null },
-            ],
-            current_game: { id: 'g-4', game_number: 4 },
-          }),
-        )
+        return HttpResponse.json(inProgressMatch(), { status: 201 })
       }),
     )
 
-    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameId: 'g-3' })
-    const meInput = await screen.findByRole('textbox', { name: 'rita.kovac score' })
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
     const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
 
-    // 11–10 is illegal (win-by-1). The button stays disabled and an inline
-    // hint explains why — no request is made.
+    // 11–10 is illegal (win-by-1). The submit button stays disabled and an
+    // inline hint explains why — no request is made.
     await user.type(meInput, '11')
     await user.type(oppInput, '10')
     const save = screen.getByRole('button', { name: /save/i })
@@ -352,196 +312,31 @@ describe('ScoreEntry — create', () => {
     await user.type(oppInput, '9')
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     expect(save).toBeEnabled()
-
-    await user.click(save)
-    await waitFor(() =>
-      expect(screen.getByText('scoring-new m-1 g-4')).toBeInTheDocument(),
-    )
-    expect(posted).toBe(1)
-  })
-
-  it('renders a server 422 detail inline and clears it when the user edits an input', async () => {
-    const user = userEvent.setup()
-    let calls = 0
-    server.use(
-      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
-      http.post('*/v1/matches/m-1/games/g-3/scores', () => {
-        calls += 1
-        if (calls === 1) {
-          // A client-legal score the server still rejects (e.g. for match
-          // state the client doesn't model) — exercises the 422 render path.
-          return HttpResponse.json(
-            { detail: 'This score was rejected by the server.' },
-            { status: 422 },
-          )
-        }
-        return HttpResponse.json(
-          inProgressMatch({
-            games: [
-              { id: 'g-3', game_number: 3, score: score('s-3', 11, 4) },
-              { id: 'g-4', game_number: 4, score: null },
-            ],
-            current_game: { id: 'g-4', game_number: 4 },
-          }),
-        )
-      }),
-    )
-
-    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameId: 'g-3' })
-    const meInput = await screen.findByRole('textbox', { name: 'rita.kovac score' })
-    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
-
-    await user.type(meInput, '11')
-    await user.type(oppInput, '4')
-    await user.click(screen.getByRole('button', { name: /save/i }))
-
-    const alert = await screen.findByRole('alert')
-    expect(alert).toHaveTextContent(/rejected by the server/i)
-    expect(meInput).toHaveAttribute('aria-invalid', 'true')
-    expect(oppInput).toHaveAttribute('aria-invalid', 'true')
-
-    // Editing either input clears the error and re-enables the field.
-    await user.clear(meInput)
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-
-    await user.type(meInput, '11')
-    await user.click(screen.getByRole('button', { name: /save/i }))
-    await waitFor(() =>
-      expect(screen.getByText('scoring-new m-1 g-4')).toBeInTheDocument(),
-    )
-  })
-
-  it('locks the page when a concurrent scorer beat us to it and the server 409s (race)', async () => {
-    // The cache says the game is un-scored, but between our GET and POST
-    // another participant scored it. The cache-first "already scored" case
-    // is caught proactively by the redirect (see the next test); this test
-    // covers the post-submit race where game.score is null in the cache.
-    server.use(
-      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
-      http.post('*/v1/matches/m-1/games/g-3/scores', () =>
-        HttpResponse.json(
-          { detail: 'This game has already been scored.' },
-          { status: 409 },
-        ),
-      ),
-    )
-
-    const user = userEvent.setup()
-    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameId: 'g-3' })
-
-    const meInput = await screen.findByRole('textbox', { name: 'rita.kovac score' })
-    await user.type(meInput, '11')
-    await user.type(screen.getByRole('textbox', { name: 'nguyen.t score' }), '6')
-    await user.click(screen.getByRole('button', { name: /save/i }))
-
-    expect(
-      await screen.findByText(/already been scored/i),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('link', { name: 'Back to match' }),
-    ).toHaveAttribute('href', '/matches/m-1')
+    expect(posted).toBe(0)
   })
 
   it('redirects to the existing score\'s edit page when landing on /scores/new for an already-scored game', async () => {
-    // Simulates the browser-Back-after-save flow: the user advanced to game 3
-    // (scoring g-3), pressed Back to /games/g-1/scores/new, but g-1 already
-    // has a score on the server. Without the redirect the page would render
-    // empty inputs over a tally that already counts the win, and an enabled
-    // Save would either 409 or duplicate.
+    // Browser-Back-after-save flow: the user advanced to game 3, pressed
+    // Back to /games/1/scores/new, but game 1 already has a score. Without
+    // the redirect we'd render empty inputs over a tally that already counts
+    // the win.
     server.use(
       http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
     )
 
-    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameId: 'g-1' })
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 1 })
 
     await waitFor(() =>
-      expect(screen.getByText('scoring-edit m-1 g-1 s-1')).toBeInTheDocument(),
+      expect(screen.getByText('scoring-edit m-1 1')).toBeInTheDocument(),
     )
-    // The /scores/new page must not have rendered its Save button.
     expect(
       screen.queryByRole('button', { name: /save/i }),
     ).not.toBeInTheDocument()
   })
 
-  it('disables the form and shows a back link when the match is no longer scorable (409)', async () => {
-    const user = userEvent.setup()
-    server.use(
-      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
-      http.post('*/v1/matches/m-1/games/g-3/scores', () =>
-        HttpResponse.json(
-          { detail: 'This match is no longer scorable.' },
-          { status: 409 },
-        ),
-      ),
-    )
-
-    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameId: 'g-3' })
-    await user.type(
-      await screen.findByRole('textbox', { name: 'rita.kovac score' }),
-      '11',
-    )
-    await user.type(screen.getByRole('textbox', { name: 'nguyen.t score' }), '6')
-    await user.click(screen.getByRole('button', { name: /save/i }))
-
-    const alert = await screen.findByText(/no longer scorable/i)
-    expect(alert).toBeInTheDocument()
-    expect(screen.getByRole('textbox', { name: 'rita.kovac score' })).toBeDisabled()
-    expect(screen.getByRole('textbox', { name: 'nguyen.t score' })).toBeDisabled()
-    // The primary "Back to match" CTA replaces the save button.
-    expect(
-      screen.getByRole('link', { name: 'Back to match' }),
-    ).toHaveAttribute('href', '/matches/m-1')
-  })
-})
-
-describe('ScoreEntry — edit', () => {
-  it('pre-populates inputs from the stored score and PUTs the new value', async () => {
-    const user = userEvent.setup()
-    let captured: unknown = null
-    server.use(
-      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
-      http.put(
-        '*/v1/matches/m-1/games/g-1/scores/s-1',
-        async ({ request }) => {
-          captured = await request.json()
-          // After editing g-1, the current_game is still g-3 (per invariant).
-          return HttpResponse.json(inProgressMatch())
-        },
-      ),
-    )
-
-    renderScoreEntry({
-      kind: 'edit',
-      matchId: 'm-1',
-      gameId: 'g-1',
-      scoreId: 's-1',
-    })
-
-    const meInput = await screen.findByRole('textbox', {
-      name: 'rita.kovac score',
-    })
-    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
-    await waitFor(() => expect(meInput).toHaveValue('11'))
-    expect(oppInput).toHaveValue('8')
-
-    await user.clear(meInput)
-    await user.type(meInput, '12')
-    await user.clear(oppInput)
-    await user.type(oppInput, '10')
-    await user.click(screen.getByRole('button', { name: /save/i }))
-
-    // After editing a past game, navigate to the current_game's /new — NOT
-    // to "the next-numbered game" (which would be g-2).
-    await waitFor(() =>
-      expect(screen.getByText('scoring-new m-1 g-3')).toBeInTheDocument(),
-    )
-    expect(captured).toEqual({ side_1_points: 12, side_2_points: 10 })
-  })
-
-  it('re-opens a completed match: navigates to the fresh current_game on the response', async () => {
-    const user = userEvent.setup()
-    // Mount in a "completed" match's edit page; the PUT response reflects the
-    // server having reconciled and appended a new trailing game.
+  it('redirects to the match page when the match is already finalized', async () => {
+    // Per-game endpoints 409 on completed matches — the FE bounces the user
+    // back to the read-only detail page instead of rendering scoring UI.
     server.use(
       http.get('*/v1/matches/m-1', () =>
         HttpResponse.json(
@@ -558,52 +353,151 @@ describe('ScoreEntry — edit', () => {
             ],
             current_game: null,
             can_score: false,
-          }),
-        ),
-      ),
-      http.put('*/v1/matches/m-1/games/g-2/scores/s-2', () =>
-        HttpResponse.json(
-          matchDetails({
-            id: 'm-1',
-            status: 'in_progress',
-            status_label: 'Live',
-            best_of: 3,
-            games_to_win: 2,
-            sides: participantSides({ meWins: 1, oppWins: 1 }),
-            games: [
-              { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
-              { id: 'g-2', game_number: 2, score: score('s-2', 9, 11) },
-              { id: 'g-3', game_number: 3, score: null },
-            ],
-            current_game: { id: 'g-3', game_number: 3 },
-            can_score: true,
+            can_finalize: false,
           }),
         ),
       ),
     )
 
-    renderScoreEntry({
-      kind: 'edit',
-      matchId: 'm-1',
-      gameId: 'g-2',
-      scoreId: 's-2',
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+
+    await waitFor(() =>
+      expect(screen.getByText('match-page m-1')).toBeInTheDocument(),
+    )
+    expect(
+      screen.queryByRole('button', { name: /save/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('surfaces a server 422 inline when finalize fails validation', async () => {
+    // Per-game writes are fire-and-forget on errors. Finalize errors *do*
+    // surface inline — typically a 422 if local validation drifted out of
+    // sync with the server's.
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          inProgressMatch({
+            sides: participantSides({ meWins: 2, oppWins: 0 }),
+            games: [
+              { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
+              { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
+            ],
+            current_game: { game_number: 3 },
+          }),
+        ),
+      ),
+      http.post('*/v1/matches/m-1/results', () =>
+        HttpResponse.json(
+          { detail: 'This payload was rejected by the server.' },
+          { status: 422 },
+        ),
+      ),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
     })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+
+    await user.type(meInput, '11')
+    await user.type(oppInput, '3')
+    await user.click(screen.getByRole('button', { name: /finalize match/i }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/rejected by the server/i)
+    expect(meInput).toHaveAttribute('aria-invalid', 'true')
+    expect(oppInput).toHaveAttribute('aria-invalid', 'true')
+
+    // Editing either input clears the error.
+    await user.clear(meInput)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})
+
+describe('ScoreEntry — edit', () => {
+  it('pre-populates inputs from the stored score and PUTs the new value', async () => {
+    const user = userEvent.setup()
+    let captured: unknown = null
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      http.put(
+        '*/v1/matches/m-1/games/1/scores',
+        async ({ request }) => {
+          captured = await request.json()
+          return HttpResponse.json(inProgressMatch())
+        },
+      ),
+    )
+
+    renderScoreEntry({ kind: 'edit', matchId: 'm-1', gameNumber: 1 })
 
     const meInput = await screen.findByRole('textbox', {
       name: 'rita.kovac score',
     })
     const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
     await waitFor(() => expect(meInput).toHaveValue('11'))
-    // Flip game 2 to a legal opponent win (9–11) so the edit re-opens the match.
+    expect(oppInput).toHaveValue('8')
+
     await user.clear(meInput)
-    await user.type(meInput, '9')
+    await user.type(meInput, '12')
     await user.clear(oppInput)
-    await user.type(oppInput, '11')
-    await user.click(screen.getByRole('button', { name: /save/i }))
+    await user.type(oppInput, '10')
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    // After editing a past game, navigate to the next un-scored slot — NOT
+    // to "the next-numbered game" (which would be game 2).
+    await waitFor(() =>
+      expect(screen.getByText('scoring-new m-1 3')).toBeInTheDocument(),
+    )
+    expect(captured).toEqual({ side_1_points: 12, side_2_points: 10 })
+  })
+
+  it('clears the saved score and lands back on the same game in create mode', async () => {
+    const user = userEvent.setup()
+    let deleted = false
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      http.delete('*/v1/matches/m-1/games/1/scores', () => {
+        deleted = true
+        return HttpResponse.json(inProgressMatch())
+      }),
+    )
+
+    renderScoreEntry({ kind: 'edit', matchId: 'm-1', gameNumber: 1 })
+
+    await screen.findByRole('textbox', { name: 'rita.kovac score' })
+    await user.click(screen.getByRole('button', { name: /clear/i }))
 
     await waitFor(() =>
-      expect(screen.getByText('scoring-new m-1 g-3')).toBeInTheDocument(),
+      expect(screen.getByText('scoring-new m-1 1')).toBeInTheDocument(),
+    )
+    expect(deleted).toBe(true)
+  })
+
+  it('redirects edit→new when the game has no saved score', async () => {
+    // Sometimes the user follows an /edit deeplink for a game whose score
+    // was cleared (or never written). The component swaps to /scores/new so
+    // the submit button targets the create endpoint.
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          inProgressMatch({
+            games: [
+              { id: 'g-1', game_number: 1, score: score('s-1', 11, 8) },
+              { id: 'g-2', game_number: 2, score: score('s-2', 9, 11) },
+            ],
+            current_game: { game_number: 3 },
+          }),
+        ),
+      ),
+    )
+
+    renderScoreEntry({ kind: 'edit', matchId: 'm-1', gameNumber: 3 })
+
+    await waitFor(() =>
+      expect(screen.getByText('scoring-new m-1 3')).toBeInTheDocument(),
     )
   })
 })
-

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -1,77 +1,71 @@
 import { useRef, useState } from 'react'
 import { Link, Navigate, useNavigate } from '@tanstack/react-router'
-import type { UseMutationResult } from '@tanstack/react-query'
 import { User as UserIcon } from 'lucide-react'
 import { ApiError } from '@/api/client'
 import {
   matchDetailRoute,
-  nextScoringDestination,
   scoringEditRoute,
+  scoringNewRoute,
+  useCreateScore,
+  useDeleteScore,
+  useFinalizeMatch,
   useMatch,
+  useUpdateScore,
   type MatchDetails,
   type MatchGameScoreWrite,
+  type MatchResultsGameWrite,
 } from '@/api/matches'
 import { AppShell } from '@/components/app-shell'
 import { cn, initialsOf } from '@/lib/utils'
-import { illegalScoreReason } from '@/lib/scoring'
+import { decidedSide, illegalScoreReason } from '@/lib/scoring'
 
-// Mirror the canonical placeholder on the match-details hero and form-history
-// rows. Solo-match scoring used to surface an "OP" avatar via initialsOf('Opponent') —
-// indistinguishable from a real two-letter monogram.
+// Placeholder for the opponent label on solo matches — mirrors the match
+// details hero. Distinct from `initialsOf('Opponent')` so users can tell
+// "no opponent" apart from a real two-letter monogram.
 const NO_OPPONENT_LABEL = 'No opponent'
 
-export type ScoreMutation = UseMutationResult<
-  MatchDetails,
-  Error,
-  MatchGameScoreWrite,
-  unknown
->
-
-export type ScoreEntryMode =
-  | { kind: 'create' }
-  | { kind: 'edit'; scoreId: string }
+export type ScoreEntryMode = { kind: 'create' } | { kind: 'edit' }
 
 export function ScoreEntry({
   matchId,
-  gameId,
+  gameNumber,
   mode,
-  mutation,
 }: {
   matchId: string
-  gameId: string
+  gameNumber: number
   mode: ScoreEntryMode
-  mutation: ScoreMutation
 }) {
-  // Remount whenever the URL targets a different game so the input state and
-  // mutation error don't leak across games.
+  // Remount whenever the URL targets a different game (or flips create/edit)
+  // so the typed-input state and finalize-error state don't leak across games.
   return (
     <ScoreEntryInner
-      key={`${gameId}:${mode.kind === 'edit' ? mode.scoreId : 'new'}`}
+      key={`${gameNumber}:${mode.kind}`}
       matchId={matchId}
-      gameId={gameId}
+      gameNumber={gameNumber}
       mode={mode}
-      mutation={mutation}
     />
   )
 }
 
 function ScoreEntryInner({
   matchId,
-  gameId,
+  gameNumber,
   mode,
-  mutation,
 }: {
   matchId: string
-  gameId: string
+  gameNumber: number
   mode: ScoreEntryMode
-  mutation: ScoreMutation
 }) {
   const navigate = useNavigate()
   const { data, isLoading } = useMatch(matchId)
+  const createMutation = useCreateScore(matchId, gameNumber)
+  const updateMutation = useUpdateScore(matchId, gameNumber)
+  const deleteMutation = useDeleteScore(matchId, gameNumber)
+  const finalizeMutation = useFinalizeMatch(matchId)
 
-  // `null` means "user hasn't typed anything yet" — render falls through to
-  // the persisted score in edit mode. This avoids a state-syncing effect
-  // (cascading-render anti-pattern) when `data` arrives after first render.
+  // `null` means "user hasn't typed anything yet" — we fall through to the
+  // persisted score in edit mode. Avoids a state-syncing effect when `data`
+  // arrives after first render.
   const [meTyped, setMeTyped] = useState<string | null>(null)
   const [oppTyped, setOppTyped] = useState<string | null>(null)
   const meRef = useRef<HTMLInputElement>(null)
@@ -87,33 +81,36 @@ function ScoreEntryInner({
 
   // The scoring screen is participant-only; spectators bounce back to the
   // read-only details page. The opponent side is always present — a real
-  // player, or the player-less placeholder for solo matches (rendered as
-  // "No opponent" with a ghost avatar below).
+  // player, or the player-less placeholder for solo matches.
   const mySide = data.sides.find((s) => s.is_current_user_side) ?? null
   const oppSide = data.sides.find((s) => !s.is_current_user_side) ?? null
   if (!mySide || !oppSide) {
     return <Navigate {...matchDetailRoute(matchId)} />
   }
 
-  const game = data.games.find((g) => g.id === gameId)
-  if (!game) {
+  // Once a match is finalized every write path 409s — there's nothing to do
+  // here. Likewise for the rare bound-violation case.
+  if (data.status === 'completed') {
+    return <Navigate {...matchDetailRoute(matchId)} />
+  }
+  if (gameNumber < 1 || gameNumber > data.best_of) {
     return <Navigate {...matchDetailRoute(matchId)} />
   }
 
-  // Landing on /scores/new for a game that's already scored (e.g. browser
-  // Back after saving and advancing) would show empty inputs alongside the
-  // tally that already counts the win. Replace into the score's edit route
-  // so the form reflects reality and a Save can't create a duplicate.
-  if (mode.kind === 'create' && game.score) {
-    return (
-      <Navigate
-        {...scoringEditRoute(matchId, gameId, game.score.id)}
-        replace
-      />
-    )
+  const game = data.games.find((g) => g.game_number === gameNumber) ?? null
+  const persistedScore = game?.score ?? null
+
+  // Mode/URL/state alignment: in create mode but a score exists → swap to
+  // the edit URL so Save doesn't try to POST .../scores/new and 409. The
+  // inverse — edit mode but no saved score — swaps to the create URL.
+  if (mode.kind === 'create' && persistedScore) {
+    return <Navigate {...scoringEditRoute(matchId, gameNumber)} replace />
+  }
+  if (mode.kind === 'edit' && !persistedScore) {
+    return <Navigate {...scoringNewRoute(matchId, gameNumber)} replace />
   }
 
-  const mySideNumber = mySide.side_number === 2 ? 2 : 1
+  const mySideNumber: 1 | 2 = mySide.side_number === 2 ? 2 : 1
   const oppUsername = oppSide.players[0]?.username ?? null
   const oppName = oppUsername ?? NO_OPPONENT_LABEL
   const meName = mySide.players[0]?.username ?? 'You'
@@ -121,12 +118,9 @@ function ScoreEntryInner({
   const oppHasPlayer = oppUsername !== null
 
   const bestOf = data.best_of
-  const gameNumber = game.game_number
-
   const meWins = mySide.games_won
   const oppWins = oppSide.games_won
 
-  const persistedScore = mode.kind === 'edit' ? game.score : null
   const persistedMe =
     persistedScore &&
     (mySideNumber === 1
@@ -143,11 +137,11 @@ function ScoreEntryInner({
   const sanitize = (value: string) => value.replace(/[^0-9]/g, '').slice(0, 2)
   const onMeChange = (value: string) => {
     setMeTyped(sanitize(value))
-    if (mutation.error) mutation.reset()
+    if (finalizeMutation.error) finalizeMutation.reset()
   }
   const onOppChange = (value: string) => {
     setOppTyped(sanitize(value))
-    if (mutation.error) mutation.reset()
+    if (finalizeMutation.error) finalizeMutation.reset()
   }
 
   const bothFilled = me !== '' && opp !== ''
@@ -155,38 +149,106 @@ function ScoreEntryInner({
     ? illegalScoreReason(Number(me), Number(opp))
     : null
   const inputsValid = bothFilled && localScoreError === null
-  const apiError = mutation.error instanceof ApiError ? mutation.error : null
+
+  // Build the hypothetical full-match games list including the current input,
+  // so we can ask the scoring lib whether saving this entry would make the
+  // match finalize-able. If so, the single submit button swaps to "Finalize
+  // match" and posts /results instead of /scores/new.
+  const hypotheticalGames: MatchResultsGameWrite[] = inputsValid
+    ? [
+        ...data.games
+          .filter((g) => g.game_number !== gameNumber && g.score)
+          .map((g) => ({
+            game_number: g.game_number,
+            side_1_points: g.score!.side_1_points,
+            side_2_points: g.score!.side_2_points,
+          })),
+        mySideNumber === 1
+          ? {
+              game_number: gameNumber,
+              side_1_points: Number(me),
+              side_2_points: Number(opp),
+            }
+          : {
+              game_number: gameNumber,
+              side_1_points: Number(opp),
+              side_2_points: Number(me),
+            },
+      ]
+    : []
+  const wouldFinalize =
+    inputsValid && decidedSide(hypotheticalGames, bestOf) !== null
+
+  // Per the fire-and-forget posture: only finalize errors are surfaced. The
+  // per-game mutations (create / update / delete) self-heal at finalize, so
+  // their errors are intentionally hidden.
+  const finalizeApiError =
+    finalizeMutation.error instanceof ApiError ? finalizeMutation.error : null
   const showScoreError =
-    localScoreError !== null || (apiError !== null && apiError.status === 422)
+    localScoreError !== null ||
+    (finalizeApiError !== null && finalizeApiError.status === 422)
 
-  // 409 from the API means the game is either already scored (create) or the
-  // match isn't scorable. Both swap out the regular controls for a back-link.
-  const lockedReason =
-    apiError && apiError.status === 409
-      ? apiError.detail ?? apiError.message
-      : null
-
-  function toBody(mine: number, opponent: number): MatchGameScoreWrite {
-    return mySideNumber === 1
-      ? { side_1_points: mine, side_2_points: opponent }
-      : { side_1_points: opponent, side_2_points: mine }
+  function predictNextScoringRoute() {
+    if (!data) return matchDetailRoute(matchId)
+    const nowScored = new Set<number>([
+      ...data.games.filter((g) => g.score).map((g) => g.game_number),
+      gameNumber,
+    ])
+    for (let n = 1; n <= data.best_of; n += 1) {
+      if (!nowScored.has(n)) return scoringNewRoute(matchId, n)
+    }
+    return matchDetailRoute(matchId)
   }
 
-  function saveGame() {
+  function toBody(): MatchGameScoreWrite {
+    return mySideNumber === 1
+      ? { side_1_points: Number(me), side_2_points: Number(opp) }
+      : { side_1_points: Number(opp), side_2_points: Number(me) }
+  }
+
+  function onSubmit() {
     if (!inputsValid) return
-    mutation.mutate(toBody(Number(me), Number(opp)), {
-      onSuccess: (response) => navigate(nextScoringDestination(response)),
+    if (wouldFinalize) {
+      finalizeMutation.mutate(
+        { games: hypotheticalGames },
+        { onSuccess: () => navigate(matchDetailRoute(matchId)) },
+      )
+      return
+    }
+    const next = predictNextScoringRoute()
+    const args = toBody()
+    // Fire-and-forget — we don't surface per-game errors, and we navigate as
+    // soon as the request settles either way. Even on failure, the canonical
+    // POST /results will reconcile the score later.
+    const settle = { onSettled: () => navigate(next) }
+    if (mode.kind === 'edit') {
+      updateMutation.mutate(args, settle)
+    } else {
+      createMutation.mutate(args, settle)
+    }
+  }
+
+  function onClear() {
+    if (mode.kind !== 'edit') return
+    deleteMutation.mutate(undefined, {
+      // After clearing, land back on this game's create route so the user
+      // can re-enter — same page, just with empty inputs and create-mode
+      // semantics.
+      onSettled: () => navigate(scoringNewRoute(matchId, gameNumber)),
     })
   }
 
-  function handleKey(e: React.KeyboardEvent<HTMLInputElement>, side: 'me' | 'opp') {
+  function handleKey(
+    e: React.KeyboardEvent<HTMLInputElement>,
+    side: 'me' | 'opp',
+  ) {
     if (e.key === 'Enter') {
       e.preventDefault()
       if (side === 'me' && me !== '') {
         oppRef.current?.focus()
         oppRef.current?.select()
       } else if (side === 'opp') {
-        saveGame()
+        onSubmit()
       }
     } else if (e.key === 'ArrowRight' && side === 'me') {
       e.preventDefault()
@@ -199,48 +261,40 @@ function ScoreEntryInner({
     }
   }
 
-  const inputsLocked = mutation.isPending || lockedReason !== null
+  // Only finalize pending state locks inputs — per-game mutations are
+  // fire-and-forget, so we don't want to make the UI feel laggy on those.
+  const inputsLocked = finalizeMutation.isPending
   const isEdit = mode.kind === 'edit'
-
-  // A typed, legal score that pushes either side to games_to_win clinches the
-  // match — even if more games would otherwise remain (e.g. 3-0 in a Bo5).
-  const gamesToWin = data.games_to_win
-  const willClinch =
-    inputsValid &&
-    (Number(me) > Number(opp)
-      ? meWins + 1 >= gamesToWin
-      : oppWins + 1 >= gamesToWin)
-  const isFinalGame = willClinch || gameNumber === bestOf
 
   const heading = isEdit
     ? `Edit game ${gameNumber} score.`
     : `Enter game ${gameNumber} score.`
-  const subtitle = isEdit
-    ? 'Save updates the score for this game.'
-    : willClinch
-      ? 'Save to finish the match.'
+  const subtitle = wouldFinalize
+    ? 'This score finishes the match — submitting will finalize it.'
+    : isEdit
+      ? 'Save updates the score for this game.'
       : gameNumber < bestOf
         ? `Save this game to continue to game ${gameNumber + 1}.`
         : 'Final game. Save to finish the match.'
-  const saveLabel = mutation.isPending
-    ? 'Saving…'
+  const submitLabel = wouldFinalize
+    ? finalizeMutation.isPending
+      ? 'Finalizing…'
+      : 'Finalize match'
     : isEdit
       ? 'Save changes →'
-      : isFinalGame
-        ? 'Save & finish match →'
-        : 'Save game & next →'
+      : gameNumber < bestOf
+        ? 'Save game & next →'
+        : 'Save final game →'
 
   return (
     <AppShell>
       <div className="entry-wrap">
         <div className="entry-head">
           <h2>{heading}</h2>
-          {!lockedReason && (
-            <div className="hint">
-              <kbd>0</kbd>–<kbd>9</kbd> score &nbsp;·&nbsp; <kbd>Enter</kbd> next
-              / save game
-            </div>
-          )}
+          <div className="hint">
+            <kbd>0</kbd>–<kbd>9</kbd> score &nbsp;·&nbsp; <kbd>Enter</kbd> next
+            / save game
+          </div>
         </div>
 
         <div className="single-entry">
@@ -284,42 +338,39 @@ function ScoreEntryInner({
             role="alert"
             className="mt-1.5 text-xs text-[color:var(--loss)]"
           >
-            {localScoreError ?? apiError?.detail ?? apiError?.message}
+            {localScoreError ??
+              finalizeApiError?.detail ??
+              finalizeApiError?.message}
           </p>
         )}
 
         <div className="single-actions">
-          {lockedReason ? (
-            <>
-              <div className="result-line subtle" role="alert">
-                {lockedReason}
-              </div>
-              <div className="action-btns">
-                <Link {...matchDetailRoute(matchId)} className="btn primary">
-                  Back to match
-                </Link>
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="result-line subtle">{subtitle}</div>
-              <div className="action-btns">
-                <button
-                  type="button"
-                  className="btn primary"
-                  disabled={!inputsValid || mutation.isPending}
-                  onClick={saveGame}
-                >
-                  {saveLabel}
-                </button>
-              </div>
-            </>
-          )}
+          <div className="result-line subtle">{subtitle}</div>
+          <div className="action-btns">
+            {isEdit && (
+              <button
+                type="button"
+                className="btn ghost"
+                onClick={onClear}
+                disabled={inputsLocked || deleteMutation.isPending}
+              >
+                Clear
+              </button>
+            )}
+            <button
+              type="button"
+              className="btn primary"
+              disabled={!inputsValid || inputsLocked}
+              onClick={onSubmit}
+            >
+              {submitLabel}
+            </button>
+          </div>
         </div>
 
         <Scoreline
           data={data}
-          activeGameId={gameId}
+          activeGameNumber={gameNumber}
           matchId={matchId}
           mySideNumber={mySideNumber}
         />
@@ -398,38 +449,26 @@ function ScoreSide({
 
 function Scoreline({
   data,
-  activeGameId,
+  activeGameNumber,
   matchId,
   mySideNumber,
 }: {
   data: MatchDetails
-  activeGameId: string
+  activeGameNumber: number
   matchId: string
   mySideNumber: 1 | 2
 }) {
-  const slots: Array<MatchDetails['games'][number] | null> = []
-  for (let n = 1; n <= data.best_of; n += 1) {
-    slots.push(data.games.find((g) => g.game_number === n) ?? null)
-  }
+  // Every cell links to its own scoring route — scored games go to edit,
+  // un-scored games go to /scores/new. Lets the user pick games in any
+  // order from the scoreline directly.
   return (
     <div className="scoreline">
       <div className="sl-label">SCORELINE</div>
       <div className="sl-cells">
-        {slots.map((g, i) => {
-          if (!g) {
-            return (
-              <div key={i} className={cn('sl-cell', 'pending')}>
-                <div className="sl-n">G{i + 1}</div>
-                <div className="sl-scores">
-                  <span className="s">—</span>
-                  <span className="dash">–</span>
-                  <span className="s">—</span>
-                </div>
-              </div>
-            )
-          }
-          const isActive = g.id === activeGameId
-          const score = g.score
+        {Array.from({ length: data.best_of }, (_, i) => i + 1).map((n) => {
+          const g = data.games.find((x) => x.game_number === n) ?? null
+          const score = g?.score ?? null
+          const isActive = n === activeGameNumber
           const cls = cn(
             'sl-cell',
             score ? 'done' : 'pending',
@@ -450,7 +489,7 @@ function Scoreline({
             : null
           const inner = (
             <>
-              <div className="sl-n">G{g.game_number}</div>
+              <div className="sl-n">G{n}</div>
               <div className="sl-scores">
                 <span className={cn('s', isMyWin === true && 'w')}>
                   {myPoints ?? '—'}
@@ -464,30 +503,21 @@ function Scoreline({
           )
           if (isActive) {
             return (
-              <div key={g.id} className={cls} aria-current="step">
+              <div key={n} className={cls} aria-current="step">
                 {inner}
               </div>
             )
           }
-          if (score) {
-            return (
-              <Link
-                key={g.id}
-                {...scoringEditRoute(matchId, g.id, score.id)}
-                className={cls}
-              >
-                {inner}
-              </Link>
-            )
-          }
+          const target = score
+            ? scoringEditRoute(matchId, n)
+            : scoringNewRoute(matchId, n)
           return (
-            <div key={g.id} className={cls}>
+            <Link key={n} {...target} className={cls}>
               {inner}
-            </div>
+            </Link>
           )
         })}
       </div>
     </div>
   )
 }
-

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -93,7 +93,11 @@ function ScoreEntryInner({
   if (data.status === 'completed') {
     return <Navigate {...matchDetailRoute(matchId)} />
   }
-  if (gameNumber < 1 || gameNumber > data.best_of) {
+  if (
+    !Number.isInteger(gameNumber) ||
+    gameNumber < 1 ||
+    gameNumber > data.best_of
+  ) {
     return <Navigate {...matchDetailRoute(matchId)} />
   }
 

--- a/web-client/src/lib/scoring.ts
+++ b/web-client/src/lib/scoring.ts
@@ -17,3 +17,48 @@ export function illegalScoreReason(a: number, b: number): string | null {
   }
   return null
 }
+
+export type GamePoints = {
+  game_number: number
+  side_1_points: number
+  side_2_points: number
+}
+
+// Mirrors the server-side finalize-payload cross-game validator in
+// api/app/matches.py (_validate_finalize_games). Returns the decided side
+// number (1 or 2) when the given games form a complete, validly-ordered,
+// decided match for the given best_of — and null otherwise. Used by the
+// scoring page to decide whether the submit button should save-this-game or
+// finalize-the-match.
+export function decidedSide(
+  games: GamePoints[],
+  bestOf: number,
+): 1 | 2 | null {
+  if (games.length === 0) return null
+
+  const numbers = games.map((g) => g.game_number).sort((a, b) => a - b)
+  // No duplicates / gaps / numbers past best_of.
+  if (numbers[numbers.length - 1] > bestOf) return null
+  for (let i = 0; i < numbers.length; i += 1) {
+    if (numbers[i] !== i + 1) return null
+  }
+
+  const target = Math.ceil(bestOf / 2)
+  const ordered = [...games].sort((a, b) => a.game_number - b.game_number)
+  const wins: Record<1 | 2, number> = { 1: 0, 2: 0 }
+  let decidedAt: number | null = null
+  let decidedBy: 1 | 2 | null = null
+  for (const g of ordered) {
+    if (illegalScoreReason(g.side_1_points, g.side_2_points)) return null
+    const winner: 1 | 2 = g.side_1_points > g.side_2_points ? 1 : 2
+    wins[winner] += 1
+    if (decidedBy === null && wins[winner] >= target) {
+      decidedBy = winner
+      decidedAt = g.game_number
+    }
+  }
+  if (decidedBy === null) return null
+  // No scored games past the decider.
+  if (decidedAt !== ordered[ordered.length - 1].game_number) return null
+  return decidedBy
+}

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -2,6 +2,7 @@ import { delay, http, HttpResponse } from 'msw'
 import type { components } from '@/api/schema'
 import { healthCheck, player, sessionResponse } from '@/test/factories'
 import {
+  finalizeSeed,
   findMatch,
   mockMatches,
   newMatchSeed,
@@ -11,7 +12,6 @@ import {
   projectRating,
   projectRecentResult,
   projectScoreBanner,
-  reconcile,
   statusCountsOf,
   validateScore,
   type SeedMatch,
@@ -285,45 +285,21 @@ const RBAC_PATHS = [
 
 type MatchCreateBody = components['schemas']['MatchCreate']
 type MatchScoreBody = components['schemas']['MatchGameScoreWrite']
+type MatchResultsBody = components['schemas']['MatchResultsWrite']
 
 function detail(message: string, status = 422) {
   return HttpResponse.json({ detail: message }, { status })
 }
 
-/** Apply a score write to an existing game, recompute the seed, and return
- * the projected MatchDetails. Validates against the same TT rules the API
- * enforces so the FE inline-error tests see the same messages. */
-function applyScore(
-  seed: SeedMatch,
-  gameId: string,
-  body: MatchScoreBody,
-  options: { scoreId?: string } = {},
-): Response {
-  // A no-opponent match is scorable against its player-less sentinel side
-  // (mirrors the API), so there's no opponent gate here.
-  if (seed.status === 'disputed' || seed.status === 'voided') {
+function enforceScorable(seed: SeedMatch): Response | null {
+  if (
+    seed.status === 'completed' ||
+    seed.status === 'disputed' ||
+    seed.status === 'voided'
+  ) {
     return detail('This match is no longer scorable.', 409)
   }
-  const game = seed.games.find((g) => g.id === gameId)
-  if (!game) return detail('Game not found.', 404)
-  if (options.scoreId !== undefined) {
-    if (game.score === null || game.score.id !== options.scoreId) {
-      return detail('Score not found.', 404)
-    }
-  } else if (game.score !== null) {
-    return detail('This game has already been scored.', 409)
-  }
-
-  const message = validateScore(body.side_1_points, body.side_2_points)
-  if (message) return detail(message, 422)
-
-  game.score = {
-    id: options.scoreId ?? `s-${seed.id}-${game.game_number}-${Date.now().toString(36)}`,
-    side_1_points: body.side_1_points,
-    side_2_points: body.side_2_points,
-  }
-  reconcile(seed)
-  return HttpResponse.json(projectMatchDetails(seed))
+  return null
 }
 
 function notNull<T>(value: T | null): value is T {
@@ -631,27 +607,107 @@ export const handlers = [
     return HttpResponse.json(projectMatchDetails(seed))
   }),
 
+  // Per-game scratchpad endpoints: write/edit/clear a single game's score.
+  // These never change match.status or side wins — finalization lives in
+  // POST .../results below.
+
   http.post(
-    '*/v1/matches/:matchId/games/:gameId/scores',
+    '*/v1/matches/:matchId/games/:gameNumber/scores/new',
     async ({ params, request }) => {
       await delay(250)
       const seed = findMatch(String(params.matchId))
       if (!seed) return detail('Match not found.', 404)
+      const gateError = enforceScorable(seed)
+      if (gateError) return gateError
+      const gameNumber = Number(params.gameNumber)
+      if (!Number.isInteger(gameNumber) || gameNumber < 1) {
+        return detail('Invalid game_number.', 422)
+      }
+      if (gameNumber > seed.best_of) {
+        return detail(
+          `This match is best of ${seed.best_of}; game ${gameNumber} can't exist.`,
+          422,
+        )
+      }
       const body = (await readJson(request)) as MatchScoreBody
-      return applyScore(seed, String(params.gameId), body)
+      const message = validateScore(body.side_1_points, body.side_2_points)
+      if (message) return detail(message, 422)
+
+      let game = seed.games.find((g) => g.game_number === gameNumber)
+      if (!game) {
+        game = {
+          id: `g-${seed.id}-${gameNumber}`,
+          game_number: gameNumber,
+          score: null,
+        }
+        seed.games.push(game)
+      } else if (game.score !== null) {
+        return detail('This game has already been scored.', 409)
+      }
+      game.score = {
+        id: `s-${seed.id}-${gameNumber}-${Date.now().toString(36)}`,
+        side_1_points: body.side_1_points,
+        side_2_points: body.side_2_points,
+      }
+      return HttpResponse.json(projectMatchDetails(seed), { status: 201 })
     },
   ),
 
   http.put(
-    '*/v1/matches/:matchId/games/:gameId/scores/:scoreId',
+    '*/v1/matches/:matchId/games/:gameNumber/scores',
     async ({ params, request }) => {
       await delay(250)
       const seed = findMatch(String(params.matchId))
       if (!seed) return detail('Match not found.', 404)
+      const gateError = enforceScorable(seed)
+      if (gateError) return gateError
+      const gameNumber = Number(params.gameNumber)
+      const game = seed.games.find((g) => g.game_number === gameNumber)
+      if (!game || game.score === null) {
+        return detail('Score not found.', 404)
+      }
       const body = (await readJson(request)) as MatchScoreBody
-      return applyScore(seed, String(params.gameId), body, {
-        scoreId: String(params.scoreId),
-      })
+      const message = validateScore(body.side_1_points, body.side_2_points)
+      if (message) return detail(message, 422)
+      game.score = {
+        id: game.score.id,
+        side_1_points: body.side_1_points,
+        side_2_points: body.side_2_points,
+      }
+      return HttpResponse.json(projectMatchDetails(seed))
+    },
+  ),
+
+  http.delete(
+    '*/v1/matches/:matchId/games/:gameNumber/scores',
+    async ({ params }) => {
+      await delay(250)
+      const seed = findMatch(String(params.matchId))
+      if (!seed) return detail('Match not found.', 404)
+      const gateError = enforceScorable(seed)
+      if (gateError) return gateError
+      const gameNumber = Number(params.gameNumber)
+      const game = seed.games.find((g) => g.game_number === gameNumber)
+      if (!game || game.score === null) {
+        return detail('Score not found.', 404)
+      }
+      game.score = null
+      return HttpResponse.json(projectMatchDetails(seed))
+    },
+  ),
+
+  http.post(
+    '*/v1/matches/:matchId/results',
+    async ({ params, request }) => {
+      await delay(250)
+      const seed = findMatch(String(params.matchId))
+      if (!seed) return detail('Match not found.', 404)
+      const gateError = enforceScorable(seed)
+      if (gateError) return gateError
+      const body = (await readJson(request)) as MatchResultsBody
+      const message = finalizeSeed(seed, body.games)
+      if (message) return detail(message, 422)
+      return HttpResponse.json(projectMatchDetails(seed), { status: 201 })
     },
   ),
 

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -96,36 +96,54 @@ function sideWinCounts(seed: SeedMatch): { side1: number; side2: number } {
   return { side1: s1, side2: s2 }
 }
 
-function currentUnscored(seed: SeedMatch): SeedGame | null {
-  return seed.games.find((g) => g.score === null) ?? null
+/** Lowest 1..best_of game number with no saved score, or null when every
+ * game in [1, best_of] is scored / the match isn't in progress. Mirrors the
+ * server's ``current_game_number`` derivation in api/app/matches.py. */
+function currentGameNumber(seed: SeedMatch): number | null {
+  if (seed.status !== 'in_progress') return null
+  const scored = new Set(
+    seed.games.filter((g) => g.score !== null).map((g) => g.game_number),
+  )
+  for (let n = 1; n <= seed.best_of; n += 1) {
+    if (!scored.has(n)) return n
+  }
+  return null
 }
 
-/** Mirrors the API's `_recompute_match`: derive status / side `won`, drop any
- * trailing unscored game on completion, append one when still in progress. */
-export function reconcile(seed: SeedMatch): void {
-  const { side1, side2 } = sideWinCounts(seed)
+/** Whether the currently-saved scores form a complete, validly-ordered,
+ * decided match — i.e. POST /results would succeed against the current
+ * scratchpad state. Mirrors the server's ``_can_finalize`` predicate. */
+function canFinalizeSeed(seed: SeedMatch): boolean {
+  if (seed.status !== 'in_progress') return false
+  const scored = seed.games
+    .filter((g) => g.score !== null)
+    .map((g) => ({
+      game_number: g.game_number,
+      side_1_points: g.score!.side_1_points,
+      side_2_points: g.score!.side_2_points,
+    }))
+  if (scored.length === 0) return false
+  const numbers = scored.map((g) => g.game_number).sort((a, b) => a - b)
+  if (numbers[numbers.length - 1] > seed.best_of) return false
+  for (let i = 0; i < numbers.length; i += 1) {
+    if (numbers[i] !== i + 1) return false
+  }
   const target = gamesToWin(seed.best_of)
-  const decided = side1 >= target || side2 >= target
-
-  if (decided) {
-    seed.status = 'completed'
-    // Runtime-completed matches need a fresh timestamp so dashboard's
-    // recent-results sort puts them ahead of pre-seeded older matches.
-    if (seed.completed_at === null) seed.completed_at = new Date().toISOString()
-    seed.games = seed.games.filter((g) => g.score !== null)
-  } else {
-    seed.status = 'in_progress'
-    seed.completed_at = null
-    if (currentUnscored(seed) === null) {
-      const nextNumber =
-        seed.games.reduce((max, g) => Math.max(max, g.game_number), 0) + 1
-      seed.games.push({
-        id: `g-${seed.id}-${nextNumber}`,
-        game_number: nextNumber,
-        score: null,
-      })
+  const ordered = scored
+    .slice()
+    .sort((a, b) => a.game_number - b.game_number)
+  let wins1 = 0
+  let wins2 = 0
+  let decidedAt: number | null = null
+  for (const g of ordered) {
+    if (g.side_1_points > g.side_2_points) wins1 += 1
+    else if (g.side_2_points > g.side_1_points) wins2 += 1
+    if (decidedAt === null && (wins1 >= target || wins2 >= target)) {
+      decidedAt = g.game_number
     }
   }
+  if (decidedAt === null) return false
+  return decidedAt === ordered[ordered.length - 1].game_number
 }
 
 function projectSides(seed: SeedMatch): {
@@ -194,7 +212,7 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
         : null,
     }))
 
-  const current = currentUnscored(seed)
+  const nextNumber = currentGameNumber(seed)
   const priors = priorCompleted(seed)
   return {
     id: seed.id,
@@ -208,10 +226,9 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
     created_at: seed.created_at,
     sides: [mySide, opponentSide],
     games,
-    current_game: current
-      ? { id: current.id, game_number: current.game_number }
-      : null,
-    can_score: current !== null,
+    current_game: nextNumber !== null ? { game_number: nextNumber } : null,
+    can_score: nextNumber !== null,
+    can_finalize: canFinalizeSeed(seed),
     recent_form: projectRecentForm(seed, priors),
     head_to_head: projectHeadToHead(seed, priors),
   }
@@ -342,10 +359,10 @@ function projectHeadToHead(
 
 export function projectListRow(seed: SeedMatch): MatchListRow {
   const { mySide, opponentSide } = projectSides(seed)
-  const current = currentUnscored(seed)
+  const nextNumber = currentGameNumber(seed)
   const scorable =
     (seed.status === 'pending' || seed.status === 'in_progress') &&
-    current !== null
+    nextNumber !== null
   return {
     id: seed.id,
     status: seed.status,
@@ -354,18 +371,18 @@ export function projectListRow(seed: SeedMatch): MatchListRow {
     sides: [mySide, opponentSide],
     best_of: seed.best_of,
     created_at: seed.created_at,
-    current_game_id: scorable ? current.id : null,
+    current_game_number: scorable ? nextNumber : null,
     can_score: scorable,
   }
 }
 
 export function projectScoreBanner(seed: SeedMatch): DashboardScoreBanner | null {
-  const current = currentUnscored(seed)
-  if (seed.status !== 'in_progress' || current === null) return null
+  const nextNumber = currentGameNumber(seed)
+  if (seed.status !== 'in_progress' || nextNumber === null) return null
   return {
     match_id: seed.id,
     opponent_username: seed.opponent?.username ?? null,
-    current_game_id: current.id,
+    current_game_number: nextNumber,
   }
 }
 
@@ -492,9 +509,7 @@ export function buildInitialSeeds(): SeedMatch[] {
       created_at: '2026-05-14T17:00:00Z',
       completed_at: null,
       opponent: { id: 'pl-okafor', username: 'okafor.d' },
-      games: [
-        { id: 'g-pending-1-1', game_number: 1, score: null },
-      ],
+      games: [],
     },
     {
       id: 'm-2207',
@@ -515,7 +530,6 @@ export function buildInitialSeeds(): SeedMatch[] {
           game_number: 2,
           score: { id: 's-2207-2', side_1_points: 9, side_2_points: 11 },
         },
-        { id: 'g-2207-3', game_number: 3, score: null },
       ],
     },
     {
@@ -638,7 +652,8 @@ export function validateScore(side1: number, side2: number): string | null {
   return null
 }
 
-/** Hardcoded current-user id used by `POST /v1/matches` to populate side 1. */
+/** Hardcoded current-user id used by `POST /v1/matches` to populate side 1.
+ * Games aren't pre-created — POST .../scores/new inserts them lazily. */
 export function newMatchSeed(input: {
   bestOf: number
   rated: boolean
@@ -654,7 +669,74 @@ export function newMatchSeed(input: {
     created_at: new Date().toISOString(),
     completed_at: null,
     opponent: input.opponent,
-    games: [{ id: `g-${id}-1`, game_number: 1, score: null }],
+    games: [],
   }
   return seed
+}
+
+/** POST /v1/matches/{id}/results: obliterate the existing games + scores,
+ * insert the payload's games, mark completed. Mirrors the server contract —
+ * the payload is canon. Returns null on validation failure, with a message
+ * suitable for a 422 detail. */
+export function finalizeSeed(
+  seed: SeedMatch,
+  games: Array<{
+    game_number: number
+    side_1_points: number
+    side_2_points: number
+  }>,
+): string | null {
+  if (games.length === 0) {
+    return 'A match needs at least one game to finalize.'
+  }
+  const numbers = games.map((g) => g.game_number)
+  if (numbers.some((n) => n > seed.best_of)) {
+    return `Each game_number must be ≤ best_of (${seed.best_of}).`
+  }
+  if (new Set(numbers).size !== numbers.length) {
+    return 'Duplicate game_number in payload.'
+  }
+  const sortedNumbers = numbers.slice().sort((a, b) => a - b)
+  for (let i = 0; i < sortedNumbers.length; i += 1) {
+    if (sortedNumbers[i] !== i + 1) {
+      return 'Games must be numbered 1..N consecutively with no gaps.'
+    }
+  }
+  for (const g of games) {
+    const message = validateScore(g.side_1_points, g.side_2_points)
+    if (message) return message
+  }
+  const ordered = games.slice().sort((a, b) => a.game_number - b.game_number)
+  const target = gamesToWin(seed.best_of)
+  let wins1 = 0
+  let wins2 = 0
+  let decidedAt: number | null = null
+  let decidedSide: 1 | 2 | null = null
+  for (const g of ordered) {
+    if (g.side_1_points > g.side_2_points) wins1 += 1
+    else wins2 += 1
+    if (decidedSide === null && (wins1 >= target || wins2 >= target)) {
+      decidedSide = wins1 >= target ? 1 : 2
+      decidedAt = g.game_number
+    }
+  }
+  if (decidedSide === null) {
+    return `No side reached ${target} game wins — the match isn't decided.`
+  }
+  if (decidedAt !== ordered[ordered.length - 1].game_number) {
+    return 'Scored games extend past the deciding game; drop any games after the decider.'
+  }
+
+  seed.games = ordered.map((g) => ({
+    id: `g-${seed.id}-${g.game_number}`,
+    game_number: g.game_number,
+    score: {
+      id: `s-${seed.id}-${g.game_number}`,
+      side_1_points: g.side_1_points,
+      side_2_points: g.side_2_points,
+    },
+  }))
+  seed.status = 'completed'
+  seed.completed_at = new Date().toISOString()
+  return null
 }

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -31,8 +31,8 @@ import { Route as AdminPermissionsRouteImport } from './routes/admin.permissions
 import { Route as MatchesMatchIdIndexRouteImport } from './routes/matches.$matchId.index'
 import { Route as PPlayersUsernameRouteImport } from './routes/p.players.$username'
 import { Route as PMatchesMatchIdRouteImport } from './routes/p.matches.$matchId'
-import { Route as MatchesMatchIdGamesGameIdScoresNewRouteImport } from './routes/matches.$matchId.games.$gameId.scores.new'
-import { Route as MatchesMatchIdGamesGameIdScoresScoreIdEditRouteImport } from './routes/matches.$matchId.games.$gameId.scores.$scoreId.edit'
+import { Route as MatchesMatchIdGamesGameNumberScoresNewRouteImport } from './routes/matches.$matchId.games.$gameNumber.scores.new'
+import { Route as MatchesMatchIdGamesGameNumberScoresEditRouteImport } from './routes/matches.$matchId.games.$gameNumber.scores.edit'
 
 const SimulatorRoute = SimulatorRouteImport.update({
   id: '/simulator',
@@ -144,16 +144,16 @@ const PMatchesMatchIdRoute = PMatchesMatchIdRouteImport.update({
   path: '/p/matches/$matchId',
   getParentRoute: () => rootRouteImport,
 } as any)
-const MatchesMatchIdGamesGameIdScoresNewRoute =
-  MatchesMatchIdGamesGameIdScoresNewRouteImport.update({
-    id: '/matches/$matchId/games/$gameId/scores/new',
-    path: '/matches/$matchId/games/$gameId/scores/new',
+const MatchesMatchIdGamesGameNumberScoresNewRoute =
+  MatchesMatchIdGamesGameNumberScoresNewRouteImport.update({
+    id: '/matches/$matchId/games/$gameNumber/scores/new',
+    path: '/matches/$matchId/games/$gameNumber/scores/new',
     getParentRoute: () => rootRouteImport,
   } as any)
-const MatchesMatchIdGamesGameIdScoresScoreIdEditRoute =
-  MatchesMatchIdGamesGameIdScoresScoreIdEditRouteImport.update({
-    id: '/matches/$matchId/games/$gameId/scores/$scoreId/edit',
-    path: '/matches/$matchId/games/$gameId/scores/$scoreId/edit',
+const MatchesMatchIdGamesGameNumberScoresEditRoute =
+  MatchesMatchIdGamesGameNumberScoresEditRouteImport.update({
+    id: '/matches/$matchId/games/$gameNumber/scores/edit',
+    path: '/matches/$matchId/games/$gameNumber/scores/edit',
     getParentRoute: () => rootRouteImport,
   } as any)
 
@@ -180,8 +180,8 @@ export interface FileRoutesByFullPath {
   '/p/matches/$matchId': typeof PMatchesMatchIdRoute
   '/p/players/$username': typeof PPlayersUsernameRoute
   '/matches/$matchId/': typeof MatchesMatchIdIndexRoute
-  '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
-  '/matches/$matchId/games/$gameId/scores/$scoreId/edit': typeof MatchesMatchIdGamesGameIdScoresScoreIdEditRoute
+  '/matches/$matchId/games/$gameNumber/scores/edit': typeof MatchesMatchIdGamesGameNumberScoresEditRoute
+  '/matches/$matchId/games/$gameNumber/scores/new': typeof MatchesMatchIdGamesGameNumberScoresNewRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -205,8 +205,8 @@ export interface FileRoutesByTo {
   '/p/matches/$matchId': typeof PMatchesMatchIdRoute
   '/p/players/$username': typeof PPlayersUsernameRoute
   '/matches/$matchId': typeof MatchesMatchIdIndexRoute
-  '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
-  '/matches/$matchId/games/$gameId/scores/$scoreId/edit': typeof MatchesMatchIdGamesGameIdScoresScoreIdEditRoute
+  '/matches/$matchId/games/$gameNumber/scores/edit': typeof MatchesMatchIdGamesGameNumberScoresEditRoute
+  '/matches/$matchId/games/$gameNumber/scores/new': typeof MatchesMatchIdGamesGameNumberScoresNewRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -232,8 +232,8 @@ export interface FileRoutesById {
   '/p/matches/$matchId': typeof PMatchesMatchIdRoute
   '/p/players/$username': typeof PPlayersUsernameRoute
   '/matches/$matchId/': typeof MatchesMatchIdIndexRoute
-  '/matches/$matchId/games/$gameId/scores/new': typeof MatchesMatchIdGamesGameIdScoresNewRoute
-  '/matches/$matchId/games/$gameId/scores/$scoreId/edit': typeof MatchesMatchIdGamesGameIdScoresScoreIdEditRoute
+  '/matches/$matchId/games/$gameNumber/scores/edit': typeof MatchesMatchIdGamesGameNumberScoresEditRoute
+  '/matches/$matchId/games/$gameNumber/scores/new': typeof MatchesMatchIdGamesGameNumberScoresNewRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -260,8 +260,8 @@ export interface FileRouteTypes {
     | '/p/matches/$matchId'
     | '/p/players/$username'
     | '/matches/$matchId/'
-    | '/matches/$matchId/games/$gameId/scores/new'
-    | '/matches/$matchId/games/$gameId/scores/$scoreId/edit'
+    | '/matches/$matchId/games/$gameNumber/scores/edit'
+    | '/matches/$matchId/games/$gameNumber/scores/new'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -285,8 +285,8 @@ export interface FileRouteTypes {
     | '/p/matches/$matchId'
     | '/p/players/$username'
     | '/matches/$matchId'
-    | '/matches/$matchId/games/$gameId/scores/new'
-    | '/matches/$matchId/games/$gameId/scores/$scoreId/edit'
+    | '/matches/$matchId/games/$gameNumber/scores/edit'
+    | '/matches/$matchId/games/$gameNumber/scores/new'
   id:
     | '__root__'
     | '/'
@@ -311,8 +311,8 @@ export interface FileRouteTypes {
     | '/p/matches/$matchId'
     | '/p/players/$username'
     | '/matches/$matchId/'
-    | '/matches/$matchId/games/$gameId/scores/new'
-    | '/matches/$matchId/games/$gameId/scores/$scoreId/edit'
+    | '/matches/$matchId/games/$gameNumber/scores/edit'
+    | '/matches/$matchId/games/$gameNumber/scores/new'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -334,8 +334,8 @@ export interface RootRouteChildren {
   PMatchesMatchIdRoute: typeof PMatchesMatchIdRoute
   PPlayersUsernameRoute: typeof PPlayersUsernameRoute
   MatchesMatchIdIndexRoute: typeof MatchesMatchIdIndexRoute
-  MatchesMatchIdGamesGameIdScoresNewRoute: typeof MatchesMatchIdGamesGameIdScoresNewRoute
-  MatchesMatchIdGamesGameIdScoresScoreIdEditRoute: typeof MatchesMatchIdGamesGameIdScoresScoreIdEditRoute
+  MatchesMatchIdGamesGameNumberScoresEditRoute: typeof MatchesMatchIdGamesGameNumberScoresEditRoute
+  MatchesMatchIdGamesGameNumberScoresNewRoute: typeof MatchesMatchIdGamesGameNumberScoresNewRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -494,18 +494,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PMatchesMatchIdRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/matches/$matchId/games/$gameId/scores/new': {
-      id: '/matches/$matchId/games/$gameId/scores/new'
-      path: '/matches/$matchId/games/$gameId/scores/new'
-      fullPath: '/matches/$matchId/games/$gameId/scores/new'
-      preLoaderRoute: typeof MatchesMatchIdGamesGameIdScoresNewRouteImport
+    '/matches/$matchId/games/$gameNumber/scores/new': {
+      id: '/matches/$matchId/games/$gameNumber/scores/new'
+      path: '/matches/$matchId/games/$gameNumber/scores/new'
+      fullPath: '/matches/$matchId/games/$gameNumber/scores/new'
+      preLoaderRoute: typeof MatchesMatchIdGamesGameNumberScoresNewRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/matches/$matchId/games/$gameId/scores/$scoreId/edit': {
-      id: '/matches/$matchId/games/$gameId/scores/$scoreId/edit'
-      path: '/matches/$matchId/games/$gameId/scores/$scoreId/edit'
-      fullPath: '/matches/$matchId/games/$gameId/scores/$scoreId/edit'
-      preLoaderRoute: typeof MatchesMatchIdGamesGameIdScoresScoreIdEditRouteImport
+    '/matches/$matchId/games/$gameNumber/scores/edit': {
+      id: '/matches/$matchId/games/$gameNumber/scores/edit'
+      path: '/matches/$matchId/games/$gameNumber/scores/edit'
+      fullPath: '/matches/$matchId/games/$gameNumber/scores/edit'
+      preLoaderRoute: typeof MatchesMatchIdGamesGameNumberScoresEditRouteImport
       parentRoute: typeof rootRouteImport
     }
   }
@@ -546,10 +546,10 @@ const rootRouteChildren: RootRouteChildren = {
   PMatchesMatchIdRoute: PMatchesMatchIdRoute,
   PPlayersUsernameRoute: PPlayersUsernameRoute,
   MatchesMatchIdIndexRoute: MatchesMatchIdIndexRoute,
-  MatchesMatchIdGamesGameIdScoresNewRoute:
-    MatchesMatchIdGamesGameIdScoresNewRoute,
-  MatchesMatchIdGamesGameIdScoresScoreIdEditRoute:
-    MatchesMatchIdGamesGameIdScoresScoreIdEditRoute,
+  MatchesMatchIdGamesGameNumberScoresEditRoute:
+    MatchesMatchIdGamesGameNumberScoresEditRoute,
+  MatchesMatchIdGamesGameNumberScoresNewRoute:
+    MatchesMatchIdGamesGameNumberScoresNewRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/web-client/src/routes/matches.$matchId.games.$gameNumber.scores.edit.tsx
+++ b/web-client/src/routes/matches.$matchId.games.$gameNumber.scores.edit.tsx
@@ -1,10 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ScoreEntry } from '@/components/matches/score-entry'
-import { useUpdateScore } from '@/api/matches'
 import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute(
-  '/matches/$matchId/games/$gameId/scores/$scoreId/edit',
+  '/matches/$matchId/games/$gameNumber/scores/edit',
 )({
   head: () => ({
     meta: [{ title: pageTitle('Edit score') }],
@@ -13,14 +12,12 @@ export const Route = createFileRoute(
 })
 
 function ScoreEditRoute() {
-  const { matchId, gameId, scoreId } = Route.useParams()
-  const mutation = useUpdateScore(matchId, gameId, scoreId)
+  const { matchId, gameNumber } = Route.useParams()
   return (
     <ScoreEntry
       matchId={matchId}
-      gameId={gameId}
-      mode={{ kind: 'edit', scoreId }}
-      mutation={mutation}
+      gameNumber={Number(gameNumber)}
+      mode={{ kind: 'edit' }}
     />
   )
 }

--- a/web-client/src/routes/matches.$matchId.games.$gameNumber.scores.new.tsx
+++ b/web-client/src/routes/matches.$matchId.games.$gameNumber.scores.new.tsx
@@ -1,10 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ScoreEntry } from '@/components/matches/score-entry'
-import { useCreateScore } from '@/api/matches'
 import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute(
-  '/matches/$matchId/games/$gameId/scores/new',
+  '/matches/$matchId/games/$gameNumber/scores/new',
 )({
   head: () => ({
     meta: [{ title: pageTitle('Enter score') }],
@@ -13,14 +12,12 @@ export const Route = createFileRoute(
 })
 
 function ScoreCreateRoute() {
-  const { matchId, gameId } = Route.useParams()
-  const mutation = useCreateScore(matchId, gameId)
+  const { matchId, gameNumber } = Route.useParams()
   return (
     <ScoreEntry
       matchId={matchId}
-      gameId={gameId}
+      gameNumber={Number(gameNumber)}
       mode={{ kind: 'create' }}
-      mutation={mutation}
     />
   )
 }

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -444,9 +444,9 @@ function MatchRow({
         <TimeCell iso={row.created_at} />
       </td>
       <td onClick={(e) => e.stopPropagation()}>
-        {row.current_game_id ? (
+        {row.current_game_number !== null ? (
           <Button asChild variant="default" size="sm">
-            <Link {...scoringNewRoute(row.id, row.current_game_id)}>
+            <Link {...scoringNewRoute(row.id, row.current_game_number)}>
               Score
             </Link>
           </Button>

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -21,8 +21,8 @@ const NewMatchPage = Route.options.component!
 function pendingMatch() {
   return matchDetails({
     id: 'm-test',
-    games: [{ id: 'g-test', game_number: 1, score: null }],
-    current_game: { id: 'g-test', game_number: 1 },
+    games: [],
+    current_game: { game_number: 1 },
   })
 }
 
@@ -43,10 +43,10 @@ function renderNewMatch() {
   })
   const scoringRoute = createRoute({
     getParentRoute: () => rootRoute,
-    path: '/matches/$matchId/games/$gameId/scores/new',
+    path: '/matches/$matchId/games/$gameNumber/scores/new',
     component: () => {
-      const { matchId, gameId } = scoringRoute.useParams()
-      return <div>Scoring route {matchId} game {gameId}</div>
+      const { matchId, gameNumber } = scoringRoute.useParams()
+      return <div>Scoring route {matchId} game {gameNumber}</div>
     },
   })
   const router = createRouter({
@@ -92,7 +92,7 @@ describe('NewMatchPage', () => {
 
     await waitFor(() =>
       expect(
-        screen.getByText('Scoring route m-test game g-test'),
+        screen.getByText('Scoring route m-test game 1'),
       ).toBeInTheDocument(),
     )
     expect(captured).toEqual({
@@ -121,7 +121,7 @@ describe('NewMatchPage', () => {
 
     await waitFor(() =>
       expect(
-        screen.getByText('Scoring route m-test game g-test'),
+        screen.getByText('Scoring route m-test game 1'),
       ).toBeInTheDocument(),
     )
     expect(captured).toEqual({
@@ -166,7 +166,7 @@ describe('NewMatchPage', () => {
     await user.click(screen.getByRole('button', { name: /start match/i }))
     await waitFor(() =>
       expect(
-        screen.getByText('Scoring route m-test game g-test'),
+        screen.getByText('Scoring route m-test game 1'),
       ).toBeInTheDocument(),
     )
     expect(captured).toEqual({

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -12,7 +12,6 @@ type RbacUser = components['schemas']['RbacUserRead']
 type Player = components['schemas']['PlayerRead']
 type MatchDetails = components['schemas']['MatchDetails']
 type MatchDetailsSide = components['schemas']['MatchDetailsSide']
-type MatchDetailsGame = components['schemas']['MatchDetailsGame']
 type MatchListRow = components['schemas']['MatchListRow']
 type MatchListResponse = components['schemas']['MatchListResponse']
 type MatchStatus = components['schemas']['MatchStatus']
@@ -187,11 +186,6 @@ export function matchDetails(
   const { mySide, opponentSide } = defaultSides(
     faker.internet.username().toLowerCase(),
   )
-  const firstGame: MatchDetailsGame = {
-    id: nextId('g'),
-    game_number: 1,
-    score: null,
-  }
   return {
     id,
     status: 'in_progress',
@@ -203,9 +197,12 @@ export function matchDetails(
     affects_rating: false,
     created_at: ISO,
     sides: [mySide, opponentSide],
-    games: [firstGame],
-    current_game: { id: firstGame.id, game_number: 1 },
+    // Games are lazily inserted by the score-write endpoints; a fresh match
+    // has no game rows yet, but `current_game` still points at the next slot.
+    games: [],
+    current_game: { game_number: 1 },
     can_score: true,
+    can_finalize: false,
     recent_form: [mySide, opponentSide]
       .filter((s) => s.players.length > 0)
       .map((s) => ({
@@ -247,7 +244,7 @@ export function matchListRow(
     sides: [mySide, opponentSide],
     best_of: 5,
     created_at: ISO,
-    current_game_id: nextId('g'),
+    current_game_number: 1,
     can_score: true,
     ...rest,
   }
@@ -320,7 +317,7 @@ export function dashboardScoreBanner(
   return {
     match_id: nextId('m'),
     opponent_username: faker.internet.username().toLowerCase(),
-    current_game_id: nextId('g'),
+    current_game_number: 1,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary
- Per-game scoring endpoints become pure scratchpad: `POST .../games/{n}/scores/new`, `PUT .../games/{n}/scores`, `DELETE .../games/{n}/scores`. They save / overwrite / clear a single game's points, addressed by game number — no side effects on `match.status`, `side.score`, `side.won`, or ratings. Game rows are created lazily on first score write; match-create no longer pre-seeds game 1.
- New `POST /v1/matches/{id}/results` is the canonical commit. The request body is canon: the server obliterates `match.games` (cascades through `MatchGame.score`), re-inserts from the payload, validates the match as a complete + decided whole (contiguous `1..N`, legal table-tennis scores, exactly one decider on the final game), sets `side.score`/`side.won`, flips status to `completed`, and applies the rating update exactly once. After finalize, every write path returns 409.
- Frontend `ScoreEntry` has a single submit button whose label and action adapt across `Save game & next →` / `Save changes →` / `Finalize match` based on whether the typed input would decide the match. Per-game mutations are fire-and-forget (no error surfacing); only finalize errors render inline. Adds a `Clear` button in edit mode that DELETEs the saved score, and makes every scoreline cell a link so games can be scored in any order.
- `MatchDetails.current_game` drops `id` (game rows may not exist yet) and adds `can_finalize: bool`. `MatchListRow.current_game_id` and `DashboardScoreBanner.current_game_id` become `current_game_number`.

## Test plan
- [x] `cd api && pytest` — 325 passed (rewrote scoring-section tests; new tests for per-game gaps, DELETE, 409-when-completed, and full `POST /results` matrix: valid, already-completed 409, gap/dup/undecided/scores-past-decider 422, non-participant 404).
- [x] `cd api && ruff check && ruff format --check && mypy` — clean (mypy --strict).
- [x] `cd web-client && npm run lint` — clean (only a pre-existing MSW worker warning).
- [x] `cd web-client && npm run test:run` — 101 passed (rewrote `score-entry.test.tsx` for the new contract; updated dashboard/match-details/new-match tests for the URL + field renames).
- [x] `cd web-client && npm run build` — clean (tsc -b + vite build).
- [x] `mise run regen-api-types` — `schema.d.ts` committed in sync.
- [ ] Manual smoke: best-of-3, score game 1 → `Save game & next →` lands on `/games/2/scores/new`; score game 2 with a winner → button morphs to `Finalize match` → POST `/results`; back-button to a scored game flips create→edit; `Clear` returns to `/scores/new`; once finalized, every score endpoint and re-POST `/results` returns 409. Spectator sees no scoring CTAs.
- [ ] Web-client Playwright (`npm run test:e2e`) — specs + page-object updated for the new URLs and contract; not executed here.
- [ ] Root e2e against the dev compose stack — not executed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)