### PR TITLE
iOS: fix Matches header clipping and new-match Cancel landing nowhere

### DIFF
--- a/ios/Fortymm/Components/FMTopBar.swift
+++ b/ios/Fortymm/Components/FMTopBar.swift
@@ -4,6 +4,15 @@ import SwiftUI
 /// title, and a translucent dark surface with a hairline bottom border. Laid
 /// over the top safe area via `.safeAreaInset` so content scrolls under it.
 struct FMTopBar: View {
+    /// Height of the bar itself.
+    static let barHeight: CGFloat = 46
+    /// Top padding a tab's scroll content needs to clear the bar. The bar is laid
+    /// over the top via the shell's `.safeAreaInset`, and that inset doesn't fully
+    /// reduce the scroll content's safe area inside the `TabView` — so content
+    /// renders under the bar unless each tab screen pads by the bar height plus a
+    /// small gap. Use this constant rather than hardcoding the value per screen.
+    static let contentInset: CGFloat = barHeight + 10
+
     let title: String
 
     var body: some View {
@@ -17,7 +26,7 @@ struct FMTopBar: View {
                 .foregroundStyle(FMColor.fg1)
         }
         .padding(.horizontal, 14)
-        .frame(height: 46)
+        .frame(height: Self.barHeight)
         .frame(maxWidth: .infinity)
         .background(alignment: .bottom) { barBackground }
     }

--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -24,12 +24,8 @@ struct DashboardView: View {
                 content
             }
             .padding(.horizontal, FMSpace.s5)
-            // The shell's frosted top bar (~46pt) is laid over the top via the
-            // TabView's `.safeAreaInset`, and that inset doesn't fully reduce the
-            // scroll content's safe area inside the tab — so content renders under
-            // the bar. Clear it with a top pad of the bar height plus a small gap,
-            // otherwise the "Dashboard · <date>" overline is hidden behind the bar.
-            .padding(.top, 56)
+            // Clear the shell's frosted top bar (see `FMTopBar.contentInset`).
+            .padding(.top, FMTopBar.contentInset)
             .padding(.bottom, FMSpace.s6)
             .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/ios/Fortymm/Matches/MatchesListView.swift
+++ b/ios/Fortymm/Matches/MatchesListView.swift
@@ -34,7 +34,8 @@ struct MatchesListView: View {
                 listCard
             }
             .padding(.horizontal, 16)
-            .padding(.top, 16)
+            // Clear the shell's frosted top bar (see `FMTopBar.contentInset`).
+            .padding(.top, FMTopBar.contentInset)
             .padding(.bottom, 24)
         }
         .background(FMColor.bgApp.ignoresSafeArea())

--- a/ios/Fortymm/Navigation/MainTabView.swift
+++ b/ios/Fortymm/Navigation/MainTabView.swift
@@ -26,7 +26,7 @@ struct MainTabView: View {
     @State private var showingNewMatch = false
 
     var body: some View {
-        TabView(selection: tabSelection) {
+        TabView(selection: $selection) {
             DashboardView()
                 .tabItem { Label("Home", systemImage: "house") }
                 .tag(FMTab.home)
@@ -35,7 +35,8 @@ struct MainTabView: View {
                 .tabItem { Label("Matches", systemImage: "sportscourt") }
                 .tag(FMTab.matches)
 
-            // Action slot — intercepted in `tabSelection`, never shown.
+            // Action slot — opens the new-match flow via `.onChange`; the bar is
+            // snapped off this tab immediately so its empty content never shows.
             Color.clear
                 .tabItem { Label("New match", systemImage: "plus") }
                 .tag(FMTab.newMatch)
@@ -51,6 +52,15 @@ struct MainTabView: View {
         .tint(FMColor.ball500)
         .toolbar(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden(true)
+        // "New match" is an action slot, not a destination: open the flow, then
+        // snap selection back to the tab we came from (`oldValue`) so the bar
+        // never rests on the empty action slot (which left the screen blank).
+        .onChange(of: selection) { oldValue, newValue in
+            if newValue == .newMatch {
+                showingNewMatch = true
+                selection = oldValue
+            }
+        }
         .safeAreaInset(edge: .top, spacing: 0) {
             FMTopBar(title: selection.title)
         }
@@ -60,18 +70,6 @@ struct MainTabView: View {
                 if toMatches { selection = .matches }
             }
         }
-    }
-
-    /// "New match" is an action slot, not a destination — tapping it opens the
-    /// flow cover and leaves the underlying tab selection unchanged.
-    private var tabSelection: Binding<FMTab> {
-        Binding(
-            get: { selection },
-            set: { newValue in
-                if newValue == .newMatch { showingNewMatch = true; return }
-                selection = newValue
-            }
-        )
     }
 }
 


### PR DESCRIPTION
## What

Fixes two iOS bugs reported in the signed-in shell, plus a small cleanup.

### Bug 1 — Matches header cut off at the top
The shell lays its frosted top bar (~46pt) over content via the `TabView`'s `.safeAreaInset`, and that inset doesn't fully reduce the scroll content's safe area inside the tab — so each tab screen has to pad its top to clear the bar. `MatchesListView` only padded `16`, leaving the **"Season record"** header tucked behind the bar. `DashboardView` already compensated with `56`.

### Bug 2 — new-match Cancel landed the user nowhere
"New match" was a real `TabView` tab holding an empty `Color.clear`, selected through a computed `Binding(get:set:)` that returned early without updating `selection`. That desynced the `TabView`'s real selection from the `selection` state — so dismissing the new-match cover left the bar stuck on the empty action slot, showing a **blank screen** (title said "Matches", tab bar highlighted "New match"). Now the `TabView` binds to plain state and `.onChange` snaps `selection` back off the action slot, so dismissing always lands on a real tab.

## Cleanup (`/simplify`)
- Hoisted the bar height / content inset into shared `FMTopBar.barHeight` / `FMTopBar.contentInset` constants — was duplicated as `46` in `FMTopBar` and `56` in two screens, which would silently drift.
- Used `onChange`'s `oldValue` instead of a redundant `lastTab` `@State`.
- Collapsed a verbatim-duplicated comment block.

## Testing
Built and run in the iPhone 17 Pro simulator. Verified: New match → **Cancel** dismisses to a populated **Matches** tab with the "Season record" header fully clearing the top bar, and Matches correctly highlighted in the tab bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)