### PR TITLE
Add iOS dashboard page with Keychain-backed session creation

### DIFF
--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+/// The signed-in landing surface. For now it does one real thing: create (or
+/// resume) the session via `GET /v1/session` and show who you are. Everything
+/// else is deliberately left for later.
+struct DashboardView: View {
+    @StateObject private var session = SessionStore()
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: FMSpace.s6) {
+                header
+                content
+            }
+            .padding(.horizontal, FMSpace.s5)
+            .padding(.vertical, FMSpace.s6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(FMColor.bgApp.ignoresSafeArea())
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await session.load() }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: FMSpace.s3) {
+            FMEyebrow(text: "Dashboard")
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Welcome to")
+                    .foregroundStyle(FMColor.fg1)
+                Text("FortyMM.")
+                    .foregroundStyle(FMColor.ball500)
+            }
+            .font(FMFont.display(40))
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch session.state {
+        case .idle, .loading:
+            loadingCard
+        case let .loaded(user):
+            sessionCard(user)
+        case let .failed(message):
+            errorCard(message)
+        }
+    }
+
+    private var loadingCard: some View {
+        FMCard {
+            HStack(spacing: FMSpace.s3) {
+                ProgressView()
+                    .tint(FMColor.ball500)
+                Text("Creating your session…")
+                    .font(FMFont.ui(FMFont.md))
+                    .foregroundStyle(FMColor.fg3)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func sessionCard(_ user: SessionUser) -> some View {
+        FMCard(featured: true) {
+            VStack(alignment: .leading, spacing: FMSpace.s4) {
+                HStack(spacing: FMSpace.s3) {
+                    FMAvatar(
+                        initials: initials(for: user.username),
+                        size: 44,
+                        color: FMColor.ball500,
+                        foreground: FMColor.fgInverse
+                    )
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(user.username)
+                            .font(FMFont.ui(FMFont.md, weight: .semibold))
+                            .foregroundStyle(FMColor.fg1)
+                        Text("Signed in")
+                            .font(FMFont.mono(FMFont.xs))
+                            .foregroundStyle(FMColor.fgMuted)
+                    }
+                    Spacer()
+                    FMBadge(text: badgeText(for: user.emailStatus), variant: .live)
+                }
+
+                Rectangle().fill(FMColor.borderSubtle).frame(height: 1)
+
+                Text(statusBlurb(for: user.emailStatus))
+                    .font(FMFont.ui(FMFont.sm))
+                    .foregroundStyle(FMColor.fg3)
+                    .lineSpacing(2)
+            }
+        }
+    }
+
+    private func errorCard(_ message: String) -> some View {
+        FMCard {
+            VStack(alignment: .leading, spacing: FMSpace.s4) {
+                Text("Couldn't start your session")
+                    .font(FMFont.ui(FMFont.md, weight: .semibold))
+                    .foregroundStyle(FMColor.fg1)
+                Text(message)
+                    .font(FMFont.ui(FMFont.sm))
+                    .foregroundStyle(FMColor.fg3)
+                    .lineSpacing(2)
+                FMButton(title: "Try again", variant: .primary, size: .md) {
+                    Task { await session.load(force: true) }
+                }
+            }
+        }
+    }
+
+    private func initials(for username: String) -> String {
+        let letters = username
+            .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+            .prefix(2)
+            .compactMap { $0.first }
+        let joined = String(letters).uppercased()
+        return joined.isEmpty ? "?" : joined
+    }
+
+    private func badgeText(for status: SessionUser.EmailStatus) -> String {
+        switch status {
+        case .guest: return "Guest"
+        case .pending: return "Pending"
+        case .verified: return "Verified"
+        }
+    }
+
+    private func statusBlurb(for status: SessionUser.EmailStatus) -> String {
+        switch status {
+        case .guest:
+            return "You're playing as a guest. Add an email later to keep your matches across devices."
+        case .pending:
+            return "Check your inbox to confirm your email and lock in your account."
+        case .verified:
+            return "Your account is verified. Your matches follow you everywhere."
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        DashboardView()
+    }
+    .preferredColorScheme(.dark)
+}

--- a/ios/Fortymm/FortymmApp.swift
+++ b/ios/Fortymm/FortymmApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct FortymmApp: App {
     var body: some Scene {
         WindowGroup {
-            LandingView()
+            RootView()
                 .preferredColorScheme(.dark)
         }
     }

--- a/ios/Fortymm/Landing/LandingSections.swift
+++ b/ios/Fortymm/Landing/LandingSections.swift
@@ -107,6 +107,8 @@ struct LandingFeatures: View {
 // MARK: - Tournaments
 
 struct LandingTournaments: View {
+    @EnvironmentObject private var router: Router
+
     private let steps: [(k: String, t: String)] = [
         ("01", "Import a player list — CSV, paste, or scan."),
         ("02", "Set constraints — courts, breaks, start times."),
@@ -143,8 +145,10 @@ struct LandingTournaments: View {
             LandingSolverCard()
 
             VStack(spacing: FMSpace.s3) {
-                FMButton(title: "Start a tournament", variant: .primary, size: .lg)
-                    .frame(maxWidth: .infinity)
+                FMButton(title: "Start a tournament", variant: .primary, size: .lg) {
+                    router.goToDashboard()
+                }
+                .frame(maxWidth: .infinity)
                 FMButton(title: "See a sample schedule", variant: .ghost, size: .lg)
                     .frame(maxWidth: .infinity)
             }
@@ -369,6 +373,8 @@ struct LandingFAQ: View {
 // MARK: - Final CTA
 
 struct LandingCTA: View {
+    @EnvironmentObject private var router: Router
+
     var body: some View {
         FMCard(featured: true) {
             VStack(alignment: .leading, spacing: FMSpace.s4) {
@@ -384,8 +390,10 @@ struct LandingCTA: View {
                     .font(FMFont.ui(FMFont.sm))
                     .foregroundStyle(FMColor.fg3)
                     .lineSpacing(2)
-                FMButton(title: "Start playing now", variant: .primary, size: .lg)
-                    .frame(maxWidth: .infinity)
+                FMButton(title: "Start playing now", variant: .primary, size: .lg) {
+                    router.goToDashboard()
+                }
+                .frame(maxWidth: .infinity)
                 Text("● Web is live · iOS in beta · Android in beta")
                     .font(FMFont.mono(FMFont.xs))
                     .foregroundStyle(FMColor.serve500)
@@ -457,5 +465,6 @@ struct LandingFooter: View {
         .padding(.vertical, FMSpace.s8)
     }
     .background(FMColor.bgApp)
+    .environmentObject(Router())
     .preferredColorScheme(.dark)
 }

--- a/ios/Fortymm/Landing/LandingView.swift
+++ b/ios/Fortymm/Landing/LandingView.swift
@@ -53,12 +53,18 @@ struct LandingSectionHeading: View {
 // MARK: - Nav
 
 private struct LandingNav: View {
+    @EnvironmentObject private var router: Router
+
     var body: some View {
         HStack(spacing: FMSpace.s3) {
             FMLogo(size: 24)
             Spacer(minLength: 0)
-            FMButton(title: "Sign in", variant: .ghost, size: .sm)
-            FMButton(title: "Start playing", variant: .primary, size: .sm)
+            FMButton(title: "Sign in", variant: .ghost, size: .sm) {
+                router.goToDashboard()
+            }
+            FMButton(title: "Start playing", variant: .primary, size: .sm) {
+                router.goToDashboard()
+            }
         }
         .padding(.horizontal, FMSpace.s5)
     }
@@ -67,6 +73,8 @@ private struct LandingNav: View {
 // MARK: - Hero
 
 private struct LandingHero: View {
+    @EnvironmentObject private var router: Router
+
     var body: some View {
         VStack(alignment: .leading, spacing: FMSpace.s6) {
             FMEyebrow(text: "No ads · No tracking · No subscriptions, ever")
@@ -86,10 +94,14 @@ private struct LandingHero: View {
                 .lineSpacing(3)
 
             VStack(spacing: FMSpace.s3) {
-                FMButton(title: "Start a match", variant: .primary, size: .lg)
-                    .frame(maxWidth: .infinity)
-                FMButton(title: "Run a tournament", variant: .secondary, size: .lg)
-                    .frame(maxWidth: .infinity)
+                FMButton(title: "Start a match", variant: .primary, size: .lg) {
+                    router.goToDashboard()
+                }
+                .frame(maxWidth: .infinity)
+                FMButton(title: "Run a tournament", variant: .secondary, size: .lg) {
+                    router.goToDashboard()
+                }
+                .frame(maxWidth: .infinity)
             }
 
             HStack(spacing: FMSpace.s4) {
@@ -263,5 +275,7 @@ private struct LandingScoreboard: View {
 }
 
 #Preview {
-    LandingView().preferredColorScheme(.dark)
+    LandingView()
+        .environmentObject(Router())
+        .preferredColorScheme(.dark)
 }

--- a/ios/Fortymm/Navigation/RootView.swift
+++ b/ios/Fortymm/Navigation/RootView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// Hosts the app's navigation stack. The landing page is the root; CTAs push
+/// the dashboard via the shared `Router` in the environment.
+struct RootView: View {
+    @StateObject private var router = Router()
+
+    var body: some View {
+        NavigationStack(path: $router.path) {
+            LandingView()
+                .navigationDestination(for: Route.self) { route in
+                    switch route {
+                    case .dashboard:
+                        DashboardView()
+                    }
+                }
+        }
+        .environmentObject(router)
+    }
+}

--- a/ios/Fortymm/Navigation/Router.swift
+++ b/ios/Fortymm/Navigation/Router.swift
@@ -1,0 +1,20 @@
+import Combine
+import SwiftUI
+
+/// Destinations reachable from the landing page. Kept tiny on purpose — the
+/// dashboard is the only real surface so far.
+enum Route: Hashable {
+    case dashboard
+}
+
+/// Drives the root `NavigationStack`. Landing-page CTAs push onto it via the
+/// environment so the scattered, private section views don't each need their
+/// own navigation plumbing.
+@MainActor
+final class Router: ObservableObject {
+    @Published var path = NavigationPath()
+
+    func goToDashboard() {
+        path.append(Route.dashboard)
+    }
+}

--- a/ios/Fortymm/Networking/APIClient.swift
+++ b/ios/Fortymm/Networking/APIClient.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Thin URLSession wrapper for talking to the FortyMM API.
+///
+/// The API is cookie-based: `GET /v1/session` mints a `User` + token on first
+/// hit and returns it in a `session` cookie. Rather than let URLSession persist
+/// that cookie to a plaintext file in the app sandbox, we turn its cookie
+/// handling off entirely and manage the token ourselves: read it from the
+/// Keychain (`SessionTokenStore`), send it as the `Cookie` header, and capture
+/// any `Set-Cookie` the server returns. Transport stays cookies (no backend
+/// change); storage becomes the Keychain.
+struct APIClient {
+    /// Base URL of the API, chosen per build configuration.
+    ///
+    /// `FMM_API_BASE_URL` (set in the scheme's environment) wins when present —
+    /// handy for pointing a local Xcode run at a dev stack
+    /// (e.g. http://localhost:8080). Note this override only applies to runs
+    /// launched from Xcode; it does not ship in a Release/TestFlight build.
+    ///
+    /// Otherwise the default is per-configuration. Production currently points
+    /// at UAT until the prod backend is live — flip the `#else` branch to the
+    /// real prod host when it exists.
+    static let baseURL: URL = {
+        if let override = ProcessInfo.processInfo.environment["FMM_API_BASE_URL"],
+           let url = URL(string: override) {
+            return url
+        }
+        return URL(string: defaultBaseURLString)!
+    }()
+
+    private static var defaultBaseURLString: String {
+        #if DEBUG
+        return "https://uat.fortymm.com"
+        #else
+        // Prod → UAT for now. Replace with the production host once it exists.
+        return "https://uat.fortymm.com"
+        #endif
+    }
+
+    static let shared = APIClient()
+
+    private let session: URLSession
+    private let decoder: JSONDecoder
+    private let tokens: SessionTokenStore
+
+    init(
+        session: URLSession = APIClient.makeSession(),
+        tokens: SessionTokenStore = .shared
+    ) {
+        self.session = session
+        self.tokens = tokens
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        self.decoder = decoder
+    }
+
+    /// A session with cookie handling disabled — nothing is read from or
+    /// written to `HTTPCookieStorage`, so no token ever lands on disk outside
+    /// the Keychain.
+    static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.default
+        config.httpCookieStorage = nil
+        config.httpShouldSetCookies = false
+        config.httpCookieAcceptPolicy = .never
+        return URLSession(configuration: config)
+    }
+
+    /// Create (or resume) the caller's session. Idempotent: with a stored token
+    /// the server resolves the existing user; without one it mints a guest and
+    /// returns a `Set-Cookie` we capture into the Keychain.
+    func getSession() async throws -> SessionResponse {
+        try await get("/v1/session")
+    }
+
+    private func get<T: Decodable>(_ path: String) async throws -> T {
+        let url = APIClient.baseURL.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let token = await tokens.token() {
+            request.setValue("session=\(token)", forHTTPHeaderField: "Cookie")
+        }
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+        await captureSessionCookie(from: http, url: url)
+        guard (200..<300).contains(http.statusCode) else {
+            throw APIError.http(status: http.statusCode)
+        }
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw APIError.decoding(error)
+        }
+    }
+
+    /// Pull a minted/rotated `session` cookie out of the response and persist
+    /// it. The API only ever sets the single `session` cookie, so folding
+    /// multiple Set-Cookie headers isn't a concern here.
+    private func captureSessionCookie(from http: HTTPURLResponse, url: URL) async {
+        guard let header = http.value(forHTTPHeaderField: "Set-Cookie") else {
+            return
+        }
+        let cookies = HTTPCookie.cookies(
+            withResponseHeaderFields: ["Set-Cookie": header],
+            for: url
+        )
+        if let token = cookies.first(where: { $0.name == "session" })?.value {
+            await tokens.update(token)
+        }
+    }
+}
+
+enum APIError: LocalizedError {
+    case invalidResponse
+    case http(status: Int)
+    case decoding(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "The server returned an unexpected response."
+        case let .http(status):
+            return "The server returned an error (HTTP \(status))."
+        case .decoding:
+            return "Couldn't read the server's response."
+        }
+    }
+}

--- a/ios/Fortymm/Networking/APIClient.swift
+++ b/ios/Fortymm/Networking/APIClient.swift
@@ -39,6 +39,10 @@ struct APIClient {
 
     static let shared = APIClient()
 
+    /// Name of the auth cookie the API sets and reads. Centralised so the send
+    /// and capture sides can't drift.
+    private static let sessionCookieName = "session"
+
     private let session: URLSession
     private let decoder: JSONDecoder
     private let tokens: SessionTokenStore
@@ -78,7 +82,10 @@ struct APIClient {
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         if let token = await tokens.token() {
-            request.setValue("session=\(token)", forHTTPHeaderField: "Cookie")
+            request.setValue(
+                "\(Self.sessionCookieName)=\(token)",
+                forHTTPHeaderField: "Cookie"
+            )
         }
 
         let (data, response) = try await session.data(for: request)
@@ -107,7 +114,7 @@ struct APIClient {
             withResponseHeaderFields: ["Set-Cookie": header],
             for: url
         )
-        if let token = cookies.first(where: { $0.name == "session" })?.value {
+        if let token = cookies.first(where: { $0.name == Self.sessionCookieName })?.value {
             await tokens.update(token)
         }
     }

--- a/ios/Fortymm/Networking/KeychainStore.swift
+++ b/ios/Fortymm/Networking/KeychainStore.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Security
+
+/// Minimal wrapper over the iOS Keychain for a single secret string. Backs the
+/// session token: a generic-password item, device-local (never synced to iCloud
+/// Keychain), readable after first unlock so background/locked requests still
+/// work. No biometric gate — the guest session is meant to be frictionless.
+struct KeychainStore {
+    let service: String
+    let account: String
+
+    init(
+        service: String = Bundle.main.bundleIdentifier ?? "com.fortymm.app",
+        account: String
+    ) {
+        self.service = service
+        self.account = account
+    }
+
+    @discardableResult
+    func save(_ value: String) -> Bool {
+        // Delete any existing item first so SecItemAdd can't fail with
+        // errSecDuplicateItem.
+        SecItemDelete(baseQuery as CFDictionary)
+        var attributes = baseQuery
+        attributes[kSecValueData as String] = Data(value.utf8)
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        return SecItemAdd(attributes as CFDictionary, nil) == errSecSuccess
+    }
+
+    func load() -> String? {
+        var query = baseQuery
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data
+        else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    func delete() {
+        SecItemDelete(baseQuery as CFDictionary)
+    }
+
+    private var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+}

--- a/ios/Fortymm/Networking/KeychainStore.swift
+++ b/ios/Fortymm/Networking/KeychainStore.swift
@@ -17,15 +17,14 @@ struct KeychainStore {
         self.account = account
     }
 
-    @discardableResult
-    func save(_ value: String) -> Bool {
+    func save(_ value: String) {
         // Delete any existing item first so SecItemAdd can't fail with
         // errSecDuplicateItem.
         SecItemDelete(baseQuery as CFDictionary)
         var attributes = baseQuery
         attributes[kSecValueData as String] = Data(value.utf8)
         attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
-        return SecItemAdd(attributes as CFDictionary, nil) == errSecSuccess
+        _ = SecItemAdd(attributes as CFDictionary, nil)
     }
 
     func load() -> String? {

--- a/ios/Fortymm/Networking/SessionTokenStore.swift
+++ b/ios/Fortymm/Networking/SessionTokenStore.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// The durable home for the session token. The Keychain is the vault; an
+/// in-memory copy is the working value used on the request hot path, so we
+/// touch the Keychain only on launch (first read) and on changes (writes) —
+/// never per request. An actor serialises access so concurrent requests can't
+/// race the cache.
+actor SessionTokenStore {
+    static let shared = SessionTokenStore()
+
+    private let keychain: KeychainStore
+    private var cached: String?
+    private var didLoad = false
+
+    init(keychain: KeychainStore = KeychainStore(account: "session-token")) {
+        self.keychain = keychain
+    }
+
+    /// The current token, lazily hydrated from the Keychain on first access.
+    func token() -> String? {
+        if !didLoad {
+            cached = keychain.load()
+            didLoad = true
+        }
+        return cached
+    }
+
+    /// Persist a freshly minted or rotated token. No-op if unchanged, so a
+    /// resumed session doesn't rewrite the Keychain on every call.
+    func update(_ token: String) {
+        guard token != cached else { return }
+        cached = token
+        didLoad = true
+        keychain.save(token)
+    }
+
+    /// Forget the session (sign-out). Clears both the cache and the vault.
+    func clear() {
+        cached = nil
+        didLoad = true
+        keychain.delete()
+    }
+}

--- a/ios/Fortymm/Session/SessionModels.swift
+++ b/ios/Fortymm/Session/SessionModels.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Mirror of the API's `SessionResponse` (see `api/app/schemas/session.py`).
+/// Decoded with `.convertFromSnakeCase`, so `confirmed_at` / `pending_email`
+/// arrive as `confirmedAt` / `pendingEmail`.
+struct SessionResponse: Decodable {
+    let data: SessionData
+    let merged: MergeSummary?
+}
+
+struct SessionData: Decodable {
+    let user: SessionUser
+}
+
+struct SessionUser: Decodable {
+    let username: String
+    let permissions: [String]
+    let email: String?
+    let confirmedAt: String?
+    let pendingEmail: String?
+}
+
+struct MergeSummary: Decodable {
+    let matchesMoved: Int
+}
+
+extension SessionUser {
+    /// Where the user sits in the guest → verified lifecycle. Mirrors
+    /// `deriveEmailStatus` in `web-client/src/api/session.ts`.
+    enum EmailStatus {
+        case guest
+        case pending
+        case verified
+    }
+
+    var emailStatus: EmailStatus {
+        if pendingEmail != nil { return .pending }
+        if confirmedAt != nil { return .verified }
+        if email != nil { return .pending }
+        return .guest
+    }
+}

--- a/ios/Fortymm/Session/SessionStore.swift
+++ b/ios/Fortymm/Session/SessionStore.swift
@@ -20,11 +20,6 @@ final class SessionStore: ObservableObject {
         self.client = client
     }
 
-    var user: SessionUser? {
-        if case let .loaded(user) = state { return user }
-        return nil
-    }
-
     /// Create or resume the session. Skips the network call if a user is
     /// already loaded, so re-entering the dashboard doesn't refetch.
     func load(force: Bool = false) async {

--- a/ios/Fortymm/Session/SessionStore.swift
+++ b/ios/Fortymm/Session/SessionStore.swift
@@ -1,0 +1,44 @@
+import Combine
+import Foundation
+
+/// Owns the app's session lifecycle. Calling `load()` hits `GET /v1/session`,
+/// which mints a guest account on first run and resumes it thereafter.
+@MainActor
+final class SessionStore: ObservableObject {
+    enum State {
+        case idle
+        case loading
+        case loaded(SessionUser)
+        case failed(String)
+    }
+
+    @Published private(set) var state: State = .idle
+
+    private let client: APIClient
+
+    init(client: APIClient = .shared) {
+        self.client = client
+    }
+
+    var user: SessionUser? {
+        if case let .loaded(user) = state { return user }
+        return nil
+    }
+
+    /// Create or resume the session. Skips the network call if a user is
+    /// already loaded, so re-entering the dashboard doesn't refetch.
+    func load(force: Bool = false) async {
+        if case .loaded = state, !force { return }
+        if case .loading = state { return }
+
+        state = .loading
+        do {
+            let response = try await client.getSession()
+            state = .loaded(response.data.user)
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription
+                ?? error.localizedDescription
+            state = .failed(message)
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds the first signed-in surface to the iOS app. The landing page's CTAs were inert; they now navigate to a new **Dashboard** that creates (or resumes) the session via `GET /v1/session`.

Scope is intentionally narrow per the ask: make session creation work and wire the CTAs. No sign-out, no further dashboard content yet.

## How

- **Networking** — `APIClient` with a per-configuration base URL. Prod (Release) points at UAT for now via `#if DEBUG`, with a labeled one-line spot to swap in a real prod host later. Cookie *transport* is preserved (no backend change), but URLSession's cookie storage is disabled so the session token never lands in a plaintext sandbox file.
- **Storage** — the token lives in the **Keychain** (device-local, `AfterFirstUnlock`, no biometric gate to keep guest sessions frictionless). `SessionTokenStore` is an `actor` that caches it in memory, so the Keychain is touched only on launch (first read) and on token mint/rotation — never on the request hot path. Responses are scanned for a minted/rotated `session` cookie and written back.
- **Navigation** — a `Router`-driven `NavigationStack`; `LandingView` is root and the landing CTAs push the Dashboard.
- **Dashboard** — shows the minted user (avatar, username, guest/pending/verified badge) with loading, error, and retry states.

## Verification

- `xcodebuild` succeeds for both **Debug** and **Release** configs.
- Verified against the live UAT API that a tokenless request mints a user + `Set-Cookie`, and that replaying the captured token as a `Cookie` header resolves the **same** user with no rotation — the contract the client relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)