### PR TITLE
Fire save-your-match prompt on live matches too

### DIFF
--- a/web-client/src/components/matches/save-your-match.test.tsx
+++ b/web-client/src/components/matches/save-your-match.test.tsx
@@ -130,16 +130,52 @@ describe('SaveYourMatch', () => {
     expect(within(prompt).getByText(/TAKES 20s/)).toBeInTheDocument()
   })
 
-  it('hides on a live (not-yet-finalized) match', async () => {
+  it('also fires on a live (in-progress) match so a guest who closes the tab before sign-off still gets nudged', async () => {
     withSession({ user: { email: null, confirmed_at: null } })
     const live = matchDetails({
       id: 'm-live',
       status: 'in_progress',
       status_label: 'Live',
+      sides: [
+        {
+          side_number: 1,
+          players: [
+            { user_id: 'u-me', username: 'rita.kovac', is_current_user: true },
+          ],
+          games_won: 2,
+          won: null,
+          is_current_user_side: true,
+        },
+        {
+          side_number: 2,
+          players: [
+            { user_id: 'u-opp', username: 'okafor.d', is_current_user: false },
+          ],
+          games_won: 1,
+          won: null,
+          is_current_user_side: false,
+        },
+      ],
     })
     withMatch('m-live', live)
 
-    const { container } = renderDetails('m-live')
+    renderDetails('m-live')
+
+    expect(
+      await screen.findByRole('region', { name: PROMPT_REGION }),
+    ).toBeInTheDocument()
+  })
+
+  it('hides on an upcoming (not-yet-started) match', async () => {
+    withSession({ user: { email: null, confirmed_at: null } })
+    const upcoming = matchDetails({
+      id: 'm-upcoming',
+      status: 'pending',
+      status_label: 'Scheduled',
+    })
+    withMatch('m-upcoming', upcoming)
+
+    const { container } = renderDetails('m-upcoming')
 
     await waitFor(() =>
       expect(container.querySelector('.md-hero')).toBeInTheDocument(),

--- a/web-client/src/components/matches/save-your-match.tsx
+++ b/web-client/src/components/matches/save-your-match.tsx
@@ -108,7 +108,11 @@ export function SaveYourMatch({
   // mint a guest user via GET /v1/session) on the standalone public-share
   // route where the viewer is never the participant. The inner body owns the
   // hook tree so the conditional return here doesn't change hook order.
-  if (view.state !== 'final') return null
+  // Show as soon as the match is being played — we don't wait for opponent
+  // sign-off. The "save it before cookies clear" risk applies the moment the
+  // guest has invested any real time, not just at the rated-finalized
+  // boundary (which can be hours later, after the guest has closed the tab).
+  if (view.state === 'upcoming') return null
   if (!view.leftSide.isCurrentUser) return null
   if (!view.rightSide || view.rightSide.isGhost) return null
   return <SaveYourMatchActive view={view} matchId={matchId} />


### PR DESCRIPTION
## Summary

- Drop the `state === 'final'` gate on the SaveYourMatch prompt — it now fires for both live (in-progress) and final matches.
- The previous gate meant the nudge only appeared after the back-end transitioned the match to completed (i.e., after both players signed off). That can be hours after the guest stopped playing — by then the tab is often closed and the cookie-clear risk has already played out.
- Keeps the upcoming/pending guard so we don't badger guests on a match that hasn't started yet.

## Test plan

- [x] vitest 116/116 (replaced the inverse 'hides on live' test with a 'fires on live' test; added an explicit 'hides on upcoming' test).
- [x] lint + build clean.
- [ ] Manual: as a guest, score game 1 of a fresh match → expect the prompt above the hero. Don't sign off; reload → still nudged. Dismiss → quiet for the rest of the visit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)