### PR TITLE
Require opponent sign-off before a match finalizes

### DIFF
--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -15,7 +15,7 @@ from typing import Any, cast
 from sqlalchemy import CursorResult, delete, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Match, MatchSidePlayer, RatingHistory, User
+from app.models import Match, MatchSidePlayer, MatchSignature, RatingHistory, User
 
 
 @dataclass(frozen=True)
@@ -38,6 +38,9 @@ async def merge_user(
       * ``from_user_id != to_user_id``.
     """
     matches_moved = await _repoint_match_side_players(
+        db, from_user_id=from_user_id, to_user_id=to_user_id
+    )
+    await _repoint_match_signatures(
         db, from_user_id=from_user_id, to_user_id=to_user_id
     )
 
@@ -97,6 +100,10 @@ async def merge_user(
     await db.execute(
         delete(MatchSidePlayer).where(MatchSidePlayer.user_id == from_user_id)
     )
+    # Same RESTRICT story for match_signatures — defensive drop after repoint.
+    await db.execute(
+        delete(MatchSignature).where(MatchSignature.user_id == from_user_id)
+    )
 
     # CASCADE cleans up user_tokens, user_roles, rating_history (user_id), and
     # any user_league_ratings / league_memberships rows that didn't re-point.
@@ -132,3 +139,30 @@ async def _repoint_match_side_players(
         {"from_id": from_user_id, "to_id": to_user_id},
     )
     return cast(CursorResult[Any], result).rowcount or 0
+
+
+async def _repoint_match_signatures(
+    db: AsyncSession,
+    *,
+    from_user_id: uuid.UUID,
+    to_user_id: uuid.UUID,
+) -> None:
+    """Re-point match_signatures from ephemeral → verified. UNIQUE(match_id,
+    user_id) collides only if both users somehow already signed the same
+    match — left out by NOT EXISTS; the ephemeral row will then be dropped by
+    the defensive ``DELETE`` in ``merge_user``."""
+    await db.execute(
+        text(
+            """
+            UPDATE match_signatures AS ms
+            SET user_id = :to_id
+            WHERE ms.user_id = :from_id
+              AND NOT EXISTS (
+                SELECT 1 FROM match_signatures other
+                WHERE other.user_id = :to_id
+                  AND other.match_id = ms.match_id
+              )
+            """
+        ),
+        {"from_id": from_user_id, "to_id": to_user_id},
+    )

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -32,6 +32,7 @@ from app.models import (
     MatchSettings,
     MatchSide,
     MatchSidePlayer,
+    MatchSignature,
     MatchStatus,
     RatingHistory,
     RatingHistorySource,
@@ -43,7 +44,6 @@ from app.players import escape_like
 from app.rate_limiting import RedisRateLimiter
 from app.ratings import get_calculator, state_rating_value, validate_state
 from app.schemas.match import (
-    STATUS_LABELS,
     MatchCreate,
     MatchDetails,
     MatchDetailsCurrentGame,
@@ -61,6 +61,7 @@ from app.schemas.match import (
     MatchListRow,
     MatchResultsGameWrite,
     MatchResultsWrite,
+    MatchSignatureView,
 )
 from app.schemas.rating import RatingChange
 from app.sessions import get_current_user, get_optional_user
@@ -108,12 +109,14 @@ def _side_schema(
 
 
 # Shared eager-load chain. Used by every read path that returns a hierarchical
-# match — async SQLAlchemy can't lazy-load mid-request, so all four collections
-# are pulled up front.
+# match — async SQLAlchemy can't lazy-load mid-request, so all collections are
+# pulled up front. Signatures are needed wherever ``can_finalize`` /
+# ``can_confirm`` / the awaiting-confirmation status label is computed.
 def match_eager_options() -> tuple[ExecutableOption, ...]:
     return (
         selectinload(Match.match_settings),
         selectinload(Match.league).selectinload(League.rating_strategy),
+        selectinload(Match.signatures),
         *_match_history_options(),
     )
 
@@ -161,6 +164,42 @@ def _is_participant(match: Match, user_id: uuid.UUID) -> bool:
     return my_side(match, user_id) is not None
 
 
+def _all_sides_have_players(match: Match) -> bool:
+    """Solo matches (no opponent picked) carry one player-less sentinel side.
+    The signature/confirmation flow needs a second human, so solo matches skip
+    it entirely; this is the predicate that detects that case."""
+    return len(match.sides) >= 2 and all(side.players for side in match.sides)
+
+
+def _all_sides_signed(match: Match) -> bool:
+    """True when every side has at least one of its players in
+    ``match.signatures``. Used to gate the in_progress → completed status
+    flip in ``POST /confirmation``."""
+    signers = {sig.user_id for sig in match.signatures}
+    return all(any(p.user_id in signers for p in side.players) for side in match.sides)
+
+
+def _status_label(match: Match) -> str:
+    """User-facing label for a match's lifecycle position. An ``in_progress``
+    match with at least one signature has a posted result waiting on the
+    other side — surface that distinctly so the FE doesn't need to know
+    about ``signatures`` to render it."""
+    if match.status == MatchStatus.in_progress and match.signatures:
+        return "Awaiting confirmation"
+    # Exhaustive — adding an enum member is a type error until handled.
+    match match.status:
+        case MatchStatus.pending:
+            return "Scheduled"
+        case MatchStatus.in_progress:
+            return "Live"
+        case MatchStatus.completed:
+            return "Final"
+        case MatchStatus.disputed:
+            return "Disputed"
+        case MatchStatus.voided:
+            return "Voided"
+
+
 def _games_to_win(best_of: int) -> int:
     return math.ceil(best_of / 2)
 
@@ -181,14 +220,27 @@ def side_win_counts(match: Match) -> dict[int, int]:
 
 
 def current_game_number(match: Match) -> int | None:
-    """The next un-scored game number for an in-progress match. ``None`` once
-    every game in ``1..best_of`` has a saved score, or when the match isn't
-    in progress (finalized / disputed / voided / settings missing).
+    """The next un-scored game number for an in-progress match. ``None`` when:
+
+    - the match isn't in progress (finalized / disputed / voided);
+    - a result is posted and awaiting confirmation (``match.signatures``
+      non-empty — score writes are locked);
+    - the currently-saved games already decide the match — even if some game
+      numbers in ``1..best_of`` were never played, there's no meaningful
+      "next game to play" (a bo3 won 2-0 has no game 3). Returning a
+      phantom number here would deep-link the dashboard / list / scoring
+      page to a game that doesn't exist.
 
     Game rows are created lazily by the score-write endpoints, so the next
     game to score may not have a ``MatchGame`` row yet — this helper exposes
     the number rather than an object so deeplinks work either way."""
     if match.status != MatchStatus.in_progress:
+        return None
+    if match.signatures:
+        return None
+    target = _games_to_win(match.match_settings.best_of)
+    wins = side_win_counts(match)
+    if any(c >= target for c in wins.values()):
         return None
     best_of = match.match_settings.best_of
     scored = {g.game_number for g in match.games if g.score is not None}
@@ -240,7 +292,7 @@ def _serialize_details(
     return MatchDetails(
         id=match.id,
         status=match.status,
-        status_label=STATUS_LABELS[match.status],
+        status_label=_status_label(match),
         league=MatchLeague(id=match.league.id, name=match.league.name),
         best_of=match.match_settings.best_of,
         games_to_win=_games_to_win(match.match_settings.best_of),
@@ -259,11 +311,21 @@ def _serialize_details(
             current_game is not None and len(match.sides) >= 2 and is_participant
         ),
         # True iff the saved games already form a decided, validly-ordered
-        # match — the FE flips the scoring page's submit button label to
-        # "Finalize match" when this is true.
+        # match AND no result is currently posted — the FE flips the scoring
+        # page's submit button label to "Post result" when this is true.
         can_finalize=(
             is_participant and len(match.sides) >= 2 and _can_finalize(match)
         ),
+        # True iff the current user can act on a posted result (Confirm or
+        # Dispute). Same predicate gates both endpoints; the FE picks which
+        # CTA to show based on whether the user has already signed.
+        can_confirm=(
+            current_user_id is not None and _can_confirm(match, current_user_id)
+        ),
+        signatures=[
+            MatchSignatureView(user_id=sig.user_id, signed_at=sig.signed_at)
+            for sig in sorted(match.signatures, key=lambda s: s.signed_at)
+        ],
         recent_form=extras.recent_form,
         head_to_head=extras.head_to_head,
     )
@@ -490,13 +552,14 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
     return MatchListRow(
         id=match.id,
         status=match.status,
-        status_label=STATUS_LABELS[match.status],
+        status_label=_status_label(match),
         league=MatchLeague(id=match.league.id, name=match.league.name),
         sides=[_side_schema(side, side_wins, current_user_id) for side in sides_sorted],
         best_of=match.match_settings.best_of,
         created_at=match.created_at,
         current_game_number=next_number if can_score else None,
         can_score=can_score,
+        can_confirm=_can_confirm(match, current_user_id),
     )
 
 
@@ -603,14 +666,69 @@ def _enforce_scorable(match: Match) -> None:
             detail="This match has no opponent and can't be scored.",
         )
     # ``completed`` lives here too — once a match is finalized via
-    # ``POST /v1/matches/{id}/results`` it's read-only. The 409 covers the
-    # per-game write endpoints *and* the re-finalize attempt.
+    # ``POST /v1/matches/{id}/results`` (and confirmed) it's read-only. The
+    # 409 covers the per-game write endpoints *and* re-posts of /results
+    # against a non-solo match that has either been finalized or is
+    # awaiting confirmation (the signatures branch below).
     if match.status in {
         MatchStatus.completed,
         MatchStatus.disputed,
         MatchStatus.voided,
     }:
         raise HTTPException(status_code=409, detail="This match is no longer scorable.")
+    # A posted result locks the scores until somebody calls /confirmation
+    # (finalize) or /dispute (rewind). Both per-game writes and a second
+    # /results call hit this branch.
+    if match.signatures:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "This match has a posted result awaiting confirmation. "
+                "Confirm or dispute it before editing scores."
+            ),
+        )
+
+
+def _enforce_confirmable(match: Match, user_id: uuid.UUID) -> None:
+    """Shared preconditions for ``POST /confirmation`` and ``POST /dispute``.
+    Caller is already known to be a participant (``_load_match_for_scoring``
+    handles the 404)."""
+    if not _all_sides_have_players(match):
+        raise HTTPException(
+            status_code=409,
+            detail="This match has no opponent and can't be signed.",
+        )
+    if match.status != MatchStatus.in_progress:
+        raise HTTPException(
+            status_code=409,
+            detail="This match is no longer awaiting confirmation.",
+        )
+    if not match.signatures:
+        raise HTTPException(
+            status_code=409,
+            detail="No posted result to act on. Post the result first.",
+        )
+    if any(sig.user_id == user_id for sig in match.signatures):
+        raise HTTPException(status_code=409, detail="You've already signed this match.")
+
+
+def _can_confirm(match: Match, user_id: uuid.UUID | None) -> bool:
+    """Mirrors ``_enforce_confirmable`` as a boolean for the BFF surface.
+    True iff a ``POST /confirmation`` or ``POST /dispute`` from ``user_id``
+    would currently succeed (ignoring transport-layer auth)."""
+    if user_id is None:
+        return False
+    if match.status != MatchStatus.in_progress:
+        return False
+    if not match.signatures:
+        return False
+    if not _all_sides_have_players(match):
+        return False
+    if not _is_participant(match, user_id):
+        return False
+    if any(sig.user_id == user_id for sig in match.signatures):
+        return False
+    return True
 
 
 async def _load_rating_changes(
@@ -1044,8 +1162,13 @@ def _games_payload_from_match(match: Match) -> list[MatchResultsGameWrite]:
 def _can_finalize(match: Match) -> bool:
     """Whether ``POST /v1/matches/{id}/results`` would succeed on the
     currently-saved scores (ignoring authorization). Drives the FE's
-    ``can_finalize`` flag and the submit button's adaptive label."""
+    ``can_finalize`` flag and the submit button's adaptive label.
+
+    Returns False once anyone has posted a result — the next action on a
+    signed match is /confirmation or /dispute, not another /results."""
     if match.status != MatchStatus.in_progress:
+        return False
+    if match.signatures:
         return False
     try:
         _validate_finalize_games(
@@ -1056,14 +1179,16 @@ def _can_finalize(match: Match) -> bool:
     return True
 
 
-async def _apply_finalized_match(
+async def _commit_canonical_games(
     db: AsyncSession,
     match: Match,
     payload: MatchResultsWrite,
     decided_side: int,
 ) -> None:
     """Replace ``match.games`` (and the attached score rows) with the canonical
-    payload and mark the match completed. The caller commits."""
+    payload and set ``side.score`` + ``side.won`` from it. **Does not change
+    ``match.status``** — the caller picks whether the result is final (solo)
+    or awaiting confirmation (non-solo)."""
     # ``Match.games`` cascades ``all, delete-orphan``; clearing the collection
     # marks each existing MatchGame (and via MatchGame.score's own cascade,
     # the MatchGameScore) for delete. We must flush the deletes before
@@ -1090,8 +1215,6 @@ async def _apply_finalized_match(
     for side in match.sides:
         side.score = new_wins.get(side.side_number, 0)
         side.won = side.side_number == decided_side
-
-    match.status = MatchStatus.completed
 
 
 # ----- scoring endpoints ---------------------------------------------------
@@ -1225,16 +1348,21 @@ async def delete_game_score(
     response_model=MatchDetails,
     status_code=status.HTTP_201_CREATED,
 )
-async def finalize_match(
+async def post_match_result(
     match_id: uuid.UUID,
     payload: MatchResultsWrite,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> MatchDetails:
-    """Take the request body as canon. Any previously-saved per-game scores
-    on this match are discarded; the payload's games (validated as a complete,
-    decided match) become the match's games + scores. Then we mark completed
-    and apply the rating update — exactly once."""
+    """Post the result of a match. Any previously-saved per-game scores are
+    discarded; the payload's games (validated as a complete, decided match)
+    become canon, and the caller's signature is recorded.
+
+    For a non-solo match the status stays ``in_progress`` until every side
+    signs — the other side acts on the posted result via ``POST /confirmation``
+    or ``POST /dispute``, and the rating update fires inside /confirmation
+    when the final signature lands. Solo matches (one side player-less)
+    finalize immediately here, since there's no second party to attest."""
     match = await _load_match_for_scoring(db, match_id, current_user.id)
     _enforce_scorable(match)
 
@@ -1245,8 +1373,85 @@ async def finalize_match(
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    await _apply_finalized_match(db, match, payload, decided_side)
-    await _apply_rating_update(db, match)
+    await _commit_canonical_games(db, match, payload, decided_side)
+
+    if not _all_sides_have_players(match):
+        # Solo path: nobody else to sign — finalize immediately, no signature
+        # row inserted. Preserves today's solo-match behavior end-to-end.
+        match.status = MatchStatus.completed
+        await _apply_rating_update(db, match)
+    else:
+        # Non-solo path: caller is the first signer. Status remains
+        # in_progress until /confirmation lands the last needed signature.
+        match.signatures.append(MatchSignature(user_id=current_user.id))
+
+    await db.commit()
+
+    reloaded = await _load_match(db, match.id)
+    assert reloaded is not None
+    extras = await _load_view_extras(db, reloaded)
+    return _serialize_details(reloaded, current_user.id, extras)
+
+
+@router.post(
+    "/matches/{match_id}/confirmation",
+    response_model=MatchDetails,
+    status_code=status.HTTP_201_CREATED,
+)
+async def confirm_match_result(
+    match_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> MatchDetails:
+    """Sign off on a posted result. When this is the last signature needed
+    (every side has at least one signing player) the match flips to
+    ``completed`` and the rating update runs — exactly once."""
+    match = await _load_match_for_scoring(db, match_id, current_user.id)
+    _enforce_confirmable(match, current_user.id)
+
+    match.signatures.append(MatchSignature(user_id=current_user.id))
+    # The new row is already visible in the collection (no flush needed).
+    if _all_sides_signed(match):
+        match.status = MatchStatus.completed
+        await _apply_rating_update(db, match)
+
+    await db.commit()
+
+    reloaded = await _load_match(db, match.id)
+    assert reloaded is not None
+    extras = await _load_view_extras(db, reloaded)
+    return _serialize_details(reloaded, current_user.id, extras)
+
+
+@router.post(
+    "/matches/{match_id}/dispute",
+    response_model=MatchDetails,
+)
+async def dispute_match_result(
+    match_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> MatchDetails:
+    """Reject a posted result. Every signature is cleared and the side
+    win flags reset to ``None``; the canonical score rows themselves stay in
+    place so the disputer can navigate to the contested game and PUT a
+    corrected score. The per-game endpoints unblock automatically once
+    signatures are empty (see ``_enforce_scorable``)."""
+    match = await _load_match_for_scoring(db, match_id, current_user.id)
+    _enforce_confirmable(match, current_user.id)
+
+    match.signatures.clear()
+    for side in match.sides:
+        # Drop the "this side won" claim — the games stay around (so the
+        # disputer can edit the contested score), but until a fresh /results
+        # call ratifies a new outcome nobody has officially won. ``side.score``
+        # is the denormalized games-won mirror — keep it consistent with
+        # ``side.won`` here so a direct DB reader doesn't see won=None with
+        # score>0 (the games still imply 2-1 etc., but the BFF derives that
+        # from MatchGame, not from side.score).
+        side.won = None
+        side.score = 0
+
     await db.commit()
 
     reloaded = await _load_match(db, match.id)

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -18,6 +18,7 @@ from fastapi import (
 )
 from pyrate_limiter import Duration, Rate
 from sqlalchemy import Select, func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
 from sqlalchemy.sql.base import ExecutableOption
@@ -712,6 +713,26 @@ def _enforce_confirmable(match: Match, user_id: uuid.UUID) -> None:
         raise HTTPException(status_code=409, detail="You've already signed this match.")
 
 
+async def _add_signature_or_409(
+    db: AsyncSession, match: Match, user_id: uuid.UUID, detail: str
+) -> None:
+    """Append a ``MatchSignature(user_id)`` to ``match`` and flush it
+    immediately. Maps the ``uq_match_signatures_match_id_user_id`` violation
+    (same user racing themselves: rapid double-click, retry, browser
+    back-button refire) to a clean 409 instead of bubbling a 500.
+
+    Flushing here, not at commit, is load-bearing: a later SELECT inside
+    the handler (e.g. ``_apply_rating_update``'s ``rating_history`` lookup)
+    would autoflush the pending insert mid-read and raise IntegrityError
+    from a context that doesn't have the helper's try/except around it."""
+    match.signatures.append(MatchSignature(user_id=user_id))
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail=detail) from exc
+
+
 def _can_confirm(match: Match, user_id: uuid.UUID | None) -> bool:
     """Mirrors ``_enforce_confirmable`` as a boolean for the BFF surface.
     True iff a ``POST /confirmation`` or ``POST /dispute`` from ``user_id``
@@ -1383,7 +1404,9 @@ async def post_match_result(
     else:
         # Non-solo path: caller is the first signer. Status remains
         # in_progress until /confirmation lands the last needed signature.
-        match.signatures.append(MatchSignature(user_id=current_user.id))
+        await _add_signature_or_409(
+            db, match, current_user.id, "Result already posted; use /confirmation."
+        )
 
     await db.commit()
 
@@ -1409,8 +1432,9 @@ async def confirm_match_result(
     match = await _load_match_for_scoring(db, match_id, current_user.id)
     _enforce_confirmable(match, current_user.id)
 
-    match.signatures.append(MatchSignature(user_id=current_user.id))
-    # The new row is already visible in the collection (no flush needed).
+    await _add_signature_or_409(
+        db, match, current_user.id, "You've already signed this match."
+    )
     if _all_sides_signed(match):
         match.status = MatchStatus.completed
         await _apply_rating_update(db, match)

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -721,10 +721,16 @@ async def _add_signature_or_409(
     (same user racing themselves: rapid double-click, retry, browser
     back-button refire) to a clean 409 instead of bubbling a 500.
 
-    Flushing here, not at commit, is load-bearing: a later SELECT inside
-    the handler (e.g. ``_apply_rating_update``'s ``rating_history`` lookup)
-    would autoflush the pending insert mid-read and raise IntegrityError
-    from a context that doesn't have the helper's try/except around it."""
+    Flushing here, not at commit, is load-bearing: it forces the
+    IntegrityError to surface inside this helper's try/except no matter
+    what the caller does next, so it can't escape from a context the
+    handler isn't guarding. The sharpest case is ``confirm_match_result``,
+    which calls ``_apply_rating_update`` right after — that helper's
+    ``rating_history`` SELECT would otherwise autoflush the pending
+    insert mid-read and raise IntegrityError from outside the try/except.
+    ``post_match_result`` doesn't have an intervening SELECT, but the
+    same flush-first contract still makes the error surface consistently
+    across both call sites."""
     match.signatures.append(MatchSignature(user_id=user_id))
     try:
         await db.flush()
@@ -1450,6 +1456,11 @@ async def confirm_match_result(
 @router.post(
     "/matches/{match_id}/dispute",
     response_model=MatchDetails,
+    # 200 (not 201): dispute is delete-like — it clears signatures and
+    # rewinds side win flags rather than creating a new resource. Declared
+    # explicitly so the contrast with /results and /confirmation (both 201,
+    # both insert a signature) is intentional in the source, not a default.
+    status_code=status.HTTP_200_OK,
 )
 async def dispute_match_result(
     match_id: uuid.UUID,

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.match_game_score import MatchGameScore
 from app.models.match_settings import MatchSettings, VerificationPolicy
 from app.models.match_side import MatchSide
 from app.models.match_side_player import MatchSidePlayer
+from app.models.match_signature import MatchSignature
 from app.models.permission import Permission
 from app.models.rating_history import RatingHistory, RatingHistorySource
 from app.models.rating_strategy import RatingStrategy
@@ -26,6 +27,7 @@ __all__ = [
     "MatchSettings",
     "MatchSide",
     "MatchSidePlayer",
+    "MatchSignature",
     "MatchStatus",
     "Permission",
     "RatingHistory",

--- a/api/app/models/match.py
+++ b/api/app/models/match.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from app.models.match_game import MatchGame
     from app.models.match_side import MatchSide
     from app.models.match_side_player import MatchSidePlayer
+    from app.models.match_signature import MatchSignature
     from app.models.user import User
 
 
@@ -103,5 +104,10 @@ class Match(Base):
     side_players: Mapped[list["MatchSidePlayer"]] = relationship(
         back_populates="match",
         cascade="all",
+        passive_deletes=True,
+    )
+    signatures: Mapped[list["MatchSignature"]] = relationship(
+        back_populates="match",
+        cascade="all, delete-orphan",
         passive_deletes=True,
     )

--- a/api/app/models/match_signature.py
+++ b/api/app/models/match_signature.py
@@ -1,0 +1,66 @@
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    LargeBinary,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.match import Match
+    from app.models.user import User
+
+
+class MatchSignature(Base):
+    """Sign-off by a match participant on the canonical posted result.
+
+    Inserted on ``POST /v1/matches/{id}/results`` (first signer) and
+    ``POST /v1/matches/{id}/confirmation`` (subsequent signers). When every
+    side has at least one row here for one of its players, the confirmation
+    handler flips ``Match.status`` to ``completed`` and applies the rating
+    update — exactly once.
+
+    ``signature`` is a forward-looking placeholder for a cryptographic blob;
+    until that exists, the row's presence is the attestation.
+    """
+
+    __tablename__ = "match_signatures"
+    __table_args__ = (
+        UniqueConstraint(
+            "match_id", "user_id", name="uq_match_signatures_match_id_user_id"
+        ),
+        Index("ix_match_signatures_match_id", "match_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    match_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("matches.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    signature: Mapped[bytes | None] = mapped_column(LargeBinary(), nullable=True)
+    signed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    match: Mapped["Match"] = relationship(back_populates="signatures")
+    user: Mapped["User"] = relationship("User")

--- a/api/app/players.py
+++ b/api/app/players.py
@@ -508,16 +508,17 @@ def _serialize_player_match(match: Match, player_id: uuid.UUID) -> PlayerMatchRo
                 )
             )
 
-    # ``mine.won`` is set on /results (before /confirmation) so it would
-    # otherwise leak the un-ratified outcome here; gate on the terminal
-    # status so an awaiting-confirmation match still reads as in_progress
-    # with no W/L (matches PlayerMatchRow.result's documented contract).
+    # ``mine.won`` is set on /results (before /confirmation), and the posted
+    # result is considered public from the moment it lands — confirmation
+    # only ratifies it for ratings/finality. Surface W/L straight from
+    # ``mine.won``; the awaiting-confirmation state is conveyed by
+    # ``status`` + the "Awaiting confirmation" label, not by hiding the
+    # outcome.
     result: Literal["W", "L"] | None = None
-    if match.status == MatchStatus.completed:
-        if mine.won is True:
-            result = "W"
-        elif mine.won is False:
-            result = "L"
+    if mine.won is True:
+        result = "W"
+    elif mine.won is False:
+        result = "L"
 
     return PlayerMatchRow(
         id=match.id,

--- a/api/app/players.py
+++ b/api/app/players.py
@@ -508,11 +508,16 @@ def _serialize_player_match(match: Match, player_id: uuid.UUID) -> PlayerMatchRo
                 )
             )
 
+    # ``mine.won`` is set on /results (before /confirmation) so it would
+    # otherwise leak the un-ratified outcome here; gate on the terminal
+    # status so an awaiting-confirmation match still reads as in_progress
+    # with no W/L (matches PlayerMatchRow.result's documented contract).
     result: Literal["W", "L"] | None = None
-    if mine.won is True:
-        result = "W"
-    elif mine.won is False:
-        result = "L"
+    if match.status == MatchStatus.completed:
+        if mine.won is True:
+            result = "W"
+        elif mine.won is False:
+            result = "L"
 
     return PlayerMatchRow(
         id=match.id,

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -10,15 +10,6 @@ from app.schemas.rating import RatingChange
 # strict majority of games; the DB additionally enforces "odd and >= 1".
 ALLOWED_BEST_OF = (1, 3, 5, 7)
 
-# Maps the internal status enum to the label the BFF sends to clients.
-STATUS_LABELS: dict[MatchStatus, str] = {
-    MatchStatus.pending: "Scheduled",
-    MatchStatus.in_progress: "Live",
-    MatchStatus.completed: "Final",
-    MatchStatus.disputed: "Disputed",
-    MatchStatus.voided: "Voided",
-}
-
 
 class MatchCreate(BaseModel):
     """Request body for ``POST /v1/matches``.
@@ -146,6 +137,15 @@ class MatchDetailsH2H(BaseModel):
     recent_meetings: list[MatchDetailsH2HMeeting]
 
 
+class MatchSignatureView(BaseModel):
+    """One participant's sign-off on the posted result. Surfaced on
+    ``MatchDetails`` so the FE can render "Awaiting <opponent>'s confirmation"
+    without joining client-side."""
+
+    user_id: uuid.UUID
+    signed_at: datetime
+
+
 class MatchDetails(BaseModel):
     id: uuid.UUID
     status: MatchStatus
@@ -162,11 +162,22 @@ class MatchDetails(BaseModel):
     games: list[MatchDetailsGame]
     current_game: MatchDetailsCurrentGame | None
     can_score: bool
-    # True when the saved games form a decided, validly-ordered match and the
-    # current user is a participant on an in-progress match. The FE uses this
-    # to swap the scoring page's submit-button label and target endpoint
-    # between "save game" and "finalize match".
+    # True when the saved games form a decided, validly-ordered match, the
+    # current user is a participant on an in-progress match, AND no posted
+    # result is currently awaiting confirmation. The FE uses this to swap
+    # the scoring page's submit button between "save game" and "post result"
+    # (the latter calls ``POST /v1/matches/{id}/results``).
     can_finalize: bool
+    # True when the current user can confirm or dispute a posted result —
+    # i.e., the match is in_progress, at least one signature exists, the
+    # caller is a participant, and the caller hasn't signed yet. Same
+    # predicate gates both /confirmation and /dispute; the FE picks which
+    # CTA to show. False for anonymous / non-participants.
+    can_confirm: bool
+    # Always present (possibly empty). Default-factoried fields become
+    # ``optional`` in the generated TS types; declared as required keeps the
+    # FE from defending against ``undefined`` at every read.
+    signatures: list[MatchSignatureView]
     recent_form: list[MatchDetailsPlayerForm] = Field(default_factory=list)
     head_to_head: MatchDetailsH2H | None = None
 
@@ -187,6 +198,10 @@ class MatchListRow(BaseModel):
     # builds the route from (match_id, current_game_number).
     current_game_number: int | None
     can_score: bool
+    # Same semantic as ``MatchDetails.can_confirm`` — lets the matches list
+    # surface an "Awaiting your confirmation" CTA on rows the caller owes a
+    # signature on.
+    can_confirm: bool
 
 
 class MatchListResponse(BaseModel):

--- a/api/migrations/versions/20260526_0000_0007_create_match_signatures_table.py
+++ b/api/migrations/versions/20260526_0000_0007_create_match_signatures_table.py
@@ -1,0 +1,70 @@
+"""create match_signatures table
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-05-26 00:00:00.000000
+
+Per the pre-deploy convention in api/CLAUDE.md, edits to this migration
+happen in place. No backfill — assumes a fresh / empty DB.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0007"
+down_revision: Union[str, None] = "0006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "match_signatures",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "match_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("matches.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # RESTRICT (not CASCADE) so an ephemeral-user delete during account
+        # merge can't silently drop a signature row; the merge service
+        # repoints user_id explicitly. See app/account_merge.py.
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        # Placeholder for an eventual cryptographic blob attesting to the
+        # canonical scores. Nothing reads or writes it yet — presence of the
+        # row is the signal.
+        sa.Column("signature", sa.LargeBinary(), nullable=True),
+        sa.Column(
+            "signed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "match_id",
+            "user_id",
+            name="uq_match_signatures_match_id_user_id",
+        ),
+    )
+    op.create_index(
+        "ix_match_signatures_match_id", "match_signatures", ["match_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_match_signatures_match_id", table_name="match_signatures")
+    op.drop_table("match_signatures")

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -4,6 +4,9 @@ The leading underscore keeps pytest from auto-collecting this as a test module;
 fixtures still belong in ``conftest.py``.
 """
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -42,3 +45,32 @@ def make_client() -> AsyncClient:
         transport=ASGITransport(app=fastapi_app),
         base_url="https://testserver",
     )
+
+
+@asynccontextmanager
+async def opponent_session(
+    db_session: AsyncSession, username: str
+) -> AsyncIterator[tuple[AsyncClient, User]]:
+    """Async context manager that mints an ephemeral session on a fresh
+    client, renames the auto-generated user to ``username``, yields
+    ``(client, user)``, and closes the client on exit.
+
+    Used by signature-flow tests that need a second human who can act on the
+    match — typically ``POST /v1/matches/{id}/confirmation`` — without the
+    test setting up (and cleaning up) the session juggling itself.
+
+    Example::
+
+        async with opponent_session(db_session, "rival") as (opp_client, opp):
+            await _play_match_to_completion(
+                api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+            )
+    """
+    client = make_client()
+    try:
+        user = await start_session(client, db_session)
+        user.username = username
+        await db_session.commit()
+        yield client, user
+    finally:
+        await client.aclose()

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -14,6 +14,7 @@ from app.models import (
     MatchSettings,
     MatchSide,
     MatchSidePlayer,
+    MatchSignature,
     MatchStatus,
     RatingHistory,
     RatingHistorySource,
@@ -293,3 +294,72 @@ async def test_merge_with_user_league_rating_collision_drops_ephemeral(
         .all()
     )
     assert [r.user_id for r in rows] == [verified.id]
+
+
+async def test_merge_repoints_match_signatures(db_session: AsyncSession):
+    """``match_signatures`` is RESTRICT on user_id, so the merge must re-point
+    every signature row from the ephemeral user onto the verified user — same
+    contract as ``match_side_players``. Otherwise the final ephemeral-user
+    delete would either fail (RESTRICT block) or orphan the audit row."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    opponent = await _make_ephemeral(db_session, "spinning-otter")
+    match = await _record_match(db_session, ephemeral, ephemeral, opponent)
+
+    db_session.add(MatchSignature(match_id=match.id, user_id=ephemeral.id))
+    db_session.add(MatchSignature(match_id=match.id, user_id=opponent.id))
+    await db_session.commit()
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    sigs = (
+        (
+            await db_session.execute(
+                select(MatchSignature).where(MatchSignature.match_id == match.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    user_ids = {sig.user_id for sig in sigs}
+    assert user_ids == {verified.id, opponent.id}
+    # And the ephemeral user is gone (would have blocked on the RESTRICT FK
+    # otherwise).
+    ephemeral_row = (
+        await db_session.execute(select(User).where(User.id == ephemeral.id))
+    ).scalar_one_or_none()
+    assert ephemeral_row is None
+
+
+async def test_merge_with_match_signature_collision_drops_ephemeral(
+    db_session: AsyncSession,
+):
+    """If both users somehow already signed the same match, the NOT EXISTS
+    guard skips the re-point and the defensive DELETE in ``merge_user`` drops
+    the leftover ephemeral row so the user delete still succeeds."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    opponent = await _make_ephemeral(db_session, "spinning-otter")
+    match = await _record_match(db_session, ephemeral, ephemeral, opponent)
+
+    # Both users carry a signature on the same match — impossible in normal
+    # flow but defended against here.
+    db_session.add(MatchSignature(match_id=match.id, user_id=ephemeral.id))
+    db_session.add(MatchSignature(match_id=match.id, user_id=verified.id))
+    await db_session.commit()
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    sigs = (
+        (
+            await db_session.execute(
+                select(MatchSignature).where(MatchSignature.match_id == match.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    # Verified's pre-existing signature survives; ephemeral's is dropped.
+    assert [sig.user_id for sig in sigs] == [verified.id]

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -15,7 +15,7 @@ from app.models import (
     RatingStrategy,
     UserLeagueRating,
 )
-from tests._helpers import make_client, make_user, start_session
+from tests._helpers import make_client, make_user, opponent_session, start_session
 
 
 async def _create_match(client: AsyncClient, opponent_id, best_of: int = 5) -> dict:
@@ -139,16 +139,19 @@ async def test_dashboard_returns_recent_results_for_completed_matches(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    match = await _create_match(api_client, opp.id, best_of=1)
-    await api_client.post(
-        f"/v1/matches/{match['id']}/results",
-        json={
-            "games": [
-                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
-            ]
-        },
-    )
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=1)
+        post = await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                ]
+            },
+        )
+        assert post.status_code == 201
+        confirm = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert confirm.status_code == 201
 
     body = (await api_client.get("/v1/dashboard")).json()
     assert len(body["recent_results"]) == 1
@@ -188,18 +191,19 @@ async def test_dashboard_scoped_to_current_user(
 
 async def _play_match(
     client: AsyncClient,
-    opponent_id,
+    opp_client: AsyncClient,
+    opp_id,
     *,
     i_win: bool,
     best_of: int = 1,
 ) -> dict:
-    """Create a match, fast-forward through a deciding result via /results
-    (the per-game scratchpad endpoints don't finalize anymore — see the
-    decouple-scoring refactor)."""
-    match = await _create_match(client, opponent_id, best_of=best_of)
+    """Create a match, post the result, and have the opponent confirm — the
+    full sign-off dance. Returns the create response (the test usually only
+    wants the match id)."""
+    match = await _create_match(client, opp_id, best_of=best_of)
     s1, s2 = (11, 4) if i_win else (4, 11)
     games_to_win = best_of // 2 + 1
-    await client.post(
+    post = await client.post(
         f"/v1/matches/{match['id']}/results",
         json={
             "games": [
@@ -208,6 +212,9 @@ async def _play_match(
             ]
         },
     )
+    assert post.status_code == 201
+    confirm = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+    assert confirm.status_code == 201
     return match
 
 
@@ -215,8 +222,8 @@ async def test_dashboard_rating_reflects_completed_match(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    await _play_match(api_client, opp.id, i_win=True)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        await _play_match(api_client, opp_client, opp.id, i_win=True)
 
     rating = (await api_client.get("/v1/dashboard")).json()["rating"]
     # Glicko-2 lifts the winner above 1500 and tightens RD.
@@ -234,11 +241,11 @@ async def test_dashboard_streak_counts_consecutive_results(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    # W, W, L — streak should be the most-recent L of length 1.
-    await _play_match(api_client, opp.id, i_win=True)
-    await _play_match(api_client, opp.id, i_win=True)
-    await _play_match(api_client, opp.id, i_win=False)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        # W, W, L — streak should be the most-recent L of length 1.
+        await _play_match(api_client, opp_client, opp.id, i_win=True)
+        await _play_match(api_client, opp_client, opp.id, i_win=True)
+        await _play_match(api_client, opp_client, opp.id, i_win=False)
 
     rating = (await api_client.get("/v1/dashboard")).json()["rating"]
     assert rating["streak"] == {"kind": "L", "n": 1}
@@ -250,13 +257,13 @@ async def test_dashboard_rating_peak_holds_after_loss(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    await _play_match(api_client, opp.id, i_win=True)
-    rating_after_win = (await api_client.get("/v1/dashboard")).json()["rating"]
-    peak_after_win = rating_after_win["current"]
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        await _play_match(api_client, opp_client, opp.id, i_win=True)
+        rating_after_win = (await api_client.get("/v1/dashboard")).json()["rating"]
+        peak_after_win = rating_after_win["current"]
 
-    await _play_match(api_client, opp.id, i_win=False)
-    rating_after_loss = (await api_client.get("/v1/dashboard")).json()["rating"]
+        await _play_match(api_client, opp_client, opp.id, i_win=False)
+        rating_after_loss = (await api_client.get("/v1/dashboard")).json()["rating"]
 
     assert rating_after_loss["current"] < peak_after_win
     assert rating_after_loss["peak"] == peak_after_win

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -4,6 +4,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models import (
     League,
@@ -13,7 +14,7 @@ from app.models import (
     MatchGameScore,
     MatchSide,
 )
-from tests._helpers import make_client, make_user, start_session
+from tests._helpers import make_client, make_user, opponent_session, start_session
 
 # ----- create -------------------------------------------------------------
 
@@ -414,19 +415,24 @@ async def test_list_q_filter_matches_caller_username(
 
 async def test_list_filter_by_status(api_client: AsyncClient, db_session: AsyncSession):
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    in_progress = await _create_match(api_client, opp.id, best_of=1)
-    # Finalize a separate match to flip it to completed.
-    completed_match = await _create_match(api_client, opp.id, best_of=1)
-    score_resp = await api_client.post(
-        f"/v1/matches/{completed_match['id']}/results",
-        json={
-            "games": [
-                {"game_number": 1, "side_1_points": 11, "side_2_points": 5},
-            ]
-        },
-    )
-    assert score_resp.status_code == 201
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        in_progress = await _create_match(api_client, opp.id, best_of=1)
+        # Finalize a separate match to flip it to completed — post + confirm
+        # so the second signer's call lands the status transition.
+        completed_match = await _create_match(api_client, opp.id, best_of=1)
+        post = await api_client.post(
+            f"/v1/matches/{completed_match['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 5},
+                ]
+            },
+        )
+        assert post.status_code == 201
+        confirm = await opp_client.post(
+            f"/v1/matches/{completed_match['id']}/confirmation"
+        )
+        assert confirm.status_code == 201
 
     listing = (
         await api_client.get("/v1/matches", params={"status": "in_progress"})
@@ -778,101 +784,158 @@ async def test_can_score_match_without_opponent(
 # ----- finalize (POST /v1/matches/{id}/results) ---------------------------
 
 
-async def test_finalize_replaces_scores_and_marks_completed(
+async def test_results_post_commits_canon_and_records_first_signature(
     api_client: AsyncClient, db_session: AsyncSession
 ):
+    """``POST /results`` commits the canonical games (obliterating the
+    scratchpad), sets ``side.won``, and inserts the caller's signature — but
+    leaves status at ``in_progress`` until the opponent confirms."""
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    match = await _create_match(api_client, opp.id, best_of=3)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
 
-    # Pre-finalize, the FE has scratched in a totally different game 1 score.
-    # The /results payload is canon — it should win.
-    await api_client.post(
-        f"/v1/matches/{match['id']}/games/1/scores/new",
-        json={"side_1_points": 5, "side_2_points": 11},
-    )
+        # Pre-post, the FE has scratched in a totally different game 1 score.
+        # The /results payload is canon — it should win.
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/1/scores/new",
+            json={"side_1_points": 5, "side_2_points": 11},
+        )
 
-    response = await api_client.post(
-        f"/v1/matches/{match['id']}/results",
-        json={
+        response = await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                    {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
+                ]
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        # Status holds at in_progress with the awaiting-confirmation label —
+        # the result is on the table, the other side hasn't signed.
+        assert body["status"] == "in_progress"
+        assert body["status_label"] == "Awaiting confirmation"
+        assert body["can_score"] is False
+        assert body["can_finalize"] is False
+        assert body["can_confirm"] is False  # poster has already signed
+        assert len(body["signatures"]) == 1
+        sides = sorted(body["sides"], key=lambda s: s["side_number"])
+        # side.won is set on /results — the games show who won, irrespective
+        # of whether the result has been ratified yet.
+        assert [s["won"] for s in sides] == [True, False]
+        # Games + scores reflect the payload, not the scratchpad.
+        games = sorted(body["games"], key=lambda g: g["game_number"])
+        assert [g["game_number"] for g in games] == [1, 2]
+        assert games[0]["score"]["side_1_points"] == 11
+        assert games[0]["score"]["side_2_points"] == 4
+
+        # DB-side sanity: no orphan score rows from the obliterated scratchpad.
+        game_rows = (await db_session.execute(select(MatchGame))).scalars().all()
+        score_rows = (await db_session.execute(select(MatchGameScore))).scalars().all()
+        assert len(game_rows) == 2
+        assert len(score_rows) == 2
+
+        # The opponent confirms — match flips to completed.
+        confirm = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert confirm.status_code == 201
+        confirmed = confirm.json()
+        assert confirmed["status"] == "completed"
+        assert confirmed["status_label"] == "Final"
+        assert len(confirmed["signatures"]) == 2
+
+
+async def test_results_409_when_already_posted(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A second ``POST /results`` on the same match (still awaiting
+    confirmation) bounces — the user should be calling /confirmation instead."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "rival") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+
+        payload = {
             "games": [
                 {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
                 {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
             ]
-        },
-    )
-    assert response.status_code == 201
-    body = response.json()
-    assert body["status"] == "completed"
-    assert body["status_label"] == "Final"
-    assert body["current_game"] is None
-    assert body["can_score"] is False
-    assert body["can_finalize"] is False
-    sides = sorted(body["sides"], key=lambda s: s["side_number"])
-    assert [s["games_won"] for s in sides] == [2, 0]
-    assert [s["won"] for s in sides] == [True, False]
-    # Games + scores reflect the payload, not the scratchpad.
-    games = sorted(body["games"], key=lambda g: g["game_number"])
-    assert [g["game_number"] for g in games] == [1, 2]
-    assert games[0]["score"]["side_1_points"] == 11
-    assert games[0]["score"]["side_2_points"] == 4
+        }
+        first = await api_client.post(
+            f"/v1/matches/{match['id']}/results", json=payload
+        )
+        assert first.status_code == 201
 
-    # DB-side sanity: no orphan score rows from the obliterated scratchpad.
-    game_rows = (await db_session.execute(select(MatchGame))).scalars().all()
-    score_rows = (await db_session.execute(select(MatchGameScore))).scalars().all()
-    assert len(game_rows) == 2
-    assert len(score_rows) == 2
+        second = await api_client.post(
+            f"/v1/matches/{match['id']}/results", json=payload
+        )
+        assert second.status_code == 409
 
 
-async def test_finalize_409_when_already_completed(
+async def test_score_endpoints_409_once_result_is_posted(
     api_client: AsyncClient, db_session: AsyncSession
 ):
+    """While awaiting confirmation, every per-game write returns 409.
+    Disputing rewinds: signatures clear, scores become editable again."""
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    match = await _create_match(api_client, opp.id, best_of=3)
+    async with opponent_session(db_session, "rival") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                    {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
+                ]
+            },
+        )
 
-    payload = {
-        "games": [
-            {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
-            {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
-        ]
-    }
-    first = await api_client.post(f"/v1/matches/{match['id']}/results", json=payload)
-    assert first.status_code == 201
-
-    second = await api_client.post(f"/v1/matches/{match['id']}/results", json=payload)
-    assert second.status_code == 409
+        # Every write path returns 409 while the posted result is awaiting
+        # confirmation.
+        post = await api_client.post(
+            f"/v1/matches/{match['id']}/games/1/scores/new",
+            json={"side_1_points": 8, "side_2_points": 11},
+        )
+        assert post.status_code == 409
+        put = await api_client.put(
+            f"/v1/matches/{match['id']}/games/1/scores",
+            json={"side_1_points": 8, "side_2_points": 11},
+        )
+        assert put.status_code == 409
+        delete = await api_client.delete(f"/v1/matches/{match['id']}/games/1/scores")
+        assert delete.status_code == 409
 
 
 async def test_score_endpoints_409_once_match_is_completed(
     api_client: AsyncClient, db_session: AsyncSession
 ):
+    """After /confirmation lands and the match is completed, every write
+    path 409s — there's no edit affordance on a finalized match."""
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    match = await _create_match(api_client, opp.id, best_of=3)
-    await api_client.post(
-        f"/v1/matches/{match['id']}/results",
-        json={
-            "games": [
-                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
-                {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
-            ]
-        },
-    )
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                    {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
+                ]
+            },
+        )
+        await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
 
-    # Every write path returns 409 once the match is finalized.
-    post = await api_client.post(
-        f"/v1/matches/{match['id']}/games/1/scores/new",
-        json={"side_1_points": 8, "side_2_points": 11},
-    )
-    assert post.status_code == 409
-    put = await api_client.put(
-        f"/v1/matches/{match['id']}/games/1/scores",
-        json={"side_1_points": 8, "side_2_points": 11},
-    )
-    assert put.status_code == 409
-    delete = await api_client.delete(f"/v1/matches/{match['id']}/games/1/scores")
-    assert delete.status_code == 409
+        post = await api_client.post(
+            f"/v1/matches/{match['id']}/games/1/scores/new",
+            json={"side_1_points": 8, "side_2_points": 11},
+        )
+        assert post.status_code == 409
+        put = await api_client.put(
+            f"/v1/matches/{match['id']}/games/1/scores",
+            json={"side_1_points": 8, "side_2_points": 11},
+        )
+        assert put.status_code == 409
+        delete = await api_client.delete(f"/v1/matches/{match['id']}/games/1/scores")
+        assert delete.status_code == 409
 
 
 @pytest.mark.parametrize(
@@ -1103,16 +1166,18 @@ async def test_list_and_get_match_include_league(
 
 async def _play_match_to_completion(
     client: AsyncClient,
-    opponent_id: uuid.UUID,
+    opp_client: AsyncClient,
+    opp_id: uuid.UUID,
     best_of: int,
     side_1_wins: bool,
 ) -> dict:
-    """Create a match and finalize it. The chosen side wins the minimum
-    number of games needed to clinch. Returns the final payload."""
-    match = await _create_match(client, opponent_id, best_of=best_of)
+    """Create a match, post the result, and have the opponent confirm it —
+    the full sign-off dance. The chosen side wins the minimum number of games
+    needed to clinch. Returns the post-confirmation MatchDetails body."""
+    match = await _create_match(client, opp_id, best_of=best_of)
     needed = best_of // 2 + 1
     s1, s2 = (11, 5) if side_1_wins else (5, 11)
-    response = await client.post(
+    post = await client.post(
         f"/v1/matches/{match['id']}/results",
         json={
             "games": [
@@ -1121,7 +1186,10 @@ async def _play_match_to_completion(
             ]
         },
     )
-    body = response.json()
+    assert post.status_code == 201
+    confirm = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+    assert confirm.status_code == 201
+    body = confirm.json()
     assert body["status"] == "completed"
     return body
 
@@ -1154,9 +1222,13 @@ async def test_details_recent_form_lists_each_player_previous_results(
     opp = await make_user(db_session, "form-rival")
     # Play two finished matches with a third party so each side has its own
     # prior history that's *not* a head-to-head meeting.
-    other = await make_user(db_session, "third-party")
-    await _play_match_to_completion(api_client, other.id, best_of=3, side_1_wins=True)
-    await _play_match_to_completion(api_client, other.id, best_of=3, side_1_wins=False)
+    async with opponent_session(db_session, "third-party") as (other_client, other):
+        await _play_match_to_completion(
+            api_client, other_client, other.id, best_of=3, side_1_wins=True
+        )
+        await _play_match_to_completion(
+            api_client, other_client, other.id, best_of=3, side_1_wins=False
+        )
     # Now start a head-to-head match and ask for its details.
     current = await _create_match(api_client, opp.id, best_of=3)
     detail = (await api_client.get(f"/v1/matches/{current['id']}")).json()
@@ -1174,11 +1246,11 @@ async def test_details_recent_form_excludes_the_current_match(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "exclude-rival")
     # Play to completion against this opp, then look up that match's detail.
-    finished = await _play_match_to_completion(
-        api_client, opp.id, best_of=3, side_1_wins=True
-    )
+    async with opponent_session(db_session, "exclude-rival") as (opp_client, opp):
+        finished = await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
 
     detail = (await api_client.get(f"/v1/matches/{finished['id']}")).json()
     forms = {f["user_id"]: f for f in detail["recent_form"]}
@@ -1194,17 +1266,20 @@ async def test_details_recent_form_excludes_matches_after_this_one(
     before this one was created counts; one completed after it does not."""
     me = await start_session(api_client, db_session)
     opp = await make_user(db_session, "after-rival")
-    other = await make_user(db_session, "after-third-party")
-    # A match I finished *before* the viewed match is created.
-    earlier = await _play_match_to_completion(
-        api_client, other.id, best_of=3, side_1_wins=True
-    )
-    # The match we'll view (in progress, so it stays "current" in time).
-    current = await _create_match(api_client, opp.id, best_of=3)
-    # A match I finish *after* the viewed match was created.
-    later = await _play_match_to_completion(
-        api_client, other.id, best_of=3, side_1_wins=False
-    )
+    async with opponent_session(db_session, "after-third-party") as (
+        other_client,
+        other,
+    ):
+        # A match I finished *before* the viewed match is created.
+        earlier = await _play_match_to_completion(
+            api_client, other_client, other.id, best_of=3, side_1_wins=True
+        )
+        # The match we'll view (in progress, so it stays "current" in time).
+        current = await _create_match(api_client, opp.id, best_of=3)
+        # A match I finish *after* the viewed match was created.
+        later = await _play_match_to_completion(
+            api_client, other_client, other.id, best_of=3, side_1_wins=False
+        )
 
     detail = (await api_client.get(f"/v1/matches/{current['id']}")).json()
     forms = {f["user_id"]: f for f in detail["recent_form"]}
@@ -1217,13 +1292,19 @@ async def test_details_head_to_head_counts_prior_meetings_per_side(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
-    rival = await make_user(db_session, "h2h-rival")
-    # Three completed prior meetings: I win two, lose one.
-    await _play_match_to_completion(api_client, rival.id, best_of=3, side_1_wins=True)
-    await _play_match_to_completion(api_client, rival.id, best_of=3, side_1_wins=True)
-    await _play_match_to_completion(api_client, rival.id, best_of=3, side_1_wins=False)
-    # New in-progress match — H2H counts only completed *prior* meetings.
-    current = await _create_match(api_client, rival.id, best_of=5)
+    async with opponent_session(db_session, "h2h-rival") as (rival_client, rival):
+        # Three completed prior meetings: I win two, lose one.
+        await _play_match_to_completion(
+            api_client, rival_client, rival.id, best_of=3, side_1_wins=True
+        )
+        await _play_match_to_completion(
+            api_client, rival_client, rival.id, best_of=3, side_1_wins=True
+        )
+        await _play_match_to_completion(
+            api_client, rival_client, rival.id, best_of=3, side_1_wins=False
+        )
+        # New in-progress match — H2H counts only completed *prior* meetings.
+        current = await _create_match(api_client, rival.id, best_of=5)
 
     detail = (await api_client.get(f"/v1/matches/{current['id']}")).json()
     h2h = detail["head_to_head"]
@@ -1252,11 +1333,15 @@ async def test_details_recent_form_includes_pre_match_rating_and_career(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     me = await start_session(api_client, db_session)
-    other = await make_user(db_session, "career-other")
-    # Two completed wins build up career stats *and* rating history before
-    # the head-to-head match is created.
-    await _play_match_to_completion(api_client, other.id, best_of=3, side_1_wins=True)
-    await _play_match_to_completion(api_client, other.id, best_of=3, side_1_wins=True)
+    async with opponent_session(db_session, "career-other") as (other_client, other):
+        # Two completed wins build up career stats *and* rating history before
+        # the head-to-head match is created.
+        await _play_match_to_completion(
+            api_client, other_client, other.id, best_of=3, side_1_wins=True
+        )
+        await _play_match_to_completion(
+            api_client, other_client, other.id, best_of=3, side_1_wins=True
+        )
 
     opp = await make_user(db_session, "pre-rating-opp")
     current = await _create_match(api_client, opp.id, best_of=3)
@@ -1288,10 +1373,10 @@ async def test_details_recent_form_excludes_self_from_career_count(
     their league-join seed (recorded before the match), but none of the
     match's own freshly-written rating rows leak into the pre-match view."""
     me = await start_session(api_client, db_session)
-    opp = await make_user(db_session, "self-exclude-opp")
-    finished = await _play_match_to_completion(
-        api_client, opp.id, best_of=3, side_1_wins=True
-    )
+    async with opponent_session(db_session, "self-exclude-opp") as (opp_client, opp):
+        finished = await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
 
     detail = (await api_client.get(f"/v1/matches/{finished['id']}")).json()
     forms = {f["user_id"]: f for f in detail["recent_form"]}
@@ -1307,12 +1392,13 @@ async def test_details_recent_form_excludes_self_from_career_count(
     assert mine["rating_before"] == 1500.0
     assert mine["rating_history"] == [1500.0]
 
-    # The opponent came in via make_user (no league join) and is only seeded
-    # when the match completes — after match creation — so they have no
-    # pre-match history.
+    # The opponent's session join seeded their rating too — but only the
+    # match-sourced rating row would predate the *next* match, and there
+    # isn't one — so their pre-match history for this match is just the
+    # seed (recorded before the match was created).
     opp_form = forms[str(opp.id)]
-    assert opp_form["rating_before"] is None
-    assert opp_form["rating_history"] == []
+    assert opp_form["rating_before"] == 1500.0
+    assert opp_form["rating_history"] == [1500.0]
 
 
 async def test_list_matches_csv_export(
@@ -1341,8 +1427,10 @@ async def test_list_matches_csv_includes_score_for_completed(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "csv-finished")
-    await _play_match_to_completion(api_client, opp.id, best_of=3, side_1_wins=True)
+    async with opponent_session(db_session, "csv-finished") as (opp_client, opp):
+        await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
 
     response = await api_client.get("/v1/matches.csv")
 
@@ -1366,3 +1454,289 @@ async def test_list_matches_csv_honors_status_filter(
     assert response.text.strip().splitlines() == [
         "Match ID,Created,Status,League,Side 1,Side 2,Score,Best of"
     ]
+
+
+# ----- signature flow (POST /confirmation + /dispute) ---------------------
+
+
+async def _post_results(client: AsyncClient, match_id: str, best_of: int = 3) -> dict:
+    """Caller wins the minimum games needed to clinch a best-of-N. Returns
+    the response body."""
+    needed = best_of // 2 + 1
+    response = await client.post(
+        f"/v1/matches/{match_id}/results",
+        json={
+            "games": [
+                {"game_number": n, "side_1_points": 11, "side_2_points": 4}
+                for n in range(1, needed + 1)
+            ]
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+async def test_confirmation_finalizes_and_lands_second_signature(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "sig-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+        confirm = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert confirm.status_code == 201
+        body = confirm.json()
+        assert body["status"] == "completed"
+        assert body["status_label"] == "Final"
+        signers = {sig["user_id"] for sig in body["signatures"]}
+        assert signers == {str(me.id), str(opp.id)}
+        assert body["can_confirm"] is False
+
+
+async def test_dispute_clears_signatures_and_rewinds_to_in_progress(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """``POST /dispute`` deletes every signature on the match, drops the
+    side.won flags back to None, and leaves the canonical games in place so
+    the disputer can navigate to the contested game and PUT a correction."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "dispute-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+        dispute = await opp_client.post(f"/v1/matches/{match['id']}/dispute")
+        assert dispute.status_code == 200
+        body = dispute.json()
+        assert body["status"] == "in_progress"
+        assert body["status_label"] == "Live"
+        assert body["signatures"] == []
+        sides = sorted(body["sides"], key=lambda s: s["side_number"])
+        assert [s["won"] for s in sides] == [None, None]
+        # games_won still reflects the canonical scores (they're preserved so
+        # the disputer can edit just the contested one); only the "this side
+        # won" claim is rescinded.
+        assert [s["games_won"] for s in sides] == [2, 0]
+        # current_game must NOT point at a never-played game number — bo3
+        # decided 2-0 has no "game 3" to score, even though one slot is
+        # un-scored in 1..best_of. Otherwise the dashboard / list / scoring
+        # page deep-links into a phantom game.
+        assert body["current_game"] is None
+        assert body["can_score"] is False
+        # Canonical games stay around so the contested score can be edited.
+        games = sorted(body["games"], key=lambda g: g["game_number"])
+        assert [g["game_number"] for g in games] == [1, 2]
+        for g in games:
+            assert g["score"] is not None
+
+        # The disputer can now PUT a correction to flip the result.
+        put = await opp_client.put(
+            f"/v1/matches/{match['id']}/games/2/scores",
+            json={"side_1_points": 5, "side_2_points": 11},
+        )
+        assert put.status_code == 200
+
+
+async def test_results_on_solo_finalizes_with_no_signature_row(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Solo matches (no opponent picked) keep today's auto-finalize behavior
+    on /results — there's no second party to attest, so the match flips
+    straight to completed and no signature row is inserted."""
+    await start_session(api_client, db_session)
+    match = (
+        await api_client.post("/v1/matches", json={"best_of": 1, "rated": False})
+    ).json()
+    body = await _post_results(api_client, match["id"], best_of=1)
+    assert body["status"] == "completed"
+    assert body["signatures"] == []
+
+
+async def test_confirmation_409_when_no_result_posted(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "early-confirm-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        response = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert response.status_code == 409
+        assert "No posted result" in response.json()["detail"]
+
+
+async def test_dispute_409_when_no_signatures(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "early-dispute-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        response = await opp_client.post(f"/v1/matches/{match['id']}/dispute")
+        assert response.status_code == 409
+
+
+async def test_signer_cannot_confirm_or_dispute_their_own_post(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """``/confirmation`` and ``/dispute`` both require the caller to be a
+    participant who *hasn't* yet signed. The first poster has already signed,
+    so they get 409 on both."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "self-sign-opp") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+        self_confirm = await api_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert self_confirm.status_code == 409
+        self_dispute = await api_client.post(f"/v1/matches/{match['id']}/dispute")
+        assert self_dispute.status_code == 409
+
+
+async def test_non_participant_cannot_confirm_or_dispute(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A non-participant gets 404, mirroring the per-game write endpoints —
+    no way to learn the match exists from a write path."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "non-part-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+        # A third party — not the poster, not the opponent — can't sign.
+        async with make_client() as bystander_client:
+            await start_session(bystander_client, db_session)
+            confirm = await bystander_client.post(
+                f"/v1/matches/{match['id']}/confirmation"
+            )
+            assert confirm.status_code == 404
+            dispute = await bystander_client.post(f"/v1/matches/{match['id']}/dispute")
+            assert dispute.status_code == 404
+
+        # Sanity: the legit opponent can still confirm.
+        confirm = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert confirm.status_code == 201
+
+
+async def test_confirmation_409_after_already_finalized(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Once both sides have signed and the match is completed, further
+    /confirmation calls 409. ``_enforce_confirmable`` catches it on the
+    ``status != in_progress`` gate."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "post-final-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+        first = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert first.status_code == 201
+
+        again = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert again.status_code == 409
+
+
+async def test_dispute_then_repost_finalizes_with_fresh_signatures(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """End-to-end: poster posts, opp disputes, poster re-posts, opp confirms.
+    The signature set after re-post contains exactly the new poster's row;
+    after confirm, both sides are present."""
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "dispute-flow-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+        dispute = await opp_client.post(f"/v1/matches/{match['id']}/dispute")
+        assert dispute.status_code == 200
+        assert dispute.json()["signatures"] == []
+
+        # Re-post (same payload — doesn't matter what changed for this test).
+        re_post = await _post_results(api_client, match["id"])
+        assert re_post["status"] == "in_progress"
+        assert [sig["user_id"] for sig in re_post["signatures"]] == [str(me.id)]
+
+        confirm = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert confirm.status_code == 201
+        body = confirm.json()
+        assert body["status"] == "completed"
+        assert {sig["user_id"] for sig in body["signatures"]} == {
+            str(me.id),
+            str(opp.id),
+        }
+
+
+async def test_dispute_zeros_side_score_to_match_won_reset(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The denormalized ``side.score`` column has to stay consistent with
+    ``side.won`` after a dispute. The BFF derives ``games_won`` from
+    ``match.games`` (so the API response keeps the canonical counts), but
+    any direct DB reader of ``side.score`` (analytics, future BFFs, the
+    rating recompute job) would otherwise see won=None alongside score>0
+    — a contradictory row state ``api/CLAUDE.md`` flags as a smell."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "side-score-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+        # After /results: side.score should reflect the win counts.
+        row = (
+            await db_session.execute(
+                select(Match)
+                .where(Match.id == uuid.UUID(match["id"]))
+                .options(selectinload(Match.sides))
+            )
+        ).scalar_one()
+        sides_by_number = {s.side_number: s for s in row.sides}
+        assert sides_by_number[1].score == 2
+        assert sides_by_number[2].score == 0
+
+        await opp_client.post(f"/v1/matches/{match['id']}/dispute")
+        db_session.expire_all()
+        row = (
+            await db_session.execute(
+                select(Match)
+                .where(Match.id == uuid.UUID(match["id"]))
+                .options(selectinload(Match.sides))
+            )
+        ).scalar_one()
+        sides_by_number = {s.side_number: s for s in row.sides}
+        # Both won AND score reset on dispute.
+        assert [sides_by_number[n].won for n in (1, 2)] == [None, None]
+        assert [sides_by_number[n].score for n in (1, 2)] == [0, 0]
+
+
+async def test_list_status_label_reflects_awaiting_confirmation(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A list row for a match with a posted-but-unconfirmed result shows
+    the ``Awaiting confirmation`` label, even though ``status`` remains
+    ``in_progress`` — the FE renders the label directly."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "list-label-opp") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+    listing = (await api_client.get("/v1/matches")).json()
+    row = next(r for r in listing["items"] if r["id"] == match["id"])
+    assert row["status"] == "in_progress"
+    assert row["status_label"] == "Awaiting confirmation"
+
+
+async def test_list_row_can_confirm_flag_for_pending_signer(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The matches list surfaces ``can_confirm`` so the FE can flag rows the
+    caller owes a signature on. The poster sees False (they signed); the
+    opponent sees True."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "list-can-confirm-opp") as (
+        opp_client,
+        opp,
+    ):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+        my_list = (await api_client.get("/v1/matches")).json()
+        my_row = next(r for r in my_list["items"] if r["id"] == match["id"])
+        assert my_row["can_confirm"] is False
+
+        opp_list = (await opp_client.get("/v1/matches")).json()
+        opp_row = next(r for r in opp_list["items"] if r["id"] == match["id"])
+        assert opp_row["can_confirm"] is True

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1632,6 +1632,36 @@ async def test_confirmation_409_after_already_finalized(
         assert again.status_code == 409
 
 
+async def test_signature_unique_violation_returns_409_not_500(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The ``_enforce_*`` predicates catch a same-user double-sign before
+    the insert, but a racing in-flight transaction can still slip past
+    them and trip ``uq_match_signatures_match_id_user_id`` at commit. Map
+    that to a 409 instead of a 500 so the user sees a coherent error on a
+    rapid double-click / retry / browser-back refire.
+
+    Simulated here by stuffing a pre-existing signature into the DB
+    *after* the in-process handler's predicate read; commit then fails on
+    the unique constraint and the helper should translate to 409."""
+    from app.models import MatchSignature
+
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "race-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+        # Race surrogate: insert a duplicate opponent signature directly so
+        # the next /confirmation appends a second MatchSignature(opp.id)
+        # and 409s on the unique constraint at commit.
+        db_session.add(MatchSignature(match_id=uuid.UUID(match["id"]), user_id=opp.id))
+        await db_session.commit()
+
+        response = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert response.status_code == 409
+        assert "already" in response.json()["detail"].lower()
+
+
 async def test_dispute_then_repost_finalizes_with_fresh_signatures(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1702,6 +1702,51 @@ async def test_dispute_zeros_side_score_to_match_won_reset(
         assert [sides_by_number[n].score for n in (1, 2)] == [0, 0]
 
 
+async def test_awaiting_confirmation_response_keeps_won_and_scores_public(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Locks the "unratified result is public" contract for both the authed
+    detail endpoint AND the anonymous public read path. From the moment
+    ``POST /results`` lands, ``side.won`` and ``games[].score`` are visible;
+    confirmation only ratifies the result for ratings/finality. The
+    awaiting state is conveyed by ``status_label="Awaiting confirmation"``,
+    NOT by hiding the outcome."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "shape-opp") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+        # Authed read (poster's perspective).
+        authed = (await api_client.get(f"/v1/matches/{match['id']}")).json()
+        assert authed["status"] == "in_progress"
+        assert authed["status_label"] == "Awaiting confirmation"
+        sides = sorted(authed["sides"], key=lambda s: s["side_number"])
+        assert [s["won"] for s in sides] == [True, False]
+        assert [s["games_won"] for s in sides] == [2, 0]
+        # Per-game scores stay visible — the opponent (and any third party)
+        # needs to see what's being attested to.
+        for g in sorted(authed["games"], key=lambda g: g["game_number"]):
+            assert g["score"] is not None
+            assert g["score"]["side_1_points"] > 0
+        assert len(authed["signatures"]) == 1
+
+        # Anonymous read (public share route via the same endpoint).
+        async with make_client() as anon:
+            anon_view = (await anon.get(f"/v1/matches/{match['id']}")).json()
+        assert anon_view["status"] == "in_progress"
+        assert anon_view["status_label"] == "Awaiting confirmation"
+        anon_sides = sorted(anon_view["sides"], key=lambda s: s["side_number"])
+        assert [s["won"] for s in anon_sides] == [True, False]
+        for g in sorted(anon_view["games"], key=lambda g: g["game_number"]):
+            assert g["score"] is not None
+        # Anonymous viewers see signatures (just user_id + signed_at — no PII).
+        assert len(anon_view["signatures"]) == 1
+        # No write affordances for the spectator.
+        assert anon_view["can_score"] is False
+        assert anon_view["can_finalize"] is False
+        assert anon_view["can_confirm"] is False
+
+
 async def test_list_status_label_reflects_awaiting_confirmation(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -567,19 +567,19 @@ async def test_list_player_matches_returns_perspective_paginated(
     assert items[1]["opponent"]["username"] == "rival.a"
 
 
-async def test_list_player_matches_result_is_null_while_awaiting_confirmation(
+async def test_list_player_matches_result_visible_while_awaiting_confirmation(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    """``PlayerMatchRow.result`` is documented as ``None`` while in_progress.
-    The new signature flow sets ``MatchSide.won`` on ``POST /results`` (before
-    the opponent has confirmed), so the row would otherwise leak the
-    unratified outcome through ``/v1/players/{id}/matches``."""
+    """The posted result is public from the moment ``POST /results`` lands;
+    confirmation only ratifies it for ratings/finality. The W/L row carries
+    the outcome immediately — the awaiting-confirmation state is conveyed
+    by ``status`` (still ``in_progress``), not by hiding the result."""
     await start_session(api_client, db_session)
     target = await make_user(db_session, "awaiting.target")
     rival = await make_user(db_session, "awaiting.rival")
-    # Simulate the post-/results, pre-/confirmation state: won is set, status
-    # is still in_progress. ``_record_match_with_winner`` already writes won
-    # on each side — pass status=in_progress to land on the awaiting state.
+    # Post-/results, pre-/confirmation: won is set, status is still
+    # in_progress. ``_record_match_with_winner`` already writes won on each
+    # side — pass status=in_progress to land on the awaiting state.
     await _record_match_with_winner(
         db_session,
         target,
@@ -594,7 +594,7 @@ async def test_list_player_matches_result_is_null_while_awaiting_confirmation(
     assert body["total"] == 1
     row = body["items"][0]
     assert row["status"] == "in_progress"
-    assert row["result"] is None
+    assert row["result"] == "W"
 
 
 async def test_list_player_matches_excludes_other_players_matches(

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -567,6 +567,36 @@ async def test_list_player_matches_returns_perspective_paginated(
     assert items[1]["opponent"]["username"] == "rival.a"
 
 
+async def test_list_player_matches_result_is_null_while_awaiting_confirmation(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """``PlayerMatchRow.result`` is documented as ``None`` while in_progress.
+    The new signature flow sets ``MatchSide.won`` on ``POST /results`` (before
+    the opponent has confirmed), so the row would otherwise leak the
+    unratified outcome through ``/v1/players/{id}/matches``."""
+    await start_session(api_client, db_session)
+    target = await make_user(db_session, "awaiting.target")
+    rival = await make_user(db_session, "awaiting.rival")
+    # Simulate the post-/results, pre-/confirmation state: won is set, status
+    # is still in_progress. ``_record_match_with_winner`` already writes won
+    # on each side — pass status=in_progress to land on the awaiting state.
+    await _record_match_with_winner(
+        db_session,
+        target,
+        rival,
+        created_at=BASE_TIME,
+        status=MatchStatus.in_progress,
+    )
+
+    response = await api_client.get(f"/v1/players/{target.id}/matches")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    row = body["items"][0]
+    assert row["status"] == "in_progress"
+    assert row["result"] is None
+
+
 async def test_list_player_matches_excludes_other_players_matches(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/api/tests/test_ratings.py
+++ b/api/tests/test_ratings.py
@@ -23,7 +23,7 @@ from app.ratings import (
     validate_state,
 )
 from app.ratings.glicko2 import CALCULATOR as GLICKO2
-from tests._helpers import make_user, start_session
+from tests._helpers import make_user, opponent_session, start_session
 
 # ----- strategy seeding ----------------------------------------------------
 
@@ -119,15 +119,20 @@ def test_validate_state_rejects_extra_keys(
 
 
 async def _score_to_completion(
-    client: AsyncClient, opponent_id: uuid.UUID, best_of: int = 1
+    client: AsyncClient,
+    opp_client: AsyncClient,
+    opp_id: uuid.UUID,
+    best_of: int = 1,
 ) -> dict:
-    """Create a rated match and finalize it — current_user (side 1) wins.
-    Per-game endpoints are scratchpad-only post the decouple-scoring refactor,
-    so completion only happens via POST /results."""
+    """Create a rated match and run the full post + confirm dance —
+    ``client``'s user (side 1) wins. Rating updates apply on the confirm
+    call. Returns the post-finalization MatchDetails *as seen by* ``client``
+    (so ``is_current_user_side`` flags reflect the original poster, which is
+    what most callers want to assert against)."""
     create = await client.post(
         "/v1/matches",
         json={
-            "opponent_user_id": str(opponent_id),
+            "opponent_user_id": str(opp_id),
             "best_of": best_of,
             "rated": True,
         },
@@ -135,7 +140,7 @@ async def _score_to_completion(
     assert create.status_code == 201
     match = create.json()
     needed = best_of // 2 + 1
-    finalize = await client.post(
+    post = await client.post(
         f"/v1/matches/{match['id']}/results",
         json={
             "games": [
@@ -144,8 +149,14 @@ async def _score_to_completion(
             ]
         },
     )
-    assert finalize.status_code == 201
-    return finalize.json()
+    assert post.status_code == 201
+    confirm = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+    assert confirm.status_code == 201
+    final = await client.get(f"/v1/matches/{match['id']}")
+    assert final.status_code == 200
+    body = final.json()
+    assert body["status"] == "completed"
+    return body
 
 
 async def test_completing_a_rated_match_writes_rating_history(
@@ -154,46 +165,103 @@ async def test_completing_a_rated_match_writes_rating_history(
     default_league: League,
 ):
     me = await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    body = await _score_to_completion(api_client, opp.id)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        body = await _score_to_completion(api_client, opp_client, opp.id)
 
-    # Two history rows, one per player, both linked to this match.
-    rows = (
-        (
-            await db_session.execute(
-                select(RatingHistory).where(
-                    RatingHistory.match_id == uuid.UUID(body["id"])
+        # Two history rows, one per player, both linked to this match.
+        rows = (
+            (
+                await db_session.execute(
+                    select(RatingHistory).where(
+                        RatingHistory.match_id == uuid.UUID(body["id"])
+                    )
                 )
             )
+            .scalars()
+            .all()
         )
-        .scalars()
-        .all()
-    )
-    assert len(rows) == 2
-    by_user = {row.user_id: row for row in rows}
-    winner = by_user[me.id]
-    loser = by_user[opp.id]
+        assert len(rows) == 2
+        by_user = {row.user_id: row for row in rows}
+        winner = by_user[me.id]
+        loser = by_user[opp.id]
 
-    assert winner.source == RatingHistorySource.match
-    assert loser.source == RatingHistorySource.match
-    assert winner.previous_rating_value == 1500.0
-    assert loser.previous_rating_value == 1500.0
-    assert winner.rating_value > 1500.0
-    assert loser.rating_value < 1500.0
-    assert winner.rating_strategy_id == default_league.rating_strategy_id
+        assert winner.source == RatingHistorySource.match
+        assert loser.source == RatingHistorySource.match
+        assert winner.previous_rating_value == 1500.0
+        assert loser.previous_rating_value == 1500.0
+        assert winner.rating_value > 1500.0
+        assert loser.rating_value < 1500.0
+        assert winner.rating_strategy_id == default_league.rating_strategy_id
 
-    # Current rating rows are upserted in lockstep.
-    ratings = (await db_session.execute(select(UserLeagueRating))).scalars().all()
-    assert {r.user_id for r in ratings} == {me.id, opp.id}
-    assert {r.league_id for r in ratings} == {default_league.id}
+        # Current rating rows are upserted in lockstep.
+        ratings = (await db_session.execute(select(UserLeagueRating))).scalars().all()
+        assert {r.user_id for r in ratings} >= {me.id, opp.id}
+        assert {r.league_id for r in ratings} == {default_league.id}
+
+
+async def test_ratings_only_apply_on_confirmation_not_results(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+):
+    """The post-#345 finalize moved ratings out of /results. With signatures
+    on top, ratings must hold off until the SECOND signature lands — the
+    /results call itself just records the first signer."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "delay-opp") as (opp_client, opp):
+        create = await api_client.post(
+            "/v1/matches",
+            json={
+                "opponent_user_id": str(opp.id),
+                "best_of": 1,
+                "rated": True,
+            },
+        )
+        match = create.json()
+        post = await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                ]
+            },
+        )
+        assert post.status_code == 201
+        # No rating rows yet — opponent hasn't confirmed.
+        rows_after_post = (
+            (
+                await db_session.execute(
+                    select(RatingHistory).where(
+                        RatingHistory.match_id == uuid.UUID(match["id"])
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert rows_after_post == []
+
+        confirm = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert confirm.status_code == 201
+        rows_after_confirm = (
+            (
+                await db_session.execute(
+                    select(RatingHistory).where(
+                        RatingHistory.match_id == uuid.UUID(match["id"])
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows_after_confirm) == 2
 
 
 async def test_match_details_response_carries_rating_change(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    body = await _score_to_completion(api_client, opp.id)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        body = await _score_to_completion(api_client, opp_client, opp.id)
 
     my_side = next(s for s in body["sides"] if s["is_current_user_side"])
     opp_side = next(s for s in body["sides"] if not s["is_current_user_side"])
@@ -211,42 +279,45 @@ async def test_unrated_match_does_not_move_ratings(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    create = await api_client.post(
-        "/v1/matches",
-        json={
-            "opponent_user_id": str(opp.id),
-            "best_of": 1,
-            "rated": False,
-        },
-    )
-    match = create.json()
-    finalize = await api_client.post(
-        f"/v1/matches/{match['id']}/results",
-        json={
-            "games": [
-                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
-            ]
-        },
-    )
-    body = finalize.json()
-    for side in body["sides"]:
-        assert side["rating_change"] is None
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        create = await api_client.post(
+            "/v1/matches",
+            json={
+                "opponent_user_id": str(opp.id),
+                "best_of": 1,
+                "rated": False,
+            },
+        )
+        match = create.json()
+        post = await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                ]
+            },
+        )
+        assert post.status_code == 201
+        confirm = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert confirm.status_code == 201
+        body = confirm.json()
+        for side in body["sides"]:
+            assert side["rating_change"] is None
 
-    # The session user has an `initial` seed row from joining the league, but
-    # an unrated match must not produce any `match`-sourced history.
-    rows = (
-        (
-            await db_session.execute(
-                select(RatingHistory).where(
-                    RatingHistory.source == RatingHistorySource.match
+        # The session user has an `initial` seed row from joining the league,
+        # but an unrated match must not produce any `match`-sourced history.
+        rows = (
+            (
+                await db_session.execute(
+                    select(RatingHistory).where(
+                        RatingHistory.source == RatingHistorySource.match
+                    )
                 )
             )
+            .scalars()
+            .all()
         )
-        .scalars()
-        .all()
-    )
-    assert rows == []
+        assert rows == []
 
 
 async def test_manual_strategy_league_skips_rating_updates(
@@ -264,65 +335,71 @@ async def test_manual_strategy_league_skips_rating_updates(
     default.rating_strategy_id = rating_strategies["manual"].id
     await db_session.commit()
 
-    me = await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    body = await _score_to_completion(api_client, opp.id)
-    my_side = next(s for s in body["sides"] if s["is_current_user_side"])
-    assert my_side["rating_change"] is None
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        body = await _score_to_completion(api_client, opp_client, opp.id)
+        my_side = next(s for s in body["sides"] if s["is_current_user_side"])
+        assert my_side["rating_change"] is None
 
-    rows = (await db_session.execute(select(RatingHistory))).scalars().all()
-    assert rows == []
+        rows = (
+            (
+                await db_session.execute(
+                    select(RatingHistory).where(
+                        RatingHistory.source == RatingHistorySource.match
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert rows == []
 
-    # `me` joined the (now manual) default league via the session hook → has a
-    # row but with the manual strategy's null initial state. `rival` was
-    # created via ``make_user`` which doesn't route through league membership,
-    # so they have no row at all.
-    ratings = (await db_session.execute(select(UserLeagueRating))).scalars().all()
-    assert len(ratings) == 1
-    assert ratings[0].user_id == me.id
-    assert ratings[0].rating_value is None
-    assert ratings[0].rating_state is None
+        # Both session users have an `initial` seed row from joining the
+        # (now manual) default league, but with the strategy's null state.
+        ratings = (await db_session.execute(select(UserLeagueRating))).scalars().all()
+        assert all(r.rating_value is None for r in ratings)
+        assert all(r.rating_state is None for r in ratings)
 
 
 async def test_finalized_match_rejects_score_edits_and_keeps_rating_history(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    """Once a match is finalized, every write path 409s — there's no way to
-    silently re-apply (or duplicate) the rating update. Re-applying ratings
-    after a correction is its own feature (tied to dispute/void flows),
-    explicitly out of scope for v1."""
+    """Once a match is finalized (both signatures, status=completed) every
+    write path 409s — there's no way to silently re-apply (or duplicate) the
+    rating update. Re-applying ratings after a correction is its own feature
+    (tied to dispute/void flows), explicitly out of scope for v1."""
     await start_session(api_client, db_session)
-    opp = await make_user(db_session, "rival")
-    body = await _score_to_completion(api_client, opp.id)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        body = await _score_to_completion(api_client, opp_client, opp.id)
 
-    # Every score-write path is locked once the match is finalized.
-    put = await api_client.put(
-        f"/v1/matches/{body['id']}/games/1/scores",
-        json={"side_1_points": 11, "side_2_points": 5},
-    )
-    assert put.status_code == 409
-    re_finalize = await api_client.post(
-        f"/v1/matches/{body['id']}/results",
-        json={
-            "games": [
-                {"game_number": 1, "side_1_points": 11, "side_2_points": 5},
-            ]
-        },
-    )
-    assert re_finalize.status_code == 409
+        # Every score-write path is locked once the match is finalized.
+        put = await api_client.put(
+            f"/v1/matches/{body['id']}/games/1/scores",
+            json={"side_1_points": 11, "side_2_points": 5},
+        )
+        assert put.status_code == 409
+        re_finalize = await api_client.post(
+            f"/v1/matches/{body['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 5},
+                ]
+            },
+        )
+        assert re_finalize.status_code == 409
 
-    rows = (
-        (
-            await db_session.execute(
-                select(RatingHistory).where(
-                    RatingHistory.match_id == uuid.UUID(body["id"])
+        rows = (
+            (
+                await db_session.execute(
+                    select(RatingHistory).where(
+                        RatingHistory.match_id == uuid.UUID(body["id"])
+                    )
                 )
             )
+            .scalars()
+            .all()
         )
-        .scalars()
-        .all()
-    )
-    assert len(rows) == 2  # still just the original pair from finalize
+        assert len(rows) == 2  # still just the original pair from finalize
 
 
 async def test_new_session_seeds_rating_for_default_league(

--- a/web-client/e2e/score-entry.spec.ts
+++ b/web-client/e2e/score-entry.spec.ts
@@ -153,6 +153,8 @@ function projectMatchDetails(seed: Seed) {
     current_game: nextNumber !== null ? { game_number: nextNumber } : null,
     can_score: nextNumber !== null,
     can_finalize: canFinalizeSeed(seed),
+    can_confirm: false,
+    signatures: [],
   }
 }
 

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -255,23 +255,69 @@ export function useDeleteScore(matchId: string, gameNumber: number) {
 }
 
 /**
- * Finalizes the match. The payload is canon — the server obliterates any
- * scratchpad-saved games + scores, inserts these, validates the match as a
- * decided whole, and applies the rating update. Unlike the per-game writes,
- * this one's errors matter: pass `throwOnError`-style handling at the call
- * site so the user can see what went wrong (most often a 422 if local
- * validation drifted out of sync, or a 409 if the match is already
- * finalized).
+ * Posts the result of a match. The payload is canon — the server obliterates
+ * any scratchpad-saved games + scores, inserts these, validates the match as
+ * a decided whole, and records the caller's signature. For a non-solo match
+ * the status stays `in_progress` until the other side confirms via
+ * `POST /confirmation`; ratings apply on that final signature, not here.
+ * Solo matches finalize immediately (no second party to attest).
+ *
+ * Unlike the per-game writes, this one's errors matter: pass
+ * `throwOnError`-style handling at the call site so the user can see what
+ * went wrong (most often a 422 if local validation drifted out of sync, or a
+ * 409 if a result has already been posted).
  */
 export function useFinalizeMatch(matchId: string) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (input: MatchResultsWrite): Promise<MatchDetails> =>
       unwrap(
-        'finalize match',
+        'post match result',
         await api.POST('/v1/matches/{match_id}/results', {
           params: { path: { match_id: matchId } },
           body: input,
+        }),
+      ),
+    onSuccess: (data) => applyScoreMutationCache(queryClient, matchId, data),
+  })
+}
+
+/**
+ * Confirms a posted result. Inserts the caller's signature; when every side
+ * has at least one signing player the server flips status to `completed` and
+ * applies the rating update — exactly once. Caller must be a participant who
+ * hasn't already signed (the BFF's `can_confirm` flag is the source of truth
+ * for whether the CTA is shown).
+ */
+export function useConfirmMatch(matchId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (): Promise<MatchDetails> =>
+      unwrap(
+        'confirm match result',
+        await api.POST('/v1/matches/{match_id}/confirmation', {
+          params: { path: { match_id: matchId } },
+        }),
+      ),
+    onSuccess: (data) => applyScoreMutationCache(queryClient, matchId, data),
+  })
+}
+
+/**
+ * Disputes a posted result. Clears every signature on the match and resets
+ * `side.won` to `null`; the canonical games stay in place so the disputer
+ * can navigate to the contested game and PUT a corrected score. Status
+ * stays `in_progress`. Same `can_confirm` predicate gates this as
+ * `useConfirmMatch`.
+ */
+export function useDisputeMatch(matchId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (): Promise<MatchDetails> =>
+      unwrap(
+        'dispute match result',
+        await api.POST('/v1/matches/{match_id}/dispute', {
+          params: { path: { match_id: matchId } },
         }),
       ),
     onSuccess: (data) => applyScoreMutationCache(queryClient, matchId, data),

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -399,13 +399,64 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Finalize Match
-         * @description Take the request body as canon. Any previously-saved per-game scores
-         *     on this match are discarded; the payload's games (validated as a complete,
-         *     decided match) become the match's games + scores. Then we mark completed
-         *     and apply the rating update — exactly once.
+         * Post Match Result
+         * @description Post the result of a match. Any previously-saved per-game scores are
+         *     discarded; the payload's games (validated as a complete, decided match)
+         *     become canon, and the caller's signature is recorded.
+         *
+         *     For a non-solo match the status stays ``in_progress`` until every side
+         *     signs — the other side acts on the posted result via ``POST /confirmation``
+         *     or ``POST /dispute``, and the rating update fires inside /confirmation
+         *     when the final signature lands. Solo matches (one side player-less)
+         *     finalize immediately here, since there's no second party to attest.
          */
-        post: operations["finalize_match_v1_matches__match_id__results_post"];
+        post: operations["post_match_result_v1_matches__match_id__results_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/matches/{match_id}/confirmation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Confirm Match Result
+         * @description Sign off on a posted result. When this is the last signature needed
+         *     (every side has at least one signing player) the match flips to
+         *     ``completed`` and the rating update runs — exactly once.
+         */
+        post: operations["confirm_match_result_v1_matches__match_id__confirmation_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/matches/{match_id}/dispute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Dispute Match Result
+         * @description Reject a posted result. Every signature is cleared and the side
+         *     win flags reset to ``None``; the canonical score rows themselves stay in
+         *     place so the disputer can navigate to the contested game and PUT a
+         *     corrected score. The per-game endpoints unblock automatically once
+         *     signatures are empty (see ``_enforce_scorable``).
+         */
+        post: operations["dispute_match_result_v1_matches__match_id__dispute_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -813,6 +864,10 @@ export interface components {
             can_score: boolean;
             /** Can Finalize */
             can_finalize: boolean;
+            /** Can Confirm */
+            can_confirm: boolean;
+            /** Signatures */
+            signatures: components["schemas"]["MatchSignatureView"][];
             /** Recent Form */
             recent_form?: components["schemas"]["MatchDetailsPlayerForm"][];
             head_to_head?: components["schemas"]["MatchDetailsH2H"] | null;
@@ -1027,6 +1082,8 @@ export interface components {
             current_game_number: number | null;
             /** Can Score */
             can_score: boolean;
+            /** Can Confirm */
+            can_confirm: boolean;
         };
         /**
          * MatchResultsGameWrite
@@ -1051,6 +1108,24 @@ export interface components {
         MatchResultsWrite: {
             /** Games */
             games: components["schemas"]["MatchResultsGameWrite"][];
+        };
+        /**
+         * MatchSignatureView
+         * @description One participant's sign-off on the posted result. Surfaced on
+         *     ``MatchDetails`` so the FE can render "Awaiting <opponent>'s confirmation"
+         *     without joining client-side.
+         */
+        MatchSignatureView: {
+            /**
+             * User Id
+             * Format: uuid
+             */
+            user_id: string;
+            /**
+             * Signed At
+             * Format: date-time
+             */
+            signed_at: string;
         };
         /**
          * MatchStatus
@@ -2428,7 +2503,7 @@ export interface operations {
             };
         };
     };
-    finalize_match_v1_matches__match_id__results_post: {
+    post_match_result_v1_matches__match_id__results_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -2447,6 +2522,72 @@ export interface operations {
         responses: {
             /** @description Successful Response */
             201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchDetails"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    confirm_match_result_v1_matches__match_id__confirmation_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                match_id: string;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchDetails"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    dispute_match_result_v1_matches__match_id__dispute_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                match_id: string;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {
   RouterProvider,
   createMemoryHistory,
@@ -695,5 +696,108 @@ describe('MatchDetailsView', () => {
       'Result · rating change',
     )
     expect(container.querySelector('.md-rating-row')).toBeNull()
+  })
+
+  it('renders Confirm/Dispute CTAs when can_confirm is true', async () => {
+    const match = matchDetails({
+      id: 'm-confirm',
+      status: 'in_progress',
+      status_label: 'Awaiting confirmation',
+      sides: [
+        {
+          side_number: 1,
+          players: [
+            { user_id: 'u-me', username: 'me', is_current_user: true },
+          ],
+          games_won: 1,
+          won: false,
+          is_current_user_side: true,
+        },
+        {
+          side_number: 2,
+          players: [
+            { user_id: 'u-opp', username: 'nguyen.t', is_current_user: false },
+          ],
+          games_won: 2,
+          won: true,
+          is_current_user_side: false,
+        },
+      ],
+      can_confirm: true,
+      signatures: [{ user_id: 'u-opp', signed_at: '2026-05-26T12:00:00Z' }],
+    })
+    let confirmHits = 0
+    let disputeHits = 0
+    server.use(
+      http.get('*/v1/matches/m-confirm', () => HttpResponse.json(match)),
+      http.post('*/v1/matches/m-confirm/confirmation', () => {
+        confirmHits += 1
+        return HttpResponse.json(
+          { ...match, can_confirm: false, status: 'completed' },
+          { status: 201 },
+        )
+      }),
+      http.post('*/v1/matches/m-confirm/dispute', () => {
+        disputeHits += 1
+        return HttpResponse.json({ ...match, can_confirm: false })
+      }),
+    )
+
+    const user = userEvent.setup()
+    renderDetails('m-confirm')
+
+    const confirmBtn = await screen.findByRole('button', {
+      name: /confirm result/i,
+    })
+    const disputeBtn = screen.getByRole('button', { name: /^dispute$/i })
+    expect(confirmBtn).toBeInTheDocument()
+    expect(disputeBtn).toBeInTheDocument()
+
+    await user.click(confirmBtn)
+    await waitFor(() => expect(confirmHits).toBe(1))
+    expect(disputeHits).toBe(0)
+  })
+
+  it('renders an "Awaiting <opponent>" indicator when the viewer is the signer', async () => {
+    const match = matchDetails({
+      id: 'm-await',
+      status: 'in_progress',
+      status_label: 'Awaiting confirmation',
+      sides: [
+        {
+          side_number: 1,
+          players: [
+            { user_id: 'u-me', username: 'me', is_current_user: true },
+          ],
+          games_won: 3,
+          won: true,
+          is_current_user_side: true,
+        },
+        {
+          side_number: 2,
+          players: [
+            { user_id: 'u-opp', username: 'nguyen.t', is_current_user: false },
+          ],
+          games_won: 1,
+          won: false,
+          is_current_user_side: false,
+        },
+      ],
+      // We've signed (can_confirm false), the opponent hasn't.
+      can_confirm: false,
+      signatures: [{ user_id: 'u-me', signed_at: '2026-05-26T12:00:00Z' }],
+    })
+    server.use(
+      http.get('*/v1/matches/m-await', () => HttpResponse.json(match)),
+    )
+
+    renderDetails('m-await')
+
+    const callout = await screen.findByTestId('match-confirm-callout')
+    expect(callout).toHaveTextContent(/awaiting/i)
+    expect(callout).toHaveTextContent(/nguyen\.t/)
+    expect(
+      within(callout).queryByRole('button', { name: /confirm result/i }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -18,7 +18,13 @@ import { Overline } from '@/components/overline'
 import { cn, initialsOf } from '@/lib/utils'
 import { fmtDateShort, fmtDateTimeShort } from '@/lib/dates'
 import { formatRatingDelta } from '@/lib/rating'
-import { scoringEditRoute, scoringNewRoute, useMatch } from '@/api/matches'
+import {
+  scoringEditRoute,
+  scoringNewRoute,
+  useConfirmMatch,
+  useDisputeMatch,
+  useMatch,
+} from '@/api/matches'
 import type { components } from '@/api/schema'
 import { ApiError } from '@/api/client'
 
@@ -111,6 +117,16 @@ type MatchView = {
   canScore: boolean
   scoreCta: { matchId: string; gameNumber: number } | null
   headToHead: H2HView | null
+  // True when the caller can hit either ``POST /confirmation`` or
+  // ``POST /dispute`` — surfaces the Confirm / Dispute CTAs.
+  canConfirm: boolean
+  // True when there's at least one signature AND the current user is among
+  // the signers — surfaces the passive "Awaiting <opponent>'s confirmation"
+  // indicator (we already signed; waiting on the other side).
+  viewerIsAwaitingOther: boolean
+  // The user whose signature we're waiting on, for the passive label. Null
+  // when there's no posted result, or when the viewer isn't a participant.
+  pendingSignerName: string | null
 }
 
 function projectSide(
@@ -244,6 +260,29 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
     data.can_score && data.current_game
       ? { matchId, gameNumber: data.current_game.game_number }
       : null
+
+  // Awaiting-confirmation indicator: which side hasn't signed yet, surfaced
+  // by username for the passive "Awaiting <opp>" copy when the viewer has
+  // already signed. Null when there's no posted result, or the viewer can't
+  // see this state (anonymous, non-participant, etc.).
+  const signers = new Set(data.signatures.map((sig) => sig.user_id))
+  const viewerUserId = viewerIsParticipant
+    ? (leftSide.players[0]?.user_id ?? null)
+    : null
+  const viewerHasSigned =
+    viewerUserId !== null && signers.has(viewerUserId)
+  const viewerIsAwaitingOther =
+    viewerIsParticipant && data.signatures.length > 0 && viewerHasSigned
+  // Find the participant who's missing from the signature set. With "at
+  // least one player per side" semantics, this picks the first un-signed
+  // player on the other side. Falls back to "your opponent" if we can't
+  // resolve a name.
+  let pendingSignerName: string | null = null
+  if (viewerIsAwaitingOther && rightSide) {
+    const missing = rightSide.players.find((p) => !signers.has(p.user_id))
+    pendingSignerName = missing?.username ?? 'your opponent'
+  }
+
   return {
     state,
     statusLabel: data.status_label,
@@ -258,6 +297,9 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
     canScore: data.can_score,
     scoreCta,
     headToHead: projectHeadToHead(data.head_to_head, leftView.sideNumber),
+    canConfirm: data.can_confirm,
+    viewerIsAwaitingOther,
+    pendingSignerName,
   }
 }
 
@@ -401,6 +443,8 @@ function MatchDetailsPage({
         </div>
 
         <HeroScoreboard view={view} matchId={matchId} />
+
+        <ConfirmationCallout view={view} matchId={matchId} />
 
         <div className="md-col-2">
           <div className="md-col-2__main">
@@ -1198,6 +1242,96 @@ function H2HRow({
 }
 
 function CommentsCard() {
+  return null
+}
+
+function ConfirmationCallout({
+  view,
+  matchId,
+}: {
+  view: MatchView
+  matchId: string
+}) {
+  const confirmMutation = useConfirmMatch(matchId)
+  const disputeMutation = useDisputeMatch(matchId)
+  const pending = confirmMutation.isPending || disputeMutation.isPending
+  // Without throwOnError, a 409 (race: opponent confirmed/disputed first,
+  // user double-clicked, etc.) would otherwise vanish — surface it inline
+  // so the button doesn't appear inert.
+  const mutationError =
+    (confirmMutation.error instanceof ApiError
+      ? confirmMutation.error
+      : null) ??
+    (disputeMutation.error instanceof ApiError ? disputeMutation.error : null)
+
+  if (view.canConfirm) {
+    return (
+      <section
+        className="md-confirm-callout"
+        data-testid="match-confirm-callout"
+      >
+        <div className="md-confirm-callout__copy">
+          <Overline as="h3">Posted result · awaiting your sign-off</Overline>
+          <p className="md-confirm-callout__body">
+            Your opponent has posted the result above. Confirm if the scores
+            are right, or dispute to send the match back to in-progress so the
+            wrong game can be re-scored.
+          </p>
+          {mutationError && (
+            <p
+              role="alert"
+              className="mt-1.5 text-xs text-[color:var(--loss)]"
+            >
+              {mutationError.detail ?? mutationError.message}
+            </p>
+          )}
+        </div>
+        <div className="md-confirm-callout__actions">
+          <button
+            type="button"
+            className="md-btn md-btn--ghost"
+            disabled={pending}
+            onClick={() => {
+              confirmMutation.reset()
+              disputeMutation.mutate()
+            }}
+          >
+            {disputeMutation.isPending ? 'Disputing…' : 'Dispute'}
+          </button>
+          <button
+            type="button"
+            className="md-btn md-btn--primary"
+            disabled={pending}
+            onClick={() => {
+              disputeMutation.reset()
+              confirmMutation.mutate()
+            }}
+          >
+            {confirmMutation.isPending ? 'Confirming…' : 'Confirm result'}
+          </button>
+        </div>
+      </section>
+    )
+  }
+
+  if (view.viewerIsAwaitingOther && view.pendingSignerName) {
+    return (
+      <section
+        className="md-confirm-callout md-confirm-callout--passive"
+        data-testid="match-confirm-callout"
+      >
+        <div className="md-confirm-callout__copy">
+          <Overline as="h3">Posted · awaiting confirmation</Overline>
+          <p className="md-confirm-callout__body">
+            You've signed off on this result. Waiting on{' '}
+            <strong>{view.pendingSignerName}</strong> to confirm or dispute
+            before the match is finalized.
+          </p>
+        </div>
+      </section>
+    )
+  }
+
   return null
 }
 

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -201,10 +201,10 @@ describe('ScoreEntry — create', () => {
     expect(captured).toEqual({ side_1_points: 11, side_2_points: 4 })
   })
 
-  it('flips the submit button to "Finalize match" when this score would decide the match', async () => {
+  it('flips the submit button to "Post result" when this score would decide the match', async () => {
     // Bo5, 2-0 on the board, entering G3. An 11-3 win clinches at 3-0, so
     // the single submit button should POST /results (atomically saving +
-    // finalizing) instead of /scores/new.
+    // posting the result for the opponent to confirm) instead of /scores/new.
     const user = userEvent.setup()
     let finalizedBody: unknown = null
     server.use(
@@ -258,15 +258,16 @@ describe('ScoreEntry — create', () => {
     await user.type(meInput, '11')
     await user.type(oppInput, '3')
 
-    // The same button morphs into "Finalize match" because saving this score
-    // would complete a decided best-of-5.
-    const finalizeBtn = screen.getByRole('button', { name: /finalize match/i })
-    expect(finalizeBtn).toBeInTheDocument()
+    // The same button morphs into "Post result" because saving this score
+    // posts the canonical result of a decided best-of-5; the match flips to
+    // "awaiting confirmation" until the opponent confirms.
+    const postBtn = screen.getByRole('button', { name: /post result/i })
+    expect(postBtn).toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: /save game & next/i }),
     ).not.toBeInTheDocument()
 
-    await user.click(finalizeBtn)
+    await user.click(postBtn)
 
     await waitFor(() =>
       expect(screen.getByText('match-page m-1')).toBeInTheDocument(),
@@ -403,7 +404,7 @@ describe('ScoreEntry — create', () => {
 
     await user.type(meInput, '11')
     await user.type(oppInput, '3')
-    await user.click(screen.getByRole('button', { name: /finalize match/i }))
+    await user.click(screen.getByRole('button', { name: /post result/i }))
 
     const alert = await screen.findByRole('alert')
     expect(alert).toHaveTextContent(/rejected by the server/i)

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -89,8 +89,10 @@ function ScoreEntryInner({
   }
 
   // Once a match is finalized every write path 409s — there's nothing to do
-  // here. Likewise for the rare bound-violation case.
-  if (data.status === 'completed') {
+  // here. Same goes once a result is posted and waiting on confirmation —
+  // scores are frozen until /confirmation or /dispute lands, and either
+  // option lives on the match-details page.
+  if (data.status === 'completed' || data.signatures.length > 0) {
     return <Navigate {...matchDetailRoute(matchId)} />
   }
   if (
@@ -274,16 +276,16 @@ function ScoreEntryInner({
     ? `Edit game ${gameNumber} score.`
     : `Enter game ${gameNumber} score.`
   const subtitle = wouldFinalize
-    ? 'This score finishes the match — submitting will finalize it.'
+    ? 'This score finishes the match — submitting posts the result for your opponent to confirm.'
     : isEdit
       ? 'Save updates the score for this game.'
       : gameNumber < bestOf
         ? `Save this game to continue to game ${gameNumber + 1}.`
-        : 'Final game. Save to finish the match.'
+        : 'Final game. Save to post the result.'
   const submitLabel = wouldFinalize
     ? finalizeMutation.isPending
-      ? 'Finalizing…'
-      : 'Finalize match'
+      ? 'Posting result…'
+      : 'Post result'
     : isEdit
       ? 'Save changes →'
       : gameNumber < bestOf

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2091,6 +2091,41 @@ body.dark.fortymm-theme {
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-md);
 }
+
+/* Awaiting-confirmation callout that sits between the hero and the cards
+   row when a posted result needs the viewer's sign-off (or is waiting on
+   the opponent's). The accent stripe + warm hue echoes the "live" hero
+   chip so the urgency reads visually. */
+.fortymm-theme .md-confirm-callout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  flex-wrap: wrap;
+  padding: 14px 18px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-left: 3px solid var(--ball-500);
+  border-radius: var(--r-md);
+}
+.fortymm-theme .md-confirm-callout--passive {
+  border-left-color: var(--ink-500);
+  opacity: 0.92;
+}
+.fortymm-theme .md-confirm-callout__copy {
+  flex: 1 1 320px;
+  min-width: 0;
+}
+.fortymm-theme .md-confirm-callout__body {
+  margin: 6px 0 0;
+  color: var(--fg-2);
+  font: 400 13px/1.45 var(--font-ui);
+}
+.fortymm-theme .md-confirm-callout__actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
 .fortymm-theme .md-card__hd {
   padding: 14px 18px 10px;
   border-bottom: 1px solid var(--ink-700);

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -2,8 +2,11 @@ import { delay, http, HttpResponse } from 'msw'
 import type { components } from '@/api/schema'
 import { healthCheck, player, sessionResponse } from '@/test/factories'
 import {
+  confirmSeed,
+  disputeSeed,
   finalizeSeed,
   findMatch,
+  MOCK_CURRENT_USER,
   mockMatches,
   newMatchSeed,
   projectListRow,
@@ -298,6 +301,15 @@ function enforceScorable(seed: SeedMatch): Response | null {
     seed.status === 'voided'
   ) {
     return detail('This match is no longer scorable.', 409)
+  }
+  // Posted-but-unconfirmed results lock the scratchpad; the next action is
+  // /confirmation or /dispute, not another score write.
+  if (seed.signatures.length > 0) {
+    return detail(
+      'This match has a posted result awaiting confirmation. ' +
+        'Confirm or dispute it before editing scores.',
+      409,
+    )
   }
   return null
 }
@@ -708,6 +720,30 @@ export const handlers = [
       const message = finalizeSeed(seed, body.games)
       if (message) return detail(message, 422)
       return HttpResponse.json(projectMatchDetails(seed), { status: 201 })
+    },
+  ),
+
+  http.post(
+    '*/v1/matches/:matchId/confirmation',
+    async ({ params }) => {
+      await delay(250)
+      const seed = findMatch(String(params.matchId))
+      if (!seed) return detail('Match not found.', 404)
+      const message = confirmSeed(seed, MOCK_CURRENT_USER.id)
+      if (message) return detail(message, 409)
+      return HttpResponse.json(projectMatchDetails(seed), { status: 201 })
+    },
+  ),
+
+  http.post(
+    '*/v1/matches/:matchId/dispute',
+    async ({ params }) => {
+      await delay(250)
+      const seed = findMatch(String(params.matchId))
+      if (!seed) return detail('Match not found.', 404)
+      const message = disputeSeed(seed, MOCK_CURRENT_USER.id)
+      if (message) return detail(message, 409)
+      return HttpResponse.json(projectMatchDetails(seed))
     },
   ),
 

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -10,6 +10,7 @@ type MatchDetailsH2H = components['schemas']['MatchDetailsH2H']
 type MatchDetailsH2HMeeting = components['schemas']['MatchDetailsH2HMeeting']
 type MatchListRow = components['schemas']['MatchListRow']
 type MatchLeague = components['schemas']['MatchLeague']
+type MatchSignatureView = components['schemas']['MatchSignatureView']
 type DashboardScoreBanner = components['schemas']['DashboardScoreBanner']
 type DashboardNextMatch = components['schemas']['DashboardNextMatch']
 type DashboardRecentResult = components['schemas']['DashboardRecentResult']
@@ -70,6 +71,11 @@ export type SeedGame = {
   score: { id: string; side_1_points: number; side_2_points: number } | null
 }
 
+export type SeedSignature = {
+  user_id: string
+  signed_at: string
+}
+
 export type SeedMatch = {
   id: string
   status: MatchStatus
@@ -79,6 +85,10 @@ export type SeedMatch = {
   completed_at: string | null
   opponent: { id: string; username: string } | null
   games: SeedGame[]
+  // Sign-offs on the posted canonical result. Empty until ``POST /results``
+  // lands the first signature; cleared by ``POST /dispute``; "full" (one row
+  // per side with players) once the match has been confirmed.
+  signatures: SeedSignature[]
 }
 
 function gamesToWin(bestOf: number): number {
@@ -101,6 +111,9 @@ function sideWinCounts(seed: SeedMatch): { side1: number; side2: number } {
  * server's ``current_game_number`` derivation in api/app/matches.py. */
 function currentGameNumber(seed: SeedMatch): number | null {
   if (seed.status !== 'in_progress') return null
+  // A posted-but-unconfirmed result locks the scratchpad — no game is
+  // "current" in a writable sense until the result is disputed.
+  if (seed.signatures.length > 0) return null
   const scored = new Set(
     seed.games.filter((g) => g.score !== null).map((g) => g.game_number),
   )
@@ -115,6 +128,9 @@ function currentGameNumber(seed: SeedMatch): number | null {
  * scratchpad state. Mirrors the server's ``_can_finalize`` predicate. */
 function canFinalizeSeed(seed: SeedMatch): boolean {
   if (seed.status !== 'in_progress') return false
+  // Once a result is posted, /confirmation or /dispute is the next action,
+  // not another /results.
+  if (seed.signatures.length > 0) return false
   const scored = seed.games
     .filter((g) => g.score !== null)
     .map((g) => ({
@@ -153,9 +169,14 @@ function projectSides(seed: SeedMatch): {
   opponentSide: MatchDetailsSide
 } {
   const { side1, side2 } = sideWinCounts(seed)
-  const decided = seed.status === 'completed'
+  // After ``POST /results`` (non-solo) the canonical games have decided the
+  // match even though status remains ``in_progress`` until the opponent
+  // confirms; mirror the API so the hero scoreboard renders the winner
+  // immediately rather than waiting on the confirmation round-trip.
+  const decided = seed.status === 'completed' || seed.signatures.length > 0
 
-  const showRatingChange = decided && seed.affects_rating && seed.opponent !== null
+  const showRatingChange =
+    seed.status === 'completed' && seed.affects_rating && seed.opponent !== null
   const myWon = side1 > side2
 
   const mySide: MatchDetailsSide = {
@@ -192,6 +213,31 @@ function projectSides(seed: SeedMatch): {
   return { mySide, opponentSide }
 }
 
+function seedStatusLabel(seed: SeedMatch): string {
+  if (seed.status === 'in_progress' && seed.signatures.length > 0) {
+    return 'Awaiting confirmation'
+  }
+  return STATUS_LABELS[seed.status]
+}
+
+function seedSignatureViews(seed: SeedMatch): MatchSignatureView[] {
+  return seed.signatures
+    .slice()
+    .sort((a, b) => a.signed_at.localeCompare(b.signed_at))
+    .map((sig) => ({ user_id: sig.user_id, signed_at: sig.signed_at }))
+}
+
+/** Mirrors the API's ``_can_confirm`` predicate from the mock current
+ * user's perspective: they're a participant on an awaiting-confirmation
+ * match (signatures non-empty, status in_progress, both sides have players)
+ * and they themselves haven't signed yet. */
+function canConfirmSeed(seed: SeedMatch): boolean {
+  if (seed.status !== 'in_progress') return false
+  if (seed.signatures.length === 0) return false
+  if (seed.opponent === null) return false
+  return !seed.signatures.some((sig) => sig.user_id === MOCK_CURRENT_USER.id)
+}
+
 export function projectMatchDetails(seed: SeedMatch): MatchDetails {
   const { mySide, opponentSide } = projectSides(seed)
 
@@ -217,7 +263,7 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
   return {
     id: seed.id,
     status: seed.status,
-    status_label: STATUS_LABELS[seed.status],
+    status_label: seedStatusLabel(seed),
     league: MOCK_DEFAULT_LEAGUE,
     best_of: seed.best_of,
     games_to_win: gamesToWin(seed.best_of),
@@ -229,6 +275,8 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
     current_game: nextNumber !== null ? { game_number: nextNumber } : null,
     can_score: nextNumber !== null,
     can_finalize: canFinalizeSeed(seed),
+    can_confirm: canConfirmSeed(seed),
+    signatures: seedSignatureViews(seed),
     recent_form: projectRecentForm(seed, priors),
     head_to_head: projectHeadToHead(seed, priors),
   }
@@ -366,13 +414,14 @@ export function projectListRow(seed: SeedMatch): MatchListRow {
   return {
     id: seed.id,
     status: seed.status,
-    status_label: STATUS_LABELS[seed.status],
+    status_label: seedStatusLabel(seed),
     league: MOCK_DEFAULT_LEAGUE,
     sides: [mySide, opponentSide],
     best_of: seed.best_of,
     created_at: seed.created_at,
     current_game_number: scorable ? nextNumber : null,
     can_score: scorable,
+    can_confirm: canConfirmSeed(seed),
   }
 }
 
@@ -510,6 +559,7 @@ export function buildInitialSeeds(): SeedMatch[] {
       completed_at: null,
       opponent: { id: 'pl-okafor', username: 'okafor.d' },
       games: [],
+      signatures: [],
     },
     {
       id: 'm-2207',
@@ -531,6 +581,7 @@ export function buildInitialSeeds(): SeedMatch[] {
           score: { id: 's-2207-2', side_1_points: 9, side_2_points: 11 },
         },
       ],
+      signatures: [],
     },
     {
       id: 'm-completed-win-1',
@@ -562,6 +613,11 @@ export function buildInitialSeeds(): SeedMatch[] {
           score: { id: 's-cw-1-4', side_1_points: 12, side_2_points: 10 },
         },
       ],
+      // Pre-signed completed match — both sides signed before completion.
+      signatures: [
+        { user_id: MOCK_CURRENT_USER.id, signed_at: '2026-05-10T18:42:00Z' },
+        { user_id: 'pl-silva', signed_at: '2026-05-10T18:43:00Z' },
+      ],
     },
     {
       id: 'm-completed-loss-1',
@@ -583,6 +639,10 @@ export function buildInitialSeeds(): SeedMatch[] {
           score: { id: 's-cl-1-2', side_1_points: 9, side_2_points: 11 },
         },
       ],
+      signatures: [
+        { user_id: 'pl-patel', signed_at: '2026-05-08T20:25:00Z' },
+        { user_id: MOCK_CURRENT_USER.id, signed_at: '2026-05-08T20:26:00Z' },
+      ],
     },
     {
       id: 'm-completed-win-2',
@@ -603,6 +663,10 @@ export function buildInitialSeeds(): SeedMatch[] {
           game_number: 2,
           score: { id: 's-cw-2-2', side_1_points: 11, side_2_points: 6 },
         },
+      ],
+      signatures: [
+        { user_id: MOCK_CURRENT_USER.id, signed_at: '2026-05-06T19:20:00Z' },
+        { user_id: 'pl-chen', signed_at: '2026-05-06T19:21:00Z' },
       ],
     },
   ]
@@ -670,14 +734,16 @@ export function newMatchSeed(input: {
     completed_at: null,
     opponent: input.opponent,
     games: [],
+    signatures: [],
   }
   return seed
 }
 
 /** POST /v1/matches/{id}/results: obliterate the existing games + scores,
- * insert the payload's games, mark completed. Mirrors the server contract —
- * the payload is canon. Returns null on validation failure, with a message
- * suitable for a 422 detail. */
+ * insert the payload's games, record the current user's signature, and
+ * (for solo matches) flip status to completed. Non-solo matches stay at
+ * ``in_progress`` until ``POST /confirmation`` lands the second signature.
+ * Returns null on validation success, or a 422-suitable detail string. */
 export function finalizeSeed(
   seed: SeedMatch,
   games: Array<{
@@ -686,6 +752,9 @@ export function finalizeSeed(
     side_2_points: number
   }>,
 ): string | null {
+  if (seed.signatures.length > 0) {
+    return 'Result already posted; use /confirmation.'
+  }
   if (games.length === 0) {
     return 'A match needs at least one game to finalize.'
   }
@@ -736,7 +805,76 @@ export function finalizeSeed(
       side_2_points: g.side_2_points,
     },
   }))
-  seed.status = 'completed'
-  seed.completed_at = new Date().toISOString()
+
+  if (seed.opponent === null) {
+    // Solo match — nobody else to sign, finalize immediately (mirror the API).
+    seed.status = 'completed'
+    seed.completed_at = new Date().toISOString()
+  } else {
+    seed.signatures.push({
+      user_id: MOCK_CURRENT_USER.id,
+      signed_at: new Date().toISOString(),
+    })
+  }
   return null
+}
+
+/** POST /v1/matches/{id}/confirmation: insert ``userId``'s signature. If
+ * every side now has at least one signing player, flip the seed to
+ * ``completed`` (mirroring ``_apply_rating_update``'s gate at the API).
+ * Returns null on success, or a 409-suitable detail string. */
+export function confirmSeed(seed: SeedMatch, userId: string): string | null {
+  const guard = confirmableGuard(seed, userId)
+  if (guard) return guard
+  seed.signatures.push({
+    user_id: userId,
+    signed_at: new Date().toISOString(),
+  })
+  if (allSidesSigned(seed)) {
+    seed.status = 'completed'
+    seed.completed_at = new Date().toISOString()
+  }
+  return null
+}
+
+/** POST /v1/matches/{id}/dispute: clear every signature; reset side win
+ * flags (derived in ``projectSides`` from ``signatures.length``, so just
+ * clearing signatures is enough). Returns null on success, or a 409-suitable
+ * detail string. */
+export function disputeSeed(seed: SeedMatch, userId: string): string | null {
+  const guard = confirmableGuard(seed, userId)
+  if (guard) return guard
+  seed.signatures = []
+  return null
+}
+
+/** Shared preconditions for confirm + dispute. ``userId`` is the FE's mock
+ * current user (handlers always pass MOCK_CURRENT_USER.id). Both endpoints
+ * 404 for non-participants, but the FE/MSW only models the current user, so
+ * we collapse to 409 for the user-facing cases (already signed, no result
+ * posted yet, etc.). */
+function confirmableGuard(seed: SeedMatch, userId: string): string | null {
+  if (seed.opponent === null) {
+    return "This match has no opponent and can't be signed."
+  }
+  if (seed.status !== 'in_progress') {
+    return 'This match is no longer awaiting confirmation.'
+  }
+  if (seed.signatures.length === 0) {
+    return 'No posted result to act on. Post the result first.'
+  }
+  if (seed.signatures.some((sig) => sig.user_id === userId)) {
+    return "You've already signed this match."
+  }
+  return null
+}
+
+function allSidesSigned(seed: SeedMatch): boolean {
+  // The mock only models singles, so side 1 is the current user and side 2
+  // is the (single) opponent. With "at least one player per side" semantics
+  // both users must appear in ``signatures``.
+  const signers = new Set(seed.signatures.map((sig) => sig.user_id))
+  if (!signers.has(MOCK_CURRENT_USER.id)) return false
+  if (seed.opponent === null) return false
+  return signers.has(seed.opponent.id)
 }

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -203,6 +203,8 @@ export function matchDetails(
     current_game: { game_number: 1 },
     can_score: true,
     can_finalize: false,
+    can_confirm: false,
+    signatures: [],
     recent_form: [mySide, opponentSide]
       .filter((s) => s.players.length > 0)
       .map((s) => ({
@@ -246,6 +248,7 @@ export function matchListRow(
     created_at: ISO,
     current_game_number: 1,
     can_score: true,
+    can_confirm: false,
     ...rest,
   }
 }


### PR DESCRIPTION
## Summary

- `POST /v1/matches/{id}/results` no longer auto-completes a non-solo match — it commits the canonical games + records the caller's signature (`match_signatures` table). Status stays `in_progress` with a derived `Awaiting confirmation` label until the opponent acts.
- `POST /v1/matches/{id}/confirmation` lands the second signature, flips status to `completed`, and runs the rating update — exactly once. `POST /v1/matches/{id}/dispute` clears signatures + side win flags so the contested game can be re-scored.
- BFF gains required `signatures` and `can_confirm`; FE adds a Confirm / Dispute callout (and a passive "Awaiting <opponent>'s confirmation" indicator for the signer) on the match-details page. Solo matches keep today's instant auto-finalize. Status enum unchanged.
- The unratified posted result is **public** from `/results` onward: `side.won`, `games[].score`, and `signatures` are all visible to authed + anonymous readers. Confirmation only ratifies it for ratings/finality.

## Notable correctness work

- Account merge repoints `match_signatures.user_id` (RESTRICT FK, mirrors `match_side_players`); defensive `DELETE` after to keep the final user delete safe.
- `current_game_number` returns `None` whenever signatures exist OR the saved games already decide the match — kills phantom "Score game N" deeplinks from the dashboard / matches list / post-dispute scoring page.
- `dispute` resets both `side.won` and `side.score` so a direct DB reader doesn't see contradictory rows.
- Signature unique-violation race (rapid double-click / retry) is caught at flush time and surfaced as a 409 instead of bubbling a 500.
- `STATUS_LABELS` dict access removed in favor of an exhaustive `match` (per api/CLAUDE.md).

## Test plan

- [x] `cd api && ruff check / format / mypy --strict / pytest` — 346 tests pass (12 new signature-flow + race + shape tests)
- [x] `cd web-client && npm run lint / build / test:run` — 103 vitest pass (incl. Confirm/Dispute callout + Awaiting indicator)
- [x] `cd web-client && npm run test:e2e` — 125 Playwright pass
- [x] `cd e2e && npm test` — 4 pass against the composed stack
- [x] `mise run regen-api-types` — no schema drift after the API changes
- [x] Manual: post result + confirm via MSW + dev stack end-to-end

## Deferred follow-ups

- Concurrent-different-users `/results` race (two posters both succeed → wedge state, recoverable via dispute). Needs an advisory lock or row lock — bigger surface than the unique-violation case fixed here.
- HeroScoreboard chip-strip currently renders no chip in the awaiting-confirmation state (the Confirmation callout below conveys the state).
- Doubles: `_can_confirm` is per-user, not per-side — partners can each sign for the same side. Not reachable while singles-only is the only surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)