### PR TITLE
Hint guests about email when they flip Rated on

### DIFF
--- a/web-client/src/routes/matches/new.css
+++ b/web-client/src/routes/matches/new.css
@@ -664,6 +664,21 @@
   line-height: 1.4;
   color: var(--fg-3);
 }
+.nm-rated-guest-hint {
+  margin: 8px 2px 0;
+  font: 400 12px var(--font-ui);
+  line-height: 1.4;
+  color: var(--fg-3);
+}
+.nm-rated-guest-link {
+  color: var(--ball-500);
+  text-decoration: underline;
+  text-decoration-color: rgba(255, 122, 26, 0.4);
+  text-underline-offset: 2px;
+}
+.nm-rated-guest-link:hover {
+  text-decoration-color: var(--ball-500);
+}
 
 /* --- Submit row --- */
 .nm-summary {

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -41,6 +41,11 @@ function renderNewMatch() {
     path: '/dashboard',
     component: () => <div>Dashboard route</div>,
   })
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/settings',
+    component: () => <div>Settings route</div>,
+  })
   const scoringRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/matches/$matchId/games/$gameNumber/scores/new',
@@ -53,6 +58,7 @@ function renderNewMatch() {
     routeTree: rootRoute.addChildren([
       newMatchRoute,
       dashboardRoute,
+      settingsRoute,
       scoringRoute,
     ]),
     history: createMemoryHistory({ initialEntries: ['/matches/new'] }),
@@ -319,6 +325,78 @@ describe('NewMatchPage — recent opponents', () => {
     expect(
       await screen.findByRole('button', { name: /ada\.lovelace/i }),
     ).toBeInTheDocument()
+  })
+})
+
+describe('NewMatchPage — rated guest hint', () => {
+  function recentWithOne() {
+    return http.get('*/v1/players/recent', () =>
+      HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }]),
+    )
+  }
+
+  it('shows a tip linking to the email settings when a guest flips Rated on', async () => {
+    const user = userEvent.setup()
+    server.use(recentWithOne())
+    renderNewMatch()
+
+    // No hint before the toggle is engaged — the moment of opt-in is the
+    // trigger, not page load.
+    await screen.findByRole('button', { name: /ada\.lovelace/i })
+    expect(screen.queryByRole('link', { name: /add an email/i })).toBeNull()
+
+    await user.click(screen.getByRole('button', { name: /ada\.lovelace/i }))
+    await user.click(screen.getByRole('switch', { name: /rated match/i }))
+
+    const link = await screen.findByRole('link', { name: /add an email/i })
+    expect(link).toHaveAttribute('href', '/settings#sec-email')
+  })
+
+  it('hides the tip again when Rated is toggled off', async () => {
+    const user = userEvent.setup()
+    server.use(recentWithOne())
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    )
+    const ratedSwitch = screen.getByRole('switch', { name: /rated match/i })
+    await user.click(ratedSwitch)
+    expect(
+      await screen.findByRole('link', { name: /add an email/i }),
+    ).toBeInTheDocument()
+
+    await user.click(ratedSwitch)
+    expect(screen.queryByRole('link', { name: /add an email/i })).toBeNull()
+  })
+
+  it('does not show the tip for a user with a confirmed email', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/session', () =>
+        HttpResponse.json(
+          sessionResponse({
+            user: {
+              email: 'rita@example.com',
+              confirmed_at: '2026-01-01T00:00:00Z',
+            },
+          }),
+        ),
+      ),
+      recentWithOne(),
+    )
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    )
+    await user.click(screen.getByRole('switch', { name: /rated match/i }))
+
+    // The toggle is on, but the rating-durability question doesn't apply.
+    expect(
+      screen.getByRole('switch', { name: /rated match/i }),
+    ).toHaveAttribute('aria-checked', 'true')
+    expect(screen.queryByRole('link', { name: /add an email/i })).toBeNull()
   })
 })
 

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
 import { ArrowRight, Search } from 'lucide-react'
 import { z } from 'zod'
 
 import { AppShell } from '@/components/app-shell'
 import { ApiError } from '@/api/client'
-import { useSession } from '@/api/session'
+import { deriveEmailStatus, useSession } from '@/api/session'
 import {
   nextScoringDestination,
   useCreateMatch,
@@ -96,6 +96,16 @@ function MatchCard() {
   const [submitted, setSubmitted] = useState(false)
 
   const me = session?.data.user ?? null
+  // The hint nudges guests toward claiming an account so their rated history
+  // survives a cookie wipe. Mirror save-your-match.tsx by using the strictest
+  // 'guest' status — users with a pending or confirmed email don't need this.
+  const isGuest =
+    me != null &&
+    deriveEmailStatus({
+      email: me.email ?? null,
+      confirmedAt: me.confirmed_at ?? null,
+      pendingEmail: me.pending_email ?? null,
+    }) === 'guest'
 
   const validation = matchFormSchema.safeParse({
     hasOpponent: opponent !== null,
@@ -171,7 +181,12 @@ function MatchCard() {
 
       <div className="nm-settings">
         <BestOfField bestOf={bestOf} setBestOf={setBestOf} />
-        <RatedField rated={rated} setRated={setRated} opponent={opponent} />
+        <RatedField
+          rated={rated}
+          setRated={setRated}
+          opponent={opponent}
+          isGuest={isGuest}
+        />
       </div>
 
       <SubmitRow
@@ -467,10 +482,12 @@ function RatedField({
   rated,
   setRated,
   opponent,
+  isGuest,
 }: {
   rated: boolean
   setRated: (rated: boolean) => void
   opponent: Opponent | null
+  isGuest: boolean
 }) {
   const ratable = opponent !== null
   const effectiveRated = rated && ratable
@@ -507,6 +524,15 @@ function RatedField({
           <div className="d">{description}</div>
         </div>
       </div>
+      {effectiveRated && isGuest && (
+        <p className="nm-rated-guest-hint">
+          Your rating sticks around once you{' '}
+          <Link to="/settings" hash="sec-email" className="nm-rated-guest-link">
+            add an email
+          </Link>
+          .
+        </p>
+      )}
     </div>
   )
 }

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -514,6 +514,9 @@ function RatedField({
           role="switch"
           aria-checked={effectiveRated}
           aria-label="Rated match"
+          aria-describedby={
+            effectiveRated && isGuest ? 'nm-rated-guest-hint' : undefined
+          }
           disabled={!ratable}
           onClick={() => ratable && setRated(!rated)}
         />
@@ -525,7 +528,7 @@ function RatedField({
         </div>
       </div>
       {effectiveRated && isGuest && (
-        <p className="nm-rated-guest-hint">
+        <p id="nm-rated-guest-hint" className="nm-rated-guest-hint">
           Your rating sticks around once you{' '}
           <Link to="/settings" hash="sec-email" className="nm-rated-guest-link">
             add an email


### PR DESCRIPTION
## Summary

- Adds an inline helper-text hint under the **Rated match** toggle on `/matches/new`: "Your rating sticks around once you [add an email](/settings#sec-email)." Shows only for guests (no email per `deriveEmailStatus`) and only when the toggle is effectively on (toggle on + opponent picked).
- Connects rating durability to claiming an account at the exact moment the user is opting into rated history — without blocking submission or feeling like a warning.
- Associates the hint with the switch via `aria-describedby`, so screen-reader users hear the rating-durability caveat as part of the control's description.

## Test plan

- [x] `npm run test:run` (vitest, 14 files / 119 tests)
- [x] `npm run lint`
- [x] `npm run build` (tsc + vite)
- [ ] Sanity: as a guest, pick an opponent, flip Rated on — hint appears; toggle off — hint disappears; clear the opponent — hint disappears (toggle is also unavailable).
- [ ] Sanity: confirm the link routes to `/settings#sec-email`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)