### PR TITLE
Nudge guests in the user menu toward claiming their account

### DIFF
--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -25,6 +25,25 @@ export function useSession() {
   return useQuery(sessionQueryOptions())
 }
 
+export type EmailStatus = 'guest' | 'pending' | 'verified'
+
+export function deriveEmailStatus({
+  email,
+  confirmedAt,
+  pendingEmail,
+}: {
+  email: string | null
+  confirmedAt: string | null
+  pendingEmail: string | null
+}): EmailStatus {
+  // A pending change wins even when the user is already verified — the FE
+  // still has something to nudge them to complete.
+  if (pendingEmail) return 'pending'
+  if (confirmedAt) return 'verified'
+  if (email) return 'pending'
+  return 'guest'
+}
+
 /** True when the current session carries `name` in its permissions list. */
 export function useHasPermission(name: string): boolean {
   const { data } = useSession()

--- a/web-client/src/components/user-menu.test.tsx
+++ b/web-client/src/components/user-menu.test.tsx
@@ -126,8 +126,47 @@ describe('UserMenu', () => {
     const trigger = await screen.findByTestId('user-menu')
     await userEvent.click(trigger)
 
-    const settings = await screen.findByRole('menuitem', { name: /settings/i })
+    const settings = await screen.findByRole('menuitem', { name: /^settings$/i })
     expect(settings).toHaveAttribute('href', '/settings')
+  })
+
+  it('shows the pulsing guest dot and Claim account item when the user has no email', async () => {
+    renderWithClient(<UserMenu />)
+
+    expect(await screen.findByTestId('user-menu-guest-dot')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('user-menu'))
+
+    const claim = await screen.findByTestId('user-menu-claim-account')
+    expect(claim).toHaveAttribute('href', '/settings#sec-email')
+    expect(claim).toHaveTextContent('Claim account')
+    expect(claim).toHaveTextContent('Save your matches and rating.')
+  })
+
+  it('hides the guest dot and Claim account item once the user has an email', async () => {
+    const verified: SessionResponse = {
+      data: {
+        user: {
+          username: 'rita.kovac',
+          permissions: [],
+          email: 'rita@kovac.club',
+          confirmed_at: '2026-05-01T00:00:00Z',
+        },
+      },
+    }
+    server.use(http.get('*/v1/session', () => HttpResponse.json(verified)))
+
+    renderWithClient(<UserMenu />)
+
+    await screen.findByText('rita.kovac')
+    expect(screen.queryByTestId('user-menu-guest-dot')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('user-menu'))
+
+    await screen.findByRole('menuitem', { name: /^settings$/i })
+    expect(
+      screen.queryByTestId('user-menu-claim-account'),
+    ).not.toBeInTheDocument()
   })
 
   it('clicking Log out calls DELETE /v1/session and redirects to /dashboard', async () => {

--- a/web-client/src/components/user-menu.test.tsx
+++ b/web-client/src/components/user-menu.test.tsx
@@ -84,9 +84,10 @@ describe('UserMenu', () => {
     expect(
       await screen.findByText(mockSession.data.user.username),
     ).toBeInTheDocument()
+    // Default mockSession has no email → guest aria-label nudges toward claiming.
     expect(screen.getByTestId('user-menu')).toHaveAttribute(
       'aria-label',
-      `Signed in as ${mockSession.data.user.username}`,
+      `Guest account ${mockSession.data.user.username} — open menu to claim`,
     )
   })
 
@@ -143,6 +144,31 @@ describe('UserMenu', () => {
     expect(claim).toHaveTextContent('Save your matches and rating.')
   })
 
+  it('hides the guest nudge once a claim is mid-flight (pending_email set)', async () => {
+    const pending: SessionResponse = {
+      data: {
+        user: {
+          username: 'rita.kovac',
+          permissions: [],
+          email: null,
+          confirmed_at: null,
+          pending_email: 'rita@kovac.club',
+        },
+      },
+    }
+    server.use(http.get('*/v1/session', () => HttpResponse.json(pending)))
+
+    renderWithClient(<UserMenu />)
+
+    await screen.findByText('rita.kovac')
+    expect(screen.queryByTestId('user-menu-guest-dot')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('user-menu'))
+    expect(
+      screen.queryByTestId('user-menu-claim-account'),
+    ).not.toBeInTheDocument()
+  })
+
   it('hides the guest dot and Claim account item once the user has an email', async () => {
     const verified: SessionResponse = {
       data: {
@@ -160,6 +186,10 @@ describe('UserMenu', () => {
 
     await screen.findByText('rita.kovac')
     expect(screen.queryByTestId('user-menu-guest-dot')).not.toBeInTheDocument()
+    expect(screen.getByTestId('user-menu')).toHaveAttribute(
+      'aria-label',
+      'Signed in as rita.kovac',
+    )
 
     await userEvent.click(screen.getByTestId('user-menu'))
 

--- a/web-client/src/components/user-menu.tsx
+++ b/web-client/src/components/user-menu.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate } from '@tanstack/react-router'
-import { LogOut, Settings } from 'lucide-react'
+import { ChevronDown, LogOut, Settings, UserPlus } from 'lucide-react'
 import { useLogout, useSession } from '@/api/session'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import {
@@ -29,7 +29,9 @@ export function UserMenu() {
     )
   }
 
-  const username = !isError && data ? data.data.user.username : 'Guest'
+  const user = !isError && data ? data.data.user : null
+  const username = user ? user.username : 'Guest'
+  const isGuest = !user?.email
 
   return (
     <DropdownMenu>
@@ -40,16 +42,53 @@ export function UserMenu() {
           data-testid="user-menu"
           aria-label={`Signed in as ${username}`}
         >
-          <UserAvatar name={username} size={30} />
+          <span className="app-shell__user-avatar-wrap">
+            <UserAvatar name={username} size={30} dim={isGuest} />
+            {isGuest && (
+              <span
+                className="app-shell__user-menu-dot--pulse"
+                aria-hidden="true"
+                data-testid="user-menu-guest-dot"
+              />
+            )}
+          </span>
           <div
             className="app-shell__user-name app-shell__user-name--truncate"
             title={username}
           >
             {username}
           </div>
+          <span className="app-shell__user-menu-chev" aria-hidden="true">
+            <ChevronDown size={14} />
+          </span>
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="min-w-44">
+      <DropdownMenuContent align="end" className="min-w-64">
+        {isGuest && (
+          <>
+            <DropdownMenuItem asChild className="p-0 focus:bg-transparent">
+              <Link
+                to="/settings"
+                hash="sec-email"
+                className="app-shell__claim-account"
+                data-testid="user-menu-claim-account"
+              >
+                <span className="app-shell__claim-account__icon">
+                  <UserPlus size={16} />
+                </span>
+                <span className="app-shell__claim-account__body">
+                  <span className="app-shell__claim-account__title">
+                    Claim account
+                  </span>
+                  <span className="app-shell__claim-account__sub">
+                    Save your matches and rating.
+                  </span>
+                </span>
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
         <DropdownMenuItem asChild>
           <Link to="/settings">
             <Settings />

--- a/web-client/src/components/user-menu.tsx
+++ b/web-client/src/components/user-menu.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate } from '@tanstack/react-router'
 import { ChevronDown, LogOut, Settings, UserPlus } from 'lucide-react'
-import { useLogout, useSession } from '@/api/session'
+import { deriveEmailStatus, useLogout, useSession } from '@/api/session'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import {
   DropdownMenu,
@@ -31,7 +31,12 @@ export function UserMenu() {
 
   const user = !isError && data ? data.data.user : null
   const username = user ? user.username : 'Guest'
-  const isGuest = !user?.email
+  const isGuest =
+    deriveEmailStatus({
+      email: user?.email ?? null,
+      confirmedAt: user?.confirmed_at ?? null,
+      pendingEmail: user?.pending_email ?? null,
+    }) === 'guest'
 
   return (
     <DropdownMenu>
@@ -40,7 +45,11 @@ export function UserMenu() {
           type="button"
           className="app-shell__user-menu app-shell__user-menu--trigger"
           data-testid="user-menu"
-          aria-label={`Signed in as ${username}`}
+          aria-label={
+            isGuest
+              ? `Guest account ${username} — open menu to claim`
+              : `Signed in as ${username}`
+          }
         >
           <span className="app-shell__user-avatar-wrap">
             <UserAvatar name={username} size={30} dim={isGuest} />
@@ -63,10 +72,13 @@ export function UserMenu() {
           </span>
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="min-w-64">
+      <DropdownMenuContent
+        align="end"
+        className={isGuest ? 'min-w-64' : 'min-w-44'}
+      >
         {isGuest && (
           <>
-            <DropdownMenuItem asChild className="p-0 focus:bg-transparent">
+            <DropdownMenuItem asChild className="p-0">
               <Link
                 to="/settings"
                 hash="sec-email"

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -766,7 +766,7 @@ body.dark.fortymm-theme {
 }
 .app-shell__claim-account__sub {
   font-size: 11px;
-  color: var(--fg-muted);
+  color: var(--fg-3);
   line-height: 1.25;
 }
 .app-shell__user-name {

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -674,6 +674,101 @@ body.dark.fortymm-theme {
   font-weight: 700;
   font-size: 12px;
 }
+.app-shell__user-avatar-wrap {
+  position: relative;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.app-shell__user-menu-dot--pulse {
+  position: absolute;
+  top: -1px;
+  right: -1px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--ball-500);
+  border: 2px solid var(--ink-900);
+  animation: app-shell-nudge-pulse 2.4s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes app-shell-nudge-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 122, 26, 0.55);
+  }
+  50% {
+    box-shadow: 0 0 0 5px rgba(255, 122, 26, 0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .app-shell__user-menu-dot--pulse {
+    animation: none;
+  }
+}
+.app-shell__user-menu-chev {
+  color: var(--fg-3);
+  display: grid;
+  place-items: center;
+  transition: transform 120ms ease;
+}
+.app-shell__user-menu--trigger[data-state='open'] .app-shell__user-menu-chev {
+  transform: rotate(180deg);
+}
+.app-shell__claim-account {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: var(--bg-accent-soft);
+  border: 1px solid rgba(255, 122, 26, 0.22);
+  text-decoration: none;
+  overflow: hidden;
+  color: var(--fg-1);
+  cursor: pointer;
+}
+.app-shell__claim-account::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 8px;
+  bottom: 8px;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: var(--ball-500);
+  box-shadow: 0 0 8px rgba(255, 122, 26, 0.5);
+}
+.app-shell__claim-account__icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  color: var(--ball-400);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  margin-left: 6px;
+}
+.app-shell__claim-account__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.app-shell__claim-account__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg-1);
+  line-height: 1.25;
+}
+.app-shell__claim-account__sub {
+  font-size: 11px;
+  color: var(--fg-muted);
+  line-height: 1.25;
+}
 .app-shell__user-name {
   font-size: 13px;
   font-weight: 500;

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -12,10 +12,12 @@ import { toast } from 'sonner'
 
 import { ApiError } from '@/api/client'
 import {
+  deriveEmailStatus,
   useResendEmailConfirmation,
   useSession,
   useSetEmail,
   useUpdateUsername,
+  type EmailStatus,
 } from '@/api/session'
 import { AppShell } from '@/components/app-shell'
 import { Turnstile, type TurnstileHandle } from '@/components/turnstile'
@@ -44,25 +46,6 @@ export const Route = createFileRoute('/settings')({
 /* ------------------------------------------------------------------ */
 /*  Types & helpers                                                   */
 /* ------------------------------------------------------------------ */
-
-type EmailStatus = 'guest' | 'pending' | 'verified'
-
-function deriveEmailStatus({
-  email,
-  confirmedAt,
-  pendingEmail,
-}: {
-  email: string | null
-  confirmedAt: string | null
-  pendingEmail: string | null
-}): EmailStatus {
-  // A pending change wins even when the user is already verified — the FE
-  // still has something to nudge them to complete.
-  if (pendingEmail) return 'pending'
-  if (confirmedAt) return 'verified'
-  if (email) return 'pending'
-  return 'guest'
-}
 
 // Mirrors api/app/schemas/session.py USERNAME_PATTERN. Client-side validation
 // is for fast feedback; the server still enforces the same rules and returns


### PR DESCRIPTION
## Summary

- Visitors with no email on file (per the canonical `deriveEmailStatus`) now see a muted avatar with a slow-pulsing accent dot on the user-menu trigger, a chevron caret so the menu is discoverable, and a "Claim account" item at the top of the open menu (soft accent tile + left accent bar) linking to `/settings#sec-email`.
- Verified users (email confirmed) see today's menu unchanged. Users mid-claim (`pending_email` set) also don't get nudged.
- Lifts `deriveEmailStatus` from `routes/settings.tsx` to `api/session.ts` so the user-menu and settings page share one source of truth.
- a11y: guest-aware aria-label on the trigger (so screen-reader users hear the claim path), AA-compliant subtitle contrast, Radix focus highlight preserved on the Claim tile, `prefers-reduced-motion` opt-out for the pulse.

## Test plan

- [x] `vitest user-menu.test.tsx` — 9 passed (guest dot/Claim shown for no-email, hidden for verified, hidden for pending-claim).
- [x] Full `npm run test:run` — 108 passed.
- [x] `npm run lint`, `npm run build` clean.
- [x] `ruff/format/mypy/pytest` (api) — 349 passed.
- [x] `web-client` Playwright — 125 passed.
- [x] Root e2e — 3/4 (the 4th is an unrelated environmental flake on the admin system-health solver round-trip; root cause + proposed fix tracked in #351).
- [ ] Manual smoke against compose: default guest sees pulse + Claim tile → click → lands at `/settings#sec-email`; after confirming email the next pageload shows no dot, no claim item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)