### PR TITLE
Fix dead Settings footer "Sign out" link (#378)

### DIFF
--- a/web-client/src/routes/settings.test.tsx
+++ b/web-client/src/routes/settings.test.tsx
@@ -10,7 +10,10 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { http, HttpResponse } from 'msw'
+
 import { mockSession } from '@/mocks/handlers'
+import { server } from '@/mocks/server'
 
 // The real Turnstile widget loads a remote script that jsdom can't run.
 // Replace it with a stub that hands back a token on click, so the form
@@ -208,5 +211,32 @@ describe('SettingsPage username section', () => {
 
     const section = input.closest('section') as HTMLElement
     expect(within(section).getByText(/no spaces/i)).toBeInTheDocument()
+  })
+})
+
+describe('SettingsPage footer sign out', () => {
+  it('exposes Sign out as a real, keyboard-focusable button', async () => {
+    await renderSettings()
+    const signOut = await screen.findByTestId('settings-footer-sign-out')
+    // Regression for #378: must be an interactive <button>, not a dead <a>.
+    expect(signOut.tagName).toBe('BUTTON')
+    signOut.focus()
+    expect(signOut).toHaveFocus()
+  })
+
+  it('signs the user out via DELETE /v1/session when clicked', async () => {
+    const user = userEvent.setup()
+    let deleteCalled = false
+    server.use(
+      http.delete('*/v1/session', async () => {
+        deleteCalled = true
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+
+    await renderSettings()
+    await user.click(await screen.findByTestId('settings-footer-sign-out'))
+
+    await waitFor(() => expect(deleteCalled).toBe(true))
   })
 })

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -1069,9 +1069,6 @@ function SettingsPage() {
                 display: 'flex',
                 justifyContent: 'flex-end',
                 marginTop: 12,
-                fontSize: 'var(--text-xs)',
-                fontFamily: 'var(--font-mono)',
-                letterSpacing: '0.06em',
               }}
             >
               <button

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -6,13 +6,18 @@ import {
   type CSSProperties,
   type ReactNode,
 } from 'react'
-import { createFileRoute, useRouterState } from '@tanstack/react-router'
+import {
+  createFileRoute,
+  useNavigate,
+  useRouterState,
+} from '@tanstack/react-router'
 import { Check, Mail } from 'lucide-react'
 import { toast } from 'sonner'
 
 import { ApiError } from '@/api/client'
 import {
   deriveEmailStatus,
+  useLogout,
   useResendEmailConfirmation,
   useSession,
   useSetEmail,
@@ -977,6 +982,8 @@ function focusEmailInput() {
 
 function SettingsPage() {
   const session = useSession()
+  const logout = useLogout()
+  const navigate = useNavigate()
   const sessionUser = session.data?.data.user
   const sessionUsername = sessionUser?.username ?? ''
   const sessionEmail = sessionUser?.email ?? null
@@ -1050,11 +1057,47 @@ function SettingsPage() {
                 <a className="fmm-link" style={{ fontSize: 'var(--text-xs)' }}>
                   Privacy
                 </a>
-                <a className="fmm-link" style={{ fontSize: 'var(--text-xs)' }}>
-                  Sign out
-                </a>
               </div>
             </ComingSoon>
+            {/*
+              "Sign out" is a real, available action (the user-menu "Log out"
+              uses the same flow), so it lives outside the coming-soon footer
+              placeholder as a genuine, keyboard-focusable button. See #378.
+            */}
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                marginTop: 12,
+                fontSize: 'var(--text-xs)',
+                fontFamily: 'var(--font-mono)',
+                letterSpacing: '0.06em',
+              }}
+            >
+              <button
+                type="button"
+                className="fmm-link"
+                data-testid="settings-footer-sign-out"
+                disabled={logout.isPending}
+                onClick={() => {
+                  logout.mutate(undefined, {
+                    onSuccess: () => {
+                      void navigate({ to: '/dashboard' })
+                    },
+                  })
+                }}
+                style={{
+                  fontSize: 'var(--text-xs)',
+                  fontFamily: 'inherit',
+                  letterSpacing: 'inherit',
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                }}
+              >
+                Sign out
+              </button>
+            </div>
           </div>
         </TooltipProvider>
       </div>


### PR DESCRIPTION
## What

The Settings footer "Sign out" control did nothing on click and wasn't keyboard- or AT-accessible (#378). Root cause: the entire footer — version string, "Privacy", and "Sign out" — was wrapped in the `<ComingSoon>` placeholder, which renders an `inert` div. "Sign out" is a genuinely available action (the user-menu "Log out" uses the same flow), so it got wrongly swept into the coming-soon placeholder.

## Change

- Pull "Sign out" **out** of the inert `<ComingSoon>` block and render it as a real, keyboard-focusable `<button>` wired to the existing `useLogout` + navigate-to-`/dashboard` flow (identical to `user-menu.tsx`).
- Reset the button's background/border/padding and inherit font props so it matches the `.fmm-link` styling (`.fmm-link` only sets color; `<button>` UA styles don't inherit font).
- Leave "Privacy" inside the `inert` placeholder — it has no destination page yet, and `inert` is the a11y-correct treatment for a non-interactive placeholder.

## Tests

Two regression tests added to `settings.test.tsx`:
- "Sign out" is an interactive, focusable `<button>` (not a dead `<a>`).
- Clicking it fires `DELETE /v1/session`.

All web-client suites green: 130 unit, 125 e2e, lint clean, `tsc -b && vite build` passes.

## Notes

- Skipped extracting a shared `useSignOut` hook for the (3-line) logout+navigate duplication with `user-menu.tsx` — the only natural home, `api/session.ts`, would couple the data layer to the router. Worth revisiting if a 3rd call site appears.
- Web-client-only change: API suite, OpenAPI schema-drift check, and root e2e are N/A.

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)