### PR TITLE
Add match-details scoreboard component tree and wire it into the page

### DIFF
--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -13,3 +13,12 @@ Show field validation errors inline, directly below the field, in red. Set
 ```
 
 Do not use toasts, alerts, or other patterns for field-level validation errors.
+
+## Tests
+
+In page objects, reach for `screen` (from `@testing-library/react`) by default
+rather than `document`. Prefer semantic queries (`screen.queryByText`,
+`getByRole`, …) over class selectors. When a check has no semantic anchor (e.g.
+an `aria-hidden` element identified only by class), anchor on a `screen` query
+and narrow with `.closest()` / `element.querySelector` instead of going through
+the global `document`.

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -6,7 +6,13 @@ import {
 } from '@tanstack/react-query'
 import { api, resolveBaseUrl, unwrap } from './client'
 import { DASHBOARD_QUERY_KEY } from './dashboard'
+import {
+  matchDetailsQuery,
+  matchQueryKey,
+} from '@/components/matches/match-details/match-details-query'
 import type { components } from './schema'
+
+export { matchQueryKey } from '@/components/matches/match-details/match-details-query'
 
 export type Player = components['schemas']['PlayerRead']
 export type MatchCreate = components['schemas']['MatchCreate']
@@ -37,10 +43,6 @@ export function playerSearchQueryKey(term: string) {
  * key so two different filters keep separate cache slots. */
 export function matchListQueryKey(params: MatchListParams) {
   return ['matches', 'list', params] as const
-}
-
-export function matchQueryKey(matchId: string) {
-  return ['matches', 'detail', matchId] as const
 }
 
 /**
@@ -154,18 +156,7 @@ export function matchesCsvUrl(
 
 /** Throws on failure so the surrounding boundary can render a retry. */
 export function useMatch(matchId: string) {
-  return useQuery({
-    queryKey: matchQueryKey(matchId),
-    queryFn: async (): Promise<MatchDetails> =>
-      unwrap(
-        'load match',
-        await api.GET('/v1/matches/{match_id}', {
-          params: { path: { match_id: matchId } },
-        }),
-      ),
-    retry: false,
-    throwOnError: true,
-  })
+  return useQuery(matchDetailsQuery(matchId))
 }
 
 /** Cache work shared by both score mutations: prime the detail cache from the

--- a/web-client/src/components/CLAUDE.md
+++ b/web-client/src/components/CLAUDE.md
@@ -1,0 +1,302 @@
+# Component conventions
+
+This codifies the pattern established by the **match-details scoreboard** refactor. The
+scoreboard subtree is the reference implementation — when in doubt, open it and copy its
+shape:
+
+```
+matches/match-details/scoreboard/
+```
+
+Build new feature surfaces this way. The two things being replaced —
+`matches/match-details/match-details.tsx` (the `projectMatchView` / `MatchView`
+god-object) and `scoreboard-old.tsx` — are the *old* pattern. Don't extend them or copy
+their style.
+
+---
+
+## The shape
+
+A component `X` is a folder of small files with fixed roles. Children that have children
+of their own get a sibling folder named after the parent, so the **path mirrors the render
+tree**:
+
+| file              | role                                                                          |
+| ----------------- | ----------------------------------------------------------------------------- |
+| `x.tsx`           | the component — **pure**, unless it's the single data node (see below)        |
+| `x-query.tsx`     | *(data node only)* query factory: shared base query + `select` projection + view-model types |
+| `x-skeleton.tsx`  | the `<Suspense>` fallback; mirrors `x`'s layout exactly                        |
+| `x.factory.ts`    | builds `x`'s props with overridable defaults                                  |
+| `x.page.tsx`      | **page object** — the only surface tests touch the DOM through                |
+| `x.test.tsx`      | the test — imports the page object + factory, nothing else                    |
+
+The reference slice, annotated with purity (`◆` = the one impure node):
+
+```
+Scoreboard(matchId)                        scoreboard.tsx                pure shell (Card)
+├─ Header(matchId)                         scoreboard/header.tsx         pure — <Suspense fallback={<HeaderSkeleton/>}>
+│  └─ HeaderData(matchId)                  header/header-data.tsx        ◆ useSuspenseQuery → hand off. Nothing else.
+│     └─ MatchHeaderDataDisplay(data)      header-data/header-data-display.tsx   pure composition
+│        ├─ Meta(status,bestOf)            …/meta.tsx                    pure leaf
+│        └─ MatchScore(sides,games,bestOf) …/match-score.tsx            pure — branches Upcoming / Played
+└─ LineScore(matchId)                      scoreboard/line-score.tsx     pure — <Suspense fallback={<LineScoreSkeleton/>}>
+   └─ LineScoreData(matchId)               line-score/line-score-data.tsx        ◆ useSuspenseQuery → hand off
+      └─ LineScoreDataDisplay(data)        …/line-score-data-display.tsx pure composition
+         └─ LineScoreGrid + Line[]         …/line.tsx                    pure leaves
+```
+
+Keep components **small**. A file does one thing: load, compose, or render a leaf. If a
+component is doing two of those, split it.
+
+---
+
+## Purity: one data node per subtree
+
+A subtree has **exactly one impure component** — the `*-data.tsx` node. Its entire body is
+a suspense query and a hand-off:
+
+```tsx
+// header-data.tsx — the whole component
+export const HeaderData = ({ matchId }: HeaderDataProps) => {
+  const { data } = useSuspenseQuery(headerDataQuery(matchId))
+  return <MatchHeaderDataDisplay matchHeaderData={data} />
+}
+```
+
+It does **nothing else** — no formatting, no derived state, no conditionals. Everything
+below it is a pure function of props. If you reach for `useQuery`, `useEffect`, `fetch`, or
+`useState`-for-data anywhere but a data node, you're in the wrong file.
+
+**Projection lives in the query's `select`, not the component.** `*-query.tsx` spreads the
+shared base query and adds a `select` built from small pure `toX` helpers, and it owns the
+view-model types:
+
+```tsx
+// header-data-query.tsx
+export type HeaderSide = { id: string; username: string }
+export type GameScore = { sideNumber: number; points: number }
+
+export const headerDataQuery = (matchId: string) => ({
+  ...matchDetailsQuery(matchId),
+  select: (data: MatchDetails) => ({
+    status: toStatusView(data),   // pure helpers, same file
+    bestOf: data.best_of,
+    sides: toSides(data),
+    games: toGames(data),
+  }),
+})
+```
+
+View-model types are single-source: sibling sections **re-export** them rather than
+redefining (`line-score-data-query.tsx` re-exports `GameScore` / `HeaderSide` from the
+header query).
+
+---
+
+## Data loading: one fetch, many `select`s
+
+Every section reads the **same** base query — `matchDetailsQuery(matchId)`, key
+`['matches','detail',matchId]` (`matches/match-details/match-details-query.ts`). Multiple
+`useSuspenseQuery` calls with that key **dedupe to a single network request**; each section
+supplies its own `select` to project just the slice it needs. Adding a section means a new
+`*-query.tsx` with a new `select` — **not** a new endpoint (the BFF returns one
+page-shaped payload; see `web-client/CLAUDE.md` and the repo BFF rule).
+
+The route warms this query in its `loader` via `queryClient.ensureQueryData(...)`
+(`routes/_authenticated/matches/$matchId.tsx`), so sections resolve from cache. They still
+declare their **own** `<Suspense>` boundary so each can pop in independently and stays
+self-contained and testable.
+
+The wrapper component is pure and tiny — just the boundary:
+
+```tsx
+// header.tsx
+export function Header({ matchId }: HeaderProps) {
+  return (
+    <Suspense fallback={<HeaderSkeleton />}>
+      <HeaderData matchId={matchId} />
+    </Suspense>
+  )
+}
+```
+
+---
+
+## Loading: skeletons that don't shift
+
+Every `<Suspense>` fallback is a dedicated `*-skeleton.tsx` that **mirrors the real layout**
+so nothing reflows when data swaps in.
+
+- **Compose from per-part skeletons that live beside their real component**:
+  `meta-skeleton.tsx` next to `meta.tsx`, `match-score-skeleton.tsx` next to
+  `match-score.tsx`, `line-skeleton.tsx` next to `line.tsx`. `HeaderSkeleton` is just
+  `<MetaSkeleton/> + <MatchScoreSkeleton/>`, mirroring `MatchHeaderDataDisplay`.
+- **Reserve identical space** by reusing the real layout primitives and class names — this
+  is the whole point. Examples to copy:
+  - `MatchScoreSkeleton` reuses the real `md-hero__row` grid and the shared `MatchScoreSlot`
+    (whose hidden `0` sizer keeps the score height reserved).
+  - `LineSkeleton`'s cell is `h-[22px]` to match a real score's 22px line height.
+  - `LineScoreSkeleton` reuses `LineScoreGrid` itself — 3 placeholder columns and
+    `showGameLabels={false}`, since the real game count isn't known yet.
+- Mark the skeleton root `aria-busy="true"` + a `data-testid` so its page object can assert
+  the busy state.
+
+---
+
+## Errors: handle them once, at the route
+
+There are **no error boundaries inside this subtree, on purpose**. The only failure that
+matters is "the match didn't load," and there's no partial state worth recovering — the
+page loads or it doesn't. So:
+
+- `matchDetailsQuery` sets `retry: false` + `throwOnError: true`, letting a failure bubble.
+- The **route** owns the boundary: `errorComponent: MatchDetailsErrorRoute`
+  (`routes/_authenticated/matches/$matchId.tsx`) maps 404 → `MatchNotFound`, re-throws the
+  rest.
+
+Add an `ErrorBoundary` inside a subtree **only** when a section can fail independently while
+the rest of the page stays useful. Don't add one reflexively.
+
+---
+
+## Factories: two tiers
+
+Build test data from factories — never hand-write object literals in a test. Which factory
+depends on what you're building:
+
+- **Wire / endpoint shape** → the **global** factory in `@/test/factories`
+  (`matchDetails(overrides)`), typed to the OpenAPI schema
+  (`components['schemas']['MatchDetails']`). This is the BFF payload; use it whenever you
+  stub the endpoint.
+- **Component props / view-models** → a **local** `*.factory.ts` beside the component, typed
+  to the component's own props (`Partial<MetaProps>`, `Partial<LineProps>`, …).
+
+Rules:
+
+- Defaults are the common case; everything is overridable via one `overrides` arg merged
+  last: `({ ...defaults, ...overrides })`.
+- **Encode intent with named helpers; randomise "don't care".** `gameWonBy(sideNumber)`
+  randomises the loser's points (faker) to signal they don't matter; `game(a, b)` sets exact
+  cells; `headerSideFactory()` faker-fills `id`/`username`. See `match-score.factory.ts` and
+  `line.factory.ts`.
+
+---
+
+## Page objects: the only way tests touch the DOM
+
+Tests **never** query the DOM directly — only through a page object. Each `x.page.tsx`
+exports `xPage` with `render(props)` and **semantic getters** that hide selectors:
+
+```tsx
+// meta.page.tsx
+export const metaPage = {
+  render(props: MetaProps) { render(<Meta {...props} />) },
+  get status()  { return document.querySelector('[data-slot="badge"]')?.textContent?.trim() ?? null },
+  get format()  { return screen.getByText(/SINGLES · BO\d+/).textContent },
+  get firstTo() { /* parse "First to N" → number | null */ },
+}
+```
+
+**Compose, don't restate.** A parent page object reuses its children's:
+
+```tsx
+// header-data-display.page.tsx
+export const matchHeaderDataDisplayPage = {
+  render(props) { render(<MatchHeaderDataDisplay {...props} />) },
+  meta: metaPage,            // reads go through the children's own objects
+  score: matchScorePage,
+}
+```
+
+`matchScorePage.forPlayer` *is* `playedMatchScorePage.forPlayer`; `playerScorePage.within(el)`
+is reused to read individual cells inside `linePage.game(username, n)`. Read through the same
+objects the children's own tests use.
+
+**Data-node page objects** own the endpoint + lifecycle, and *still* read through the leaf
+page objects — so a data-node test exercises the real `select` projection end-to-end:
+
+```tsx
+// header-data.page.tsx
+export const headerDataPage = {
+  // Owns method + path; callers pass only the resolver, so the route string lives once.
+  mockEndpoint(resolver: HttpResponseResolver) {
+    server.use(http.get("*/v1/matches/:matchId", resolver))
+  },
+  render(matchId: string) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Suspense fallback={<div data-testid="header-data-loading" />}>
+          <HeaderData matchId={matchId} />
+        </Suspense>
+      </QueryClientProvider>,
+    )
+  },
+  get isLoading() { return screen.queryByTestId("header-data-loading") !== null },
+  // settle() awaits a marker ONLY the loaded UI renders — never the skeleton.
+  settle() { return screen.findByRole("group", { name: "Match score" }) },
+  meta: metaPage,
+  score: matchScorePage,
+}
+```
+
+Notes:
+- Each render builds a **fresh `QueryClient` with `retry: false`**.
+- The data-node page object isolates the node with a **bare `data-testid` fallback**; the
+  *real* skeleton is tested via the wrapper page object.
+- `settle()` must wait on something the skeleton does **not** render — header uses the
+  `role="group" name="Match score"` strip; line score uses `findByText("G1")` because the
+  skeleton renders the grid but no column labels.
+- The wrapper page object stitches them together:
+  `headerPage = { mockEndpoint: headerDataPage.mockEndpoint, skeleton: headerSkeletonPage, data: headerDataPage }`.
+
+---
+
+## Mocking endpoints
+
+- The global MSW server (`@/mocks/server`) is started by `src/test/setup.ts` with
+  `onUnhandledRequest: 'error'` — **every** request needs a handler. The default
+  `GET */v1/matches/:matchId` lives in `src/mocks/handlers.ts` (mock store +
+  `projectMatchDetails`).
+- **Per test, override with `server.use(...)` — always via the page object's
+  `mockEndpoint`**, so the route string is defined in exactly one place. Shape the response
+  per test:
+  - `HttpResponse.json(matchDetails({ status: "completed", ... }))` for a specific case,
+  - `await delay(ms)` before responding to hold the skeleton on screen,
+  - return an error status to drive the failure path.
+- **Wildcard the host** (`"*/v1/matches/:matchId"`) — the base URL varies (MSW dev vs the
+  compose stack).
+
+---
+
+## Tests: putting it together
+
+- **Pure component** — feed the local prop factory, assert via getters:
+  ```tsx
+  matchHeaderDataDisplayPage.render(matchHeaderDataDisplayFactory({ bestOf: 7 }))
+  expect(matchHeaderDataDisplayPage.meta.format).toBe("SINGLES · BO7")
+  ```
+- **Data node** — stub the endpoint with the *global* `matchDetails` factory, settle, then
+  assert through the reused leaf getters (this is where the `select` projection is covered):
+  ```tsx
+  headerDataPage.mockEndpoint(() => HttpResponse.json(matchDetails({ status: "in_progress", ... })))
+  headerDataPage.render(match.id)
+  await headerDataPage.settle()
+  expect(headerDataPage.meta.status).toBe("Live · Game 3")
+  ```
+  `header-data.test.tsx` is the worked example: status→badge mapping, side ordering, dropped
+  unscored games, the no-opponent sentinel.
+- **Loading / swap** — `delay` the response, assert `skeleton.isBusy`, `await data.settle()`,
+  assert the loaded state (`header.test.tsx`).
+
+---
+
+## Checklist for a new component
+
+1. `x.tsx` — pure. If it needs data, it's a `<Suspense>` wrapper around `x-data.tsx`.
+2. Needs data? → `x-data.tsx` (only `useSuspenseQuery` + hand-off) + `x-query.tsx`
+   (`select` + view-model types, reusing the shared base query) + `x-skeleton.tsx`.
+3. `x.factory.ts` for props — or extend `@/test/factories` if it's a wire shape.
+4. `x.page.tsx` — semantic getters; reuse children's page objects.
+5. `x.test.tsx` — through the page object only.
+6. Children that have children get a sibling `x/` folder. Recurse.

--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -68,57 +68,6 @@ function renderDetails(matchId: string) {
 }
 
 describe('MatchDetailsView', () => {
-  it('renders the hero scoreline from the participant sides counts', async () => {
-    const match = matchDetails({
-      id: 'm-1',
-      status: 'completed',
-      status_label: 'Final',
-      sides: [
-        {
-          side_number: 1,
-          players: [
-            { user_id: 'u-me', username: 'me', is_current_user: true },
-          ],
-          games_won: 3,
-          won: true,
-          is_current_user_side: true,
-        },
-        {
-          side_number: 2,
-          players: [
-            { user_id: 'u-opp', username: 'nguyen.t', is_current_user: false },
-          ],
-          games_won: 1,
-          won: false,
-          is_current_user_side: false,
-        },
-      ],
-      games: [],
-      current_game: null,
-      can_score: false,
-    })
-    server.use(
-      http.get('*/v1/matches/m-1', () => HttpResponse.json(match)),
-    )
-
-    const { container } = renderDetails('m-1')
-
-    // Wait for the hero to render; each side's games_won shows up as the
-    // headline score number, current-user side on the left.
-    await waitFor(() =>
-      expect(container.querySelector('.md-hero__name')).toHaveTextContent(
-        'me',
-      ),
-    )
-    const leftScore = container.querySelector('.md-hero__score--l')
-    const rightScore = container.querySelector('.md-hero__score--r')
-    expect(leftScore).toHaveTextContent('3')
-    expect(rightScore).toHaveTextContent('1')
-    // My side won — the win modifier is on the left, not the right.
-    expect(leftScore).toHaveClass('md-hero__score--win')
-    expect(rightScore).not.toHaveClass('md-hero__score--win')
-  })
-
   it('shows a Score CTA only when can_score is true and links to current_game', async () => {
     const game1 = { id: 'g-1', game_number: 1, score: null }
     const match = matchDetails({
@@ -163,64 +112,6 @@ describe('MatchDetailsView', () => {
     expect(
       screen.queryByRole('link', { name: 'Score' }),
     ).not.toBeInTheDocument()
-  })
-
-  it('links each scored game cell on my row to its scores/edit route', async () => {
-    const match = matchDetails({
-      id: 'm-4',
-      status: 'in_progress',
-      status_label: 'Live',
-      best_of: 5,
-      games_to_win: 3,
-      sides: [
-        {
-          side_number: 1,
-          players: [
-            { user_id: 'u-me', username: 'me', is_current_user: true },
-          ],
-          games_won: 1,
-          won: null,
-          is_current_user_side: true,
-        },
-        {
-          side_number: 2,
-          players: [
-            { user_id: 'u-opp', username: 'opp', is_current_user: false },
-          ],
-          games_won: 0,
-          won: null,
-          is_current_user_side: false,
-        },
-      ],
-      games: [
-        {
-          id: 'g-1',
-          game_number: 1,
-          score: {
-            id: 's-1',
-            side_1_points: 11,
-            side_2_points: 4,
-            winner_side_number: 1,
-          },
-        },
-        { id: 'g-2', game_number: 2, score: null },
-      ],
-      current_game: { game_number: 2 },
-      can_score: true,
-    })
-    server.use(
-      http.get('*/v1/matches/m-4', () => HttpResponse.json(match)),
-    )
-
-    renderDetails('m-4')
-
-    await screen.findByRole('link', { name: 'Score' })
-    // The first-game cell on my row is a link to the edit route for game 1.
-    const editLink = screen.getByRole('link', { name: '11' })
-    expect(editLink).toHaveAttribute(
-      'href',
-      '/matches/m-4/games/1/scores/edit',
-    )
   })
 
   it('renders an error fallback when the match fails to load', async () => {

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -3,7 +3,6 @@ import { Link, useRouter } from '@tanstack/react-router'
 import {
   Check,
   ChevronRight,
-  Clock,
   Copy,
   Download,
   Link2,
@@ -15,11 +14,11 @@ import {
 
 import { AppShell } from '@/components/app-shell'
 import { Overline } from '@/components/overline'
-import { cn, initialsOf } from '@/lib/utils'
+import { cn } from '@/lib/utils'
+import { initialsOf } from '@/lib/initials-of'
 import { fmtDateShort, fmtDateTimeShort } from '@/lib/dates'
 import { formatRatingDelta } from '@/lib/rating'
 import {
-  scoringEditRoute,
   scoringNewRoute,
   useConfirmMatch,
   useDisputeMatch,
@@ -29,6 +28,7 @@ import type { components } from '@/api/schema'
 import { ApiError } from '@/api/client'
 
 import { SaveYourMatch } from './save-your-match'
+import { Scoreboard } from './match-details/scoreboard'
 
 type MatchDetails = components['schemas']['MatchDetails']
 type MatchDetailsGame = components['schemas']['MatchDetailsGame']
@@ -446,7 +446,7 @@ function MatchDetailsPage({
 
         <SaveYourMatch key={matchId} view={view} matchId={matchId} />
 
-        <HeroScoreboard view={view} matchId={matchId} />
+        <Scoreboard matchId={matchId} />
 
         <ConfirmationCallout view={view} matchId={matchId} />
 
@@ -529,280 +529,6 @@ function Breadcrumb({
       <span>›</span>
       <span className="md-breadcrumb__current">Match {matchId.slice(0, 6)}</span>
     </div>
-  )
-}
-
-function HeroScoreboard({
-  view,
-  matchId,
-}: {
-  view: MatchView
-  matchId: string
-}) {
-  const isLive = view.state === 'live'
-  const isUpcoming = view.state === 'upcoming'
-
-  return (
-    <section className="md-hero">
-      <div className="md-hero__grid-bg" aria-hidden="true" />
-
-      <div className="md-hero__strip">
-        <div className="md-hero__strip-l">
-          {isLive && view.currentGameNumber !== null && (
-            <span className="md-chip md-chip--live">
-              <span className="dot" />
-              Live · Game {view.currentGameNumber}
-            </span>
-          )}
-          {view.state === 'final' && (
-            <span className="md-chip md-chip--final">
-              <span className="dot" />
-              Final
-            </span>
-          )}
-          {isUpcoming && (
-            <span className="md-chip md-chip--upcoming">
-              <span className="dot" />
-              {view.statusLabel}
-            </span>
-          )}
-        </div>
-        <div className="md-hero__strip-r">
-          <span className="md-hero__strip-meta">
-            SINGLES · BO{view.bestOf}
-          </span>
-          {!isUpcoming && (
-            <span className="md-hero__strip-meta md-hero__strip-meta--with-icon">
-              <Clock size={13} strokeWidth={1.75} />
-              First to {view.gamesToWin}
-            </span>
-          )}
-        </div>
-      </div>
-
-      <div className="md-hero__row">
-        <PlayerSide side={view.leftSide} pos="l" />
-        <div className="md-hero__score-block">
-          {isUpcoming ? (
-            <>
-              <div className="md-hero__vs-label">VS</div>
-              <div className="md-hero__vs-dash">—</div>
-              <div className="md-hero__vs-label">{view.statusLabel}</div>
-            </>
-          ) : (
-            <>
-              <div className="md-hero__score-row">
-                <div
-                  className={cn(
-                    'md-hero__score md-hero__score--l',
-                    view.leftSide.won && 'md-hero__score--win',
-                  )}
-                >
-                  {view.leftSide.gamesWon}
-                </div>
-                <div className="md-hero__score-dash">—</div>
-                <div
-                  className={cn(
-                    'md-hero__score md-hero__score--r',
-                    view.rightSide?.won && 'md-hero__score--win',
-                  )}
-                >
-                  {view.rightSide?.gamesWon ?? 0}
-                </div>
-              </div>
-              <div className="md-hero__score-caption">{view.statusLabel}</div>
-            </>
-          )}
-        </div>
-        {view.rightSide ? (
-          <PlayerSide side={view.rightSide} pos="r" />
-        ) : (
-          <NoOpponentSide pos="r" />
-        )}
-      </div>
-
-      {!isUpcoming && view.rightSide && (
-        <GameGrid view={view} matchId={matchId} />
-      )}
-    </section>
-  )
-}
-
-function PlayerSide({ side, pos }: { side: SideView; pos: 'l' | 'r' }) {
-  if (side.isGhost) return <NoOpponentSide pos={pos} />
-  const win = side.won === true
-  return (
-    <div className={`md-hero__player md-hero__player--${pos}`}>
-      <div className="md-hero__player-row">
-        <div
-          className={cn(
-            'md-avatar md-hero__avatar-singles',
-            win ? 'md-avatar--win' : 'md-avatar--loss',
-          )}
-        >
-          {side.initials}
-        </div>
-        <div className={`md-hero__player-text--${pos}`}>
-          <div className={cn('md-hero__name', win && 'md-hero__name--win')}>
-            {side.username}
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function NoOpponentSide({ pos }: { pos: 'l' | 'r' }) {
-  return (
-    <div className={`md-hero__player md-hero__player--${pos}`}>
-      <div className="md-hero__player-row">
-        <div
-          className="md-avatar md-avatar--ghost md-hero__avatar-singles"
-          aria-hidden="true"
-        >
-          <User size={26} strokeWidth={1.75} />
-        </div>
-        <div className={`md-hero__player-text--${pos}`}>
-          <div className="md-hero__name md-hero__name--ghost">
-            {NO_OPPONENT_LABEL}
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function GameGrid({ view, matchId }: { view: MatchView; matchId: string }) {
-  // Pad to best_of so the grid always renders the same number of cells.
-  const slots: Array<GameView | null> = []
-  for (let n = 1; n <= view.bestOf; n += 1) {
-    slots.push(view.games.find((g) => g.gameNumber === n) ?? null)
-  }
-  // Per-cell edit links are gated on participation — spectators can't write
-  // scores, so the row never wraps cells in `<Link>`s for them.
-  const canEdit = view.leftSide.isCurrentUser
-  return (
-    <div className="md-games">
-      <div
-        className="md-games__grid"
-        style={{ '--md-games-count': view.bestOf } as React.CSSProperties}
-      >
-        <div className="md-games__kicker">GAMES</div>
-        {slots.map((_, i) => (
-          <div key={`h-${i}`} className="md-games__col-label">
-            G{i + 1}
-          </div>
-        ))}
-        <div className="md-games__col-label">SETS</div>
-
-        <GameGridSide
-          side={view.leftSide}
-          slots={slots}
-          rowSide="left"
-          matchId={matchId}
-          currentGameNumber={view.currentGameNumber}
-          canEdit={canEdit}
-        />
-        {view.rightSide && (
-          <GameGridSide
-            side={view.rightSide}
-            slots={slots}
-            rowSide="right"
-            matchId={matchId}
-            currentGameNumber={view.currentGameNumber}
-            canEdit={false}
-          />
-        )}
-      </div>
-    </div>
-  )
-}
-
-function GameGridSide({
-  side,
-  slots,
-  rowSide,
-  matchId,
-  currentGameNumber,
-  canEdit,
-}: {
-  side: SideView
-  slots: Array<GameView | null>
-  rowSide: 'left' | 'right'
-  matchId: string
-  currentGameNumber: number | null
-  canEdit: boolean
-}) {
-  const won = side.won === true
-  return (
-    <>
-      <div className="md-games__player">
-        {side.isGhost ? (
-          <span className="md-avatar md-avatar--ghost" aria-hidden="true">
-            <User size={14} strokeWidth={1.75} />
-          </span>
-        ) : (
-          <span
-            className={cn('md-avatar', won ? 'md-avatar--win' : 'md-avatar--loss')}
-          >
-            {side.initials}
-          </span>
-        )}
-        <span className="md-games__player-name">
-          {side.isGhost ? NO_OPPONENT_LABEL : side.username}
-        </span>
-      </div>
-      {slots.map((g, i) => {
-        if (!g) {
-          return (
-            <div key={i} className="md-games__cell md-games__cell--empty">
-              —
-            </div>
-          )
-        }
-        if (!g.score) {
-          const isLiveCell = currentGameNumber === g.gameNumber
-          return (
-            <div
-              key={i}
-              className={cn(
-                'md-games__cell md-games__cell--empty',
-                isLiveCell && 'md-games__cell--live',
-              )}
-            >
-              —
-            </div>
-          )
-        }
-        const cellWin =
-          rowSide === 'left' ? g.score.leftWon : !g.score.leftWon
-        const value =
-          rowSide === 'left' ? g.score.leftPoints : g.score.rightPoints
-        const editTo =
-          canEdit && g.scoreId ? scoringEditRoute(matchId, g.gameNumber) : null
-        const className = cn(
-          'md-games__cell',
-          cellWin ? 'md-games__cell--win' : 'md-games__cell--loss',
-        )
-        // Only render the per-cell edit link on the participant's own row so
-        // the user doesn't see two stacked links over the same cell.
-        if (editTo) {
-          return (
-            <Link key={i} {...editTo} className={className}>
-              {value}
-            </Link>
-          )
-        }
-        return (
-          <div key={i} className={className}>
-            {value}
-          </div>
-        )
-      })}
-      <div className={cn('md-games__total', won && 'md-games__total--win')}>
-        {side.gamesWon}
-      </div>
-    </>
   )
 }
 

--- a/web-client/src/components/matches/match-details/match-details-query.ts
+++ b/web-client/src/components/matches/match-details/match-details-query.ts
@@ -1,0 +1,21 @@
+import { api, unwrap } from '@/api/client'
+import type { MatchDetails } from '@/api/matches'
+
+export function matchQueryKey(matchId: string) {
+  return ['matches', 'detail', matchId] as const
+}
+
+export function matchDetailsQuery(matchId: string) {
+  return {
+    queryKey: matchQueryKey(matchId),
+    queryFn: async (): Promise<MatchDetails> =>
+      unwrap(
+        'load match',
+        await api.GET('/v1/matches/{match_id}', {
+          params: { path: { match_id: matchId } },
+        }),
+      ),
+    retry: false,
+    throwOnError: true,
+  }
+}

--- a/web-client/src/components/matches/match-details/scoreboard.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard.page.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, type HttpResponseResolver } from "msw";
+import { server } from "@/mocks/server";
+import { Scoreboard } from "./scoreboard";
+import { headerDataPage } from "./scoreboard/header/header-data.page";
+import { headerSkeletonPage } from "./scoreboard/header/header-skeleton.page";
+import { lineScoreDataPage } from "./scoreboard/line-score/line-score-data.page";
+import { lineScoreSkeletonPage } from "./scoreboard/line-score/line-score-skeleton.page";
+
+export const scoreboardPage = {
+    mockEndpoint(resolver: HttpResponseResolver) {
+        server.use(http.get("*/v1/matches/:matchId", resolver));
+    },
+
+    render(matchId: string) {
+        const queryClient = new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+        });
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Scoreboard matchId={matchId} />
+            </QueryClientProvider>,
+        );
+    },
+
+    async settle() {
+        await headerDataPage.settle();
+        await lineScoreDataPage.settle();
+    },
+
+    header: headerDataPage,
+    lineScore: lineScoreDataPage,
+
+    headerSkeleton: headerSkeletonPage,
+    lineScoreSkeleton: lineScoreSkeletonPage,
+};

--- a/web-client/src/components/matches/match-details/scoreboard.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { HttpResponse, delay } from "msw";
+import { matchDetails } from "@/test/factories";
+import type { MatchDetails } from "@/api/matches";
+import { scoreboardPage } from "./scoreboard.page";
+
+type Side = MatchDetails["sides"][number];
+type Game = MatchDetails["games"][number];
+
+const side = (sideNumber: number, username: string): Side => ({
+  side_number: sideNumber,
+  players: [{ user_id: `u-${username}`, username, is_current_user: sideNumber === 1 }],
+  games_won: 0,
+  won: null,
+  is_current_user_side: sideNumber === 1,
+});
+
+const scoredGame = (gameNumber: number, side1: number, side2: number): Game => ({
+  id: `g-${gameNumber}`,
+  game_number: gameNumber,
+  score: {
+    id: `s-${gameNumber}`,
+    side_1_points: side1,
+    side_2_points: side2,
+    winner_side_number: side1 > side2 ? 1 : 2,
+  },
+});
+
+describe("Scoreboard", () => {
+  it("renders the header strip and the line score from one match", async () => {
+    const match = matchDetails({
+      id: "m-board",
+      status: "completed",
+      best_of: 5,
+      sides: [side(1, "ada"), side(2, "bo")],
+      games: [
+        scoredGame(1, 11, 4),
+        scoredGame(2, 11, 6),
+        scoredGame(3, 9, 11),
+        scoredGame(4, 11, 8),
+      ],
+    });
+    scoreboardPage.mockEndpoint(() => HttpResponse.json(match));
+    scoreboardPage.render(match.id);
+    await scoreboardPage.settle();
+
+    // Header strip: final badge + sets tally.
+    expect(scoreboardPage.header.meta.status).toBe("Final");
+    expect(scoreboardPage.header.score.forPlayer("ada").score).toBe(3);
+    expect(scoreboardPage.header.score.forPlayer("bo").score).toBe(1);
+
+    // Line score: grid laid out for the best-of, with each side's per-game points.
+    expect(scoreboardPage.lineScore.grid.columnLabels).toEqual([
+      "G1",
+      "G2",
+      "G3",
+      "G4",
+      "G5",
+    ]);
+    expect(scoreboardPage.lineScore.line.forUser("ada").game(1).score).toBe(11);
+    expect(scoreboardPage.lineScore.line.forUser("bo").game(3).score).toBe(11);
+  });
+
+  it("shows both skeletons while the match loads, then swaps in both sections", async () => {
+    const match = matchDetails({ id: "m-board-load", best_of: 5 });
+    scoreboardPage.mockEndpoint(async () => {
+      await delay(50);
+      return HttpResponse.json(match);
+    });
+
+    scoreboardPage.render(match.id);
+
+    // Each section renders its own skeleton until the request resolves.
+    expect(scoreboardPage.headerSkeleton.isBusy).toBe(true);
+    expect(scoreboardPage.lineScoreSkeleton.placeholderCount).toBeGreaterThan(0);
+
+    // ...then both real sections take their place.
+    await scoreboardPage.settle();
+    expect(scoreboardPage.header.meta.status).toBe("Live · Game 1");
+    expect(scoreboardPage.lineScore.grid.columnLabels).toEqual([
+      "G1",
+      "G2",
+      "G3",
+      "G4",
+      "G5",
+    ]);
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard.tsx
@@ -1,0 +1,18 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Header } from "./scoreboard/header";
+import { LineScore } from "./scoreboard/line-score";
+
+interface MatchViewProps {
+    matchId: string;
+}
+
+export const Scoreboard = ({ matchId }: MatchViewProps) => (
+  <Card>
+    <CardHeader>
+      <Header matchId={matchId} />
+    </CardHeader>
+    <CardContent className="flex flex-col gap-6">
+      <LineScore matchId={matchId} />
+    </CardContent>
+  </Card>
+);

--- a/web-client/src/components/matches/match-details/scoreboard/header.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header.page.tsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Header } from "./header";
+import { headerDataPage } from "./header/header-data.page";
+import { headerSkeletonPage } from "./header/header-skeleton.page";
+
+export const headerPage = {
+    // Header reads the same match-details endpoint as HeaderData, so reuse its
+    // stub rather than restating the route here.
+    mockEndpoint: headerDataPage.mockEndpoint,
+
+    render(matchId: string) {
+        const queryClient = new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+        });
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Header matchId={matchId} />
+            </QueryClientProvider>,
+        );
+    },
+
+    // While the match request is in flight Header's Suspense boundary renders
+    // the HeaderSkeleton — read it through its own page object.
+    skeleton: headerSkeletonPage,
+
+    // Once the request resolves the loaded strip is exactly what HeaderData
+    // renders, so settle/meta/score come straight from its page object.
+    data: headerDataPage,
+};

--- a/web-client/src/components/matches/match-details/scoreboard/header.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { HttpResponse, delay } from "msw";
+import { matchDetails } from "@/test/factories";
+import { headerPage } from "./header.page";
+
+describe("Header", () => {
+  it("shows the skeleton while the match loads, then swaps in the header data", async () => {
+    const match = matchDetails({ id: "m-header" });
+    headerPage.mockEndpoint(async () => {
+      await delay(50);
+      return HttpResponse.json(match);
+    });
+
+    headerPage.render(match.id);
+
+    // Suspense renders the skeleton until the request resolves...
+    expect(headerPage.skeleton.isBusy).toBe(true);
+
+    // ...then the real header strip takes its place, rendering the resolved
+    // match — the default in-progress fixture maps to the live badge.
+    await headerPage.data.settle();
+    expect(headerPage.data.meta.status).toBe("Live · Game 1");
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/header.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+import { HeaderData } from './header/header-data'
+import { HeaderSkeleton } from './header/header-skeleton'
+
+interface HeaderProps {
+  matchId: string;
+}
+
+export function Header({ matchId }: HeaderProps) {
+  return (
+    <Suspense fallback={<HeaderSkeleton />}>
+      <HeaderData matchId={matchId} />
+    </Suspense>
+  );
+}

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data.page.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, type HttpResponseResolver } from "msw";
+import { server } from "@/mocks/server";
+import { HeaderData } from "./header-data";
+import { metaPage } from "./header-data/header-data-display/meta.page";
+import { matchScorePage } from "./header-data/header-data-display/match-score.page";
+
+const LOADING_TESTID = "header-data-loading";
+
+export const headerDataPage = {
+    /**
+     * Stub the match-details endpoint this boundary reads. Owns the GET + path;
+     * callers pass only the resolver, so each test shapes the exact response —
+     * or failure — without restating the route.
+     */
+    mockEndpoint(resolver: HttpResponseResolver) {
+        server.use(http.get("*/v1/matches/:matchId", resolver));
+    },
+
+    render(matchId: string) {
+        const queryClient = new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+        });
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Suspense fallback={<div data-testid={LOADING_TESTID} />}>
+                    <HeaderData matchId={matchId} />
+                </Suspense>
+            </QueryClientProvider>,
+        );
+    },
+
+    get isLoading() {
+        return screen.queryByTestId(LOADING_TESTID) !== null;
+    },
+
+    /** Resolves once the fetched header strip has rendered. */
+    settle() {
+        return screen.findByRole("group", { name: "Match score" });
+    },
+
+    // The display is built from Meta + MatchScore, so reads go through their
+    // page objects — exercising the real select() transform end to end.
+    meta: metaPage,
+    score: matchScorePage,
+};

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "vitest";
+import { HttpResponse, delay } from "msw";
+import { matchDetails } from "@/test/factories";
+import type { MatchDetails } from "@/api/matches";
+import { headerDataPage } from "./header-data.page";
+
+type Side = MatchDetails["sides"][number];
+type Game = MatchDetails["games"][number];
+
+// A participant side. side 1 is the current user; pass `null` for a player-less
+// (no-opponent sentinel) side.
+const side = (sideNumber: number, username: string | null): Side => ({
+  side_number: sideNumber,
+  players:
+    username === null
+      ? []
+      : [{ user_id: `u-${username}`, username, is_current_user: sideNumber === 1 }],
+  games_won: 0,
+  won: null,
+  is_current_user_side: sideNumber === 1,
+});
+
+const scoredGame = (gameNumber: number, side1: number, side2: number): Game => ({
+  id: `g-${gameNumber}`,
+  game_number: gameNumber,
+  score: {
+    id: `s-${gameNumber}`,
+    side_1_points: side1,
+    side_2_points: side2,
+    winner_side_number: side1 > side2 ? 1 : 2,
+  },
+});
+
+const unscoredGame = (gameNumber: number): Game => ({
+  id: `g-${gameNumber}`,
+  game_number: gameNumber,
+  score: null,
+});
+
+// Render a match through the real query + select transform and wait for the
+// header strip to paint.
+async function show(match: MatchDetails) {
+  headerDataPage.mockEndpoint(() => HttpResponse.json(match));
+  headerDataPage.render(match.id);
+  await headerDataPage.settle();
+}
+
+describe("HeaderData", () => {
+  it("shows a loading placeholder until the match resolves", async () => {
+    const match = matchDetails({
+      id: "m-load",
+      status: "completed",
+      sides: [side(1, "ada"), side(2, "bo")],
+      games: [scoredGame(1, 11, 3)],
+    });
+    headerDataPage.mockEndpoint(async () => {
+      await delay(50);
+      return HttpResponse.json(match);
+    });
+
+    headerDataPage.render(match.id);
+    expect(headerDataPage.isLoading).toBe(true);
+
+    await headerDataPage.settle();
+    expect(headerDataPage.isLoading).toBe(false);
+  });
+
+  it("maps an in-progress match to the live badge with its game number", async () => {
+    await show(
+      matchDetails({
+        id: "m-live",
+        status: "in_progress",
+        current_game: { game_number: 3 },
+        best_of: 5,
+        sides: [side(1, "ada"), side(2, "bo")],
+        games: [scoredGame(1, 11, 7), scoredGame(2, 5, 11)],
+      }),
+    );
+
+    expect(headerDataPage.meta.status).toBe("Live · Game 3");
+    expect(headerDataPage.meta.format).toBe("SINGLES · BO5");
+    expect(headerDataPage.meta.firstTo).toBe(3);
+    expect(headerDataPage.score.forPlayer("ada").score).toBe(1);
+    expect(headerDataPage.score.forPlayer("bo").score).toBe(1);
+  });
+
+  it("maps an in-progress match with no current game to awaiting confirmation", async () => {
+    await show(
+      matchDetails({
+        id: "m-await",
+        status: "in_progress",
+        current_game: null,
+        sides: [side(1, "ada"), side(2, "bo")],
+        games: [scoredGame(1, 11, 4), scoredGame(2, 11, 6)],
+      }),
+    );
+
+    expect(headerDataPage.meta.status).toBe("Awaiting confirmation");
+  });
+
+  it("maps a pending match to the upcoming badge with a VS scoreline", async () => {
+    await show(
+      matchDetails({
+        id: "m-pending",
+        status: "pending",
+        status_label: "Sat 10am",
+        current_game: { game_number: 1 },
+        sides: [side(1, "ada"), side(2, "bo")],
+        games: [],
+      }),
+    );
+
+    expect(headerDataPage.meta.status).toBe("Upcoming");
+    // No games played yet, so the meta strip hides "first to N"...
+    expect(headerDataPage.meta.firstTo).toBeNull();
+    // ...and the score shows "VS" rather than a tally.
+    expect(headerDataPage.score.hasVersusLabel()).toBe(true);
+    expect(headerDataPage.score.playerOrder).toEqual(["ada", "bo"]);
+  });
+
+  it("maps a completed match to the final badge and flags the clincher", async () => {
+    await show(
+      matchDetails({
+        id: "m-final",
+        status: "completed",
+        best_of: 5,
+        sides: [side(1, "ada"), side(2, "bo")],
+        games: [
+          scoredGame(1, 11, 4),
+          scoredGame(2, 11, 6),
+          scoredGame(3, 9, 11),
+          scoredGame(4, 11, 8),
+        ],
+      }),
+    );
+
+    expect(headerDataPage.meta.status).toBe("Final");
+    expect(headerDataPage.score.forPlayer("ada").score).toBe(3);
+    expect(headerDataPage.score.forPlayer("ada").won).toBe(true);
+    expect(headerDataPage.score.forPlayer("bo").score).toBe(1);
+    expect(headerDataPage.score.forPlayer("bo").won).toBe(false);
+  });
+
+  it.each(["disputed", "voided"] as const)(
+    "maps a %s match to the final badge",
+    async (status) => {
+      await show(
+        matchDetails({
+          id: `m-${status}`,
+          status,
+          sides: [side(1, "ada"), side(2, "bo")],
+          games: [scoredGame(1, 11, 4), scoredGame(2, 4, 11)],
+        }),
+      );
+
+      expect(headerDataPage.meta.status).toBe("Final");
+    },
+  );
+
+  it("orders the sides by side_number regardless of API order", async () => {
+    await show(
+      matchDetails({
+        id: "m-order",
+        status: "in_progress",
+        current_game: { game_number: 2 },
+        // Returned out of order: side 2 first.
+        sides: [side(2, "bo"), side(1, "ada")],
+        games: [scoredGame(1, 11, 3)],
+      }),
+    );
+
+    expect(headerDataPage.score.playerOrder).toEqual(["ada", "bo"]);
+    // Side 1 (ada) took game 1, so the tally tracks the sorted sides too.
+    expect(headerDataPage.score.forPlayer("ada").score).toBe(1);
+    expect(headerDataPage.score.forPlayer("bo").score).toBe(0);
+  });
+
+  it("maps side 1 points left, side 2 points right, and drops unscored games", async () => {
+    await show(
+      matchDetails({
+        id: "m-tally",
+        status: "in_progress",
+        current_game: { game_number: 4 },
+        sides: [side(1, "ada"), side(2, "bo")],
+        // bo (side 2) takes games 1-2, ada (side 1) takes game 3, game 4 unscored.
+        games: [
+          scoredGame(1, 5, 11),
+          scoredGame(2, 3, 11),
+          scoredGame(3, 11, 9),
+          unscoredGame(4),
+        ],
+      }),
+    );
+
+    // ada === 1 (not 2) proves the unscored game 4 was dropped rather than
+    // counted as a side-1 win.
+    expect(headerDataPage.score.forPlayer("ada").score).toBe(1);
+    expect(headerDataPage.score.forPlayer("bo").score).toBe(2);
+  });
+
+  it("renders a player-less side as the No opponent placeholder", async () => {
+    await show(
+      matchDetails({
+        id: "m-solo",
+        status: "in_progress",
+        current_game: { game_number: 2 },
+        sides: [side(1, "ada"), side(2, null)],
+        games: [scoredGame(1, 11, 3)],
+      }),
+    );
+
+    expect(headerDataPage.score.playerOrder).toEqual(["ada", "No opponent"]);
+  });
+
+  it("passes best_of through to the format and first-to labels", async () => {
+    await show(
+      matchDetails({
+        id: "m-bo7",
+        status: "completed",
+        best_of: 7,
+        sides: [side(1, "ada"), side(2, "bo")],
+        games: [scoredGame(1, 11, 4)],
+      }),
+    );
+
+    expect(headerDataPage.meta.format).toBe("SINGLES · BO7");
+    expect(headerDataPage.meta.firstTo).toBe(4);
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data.tsx
@@ -1,0 +1,13 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { headerDataQuery } from "./header-data/header-data-query";
+import { MatchHeaderDataDisplay } from "./header-data/header-data-display";
+
+interface HeaderDataProps {
+  matchId: string;
+}
+
+export const HeaderData = ({ matchId }: HeaderDataProps) => {
+    const { data: matchHeaderData } = useSuspenseQuery(headerDataQuery(matchId));
+
+    return <MatchHeaderDataDisplay matchHeaderData={matchHeaderData} />
+};

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display.factory.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display.factory.ts
@@ -1,0 +1,14 @@
+import type { MatchHeaderDataDisplayProps } from "./header-data-display";
+import { headerSideFactory } from "./header-data-display/match-score.factory";
+
+export const matchHeaderDataDisplayFactory = (
+    overrides: Partial<MatchHeaderDataDisplayProps["matchHeaderData"]> = {},
+): MatchHeaderDataDisplayProps => ({
+    matchHeaderData: {
+        status: { kind: "final" },
+        bestOf: 5,
+        sides: [headerSideFactory(), headerSideFactory()],
+        games: [],
+        ...overrides,
+    },
+});

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display.page.tsx
@@ -1,0 +1,18 @@
+import { render } from "@testing-library/react";
+import {
+    MatchHeaderDataDisplay,
+    type MatchHeaderDataDisplayProps,
+} from "./header-data-display";
+import { metaPage } from "./header-data-display/meta.page";
+import { matchScorePage } from "./header-data-display/match-score.page";
+
+export const matchHeaderDataDisplayPage = {
+    render(props: MatchHeaderDataDisplayProps) {
+        render(<MatchHeaderDataDisplay {...props} />);
+    },
+
+    // The display is pure composition, so it reuses the child page objects to
+    // confirm each section received its data.
+    meta: metaPage,
+    score: matchScorePage,
+};

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { matchHeaderDataDisplayPage } from "./header-data-display.page";
+import { matchHeaderDataDisplayFactory } from "./header-data-display.factory";
+import { headerSideFactory, gameWonBy } from "./header-data-display/match-score.factory";
+
+describe("MatchHeaderDataDisplay", () => {
+  const sides = [
+    headerSideFactory({ username: "Ada" }),
+    headerSideFactory({ username: "Bernie" }),
+  ];
+
+  it("wires the match details through to the Meta strip", () => {
+    matchHeaderDataDisplayPage.render(
+      matchHeaderDataDisplayFactory({ status: { kind: "final" }, bestOf: 7 }),
+    );
+
+    expect(matchHeaderDataDisplayPage.meta.format).toBe("SINGLES · BO7");
+    expect(matchHeaderDataDisplayPage.meta.firstTo).toBe(4);
+  });
+
+  it("wires the players and games through to the match score", () => {
+    matchHeaderDataDisplayPage.render(
+      matchHeaderDataDisplayFactory({
+        sides,
+        games: [gameWonBy(0), gameWonBy(1), gameWonBy(0)],
+      }),
+    );
+
+    expect(matchHeaderDataDisplayPage.score.forPlayer("Ada").score).toBe(2);
+    expect(matchHeaderDataDisplayPage.score.forPlayer("Bernie").score).toBe(1);
+  });
+
+  it("shows the upcoming match score when no games have been played", () => {
+    matchHeaderDataDisplayPage.render(
+      matchHeaderDataDisplayFactory({
+        sides,
+        status: { kind: "upcoming", label: "Sat 10am" },
+        games: [],
+      }),
+    );
+
+    expect(matchHeaderDataDisplayPage.score.hasVersusLabel()).toBe(true);
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display.tsx
@@ -1,0 +1,22 @@
+import type { StatusView } from "@/components/matches/match-status-badge";
+import type { GameScore, HeaderSide } from "./header-data-query";
+import { Meta } from "./header-data-display/meta";
+import { MatchScore } from "./header-data-display/match-score";
+
+export interface MatchHeaderData {
+    status: StatusView;
+    bestOf: number;
+    sides: HeaderSide[];
+    games: GameScore[][];
+}
+
+export interface MatchHeaderDataDisplayProps {
+    matchHeaderData: MatchHeaderData;
+}
+
+export const MatchHeaderDataDisplay = ({ matchHeaderData }: MatchHeaderDataDisplayProps) => {
+    return <div>
+        <Meta status={matchHeaderData.status} bestOf={matchHeaderData.bestOf} />
+        <MatchScore sides={matchHeaderData.sides} games={matchHeaderData.games} bestOf={matchHeaderData.bestOf} />
+    </div>
+}

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score-skeleton.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score-skeleton.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from '@/components/ui/skeleton'
+import { MatchScoreSlot } from './match-score-slot'
+
+// Loading placeholder for <MatchScore />: mirrors the five-cell md-hero row
+// (player · score · divider · score · player) so it reserves the same size and
+// rearranges identically at the narrow breakpoint. The center slot keeps the
+// score height reserved while the match data is in flight.
+export const MatchScoreSkeleton = () => (
+  <div className="md-hero__row">
+    <div className="md-hero__player md-hero__player--l">
+      <div className="md-hero__player-row">
+        <Skeleton className="md-avatar md-hero__avatar-singles" />
+        <div className="md-hero__player-text--l">
+          <Skeleton className="h-5 w-28" />
+        </div>
+      </div>
+    </div>
+
+    <div className="md-hero__score md-hero__score--l">
+      <Skeleton className="h-[0.7em] w-full" />
+    </div>
+
+    <MatchScoreSlot>
+      <Skeleton className="h-4 w-8" />
+    </MatchScoreSlot>
+
+    <div className="md-hero__score md-hero__score--r">
+      <Skeleton className="h-[0.7em] w-full" />
+    </div>
+
+    <div className="md-hero__player md-hero__player--r">
+      <div className="md-hero__player-row">
+        <Skeleton className="md-avatar md-hero__avatar-singles" />
+        <div className="md-hero__player-text--l">
+          <Skeleton className="h-5 w-28" />
+        </div>
+      </div>
+    </div>
+  </div>
+)

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score-slot.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score-slot.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react'
+
+export const MatchScoreSlot = ({ children }: { children: ReactNode }) => (
+  <div className="md-hero__score-block">
+    <div className="md-hero__score-sizer" aria-hidden>
+      <span className="md-hero__score">0</span>
+    </div>
+    <div className="md-hero__score-content">{children}</div>
+  </div>
+)

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.factory.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.factory.ts
@@ -1,0 +1,31 @@
+import { faker } from "@faker-js/faker";
+import type { MatchScoreProps } from "./match-score";
+import type { UpcomingMatchScoreProps } from "./upcoming-match-score";
+import type { GameScore, HeaderSide } from "../header-data-query";
+
+export const headerSideFactory = (overrides: Partial<HeaderSide> = {}): HeaderSide => ({
+    id: faker.string.uuid(),
+    username: faker.person.firstName(),
+    ...overrides,
+});
+
+// A single game whose winner is `sideNumber`; the loser's points are noise the
+// scoring logic ignores, so they're randomised to signal "don't care".
+export const gameWonBy = (sideNumber: number): GameScore[] => [
+    { sideNumber: 0, points: sideNumber === 0 ? 11 : faker.number.int({ min: 0, max: 9 }) },
+    { sideNumber: 1, points: sideNumber === 1 ? 11 : faker.number.int({ min: 0, max: 9 }) },
+];
+
+export const matchScoreFactory = (overrides: Partial<MatchScoreProps> = {}): MatchScoreProps => ({
+    sides: [headerSideFactory(), headerSideFactory()],
+    games: [],
+    bestOf: 5,
+    ...overrides,
+});
+
+export const upcomingMatchScoreFactory = (
+    overrides: Partial<UpcomingMatchScoreProps> = {},
+): UpcomingMatchScoreProps => ({
+    sides: [headerSideFactory(), headerSideFactory()],
+    ...overrides,
+});

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.page.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import { MatchScore, type MatchScoreProps } from "./match-score";
+import { playedMatchScorePage } from "./played-match-score.page";
+import { upcomingMatchScorePage } from "./upcoming-match-score.page";
+
+export const matchScorePage = {
+    render(props: MatchScoreProps) {
+        render(<MatchScore {...props} />);
+    },
+
+    // MatchScore delegates rendering to the played / upcoming subcomponents, so
+    // it reuses their page objects to read the rendered result.
+    forPlayer: playedMatchScorePage.forPlayer,
+    hasPlayer: upcomingMatchScorePage.hasPlayer,
+    hasVersusLabel: () => upcomingMatchScorePage.hasVersusLabel,
+
+    // Participant names in render order — [left, right] — so callers can assert
+    // sides land on the expected side of the hero row.
+    get playerOrder() {
+        return Array.from(document.querySelectorAll(".md-hero__name")).map(
+            (element) => element.textContent,
+        );
+    },
+};

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { matchScorePage } from "./match-score.page";
+import { headerSideFactory, gameWonBy, matchScoreFactory } from "./match-score.factory";
+
+describe("MatchScore", () => {
+  const sides = [
+    headerSideFactory({ username: "Ada" }),
+    headerSideFactory({ username: "Bernie" }),
+  ];
+
+  // The played / upcoming branches are covered by their own suites; here we just
+  // confirm MatchScore renders the played-match score for a started match.
+  it("renders the played-match score", () => {
+    matchScorePage.render(
+      matchScoreFactory({
+        sides,
+        games: [gameWonBy(0), gameWonBy(1), gameWonBy(0)],
+      }),
+    );
+
+    expect(matchScorePage.forPlayer("Ada").score).toBe(2);
+    expect(matchScorePage.forPlayer("Bernie").score).toBe(1);
+    expect(matchScorePage.hasVersusLabel()).toBe(false);
+  });
+
+  it("renders the upcoming-match score when no games have been played", () => {
+    matchScorePage.render(matchScoreFactory({ sides, games: [] }));
+
+    expect(matchScorePage.hasVersusLabel()).toBe(true);
+    expect(matchScorePage.hasPlayer("Ada")).toBe(true);
+    expect(matchScorePage.hasPlayer("Bernie")).toBe(true);
+  });
+
+  it("places the first side on the left and the second on the right", () => {
+    matchScorePage.render(
+      matchScoreFactory({ sides, games: [gameWonBy(0)] }),
+    );
+
+    expect(matchScorePage.playerOrder).toEqual(["Ada", "Bernie"]);
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.tsx
@@ -1,0 +1,20 @@
+import type { GameScore, HeaderSide } from '../header-data-query'
+import { UpcomingMatchScore } from './upcoming-match-score'
+import { PlayedMatchScore } from './played-match-score'
+
+export interface MatchScoreProps {
+  sides: HeaderSide[]
+  games: GameScore[][]
+  bestOf: number
+}
+
+export const MatchScore = ({ sides, games, bestOf }: MatchScoreProps) => {
+  // A match with no games played yet is upcoming: show "VS" rather than a score.
+  const isUpcoming = games.length === 0
+
+  return isUpcoming ? (
+    <UpcomingMatchScore sides={sides} />
+  ) : (
+    <PlayedMatchScore sides={sides} games={games} bestOf={bestOf} />
+  )
+}

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/meta-skeleton.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/meta-skeleton.tsx
@@ -1,0 +1,16 @@
+import { MatchStatusBadgeSkeleton } from '@/components/matches/match-status-badge-skeleton'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function MetaSkeleton() {
+  return (
+    <div className="md-hero__strip" aria-busy="true" data-testid="header-skeleton">
+      <div className="md-hero__strip-l">
+        <MatchStatusBadgeSkeleton />
+      </div>
+      <div className="md-hero__strip-r">
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-4 w-24" />
+      </div>
+    </div>
+  )
+};

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/meta.factory.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/meta.factory.ts
@@ -1,0 +1,8 @@
+import type { MetaProps } from "./meta";
+import type { StatusView } from "@/components/matches/match-status-badge";
+
+export const metaFactory = (overrides: Partial<MetaProps> = {}): MetaProps => ({
+    status: { kind: "final" } satisfies StatusView,
+    bestOf: 5,
+    ...overrides,
+});

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/meta.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/meta.page.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { Meta, type MetaProps } from "./meta";
+
+export const metaPage = {
+    render(props: MetaProps) {
+        render(<Meta {...props} />);
+    },
+
+    // The status badge text, e.g. "Live · Game 3", "Upcoming", "Final".
+    get status() {
+        return document.querySelector('[data-slot="badge"]')?.textContent?.trim() ?? null;
+    },
+
+    get format() {
+        return screen.getByText(/SINGLES · BO\d+/).textContent;
+    },
+
+    get firstTo() {
+        const element = screen.queryByText(/First to \d+/);
+        if (element === null) return null;
+        return Number.parseInt(element.textContent?.replace(/\D+/g, "") ?? "", 10);
+    },
+};

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/meta.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/meta.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { metaPage } from "./meta.page";
+import { metaFactory } from "./meta.factory";
+
+describe("Meta", () => {
+  it("shows the singles / best-of format", () => {
+    metaPage.render(metaFactory({ bestOf: 7 }));
+
+    expect(metaPage.format).toBe("SINGLES · BO7");
+  });
+
+  it("shows how many games win the match once it is under way", () => {
+    metaPage.render(metaFactory({ status: { kind: "final" }, bestOf: 5 }));
+
+    expect(metaPage.firstTo).toBe(3);
+  });
+
+  it("rounds the games-to-win up for odd best-of lengths", () => {
+    metaPage.render(metaFactory({ status: { kind: "live", gameNumber: 1 }, bestOf: 3 }));
+
+    expect(metaPage.firstTo).toBe(2);
+  });
+
+  it("hides the games-to-win for an upcoming match", () => {
+    metaPage.render(
+      metaFactory({ status: { kind: "upcoming", label: "Sat 10am" }, bestOf: 5 }),
+    );
+
+    expect(metaPage.firstTo).toBeNull();
+  });
+
+  it("shows the live status badge with its game number", () => {
+    metaPage.render(metaFactory({ status: { kind: "live", gameNumber: 3 } }));
+
+    expect(metaPage.status).toBe("Live · Game 3");
+  });
+
+  it("shows the final status badge", () => {
+    metaPage.render(metaFactory({ status: { kind: "final" } }));
+
+    expect(metaPage.status).toBe("Final");
+  });
+
+  it("shows the upcoming status badge", () => {
+    metaPage.render(
+      metaFactory({ status: { kind: "upcoming", label: "Sat 10am" } }),
+    );
+
+    expect(metaPage.status).toBe("Upcoming");
+  });
+
+  it("shows the awaiting-confirmation status badge", () => {
+    metaPage.render(metaFactory({ status: { kind: "awaiting-confirmation" } }));
+
+    expect(metaPage.status).toBe("Awaiting confirmation");
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/meta.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/meta.tsx
@@ -1,0 +1,33 @@
+import { Clock } from 'lucide-react'
+
+import {
+  MatchStatusBadge,
+  type StatusView,
+} from '@/components/matches/match-status-badge'
+
+export interface MetaProps {
+  status: StatusView;
+  bestOf: number;
+}
+
+export function Meta({ status, bestOf }: MetaProps) {
+  const isUpcoming = status.kind === 'upcoming';
+  const gamesToWin = Math.ceil(bestOf / 2);
+
+  return (
+    <div className="md-hero__strip">
+      <div className="md-hero__strip-l">
+        <MatchStatusBadge status={status} />
+      </div>
+      <div className="md-hero__strip-r">
+        <span className="md-hero__strip-meta">SINGLES · BO{bestOf}</span>
+        {!isUpcoming && (
+          <span className="md-hero__strip-meta md-hero__strip-meta--with-icon">
+            <Clock size={13} strokeWidth={1.75} />
+            First to {gamesToWin}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/played-match-score.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/played-match-score.page.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { PlayedMatchScore, type PlayedMatchScoreProps } from "./played-match-score";
+import { playerScorePage } from "../../../player-score.page";
+
+export const playedMatchScorePage = {
+    render(props: PlayedMatchScoreProps) {
+        render(<PlayedMatchScore {...props} />);
+    },
+
+    forPlayer(username: string) {
+        return playerScorePage.within(screen.getByLabelText(`${username} sets`));
+    },
+};

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/played-match-score.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/played-match-score.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { playedMatchScorePage } from "./played-match-score.page";
+import { headerSideFactory, gameWonBy, matchScoreFactory } from "./match-score.factory";
+
+describe("PlayedMatchScore", () => {
+  const sides = [
+    headerSideFactory({ username: "Ada" }),
+    headerSideFactory({ username: "Bernie" }),
+  ];
+
+  it("tallies the games each player has won", () => {
+    playedMatchScorePage.render(
+      matchScoreFactory({
+        sides,
+        games: [gameWonBy(0), gameWonBy(1), gameWonBy(0)],
+      }),
+    );
+
+    expect(playedMatchScorePage.forPlayer("Ada").score).toBe(2);
+    expect(playedMatchScorePage.forPlayer("Bernie").score).toBe(1);
+  });
+
+  it("marks the player who has clinched the match as the winner", () => {
+    playedMatchScorePage.render(
+      matchScoreFactory({
+        sides,
+        games: [gameWonBy(0), gameWonBy(0)],
+        bestOf: 3,
+      }),
+    );
+
+    expect(playedMatchScorePage.forPlayer("Ada").won).toBe(true);
+    expect(playedMatchScorePage.forPlayer("Bernie").won).toBe(false);
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/played-match-score.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/played-match-score.tsx
@@ -1,0 +1,49 @@
+import type { GameScore, HeaderSide } from '../header-data-query'
+import { MatchScoreSlot } from './match-score-slot'
+import { PlayerScore } from '../../../player-score'
+import { Participant } from '../../../participant'
+
+export interface PlayedMatchScoreProps {
+  sides: HeaderSide[]
+  games: GameScore[][]
+  bestOf: number
+}
+
+export const PlayedMatchScore = ({ sides, games, bestOf }: PlayedMatchScoreProps) => {
+  const winnerOf = (game: GameScore[]) =>
+    game.reduce((best, side) => (side.points > best.points ? side : best)).sideNumber
+  const gamesWonBy = (sideNumber: number) =>
+    games.filter((game) => winnerOf(game) === sideNumber).length
+
+  const leftScore = gamesWonBy(0)
+  const rightScore = gamesWonBy(1)
+
+  const gamesToWin = Math.floor(bestOf / 2) + 1
+  const leftWon = leftScore >= gamesToWin
+  const rightWon = rightScore >= gamesToWin
+
+  const [left, right] = sides
+
+  return (
+    <div className="md-hero__row" role="group" aria-label="Match score">
+      <Participant size="hero" align="l" username={left.username} won={leftWon} />
+      <PlayerScore
+        className="md-hero__score md-hero__score--l"
+        label={`${left.username} sets`}
+        score={leftScore}
+        won={leftWon}
+      />
+      <MatchScoreSlot>
+        <span className="md-hero__score-dash">—</span>
+        <span className="md-hero__score-vs">vs</span>
+      </MatchScoreSlot>
+      <PlayerScore
+        className="md-hero__score md-hero__score--r"
+        label={`${right.username} sets`}
+        score={rightScore}
+        won={rightWon}
+      />
+      <Participant size="hero" align="r" username={right.username} won={rightWon} />
+    </div>
+  )
+}

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/upcoming-match-score.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/upcoming-match-score.page.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { UpcomingMatchScore, type UpcomingMatchScoreProps } from "./upcoming-match-score";
+
+export const upcomingMatchScorePage = {
+    render(props: UpcomingMatchScoreProps) {
+        render(<UpcomingMatchScore {...props} />);
+    },
+
+    get hasVersusLabel() {
+        return screen.queryByText("VS") !== null;
+    },
+
+    hasPlayer(username: string) {
+        return screen.queryByText(username) !== null;
+    },
+
+    scoreFor(username: string) {
+        return screen.queryByLabelText(`${username} sets`);
+    },
+};

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/upcoming-match-score.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/upcoming-match-score.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { upcomingMatchScorePage } from "./upcoming-match-score.page";
+import { headerSideFactory, upcomingMatchScoreFactory } from "./match-score.factory";
+
+describe("UpcomingMatchScore", () => {
+  const sides = [
+    headerSideFactory({ username: "Ada" }),
+    headerSideFactory({ username: "Bernie" }),
+  ];
+
+  it("shows both players", () => {
+    upcomingMatchScorePage.render(upcomingMatchScoreFactory({ sides }));
+
+    expect(upcomingMatchScorePage.hasPlayer("Ada")).toBe(true);
+    expect(upcomingMatchScorePage.hasPlayer("Bernie")).toBe(true);
+  });
+
+  it('shows "VS" instead of a score line', () => {
+    upcomingMatchScorePage.render(upcomingMatchScoreFactory({ sides }));
+
+    expect(upcomingMatchScorePage.hasVersusLabel).toBe(true);
+    expect(upcomingMatchScorePage.scoreFor("Ada")).toBeNull();
+    expect(upcomingMatchScorePage.scoreFor("Bernie")).toBeNull();
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/upcoming-match-score.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/upcoming-match-score.tsx
@@ -1,0 +1,21 @@
+import type { HeaderSide } from '../header-data-query'
+import { MatchScoreSlot } from './match-score-slot'
+import { Participant } from '../../../participant'
+
+export interface UpcomingMatchScoreProps {
+  sides: HeaderSide[]
+}
+
+export const UpcomingMatchScore = ({ sides }: UpcomingMatchScoreProps) => {
+  const [left, right] = sides
+
+  return (
+    <div className="md-hero__row" role="group" aria-label="Match score">
+      <Participant size="hero" align="l" username={left.username} />
+      <MatchScoreSlot>
+        <span className="md-hero__vs-label">VS</span>
+      </MatchScoreSlot>
+      <Participant size="hero" align="r" username={right.username} />
+    </div>
+  )
+}

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-query.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-query.tsx
@@ -1,0 +1,51 @@
+import type { MatchDetails } from "@/api/matches";
+import type { StatusView } from "@/components/matches/match-status-badge";
+import { matchDetailsQuery } from "../../../match-details-query";
+
+function toStatusView(data: MatchDetails): StatusView {
+    switch (data.status) {
+        case "in_progress":
+            return data.current_game
+                ? { kind: "live", gameNumber: data.current_game.game_number }
+                : { kind: "awaiting-confirmation" };
+        case "pending":
+            return { kind: "upcoming", label: data.status_label };
+        case "completed":
+        case "disputed":
+        case "voided":
+            return { kind: "final" };
+    }
+}
+
+export type HeaderSide = { id: string; username: string };
+export type GameScore = { sideNumber: number; points: number };
+
+function toSides(data: MatchDetails): HeaderSide[] {
+    return [...data.sides]
+        .sort((a, b) => a.side_number - b.side_number)
+        .map((side) => ({
+            id: side.players[0]?.user_id ?? "",
+            username: side.players[0]?.username ?? "",
+        }));
+}
+
+function toGames(data: MatchDetails): GameScore[][] {
+    return data.games.flatMap((game) =>
+        game.score
+            ? [[
+                  { sideNumber: 0, points: game.score.side_1_points },
+                  { sideNumber: 1, points: game.score.side_2_points },
+              ]]
+            : [],
+    );
+}
+
+export const headerDataQuery = (matchId: string) => ({
+    ...matchDetailsQuery(matchId),
+    select: (data: MatchDetails) => ({
+        status: toStatusView(data),
+        bestOf: data.best_of,
+        sides: toSides(data),
+        games: toGames(data),
+    }),
+});

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-skeleton.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-skeleton.page.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { HeaderSkeleton } from "./header-skeleton";
+
+export const headerSkeletonPage = {
+    render() {
+        render(<HeaderSkeleton />);
+    },
+
+    get isBusy() {
+        return screen.getByTestId("header-skeleton").getAttribute("aria-busy") === "true";
+    },
+
+    // The score row mirrors the md-hero layout; its presence confirms the
+    // MatchScore half of the skeleton rendered alongside the Meta strip.
+    get hasScorePlaceholder() {
+        return document.querySelector(".md-hero__row") !== null;
+    },
+
+    get placeholderCount() {
+        return document.querySelectorAll('[data-slot="skeleton"]').length;
+    },
+};

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-skeleton.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-skeleton.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { headerSkeletonPage } from "./header-skeleton.page";
+
+describe("HeaderSkeleton", () => {
+  it("renders a busy loading placeholder", () => {
+    headerSkeletonPage.render();
+
+    expect(headerSkeletonPage.isBusy).toBe(true);
+  });
+
+  it("reserves space for both the meta strip and the score row", () => {
+    headerSkeletonPage.render();
+
+    expect(headerSkeletonPage.hasScorePlaceholder).toBe(true);
+    expect(headerSkeletonPage.placeholderCount).toBeGreaterThan(0);
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-skeleton.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-skeleton.tsx
@@ -1,0 +1,14 @@
+import { MetaSkeleton } from './header-data/header-data-display/meta-skeleton'
+import { MatchScoreSkeleton } from './header-data/header-data-display/match-score-skeleton'
+
+// Loading placeholder for <HeaderData />. Mirrors the `MatchHeaderDataDisplay`
+// layout — the `Meta` strip on top, the `MatchScore` hero row beneath —
+// composed from the per-part skeletons that live beside their components.
+export function HeaderSkeleton() {
+  return (
+    <div>
+      <MetaSkeleton />
+      <MatchScoreSkeleton />
+    </div>
+  )
+}

--- a/web-client/src/components/matches/match-details/scoreboard/line-score.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score.page.tsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { LineScore } from "./line-score";
+import { lineScoreDataPage } from "./line-score/line-score-data.page";
+import { lineScoreSkeletonPage } from "./line-score/line-score-skeleton.page";
+
+export const lineScorePage = {
+    // LineScore reads the same match-details endpoint as LineScoreData, so reuse
+    // its stub rather than restating the route here.
+    mockEndpoint: lineScoreDataPage.mockEndpoint,
+
+    render(matchId: string) {
+        const queryClient = new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+        });
+        render(
+            <QueryClientProvider client={queryClient}>
+                <LineScore matchId={matchId} />
+            </QueryClientProvider>,
+        );
+    },
+
+    // While the match request is in flight LineScore's Suspense boundary renders
+    // the LineScoreSkeleton — read it through its own page object.
+    skeleton: lineScoreSkeletonPage,
+
+    // Once the request resolves the loaded grid is exactly what LineScoreData
+    // renders, so settle/grid/line come straight from its page object.
+    data: lineScoreDataPage,
+};

--- a/web-client/src/components/matches/match-details/scoreboard/line-score.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { HttpResponse, delay } from "msw";
+import { matchDetails } from "@/test/factories";
+import { lineScorePage } from "./line-score.page";
+
+describe("LineScore", () => {
+  it("shows the skeleton while the match loads, then swaps in the line score", async () => {
+    const match = matchDetails({ id: "m-line", best_of: 5 });
+    lineScorePage.mockEndpoint(async () => {
+      await delay(50);
+      return HttpResponse.json(match);
+    });
+
+    lineScorePage.render(match.id);
+
+    // Suspense renders the skeleton until the request resolves...
+    expect(lineScorePage.skeleton.placeholderCount).toBeGreaterThan(0);
+
+    // ...then the real grid takes its place, labelling its columns for the
+    // resolved best-of.
+    await lineScorePage.data.settle();
+    expect(lineScorePage.data.grid.columnLabels).toEqual([
+      "G1",
+      "G2",
+      "G3",
+      "G4",
+      "G5",
+    ]);
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/line-score.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+
+import { LineScoreData } from './line-score/line-score-data'
+import { LineScoreSkeleton } from './line-score/line-score-skeleton'
+
+interface LineScoreProps {
+  matchId: string
+}
+
+export function LineScore({ matchId }: LineScoreProps) {
+  return (
+    <Suspense fallback={<LineScoreSkeleton />}>
+      <LineScoreData matchId={matchId} />
+    </Suspense>
+  )
+}

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data.page.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, type HttpResponseResolver } from "msw";
+import { server } from "@/mocks/server";
+import { LineScoreData } from "./line-score-data";
+import { linePage } from "./line-score-data/line-score-data-display/line.page";
+import { lineScoreGridPage } from "./line-score-data/line-score-data-display/line-score-grid.page";
+
+const LOADING_TESTID = "line-score-data-loading";
+
+export const lineScoreDataPage = {
+    /**
+     * Stub the match-details endpoint this boundary reads. Owns the GET + path;
+     * callers pass only the resolver, so each test shapes the exact response —
+     * or failure — without restating the route.
+     */
+    mockEndpoint(resolver: HttpResponseResolver) {
+        server.use(http.get("*/v1/matches/:matchId", resolver));
+    },
+
+    render(matchId: string) {
+        const queryClient = new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+        });
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Suspense fallback={<div data-testid={LOADING_TESTID} />}>
+                    <LineScoreData matchId={matchId} />
+                </Suspense>
+            </QueryClientProvider>,
+        );
+    },
+
+    get isLoading() {
+        return screen.queryByTestId(LOADING_TESTID) !== null;
+    },
+
+    /**
+     * Resolves once the fetched line score has rendered. The grouped grid is
+     * also rendered by the loading skeleton, so we wait on the first real
+     * game-column label ("G1") instead — only the loaded grid labels its
+     * columns.
+     */
+    settle() {
+        return screen.findByText("G1");
+    },
+
+    // The display is built from the grid shell + one row per side, so reads go
+    // through their page objects — exercising the real select() transform end
+    // to end.
+    grid: lineScoreGridPage,
+    line: linePage,
+};

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { HttpResponse, delay } from "msw";
+import { matchDetails } from "@/test/factories";
+import type { MatchDetails } from "@/api/matches";
+import { lineScoreDataPage } from "./line-score-data.page";
+
+type Side = MatchDetails["sides"][number];
+type Game = MatchDetails["games"][number];
+
+// A participant side. Side 1 is the current user; pass `null` for a player-less
+// (no-opponent sentinel) side.
+const side = (sideNumber: number, username: string | null): Side => ({
+  side_number: sideNumber,
+  players:
+    username === null
+      ? []
+      : [{ user_id: `u-${username}`, username, is_current_user: sideNumber === 1 }],
+  games_won: 0,
+  won: null,
+  is_current_user_side: sideNumber === 1,
+});
+
+const scoredGame = (gameNumber: number, side1: number, side2: number): Game => ({
+  id: `g-${gameNumber}`,
+  game_number: gameNumber,
+  score: {
+    id: `s-${gameNumber}`,
+    side_1_points: side1,
+    side_2_points: side2,
+    winner_side_number: side1 > side2 ? 1 : 2,
+  },
+});
+
+const unscoredGame = (gameNumber: number): Game => ({
+  id: `g-${gameNumber}`,
+  game_number: gameNumber,
+  score: null,
+});
+
+// Render a match through the real query + select transform and wait for the
+// line score to paint.
+async function show(match: MatchDetails) {
+  lineScoreDataPage.mockEndpoint(() => HttpResponse.json(match));
+  lineScoreDataPage.render(match.id);
+  await lineScoreDataPage.settle();
+}
+
+describe("LineScoreData", () => {
+  it("shows a loading placeholder until the match resolves", async () => {
+    const match = matchDetails({
+      id: "m-load",
+      sides: [side(1, "ada"), side(2, "bo")],
+      games: [scoredGame(1, 11, 3)],
+    });
+    lineScoreDataPage.mockEndpoint(async () => {
+      await delay(50);
+      return HttpResponse.json(match);
+    });
+
+    lineScoreDataPage.render(match.id);
+    expect(lineScoreDataPage.isLoading).toBe(true);
+
+    await lineScoreDataPage.settle();
+    expect(lineScoreDataPage.isLoading).toBe(false);
+  });
+
+  it("renders a row per side with each side's per-game points", async () => {
+    await show(
+      matchDetails({
+        id: "m-rows",
+        sides: [side(1, "ada"), side(2, "bo")],
+        games: [scoredGame(1, 11, 7), scoredGame(2, 9, 11)],
+      }),
+    );
+
+    expect(lineScoreDataPage.line.forUser("ada").exists).toBe(true);
+    expect(lineScoreDataPage.line.forUser("bo").exists).toBe(true);
+    expect(lineScoreDataPage.line.forUser("ada").game(1).score).toBe(11);
+    expect(lineScoreDataPage.line.forUser("bo").game(1).score).toBe(7);
+    expect(lineScoreDataPage.line.forUser("ada").game(2).score).toBe(9);
+    expect(lineScoreDataPage.line.forUser("bo").game(2).score).toBe(11);
+  });
+
+  it("lays the grid out for the match's best-of", async () => {
+    await show(
+      matchDetails({
+        id: "m-bo7",
+        best_of: 7,
+        sides: [side(1, "ada"), side(2, "bo")],
+        games: [scoredGame(1, 11, 4)],
+      }),
+    );
+
+    expect(lineScoreDataPage.grid.columnLabels).toEqual([
+      "G1",
+      "G2",
+      "G3",
+      "G4",
+      "G5",
+      "G6",
+      "G7",
+    ]);
+  });
+
+  it("orders the sides by side_number regardless of API order", async () => {
+    await show(
+      matchDetails({
+        id: "m-order",
+        // Returned out of order: side 2 first.
+        sides: [side(2, "bo"), side(1, "ada")],
+        games: [scoredGame(1, 11, 3)],
+      }),
+    );
+
+    // Side 1 (ada) maps to side_1_points, side 2 (bo) to side_2_points, even
+    // though the API returned them reversed.
+    expect(lineScoreDataPage.line.forUser("ada").game(1).score).toBe(11);
+    expect(lineScoreDataPage.line.forUser("bo").game(1).score).toBe(3);
+  });
+
+  it("maps side 1 points left, side 2 points right, and drops unscored games", async () => {
+    await show(
+      matchDetails({
+        id: "m-tally",
+        best_of: 5,
+        sides: [side(1, "ada"), side(2, "bo")],
+        games: [scoredGame(1, 5, 11), unscoredGame(2)],
+      }),
+    );
+
+    expect(lineScoreDataPage.line.forUser("ada").game(1).score).toBe(5);
+    expect(lineScoreDataPage.line.forUser("bo").game(1).score).toBe(11);
+    // The unscored game 2 was dropped, so it renders as an empty cell rather
+    // than a scored one.
+    expect(lineScoreDataPage.line.forUser("ada").game(2).exists).toBe(false);
+  });
+
+  it("renders a player-less side as the No opponent placeholder", async () => {
+    await show(
+      matchDetails({
+        id: "m-solo",
+        sides: [side(1, "ada"), side(2, null)],
+        games: [scoredGame(1, 11, 3)],
+      }),
+    );
+
+    expect(lineScoreDataPage.line.forUser("ada").exists).toBe(true);
+    expect(lineScoreDataPage.line.forUser("No opponent").exists).toBe(true);
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data.tsx
@@ -1,0 +1,14 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+import { lineScoreDataQuery } from './line-score-data/line-score-data-query'
+import { LineScoreDataDisplay } from './line-score-data/line-score-data-display'
+
+interface LineScoreDataProps {
+  matchId: string
+}
+
+export const LineScoreData = ({ matchId }: LineScoreDataProps) => {
+  const { data: lineScoreData } = useSuspenseQuery(lineScoreDataQuery(matchId))
+
+  return <LineScoreDataDisplay lineScoreData={lineScoreData} />
+}

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display.factory.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display.factory.ts
@@ -1,0 +1,13 @@
+import type { LineScoreDataDisplayProps } from "./line-score-data-display";
+import { lineSideFactory } from "./line-score-data-display/line.factory";
+
+export const lineScoreDataDisplayFactory = (
+    overrides: Partial<LineScoreDataDisplayProps["lineScoreData"]> = {},
+): LineScoreDataDisplayProps => ({
+    lineScoreData: {
+        bestOf: 5,
+        sides: [lineSideFactory(), lineSideFactory()],
+        games: [],
+        ...overrides,
+    },
+});

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display.page.tsx
@@ -1,0 +1,19 @@
+import { render } from "@testing-library/react";
+import {
+    LineScoreDataDisplay,
+    type LineScoreDataDisplayProps,
+} from "./line-score-data-display";
+import { linePage } from "./line-score-data-display/line.page";
+import { lineScoreGridPage } from "./line-score-data-display/line-score-grid.page";
+
+export const lineScoreDataDisplayPage = {
+    render(props: LineScoreDataDisplayProps) {
+        render(<LineScoreDataDisplay {...props} />);
+    },
+
+    // The display is pure composition — the grid shell wrapping one row per
+    // side — so it reuses the child page objects to confirm each part received
+    // its data.
+    grid: lineScoreGridPage,
+    line: linePage,
+};

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { lineScoreDataDisplayPage } from "./line-score-data-display.page";
+import { lineScoreDataDisplayFactory } from "./line-score-data-display.factory";
+import { lineSideFactory, game } from "./line-score-data-display/line.factory";
+
+describe("LineScoreDataDisplay", () => {
+  const sides = [
+    lineSideFactory({ username: "Ada" }),
+    lineSideFactory({ username: "Bernie" }),
+  ];
+
+  it("renders a row for every side", () => {
+    lineScoreDataDisplayPage.render(lineScoreDataDisplayFactory({ sides }));
+
+    expect(lineScoreDataDisplayPage.line.forUser("Ada").exists).toBe(true);
+    expect(lineScoreDataDisplayPage.line.forUser("Bernie").exists).toBe(true);
+  });
+
+  it("lays the grid out for the match's best-of", () => {
+    lineScoreDataDisplayPage.render(
+      lineScoreDataDisplayFactory({ sides, bestOf: 7 }),
+    );
+
+    expect(lineScoreDataDisplayPage.grid.columnLabels).toEqual([
+      "G1",
+      "G2",
+      "G3",
+      "G4",
+      "G5",
+      "G6",
+      "G7",
+    ]);
+  });
+
+  it("wires each side's per-game points into its row", () => {
+    lineScoreDataDisplayPage.render(
+      lineScoreDataDisplayFactory({ sides, games: [game(11, 7), game(9, 11)] }),
+    );
+
+    expect(lineScoreDataDisplayPage.line.forUser("Ada").game(1).score).toBe(11);
+    expect(lineScoreDataDisplayPage.line.forUser("Bernie").game(1).score).toBe(7);
+    expect(lineScoreDataDisplayPage.line.forUser("Ada").game(2).score).toBe(9);
+    expect(lineScoreDataDisplayPage.line.forUser("Bernie").game(2).score).toBe(11);
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display.tsx
@@ -1,0 +1,18 @@
+import type { LineScoreData } from './line-score-data-query'
+import { Line } from './line-score-data-display/line'
+import { LineScoreGrid } from './line-score-data-display/line-score-grid'
+
+export interface LineScoreDataDisplayProps {
+  lineScoreData: LineScoreData
+}
+
+export const LineScoreDataDisplay = ({ lineScoreData }: LineScoreDataDisplayProps) => {
+  const { bestOf, sides, games } = lineScoreData
+  return (
+    <LineScoreGrid bestOf={bestOf}>
+      {sides.map((side, i) => (
+        <Line key={i} bestOf={bestOf} sides={sides} games={games} side={side} />
+      ))}
+    </LineScoreGrid>
+  )
+}

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line-score-grid.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line-score-grid.page.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { LineScoreGrid } from "./line-score-grid";
+
+export const lineScoreGridPage = {
+    render(props: ComponentProps<typeof LineScoreGrid>) {
+        render(<LineScoreGrid {...props} />);
+    },
+
+    // The grouped grid the rows live in, exposed for assistive tech.
+    get group() {
+        return screen.queryByRole("group", { name: "Game scores" });
+    },
+
+    get hasKicker() {
+        return screen.queryByText("GAMES") !== null;
+    },
+
+    // The per-game column headers in order — "G1", "G2", … when labelled, or
+    // empty strings while the real game count is still unknown.
+    get columnLabels() {
+        return Array.from(document.querySelectorAll(".md-games__col-label")).map(
+            (element) => element.textContent,
+        );
+    },
+};

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line-score-grid.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line-score-grid.test.tsx
@@ -1,0 +1,37 @@
+import { screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { lineScoreGridPage } from "./line-score-grid.page";
+
+describe("LineScoreGrid", () => {
+  it("labels each game column G1…GN for the match's best-of", () => {
+    lineScoreGridPage.render({ bestOf: 5, children: null });
+
+    expect(lineScoreGridPage.columnLabels).toEqual(["G1", "G2", "G3", "G4", "G5"]);
+  });
+
+  it("reserves the columns without labels while the game count is unknown", () => {
+    lineScoreGridPage.render({ bestOf: 3, showGameLabels: false, children: null });
+
+    // The placeholder columns still render so the rows don't reflow into the
+    // header row, but blank — we can't know the labels are right yet.
+    expect(lineScoreGridPage.columnLabels).toEqual(["", "", ""]);
+  });
+
+  it("renders the GAMES kicker", () => {
+    lineScoreGridPage.render({ bestOf: 3, children: null });
+
+    expect(lineScoreGridPage.hasKicker).toBe(true);
+  });
+
+  it("groups the grid for assistive tech", () => {
+    lineScoreGridPage.render({ bestOf: 3, children: null });
+
+    expect(lineScoreGridPage.group).not.toBeNull();
+  });
+
+  it("renders the supplied rows as children", () => {
+    lineScoreGridPage.render({ bestOf: 3, children: <div>row content</div> });
+
+    expect(screen.getByText("row content")).not.toBeNull();
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line-score-grid.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line-score-grid.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react'
+
+// The md-games grid shell: the GAMES kicker + per-game column labels, with the
+// trailing SETS/total column dropped for the line-score layout. Shared by
+// <LineScoreDataDisplay /> and <LineScoreSkeleton /> so both reserve the same
+// columns. Callers supply the rows (<Line /> or <LineSkeleton />) as children.
+//
+// While loading we don't yet know the real game count, so `showGameLabels` is
+// false: the column-label cells still render (filling the first grid row so the
+// player rows don't reflow into it, and keeping its height via the GAMES
+// kicker) but without the "G1/G2/…" text we can't know is correct yet.
+export const LineScoreGrid = ({
+  bestOf,
+  showGameLabels = true,
+  children,
+}: {
+  bestOf: number
+  showGameLabels?: boolean
+  children: ReactNode
+}) => (
+  <div className="md-games">
+    <div
+      className="md-games__grid"
+      role="group"
+      aria-label="Game scores"
+      style={
+        {
+          '--md-games-count': bestOf,
+          gridTemplateColumns: `var(--md-games-kicker, 130px) repeat(${bestOf}, 1fr)`,
+        } as React.CSSProperties
+      }
+    >
+      <div className="md-games__kicker">GAMES</div>
+      {Array.from({ length: bestOf }, (_, i) => (
+        <div key={`h-${i}`} className="md-games__col-label">
+          {showGameLabels ? `G${i + 1}` : ''}
+        </div>
+      ))}
+      {children}
+    </div>
+  </div>
+)

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line-skeleton.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line-skeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+// Loading placeholder for one <Line /> row: an avatar + name in the player
+// column, then one skeleton per game cell. Emits the same grid children as
+// <Line /> so it slots into the md-games grid identically.
+export const LineSkeleton = ({ bestOf }: { bestOf: number }) => (
+  <>
+    <div className="md-games__player">
+      <Skeleton className="md-avatar" />
+      <Skeleton className="h-4 w-24" />
+    </div>
+    {Array.from({ length: bestOf }, (_, i) => (
+      <div key={i} className="md-games__cell">
+        {/* h-[22px] matches the 22px line height of a real score so the cell —
+            and therefore the row — keeps the same height as the loaded state. */}
+        <Skeleton className="h-[22px] w-5" />
+      </div>
+    ))}
+  </>
+)

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line.factory.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line.factory.ts
@@ -1,0 +1,37 @@
+import { faker } from "@faker-js/faker";
+import type { LineProps } from "./line";
+import type { GameScore, HeaderSide } from "../line-score-data-query";
+
+export const lineSideFactory = (overrides: Partial<HeaderSide> = {}): HeaderSide => ({
+    id: faker.string.uuid(),
+    username: faker.person.firstName(),
+    ...overrides,
+});
+
+// A single game with explicit per-side points, for asserting the exact value
+// that lands in each cell.
+export const game = (side0Points: number, side1Points: number): GameScore[] => [
+    { sideNumber: 0, points: side0Points },
+    { sideNumber: 1, points: side1Points },
+];
+
+// A game won by `sideNumber`; the loser's points are noise the scoring logic
+// ignores, so they're randomised to signal "don't care". Use when only the
+// winner / games-won tally matters.
+export const gameWonBy = (sideNumber: number): GameScore[] =>
+    sideNumber === 0
+        ? game(11, faker.number.int({ min: 0, max: 9 }))
+        : game(faker.number.int({ min: 0, max: 9 }), 11);
+
+export const lineFactory = (overrides: Partial<LineProps> = {}): LineProps => {
+    const sides = overrides.sides ?? [lineSideFactory(), lineSideFactory()];
+    return {
+        bestOf: 5,
+        sides,
+        games: [],
+        // Default to rendering the first side's row; callers pass `side` (a
+        // reference to one of `sides`) to render the opposite row.
+        side: sides[0],
+        ...overrides,
+    };
+};

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line.page.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { Line, type LineProps } from "./line";
+import { playerScorePage } from "../../../player-score.page";
+
+// The participant name element for a given player (the avatar + name live in
+// `.md-games__player`; the name is its `.md-games__player-name` span). A row
+// renders exactly one, but the display stacks several, so reads are keyed by
+// username to stay valid once composed.
+const playerNameEl = (username: string) =>
+    Array.from(document.querySelectorAll(".md-games__player-name")).find(
+        (element) => element.textContent === username,
+    ) ?? null;
+
+// One game cell for a player, read through the PlayerScore page object. A played
+// game is a labelled PlayerScore ("<username>, game <n>"); a not-yet-played slot
+// renders an unlabelled em-dash cell, so `exists` is false for it.
+const gameReader = (username: string, gameNumber: number) => {
+    const element = screen.queryByLabelText(`${username}, game ${gameNumber}`);
+    return {
+        get exists() {
+            return element !== null;
+        },
+        get score() {
+            return element === null ? null : playerScorePage.within(element).score;
+        },
+        get won() {
+            return element === null ? false : playerScorePage.within(element).won;
+        },
+    };
+};
+
+// All reads scoped to a single participant's row.
+const userReader = (username: string) => ({
+    // Whether this participant's row rendered at all.
+    get exists() {
+        return playerNameEl(username) !== null;
+    },
+    // True once this side has clinched the match — the winner treatment is
+    // driven by `data-won` on the participant name.
+    get won() {
+        return playerNameEl(username)?.getAttribute("data-won") === "true";
+    },
+    game(gameNumber: number) {
+        return gameReader(username, gameNumber);
+    },
+});
+
+export const linePage = {
+    render(props: LineProps) {
+        render(<Line {...props} />);
+    },
+
+    // Scope reads to one participant, e.g. linePage.forUser("Ada").won,
+    // .game(1).won, .game(1).exists, .game(1).score.
+    forUser(username: string) {
+        return userReader(username);
+    },
+
+    // Cells with no score yet render an em dash placeholder.
+    get emptyCellCount() {
+        return document.querySelectorAll(".md-games__cell--empty").length;
+    },
+
+    // Every cell — played or empty — carries `.md-games__cell`, so this is the
+    // padded-to-best-of column count.
+    get cellCount() {
+        return document.querySelectorAll(".md-games__cell").length;
+    },
+};

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { linePage } from "./line.page";
+import { lineSideFactory, game, gameWonBy, lineFactory } from "./line.factory";
+
+describe("Line", () => {
+  const sides = [
+    lineSideFactory({ username: "Ada" }),
+    lineSideFactory({ username: "Bernie" }),
+  ];
+
+  it("labels the row with its side's participant", () => {
+    linePage.render(lineFactory({ sides, side: sides[0] }));
+
+    expect(linePage.forUser("Ada").exists).toBe(true);
+  });
+
+  it("shows this side's points for each played game", () => {
+    linePage.render(
+      lineFactory({ sides, side: sides[0], games: [game(11, 7), game(9, 11)] }),
+    );
+
+    expect(linePage.forUser("Ada").game(1).score).toBe(11);
+    expect(linePage.forUser("Ada").game(2).score).toBe(9);
+  });
+
+  it("shows the opponent's points when rendering the opponent's row", () => {
+    linePage.render(
+      lineFactory({ sides, side: sides[1], games: [game(11, 7), game(9, 11)] }),
+    );
+
+    expect(linePage.forUser("Bernie").game(1).score).toBe(7);
+    expect(linePage.forUser("Bernie").game(2).score).toBe(11);
+  });
+
+  it("marks the games this side won and leaves the rest unmarked", () => {
+    linePage.render(
+      lineFactory({ sides, side: sides[0], games: [game(11, 7), game(9, 11)] }),
+    );
+
+    expect(linePage.forUser("Ada").game(1).won).toBe(true);
+    expect(linePage.forUser("Ada").game(2).won).toBe(false);
+  });
+
+  it("pads to best-of with empty cells for games not yet played", () => {
+    linePage.render(
+      lineFactory({ sides, side: sides[0], games: [game(11, 7)], bestOf: 5 }),
+    );
+
+    expect(linePage.cellCount).toBe(5);
+    expect(linePage.emptyCellCount).toBe(4);
+    // The not-yet-played slots carry no labelled score cell.
+    expect(linePage.forUser("Ada").game(2).exists).toBe(false);
+  });
+
+  it("flags the side that has clinched the match as the winner", () => {
+    linePage.render(
+      lineFactory({
+        sides,
+        side: sides[0],
+        games: [gameWonBy(0), gameWonBy(0)],
+        bestOf: 3,
+      }),
+    );
+
+    expect(linePage.forUser("Ada").won).toBe(true);
+  });
+
+  it("does not flag a side that has not yet clinched the match", () => {
+    linePage.render(
+      lineFactory({
+        sides,
+        side: sides[0],
+        games: [gameWonBy(0), gameWonBy(1)],
+        bestOf: 5,
+      }),
+    );
+
+    expect(linePage.forUser("Ada").won).toBe(false);
+  });
+
+  it("renders a player-less side as the No opponent placeholder", () => {
+    const ghostSides = [lineSideFactory({ username: "Ada" }), lineSideFactory({ username: "" })];
+    linePage.render(lineFactory({ sides: ghostSides, side: ghostSides[1] }));
+
+    expect(linePage.forUser("No opponent").exists).toBe(true);
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-display/line.tsx
@@ -1,0 +1,56 @@
+import { cn } from '@/lib/utils'
+
+import type { GameScore, HeaderSide } from '../line-score-data-query'
+import { Participant } from '../../../participant'
+import { PlayerScore } from '../../../player-score'
+
+export interface LineProps {
+  bestOf: number
+  sides: HeaderSide[]
+  games: GameScore[][]
+  // The side this row renders.
+  side: HeaderSide
+}
+
+// The side index a game went to is the one with the most points.
+const winnerOf = (game: GameScore[]) =>
+  game.reduce((best, s) => (s.points > best.points ? s : best)).sideNumber
+
+const pointsFor = (game: GameScore[], sideNumber: number) =>
+  game.find((s) => s.sideNumber === sideNumber)?.points ?? 0
+
+export const Line = ({ bestOf, sides, games, side }: LineProps) => {
+  const sideNumber = sides.indexOf(side)
+  // Pad to best_of so every line renders the same number of cells.
+  const slots = Array.from({ length: bestOf }, (_, i) => games[i] ?? null)
+
+  // A side wins the match once it clinches a majority of best_of games.
+  const gamesToWin = Math.floor(bestOf / 2) + 1
+  const gamesWon = games.filter((game) => winnerOf(game) === sideNumber).length
+  const winner = gamesWon >= gamesToWin
+
+  return (
+    <>
+      <Participant size="line" username={side.username} won={winner} />
+      {slots.map((game, i) => {
+        if (!game) {
+          return (
+            <div key={i} className="md-games__cell md-games__cell--empty">
+              —
+            </div>
+          )
+        }
+        const cellWin = winnerOf(game) === sideNumber
+        return (
+          <PlayerScore
+            key={i}
+            className={cn('md-games__cell', !cellWin && 'md-games__cell--loss')}
+            label={`${side.username}, game ${i + 1}`}
+            score={pointsFor(game, sideNumber)}
+            won={cellWin}
+          />
+        )
+      })}
+    </>
+  )
+}

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-query.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-data/line-score-data-query.tsx
@@ -1,0 +1,45 @@
+import type { MatchDetails } from '@/api/matches'
+
+import { matchDetailsQuery } from '../../../match-details-query'
+
+// The line score shares the header's projected side/game shapes — those are the
+// canonical contracts for a match's participants and per-game points.
+export type { GameScore, HeaderSide } from '../../header/header-data/header-data-query'
+import type { GameScore, HeaderSide } from '../../header/header-data/header-data-query'
+
+export type LineScoreData = {
+  bestOf: number
+  sides: HeaderSide[]
+  games: GameScore[][]
+}
+
+function toSides(data: MatchDetails): HeaderSide[] {
+  return [...data.sides]
+    .sort((a, b) => a.side_number - b.side_number)
+    .map((side) => ({
+      id: side.players[0]?.user_id ?? '',
+      username: side.players[0]?.username ?? '',
+    }))
+}
+
+function toGames(data: MatchDetails): GameScore[][] {
+  return data.games.flatMap((game) =>
+    game.score
+      ? [
+          [
+            { sideNumber: 0, points: game.score.side_1_points },
+            { sideNumber: 1, points: game.score.side_2_points },
+          ],
+        ]
+      : [],
+  )
+}
+
+export const lineScoreDataQuery = (matchId: string) => ({
+  ...matchDetailsQuery(matchId),
+  select: (data: MatchDetails): LineScoreData => ({
+    bestOf: data.best_of,
+    sides: toSides(data),
+    games: toGames(data),
+  }),
+})

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-skeleton.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-skeleton.page.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { LineScoreSkeleton } from "./line-score-skeleton";
+
+export const lineScoreSkeletonPage = {
+    render() {
+        render(<LineScoreSkeleton />);
+    },
+
+    // The skeleton reuses the real grid shell, so the grouped grid being present
+    // confirms it reserves the same columns the loaded line score will fill.
+    get hasGridPlaceholder() {
+        return screen.queryByRole("group", { name: "Game scores" }) !== null;
+    },
+
+    get placeholderCount() {
+        return document.querySelectorAll('[data-slot="skeleton"]').length;
+    },
+
+    // One `.md-games__player` per skeleton row, so this is the reserved side
+    // count.
+    get rowCount() {
+        return document.querySelectorAll(".md-games__player").length;
+    },
+
+    get columnLabels() {
+        return Array.from(document.querySelectorAll(".md-games__col-label")).map(
+            (element) => element.textContent,
+        );
+    },
+};

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-skeleton.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-skeleton.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { lineScoreSkeletonPage } from "./line-score-skeleton.page";
+
+describe("LineScoreSkeleton", () => {
+  it("reserves the line-score grid while the data loads", () => {
+    lineScoreSkeletonPage.render();
+
+    expect(lineScoreSkeletonPage.hasGridPlaceholder).toBe(true);
+    expect(lineScoreSkeletonPage.placeholderCount).toBeGreaterThan(0);
+  });
+
+  it("reserves a row for each of the two sides", () => {
+    lineScoreSkeletonPage.render();
+
+    expect(lineScoreSkeletonPage.rowCount).toBe(2);
+  });
+
+  it("hides the game-column labels until the real game count is known", () => {
+    lineScoreSkeletonPage.render();
+
+    expect(lineScoreSkeletonPage.columnLabels.every((label) => label === "")).toBe(
+      true,
+    );
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-skeleton.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/line-score/line-score-skeleton.tsx
@@ -1,0 +1,16 @@
+import { LineScoreGrid } from './line-score-data/line-score-data-display/line-score-grid'
+import { LineSkeleton } from './line-score-data/line-score-data-display/line-skeleton'
+
+// Loading placeholder for <LineScoreData />. Mirrors the `LineScoreDataDisplay`
+// layout — the md-games grid with one row per side — composed from the per-row
+// skeleton beside its component. The real game count is unknown while the data
+// is in flight, so it shows three placeholder columns (and no G1/G2/… labels,
+// which we can't know are correct yet) and the common two-sides shape.
+const SKELETON_GAME_COLUMNS = 3
+
+export const LineScoreSkeleton = () => (
+  <LineScoreGrid bestOf={SKELETON_GAME_COLUMNS} showGameLabels={false}>
+    <LineSkeleton bestOf={SKELETON_GAME_COLUMNS} />
+    <LineSkeleton bestOf={SKELETON_GAME_COLUMNS} />
+  </LineScoreGrid>
+)

--- a/web-client/src/components/matches/match-details/scoreboard/participant.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/participant.tsx
@@ -1,0 +1,109 @@
+import { User } from 'lucide-react'
+import { cva } from 'class-variance-authority'
+
+import { initialsOf } from '@/lib/initials-of'
+
+export const NO_OPPONENT_LABEL = 'No opponent'
+
+// Shared "avatar + name" identity, used by both the hero header (size: 'hero')
+// and the compact line-score row (size: 'line'). A single `state` — derived
+// from the side's win / no-opponent status — drives the winner, loser, and
+// no-opponent treatments so the two surfaces stay in sync. An empty username
+// is treated as the "no opponent" placeholder.
+type Size = 'hero' | 'line'
+type State = 'win' | 'loss' | 'ghost'
+
+const avatarVariants = cva('md-avatar', {
+  variants: {
+    size: {
+      hero: 'md-hero__avatar-singles',
+      line: '',
+    },
+    state: {
+      win: 'md-avatar--win',
+      loss: 'md-avatar--loss',
+      ghost: 'md-avatar--ghost',
+    },
+  },
+})
+
+const nameVariants = cva('', {
+  variants: {
+    size: {
+      hero: 'md-hero__name',
+      line: 'md-games__player-name min-w-0 truncate',
+    },
+    // The winner/ghost colour classes are size-specific, so they're applied as
+    // compound variants below rather than on `state` alone.
+    state: { win: '', loss: '', ghost: '' },
+  },
+  // The winner colour is driven by the `data-won` attribute (see the name
+  // elements below), so only the no-opponent (ghost) treatment lives here.
+  compoundVariants: [
+    { size: 'hero', state: 'ghost', class: 'md-hero__name--ghost' },
+    { size: 'line', state: 'ghost', class: 'md-games__player-name--ghost' },
+  ],
+})
+
+interface ParticipantProps {
+  // Empty string renders the "no opponent" placeholder.
+  username: string
+  won?: boolean
+  size: Size
+  // Hero only: which side, for the mirrored left/right alignment.
+  align?: 'l' | 'r'
+}
+
+export function Participant({
+  username,
+  won = false,
+  size,
+  align = 'l',
+}: ParticipantProps) {
+  const isGhost = username === ''
+  const state: State = isGhost ? 'ghost' : won ? 'win' : 'loss'
+
+  const avatar = (
+    <span
+      className={avatarVariants({ size, state })}
+      aria-hidden={isGhost || undefined}
+    >
+      {isGhost ? (
+        <User size={size === 'hero' ? 26 : 14} strokeWidth={1.75} />
+      ) : (
+        initialsOf(username)
+      )}
+    </span>
+  )
+  const label = isGhost ? NO_OPPONENT_LABEL : username
+
+  if (size === 'hero') {
+    return (
+      <div className={`md-hero__player md-hero__player--${align}`}>
+        <div className="md-hero__player-row">
+          {avatar}
+          <div className={`md-hero__player-text--${align}`}>
+            <div
+              className={nameVariants({ size, state })}
+              data-won={state === 'win' || undefined}
+            >
+              {label}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="md-games__player min-w-0">
+      {avatar}
+      <span
+        className={nameVariants({ size, state })}
+        data-won={state === 'win' || undefined}
+      >
+        {label}
+      </span>
+    </div>
+  )
+}

--- a/web-client/src/components/matches/match-details/scoreboard/player-score.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/player-score.page.tsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import { PlayerScore, type PlayerScoreProps } from "./player-score";
+
+const read = (element: HTMLElement) => ({
+    get score() {
+        return Number.parseInt(element.textContent ?? "", 10);
+    },
+
+    get won() {
+        return element.textContent?.includes(", winner") ?? false;
+    },
+});
+
+export const playerScorePage = {
+    render(props: PlayerScoreProps) {
+        render(<PlayerScore {...props} />);
+    },
+
+    within(element: HTMLElement) {
+        return read(element);
+    },
+
+    get score() {
+        return read(document.body).score;
+    },
+
+    get won() {
+        return read(document.body).won;
+    },
+};

--- a/web-client/src/components/matches/match-details/scoreboard/player-score.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/player-score.test.tsx
@@ -1,0 +1,26 @@
+import { screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { playerScorePage } from "./player-score.page";
+
+describe("PlayerScore", () => {
+  it("renders the score value", () => {
+    playerScorePage.render({ label: "Ada sets", score: 3, won: false });
+    expect(playerScorePage.score).toBe(3);
+  });
+
+  it("indicates when the score is a winning score", () => {
+    playerScorePage.render({ label: "Ada sets", score: 3, won: true });
+    expect(playerScorePage.won).toBe(true);
+  });
+
+  it("does not indicate when the score is not a winning score", () => {
+    playerScorePage.render({ label: "Ada sets", score: 2, won: false });
+    expect(playerScorePage.won).toBe(false);
+  });
+
+  it("applies the provided label", () => {
+    playerScorePage.render({ label: "Ada, game 1", score: 1, won: false });
+    const page = playerScorePage.within(screen.getByLabelText("Ada, game 1"));
+    expect(page.score).toBe(1);
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/player-score.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/player-score.tsx
@@ -1,0 +1,18 @@
+export interface PlayerScoreProps {
+  label: string
+  score: number
+  won: boolean
+  className?: string
+}
+
+export const PlayerScore = ({
+  label,
+  score,
+  won,
+  className,
+}: PlayerScoreProps) => (
+  <div className={className} aria-label={label} data-won={won || undefined}>
+    {score}
+    {won && <span className="sr-only">, winner</span>}
+  </div>
+)

--- a/web-client/src/components/matches/match-status-badge-skeleton.tsx
+++ b/web-client/src/components/matches/match-status-badge-skeleton.tsx
@@ -1,0 +1,9 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+// Loading placeholder for <MatchStatusBadge />: a pill the size of a status
+// chip. Matches the real `Badge` height (h-5) and approximate width so the meta
+// strip reserves the same space — a taller or wider placeholder shifts the row
+// below (and, on narrow viewports, wraps the strip onto a second line).
+export function MatchStatusBadgeSkeleton() {
+  return <Skeleton className="h-5 w-16 rounded-full" />
+}

--- a/web-client/src/components/matches/match-status-badge.tsx
+++ b/web-client/src/components/matches/match-status-badge.tsx
@@ -17,7 +17,7 @@ const BADGES: {
   live: ({ gameNumber }) => <LiveMatchBadge gameNumber={gameNumber} />,
   'awaiting-confirmation': () => <AwaitingConfirmationBadge />,
   final: () => <FinalMatchBadge />,
-  upcoming: ({ label }) => <UpcomingMatchBadge label={label} />,
+  upcoming: () => <UpcomingMatchBadge />,
 }
 
 export function MatchStatusBadge({ status }: { status: StatusView }) {

--- a/web-client/src/components/matches/match-status-badge.tsx
+++ b/web-client/src/components/matches/match-status-badge.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react'
+
+import { AwaitingConfirmationBadge } from './match-status-badge/awaiting-confirmation-badge'
+import { FinalMatchBadge } from './match-status-badge/final-match-badge'
+import { LiveMatchBadge } from './match-status-badge/live-match-badge'
+import { UpcomingMatchBadge } from './match-status-badge/upcoming-match-badge'
+
+export type StatusView =
+  | { kind: 'live'; gameNumber: number }
+  | { kind: 'awaiting-confirmation' }
+  | { kind: 'final' }
+  | { kind: 'upcoming'; label: string }
+
+const BADGES: {
+  [K in StatusView['kind']]: (status: Extract<StatusView, { kind: K }>) => ReactNode
+} = {
+  live: ({ gameNumber }) => <LiveMatchBadge gameNumber={gameNumber} />,
+  'awaiting-confirmation': () => <AwaitingConfirmationBadge />,
+  final: () => <FinalMatchBadge />,
+  upcoming: ({ label }) => <UpcomingMatchBadge label={label} />,
+}
+
+export function MatchStatusBadge({ status }: { status: StatusView }) {
+  const badge = BADGES[status.kind] as (status: StatusView) => ReactNode
+  return badge(status)
+}

--- a/web-client/src/components/matches/match-status-badge/awaiting-confirmation-badge.tsx
+++ b/web-client/src/components/matches/match-status-badge/awaiting-confirmation-badge.tsx
@@ -1,0 +1,10 @@
+import { Badge } from '@/components/ui/badge'
+
+export function AwaitingConfirmationBadge() {
+  return (
+    <Badge variant="secondary">
+      <span className="size-2.5 rounded-full bg-current" aria-hidden />
+      Awaiting confirmation
+    </Badge>
+  )
+}

--- a/web-client/src/components/matches/match-status-badge/final-match-badge.tsx
+++ b/web-client/src/components/matches/match-status-badge/final-match-badge.tsx
@@ -1,0 +1,13 @@
+import { Badge } from '@/components/ui/badge'
+
+export function FinalMatchBadge() {
+  return (
+    <Badge
+      variant="outline"
+      className="border-[color:var(--ball-500)] bg-[rgba(255,122,26,0.1)] text-[color:var(--ball-500)]"
+    >
+      <span className="size-2.5 rounded-full bg-current" aria-hidden />
+      Final
+    </Badge>
+  )
+}

--- a/web-client/src/components/matches/match-status-badge/live-match-badge.tsx
+++ b/web-client/src/components/matches/match-status-badge/live-match-badge.tsx
@@ -1,0 +1,13 @@
+import { Badge } from '@/components/ui/badge'
+
+export function LiveMatchBadge({ gameNumber }: { gameNumber: number }) {
+  return (
+    <Badge
+      variant="outline"
+      className="border-[color:var(--serve-500)] bg-[color:var(--bg-live-soft)] text-[color:var(--serve-500)]"
+    >
+      <span className="ball-dot ball-dot--live" aria-hidden />
+      Live · Game {gameNumber}
+    </Badge>
+  )
+}

--- a/web-client/src/components/matches/match-status-badge/upcoming-match-badge.tsx
+++ b/web-client/src/components/matches/match-status-badge/upcoming-match-badge.tsx
@@ -1,0 +1,13 @@
+import { Badge } from '@/components/ui/badge'
+
+export function UpcomingMatchBadge() {
+  return (
+    <Badge
+      variant="outline"
+      className="border-[color:var(--warn)] bg-[rgba(255,196,61,0.1)] text-[color:var(--warn)]"
+    >
+      <span className="size-2.5 rounded-full bg-current" aria-hidden />
+      Upcoming
+    </Badge>
+  )
+}

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -17,7 +17,8 @@ import {
   type MatchResultsGameWrite,
 } from '@/api/matches'
 import { AppShell } from '@/components/app-shell'
-import { cn, initialsOf } from '@/lib/utils'
+import { cn } from '@/lib/utils'
+import { initialsOf } from '@/lib/initials-of'
 import { decidedSide, illegalScoreReason } from '@/lib/scoring'
 
 // Placeholder for the opponent label on solo matches — mirrors the match

--- a/web-client/src/components/ui/user-avatar.tsx
+++ b/web-client/src/components/ui/user-avatar.tsx
@@ -1,7 +1,8 @@
 import type { CSSProperties } from 'react'
 import { User as UserIcon } from 'lucide-react'
 
-import { cn, initialsOf } from '@/lib/utils'
+import { cn } from '@/lib/utils'
+import { initialsOf } from '@/lib/initials-of'
 
 function hueFor(name: string): number {
   let hue = 0

--- a/web-client/src/lib/initials-of.test.ts
+++ b/web-client/src/lib/initials-of.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import { initialsOf } from './initials-of'
+
+describe('initialsOf', () => {
+  describe('two-or-more parts → first letter of the first two', () => {
+    it.each([
+      ['space-separated name', 'John Smith', 'JS'],
+      ['dotted username', 'rita.kovac', 'RK'],
+      ['underscore separator', 'john_smith', 'JS'],
+      ['hyphen separator', 'mary-jane', 'MJ'],
+      ['ignores all parts after the second', 'jean.luc.picard', 'JL'],
+      ['four parts still only uses two', 'a.b.c.d', 'AB'],
+      ['second part starting with a digit', 'agent 007', 'A0'],
+      ['tabs and newlines count as whitespace', 'john\tsmith', 'JS'],
+    ])('%s: %j → %j', (_label, input, expected) => {
+      expect(initialsOf(input)).toBe(expected)
+    })
+  })
+
+  describe('single part → first two characters', () => {
+    it.each([
+      ['multi-letter single name', 'alice', 'AL'],
+      ['one-character name', 'a', 'A'],
+      ['name with trailing digits', 'bob123', 'BO'],
+    ])('%s: %j → %j', (_label, input, expected) => {
+      expect(initialsOf(input)).toBe(expected)
+    })
+  })
+
+  describe('uppercases the result', () => {
+    it('upcases lowercase ASCII', () => {
+      expect(initialsOf('li wei')).toBe('LW')
+      expect(initialsOf('alice')).toBe('AL')
+    })
+
+    it('leaves already-uppercase input uppercase', () => {
+      expect(initialsOf('Foo Bar')).toBe('FB')
+    })
+
+    it('upcases non-ASCII letters', () => {
+      expect(initialsOf('élodie dubois')).toBe('ÉD')
+    })
+  })
+
+  describe('collapses runs of separators and trims edges', () => {
+    it.each([
+      ['repeated dots', 'john..smith', 'JS'],
+      ['mixed adjacent separators', 'john -  smith', 'JS'],
+      ['leading separator', '.alice', 'AL'],
+      ['trailing separator', 'alice.', 'AL'],
+      ['surrounding whitespace', '  bob  ', 'BO'],
+    ])('%s: %j → %j', (_label, input, expected) => {
+      expect(initialsOf(input)).toBe(expected)
+    })
+  })
+
+  describe('zero parts → first two characters of the raw input', () => {
+    it('returns empty string for empty input', () => {
+      // user-avatar.tsx relies on '' for empty input.
+      expect(initialsOf('')).toBe('')
+    })
+
+    it('returns the first two raw chars when the input is only separators', () => {
+      expect(initialsOf('...')).toBe('..')
+    })
+
+    it('whitespace-only input yields its first two (space) chars', () => {
+      expect(initialsOf('   ')).toBe('  ')
+    })
+  })
+
+  describe('characters outside the separator set are not split on', () => {
+    it('passes a lone ellipsis through unchanged', () => {
+      // '…' (U+2026) is not in the [.\s_-] split set, so it is treated as a
+      // single one-character part. user-avatar.tsx depends on this passthrough.
+      expect(initialsOf('…')).toBe('…')
+    })
+  })
+})

--- a/web-client/src/lib/initials-of.ts
+++ b/web-client/src/lib/initials-of.ts
@@ -1,0 +1,9 @@
+/** Two-letter monogram for an avatar bubble: first letter of each of the
+ * first two name parts, or the first two characters when there's only one
+ * part. Splits on whitespace and common username separators. */
+export function initialsOf(name: string): string {
+  const parts = name.split(/[.\s_-]+/).filter(Boolean)
+  if (parts.length === 0) return name.slice(0, 2).toUpperCase()
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[1][0]).toUpperCase()
+}

--- a/web-client/src/lib/utils.ts
+++ b/web-client/src/lib/utils.ts
@@ -4,13 +4,3 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
-
-/** Two-letter monogram for an avatar bubble: first letter of each of the
- * first two name parts, or the first two characters when there's only one
- * part. Splits on whitespace and common username separators. */
-export function initialsOf(name: string): string {
-  const parts = name.split(/[.\s_-]+/).filter(Boolean)
-  if (parts.length === 0) return name.slice(0, 2).toUpperCase()
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
-  return (parts[0][0] + parts[1][0]).toUpperCase()
-}

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -562,6 +562,19 @@ export function buildInitialSeeds(): SeedMatch[] {
       signatures: [],
     },
     {
+      // No opponent yet: a player-less sentinel side, exercising the
+      // "No opponent" placeholder in the scoreboard header and line score.
+      id: 'm-open-1',
+      status: 'pending',
+      best_of: 5,
+      affects_rating: true,
+      created_at: '2026-05-14T17:00:00Z',
+      completed_at: null,
+      opponent: null,
+      games: [],
+      signatures: [],
+    },
+    {
       id: 'm-2207',
       status: 'in_progress',
       best_of: 5,


### PR DESCRIPTION
## What

Extracts the **scoreboard** work from the larger `match-page-cleanup` WIP branch into a shippable change, and wires it into the match details page.

- Adds the self-contained `<Scoreboard matchId>` component tree under `match-details/scoreboard/` (header + line-score, with colocated `.page.tsx` harnesses, factories, and unit tests), plus the supporting `match-status-badge` tree, `match-details-query`, and `lib/initials-of`.
- Replaces the inline `HeroScoreboard` (and its `PlayerSide` / `NoOpponentSide` / `GameGrid` / `GameGridSide` helpers) in `match-details-page.tsx` with the new component.

## Notes

- The new `<Scoreboard>` self-fetches via `match-details-query`, so the page just passes `matchId`.
- `initialsOf` moved out of `@/lib/utils` into `@/lib/initials-of`; the page import was repointed accordingly.
- Fixed a latent type bug in `MatchStatusBadge` (it passed a `label` prop the prop-less `UpcomingMatchBadge` doesn't accept).
- Dropped two `match-details-page.test.tsx` cases that asserted on the now-removed inline scoreboard DOM — that behavior is now covered by the scoreboard tree's own tests.

## Verification

- ✅ `npm run build` (tsc + vite)
- ✅ `npm run lint`
- ✅ `npm run test:run` — 213 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)