### PR TITLE
Hide stale "awaiting confirmation" notice once a match is finalized (#358)

### DIFF
--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -800,4 +800,51 @@ describe('MatchDetailsView', () => {
       within(callout).queryByRole('button', { name: /confirm result/i }),
     ).not.toBeInTheDocument()
   })
+
+  it('drops the "awaiting confirmation" notice once the match is finalized', async () => {
+    // Regression for the stale-notice bug (#358): after the opponent confirms,
+    // the match is Final but the viewer's signature stays in the response.
+    // The passive "waiting on your opponent" callout must not linger.
+    const match = matchDetails({
+      id: 'm-final',
+      status: 'completed',
+      status_label: 'Final',
+      sides: [
+        {
+          side_number: 1,
+          players: [
+            { user_id: 'u-me', username: 'me', is_current_user: true },
+          ],
+          games_won: 3,
+          won: true,
+          is_current_user_side: true,
+        },
+        {
+          side_number: 2,
+          players: [
+            { user_id: 'u-opp', username: 'nguyen.t', is_current_user: false },
+          ],
+          games_won: 1,
+          won: false,
+          is_current_user_side: false,
+        },
+      ],
+      can_confirm: false,
+      // Both players have now signed; signatures persist as a historical record.
+      signatures: [
+        { user_id: 'u-me', signed_at: '2026-05-26T12:00:00Z' },
+        { user_id: 'u-opp', signed_at: '2026-05-26T12:05:00Z' },
+      ],
+    })
+    server.use(
+      http.get('*/v1/matches/m-final', () => HttpResponse.json(match)),
+    )
+
+    renderDetails('m-final')
+
+    // Wait for the page to render (the Final status is shown), then assert
+    // the stale awaiting-confirmation callout is gone.
+    await screen.findAllByText('Final')
+    expect(screen.queryByTestId('match-confirm-callout')).not.toBeInTheDocument()
+  })
 })

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -273,8 +273,15 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
     : null
   const viewerHasSigned =
     viewerUserId !== null && signers.has(viewerUserId)
+  // Only an in-progress match can be awaiting confirmation. Once it's
+  // finalized (completed) or otherwise terminal, the signatures stay in the
+  // response as a historical record — guard on status so the passive
+  // "waiting on <opponent>" notice doesn't linger past the Final badge.
   const viewerIsAwaitingOther =
-    viewerIsParticipant && data.signatures.length > 0 && viewerHasSigned
+    data.status === 'in_progress' &&
+    viewerIsParticipant &&
+    data.signatures.length > 0 &&
+    viewerHasSigned
   // Find the participant who's missing from the signature set. With "at
   // least one player per side" semantics, this picks the first un-signed
   // player on the other side. Falls back to "your opponent" if we can't


### PR DESCRIPTION
Fixes #358.

## Problem
After the opponent clicks **Confirm result** and the match becomes `Final`, the passive **"Posted · awaiting confirmation"** callout ("You've signed off on this result. Waiting on **your opponent** to confirm or dispute…") stayed rendered above the players card. Both players saw it, and it **survived a full reload** — because it's driven by the BFF response, not React cache.

## Root cause
`projectMatchView` computed `viewerIsAwaitingOther` from only:
- viewer is a participant, **and**
- at least one signature exists, **and**
- the viewer has signed

It never checked match status. Once the match is finalized the signatures legitimately remain in the `/v1/matches/{id}` response as a historical record, so the condition stayed true and the notice lingered.

## Fix
Guard the flag on `data.status === 'in_progress'` — only an in-progress match can be awaiting confirmation. Once it's `completed` (or otherwise terminal), the notice disappears.

## Tests
- Added a regression test: a finalized (`completed`) match whose response still carries both players' signatures renders **no** `match-confirm-callout`.
- Existing awaiting/confirm tests unchanged and green; full web-client suite (129 tests) passes, `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)