### PR TITLE
Drop stale "awaiting confirmation" notice on finalized matches (#358)

### DIFF
--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -800,4 +800,54 @@ describe('MatchDetailsView', () => {
       within(callout).queryByRole('button', { name: /confirm result/i }),
     ).not.toBeInTheDocument()
   })
+
+  it('drops the awaiting-confirmation notice once the match is finalized (#358)', async () => {
+    // The opponent has now confirmed: status flips to `completed` and both
+    // signatures are on record. The signer's passive "awaiting" notice must
+    // disappear rather than linger above the Final match.
+    const match = matchDetails({
+      id: 'm-final',
+      status: 'completed',
+      status_label: 'Final',
+      sides: [
+        {
+          side_number: 1,
+          players: [
+            { user_id: 'u-me', username: 'me', is_current_user: true },
+          ],
+          games_won: 3,
+          won: true,
+          is_current_user_side: true,
+        },
+        {
+          side_number: 2,
+          players: [
+            { user_id: 'u-opp', username: 'nguyen.t', is_current_user: false },
+          ],
+          games_won: 1,
+          won: false,
+          is_current_user_side: false,
+        },
+      ],
+      can_confirm: false,
+      signatures: [
+        { user_id: 'u-me', signed_at: '2026-05-26T12:00:00Z' },
+        { user_id: 'u-opp', signed_at: '2026-05-26T12:05:00Z' },
+      ],
+    })
+    server.use(
+      http.get('*/v1/matches/m-final', () => HttpResponse.json(match)),
+    )
+
+    const { container } = renderDetails('m-final')
+
+    // Wait for the match content to render, then assert the awaiting callout
+    // is gone (it must not linger above a Final match).
+    await waitFor(() =>
+      expect(container.querySelector('.md-card__hd h3')).toBeInTheDocument(),
+    )
+    expect(
+      screen.queryByTestId('match-confirm-callout'),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -267,6 +267,12 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
   // by username for the passive "Awaiting <opp>" copy when the viewer has
   // already signed. Null when there's no posted result, or the viewer can't
   // see this state (anonymous, non-participant, etc.).
+  //
+  // Gated on ``in_progress``: a posted result keeps the match in_progress
+  // until the other side signs, at which point /confirmation flips it to
+  // ``completed``. Once finalized (or disputed/voided) the signatures still
+  // exist, so without this status check the passive notice would linger above
+  // a Final match — even across a reload. See #358.
   const signers = new Set(data.signatures.map((sig) => sig.user_id))
   const viewerUserId = viewerIsParticipant
     ? (leftSide.players[0]?.user_id ?? null)
@@ -274,7 +280,10 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
   const viewerHasSigned =
     viewerUserId !== null && signers.has(viewerUserId)
   const viewerIsAwaitingOther =
-    viewerIsParticipant && data.signatures.length > 0 && viewerHasSigned
+    data.status === 'in_progress' &&
+    viewerIsParticipant &&
+    data.signatures.length > 0 &&
+    viewerHasSigned
   // Find the participant who's missing from the signature set. With "at
   // least one player per side" semantics, this picks the first un-signed
   // player on the other side. Falls back to "your opponent" if we can't

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -268,11 +268,11 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
   // already signed. Null when there's no posted result, or the viewer can't
   // see this state (anonymous, non-participant, etc.).
   //
-  // Gated on ``in_progress``: a posted result keeps the match in_progress
-  // until the other side signs, at which point /confirmation flips it to
-  // ``completed``. Once finalized (or disputed/voided) the signatures still
-  // exist, so without this status check the passive notice would linger above
-  // a Final match — even across a reload. See #358.
+  // Gated on the live (``in_progress``) state: a posted result keeps the match
+  // in_progress until the other side signs, at which point /confirmation flips
+  // it to ``completed``. Once finalized (or disputed/voided) the signatures
+  // still exist, so without this status check the passive notice would linger
+  // above a Final match — even across a reload. See #358.
   const signers = new Set(data.signatures.map((sig) => sig.user_id))
   const viewerUserId = viewerIsParticipant
     ? (leftSide.players[0]?.user_id ?? null)
@@ -280,7 +280,7 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
   const viewerHasSigned =
     viewerUserId !== null && signers.has(viewerUserId)
   const viewerIsAwaitingOther =
-    data.status === 'in_progress' &&
+    state === 'live' &&
     viewerIsParticipant &&
     data.signatures.length > 0 &&
     viewerHasSigned


### PR DESCRIPTION
## What

Fixes #358. After the opponent clicks **Confirm result**, the match correctly flips to `Final`, but the passive **"Posted · awaiting confirmation"** notice kept rendering above the players card for both players — and survived a full page reload.

## Root cause

In `match-details-page.tsx`, the `viewerIsAwaitingOther` flag was computed purely from signatures:

```ts
viewerIsParticipant && data.signatures.length > 0 && viewerHasSigned
```

A posted result keeps the match `in_progress` until the other side signs; `/confirmation` then flips it to `completed`. But the signatures stay on record, so once finalized the flag was still `true` and the notice lingered. Because it's derived deterministically from (correct) server data, a reload didn't clear it.

## Fix

Gate the flag on `data.status === 'in_progress'` — the only state where awaiting-confirmation is meaningful. Once the match is `completed` (or `disputed`/`voided`), the passive notice no longer renders.

## Tests

Added a regression test: a `completed` match carrying both signatures no longer renders the confirm callout. Verified the test goes red without the fix and green with it. Full web-client suite green (131 unit), lint + `tsc -b && vite build` pass.

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)