### PR TITLE
Fix scoreboard "VS" vs score layout for live matches (#394)

### DIFF
--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display.tsx
@@ -17,6 +17,6 @@ export interface MatchHeaderDataDisplayProps {
 export const MatchHeaderDataDisplay = ({ matchHeaderData }: MatchHeaderDataDisplayProps) => {
     return <div>
         <Meta status={matchHeaderData.status} bestOf={matchHeaderData.bestOf} />
-        <MatchScore sides={matchHeaderData.sides} games={matchHeaderData.games} bestOf={matchHeaderData.bestOf} />
+        <MatchScore status={matchHeaderData.status} sides={matchHeaderData.sides} games={matchHeaderData.games} bestOf={matchHeaderData.bestOf} />
     </div>
 }

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.factory.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.factory.ts
@@ -17,6 +17,10 @@ export const gameWonBy = (sideNumber: number): GameScore[] => [
 ];
 
 export const matchScoreFactory = (overrides: Partial<MatchScoreProps> = {}): MatchScoreProps => ({
+    // A played (final) match is the common "show a score" case; override `status`
+    // with `{ kind: "upcoming", ... }` for the VS layout or `{ kind: "live", ... }`
+    // for an in-progress match.
+    status: { kind: "final" },
     sides: [headerSideFactory(), headerSideFactory()],
     games: [],
     bestOf: 5,

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.test.tsx
@@ -9,10 +9,11 @@ describe("MatchScore", () => {
   ];
 
   // The played / upcoming branches are covered by their own suites; here we just
-  // confirm MatchScore renders the played-match score for a started match.
-  it("renders the played-match score", () => {
+  // confirm MatchScore picks the layout from the resolved status.
+  it("renders the played-match score for a final match", () => {
     matchScorePage.render(
       matchScoreFactory({
+        status: { kind: "final" },
         sides,
         games: [gameWonBy(0), gameWonBy(1), gameWonBy(0)],
       }),
@@ -23,17 +24,40 @@ describe("MatchScore", () => {
     expect(matchScorePage.hasVersusLabel()).toBe(false);
   });
 
-  it("renders the upcoming-match score when no games have been played", () => {
-    matchScorePage.render(matchScoreFactory({ sides, games: [] }));
+  it("renders the upcoming (VS) layout for a pending match", () => {
+    matchScorePage.render(
+      matchScoreFactory({
+        status: { kind: "upcoming", label: "Upcoming" },
+        sides,
+        games: [],
+      }),
+    );
 
     expect(matchScorePage.hasVersusLabel()).toBe(true);
     expect(matchScorePage.hasPlayer("Ada")).toBe(true);
     expect(matchScorePage.hasPlayer("Bernie")).toBe(true);
   });
 
+  // Regression (#394): a live match between start and its first completed game
+  // has no scored games yet, but its badge reads "Live · Game N". The score block
+  // must agree — show 0 – 0, not the upcoming "VS" layout.
+  it("renders 0 – 0 (not VS) for a live match with no completed game", () => {
+    matchScorePage.render(
+      matchScoreFactory({
+        status: { kind: "live", gameNumber: 1 },
+        sides,
+        games: [],
+      }),
+    );
+
+    expect(matchScorePage.hasVersusLabel()).toBe(false);
+    expect(matchScorePage.forPlayer("Ada").score).toBe(0);
+    expect(matchScorePage.forPlayer("Bernie").score).toBe(0);
+  });
+
   it("places the first side on the left and the second on the right", () => {
     matchScorePage.render(
-      matchScoreFactory({ sides, games: [gameWonBy(0)] }),
+      matchScoreFactory({ status: { kind: "final" }, sides, games: [gameWonBy(0)] }),
     );
 
     expect(matchScorePage.playerOrder).toEqual(["Ada", "Bernie"]);

--- a/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/header/header-data/header-data-display/match-score.tsx
@@ -1,16 +1,21 @@
+import type { StatusView } from '@/components/matches/match-status-badge'
 import type { GameScore, HeaderSide } from '../header-data-query'
 import { UpcomingMatchScore } from './upcoming-match-score'
 import { PlayedMatchScore } from './played-match-score'
 
 export interface MatchScoreProps {
+  status: StatusView
   sides: HeaderSide[]
   games: GameScore[][]
   bestOf: number
 }
 
-export const MatchScore = ({ sides, games, bestOf }: MatchScoreProps) => {
-  // A match with no games played yet is upcoming: show "VS" rather than a score.
-  const isUpcoming = games.length === 0
+export const MatchScore = ({ status, sides, games, bestOf }: MatchScoreProps) => {
+  // Only a not-yet-started (pending) match is upcoming: show "VS" rather than a
+  // score. A live match with no completed game yet still shows a score (0 – 0),
+  // matching its "Live · Game N" badge. Branching on games.length would wrongly
+  // render "VS" for the normal pre-first-game state of every live match.
+  const isUpcoming = status.kind === 'upcoming'
 
   return isUpcoming ? (
     <UpcomingMatchScore sides={sides} />


### PR DESCRIPTION
Fixes #394.

## Problem
`MatchScore` chose the upcoming **"VS"** layout vs. the played-score layout from `games.length === 0`. But `games` only holds *completed* games (the header projection's `toGames` drops unscored ones), so a live match playing its first game — `in_progress`, `current_game` set, no completed game yet — rendered "VS" even though `toStatusView` resolved the badge to **"Live · Game 1"**. The score block and the status badge disagreed, and this is the normal state of every match between start and the first finished game.

## Fix
Branch on the already-resolved status (`status.kind === 'upcoming'`) instead of `games.length`:
- a **pending** (not-yet-started) match still shows "VS";
- a **live** match with no completed game shows **0 – 0** (which `PlayedMatchScore` already produces from an empty `games` array), consistent with the badge.

## Changes
- `match-score.tsx` — thread `status: StatusView` into props; branch on it.
- `header-data-display.tsx` — pass `status` through.
- `match-score.factory.ts` — add a `status` default.
- `match-score.test.tsx` — status-driven cases + a regression test asserting `0 – 0` (not "VS") for a live match with no completed game.

## Testing
- Scoreboard header suite: 33/33 passing (incl. the new regression test).
- Lint clean on the changed subtree.

> Note: based on `match-page-cleanup` because the fix sits on top of the scoreboard component tree (`aedd0a9`), which lives on that branch rather than `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)