### PR TITLE
Move Settings link from sidenav into a topbar user menu

### DIFF
--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -4,7 +4,6 @@ import {
   ChevronDown,
   Gauge,
   Key,
-  Settings,
   Shield,
   TriangleAlert,
   Users,
@@ -36,12 +35,6 @@ type NavItem = {
 type NavSection = {
   label?: string
   items: NavItem[]
-}
-
-const SETTINGS_ITEM: NavItem = {
-  label: 'Settings',
-  to: '/settings',
-  icon: <Settings size={18} strokeWidth={2} />,
 }
 
 const NAV_SECTIONS: NavSection[] = [
@@ -287,11 +280,6 @@ export function AppShell({ children }: AppShellProps) {
             </div>
           ))}
         </nav>
-        <div className="app-shell__nav-footer">
-          <ul className="app-shell__nav-list">
-            {renderNavItem(SETTINGS_ITEM, pathname, closeOnMobile)}
-          </ul>
-        </div>
       </aside>
 
       <div className="app-shell__main">

--- a/web-client/src/components/user-menu.test.tsx
+++ b/web-client/src/components/user-menu.test.tsx
@@ -1,4 +1,13 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse, delay } from 'msw'
 import { describe, expect, it } from 'vitest'
@@ -16,21 +25,40 @@ function renderWithClient(ui: React.ReactElement) {
       mutations: { retry: false },
     },
   })
-  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <>{ui}</>,
+  })
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/settings',
+    component: () => <div>Settings page</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, settingsRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
 }
 
 describe('UserMenu', () => {
   it('shows a loading skeleton while the session is fetching', async () => {
     server.use(
       http.get('*/v1/session', async () => {
-        await delay(50)
+        await delay(100)
         return HttpResponse.json(mockSession)
       }),
     )
 
     renderWithClient(<UserMenu />)
 
-    expect(screen.getByTestId('user-menu-skeleton')).toBeInTheDocument()
+    expect(await screen.findByTestId('user-menu-skeleton')).toBeInTheDocument()
     expect(screen.getByLabelText('Loading user menu')).toHaveAttribute(
       'aria-busy',
       'true',
@@ -81,5 +109,15 @@ describe('UserMenu', () => {
     const nameEl = await screen.findByText(longName)
     expect(nameEl).toHaveClass('app-shell__user-name--truncate')
     expect(nameEl).toHaveAttribute('title', longName)
+  })
+
+  it('opens a menu with a Settings link pointing at /settings', async () => {
+    renderWithClient(<UserMenu />)
+
+    const trigger = await screen.findByTestId('user-menu')
+    await userEvent.click(trigger)
+
+    const settings = await screen.findByRole('menuitem', { name: /settings/i })
+    expect(settings).toHaveAttribute('href', '/settings')
   })
 })

--- a/web-client/src/components/user-menu.tsx
+++ b/web-client/src/components/user-menu.tsx
@@ -1,5 +1,15 @@
+import { Link } from '@tanstack/react-router'
+import { Settings } from 'lucide-react'
 import { useSession } from '@/api/session'
 import { UserAvatar } from '@/components/ui/user-avatar'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 
 export function UserMenu() {
   const { data, isLoading, isError } = useSession()
@@ -21,18 +31,33 @@ export function UserMenu() {
   const username = !isError && data ? data.data.user.username : 'Guest'
 
   return (
-    <div
-      className="app-shell__user-menu"
-      data-testid="user-menu"
-      aria-label={`Signed in as ${username}`}
-    >
-      <UserAvatar name={username} size={30} />
-      <div
-        className="app-shell__user-name app-shell__user-name--truncate"
-        title={username}
-      >
-        {username}
-      </div>
-    </div>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="app-shell__user-menu app-shell__user-menu--trigger"
+          data-testid="user-menu"
+          aria-label={`Signed in as ${username}`}
+        >
+          <UserAvatar name={username} size={30} />
+          <div
+            className="app-shell__user-name app-shell__user-name--truncate"
+            title={username}
+          >
+            {username}
+          </div>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-44">
+        <DropdownMenuLabel className="truncate">{username}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link to="/settings">
+            <Settings />
+            Settings
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -649,6 +649,19 @@ body.dark.fortymm-theme {
   border: 1px solid var(--border-subtle);
   color: var(--fg-1);
 }
+.app-shell__user-menu--trigger {
+  cursor: pointer;
+  font: inherit;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+.app-shell__user-menu--trigger:hover,
+.app-shell__user-menu--trigger[data-state='open'] {
+  background: var(--bg-hover);
+}
+.app-shell__user-menu--trigger:focus-visible {
+  outline: 2px solid var(--ball-500);
+  outline-offset: 2px;
+}
 .app-shell__user-avatar {
   width: 30px;
   height: 30px;
@@ -759,10 +772,6 @@ body.dark.fortymm-theme {
   display: flex;
   flex-direction: column;
   gap: 20px;
-}
-.app-shell__nav-footer {
-  padding: 12px 12px 16px;
-  flex-shrink: 0;
 }
 .app-shell__nav-label {
   font-family: var(--font-ui);


### PR DESCRIPTION
## Summary
- Topbar `UserMenu` is now a Radix dropdown trigger; the menu has a header for the current username and a Settings link to `/settings`
- Drops the standalone Settings entry from the sidenav footer (and its CSS) so account-level actions live in one place
- Adds a unit test covering the dropdown's Settings link href

## Test plan
- [x] `npm run build` (tsc + vite)
- [x] `npm run lint`
- [x] `npm run test:run` — 104 tests pass, including new dropdown test
- [x] Manual: opened menu in dev server via Playwright; Settings link href is `/settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)