### PR TITLE
iOS: custom top bar + native TabView bottom nav on dashboard

### DIFF
--- a/ios/Fortymm/Components/FMComingSoon.swift
+++ b/ios/Fortymm/Components/FMComingSoon.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Placeholder screen for the tabs that don't have a real surface yet. The top
+/// bar is owned by `MainTabView`, so this is just the screen's content.
+struct FMComingSoon: View {
+    let title: String
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: FMSpace.s3) {
+                FMEyebrow(text: title)
+                Text("Coming soon.")
+                    .font(FMFont.display(40))
+                    .foregroundStyle(FMColor.fg1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, FMSpace.s5)
+            .padding(.vertical, FMSpace.s6)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(FMColor.bgApp.ignoresSafeArea())
+    }
+}
+
+#Preview {
+    FMComingSoon(title: "Matches")
+        .preferredColorScheme(.dark)
+}

--- a/ios/Fortymm/Components/FMLogo.swift
+++ b/ios/Fortymm/Components/FMLogo.swift
@@ -1,5 +1,30 @@
 import SwiftUI
 
+/// The glossy ball-orange disc on its own — the brand mark used in the iOS
+/// top bar where the full wordmark would be too wide. Shared by `FMLogo`.
+struct FMBall: View {
+    var size: CGFloat = 24
+
+    var body: some View {
+        Circle()
+            .fill(
+                RadialGradient(
+                    colors: [Color(hex: 0xFFB57A), FMColor.ball500, FMColor.ball700],
+                    center: UnitPoint(x: 0.35, y: 0.35),
+                    startRadius: 0,
+                    endRadius: size * 0.9
+                )
+            )
+            .frame(width: size, height: size)
+            .overlay(alignment: .topLeading) {
+                Ellipse()
+                    .fill(Color.white.opacity(0.22))
+                    .frame(width: size * 0.4, height: size * 0.24)
+                    .offset(x: size * 0.18, y: size * 0.18)
+            }
+    }
+}
+
 /// The FortyMM wordmark: a glossy ball-orange disc followed by the
 /// condensed-display "FORTYMM" wordmark with an accent period.
 struct FMLogo: View {
@@ -7,22 +32,7 @@ struct FMLogo: View {
 
     var body: some View {
         HStack(spacing: size * 0.36) {
-            Circle()
-                .fill(
-                    RadialGradient(
-                        colors: [Color(hex: 0xFFB57A), FMColor.ball500, FMColor.ball700],
-                        center: UnitPoint(x: 0.35, y: 0.35),
-                        startRadius: 0,
-                        endRadius: size * 0.9
-                    )
-                )
-                .frame(width: size, height: size)
-                .overlay(alignment: .topLeading) {
-                    Ellipse()
-                        .fill(Color.white.opacity(0.22))
-                        .frame(width: size * 0.4, height: size * 0.24)
-                        .offset(x: size * 0.18, y: size * 0.18)
-                }
+            FMBall(size: size)
 
             HStack(spacing: 0) {
                 Text("FORTYMM")

--- a/ios/Fortymm/Components/FMTopBar.swift
+++ b/ios/Fortymm/Components/FMTopBar.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// Compact, centered top bar: the brand ball on the left, an absolutely-centered
+/// title, and a translucent dark surface with a hairline bottom border. Laid
+/// over the top safe area via `.safeAreaInset` so content scrolls under it.
+struct FMTopBar: View {
+    let title: String
+
+    var body: some View {
+        ZStack {
+            HStack {
+                FMBall(size: 24)
+                Spacer()
+            }
+            Text(title)
+                .font(FMFont.ui(FMFont.md, weight: .bold))
+                .foregroundStyle(FMColor.fg1)
+        }
+        .padding(.horizontal, 14)
+        .frame(height: 46)
+        .frame(maxWidth: .infinity)
+        .background(alignment: .bottom) { barBackground }
+    }
+
+    private var barBackground: some View {
+        ZStack {
+            Rectangle().fill(.ultraThinMaterial)
+            Rectangle().fill(FMColor.ink950.opacity(0.7))
+        }
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(FMColor.borderSubtle).frame(height: 1)
+        }
+        .ignoresSafeArea(edges: .top)
+    }
+}
+
+#Preview {
+    ZStack {
+        FMColor.bgApp.ignoresSafeArea()
+        VStack(spacing: 0) {
+            FMTopBar(title: "FortyMM")
+            Spacer()
+        }
+    }
+    .preferredColorScheme(.dark)
+}

--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -17,7 +17,6 @@ struct DashboardView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(FMColor.bgApp.ignoresSafeArea())
-        .navigationBarTitleDisplayMode(.inline)
         .task { await session.load() }
     }
 

--- a/ios/Fortymm/Navigation/MainTabView.swift
+++ b/ios/Fortymm/Navigation/MainTabView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// The five bottom-nav slots. `newMatch` is an action slot, not a screen —
+/// selecting it triggers the new-match flow rather than switching tabs.
+enum FMTab: Hashable {
+    case home, matches, newMatch, tournaments, profile
+
+    /// Title shown in the top bar for the tab.
+    var title: String {
+        switch self {
+        case .home: return "FortyMM"
+        case .matches: return "Matches"
+        case .newMatch: return "New match"
+        case .tournaments: return "Tournaments"
+        case .profile: return "You"
+        }
+    }
+}
+
+/// The signed-in app shell. Uses the system `TabView` so the bottom bar is the
+/// real iOS tab bar (free safe-area handling, accessibility, the standard look),
+/// tinted ball-orange for the active tab. Today only Home is a real screen. The
+/// shell owns the single top bar so each tab screen is just its content.
+struct MainTabView: View {
+    @State private var selection: FMTab = .home
+
+    var body: some View {
+        TabView(selection: tabSelection) {
+            DashboardView()
+                .tabItem { Label("Home", systemImage: "house") }
+                .tag(FMTab.home)
+
+            FMComingSoon(title: "Matches")
+                .tabItem { Label("Matches", systemImage: "sportscourt") }
+                .tag(FMTab.matches)
+
+            // Action slot — intercepted in `tabSelection`, never shown.
+            Color.clear
+                .tabItem { Label("New match", systemImage: "plus") }
+                .tag(FMTab.newMatch)
+
+            FMComingSoon(title: "Tournaments")
+                .tabItem { Label("Tournaments", systemImage: "trophy") }
+                .tag(FMTab.tournaments)
+
+            FMComingSoon(title: "You")
+                .tabItem { Label("You", systemImage: "person.crop.circle") }
+                .tag(FMTab.profile)
+        }
+        .tint(FMColor.ball500)
+        .toolbar(.hidden, for: .navigationBar)
+        .navigationBarBackButtonHidden(true)
+        .safeAreaInset(edge: .top, spacing: 0) {
+            FMTopBar(title: selection.title)
+        }
+    }
+
+    /// Keeps the current tab when the "New match" slot is tapped — that slot is
+    /// an action, not a destination. The flow itself isn't built yet.
+    private var tabSelection: Binding<FMTab> {
+        Binding(
+            get: { selection },
+            set: { newValue in
+                guard newValue != .newMatch else { return }
+                selection = newValue
+            }
+        )
+    }
+}
+
+#Preview {
+    NavigationStack { MainTabView() }
+        .preferredColorScheme(.dark)
+}

--- a/ios/Fortymm/Navigation/RootView.swift
+++ b/ios/Fortymm/Navigation/RootView.swift
@@ -11,7 +11,7 @@ struct RootView: View {
                 .navigationDestination(for: Route.self) { route in
                     switch route {
                     case .dashboard:
-                        DashboardView()
+                        MainTabView()
                     }
                 }
         }


### PR DESCRIPTION
Replaces the dashboard's default navigation chrome with the FortyMM iOS design (from the Claude Design handoff).

## What changed
- **`FMTopBar`** — compact centered top bar: brand ball on the left, centered title, translucent dark surface with a hairline bottom border. Owned by the app shell so each tab screen is just its content; the title is derived from the selected tab.
- **`FMBall`** — the glossy ball-orange disc extracted from `FMLogo` for reuse in the top bar.
- **`MainTabView`** — signed-in app shell hosting the **native iOS `TabView`** bottom nav: Home · Matches · New match · Tournaments · You, active tab tinted ball-orange. "New match" is an action slot (intercepted via the selection binding); its flow isn't built yet.
- **`FMComingSoon`** — placeholder screens for the not-yet-built tabs.
- **`Route.dashboard`** now resolves to `MainTabView` instead of `DashboardView`.

## Notes
- Bottom nav uses the system `TabView` (per request to use the built-in bar) rather than a custom bar — the tradeoff is "New match" renders as a plain `+` tab instead of the design's bordered orange tile, since the system tab bar doesn't allow per-item styling.
- No back/sign-out path out of the tab shell yet (back button hidden) — fine for current scope, worth a follow-up when auth lands.
- iOS-only diff; no `api/`, `web-client/`, or `e2e/` files touched.

## Verification
- `xcodebuild` clean (BUILD SUCCEEDED).
- Simulator screenshots of Home and a placeholder tab confirm the top bar (border + reactive title) and native bottom nav render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)