### PR TITLE
Serialize match sign-off transitions with a row lock (fixes #365)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1267,11 +1267,38 @@ async def _commit_canonical_games(
 # ----- scoring endpoints ---------------------------------------------------
 
 
+async def _lock_match_row(db: AsyncSession, match_id: uuid.UUID) -> None:
+    """Take a transaction-scoped row lock on the ``matches`` row so the
+    sign-off transitions (``/results``, ``/confirmation``, ``/dispute``)
+    serialize against each other.
+
+    Without this, a participant firing ``/confirmation`` and ``/dispute``
+    concurrently lets both transactions pass ``_enforce_confirmable`` on the
+    same pre-image and both commit — finalizing the match with ``won=None``,
+    a single signature, and a rating change applied (issue #365). The lock
+    forces the second transaction to wait for the first to commit and then
+    re-read the post-image, so its guard returns a clean 409.
+
+    It's a thin ``SELECT matches.id ... FOR UPDATE`` rather than locking the
+    full eager query: ``match_eager_options`` outer-joins nullable child rows
+    (sides without players, gameless matches), which Postgres refuses to lock
+    (``FOR UPDATE cannot be applied to the nullable side of an outer join``).
+    Locking just the parent row is enough — every sign-off transition reads
+    and writes that match's children under cover of this lock."""
+    await db.execute(select(Match.id).where(Match.id == match_id).with_for_update())
+
+
 async def _load_match_for_scoring(
     db: AsyncSession,
     match_id: uuid.UUID,
     current_user_id: uuid.UUID,
+    *,
+    lock: bool = False,
 ) -> Match:
+    # ``lock`` callers (the sign-off transitions) take the row lock *before*
+    # the eager load so the match state they read is the serialized one.
+    if lock:
+        await _lock_match_row(db, match_id)
     match = await _load_match(db, match_id)
     if match is None or not _is_participant(match, current_user_id):
         raise HTTPException(status_code=404, detail="Match not found.")
@@ -1410,7 +1437,7 @@ async def post_match_result(
     or ``POST /dispute``, and the rating update fires inside /confirmation
     when the final signature lands. Solo matches (one side player-less)
     finalize immediately here, since there's no second party to attest."""
-    match = await _load_match_for_scoring(db, match_id, current_user.id)
+    match = await _load_match_for_scoring(db, match_id, current_user.id, lock=True)
     _enforce_scorable(match)
 
     try:
@@ -1455,7 +1482,7 @@ async def confirm_match_result(
     """Sign off on a posted result. When this is the last signature needed
     (every side has at least one signing player) the match flips to
     ``completed`` and the rating update runs — exactly once."""
-    match = await _load_match_for_scoring(db, match_id, current_user.id)
+    match = await _load_match_for_scoring(db, match_id, current_user.id, lock=True)
     _enforce_confirmable(match, current_user.id)
 
     await _add_signature_or_409(
@@ -1492,7 +1519,7 @@ async def dispute_match_result(
     place so the disputer can navigate to the contested game and PUT a
     corrected score. The per-game endpoints unblock automatically once
     signatures are empty (see ``_enforce_scorable``)."""
-    match = await _load_match_for_scoring(db, match_id, current_user.id)
+    match = await _load_match_for_scoring(db, match_id, current_user.id, lock=True)
     _enforce_confirmable(match, current_user.id)
 
     match.signatures.clear()

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1279,12 +1279,14 @@ async def _lock_match_row(db: AsyncSession, match_id: uuid.UUID) -> None:
     forces the second transaction to wait for the first to commit and then
     re-read the post-image, so its guard returns a clean 409.
 
-    It's a thin ``SELECT matches.id ... FOR UPDATE`` rather than locking the
-    full eager query: ``match_eager_options`` outer-joins nullable child rows
-    (sides without players, gameless matches), which Postgres refuses to lock
-    (``FOR UPDATE cannot be applied to the nullable side of an outer join``).
-    Locking just the parent row is enough — every sign-off transition reads
-    and writes that match's children under cover of this lock."""
+    It's a thin ``SELECT matches.id ... FOR UPDATE`` rather than adding
+    ``.with_for_update()`` to the eager ``_load_match`` query: a narrow
+    lock-only select is cheaper than re-running ``match_eager_options`` (which
+    fans out into a selectinload query per relationship) just to take the lock,
+    and acquiring it on its own line makes the lock-then-read ordering explicit
+    — the subsequent load sees the serialized state. Locking just the parent
+    row is enough — every sign-off transition reads and writes that match's
+    children under cover of this lock."""
     await db.execute(select(Match.id).where(Match.id == match_id).with_for_update())
 
 

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1,5 +1,6 @@
 import asyncio
 import uuid
+from collections.abc import Awaitable, Callable
 
 import pytest
 from fastapi import HTTPException
@@ -1849,18 +1850,20 @@ async def test_concurrent_confirm_and_dispute_serialize(
         match_id = uuid.UUID(match["id"])
         opp_id = opp.id
 
-        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        make_session = async_sessionmaker(engine, expire_on_commit=False)
 
-        async def run(handler: object) -> object:
+        async def run(
+            handler: Callable[[uuid.UUID, User, AsyncSession], Awaitable[object]],
+        ) -> object:
             # Each racer gets its own session/connection, mirroring two
             # concurrent requests. Return the HTTP status on rejection so the
             # assertions can tell winner from loser.
-            async with sessionmaker() as session:
+            async with make_session() as session:
                 opp_user = (
                     await session.execute(select(User).where(User.id == opp_id))
                 ).scalar_one()
                 try:
-                    await handler(match_id, opp_user, session)  # type: ignore[operator]
+                    await handler(match_id, opp_user, session)
                     return "ok"
                 except HTTPException as exc:
                     return exc.status_code
@@ -1874,8 +1877,7 @@ async def test_concurrent_confirm_and_dispute_serialize(
         assert sorted(str(o) for o in outcomes) == ["409", "ok"], outcomes
 
         # The committed match holds its invariants no matter which won.
-        sm = async_sessionmaker(engine, expire_on_commit=False)
-        async with sm() as verify:
+        async with make_session() as verify:
             final = (
                 await verify.execute(
                     select(Match)

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1,11 +1,14 @@
+import asyncio
 import uuid
 
 import pytest
+from fastapi import HTTPException
 from httpx import AsyncClient
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
+from app.matches import confirm_match_result, dispute_match_result
 from app.models import (
     League,
     LeagueVisibility,
@@ -13,6 +16,8 @@ from app.models import (
     MatchGame,
     MatchGameScore,
     MatchSide,
+    MatchStatus,
+    User,
 )
 from tests._helpers import make_client, make_user, opponent_session, start_session
 
@@ -1815,3 +1820,77 @@ async def test_list_row_can_confirm_flag_for_pending_signer(
         opp_list = (await opp_client.get("/v1/matches")).json()
         opp_row = next(r for r in opp_list["items"] if r["id"] == match["id"])
         assert opp_row["can_confirm"] is True
+
+
+async def test_concurrent_confirm_and_dispute_serialize(
+    api_client: AsyncClient, db_session: AsyncSession, engine: AsyncEngine
+):
+    """Regression for #365. The opponent firing ``POST /confirmation`` and
+    ``POST /dispute`` at the same instant must not corrupt the match.
+
+    Before the row lock in ``_load_match_for_scoring(..., lock=True)`` both
+    transactions read the same pre-image, both passed ``_enforce_confirmable``,
+    and both committed — leaving a ``completed`` match with ``won=None`` on
+    both sides, a single signature, and a rating change applied. The lock
+    serializes them: exactly one transition wins, the other re-reads the
+    committed post-image and 409s, and the match invariants always hold.
+
+    This drives the two route handlers on *separate* DB sessions (real
+    distinct Postgres connections) via ``asyncio.gather`` so the ``FOR UPDATE``
+    actually blocks — the shared ``db_session`` override can't surface the race.
+    """
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "race-opp") as (_opp_client, opp):
+        # Set up a rated best-of-1 in "Awaiting confirmation": creator posts a
+        # decided result, leaving the opponent owing a signature. These HTTP
+        # calls commit, so fresh sessions on the same engine see the rows.
+        match = await _create_match(api_client, opp.id, best_of=1)
+        await _post_results(api_client, match["id"], best_of=1)
+        match_id = uuid.UUID(match["id"])
+        opp_id = opp.id
+
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+
+        async def run(handler: object) -> object:
+            # Each racer gets its own session/connection, mirroring two
+            # concurrent requests. Return the HTTP status on rejection so the
+            # assertions can tell winner from loser.
+            async with sessionmaker() as session:
+                opp_user = (
+                    await session.execute(select(User).where(User.id == opp_id))
+                ).scalar_one()
+                try:
+                    await handler(match_id, opp_user, session)  # type: ignore[operator]
+                    return "ok"
+                except HTTPException as exc:
+                    return exc.status_code
+
+        outcomes = await asyncio.gather(
+            run(confirm_match_result), run(dispute_match_result)
+        )
+
+        # Exactly one transition wins; the other is cleanly rejected (409),
+        # never a second silent success.
+        assert sorted(str(o) for o in outcomes) == ["409", "ok"], outcomes
+
+        # The committed match holds its invariants no matter which won.
+        sm = async_sessionmaker(engine, expire_on_commit=False)
+        async with sm() as verify:
+            final = (
+                await verify.execute(
+                    select(Match)
+                    .where(Match.id == match_id)
+                    .options(selectinload(Match.sides), selectinload(Match.signatures))
+                )
+            ).scalar_one()
+            sides = sorted(final.sides, key=lambda s: s.side_number)
+            if final.status == MatchStatus.completed:
+                # Confirm won: a real outcome and both signatures present.
+                assert {s.won for s in sides} == {True, False}, [s.won for s in sides]
+                assert len(final.signatures) == 2
+            else:
+                # Dispute won: rewound to in_progress with no live signatures
+                # and no recorded winner.
+                assert final.status == MatchStatus.in_progress
+                assert final.signatures == []
+                assert [s.won for s in sides] == [None, None]


### PR DESCRIPTION
## Problem

A participant firing `POST /v1/matches/{id}/confirmation` and `POST /v1/matches/{id}/dispute` concurrently corrupts a rated match. Both transactions read the same pre-image, both pass `_enforce_confirmable`, and both commit — leaving:

- status `completed` / **Final**
- `won = None` on **both** sides
- only **1** signature (should be 2)
- **rating change applied** anyway

**Reproduced 12/12 on uat.fortymm.com** (deterministically — the unguarded transitions lose the race every time): every trial returned `confirm=201` *and* `dispute=200`, ending `completed` with `sigs=1`, `won_null=2`, and the opponent's rating moved off baseline while their W-L record (derived from the now-null `won`) stayed `0–0`.

## Fix

Take a transaction-scoped `SELECT matches.id ... FOR UPDATE` at the top of the three sign-off transitions (`/results`, `/confirmation`, `/dispute`) via a new `_load_match_for_scoring(..., lock=True)`. The transitions now serialize: one wins, the other waits for the commit, re-reads the post-image, and its existing guard returns a clean **409** (`"This match is no longer awaiting confirmation"` / `"No posted result to act on"`). Match invariants always hold.

It's a thin parent-row lock rather than locking the eager query, because `match_eager_options` outer-joins nullable children (sides without players, gameless matches) which Postgres refuses to lock (`FOR UPDATE cannot be applied to the nullable side of an outer join`). Locking the parent row is sufficient — every sign-off transition reads and writes that match's children under cover of the lock.

The per-game scratchpad writes are intentionally left unlocked (their concurrent-500 is a separate issue, #362).

## Tests

Adds `test_concurrent_confirm_and_dispute_serialize` — races the two handlers on **separate DB sessions** (real distinct Postgres connections) via `asyncio.gather`, since the shared-`db_session` test override can't surface a row-lock race. Verified it **fails on the old code** (`['ok', 'ok']` — both succeed, reproducing the corruption in-process) and **passes with the lock** (one `ok`, one `409`).

`ruff`, `ruff format --check`, `mypy --strict`, and the full `test_matches.py` + `test_ratings.py` suites (102 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)