### PR TITLE
iOS: account settings (username/email) + magic-link sign-in

### DIFF
--- a/ios/Fortymm/Login/CheckInboxView.swift
+++ b/ios/Fortymm/Login/CheckInboxView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+import UIKit
+
+/// Step 02 — "check your inbox". Confirms where the link went, offers to open
+/// Mail or resend, and counts the link's 15-minute life down. Resend re-hits the
+/// captcha-gated request endpoint, so it carries its own (compact) Turnstile.
+struct CheckInboxView: View {
+    let email: String
+    var onStartOver: () -> Void
+
+    private let service = LoginService.shared
+    @State private var captcha = TurnstileController()
+
+    @State private var captchaToken: String?
+    @State private var resending = false
+    @State private var notice: String?
+    @State private var serverError: String?
+    @State private var expiresAt = Date().addingTimeInterval(15 * 60)
+
+    var body: some View {
+        LoginScaffold(
+            eyebrow: "The ball is in your inbox",
+            line1: "Sent.",
+            line2: "Go fetch.",
+            stepNo: "02",
+            stepLabel: "Check inbox",
+            title: "Link sent to \(email)",
+            subtitle: "A sign-in link is flying toward \(email) right now. Open it on this "
+                + "device to log in. Expires in 15 — like a real rally."
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                receipt
+
+                HStack(spacing: 10) {
+                    LoginButton(title: "Open Mail") { openMail() }
+                    LoginButton(title: "Resend", kind: .ghost, loading: resending, fullWidth: false) {
+                        Task { await resend() }
+                    }
+                }
+
+                resendVerification
+
+                if let notice {
+                    Text(notice)
+                        .font(FMFont.ui(FMFont.xs))
+                        .foregroundStyle(FMColor.win)
+                } else if let serverError {
+                    Text(serverError)
+                        .font(FMFont.ui(FMFont.xs))
+                        .foregroundStyle(FMColor.loss)
+                }
+
+                LoginFineprint {
+                    Text("No link? Check spam. Or hit resend — we don't mind.\n")
+                        + Text("Wrong address? ").foregroundColor(FMColor.fgMuted)
+                        + Text("Start over.").foregroundColor(FMColor.ball500)
+                }
+                .onTapGesture { onStartOver() }
+
+                ExpiresCountdown(expiresAt: expiresAt)
+                    .padding(.top, 4)
+            }
+        }
+    }
+
+    private var receipt: some View {
+        ReceiptCard {
+            ReceiptRow(key: "To", value: email)
+            ReceiptDivider()
+            ReceiptRow(key: "Subject", value: "Your FortyMM sign-in link")
+            ReceiptDivider()
+            ReceiptRow(key: "From", value: "no-reply@fortymm.com", valueColor: FMColor.fg3)
+        }
+    }
+
+    /// Compact challenge that arms the resend button. With the always-passes test
+    /// key it self-solves invisibly; a real key would surface a small widget.
+    private var resendVerification: some View {
+        TurnstileView(
+            controller: captcha,
+            onToken: { captchaToken = $0 },
+            onExpire: { captchaToken = nil },
+            onError: { captchaToken = nil }
+        )
+        .frame(height: 60)
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private func resend() async {
+        guard let token = captchaToken else {
+            serverError = "Hang on — finishing the verification check."
+            return
+        }
+        notice = nil
+        serverError = nil
+        resending = true
+        defer { resending = false }
+        do {
+            _ = try await service.requestLink(email: email, captchaToken: token)
+            resetCaptcha()
+            expiresAt = Date().addingTimeInterval(15 * 60)
+            notice = "New link sent to \(email)."
+        } catch {
+            resetCaptcha()
+            serverError = error.fmMessage
+        }
+    }
+
+    /// Clear the spent token and reset the widget so the next resend mints a
+    /// fresh one (Turnstile tokens are single-use).
+    private func resetCaptcha() {
+        captcha.reset()
+        captchaToken = nil
+    }
+
+    private func openMail() {
+        guard let url = URL(string: "message://"), UIApplication.shared.canOpenURL(url) else { return }
+        UIApplication.shared.open(url)
+    }
+}
+
+/// "LINK EXPIRES IN mm:ss" with a draining progress bar, ticking once a second.
+struct ExpiresCountdown: View {
+    let expiresAt: Date
+    private let total: TimeInterval = 15 * 60
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            let remaining = max(0, expiresAt.timeIntervalSince(context.date))
+            HStack(spacing: 12) {
+                Text("Link expires in")
+                    .font(FMFont.mono(10.5))
+                    .tracking(1.6)
+                    .foregroundStyle(FMColor.fg3)
+                    .textCase(.uppercase)
+                Text(format(remaining))
+                    .font(FMFont.mono(18, weight: .bold))
+                    .foregroundStyle(remaining < 60 ? FMColor.loss : FMColor.ball500)
+                Spacer()
+                progress(fraction: remaining / total)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(FMColor.bgPanel)
+            .fmRoundedBorder(radius: FMRadius.md, color: FMColor.borderSubtle)
+        }
+    }
+
+    private func progress(fraction: Double) -> some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule().fill(FMColor.ink700)
+                Capsule()
+                    .fill(LinearGradient(
+                        colors: [FMColor.ball500, FMColor.ball400],
+                        startPoint: .leading, endPoint: .trailing
+                    ))
+                    .frame(width: geo.size.width * max(0, min(1, fraction)))
+            }
+        }
+        .frame(width: 90, height: 4)
+    }
+
+    private func format(_ seconds: TimeInterval) -> String {
+        let s = Int(seconds.rounded())
+        return String(format: "%02d:%02d", s / 60, s % 60)
+    }
+}

--- a/ios/Fortymm/Login/LoginComponents.swift
+++ b/ios/Fortymm/Login/LoginComponents.swift
@@ -1,0 +1,471 @@
+import SwiftUI
+
+// Native reimplementation of the FortyMM "Login flow" design (Claude Design
+// handoff). The web mock is a split shell (hero left, stepped form right); on
+// mobile it reflows to a single column — hero on top, form panel below — which
+// is what these components render. Colours/spacing/type come straight from the
+// shared design tokens (`FMColor` / `FMFont` / `FMRadius`).
+
+// MARK: - Hero
+
+/// The leading `● TEXT` overline, tinted per screen (accent / live / loss).
+struct LoginEyebrow: View {
+    let text: String
+    var color: Color = FMColor.ball500
+
+    var body: some View {
+        HStack(spacing: 7) {
+            Circle().fill(color).frame(width: 7, height: 7)
+            Text(text.uppercased())
+                .font(FMFont.ui(11, weight: .semibold))
+                .tracking(2.0)
+                .foregroundStyle(color)
+        }
+    }
+}
+
+/// The two-line Bebas display headline; the second line carries the accent.
+struct LoginDisplay: View {
+    let line1: String
+    let line2: String
+    var accent: Color = FMColor.ball500
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(line1.uppercased())
+                .foregroundStyle(FMColor.fg1)
+            Text(line2.uppercased())
+                .foregroundStyle(accent)
+        }
+        .font(FMFont.display(54))
+        .tracking(0.5)
+        .lineSpacing(-6)
+    }
+}
+
+/// The mobile hero block: wordmark, eyebrow, headline. (The desktop mock's
+/// "math is quiet" solver line + footer are dropped at phone width by design.)
+struct LoginHero: View {
+    let eyebrow: String
+    var eyebrowColor: Color = FMColor.ball500
+    let line1: String
+    let line2: String
+    var accent: Color = FMColor.ball500
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            FMLogo(size: 26)
+            LoginEyebrow(text: eyebrow, color: eyebrowColor)
+            LoginDisplay(line1: line1, line2: line2, accent: accent)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Form panel scaffold
+
+/// One login screen: hero on top, then the stepped form panel (numbered chip +
+/// label + progress dots, title, subtitle, then the screen's own content).
+struct LoginScaffold<Content: View>: View {
+    let eyebrow: String
+    var eyebrowColor: Color = FMColor.ball500
+    let line1: String
+    let line2: String
+    var accent: Color = FMColor.ball500
+    let stepNo: String
+    let stepLabel: String
+    let title: String
+    let subtitle: String
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 26) {
+                LoginHero(
+                    eyebrow: eyebrow, eyebrowColor: eyebrowColor,
+                    line1: line1, line2: line2, accent: accent
+                )
+                VStack(alignment: .leading, spacing: 16) {
+                    LoginStepHeader(stepNo: stepNo, stepLabel: stepLabel, accent: accent)
+                    Text(title)
+                        .font(FMFont.ui(24, weight: .semibold))
+                        .foregroundStyle(FMColor.fg1)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text(subtitle)
+                        .font(FMFont.ui(14.5))
+                        .foregroundStyle(FMColor.fg3)
+                        .lineSpacing(3)
+                        .fixedSize(horizontal: false, vertical: true)
+                    content
+                }
+            }
+            .padding(.horizontal, 22)
+            .padding(.top, 18)
+            .padding(.bottom, 32)
+        }
+        .background(LoginBackground())
+    }
+}
+
+/// The numbered step chip + label + hairline + progress dots.
+struct LoginStepHeader: View {
+    let stepNo: String
+    let stepLabel: String
+    var accent: Color = FMColor.ball500
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(stepNo)
+                .font(FMFont.mono(11, weight: .bold))
+                .tracking(1.6)
+                .foregroundStyle(accent)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(FMColor.bgAccentSoft)
+                .clipShape(Capsule())
+                .overlay(Capsule().stroke(FMColor.borderSubtle, lineWidth: 1))
+            Text(stepLabel.uppercased())
+                .font(FMFont.ui(11, weight: .semibold))
+                .tracking(1.6)
+                .foregroundStyle(FMColor.fg3)
+            Rectangle().fill(FMColor.borderSubtle).frame(height: 1)
+            StepDots(active: stepNo == "!!" ? -1 : (Int(stepNo) ?? 1))
+        }
+    }
+}
+
+/// Four progress pills; the active one widens. `active == -1` is the error
+/// state (last pill turns loss-red, the rest go inert).
+struct StepDots: View {
+    let active: Int
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(1...4, id: \.self) { n in
+                Capsule()
+                    .fill(color(for: n))
+                    .frame(width: n == active ? 18 : 6, height: 6)
+            }
+        }
+        .animation(.easeOut(duration: 0.2), value: active)
+    }
+
+    private func color(for n: Int) -> Color {
+        if active == -1 {
+            return n == 4 ? FMColor.loss : FMColor.ink500
+        }
+        return n <= active ? FMColor.ball500 : FMColor.borderSubtle
+    }
+}
+
+/// Dot-grid texture + warm halo behind a login screen.
+struct LoginBackground: View {
+    var body: some View {
+        FMColor.bgApp
+            .overlay(alignment: .topLeading) {
+                RadialGradient(
+                    colors: [FMColor.ball500.opacity(0.18), .clear],
+                    center: .topLeading, startRadius: 0, endRadius: 320
+                )
+                .frame(width: 460, height: 460)
+                .offset(x: -90, y: -70)
+                .allowsHitTesting(false)
+            }
+            .ignoresSafeArea()
+    }
+}
+
+// MARK: - Receipt cards
+
+/// The bordered "receipt" card used for the inbox / verify / success / error
+/// detail blocks. `tint` drives the border + glow (accent / live / loss).
+struct ReceiptCard<Content: View>: View {
+    var tint: Color = FMColor.borderSubtle
+    var glow: Bool = false
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            content
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(FMColor.bgCard)
+        .fmRoundedBorder(radius: FMRadius.md, color: tint)
+        .shadow(color: glow ? tint.opacity(0.22) : .clear, radius: 18, y: 6)
+    }
+}
+
+/// A receipt header: leading badge (spinner / check / x), a mono eyebrow, and a
+/// one-line title.
+struct ReceiptHeader<Badge: View>: View {
+    @ViewBuilder var badge: Badge
+    let eyebrow: String
+    var eyebrowColor: Color
+    let title: String
+
+    var body: some View {
+        HStack(spacing: 14) {
+            badge
+            VStack(alignment: .leading, spacing: 4) {
+                Text(eyebrow)
+                    .font(FMFont.mono(10.5, weight: .bold))
+                    .tracking(2.0)
+                    .foregroundStyle(eyebrowColor)
+                Text(title)
+                    .font(FMFont.ui(14, weight: .medium))
+                    .foregroundStyle(FMColor.fg1)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.bottom, 12)
+    }
+}
+
+/// A key/value receipt row (uppercase label + mono value).
+struct ReceiptRow: View {
+    let key: String
+    let value: String
+    var valueColor: Color = FMColor.fg1
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Text(key.uppercased())
+                .font(FMFont.ui(11, weight: .semibold))
+                .tracking(1.4)
+                .foregroundStyle(FMColor.fg3)
+                .frame(width: 78, alignment: .leading)
+            Text(value)
+                .font(FMFont.mono(13))
+                .foregroundStyle(valueColor)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 6)
+    }
+}
+
+struct ReceiptDivider: View {
+    var body: some View {
+        Rectangle().fill(FMColor.ink700).frame(height: 1)
+    }
+}
+
+// MARK: - Solver log
+
+/// The mono request log shown while verifying (and its failed variant). Each row
+/// is (status, method, path, note); `status` is colour-coded green/amber/red.
+struct SolverLog: View {
+    struct Line: Identifiable {
+        let id = UUID()
+        let status: String
+        let method: String
+        let path: String
+        let note: String
+    }
+
+    let lines: [Line]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            ForEach(lines) { line in
+                HStack(spacing: 10) {
+                    Text(line.status)
+                        .foregroundStyle(statusColor(line.status))
+                        .frame(width: 34, alignment: .leading)
+                    Text(line.method)
+                        .foregroundStyle(FMColor.fg2)
+                        .frame(width: 42, alignment: .leading)
+                    Text(line.path)
+                        .foregroundStyle(statusColor(line.status) == FMColor.loss ? FMColor.loss : FMColor.ball500)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Text(line.note)
+                        .foregroundStyle(FMColor.fgMuted)
+                        .lineLimit(1)
+                }
+                .font(FMFont.mono(11.5))
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(FMColor.ink950)
+        .fmRoundedBorder(radius: FMRadius.md, color: FMColor.borderSubtle)
+    }
+
+    private func statusColor(_ status: String) -> Color {
+        switch status {
+        case "200": return FMColor.serve500
+        case "…", "···": return FMColor.warn
+        default: return FMColor.loss
+        }
+    }
+}
+
+// MARK: - Badges & spinner
+
+/// Indeterminate orange arc spinner (the verify badge).
+struct LoginSpinner: View {
+    var size: CGFloat = 36
+    @State private var spinning = false
+
+    var body: some View {
+        Circle()
+            .trim(from: 0, to: 0.7)
+            .stroke(FMColor.ball500, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+            .frame(width: size, height: size)
+            .rotationEffect(.degrees(spinning ? 360 : 0))
+            .animation(.linear(duration: 1).repeatForever(autoreverses: false), value: spinning)
+            .onAppear { spinning = true }
+    }
+}
+
+/// Circular status badge — a green check or red cross in a soft-tinted disc.
+struct StatusBadge: View {
+    enum Kind { case success, failure }
+    let kind: Kind
+    var size: CGFloat = 36
+
+    private var tint: Color { kind == .success ? FMColor.serve500 : FMColor.loss }
+    private var symbol: String { kind == .success ? "checkmark" : "xmark" }
+
+    var body: some View {
+        ZStack {
+            Circle().fill(tint.opacity(0.16))
+            Circle().stroke(tint, lineWidth: 1.5)
+            Image(systemName: symbol)
+                .font(.system(size: size * 0.42, weight: .heavy))
+                .foregroundStyle(tint)
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+// MARK: - Buttons & misc
+
+/// The login primary/ghost button. Primary is the ball-orange glow button with
+/// an in-flight spinner; ghost is bordered. Disabled primary dims to ink.
+struct LoginButton: View {
+    enum Kind { case primary, ghost }
+
+    let title: String
+    var kind: Kind = .primary
+    var loading: Bool = false
+    var enabled: Bool = true
+    var fullWidth: Bool = true
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Group {
+                if loading {
+                    ProgressView().tint(kind == .primary ? FMColor.fgInverse : FMColor.fg1)
+                } else {
+                    Text(title).font(FMFont.ui(kind == .primary ? 15 : 14, weight: kind == .primary ? .bold : .semibold))
+                }
+            }
+            .foregroundStyle(foreground)
+            .frame(maxWidth: fullWidth ? .infinity : nil)
+            .frame(height: 50)
+            .padding(.horizontal, fullWidth ? 0 : 18)
+            .background(background)
+            .fmRoundedBorder(radius: FMRadius.md, color: borderColor)
+            .shadow(color: kind == .primary && enabled ? FMColor.ball500.opacity(0.3) : .clear, radius: 12, y: 7)
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled || loading)
+    }
+
+    private var foreground: Color {
+        switch kind {
+        case .primary: return enabled ? FMColor.fgInverse : FMColor.fgMuted
+        case .ghost: return FMColor.fg2
+        }
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        switch kind {
+        case .primary: enabled ? FMColor.ball500 : FMColor.ink800
+        case .ghost: Color.clear
+        }
+    }
+
+    private var borderColor: Color {
+        switch kind {
+        case .primary: enabled ? FMColor.ball500 : FMColor.borderSubtle
+        case .ghost: FMColor.borderDefault
+        }
+    }
+}
+
+/// "── OR ──" divider.
+struct LoginDivider: View {
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Rectangle().fill(FMColor.borderSubtle).frame(height: 1)
+            Text(label)
+                .font(FMFont.mono(10.5))
+                .tracking(2.5)
+                .foregroundStyle(FMColor.fgMuted)
+            Rectangle().fill(FMColor.borderSubtle).frame(height: 1)
+        }
+    }
+}
+
+/// The email field: an "@" prefix box, a mono input, and a live VALID/FAILED
+/// status chip. `invalid` flips the accent to loss-red.
+struct LoginEmailField: View {
+    @Binding var text: String
+    var invalid: Bool = false
+    var focused: FocusState<Bool>.Binding
+
+    private var tint: Color { invalid ? FMColor.loss : FMColor.ball500 }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Text("@")
+                .font(FMFont.mono(14, weight: .bold))
+                .foregroundStyle(tint)
+                .frame(width: 44, height: 50)
+                .background(tint.opacity(0.06))
+                .overlay(alignment: .trailing) {
+                    Rectangle().fill(FMColor.borderSubtle).frame(width: 1)
+                }
+            TextField(
+                "",
+                text: $text,
+                prompt: Text("you@yourclub.com").foregroundStyle(FMColor.fgMuted)
+            )
+            .font(FMFont.mono(15, weight: .medium))
+            .foregroundStyle(FMColor.fg1)
+            .focused(focused)
+            .keyboardType(.emailAddress)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .submitLabel(.go)
+            .padding(.horizontal, 14)
+            Text(invalid ? "● FAILED" : "● VALID")
+                .font(FMFont.mono(11))
+                .tracking(1.4)
+                .foregroundStyle(invalid ? FMColor.loss : FMColor.serve500)
+                .padding(.trailing, 14)
+        }
+        .background(FMColor.bgCard)
+        .fmRoundedBorder(radius: FMRadius.md, color: invalid ? FMColor.loss : FMColor.borderDefault)
+    }
+}
+
+/// Fineprint paragraph helper — small tertiary copy under the actions.
+struct LoginFineprint<Content: View>: View {
+    @ViewBuilder var content: Content
+    var body: some View {
+        content
+            .font(FMFont.ui(12.5))
+            .foregroundStyle(FMColor.fg3)
+            .lineSpacing(3)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}

--- a/ios/Fortymm/Login/LoginFlowView.swift
+++ b/ios/Fortymm/Login/LoginFlowView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// Drives the magic-link sign-in flow: email entry → check inbox, and (once a
+/// link can open the app) the verify → signed-in / expired landing. Presented
+/// modally; reports the resolved session back so the caller can fold it into
+/// `SessionStore`.
+struct LoginFlowView: View {
+    /// Where the flow begins. `.verifying` is the deep-link entry — wire it to a
+    /// universal-link handler later; `.email` is the in-app entry used today.
+    enum Start {
+        case email
+        case verifying(token: String)
+    }
+
+    var onClose: () -> Void
+    var onSignedIn: (SessionResponse) -> Void
+
+    private enum Step {
+        case email
+        case sent(email: String)
+        case verifying(token: String)
+    }
+    @State private var step: Step
+
+    init(
+        start: Start = .email,
+        onClose: @escaping () -> Void,
+        onSignedIn: @escaping (SessionResponse) -> Void
+    ) {
+        self.onClose = onClose
+        self.onSignedIn = onSignedIn
+        switch start {
+        case .email:
+            _step = State(initialValue: .email)
+        case let .verifying(token):
+            _step = State(initialValue: .verifying(token: token))
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            content
+        }
+        .background(LoginBackground())
+    }
+
+    private var header: some View {
+        HStack {
+            Spacer()
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(FMColor.fg3)
+                    .frame(width: 40, height: 40)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 6)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch step {
+        case .email:
+            SignInView { sentTo in step = .sent(email: sentTo) }
+        case let .sent(email):
+            CheckInboxView(email: email) { step = .email }
+        case let .verifying(token):
+            VerifyLoginView(
+                token: token,
+                onSignedIn: onSignedIn,
+                onRestart: { step = .email }
+            )
+        }
+    }
+}

--- a/ios/Fortymm/Login/LoginService.swift
+++ b/ios/Fortymm/Login/LoginService.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Gateway to the magic-link sign-in endpoints. Mirrors how `MatchService` /
+/// `ProfileService` wrap `APIClient`.
+///
+/// The flow: `requestLink` emails a single-use, 15-minute token; the user taps
+/// the link and `consume` redeems it, minting a fresh session and folding the
+/// caller's current guest matches into the signed-in account.
+struct LoginService {
+    static let shared = LoginService()
+
+    private let client: APIClient
+    init(client: APIClient = .shared) { self.client = client }
+
+    /// Request a sign-in link (`POST /v1/login/request`, 202). Captcha-gated like
+    /// the web flow. Returns the lowercased address the link was sent to — the
+    /// server echoes it identically whether or not an account exists, so the
+    /// response leaks nothing about who's registered.
+    @discardableResult
+    func requestLink(
+        email: String,
+        captchaToken: String,
+        honeypot: String = ""
+    ) async throws -> String {
+        let response: LoginRequestAccepted = try await client.post(
+            "/v1/login/request",
+            body: RequestLoginBody(
+                email: email, captchaToken: captchaToken, fmmHpToken: honeypot
+            )
+        )
+        return response.email
+    }
+
+    /// Redeem a magic-link token (`POST /v1/login/consume`). Returns the full
+    /// session — including `merged` when the prior guest's matches were carried
+    /// into the account — so the success screen can report what moved.
+    ///
+    /// Classifies failure for the caller: a `4xx` is a rejected token (expired,
+    /// used, wrong account) and terminal; anything else (server error, offline)
+    /// is transient and worth a retry. Keeping that distinction here, not in the
+    /// view, is the same boundary-typing the rest of the API layer follows.
+    func consume(token: String) async throws -> SessionResponse {
+        do {
+            return try await client.post(
+                "/v1/login/consume", body: ConsumeLoginBody(token: token)
+            )
+        } catch let APIError.http(status, _) where (400..<500).contains(status) {
+            throw LoginConsumeError.rejected
+        } catch {
+            throw LoginConsumeError.unreachable
+        }
+    }
+}
+
+/// Why redeeming a sign-in link failed, classified for the UI.
+enum LoginConsumeError: Error {
+    /// The link is no longer valid — expired, already used, or for another
+    /// account. Terminal; the user must request a fresh link.
+    case rejected
+    /// The server couldn't be reached (5xx / timeout / offline). Retrying the
+    /// same still-valid link may succeed.
+    case unreachable
+}
+
+/// 202 body for the link-request endpoint — just the echoed address.
+struct LoginRequestAccepted: Decodable {
+    let email: String
+}
+
+// MARK: - Request bodies (snake_case via APIClient's encoder)
+
+private struct RequestLoginBody: Encodable {
+    let email: String
+    let captchaToken: String
+    let fmmHpToken: String
+}
+
+private struct ConsumeLoginBody: Encodable {
+    let token: String
+}

--- a/ios/Fortymm/Login/SignInView.swift
+++ b/ios/Fortymm/Login/SignInView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+/// Step 01 — email entry. Collects an address, runs the Turnstile challenge
+/// (the request endpoint is captcha-gated like the web flow), and requests a
+/// magic sign-in link. On success it hands the address up so the flow can show
+/// the "check your inbox" screen.
+struct SignInView: View {
+    var onSent: (String) -> Void
+
+    private let service = LoginService.shared
+    @State private var captcha = TurnstileController()
+
+    @State private var email = ""
+    @State private var touched = false
+    @State private var captchaToken: String?
+    @State private var serverError: String?
+    @State private var sending = false
+    @FocusState private var focused: Bool
+
+    private var validation: FieldValidation { ProfileRules.email(email) }
+    private var invalid: Bool { serverError != nil || (touched && !validation.ok) }
+    private var canSend: Bool { validation.ok && captchaToken != nil && !sending }
+
+    var body: some View {
+        LoginScaffold(
+            eyebrow: "No passwords · No bullshit · No tracking",
+            line1: "Show us",
+            line2: "your serve.",
+            stepNo: "01",
+            stepLabel: "Sign in",
+            title: "Your email",
+            subtitle: "Drop your email. We send a one-tap link — open it and you're in. "
+                + "We never made a password, so we can't lose yours."
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                LoginEmailField(text: $email, invalid: invalid, focused: $focused)
+                    .onChange(of: email) { _, _ in if serverError != nil { serverError = nil } }
+
+                TurnstileView(
+                    controller: captcha,
+                    onToken: { token in
+                        captchaToken = token
+                        if serverError != nil { serverError = nil }
+                    },
+                    onExpire: { captchaToken = nil },
+                    onError: { captchaToken = nil }
+                )
+                .frame(height: 72)
+                .frame(maxWidth: .infinity, alignment: .center)
+
+                if let serverError {
+                    Text(serverError)
+                        .font(FMFont.ui(FMFont.xs))
+                        .foregroundStyle(FMColor.loss)
+                } else if validation.ok, captchaToken == nil {
+                    Text("Complete the challenge above to send your link.")
+                        .font(FMFont.ui(FMFont.xs))
+                        .foregroundStyle(FMColor.fgMuted)
+                }
+
+                LoginButton(title: "Send the link", loading: sending, enabled: canSend) {
+                    Task { await send() }
+                }
+
+                LoginDivider(label: "OR")
+
+                LoginFineprint {
+                    Text("New here? Same flow — we'll create your account when you confirm.")
+                        + Text("\nBy signing in you agree to play fair. That's it.")
+                        .foregroundColor(FMColor.fgMuted)
+                }
+            }
+        }
+        .onAppear { focused = true }
+    }
+
+    private func send() async {
+        guard validation.ok else { touched = true; return }
+        guard let token = captchaToken else {
+            serverError = "Complete the challenge above to continue."
+            return
+        }
+        serverError = nil
+        sending = true
+        defer { sending = false }
+        do {
+            let sentTo = try await service.requestLink(email: email, captchaToken: token)
+            onSent(sentTo)
+        } catch {
+            resetCaptcha()
+            serverError = error.fmMessage
+        }
+    }
+
+    /// Clear the spent token and reset the widget so the next attempt mints a
+    /// fresh one (Turnstile tokens are single-use).
+    private func resetCaptcha() {
+        captcha.reset()
+        captchaToken = nil
+    }
+}

--- a/ios/Fortymm/Login/VerifyLoginView.swift
+++ b/ios/Fortymm/Login/VerifyLoginView.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+
+/// Step 03+ — the magic-link landing. Redeems the token (`/v1/login/consume`)
+/// and resolves to one of three terminal states: signed in, link expired/used,
+/// or server unreachable.
+///
+/// This screen's only trigger is the user tapping the emailed link, which today
+/// opens Safari rather than the app — so it stays dormant until universal-link
+/// handling is added. It's fully wired now: feed it a token via `LoginFlowView`
+/// and it runs end-to-end. Built ahead so wiring the deep link later is a
+/// one-liner.
+struct VerifyLoginView: View {
+    let token: String
+    var onSignedIn: (SessionResponse) -> Void
+    var onRestart: () -> Void
+
+    private let service = LoginService.shared
+
+    private enum Phase {
+        case verifying
+        case success(SessionResponse)
+        case expired
+        case unreachable
+    }
+    @State private var phase: Phase = .verifying
+
+    var body: some View {
+        Group {
+            switch phase {
+            case .verifying: verifying
+            case let .success(response): success(response)
+            case .expired: expired
+            case .unreachable: unreachable
+            }
+        }
+        .task { await verify() }
+    }
+
+    // MARK: Verifying
+
+    private var verifying: some View {
+        LoginScaffold(
+            eyebrow: "Checking the score",
+            line1: "Hold up.",
+            line2: "Reading your link.",
+            stepNo: "03",
+            stepLabel: "Verifying link",
+            title: "Confirming your sign-in",
+            subtitle: "Just a sec — confirming you're you."
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                ReceiptCard(tint: FMColor.ball500.opacity(0.6), glow: true) {
+                    ReceiptHeader(
+                        badge: { LoginSpinner() },
+                        eyebrow: "● VERIFYING TOKEN",
+                        eyebrowColor: FMColor.ball500,
+                        title: "Confirming signature & expiry…"
+                    )
+                }
+                SolverLog(lines: [
+                    .init(status: "200", method: "POST", path: "/auth/verify", note: "signature ok"),
+                    .init(status: "200", method: "GET", path: "/auth/session", note: "device match"),
+                    .init(status: "…", method: "···", path: "/auth/grant", note: "minting session…"),
+                ])
+            }
+        }
+    }
+
+    // MARK: Success
+
+    private func success(_ response: SessionResponse) -> some View {
+        let user = response.data.user
+        let moved = response.merged?.matchesMoved ?? 0
+        return LoginScaffold(
+            eyebrow: "You're in",
+            eyebrowColor: FMColor.serve500,
+            line1: "Welcome back,",
+            line2: "@\(user.username).",
+            accent: FMColor.serve500,
+            stepNo: "04",
+            stepLabel: "Signed in",
+            title: "Account verified",
+            subtitle: "Warming up the courts."
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                ReceiptCard(tint: FMColor.serve500.opacity(0.6), glow: true) {
+                    ReceiptHeader(
+                        badge: { StatusBadge(kind: .success) },
+                        eyebrow: "● SESSION OPENED",
+                        eyebrowColor: FMColor.serve500,
+                        title: "@\(user.username)"
+                    )
+                    ReceiptDivider()
+                    ReceiptRow(
+                        key: "Account",
+                        value: user.email ?? "guest",
+                        valueColor: FMColor.fg2
+                    )
+                    if moved > 0 {
+                        ReceiptDivider()
+                        ReceiptRow(
+                            key: "Matches",
+                            value: "\(moved) brought with you",
+                            valueColor: FMColor.serve500
+                        )
+                    }
+                }
+                LoginButton(title: "Enter FortyMM") { onSignedIn(response) }
+            }
+        }
+    }
+
+    // MARK: Expired / used
+
+    private var expired: some View {
+        LoginScaffold(
+            eyebrow: "Net out",
+            eyebrowColor: FMColor.loss,
+            line1: "That one missed.",
+            line2: "Try again.",
+            accent: FMColor.loss,
+            stepNo: "!!",
+            stepLabel: "Link invalid",
+            title: "This link can't be used",
+            subtitle: "Your link expired or was already used. Links are good for 15 minutes "
+                + "and a single tap — strict for a reason. We'll send a fresh one."
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                ReceiptCard(tint: FMColor.loss.opacity(0.6), glow: true) {
+                    ReceiptHeader(
+                        badge: { StatusBadge(kind: .failure) },
+                        eyebrow: "● TOKEN REJECTED",
+                        eyebrowColor: FMColor.loss,
+                        title: "Link expired or already used"
+                    )
+                    ReceiptDivider()
+                    ReceiptRow(key: "Lifetime", value: "15 min · single use")
+                    ReceiptDivider()
+                    ReceiptRow(key: "Fix", value: "Request a fresh link", valueColor: FMColor.fg2)
+                }
+                LoginButton(title: "Send a new link") { onRestart() }
+            }
+        }
+    }
+
+    // MARK: Server unreachable
+
+    private var unreachable: some View {
+        LoginScaffold(
+            eyebrow: "Off the table",
+            eyebrowColor: FMColor.loss,
+            line1: "Lost signal.",
+            line2: "Retry.",
+            accent: FMColor.loss,
+            stepNo: "03",
+            stepLabel: "Verifying · failed",
+            title: "Couldn't reach the server",
+            subtitle: "We couldn't talk to the auth server. Check your connection — your link "
+                + "is still valid for the next few minutes."
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                ReceiptCard(tint: FMColor.loss.opacity(0.6), glow: true) {
+                    ReceiptHeader(
+                        badge: { StatusBadge(kind: .failure) },
+                        eyebrow: "● ERR_NETWORK_UNREACHABLE",
+                        eyebrowColor: FMColor.loss,
+                        title: "auth.fortymm.com is unreachable"
+                    )
+                }
+                SolverLog(lines: [
+                    .init(status: "200", method: "POST", path: "/auth/verify", note: "signature ok"),
+                    .init(status: "…", method: "GET", path: "/auth/session", note: "connecting…"),
+                    .init(status: "522", method: "GET", path: "/auth/session", note: "origin unreachable"),
+                    .init(status: "ERR", method: "···", path: "/auth/session", note: "gave up after 12s"),
+                ])
+                HStack(spacing: 10) {
+                    LoginButton(title: "Retry") { Task { await verify() } }
+                    LoginButton(title: "Send a new link", kind: .ghost, fullWidth: false) { onRestart() }
+                }
+            }
+        }
+    }
+
+    // MARK: Consume
+
+    private func verify() async {
+        phase = .verifying
+        do {
+            phase = .success(try await service.consume(token: token))
+        } catch LoginConsumeError.rejected {
+            phase = .expired
+        } catch {
+            // Unreachable (or any other transient failure) — offer a retry.
+            phase = .unreachable
+        }
+    }
+}

--- a/ios/Fortymm/Navigation/MainTabView.swift
+++ b/ios/Fortymm/Navigation/MainTabView.swift
@@ -43,7 +43,7 @@ struct MainTabView: View {
                 .tabItem { Label("New match", systemImage: "plus") }
                 .tag(FMTab.newMatch)
 
-            FMComingSoon(title: "You")
+            ProfileView()
                 .fmTopBar(FMTab.profile.title)
                 .tabItem { Label("You", systemImage: "person.crop.circle") }
                 .tag(FMTab.profile)

--- a/ios/Fortymm/Networking/APIClient.swift
+++ b/ios/Fortymm/Networking/APIClient.swift
@@ -112,6 +112,13 @@ struct APIClient {
         try await send("PUT", path, body: body)
     }
 
+    func patch<T: Decodable>(
+        _ path: String,
+        body: (some Encodable)? = Optional<Empty>.none
+    ) async throws -> T {
+        try await send("PATCH", path, body: body)
+    }
+
     func delete<T: Decodable>(_ path: String) async throws -> T {
         try await send("DELETE", path, body: Optional<Empty>.none)
     }

--- a/ios/Fortymm/Profile/ChangeEmailView.swift
+++ b/ios/Fortymm/Profile/ChangeEmailView.swift
@@ -204,6 +204,9 @@ struct ChangeEmailView: View {
             let updated = try await service.resendEmailConfirmation(captchaToken: token)
             session.apply(updated)
             resetCaptcha()
+            // Drop any prior error so it doesn't linger under the field beside
+            // the success notice (the two render in separate regions).
+            serverError = nil
             notice = "Verification link re-sent to \(displayAddress)."
         } catch {
             resetCaptcha()

--- a/ios/Fortymm/Profile/ChangeEmailView.swift
+++ b/ios/Fortymm/Profile/ChangeEmailView.swift
@@ -1,0 +1,220 @@
+import SwiftUI
+
+/// Sheet for adding or changing the account email (`POST /v1/me/email`). The
+/// address is the only way to keep an account beyond the current device, so the
+/// flow is: enter email → solve Turnstile → we send a confirmation link → the
+/// address is `pending` until the link is opened. A pending change can have its
+/// link re-sent from here.
+struct ChangeEmailView: View {
+    let user: SessionUser
+    var onDone: () -> Void
+
+    @EnvironmentObject private var session: SessionStore
+    private let service = ProfileService.shared
+    @State private var captcha = TurnstileController()
+
+    @State private var value: String
+    @State private var touched = false
+    @State private var captchaToken: String?
+    @State private var serverError: String?
+    @State private var notice: String?
+    @State private var saving = false
+    @State private var resending = false
+    @FocusState private var focused: Bool
+
+    init(user: SessionUser, onDone: @escaping () -> Void) {
+        self.user = user
+        self.onDone = onDone
+        _value = State(initialValue: user.pendingEmail ?? user.email ?? "")
+    }
+
+    private var displayAddress: String { user.pendingEmail ?? user.email ?? "" }
+    private var hasAddress: Bool { user.email != nil || user.pendingEmail != nil }
+    private var validation: FieldValidation { ProfileRules.email(value) }
+    private var dirty: Bool { value != displayAddress }
+    private var canSave: Bool {
+        validation.ok && dirty && captchaToken != nil && !saving
+    }
+
+    private var displayedError: String? {
+        ProfileRules.displayError(validation, serverError: serverError, show: touched)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            EditorHeader(title: hasAddress ? "Email" : "Add email", onCancel: onDone) {
+                EditorActionButton(
+                    title: hasAddress ? "Update" : "Add",
+                    loading: saving,
+                    enabled: canSave
+                ) { Task { await save() } }
+            }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    intro
+                    field
+                    captchaSection
+                    if hasAddress { statusCard }
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 14)
+                .padding(.bottom, 28)
+            }
+        }
+        .background(FMColor.ink950.ignoresSafeArea())
+        .onAppear { if !hasAddress { focused = true } }
+    }
+
+    private var intro: some View {
+        Text(
+            "We use your email for sign-in and account recovery — nothing else. "
+                + "No newsletters, no tracking."
+        )
+        .font(FMFont.ui(13))
+        .foregroundStyle(FMColor.fg3)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var field: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Eyebrow("Email address")
+            HStack(spacing: 9) {
+                Image(systemName: "envelope")
+                    .font(.system(size: 15))
+                    .foregroundStyle(FMColor.fgMuted)
+                TextField(
+                    "",
+                    text: $value,
+                    prompt: Text("you@example.com").foregroundStyle(FMColor.fgMuted)
+                )
+                .font(FMFont.mono(15))
+                .foregroundStyle(FMColor.fg1)
+                .focused($focused)
+                .keyboardType(.emailAddress)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .submitLabel(.done)
+                .onChange(of: value) { _, _ in if serverError != nil { serverError = nil } }
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 44)
+            .background(FMColor.ink800)
+            .fmRoundedBorder(
+                radius: FMRadius.md,
+                color: displayedError != nil ? FMColor.loss : FMColor.borderSubtle
+            )
+            if let displayedError {
+                Text(displayedError)
+                    .font(FMFont.ui(FMFont.xs))
+                    .foregroundStyle(FMColor.loss)
+            }
+        }
+    }
+
+    /// The Turnstile widget plus a hint that explains why Save is gated until a
+    /// token lands. With the always-passes test key the widget self-solves and
+    /// the token arrives within a moment, so the hint is short-lived in dev.
+    private var captchaSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            TurnstileView(
+                controller: captcha,
+                onToken: { token in
+                    captchaToken = token
+                    if serverError != nil { serverError = nil }
+                },
+                onExpire: { captchaToken = nil },
+                onError: { captchaToken = nil }
+            )
+            .frame(height: 72)
+            .frame(maxWidth: .infinity, alignment: .center)
+
+            if dirty, validation.ok, captchaToken == nil {
+                Text("Complete the challenge above to continue.")
+                    .font(FMFont.ui(FMFont.xs))
+                    .foregroundStyle(FMColor.fgMuted)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var statusCard: some View {
+        if user.emailStatus == .verified {
+            FMAlert(
+                title: "Account claimed.",
+                message: "Verified. You can sign in from anywhere — and change this any time; we'll send a fresh link.",
+                variant: .success
+            )
+        } else {
+            VStack(alignment: .leading, spacing: 12) {
+                FMAlert(
+                    title: "Waiting for verification.",
+                    message: "Open the link we sent to \(displayAddress) to finish claiming your account.",
+                    variant: .warn
+                )
+                if let notice {
+                    Text(notice)
+                        .font(FMFont.ui(FMFont.xs))
+                        .foregroundStyle(FMColor.win)
+                }
+                Button { Task { await resend() } } label: {
+                    HStack(spacing: 7) {
+                        if resending { ProgressView().tint(FMColor.fg1) }
+                        Text(resending ? "Resending…" : "Resend link")
+                            .font(FMFont.ui(13, weight: .semibold))
+                    }
+                    .foregroundStyle(captchaToken == nil ? FMColor.fgMuted : FMColor.fg1)
+                    .padding(.horizontal, 14)
+                    .frame(height: 38)
+                    .fmRoundedBorder(radius: FMRadius.md, color: FMColor.borderDefault)
+                }
+                .buttonStyle(.plain)
+                .disabled(resending || captchaToken == nil)
+            }
+        }
+    }
+
+    private func save() async {
+        guard validation.ok, dirty else { return }
+        guard let token = captchaToken else {
+            serverError = "Complete the challenge above to continue."
+            return
+        }
+        serverError = nil
+        saving = true
+        defer { saving = false }
+        do {
+            let updated = try await service.setEmail(value, captchaToken: token)
+            session.apply(updated)
+            onDone()
+        } catch {
+            resetCaptcha()
+            serverError = error.fmMessage
+        }
+    }
+
+    private func resend() async {
+        guard let token = captchaToken else {
+            serverError = "Complete the challenge above, then tap Resend."
+            return
+        }
+        notice = nil
+        resending = true
+        defer { resending = false }
+        do {
+            let updated = try await service.resendEmailConfirmation(captchaToken: token)
+            session.apply(updated)
+            resetCaptcha()
+            notice = "Verification link re-sent to \(displayAddress)."
+        } catch {
+            resetCaptcha()
+            serverError = error.fmMessage
+        }
+    }
+
+    /// Clear the spent token and reset the widget so the next attempt mints a
+    /// fresh one rather than replaying a now-used (single-use) token.
+    private func resetCaptcha() {
+        captcha.reset()
+        captchaToken = nil
+    }
+}

--- a/ios/Fortymm/Profile/ChangeUsernameView.swift
+++ b/ios/Fortymm/Profile/ChangeUsernameView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+/// Sheet for changing the handle other players find you by (`PATCH /v1/me`).
+/// Validates client-side for fast feedback, but the server owns the final word
+/// — a 409 (taken) or 422 (malformed) comes back as an inline error. On success
+/// the refreshed user is folded into `SessionStore` and the sheet dismisses.
+struct ChangeUsernameView: View {
+    let current: String
+    var onDone: () -> Void
+
+    @EnvironmentObject private var session: SessionStore
+    private let service = ProfileService.shared
+
+    @State private var value: String
+    @State private var touched = false
+    @State private var serverError: String?
+    @State private var saving = false
+    @FocusState private var focused: Bool
+
+    init(current: String, onDone: @escaping () -> Void) {
+        self.current = current
+        self.onDone = onDone
+        _value = State(initialValue: current)
+    }
+
+    private var clientValidation: FieldValidation { ProfileRules.username(value) }
+    private var dirty: Bool { value != current }
+    private var canSave: Bool { clientValidation.ok && dirty && !saving }
+
+    // Show character-set errors immediately (the user just typed something
+    // disallowed); gate length errors on blur so we don't nag mid-type.
+    private var displayedError: String? {
+        ProfileRules.displayError(
+            clientValidation,
+            serverError: serverError,
+            show: touched || ProfileRules.usernameHasInvalidChar(value)
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            EditorHeader(title: "Username", onCancel: onDone) {
+                EditorActionButton(title: "Save", loading: saving, enabled: canSave) {
+                    Task { await save() }
+                }
+            }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    field
+                    preview
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 14)
+                .padding(.bottom, 28)
+            }
+        }
+        .background(FMColor.ink950.ignoresSafeArea())
+        .onAppear { focused = true }
+    }
+
+    private var field: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(alignment: .firstTextBaseline) {
+                Eyebrow("Username")
+                Spacer()
+                Text("\(value.count)/\(ProfileRules.usernameMax)")
+                    .font(FMFont.mono(11))
+                    .foregroundStyle(
+                        value.count > ProfileRules.usernameMax ? FMColor.loss : FMColor.fgMuted
+                    )
+            }
+            HStack(spacing: 0) {
+                Text("@")
+                    .font(FMFont.mono(15))
+                    .foregroundStyle(FMColor.fgMuted)
+                    .padding(.leading, 12)
+                TextField(
+                    "",
+                    text: $value,
+                    prompt: Text("your-name").foregroundStyle(FMColor.fgMuted)
+                )
+                .font(FMFont.mono(15))
+                .foregroundStyle(FMColor.fg1)
+                .focused($focused)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .submitLabel(.done)
+                .onSubmit { Task { await save() } }
+                .padding(.horizontal, 6)
+                .onChange(of: value) { _, _ in if serverError != nil { serverError = nil } }
+            }
+            .frame(height: 44)
+            .background(FMColor.ink800)
+            .fmRoundedBorder(
+                radius: FMRadius.md,
+                color: displayedError != nil ? FMColor.loss : FMColor.borderSubtle
+            )
+
+            if let displayedError {
+                Text(displayedError)
+                    .font(FMFont.ui(FMFont.xs))
+                    .foregroundStyle(FMColor.loss)
+            } else if dirty, clientValidation.ok {
+                Text("Looks good. Save to make it stick.")
+                    .font(FMFont.ui(FMFont.xs))
+                    .foregroundStyle(FMColor.win)
+            } else {
+                Text(
+                    "Lowercase letters, numbers, dots, hyphens and underscores. "
+                        + "\(ProfileRules.usernameMin)–\(ProfileRules.usernameMax) characters."
+                )
+                .font(FMFont.ui(FMFont.xs))
+                .foregroundStyle(FMColor.fgMuted)
+            }
+        }
+    }
+
+    private var preview: some View {
+        HStack(spacing: 14) {
+            FMAvatar(
+                initials: value.fmInitials,
+                size: 38,
+                color: clientValidation.ok ? FMColor.ink600 : FMColor.ink700,
+                foreground: clientValidation.ok ? FMColor.fg2 : FMColor.fgMuted
+            )
+            VStack(alignment: .leading, spacing: 2) {
+                Eyebrow("Preview")
+                Text(clientValidation.ok ? "@\(value)" : "—")
+                    .font(FMFont.mono(15))
+                    .foregroundStyle(FMColor.fg1)
+            }
+            Spacer()
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(FMColor.bgPanel)
+        .fmRoundedBorder(radius: FMRadius.md, color: FMColor.borderSubtle)
+    }
+
+    private func save() async {
+        guard canSave else { return }
+        serverError = nil
+        saving = true
+        defer { saving = false }
+        do {
+            let user = try await service.updateUsername(value)
+            session.apply(user)
+            onDone()
+        } catch {
+            serverError = error.fmMessage
+        }
+    }
+}

--- a/ios/Fortymm/Profile/ProfileService.swift
+++ b/ios/Fortymm/Profile/ProfileService.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// The profile/settings gateway to the API. Wraps `APIClient` with the
+/// account-management endpoints — username (`PATCH /v1/me`) and the
+/// Turnstile-gated email change + resend (`POST /v1/me/email[/resend]`). Each
+/// returns the refreshed `SessionUser` so the caller can fold it straight into
+/// `SessionStore` without a second `GET /v1/session`.
+struct ProfileService {
+    static let shared = ProfileService()
+
+    private let client: APIClient
+    init(client: APIClient = .shared) { self.client = client }
+
+    /// Change the username (`PATCH /v1/me`). The server enforces the same
+    /// pattern the client checks, plus uniqueness: a duplicate comes back 409
+    /// and a malformed value 422 — both surface as `APIError.http` carrying the
+    /// server's `detail`, which the caller shows inline.
+    func updateUsername(_ username: String) async throws -> SessionUser {
+        let response: SessionResponse = try await client.patch(
+            "/v1/me", body: UpdateUsernameBody(username: username)
+        )
+        return response.data.user
+    }
+
+    /// Request an email change (`POST /v1/me/email`, 202). The server emails a
+    /// confirmation link and returns the session with `pendingEmail` set — the
+    /// address only goes live once that link is opened. `captchaToken` is the
+    /// Cloudflare Turnstile token (validated server-side via siteverify, exactly
+    /// as for the web client); `honeypot` is the off-screen bot trap, normally
+    /// empty for a real user.
+    func setEmail(
+        _ email: String,
+        captchaToken: String,
+        honeypot: String = ""
+    ) async throws -> SessionUser {
+        let response: SessionResponse = try await client.post(
+            "/v1/me/email",
+            body: SetEmailBody(
+                email: email, captchaToken: captchaToken, fmmHpToken: honeypot
+            )
+        )
+        return response.data.user
+    }
+
+    /// Re-send the pending confirmation link (`POST /v1/me/email/resend`, 202).
+    /// Also Turnstile-gated — generate a fresh token right before calling.
+    func resendEmailConfirmation(
+        captchaToken: String,
+        honeypot: String = ""
+    ) async throws -> SessionUser {
+        let response: SessionResponse = try await client.post(
+            "/v1/me/email/resend",
+            body: ResendEmailBody(captchaToken: captchaToken, fmmHpToken: honeypot)
+        )
+        return response.data.user
+    }
+}
+
+// MARK: - Request bodies
+//
+// Encoded with `APIClient`'s `.convertToSnakeCase` strategy, so `captchaToken`
+// ships as `captcha_token` and `fmmHpToken` as `fmm_hp_token` — matching the
+// pydantic `SetEmailRequest` / `CaptchaProtectedRequest` field names.
+
+private struct UpdateUsernameBody: Encodable {
+    let username: String
+}
+
+private struct SetEmailBody: Encodable {
+    let email: String
+    let captchaToken: String
+    let fmmHpToken: String
+}
+
+private struct ResendEmailBody: Encodable {
+    let captchaToken: String
+    let fmmHpToken: String
+}

--- a/ios/Fortymm/Profile/ProfileValidation.swift
+++ b/ios/Fortymm/Profile/ProfileValidation.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Result of a client-side field check: ok plus an optional human-readable
+/// reason. Mirrors the web client's `Validation` shape.
+struct FieldValidation {
+    let ok: Bool
+    var error: String?
+
+    static let valid = FieldValidation(ok: true, error: nil)
+    static func invalid(_ error: String) -> FieldValidation {
+        FieldValidation(ok: false, error: error)
+    }
+}
+
+/// Client-side username/email rules. These exist for fast feedback only — the
+/// API enforces the same pattern (`api/app/schemas/session.py`) and owns
+/// uniqueness (409). Kept in lockstep with the web client's `validateUsername`
+/// / `validateEmail` so the two clients reject the same inputs with the same
+/// wording.
+enum ProfileRules {
+    static let usernameMin = 3
+    static let usernameMax = 40
+
+    /// Lowercase alphanumerics with optional dots/hyphens/underscores between,
+    /// starting and ending with an alphanumeric.
+    private static let usernamePattern = "^[a-z0-9](?:[a-z0-9._-]{1,38}[a-z0-9])?$"
+    private static let emailPattern = #"^[^\s@]+@[^\s@]+\.[^\s@]{2,}$"#
+
+    static func username(_ value: String) -> FieldValidation {
+        if value.isEmpty { return .invalid("Username is required.") }
+        // Surface the specific reason first — char checks before length checks,
+        // so "Fo" reads as "uppercase isn't allowed" rather than "too short".
+        if value.range(of: "[A-Z]", options: .regularExpression) != nil {
+            return .invalid("Lowercase letters only — no uppercase.")
+        }
+        if value.range(of: #"\s"#, options: .regularExpression) != nil {
+            return .invalid("No spaces — try a dot, hyphen or underscore instead.")
+        }
+        if value.count > usernameMax {
+            return .invalid("No more than \(usernameMax) characters.")
+        }
+        if value.count < usernameMin {
+            return .invalid("At least \(usernameMin) characters.")
+        }
+        if value.range(of: usernamePattern, options: .regularExpression) == nil {
+            return .invalid(
+                "Lowercase letters, numbers, dots, hyphens and underscores. "
+                    + "Must start and end with a letter or number."
+            )
+        }
+        return .valid
+    }
+
+    /// True when the value contains a character outside the allowed set — the
+    /// signal for showing the error immediately rather than waiting for blur.
+    static func usernameHasInvalidChar(_ value: String) -> Bool {
+        value.range(of: "[^a-z0-9._-]", options: .regularExpression) != nil
+    }
+
+    static func email(_ value: String) -> FieldValidation {
+        if value.isEmpty {
+            return .invalid("Email is required to claim your account.")
+        }
+        if value.range(of: emailPattern, options: .regularExpression) == nil {
+            return .invalid("That doesn't look like a valid email.")
+        }
+        return .valid
+    }
+
+    /// The error to surface for a field: a server error always wins; otherwise
+    /// the client-side reason, but only once `show` is true (the caller gates
+    /// this on blur and/or an obviously-bad character so we don't nag mid-type).
+    static func displayError(
+        _ validation: FieldValidation,
+        serverError: String?,
+        show: Bool
+    ) -> String? {
+        if let serverError { return serverError }
+        return (show && !validation.ok) ? validation.error : nil
+    }
+}

--- a/ios/Fortymm/Profile/ProfileView.swift
+++ b/ios/Fortymm/Profile/ProfileView.swift
@@ -1,0 +1,274 @@
+import SwiftUI
+
+/// The "You" tab: an account hub showing your identity and email-claim status,
+/// with entry points into the username and email editors. The shell lays its
+/// frosted top bar over this screen (`.fmTopBar`), so this is just the content.
+/// The editors are presented as sheets — the app's modal idiom for focused
+/// sub-tasks (matching the new-match flow's full-screen cover).
+struct ProfileView: View {
+    @EnvironmentObject private var session: SessionStore
+
+    private enum Editor: Identifiable {
+        case username, email
+        var id: Int { hashValue }
+    }
+    @State private var editor: Editor?
+    @State private var showingSignIn = false
+
+    var body: some View {
+        ScrollView {
+            if let user = session.user {
+                content(for: user)
+            } else {
+                // RootView only shows the shell once the session is loaded, so
+                // this is a defensive fallback rather than an expected state.
+                ProgressView()
+                    .tint(FMColor.ball500)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 80)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(FMColor.bgApp.ignoresSafeArea())
+        .sheet(item: $editor) { which in
+            sheet(for: which)
+                .presentationDragIndicator(.visible)
+        }
+        .fullScreenCover(isPresented: $showingSignIn) {
+            LoginFlowView(
+                onClose: { showingSignIn = false },
+                onSignedIn: { response in
+                    session.apply(response.data.user)
+                    showingSignIn = false
+                }
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func content(for user: SessionUser) -> some View {
+        VStack(alignment: .leading, spacing: 20) {
+            identity(user)
+            if user.emailStatus != .verified {
+                claimBanner(user)
+            }
+            VStack(spacing: 10) {
+                SettingRow(
+                    icon: "at",
+                    label: "Username",
+                    value: "@\(user.username)"
+                ) { editor = .username }
+                SettingRow(
+                    icon: "envelope",
+                    label: "Email",
+                    value: emailRowValue(user),
+                    valueTint: emailRowTint(user)
+                ) { editor = .email }
+            }
+            if user.emailStatus != .verified {
+                signInRow
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 4)
+        .padding(.bottom, 28)
+    }
+
+    /// Entry into the magic-link sign-in flow. Shown for guests/pending users —
+    /// signing into an existing account brings their guest matches along.
+    private var signInRow: some View {
+        Button { showingSignIn = true } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "person.badge.key")
+                    .font(.system(size: 15, weight: .semibold))
+                Text("Already have an account? Sign in")
+                    .font(FMFont.ui(14, weight: .semibold))
+                Spacer()
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 13, weight: .bold))
+            }
+            .foregroundStyle(FMColor.ball500)
+            .padding(.horizontal, 16)
+            .frame(height: 52)
+            .background(FMColor.bgAccentSoft)
+            .fmRoundedBorder(radius: FMRadius.md, color: FMColor.ball500.opacity(0.4))
+        }
+        .buttonStyle(.plain)
+        .padding(.top, 2)
+    }
+
+    private func identity(_ user: SessionUser) -> some View {
+        HStack(spacing: 14) {
+            FMAvatar(initials: user.username.fmInitials, size: 52)
+            VStack(alignment: .leading, spacing: 5) {
+                Text("@\(user.username)")
+                    .font(FMFont.ui(18, weight: .bold))
+                    .foregroundStyle(FMColor.fg1)
+                    .lineLimit(1)
+                statusBadge(user.emailStatus)
+            }
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private func statusBadge(_ status: SessionUser.EmailStatus) -> some View {
+        switch status {
+        case .verified:
+            FMBadge(text: "Verified", variant: .live, icon: nil)
+        case .pending:
+            FMBadge(text: "Pending", variant: .outline)
+        case .guest:
+            FMBadge(text: "Guest", variant: .primary)
+        }
+    }
+
+    private func claimBanner(_ user: SessionUser) -> some View {
+        Button { editor = .email } label: {
+            FMAlert(
+                title: user.emailStatus == .guest
+                    ? "You're playing as a guest."
+                    : "Check your inbox.",
+                message: user.emailStatus == .guest
+                    ? "Add an email so we don't lose your ratings if you change devices."
+                    : "Open the link we sent to \(user.pendingEmail ?? user.email ?? "your inbox") to finish claiming your account.",
+                variant: user.emailStatus == .guest ? .info : .warn
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func sheet(for editor: Editor) -> some View {
+        switch editor {
+        case .username:
+            ChangeUsernameView(current: session.user?.username ?? "") {
+                self.editor = nil
+            }
+            .environmentObject(session)
+        case .email:
+            if let user = session.user {
+                ChangeEmailView(user: user) { self.editor = nil }
+                    .environmentObject(session)
+            }
+        }
+    }
+
+    private func emailRowValue(_ user: SessionUser) -> String {
+        user.pendingEmail ?? user.email ?? "Not set"
+    }
+
+    private func emailRowTint(_ user: SessionUser) -> Color {
+        switch user.emailStatus {
+        case .verified: return FMColor.fg2
+        case .pending: return FMColor.warn
+        case .guest: return FMColor.fgMuted
+        }
+    }
+}
+
+/// A tappable settings row: leading icon, label, current value, chevron.
+private struct SettingRow: View {
+    let icon: String
+    let label: String
+    let value: String
+    var valueTint: Color = FMColor.fg3
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(FMColor.fg3)
+                    .frame(width: 22)
+                Text(label)
+                    .font(FMFont.ui(15, weight: .semibold))
+                    .foregroundStyle(FMColor.fg1)
+                Spacer()
+                Text(value)
+                    .font(FMFont.mono(13))
+                    .foregroundStyle(valueTint)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(FMColor.fgMuted)
+            }
+            .padding(.horizontal, 16)
+            .frame(height: 56)
+            .background(FMColor.bgCard)
+            .fmRoundedBorder(radius: FMRadius.md, color: FMColor.borderSubtle)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// Shared header for the editor sheets: a Cancel button, a centered title, and
+/// a trailing action (the Save/Update button). Mirrors the frosted top-bar look
+/// without depending on the tab shell's `FMTopBar`.
+struct EditorHeader<Trailing: View>: View {
+    let title: String
+    let onCancel: () -> Void
+    @ViewBuilder let trailing: Trailing
+
+    var body: some View {
+        ZStack {
+            Text(title)
+                .font(FMFont.ui(FMFont.md, weight: .bold))
+                .foregroundStyle(FMColor.fg1)
+            HStack {
+                Button(action: onCancel) {
+                    Text("Cancel")
+                        .font(FMFont.ui(15, weight: .medium))
+                        .foregroundStyle(FMColor.fg3)
+                }
+                .buttonStyle(.plain)
+                Spacer()
+                trailing
+            }
+        }
+        .padding(.horizontal, 16)
+        .frame(height: 56)
+        .frame(maxWidth: .infinity)
+        .background(FMColor.ink900)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(FMColor.borderSubtle).frame(height: 1)
+        }
+    }
+}
+
+/// The pill-shaped primary action in an editor sheet's header: a spinner while
+/// the request is in flight, dimmed when disabled. Shared by both editors so
+/// the save/update button is defined once.
+struct EditorActionButton: View {
+    let title: String
+    let loading: Bool
+    let enabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Group {
+                if loading {
+                    ProgressView().tint(FMColor.fgInverse)
+                } else {
+                    Text(title).font(FMFont.ui(14, weight: .bold))
+                }
+            }
+            .foregroundStyle(enabled ? FMColor.fgInverse : FMColor.fgMuted)
+            .frame(height: 34)
+            .padding(.horizontal, 16)
+            .background(enabled ? FMColor.ball500 : FMColor.ink800)
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+    }
+}
+
+#Preview {
+    ProfileView()
+        .environmentObject(SessionStore())
+        .preferredColorScheme(.dark)
+}

--- a/ios/Fortymm/Profile/TurnstileView.swift
+++ b/ios/Fortymm/Profile/TurnstileView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+import WebKit
+
+/// Imperative handle the parent holds to drive a `TurnstileView` — today just a
+/// `reset()` to clear a spent token after a submit (Turnstile tokens are
+/// single-use and expire ~300s after issue, so we mint a fresh one per attempt).
+/// Mirrors the web client's `TurnstileHandle`. A plain command handle (no
+/// observable state), held by the parent via `@State` and read by the
+/// representable.
+@MainActor
+final class TurnstileController {
+    fileprivate var onReset: (() -> Void)?
+
+    func reset() { onReset?() }
+}
+
+/// Renders the Cloudflare Turnstile widget inside a `WKWebView` and surfaces the
+/// resulting token to SwiftUI. Turnstile is a browser bot-deterrent with no
+/// native SDK, so we host the widget in a tiny web page, capture its callback
+/// via a JS message handler, and hand the token back — the same token the web
+/// client posts as `captcha_token`, which the API validates through its
+/// siteverify round-trip with no server-side branching.
+///
+/// The site key defaults to Cloudflare's documented always-passes test key
+/// (`1x00000000000000000000AA`), matching the web client and the API's dev test
+/// secret, so this works end-to-end against UAT with no extra setup. Point a
+/// real, domain-locked key at it via the `FMM_TURNSTILE_SITE_KEY` scheme
+/// environment variable for production; the page is loaded with the API host as
+/// its origin so a domain-restricted key still validates.
+struct TurnstileView: UIViewRepresentable {
+    let controller: TurnstileController
+    var onToken: (String) -> Void
+    var onExpire: () -> Void = {}
+    var onError: () -> Void = {}
+
+    /// JS → Swift message channel name; shared by the handler registration and
+    /// the `postMessage` calls in the page so the two can't drift.
+    private static let messageName = "turnstile"
+
+    static let siteKey: String =
+        ProcessInfo.processInfo.environment["FMM_TURNSTILE_SITE_KEY"]
+            ?? "1x00000000000000000000AA"
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let controllerJS = WKUserContentController()
+        controllerJS.add(context.coordinator, name: Self.messageName)
+        config.userContentController = controllerJS
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        // Let the dark app background show through the widget's margins.
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        webView.scrollView.isScrollEnabled = false
+
+        // Wire the reset handle to the page's helper. Assigning a plain stored
+        // property (not @Published) during view setup doesn't publish, so this
+        // doesn't trip "modifying state during view update".
+        controller.onReset = { [weak webView] in
+            webView?.evaluateJavaScript("window.fmmResetTurnstile && window.fmmResetTurnstile();")
+        }
+
+        // Load with the API host as the origin so a domain-locked production key
+        // matches its allowed-hostnames list.
+        webView.loadHTMLString(Self.html, baseURL: APIClient.baseURL)
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    /// Tear down the message handler so the coordinator (which retains `self`)
+    /// can be released and we don't leak across view identity changes.
+    static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
+        uiView.configuration.userContentController
+            .removeScriptMessageHandler(forName: messageName)
+    }
+
+    final class Coordinator: NSObject, WKScriptMessageHandler {
+        private let parent: TurnstileView
+        init(_ parent: TurnstileView) { self.parent = parent }
+
+        // Delivered on the main thread by WebKit, so forwarding into SwiftUI
+        // state setters is safe.
+        func userContentController(
+            _ controller: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            guard
+                let body = message.body as? [String: Any],
+                let event = body["event"] as? String
+            else { return }
+            switch event {
+            case "token":
+                if let token = body["token"] as? String, !token.isEmpty {
+                    parent.onToken(token)
+                }
+            case "expired":
+                parent.onExpire()
+            case "error":
+                parent.onError()
+            default:
+                break
+            }
+        }
+    }
+
+    /// Minimal page that renders the widget explicitly (so we can keep its id
+    /// for `reset`) and posts every lifecycle event back over the message
+    /// channel. `interaction-only` keeps the UI minimal — invisible when no
+    /// challenge is needed, matching the web client's appearance.
+    private static var html: String {
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+          <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=fmmOnTurnstileLoad" async defer></script>
+          <style>
+            html, body { margin: 0; padding: 0; background: transparent; }
+            #cf { display: flex; justify-content: center; padding: 2px 0; }
+          </style>
+        </head>
+        <body>
+          <div id="cf"></div>
+          <script>
+            var fmmWidgetId;
+            function fmmPost(event, token) {
+              window.webkit.messageHandlers.\(messageName).postMessage({ event: event, token: token || "" });
+            }
+            function fmmResetTurnstile() {
+              if (window.turnstile && fmmWidgetId !== undefined) {
+                window.turnstile.reset(fmmWidgetId);
+              }
+            }
+            window.fmmOnTurnstileLoad = function () {
+              fmmWidgetId = window.turnstile.render('#cf', {
+                sitekey: '\(siteKey)',
+                theme: 'dark',
+                appearance: 'interaction-only',
+                callback: function (t) { fmmPost('token', t); },
+                'expired-callback': function () { fmmPost('expired'); },
+                'error-callback': function () { fmmPost('error'); }
+              });
+            };
+          </script>
+        </body>
+        </html>
+        """
+    }
+}

--- a/ios/Fortymm/Session/SessionStore.swift
+++ b/ios/Fortymm/Session/SessionStore.swift
@@ -14,10 +14,24 @@ final class SessionStore: ObservableObject {
 
     @Published private(set) var state: State = .idle
 
+    /// The signed-in user when the session has resolved, else nil. Lets screens
+    /// read the user without re-switching over `state` at every call site.
+    var user: SessionUser? {
+        if case let .loaded(user) = state { return user }
+        return nil
+    }
+
     private let client: APIClient
 
     init(client: APIClient = .shared) {
         self.client = client
+    }
+
+    /// Fold an updated user — returned by a profile mutation (username/email
+    /// change) — straight into the loaded state, so the UI reflects the change
+    /// without a second `GET /v1/session` round-trip.
+    func apply(_ user: SessionUser) {
+        state = .loaded(user)
     }
 
     /// Create or resume the session. Skips the network call if a user is


### PR DESCRIPTION
Builds the **You** tab from a `FMComingSoon` placeholder into a real account hub, and adds a native **magic-link sign-in** flow. Both wire to existing API endpoints — **no server changes**.

## Profile / account settings
- **Change username** (`PATCH /v1/me`) and **change email** (`POST /v1/me/email`) editors, presented as sheets from the "You" tab. Client-side validation (`ProfileRules`) mirrors the web client and the server's pattern; 409/422 surface inline.
- **Cloudflare Turnstile in a `WKWebView`** (`TurnstileView`) — captures the token via a JS message handler and posts it as the `captcha_token` field the API already verifies through siteverify, so there's no server branch. Defaults to the always-passes test sitekey (matches web + the dev secret); a real key drops in via `FMM_TURNSTILE_SITE_KEY`.
- `APIClient` gains a `PATCH` verb; `SessionStore` gains a `user` accessor + `apply(_:)` to fold a mutation result back in without a re-fetch.

## Magic-link sign-in (`Login/`)
Implemented from the Claude Design handoff (`Login flow.html`), reflowed to the mobile single-column layout.
- **Email entry** (Turnstile-gated, `POST /v1/login/request`) and **check-your-inbox** (resend + live 15-min countdown) — live and reachable via "Already have an account? Sign in" on the You tab.
- **Verify → signed-in / expired / unreachable** landing, wired to `POST /v1/login/consume` with a typed `LoginConsumeError` (4xx = rejected/terminal, else = retryable). **Dormant** until the app can open `fortymm.com` links — the deep-link/universal-link work was deferred. `LoginFlowView.Start.verifying(token:)` is the clean seam to wire a handler to later (Team `3A8872P8KP`, bundle `com.fortymm.ios-client`).

## Verification
- Builds clean for the iOS Simulator (no warnings in the new code).
- Ran on-device against UAT: email entry, check-inbox, and the change-email Turnstile flow all confirmed end-to-end (token round-trips through the WebView; the consume call was verified by a rejected token landing on the expired screen).
- Two `/simplify` passes applied (shared header/button/error+captcha-reset helpers; typed consume error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)