### PR TITLE
Account merge on existing email: tombstone guests, session-ended handling, token-bound login + confirm gate

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -43,12 +43,16 @@ change, run from `api/`:
 
 When you add a model (or column) with a foreign key to `users.id`, also update
 the ephemeral→verified account-merge logic to handle the new FK — re-point it
-to the surviving user, or rely on `ON DELETE CASCADE` and let the ephemeral
-user's deletion clean it up. Grep for `merge_user` to find it.
+to the surviving user, or delete the ephemeral's rows explicitly. Grep for
+`merge_user` to find it.
 
-Skipping this means a merged user silently leaves orphan rows, or a `RESTRICT`
-FK blocks the final ephemeral-user delete and the whole merge transaction
-fails.
+`merge_user` **tombstones** (soft-deletes) the ephemeral user — sets
+`merged_into_user_id` and keeps the row so its session token still resolves —
+rather than `DELETE`ing it. So `ON DELETE CASCADE` does **not** fire on a merge:
+every owned table is cleaned up by an explicit statement in `merge_user`. A new
+FK you don't handle there will silently leave the merged user's rows pointing at
+a tombstoned ghost. (Auth-layer queries must also exclude tombstoned users —
+`merged_into_user_id IS NOT NULL` — so ghosts don't surface in listings/search.)
 
 ## Pre-deploy: edit migrations in place
 

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -1,7 +1,14 @@
-"""Re-point ownership from an ephemeral user to a verified user, then delete
-the ephemeral user. Called from sign-in (``/v1/login/consume``) and email
-confirmation (``/v1/me/email/confirm``) when the browser arrived with a
-different ephemeral session than the target account.
+"""Re-point ownership from an ephemeral user to a verified user, then
+*tombstone* (soft-delete) the ephemeral user. Called from sign-in
+(``/v1/login/consume``) and email confirmation (``/v1/me/email/confirm``) when
+the browser arrived with a different ephemeral session than the target account.
+
+The ephemeral row is kept (``merged_into_user_id`` set) rather than dropped so
+its session token still resolves and the auth layer can tell the holder their
+session was merged instead of silently minting a fresh guest. Because we no
+longer rely on ``ON DELETE CASCADE``, the ephemeral user's owned rows
+(roles, leftover league rows, rating history, non-session tokens) are cleaned up
+explicitly here.
 
 Leaves the verified user's ``user_league_ratings`` and ``rating_history``
 stale relative to the freshly-moved matches — the caller enqueues the
@@ -10,12 +17,28 @@ stale relative to the freshly-moved matches — the caller enqueues the
 
 import uuid
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any, cast
 
 from sqlalchemy import CursorResult, delete, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Match, MatchSidePlayer, MatchSignature, RatingHistory, User
+from app.models import (
+    LeagueMembership,
+    Match,
+    MatchSidePlayer,
+    MatchSignature,
+    RatingHistory,
+    User,
+    UserLeagueRating,
+    UserRole,
+    UserToken,
+)
+
+# Must match ``app.sessions.SESSION_TOKEN_CONTEXT``. Hardcoded to avoid a
+# circular import (sessions imports this module). Session tokens are KEPT on the
+# tombstoned guest so its cookie still resolves; every other token is dropped.
+_SESSION_TOKEN_CONTEXT = "session"
 
 
 @dataclass(frozen=True)
@@ -29,8 +52,9 @@ async def merge_user(
     from_user_id: uuid.UUID,
     to_user_id: uuid.UUID,
 ) -> MergeSummary:
-    """Re-point ``from_user_id``'s data onto ``to_user_id`` and delete the
-    ephemeral row. Runs inside the caller's transaction — does not commit.
+    """Re-point ``from_user_id``'s data onto ``to_user_id`` and tombstone the
+    ephemeral row (``merged_into_user_id`` set; row kept). Runs inside the
+    caller's transaction — does not commit.
 
     Caller invariants:
       * ``from_user_id`` is ephemeral (``confirmed_at IS NULL``).
@@ -60,7 +84,7 @@ async def merge_user(
 
     # user_league_ratings / league_memberships both have UNIQUE(league_id,
     # user_id). Re-point only where the verified user has no row in that
-    # league; the leftover ephemeral rows cascade-delete with the user below.
+    # league; the leftover ephemeral rows are dropped explicitly below.
     # Don't try to merge JSONB rating state — a rating recompute against the
     # merged match list is the only correct reconciliation.
     await db.execute(
@@ -105,9 +129,32 @@ async def merge_user(
         delete(MatchSignature).where(MatchSignature.user_id == from_user_id)
     )
 
-    # CASCADE cleans up user_tokens, user_roles, rating_history (user_id), and
-    # any user_league_ratings / league_memberships rows that didn't re-point.
-    await db.execute(delete(User).where(User.id == from_user_id))
+    # We tombstone rather than DELETE the user, so the rows that used to ride
+    # ``ON DELETE CASCADE`` must be dropped explicitly. Order doesn't matter —
+    # none of these reference each other. Keep the guest's *session* tokens so
+    # its cookie still resolves to this (now-tombstoned) row.
+    await db.execute(delete(UserRole).where(UserRole.user_id == from_user_id))
+    await db.execute(delete(RatingHistory).where(RatingHistory.user_id == from_user_id))
+    await db.execute(
+        delete(UserLeagueRating).where(UserLeagueRating.user_id == from_user_id)
+    )
+    await db.execute(
+        delete(LeagueMembership).where(LeagueMembership.user_id == from_user_id)
+    )
+    await db.execute(
+        delete(UserToken).where(
+            UserToken.user_id == from_user_id,
+            UserToken.context != _SESSION_TOKEN_CONTEXT,
+        )
+    )
+
+    # Tombstone: keep the row (and its session tokens) so the guest's cookie
+    # still resolves and the auth layer can report the merge.
+    await db.execute(
+        update(User)
+        .where(User.id == from_user_id)
+        .values(merged_into_user_id=to_user_id, merged_at=datetime.now(UTC))
+    )
     await db.flush()
 
     return MergeSummary(matches_moved=matches_moved)

--- a/api/app/email.py
+++ b/api/app/email.py
@@ -142,3 +142,31 @@ def send_login_email(to_email: str, raw_token: str, username: str) -> None:
         log_url=login_url,
         dev_label="sign-in",
     )
+
+
+def send_merge_email(to_email: str, raw_token: str, username: str) -> None:
+    """Render and deliver the 'link your guest session to this account' email.
+
+    Sent when someone playing as a guest enters an address that already belongs
+    to ``username``'s account. The link redeems through the same
+    ``/confirm-email`` route as a normal confirmation, but the server folds the
+    guest's matches into this account and signs them in (see
+    ``app.sessions.confirm_email``)."""
+    confirm_url = _confirm_url(raw_token)
+    _deliver(
+        to_email=to_email,
+        subject="Sign in to your FortyMM account",
+        body=(
+            f"Hi @{username},\n\n"
+            "Someone — probably you — entered this email while playing FortyMM "
+            "as a guest. Click the link below to sign in to your existing "
+            "account. We'll bring any matches from that guest session along "
+            "with you.\n\n"
+            f"{confirm_url}\n\n"
+            "If this wasn't you, you can ignore this email. Nobody can sign in "
+            "or move anything without this link.\n"
+        ),
+        log_event="email_merge_link",
+        log_url=confirm_url,
+        dev_label="account-link",
+    )

--- a/api/app/models/user.py
+++ b/api/app/models/user.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, String, func
+from sqlalchemy import DateTime, ForeignKey, String, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -23,6 +23,20 @@ class User(Base):
         String(320), unique=True, nullable=True, index=True
     )
     confirmed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Set when this (ephemeral) user has been folded into another account by the
+    # merge service. A live user has both NULL; a tombstoned guest has both set.
+    # The row is kept (not deleted) so its session token still resolves and the
+    # auth layer can tell the holder their session was merged. See
+    # ``app.account_merge.merge_user``.
+    merged_into_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    merged_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(

--- a/api/app/players.py
+++ b/api/app/players.py
@@ -135,6 +135,7 @@ async def list_recent_opponents(
                     select(User)
                     .where(
                         User.id != current_user.id,
+                        User.merged_into_user_id.is_(None),
                         User.id.notin_(played_ids),
                     )
                     .order_by(User.username)
@@ -174,6 +175,8 @@ async def search_players(
         select(User)
         .where(
             User.id != current_user.id,
+            # Exclude tombstoned (merged-away) guests so ghosts never surface.
+            User.merged_into_user_id.is_(None),
             User.username.ilike(pattern, escape="\\"),
         )
         .order_by(User.username)
@@ -344,6 +347,7 @@ async def list_players(
 
     base = (
         select(User)
+        .where(User.merged_into_user_id.is_(None))
         .outerjoin(
             UserLeagueRating,
             and_(
@@ -362,7 +366,9 @@ async def list_players(
     # `total` keys the pagination footer + drives the "Showing N-M of T" line.
     # Build the count from the same `q` filter; an unfiltered roster total
     # would mislead users searching for a niche substring.
-    count_query: Select[tuple[int]] = select(func.count()).select_from(User)
+    count_query: Select[tuple[int]] = (
+        select(func.count()).select_from(User).where(User.merged_into_user_id.is_(None))
+    )
     if q and q.strip():
         count_query = _username_substring_filter(count_query, q)
     total = (await db.execute(count_query)).scalar_one()
@@ -379,13 +385,23 @@ async def list_players(
 
 async def _load_player_by_id(db: AsyncSession, player_id: uuid.UUID) -> User | None:
     return (
-        await db.execute(select(User).where(User.id == player_id))
+        await db.execute(
+            select(User).where(
+                User.id == player_id,
+                User.merged_into_user_id.is_(None),
+            )
+        )
     ).scalar_one_or_none()
 
 
 async def _load_player_by_username(db: AsyncSession, username: str) -> User | None:
     return (
-        await db.execute(select(User).where(User.username == username))
+        await db.execute(
+            select(User).where(
+                User.username == username,
+                User.merged_into_user_id.is_(None),
+            )
+        )
     ).scalar_one_or_none()
 
 

--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 # Lowercase alphanumerics with optional dots/hyphens/underscores between them.
 # Must start and end with an alphanumeric so we don't store names that look
@@ -69,6 +69,10 @@ class ResendEmailRequest(CaptchaProtectedRequest):
 
 class ConfirmEmailRequest(BaseModel):
     token: str = Field(min_length=1, max_length=512)
+    # When the link would fold a guest into this account, the client can offer
+    # the owner a "sign in but don't bring those matches" choice. Defaults to
+    # merging (the common, desired path).
+    skip_merge: bool = False
 
 
 class RequestLoginRequest(CaptchaProtectedRequest):
@@ -85,3 +89,27 @@ class LoginRequestAccepted(BaseModel):
 
 class ConsumeLoginRequest(BaseModel):
     token: str = Field(min_length=1, max_length=512)
+    # See ConfirmEmailRequest.skip_merge — sign in without folding the recorded
+    # guest's matches in.
+    skip_merge: bool = False
+
+
+class MergePreviewRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    token: str = Field(min_length=1, max_length=512)
+
+
+class MergePreview(BaseModel):
+    """Side-effect-free look at an emailed link before it's consumed, so the
+    client can decide whether to show a "bring N matches over?" confirmation.
+
+    ``is_merge`` is true only for a link that would fold a guest into another
+    account (a settings merge token, or a sign-in token that recorded a
+    requesting guest). The client shows the gate only when there are matches to
+    carry (``guest_matches_count > 0``); otherwise it finalizes silently."""
+
+    is_merge: bool
+    owner_username: str | None = None
+    guest_username: str | None = None
+    guest_matches_count: int = 0

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -10,7 +10,7 @@ from coolname import generate_slug
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
 from pyrate_limiter import Duration, Rate
 from rq.job import Job
-from sqlalchemy import delete, select
+from sqlalchemy import ColumnElement, delete, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -48,6 +48,12 @@ SESSION_TOKEN_CONTEXT = "session"
 # us an audit trail of what each token was changing away from. Look up
 # pending tokens by `context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)`.
 EMAIL_CHANGE_CONTEXT_PREFIX = "change:"
+# A guest (no confirmed email of their own) who enters an address that already
+# belongs to a verified account gets a *merge* token rather than a plain change
+# token. Confirming it folds the guest's data into the owning account and signs
+# the browser in as that account — instead of stamping the address onto the
+# guest. The context records the owning account's id: "merge:<uuid>".
+EMAIL_MERGE_CONTEXT_PREFIX = "merge:"
 LOGIN_TOKEN_CONTEXT = "login"
 LOGIN_TOKEN_LIFETIME = timedelta(minutes=15)
 SESSION_LIFETIME = timedelta(days=30)
@@ -61,6 +67,30 @@ def _email_change_context(old_email: str | None) -> str:
 def _old_email_from_context(context: str) -> str | None:
     """Inverse of ``_email_change_context``."""
     return context.removeprefix(EMAIL_CHANGE_CONTEXT_PREFIX) or None
+
+
+def _merge_context(target_user_id: uuid.UUID) -> str:
+    return f"{EMAIL_MERGE_CONTEXT_PREFIX}{target_user_id}"
+
+
+def _target_id_from_merge_context(context: str) -> uuid.UUID | None:
+    """Inverse of ``_merge_context``. Returns ``None`` on a malformed id so a
+    corrupt context surfaces as an opaque "invalid link" rather than a 500."""
+    try:
+        return uuid.UUID(context.removeprefix(EMAIL_MERGE_CONTEXT_PREFIX))
+    except ValueError:
+        return None
+
+
+def _pending_email_token_clause() -> ColumnElement[bool]:
+    """Match either flavour of pending email token — a plain change token
+    (``change:OLD``) or a merge-into-existing-account token (``merge:<uuid>``).
+    Both drive the session's ``pending_email`` and both are consumed by
+    ``confirm_email``."""
+    return or_(
+        UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
+        UserToken.context.startswith(EMAIL_MERGE_CONTEXT_PREFIX),
+    )
 
 
 def _hash_cookie_for_key(cookie: str) -> str:
@@ -399,7 +429,7 @@ async def _pending_change_token(
         select(UserToken)
         .where(
             UserToken.user_id == user_id,
-            UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
+            _pending_email_token_clause(),
         )
         .limit(1)
     )
@@ -415,7 +445,7 @@ async def _issue_confirmation_token(
     await db.execute(
         delete(UserToken).where(
             UserToken.user_id == user.id,
-            UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
+            _pending_email_token_clause(),
         )
     )
     raw_token = secrets.token_urlsafe(32)
@@ -458,6 +488,12 @@ def _enqueue_login_email(to_email: str, raw_token: str, username: str) -> Job:
     )
 
 
+def _enqueue_merge_email(to_email: str, raw_token: str, username: str) -> Job:
+    return _enqueue_email_job(
+        "app.email.send_merge_email", to_email, raw_token, username
+    )
+
+
 def _enqueue_rating_recompute_after_merge(user_id: uuid.UUID) -> None:
     """Fire-and-forget the rating recompute for ``user_id`` after a merge.
 
@@ -478,6 +514,49 @@ def _enqueue_rating_recompute_after_merge(user_id: uuid.UUID) -> None:
             "Failed to enqueue rating recompute after merge",
             extra={"user_id": str(user_id)},
         )
+
+
+async def _begin_account_merge(
+    db: AsyncSession, guest: User, email: str
+) -> SessionResponse:
+    """Issue a merge token for an ephemeral ``guest`` who entered an address
+    owned by an existing account, and email that account a sign-in link.
+
+    Mirrors ``set_email``'s issue/enqueue/commit dance, including the
+    enumeration-safe fallbacks: every exit returns the same 202 + session shape
+    as a first-time set, so the caller can't distinguish a taken address from a
+    free one."""
+    target = (
+        await db.execute(select(User).where(User.email == email))
+    ).scalar_one_or_none()
+    if target is None or target.id == guest.id:
+        # Lost the race (the owner just changed their address out from under
+        # us) or, impossibly, our own row — nothing to merge into.
+        return await _build_session_response(db, guest)
+
+    raw_token = await _issue_confirmation_token(
+        db, guest, email, _merge_context(target.id)
+    )
+    try:
+        job = _enqueue_merge_email(email, raw_token, target.username)
+    except Exception:
+        await db.rollback()
+        await db.refresh(guest)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Email service unavailable. Try again in a moment.",
+        ) from None
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        try:
+            job.cancel()
+        except Exception:
+            pass
+        await db.refresh(guest)
+        return await _build_session_response(db, guest)
+    return await _build_session_response(db, guest)
 
 
 @router.post(
@@ -509,12 +588,20 @@ async def set_email(
     if old_email != email and await name_taken(
         db, User.id, User.email, email, exclude_id=current_user.id
     ):
-        # Don't reveal that the email belongs to another user — that
-        # differential lets attackers enumerate the user base by cycling
-        # `GET /v1/session` for fresh rate-limit buckets. Return the same
-        # 202 + unchanged session shape as the success path. The legitimate
-        # owner is unaffected; the typo-on-someone-else's-address case sees
-        # a "sent" toast but never receives an email.
+        # The address already belongs to another account. A *guest* (no
+        # confirmed email of their own) almost certainly means "this is me —
+        # sign me into my real account and bring my guest matches along." Email
+        # the owner a merge link; clicking it folds this guest into their
+        # account (see ``confirm_email``'s merge branch). The response is the
+        # same 202 + pending_email shape as a first-time set, so an attacker
+        # still can't tell a taken address from a free one by cycling fresh
+        # `/v1/session` cookies.
+        #
+        # A caller who already has a confirmed email is *changing* addresses,
+        # not merging — silently absorbing their account into someone else's
+        # would be data loss, so keep the enumeration-safe no-op for them.
+        if current_user.confirmed_at is None:
+            return await _begin_account_merge(db, current_user, email)
         return await _build_session_response(db, current_user)
 
     raw_token = await _issue_confirmation_token(
@@ -582,9 +669,18 @@ async def resend_email_confirmation(
         pending.context,
     )
     try:
-        job = _enqueue_confirmation_email(
-            pending.sent_to, raw_token, current_user.username
-        )
+        # A merge token re-sends the "sign in to your existing account" email
+        # to the owner, not the plain confirmation copy — same /confirm-email
+        # link either way, but the wording has to match what's happening.
+        if pending.context.startswith(EMAIL_MERGE_CONTEXT_PREFIX):
+            target_id = _target_id_from_merge_context(pending.context)
+            target = await db.get(User, target_id) if target_id is not None else None
+            owner_username = target.username if target else current_user.username
+            job = _enqueue_merge_email(pending.sent_to, raw_token, owner_username)
+        else:
+            job = _enqueue_confirmation_email(
+                pending.sent_to, raw_token, current_user.username
+            )
     except Exception:
         await db.rollback()
         raise HTTPException(
@@ -623,12 +719,17 @@ async def confirm_email(
     orphan guest user on every cross-device click. The endpoint also
     rotates the caller's session cookie to the token's owner so the
     confirming browser ends up signed in as the right user.
+
+    A *merge* token (``merge:<uuid>``) is handled separately: instead of
+    stamping an address onto the guest that requested it, the guest is folded
+    into the account that owns the address and the caller is signed in as that
+    account. See ``_confirm_account_merge``.
     """
     token_row = (
         await db.execute(
             select(UserToken).where(
                 UserToken.token == _hash_token(payload.token),
-                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
+                _pending_email_token_clause(),
             )
         )
     ).scalar_one_or_none()
@@ -637,6 +738,8 @@ async def confirm_email(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="That confirmation link is invalid or expired.",
         )
+    if token_row.context.startswith(EMAIL_MERGE_CONTEXT_PREFIX):
+        return await _confirm_account_merge(db, response, token_row)
     user = (
         await db.execute(select(User).where(User.id == token_row.user_id))
     ).scalar_one_or_none()
@@ -690,6 +793,55 @@ async def confirm_email(
         _enqueue_rating_recompute_after_merge(user.id)
     _set_session_cookie(response, raw_session)
     return await _build_session_response(db, user, merged=merged)
+
+
+async def _confirm_account_merge(
+    db: AsyncSession, response: Response, token_row: UserToken
+) -> SessionResponse:
+    """Consume a merge token: fold the ephemeral guest that requested it into
+    the account that owns the target address, then rotate the caller's session
+    cookie to that account. The guest row — and this token, via CASCADE — is
+    deleted by ``merge_user``, so the link is single-use.
+
+    The merge is bound to the *requesting* guest recorded on the token, not to
+    whatever session the click arrives with, so it does the right thing across
+    devices (desktop request, phone click)."""
+    target_id = _target_id_from_merge_context(token_row.context)
+    guest = await db.get(User, token_row.user_id)
+    target = await db.get(User, target_id) if target_id is not None else None
+    # The token is only trustworthy while the target still owns the address it
+    # was cut against. Reject (and burn the token) if the owner changed their
+    # email, the guest is gone or has since verified an email of its own, or the
+    # ids somehow collapsed — surfacing the opaque error so nothing leaks.
+    if (
+        guest is None
+        or target is None
+        or guest.id == target.id
+        or guest.confirmed_at is not None
+        or target.email != token_row.sent_to
+    ):
+        await db.delete(token_row)
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That confirmation link is invalid or expired.",
+        )
+
+    raw_session = secrets.token_urlsafe(32)
+    summary = await merge_user(db, from_user_id=guest.id, to_user_id=target.id)
+    db.add(
+        UserToken(
+            user_id=target.id,
+            context=SESSION_TOKEN_CONTEXT,
+            token=_hash_token(raw_session),
+        )
+    )
+    await db.commit()
+    merged = MergeSummary(matches_moved=summary.matches_moved)
+    if merged.matches_moved > 0:
+        _enqueue_rating_recompute_after_merge(target.id)
+    _set_session_cookie(response, raw_session)
+    return await _build_session_response(db, target, merged=merged)
 
 
 @router.post(

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -10,7 +10,7 @@ from coolname import generate_slug
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
 from pyrate_limiter import Duration, Rate
 from rq.job import Job
-from sqlalchemy import ColumnElement, delete, or_, select
+from sqlalchemy import ColumnElement, delete, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,13 +19,23 @@ from app import queue as queue_module
 from app.account_merge import merge_user
 from app.db import get_session
 from app.leagues import add_user_to_default_league
-from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
+from app.models import (
+    MatchSidePlayer,
+    Permission,
+    Role,
+    RolePermission,
+    User,
+    UserRole,
+    UserToken,
+)
 from app.rate_limiting import RedisRateLimiter
 from app.ratings.jobs import RECOMPUTE_AFTER_MERGE_JOB
 from app.schemas.session import (
     ConfirmEmailRequest,
     ConsumeLoginRequest,
     LoginRequestAccepted,
+    MergePreview,
+    MergePreviewRequest,
     MergeSummary,
     RequestLoginRequest,
     ResendEmailRequest,
@@ -96,6 +106,74 @@ def _pending_email_token_clause() -> ColumnElement[bool]:
         UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
         UserToken.context.startswith(EMAIL_MERGE_CONTEXT_PREFIX),
     )
+
+
+# A login token records the *requesting* guest in its context so the merge it
+# drives is token-bound (works cross-device) like the settings merge: bare
+# ``login`` when the requester wasn't an ephemeral guest, else
+# ``login:<guest-id>``.
+_LOGIN_CONTEXT_PREFIX = f"{LOGIN_TOKEN_CONTEXT}:"
+
+
+def _login_context(guest_id: uuid.UUID | None) -> str:
+    return (
+        LOGIN_TOKEN_CONTEXT
+        if guest_id is None
+        else f"{_LOGIN_CONTEXT_PREFIX}{guest_id}"
+    )
+
+
+def _guest_id_from_login_context(context: str) -> uuid.UUID | None:
+    """The requesting guest recorded on a login token, or ``None`` for a bare
+    ``login`` context (or a malformed id)."""
+    if not context.startswith(_LOGIN_CONTEXT_PREFIX):
+        return None
+    try:
+        return uuid.UUID(context.removeprefix(_LOGIN_CONTEXT_PREFIX))
+    except ValueError:
+        return None
+
+
+def _login_token_clause() -> ColumnElement[bool]:
+    """Match both login-token flavours (bare ``login`` and ``login:<guest>``)."""
+    return or_(
+        UserToken.context == LOGIN_TOKEN_CONTEXT,
+        UserToken.context.startswith(_LOGIN_CONTEXT_PREFIX),
+    )
+
+
+async def _guest_match_count(db: AsyncSession, guest_id: uuid.UUID) -> int:
+    """How many distinct matches the guest is on — what a merge would carry
+    over. ``UNIQUE(match_id, user_id)`` means one row per match, but count
+    distinct match ids defensively."""
+    return (
+        await db.execute(
+            select(func.count(func.distinct(MatchSidePlayer.match_id))).where(
+                MatchSidePlayer.user_id == guest_id
+            )
+        )
+    ).scalar_one()
+
+
+async def _merge_guest_into(
+    db: AsyncSession, *, guest: User | None, target: User
+) -> MergeSummary | None:
+    """Fold an ephemeral ``guest`` into ``target`` when it's safe, returning the
+    summary. ``None`` (no merge) when the guest is missing, is the target, has
+    verified an email of its own (would be data loss), or is already tombstoned.
+    Runs in the caller's transaction — does not commit.
+
+    The single guard used by every merge path: token-bound sign-in/confirm and
+    the browser-bound prior-session fold."""
+    if (
+        guest is None
+        or guest.id == target.id
+        or guest.confirmed_at is not None
+        or guest.merged_into_user_id is not None
+    ):
+        return None
+    summary = await merge_user(db, from_user_id=guest.id, to_user_id=target.id)
+    return MergeSummary(matches_moved=summary.matches_moved)
 
 
 def _hash_cookie_for_key(cookie: str) -> str:
@@ -270,31 +348,17 @@ async def _build_session_response(
 async def _maybe_merge_prior_session(
     db: AsyncSession, session_cookie: str | None, target_user: User
 ) -> MergeSummary | None:
-    """If the browser arrived with a session cookie identifying a *different*
-    ephemeral user than ``target_user``, fold that user's data into the target
-    and return a summary. Otherwise return None.
+    """Browser-bound fold: if the clicking browser arrived with an ephemeral
+    guest cookie, fold that guest into ``target_user``. The fallback used by
+    sign-in when the token didn't record a specific requesting guest.
 
-    Only runs for ephemeral prior users (``confirmed_at IS NULL``) — a verified
-    prior session means two real accounts share a browser, and silently
-    siphoning data out of one would be data loss.
+    ``_merge_guest_into`` enforces the safety guards (skip a verified prior —
+    two real accounts sharing a browser — or an already-tombstoned ghost).
     """
     if not session_cookie:
         return None
     prior_user = await _find_session_user(db, session_cookie)
-    if prior_user is None or prior_user.id == target_user.id:
-        return None
-    # Skip a verified prior (two real accounts share a browser — siphoning one
-    # would be data loss) and an already-tombstoned prior (a ghost; never
-    # re-merge it).
-    if (
-        prior_user.confirmed_at is not None
-        or prior_user.merged_into_user_id is not None
-    ):
-        return None
-    summary = await merge_user(
-        db, from_user_id=prior_user.id, to_user_id=target_user.id
-    )
-    return MergeSummary(matches_moved=summary.matches_moved)
+    return await _merge_guest_into(db, guest=prior_user, target=target_user)
 
 
 async def _load_permissions(db: AsyncSession, user_id: uuid.UUID) -> list[str]:
@@ -809,7 +873,9 @@ async def confirm_email(
             detail="That confirmation link is invalid or expired.",
         )
     if token_row.context.startswith(EMAIL_MERGE_CONTEXT_PREFIX):
-        return await _confirm_account_merge(db, response, token_row)
+        return await _confirm_account_merge(
+            db, response, token_row, skip_merge=payload.skip_merge
+        )
     user = (
         await db.execute(select(User).where(User.id == token_row.user_id))
     ).scalar_one_or_none()
@@ -866,29 +932,29 @@ async def confirm_email(
 
 
 async def _confirm_account_merge(
-    db: AsyncSession, response: Response, token_row: UserToken
+    db: AsyncSession,
+    response: Response,
+    token_row: UserToken,
+    *,
+    skip_merge: bool = False,
 ) -> SessionResponse:
     """Consume a merge token: fold the ephemeral guest that requested it into
     the account that owns the target address, then rotate the caller's session
-    cookie to that account. The guest row — and this token, via CASCADE — is
-    deleted by ``merge_user``, so the link is single-use.
+    cookie to that account. The merge deletes the guest's non-session tokens
+    (this one included), so the link is single-use.
 
     The merge is bound to the *requesting* guest recorded on the token, not to
     whatever session the click arrives with, so it does the right thing across
-    devices (desktop request, phone click)."""
+    devices (desktop request, phone click). ``skip_merge`` signs the owner in
+    without folding the guest (the gate's "not now")."""
     target_id = _target_id_from_merge_context(token_row.context)
     guest = await db.get(User, token_row.user_id)
     target = await db.get(User, target_id) if target_id is not None else None
     # The token is only trustworthy while the target still owns the address it
     # was cut against. Reject (and burn the token) if the owner changed their
-    # email, the guest is gone or has since verified an email of its own, or the
-    # ids somehow collapsed — surfacing the opaque error so nothing leaks.
+    # email or is itself tombstoned — surfacing the opaque error so nothing leaks.
     if (
-        guest is None
-        or target is None
-        or guest.id == target.id
-        or guest.confirmed_at is not None
-        or guest.merged_into_user_id is not None
+        target is None
         or target.merged_into_user_id is not None
         or target.email != token_row.sent_to
     ):
@@ -900,7 +966,14 @@ async def _confirm_account_merge(
         )
 
     raw_session = secrets.token_urlsafe(32)
-    summary = await merge_user(db, from_user_id=guest.id, to_user_id=target.id)
+    merged = (
+        None if skip_merge else await _merge_guest_into(db, guest=guest, target=target)
+    )
+    if merged is None:
+        # Nothing folded (declined, or guest gone / already verified / tombstoned)
+        # — the inbox click still proves ownership, so sign them in as the owner.
+        # A merge would have deleted this token; do it explicitly to stay single-use.
+        await db.delete(token_row)
     db.add(
         UserToken(
             user_id=target.id,
@@ -909,8 +982,7 @@ async def _confirm_account_merge(
         )
     )
     await db.commit()
-    merged = MergeSummary(matches_moved=summary.matches_moved)
-    if merged.matches_moved > 0:
+    if merged is not None and merged.matches_moved > 0:
         _enqueue_rating_recompute_after_merge(target.id)
     _set_session_cookie(response, raw_session)
     return await _build_session_response(db, target, merged=merged)
@@ -927,6 +999,7 @@ async def _confirm_account_merge(
 )
 async def request_login_email(
     payload: RequestLoginRequest,
+    session_cookie: Annotated[str | None, Cookie(alias=SESSION_COOKIE_NAME)] = None,
     db: AsyncSession = Depends(get_session),
 ) -> LoginRequestAccepted:
     """Mint a magic-link sign-in token and email it.
@@ -942,6 +1015,10 @@ async def request_login_email(
     someone sign in without proving control of the inbox; the confirmation
     link clears that hurdle and (per ``confirm_email``) rotates them into
     a session anyway.
+
+    Records the requesting browser's guest on the token so the merge it drives
+    is token-bound (follows the guest cross-device), mirroring the settings
+    merge flow.
     """
     email = payload.email.lower()
 
@@ -960,25 +1037,53 @@ async def request_login_email(
         await _issue_and_send_confirmation_email(db, user, email)
         return LoginRequestAccepted(email=email)
 
-    await _issue_and_send_login_email(db, user, email)
+    guest_id = await _requesting_guest_id(db, session_cookie, target=user)
+    await _issue_and_send_login_email(db, user, email, merge_from_guest_id=guest_id)
     return LoginRequestAccepted(email=email)
 
 
-async def _issue_and_send_login_email(db: AsyncSession, user: User, email: str) -> None:
+async def _requesting_guest_id(
+    db: AsyncSession, session_cookie: str | None, *, target: User
+) -> uuid.UUID | None:
+    """The id of the requesting browser's guest, when it's an ephemeral guest
+    distinct from ``target`` — so a sign-in can carry its matches over. ``None``
+    for a verified / tombstoned / absent requester."""
+    if not session_cookie:
+        return None
+    requester = await _find_session_user(db, session_cookie)
+    if (
+        requester is None
+        or requester.id == target.id
+        or requester.confirmed_at is not None
+        or requester.merged_into_user_id is not None
+    ):
+        return None
+    return requester.id
+
+
+async def _issue_and_send_login_email(
+    db: AsyncSession,
+    user: User,
+    email: str,
+    merge_from_guest_id: uuid.UUID | None = None,
+) -> None:
     """Replace any live login token for this user with a fresh one and
     enqueue the sign-in email. Enqueue before commit so a Redis flap
-    rolls the DB write back instead of stranding a tokenless user."""
+    rolls the DB write back instead of stranding a tokenless user.
+
+    ``merge_from_guest_id`` is recorded in the token context so consuming the
+    link folds that specific guest in (token-bound)."""
     await db.execute(
         delete(UserToken).where(
             UserToken.user_id == user.id,
-            UserToken.context == LOGIN_TOKEN_CONTEXT,
+            _login_token_clause(),
         )
     )
     raw_token = secrets.token_urlsafe(32)
     db.add(
         UserToken(
             user_id=user.id,
-            context=LOGIN_TOKEN_CONTEXT,
+            context=_login_context(merge_from_guest_id),
             token=_hash_token(raw_token),
             sent_to=email,
         )
@@ -1053,7 +1158,7 @@ async def consume_login_token(
         await db.execute(
             select(UserToken).where(
                 UserToken.token == _hash_token(payload.token),
-                UserToken.context == LOGIN_TOKEN_CONTEXT,
+                _login_token_clause(),
             )
         )
     ).scalar_one_or_none()
@@ -1096,9 +1201,20 @@ async def consume_login_token(
             detail="That sign-in link no longer matches your email.",
         )
 
+    # Token-bound merge: fold the guest recorded at request time (follows the
+    # user cross-device). Fall back to the clicking browser's guest when the
+    # token didn't record one (bare ``login``). ``skip_merge`` lets the owner
+    # sign in without bringing the guest's matches over (the gate's "not now").
+    recorded_guest_id = _guest_id_from_login_context(token_row.context)
     # Single-use: delete the link the moment we accept it.
     await db.delete(token_row)
-    merged = await _maybe_merge_prior_session(db, session_cookie, user)
+    if payload.skip_merge:
+        merged = None
+    elif recorded_guest_id is not None:
+        guest = await db.get(User, recorded_guest_id)
+        merged = await _merge_guest_into(db, guest=guest, target=user)
+    else:
+        merged = await _maybe_merge_prior_session(db, session_cookie, user)
     raw_session = secrets.token_urlsafe(32)
     db.add(
         UserToken(
@@ -1112,3 +1228,66 @@ async def consume_login_token(
         _enqueue_rating_recompute_after_merge(user.id)
     _set_session_cookie(response, raw_session)
     return await _build_session_response(db, user, merged=merged)
+
+
+@router.post(
+    "/v1/merge/preview",
+    response_model=MergePreview,
+    dependencies=[Depends(login_consume_ip_rate_limit)],
+)
+async def preview_merge(
+    payload: MergePreviewRequest,
+    db: AsyncSession = Depends(get_session),
+) -> MergePreview:
+    """Side-effect-free look at an emailed link before it's consumed, so the
+    client can show a "bring N matches over?" confirmation. Never consumes,
+    rotates, or merges — a wrong/expired token simply returns ``is_merge=False``
+    and the client finalizes through the real confirm/consume endpoint.
+
+    Safe to return usernames + counts: the 256-bit token is the bearer
+    credential, so only someone holding the link can ask."""
+    token_row = (
+        await db.execute(
+            select(UserToken).where(
+                UserToken.token == _hash_token(payload.token),
+                or_(
+                    _login_token_clause(),
+                    UserToken.context.startswith(EMAIL_MERGE_CONTEXT_PREFIX),
+                ),
+            )
+        )
+    ).scalar_one_or_none()
+    if token_row is None:
+        return MergePreview(is_merge=False)
+
+    if token_row.context.startswith(EMAIL_MERGE_CONTEXT_PREFIX):
+        # Settings merge token: lives on the *guest*; the owner is in the context.
+        owner_id = _target_id_from_merge_context(token_row.context)
+        owner = await db.get(User, owner_id) if owner_id is not None else None
+        guest = await db.get(User, token_row.user_id)
+    else:
+        # Login token: lives on the *owner*; a recorded guest is in the context.
+        owner = await db.get(User, token_row.user_id)
+        guest_id = _guest_id_from_login_context(token_row.context)
+        guest = await db.get(User, guest_id) if guest_id is not None else None
+
+    # Only a *mergeable* guest counts — mirror ``_merge_guest_into``'s guards so
+    # the preview matches what confirm/consume will actually do.
+    if (
+        owner is None
+        or guest is None
+        or guest.id == owner.id
+        or guest.confirmed_at is not None
+        or guest.merged_into_user_id is not None
+    ):
+        return MergePreview(
+            is_merge=False,
+            owner_username=owner.username if owner is not None else None,
+        )
+
+    return MergePreview(
+        is_merge=True,
+        owner_username=owner.username,
+        guest_username=guest.username,
+        guest_matches_count=await _guest_match_count(db, guest.id),
+    )

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -176,6 +176,32 @@ async def _merge_guest_into(
     return MergeSummary(matches_moved=summary.matches_moved)
 
 
+async def _sign_in_after_merge(
+    db: AsyncSession,
+    response: Response,
+    user: User,
+    merged: MergeSummary | None,
+) -> SessionResponse:
+    """Mint a fresh session for ``user``, commit the pending transaction, fire
+    the rating recompute when matches moved, rotate the cookie, and return the
+    session. The shared tail of the token-bound merge sign-in paths
+    (``consume_login_token`` and ``_confirm_account_merge``): the caller stages
+    the token deletion + merge, this finalizes."""
+    raw_session = secrets.token_urlsafe(32)
+    db.add(
+        UserToken(
+            user_id=user.id,
+            context=SESSION_TOKEN_CONTEXT,
+            token=_hash_token(raw_session),
+        )
+    )
+    await db.commit()
+    if merged is not None and merged.matches_moved > 0:
+        _enqueue_rating_recompute_after_merge(user.id)
+    _set_session_cookie(response, raw_session)
+    return await _build_session_response(db, user, merged=merged)
+
+
 def _hash_cookie_for_key(cookie: str) -> str:
     """Hash the raw session cookie before putting it into a Redis key. The
     cookie is a bearer credential; if it lands in Redis verbatim (snapshots,
@@ -965,7 +991,6 @@ async def _confirm_account_merge(
             detail="That confirmation link is invalid or expired.",
         )
 
-    raw_session = secrets.token_urlsafe(32)
     merged = (
         None if skip_merge else await _merge_guest_into(db, guest=guest, target=target)
     )
@@ -974,18 +999,7 @@ async def _confirm_account_merge(
         # — the inbox click still proves ownership, so sign them in as the owner.
         # A merge would have deleted this token; do it explicitly to stay single-use.
         await db.delete(token_row)
-    db.add(
-        UserToken(
-            user_id=target.id,
-            context=SESSION_TOKEN_CONTEXT,
-            token=_hash_token(raw_session),
-        )
-    )
-    await db.commit()
-    if merged is not None and merged.matches_moved > 0:
-        _enqueue_rating_recompute_after_merge(target.id)
-    _set_session_cookie(response, raw_session)
-    return await _build_session_response(db, target, merged=merged)
+    return await _sign_in_after_merge(db, response, target, merged)
 
 
 @router.post(
@@ -1215,19 +1229,7 @@ async def consume_login_token(
         merged = await _merge_guest_into(db, guest=guest, target=user)
     else:
         merged = await _maybe_merge_prior_session(db, session_cookie, user)
-    raw_session = secrets.token_urlsafe(32)
-    db.add(
-        UserToken(
-            user_id=user.id,
-            context=SESSION_TOKEN_CONTEXT,
-            token=_hash_token(raw_session),
-        )
-    )
-    await db.commit()
-    if merged is not None and merged.matches_moved > 0:
-        _enqueue_rating_recompute_after_merge(user.id)
-    _set_session_cookie(response, raw_session)
-    return await _build_session_response(db, user, merged=merged)
+    return await _sign_in_after_merge(db, response, user, merged)
 
 
 @router.post(

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -43,6 +43,11 @@ router = APIRouter()
 
 SESSION_COOKIE_NAME = "session"
 SESSION_TOKEN_CONTEXT = "session"
+# Stable `code` on the 401 we raise when a cookie resolves to a tombstoned
+# (merged-away) guest, so clients can tell "your session was merged, sign in"
+# apart from an ordinary auth failure and redirect to login (with the owner's
+# email prefilled) instead of looping.
+SESSION_MERGED_CODE = "session_merged"
 # Email-change confirmation tokens carry the *prior* address in their context
 # (e.g. "change:old@example.com", or "change:" on first-ever set). This gives
 # us an audit trail of what each token was changing away from. Look up
@@ -204,6 +209,45 @@ async def _find_session_user(db: AsyncSession, raw_token: str) -> User | None:
     return user_result.scalar_one_or_none()
 
 
+def _clear_cookie_header() -> dict[str, str]:
+    """A ``Set-Cookie`` that clears the session cookie, for attaching to the 401
+    we raise when a cookie resolves to a tombstoned guest. The cookie is
+    HttpOnly, so only the server can drop it — clearing it lets the holder start
+    a fresh guest from the login screen. Mirror ``_clear_session_cookie``'s
+    attributes so the browser actually matches and drops it."""
+    attrs = [
+        f"{SESSION_COOKIE_NAME}=",
+        "Path=/",
+        "Max-Age=0",
+        "HttpOnly",
+        "SameSite=lax",
+    ]
+    if _cookie_secure():
+        attrs.append("Secure")
+    return {"set-cookie": "; ".join(attrs)}
+
+
+async def _merged_session_exception(db: AsyncSession, user: User) -> HTTPException:
+    """Build the 401 for a cookie that resolves to a tombstoned (merged-away)
+    guest. Carries the stable ``SESSION_MERGED_CODE`` so clients redirect to
+    login rather than treating it as an ordinary auth failure, plus the owning
+    account's email to prefill — safe, since the holder is the one who entered
+    it. Also clears the dead cookie."""
+    owner = await db.get(User, user.merged_into_user_id)
+    detail: dict[str, str] = {
+        "code": SESSION_MERGED_CODE,
+        "message": "This guest session was merged into your account. "
+        "Sign in to continue.",
+    }
+    if owner is not None and owner.email:
+        detail["email"] = owner.email
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=detail,
+        headers=_clear_cookie_header(),
+    )
+
+
 async def _build_session_response(
     db: AsyncSession, user: User, merged: MergeSummary | None = None
 ) -> SessionResponse:
@@ -239,7 +283,13 @@ async def _maybe_merge_prior_session(
     prior_user = await _find_session_user(db, session_cookie)
     if prior_user is None or prior_user.id == target_user.id:
         return None
-    if prior_user.confirmed_at is not None:
+    # Skip a verified prior (two real accounts share a browser — siphoning one
+    # would be data loss) and an already-tombstoned prior (a ghost; never
+    # re-merge it).
+    if (
+        prior_user.confirmed_at is not None
+        or prior_user.merged_into_user_id is not None
+    ):
         return None
     summary = await merge_user(
         db, from_user_id=prior_user.id, to_user_id=target_user.id
@@ -314,6 +364,12 @@ async def get_session_endpoint(
     user: User | None = None
     if session_cookie:
         user = await _find_session_user(db, session_cookie)
+        if user is not None and user.merged_into_user_id is not None:
+            # The cookie's guest was folded into another account. Don't silently
+            # mint a fresh guest (that would quietly swap identities) — tell the
+            # holder so they sign in. A no-cookie / garbage-cookie request still
+            # mints below, preserving the zero-friction first visit.
+            raise await _merged_session_exception(db, user)
     if user is None:
         user, raw_token = await _create_session(db)
         _set_session_cookie(response, raw_token)
@@ -355,18 +411,32 @@ async def get_optional_user(
     """
     if not session_cookie:
         return None
-    return await _find_session_user(db, session_cookie)
+    user = await _find_session_user(db, session_cookie)
+    if user is not None and user.merged_into_user_id is not None:
+        # Tombstoned guest → render anonymously on optional endpoints; the next
+        # required-auth call (or the session bootstrap) surfaces the redirect.
+        return None
+    return user
 
 
 async def get_current_user(
-    user: Annotated[User | None, Depends(get_optional_user)],
+    session_cookie: Annotated[str | None, Cookie(alias=SESSION_COOKIE_NAME)] = None,
+    db: AsyncSession = Depends(get_session),
 ) -> User:
     """Resolve the authenticated user from the session cookie.
 
     Unlike ``GET /v1/session``, this dependency never mints a new session —
     endpoints that create or mutate data require an already-established
     session and respond ``401`` otherwise.
+
+    Resolves the cookie directly (rather than via ``get_optional_user``) so it
+    can tell a *tombstoned* guest — whose cookie still resolves — apart from no
+    session at all, and raise the structured ``session_merged`` 401 that sends
+    the holder to sign in instead of letting them act as a merged-away ghost.
     """
+    user = await _find_session_user(db, session_cookie) if session_cookie else None
+    if user is not None and user.merged_into_user_id is not None:
+        raise await _merged_session_exception(db, user)
     if user is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -818,6 +888,8 @@ async def _confirm_account_merge(
         or target is None
         or guest.id == target.id
         or guest.confirmed_at is not None
+        or guest.merged_into_user_id is not None
+        or target.merged_into_user_id is not None
         or target.email != token_row.sent_to
     ):
         await db.delete(token_row)

--- a/api/migrations/versions/20260510_0000_0001_create_users_table.py
+++ b/api/migrations/versions/20260510_0000_0001_create_users_table.py
@@ -41,14 +41,38 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             nullable=False,
         ),
+        # Tombstone for an ephemeral user folded into another account by the
+        # merge service. Soft-delete (rather than DROP) so the guest's session
+        # token still resolves and `GET /v1/session` can tell the holder their
+        # session was merged, instead of silently minting a fresh guest.
+        sa.Column(
+            "merged_into_user_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "merged_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
         sa.UniqueConstraint("username", name="uq_users_username"),
         sa.UniqueConstraint("email", name="uq_users_email"),
+        sa.ForeignKeyConstraint(
+            ["merged_into_user_id"],
+            ["users.id"],
+            name="fk_users_merged_into_user_id_users",
+            ondelete="SET NULL",
+        ),
     )
     op.create_index("ix_users_username", "users", ["username"])
     op.create_index("ix_users_email", "users", ["email"])
+    op.create_index(
+        "ix_users_merged_into_user_id", "users", ["merged_into_user_id"]
+    )
 
 
 def downgrade() -> None:
+    op.drop_index("ix_users_merged_into_user_id", table_name="users")
     op.drop_index("ix_users_email", table_name="users")
     op.drop_index("ix_users_username", table_name="users")
     op.drop_table("users")

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -104,9 +104,12 @@ async def test_merge_repoints_match_side_players_and_creator(
     assert creator_id == verified.id
 
 
-async def test_merge_deletes_ephemeral_user_and_cascades_tokens(
+async def test_merge_tombstones_ephemeral_user_keeping_session_token(
     db_session: AsyncSession,
 ):
+    """Soft-delete: the ephemeral row survives with ``merged_into_user_id`` set,
+    its *session* token is kept (so its cookie still resolves and the auth layer
+    can report the merge), and its non-session tokens are dropped."""
     ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
     verified = await _make_verified(db_session, "rita@example.com")
 
@@ -117,15 +120,26 @@ async def test_merge_deletes_ephemeral_user_and_cascades_tokens(
             token=hashlib.sha256(b"raw").digest(),
         )
     )
+    db_session.add(
+        UserToken(
+            user_id=ephemeral.id,
+            context="login",
+            token=hashlib.sha256(b"login-raw").digest(),
+        )
+    )
     await db_session.commit()
 
     await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
     await db_session.commit()
 
-    assert (
+    tombstoned = (
         await db_session.execute(select(User).where(User.id == ephemeral.id))
-    ).scalar_one_or_none() is None
-    leftover_tokens = (
+    ).scalar_one_or_none()
+    assert tombstoned is not None
+    assert tombstoned.merged_into_user_id == verified.id
+    assert tombstoned.merged_at is not None
+
+    leftover = (
         (
             await db_session.execute(
                 select(UserToken).where(UserToken.user_id == ephemeral.id)
@@ -134,7 +148,8 @@ async def test_merge_deletes_ephemeral_user_and_cascades_tokens(
         .scalars()
         .all()
     )
-    assert leftover_tokens == []
+    # Session token kept (tombstone key); the login token dropped.
+    assert [t.context for t in leftover] == [SESSION_TOKEN_CONTEXT]
 
 
 async def test_merge_moves_league_membership_when_target_has_none(
@@ -324,12 +339,13 @@ async def test_merge_repoints_match_signatures(db_session: AsyncSession):
     )
     user_ids = {sig.user_id for sig in sigs}
     assert user_ids == {verified.id, opponent.id}
-    # And the ephemeral user is gone (would have blocked on the RESTRICT FK
-    # otherwise).
+    # And the ephemeral user is tombstoned, not dropped — the RESTRICT FK on
+    # match_signatures.user_id was satisfied by the re-point above.
     ephemeral_row = (
         await db_session.execute(select(User).where(User.id == ephemeral.id))
     ).scalar_one_or_none()
-    assert ephemeral_row is None
+    assert ephemeral_row is not None
+    assert ephemeral_row.merged_into_user_id == verified.id
 
 
 async def test_merge_with_match_signature_collision_drops_ephemeral(

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -688,10 +688,12 @@ async def test_confirm_merge_signs_in_as_owner_and_moves_matches(
     assert body["data"]["user"]["email"] == "taken@example.com"
     assert body["merged"]["matches_moved"] == 1
 
-    # The guest row is gone — folded into the owner.
-    assert (
+    # The guest row is tombstoned — folded into the owner (soft-delete).
+    tombstoned = (
         await db_session.execute(select(User).where(User.id == guest.id))
-    ).scalar_one_or_none() is None
+    ).scalar_one_or_none()
+    assert tombstoned is not None
+    assert tombstoned.merged_into_user_id == owner.id
 
     # The match's player now points at the owner.
     player_ids = {
@@ -738,9 +740,11 @@ async def test_confirm_merge_works_cross_device_via_token_binding(
         assert response.json()["data"]["user"]["username"] == "owner"
         assert other.cookies.get("session")
 
-    assert (
+    tombstoned = (
         await db_session.execute(select(User).where(User.id == guest.id))
-    ).scalar_one_or_none() is None
+    ).scalar_one_or_none()
+    assert tombstoned is not None
+    assert tombstoned.merged_into_user_id == owner.id
 
 
 async def test_confirm_merge_rejected_when_owner_changed_email(
@@ -766,10 +770,12 @@ async def test_confirm_merge_rejected_when_owner_changed_email(
     response = await api_client.post("/v1/me/email/confirm", json={"token": raw_token})
     assert response.status_code == 400
 
-    # Guest survives (nothing merged) and the token is gone.
-    assert (
+    # Guest survives un-tombstoned (nothing merged) and the token is gone.
+    survivor = (
         await db_session.execute(select(User).where(User.id == guest.id))
-    ).scalar_one_or_none() is not None
+    ).scalar_one_or_none()
+    assert survivor is not None
+    assert survivor.merged_into_user_id is None
     tokens = (
         (
             await db_session.execute(

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -9,9 +9,22 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
+from app.leagues import get_default_league
 from app.main import app
-from app.models import User, UserToken
-from app.sessions import EMAIL_CHANGE_CONTEXT_PREFIX
+from app.models import (
+    Match,
+    MatchSettings,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    User,
+    UserToken,
+)
+from app.sessions import (
+    EMAIL_CHANGE_CONTEXT_PREFIX,
+    EMAIL_MERGE_CONTEXT_PREFIX,
+    _pending_email_token_clause,
+)
 from tests._helpers import start_session
 
 
@@ -39,6 +52,36 @@ VALID_BODY = {
 async def _set_email(client: AsyncClient, **overrides) -> "httpx.Response":  # noqa: F821
     body = {**VALID_BODY, **overrides}
     return await client.post("/v1/me/email", json=body)
+
+
+def _finished_send_jobs(fake_email_queue) -> list:
+    """Every finished email-send job, oldest first."""
+    jobs = [
+        fake_email_queue.fetch_job(job_id)
+        for job_id in fake_email_queue.finished_job_registry.get_job_ids()
+    ]
+    jobs = [j for j in jobs if j is not None]
+    jobs.sort(key=lambda j: j.enqueued_at)
+    return jobs
+
+
+async def _record_match(db: AsyncSession, creator: User, *players: User) -> Match:
+    """Minimal completed match so a merge has something to move."""
+    league = await get_default_league(db)
+    settings = MatchSettings(team_size=1, best_of=5, affects_rating=False)
+    match = Match(
+        match_settings=settings,
+        league=league,
+        created_by_user_id=creator.id,
+        status=MatchStatus.completed,
+    )
+    for side_number, player in enumerate(players, start=1):
+        side = MatchSide(match=match, side_number=side_number)
+        side.players.append(MatchSidePlayer(match=match, user=player))
+    db.add(match)
+    await db.commit()
+    await db.refresh(match)
+    return match
 
 
 # ---- set email ------------------------------------------------------------
@@ -164,30 +207,79 @@ async def test_set_email_rejects_failed_captcha(
     assert "Captcha" in response.json()["detail"]
 
 
-async def test_set_email_with_taken_address_is_enumeration_safe(
+async def test_set_email_taken_address_starts_merge_for_guest(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    """Submitting an address belonging to someone else must look identical
-    to a no-op success — same 202, same session response shape, no token
-    issued, no email enqueued. Returning 409 would let an attacker cycle
-    fresh `/v1/session` cookies to enumerate the user base."""
-    db_session.add(User(username="other", email="taken@example.com"))
+    """A guest who enters an address owned by an existing account is offered a
+    merge: we email the owner a sign-in link (a ``merge:<owner-id>`` token) and
+    return the *same* 202 + ``pending_email`` shape as a first-time set. The
+    HTTP response is identical to a free-address submit, so an attacker still
+    can't enumerate accounts by cycling fresh `/v1/session` cookies."""
+    owner = User(
+        username="other", email="taken@example.com", confirmed_at=datetime.now(UTC)
+    )
+    db_session.add(owner)
     await db_session.commit()
+    await db_session.refresh(owner)
     me = await start_session(api_client, db_session)
+
+    response = await _set_email(api_client, email="taken@example.com")
+    assert response.status_code == 202
+    # Same outward shape as a normal pending set.
+    assert response.json()["data"]["user"]["pending_email"] == "taken@example.com"
+
+    await db_session.refresh(me)
+    # The guest's own row is untouched until they click the link.
+    assert me.email is None
+    assert me.confirmed_at is None
+
+    token = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_MERGE_CONTEXT_PREFIX),
+                UserToken.user_id == me.id,
+            )
+        )
+    ).scalar_one()
+    assert token.context == f"{EMAIL_MERGE_CONTEXT_PREFIX}{owner.id}"
+    assert token.sent_to == "taken@example.com"
+
+    # The owner got the "sign in to your account" email, addressed to them.
+    jobs = _finished_send_jobs(fake_email_queue)
+    assert len(jobs) == 1
+    assert jobs[0].func_name == "app.email.send_merge_email"
+    assert jobs[0].args[0] == "taken@example.com"
+    assert jobs[0].args[2] == owner.username
+
+
+async def test_set_email_taken_address_is_noop_for_verified_caller(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """A caller who already has a confirmed email is *changing* addresses, not
+    merging. Folding their established account into someone else's would be
+    data loss — so a taken address stays the enumeration-safe no-op: no token,
+    no email."""
+    db_session.add(
+        User(
+            username="other", email="taken@example.com", confirmed_at=datetime.now(UTC)
+        )
+    )
+    me = await start_session(api_client, db_session)
+    me.email = "mine@example.com"
+    me.confirmed_at = datetime.now(UTC)
+    await db_session.commit()
 
     response = await _set_email(api_client, email="taken@example.com")
     assert response.status_code == 202
 
     await db_session.refresh(me)
-    # Caller's own row is untouched.
-    assert me.email is None
-    assert me.confirmed_at is None
+    assert me.email == "mine@example.com"
 
     tokens = (
         (
             await db_session.execute(
                 select(UserToken).where(
-                    UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX),
+                    _pending_email_token_clause(),
                     UserToken.user_id == me.id,
                 )
             )
@@ -387,13 +479,7 @@ async def test_changing_email_preserves_prior_verification(
 def _all_send_tokens(fake_email_queue) -> list[str]:
     """Return every raw token handed to a finished email send job, ordered
     by enqueue time (oldest first)."""
-    jobs = [
-        fake_email_queue.fetch_job(job_id)
-        for job_id in fake_email_queue.finished_job_registry.get_job_ids()
-    ]
-    jobs = [j for j in jobs if j is not None]
-    jobs.sort(key=lambda j: j.enqueued_at)
-    return [j.args[1] for j in jobs]
+    return [j.args[1] for j in _finished_send_jobs(fake_email_queue)]
 
 
 async def _capture_raw_token(
@@ -570,6 +656,159 @@ async def test_token_is_stored_hashed_not_plaintext(
     ).scalar_one()
     assert token_row.token == hashlib.sha256(raw_token.encode("utf-8")).digest()
     assert token_row.token != raw_token.encode("utf-8")
+
+
+# ---- confirm: merge into an existing account ------------------------------
+
+
+async def test_confirm_merge_signs_in_as_owner_and_moves_matches(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """Clicking a merge link folds the requesting guest into the account that
+    owns the address, carries their matches over, and signs the browser in as
+    that account."""
+    owner = User(
+        username="owner", email="taken@example.com", confirmed_at=datetime.now(UTC)
+    )
+    opponent = User(username="opponent")
+    db_session.add_all([owner, opponent])
+    await db_session.commit()
+    await db_session.refresh(owner)
+
+    guest = await start_session(api_client, db_session)
+    match = await _record_match(db_session, guest, guest, opponent)
+
+    raw_token = await _capture_raw_token(
+        api_client, db_session, fake_email_queue, email="taken@example.com"
+    )
+    response = await api_client.post("/v1/me/email/confirm", json={"token": raw_token})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["user"]["username"] == "owner"
+    assert body["data"]["user"]["email"] == "taken@example.com"
+    assert body["merged"]["matches_moved"] == 1
+
+    # The guest row is gone — folded into the owner.
+    assert (
+        await db_session.execute(select(User).where(User.id == guest.id))
+    ).scalar_one_or_none() is None
+
+    # The match's player now points at the owner.
+    player_ids = {
+        p.user_id
+        for p in (
+            await db_session.execute(
+                select(MatchSidePlayer).where(MatchSidePlayer.match_id == match.id)
+            )
+        )
+        .scalars()
+        .all()
+    }
+    assert owner.id in player_ids
+    assert guest.id not in player_ids
+
+    # The browser's cookie now resolves to the owner.
+    whoami = await api_client.get("/v1/session")
+    assert whoami.json()["data"]["user"]["username"] == "owner"
+
+
+async def test_confirm_merge_works_cross_device_via_token_binding(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """The merge follows the *requesting* guest recorded on the token, not the
+    session that clicks the link — so a desktop request confirmed on a fresh
+    (cookieless) browser still merges the right guest."""
+    from tests._helpers import make_client
+
+    owner = User(
+        username="owner", email="taken@example.com", confirmed_at=datetime.now(UTC)
+    )
+    db_session.add(owner)
+    await db_session.commit()
+    await db_session.refresh(owner)
+
+    guest = await start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(
+        api_client, db_session, fake_email_queue, email="taken@example.com"
+    )
+
+    async with make_client() as other:
+        response = await other.post("/v1/me/email/confirm", json={"token": raw_token})
+        assert response.status_code == 200
+        assert response.json()["data"]["user"]["username"] == "owner"
+        assert other.cookies.get("session")
+
+    assert (
+        await db_session.execute(select(User).where(User.id == guest.id))
+    ).scalar_one_or_none() is None
+
+
+async def test_confirm_merge_rejected_when_owner_changed_email(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """The token is only good while the owner still holds the address it was
+    cut against. If they move off it, the merge link is burned and refused —
+    no guess about who owns what leaks."""
+    owner = User(
+        username="owner", email="taken@example.com", confirmed_at=datetime.now(UTC)
+    )
+    db_session.add(owner)
+    await db_session.commit()
+
+    guest = await start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(
+        api_client, db_session, fake_email_queue, email="taken@example.com"
+    )
+
+    owner.email = "moved@example.com"
+    await db_session.commit()
+
+    response = await api_client.post("/v1/me/email/confirm", json={"token": raw_token})
+    assert response.status_code == 400
+
+    # Guest survives (nothing merged) and the token is gone.
+    assert (
+        await db_session.execute(select(User).where(User.id == guest.id))
+    ).scalar_one_or_none() is not None
+    tokens = (
+        (
+            await db_session.execute(
+                select(UserToken).where(
+                    UserToken.context.startswith(EMAIL_MERGE_CONTEXT_PREFIX)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert tokens == []
+
+
+async def test_resend_merge_token_resends_the_merge_email(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """Resending a pending merge re-sends the 'sign in to your account' email
+    to the owner — not the plain confirmation copy."""
+    owner = User(
+        username="owner", email="taken@example.com", confirmed_at=datetime.now(UTC)
+    )
+    db_session.add(owner)
+    await db_session.commit()
+    await db_session.refresh(owner)
+
+    await start_session(api_client, db_session)
+    await _set_email(api_client, email="taken@example.com")
+
+    response = await api_client.post(
+        "/v1/me/email/resend",
+        json={"captcha_token": "x", "fmm_hp_token": ""},
+    )
+    assert response.status_code == 202
+
+    last = _finished_send_jobs(fake_email_queue)[-1]
+    assert last.func_name == "app.email.send_merge_email"
+    assert last.args[0] == "taken@example.com"
+    assert last.args[2] == owner.username
 
 
 # ---- resend ---------------------------------------------------------------

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -616,3 +616,155 @@ async def test_consume_skips_recompute_when_no_prior_session(
     assert response.status_code == 200
     assert response.json().get("merged") is None
     assert fake_ratings_queue.get_jobs() == []
+
+
+# ---- token-bound (cross-device) merge + preview --------------------------
+
+
+def _login_email_tokens(fake_email_queue) -> list[str]:
+    """Raw tokens handed to finished login-email jobs, oldest first."""
+    jobs = [
+        fake_email_queue.fetch_job(job_id)
+        for job_id in fake_email_queue.finished_job_registry.get_job_ids()
+    ]
+    jobs = [j for j in jobs if j is not None]
+    jobs.sort(key=lambda j: j.enqueued_at)
+    return [j.args[1] for j in jobs]
+
+
+async def _login_token_for(db_session: AsyncSession, user: User) -> UserToken:
+    return (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.user_id == user.id,
+                UserToken.context.startswith(LOGIN_TOKEN_CONTEXT),
+            )
+        )
+    ).scalar_one()
+
+
+async def test_request_records_requesting_guest_on_login_token(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """A guest who requests a sign-in link for their existing email has their
+    id stamped on the token context, so the merge is token-bound."""
+    rita = await _make_confirmed_user(db_session, "rita@example.com")
+    guest = await start_session(api_client, db_session)
+
+    response = await api_client.post("/v1/login/request", json=REQUEST_BODY)
+    assert response.status_code == 202
+
+    token = await _login_token_for(db_session, rita)
+    assert token.context == f"{LOGIN_TOKEN_CONTEXT}:{guest.id}"
+
+
+async def test_token_bound_login_merges_cross_device(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """The guest requests on browser A (with matches); the link is opened on a
+    cookieless browser B. The guest's matches still follow into the account —
+    the merge is bound to the recorded guest, not B's (absent) session."""
+    rita = await _make_confirmed_user(db_session, "rita@example.com")
+    guest = await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "opp-crossdev")
+    match = await _record_singles_match(db_session, guest, opponent)
+
+    await api_client.post("/v1/login/request", json=REQUEST_BODY)
+    raw = _login_email_tokens(fake_email_queue)[-1]
+
+    async with make_client() as cookieless:
+        response = await cookieless.post("/v1/login/consume", json={"token": raw})
+        assert response.status_code == 200
+        assert response.json()["data"]["user"]["username"] == "rita"
+        assert response.json()["merged"] == {"matches_moved": 1}
+
+    players = (
+        (
+            await db_session.execute(
+                select(MatchSidePlayer).where(MatchSidePlayer.match_id == match.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {p.user_id for p in players} == {rita.id, opponent.id}
+
+
+async def test_merge_preview_for_login_token_does_not_consume(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    await _make_confirmed_user(db_session, "rita@example.com")
+    guest = await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "opp-preview")
+    await _record_singles_match(db_session, guest, opponent)
+    await api_client.post("/v1/login/request", json=REQUEST_BODY)
+    raw = _login_email_tokens(fake_email_queue)[-1]
+
+    async with make_client() as cookieless:
+        preview = await cookieless.post("/v1/merge/preview", json={"token": raw})
+        assert preview.status_code == 200
+        body = preview.json()
+        assert body["is_merge"] is True
+        assert body["owner_username"] == "rita"
+        assert body["guest_username"] == guest.username
+        assert body["guest_matches_count"] == 1
+
+        # Preview is side-effect-free: the token still signs in afterwards.
+        consume = await cookieless.post("/v1/login/consume", json={"token": raw})
+        assert consume.status_code == 200
+
+
+async def test_merge_preview_bare_login_is_not_a_merge(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    rita = await _make_confirmed_user(db_session, "rita@example.com")
+    raw = "raw-bare-login-preview"
+    await _issue_login_token(db_session, rita, raw)  # bare "login" context
+
+    response = await api_client.post("/v1/merge/preview", json={"token": raw})
+    assert response.status_code == 200
+    assert response.json()["is_merge"] is False
+
+
+async def test_merge_preview_unknown_token_is_not_a_merge(api_client: AsyncClient):
+    response = await api_client.post("/v1/merge/preview", json={"token": "nope"})
+    assert response.status_code == 200
+    assert response.json()["is_merge"] is False
+
+
+async def test_consume_skip_merge_signs_in_without_folding(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """The gate's "not now": sign in as the owner but leave the guest's matches
+    behind (guest stays a live, un-tombstoned session)."""
+    await _make_confirmed_user(db_session, "rita@example.com")
+    guest = await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "opp-skip")
+    match = await _record_singles_match(db_session, guest, opponent)
+
+    await api_client.post("/v1/login/request", json=REQUEST_BODY)
+    raw = _login_email_tokens(fake_email_queue)[-1]
+
+    async with make_client() as cookieless:
+        response = await cookieless.post(
+            "/v1/login/consume", json={"token": raw, "skip_merge": True}
+        )
+        assert response.status_code == 200
+        assert response.json()["data"]["user"]["username"] == "rita"
+        assert response.json().get("merged") is None
+
+    # Match stayed on the guest; the guest is not tombstoned.
+    players = (
+        (
+            await db_session.execute(
+                select(MatchSidePlayer).where(MatchSidePlayer.match_id == match.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert guest.id in {p.user_id for p in players}
+    survivor = (
+        await db_session.execute(select(User).where(User.id == guest.id))
+    ).scalar_one()
+    assert survivor.merged_into_user_id is None

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -502,9 +502,12 @@ async def test_consume_merges_ephemeral_matches_into_verified_account(
     ).scalar_one()
     assert creator_id == rita.id
 
-    assert (
+    # The guest is tombstoned (soft-delete), not dropped.
+    tombstoned = (
         await db_session.execute(select(User).where(User.id == guest.id))
-    ).scalar_one_or_none() is None
+    ).scalar_one_or_none()
+    assert tombstoned is not None
+    assert tombstoned.merged_into_user_id == rita.id
 
 
 async def test_consume_omits_merge_when_no_prior_session(

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -1,5 +1,6 @@
 import hashlib
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 
 import pytest
 import pytest_asyncio
@@ -11,7 +12,7 @@ from app.db import get_session
 from app.main import app
 from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
 from app.sessions import SESSION_COOKIE_NAME, SESSION_TOKEN_CONTEXT
-from tests._helpers import make_client
+from tests._helpers import make_client, start_session
 
 
 @pytest_asyncio.fixture
@@ -361,3 +362,52 @@ async def test_update_username_preserves_user_id_and_permissions(
         await db_session.execute(select(User).where(User.username == "renamed"))
     ).scalar_one()
     assert refreshed.id == original_id
+
+
+# ---- tombstoned (merged-away) sessions ------------------------------------
+
+
+async def _tombstone(db_session: AsyncSession, guest: User, owner_email: str) -> User:
+    """Stand up a verified owner and fold ``guest`` into it (soft-delete)."""
+    owner = User(username="owner", email=owner_email, confirmed_at=datetime.now(UTC))
+    db_session.add(owner)
+    await db_session.commit()
+    await db_session.refresh(owner)
+    guest.merged_into_user_id = owner.id
+    guest.merged_at = datetime.now(UTC)
+    await db_session.commit()
+    return owner
+
+
+async def test_session_with_merged_cookie_401s_instead_of_minting(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A cookie whose guest was merged away must not silently mint a fresh
+    guest — it returns the structured `session_merged` 401 (with the owner's
+    email to prefill) and clears the dead cookie."""
+    guest = await start_session(api_client, db_session)
+    await _tombstone(db_session, guest, "owner@example.com")
+
+    response = await api_client.get("/v1/session")
+    assert response.status_code == 401
+    detail = response.json()["detail"]
+    assert detail["code"] == "session_merged"
+    assert detail["email"] == "owner@example.com"
+    # The dead cookie is cleared so the holder can start fresh.
+    assert "max-age=0" in response.headers.get("set-cookie", "").lower()
+
+
+async def test_authed_endpoint_with_merged_cookie_401s(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The check lives at the shared auth seam, so *any* authed request — not
+    just GET /v1/session — rejects a tombstoned cookie instead of acting as the
+    merged-away ghost."""
+    guest = await start_session(api_client, db_session)
+    await _tombstone(db_session, guest, "owner@example.com")
+
+    response = await api_client.patch("/v1/me", json={"username": "ghost-rename"})
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "session_merged"
+    # (A garbage / no-token cookie still mints — see
+    # test_creates_new_session_when_cookie_invalid — only tombstones 401.)

--- a/ios/Fortymm/Login/ConfirmEmailView.swift
+++ b/ios/Fortymm/Login/ConfirmEmailView.swift
@@ -43,7 +43,12 @@ struct ConfirmEmailView: View {
     private var content: some View {
         switch phase {
         case .verifying: verifying
-        case let .gate(preview): gate(preview)
+        case let .gate(preview):
+            MergeGateView(
+                preview: preview,
+                onBringThemOver: { Task { await confirm(skipMerge: false) } },
+                onNotNow: { Task { await confirm(skipMerge: true) } }
+            )
         case let .success(response): success(response)
         case .expired: expired
         case .unreachable: unreachable
@@ -181,43 +186,6 @@ struct ConfirmEmailView: View {
                 HStack(spacing: 10) {
                     LoginButton(title: "Retry") { Task { await confirm(skipMerge: false) } }
                     LoginButton(title: "Close", kind: .ghost, fullWidth: false) { onClose() }
-                }
-            }
-        }
-    }
-
-    // MARK: Gate (cross-device confirm)
-
-    private func gate(_ preview: MergePreview) -> some View {
-        let count = preview.guestMatchesCount
-        let matchLabel = count == 1 ? "1 match" : "\(count) matches"
-        let from = preview.guestUsername.map { "@\($0)" } ?? "your guest session"
-        return LoginScaffold(
-            eyebrow: "Bring your matches",
-            eyebrowColor: FMColor.serve500,
-            line1: "Bring your",
-            line2: "matches over?",
-            accent: FMColor.serve500,
-            stepNo: "03",
-            stepLabel: "Confirm merge",
-            title: "Bring your matches over?",
-            subtitle: "Signing in as @\(preview.ownerUsername ?? "your account"). "
-                + "We can bring the \(matchLabel) from \(from) into this account."
-        ) {
-            VStack(alignment: .leading, spacing: 14) {
-                ReceiptCard(tint: FMColor.serve500.opacity(0.6), glow: true) {
-                    ReceiptHeader(
-                        badge: { StatusBadge(kind: .success) },
-                        eyebrow: "● BRING MATCHES",
-                        eyebrowColor: FMColor.serve500,
-                        title: "\(matchLabel) from \(from)"
-                    )
-                }
-                LoginButton(title: "Bring them over") {
-                    Task { await confirm(skipMerge: false) }
-                }
-                LoginButton(title: "Not now — just sign me in", kind: .ghost) {
-                    Task { await confirm(skipMerge: true) }
                 }
             }
         }

--- a/ios/Fortymm/Login/ConfirmEmailView.swift
+++ b/ios/Fortymm/Login/ConfirmEmailView.swift
@@ -19,9 +19,11 @@ struct ConfirmEmailView: View {
     var onClose: () -> Void
 
     private let service = ProfileService.shared
+    private let loginService = LoginService.shared
 
     private enum Phase {
         case verifying
+        case gate(MergePreview)
         case success(SessionResponse)
         case expired
         case unreachable
@@ -34,13 +36,14 @@ struct ConfirmEmailView: View {
             content
         }
         .background(LoginBackground())
-        .task { await confirm() }
+        .task { await start() }
     }
 
     @ViewBuilder
     private var content: some View {
         switch phase {
         case .verifying: verifying
+        case let .gate(preview): gate(preview)
         case let .success(response): success(response)
         case .expired: expired
         case .unreachable: unreachable
@@ -176,8 +179,45 @@ struct ConfirmEmailView: View {
                     )
                 }
                 HStack(spacing: 10) {
-                    LoginButton(title: "Retry") { Task { await confirm() } }
+                    LoginButton(title: "Retry") { Task { await confirm(skipMerge: false) } }
                     LoginButton(title: "Close", kind: .ghost, fullWidth: false) { onClose() }
+                }
+            }
+        }
+    }
+
+    // MARK: Gate (cross-device confirm)
+
+    private func gate(_ preview: MergePreview) -> some View {
+        let count = preview.guestMatchesCount
+        let matchLabel = count == 1 ? "1 match" : "\(count) matches"
+        let from = preview.guestUsername.map { "@\($0)" } ?? "your guest session"
+        return LoginScaffold(
+            eyebrow: "Bring your matches",
+            eyebrowColor: FMColor.serve500,
+            line1: "Bring your",
+            line2: "matches over?",
+            accent: FMColor.serve500,
+            stepNo: "03",
+            stepLabel: "Confirm merge",
+            title: "Bring your matches over?",
+            subtitle: "Signing in as @\(preview.ownerUsername ?? "your account"). "
+                + "We can bring the \(matchLabel) from \(from) into this account."
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                ReceiptCard(tint: FMColor.serve500.opacity(0.6), glow: true) {
+                    ReceiptHeader(
+                        badge: { StatusBadge(kind: .success) },
+                        eyebrow: "● BRING MATCHES",
+                        eyebrowColor: FMColor.serve500,
+                        title: "\(matchLabel) from \(from)"
+                    )
+                }
+                LoginButton(title: "Bring them over") {
+                    Task { await confirm(skipMerge: false) }
+                }
+                LoginButton(title: "Not now — just sign me in", kind: .ghost) {
+                    Task { await confirm(skipMerge: true) }
                 }
             }
         }
@@ -185,10 +225,23 @@ struct ConfirmEmailView: View {
 
     // MARK: Confirm
 
-    private func confirm() async {
+    /// Preview the link first; a merge that would carry matches over waits at
+    /// the gate, everything else confirms straight away.
+    private func start() async {
+        let preview = await loginService.mergePreview(token: token)
+        if preview.isMerge, preview.guestMatchesCount > 0 {
+            phase = .gate(preview)
+        } else {
+            await confirm(skipMerge: false)
+        }
+    }
+
+    private func confirm(skipMerge: Bool) async {
         phase = .verifying
         do {
-            phase = .success(try await service.confirmEmail(token: token))
+            phase = .success(
+                try await service.confirmEmail(token: token, skipMerge: skipMerge)
+            )
         } catch LoginConsumeError.rejected {
             // Invalid / expired / already-used link — terminal.
             phase = .expired

--- a/ios/Fortymm/Login/LoginFlowView.swift
+++ b/ios/Fortymm/Login/LoginFlowView.swift
@@ -6,9 +6,10 @@ import SwiftUI
 /// `SessionStore`.
 struct LoginFlowView: View {
     /// Where the flow begins. `.verifying` is the deep-link entry — wire it to a
-    /// universal-link handler later; `.email` is the in-app entry used today.
+    /// universal-link handler later; `.email` is the in-app entry used today
+    /// (optionally prefilled, e.g. with the owner's email after a session merge).
     enum Start {
-        case email
+        case email(prefill: String = "")
         case verifying(token: String)
     }
 
@@ -16,22 +17,22 @@ struct LoginFlowView: View {
     var onSignedIn: (SessionResponse) -> Void
 
     private enum Step {
-        case email
+        case email(prefill: String)
         case sent(email: String)
         case verifying(token: String)
     }
     @State private var step: Step
 
     init(
-        start: Start = .email,
+        start: Start = .email(),
         onClose: @escaping () -> Void,
         onSignedIn: @escaping (SessionResponse) -> Void
     ) {
         self.onClose = onClose
         self.onSignedIn = onSignedIn
         switch start {
-        case .email:
-            _step = State(initialValue: .email)
+        case let .email(prefill):
+            _step = State(initialValue: .email(prefill: prefill))
         case let .verifying(token):
             _step = State(initialValue: .verifying(token: token))
         }
@@ -48,15 +49,15 @@ struct LoginFlowView: View {
     @ViewBuilder
     private var content: some View {
         switch step {
-        case .email:
-            SignInView { sentTo in step = .sent(email: sentTo) }
+        case let .email(prefill):
+            SignInView(initialEmail: prefill) { sentTo in step = .sent(email: sentTo) }
         case let .sent(email):
-            CheckInboxView(email: email) { step = .email }
+            CheckInboxView(email: email) { step = .email(prefill: "") }
         case let .verifying(token):
             VerifyLoginView(
                 token: token,
                 onSignedIn: onSignedIn,
-                onRestart: { step = .email }
+                onRestart: { step = .email(prefill: "") }
             )
         }
     }

--- a/ios/Fortymm/Login/LoginService.swift
+++ b/ios/Fortymm/Login/LoginService.swift
@@ -39,15 +39,36 @@ struct LoginService {
     /// used, wrong account) and terminal; anything else (server error, offline)
     /// is transient and worth a retry. Keeping that distinction here, not in the
     /// view, is the same boundary-typing the rest of the API layer follows.
-    func consume(token: String) async throws -> SessionResponse {
+    func consume(token: String, skipMerge: Bool = false) async throws -> SessionResponse {
         do {
             return try await client.post(
-                "/v1/login/consume", body: ConsumeLoginBody(token: token)
+                "/v1/login/consume",
+                body: ConsumeLoginBody(token: token, skipMerge: skipMerge)
             )
         } catch let APIError.http(status, _) where (400..<500).contains(status) {
             throw LoginConsumeError.rejected
         } catch {
             throw LoginConsumeError.unreachable
+        }
+    }
+
+    /// Side-effect-free preview of an emailed link (`POST /v1/merge/preview`),
+    /// used by both the sign-in and email-confirm landings to decide whether to
+    /// show the "bring N matches over?" gate before finalizing. Non-throwing: a
+    /// preview failure simply reports "not a merge" so the caller finalizes
+    /// straight away rather than blocking on a hiccup.
+    func mergePreview(token: String) async -> MergePreview {
+        do {
+            return try await client.post(
+                "/v1/merge/preview", body: MergePreviewBody(token: token)
+            )
+        } catch {
+            return MergePreview(
+                isMerge: false,
+                ownerUsername: nil,
+                guestUsername: nil,
+                guestMatchesCount: 0
+            )
         }
     }
 }
@@ -76,5 +97,10 @@ private struct RequestLoginBody: Encodable {
 }
 
 private struct ConsumeLoginBody: Encodable {
+    let token: String
+    let skipMerge: Bool
+}
+
+private struct MergePreviewBody: Encodable {
     let token: String
 }

--- a/ios/Fortymm/Login/MergeGateView.swift
+++ b/ios/Fortymm/Login/MergeGateView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+/// Cross-device confirm gate: shown before folding a guest's matches into the
+/// account being signed into, so foreign matches are never imported without the
+/// owner's say-so. Shared by the sign-in (`VerifyLoginView`) and email-confirm
+/// (`ConfirmEmailView`) landings — only the finalize action differs, passed as a
+/// closure. Only rendered when there are matches to carry.
+struct MergeGateView: View {
+    let preview: MergePreview
+    var onBringThemOver: () -> Void
+    var onNotNow: () -> Void
+
+    var body: some View {
+        let count = preview.guestMatchesCount
+        let matchLabel = count == 1 ? "1 match" : "\(count) matches"
+        let from = preview.guestUsername.map { "@\($0)" } ?? "your guest session"
+        return LoginScaffold(
+            eyebrow: "Bring your matches",
+            eyebrowColor: FMColor.serve500,
+            line1: "Bring your",
+            line2: "matches over?",
+            accent: FMColor.serve500,
+            stepNo: "03",
+            stepLabel: "Confirm merge",
+            title: "Bring your matches over?",
+            subtitle: "Signing in as @\(preview.ownerUsername ?? "your account"). "
+                + "We can bring the \(matchLabel) from \(from) into this account."
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                ReceiptCard(tint: FMColor.serve500.opacity(0.6), glow: true) {
+                    ReceiptHeader(
+                        badge: { StatusBadge(kind: .success) },
+                        eyebrow: "● BRING MATCHES",
+                        eyebrowColor: FMColor.serve500,
+                        title: "\(matchLabel) from \(from)"
+                    )
+                }
+                LoginButton(title: "Bring them over", action: onBringThemOver)
+                LoginButton(
+                    title: "Not now — just sign me in",
+                    kind: .ghost,
+                    action: onNotNow
+                )
+            }
+        }
+    }
+}

--- a/ios/Fortymm/Login/SessionEndedView.swift
+++ b/ios/Fortymm/Login/SessionEndedView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// Shown when the caller's guest session was merged into another account (on
+/// this or another device). Rather than silently mint a different guest, we
+/// explain what happened and offer to sign in (email prefilled) or start over as
+/// a fresh guest. Mirrors the web app's redirect-to-login-with-a-flash.
+struct SessionEndedView: View {
+    let reason: String
+    let email: String?
+    /// Folded back into `SessionStore` after a successful sign-in.
+    var onSignedIn: (SessionResponse) -> Void
+    /// Start fresh as a new guest (the dead cookie was already cleared).
+    var onContinueAsGuest: () -> Void
+
+    @State private var showSignIn = false
+
+    var body: some View {
+        VStack(spacing: FMSpace.s5) {
+            FMLogo(size: 30)
+            VStack(spacing: FMSpace.s2) {
+                Text("Signed out")
+                    .font(FMFont.ui(FMFont.md, weight: .semibold))
+                    .foregroundStyle(FMColor.fg1)
+                Text(reason)
+                    .font(FMFont.ui(FMFont.sm))
+                    .foregroundStyle(FMColor.fg3)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(2)
+            }
+            VStack(spacing: FMSpace.s3) {
+                FMButton(title: "Sign in", variant: .primary, size: .md) {
+                    showSignIn = true
+                }
+                FMButton(title: "Continue as guest", variant: .ghost, size: .md) {
+                    onContinueAsGuest()
+                }
+            }
+        }
+        .padding(.horizontal, FMSpace.s6)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(FMColor.bgApp.ignoresSafeArea())
+        .fullScreenCover(isPresented: $showSignIn) {
+            LoginFlowView(
+                start: .email(prefill: email ?? ""),
+                onClose: { showSignIn = false },
+                onSignedIn: { response in
+                    showSignIn = false
+                    onSignedIn(response)
+                }
+            )
+        }
+    }
+}

--- a/ios/Fortymm/Login/SignInView.swift
+++ b/ios/Fortymm/Login/SignInView.swift
@@ -10,12 +10,17 @@ struct SignInView: View {
     private let service = LoginService.shared
     @State private var captcha = TurnstileController()
 
-    @State private var email = ""
+    @State private var email: String
     @State private var touched = false
     @State private var captchaToken: String?
     @State private var serverError: String?
     @State private var sending = false
     @FocusState private var focused: Bool
+
+    init(initialEmail: String = "", onSent: @escaping (String) -> Void) {
+        self.onSent = onSent
+        _email = State(initialValue: initialEmail)
+    }
 
     private var validation: FieldValidation { ProfileRules.email(email) }
     private var invalid: Bool { serverError != nil || (touched && !validation.ok) }

--- a/ios/Fortymm/Login/VerifyLoginView.swift
+++ b/ios/Fortymm/Login/VerifyLoginView.swift
@@ -29,7 +29,12 @@ struct VerifyLoginView: View {
         Group {
             switch phase {
             case .verifying: verifying
-            case let .gate(preview): gate(preview)
+            case let .gate(preview):
+                MergeGateView(
+                    preview: preview,
+                    onBringThemOver: { Task { await verify(skipMerge: false) } },
+                    onNotNow: { Task { await verify(skipMerge: true) } }
+                )
             case let .success(response): success(response)
             case .expired: expired
             case .unreachable: unreachable
@@ -178,43 +183,6 @@ struct VerifyLoginView: View {
                 HStack(spacing: 10) {
                     LoginButton(title: "Retry") { Task { await verify(skipMerge: false) } }
                     LoginButton(title: "Send a new link", kind: .ghost, fullWidth: false) { onRestart() }
-                }
-            }
-        }
-    }
-
-    // MARK: Gate (cross-device confirm)
-
-    private func gate(_ preview: MergePreview) -> some View {
-        let count = preview.guestMatchesCount
-        let matchLabel = count == 1 ? "1 match" : "\(count) matches"
-        let from = preview.guestUsername.map { "@\($0)" } ?? "your guest session"
-        return LoginScaffold(
-            eyebrow: "Bring your matches",
-            eyebrowColor: FMColor.serve500,
-            line1: "Bring your",
-            line2: "matches over?",
-            accent: FMColor.serve500,
-            stepNo: "03",
-            stepLabel: "Confirm merge",
-            title: "Bring your matches over?",
-            subtitle: "Signing in as @\(preview.ownerUsername ?? "your account"). "
-                + "We can bring the \(matchLabel) from \(from) into this account."
-        ) {
-            VStack(alignment: .leading, spacing: 14) {
-                ReceiptCard(tint: FMColor.serve500.opacity(0.6), glow: true) {
-                    ReceiptHeader(
-                        badge: { StatusBadge(kind: .success) },
-                        eyebrow: "● BRING MATCHES",
-                        eyebrowColor: FMColor.serve500,
-                        title: "\(matchLabel) from \(from)"
-                    )
-                }
-                LoginButton(title: "Bring them over") {
-                    Task { await verify(skipMerge: false) }
-                }
-                LoginButton(title: "Not now — just sign me in", kind: .ghost) {
-                    Task { await verify(skipMerge: true) }
                 }
             }
         }

--- a/ios/Fortymm/Login/VerifyLoginView.swift
+++ b/ios/Fortymm/Login/VerifyLoginView.swift
@@ -18,6 +18,7 @@ struct VerifyLoginView: View {
 
     private enum Phase {
         case verifying
+        case gate(MergePreview)
         case success(SessionResponse)
         case expired
         case unreachable
@@ -28,12 +29,13 @@ struct VerifyLoginView: View {
         Group {
             switch phase {
             case .verifying: verifying
+            case let .gate(preview): gate(preview)
             case let .success(response): success(response)
             case .expired: expired
             case .unreachable: unreachable
             }
         }
-        .task { await verify() }
+        .task { await start() }
     }
 
     // MARK: Verifying
@@ -174,8 +176,45 @@ struct VerifyLoginView: View {
                     .init(status: "ERR", method: "···", path: "/auth/session", note: "gave up after 12s"),
                 ])
                 HStack(spacing: 10) {
-                    LoginButton(title: "Retry") { Task { await verify() } }
+                    LoginButton(title: "Retry") { Task { await verify(skipMerge: false) } }
                     LoginButton(title: "Send a new link", kind: .ghost, fullWidth: false) { onRestart() }
+                }
+            }
+        }
+    }
+
+    // MARK: Gate (cross-device confirm)
+
+    private func gate(_ preview: MergePreview) -> some View {
+        let count = preview.guestMatchesCount
+        let matchLabel = count == 1 ? "1 match" : "\(count) matches"
+        let from = preview.guestUsername.map { "@\($0)" } ?? "your guest session"
+        return LoginScaffold(
+            eyebrow: "Bring your matches",
+            eyebrowColor: FMColor.serve500,
+            line1: "Bring your",
+            line2: "matches over?",
+            accent: FMColor.serve500,
+            stepNo: "03",
+            stepLabel: "Confirm merge",
+            title: "Bring your matches over?",
+            subtitle: "Signing in as @\(preview.ownerUsername ?? "your account"). "
+                + "We can bring the \(matchLabel) from \(from) into this account."
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                ReceiptCard(tint: FMColor.serve500.opacity(0.6), glow: true) {
+                    ReceiptHeader(
+                        badge: { StatusBadge(kind: .success) },
+                        eyebrow: "● BRING MATCHES",
+                        eyebrowColor: FMColor.serve500,
+                        title: "\(matchLabel) from \(from)"
+                    )
+                }
+                LoginButton(title: "Bring them over") {
+                    Task { await verify(skipMerge: false) }
+                }
+                LoginButton(title: "Not now — just sign me in", kind: .ghost) {
+                    Task { await verify(skipMerge: true) }
                 }
             }
         }
@@ -183,10 +222,23 @@ struct VerifyLoginView: View {
 
     // MARK: Consume
 
-    private func verify() async {
+    /// Preview the link first; a merge that would carry matches over waits at
+    /// the gate, everything else signs in straight away.
+    private func start() async {
+        let preview = await service.mergePreview(token: token)
+        if preview.isMerge, preview.guestMatchesCount > 0 {
+            phase = .gate(preview)
+        } else {
+            await verify(skipMerge: false)
+        }
+    }
+
+    private func verify(skipMerge: Bool) async {
         phase = .verifying
         do {
-            phase = .success(try await service.consume(token: token))
+            phase = .success(
+                try await service.consume(token: token, skipMerge: skipMerge)
+            )
         } catch LoginConsumeError.rejected {
             phase = .expired
         } catch {

--- a/ios/Fortymm/Navigation/RootView.swift
+++ b/ios/Fortymm/Navigation/RootView.swift
@@ -27,6 +27,13 @@ struct RootView: View {
                 .fullScreenCover(item: $session.pendingDeepLink) { link in
                     deepLinkDestination(link)
                 }
+        case let .signedOut(reason, email):
+            SessionEndedView(
+                reason: reason,
+                email: email,
+                onSignedIn: { session.resolveDeepLink($0) },
+                onContinueAsGuest: { Task { await session.load(force: true) } }
+            )
         case let .failed(message):
             sessionFailedView(message)
         }

--- a/ios/Fortymm/Networking/APIClient.swift
+++ b/ios/Fortymm/Networking/APIClient.swift
@@ -39,6 +39,12 @@ struct APIClient {
 
     static let shared = APIClient()
 
+    /// Posted (from any request) when the API reports the caller's session was
+    /// merged away on another device — `401` with `{"detail":{"code":
+    /// "session_merged", ...}}`. `SessionStore` observes it and routes to
+    /// sign-in. `userInfo` carries `"message"` and (optionally) `"email"`.
+    static let sessionEndedNotification = Notification.Name("com.fortymm.sessionEnded")
+
     /// Name of the auth cookie the API sets and reads. Centralised so the send
     /// and capture sides can't drift.
     private static let sessionCookieName = "session"
@@ -169,6 +175,18 @@ struct APIClient {
         }
         await captureSessionCookie(from: http, url: url)
         guard (200..<300).contains(http.statusCode) else {
+            // A merged-away guest's cookie still resolves server-side, so this
+            // can land on *any* request — broadcast it (and drop the dead token)
+            // so the app routes to sign-in instead of acting as the ghost.
+            if http.statusCode == 401, let info = Self.mergedSessionInfo(from: data) {
+                await tokens.clear()
+                var userInfo: [String: Any] = ["message": info.message]
+                if let email = info.email { userInfo["email"] = email }
+                NotificationCenter.default.post(
+                    name: Self.sessionEndedNotification, object: nil, userInfo: userInfo
+                )
+                throw APIError.sessionMerged(message: info.message, email: info.email)
+            }
             throw APIError.http(status: http.statusCode, detail: Self.detail(from: data))
         }
         do {
@@ -210,6 +228,26 @@ struct APIClient {
         return nil
     }
 
+    /// Parse the structured `session_merged` 401 body — `{"detail":{"code":
+    /// "session_merged","message":...,"email":...}}` — returning the message and
+    /// the owning account's email (to prefill on sign-in). `nil` for any other 401.
+    private static func mergedSessionInfo(from data: Data) -> (message: String, email: String?)? {
+        struct Body: Decodable {
+            struct Detail: Decodable {
+                let code: String
+                let message: String?
+                let email: String?
+            }
+            let detail: Detail
+        }
+        guard let parsed = try? JSONDecoder().decode(Body.self, from: data),
+              parsed.detail.code == "session_merged" else { return nil }
+        return (
+            parsed.detail.message ?? "Your session has ended. Sign in to continue.",
+            parsed.detail.email
+        )
+    }
+
     /// Pull a minted/rotated `session` cookie out of the response and persist
     /// it. The API only ever sets the single `session` cookie, so folding
     /// multiple Set-Cookie headers isn't a concern here.
@@ -221,8 +259,15 @@ struct APIClient {
             withResponseHeaderFields: ["Set-Cookie": header],
             for: url
         )
-        if let token = cookies.first(where: { $0.name == Self.sessionCookieName })?.value {
-            await tokens.update(token)
+        guard let cookie = cookies.first(where: { $0.name == Self.sessionCookieName })
+        else { return }
+        if cookie.value.isEmpty {
+            // A clearing Set-Cookie (e.g. the session-merged 401 clears the dead
+            // cookie). Drop the stored token so the next call starts cookieless
+            // and mints a fresh guest.
+            await tokens.clear()
+        } else {
+            await tokens.update(cookie.value)
         }
     }
 }
@@ -240,6 +285,7 @@ extension Error {
 enum APIError: LocalizedError {
     case invalidResponse
     case http(status: Int, detail: String? = nil)
+    case sessionMerged(message: String, email: String?)
     case decoding(Error)
 
     var errorDescription: String? {
@@ -249,6 +295,8 @@ enum APIError: LocalizedError {
         case let .http(status, detail):
             // Prefer the API's own message when it sent one.
             return detail ?? "The server returned an error (HTTP \(status))."
+        case let .sessionMerged(message, _):
+            return message
         case .decoding:
             return "Couldn't read the server's response."
         }

--- a/ios/Fortymm/Profile/ProfileService.swift
+++ b/ios/Fortymm/Profile/ProfileService.swift
@@ -67,10 +67,11 @@ struct ProfileService {
     /// already used) and terminal; anything else is transient and worth a retry.
     /// Keeping that boundary-typing in the service, not the view, is the
     /// convention the rest of the API layer follows.
-    func confirmEmail(token: String) async throws -> SessionResponse {
+    func confirmEmail(token: String, skipMerge: Bool = false) async throws -> SessionResponse {
         do {
             return try await client.post(
-                "/v1/me/email/confirm", body: ConfirmEmailBody(token: token)
+                "/v1/me/email/confirm",
+                body: ConfirmEmailBody(token: token, skipMerge: skipMerge)
             )
         } catch let APIError.http(status, _) where (400..<500).contains(status) {
             throw LoginConsumeError.rejected
@@ -103,4 +104,5 @@ private struct ResendEmailBody: Encodable {
 
 private struct ConfirmEmailBody: Encodable {
     let token: String
+    let skipMerge: Bool
 }

--- a/ios/Fortymm/Session/SessionModels.swift
+++ b/ios/Fortymm/Session/SessionModels.swift
@@ -24,6 +24,17 @@ struct MergeSummary: Decodable {
     let matchesMoved: Int
 }
 
+/// Mirror of the API's `MergePreview` (`POST /v1/merge/preview`). A
+/// side-effect-free look at an emailed link so the verify/confirm screens can
+/// show a "bring N matches over?" gate before finalizing. ``isMerge`` is true
+/// only when the link would fold a guest with matches into another account.
+struct MergePreview: Decodable {
+    let isMerge: Bool
+    let ownerUsername: String?
+    let guestUsername: String?
+    let guestMatchesCount: Int
+}
+
 extension SessionUser {
     /// Where the user sits in the guest → verified lifecycle. Mirrors
     /// `deriveEmailStatus` in `web-client/src/api/session.ts`.

--- a/ios/Fortymm/Session/SessionStore.swift
+++ b/ios/Fortymm/Session/SessionStore.swift
@@ -9,6 +9,10 @@ final class SessionStore: ObservableObject {
         case idle
         case loading
         case loaded(SessionUser)
+        /// The cookie's guest was merged into another account (on this or another
+        /// device). Route to sign-in with the reason + the owner's email to
+        /// prefill — never silently mint a different guest.
+        case signedOut(reason: String, email: String?)
         case failed(String)
     }
 
@@ -44,9 +48,29 @@ final class SessionStore: ObservableObject {
     }
 
     private let client: APIClient
+    private var cancellables = Set<AnyCancellable>()
 
     init(client: APIClient = .shared) {
         self.client = client
+        // Any request can report the session was merged away (the dead cookie
+        // still resolves server-side). Listen globally and route to sign-in.
+        NotificationCenter.default
+            .publisher(for: APIClient.sessionEndedNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] note in
+                let reason = (note.userInfo?["message"] as? String)
+                    ?? "Your session has ended. Sign in to continue."
+                let email = note.userInfo?["email"] as? String
+                Task { @MainActor in self?.signedOut(reason: reason, email: email) }
+            }
+            .store(in: &cancellables)
+    }
+
+    /// Drop into the signed-out state (merged away). Clears any pending deep
+    /// link so its cover doesn't sit over the sign-in screen.
+    func signedOut(reason: String, email: String?) {
+        pendingDeepLink = nil
+        state = .signedOut(reason: reason, email: email)
     }
 
     /// Fold an updated user — returned by a profile mutation (username/email
@@ -66,6 +90,8 @@ final class SessionStore: ObservableObject {
         do {
             let response = try await client.getSession()
             state = .loaded(response.data.user)
+        } catch let APIError.sessionMerged(message, email) {
+            signedOut(reason: message, email: email)
         } catch {
             state = .failed(error.fmMessage)
         }

--- a/web-client/src/api/client.test.ts
+++ b/web-client/src/api/client.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+
+import { server } from '@/mocks/server'
+import { sessionResponse } from '@/test/factories'
+import { api, setSessionEndedHandler } from './client'
+
+afterEach(() => setSessionEndedHandler(null))
+
+/** Force the middleware's internal latch back to "not firing" via a 200. */
+async function resetLatch() {
+  server.use(
+    http.get('*/v1/session', () => HttpResponse.json(sessionResponse()), {
+      once: true,
+    }),
+  )
+  await api.GET('/v1/session')
+}
+
+function merged401(detail: Record<string, unknown>) {
+  server.use(
+    http.get('*/v1/session', () =>
+      HttpResponse.json({ detail }, { status: 401 }),
+    ),
+  )
+}
+
+it('fires the session-ended handler on a session_merged 401', async () => {
+  await resetLatch()
+  const handler = vi.fn()
+  setSessionEndedHandler(handler)
+
+  merged401({
+    code: 'session_merged',
+    message: 'Merged away. Sign in.',
+    email: 'owner@example.com',
+  })
+  await api.GET('/v1/session')
+
+  expect(handler).toHaveBeenCalledTimes(1)
+  expect(handler).toHaveBeenCalledWith({
+    message: 'Merged away. Sign in.',
+    email: 'owner@example.com',
+  })
+})
+
+it('ignores an ordinary (non-structured) 401', async () => {
+  await resetLatch()
+  const handler = vi.fn()
+  setSessionEndedHandler(handler)
+
+  merged401({ code: 'unauthenticated' }) // not session_merged
+  await api.GET('/v1/session')
+  server.use(
+    http.get('*/v1/players/search', () =>
+      HttpResponse.json({ detail: 'authentication required' }, { status: 401 }),
+    ),
+  )
+  await api.GET('/v1/players/search', { params: { query: { q: 'x' } } })
+
+  expect(handler).not.toHaveBeenCalled()
+})
+
+it('latches so a burst of 401s redirects only once', async () => {
+  await resetLatch()
+  const handler = vi.fn()
+  setSessionEndedHandler(handler)
+
+  merged401({ code: 'session_merged', message: 'm' })
+  await api.GET('/v1/session')
+  await api.GET('/v1/session')
+
+  expect(handler).toHaveBeenCalledTimes(1)
+})

--- a/web-client/src/api/client.ts
+++ b/web-client/src/api/client.ts
@@ -15,6 +15,75 @@ export const api = createClient<paths>({
   fetch: (...args) => globalThis.fetch(...args),
 })
 
+/**
+ * Info carried by the `session_merged` 401: the backend's human message and the
+ * owning account's email (to prefill on the login screen).
+ */
+export interface SessionEndedInfo {
+  message: string
+  email?: string
+}
+
+let sessionEndedHandler: ((info: SessionEndedInfo) => void) | null = null
+let sessionEndedFiring = false
+
+/**
+ * Register the global "your session was merged away" handler (set once at app
+ * bootstrap). It fires from the response middleware below for *any* request, so
+ * a guest whose account was merged on another device is sent to sign in no
+ * matter which call surfaces it — not just the session bootstrap.
+ */
+export function setSessionEndedHandler(
+  fn: ((info: SessionEndedInfo) => void) | null,
+): void {
+  sessionEndedHandler = fn
+}
+
+async function readSessionMerged(
+  response: Response,
+): Promise<SessionEndedInfo | null> {
+  try {
+    const body = (await response.clone().json()) as {
+      detail?: { code?: unknown; message?: unknown; email?: unknown }
+    }
+    const detail = body?.detail
+    if (
+      detail &&
+      typeof detail === 'object' &&
+      detail.code === 'session_merged'
+    ) {
+      return {
+        message:
+          typeof detail.message === 'string'
+            ? detail.message
+            : 'Your session has ended. Sign in to continue.',
+        email: typeof detail.email === 'string' ? detail.email : undefined,
+      }
+    }
+  } catch {
+    // Non-JSON / already-consumed body — not our structured 401.
+  }
+  return null
+}
+
+api.use({
+  async onResponse({ response }) {
+    // Reset the latch on any healthy response so a later genuine session-end
+    // can fire again.
+    if (response.ok) {
+      sessionEndedFiring = false
+    } else if (response.status === 401 && !sessionEndedFiring) {
+      const info = await readSessionMerged(response)
+      if (info) {
+        // Latch so a burst of in-flight 401s triggers a single redirect.
+        sessionEndedFiring = true
+        sessionEndedHandler?.(info)
+      }
+    }
+    return response
+  },
+})
+
 export function extractDetail(value: unknown): string | null {
   if (!value || typeof value !== 'object') return null
   const detail = (value as { detail?: unknown }).detail

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -103,6 +103,11 @@ export interface paths {
          *     orphan guest user on every cross-device click. The endpoint also
          *     rotates the caller's session cookie to the token's owner so the
          *     confirming browser ends up signed in as the right user.
+         *
+         *     A *merge* token (``merge:<uuid>``) is handled separately: instead of
+         *     stamping an address onto the guest that requested it, the guest is folded
+         *     into the account that owns the address and the caller is signed in as that
+         *     account. See ``_confirm_account_merge``.
          */
         post: operations["confirm_email_v1_me_email_confirm_post"];
         delete?: never;
@@ -135,6 +140,10 @@ export interface paths {
          *     someone sign in without proving control of the inbox; the confirmation
          *     link clears that hurdle and (per ``confirm_email``) rotates them into
          *     a session anyway.
+         *
+         *     Records the requesting browser's guest on the token so the merge it drives
+         *     is token-bound (follows the guest cross-device), mirroring the settings
+         *     merge flow.
          */
         post: operations["request_login_email_v1_login_request_post"];
         delete?: never;
@@ -162,6 +171,32 @@ export interface paths {
          *     which guest session (if any) the browser arrived with.
          */
         post: operations["consume_login_token_v1_login_consume_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/merge/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Preview Merge
+         * @description Side-effect-free look at an emailed link before it's consumed, so the
+         *     client can show a "bring N matches over?" confirmation. Never consumes,
+         *     rotates, or merges — a wrong/expired token simply returns ``is_merge=False``
+         *     and the client finalizes through the real confirm/consume endpoint.
+         *
+         *     Safe to return usernames + counts: the 256-bit token is the bearer
+         *     credential, so only someone holding the link can ask.
+         */
+        post: operations["preview_merge_v1_merge_preview_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -665,11 +700,21 @@ export interface components {
         ConfirmEmailRequest: {
             /** Token */
             token: string;
+            /**
+             * Skip Merge
+             * @default false
+             */
+            skip_merge: boolean;
         };
         /** ConsumeLoginRequest */
         ConsumeLoginRequest: {
             /** Token */
             token: string;
+            /**
+             * Skip Merge
+             * @default false
+             */
+            skip_merge: boolean;
         };
         /** DashboardNextMatch */
         DashboardNextMatch: {
@@ -1141,6 +1186,34 @@ export interface components {
          * @enum {string}
          */
         MatchStatus: "pending" | "in_progress" | "completed" | "disputed" | "voided";
+        /**
+         * MergePreview
+         * @description Side-effect-free look at an emailed link before it's consumed, so the
+         *     client can decide whether to show a "bring N matches over?" confirmation.
+         *
+         *     ``is_merge`` is true only for a link that would fold a guest into another
+         *     account (a settings merge token, or a sign-in token that recorded a
+         *     requesting guest). The client shows the gate only when there are matches to
+         *     carry (``guest_matches_count > 0``); otherwise it finalizes silently.
+         */
+        MergePreview: {
+            /** Is Merge */
+            is_merge: boolean;
+            /** Owner Username */
+            owner_username?: string | null;
+            /** Guest Username */
+            guest_username?: string | null;
+            /**
+             * Guest Matches Count
+             * @default 0
+             */
+            guest_matches_count: number;
+        };
+        /** MergePreviewRequest */
+        MergePreviewRequest: {
+            /** Token */
+            token: string;
+        };
         /**
          * MergeSummary
          * @description Reported by sign-in / email-confirm responses when the call merged the
@@ -1731,7 +1804,9 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody: {
             content: {
@@ -1781,6 +1856,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SessionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_merge_v1_merge_preview_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MergePreviewRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MergePreview"];
                 };
             };
             /** @description Validation Error */

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -125,13 +125,36 @@ export function useResendEmailConfirmation() {
   })
 }
 
+export type MergePreview = components['schemas']['MergePreview']
+
+/** Side-effect-free look at an emailed link, to decide whether to show the
+ * "bring N matches over?" gate before finalizing. */
+export function useMergePreview() {
+  return useMutation({
+    mutationFn: async (token: string): Promise<MergePreview> =>
+      unwrap('check link', await api.POST('/v1/merge/preview', { body: { token } })),
+  })
+}
+
+/** Input for the finalize mutations. `skipMerge` is the gate's "not now": sign
+ * in without folding the guest's matches in. */
+export interface FinalizeTokenInput {
+  token: string
+  skipMerge?: boolean
+}
+
 export function useConfirmEmail() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: async (token: string): Promise<Session> =>
+    mutationFn: async ({
+      token,
+      skipMerge = false,
+    }: FinalizeTokenInput): Promise<Session> =>
       unwrap(
         'confirm email',
-        await api.POST('/v1/me/email/confirm', { body: { token } }),
+        await api.POST('/v1/me/email/confirm', {
+          body: { token, skip_merge: skipMerge },
+        }),
       ),
     onSuccess: (session) => {
       qc.setQueryData(SESSION_QUERY_KEY, session)
@@ -183,10 +206,15 @@ export function useLogout() {
 export function useConsumeLoginToken() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: async (token: string): Promise<Session> =>
+    mutationFn: async ({
+      token,
+      skipMerge = false,
+    }: FinalizeTokenInput): Promise<Session> =>
       unwrap(
         'sign in',
-        await api.POST('/v1/login/consume', { body: { token } }),
+        await api.POST('/v1/login/consume', {
+          body: { token, skip_merge: skipMerge },
+        }),
       ),
     onSuccess: (session) => {
       qc.setQueryData(SESSION_QUERY_KEY, session)

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -4,7 +4,7 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query'
-import { api, unwrap } from './client'
+import { ApiError, api, unwrap } from './client'
 import type { components } from './schema'
 
 export type Session = components['schemas']['SessionResponse']
@@ -18,6 +18,11 @@ export function sessionQueryOptions() {
     queryFn: async (): Promise<Session> =>
       unwrap('load session', await api.GET('/v1/session')),
     staleTime: 1000 * 60 * 5,
+    // Don't retry a 401 (session merged away): the 401 already cleared the
+    // cookie, so a retry would silently mint a *new* guest and race the
+    // redirect-to-login. Transient errors still retry.
+    retry: (failureCount, error) =>
+      !(error instanceof ApiError && error.status === 401) && failureCount < 3,
   })
 }
 

--- a/web-client/src/components/login/merge-gate.tsx
+++ b/web-client/src/components/login/merge-gate.tsx
@@ -1,0 +1,75 @@
+interface MergeGateProps {
+  ownerUsername: string
+  guestUsername: string | null
+  matchesCount: number
+  busy: boolean
+  onBringThemOver: () => void
+  onNotNow: () => void
+}
+
+/**
+ * Cross-device confirm gate: shown before folding a guest's matches into the
+ * account being signed into, so foreign matches are never imported without the
+ * owner's say-so. Only rendered when there are matches to carry
+ * (`matchesCount > 0`); empty guests finalize silently.
+ */
+export function MergeGate({
+  ownerUsername,
+  guestUsername,
+  matchesCount,
+  busy,
+  onBringThemOver,
+  onNotNow,
+}: MergeGateProps) {
+  const matchLabel = matchesCount === 1 ? '1 match' : `${matchesCount} matches`
+  const from = guestUsername ? `@${guestUsername}` : 'your guest session'
+  return (
+    <div
+      style={{
+        maxWidth: 520,
+        margin: '64px auto',
+        padding: 24,
+        textAlign: 'center',
+      }}
+    >
+      <h1
+        style={{
+          fontFamily: 'var(--font-display)',
+          fontSize: 40,
+          margin: '0 0 12px',
+        }}
+      >
+        Bring your matches over?
+      </h1>
+      <p style={{ color: 'var(--fg-2)' }}>
+        You're signing in as <strong>@{ownerUsername}</strong>. We can bring the{' '}
+        <strong>{matchLabel}</strong> you played in {from} into this account.
+      </p>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          marginTop: 24,
+        }}
+      >
+        <button
+          type="button"
+          className="fmm-btn fmm-btn--primary"
+          disabled={busy}
+          onClick={onBringThemOver}
+        >
+          Bring them over
+        </button>
+        <button
+          type="button"
+          className="fmm-btn fmm-btn--quiet"
+          disabled={busy}
+          onClick={onNotNow}
+        >
+          Not now — just sign me in
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web-client/src/lib/landing-redirect.ts
+++ b/web-client/src/lib/landing-redirect.ts
@@ -16,3 +16,11 @@ export function hasAppEntered(): boolean {
     return false
   }
 }
+
+export function clearAppEntered(): void {
+  try {
+    window.localStorage.removeItem(APP_ENTERED_KEY)
+  } catch {
+    // Best-effort — see markAppEntered.
+  }
+}

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -3,9 +3,13 @@ import { createRoot } from 'react-dom/client'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { toast } from 'sonner'
 import './index.css'
 import { Toaster } from '@/components/ui/sonner'
 import { NotFoundPage } from '@/components/not-found-page'
+import { setSessionEndedHandler } from '@/api/client'
+import { SESSION_QUERY_KEY } from '@/api/session'
+import { clearAppEntered } from '@/lib/landing-redirect'
 import { routeTree } from './routeTree.gen'
 
 const queryClient = new QueryClient({
@@ -27,6 +31,15 @@ declare module '@tanstack/react-router' {
     router: typeof router
   }
 }
+
+// When any request reports the session was merged away on another device, drop
+// the stale session, flash the reason, and route to sign-in (email prefilled).
+setSessionEndedHandler(({ message, email }) => {
+  clearAppEntered()
+  queryClient.removeQueries({ queryKey: SESSION_QUERY_KEY })
+  toast.message(message)
+  void router.navigate({ to: '/login', search: { email, error: undefined } })
+})
 
 async function unregisterServiceWorkers() {
   if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -518,6 +518,16 @@ export const handlers = [
     }
     return HttpResponse.json(mockSession)
   }),
+  // Default: not a merge, so the verify/confirm screens finalize straight away.
+  // Tests that exercise the gate override this with `server.use(...)`.
+  http.post('*/v1/merge/preview', () =>
+    HttpResponse.json({
+      is_merge: false,
+      owner_username: null,
+      guest_username: null,
+      guest_matches_count: 0,
+    }),
+  ),
   // ----- matches ---------------------------------------------------------
   http.post('*/v1/matches', async ({ request }) => {
     await delay(400)

--- a/web-client/src/routes/confirm-email.tsx
+++ b/web-client/src/routes/confirm-email.tsx
@@ -3,7 +3,8 @@ import { Link, createFileRoute } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
 import { ApiError } from '@/api/client'
-import { useConfirmEmail } from '@/api/session'
+import { useConfirmEmail, useMergePreview } from '@/api/session'
+import { MergeGate } from '@/components/login/merge-gate'
 import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute('/confirm-email')({
@@ -18,14 +19,25 @@ export const Route = createFileRoute('/confirm-email')({
 
 function ConfirmEmailPage() {
   const { token } = Route.useSearch()
+  const preview = useMergePreview()
   const confirm = useConfirmEmail()
   const fired = useRef(false)
 
+  // Preview the link first. A merge that would carry matches over waits for the
+  // user at the gate; everything else (plain confirm, empty guest, or a preview
+  // failure) finalizes straight away.
   useEffect(() => {
     if (fired.current || !token) return
     fired.current = true
-    confirm.mutate(token)
-  }, [token, confirm])
+    preview.mutate(token, {
+      onSuccess: (p) => {
+        if (!(p.is_merge && p.guest_matches_count > 0)) {
+          confirm.mutate({ token })
+        }
+      },
+      onError: () => confirm.mutate({ token }),
+    })
+  }, [token, preview, confirm])
 
   useEffect(() => {
     if (!confirm.isSuccess) return
@@ -39,13 +51,19 @@ function ConfirmEmailPage() {
     }
   }, [confirm.isSuccess, confirm.data])
 
-  const status: 'missing-token' | 'confirming' | 'ok' | 'error' = !token
+  const p = preview.data
+  const showGate =
+    confirm.status === 'idle' && !!p && p.is_merge && p.guest_matches_count > 0
+
+  const status: 'missing-token' | 'gate' | 'confirming' | 'ok' | 'error' = !token
     ? 'missing-token'
     : confirm.isSuccess
       ? 'ok'
       : confirm.isError
         ? 'error'
-        : 'confirming'
+        : showGate
+          ? 'gate'
+          : 'confirming'
 
   const errorMsg =
     status === 'missing-token'
@@ -53,6 +71,19 @@ function ConfirmEmailPage() {
       : confirm.error instanceof ApiError && confirm.error.detail
         ? confirm.error.detail
         : 'Confirmation failed.'
+
+  if (status === 'gate' && p) {
+    return (
+      <MergeGate
+        ownerUsername={p.owner_username ?? ''}
+        guestUsername={p.guest_username ?? null}
+        matchesCount={p.guest_matches_count}
+        busy={confirm.isPending}
+        onBringThemOver={() => confirm.mutate({ token })}
+        onNotNow={() => confirm.mutate({ token, skipMerge: true })}
+      />
+    )
+  }
 
   // Intentionally NOT wrapped in <AppShell> — AppShell calls useSession()
   // on mount, and `GET /v1/session` auto-mints a guest user for cookieless

--- a/web-client/src/routes/login.test.tsx
+++ b/web-client/src/routes/login.test.tsx
@@ -228,4 +228,71 @@ describe('/login/verifying flow', () => {
     })
     expect(toast.success).not.toHaveBeenCalled()
   })
+
+  it('shows the merge gate and consumes with the chosen skip_merge', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('*/v1/merge/preview', () =>
+        HttpResponse.json({
+          is_merge: true,
+          owner_username: 'rita',
+          guest_username: 'drifting-grouse',
+          guest_matches_count: 2,
+        }),
+      ),
+    )
+    const consumed: Array<{ skip_merge?: boolean }> = []
+    server.use(
+      http.post('*/v1/login/consume', async ({ request }) => {
+        consumed.push(
+          (await request.json()) as { skip_merge?: boolean },
+        )
+        return HttpResponse.json(mockSession)
+      }),
+    )
+
+    renderAt('/login/verifying?token=merge-token')
+
+    // Gate appears instead of auto-finalizing.
+    await screen.findByRole('heading', { name: /bring your matches over/i })
+    expect(screen.getByText(/2 matches/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /bring them over/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /welcome back/i })).toBeInTheDocument(),
+    )
+    expect(consumed).toEqual([{ token: 'merge-token', skip_merge: false }])
+  })
+
+  it('signs in without merging when "not now" is chosen', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('*/v1/merge/preview', () =>
+        HttpResponse.json({
+          is_merge: true,
+          owner_username: 'rita',
+          guest_username: 'drifting-grouse',
+          guest_matches_count: 1,
+        }),
+      ),
+    )
+    const consumed: Array<{ skip_merge?: boolean }> = []
+    server.use(
+      http.post('*/v1/login/consume', async ({ request }) => {
+        consumed.push((await request.json()) as { skip_merge?: boolean })
+        return HttpResponse.json(mockSession)
+      }),
+    )
+
+    renderAt('/login/verifying?token=merge-token')
+
+    await screen.findByRole('heading', { name: /bring your matches over/i })
+    await user.click(screen.getByRole('button', { name: /not now/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /welcome back/i })).toBeInTheDocument(),
+    )
+    expect(consumed).toEqual([{ token: 'merge-token', skip_merge: true }])
+  })
 })

--- a/web-client/src/routes/login.verifying.tsx
+++ b/web-client/src/routes/login.verifying.tsx
@@ -3,7 +3,11 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
 import { ApiError } from '@/api/client'
-import { useConsumeLoginToken, useMergePreview } from '@/api/session'
+import {
+  type MergePreview,
+  useConsumeLoginToken,
+  useMergePreview,
+} from '@/api/session'
 import {
   ScreenError,
   ScreenVerify,
@@ -13,7 +17,6 @@ import { MergeGate } from '@/components/login/merge-gate'
 import { pageTitle } from '@/lib/page-title'
 
 type VerifyError = 'expired' | 'net'
-type Phase = 'idle' | 'previewing' | 'gate' | 'consuming'
 
 export const Route = createFileRoute('/login/verifying')({
   head: () => ({
@@ -34,11 +37,13 @@ function LoginVerifyingPage() {
   const navigate = useNavigate()
   const preview = useMergePreview()
   const consume = useConsumeLoginToken()
-  const [phase, setPhase] = useState<Phase>('idle')
+  // Holds the preview only while the cross-device gate is up; everything else
+  // (previewing, consuming) renders the same verifying screen.
+  const [gate, setGate] = useState<MergePreview | null>(null)
   const fired = useRef(false)
 
   const runConsume = (skipMerge: boolean) => {
-    setPhase('consuming')
+    setGate(null)
     consume.mutate(
       { token, skipMerge },
       {
@@ -73,11 +78,10 @@ function LoginVerifyingPage() {
   useEffect(() => {
     if (fired.current || !token || error) return
     fired.current = true
-    setPhase('previewing')
     preview.mutate(token, {
       onSuccess: (p) => {
         if (p.is_merge && p.guest_matches_count > 0) {
-          setPhase('gate')
+          setGate(p)
         } else {
           runConsume(false)
         }
@@ -114,7 +118,7 @@ function LoginVerifyingPage() {
         retrying={consume.isPending}
         onRetry={() => {
           fired.current = false
-          setPhase('idle')
+          setGate(null)
           navigate({ to: '/login/verifying', search: { token, error: undefined } })
         }}
         onSendNewLink={() =>
@@ -124,13 +128,12 @@ function LoginVerifyingPage() {
     )
   }
 
-  if (phase === 'gate' && preview.data) {
-    const p = preview.data
+  if (gate) {
     return (
       <MergeGate
-        ownerUsername={p.owner_username ?? ''}
-        guestUsername={p.guest_username ?? null}
-        matchesCount={p.guest_matches_count}
+        ownerUsername={gate.owner_username ?? ''}
+        guestUsername={gate.guest_username ?? null}
+        matchesCount={gate.guest_matches_count}
         busy={consume.isPending}
         onBringThemOver={() => runConsume(false)}
         onNotNow={() => runConsume(true)}

--- a/web-client/src/routes/login.verifying.tsx
+++ b/web-client/src/routes/login.verifying.tsx
@@ -1,23 +1,19 @@
 import { useEffect, useRef, useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { api, ApiError, unwrap } from '@/api/client'
-import { SESSION_QUERY_KEY, type Session } from '@/api/session'
+import { ApiError } from '@/api/client'
+import { useConsumeLoginToken, useMergePreview } from '@/api/session'
 import {
   ScreenError,
   ScreenVerify,
   ScreenVerifyNetError,
 } from '@/components/login/login-screens'
+import { MergeGate } from '@/components/login/merge-gate'
 import { pageTitle } from '@/lib/page-title'
 
 type VerifyError = 'expired' | 'net'
-type ConsumeState =
-  | { status: 'idle' }
-  | { status: 'pending' }
-  | { status: 'success' }
-  | { status: 'error'; error: unknown }
+type Phase = 'idle' | 'previewing' | 'gate' | 'consuming'
 
 export const Route = createFileRoute('/login/verifying')({
   head: () => ({
@@ -36,67 +32,67 @@ export const Route = createFileRoute('/login/verifying')({
 function LoginVerifyingPage() {
   const { token, error } = Route.useSearch()
   const navigate = useNavigate()
-  const qc = useQueryClient()
-  const [state, setState] = useState<ConsumeState>({ status: 'idle' })
+  const preview = useMergePreview()
+  const consume = useConsumeLoginToken()
+  const [phase, setPhase] = useState<Phase>('idle')
   const fired = useRef(false)
 
-  // Fire the consume exactly once across mounts and pick up the result on
-  // whichever render observes it. We intentionally don't cancel from the
-  // effect cleanup: StrictMode's simulated unmount fires the cleanup before
-  // the response arrives, and a second mount whose effect early-returns
-  // would then never learn the outcome.
+  const runConsume = (skipMerge: boolean) => {
+    setPhase('consuming')
+    consume.mutate(
+      { token, skipMerge },
+      {
+        onSuccess: (session) => {
+          const moved = session.merged?.matches_moved ?? 0
+          if (moved > 0) {
+            toast.success(
+              moved === 1
+                ? 'We brought your 1 match with you.'
+                : `We brought your ${moved} matches with you.`,
+            )
+          }
+          navigate({ to: '/login/welcome' })
+        },
+        onError: (err) => {
+          if (err instanceof ApiError && err.status >= 400 && err.status < 500) {
+            navigate({
+              to: '/login/verifying',
+              search: { token: '', error: 'expired' },
+            })
+          } else {
+            navigate({ to: '/login/verifying', search: { token, error: 'net' } })
+          }
+        },
+      },
+    )
+  }
+
+  // Preview first; a merge that would carry matches over waits at the gate,
+  // everything else signs in straight away. We don't cancel from cleanup so
+  // StrictMode's simulated unmount can't strand an in-flight request.
   useEffect(() => {
     if (fired.current || !token || error) return
     fired.current = true
-    setState({ status: 'pending' })
-    ;(async () => {
-      try {
-        const result = await api.POST('/v1/login/consume', { body: { token } })
-        const session = unwrap('sign in', result) as Session
-        qc.setQueryData(SESSION_QUERY_KEY, session)
-        const movedMatches = session.merged?.matches_moved ?? 0
-        if (movedMatches > 0) {
-          toast.success(
-            movedMatches === 1
-              ? 'We brought your 1 match with you.'
-              : `We brought your ${movedMatches} matches with you.`,
-          )
+    setPhase('previewing')
+    preview.mutate(token, {
+      onSuccess: (p) => {
+        if (p.is_merge && p.guest_matches_count > 0) {
+          setPhase('gate')
+        } else {
+          runConsume(false)
         }
-        setState({ status: 'success' })
-      } catch (err) {
-        setState({ status: 'error', error: err })
-      }
-    })()
-  }, [token, error, qc])
-
-  useEffect(() => {
-    if (state.status === 'success') {
-      navigate({ to: '/login/welcome' })
-    } else if (state.status === 'error') {
-      const err = state.error
-      if (err instanceof ApiError && err.status >= 400 && err.status < 500) {
-        navigate({
-          to: '/login/verifying',
-          search: { token: '', error: 'expired' },
-        })
-      } else {
-        navigate({
-          to: '/login/verifying',
-          search: { token, error: 'net' },
-        })
-      }
-    }
-  }, [state, navigate, token])
+      },
+      onError: () => runConsume(false),
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token, error])
 
   if (!token && !error) {
     return (
       <ScreenError
         detail="This link is missing its token."
         onRequestNew={() =>
-          navigate({
-            to: '/login',
-            search: { error: undefined, email: undefined },
-          })
+          navigate({ to: '/login', search: { error: undefined, email: undefined } })
         }
       />
     )
@@ -106,10 +102,7 @@ function LoginVerifyingPage() {
     return (
       <ScreenError
         onRequestNew={() =>
-          navigate({
-            to: '/login',
-            search: { error: undefined, email: undefined },
-          })
+          navigate({ to: '/login', search: { error: undefined, email: undefined } })
         }
       />
     )
@@ -118,21 +111,29 @@ function LoginVerifyingPage() {
   if (error === 'net') {
     return (
       <ScreenVerifyNetError
-        retrying={state.status === 'pending'}
+        retrying={consume.isPending}
         onRetry={() => {
           fired.current = false
-          setState({ status: 'idle' })
-          navigate({
-            to: '/login/verifying',
-            search: { token, error: undefined },
-          })
+          setPhase('idle')
+          navigate({ to: '/login/verifying', search: { token, error: undefined } })
         }}
         onSendNewLink={() =>
-          navigate({
-            to: '/login',
-            search: { error: undefined, email: undefined },
-          })
+          navigate({ to: '/login', search: { error: undefined, email: undefined } })
         }
+      />
+    )
+  }
+
+  if (phase === 'gate' && preview.data) {
+    const p = preview.data
+    return (
+      <MergeGate
+        ownerUsername={p.owner_username ?? ''}
+        guestUsername={p.guest_username ?? null}
+        matchesCount={p.guest_matches_count}
+        busy={consume.isPending}
+        onBringThemOver={() => runConsume(false)}
+        onNotNow={() => runConsume(true)}
       />
     )
   }


### PR DESCRIPTION
## What

When a guest enters an email that already belongs to an account, fold the guest into that account and sign them in — across the **settings claim** flow and the **magic-link login** flow, on web and iOS.

### Workstreams (sequenced)
1. **Settings merge** — `POST /v1/me/email` with an email owned by a verified account issues a token-bound `merge:<owner-id>` token and emails the owner a link; confirming it folds the guest in and signs in as the owner. Enumeration-safe.
2. **Tombstone (soft-delete)** — `merge_user` now sets `merged_into_user_id`/`merged_at` and keeps the row (+ its session token) instead of hard-deleting, with explicit cleanup of what used to ride `ON DELETE CASCADE`. User-listing queries exclude tombstoned rows. (Users migration edited in place, pre-deploy convention.)
3. **Session-ended at the shared auth seam** — a tombstoned cookie returns a structured `401 {code: session_merged, email}` on *every* authed request; web (openapi-fetch middleware) and iOS (`APIClient` + `SessionStore.signedOut` → `SessionEndedView`) catch it globally and route to sign-in with a flash + prefilled email.
4. **Token-bound login + cross-device confirm gate** — login records the requesting guest (`login:<guest-id>`) so matches follow cross-device; a side-effect-free `POST /v1/merge/preview` drives a "bring N matches over?" interstitial (web `MergeGate`, iOS `MergeGateView`); `skip_merge` powers "not now".

## Testing
- API: ruff + `ruff format` + `mypy --strict` clean; **362 pytest** pass; migration up/down verified.
- Web: lint + `tsc -b && vite build` clean; **136 vitest** pass; `schema.d.ts` regenerated.
- iOS: simulator build succeeds.
- **Live UAT** (fresh DB): backend matrix 17/17; web gate + session-ended + login gate + "not now" verified via Playwright; iOS app runs against the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)