### PR TITLE
Add per-cell ✕ clear + tighten mobile layout on score entry

### DIFF
--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -255,6 +255,30 @@ export function useDeleteScore(matchId: string, gameNumber: number) {
 }
 
 /**
+ * Same as `useDeleteScore` but the game number is supplied at mutate-call
+ * time — used by the scoreline's per-cell ✕, which needs to clear any logged
+ * game from a single hook (hooks rules forbid one per cell).
+ */
+export function useDeleteScoreForMatch(matchId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (gameNumber: number): Promise<MatchDetails> =>
+      unwrap(
+        'clear score',
+        await api.DELETE(
+          '/v1/matches/{match_id}/games/{game_number}/scores',
+          {
+            params: {
+              path: { match_id: matchId, game_number: gameNumber },
+            },
+          },
+        ),
+      ),
+    onSuccess: (data) => applyScoreMutationCache(queryClient, matchId, data),
+  })
+}
+
+/**
  * Posts the result of a match. The payload is canon — the server obliterates
  * any scratchpad-saved games + scores, inserts these, validates the match as
  * a decided whole, and records the caller's signature. For a non-solo match

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -490,15 +490,10 @@ describe('ScoreEntry — edit', () => {
       http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
       http.delete('*/v1/matches/m-1/games/:gameNumber/scores', ({ params }) => {
         deletedGameNumber = Number(params.gameNumber)
-        return HttpResponse.json(
-          inProgressMatch({
-            sides: participantSides({ meWins: 0, oppWins: 1 }),
-            games: [
-              { id: 'g-2', game_number: 2, score: score('s-2', 9, 11) },
-            ],
-            current_game: { game_number: 1 },
-          }),
-        )
+        // Test only asserts the path param + that we stay on the page +
+        // focus — no response field is read, so any valid MatchDetails will
+        // do.
+        return HttpResponse.json(inProgressMatch())
       }),
     )
 

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -469,12 +469,56 @@ describe('ScoreEntry — edit', () => {
     renderScoreEntry({ kind: 'edit', matchId: 'm-1', gameNumber: 1 })
 
     await screen.findByRole('textbox', { name: 'rita.kovac score' })
-    await user.click(screen.getByRole('button', { name: /clear/i }))
+    // Match the standalone "Clear" button — the scoreline cells carry
+    // "Clear game N" labels and would otherwise collide with /clear/i.
+    await user.click(screen.getByRole('button', { name: /^clear$/i }))
 
     await waitFor(() =>
       expect(screen.getByText('scoring-new m-1 1')).toBeInTheDocument(),
     )
     expect(deleted).toBe(true)
+  })
+
+  it("✕ on another game's cell clears that game in place without leaving the page", async () => {
+    // User is entering game 3 in /new mode. Game 1 is already logged. They
+    // tap the ✕ on G1's scoreline cell: G1 is cleared via DELETE
+    // /v1/matches/m-1/games/1/scores, the page stays put (no redirect), and
+    // focus lands on the first empty input on the active game.
+    const user = userEvent.setup()
+    let deletedGameNumber: number | null = null
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      http.delete('*/v1/matches/m-1/games/:gameNumber/scores', ({ params }) => {
+        deletedGameNumber = Number(params.gameNumber)
+        return HttpResponse.json(
+          inProgressMatch({
+            sides: participantSides({ meWins: 0, oppWins: 1 }),
+            games: [
+              { id: 'g-2', game_number: 2, score: score('s-2', 9, 11) },
+            ],
+            current_game: { game_number: 1 },
+          }),
+        )
+      }),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    // Type something in the opp input so we can verify focus lands on the
+    // first *empty* input — which should still be the me input.
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    await user.type(oppInput, '7')
+
+    await user.click(screen.getByRole('button', { name: /clear game 1/i }))
+
+    await waitFor(() => expect(deletedGameNumber).toBe(1))
+    // No redirect — still on the active game's entry route.
+    expect(
+      screen.queryByText(/scoring-(new|edit) m-1/),
+    ).not.toBeInTheDocument()
+    expect(meInput).toHaveFocus()
   })
 
   it('redirects edit→new when the game has no saved score', async () => {

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react'
 import { Link, Navigate, useNavigate } from '@tanstack/react-router'
-import { User as UserIcon } from 'lucide-react'
+import { User as UserIcon, X as XIcon } from 'lucide-react'
 import { ApiError } from '@/api/client'
 import {
   matchDetailRoute,
@@ -8,6 +8,7 @@ import {
   scoringNewRoute,
   useCreateScore,
   useDeleteScore,
+  useDeleteScoreForMatch,
   useFinalizeMatch,
   useMatch,
   useUpdateScore,
@@ -61,6 +62,7 @@ function ScoreEntryInner({
   const createMutation = useCreateScore(matchId, gameNumber)
   const updateMutation = useUpdateScore(matchId, gameNumber)
   const deleteMutation = useDeleteScore(matchId, gameNumber)
+  const cellDeleteMutation = useDeleteScoreForMatch(matchId)
   const finalizeMutation = useFinalizeMatch(matchId)
 
   // `null` means "user hasn't typed anything yet" — we fall through to the
@@ -234,14 +236,33 @@ function ScoreEntryInner({
     }
   }
 
+  // After any clear, drop focus into the first input that's still empty so
+  // the user can keep typing without grabbing the mouse.
+  function focusFirstEmpty() {
+    if (meRef.current && meRef.current.value === '') {
+      meRef.current.focus()
+    } else if (oppRef.current && oppRef.current.value === '') {
+      oppRef.current.focus()
+    }
+  }
+
   function onClear() {
     if (mode.kind !== 'edit') return
     deleteMutation.mutate(undefined, {
       // After clearing, land back on this game's create route so the user
       // can re-enter — same page, just with empty inputs and create-mode
-      // semantics.
+      // semantics. The remount's autoFocus puts focus on the me-input,
+      // which is the first empty input.
       onSettled: () => navigate(scoringNewRoute(matchId, gameNumber)),
     })
+  }
+
+  // Per-cell ✕ — clears the score for any logged game from the scoreline
+  // strip. Fire-and-forget like the per-game writes; we just refocus the
+  // first empty input on the current page so the user can keep typing.
+  function onClearCell(n: number) {
+    cellDeleteMutation.mutate(n)
+    focusFirstEmpty()
   }
 
   function handleKey(
@@ -379,6 +400,7 @@ function ScoreEntryInner({
           activeGameNumber={gameNumber}
           matchId={matchId}
           mySideNumber={mySideNumber}
+          onClearCell={onClearCell}
         />
       </div>
     </AppShell>
@@ -458,15 +480,18 @@ function Scoreline({
   activeGameNumber,
   matchId,
   mySideNumber,
+  onClearCell,
 }: {
   data: MatchDetails
   activeGameNumber: number
   matchId: string
   mySideNumber: 1 | 2
+  onClearCell: (gameNumber: number) => void
 }) {
   // Every cell links to its own scoring route — scored games go to edit,
   // un-scored games go to /scores/new. Lets the user pick games in any
-  // order from the scoreline directly.
+  // order from the scoreline directly. Logged cells also carry a ✕ button
+  // (desktop hover; hidden on touch) that clears that game in place.
   return (
     <div className="scoreline">
       <div className="sl-label">SCORELINE</div>
@@ -493,6 +518,23 @@ function Scoreline({
           const isMyWin = score
             ? score.winner_side_number === mySideNumber
             : null
+          const clearBtn = score ? (
+            <button
+              type="button"
+              className="sl-clear"
+              aria-label={`Clear game ${n}`}
+              title={`Clear game ${n}`}
+              onClick={(e) => {
+                // Stop the surrounding Link from navigating to /edit on the
+                // cell we just cleared.
+                e.preventDefault()
+                e.stopPropagation()
+                onClearCell(n)
+              }}
+            >
+              <XIcon size={14} strokeWidth={2.5} aria-hidden />
+            </button>
+          ) : null
           const inner = (
             <>
               <div className="sl-n">G{n}</div>
@@ -505,6 +547,7 @@ function Scoreline({
                   {oppPoints ?? '—'}
                 </span>
               </div>
+              {clearBtn}
             </>
           )
           if (isActive) {

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -237,12 +237,14 @@ function ScoreEntryInner({
   }
 
   // After any clear, drop focus into the first input that's still empty so
-  // the user can keep typing without grabbing the mouse.
+  // the user can keep typing without grabbing the mouse. Reads the controlled
+  // state, not the DOM — those are equal but the state is canonical and
+  // doesn't drift if React batches a render between mutate() and this call.
   function focusFirstEmpty() {
-    if (meRef.current && meRef.current.value === '') {
-      meRef.current.focus()
-    } else if (oppRef.current && oppRef.current.value === '') {
-      oppRef.current.focus()
+    if (me === '') {
+      meRef.current?.focus()
+    } else if (opp === '') {
+      oppRef.current?.focus()
     }
   }
 
@@ -401,6 +403,7 @@ function ScoreEntryInner({
           matchId={matchId}
           mySideNumber={mySideNumber}
           onClearCell={onClearCell}
+          clearDisabled={inputsLocked || cellDeleteMutation.isPending}
         />
       </div>
     </AppShell>
@@ -481,21 +484,28 @@ function Scoreline({
   matchId,
   mySideNumber,
   onClearCell,
+  clearDisabled,
 }: {
   data: MatchDetails
   activeGameNumber: number
   matchId: string
   mySideNumber: 1 | 2
   onClearCell: (gameNumber: number) => void
+  clearDisabled: boolean
 }) {
   // Every cell links to its own scoring route — scored games go to edit,
   // un-scored games go to /scores/new. Lets the user pick games in any
   // order from the scoreline directly. Logged cells also carry a ✕ button
   // (desktop hover; hidden on touch) that clears that game in place.
+  // `--sl-cell-count` drives the mobile grid template so the cells fit
+  // exactly the best-of width (the desktop layout flex-wraps regardless).
   return (
     <div className="scoreline">
       <div className="sl-label">SCORELINE</div>
-      <div className="sl-cells">
+      <div
+        className="sl-cells"
+        style={{ '--sl-cell-count': data.best_of } as React.CSSProperties}
+      >
         {Array.from({ length: data.best_of }, (_, i) => i + 1).map((n) => {
           const g = data.games.find((x) => x.game_number === n) ?? null
           const score = g?.score ?? null
@@ -524,9 +534,12 @@ function Scoreline({
               className="sl-clear"
               aria-label={`Clear game ${n}`}
               title={`Clear game ${n}`}
+              disabled={clearDisabled}
               onClick={(e) => {
                 // Stop the surrounding Link from navigating to /edit on the
-                // cell we just cleared.
+                // cell we just cleared. preventDefault is what blocks
+                // TanStack Router's nav (it checks defaultPrevented before
+                // dispatching) — stopPropagation is belt-and-suspenders.
                 e.preventDefault()
                 e.stopPropagation()
                 onClearCell(n)

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1934,51 +1934,204 @@ body.dark.fortymm-theme {
   color: var(--fg-3);
 }
 
-/* ---------- Responsive ---------- */
-@media (max-width: 820px) {
+/* ---------- Per-cell ✕ clear button ----------
+   Desktop-only affordance on logged scoreline cells: small ✕ in the top-right,
+   revealed on hover/focus, fires a per-game DELETE. Hidden on touch + below
+   880px (where the main "Clear" button above is the real clear affordance and
+   ✕ becomes too small to tap reliably). */
+.fortymm-theme .sl-cell {
+  position: relative;
+}
+.fortymm-theme .sl-clear {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--fg-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  transform: scale(0.85);
+  transition:
+    opacity var(--dur-fast, 120ms) var(--ease-out, cubic-bezier(0.2, 0.8, 0.2, 1)),
+    transform var(--dur-fast, 120ms) var(--ease-out, cubic-bezier(0.2, 0.8, 0.2, 1)),
+    background var(--dur-fast, 120ms),
+    color var(--dur-fast, 120ms),
+    border-color var(--dur-fast, 120ms);
+}
+.fortymm-theme .sl-cell:hover .sl-clear,
+.fortymm-theme .sl-cell:focus-within .sl-clear {
+  opacity: 1;
+  transform: scale(1);
+}
+.fortymm-theme .sl-clear:hover {
+  background: rgba(255, 77, 109, 0.12);
+  color: var(--loss);
+  border-color: rgba(255, 77, 109, 0.4);
+}
+.fortymm-theme .sl-clear:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(255, 77, 109, 0.5);
+  opacity: 1;
+  transform: scale(1);
+}
+/* Touch + small viewports — the main "Clear" button is the only clear
+   affordance there, the ✕ would be too small to tap safely. */
+@media (hover: none), (max-width: 880px) {
+  .fortymm-theme .sl-clear {
+    display: none;
+  }
+}
+
+/* ---------- Responsive ----------
+   Side-by-side three-column layout is kept down to phone widths so the whole
+   entry surface stays above the fold; the typography and avatars shrink to
+   fit instead of stacking. */
+@media (max-width: 880px) {
   .fortymm-theme .entry-wrap {
-    padding: 20px 16px;
+    padding: 16px 14px;
+    gap: 14px;
+  }
+  .fortymm-theme .entry-head {
+    margin-bottom: 4px;
+    gap: 8px;
+    align-items: center;
   }
   .fortymm-theme .entry-head h2 {
-    font-size: 32px;
+    font-size: 26px;
   }
   .fortymm-theme .entry-head .hint {
     display: none;
   }
+
   .fortymm-theme .single-entry {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 0;
+  }
+  .fortymm-theme .se-side {
+    padding: 14px 12px 18px;
+    gap: 10px;
+  }
+  .fortymm-theme .se-head {
+    gap: 8px;
+    align-items: center;
+  }
+  .fortymm-theme .se-head .av {
+    width: 32px;
+    height: 32px;
+    font-size: 12px;
+  }
+  .fortymm-theme .se-head .nm {
+    font-size: 13px;
+    max-width: 120px;
+    line-height: 1.15;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .fortymm-theme .se-head .rt {
+    display: none;
   }
   .fortymm-theme .se-mid {
-    flex-direction: row;
-    gap: 16px;
-    border-left: none;
-    border-right: none;
-    border-top: 1px solid var(--ink-600);
-    border-bottom: 1px solid var(--ink-600);
-    padding: 14px;
+    padding: 14px 6px;
+    min-width: 36px;
+  }
+  .fortymm-theme .se-vs {
+    font-size: 14px;
+  }
+  .fortymm-theme .se-games {
+    font-size: 14px;
   }
   .fortymm-theme .big-input {
-    font-size: 120px;
+    font-size: 72px;
+    padding: 6px 0 0;
   }
-  .fortymm-theme .se-side.opp {
-    align-items: stretch;
-    text-align: left;
-  }
-  .fortymm-theme .se-head.right {
-    justify-content: flex-start;
-  }
+
+  /* Single row of buttons, equal-width, full-bleed across the card. */
   .fortymm-theme .single-actions {
-    flex-direction: column;
+    flex-direction: row;
     align-items: stretch;
-    gap: 16px;
+    flex-wrap: nowrap;
+    gap: 8px;
+    padding: 0;
+  }
+  .fortymm-theme .result-line {
+    display: none;
   }
   .fortymm-theme .action-btns {
-    justify-content: flex-end;
+    width: 100%;
+    gap: 8px;
+  }
+  .fortymm-theme .action-btns .btn {
+    flex: 1 1 0;
+    justify-content: center;
+    padding: 12px 10px;
+    font-size: 13px;
+    min-height: 44px;
+  }
+
+  /* Scoreline: tighter cells, wraps to a 5-up grid so all best-of-5 games
+     stay on one row on a 375px viewport. */
+  .fortymm-theme .scoreline {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    padding: 12px 14px;
+  }
+  .fortymm-theme .sl-cells {
+    display: grid;
+    grid-template-columns: repeat(var(--sl-cell-count, 5), 1fr);
+    gap: 6px;
+  }
+  .fortymm-theme .sl-cell {
+    min-width: 0;
+    padding: 8px 4px;
+    gap: 3px;
+  }
+  .fortymm-theme .sl-cell .sl-n {
+    font-size: 9px;
+    letter-spacing: 0.14em;
+  }
+  .fortymm-theme .sl-cell .sl-scores {
+    font-size: 14px;
+    gap: 3px;
+  }
+}
+
+@media (max-width: 380px) {
+  .fortymm-theme .entry-head h2 {
+    font-size: 22px;
+  }
+  .fortymm-theme .se-head .nm {
+    font-size: 11px;
+    max-width: 80px;
+  }
+  .fortymm-theme .big-input {
+    font-size: 54px;
+  }
+  .fortymm-theme .se-mid {
+    min-width: 28px;
+    padding: 12px 4px;
+  }
+  .fortymm-theme .sl-cell .sl-scores {
+    font-size: 12px;
+  }
+  .fortymm-theme .action-btns .btn {
+    font-size: 12px;
+    padding: 11px 8px;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .fortymm-theme .sl-cell {
+  .fortymm-theme .sl-cell,
+  .fortymm-theme .sl-clear {
     transition: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- Logged scoreline cells now carry a hover-revealed ✕ on desktop that fires a fire-and-forget per-game DELETE; touch + ≤880px keeps the existing main "Clear" button as the only clear affordance there.
- Replaces the 820px stack-to-single-column responsive behavior with 880/380px breakpoints that keep the three-column side-by-side layout, shrinking typography and avatars so the whole entry surface fits above the fold on phones.
- Both clear paths drop focus into the first empty score input — the main button via the existing edit→new remount + `autoFocus`, the per-cell ✕ via an explicit state-driven `focusFirstEmpty()`.

## Test plan
- [x] `npm run test:run` — 128/128 vitest pass (added a positive test for ✕ on a non-active cell: DELETE fires, no redirect, focus lands on the empty me input)
- [x] `npm run build` — tsc + vite build clean
- [x] `npm run lint` — clean (one pre-existing unrelated warning)
- [x] `npx playwright test` — 125/125 web-client e2e pass
- [ ] Manual: clear an active-cell ✕ in `/edit` mode and confirm the route-guard redirect to `/scores/new` fires
- [ ] Manual: verify mobile layout at 375px (iPhone SE) and 360px keeps all five scoreline cells on one row

🤖 Generated with [Claude Code](https://claude.com/claude-code)