### PR TITLE
iOS: resume & finalize stranded live matches (fixes #445)

### DIFF
--- a/ios/Fortymm/Components/ViewModifiers.swift
+++ b/ios/Fortymm/Components/ViewModifiers.swift
@@ -9,4 +9,39 @@ extension View {
             )
             .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
     }
+
+    /// Run `action` whenever the app returns to the foreground. `.onChange`
+    /// doesn't fire for the initial `.active` value, so this only triggers on a
+    /// real background/inactive → active transition — used by the dashboard,
+    /// matches list, and match detail to pick up cross-device changes.
+    func refetchOnForeground(_ action: @escaping () -> Void) -> some View {
+        modifier(RefetchOnForeground(action: action))
+    }
+
+    /// Present the resume-scoring flow over this view, driven by `item`. On
+    /// dismissal it clears `item` and runs `onFinish` (the surface's refetch),
+    /// so a resumed/posted match is reflected instead of the stale pre-resume
+    /// copy. Centralizes the three identical resume covers.
+    func resumeScoringCover(
+        _ item: Binding<ResumeScoring?>,
+        onFinish: @escaping () -> Void
+    ) -> some View {
+        fullScreenCover(item: item) { ctx in
+            MatchFlowView(resume: ctx) { _ in
+                item.wrappedValue = nil
+                onFinish()
+            }
+        }
+    }
+}
+
+private struct RefetchOnForeground: ViewModifier {
+    @Environment(\.scenePhase) private var scenePhase
+    let action: () -> Void
+
+    func body(content: Content) -> some View {
+        content.onChange(of: scenePhase) { _, phase in
+            if phase == .active { action() }
+        }
+    }
 }

--- a/ios/Fortymm/Dashboard/DashboardStore.swift
+++ b/ios/Fortymm/Dashboard/DashboardStore.swift
@@ -22,23 +22,30 @@ final class DashboardStore: ObservableObject {
         self.client = client
     }
 
-    /// Fetch (or refetch) the dashboard. Skips the network call once loaded
-    /// unless `force` is set, so re-entering the tab doesn't refetch; pull to
-    /// refresh passes `force: true`.
+    /// Fetch (or refetch) the dashboard. Without `force`, skips the call once
+    /// loaded; with `force` (re-entering the tab, pull-to-refresh, or after a
+    /// score is posted) it refetches *in place* — the existing content stays on
+    /// screen and is swapped only when the new data arrives, so re-appearing the
+    /// tab doesn't flash the loading card. A transient forced-refresh failure
+    /// keeps the good content rather than replacing it with an error.
     ///
     /// `GET /v1/dashboard` requires auth, but the session gate guarantees the
     /// session cookie is already minted and stored before this screen renders,
     /// so there's no need to fetch the session here first.
     func load(force: Bool = false) async {
-        if case .loaded = state, !force { return }
         if case .loading = state { return }
+        let alreadyLoaded: Bool
+        if case .loaded = state { alreadyLoaded = true } else { alreadyLoaded = false }
+        if alreadyLoaded && !force { return }
 
-        state = .loading
+        if !alreadyLoaded { state = .loading }
         do {
             let dashboard: DashboardResponse = try await client.get("/v1/dashboard")
             state = .loaded(dashboard)
         } catch {
-            state = .failed(error.fmMessage)
+            // Only surface the error when there's nothing already on screen;
+            // a failed background refresh shouldn't blank a working dashboard.
+            if !alreadyLoaded { state = .failed(error.fmMessage) }
         }
     }
 }

--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -8,8 +8,23 @@ import SwiftUI
 /// environment, so the greeting reads the username from there rather than
 /// refetching it.
 struct DashboardView: View {
+    /// Most "Score needed" banners to show inline before collapsing the rest
+    /// into a "+N more" link (mirrors the web's primary + secondary + more).
+    private static let maxBanners = 2
+
     @EnvironmentObject private var session: SessionStore
     @StateObject private var store = DashboardStore()
+    var service: MatchService = .shared
+    /// Called by the "+N more" banner overflow link to send the user to the
+    /// Matches tab, filtered to their live (score-needed) matches. The argument
+    /// is the current username, used as the list's search filter. Nil in previews.
+    var onShowAllScores: ((String?) -> Void)? = nil
+
+    /// Non-nil while the resume-scoring flow is presented over the dashboard;
+    /// `resumeLoading` covers the brief fetch of the full match (the banner
+    /// carries only the id, opponent, and current game number).
+    @State private var resuming: ResumeScoring?
+    @State private var resumeLoading = false
 
     private static let longDate: DateFormatter = {
         let f = DateFormatter()
@@ -18,19 +33,45 @@ struct DashboardView: View {
     }()
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: FMSpace.s6) {
-                header(greeting: greeting)
-                content
+        ZStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: FMSpace.s6) {
+                    header(greeting: greeting)
+                    content
+                }
+                .padding(.horizontal, FMSpace.s5)
+                // Top inset for the shell's frosted bar is reserved by `.fmTopBar`.
+                .padding(.bottom, FMSpace.s6)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .padding(.horizontal, FMSpace.s5)
-            // Top inset for the shell's frosted bar is reserved by `.fmTopBar`.
-            .padding(.bottom, FMSpace.s6)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(FMColor.bgApp.ignoresSafeArea())
+            .refreshable { await store.load(force: true) }
+            // onAppear (not task) so returning to the Home tab after posting /
+            // resuming a match re-fetches — clearing a stale "Score needed"
+            // banner and refreshing recent results. force: true silently
+            // refreshes in place once content is loaded.
+            .onAppear { Task { await store.load(force: true) } }
+            // Returning to the foreground may surface cross-device changes (a
+            // match the other player just confirmed) — refetch in place.
+            .refetchOnForeground { Task { await store.load(force: true) } }
+
+            if resumeLoading { FMBlockingSpinner() }
         }
-        .background(FMColor.bgApp.ignoresSafeArea())
-        .refreshable { await store.load(force: true) }
-        .task { await store.load() }
+        // The match just changed (result posted / games entered) — refetch so the
+        // score banner clears and the recent results update.
+        .resumeScoringCover($resuming) { Task { await store.load(force: true) } }
+    }
+
+    /// Fetch the full match behind a score banner and open the resume flow.
+    /// Falls back silently if the match can no longer be scored.
+    private func openResume(_ matchId: UUID) {
+        guard !resumeLoading else { return }
+        resumeLoading = true
+        Task {
+            let detail = try? await service.matchDetails(matchId)
+            resumeLoading = false
+            if let ctx = detail?.resumeContext { resuming = ctx }
+        }
     }
 
     @ViewBuilder
@@ -53,6 +94,13 @@ struct DashboardView: View {
         return "Hi"
     }
 
+    /// The signed-in username, used to filter the matches list when the user
+    /// taps "+N more to score". Nil if the session isn't resolved.
+    private var currentUsername: String? {
+        if case let .loaded(user) = session.state { return user.username }
+        return nil
+    }
+
     private func header(greeting: String) -> some View {
         VStack(alignment: .leading, spacing: FMSpace.s2) {
             DashOverline(text: "Dashboard · \(Self.longDate.string(from: Date()))")
@@ -65,6 +113,20 @@ struct DashboardView: View {
     @ViewBuilder
     private func yourGame(_ data: DashboardResponse) -> some View {
         VStack(alignment: .leading, spacing: FMSpace.s4) {
+            // Top-priority: matches stranded mid-scoring that need the user to
+            // finish entering a result (issue #445). Mirrors the web dashboard's
+            // "Score needed" banners — capped so a backlog of stranded matches
+            // doesn't bury the rest of the dashboard; the overflow link sends the
+            // user to the Matches tab to work through the rest.
+            ForEach(data.scoreBanners.prefix(Self.maxBanners), id: \.matchId) { banner in
+                ScoreNeededBanner(banner: banner) { openResume(banner.matchId) }
+            }
+            if data.scoreBanners.count > Self.maxBanners {
+                MorePendingLink(count: data.scoreBanners.count - Self.maxBanners) {
+                    onShowAllScores?(currentUsername)
+                }
+            }
+
             HStack(alignment: .firstTextBaseline, spacing: FMSpace.s3) {
                 Text("Your game")
                     .font(FMFont.ui(FMFont.md, weight: .semibold))
@@ -125,6 +187,68 @@ struct DashboardView: View {
                 }
             }
         }
+    }
+}
+
+/// Dashboard banner for a match stranded mid-scoring — a one-tap path back into
+/// score entry so a Live match the user owns is never permanently stranded
+/// (issue #445). Mirrors the web dashboard's "Score needed" banner.
+private struct ScoreNeededBanner: View {
+    let banner: DashboardScoreBanner
+    let onResume: () -> Void
+
+    var body: some View {
+        FMCard(featured: true) {
+            HStack(alignment: .center, spacing: FMSpace.s4) {
+                VStack(alignment: .leading, spacing: FMSpace.s1) {
+                    HStack(spacing: 7) {
+                        Circle().fill(FMColor.ball500).frame(width: 7, height: 7)
+                            .shadow(color: FMColor.ball500.opacity(0.55), radius: 5)
+                        DashOverline(text: "Score needed")
+                    }
+                    Text(opponentLine)
+                        .font(FMFont.ui(FMFont.md, weight: .semibold))
+                        .foregroundStyle(FMColor.fg1)
+                        .lineLimit(1)
+                    Text("Game \(banner.currentGameNumber) is waiting on a score.")
+                        .font(FMFont.ui(FMFont.sm))
+                        .foregroundStyle(FMColor.fg3)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: FMSpace.s3)
+                FMButton(title: "Enter score", variant: .primary, size: .sm, action: onResume)
+            }
+        }
+    }
+
+    private var opponentLine: String {
+        if let opponent = banner.opponentUsername { return "vs @\(opponent)" }
+        return "Solo match"
+    }
+}
+
+/// Overflow link shown under the capped score banners — "+N more to score" —
+/// routing the user to the Matches tab to clear the rest.
+private struct MorePendingLink: View {
+    let count: Int
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: FMSpace.s2) {
+                Text("+\(count) more to score")
+                    .font(FMFont.ui(FMFont.sm, weight: .semibold))
+                    .foregroundStyle(FMColor.fgAccent)
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(FMColor.fgAccent)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, FMSpace.s1)
+            .padding(.vertical, FMSpace.s1)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/ios/Fortymm/MatchFlow/MatchAPI.swift
+++ b/ios/Fortymm/MatchFlow/MatchAPI.swift
@@ -115,6 +115,12 @@ struct MatchListRowDTO: Decodable {
     let sides: [MatchSideDTO]
     let bestOf: Int
     let createdAt: Date
+    /// Next game to score; nil once every game is scored or the match is
+    /// finalized. Game rows are created lazily, so this is a number, not an id.
+    let currentGameNumber: Int?
+    /// The viewer can enter scores for this (live) match — drives the row's
+    /// "Score" affordance.
+    let canScore: Bool
     let canConfirm: Bool
 }
 

--- a/ios/Fortymm/MatchFlow/MatchDetailView.swift
+++ b/ios/Fortymm/MatchFlow/MatchDetailView.swift
@@ -18,6 +18,8 @@ struct MatchDetailView: View {
     /// A confirm/dispute request is in flight (blocks the footer + dims the UI).
     @State private var actioning = false
     @State private var actionError: String?
+    /// Non-nil while the resume-scoring flow is presented over this screen.
+    @State private var resuming: ResumeScoring?
 
     /// What the screen renders: the freshest copy we have.
     private var match: FinalMatch { live ?? initial }
@@ -50,6 +52,9 @@ struct MatchDetailView: View {
             else { withAnimation(.spring(response: 0.42, dampingFraction: 0.5).delay(0.06)) { reveal = true } }
         }
         .task { await refresh() }
+        // Foregrounding may reveal a cross-device change (the opponent confirmed
+        // or disputed the posted result) — refetch so the status isn't stale.
+        .refetchOnForeground { Task { await refresh(force: true) } }
         .alert(
             "Something went wrong",
             isPresented: Binding(
@@ -61,6 +66,9 @@ struct MatchDetailView: View {
         } message: {
             Text(actionError ?? "")
         }
+        // The match changed underneath us (games posted, or simply more games
+        // entered) — refetch so the detail reflects the new state.
+        .resumeScoringCover($resuming) { Task { await refresh(force: true) } }
     }
 
     /// Sign off on (or dispute) the posted result, then refresh from the server
@@ -68,6 +76,24 @@ struct MatchDetailView: View {
     /// back to live). Surfaces an alert on failure and leaves the screen as-is.
     private func confirm() async { await act { try await service.confirmMatch($0) } }
     private func dispute() async { await act { try await service.disputeMatch($0) } }
+
+    /// Post the result of a match that's been scored to a decision but never
+    /// posted (the `can_finalize` recovery path) — sends the already-saved games
+    /// and refreshes. For a solo match this finalizes immediately; a two-player
+    /// match moves to awaiting the opponent's confirmation.
+    private func finalize() async {
+        guard !actioning, let id = UUID(uuidString: match.id) else { return }
+        actioning = true
+        defer { actioning = false }
+        do {
+            let updated = try await service.postResult(
+                matchId: id, games: match.games, yourSideNumber: match.yourSideNumber
+            )
+            withAnimation { live = updated }
+        } catch {
+            actionError = error.fmMessage
+        }
+    }
 
     private func act(_ run: (UUID) async throws -> FinalMatch) async {
         guard !actioning, let id = UUID(uuidString: match.id) else { return }
@@ -82,12 +108,16 @@ struct MatchDetailView: View {
     }
 
     /// Pull the full detail (games, rating, head-to-head, current status) for
-    /// the match. Skipped when we already hold the full payload (a freshly
-    /// posted result), or for non-server ids (e.g. SwiftUI previews); a list
-    /// row arrives without games, so that path fetches.
-    private func refresh() async {
-        guard initial.games.isEmpty, let id = UUID(uuidString: initial.id) else { return }
-        live = try? await service.matchDetails(id)
+    /// the match. On first load (`force: false`) it's skipped when we already
+    /// hold the full payload (a freshly posted result) or for non-server ids
+    /// (e.g. SwiftUI previews) — a list row arrives without games, so that path
+    /// fetches. `force: true` always refetches: used after an action (resume,
+    /// sign-off) or on foreground, where the held copy is known to be stale.
+    private func refresh(force: Bool = false) async {
+        guard force || initial.games.isEmpty, let id = UUID(uuidString: match.id) else { return }
+        if let updated = try? await service.matchDetails(id) {
+            withAnimation { live = updated }
+        }
     }
 
     // MARK: Breadcrumb
@@ -337,6 +367,10 @@ struct MatchDetailView: View {
         Group {
             if match.canConfirm {
                 confirmFooter
+            } else if match.canFinalize {
+                finalizeFooter
+            } else if let ctx = match.resumeContext {
+                resumeFooter(ctx)
             } else {
                 defaultFooter
             }
@@ -358,19 +392,46 @@ struct MatchDetailView: View {
         }
     }
 
-    /// Default footer: back to the matches list.
-    private var defaultFooter: some View {
-        Button(action: onBack) {
-            Text("Back to matches")
-                .font(FMFont.ui(16, weight: .bold))
-                .foregroundStyle(FMColor.fgInverse)
-                .frame(maxWidth: .infinity)
-                .frame(height: 50)
-                .background(BallGradient())
-                .clipShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
-                .shadow(color: FMColor.ball500.opacity(0.32), radius: 11, y: 8)
+    /// The footer's full-width ball-gradient pill — shared by every primary
+    /// footer action (back, post, resume, confirm) so the shape/shadow live once.
+    private func footerButton(
+        _ title: String, showArrow: Bool = true, disabled: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Text(title).font(FMFont.ui(16, weight: .bold))
+                if showArrow { Image(systemName: "arrow.right").font(.system(size: 15, weight: .bold)) }
+            }
+            .foregroundStyle(FMColor.fgInverse)
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
+            .background(BallGradient())
+            .clipShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
+            .shadow(color: FMColor.ball500.opacity(0.32), radius: 11, y: 8)
         }
         .buttonStyle(.plain)
+        .disabled(disabled)
+    }
+
+    /// Default footer: back to the matches list.
+    private var defaultFooter: some View {
+        footerButton("Back to matches", showArrow: false, action: onBack)
+    }
+
+    /// Finalize footer: shown for a match scored to a decision but never posted.
+    /// This is the recovery path for a match stranded *past* the decider (issue
+    /// #445) — `can_score` is false (no next game), so "Post result" is the only
+    /// way forward. One tap posts the saved games.
+    private var finalizeFooter: some View {
+        footerButton("Post result", disabled: actioning) { Task { await finalize() } }
+    }
+
+    /// Resume footer: shown for a live match the viewer can still score. This is
+    /// the recovery path for a match stranded mid-scoring (issue #445) — a Live
+    /// match you own always offers a way to continue.
+    private func resumeFooter(_ ctx: ResumeScoring) -> some View {
+        footerButton(match.games.isEmpty ? "Enter scores" : "Resume scoring") { resuming = ctx }
     }
 
     /// Sign-off footer: shown when the current user owes a confirm/dispute on a
@@ -387,18 +448,9 @@ struct MatchDetailView: View {
             }
             .buttonStyle(.plain)
             .disabled(actioning)
-            Button { Task { await confirm() } } label: {
-                Text("Confirm result")
-                    .font(FMFont.ui(16, weight: .bold))
-                    .foregroundStyle(FMColor.fgInverse)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 50)
-                    .background(BallGradient())
-                    .clipShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
-                    .shadow(color: FMColor.ball500.opacity(0.32), radius: 11, y: 8)
+            footerButton("Confirm result", showArrow: false, disabled: actioning) {
+                Task { await confirm() }
             }
-            .buttonStyle(.plain)
-            .disabled(actioning)
         }
     }
 }

--- a/ios/Fortymm/MatchFlow/MatchFlowView.swift
+++ b/ios/Fortymm/MatchFlow/MatchFlowView.swift
@@ -9,16 +9,36 @@ import SwiftUI
 /// shows "Awaiting confirmation" honestly, rather than an optimistic result.
 struct MatchFlowView: View {
     var service: MatchService = .shared
+    /// When set, the flow skips setup and opens straight into scoring an
+    /// existing live match (the "resume" entry point from the detail/list/
+    /// dashboard surfaces). Nil ⇒ the normal new-match flow.
+    var resume: ResumeScoring?
     /// Close the flow. `toMatches` = land on the Matches tab (vs. just dismiss).
     var onClose: (_ toMatches: Bool) -> Void
 
-    private enum Step { case setup, score, detail }
-    @State private var step: Step = .setup
-    @State private var opponent: MatchPlayer?
-    @State private var bestOf = 5
-    @State private var rated = false
+    init(
+        service: MatchService = .shared,
+        resume: ResumeScoring? = nil,
+        onClose: @escaping (_ toMatches: Bool) -> Void
+    ) {
+        self.service = service
+        self.resume = resume
+        self.onClose = onClose
+        _step = State(initialValue: resume == nil ? .setup : .score)
+        _matchId = State(initialValue: resume?.matchId)
+        _opponent = State(initialValue: resume?.config.opponent)
+        _bestOf = State(initialValue: resume?.config.bestOf ?? 5)
+        _rated = State(initialValue: resume?.config.rated ?? false)
+    }
 
-    /// Server match id, captured when the match is created on "Start match".
+    private enum Step { case setup, score, detail }
+    @State private var step: Step
+    @State private var opponent: MatchPlayer?
+    @State private var bestOf: Int
+    @State private var rated: Bool
+
+    /// Server match id, captured when the match is created on "Start match",
+    /// or supplied up front when resuming an existing match.
     @State private var matchId: UUID?
     @State private var final: FinalMatch?
 
@@ -46,8 +66,14 @@ struct MatchFlowView: View {
             case .score:
                 ScoreEntryView(
                     config: config,
+                    initialGames: resume?.games ?? [],
                     onPost: post,
-                    onExit: { withAnimation { step = .setup } }
+                    // Resuming has no setup step to fall back to — exiting closes
+                    // the flow (back to wherever it was launched from).
+                    onExit: {
+                        if resume == nil { withAnimation { step = .setup } }
+                        else { onClose(false) }
+                    }
                 )
                 .transition(.move(edge: .trailing).combined(with: .opacity))
             case .detail:
@@ -99,7 +125,10 @@ struct MatchFlowView: View {
         busy = true
         Task {
             do {
-                final = try await service.postResult(matchId: matchId, games: games)
+                final = try await service.postResult(
+                    matchId: matchId, games: games,
+                    yourSideNumber: resume?.yourSideNumber ?? 1
+                )
                 withAnimation { step = .detail }
             } catch {
                 errorMessage = error.fmMessage

--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -128,6 +128,53 @@ struct FinalMatch: Identifiable {
     /// True when the signed-in user is on one of the sides. When false the row
     /// is a spectator view: the W/L badge and rating delta don't apply.
     var viewerIsParticipant: Bool = true
+    /// True while the match is live (`in_progress`) — not yet decided or voided.
+    var inProgress: Bool = false
+    /// The viewer can enter/continue scores: a participant on a live match with
+    /// no posted result currently awaiting confirmation. Drives the "resume
+    /// scoring" affordances on the detail, list, and dashboard surfaces.
+    var canScore: Bool = false
+    /// The saved games already form a decided, valid match and the viewer can
+    /// post the result. True for a match scored to a decision but never posted
+    /// (e.g. a web user entered the games then left) — which `canScore` is
+    /// *false* for, since there's no next game to enter. Drives the detail
+    /// screen's "Post result" recovery path.
+    var canFinalize: Bool = false
+    /// The viewer's side number (1 or 2). Used to orient entered scores back to
+    /// the canonical side-1/side-2 axis when resuming a match the viewer didn't
+    /// create. Defaults to side 1 (the match creator).
+    var yourSideNumber: Int = 1
+
+    /// The viewer can resume entering scores: a participant on a live match with
+    /// no posted result awaiting confirmation. Single source of truth for the
+    /// "Score" affordances on the list, detail, and dashboard surfaces.
+    var canResume: Bool { canScore && inProgress && !awaitingConfirmation }
+
+    /// Context for resuming live scoring, or `nil` when the viewer can't (or
+    /// needn't) continue this match. Built from the viewer-relative projection
+    /// so `you` stays side `yourSideNumber` and the entered games re-orient
+    /// correctly on post.
+    var resumeContext: ResumeScoring? {
+        guard canResume, let uuid = UUID(uuidString: id) else { return nil }
+        return ResumeScoring(
+            matchId: uuid,
+            config: MatchConfig(opponent: solo ? nil : opponent, bestOf: bestOf, rated: rated),
+            games: games,
+            yourSideNumber: yourSideNumber
+        )
+    }
+}
+
+/// Everything the scoring flow needs to resume an existing in-progress match:
+/// its server id, the match config (opponent / best-of / rated), the games
+/// already entered, and which side the viewer is on. `Identifiable` so it can
+/// drive a `.fullScreenCover(item:)` straight into the score-entry screen.
+struct ResumeScoring: Identifiable {
+    let matchId: UUID
+    let config: MatchConfig
+    let games: [Game]
+    var yourSideNumber: Int = 1
+    var id: UUID { matchId }
 }
 
 /// A page of the match list plus the per-status counts that drive the filter

--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -145,10 +145,13 @@ struct FinalMatch: Identifiable {
     /// create. Defaults to side 1 (the match creator).
     var yourSideNumber: Int = 1
 
-    /// The viewer can resume entering scores: a participant on a live match with
-    /// no posted result awaiting confirmation. Single source of truth for the
-    /// "Score" affordances on the list, detail, and dashboard surfaces.
-    var canResume: Bool { canScore && inProgress && !awaitingConfirmation }
+    /// The viewer can resume entering scores. Relies solely on the server's
+    /// `canScore`, which is already false once a result is awaiting confirmation
+    /// (the BFF only exposes a next game while one exists) — so this stays
+    /// correct on the *list* surface too, where `awaitingConfirmation` is only a
+    /// games-won guess (the list row carries no signatures). Single source of
+    /// truth for the "Score" affordances on the list, detail, and dashboard.
+    var canResume: Bool { canScore && inProgress }
 
     /// Context for resuming live scoring, or `nil` when the viewer can't (or
     /// needn't) continue this match. Built from the viewer-relative projection

--- a/ios/Fortymm/MatchFlow/MatchService.swift
+++ b/ios/Fortymm/MatchFlow/MatchService.swift
@@ -51,13 +51,18 @@ struct MatchService {
     /// Post the canonical result (`POST /v1/matches/{id}/results`) and return
     /// the resulting match. For a solo match this comes back `completed`; for a
     /// two-player match it stays awaiting the opponent's confirmation.
-    func postResult(matchId: UUID, games: [Game]) async throws -> FinalMatch {
+    /// `yourSideNumber` orients the entered scores (`a` = you, `b` = them) back
+    /// to the canonical side-1/side-2 axis the API expects. A freshly created
+    /// match puts the creator on side 1; resuming a match the viewer didn't
+    /// create may put them on side 2, in which case the points are swapped.
+    func postResult(matchId: UUID, games: [Game], yourSideNumber: Int = 1) async throws -> FinalMatch {
+        let youAreSide1 = yourSideNumber != 2
         let payload = PostResultsBody(games: games.enumerated().compactMap { i, g in
             guard let a = g.a, let b = g.b else { return nil }
-            // `a` is always the current user's (side-1) points: a freshly
-            // created match puts the creator on side 1.
             return PostResultsBody.GameWrite(
-                gameNumber: i + 1, side1Points: a, side2Points: b
+                gameNumber: i + 1,
+                side1Points: youAreSide1 ? a : b,
+                side2Points: youAreSide1 ? b : a
             )
         })
         let details: MatchDetailsDTO = try await client.post(
@@ -129,7 +134,8 @@ struct MatchService {
         common(
             id: d.id, status: d.status, statusLabel: d.statusLabel,
             league: d.league, sides: d.sides, bestOf: d.bestOf,
-            createdAt: d.createdAt, canConfirm: d.canConfirm,
+            createdAt: d.createdAt, canConfirm: d.canConfirm, canScore: d.canScore,
+            canFinalize: d.canFinalize,
             ratedHint: d.affectsRating, games: d.games, h2h: d.headToHead,
             // The detail DTO carries the authoritative sign-off signal: a result
             // is awaiting confirmation iff someone has signed. (A dispute clears
@@ -143,7 +149,10 @@ struct MatchService {
         common(
             id: r.id, status: r.status, statusLabel: r.statusLabel,
             league: r.league, sides: r.sides, bestOf: r.bestOf,
-            createdAt: r.createdAt, canConfirm: r.canConfirm,
+            createdAt: r.createdAt, canConfirm: r.canConfirm, canScore: r.canScore,
+            // The list row omits can_finalize; the detail refetch (on open) fills
+            // in the authoritative value and surfaces the "Post result" path.
+            canFinalize: false,
             ratedHint: nil, games: nil, h2h: nil,
             // The list row omits signatures; fall back to the games-won heuristic.
             // This row is transient anyway — the detail view refetches on open and
@@ -158,8 +167,8 @@ struct MatchService {
     private static func common(
         id: UUID, status: APIMatchStatus, statusLabel: String,
         league: MatchLeagueDTO, sides: [MatchSideDTO], bestOf: Int,
-        createdAt: Date, canConfirm: Bool, ratedHint: Bool?,
-        games: [MatchGameDTO]?, h2h: H2HDTO?, signaturesPosted: Bool?
+        createdAt: Date, canConfirm: Bool, canScore: Bool, canFinalize: Bool,
+        ratedHint: Bool?, games: [MatchGameDTO]?, h2h: H2HDTO?, signaturesPosted: Bool?
     ) -> FinalMatch {
         let viewerIsParticipant = sides.contains(where: \.isCurrentUserSide)
         let mine = sides.first(where: \.isCurrentUserSide) ?? sides.first
@@ -247,7 +256,14 @@ struct MatchService {
             sideB: (side2?.players.isEmpty ?? true) ? .guest : sidePlayer(side2),
             sideAGames: side1?.gamesWon ?? 0,
             sideBGames: side2?.gamesWon ?? 0,
-            viewerIsParticipant: viewerIsParticipant
+            viewerIsParticipant: viewerIsParticipant,
+            inProgress: status == .inProgress,
+            // The server already encodes the full predicate (participant on a
+            // live match, no result awaiting confirmation); the `awaitingConfirmation`
+            // guard in `resumeContext` is a belt-and-suspenders local check.
+            canScore: canScore && viewerIsParticipant,
+            canFinalize: canFinalize && viewerIsParticipant,
+            yourSideNumber: mine?.sideNumber ?? 1
         )
     }
 

--- a/ios/Fortymm/MatchFlow/MatchService.swift
+++ b/ios/Fortymm/MatchFlow/MatchService.swift
@@ -258,9 +258,10 @@ struct MatchService {
             sideBGames: side2?.gamesWon ?? 0,
             viewerIsParticipant: viewerIsParticipant,
             inProgress: status == .inProgress,
-            // The server already encodes the full predicate (participant on a
-            // live match, no result awaiting confirmation); the `awaitingConfirmation`
-            // guard in `resumeContext` is a belt-and-suspenders local check.
+            // `canScore` is the server's authoritative "there's a next game to
+            // enter" signal (already false once a result is awaiting
+            // confirmation); `canResume` is built on it, so it stays correct on
+            // the list surface where `awaitingConfirmation` is only a heuristic.
             canScore: canScore && viewerIsParticipant,
             canFinalize: canFinalize && viewerIsParticipant,
             yourSideNumber: mine?.sideNumber ?? 1

--- a/ios/Fortymm/MatchFlow/ScoreEntryView.swift
+++ b/ios/Fortymm/MatchFlow/ScoreEntryView.swift
@@ -6,6 +6,10 @@ import SwiftUI
 /// and by tapping a score field directly.
 struct ScoreEntryView: View {
     let config: MatchConfig
+    /// Games already entered for this match, in order (game 1…N). Empty for a
+    /// new match; populated when resuming a live one so the user continues from
+    /// where they left off rather than re-entering scored games.
+    var initialGames: [Game] = []
     /// Hand the completed games (in order, game 1…N) up to the coordinator,
     /// which posts them to the API and renders the server's result.
     var onPost: ([Game]) -> Void
@@ -56,7 +60,17 @@ struct ScoreEntryView: View {
         }
         .background(FMColor.ink950.ignoresSafeArea())
         .onAppear {
-            if games.isEmpty { games = Array(repeating: Game(), count: config.bestOf) }
+            if games.isEmpty {
+                // Seed every slot from `initialGames` (already-entered games when
+                // resuming), padded/clipped to the match length, then land on the
+                // first slot still needing a score.
+                var seeded = Array(initialGames.prefix(config.bestOf))
+                if seeded.count < config.bestOf {
+                    seeded += Array(repeating: Game(), count: config.bestOf - seeded.count)
+                }
+                games = seeded
+                active = seeded.firstIndex { !MatchRules.gameComplete($0) } ?? 0
+            }
             focusYou()
         }
         // Switching game (or editing) → raise the keypad on your side.

--- a/ios/Fortymm/Matches/MatchesListView.swift
+++ b/ios/Fortymm/Matches/MatchesListView.swift
@@ -5,12 +5,25 @@ import SwiftUI
 /// feed (newest first) with each row showing both participants. Tapping a row
 /// opens its detail. All filtering is server-side via `GET /v1/matches`;
 /// pull-to-refresh and re-entering the tab re-fetch.
+/// A filter another surface wants the matches list to adopt when it routes here
+/// (e.g. the dashboard's "+N more to score" link → the user's live matches).
+struct MatchesFilter: Equatable {
+    var status: APIMatchStatus?
+    var query: String = ""
+}
+
 struct MatchesListView: View {
     var service: MatchService = .shared
+    /// Set by another tab to pre-apply a filter on arrival; cleared once applied.
+    var pendingFilter: Binding<MatchesFilter?> = .constant(nil)
 
     @State private var statusTab: StatusTab = .all
     @State private var query = ""
     @State private var selected: FinalMatch?
+    /// Non-nil while the resume-scoring flow is presented; `resumeLoading` covers
+    /// the brief fetch of the full match (the list row lacks the entered games).
+    @State private var resuming: ResumeScoring?
+    @State private var resumeLoading = false
 
     @State private var matches: [FinalMatch] = []
     @State private var statusCounts: [String: Int] = [:]
@@ -22,38 +35,93 @@ struct MatchesListView: View {
     /// Debounce handle for the search field so each keystroke doesn't fire a
     /// request.
     @State private var searchTask: Task<Void, Never>?
+    /// Set while applying a cross-tab filter, to swallow the one debounced reload
+    /// that programmatically changing `query` would otherwise schedule on top of
+    /// `applyPendingFilter`'s own reload.
+    @State private var suppressQueryReload = false
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 0) {
-                searchField
-                statusTabs
-                listCard
+        ZStack {
+            ScrollView {
+                VStack(spacing: 0) {
+                    searchField
+                    statusTabs
+                    listCard
+                }
+                .padding(.horizontal, 16)
+                // Top inset for the shell's frosted bar is reserved by `.fmTopBar`.
+                .padding(.bottom, 24)
             }
-            .padding(.horizontal, 16)
-            // Top inset for the shell's frosted bar is reserved by `.fmTopBar`.
-            .padding(.bottom, 24)
-        }
-        .background(FMColor.bgApp.ignoresSafeArea())
-        .refreshable { await load() }
-        // onAppear (not task) so returning to the tab after posting a match
-        // re-fetches and surfaces it at the top.
-        .onAppear { reload() }
-        .onChange(of: query) { _, _ in
-            searchTask?.cancel()
-            searchTask = Task {
-                try? await Task.sleep(for: .milliseconds(350))
-                if !Task.isCancelled { reload() }
+            .background(FMColor.bgApp.ignoresSafeArea())
+            .refreshable { await load() }
+            // onAppear (not task) so returning to the tab after posting a match
+            // re-fetches and surfaces it at the top. A queued cross-tab filter is
+            // applied here rather than via .onChange, because TabView renders this
+            // tab lazily — .onChange isn't observing when the value is set on the
+            // other tab, but .onAppear fires when the tab becomes visible.
+            .onAppear {
+                if pendingFilter.wrappedValue != nil { applyPendingFilter() }
+                else { reload() }
             }
+            // Foregrounding may surface cross-device changes (a match the opponent
+            // just confirmed/disputed) — re-fetch the feed.
+            .refetchOnForeground { reload() }
+            // Also handle the case where this tab is already visible when the
+            // filter is set (no fresh .onAppear) — apply it live.
+            .onChange(of: pendingFilter.wrappedValue) { _, filter in
+                if filter != nil { applyPendingFilter() }
+            }
+            .onChange(of: query) { _, _ in
+                if suppressQueryReload { suppressQueryReload = false; return }
+                searchTask?.cancel()
+                searchTask = Task {
+                    try? await Task.sleep(for: .milliseconds(350))
+                    if !Task.isCancelled { reload() }
+                }
+            }
+            .fullScreenCover(item: $selected) { match in
+                MatchDetailView(initial: match, onBack: { selected = nil })
+            }
+            // The list now has a stale row for the resumed match (it just gained a
+            // posted result / more games) — refetch so it reflects reality.
+            .resumeScoringCover($resuming) { reload() }
+
+            if resumeLoading { FMBlockingSpinner() }
         }
-        .fullScreenCover(item: $selected) { match in
-            MatchDetailView(initial: match, onBack: { selected = nil })
+    }
+
+    /// Fetch the full match (the list row omits the entered games) and open the
+    /// resume-scoring flow. Falls back to the detail screen if the match can no
+    /// longer be scored (state changed since the list was fetched).
+    private func openResume(_ match: FinalMatch) {
+        guard !resumeLoading, let id = UUID(uuidString: match.id) else { return }
+        resumeLoading = true
+        Task {
+            let detail = try? await service.matchDetails(id)
+            resumeLoading = false
+            if let ctx = detail?.resumeContext { resuming = ctx }
+            else { selected = detail ?? match }
         }
     }
 
     private func reload() {
         loadTask?.cancel()
         loadTask = Task { await load() }
+    }
+
+    /// Apply a queued cross-tab filter (status tab + search query) and refetch,
+    /// then clear it so it isn't re-applied on the next appearance.
+    private func applyPendingFilter() {
+        guard let filter = pendingFilter.wrappedValue else { return }
+        statusTab = StatusTab.tab(for: filter.status)
+        // Changing `query` schedules a debounced reload via .onChange; suppress
+        // it so the explicit reload() below is the only fetch.
+        if query != filter.query {
+            suppressQueryReload = true
+            query = filter.query
+        }
+        pendingFilter.wrappedValue = nil
+        reload()
     }
 
     /// Fetch the match list for the active status tab + search. Shows a spinner
@@ -154,7 +222,13 @@ struct MatchesListView: View {
                 listNote(emptyMessage)
             } else {
                 ForEach(Array(matches.enumerated()), id: \.element.id) { i, m in
-                    MatchRow(match: m) { selected = m }
+                    MatchRow(
+                        match: m,
+                        onOpen: { selected = m },
+                        // A live match the viewer can score gets a one-tap
+                        // "Score" affordance straight into the entry flow.
+                        onResume: m.canResume ? { openResume(m) } : nil
+                    )
                     if i < matches.count - 1 { Divider().overlay(FMColor.ink700) }
                 }
             }
@@ -207,6 +281,12 @@ private enum StatusTab: CaseIterable, Identifiable {
         }
     }
 
+    /// The tab matching an API status (inverse of `apiStatus`); falls back to
+    /// "All" for nil or any status without a dedicated tab.
+    static func tab(for status: APIMatchStatus?) -> StatusTab {
+        allCases.first { $0.apiStatus == status } ?? .all
+    }
+
     /// `status_counts` key for this tab's badge — derived from `apiStatus` so the
     /// filter value and the count lookup can't drift apart. Nil for "All", which
     /// sums every status instead.
@@ -216,6 +296,9 @@ private enum StatusTab: CaseIterable, Identifiable {
 private struct MatchRow: View {
     let match: FinalMatch
     let onOpen: () -> Void
+    /// When non-nil, the row shows a "Score" chip (in place of the chevron) that
+    /// resumes scoring — for a live match the viewer can still enter.
+    var onResume: (() -> Void)? = nil
 
     /// How this row reads to the viewer: still in flight, one the viewer only
     /// spectated, or their own decided win/loss. `tint` and `badge` are both pure
@@ -249,55 +332,80 @@ private struct MatchRow: View {
     }
 
     var body: some View {
-        Button(action: onOpen) {
-            HStack(spacing: 13) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 11, style: .continuous)
-                        .fill(tint.opacity(0.12))
-                        .overlay(RoundedRectangle(cornerRadius: 11, style: .continuous)
-                            .stroke(tint.opacity(0.2), lineWidth: 1))
-                        .frame(width: 42, height: 42)
-                    Text(badge)
-                        .font(FMFont.ui(15, weight: .bold))
-                        .foregroundStyle(tint)
-                }
-                VStack(alignment: .leading, spacing: 1) {
-                    // Both participants, side-1-first — this list is a global feed,
-                    // so the viewer often isn't one of them.
-                    (Text(match.sideA.handle).foregroundStyle(FMColor.fg1)
-                        + Text(" vs ").foregroundStyle(FMColor.fg3)
-                        + Text(match.sideB.handle).foregroundStyle(FMColor.fg1))
-                        .font(FMFont.ui(15, weight: .semibold))
-                        .lineLimit(1)
-                    Text("\(match.when) · \(subtitle)")
-                        .font(FMFont.ui(12.5))
-                        .foregroundStyle(FMColor.fg3)
-                        .lineLimit(1)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                VStack(alignment: .trailing, spacing: 0) {
-                    HStack(spacing: 2) {
-                        Text("\(match.sideAGames)")
-                        Text("–").foregroundStyle(FMColor.fgMuted)
-                        Text("\(match.sideBGames)")
+        // The body content opens the detail; the trailing slot is a *sibling*
+        // (not nested) button so a "Score" chip can launch the resume flow
+        // independently of the row tap.
+        HStack(spacing: 8) {
+            Button(action: onOpen) {
+                HStack(spacing: 13) {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 11, style: .continuous)
+                            .fill(tint.opacity(0.12))
+                            .overlay(RoundedRectangle(cornerRadius: 11, style: .continuous)
+                                .stroke(tint.opacity(0.2), lineWidth: 1))
+                            .frame(width: 42, height: 42)
+                        Text(badge)
+                            .font(FMFont.ui(15, weight: .bold))
+                            .foregroundStyle(tint)
                     }
-                    .font(FMFont.mono(18, weight: .bold))
-                    .foregroundStyle(FMColor.fg1)
-                    if let delta = match.ratingDelta {
-                        Text("\(delta >= 0 ? "+" : "")\(delta)")
-                            .font(FMFont.mono(12, weight: .semibold))
-                            .foregroundStyle(delta >= 0 ? FMColor.serve500 : FMColor.loss)
+                    VStack(alignment: .leading, spacing: 1) {
+                        // Both participants, side-1-first — this list is a global feed,
+                        // so the viewer often isn't one of them.
+                        (Text(match.sideA.handle).foregroundStyle(FMColor.fg1)
+                            + Text(" vs ").foregroundStyle(FMColor.fg3)
+                            + Text(match.sideB.handle).foregroundStyle(FMColor.fg1))
+                            .font(FMFont.ui(15, weight: .semibold))
+                            .lineLimit(1)
+                        Text("\(match.when) · \(subtitle)")
+                            .font(FMFont.ui(12.5))
+                            .foregroundStyle(FMColor.fg3)
+                            .lineLimit(1)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    VStack(alignment: .trailing, spacing: 0) {
+                        HStack(spacing: 2) {
+                            Text("\(match.sideAGames)")
+                            Text("–").foregroundStyle(FMColor.fgMuted)
+                            Text("\(match.sideBGames)")
+                        }
+                        .font(FMFont.mono(18, weight: .bold))
+                        .foregroundStyle(FMColor.fg1)
+                        if let delta = match.ratingDelta {
+                            Text("\(delta >= 0 ? "+" : "")\(delta)")
+                                .font(FMFont.mono(12, weight: .semibold))
+                                .foregroundStyle(delta >= 0 ? FMColor.serve500 : FMColor.loss)
+                        }
                     }
                 }
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(FMColor.ink500)
+                .padding(.leading, 14)
+                .padding(.vertical, 15)
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 15)
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+
+            trailing
+                .padding(.trailing, 14)
         }
-        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var trailing: some View {
+        if let onResume {
+            Button(action: onResume) {
+                Text("Score")
+                    .font(FMFont.ui(13, weight: .bold))
+                    .foregroundStyle(FMColor.fgInverse)
+                    .padding(.horizontal, 14)
+                    .frame(height: 32)
+                    .background(BallGradient())
+                    .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+        } else {
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(FMColor.ink500)
+        }
     }
 
     /// Pending matches show their status; decided ones show the format label.

--- a/ios/Fortymm/Navigation/MainTabView.swift
+++ b/ios/Fortymm/Navigation/MainTabView.swift
@@ -24,15 +24,21 @@ enum FMTab: Hashable {
 struct MainTabView: View {
     @State private var selection: FMTab = .home
     @State private var showingNewMatch = false
+    /// A filter the Matches list should adopt when another tab routes to it
+    /// (the dashboard's "+N more to score" link → the user's live matches).
+    @State private var matchesFilter: MatchesFilter?
 
     var body: some View {
         TabView(selection: $selection) {
-            DashboardView()
+            DashboardView(onShowAllScores: { username in
+                matchesFilter = MatchesFilter(status: .inProgress, query: username ?? "")
+                selection = .matches
+            })
                 .fmTopBar(FMTab.home.title)
                 .tabItem { Label("Home", systemImage: "house") }
                 .tag(FMTab.home)
 
-            MatchesListView()
+            MatchesListView(pendingFilter: $matchesFilter)
                 .fmTopBar(FMTab.matches.title)
                 .tabItem { Label("Matches", systemImage: "sportscourt") }
                 .tag(FMTab.matches)


### PR DESCRIPTION
## Why

A match the user owns could be left **Live with no way to finish it**: backing out of score entry strands it at 0-0 (#445), and a match scored to a decision but never posted has no finalize path. iOS had no resume entry point at all — the web client solved this with banners + resume affordances, but they were never ported.

## What

Ports the recovery UX natively across all three surfaces, plus the refetch behavior so a resumed/posted match doesn't read as stale.

**Resume / finalize**
- **Score entry** can resume: `ScoreEntryView` accepts already-entered games and lands on the first unscored game; `MatchFlowView` gains a `resume:` entry point that opens straight into scoring an existing match.
- **Match detail** — `Enter scores`/`Resume scoring` footer for a scorable live match; **`Post result`** for a decided-but-unposted one (`can_finalize`).
- **Matches list** — a `Score` chip on the viewer's own live rows.
- **Dashboard** — renders the `score_banners` it already fetched, **capped at 2** with a `+N more to score` link that filters the matches list to the user's live matches (`status=live` + `q=username`), mirroring the web.
- `postResult` orients entered scores by the viewer's side, so resuming a match you didn't create (side 2) doesn't invert the score.
- Decodes `can_score` / `current_game_number` on list rows (API already returns them); threads `can_finalize` from the detail BFF.

**Refetch (cf #452)**
- Refetch on (re)appearance, on foreground (`scenePhase`), and after a resume/post mutation, so cross-device and own changes surface without a relaunch. The dashboard refreshes in place without flashing the loading card or clobbering good content on a transient failure.

**Gating** — resume/finalize affordances are participant-only (`canScore`/`canFinalize && viewerIsParticipant`): you can only score your own matches.

**Shared helpers** — `.refetchOnForeground` and `.resumeScoringCover` view modifiers, a `footerButton` helper, and `FinalMatch.canResume` keep the three surfaces from copy-pasting the same wiring.

## Testing

Black-box QA driven on the iOS simulator (via `idb`) against the real UAT backend:
- Resume verified end-to-end from all three surfaces (dashboard banner, list chip, detail footer) → entered scores → **posted to FINAL**.
- `Post result` finalizes a previously-stranded 3-0 Live match.
- `+N more to score` lands on Matches filtered to the user's live matches.
- Gating confirmed across a 78-match live feed: chips appear only on the viewer's own scorable rows; other users' live matches and awaiting-confirmation rows show a plain chevron.
- Refetch confirmed: posting clears the dashboard banner without a relaunch.

iOS only — no API/web changes. `xcodebuild` green.

Closes #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)