### PR TITLE
matches: both participants + server-side filters; drop personal cruft

### DIFF
--- a/ios/Fortymm/MatchFlow/MatchAPI.swift
+++ b/ios/Fortymm/MatchFlow/MatchAPI.swift
@@ -123,6 +123,10 @@ struct MatchListResponseDTO: Decodable {
     let page: Int
     let pageSize: Int
     let total: Int
+    /// Per-status totals for the filter tabs, keyed by the raw API status string
+    /// ("pending", "in_progress", …). Honors the active `q` but not the status
+    /// filter, so the counts stay stable as the user switches tabs.
+    let statusCounts: [String: Int]
 }
 
 // MARK: - Players (opponent picker)
@@ -131,16 +135,6 @@ struct PlayerReadDTO: Decodable {
     let id: UUID
     let username: String
     let rating: Double?
-}
-
-/// `GET /v1/players/{id}` — current user's own record drives the season card.
-struct PlayerDetailDTO: Decodable {
-    let id: UUID
-    let username: String
-    let rating: Double?
-    let wins: Int
-    let losses: Int
-    let form: String   // newest-first "WLWWL", up to 5
 }
 
 // MARK: - Request bodies

--- a/ios/Fortymm/MatchFlow/MatchDetailView.swift
+++ b/ios/Fortymm/MatchFlow/MatchDetailView.swift
@@ -10,7 +10,6 @@ struct MatchDetailView: View {
     let initial: FinalMatch
     var service: MatchService = .shared
     var onBack: () -> Void
-    var onAgain: () -> Void
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var reveal = false
@@ -345,9 +344,8 @@ struct MatchDetailView: View {
         .padding(.horizontal, 16)
         .padding(.top, 14)
         .padding(.bottom, 30)
-        // Solid backing so scrolled content never shows through the bar or the
-        // outlined "Log another" button; the short fade above lets content
-        // dissolve as it scrolls up toward the bar.
+        // Solid backing so scrolled content never shows through the footer bar;
+        // the short fade above lets content dissolve as it scrolls up toward it.
         .background {
             FMColor.ink950
                 .ignoresSafeArea()
@@ -360,30 +358,19 @@ struct MatchDetailView: View {
         }
     }
 
-    /// Default footer: log another / back to the matches list.
+    /// Default footer: back to the matches list.
     private var defaultFooter: some View {
-        HStack(spacing: 10) {
-            Button(action: onAgain) {
-                Text("Log another")
-                    .font(FMFont.ui(15, weight: .semibold))
-                    .foregroundStyle(FMColor.fg2)
-                    .padding(.horizontal, 22)
-                    .frame(height: 50)
-                    .fmRoundedBorder(radius: 13, color: FMColor.borderDefault)
-            }
-            .buttonStyle(.plain)
-            Button(action: onBack) {
-                Text("Back to matches")
-                    .font(FMFont.ui(16, weight: .bold))
-                    .foregroundStyle(FMColor.fgInverse)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 50)
-                    .background(BallGradient())
-                    .clipShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
-                    .shadow(color: FMColor.ball500.opacity(0.32), radius: 11, y: 8)
-            }
-            .buttonStyle(.plain)
+        Button(action: onBack) {
+            Text("Back to matches")
+                .font(FMFont.ui(16, weight: .bold))
+                .foregroundStyle(FMColor.fgInverse)
+                .frame(maxWidth: .infinity)
+                .frame(height: 50)
+                .background(BallGradient())
+                .clipShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
+                .shadow(color: FMColor.ball500.opacity(0.32), radius: 11, y: 8)
         }
+        .buttonStyle(.plain)
     }
 
     /// Sign-off footer: shown when the current user owes a confirm/dispute on a

--- a/ios/Fortymm/MatchFlow/MatchFlowView.swift
+++ b/ios/Fortymm/MatchFlow/MatchFlowView.swift
@@ -54,8 +54,7 @@ struct MatchFlowView: View {
                 if let final {
                     MatchDetailView(
                         initial: final,
-                        onBack: { onClose(true) },
-                        onAgain: resetForAnother
+                        onBack: { onClose(true) }
                     )
                     .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
@@ -107,13 +106,6 @@ struct MatchFlowView: View {
             }
             busy = false
         }
-    }
-
-    private func resetForAnother() {
-        opponent = nil
-        final = nil
-        matchId = nil
-        withAnimation { step = .setup }
     }
 }
 

--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -114,6 +114,27 @@ struct FinalMatch: Identifiable {
     var canConfirm: Bool = false
     /// Server head-to-head, when the detail BFF provided it.
     var h2h: MatchH2H? = nil
+    // --- neutral, side-ordered view (for the matches list, which is a global
+    // feed where the viewer often isn't a participant). `you`/`opponent`/`win`
+    // above are the viewer-relative projection used by the detail screen; the
+    // fields below are framed by side number instead so a row can show *both*
+    // participants without pretending side 1 is the viewer. ---
+    /// Side 1 and side 2 players, in canonical side-number order.
+    var sideA: MatchPlayer = MatchSeed.me
+    var sideB: MatchPlayer = .guest
+    /// Games won by side 1 / side 2.
+    var sideAGames: Int = 0
+    var sideBGames: Int = 0
+    /// True when the signed-in user is on one of the sides. When false the row
+    /// is a spectator view: the W/L badge and rating delta don't apply.
+    var viewerIsParticipant: Bool = true
+}
+
+/// A page of the match list plus the per-status counts that drive the filter
+/// tab badges. `statusCounts` is keyed by the raw API status string.
+struct MatchListPage {
+    let items: [FinalMatch]
+    let statusCounts: [String: Int]
 }
 
 /// Head-to-head summary from the detail BFF, framed from the current user's

--- a/ios/Fortymm/MatchFlow/MatchService.swift
+++ b/ios/Fortymm/MatchFlow/MatchService.swift
@@ -96,36 +96,30 @@ struct MatchService {
     }
 
     /// The current user's matches, newest first (`GET /v1/matches`).
-    func listMatches(page: Int = 1, pageSize: Int = 50) async throws -> [FinalMatch] {
-        let response: MatchListResponseDTO = try await client.get(
-            "/v1/matches",
-            query: [
-                URLQueryItem(name: "page", value: String(page)),
-                URLQueryItem(name: "page_size", value: String(pageSize)),
-            ]
-        )
-        return response.items.map(Self.finalMatch(from:))
-    }
-
-    /// Current user's season record for the Matches-tab header. The session
-    /// doesn't expose the user's id, so we discover it from their own matches
-    /// (they appear as `is_current_user` on every row) and fetch the player
-    /// profile. Returns nil when the user has no matches yet (nothing to show).
-    func myRecord() async throws -> MyRecord? {
-        let response: MatchListResponseDTO = try await client.get(
-            "/v1/matches",
-            query: [URLQueryItem(name: "page_size", value: "1")]
-        )
-        let myId = response.items
-            .flatMap(\.sides).flatMap(\.players)
-            .first(where: \.isCurrentUser)?.userId
-        guard let myId else { return nil }
-        let player: PlayerDetailDTO = try await client.get("/v1/players/\(myId.uuidString)")
-        return MyRecord(
-            wins: player.wins,
-            losses: player.losses,
-            rating: player.rating.map { Int($0.rounded()) },
-            form: player.form
+    /// The global match feed, optionally narrowed by lifecycle `status` and a
+    /// player-name search `query` (both server-side, mirroring the web `/matches`
+    /// filters). Returns the rows plus the per-status counts that drive the tab
+    /// badges.
+    func listMatches(
+        status: APIMatchStatus? = nil,
+        query: String? = nil,
+        page: Int = 1,
+        pageSize: Int = 50
+    ) async throws -> MatchListPage {
+        var items: [URLQueryItem] = [
+            URLQueryItem(name: "page", value: String(page)),
+            URLQueryItem(name: "page_size", value: String(pageSize)),
+        ]
+        if let status {
+            items.append(URLQueryItem(name: "status", value: status.rawValue))
+        }
+        if let query, !query.trimmingCharacters(in: .whitespaces).isEmpty {
+            items.append(URLQueryItem(name: "q", value: query))
+        }
+        let response: MatchListResponseDTO = try await client.get("/v1/matches", query: items)
+        return MatchListPage(
+            items: response.items.map(Self.finalMatch(from:)),
+            statusCounts: response.statusCounts
         )
     }
 
@@ -167,6 +161,7 @@ struct MatchService {
         createdAt: Date, canConfirm: Bool, ratedHint: Bool?,
         games: [MatchGameDTO]?, h2h: H2HDTO?, signaturesPosted: Bool?
     ) -> FinalMatch {
+        let viewerIsParticipant = sides.contains(where: \.isCurrentUserSide)
         let mine = sides.first(where: \.isCurrentUserSide) ?? sides.first
         let theirs = sides.first { $0.sideNumber != mine?.sideNumber }
         let mineIsSide1 = (mine?.sideNumber ?? 1) == 1
@@ -191,6 +186,25 @@ struct MatchService {
                 rating: theirs?.ratingChange?.before.map { Int($0.rounded()) } ?? 1500,
                 userId: theirs?.players.first?.userId
             )
+
+        // Side-ordered players for the neutral list row — built straight from
+        // the side, independent of the viewer-relative you/them projection, so a
+        // spectator row shows both real participants rather than labelling side 1
+        // "You". This projection is deliberately viewer-agnostic, so `you` stays
+        // false; the viewer-relative `you`/`opponent` fields carry that flag
+        // instead. A player-less side (solo opponent) reads as the Guest sentinel.
+        func sidePlayer(_ side: MatchSideDTO?) -> MatchPlayer {
+            guard let p = side?.players.first else { return .guest }
+            return MatchPlayer(
+                handle: p.username,
+                initials: p.username.fmInitials,
+                avatarColor: MatchPlayer.avatarColor(for: p.username),
+                rating: side?.ratingChange?.before.map { Int($0.rounded()) } ?? 1500,
+                userId: p.userId
+            )
+        }
+        let side1 = sides.first { $0.sideNumber == 1 } ?? sides.first
+        let side2 = sides.first { $0.sideNumber == 2 }
 
         let mappedGames: [Game] = (games ?? [])
             .sorted { $0.gameNumber < $1.gameNumber }
@@ -219,14 +233,21 @@ struct MatchService {
             rated: rated,
             setsWon: SetScore(a: mine?.gamesWon ?? 0, b: theirs?.gamesWon ?? 0),
             win: mine?.won ?? false,
-            ratingDelta: (rated && decided) ? delta : nil,
+            // Rating delta is the viewer's own change — only meaningful when the
+            // viewer actually played in this match.
+            ratingDelta: (rated && decided && viewerIsParticipant) ? delta : nil,
             when: relativeWhen(createdAt),
             context: rated ? "Rated · \(league.name)" : "Casual",
             statusLabel: statusLabel,
             decided: decided,
             awaitingConfirmation: awaitingConfirmation,
             canConfirm: canConfirm,
-            h2h: h2h.map { mapH2H($0, mineIsSide1: mineIsSide1) }
+            h2h: h2h.map { mapH2H($0, mineIsSide1: mineIsSide1) },
+            sideA: sidePlayer(side1),
+            sideB: (side2?.players.isEmpty ?? true) ? .guest : sidePlayer(side2),
+            sideAGames: side1?.gamesWon ?? 0,
+            sideBGames: side2?.gamesWon ?? 0,
+            viewerIsParticipant: viewerIsParticipant
         )
     }
 
@@ -268,23 +289,5 @@ struct MatchService {
         }
         if cal.isDateInYesterday(date) { return "Yesterday" }
         return dayFormatter.string(from: date)
-    }
-}
-
-/// Current user's season record, derived from their player profile.
-struct MyRecord {
-    let wins: Int
-    let losses: Int
-    let rating: Int?
-    let form: String   // newest-first "WLWWL"
-
-    var total: Int { wins + losses }
-    var winRate: Int { total == 0 ? 0 : Int((Double(wins) / Double(total) * 100).rounded()) }
-
-    /// Leading run of the form string, e.g. "WWL" → "2W". "—" when no matches.
-    var streak: String {
-        guard let first = form.first else { return "—" }
-        let n = form.prefix { $0 == first }.count
-        return "\(n)\(first)"
     }
 }

--- a/ios/Fortymm/Matches/MatchesListView.swift
+++ b/ios/Fortymm/Matches/MatchesListView.swift
@@ -1,36 +1,33 @@
 import SwiftUI
 
-/// The Matches tab: season-record header, a wins/losses filter, and the list of
-/// the current user's matches (newest first). Tapping a row opens its detail.
-/// Backed by the API (`GET /v1/matches` for the list, the player profile for the
-/// record); pull-to-refresh and re-entering the tab re-fetch.
+/// The Matches tab: a player search, lifecycle status tabs (All / Live / Up
+/// next / Final, mirroring the web `/matches` filters), and the global match
+/// feed (newest first) with each row showing both participants. Tapping a row
+/// opens its detail. All filtering is server-side via `GET /v1/matches`;
+/// pull-to-refresh and re-entering the tab re-fetch.
 struct MatchesListView: View {
     var service: MatchService = .shared
 
-    @State private var filter = 0   // 0 all · 1 wins · 2 losses
+    @State private var statusTab: StatusTab = .all
+    @State private var query = ""
     @State private var selected: FinalMatch?
 
     @State private var matches: [FinalMatch] = []
-    @State private var record: MyRecord?
+    @State private var statusCounts: [String: Int] = [:]
     @State private var loading = true
-    @State private var inFlight = false
     @State private var errorMessage: String?
-
-    /// Wins/Losses filter only over *decided* matches; pending ones show only
-    /// under "All".
-    private var shown: [FinalMatch] {
-        switch filter {
-        case 1: return matches.filter { $0.decided && $0.win }
-        case 2: return matches.filter { $0.decided && !$0.win }
-        default: return matches
-        }
-    }
+    /// Coalesces overlapping fetches (tab switch racing a search) — each reload
+    /// cancels the previous so the latest filter always wins.
+    @State private var loadTask: Task<Void, Never>?
+    /// Debounce handle for the search field so each keystroke doesn't fire a
+    /// request.
+    @State private var searchTask: Task<Void, Never>?
 
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
-                recordCard
-                filterBar
+                searchField
+                statusTabs
                 listCard
             }
             .padding(.horizontal, 16)
@@ -41,79 +38,97 @@ struct MatchesListView: View {
         .refreshable { await load() }
         // onAppear (not task) so returning to the tab after posting a match
         // re-fetches and surfaces it at the top.
-        .onAppear { Task { await load() } }
+        .onAppear { reload() }
+        .onChange(of: query) { _, _ in
+            searchTask?.cancel()
+            searchTask = Task {
+                try? await Task.sleep(for: .milliseconds(350))
+                if !Task.isCancelled { reload() }
+            }
+        }
         .fullScreenCover(item: $selected) { match in
-            MatchDetailView(initial: match, onBack: { selected = nil }, onAgain: { selected = nil })
+            MatchDetailView(initial: match, onBack: { selected = nil })
         }
     }
 
-    /// Fetch the match list and the season record together. Shows a spinner
-    /// only on the first load; refreshes keep the existing content in place.
+    private func reload() {
+        loadTask?.cancel()
+        loadTask = Task { await load() }
+    }
+
+    /// Fetch the match list for the active status tab + search. Shows a spinner
+    /// only on the first load; refreshes keep the existing content in place. A
+    /// cancelled (superseded) fetch drops its result rather than overwriting a
+    /// newer one.
     private func load() async {
-        guard !inFlight else { return }
-        inFlight = true
-        defer { inFlight = false }
         if matches.isEmpty { loading = true }
         do {
-            // Independent calls — run them concurrently.
-            async let list = service.listMatches()
-            async let rec = service.myRecord()
-            matches = try await list
-            record = try await rec
+            let page = try await service.listMatches(status: statusTab.apiStatus, query: query)
+            if Task.isCancelled { return }
+            matches = page.items
+            statusCounts = page.statusCounts
             errorMessage = nil
         } catch {
+            if Task.isCancelled { return }
             errorMessage = error.fmMessage
         }
         loading = false
     }
 
-    private var recordCard: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Eyebrow("Season record")
-                .padding(.bottom, 10)
-            HStack(alignment: .top) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text("\(record?.wins ?? 0)").foregroundStyle(FMColor.fg1)
-                    Text("–").foregroundStyle(FMColor.ink500)
-                    Text("\(record?.losses ?? 0)").foregroundStyle(FMColor.fg1)
+    private func count(for tab: StatusTab) -> Int {
+        guard let key = tab.countKey else { return statusCounts.values.reduce(0, +) }
+        return statusCounts[key] ?? 0
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 9) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 16, weight: .regular))
+                .foregroundStyle(FMColor.fg3)
+            TextField("", text: $query, prompt: Text("Search players").foregroundStyle(FMColor.fgMuted))
+                .font(FMFont.ui(15, weight: .medium))
+                .foregroundStyle(FMColor.fg1)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+            if !query.isEmpty {
+                Button { query = "" } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 16))
+                        .foregroundStyle(FMColor.fgMuted)
                 }
-                .font(FMFont.mono(56, weight: .bold))
-                Spacer()
-                VStack(alignment: .trailing, spacing: 4) {
-                    Text("\(record?.winRate ?? 0)%")
-                        .font(FMFont.mono(28, weight: .bold))
-                        .foregroundStyle(FMColor.serve500)
-                    Eyebrow("Win rate")
-                }
+                .buttonStyle(.plain)
             }
-            HStack(spacing: 18) {
-                stat("Current streak", record?.streak ?? "—", FMColor.serve500)
-                stat("This season", "\(record?.total ?? 0) logged", FMColor.fg1)
-            }
-            .padding(.top, 14)
         }
-        .padding(18)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .frame(height: 44)
         .background(FMColor.ink800)
-        .fmRoundedBorder(radius: 16, color: FMColor.borderSubtle)
+        .fmRoundedBorder(radius: FMRadius.md, color: FMColor.borderDefault)
+        .padding(.top, 18)
+        .padding(.bottom, 12)
     }
 
-    private func stat(_ label: String, _ value: String, _ color: Color) -> some View {
-        (Text(label + " ").font(FMFont.ui(13)).foregroundStyle(FMColor.fg3)
-            + Text(value).font(FMFont.mono(13, weight: .semibold)).foregroundStyle(color))
-    }
-
-    private var filterBar: some View {
+    private var statusTabs: some View {
         HStack(spacing: 4) {
-            ForEach(Array(["All", "Wins", "Losses"].enumerated()), id: \.offset) { i, label in
-                Button { filter = i } label: {
-                    Text(label)
-                        .font(FMFont.ui(14, weight: .semibold))
-                        .foregroundStyle(filter == i ? FMColor.fg1 : FMColor.fg3)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 10)
-                        .background(filter == i ? FMColor.ink600 : Color.clear)
-                        .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+            ForEach(StatusTab.allCases) { tab in
+                let active = tab == statusTab
+                Button {
+                    guard tab != statusTab else { return }
+                    statusTab = tab
+                    reload()
+                } label: {
+                    HStack(spacing: 5) {
+                        Text(tab.label).font(FMFont.ui(13, weight: .semibold))
+                        Text("\(count(for: tab))")
+                            .font(FMFont.mono(12, weight: .semibold))
+                            .foregroundStyle(active ? FMColor.fg3 : FMColor.fgMuted)
+                    }
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+                    .foregroundStyle(active ? FMColor.fg1 : FMColor.fg3)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background(active ? FMColor.ink600 : Color.clear)
+                    .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
                 }
                 .buttonStyle(.plain)
             }
@@ -121,7 +136,7 @@ struct MatchesListView: View {
         .padding(5)
         .background(FMColor.ink800)
         .fmRoundedBorder(radius: 13, color: FMColor.borderSubtle)
-        .padding(.vertical, 18)
+        .padding(.bottom, 18)
     }
 
     @ViewBuilder
@@ -135,12 +150,12 @@ struct MatchesListView: View {
                     .padding(.vertical, 40)
             } else if let errorMessage {
                 listNote(errorMessage)
-            } else if shown.isEmpty {
-                listNote(matches.isEmpty ? "Nothing here yet. Go play." : "No matches in this filter.")
+            } else if matches.isEmpty {
+                listNote(emptyMessage)
             } else {
-                ForEach(Array(shown.enumerated()), id: \.element.id) { i, m in
+                ForEach(Array(matches.enumerated()), id: \.element.id) { i, m in
                     MatchRow(match: m) { selected = m }
-                    if i < shown.count - 1 { Divider().overlay(FMColor.ink700) }
+                    if i < matches.count - 1 { Divider().overlay(FMColor.ink700) }
                 }
             }
         }
@@ -157,21 +172,80 @@ struct MatchesListView: View {
             .padding(.vertical, 40)
             .padding(.horizontal, 16)
     }
+
+    private var emptyMessage: String {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty { return "No matches for “\(trimmed)”." }
+        if statusTab != .all { return "No \(statusTab.label.lowercased()) matches." }
+        return "Nothing here yet. Go play."
+    }
+}
+
+/// Lifecycle filter tabs, mirroring the web `/matches` status tabs. The
+/// `apiStatus` is sent as the `status` query param (nil = no filter); the
+/// `countKey` indexes the server's `status_counts` for the tab badge.
+private enum StatusTab: CaseIterable, Identifiable {
+    case all, live, upNext, final
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .all: return "All"
+        case .live: return "Live"
+        case .upNext: return "Up next"
+        case .final: return "Final"
+        }
+    }
+
+    var apiStatus: APIMatchStatus? {
+        switch self {
+        case .all: return nil
+        case .live: return .inProgress
+        case .upNext: return .pending
+        case .final: return .completed
+        }
+    }
+
+    /// `status_counts` key for this tab's badge — derived from `apiStatus` so the
+    /// filter value and the count lookup can't drift apart. Nil for "All", which
+    /// sums every status instead.
+    var countKey: String? { apiStatus?.rawValue }
 }
 
 private struct MatchRow: View {
     let match: FinalMatch
     let onOpen: () -> Void
 
-    /// Outcome tint: green win / red loss once decided, amber while pending.
-    private var tint: Color {
-        guard match.decided else { return FMColor.warn }
-        return match.win ? FMColor.serve500 : FMColor.loss
+    /// How this row reads to the viewer: still in flight, one the viewer only
+    /// spectated, or their own decided win/loss. `tint` and `badge` are both pure
+    /// functions of this, so the pending/spectator/own classification lives once.
+    private enum Outcome { case pending, spectated, won, lost }
+    private var outcome: Outcome {
+        guard match.decided else { return .pending }
+        guard match.viewerIsParticipant else { return .spectated }
+        return match.win ? .won : .lost
     }
-    /// Single-glyph badge: W / L when decided, a dot while awaiting confirmation.
+
+    /// Outcome tint: amber while pending, neutral for a spectated match, the
+    /// viewer's own win/loss in green/red.
+    private var tint: Color {
+        switch outcome {
+        case .pending: return FMColor.warn
+        case .spectated: return FMColor.fg3
+        case .won: return FMColor.serve500
+        case .lost: return FMColor.loss
+        }
+    }
+    /// Single-glyph badge: a dot while awaiting confirmation, a neutral check for
+    /// a spectated decided match, W / L for the viewer's own decided matches.
     private var badge: String {
-        guard match.decided else { return "•" }
-        return match.win ? "W" : "L"
+        switch outcome {
+        case .pending: return "•"
+        case .spectated: return "✓"
+        case .won: return "W"
+        case .lost: return "L"
+        }
     }
 
     var body: some View {
@@ -188,9 +262,12 @@ private struct MatchRow: View {
                         .foregroundStyle(tint)
                 }
                 VStack(alignment: .leading, spacing: 1) {
-                    Text("vs \(match.opponent.handle)")
+                    // Both participants, side-1-first — this list is a global feed,
+                    // so the viewer often isn't one of them.
+                    (Text(match.sideA.handle).foregroundStyle(FMColor.fg1)
+                        + Text(" vs ").foregroundStyle(FMColor.fg3)
+                        + Text(match.sideB.handle).foregroundStyle(FMColor.fg1))
                         .font(FMFont.ui(15, weight: .semibold))
-                        .foregroundStyle(FMColor.fg1)
                         .lineLimit(1)
                     Text("\(match.when) · \(subtitle)")
                         .font(FMFont.ui(12.5))
@@ -200,9 +277,9 @@ private struct MatchRow: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 VStack(alignment: .trailing, spacing: 0) {
                     HStack(spacing: 2) {
-                        Text("\(match.setsWon.a)")
+                        Text("\(match.sideAGames)")
                         Text("–").foregroundStyle(FMColor.fgMuted)
-                        Text("\(match.setsWon.b)")
+                        Text("\(match.sideBGames)")
                     }
                     .font(FMFont.mono(18, weight: .bold))
                     .foregroundStyle(FMColor.fg1)

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -338,7 +338,7 @@ function MatchTable({
         </div>
         <div className="empty-title">No matches yet</div>
         <div className="empty-sub">
-          Start a new match or clear the filters to see your history.
+          Start a new match or clear the filters to see what's being played.
         </div>
         <Button
           variant="ghost"


### PR DESCRIPTION
## Why

`/matches` is a **global feed** of every user's matches (see #435), but the iOS Matches tab framed it as the signed-in user's personal history — "vs Opponent", a personal W/L per row, and a "Season record" card. On a global feed most rows aren't yours, so that framing was wrong (and the season card silently showed 0–0). This reframes the tab around what the endpoint actually returns.

## Changes

**iOS — Matches list**
- **Both participants per row** (`sideA vs sideB`) with a neutral side-ordered score. The W/L badge and rating delta now appear **only for the viewer's own matches**; matches you only spectated get a neutral ✓.
- **Server-side filters mirroring the web** `/matches`: a debounced **"Search players"** box (`q`) and **status tabs — All / Live / Up next / Final** with live counts from `status_counts`.
- **Removed the Season Record card** and its client-side `myRecord()` hack (it discovered your user id from the first list row — broken on a global feed), plus the now-unused `MyRecord` / `PlayerDetailDTO`.

**iOS — Match detail**
- **Removed the "Log another" button** (footer is now a full-width "Back to matches"), along with the now-dead `onAgain` / `resetForAnother` wiring.

**Web**
- Reworded the `/matches` empty-state copy off "your history" to match the global feed (per #435, option: keep global + fix the framing).

## Testing

Built and run in the iOS simulator against UAT: verified both-participant rows, the W/L-vs-✓ badge distinction, server-side status filtering (Final tab → completed only, counts from the server), the season card gone, and the detail footer with no "Log another".

Closes #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)