### PR TITLE
Add iOS landing page

### DIFF
--- a/ios/Fortymm/Components/FMLogo.swift
+++ b/ios/Fortymm/Components/FMLogo.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+/// The FortyMM wordmark: a glossy ball-orange disc followed by the
+/// condensed-display "FORTYMM" wordmark with an accent period.
+struct FMLogo: View {
+    var size: CGFloat = 26
+
+    var body: some View {
+        HStack(spacing: size * 0.36) {
+            Circle()
+                .fill(
+                    RadialGradient(
+                        colors: [Color(hex: 0xFFB57A), FMColor.ball500, FMColor.ball700],
+                        center: UnitPoint(x: 0.35, y: 0.35),
+                        startRadius: 0,
+                        endRadius: size * 0.9
+                    )
+                )
+                .frame(width: size, height: size)
+                .overlay(alignment: .topLeading) {
+                    Ellipse()
+                        .fill(Color.white.opacity(0.22))
+                        .frame(width: size * 0.4, height: size * 0.24)
+                        .offset(x: size * 0.18, y: size * 0.18)
+                }
+
+            HStack(spacing: 0) {
+                Text("FORTYMM")
+                    .foregroundStyle(FMColor.fg1)
+                Text(".")
+                    .foregroundStyle(FMColor.ball500)
+            }
+            .font(FMFont.display(size * 0.95))
+            .tracking(1.5)
+        }
+    }
+}
+
+/// Small uppercase section label with a leading ball-orange dot —
+/// the recurring "eyebrow" used above every landing section heading.
+struct FMEyebrow: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: FMSpace.s2) {
+            Circle()
+                .fill(FMColor.ball500)
+                .frame(width: 6, height: 6)
+            Text(text.uppercased())
+                .font(FMFont.mono(FMFont.xs, weight: .medium))
+                .tracking(1.5)
+                .foregroundStyle(FMColor.fg3)
+        }
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: 24) {
+        FMLogo(size: 26)
+        FMLogo(size: 40)
+        FMEyebrow(text: "No ads · No tracking · No subscriptions")
+    }
+    .padding()
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(FMColor.bgApp)
+    .preferredColorScheme(.dark)
+}

--- a/ios/Fortymm/FortymmApp.swift
+++ b/ios/Fortymm/FortymmApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct FortymmApp: App {
     var body: some Scene {
         WindowGroup {
-            DesignSystemView()
+            LandingView()
                 .preferredColorScheme(.dark)
         }
     }

--- a/ios/Fortymm/Landing/LandingSections.swift
+++ b/ios/Fortymm/Landing/LandingSections.swift
@@ -1,0 +1,465 @@
+import Combine
+import SwiftUI
+
+// MARK: - Features
+
+struct LandingFeatures: View {
+    @State private var tab = 0
+
+    private struct Panel {
+        let heading: String
+        let body: String
+        let bullets: [String]
+    }
+
+    private let tabs = ["Track matches", "See ratings", "Run tournaments", "Spectate"]
+
+    private let panels: [Panel] = [
+        Panel(heading: "Scores in, history out.",
+              body: "Tap the score after every rally. Games end themselves — the app watches for deuce, win-by-2, change-of-ends. Save the match and it's on your profile, in your club feed, and in your head-to-head record.",
+              bullets: ["Score with one finger on the bench",
+                        "Auto-detect deuce & game point",
+                        "Head-to-head and rating delta on save"]),
+        Panel(heading: "A rating you can trust.",
+              body: "Glicko-2 under the hood. Every match moves your number. Every number has a confidence range. Nothing is gamed, nothing is pay-to-win — because there's nothing to pay for.",
+              bullets: ["Provisional → stable as you play",
+                        "Separate singles and doubles ratings",
+                        "Club-level and global leaderboards"]),
+        Panel(heading: "The schedule, solved.",
+              body: "Our scheduler treats your constraints as rules: how many courts, how long the lunch break, who can't play back-to-back. It returns a schedule that respects every one.",
+              bullets: ["Round-robin, single-elim, double-elim, Swiss",
+                        "Live scoring from the scorers' table",
+                        "Public bracket link for spectators"]),
+        Panel(heading: "Broadcast, without a broadcaster.",
+              body: "Every tournament has a public spectator URL. Big type. Live scores. Upcoming matches on the right. Share it with anyone — works without an account, without an app.",
+              bullets: ["Full-screen court view",
+                        "Per-player follow links",
+                        "Embed on your club's website"]),
+    ]
+
+    private let bullets: [(n: String, t: String, d: String)] = [
+        ("01", "Match log", "Tap in scores. Games auto-advance. Rating delta shows up the moment you save."),
+        ("02", "Clubs & ladders", "Every club gets a feed, a ladder, and a challenge board. Set it up in a minute."),
+        ("03", "Smart schedules", "Constraints in, schedule out — fewer back-to-backs, smarter court assignments."),
+        ("04", "Ephemeral accounts", "You get an account when you start playing. Upgrade it by adding an email — whenever."),
+        ("05", "Live spectator view", "Share a link. Parents, friends, your grandma — they all get the live bracket."),
+        ("06", "Export your data", "One JSON download. Full match history. It's yours. Delete your account and take it with you."),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: FMSpace.s6) {
+            LandingSectionHeading(eyebrow: "The product",
+                                  line1: "Everything a club needs.",
+                                  line2: "Nothing anyone would sell you.")
+
+            FMTabs(items: tabs, selection: $tab)
+
+            let panel = panels[tab]
+            FMCard {
+                VStack(alignment: .leading, spacing: FMSpace.s3) {
+                    Text(panel.heading)
+                        .font(FMFont.ui(FMFont.lg, weight: .semibold))
+                        .foregroundStyle(FMColor.fg1)
+                    Text(panel.body)
+                        .font(FMFont.ui(FMFont.sm))
+                        .foregroundStyle(FMColor.fg3)
+                        .lineSpacing(2)
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(panel.bullets, id: \.self) { b in
+                            HStack(alignment: .top, spacing: 8) {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 11, weight: .bold))
+                                    .foregroundStyle(FMColor.serve500)
+                                    .padding(.top, 2)
+                                Text(b)
+                                    .font(FMFont.ui(FMFont.sm))
+                                    .foregroundStyle(FMColor.fg2)
+                            }
+                        }
+                    }
+                    .padding(.top, 2)
+                }
+            }
+
+            VStack(spacing: FMSpace.s3) {
+                ForEach(bullets, id: \.n) { b in
+                    FMCard {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(b.n)
+                                .font(FMFont.mono(FMFont.xs))
+                                .foregroundStyle(FMColor.fgAccent)
+                            Text(b.t)
+                                .font(FMFont.ui(FMFont.md, weight: .semibold))
+                                .foregroundStyle(FMColor.fg1)
+                            Text(b.d)
+                                .font(FMFont.ui(FMFont.sm))
+                                .foregroundStyle(FMColor.fg3)
+                                .lineSpacing(2)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, FMSpace.s5)
+    }
+}
+
+// MARK: - Tournaments
+
+struct LandingTournaments: View {
+    private let steps: [(k: String, t: String)] = [
+        ("01", "Import a player list — CSV, paste, or scan."),
+        ("02", "Set constraints — courts, breaks, start times."),
+        ("03", "Generate — and share the bracket link."),
+        ("04", "Score live from the scorers' table."),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: FMSpace.s6) {
+            LandingSectionHeading(eyebrow: "For tournament directors",
+                                  line1: "The math is quiet.",
+                                  line2: "The rallies are loud.",
+                                  line2Color: FMColor.ball500)
+
+            Text("Running a tournament is a scheduling nightmare. Byes, constraints, courts, breaks, the player who drove four hours and can't go back-to-back. FortyMM's scheduler treats your constraints as rules and gives you a schedule that respects every one.")
+                .font(FMFont.ui(FMFont.md))
+                .foregroundStyle(FMColor.fg3)
+                .lineSpacing(3)
+
+            VStack(spacing: FMSpace.s3) {
+                ForEach(steps, id: \.k) { s in
+                    HStack(spacing: FMSpace.s3) {
+                        Text(s.k)
+                            .font(FMFont.mono(FMFont.sm, weight: .semibold))
+                            .foregroundStyle(FMColor.fgAccent)
+                        Text(s.t)
+                            .font(FMFont.ui(FMFont.sm))
+                            .foregroundStyle(FMColor.fg2)
+                        Spacer()
+                    }
+                }
+            }
+
+            LandingSolverCard()
+
+            VStack(spacing: FMSpace.s3) {
+                FMButton(title: "Start a tournament", variant: .primary, size: .lg)
+                    .frame(maxWidth: .infinity)
+                FMButton(title: "See a sample schedule", variant: .ghost, size: .lg)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(.horizontal, FMSpace.s5)
+    }
+}
+
+private struct LandingSolverCard: View {
+    @State private var line = 0
+    private let timer = Timer.publish(every: 1.2, on: .main, in: .common).autoconnect()
+
+    private let lines: [(t: String, txt: String)] = [
+        ("constraint", "32 players · 4 courts · 3 hr block"),
+        ("constraint", "no back-to-back within 20 min"),
+        ("constraint", "seeds 1–4 on court 1 in R16"),
+        ("constraint", "lunch break 12:30–13:15"),
+        ("solve", "schedule found in 287 ms"),
+    ]
+
+    var body: some View {
+        FMCard {
+            VStack(alignment: .leading, spacing: FMSpace.s3) {
+                HStack {
+                    Text("scheduler.fortymm")
+                        .font(FMFont.mono(FMFont.xs))
+                        .foregroundStyle(FMColor.fgMuted)
+                    Spacer()
+                    HStack(spacing: 4) {
+                        ForEach(0..<3) { _ in
+                            Circle().fill(FMColor.borderDefault).frame(width: 6, height: 6)
+                        }
+                    }
+                }
+                Rectangle().fill(FMColor.borderSubtle).frame(height: 1)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(0..<min(line + 1, lines.count), id: \.self) { i in
+                        let l = lines[i]
+                        HStack(spacing: 8) {
+                            Text(l.t == "solve" ? "✓" : "›")
+                                .foregroundStyle(l.t == "solve" ? FMColor.serve500 : FMColor.fgAccent)
+                            Text(l.t.uppercased())
+                                .foregroundStyle(FMColor.fgMuted)
+                                .frame(width: 78, alignment: .leading)
+                            Text(l.txt)
+                                .foregroundStyle(FMColor.fg2)
+                        }
+                        .font(FMFont.mono(FMFont.xs))
+                    }
+                }
+
+                if line >= lines.count {
+                    solverGrid
+                }
+            }
+        }
+        .onReceive(timer) { _ in
+            line = (line + 1) % (lines.count + 2)
+        }
+    }
+
+    private var solverGrid: some View {
+        VStack(spacing: 4) {
+            ForEach(0..<4, id: \.self) { r in
+                HStack(spacing: 4) {
+                    Text("CT\(r + 1)")
+                        .font(FMFont.mono(9))
+                        .foregroundStyle(FMColor.fgMuted)
+                        .frame(width: 28, alignment: .leading)
+                    ForEach(0..<8, id: \.self) { c in
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(cellColor(r, c))
+                            .frame(height: 14)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+        }
+        .padding(.top, 4)
+    }
+
+    private func cellColor(_ r: Int, _ c: Int) -> Color {
+        if (r + c) % 3 == 0 { return FMColor.ball500 }
+        if (r + c) % 5 == 0 { return FMColor.serve500 }
+        return FMColor.ink700
+    }
+}
+
+// MARK: - Manifesto
+
+struct LandingManifesto: View {
+    private let promises: [(n: String, t: String, d: String)] = [
+        ("01", "No ads. Not now, not ever.", "Every other sports-tracker ends up plastered in sportsbook banners. Ours won't. That's a commitment, not a roadmap item."),
+        ("02", "No premium tier.", "Every feature works for everyone. No unlocks. No trials. No \"upgrade to see the full bracket\" garbage."),
+        ("03", "We don't sell your data.", "No trackers. No third-party analytics. No cookie-consent theater. We keep what the app needs. Nothing else."),
+        ("04", "Accounts are optional.", "You get one the moment you open the app. Your matches are tracked immediately. Add an email when — or if — you want to keep them forever."),
+        ("05", "Your data is yours.", "One-click export. One-click anonymize. Your name, photo, and email vanish from every record, instantly."),
+        ("06", "Open-source, GPLv3.", "Read the code. Self-host if you want. If we ever do something shady, fork us."),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: FMSpace.s6) {
+            LandingSectionHeading(eyebrow: "Manifesto",
+                                  line1: "Six promises.",
+                                  line2: "Zero asterisks.",
+                                  line2Color: FMColor.ball500)
+
+            Text("Most sports-tracker apps start free, then put the good stuff behind a paywall, then start selling your data, then go out of business. We're doing none of those things. Here's the commitment in writing.")
+                .font(FMFont.ui(FMFont.sm))
+                .foregroundStyle(FMColor.fg3)
+                .lineSpacing(2)
+
+            VStack(spacing: FMSpace.s3) {
+                ForEach(promises, id: \.n) { p in
+                    FMCard {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(p.n)
+                                .font(FMFont.mono(FMFont.xs))
+                                .foregroundStyle(FMColor.fgAccent)
+                            Text(p.t)
+                                .font(FMFont.ui(FMFont.md, weight: .semibold))
+                                .foregroundStyle(FMColor.fg1)
+                            Text(p.d)
+                                .font(FMFont.ui(FMFont.sm))
+                                .foregroundStyle(FMColor.fg3)
+                                .lineSpacing(2)
+                        }
+                    }
+                }
+            }
+
+            founder
+        }
+        .padding(.horizontal, FMSpace.s5)
+    }
+
+    private var founder: some View {
+        FMCard(featured: true) {
+            VStack(alignment: .leading, spacing: FMSpace.s3) {
+                FMEyebrow(text: "Made by players")
+                Text("“I run a small club in the back of a community center. Every Tuesday it's 24 people and one chalkboard. I got tired of apps that wanted my email, my credit card, and my grandmother's maiden name just to log a best-of-five. So I built this with a few friends. It's free because that's the whole point.”")
+                    .font(FMFont.ui(FMFont.md))
+                    .foregroundStyle(FMColor.fg2)
+                    .lineSpacing(3)
+                HStack(spacing: FMSpace.s3) {
+                    FMAvatar(initials: "TN", size: 40, color: FMColor.ball500, foreground: FMColor.fgInverse)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("T. Nguyen")
+                            .font(FMFont.ui(FMFont.sm, weight: .semibold))
+                            .foregroundStyle(FMColor.fg1)
+                        Text("Founder · Rated 2145 · Will beat you at short pips")
+                            .font(FMFont.ui(FMFont.xs))
+                            .foregroundStyle(FMColor.fgMuted)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - FAQ
+
+struct LandingFAQ: View {
+    @State private var open = 0
+
+    private let qs: [(q: String, a: String)] = [
+        ("Is it really free?", "Yes. Free forever, no credit card, no \"try it free\" gotcha. We're players. Running the servers costs about the price of a nice paddle per month. We're fine."),
+        ("Do I need an account?", "No. The first time you open the app we quietly give you an ephemeral account — your matches and ratings start tracking immediately. Add an email any time to upgrade it to a real account."),
+        ("How does the rating work?", "Glicko-2 — a modern rating system that tracks both your skill and the uncertainty around it. Play more, uncertainty drops. Beat a higher-rated player, you gain more."),
+        ("Can I run a tournament?", "Yes — that's half the product. Round-robin, single-elim, double-elim, Swiss, custom. Our scheduler respects your constraints. Free for any club, any size, any country."),
+        ("How do you make money?", "We don't. The project is funded out-of-pocket and accepts small donations from clubs that want to. No investors, no runway, no growth team."),
+        ("Can I self-host it?", "Yes. The whole stack is open source. Docker compose, one command, on a $5 VPS. The data is portable and the code is yours."),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: FMSpace.s6) {
+            LandingSectionHeading(eyebrow: "FAQ",
+                                  line1: "Short answers",
+                                  line2: "to what everyone asks.")
+
+            VStack(spacing: FMSpace.s3) {
+                ForEach(Array(qs.enumerated()), id: \.offset) { i, item in
+                    FMCard {
+                        VStack(alignment: .leading, spacing: FMSpace.s3) {
+                            Button {
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    open = open == i ? -1 : i
+                                }
+                            } label: {
+                                HStack(alignment: .firstTextBaseline, spacing: FMSpace.s3) {
+                                    Text(String(format: "%02d", i + 1))
+                                        .font(FMFont.mono(FMFont.xs))
+                                        .foregroundStyle(FMColor.fgAccent)
+                                    Text(item.q)
+                                        .font(FMFont.ui(FMFont.md, weight: .semibold))
+                                        .foregroundStyle(FMColor.fg1)
+                                        .multilineTextAlignment(.leading)
+                                    Spacer()
+                                    Image(systemName: open == i ? "minus" : "plus")
+                                        .font(.system(size: 13, weight: .bold))
+                                        .foregroundStyle(FMColor.fgMuted)
+                                }
+                            }
+                            .buttonStyle(.plain)
+
+                            if open == i {
+                                Text(item.a)
+                                    .font(FMFont.ui(FMFont.sm))
+                                    .foregroundStyle(FMColor.fg3)
+                                    .lineSpacing(2)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, FMSpace.s5)
+    }
+}
+
+// MARK: - Final CTA
+
+struct LandingCTA: View {
+    var body: some View {
+        FMCard(featured: true) {
+            VStack(alignment: .leading, spacing: FMSpace.s4) {
+                FMEyebrow(text: "One tap. No form.")
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("Open FortyMM.")
+                        .foregroundStyle(FMColor.fg1)
+                    Text("Play your first match.")
+                        .foregroundStyle(FMColor.ball500)
+                }
+                .font(FMFont.display(40))
+                Text("We give you an account the moment the app loads. Your first match is already being tracked. If you ever want to keep it, add an email.")
+                    .font(FMFont.ui(FMFont.sm))
+                    .foregroundStyle(FMColor.fg3)
+                    .lineSpacing(2)
+                VStack(spacing: FMSpace.s3) {
+                    FMButton(title: "Start playing now", variant: .primary, size: .lg)
+                        .frame(maxWidth: .infinity)
+                    FMButton(title: "Get the iOS app", variant: .secondary, size: .lg)
+                        .frame(maxWidth: .infinity)
+                }
+                Text("● Web is live · iOS in beta · Android in beta")
+                    .font(FMFont.mono(FMFont.xs))
+                    .foregroundStyle(FMColor.serve500)
+            }
+        }
+        .padding(.horizontal, FMSpace.s5)
+    }
+}
+
+// MARK: - Footer
+
+struct LandingFooter: View {
+    private let cols: [(h: String, items: [String])] = [
+        ("Product", ["Web app", "iOS (beta)", "Android (beta)", "Spectator view"]),
+        ("Directors", ["Run a tournament", "Scheduler", "Sample draws"]),
+        ("Community", ["Discord", "GitHub", "Clubs map", "Contribute"]),
+        ("Never", ["Ads", "Trackers", "Premium", "Cookie banners"]),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: FMSpace.s5) {
+            Rectangle().fill(FMColor.borderSubtle).frame(height: 1)
+
+            FMLogo(size: 22)
+            Text("Made by players, in basements and rec centers.\n© 2026 FortyMM. GPLv3. For the love of the game.")
+                .font(FMFont.ui(FMFont.xs))
+                .foregroundStyle(FMColor.fgMuted)
+                .lineSpacing(2)
+
+            FlowLayout(spacing: 24, lineSpacing: 20) {
+                ForEach(cols, id: \.h) { col in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(col.h.uppercased())
+                            .font(FMFont.mono(9))
+                            .tracking(1)
+                            .foregroundStyle(FMColor.fg2)
+                        ForEach(col.items, id: \.self) { item in
+                            Text(item)
+                                .font(FMFont.ui(FMFont.sm))
+                                .foregroundStyle(FMColor.fgMuted)
+                        }
+                    }
+                }
+            }
+
+            Rectangle().fill(FMColor.borderSubtle).frame(height: 1)
+            HStack {
+                Text("v0.9.0 · status: operational")
+                Spacer()
+                Text("Play more. Pay never.")
+            }
+            .font(FMFont.mono(FMFont.xs))
+            .foregroundStyle(FMColor.fgMuted)
+        }
+        .padding(.horizontal, FMSpace.s5)
+    }
+}
+
+#Preview {
+    ScrollView {
+        VStack(spacing: FMSpace.s16) {
+            LandingFeatures()
+            LandingTournaments()
+            LandingManifesto()
+            LandingFAQ()
+            LandingCTA()
+            LandingFooter()
+        }
+        .padding(.vertical, FMSpace.s8)
+    }
+    .background(FMColor.bgApp)
+    .preferredColorScheme(.dark)
+}

--- a/ios/Fortymm/Landing/LandingSections.swift
+++ b/ios/Fortymm/Landing/LandingSections.swift
@@ -384,12 +384,8 @@ struct LandingCTA: View {
                     .font(FMFont.ui(FMFont.sm))
                     .foregroundStyle(FMColor.fg3)
                     .lineSpacing(2)
-                VStack(spacing: FMSpace.s3) {
-                    FMButton(title: "Start playing now", variant: .primary, size: .lg)
-                        .frame(maxWidth: .infinity)
-                    FMButton(title: "Get the iOS app", variant: .secondary, size: .lg)
-                        .frame(maxWidth: .infinity)
-                }
+                FMButton(title: "Start playing now", variant: .primary, size: .lg)
+                    .frame(maxWidth: .infinity)
                 Text("● Web is live · iOS in beta · Android in beta")
                     .font(FMFont.mono(FMFont.xs))
                     .foregroundStyle(FMColor.serve500)

--- a/ios/Fortymm/Landing/LandingView.swift
+++ b/ios/Fortymm/Landing/LandingView.swift
@@ -1,0 +1,267 @@
+import Combine
+import SwiftUI
+
+/// Marketing landing page for the FortyMM iOS app, mirroring the web
+/// reference at uat.fortymm.com. Built entirely from design-system
+/// components and tokens. Every call-to-action is intentionally inert
+/// for now — buttons render but don't navigate anywhere yet.
+struct LandingView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: FMSpace.s16) {
+                LandingNav()
+                LandingHero()
+                LandingFeatures()
+                LandingTournaments()
+                LandingManifesto()
+                LandingFAQ()
+                LandingCTA()
+                LandingFooter()
+            }
+            .padding(.vertical, FMSpace.s6)
+        }
+        .background(FMColor.bgApp.ignoresSafeArea())
+    }
+}
+
+// MARK: - Shared section heading
+
+/// Eyebrow + two-line display headline, the recurring section header
+/// used throughout the landing page.
+struct LandingSectionHeading: View {
+    let eyebrow: String
+    let line1: String
+    let line2: String
+    var line2Color: Color = FMColor.fg3
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: FMSpace.s3) {
+            FMEyebrow(text: eyebrow)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(line1)
+                    .foregroundStyle(FMColor.fg1)
+                Text(line2)
+                    .foregroundStyle(line2Color)
+            }
+            .font(FMFont.display(34))
+            .tracking(0.5)
+            .lineSpacing(2)
+        }
+    }
+}
+
+// MARK: - Nav
+
+private struct LandingNav: View {
+    var body: some View {
+        HStack(spacing: FMSpace.s3) {
+            FMLogo(size: 24)
+            Spacer(minLength: 0)
+            FMButton(title: "Sign in", variant: .ghost, size: .sm)
+            FMButton(title: "Start playing", variant: .primary, size: .sm)
+        }
+        .padding(.horizontal, FMSpace.s5)
+    }
+}
+
+// MARK: - Hero
+
+private struct LandingHero: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: FMSpace.s6) {
+            FMEyebrow(text: "No ads · No tracking · No subscriptions, ever")
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Play more.")
+                    .foregroundStyle(FMColor.fg1)
+                Text("Pay never.")
+                    .foregroundStyle(FMColor.ball500)
+            }
+            .font(FMFont.display(60))
+            .lineSpacing(-4)
+
+            Text("FortyMM is a table-tennis match tracker and tournament platform — made by players, for players. No download, no sign-up. When you want a real account, just add an email.")
+                .font(FMFont.ui(FMFont.md))
+                .foregroundStyle(FMColor.fg3)
+                .lineSpacing(3)
+
+            VStack(spacing: FMSpace.s3) {
+                FMButton(title: "Start a match", variant: .primary, size: .lg)
+                    .frame(maxWidth: .infinity)
+                FMButton(title: "Run a tournament", variant: .secondary, size: .lg)
+                    .frame(maxWidth: .infinity)
+            }
+
+            HStack(spacing: FMSpace.s4) {
+                heroMeta(icon: "iphone", text: "Web. iOS & Android soon.")
+                Rectangle().fill(FMColor.borderSubtle).frame(width: 1, height: 14)
+                heroMeta(icon: "star", text: "Open source. GPLv3.")
+            }
+            .padding(.top, FMSpace.s1)
+
+            LandingScoreboard()
+                .padding(.top, FMSpace.s4)
+
+            LandingStatsStrip()
+        }
+        .padding(.horizontal, FMSpace.s5)
+    }
+
+    private func heroMeta(icon: String, text: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundStyle(FMColor.fgMuted)
+            Text(text)
+                .font(FMFont.ui(FMFont.xs))
+                .foregroundStyle(FMColor.fgMuted)
+        }
+    }
+}
+
+// MARK: - Stats strip
+
+private struct LandingStatsStrip: View {
+    private let stats: [(n: String, l: String, accent: Bool)] = [
+        ("12,480", "matches logged", false),
+        ("340", "clubs worldwide", false),
+        ("1,102", "tournaments run", false),
+        ("0", "dollars charged", true),
+    ]
+
+    private let columns = [GridItem(.flexible(), spacing: FMSpace.s4),
+                           GridItem(.flexible(), spacing: FMSpace.s4)]
+
+    var body: some View {
+        FMCard {
+            LazyVGrid(columns: columns, alignment: .leading, spacing: FMSpace.s4) {
+                ForEach(Array(stats.enumerated()), id: \.offset) { _, s in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(s.n)
+                            .font(FMFont.display(30))
+                            .foregroundStyle(s.accent ? FMColor.ball500 : FMColor.fg1)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.7)
+                        Text(s.l.uppercased())
+                            .font(FMFont.mono(9))
+                            .tracking(0.8)
+                            .foregroundStyle(FMColor.fgMuted)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Animated live scoreboard
+
+private struct LandingScoreboard: View {
+    @State private var tick = 0
+    private let timer = Timer.publish(every: 2.6, on: .main, in: .common).autoconnect()
+
+    private let seq: [(Int, Int)] = [
+        (8, 8), (9, 8), (9, 9), (10, 9), (10, 10), (11, 10), (11, 11), (12, 11),
+    ]
+
+    private var score: (a: Int, b: Int) { seq[tick % seq.count] }
+    private var aServing: Bool { tick % 4 < 2 }
+
+    var body: some View {
+        FMCard {
+            VStack(spacing: FMSpace.s3) {
+                HStack {
+                    FMBadge(text: "Live · Game 4 · BO5", variant: .live)
+                    Spacer()
+                    Text("COURT 3 · 19:42")
+                        .font(FMFont.mono(FMFont.xs))
+                        .foregroundStyle(FMColor.fgMuted)
+                }
+
+                player(name: "Nguyen, T.", initials: "NG", seed: "1", rating: "2145",
+                       score: score.a, winning: score.a > score.b, serving: aServing)
+                Rectangle().fill(FMColor.borderSubtle).frame(height: 1)
+                player(name: "Okafor, D.", initials: "OK", seed: "8", rating: "1988",
+                       score: score.b, winning: score.b > score.a, serving: !aServing)
+
+                HStack(spacing: 6) {
+                    gameBox((11, 6), label: "G1", live: false)
+                    gameBox((9, 11), label: "G2", live: false)
+                    gameBox((11, 8), label: "G3", live: false)
+                    gameBox(score, label: "G4", live: true)
+                }
+                .padding(.top, 2)
+
+                HStack {
+                    Text("Sets 2–1")
+                        .font(FMFont.ui(FMFont.xs))
+                        .foregroundStyle(FMColor.fg3)
+                    Spacer()
+                    Text("Next: ")
+                        .font(FMFont.ui(FMFont.xs))
+                        .foregroundStyle(FMColor.fgMuted)
+                        + Text("+8 rating")
+                        .font(FMFont.mono(FMFont.xs))
+                        .foregroundColor(FMColor.fgAccent)
+                }
+            }
+        }
+        .onReceive(timer) { _ in
+            withAnimation(.easeInOut(duration: 0.3)) { tick += 1 }
+        }
+    }
+
+    private func player(name: String, initials: String, seed: String, rating: String,
+                        score: Int, winning: Bool, serving: Bool) -> some View {
+        HStack(spacing: FMSpace.s3) {
+            FMAvatar(initials: initials, size: 36,
+                     color: winning ? FMColor.ball500 : FMColor.ink600,
+                     foreground: winning ? FMColor.fgInverse : FMColor.fg2)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(name)
+                        .font(FMFont.ui(FMFont.md, weight: .semibold))
+                        .foregroundStyle(FMColor.fg1)
+                    if serving {
+                        Circle().fill(FMColor.ball500).frame(width: 6, height: 6)
+                    }
+                }
+                Text("SEED \(seed) · \(rating)")
+                    .font(FMFont.mono(FMFont.xs))
+                    .foregroundStyle(FMColor.fgMuted)
+            }
+            Spacer()
+            Text(String(format: "%02d", score))
+                .font(FMFont.display(40))
+                .foregroundStyle(winning ? FMColor.ball500 : FMColor.fg1)
+                .contentTransition(.numericText())
+                .monospacedDigit()
+        }
+    }
+
+    private func gameBox(_ g: (Int, Int), label: String, live: Bool) -> some View {
+        VStack(spacing: 2) {
+            Text(label)
+                .font(FMFont.mono(9))
+                .foregroundStyle(FMColor.fgMuted)
+            Text("\(g.0)")
+                .font(FMFont.mono(FMFont.sm, weight: .semibold))
+                .foregroundStyle(g.0 > g.1 ? FMColor.win : FMColor.fg3)
+            Rectangle().fill(FMColor.borderSubtle).frame(height: 1).frame(width: 16)
+            Text("\(g.1)")
+                .font(FMFont.mono(FMFont.sm, weight: .semibold))
+                .foregroundStyle(g.1 > g.0 ? FMColor.win : FMColor.fg3)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+        .background(live ? FMColor.bgAccentSoft : FMColor.bgRaised)
+        .fmRoundedBorder(radius: FMRadius.sm,
+                         color: live ? FMColor.borderAccent : FMColor.borderSubtle)
+    }
+}
+
+#Preview {
+    LandingView().preferredColorScheme(.dark)
+}


### PR DESCRIPTION
Adds a marketing landing page to the iOS app, mirroring the web reference at uat.fortymm.com. Built entirely from design-system components (FMButton, FMCard, FMBadge, FMTabs, FMAvatar, FlowLayout) and tokens.

Sections: nav, hero with animated live scoreboard + stats, feature tabs, tournaments with animated solver, manifesto, FAQ accordion, final CTA, and footer. New reusable components: FMLogo and FMEyebrow.

The app root now shows LandingView (was DesignSystemView, which is retained). All CTA buttons are intentionally inert for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)