### PR TITLE
Save-your-match prompt for guest finalizers

### DIFF
--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -28,6 +28,8 @@ import {
 import type { components } from '@/api/schema'
 import { ApiError } from '@/api/client'
 
+import { SaveYourMatch } from './save-your-match'
+
 type MatchDetails = components['schemas']['MatchDetails']
 type MatchDetailsGame = components['schemas']['MatchDetailsGame']
 type MatchDetailsSide = components['schemas']['MatchDetailsSide']
@@ -98,7 +100,7 @@ type H2HView = {
   recentMeetings: H2HMeetingView[]
 }
 
-type MatchView = {
+export type MatchView = {
   state: HeroState
   statusLabel: string
   bestOf: number
@@ -441,6 +443,8 @@ function MatchDetailsPage({
             )}
           </div>
         </div>
+
+        <SaveYourMatch key={matchId} view={view} matchId={matchId} />
 
         <HeroScoreboard view={view} matchId={matchId} />
 

--- a/web-client/src/components/matches/save-your-match.test.tsx
+++ b/web-client/src/components/matches/save-your-match.test.tsx
@@ -1,0 +1,298 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { server } from '@/mocks/server'
+import { matchDetails, sessionResponse } from '@/test/factories'
+import { MatchDetailsView } from '@/components/matches/match-details-page'
+
+const SAVE_LABEL = /save this match/i
+const PROMPT_LABEL = /save this match/i
+const PROMPT_REGION = /^Save this match$/i
+
+function withSession(overrides: Parameters<typeof sessionResponse>[0] = {}) {
+  server.use(
+    http.get('*/v1/session', () => HttpResponse.json(sessionResponse(overrides))),
+  )
+}
+
+function withMatch(matchId: string, match: ReturnType<typeof matchDetails>) {
+  server.use(http.get(`*/v1/matches/${matchId}`, () => HttpResponse.json(match)))
+}
+
+function renderDetails(matchId: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute()
+  const detailsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/details',
+    component: () => <MatchDetailsView matchId={matchId} />,
+  })
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/settings',
+    component: () => <div>settings-page</div>,
+  })
+  const matchesList = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches',
+    component: () => <div>matches-list</div>,
+  })
+  const matchPage = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches/$matchId',
+    component: () => <div>match-page</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([
+      detailsRoute,
+      settingsRoute,
+      matchesList,
+      matchPage,
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/details'] }),
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+function finalizedMatch(matchId: string) {
+  return matchDetails({
+    id: matchId,
+    status: 'completed',
+    status_label: 'Final',
+    sides: [
+      {
+        side_number: 1,
+        players: [
+          { user_id: 'u-me', username: 'rita.kovac', is_current_user: true },
+        ],
+        games_won: 3,
+        won: true,
+        is_current_user_side: true,
+      },
+      {
+        side_number: 2,
+        players: [
+          { user_id: 'u-opp', username: 'okafor.d', is_current_user: false },
+        ],
+        games_won: 1,
+        won: false,
+        is_current_user_side: false,
+      },
+    ],
+    games: [],
+    current_game: null,
+    can_score: false,
+  })
+}
+
+describe('SaveYourMatch', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('nudges the guest finalizer with opponent + score + CTA to /settings#sec-email', async () => {
+    withSession({ user: { email: null, confirmed_at: null } })
+    withMatch('m-guest', finalizedMatch('m-guest'))
+
+    renderDetails('m-guest')
+
+    const prompt = await screen.findByRole('region', { name: PROMPT_REGION })
+    // Anchors on the specific match: opponent name + score blips + date.
+    expect(within(prompt).getByText(/rivalry with okafor\.d/i)).toBeInTheDocument()
+    const blips = within(prompt).getAllByText(/^[0-9]+$/)
+    expect(blips.map((n) => n.textContent)).toEqual(['3', '1'])
+    // Primary CTA goes to the settings email section.
+    const cta = within(prompt).getByRole('link', { name: SAVE_LABEL })
+    expect(cta).toHaveAttribute('href', '/settings#sec-email')
+    // Dismiss is present, "TAKES 20s · EMAIL ONLY" hint is shown.
+    expect(
+      within(prompt).getByRole('button', { name: /not now/i }),
+    ).toBeInTheDocument()
+    expect(within(prompt).getByText(/TAKES 20s/)).toBeInTheDocument()
+  })
+
+  it('hides on a live (not-yet-finalized) match', async () => {
+    withSession({ user: { email: null, confirmed_at: null } })
+    const live = matchDetails({
+      id: 'm-live',
+      status: 'in_progress',
+      status_label: 'Live',
+    })
+    withMatch('m-live', live)
+
+    const { container } = renderDetails('m-live')
+
+    await waitFor(() =>
+      expect(container.querySelector('.md-hero')).toBeInTheDocument(),
+    )
+    expect(
+      screen.queryByRole('region', { name: PROMPT_REGION }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides when the viewer already has a confirmed email', async () => {
+    withSession({
+      user: { email: 'rita@example.com', confirmed_at: '2026-05-01T00:00:00Z' },
+    })
+    withMatch('m-verified', finalizedMatch('m-verified'))
+
+    const { container } = renderDetails('m-verified')
+
+    await waitFor(() =>
+      expect(container.querySelector('.md-hero')).toBeInTheDocument(),
+    )
+    expect(
+      screen.queryByRole('region', { name: PROMPT_REGION }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides for a spectator (not a participant), even if the viewer is a guest', async () => {
+    withSession({ user: { email: null, confirmed_at: null } })
+    const spectatorMatch = matchDetails({
+      id: 'm-spec-guest',
+      status: 'completed',
+      status_label: 'Final',
+      sides: [
+        {
+          side_number: 1,
+          players: [{ user_id: 'u-a', username: 'ada.l', is_current_user: false }],
+          games_won: 3,
+          won: true,
+          is_current_user_side: false,
+        },
+        {
+          side_number: 2,
+          players: [{ user_id: 'u-b', username: 'bo.k', is_current_user: false }],
+          games_won: 0,
+          won: false,
+          is_current_user_side: false,
+        },
+      ],
+      games: [],
+      current_game: null,
+      can_score: false,
+    })
+    withMatch('m-spec-guest', spectatorMatch)
+
+    const { container } = renderDetails('m-spec-guest')
+
+    await waitFor(() =>
+      expect(container.querySelector('.md-hero')).toBeInTheDocument(),
+    )
+    expect(
+      screen.queryByRole('region', { name: PROMPT_REGION }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('swaps to a "save it" receipt after Not now, then persists dismissal across reloads', async () => {
+    withSession({ user: { email: null, confirmed_at: null } })
+    withMatch('m-dismiss', finalizedMatch('m-dismiss'))
+
+    const user = userEvent.setup()
+    const first = renderDetails('m-dismiss')
+
+    const prompt = await screen.findByRole('region', { name: PROMPT_REGION })
+    await user.click(within(prompt).getByRole('button', { name: /not now/i }))
+
+    // The full prompt is gone; a quiet receipt with an undo affordance stays.
+    expect(
+      screen.queryByRole('region', { name: PROMPT_REGION }),
+    ).not.toBeInTheDocument()
+    const receipt = screen.getByRole('status')
+    expect(receipt).toHaveTextContent(/lives on your device only/i)
+    // The receipt's "Save it" is a real CTA — it links straight to the email
+    // section, not a re-surface of the prompt.
+    expect(
+      within(receipt).getByRole('link', { name: /save it/i }),
+    ).toHaveAttribute('href', '/settings#sec-email')
+
+    // Persistence: a fresh render reads the dismissal from storage and renders
+    // nothing at all (the brief is "don't badger them if they revisit").
+    first.unmount()
+    withMatch('m-dismiss', finalizedMatch('m-dismiss'))
+
+    const { container } = renderDetails('m-dismiss')
+    await waitFor(() =>
+      expect(container.querySelector('.md-hero')).toBeInTheDocument(),
+    )
+    expect(
+      screen.queryByRole('region', { name: PROMPT_LABEL }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/lives on your device only/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides on a finalized no-opponent (ghost) match', async () => {
+    withSession({ user: { email: null, confirmed_at: null } })
+    const solo = matchDetails({
+      id: 'm-solo-final',
+      status: 'completed',
+      status_label: 'Final',
+      sides: [
+        {
+          side_number: 1,
+          players: [
+            { user_id: 'u-me', username: 'rita.kovac', is_current_user: true },
+          ],
+          games_won: 0,
+          won: true,
+          is_current_user_side: true,
+        },
+        // No-opponent sentinel: a real side row with no player.
+        {
+          side_number: 2,
+          players: [],
+          games_won: 0,
+          won: false,
+          is_current_user_side: false,
+        },
+      ],
+      games: [],
+      current_game: null,
+      can_score: false,
+    })
+    withMatch('m-solo-final', solo)
+
+    const { container } = renderDetails('m-solo-final')
+
+    await waitFor(() =>
+      expect(container.querySelector('.md-hero')).toBeInTheDocument(),
+    )
+    expect(
+      screen.queryByRole('region', { name: PROMPT_REGION }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('treats each match independently — dismissing one does not silence another', async () => {
+    window.localStorage.setItem('fm.savePromptDismissed.m-other', '1')
+    withSession({ user: { email: null, confirmed_at: null } })
+    withMatch('m-fresh', finalizedMatch('m-fresh'))
+
+    renderDetails('m-fresh')
+
+    // m-fresh still nudges even though m-other was dismissed.
+    expect(
+      await screen.findByRole('region', { name: PROMPT_REGION }),
+    ).toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/matches/save-your-match.tsx
+++ b/web-client/src/components/matches/save-your-match.tsx
@@ -1,0 +1,195 @@
+import { useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { ChevronRight } from 'lucide-react'
+
+import { deriveEmailStatus, useSession } from '@/api/session'
+import { fmtDate } from '@/lib/dates'
+import { cn } from '@/lib/utils'
+
+import type { MatchView } from './match-details-page'
+
+// Per-match key. Dismissing on one finalized match doesn't quiet the prompt
+// on the next — a guest with multiple matches still gets the nudge once per
+// result they care about.
+const DISMISS_KEY_PREFIX = 'fm.savePromptDismissed.'
+const SETTINGS_EMAIL_HASH = 'sec-email'
+
+function readDismissed(matchId: string): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return window.localStorage.getItem(DISMISS_KEY_PREFIX + matchId) === '1'
+  } catch {
+    return false
+  }
+}
+
+function writeDismissed(matchId: string, value: boolean) {
+  if (typeof window === 'undefined') return
+  try {
+    if (value) {
+      window.localStorage.setItem(DISMISS_KEY_PREFIX + matchId, '1')
+    } else {
+      window.localStorage.removeItem(DISMISS_KEY_PREFIX + matchId)
+    }
+  } catch {
+    /* private mode / quota — fail open; better to re-nudge than crash */
+  }
+}
+
+function MatchAnchor({ view }: { view: MatchView }) {
+  // The outer gate guarantees a real opponent on the right side; we can
+  // dereference freely here.
+  const me = view.leftSide
+  const opp = view.rightSide!
+  const iWon = me.won === true
+  return (
+    <div className="md-save__anchor" aria-label="Match summary">
+      <div
+        className={cn(
+          'md-avatar md-save__avatar',
+          iWon ? 'md-avatar--win' : 'md-avatar--loss',
+        )}
+      >
+        {me.initials}
+      </div>
+      <div className="md-save__blips">
+        <span className={cn('md-save__blip', iWon && 'md-save__blip--win')}>
+          {me.gamesWon}
+        </span>
+        <span className="md-save__blip-dash">–</span>
+        <span className={cn('md-save__blip', !iWon && 'md-save__blip--win')}>
+          {opp.gamesWon}
+        </span>
+      </div>
+      <div
+        className={cn(
+          'md-avatar md-save__avatar',
+          iWon ? 'md-avatar--loss' : 'md-avatar--win',
+        )}
+      >
+        {opp.initials}
+      </div>
+      <span className="md-save__date">{fmtDate(view.createdAt).toUpperCase()}</span>
+    </div>
+  )
+}
+
+function DismissedReceipt() {
+  // The receipt sticks around for the rest of the session after "Not now",
+  // so the user has a recoverable affordance without a re-nudge. "Save it"
+  // routes straight to the email flow — the label promises a commit, not an
+  // undo, so we navigate rather than restore the prompt.
+  return (
+    <div className="md-save-receipt" role="status">
+      <span aria-hidden="true">—</span>
+      <span>
+        This match lives on your device only.{' '}
+        <Link
+          to="/settings"
+          hash={SETTINGS_EMAIL_HASH}
+          className="md-save-receipt__undo"
+        >
+          Save it
+        </Link>{' '}
+        to keep it.
+      </span>
+    </div>
+  )
+}
+
+export function SaveYourMatch({
+  view,
+  matchId,
+}: {
+  view: MatchView
+  matchId: string
+}) {
+  // Cheap, props-only gates first so we never call useSession() (and thereby
+  // mint a guest user via GET /v1/session) on the standalone public-share
+  // route where the viewer is never the participant. The inner body owns the
+  // hook tree so the conditional return here doesn't change hook order.
+  if (view.state !== 'final') return null
+  if (!view.leftSide.isCurrentUser) return null
+  if (!view.rightSide || view.rightSide.isGhost) return null
+  return <SaveYourMatchActive view={view} matchId={matchId} />
+}
+
+function SaveYourMatchActive({
+  view,
+  matchId,
+}: {
+  view: MatchView
+  matchId: string
+}) {
+  const { data: session } = useSession()
+
+  // 'cold' = dismissed on a prior visit (read from localStorage). We hide
+  // entirely in that case — the brief is explicit: don't badger on revisit.
+  // 'session' = dismissed in this session — we swap in a quiet receipt so the
+  // user can still find their way back to the email flow without a re-nudge.
+  const [dismissed, setDismissed] = useState<'cold' | 'session' | false>(() =>
+    readDismissed(matchId) ? 'cold' : false,
+  )
+
+  const user = session?.data.user
+  if (!user) return null
+  // Reuse the canonical guest/pending/verified split from /settings so this
+  // prompt and the topbar UserMenu agree on who counts as a guest (e.g. a
+  // user with `pending_email` is no longer "guest", they're "pending").
+  const isGuest =
+    deriveEmailStatus({
+      email: user.email ?? null,
+      confirmedAt: user.confirmed_at ?? null,
+      pendingEmail: user.pending_email ?? null,
+    }) === 'guest'
+  if (!isGuest) return null
+
+  if (dismissed === 'cold') return null
+  if (dismissed === 'session') return <DismissedReceipt />
+
+  const handleDismiss = () => {
+    writeDismissed(matchId, true)
+    setDismissed('session')
+  }
+
+  return (
+    <section className="md-save" aria-label="Save this match">
+      <div className="md-save__hd">
+        <div className="md-save__kicker">
+          <span className="ball-dot" aria-hidden="true" /> Nice match
+        </div>
+        <MatchAnchor view={view} />
+      </div>
+
+      <div>
+        <h3 className="md-save__headline">
+          Let&rsquo;s make sure this one sticks around.
+        </h3>
+        <p className="md-save__body">
+          Add an email and your rating and rivalry with {view.rightSide!.username}{' '}
+          are saved across devices. Right now, clearing cookies erases this
+          match.
+        </p>
+      </div>
+
+      <div className="md-save__actions">
+        <Link
+          to="/settings"
+          hash={SETTINGS_EMAIL_HASH}
+          className="md-btn md-btn--primary"
+        >
+          Save this match
+          <ChevronRight size={14} />
+        </Link>
+        <button
+          type="button"
+          className="md-btn md-btn--ghost"
+          onClick={handleDismiss}
+        >
+          Not now
+        </button>
+        <span className="md-save__hint">TAKES 20s · EMAIL ONLY</span>
+      </div>
+    </section>
+  )
+}

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2230,6 +2230,154 @@ body.dark.fortymm-theme {
   gap: 8px;
   flex-shrink: 0;
 }
+/* ---------- Save-your-match prompt (guest finalizer nudge) ----------
+   Sits above the hero scoreboard, which carries no top margin of its own;
+   md-save's margin-bottom supplies the gap below the prompt. (Spacing
+   between top-level page blocks is heterogeneous — see md-header's
+   margin-bottom, md-col-2's margin-top.) */
+.fortymm-theme .md-save,
+.fortymm-theme .md-save-receipt {
+  margin-bottom: 24px;
+}
+.fortymm-theme .md-save {
+  position: relative;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-lg);
+  padding: 22px 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--shadow-sm);
+}
+.fortymm-theme .md-save__hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.fortymm-theme .md-save__kicker {
+  font: 600 11px var(--font-mono);
+  color: var(--ball-500);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.fortymm-theme .md-save__anchor {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font: 500 13px var(--font-ui);
+  color: var(--fg-2);
+}
+.fortymm-theme .md-save__avatar {
+  width: 28px;
+  height: 28px;
+  font-size: 11px;
+}
+.fortymm-theme .md-save__avatar.md-avatar--win {
+  box-shadow: none;
+}
+.fortymm-theme .md-save__blips {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.fortymm-theme .md-save__blip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: var(--r-sm);
+  background: var(--bg-panel);
+  color: var(--fg-3);
+  font: 700 12px var(--font-mono);
+  border: 1px solid var(--border-subtle);
+  font-variant-numeric: tabular-nums;
+}
+.fortymm-theme .md-save__blip--win {
+  background: rgba(0, 226, 154, 0.14);
+  color: var(--serve-500);
+  border-color: rgba(0, 226, 154, 0.3);
+}
+.fortymm-theme .md-save__blip-dash {
+  font: 500 11px var(--font-mono);
+  color: var(--fg-3);
+}
+.fortymm-theme .md-save__date {
+  font: 500 11px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.08em;
+  margin-left: 2px;
+}
+.fortymm-theme .md-save__headline {
+  margin: 0;
+  font: 700 22px var(--font-ui);
+  color: var(--fg-1);
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+.fortymm-theme .md-save__body {
+  margin: 8px 0 0;
+  font: 400 13px/1.55 var(--font-ui);
+  color: var(--fg-3);
+  max-width: 520px;
+}
+.fortymm-theme .md-save__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.fortymm-theme .md-save__hint {
+  font: 500 10px var(--font-mono);
+  color: var(--fg-3);
+  letter-spacing: 0.14em;
+  margin-left: auto;
+}
+
+.fortymm-theme .md-save-receipt {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 16px;
+  background: transparent;
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--r-md);
+  color: var(--fg-3);
+  font: 500 12px var(--font-ui);
+}
+.fortymm-theme .md-save-receipt__undo {
+  color: var(--fg-2);
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: var(--border-subtle);
+  text-underline-offset: 3px;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+}
+.fortymm-theme .md-save-receipt__undo:hover {
+  color: var(--fg-1);
+  text-decoration-color: var(--chalk-500);
+}
+
+@media (max-width: 560px) {
+  .fortymm-theme .md-save {
+    padding: 18px 18px;
+  }
+  .fortymm-theme .md-save__hint {
+    width: 100%;
+    margin-left: 0;
+  }
+}
+
 .fortymm-theme .md-card__hd {
   padding: 14px 18px 10px;
   border-bottom: 1px solid var(--ink-700);


### PR DESCRIPTION
## Summary

- Pitches the email-claim flow at the highest-investment moment a guest can have — right after a match enters the finalized state (`status === completed`).
- Renders only for the participant guest (no email + not confirmed); one primary CTA to `/settings#sec-email`, a secondary "Not now" that swaps in a quiet receipt link, and per-match dismissal persisted to `localStorage` so revisits stay silent.
- Cheap props-only gates short-circuit before `useSession()` is called, so the standalone `/p/matches/$matchId` public-share route doesn't mint a guest user for anonymous viewers.

## Notes

- Renders above the hero scoreboard on `/matches/$matchId` Final state; uses existing `.md-btn` / `.md-avatar` chrome plus a new scoped `.md-save*` block in `index.css`.
- Reuses `deriveEmailStatus` (single source of truth for guest/pending/verified) and `fmtDate` (timezone-safe via `parseApiDate`).
- `key={matchId}` on the render site so dismissed state doesn't leak across matches.

## Test plan

- [x] `npm run test:run` — 115 passed (7 new for SaveYourMatch: guest nudge, live-state hide, verified-user hide, spectator hide, ghost-opponent hide, Not-now → receipt → reload persistence, per-match isolation)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean (tsc -b && vite build)
- [ ] Manual: as a guest, finalize a match → expect the nudge above the hero; click Save → land on `/settings#sec-email`; dismiss → receipt remains in-session and clears the prompt on reload.
- [ ] Manual: as a confirmed user, finalize a match → no nudge.
- [ ] Manual: open a finalized match via `/p/matches/<id>` while signed-out → no nudge, and the request log shows no extra `/v1/session` call from this component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)