### PR TITLE
Feature the match sign-off, save, and guest banners

### DIFF
--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -456,11 +456,11 @@ function MatchDetailsPage({
           </div>
         </div>
 
+        <ConfirmationCallout view={view} matchId={matchId} />
+
         <SaveYourMatch key={matchId} view={view} matchId={matchId} />
 
         <HeroScoreboard view={view} matchId={matchId} />
-
-        <ConfirmationCallout view={view} matchId={matchId} />
 
         <div className="md-col-2">
           <div className="md-col-2__main">
@@ -1283,13 +1283,19 @@ function ConfirmationCallout({
   if (view.canConfirm) {
     return (
       <section
-        className="md-confirm-callout"
+        className="md-confirm-callout md-confirm-callout--featured"
         data-testid="match-confirm-callout"
       >
         <div className="md-confirm-callout__copy">
-          <Overline as="h3">Posted result · awaiting your sign-off</Overline>
+          <div className="md-confirm-callout__kicker">
+            <span className="ball-dot" aria-hidden="true" /> Posted result ·
+            awaiting your sign-off
+          </div>
+          <h3 className="md-confirm-callout__headline">
+            Confirm the result to finalize this match.
+          </h3>
           <p className="md-confirm-callout__body">
-            Your opponent has posted the result above. Confirm if the scores
+            Your opponent has posted the result below. Confirm if the scores
             are right, or dispute to send the match back to in-progress so the
             wrong game can be re-scored.
           </p>

--- a/web-client/src/components/matches/save-your-match.tsx
+++ b/web-client/src/components/matches/save-your-match.tsx
@@ -157,7 +157,10 @@ function SaveYourMatchActive({
   }
 
   return (
-    <section className="md-save" aria-label="Save this match">
+    <section
+      className={cn('md-save', view.canConfirm && 'md-save--soft')}
+      aria-label="Save this match"
+    >
       <div className="md-save__hd">
         <div className="md-save__kicker">
           <span className="ball-dot" aria-hidden="true" /> Nice match

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2367,16 +2367,19 @@ body.dark.fortymm-theme {
   border-radius: var(--r-md);
 }
 
-/* Awaiting-confirmation callout that sits between the hero and the cards
-   row when a posted result needs the viewer's sign-off (or is waiting on
-   the opponent's). The accent stripe + warm hue echoes the "live" hero
-   chip so the urgency reads visually. */
+/* Sign-off callout that leads the match-details page when a posted result
+   needs the viewer's action (or is waiting on the opponent's). The active
+   "your sign-off" state is a Featured card (orange ring + accent glow, the
+   same treatment as the dashboard score banner) so the one thing the viewer
+   must do is the first thing they see; the passive "waiting on them" state
+   stays a quiet accent-stripe note. */
 .fortymm-theme .md-confirm-callout {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 18px;
   flex-wrap: wrap;
+  margin-bottom: 24px;
   padding: 14px 18px;
   background: var(--bg-card);
   border: 1px solid var(--border-subtle);
@@ -2387,14 +2390,43 @@ body.dark.fortymm-theme {
   border-left-color: var(--ink-500);
   opacity: 0.92;
 }
+/* Featured treatment for the active sign-off state. */
+.fortymm-theme .md-confirm-callout--featured {
+  align-items: center;
+  padding: 22px 26px;
+  border: 1px solid var(--ball-500);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-glow);
+}
 .fortymm-theme .md-confirm-callout__copy {
   flex: 1 1 320px;
   min-width: 0;
+}
+.fortymm-theme .md-confirm-callout__kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font: 600 11px var(--font-mono);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ball-500);
+}
+.fortymm-theme .md-confirm-callout__headline {
+  margin: 12px 0 0;
+  font: 700 22px var(--font-ui);
+  color: var(--fg-1);
+  letter-spacing: -0.01em;
+  line-height: 1.2;
 }
 .fortymm-theme .md-confirm-callout__body {
   margin: 6px 0 0;
   color: var(--fg-2);
   font: 400 13px/1.45 var(--font-ui);
+}
+.fortymm-theme .md-confirm-callout--featured .md-confirm-callout__body {
+  margin-top: 8px;
+  max-width: 520px;
+  color: var(--fg-3);
 }
 .fortymm-theme .md-confirm-callout__actions {
   display: flex;
@@ -2413,13 +2445,13 @@ body.dark.fortymm-theme {
 .fortymm-theme .md-save {
   position: relative;
   background: var(--bg-card);
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--ball-500);
   border-radius: var(--r-lg);
   padding: 22px 26px;
   display: flex;
   flex-direction: column;
   gap: 16px;
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-glow);
 }
 .fortymm-theme .md-save__hd {
   display: flex;

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2453,6 +2453,13 @@ body.dark.fortymm-theme {
   gap: 16px;
   box-shadow: var(--shadow-glow);
 }
+/* When the featured sign-off callout leads the page above this card, step the
+   save nudge down to the plain card treatment so two Featured glows don't
+   compete — the sign-off action stays the single point of emphasis. */
+.fortymm-theme .md-save--soft {
+  border-color: var(--border-subtle);
+  box-shadow: var(--shadow-sm);
+}
 .fortymm-theme .md-save__hd {
   display: flex;
   align-items: center;

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -464,7 +464,11 @@ function ClaimBanner({
         background: guest
           ? 'linear-gradient(90deg, rgba(255,122,26,0.18), rgba(255,122,26,0.05) 70%)'
           : 'linear-gradient(90deg, rgba(255,196,61,0.18), rgba(255,196,61,0.04) 70%)',
-        border: `1px solid ${guest ? 'rgba(255,122,26,0.35)' : 'rgba(255,196,61,0.3)'}`,
+        border: `1px solid ${guest ? 'var(--ball-500)' : 'rgba(255,196,61,0.3)'}`,
+        // Guest is the urgent, act-now state — give it the Featured accent glow
+        // (matches the match-details sign-off / save-your-match cards). The
+        // pending "check your inbox" state is informational, so it stays flat.
+        boxShadow: guest ? 'var(--shadow-glow)' : undefined,
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>


### PR DESCRIPTION
Turns the three "act now" prompts into **Featured** cards — accent border + `var(--shadow-glow)`, the same idiom already shipped on the dashboard score banner.

## Changes

- **Sign-off callout → featured card at the top.** `ConfirmationCallout`'s active `POSTED RESULT · AWAITING YOUR SIGN-OFF` state becomes a featured card (ball-dot kicker + headline replacing the plain overline) and moves to the **first** content block on the match-details page, above the scoreboard. Copy flips "the result **above**" → "**below**" to match the new order. The passive "waiting on opponent" state stays the quiet accent-stripe note.
- **"Nice match" save nudge → featured look.** `md-save` gains the `--ball-500` border + glow (was a plain subtle border + `--shadow-sm`).
- **Settings guest banner → featured look.** The `ClaimBanner` guest variant gains the accent border + glow; the pending "check your inbox" variant stays flat (informational, not act-now).

## Verification

- `tsc -b` clean, eslint clean
- All 36 tests pass across `match-details-page.test.tsx`, `save-your-match.test.tsx`, `settings.test.tsx` — testid, "awaiting" copy, opponent name, and Confirm/Dispute buttons all preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)