### PR TITLE
iOS: reserve the top-bar inset in the shell instead of per screen

### DIFF
--- a/ios/Fortymm/Components/FMTopBar.swift
+++ b/ios/Fortymm/Components/FMTopBar.swift
@@ -6,12 +6,6 @@ import SwiftUI
 struct FMTopBar: View {
     /// Height of the bar itself.
     static let barHeight: CGFloat = 46
-    /// Top padding a tab's scroll content needs to clear the bar. The bar is laid
-    /// over the top via the shell's `.safeAreaInset`, and that inset doesn't fully
-    /// reduce the scroll content's safe area inside the `TabView` — so content
-    /// renders under the bar unless each tab screen pads by the bar height plus a
-    /// small gap. Use this constant rather than hardcoding the value per screen.
-    static let contentInset: CGFloat = barHeight + 10
 
     let title: String
 
@@ -40,6 +34,19 @@ struct FMTopBar: View {
             Rectangle().fill(FMColor.borderSubtle).frame(height: 1)
         }
         .ignoresSafeArea(edges: .top)
+    }
+}
+
+extension View {
+    /// Lay the shell's frosted top bar over this screen, reserving safe area for it
+    /// (bar height plus a small gap) so the screen's own `ScrollView` automatically
+    /// insets its content below the bar — no per-screen top padding required.
+    ///
+    /// Attach this to each tab *screen*, not to the `TabView`: a `.safeAreaInset`
+    /// on a `TabView` doesn't propagate the inset into the per-tab scroll views, so
+    /// their content renders under the bar.
+    func fmTopBar(_ title: String) -> some View {
+        safeAreaInset(edge: .top, spacing: 10) { FMTopBar(title: title) }
     }
 }
 

--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -24,8 +24,7 @@ struct DashboardView: View {
                 content
             }
             .padding(.horizontal, FMSpace.s5)
-            // Clear the shell's frosted top bar (see `FMTopBar.contentInset`).
-            .padding(.top, FMTopBar.contentInset)
+            // Top inset for the shell's frosted bar is reserved by `.fmTopBar`.
             .padding(.bottom, FMSpace.s6)
             .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/ios/Fortymm/Matches/MatchesListView.swift
+++ b/ios/Fortymm/Matches/MatchesListView.swift
@@ -34,8 +34,7 @@ struct MatchesListView: View {
                 listCard
             }
             .padding(.horizontal, 16)
-            // Clear the shell's frosted top bar (see `FMTopBar.contentInset`).
-            .padding(.top, FMTopBar.contentInset)
+            // Top inset for the shell's frosted bar is reserved by `.fmTopBar`.
             .padding(.bottom, 24)
         }
         .background(FMColor.bgApp.ignoresSafeArea())

--- a/ios/Fortymm/Navigation/MainTabView.swift
+++ b/ios/Fortymm/Navigation/MainTabView.swift
@@ -20,7 +20,8 @@ enum FMTab: Hashable {
 /// The signed-in app shell. Uses the system `TabView` so the bottom bar is the
 /// real iOS tab bar (free safe-area handling, accessibility, the standard look),
 /// tinted ball-orange for the active tab. Today only Home is a real screen. The
-/// shell owns the single top bar so each tab screen is just its content.
+/// shell lays the frosted top bar over each tab screen (`.fmTopBar`), so the
+/// screens carry only their own content.
 struct MainTabView: View {
     @State private var selection: FMTab = .home
     @State private var showingNewMatch = false
@@ -28,10 +29,12 @@ struct MainTabView: View {
     var body: some View {
         TabView(selection: $selection) {
             DashboardView()
+                .fmTopBar(FMTab.home.title)
                 .tabItem { Label("Home", systemImage: "house") }
                 .tag(FMTab.home)
 
             MatchesListView()
+                .fmTopBar(FMTab.matches.title)
                 .tabItem { Label("Matches", systemImage: "sportscourt") }
                 .tag(FMTab.matches)
 
@@ -42,10 +45,12 @@ struct MainTabView: View {
                 .tag(FMTab.newMatch)
 
             FMComingSoon(title: "Tournaments")
+                .fmTopBar(FMTab.tournaments.title)
                 .tabItem { Label("Tournaments", systemImage: "trophy") }
                 .tag(FMTab.tournaments)
 
             FMComingSoon(title: "You")
+                .fmTopBar(FMTab.profile.title)
                 .tabItem { Label("You", systemImage: "person.crop.circle") }
                 .tag(FMTab.profile)
         }
@@ -60,9 +65,6 @@ struct MainTabView: View {
                 showingNewMatch = true
                 selection = oldValue
             }
-        }
-        .safeAreaInset(edge: .top, spacing: 0) {
-            FMTopBar(title: selection.title)
         }
         .fullScreenCover(isPresented: $showingNewMatch) {
             MatchFlowView { toMatches in


### PR DESCRIPTION
## What

Follow-up to #425. That PR removed the magic-number drift but left each tab screen responsible for padding its own scroll content to clear the shell's frosted top bar — a footgun every future tab would have to remember (forget it and the header silently clips, which is the exact bug #425 fixed for Matches).

This moves the inset into the shell so screens no longer compensate at all.

## Why the old approach needed per-screen padding

The top bar was attached to the `TabView` via `.safeAreaInset`, and that inset **doesn't propagate into the per-tab scroll views** — so each tab's content rendered under the bar unless the screen manually re-added the top padding.

## Change

- New `View.fmTopBar(_:)` helper that attaches the bar via `.safeAreaInset(edge: .top, spacing: 10)` to a **screen** (not the TabView). A `ScrollView` with a top `.safeAreaInset` automatically insets its content below the bar while letting it scroll underneath — exactly the intended effect, no manual padding.
- `MainTabView` applies `.fmTopBar(...)` to each tab screen instead of one `.safeAreaInset` on the TabView.
- Deleted the per-screen `.padding(.top, FMTopBar.contentInset)` from `DashboardView` and `MatchesListView`, and removed the now-unused `FMTopBar.contentInset` constant (`barHeight` stays). The gap below the bar is now the `.safeAreaInset` spacing.

Net effect: a new tab screen gets correct top-bar insetting just by being listed in the shell — nothing to remember.

## Testing

Built and run in the iPhone 17 Pro simulator. Verified the header clears the bar with content scrolling under it on **Home**, **Matches**, and the **Coming soon** placeholders (the placeholders previously had no compensation at all, so this also makes them consistent). New-match Cancel still lands on Matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)