### PR TITLE
iOS: dashboard "Your game" widgets (rating + recent matches) from /v1/dashboard

### DIFF
--- a/ios/Fortymm/Dashboard/DashboardModels.swift
+++ b/ios/Fortymm/Dashboard/DashboardModels.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Mirror of the API's `DashboardResponse` (see `api/app/schemas/dashboard.py`),
+/// which backs the dashboard's "Your game" widgets. Decoded with
+/// `.convertFromSnakeCase`, so `recent_results` / `spark_data` / `my_rating_change`
+/// arrive as `recentResults` / `sparkData` / `myRatingChange`.
+struct DashboardResponse: Decodable {
+    let scoreBanners: [DashboardScoreBanner]
+    let nextMatch: DashboardNextMatch?
+    let recentResults: [DashboardRecentResult]
+    let rating: DashboardRating?
+    let completedMatchCount: Int
+}
+
+struct DashboardScoreBanner: Decodable {
+    let matchId: UUID
+    let opponentUsername: String?
+    let currentGameNumber: Int
+}
+
+struct DashboardNextMatch: Decodable {
+    let matchId: UUID
+    let opponentUsername: String?
+    let bestOf: Int
+    let createdAt: Date
+}
+
+/// One row of the "Recent matches" table.
+struct DashboardRecentResult: Decodable, Identifiable {
+    let matchId: UUID
+    let opponentUsername: String?
+    let isWin: Bool
+    let myGamesWon: Int
+    let opponentGamesWon: Int
+    let completedAt: Date
+    let myRatingChange: RatingChange?
+
+    var id: UUID { matchId }
+}
+
+struct RatingChange: Decodable {
+    let before: Double?
+    let after: Double
+    let delta: Double
+}
+
+/// The "Current rating" card payload. Emitted only for automatic-strategy
+/// leagues with a rated user — `nil` otherwise (manual league / unrated).
+struct DashboardRating: Decodable {
+    let leagueId: UUID
+    let leagueName: String
+    let strategyKey: String
+    let current: Double
+    let delta: Double
+    let peak: Double
+    let percentile: Int?
+    let sparkData: [Double]
+    let streak: DashboardStreak?
+    let stats: [DashboardRatingStat]
+}
+
+struct DashboardStreak: Decodable {
+    let kind: String   // "W" | "L"
+    let n: Int
+}
+
+struct DashboardRatingStat: Decodable {
+    let label: String
+    let value: String   // pre-formatted server-side
+}
+
+extension DashboardRating {
+    /// Human label for the rating strategy, mirroring `ratingStrategyLabel`
+    /// in `web-client/src/components/dashboard/dashboard-page.tsx`.
+    var strategyLabel: String {
+        switch strategyKey {
+        case "glicko2": return "Glicko-2"
+        case "manual": return "Manual"
+        default: return strategyKey
+        }
+    }
+}

--- a/ios/Fortymm/Dashboard/DashboardSparkline.swift
+++ b/ios/Fortymm/Dashboard/DashboardSparkline.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+/// A compact rating sparkline: a gradient-filled area under a stroked line with
+/// a marker on the latest point. Mirrors the SVG `Sparkline` in
+/// `web-client/src/components/dashboard/dashboard-page.tsx`.
+///
+/// Needs ≥2 points to draw a line; a single point (or none) renders a flat
+/// baseline so the freshly-rated case still looks intentional.
+struct DashboardSparkline: View {
+    let data: [Double]
+    var color: Color = FMColor.ball500
+    var height: CGFloat = 48
+
+    private var points: [Double] {
+        switch data.count {
+        case 0: return [0, 0]
+        case 1: return [data[0], data[0]]
+        default: return data
+        }
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let pts = positions(in: geo.size)
+            ZStack {
+                // Gradient fill under the curve.
+                areaPath(through: pts, height: geo.size.height)
+                    .fill(
+                        LinearGradient(
+                            colors: [color.opacity(0.35), color.opacity(0)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                // The line itself.
+                linePath(through: pts)
+                    .stroke(
+                        color,
+                        style: StrokeStyle(lineWidth: 1.75, lineCap: .round, lineJoin: .round)
+                    )
+                // Latest-point marker with a soft halo.
+                if let last = pts.last {
+                    Circle().fill(color.opacity(0.25)).frame(width: 10, height: 10).position(last)
+                    Circle().fill(color).frame(width: 5.2, height: 5.2).position(last)
+                }
+            }
+        }
+        .frame(height: height)
+    }
+
+    private func positions(in size: CGSize) -> [CGPoint] {
+        let pts = points
+        let minV = pts.min() ?? 0
+        let maxV = pts.max() ?? 0
+        let range = (maxV - minV) == 0 ? 1 : (maxV - minV)
+        let pad: CGFloat = 3
+        let n = max(pts.count - 1, 1)
+        return pts.enumerated().map { i, v in
+            let x = pad + (CGFloat(i) / CGFloat(n)) * (size.width - pad * 2)
+            let y = size.height - pad - CGFloat((v - minV) / range) * (size.height - pad * 2)
+            return CGPoint(x: x, y: y)
+        }
+    }
+
+    /// The open polyline through all points — shared by the stroked line and
+    /// the gradient area, which just closes it down to the baseline.
+    private func linePath(through pts: [CGPoint]) -> Path {
+        Path { p in
+            guard let first = pts.first else { return }
+            p.move(to: first)
+            pts.dropFirst().forEach { p.addLine(to: $0) }
+        }
+    }
+
+    private func areaPath(through pts: [CGPoint], height: CGFloat) -> Path {
+        guard let first = pts.first, let last = pts.last else { return Path() }
+        var p = linePath(through: pts)
+        p.addLine(to: CGPoint(x: last.x, y: height))
+        p.addLine(to: CGPoint(x: first.x, y: height))
+        p.closeSubpath()
+        return p
+    }
+}
+
+#Preview {
+    DashboardSparkline(data: [1500, 1480, 1465, 1440, 1410, 1380, 1320, 1290, 1260, 1249])
+        .padding()
+        .frame(width: 300)
+        .background(FMColor.bgPanel)
+        .preferredColorScheme(.dark)
+}

--- a/ios/Fortymm/Dashboard/DashboardStore.swift
+++ b/ios/Fortymm/Dashboard/DashboardStore.swift
@@ -1,0 +1,52 @@
+import Combine
+import Foundation
+
+/// Owns the dashboard's data. `load()` fetches the BFF endpoint `GET /v1/dashboard`
+/// (all the "Your game" widgets, pre-shaped) alongside `GET /v1/session` for the
+/// signed-in username used in the greeting. The two are independent, so they run
+/// concurrently.
+@MainActor
+final class DashboardStore: ObservableObject {
+    struct Loaded {
+        let username: String
+        let dashboard: DashboardResponse
+    }
+
+    enum State {
+        case idle
+        case loading
+        case loaded(Loaded)
+        case failed(String)
+    }
+
+    @Published private(set) var state: State = .idle
+
+    private let client: APIClient
+
+    init(client: APIClient = .shared) {
+        self.client = client
+    }
+
+    /// Fetch (or refetch) the dashboard. Skips the network call once loaded
+    /// unless `force` is set, so re-entering the tab doesn't refetch; pull to
+    /// refresh passes `force: true`.
+    ///
+    /// The two calls are sequenced, not concurrent: `GET /v1/session` is what
+    /// mints and stores the guest's session cookie on first launch, and
+    /// `GET /v1/dashboard` requires auth — firing them in parallel races the
+    /// dashboard ahead of the cookie and 401s. (Mirrors the web client, which
+    /// only enables the dashboard query after the session query succeeds.)
+    func load(force: Bool = false) async {
+        if case .loaded = state, !force { return }
+        if case .loading = state { return }
+
+        state = .loading
+        do {
+            let session = try await client.getSession()
+            let dashboard: DashboardResponse = try await client.get("/v1/dashboard")
+            state = .loaded(Loaded(username: session.data.user.username, dashboard: dashboard))
+        } catch {
+            state = .failed(error.fmMessage)
+        }
+    }
+}

--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -1,48 +1,94 @@
 import SwiftUI
 
-/// The signed-in landing surface. For now it does one real thing: create (or
-/// resume) the session via `GET /v1/session` and show who you are. Everything
-/// else is deliberately left for later.
+/// The signed-in landing surface. Shows the "Your game" widgets — the current
+/// rating card (with sparkline) and the recent-matches table — fed by the BFF
+/// endpoint `GET /v1/dashboard`. Mirrors the web dashboard's "Your game" row.
 struct DashboardView: View {
-    @StateObject private var session = SessionStore()
+    @StateObject private var store = DashboardStore()
+
+    private static let longDate: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "EEEE, MMMM d"   // e.g. "Wednesday, June 3"
+        return f
+    }()
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: FMSpace.s6) {
-                header
                 content
             }
             .padding(.horizontal, FMSpace.s5)
-            .padding(.vertical, FMSpace.s6)
+            // The shell's frosted top bar (~46pt) is laid over the top via the
+            // TabView's `.safeAreaInset`, and that inset doesn't fully reduce the
+            // scroll content's safe area inside the tab — so content renders under
+            // the bar. Clear it with a top pad of the bar height plus a small gap,
+            // otherwise the "Dashboard · <date>" overline is hidden behind the bar.
+            .padding(.top, 56)
+            .padding(.bottom, FMSpace.s6)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(FMColor.bgApp.ignoresSafeArea())
-        .task { await session.load() }
-    }
-
-    private var header: some View {
-        VStack(alignment: .leading, spacing: FMSpace.s3) {
-            FMEyebrow(text: "Dashboard")
-            VStack(alignment: .leading, spacing: 0) {
-                Text("Welcome to")
-                    .foregroundStyle(FMColor.fg1)
-                Text("FortyMM.")
-                    .foregroundStyle(FMColor.ball500)
-            }
-            .font(FMFont.display(40))
-        }
+        .refreshable { await store.load(force: true) }
+        .task { await store.load() }
     }
 
     @ViewBuilder
     private var content: some View {
-        switch session.state {
+        switch store.state {
         case .idle, .loading:
+            header(greeting: "Hi")
             loadingCard
-        case let .loaded(user):
-            sessionCard(user)
+        case let .loaded(loaded):
+            header(greeting: "Hi, @\(loaded.username)")
+            yourGame(loaded.dashboard)
         case let .failed(message):
+            header(greeting: "Hi")
             errorCard(message)
         }
+    }
+
+    private func header(greeting: String) -> some View {
+        VStack(alignment: .leading, spacing: FMSpace.s2) {
+            DashOverline(text: "Dashboard · \(Self.longDate.string(from: Date()))")
+            (Text(greeting).foregroundStyle(FMColor.fg1)
+                + Text(".").foregroundStyle(FMColor.ball500))
+                .font(FMFont.ui(FMFont.xl2, weight: .bold))
+        }
+    }
+
+    @ViewBuilder
+    private func yourGame(_ data: DashboardResponse) -> some View {
+        VStack(alignment: .leading, spacing: FMSpace.s4) {
+            HStack(alignment: .firstTextBaseline, spacing: FMSpace.s3) {
+                Text("Your game")
+                    .font(FMFont.ui(FMFont.md, weight: .semibold))
+                    .foregroundStyle(FMColor.fg1)
+                Text(yourGameSubtitle(data.rating))
+                    .font(FMFont.ui(FMFont.sm))
+                    .foregroundStyle(FMColor.fgMuted)
+                Spacer()
+            }
+
+            if let rating = data.rating {
+                DashboardRatingCard(rating: rating)
+            } else {
+                FMCard {
+                    VStack(alignment: .leading, spacing: FMSpace.s3) {
+                        DashOverline(text: "Current rating")
+                        Text("Not in a rated league yet.")
+                            .font(FMFont.ui(FMFont.sm))
+                            .foregroundStyle(FMColor.fg3)
+                    }
+                }
+            }
+
+            DashboardRecentResultsCard(rows: data.recentResults)
+        }
+    }
+
+    private func yourGameSubtitle(_ rating: DashboardRating?) -> String {
+        guard let rating else { return "Last 30 days" }
+        return "\(rating.strategyLabel) · last 30 days"
     }
 
     private var loadingCard: some View {
@@ -50,7 +96,7 @@ struct DashboardView: View {
             HStack(spacing: FMSpace.s3) {
                 ProgressView()
                     .tint(FMColor.ball500)
-                Text("Creating your session…")
+                Text("Loading your dashboard…")
                     .font(FMFont.ui(FMFont.md))
                     .foregroundStyle(FMColor.fg3)
             }
@@ -58,42 +104,10 @@ struct DashboardView: View {
         }
     }
 
-    private func sessionCard(_ user: SessionUser) -> some View {
-        FMCard(featured: true) {
-            VStack(alignment: .leading, spacing: FMSpace.s4) {
-                HStack(spacing: FMSpace.s3) {
-                    FMAvatar(
-                        initials: initials(for: user.username),
-                        size: 44,
-                        color: FMColor.ball500,
-                        foreground: FMColor.fgInverse
-                    )
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(user.username)
-                            .font(FMFont.ui(FMFont.md, weight: .semibold))
-                            .foregroundStyle(FMColor.fg1)
-                        Text("Signed in")
-                            .font(FMFont.mono(FMFont.xs))
-                            .foregroundStyle(FMColor.fgMuted)
-                    }
-                    Spacer()
-                    FMBadge(text: badgeText(for: user.emailStatus), variant: .live)
-                }
-
-                Rectangle().fill(FMColor.borderSubtle).frame(height: 1)
-
-                Text(statusBlurb(for: user.emailStatus))
-                    .font(FMFont.ui(FMFont.sm))
-                    .foregroundStyle(FMColor.fg3)
-                    .lineSpacing(2)
-            }
-        }
-    }
-
     private func errorCard(_ message: String) -> some View {
         FMCard {
             VStack(alignment: .leading, spacing: FMSpace.s4) {
-                Text("Couldn't start your session")
+                Text("Couldn't load your dashboard")
                     .font(FMFont.ui(FMFont.md, weight: .semibold))
                     .foregroundStyle(FMColor.fg1)
                 Text(message)
@@ -101,30 +115,9 @@ struct DashboardView: View {
                     .foregroundStyle(FMColor.fg3)
                     .lineSpacing(2)
                 FMButton(title: "Try again", variant: .primary, size: .md) {
-                    Task { await session.load(force: true) }
+                    Task { await store.load(force: true) }
                 }
             }
-        }
-    }
-
-    private func initials(for username: String) -> String { username.fmInitials }
-
-    private func badgeText(for status: SessionUser.EmailStatus) -> String {
-        switch status {
-        case .guest: return "Guest"
-        case .pending: return "Pending"
-        case .verified: return "Verified"
-        }
-    }
-
-    private func statusBlurb(for status: SessionUser.EmailStatus) -> String {
-        switch status {
-        case .guest:
-            return "You're playing as a guest. Add an email later to keep your matches across devices."
-        case .pending:
-            return "Check your inbox to confirm your email and lock in your account."
-        case .verified:
-            return "Your account is verified. Your matches follow you everywhere."
         }
     }
 }

--- a/ios/Fortymm/Dashboard/DashboardWidgets.swift
+++ b/ios/Fortymm/Dashboard/DashboardWidgets.swift
@@ -1,0 +1,258 @@
+import SwiftUI
+
+// MARK: - Shared bits
+
+/// Small uppercase label used inside the dashboard cards. Mirrors the web
+/// `Overline` (no leading dot, unlike `FMEyebrow`).
+struct DashOverline: View {
+    let text: String
+    var size: CGFloat = FMFont.xs
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(FMFont.mono(size, weight: .medium))
+            .tracking(1.4)
+            .foregroundStyle(FMColor.fgMuted)
+    }
+}
+
+enum DashPillTone {
+    case win, loss
+
+    var fg: Color { self == .win ? FMColor.serve500 : FMColor.loss }
+    var bg: Color { fg.opacity(0.12) }
+}
+
+/// Rounded mono pill — the streak ("L4") and per-match delta ("−88 last match").
+private struct DashPill: View {
+    let text: String
+    let tone: DashPillTone
+
+    var body: some View {
+        Text(text)
+            .font(FMFont.mono(FMFont.xs, weight: .semibold))
+            .foregroundStyle(tone.fg)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 3)
+            .background(tone.bg, in: Capsule())
+    }
+}
+
+/// A single stat tile in the rating card's 3-up grid (Peak / RD / Volatility…).
+private struct DashStatTile: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            DashOverline(text: label, size: 9)
+            Text(value)
+                .font(FMFont.mono(FMFont.base, weight: .bold))
+                .foregroundStyle(FMColor.fg1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .dashInsetBox()
+    }
+}
+
+/// Signed integer label, e.g. `+12` / `-88`. Negative values already carry a
+/// minus, so only positives need the explicit `+`.
+private func signedRating(_ value: Double) -> String {
+    let n = Int(value.rounded())
+    return n >= 0 ? "+\(n)" : "\(n)"
+}
+
+/// A rounded rating as a plain digit string, e.g. `1500` — no locale grouping
+/// separator (the design shows bare four-digit ratings, not "1,500").
+private func plainRating(_ value: Double) -> String {
+    String(Int(value.rounded()))
+}
+
+private extension View {
+    /// The inset "well" shared by the sparkline panel and the stat tiles: a
+    /// darker fill with a hairline border.
+    func dashInsetBox() -> some View {
+        background(FMColor.ink900)
+            .fmRoundedBorder(radius: FMRadius.md, color: FMColor.ink700)
+    }
+}
+
+// MARK: - Current rating card
+
+struct DashboardRatingCard: View {
+    let rating: DashboardRating
+
+    // Peak tile, then up to two strategy-specific stats (the grid is 3-up).
+    private var tiles: [(label: String, value: String)] {
+        [("Peak", plainRating(rating.peak))]
+            + rating.stats.prefix(2).map { ($0.label, $0.value) }
+    }
+
+    var body: some View {
+        FMCard {
+            VStack(alignment: .leading, spacing: FMSpace.s4) {
+                HStack {
+                    DashOverline(text: "Current rating")
+                    Spacer()
+                    if let streak = rating.streak {
+                        DashPill(
+                            text: "\(streak.kind)\(streak.n)",
+                            tone: streak.kind == "W" ? .win : .loss
+                        )
+                    }
+                }
+
+                HStack(alignment: .firstTextBaseline, spacing: FMSpace.s3) {
+                    Text(verbatim: plainRating(rating.current))
+                        .font(FMFont.mono(56, weight: .bold))
+                        .foregroundStyle(FMColor.fg1)
+                    VStack(alignment: .leading, spacing: 5) {
+                        DashPill(
+                            text: "\(signedRating(rating.delta)) last match",
+                            tone: rating.delta >= 0 ? .win : .loss
+                        )
+                        percentileLine
+                    }
+                }
+
+                sparklineBox
+
+                HStack(spacing: FMSpace.s2) {
+                    ForEach(tiles, id: \.label) { tile in
+                        DashStatTile(label: tile.label, value: tile.value)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var percentileLine: some View {
+        if let percentile = rating.percentile {
+            (Text("Top ").foregroundStyle(FMColor.fgMuted)
+                + Text("\(percentile)%")
+                    .font(FMFont.mono(FMFont.xs))
+                    .foregroundStyle(FMColor.fg3)
+                + Text(" in \(rating.leagueName)").foregroundStyle(FMColor.fgMuted))
+                .font(FMFont.ui(FMFont.xs))
+        } else {
+            Text(rating.leagueName)
+                .font(FMFont.ui(FMFont.xs))
+                .foregroundStyle(FMColor.fgMuted)
+        }
+    }
+
+    private var sparklineBox: some View {
+        VStack(spacing: 6) {
+            DashboardSparkline(data: rating.sparkData)
+            HStack {
+                Text("30 days ago")
+                Spacer()
+                Text(verbatim: "Today · peak \(plainRating(rating.peak))")
+            }
+            .font(FMFont.mono(10))
+            .tracking(0.8)
+            .foregroundStyle(FMColor.fgMuted)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .dashInsetBox()
+    }
+}
+
+// MARK: - Recent matches card
+
+struct DashboardRecentResultsCard: View {
+    let rows: [DashboardRecentResult]
+
+    private var wins: Int { rows.filter(\.isWin).count }
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"   // e.g. "Jun 3"
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                DashOverline(text: "Recent matches")
+                Spacer()
+                (Text("\(wins)-\(rows.count - wins)")
+                    .font(FMFont.mono(FMFont.xs))
+                    .foregroundStyle(FMColor.fg2)
+                    + Text(" · last \(rows.count)")
+                    .font(FMFont.ui(FMFont.xs))
+                    .foregroundStyle(FMColor.fgMuted))
+            }
+            .padding(.horizontal, FMSpace.s4)
+            .padding(.top, FMSpace.s4)
+            .padding(.bottom, FMSpace.s3)
+
+            Rectangle().fill(FMColor.ink700).frame(height: 1)
+
+            if rows.isEmpty {
+                Text("No completed matches yet.")
+                    .font(FMFont.ui(FMFont.sm))
+                    .foregroundStyle(FMColor.fg3)
+                    .padding(FMSpace.s4)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                ForEach(Array(rows.enumerated()), id: \.element.id) { i, row in
+                    if i > 0 { Rectangle().fill(FMColor.ink700).frame(height: 1) }
+                    resultRow(row)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(FMColor.bgCard)
+        .fmRoundedBorder(radius: FMRadius.lg, color: FMColor.borderSubtle)
+    }
+
+    private func resultRow(_ row: DashboardRecentResult) -> some View {
+        let opponent = row.opponentUsername
+        let tint = row.isWin ? FMColor.serve500 : FMColor.loss
+        return HStack(spacing: FMSpace.s2) {
+            Circle()
+                .fill(tint)
+                .frame(width: 6, height: 6)
+                .shadow(color: tint.opacity(0.5), radius: 3)
+            FMAvatar(
+                initials: (opponent ?? "?").fmInitials,
+                size: 24,
+                color: FMColor.ink600,
+                foreground: FMColor.fg2
+            )
+            Text(opponent ?? "No opponent")
+                .font(FMFont.ui(FMFont.sm, weight: .medium))
+                .foregroundStyle(opponent == nil ? FMColor.fgMuted : FMColor.fg1)
+                .italic(opponent == nil)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text("\(row.myGamesWon)-\(row.opponentGamesWon)")
+                .font(FMFont.mono(FMFont.sm, weight: .medium))
+                .foregroundStyle(tint)
+
+            Group {
+                if let change = row.myRatingChange {
+                    Text(signedRating(change.delta))
+                        .foregroundStyle(change.delta >= 0 ? FMColor.serve500 : FMColor.loss)
+                } else {
+                    Text("—").foregroundStyle(FMColor.fgMuted)
+                }
+            }
+            .font(FMFont.mono(FMFont.xs, weight: .medium))
+            .frame(width: 46, alignment: .trailing)
+
+            Text(Self.dayFormatter.string(from: row.completedAt))
+                .font(FMFont.mono(FMFont.xs))
+                .foregroundStyle(FMColor.fgMuted)
+                .frame(width: 48, alignment: .trailing)
+        }
+        .padding(.horizontal, FMSpace.s4)
+        .padding(.vertical, 11)
+    }
+}


### PR DESCRIPTION
## What

Ports the web dashboard's **"Your game"** row to iOS, fed by the BFF endpoint `GET /v1/dashboard`, and removes the old welcome/session card:

- **Current rating card** — rating, win/loss streak pill, per-match delta pill, percentile (`Top N% in <league>`), a sparkline, and the Peak/RD/Volatility stat tiles.
- **Recent matches table** — opponent (avatar + win/loss dot), score, rating Δ, and date, with a W–L header and an empty state.
- **Header** — `Hi, @username.` greeting with a `Dashboard · <date>` overline.

States covered: loading, failed (retry), no-rating ("Not in a rated league yet."), and no-matches.

## Notes

- Session is fetched **before** the dashboard so the guest cookie is minted before the authed `/v1/dashboard` call (mirrors the web client gating dashboard on session success).
- New files are auto-picked up via the filesystem-synchronized Xcode group — no `.pbxproj` edits.
- IDs typed as `UUID` to match the rest of the iOS DTOs.

## Testing

- `xcodebuild` green (the iOS target ships no XCTest target).
- Verified live on the simulator against UAT; validated the `/v1/dashboard` JSON contract against the Swift `Decodable` structs.

## Follow-ups (non-blocking)

- `DashboardView` uses `.padding(.top, 56)` to clear the shell's frosted top bar — a localized workaround for a `TabView` + `.safeAreaInset` overlap that `MatchesListView` likely shares; a shell-level fix is the deeper altitude but touches other tabs.
- `SessionStore` is now unused (left as the canonical session loader).
- `score_banners` / `next_match` are decoded but not yet rendered (intentional partial port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)