### PR TITLE
Add dashboard guest persistence banner (tone B)

### DIFF
--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -80,10 +80,17 @@ async def get_dashboard(
         .order_by(Match.updated_at.desc())
         .limit(RECENT_RESULTS_LIMIT)
     )
+    # COUNT runs separately from the LIMIT-bound completed_q above so the
+    # banner can reference "Your N matches" even when N exceeds the recent
+    # window. Cheap enough to be unconditional — no FE feature flag.
+    completed_count_q = participant_filter(
+        select(func.count(Match.id)), current_user.id
+    ).where(Match.status == MatchStatus.completed)
 
     pending = (await db.execute(pending_q)).scalars().all()
     in_progress = (await db.execute(in_progress_q)).scalars().all()
     completed = (await db.execute(completed_q)).scalars().all()
+    completed_match_count = int((await db.execute(completed_count_q)).scalar_one())
 
     rating_changes = await _load_my_rating_changes(
         db, current_user.id, [m.id for m in completed]
@@ -102,6 +109,7 @@ async def get_dashboard(
         next_match=next_match,
         recent_results=recent_results,
         rating=rating,
+        completed_match_count=completed_match_count,
     )
 
 

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -80,17 +80,21 @@ async def get_dashboard(
         .order_by(Match.updated_at.desc())
         .limit(RECENT_RESULTS_LIMIT)
     )
-    # COUNT runs separately from the LIMIT-bound completed_q above so the
-    # banner can reference "Your N matches" even when N exceeds the recent
-    # window. Cheap enough to be unconditional — no FE feature flag.
-    completed_count_q = participant_filter(
-        select(func.count(Match.id)), current_user.id
-    ).where(Match.status == MatchStatus.completed)
 
     pending = (await db.execute(pending_q)).scalars().all()
     in_progress = (await db.execute(in_progress_q)).scalars().all()
     completed = (await db.execute(completed_q)).scalars().all()
-    completed_match_count = int((await db.execute(completed_count_q)).scalar_one())
+
+    # When completed_q didn't hit its LIMIT, we already have the exact count
+    # and can skip the extra round-trip; only the user-with-history case pays
+    # for a separate COUNT.
+    if len(completed) < RECENT_RESULTS_LIMIT:
+        completed_match_count = len(completed)
+    else:
+        completed_count_q = participant_filter(
+            select(func.count(Match.id)), current_user.id
+        ).where(Match.status == MatchStatus.completed)
+        completed_match_count = int((await db.execute(completed_count_q)).scalar_one())
 
     rating_changes = await _load_my_rating_changes(
         db, current_user.id, [m.id for m in completed]

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -351,9 +351,9 @@ def _add_side(match: Match, side_number: int, player: User | None) -> None:
 # ----- list helpers --------------------------------------------------------
 
 
-def participant_filter(
-    query: Select[tuple[Match]], current_user_id: uuid.UUID
-) -> Select[tuple[Match]]:
+def participant_filter[SelectT: Select[Any]](
+    query: SelectT, current_user_id: uuid.UUID
+) -> SelectT:
     me_in_match = (
         select(MatchSidePlayer.id)
         .where(

--- a/api/app/schemas/dashboard.py
+++ b/api/app/schemas/dashboard.py
@@ -73,3 +73,7 @@ class DashboardResponse(BaseModel):
     next_match: DashboardNextMatch | None
     recent_results: list[DashboardRecentResult]
     rating: DashboardRating | None = None
+    # Total completed matches the current user participated in. The guest
+    # persistence banner uses this to reference history concretely ("Your N
+    # matches…") and to stay hidden until the user has any history at all.
+    completed_match_count: int

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -46,6 +46,7 @@ async def test_dashboard_empty_when_user_has_no_matches(
     assert body["score_banners"] == []
     assert body["next_match"] is None
     assert body["recent_results"] == []
+    assert body["completed_match_count"] == 0
     # A fresh signup is auto-joined to the default Glicko-2 league with
     # initial state, so the rating widget lights up immediately with peak ==
     # current, a null streak, and a sparkline holding the lone seed point.
@@ -155,6 +156,7 @@ async def test_dashboard_returns_recent_results_for_completed_matches(
 
     body = (await api_client.get("/v1/dashboard")).json()
     assert len(body["recent_results"]) == 1
+    assert body["completed_match_count"] == 1
     result = body["recent_results"][0]
     assert result["match_id"] == match["id"]
     assert result["opponent_username"] == "rival"

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -184,6 +184,9 @@ async def test_dashboard_scoped_to_current_user(
     assert body["score_banners"] == []
     assert body["next_match"] is None
     assert body["recent_results"] == []
+    # Pin that completed_match_count also follows the participant filter —
+    # Bob's completed match must not bleed into Alice's history total.
+    assert body["completed_match_count"] == 0
     # Alice has her own seeded league row but no completed matches of her own
     # — the rating starts at the initial Glicko-2 values, untouched by Bob's
     # match.

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -763,6 +763,8 @@ export interface components {
             /** Recent Results */
             recent_results: components["schemas"]["DashboardRecentResult"][];
             rating?: components["schemas"]["DashboardRating"] | null;
+            /** Completed Match Count */
+            completed_match_count: number;
         };
         /** DashboardScoreBanner */
         DashboardScoreBanner: {

--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -9,7 +9,7 @@ import {
 } from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { mockSession } from '@/mocks/handlers'
 import { server } from '@/mocks/server'
 import {
@@ -327,21 +327,17 @@ describe('DashboardPage', () => {
 })
 
 describe('DashboardPage · guest persistence banner', () => {
-  // The mock session is module-shared mutable state; snapshot and restore it
-  // so the verified-user case doesn't bleed into other suites.
+  // The mock session is module-shared mutable state; snapshot every field
+  // deriveEmailStatus reads so unrelated suites can't bleed into ours.
   const originalConfirmedAt = mockSession.data.user.confirmed_at
   const originalEmail = mockSession.data.user.email
+  const originalPendingEmail = mockSession.data.user.pending_email
 
   beforeEach(() => {
     window.sessionStorage.removeItem(GUEST_PERSIST_DISMISS_KEY)
     mockSession.data.user.confirmed_at = originalConfirmedAt
     mockSession.data.user.email = originalEmail
-  })
-
-  afterEach(() => {
-    window.sessionStorage.removeItem(GUEST_PERSIST_DISMISS_KEY)
-    mockSession.data.user.confirmed_at = originalConfirmedAt
-    mockSession.data.user.email = originalEmail
+    mockSession.data.user.pending_email = originalPendingEmail
   })
 
   it("shows for a guest with one or more completed matches and quotes the user's history", async () => {

--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import {
   RouterProvider,
   createMemoryHistory,
@@ -8,7 +9,8 @@ import {
 } from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mockSession } from '@/mocks/handlers'
 import { server } from '@/mocks/server'
 import {
   dashboardRating,
@@ -16,6 +18,7 @@ import {
   dashboardResponse,
   dashboardScoreBanner,
 } from '@/test/factories'
+import { GUEST_PERSIST_DISMISS_KEY } from './guest-persist-banner'
 import { DashboardPage } from './dashboard-page'
 
 function renderDashboard() {
@@ -50,12 +53,18 @@ function renderDashboard() {
       )
     },
   })
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/settings',
+    component: () => <div>Settings route</div>,
+  })
   const router = createRouter({
     routeTree: rootRoute.addChildren([
       dashboardRoute,
       newMatchRoute,
       matchesRoute,
       scoringRoute,
+      settingsRoute,
     ]),
     history: createMemoryHistory({ initialEntries: ['/dashboard'] }),
   })
@@ -314,5 +323,124 @@ describe('DashboardPage', () => {
     expect(more).toHaveTextContent('+2')
     expect(more).toHaveTextContent(/more pending/i)
     expect(more).toHaveAttribute('href', '/matches?q=rita.kovac&status=live')
+  })
+})
+
+describe('DashboardPage · guest persistence banner', () => {
+  // The mock session is module-shared mutable state; snapshot and restore it
+  // so the verified-user case doesn't bleed into other suites.
+  const originalConfirmedAt = mockSession.data.user.confirmed_at
+  const originalEmail = mockSession.data.user.email
+
+  beforeEach(() => {
+    window.sessionStorage.removeItem(GUEST_PERSIST_DISMISS_KEY)
+    mockSession.data.user.confirmed_at = originalConfirmedAt
+    mockSession.data.user.email = originalEmail
+  })
+
+  afterEach(() => {
+    window.sessionStorage.removeItem(GUEST_PERSIST_DISMISS_KEY)
+    mockSession.data.user.confirmed_at = originalConfirmedAt
+    mockSession.data.user.email = originalEmail
+  })
+
+  it("shows for a guest with one or more completed matches and quotes the user's history", async () => {
+    server.use(
+      http.get('*/v1/dashboard', () =>
+        HttpResponse.json(
+          dashboardResponse({
+            completed_match_count: 4,
+            rating: dashboardRating({ current: 1847 }),
+          }),
+        ),
+      ),
+    )
+    renderDashboard()
+
+    const banner = await screen.findByTestId('dashboard-guest-persist-banner')
+    expect(banner).toHaveTextContent('4')
+    expect(banner).toHaveTextContent(/matches and rating/i)
+    expect(banner).toHaveTextContent('1847')
+    expect(banner).toHaveTextContent(/live on this device only/i)
+    const cta = within(banner).getByRole('link', { name: /add an email/i })
+    expect(cta).toHaveAttribute('href', '/settings#sec-email')
+  })
+
+  it('drops the rating fragment when the user has no rated league', async () => {
+    server.use(
+      http.get('*/v1/dashboard', () =>
+        HttpResponse.json(
+          dashboardResponse({ completed_match_count: 1, rating: null }),
+        ),
+      ),
+    )
+    renderDashboard()
+
+    const banner = await screen.findByTestId('dashboard-guest-persist-banner')
+    expect(banner).toHaveTextContent('Your 1 match live on this device only.')
+    expect(banner).not.toHaveTextContent(/rating/i)
+  })
+
+  it('stays hidden for a zero-match guest — nothing to lose yet', async () => {
+    server.use(
+      http.get('*/v1/dashboard', () =>
+        HttpResponse.json(
+          dashboardResponse({ completed_match_count: 0, rating: null }),
+        ),
+      ),
+    )
+    renderDashboard()
+
+    // Wait until something else from the dashboard has rendered, then
+    // confirm the banner is absent.
+    await screen.findByRole('heading', { name: /Hi, @rita\.kovac/ })
+    expect(
+      screen.queryByTestId('dashboard-guest-persist-banner'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('stays hidden for verified users regardless of match count', async () => {
+    mockSession.data.user.email = 'rita@example.com'
+    mockSession.data.user.confirmed_at = '2026-05-01T10:00:00Z'
+    server.use(
+      http.get('*/v1/dashboard', () =>
+        HttpResponse.json(dashboardResponse({ completed_match_count: 12 })),
+      ),
+    )
+    renderDashboard()
+
+    await screen.findByRole('heading', { name: /Hi, @rita\.kovac/ })
+    expect(
+      screen.queryByTestId('dashboard-guest-persist-banner'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('disappears on dismiss and stays dismissed within the session', async () => {
+    server.use(
+      http.get('*/v1/dashboard', () =>
+        HttpResponse.json(dashboardResponse({ completed_match_count: 2 })),
+      ),
+    )
+    const { unmount } = renderDashboard()
+    const banner = await screen.findByTestId('dashboard-guest-persist-banner')
+    await userEvent.click(
+      within(banner).getByRole('button', { name: /dismiss/i }),
+    )
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('dashboard-guest-persist-banner'),
+      ).not.toBeInTheDocument(),
+    )
+    expect(
+      window.sessionStorage.getItem(GUEST_PERSIST_DISMISS_KEY),
+    ).toBe('1')
+
+    // Re-mount within the same "session" — the banner should remain hidden.
+    unmount()
+    renderDashboard()
+    await screen.findByRole('heading', { name: /Hi, @rita\.kovac/ })
+    expect(
+      screen.queryByTestId('dashboard-guest-persist-banner'),
+    ).not.toBeInTheDocument()
   })
 })

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -9,8 +9,9 @@ import type {
   DashboardScoreBanner,
 } from '@/api/dashboard'
 import { scoringNewRoute } from '@/api/matches'
-import { useSession } from '@/api/session'
+import { deriveEmailStatus, useSession } from '@/api/session'
 import { Overline } from '@/components/overline'
+import { GuestPersistBanner } from '@/components/dashboard/guest-persist-banner'
 import { fmtDateShort, fmtLongDate } from '@/lib/dates'
 import { formatRatingDelta } from '@/lib/rating'
 
@@ -1036,8 +1037,20 @@ export function DashboardPage() {
   const dashboard = useDashboard({ enabled: session.isSuccess })
   const isLoading = dashboard.isPending
   const data = dashboard.data
-  const username = session.data?.data.user.username
+  const user = session.data?.data.user
+  const username = user?.username
   const greeting = username ? `Hi, @${username}` : 'Hi'
+  // Guest with at least one completed match — "you have things to lose now".
+  // Zero-match guests and verified/pending-verification users never see this.
+  const showGuestPersistBanner =
+    user !== undefined &&
+    data !== undefined &&
+    deriveEmailStatus({
+      email: user.email ?? null,
+      confirmedAt: user.confirmed_at ?? null,
+      pendingEmail: user.pending_email ?? null,
+    }) === 'guest' &&
+    data.completed_match_count >= 1
   return (
     <div
       style={{
@@ -1048,6 +1061,12 @@ export function DashboardPage() {
         boxSizing: 'border-box',
       }}
     >
+      {showGuestPersistBanner && (
+        <GuestPersistBanner
+          matchCount={data.completed_match_count}
+          rating={data.rating ? Math.round(data.rating.current) : null}
+        />
+      )}
       <PageTitle greeting={greeting} />
       {isLoading ? (
         <SkeletonCard label="Loading score banner" height={140} />

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -1042,15 +1042,14 @@ export function DashboardPage() {
   const greeting = username ? `Hi, @${username}` : 'Hi'
   // Guest with at least one completed match — "you have things to lose now".
   // Zero-match guests and verified/pending-verification users never see this.
-  const showGuestPersistBanner =
+  const isGuest =
     user !== undefined &&
-    data !== undefined &&
     deriveEmailStatus({
       email: user.email ?? null,
       confirmedAt: user.confirmed_at ?? null,
       pendingEmail: user.pending_email ?? null,
-    }) === 'guest' &&
-    data.completed_match_count >= 1
+    }) === 'guest'
+  const showGuestPersistBanner = isGuest && (data?.completed_match_count ?? 0) >= 1
   return (
     <div
       style={{
@@ -1061,7 +1060,7 @@ export function DashboardPage() {
         boxSizing: 'border-box',
       }}
     >
-      {showGuestPersistBanner && (
+      {showGuestPersistBanner && data && (
         <GuestPersistBanner
           matchCount={data.completed_match_count}
           rating={data.rating ? Math.round(data.rating.current) : null}

--- a/web-client/src/components/dashboard/guest-persist-banner.tsx
+++ b/web-client/src/components/dashboard/guest-persist-banner.tsx
@@ -1,6 +1,6 @@
 import { useState, type CSSProperties, type ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
-import { X } from 'lucide-react'
+import { Smartphone, X } from 'lucide-react'
 
 const C = {
   ink800: 'var(--ink-800)',
@@ -59,37 +59,6 @@ function Mono({
   )
 }
 
-function DeviceIcon({ size = 15, color }: { size?: number; color: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      style={{ display: 'block' }}
-    >
-      <rect
-        x="6.5"
-        y="3"
-        width="11"
-        height="18"
-        rx="2.25"
-        fill="none"
-        stroke={color}
-        strokeWidth="1.75"
-      />
-      <path
-        d="M11 18h2"
-        fill="none"
-        stroke={color}
-        strokeWidth="1.75"
-        strokeLinecap="round"
-      />
-      <circle cx="12" cy="9.5" r="1.6" fill={color} />
-    </svg>
-  )
-}
-
 type GuestPersistBannerProps = {
   matchCount: number
   rating: number | null
@@ -135,7 +104,7 @@ export function GuestPersistBanner({
           flexShrink: 0,
         }}
       >
-        <DeviceIcon color={C.ball400} />
+        <Smartphone size={15} strokeWidth={1.75} color={C.ball400} aria-hidden />
       </div>
 
       <div
@@ -169,11 +138,8 @@ export function GuestPersistBanner({
             whiteSpace: 'nowrap',
           }}
         >
-          Add an email to keep them
+          Add an email to keep them →
         </Link>
-        <span style={{ color: C.ball400, fontWeight: 600, marginLeft: 5 }}>
-          →
-        </span>
       </div>
 
       <button

--- a/web-client/src/components/dashboard/guest-persist-banner.tsx
+++ b/web-client/src/components/dashboard/guest-persist-banner.tsx
@@ -1,0 +1,204 @@
+import { useState, type CSSProperties, type ReactNode } from 'react'
+import { Link } from '@tanstack/react-router'
+import { X } from 'lucide-react'
+
+const C = {
+  ink800: 'var(--ink-800)',
+  chalk50: 'var(--chalk-50)',
+  chalk100: 'var(--chalk-100)',
+  chalk300: 'var(--chalk-300)',
+  chalk500: 'var(--chalk-500)',
+  ball400: 'var(--ball-400)',
+}
+
+const UI = "'Space Grotesk', ui-sans-serif, system-ui, sans-serif"
+const MONO = "'JetBrains Mono', ui-monospace, monospace"
+
+// Reappears every browser session. We don't gate harder than that — the
+// design's whole point is a quiet recurring reminder, not a one-shot.
+export const GUEST_PERSIST_DISMISS_KEY = 'fm:guest-persist:dismissed'
+
+function isDismissedThisSession(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return window.sessionStorage.getItem(GUEST_PERSIST_DISMISS_KEY) === '1'
+  } catch {
+    // sessionStorage throws in some embed/private modes; treat as not
+    // dismissed so the banner still surfaces.
+    return false
+  }
+}
+
+function rememberDismissal() {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(GUEST_PERSIST_DISMISS_KEY, '1')
+  } catch {
+    // Swallow — the visual dismissal is enough; we just won't persist it.
+  }
+}
+
+function Mono({
+  children,
+  color = C.chalk50,
+}: {
+  children: ReactNode
+  color?: string
+}) {
+  return (
+    <span
+      style={{
+        font: `600 14px ${MONO}`,
+        fontVariantNumeric: 'tabular-nums',
+        color,
+        letterSpacing: '-0.01em',
+      }}
+    >
+      {children}
+    </span>
+  )
+}
+
+function DeviceIcon({ size = 15, color }: { size?: number; color: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      style={{ display: 'block' }}
+    >
+      <rect
+        x="6.5"
+        y="3"
+        width="11"
+        height="18"
+        rx="2.25"
+        fill="none"
+        stroke={color}
+        strokeWidth="1.75"
+      />
+      <path
+        d="M11 18h2"
+        fill="none"
+        stroke={color}
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+      <circle cx="12" cy="9.5" r="1.6" fill={color} />
+    </svg>
+  )
+}
+
+type GuestPersistBannerProps = {
+  matchCount: number
+  rating: number | null
+  style?: CSSProperties
+}
+
+export function GuestPersistBanner({
+  matchCount,
+  rating,
+  style,
+}: GuestPersistBannerProps) {
+  const [dismissed, setDismissed] = useState(() => isDismissedThisSession())
+
+  if (dismissed) return null
+
+  return (
+    <div
+      data-testid="dashboard-guest-persist-banner"
+      role="status"
+      style={{
+        position: 'relative',
+        background: `linear-gradient(180deg, rgba(255,122,26,0.055) 0%, rgba(255,122,26,0.02) 100%), ${C.ink800}`,
+        border: '1px solid rgba(255,122,26,0.22)',
+        borderRadius: 10,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 14,
+        padding: '11px 12px 11px 14px',
+        marginBottom: 20,
+        overflow: 'hidden',
+        ...style,
+      }}
+    >
+      <div
+        style={{
+          width: 30,
+          height: 30,
+          borderRadius: 7,
+          background: 'rgba(255,122,26,0.10)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <DeviceIcon color={C.ball400} />
+      </div>
+
+      <div
+        style={{
+          flex: 1,
+          minWidth: 0,
+          font: `400 14px ${UI}`,
+          color: C.chalk100,
+          lineHeight: 1.4,
+        }}
+      >
+        <span>Your </span>
+        <Mono>{matchCount}</Mono>
+        <span> {matchCount === 1 ? 'match' : 'matches'}</span>
+        {rating !== null && (
+          <>
+            <span> and rating </span>
+            <Mono>{rating}</Mono>
+          </>
+        )}
+        <span style={{ color: C.chalk300 }}> live on this device only. </span>
+        <Link
+          to="/settings"
+          hash="sec-email"
+          style={{
+            color: C.ball400,
+            fontWeight: 600,
+            textDecoration: 'none',
+            borderBottom: `1px solid ${C.ball400}`,
+            paddingBottom: 1,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          Add an email to keep them
+        </Link>
+        <span style={{ color: C.ball400, fontWeight: 600, marginLeft: 5 }}>
+          →
+        </span>
+      </div>
+
+      <button
+        type="button"
+        aria-label="Dismiss for this session"
+        onClick={() => {
+          rememberDismissal()
+          setDismissed(true)
+        }}
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 6,
+          background: 'transparent',
+          border: 'none',
+          color: C.chalk500,
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <X size={14} strokeWidth={1.75} />
+      </button>
+    </div>
+  )
+}

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -757,8 +757,16 @@ export const handlers = [
     const scoreBanners = mockMatches.map(projectScoreBanner).filter(notNull)
     const nextMatch =
       mockMatches.map(projectNextMatch).find(notNull) ?? null
-    const completedMatches = mockMatches.map(projectRecentResult).filter(notNull)
-    const recentResults = completedMatches
+    // Match the real BFF's participant-filtered COUNT, which doesn't care
+    // whether the opponent slot is registered — projectRecentResult drops
+    // null-opponent matches from the *display* list, but they still count
+    // toward the user's history.
+    const completedMatchCount = mockMatches.filter(
+      (m) => m.status === 'completed',
+    ).length
+    const recentResults = mockMatches
+      .map(projectRecentResult)
+      .filter(notNull)
       .sort((a, b) => b.completed_at.localeCompare(a.completed_at))
       .slice(0, 5)
     return HttpResponse.json({
@@ -766,7 +774,7 @@ export const handlers = [
       next_match: nextMatch,
       recent_results: recentResults,
       rating: projectRating(mockMatches),
-      completed_match_count: completedMatches.length,
+      completed_match_count: completedMatchCount,
     })
   }),
 

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -757,9 +757,8 @@ export const handlers = [
     const scoreBanners = mockMatches.map(projectScoreBanner).filter(notNull)
     const nextMatch =
       mockMatches.map(projectNextMatch).find(notNull) ?? null
-    const recentResults = mockMatches
-      .map(projectRecentResult)
-      .filter(notNull)
+    const completedMatches = mockMatches.map(projectRecentResult).filter(notNull)
+    const recentResults = completedMatches
       .sort((a, b) => b.completed_at.localeCompare(a.completed_at))
       .slice(0, 5)
     return HttpResponse.json({
@@ -767,6 +766,7 @@ export const handlers = [
       next_match: nextMatch,
       recent_results: recentResults,
       rating: projectRating(mockMatches),
+      completed_match_count: completedMatches.length,
     })
   }),
 

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -284,11 +284,15 @@ export function matchListResponse(
 export function dashboardResponse(
   overrides: Partial<DashboardResponse> = {},
 ): DashboardResponse {
+  const recent_results = overrides.recent_results ?? []
   return {
     score_banners: [],
     next_match: null,
-    recent_results: [],
+    recent_results,
     rating: dashboardRating(),
+    // Default mirrors the visible list. Override directly to model the
+    // "history exceeds the recent window" case the guest banner cares about.
+    completed_match_count: recent_results.length,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary
- Slim warm-tinted full-width banner above the dashboard for guests with one or more completed matches — references their actual history (`Your N matches and rating R live on this device only`), inline CTA to `/settings#sec-email`, dismissible per browser session via `sessionStorage`.
- Hidden for verified/pending-confirmation users and for zero-match guests. Implements tone B from the design handoff (warm ball-500 tint, lower visual weight than the score-pending banner).
- Adds `completed_match_count: int` to the `/v1/dashboard` BFF so the banner can quote totals that exceed the 5-row `recent_results` window. The dashboard query skips the extra COUNT round-trip when `len(completed) < RECENT_RESULTS_LIMIT`, so only users with ≥5 completed matches pay for it.
- Widens `participant_filter` in `api/app/matches.py` to be row-shape generic (same pattern as the sibling `_player_username_filter`) so it can accept the `select(func.count(Match.id))` shape.

## Test plan
- [x] `pytest tests/test_dashboard.py` — 13 pass (includes new `completed_match_count` assertions and cross-user isolation pin)
- [x] `pytest` (full API suite) — 349 pass
- [x] `ruff check`, `ruff format --check`, `mypy --strict` — clean
- [x] `npm run test:run` — 121 vitest pass (5 new banner cases: shows for guest w/ history, drops rating fragment when unrated, hidden at zero matches, hidden for verified users, dismissal persists across remount within a session)
- [x] `npm run lint && npm run build` — clean
- [ ] Manual: confirm banner renders for a new guest after completing one match, links to `/settings#sec-email`, and stays dismissed across dashboard reloads within the same browser session

🤖 Generated with [Claude Code](https://claude.com/claude-code)