### PR TITLE
iOS: remove the Tournaments tab

### DIFF
--- a/ios/Fortymm/Navigation/MainTabView.swift
+++ b/ios/Fortymm/Navigation/MainTabView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
-/// The five bottom-nav slots. `newMatch` is an action slot, not a screen —
+/// The four bottom-nav slots. `newMatch` is an action slot, not a screen —
 /// selecting it triggers the new-match flow rather than switching tabs.
 enum FMTab: Hashable {
-    case home, matches, newMatch, tournaments, profile
+    case home, matches, newMatch, profile
 
     /// Title shown in the top bar for the tab.
     var title: String {
@@ -11,7 +11,6 @@ enum FMTab: Hashable {
         case .home: return "FortyMM"
         case .matches: return "Matches"
         case .newMatch: return "New match"
-        case .tournaments: return "Tournaments"
         case .profile: return "You"
         }
     }
@@ -43,11 +42,6 @@ struct MainTabView: View {
             Color.clear
                 .tabItem { Label("New match", systemImage: "plus") }
                 .tag(FMTab.newMatch)
-
-            FMComingSoon(title: "Tournaments")
-                .fmTopBar(FMTab.tournaments.title)
-                .tabItem { Label("Tournaments", systemImage: "trophy") }
-                .tag(FMTab.tournaments)
 
             FMComingSoon(title: "You")
                 .fmTopBar(FMTab.profile.title)


### PR DESCRIPTION
## Summary
- Remove the Tournaments tab from the iOS bottom navigation. It was a "Coming Soon" placeholder, so the bottom nav is now **Home, Matches, New match, You**.
- Dropped the `tournaments` case from the `FMTab` enum (and its title) and the corresponding tab block in `MainTabView.swift`.

## Testing
- `xcodebuild ... build` → **BUILD SUCCEEDED**
- Launched on the iPhone 17 Pro simulator and confirmed the four-slot bottom nav with no Tournaments tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)