### PR TITLE
Make player profile header span full width

### DIFF
--- a/web-client/src/components/players/player-profile.css
+++ b/web-client/src/components/players/player-profile.css
@@ -48,7 +48,6 @@
   grid-template-columns: auto 1fr auto;
   align-items: center;
   gap: clamp(20px, 4vw, 28px);
-  max-width: 1280px;
 }
 
 .player-profile__avatar-ring {


### PR DESCRIPTION
## What

The player profile header banner (avatar, name, FortyMM rating) was capped at `max-width: 1280px` while the matches table below it spans the full viewport. This made the header look oddly narrow next to the table.

## Change

Removed the `max-width: 1280px` from `.player-profile__hero-row`. The hero and the matches section already share the same horizontal padding (`clamp(20px, 5vw, 40px)`), so dropping the cap makes the header grow edge-to-edge in lockstep with the table — the rating chip now aligns with the table's RESULT column on the right.

One-line CSS change, no JS/markup touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)