### PR TITLE
iOS: fix score-entry edge collision, opaque match-detail footer, drop keyboard button

### DIFF
--- a/ios/Fortymm/MatchFlow/MatchDetailView.swift
+++ b/ios/Fortymm/MatchFlow/MatchDetailView.swift
@@ -290,11 +290,19 @@ struct MatchDetailView: View {
         .padding(.horizontal, 16)
         .padding(.top, 14)
         .padding(.bottom, 30)
-        .background(
-            LinearGradient(colors: [.clear, FMColor.ink950.opacity(0.96)],
-                           startPoint: .top, endPoint: .bottom)
+        // Solid backing so scrolled content never shows through the bar or the
+        // outlined "Log another" button; the short fade above lets content
+        // dissolve as it scrolls up toward the bar.
+        .background {
+            FMColor.ink950
                 .ignoresSafeArea()
-        )
+                .overlay(alignment: .top) {
+                    LinearGradient(colors: [.clear, FMColor.ink950],
+                                   startPoint: .top, endPoint: .bottom)
+                        .frame(height: 24)
+                        .offset(y: -24)
+                }
+        }
     }
 }
 

--- a/ios/Fortymm/MatchFlow/ScoreEntryView.swift
+++ b/ios/Fortymm/MatchFlow/ScoreEntryView.swift
@@ -147,36 +147,25 @@ struct ScoreEntryView: View {
 
     @ViewBuilder
     private var actionRow: some View {
-        if editing {
-            HStack(spacing: 10) {
-                Button(action: clearEdit) {
-                    Text("Clear")
-                        .font(FMFont.ui(15, weight: .semibold))
-                        .foregroundStyle(FMColor.fg2)
-                        .padding(.horizontal, 20)
-                        .frame(height: 48)
-                        .fmRoundedBorder(radius: 13, color: FMColor.borderDefault)
-                }
-                .buttonStyle(.plain)
-                PrimaryAction(title: "Save changes", filled: currentValid, enabled: currentValid, action: saveEdit)
-            }
-        } else if deciding {
+        if deciding {
+            // A valid result that reaches `need` ends the match — offer Post,
+            // whether reached by live entry or by editing an earlier game (e.g.
+            // fixing game 2 that turns out to clinch the match).
             HStack(spacing: 12) {
-                Text("This finishes the match — post the result.")
-                    .font(FMFont.ui(12, weight: .medium))
-                    .foregroundStyle(FMColor.fg3)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Button(action: post) {
-                    Text("Post result")
-                        .font(FMFont.ui(16, weight: .bold))
-                        .foregroundStyle(FMColor.fgInverse)
-                        .padding(.horizontal, 26)
-                        .frame(height: 50)
-                        .background(BallGradient())
-                        .clipShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
-                        .shadow(color: FMColor.ball500.opacity(0.32), radius: 11, y: 8)
+                if editing {
+                    clearButton
+                } else {
+                    Text("This finishes the match — post the result.")
+                        .font(FMFont.ui(12, weight: .medium))
+                        .foregroundStyle(FMColor.fg3)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .buttonStyle(.plain)
+                postButton(expand: editing)
+            }
+        } else if editing {
+            HStack(spacing: 10) {
+                clearButton
+                PrimaryAction(title: "Save changes", filled: currentValid, enabled: currentValid, action: saveEdit)
             }
         } else {
             // Neutral "save & next" — raised dark surface, not the hero gradient.
@@ -194,6 +183,35 @@ struct ScoreEntryView: View {
             .buttonStyle(.plain)
             .disabled(!currentValid)
         }
+    }
+
+    private var clearButton: some View {
+        Button(action: clearEdit) {
+            Text("Clear")
+                .font(FMFont.ui(15, weight: .semibold))
+                .foregroundStyle(FMColor.fg2)
+                .padding(.horizontal, 20)
+                .frame(height: 48)
+                .fmRoundedBorder(radius: 13, color: FMColor.borderDefault)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func postButton(expand: Bool) -> some View {
+        Button(action: post) {
+            HStack(spacing: 8) {
+                Text("Post result").font(FMFont.ui(16, weight: .bold))
+                if expand { Image(systemName: "arrow.right").font(.system(size: 15, weight: .bold)) }
+            }
+            .foregroundStyle(FMColor.fgInverse)
+            .padding(.horizontal, 26)
+            .frame(maxWidth: expand ? .infinity : nil)
+            .frame(height: 50)
+            .background(BallGradient())
+            .clipShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
+            .shadow(color: FMColor.ball500.opacity(0.32), radius: 11, y: 8)
+        }
+        .buttonStyle(.plain)
     }
 
     private var hint: some View {

--- a/ios/Fortymm/MatchFlow/ScoreEntryView.swift
+++ b/ios/Fortymm/MatchFlow/ScoreEntryView.swift
@@ -82,6 +82,8 @@ struct ScoreEntryView: View {
                 MetaChip(text: config.rated ? "Rated" : "Casual", accent: config.rated)
             }
             DisplayTitle(editing ? "EDIT GAME \(active + 1) SCORE" : "ENTER GAME \(active + 1) SCORE", size: 32)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
                 .padding(.horizontal, 4)
                 .padding(.bottom, 14)
         }
@@ -402,9 +404,13 @@ private struct GameChip: View {
                     }
                 }
                 .font(FMFont.mono(13, weight: .bold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
             }
+            // No fixed min width: chips share the row evenly and shrink to fit so
+            // a full best-of-7 scoreline never forces the screen wider than it is
+            // (which on narrow phones pushed the whole layout past both edges).
             .frame(maxWidth: .infinity)
-            .frame(minWidth: 52)
             .padding(.horizontal, 4)
             .padding(.top, 8)
             .padding(.bottom, 7)

--- a/ios/Fortymm/MatchFlow/ScoreEntryView.swift
+++ b/ios/Fortymm/MatchFlow/ScoreEntryView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 /// Screen 2 — live, game-by-game score entry, plus edit mode for completed
-/// games. Scores are native `.numberPad` text fields (no in-app keypad); the
-/// keyboard toolbar carries the "next / submit" action since numberPad has no
-/// return key.
+/// games. Scores are native `.numberPad` text fields (no in-app keypad);
+/// advancing between sides / submitting is done via the on-screen action row
+/// and by tapping a score field directly.
 struct ScoreEntryView: View {
     let config: MatchConfig
     var onPost: (FinalMatch) -> Void
@@ -53,9 +53,6 @@ struct ScoreEntryView: View {
             hint
         }
         .background(FMColor.ink950.ignoresSafeArea())
-        .toolbar {
-            ToolbarItemGroup(placement: .keyboard) { keyboardAccessory }
-        }
         .onAppear {
             if games.isEmpty { games = Array(repeating: Game(), count: config.bestOf) }
             focusYou()
@@ -208,28 +205,6 @@ struct ScoreEntryView: View {
             .padding(.bottom, 24)
     }
 
-    // MARK: Keyboard accessory (replaces the missing numberPad return key)
-
-    @ViewBuilder
-    private var keyboardAccessory: some View {
-        Spacer()
-        if focus == .you {
-            Button("Next") { focus = .opponent }
-                .font(FMFont.ui(15, weight: .semibold))
-                .tint(FMColor.ball500)
-        } else {
-            Button(submitLabel) { submitCurrent() }
-                .font(FMFont.ui(15, weight: .bold))
-                .tint(FMColor.ball500)
-                .disabled(!currentValid)
-        }
-    }
-
-    private var submitLabel: String {
-        if editing { return "Save changes" }
-        return deciding ? "Post result" : "Save & next"
-    }
-
     // MARK: Binding + actions
 
     /// Two-digit numeric binding for one side, clamped to 40 (matches prototype).
@@ -255,13 +230,6 @@ struct ScoreEntryView: View {
 
     private func focusYou() {
         DispatchQueue.main.async { focus = .you }
-    }
-
-    private func submitCurrent() {
-        guard currentValid else { return }
-        if editing { saveEdit() }
-        else if deciding { post() }
-        else { saveNext() }
     }
 
     private func saveNext() {


### PR DESCRIPTION
Three iOS UI fixes for the native match flow.

## 1. Score-entry layout overflowed on narrow phones
`GameChip` had a fixed `minWidth: 52`, so a full best-of-7 scoreline (7 chips + the "SCORELINE" label + paddings) exceeded the width of narrow devices (mini/SE). Centered, that forced the whole `VStack` wider than the screen, pushing every element's horizontal padding off **both** edges and clipping the title — the "everything hits the edge" bug reported from a phone.

Fix: chips now share the row evenly and shrink to fit (`minimumScaleFactor`), and the title scales instead of overflowing. Verified by building + screenshotting at the worst case (BO7 on a 320pt iPhone SE) down through normal widths.

## 2. Match-detail footer was see-through
The footer background was a `.clear → ink950.opacity(0.96)` gradient over the `ScrollView`, so its top was transparent and the outlined "Log another" button showed scrolling content behind it. Fix: solid `ink950` backing with a short fade above the bar so content still dissolves as it scrolls up.

## 3. Removed the keyboard-toolbar "Save & next"/"Next" button
It floated awkwardly over the number pad and duplicated controls already on screen (the action row submits; tapping a score field switches sides). Dropped the now-unused `keyboardAccessory` / `submitLabel` / `submitCurrent` helpers with it.

## Verification
iOS-only changes (no API/web-client code touched). Verified by building the app for the simulator and screenshotting each screen across device widths and match formats; clean Debug build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)