### PR TITLE
Auto-focus the email input when /settings is opened from a recovery nudge

### DIFF
--- a/web-client/src/routes/settings.test.tsx
+++ b/web-client/src/routes/settings.test.tsx
@@ -41,12 +41,8 @@ beforeEach(() => {
       }
     }
   }
-  // jsdom doesn't implement Element.prototype.scrollIntoView, which TanStack
-  // Router's hash-scroll restoration calls on initial render when a hash is
-  // present. Stubbing it keeps the route from blowing up the error boundary.
-  if (!Element.prototype.scrollIntoView) {
-    Element.prototype.scrollIntoView = function () {}
-  }
+  // jsdom lacks scrollIntoView; TanStack Router calls it for hash restoration.
+  Element.prototype.scrollIntoView = () => {}
   // Reset the shared session between tests so honeypot/email checks start fresh.
   mockSession.data.user.email = null
   mockSession.data.user.confirmed_at = null
@@ -134,7 +130,7 @@ describe('SettingsPage email section', () => {
     )
   })
 
-  it('focuses the email input when deep-linked via #sec-email', async () => {
+  it('focuses the email input when a guest is deep-linked via #sec-email', async () => {
     await renderSettings('/settings#sec-email')
     const emailInput = await screen.findByLabelText(/^email$/i)
     await waitFor(() => expect(emailInput).toHaveFocus())
@@ -143,8 +139,14 @@ describe('SettingsPage email section', () => {
   it("doesn't focus the email input on a plain /settings load", async () => {
     await renderSettings()
     const emailInput = await screen.findByLabelText(/^email$/i)
-    // Give the useEffect a tick to run; assert focus stayed off the field.
-    await new Promise((r) => setTimeout(r, 0))
+    expect(emailInput).not.toHaveFocus()
+  })
+
+  it("doesn't focus the email input for a verified user landing on #sec-email", async () => {
+    mockSession.data.user.email = 'rita@example.com'
+    mockSession.data.user.confirmed_at = '2026-01-01T00:00:00Z'
+    await renderSettings('/settings#sec-email')
+    const emailInput = await screen.findByLabelText(/^email$/i)
     expect(emailInput).not.toHaveFocus()
   })
 

--- a/web-client/src/routes/settings.test.tsx
+++ b/web-client/src/routes/settings.test.tsx
@@ -41,6 +41,12 @@ beforeEach(() => {
       }
     }
   }
+  // jsdom doesn't implement Element.prototype.scrollIntoView, which TanStack
+  // Router's hash-scroll restoration calls on initial render when a hash is
+  // present. Stubbing it keeps the route from blowing up the error boundary.
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = function () {}
+  }
   // Reset the shared session between tests so honeypot/email checks start fresh.
   mockSession.data.user.email = null
   mockSession.data.user.confirmed_at = null
@@ -48,7 +54,7 @@ beforeEach(() => {
   mockSession.data.user.username = 'rita.kovac'
 })
 
-async function renderSettings() {
+async function renderSettings(initialEntry = '/settings') {
   const { Route } = await import('./settings')
   const SettingsPage = Route.options.component!
 
@@ -66,7 +72,7 @@ async function renderSettings() {
   })
   const router = createRouter({
     routeTree: rootRoute.addChildren([settingsRoute]),
-    history: createMemoryHistory({ initialEntries: ['/settings'] }),
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
   })
   return render(
     <QueryClientProvider client={queryClient}>
@@ -126,6 +132,20 @@ describe('SettingsPage email section', () => {
     await waitFor(() =>
       expect(mockSession.data.user.pending_email).toBeNull(),
     )
+  })
+
+  it('focuses the email input when deep-linked via #sec-email', async () => {
+    await renderSettings('/settings#sec-email')
+    const emailInput = await screen.findByLabelText(/^email$/i)
+    await waitFor(() => expect(emailInput).toHaveFocus())
+  })
+
+  it("doesn't focus the email input on a plain /settings load", async () => {
+    await renderSettings()
+    const emailInput = await screen.findByLabelText(/^email$/i)
+    // Give the useEffect a tick to run; assert focus stayed off the field.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(emailInput).not.toHaveFocus()
   })
 
   it('requires the captcha before the submit button enables', async () => {

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -970,6 +970,11 @@ function scrollToSection(id: string) {
   window.scrollTo({ top: y, behavior: 'smooth' })
 }
 
+function focusEmailInput() {
+  // preventScroll so focus() doesn't fight the smooth scroll above.
+  document.getElementById('email')?.focus({ preventScroll: true })
+}
+
 function SettingsPage() {
   const session = useSession()
   const sessionUser = session.data?.data.user
@@ -987,18 +992,18 @@ function SettingsPage() {
   const claimed = effectiveStatus === 'verified'
 
   // Honor /settings#sec-* deep links from external nav. When the email
-  // section is the target — every account-recovery nudge points here —
-  // also focus the input so the user can start typing immediately. Pass
-  // preventScroll so focus() doesn't fight the smooth scroll above.
+  // section is the target and the account isn't already claimed, focus
+  // the input so users arriving from a recovery nudge can start typing.
+  // Wait for the session to resolve before deciding — otherwise verified
+  // users hitting a stale #sec-email URL would briefly look like guests
+  // and get their soft keyboard popped before we know better.
+  const sessionLoaded = !!sessionUser
   useEffect(() => {
     const id = hash.replace(/^#/, '')
     if (!id) return
     scrollToSection(id)
-    if (id === 'sec-email') {
-      const input = document.getElementById('email') as HTMLInputElement | null
-      input?.focus({ preventScroll: true })
-    }
-  }, [hash])
+    if (id === 'sec-email' && sessionLoaded && !claimed) focusEmailInput()
+  }, [hash, sessionLoaded, claimed])
 
   return (
     <AppShell>
@@ -1012,8 +1017,7 @@ function SettingsPage() {
               email={sessionPendingEmail ?? sessionEmail ?? ''}
               onJump={() => {
                 scrollToSection('sec-email')
-                const input = document.getElementById('email') as HTMLInputElement | null
-                input?.focus({ preventScroll: true })
+                focusEmailInput()
               }}
             />
 

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -986,10 +986,18 @@ function SettingsPage() {
   })
   const claimed = effectiveStatus === 'verified'
 
-  // Honor /settings#sec-* deep links from external nav.
+  // Honor /settings#sec-* deep links from external nav. When the email
+  // section is the target — every account-recovery nudge points here —
+  // also focus the input so the user can start typing immediately. Pass
+  // preventScroll so focus() doesn't fight the smooth scroll above.
   useEffect(() => {
     const id = hash.replace(/^#/, '')
-    if (id) scrollToSection(id)
+    if (!id) return
+    scrollToSection(id)
+    if (id === 'sec-email') {
+      const input = document.getElementById('email') as HTMLInputElement | null
+      input?.focus({ preventScroll: true })
+    }
   }, [hash])
 
   return (
@@ -1002,7 +1010,11 @@ function SettingsPage() {
             <ClaimBanner
               status={effectiveStatus}
               email={sessionPendingEmail ?? sessionEmail ?? ''}
-              onJump={() => scrollToSection('sec-email')}
+              onJump={() => {
+                scrollToSection('sec-email')
+                const input = document.getElementById('email') as HTMLInputElement | null
+                input?.focus({ preventScroll: true })
+              }}
             />
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>


### PR DESCRIPTION
## Summary

All five guest-claim nudges (user-menu Claim tile, dashboard guest-persist banner, save-your-match prompt, rated-toggle hint on /matches/new, and confirm-email page) deep-link to `/settings#sec-email`. The settings page's existing hash effect scrolled to the section but left the user to click into the input themselves. This PR auto-focuses the input on arrival so users from a nudge can start typing immediately (and pops the mobile keyboard).

- One `focusEmailInput()` helper is invoked from both the hash `useEffect` and the in-page `ClaimBanner` "Add email" / "Verify now" button, so both paths stay in sync.
- `focus({ preventScroll: true })` keeps the existing smooth scroll from fighting focus.
- Gated on `sessionUser` being resolved AND `!claimed` — a verified user landing on a stale `#sec-email` URL no longer gets their soft keyboard popped before the session query has resolved.

Three tests cover the gate: focuses for a guest, no focus on plain `/settings`, no focus for a verified user on `#sec-email`.

## Test plan

- [x] `npm run test:run` — 127/127 vitest
- [x] `npm run lint` — clean (1 pre-existing warning in `mockServiceWorker.js`)
- [x] `npm run build` — tsc + vite OK
- [x] `npm run test:e2e` — 125/125 Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)