### PR TITLE
Add log out option to the user menu

### DIFF
--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -262,6 +262,19 @@ def _set_session_cookie(response: Response, raw_token: str) -> None:
     )
 
 
+def _clear_session_cookie(response: Response) -> None:
+    # Must mirror _set_session_cookie's attributes — browsers match
+    # cookies on (name, path, domain) and silently drop a clearing cookie
+    # whose attributes don't match the original.
+    response.delete_cookie(
+        key=SESSION_COOKIE_NAME,
+        path="/",
+        httponly=True,
+        secure=_cookie_secure(),
+        samesite="lax",
+    )
+
+
 @router.get("/v1/session", response_model=SessionResponse)
 async def get_session_endpoint(
     response: Response,
@@ -275,6 +288,27 @@ async def get_session_endpoint(
         user, raw_token = await _create_session(db)
         _set_session_cookie(response, raw_token)
     return await _build_session_response(db, user)
+
+
+@router.delete("/v1/session", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_session_endpoint(
+    response: Response,
+    session_cookie: Annotated[str | None, Cookie(alias=SESSION_COOKIE_NAME)] = None,
+    db: AsyncSession = Depends(get_session),
+) -> None:
+    """Sign the caller out *of this browser*. Revokes the token row tied to
+    the current cookie (other devices keep their own tokens) and clears the
+    cookie. Idempotent — a missing or already-invalid cookie still 204s and
+    clears whatever the browser is holding."""
+    if session_cookie:
+        await db.execute(
+            delete(UserToken).where(
+                UserToken.token == _hash_token(session_cookie),
+                UserToken.context == SESSION_TOKEN_CONTEXT,
+            )
+        )
+        await db.commit()
+    _clear_session_cookie(response)
 
 
 async def get_optional_user(

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -99,6 +99,49 @@ async def test_creates_new_session_when_cookie_invalid(
     assert tokens[0].token == hashlib.sha256(new_token.encode("utf-8")).digest()
 
 
+def _assert_session_cookie_cleared(response) -> None:
+    # delete_cookie sets max-age=0 (and may also send expires=Thu, 01 Jan 1970...).
+    # Either signal is sufficient.
+    cookie_header = response.headers.get("set-cookie", "").lower()
+    assert "max-age=0" in cookie_header or "expires=thu, 01 jan 1970" in cookie_header
+
+
+async def test_delete_session_revokes_token_and_clears_cookie(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    first = await api_client.get("/v1/session")
+    raw_token = first.cookies.get(SESSION_COOKIE_NAME)
+    assert raw_token
+
+    response = await api_client.delete("/v1/session")
+    assert response.status_code == 204
+    _assert_session_cookie_cleared(response)
+
+    tokens = (await db_session.execute(select(UserToken))).scalars().all()
+    assert tokens == []
+
+
+@pytest.mark.parametrize(
+    "cookie_value",
+    [None, "not-a-real-token"],
+    ids=["no_cookie", "unknown_cookie"],
+)
+async def test_delete_session_is_idempotent(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    cookie_value: str | None,
+):
+    if cookie_value is not None:
+        api_client.cookies.set(SESSION_COOKIE_NAME, cookie_value, domain="testserver")
+    response = await api_client.delete("/v1/session")
+    assert response.status_code == 204
+    _assert_session_cookie_cleared(response)
+
+    # No prior GET — DELETE must not mint a user.
+    users = (await db_session.execute(select(User))).scalars().all()
+    assert users == []
+
+
 async def test_token_is_stored_hashed_not_plaintext(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -15,7 +15,14 @@ export interface paths {
         get: operations["get_session_endpoint_v1_session_get"];
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Delete Session Endpoint
+         * @description Sign the caller out *of this browser*. Revokes the token row tied to
+         *     the current cookie (other devices keep their own tokens) and clears the
+         *     cookie. Idempotent — a missing or already-invalid cookie still 204s and
+         *     clears whatever the browser is holding.
+         */
+        delete: operations["delete_session_endpoint_v1_session_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -1536,6 +1543,35 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SessionResponse"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_session_endpoint_v1_session_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -141,6 +141,21 @@ export function useRequestLogin() {
   })
 }
 
+export function useLogout() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (): Promise<void> => {
+      unwrap('sign out', await api.DELETE('/v1/session'), { allowEmpty: true })
+    },
+    // Drop ALL cached per-user data (matches, dashboard, players, ...), not
+    // just SESSION_QUERY_KEY — otherwise the prior user's BFF responses leak
+    // into the next ephemeral session.
+    onSuccess: () => {
+      qc.clear()
+    },
+  })
+}
+
 export function useConsumeLoginToken() {
   const qc = useQueryClient()
   return useMutation({

--- a/web-client/src/components/user-menu.test.tsx
+++ b/web-client/src/components/user-menu.test.tsx
@@ -36,8 +36,17 @@ function renderWithClient(ui: React.ReactElement) {
     path: '/settings',
     component: () => <div>Settings page</div>,
   })
+  const dashboardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/dashboard',
+    component: () => <div>Dashboard page</div>,
+  })
   const router = createRouter({
-    routeTree: rootRoute.addChildren([indexRoute, settingsRoute]),
+    routeTree: rootRoute.addChildren([
+      indexRoute,
+      settingsRoute,
+      dashboardRoute,
+    ]),
     history: createMemoryHistory({ initialEntries: ['/'] }),
   })
   return render(
@@ -119,5 +128,27 @@ describe('UserMenu', () => {
 
     const settings = await screen.findByRole('menuitem', { name: /settings/i })
     expect(settings).toHaveAttribute('href', '/settings')
+  })
+
+  it('clicking Log out calls DELETE /v1/session and redirects to /dashboard', async () => {
+    let deleteCalls = 0
+    server.use(
+      http.delete('*/v1/session', () => {
+        deleteCalls += 1
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+
+    renderWithClient(<UserMenu />)
+
+    await screen.findByText(mockSession.data.user.username)
+    await userEvent.click(screen.getByTestId('user-menu'))
+
+    await userEvent.click(await screen.findByTestId('user-menu-logout'))
+
+    await waitFor(() => {
+      expect(deleteCalls).toBe(1)
+    })
+    expect(await screen.findByText('Dashboard page')).toBeInTheDocument()
   })
 })

--- a/web-client/src/components/user-menu.tsx
+++ b/web-client/src/components/user-menu.tsx
@@ -1,18 +1,19 @@
-import { Link } from '@tanstack/react-router'
-import { Settings } from 'lucide-react'
-import { useSession } from '@/api/session'
+import { Link, useNavigate } from '@tanstack/react-router'
+import { LogOut, Settings } from 'lucide-react'
+import { useLogout, useSession } from '@/api/session'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 
 export function UserMenu() {
   const { data, isLoading, isError } = useSession()
+  const logout = useLogout()
+  const navigate = useNavigate()
 
   if (isLoading) {
     return (
@@ -49,13 +50,26 @@ export function UserMenu() {
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-44">
-        <DropdownMenuLabel className="truncate">{username}</DropdownMenuLabel>
-        <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
           <Link to="/settings">
             <Settings />
             Settings
           </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          variant="destructive"
+          data-testid="user-menu-logout"
+          onSelect={() => {
+            logout.mutate(undefined, {
+              onSuccess: () => {
+                void navigate({ to: '/dashboard' })
+              },
+            })
+          }}
+        >
+          <LogOut />
+          Log out
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -327,6 +327,10 @@ export const handlers = [
     await delay(600)
     return HttpResponse.json(mockSession)
   }),
+  http.delete('*/v1/session', async () => {
+    await delay(150)
+    return new HttpResponse(null, { status: 204 })
+  }),
   // ----- /v1/players list + per-player profile + per-player matches ------
   // BFF endpoints — each returns exactly what its consumer page needs. The
   // dev-only handlers below synthesize deterministic W-L + form so the


### PR DESCRIPTION
## Summary

- Adds `DELETE /v1/session` — revokes the current cookie's token row, clears the cookie, idempotent.
- New `useLogout` hook clears the full React Query cache so the prior user's BFF data can't leak into the next ephemeral session.
- User menu gains a destructive Log out item under Settings; selecting it calls the endpoint, wipes per-user cache, and routes back to `/dashboard`, where the next render mints a fresh ephemeral guest.
- Removes the in-menu username label to match the design handoff.

## Test plan

- [x] `pytest tests/test_session.py` — covers happy path, idempotent (no cookie / unknown cookie), and that the Set-Cookie clears.
- [x] Full `pytest` — 349 passed.
- [x] `vitest user-menu.test.tsx` — new test asserts the logout click hits `DELETE /v1/session` once and navigates to `/dashboard`.
- [x] Full `npm run test:run` — 105 passed.
- [x] `npm run lint`, `npm run build` clean (`tsc -b && vite build`).
- [x] `ruff check`, `ruff format --check`, `mypy` clean.
- [x] OpenAPI schema regenerated; no drift.
- [ ] Manual smoke against `docker compose -f docker-compose.dev.yml up`: open menu → Log out → land on `/dashboard` with a fresh username; DevTools shows `DELETE /v1/session` 204 then `GET /v1/session`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)