### PR TITLE
web: use shared design-system components for dashboard panels

### DIFF
--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -1,5 +1,18 @@
 # web-client
 
+## Design system
+
+Prefer the shared design-system components in `src/components/ui` (showcased on
+the `/design-system` route) whenever one fits the need, instead of hand-rolling a
+bespoke inline-styled element. Before building a panel, banner, button, badge,
+etc., check `/design-system` for an existing component and use it — match the
+semantics, not just the look (e.g. a content panel is a `Card`; a dismissible
+"the app talking back" status/notice is an `Alert`, not a `Card`). Apply accent
+treatments via the same className/token patterns the showcase uses (e.g. the
+`--ball-500`/`--warn`/`--serve-500` tints, `var(--shadow-glow)` for the
+"Featured" highlight) rather than reinventing borders and gradients. Reach for a
+custom element only when nothing in the design system is a reasonable fit.
+
 ## Forms
 
 Show field validation errors inline, directly below the field, in red. Set

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -1,8 +1,10 @@
-import type { CSSProperties, ReactNode } from 'react'
+import type { ComponentProps, CSSProperties, ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
 import { ArrowRight, ChevronRight, Plus, X } from 'lucide-react'
 import { useDashboard } from '@/api/dashboard'
 import { UserAvatar } from '@/components/ui/user-avatar'
+import { Card as UICard } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
 import type {
   DashboardRating,
   DashboardRecentResult,
@@ -311,28 +313,38 @@ function Button({
   )
 }
 
+// The shared design-system Card (`@/components/ui/card`). `display: 'block'`
+// neutralizes the shadcn Card's default flex/gap so callers keep full control of
+// their inner layout (e.g. RatingCard re-enables flex via its own style;
+// RecentResultsCard stays block). Pass `highlight` for the design-system
+// "Featured" treatment — an orange ring plus the accent glow shadow, and
+// nothing else.
 function Card({
   children,
   padding = 20,
   style,
+  highlight = false,
+  className,
+  ...rest
 }: {
   children: ReactNode
   padding?: number | string
-  style?: CSSProperties
-}) {
+  highlight?: boolean
+} & Omit<ComponentProps<'div'>, 'children'>) {
   return (
-    <div
+    <UICard
+      className={cn(highlight && 'ring-2 ring-[color:var(--ball-500)]', className)}
       style={{
-        background: C.ink800,
-        border: `1px solid ${C.ink600}`,
-        borderRadius: 10,
+        display: 'block',
         padding,
         position: 'relative',
+        ...(highlight ? { boxShadow: 'var(--shadow-glow)' } : null),
         ...style,
       }}
+      {...rest}
     >
       {children}
-    </div>
+    </UICard>
   )
 }
 
@@ -503,40 +515,7 @@ function ScoreBanner({
     banner.current_game_number,
   )
   return (
-    <div
-      data-testid="dashboard-score-banner"
-      className="banner-glow"
-      style={{
-        position: 'relative',
-        background: `linear-gradient(180deg, rgba(255,122,26,0.10) 0%, rgba(11,13,18,0) 100%), ${C.ink800}`,
-        border: '1px solid rgba(255,122,26,0.42)',
-        borderRadius: 14,
-        overflow: 'hidden',
-      }}
-    >
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          height: 3,
-          background: `linear-gradient(90deg, ${accent} 0%, ${accent} 60%, transparent 100%)`,
-        }}
-      />
-      <div
-        style={{
-          position: 'absolute',
-          inset: 0,
-          pointerEvents: 'none',
-          backgroundImage:
-            'radial-gradient(circle at center, rgba(255,122,26,0.09) 1.2px, transparent 1.8px)',
-          backgroundSize: '40px 40px',
-          maskImage: 'linear-gradient(180deg, rgba(0,0,0,0.7), transparent)',
-          WebkitMaskImage: 'linear-gradient(180deg, rgba(0,0,0,0.7), transparent)',
-        }}
-      />
-
+    <Card highlight padding={0} data-testid="dashboard-score-banner">
       <div style={{ position: 'relative', padding: compact ? '20px 18px' : '22px 26px' }}>
         <div
           style={{
@@ -637,7 +616,7 @@ function ScoreBanner({
       >
         <X size={14} strokeWidth={1.75} />
       </button>
-    </div>
+    </Card>
   )
 }
 

--- a/web-client/src/components/dashboard/guest-persist-banner.tsx
+++ b/web-client/src/components/dashboard/guest-persist-banner.tsx
@@ -1,17 +1,9 @@
 import { useState, type CSSProperties, type ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
 import { Smartphone, X } from 'lucide-react'
+import { Alert, AlertAction, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
 
-const C = {
-  ink800: 'var(--ink-800)',
-  chalk50: 'var(--chalk-50)',
-  chalk100: 'var(--chalk-100)',
-  chalk300: 'var(--chalk-300)',
-  chalk500: 'var(--chalk-500)',
-  ball400: 'var(--ball-400)',
-}
-
-const UI = "'Space Grotesk', ui-sans-serif, system-ui, sans-serif"
 const MONO = "'JetBrains Mono', ui-monospace, monospace"
 
 // Reappears every browser session. We don't gate harder than that — the
@@ -38,19 +30,13 @@ function rememberDismissal() {
   }
 }
 
-function Mono({
-  children,
-  color = C.chalk50,
-}: {
-  children: ReactNode
-  color?: string
-}) {
+function Mono({ children }: { children: ReactNode }) {
   return (
     <span
       style={{
         font: `600 14px ${MONO}`,
         fontVariantNumeric: 'tabular-nums',
-        color,
+        color: 'var(--chalk-50)',
         letterSpacing: '-0.01em',
       }}
     >
@@ -65,6 +51,11 @@ type GuestPersistBannerProps = {
   style?: CSSProperties
 }
 
+// A dismissible "your data is local-only" nudge for guests. Built on the
+// design-system Alert (it's a status message, not a content panel): bare
+// leading icon, AlertDescription for the copy, and the AlertAction slot for
+// the dismiss control. Tinted with the ball accent to match the rest of the
+// guest-conversion surface.
 export function GuestPersistBanner({
   matchCount,
   rating,
@@ -75,47 +66,14 @@ export function GuestPersistBanner({
   if (dismissed) return null
 
   return (
-    <div
+    <Alert
       data-testid="dashboard-guest-persist-banner"
       role="status"
-      style={{
-        position: 'relative',
-        background: `linear-gradient(180deg, rgba(255,122,26,0.055) 0%, rgba(255,122,26,0.02) 100%), ${C.ink800}`,
-        border: '1px solid rgba(255,122,26,0.22)',
-        borderRadius: 10,
-        display: 'flex',
-        alignItems: 'center',
-        gap: 14,
-        padding: '11px 12px 11px 14px',
-        marginBottom: 20,
-        overflow: 'hidden',
-        ...style,
-      }}
+      className="mb-5 border-[color:var(--ball-500)]/25 bg-[color:var(--ball-500)]/8"
+      style={style}
     >
-      <div
-        style={{
-          width: 30,
-          height: 30,
-          borderRadius: 7,
-          background: 'rgba(255,122,26,0.10)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          flexShrink: 0,
-        }}
-      >
-        <Smartphone size={15} strokeWidth={1.75} color={C.ball400} aria-hidden />
-      </div>
-
-      <div
-        style={{
-          flex: 1,
-          minWidth: 0,
-          font: `400 14px ${UI}`,
-          color: C.chalk100,
-          lineHeight: 1.4,
-        }}
-      >
+      <Smartphone className="text-[color:var(--ball-400)]" aria-hidden />
+      <AlertDescription className="text-[color:var(--fg-2)]">
         <span>Your </span>
         <Mono>{matchCount}</Mono>
         <span> {matchCount === 1 ? 'match' : 'matches'}</span>
@@ -125,46 +83,30 @@ export function GuestPersistBanner({
             <Mono>{rating}</Mono>
           </>
         )}
-        <span style={{ color: C.chalk300 }}> live on this device only. </span>
+        <span className="text-[color:var(--chalk-300)]"> live on this device only. </span>
         <Link
           to="/settings"
           hash="sec-email"
-          style={{
-            color: C.ball400,
-            fontWeight: 600,
-            textDecoration: 'none',
-            borderBottom: `1px solid ${C.ball400}`,
-            paddingBottom: 1,
-            whiteSpace: 'nowrap',
-          }}
+          className="font-semibold whitespace-nowrap text-[color:var(--ball-400)]"
         >
           Add an email to keep them →
         </Link>
-      </div>
-
-      <button
-        type="button"
-        aria-label="Dismiss for this session"
-        onClick={() => {
-          rememberDismissal()
-          setDismissed(true)
-        }}
-        style={{
-          width: 28,
-          height: 28,
-          borderRadius: 6,
-          background: 'transparent',
-          border: 'none',
-          color: C.chalk500,
-          cursor: 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          flexShrink: 0,
-        }}
-      >
-        <X size={14} strokeWidth={1.75} />
-      </button>
-    </div>
+      </AlertDescription>
+      <AlertAction className="top-1/2 -translate-y-1/2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Dismiss for this session"
+          className="text-[color:var(--chalk-500)]"
+          onClick={() => {
+            rememberDismissal()
+            setDismissed(true)
+          }}
+        >
+          <X />
+        </Button>
+      </AlertAction>
+    </Alert>
   )
 }


### PR DESCRIPTION
## What

Replace the dashboard's bespoke inline-styled panels with the shared design-system components.

- **Rating + Recent-matches panels** (and the empty state) now render the shared `Card` (`@/components/ui/card`) via a thin wrapper, in its default (non-highlighted) form.
- **"Score needed" hero** uses that same `Card` with only the design-system "Featured" highlight (orange ring + `var(--shadow-glow)`), dropping its old gradient background, top accent line, and dot-pattern overlay.
- **Guest "live on this device only" banner** is now the design-system `Alert` (leading icon + `AlertDescription` + `AlertAction` dismiss), ball-tinted to match — replacing its hand-rolled `role="status"` div. Session-dismiss behavior is preserved.

Also adds a `web-client/CLAUDE.md` rule to prefer design-system components (matching semantics, not just looks) over bespoke inline-styled elements.

Net ~134 lines of hand-rolled gradient/border CSS removed.

## Notes

- The "Score needed" ✕ remains a decorative no-op — it was never wired to dismiss anything on `main` either, so this PR leaves that behavior unchanged.
- Rebased on top of #422 (responsive dashboard); the hero's `compact` responsive padding is preserved.

## Testing

- `tsc -b` + `vite build`: green
- vitest: 131/131
- eslint: clean
- web-client Playwright e2e: 125 passed
- Verified visually in the running app (guest Alert, highlighted hero, plain rating/recent cards; dismiss ✕ vertically centered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)