### PR TITLE
Make scorability hinge on the signature, not "a next game exists"

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -316,11 +316,13 @@ def _serialize_details(
         ],
         games=games,
         current_game=current_game,
-        # Spectators see scores, never the Score CTA — writes still 404 for
-        # non-participants in the score endpoints below.
-        can_score=(
-            current_game is not None and len(match.sides) >= 2 and is_participant
-        ),
+        # "This participant may edit scores" — true whenever the match is
+        # scorable (no signature; see ``_is_scorable``), *independent* of
+        # whether there's a next un-played game. A decided-but-unsigned board
+        # (e.g. just after a dispute) is still editable, so this is True while
+        # ``current_game`` is None. Spectators get the read-only view — writes
+        # 404 for non-participants in the score endpoints regardless.
+        can_score=(is_participant and _is_scorable(match)),
         # True iff the saved games already form a decided, validly-ordered
         # match AND no result is currently posted — the FE flips the scoring
         # page's submit button label to "Post result" when this is true.
@@ -554,12 +556,12 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
     side_wins = side_win_counts(match)
     sides_sorted = sorted(match.sides, key=lambda s: s.side_number)
     next_number = current_game_number(match)
-    can_score = (
-        match.status in {MatchStatus.pending, MatchStatus.in_progress}
-        and len(match.sides) >= 2
-        and next_number is not None
-        and _is_participant(match, current_user_id)
-    )
+    is_participant = _is_participant(match, current_user_id)
+    # Editability follows the no-signature scratchpad rule (``_is_scorable``),
+    # not whether a next game exists — so a decided-but-unsigned row still reads
+    # as scorable. ``current_game_number`` stays the next-playable-game
+    # deep-link target (None when decided or signed); suppressed for spectators.
+    can_score = is_participant and _is_scorable(match)
 
     return MatchListRow(
         id=match.id,
@@ -569,7 +571,7 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
         sides=[_side_schema(side, side_wins, current_user_id) for side in sides_sorted],
         best_of=match.match_settings.best_of,
         created_at=match.created_at,
-        current_game_number=next_number if can_score else None,
+        current_game_number=next_number if is_participant else None,
         can_score=can_score,
         can_confirm=_can_confirm(match, current_user_id),
     )
@@ -680,23 +682,47 @@ async def get_match(
 # ----- score writes --------------------------------------------------------
 
 
+# A match that has reached one of these states is read-only — never scorable.
+_TERMINAL_STATUSES = {
+    MatchStatus.completed,
+    MatchStatus.disputed,
+    MatchStatus.voided,
+}
+
+
+def _is_scorable(match: Match) -> bool:
+    """Whether a match accepts score writes right now (ignoring who's asking).
+
+    The saved games are a provisional *scratchpad* until somebody signs the
+    result: editable regardless of whether they already decide the match. So
+    the only gates are structural — two sides, a non-terminal status, and **no
+    signature**. A posted result (≥1 signature) locks the scores until it's
+    confirmed or disputed; a dispute clears the signatures and the match is
+    scorable again with its games intact.
+
+    Single source of truth shared by the write-path guard
+    (``_enforce_scorable``) and the BFF ``can_score`` flag, so the flag the
+    clients trust can never disagree with what the score endpoints accept."""
+    return (
+        len(match.sides) >= 2
+        and match.status not in _TERMINAL_STATUSES
+        and not match.signatures
+    )
+
+
 def _enforce_scorable(match: Match) -> None:
+    """Raise when a match can't be scored. ``_is_scorable`` owns the *decision*;
+    this only picks the reason-specific status/message for a rejection, so the
+    write guard can't drift from the ``can_score`` flag — a future gate added to
+    ``_is_scorable`` falls through to the catch-all 409 rather than being
+    silently accepted."""
+    if _is_scorable(match):
+        return
     if len(match.sides) < 2:
         raise HTTPException(
             status_code=422,
             detail="This match has no opponent and can't be scored.",
         )
-    # ``completed`` lives here too — once a match is finalized via
-    # ``POST /v1/matches/{id}/results`` (and confirmed) it's read-only. The
-    # 409 covers the per-game write endpoints *and* re-posts of /results
-    # against a non-solo match that has either been finalized or is
-    # awaiting confirmation (the signatures branch below).
-    if match.status in {
-        MatchStatus.completed,
-        MatchStatus.disputed,
-        MatchStatus.voided,
-    }:
-        raise HTTPException(status_code=409, detail="This match is no longer scorable.")
     # A posted result locks the scores until somebody calls /confirmation
     # (finalize) or /dispute (rewind). Both per-game writes and a second
     # /results call hit this branch.
@@ -708,6 +734,9 @@ def _enforce_scorable(match: Match) -> None:
                 "Confirm or dispute it before editing scores."
             ),
         )
+    # Terminal status (``completed``/``disputed``/``voided``) — or any future
+    # ``_is_scorable`` gate without a message of its own.
+    raise HTTPException(status_code=409, detail="This match is no longer scorable.")
 
 
 def _enforce_confirmable(match: Match, user_id: uuid.UUID) -> None:

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1528,7 +1528,14 @@ async def test_dispute_clears_signatures_and_rewinds_to_in_progress(
         # un-scored in 1..best_of. Otherwise the dashboard / list / scoring
         # page deep-links into a phantom game.
         assert body["current_game"] is None
-        assert body["can_score"] is False
+        # ...but the match IS scorable again: clearing the signatures reopens
+        # the scratchpad, so can_score is True even though there's no next game
+        # to play (the disputer edits the contested game in place). Editability
+        # follows the signature, not whether the board currently decides it.
+        assert body["can_score"] is True
+        # The saved scores are still valid + decided, so a mistaken dispute can
+        # be undone by re-posting them unchanged (back into the sign-off flow).
+        assert body["can_finalize"] is True
         # Canonical games stay around so the contested score can be edited.
         games = sorted(body["games"], key=lambda g: g["game_number"])
         assert [g["game_number"] for g in games] == [1, 2]

--- a/ios/Fortymm/MatchFlow/MatchDetailView.swift
+++ b/ios/Fortymm/MatchFlow/MatchDetailView.swift
@@ -419,12 +419,29 @@ struct MatchDetailView: View {
         footerButton("Back to matches", showArrow: false, action: onBack)
     }
 
-    /// Finalize footer: shown for a match scored to a decision but never posted.
-    /// This is the recovery path for a match stranded *past* the decider (issue
-    /// #445) — `can_score` is false (no next game), so "Post result" is the only
-    /// way forward. One tap posts the saved games.
+    /// Finalize footer: a decided, unsigned board. The primary action re-posts
+    /// the saved games into the sign-off flow — both the recovery path for a
+    /// match stranded *past* the decider (issue #445) and the one-tap fix for a
+    /// mistaken dispute (resubmit the scores unchanged). Because the scores are
+    /// a scratchpad until someone signs, the board is also still editable, so we
+    /// also offer "Edit scores" to correct a game before posting.
+    @ViewBuilder
     private var finalizeFooter: some View {
-        footerButton("Post result", disabled: actioning) { Task { await finalize() } }
+        VStack(spacing: 10) {
+            footerButton("Post result", disabled: actioning) { Task { await finalize() } }
+            if let ctx = match.resumeContext {
+                Button { resuming = ctx } label: {
+                    Text("Edit scores")
+                        .font(FMFont.ui(15, weight: .semibold))
+                        .foregroundStyle(FMColor.fg2)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 48)
+                        .fmRoundedBorder(radius: 13, color: FMColor.borderDefault)
+                }
+                .buttonStyle(.plain)
+                .disabled(actioning)
+            }
+        }
     }
 
     /// Resume footer: shown for a live match the viewer can still score. This is

--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -136,21 +136,22 @@ struct FinalMatch: Identifiable {
     var canScore: Bool = false
     /// The saved games already form a decided, valid match and the viewer can
     /// post the result. True for a match scored to a decision but never posted
-    /// (e.g. a web user entered the games then left) — which `canScore` is
-    /// *false* for, since there's no next game to enter. Drives the detail
-    /// screen's "Post result" recovery path.
+    /// (e.g. a web user entered the games then left, or a dispute that cleared
+    /// the signatures). `canScore` is *also* true here — the board stays
+    /// editable until signed — so the detail screen offers both "Post result"
+    /// (resubmit) and "Edit scores".
     var canFinalize: Bool = false
     /// The viewer's side number (1 or 2). Used to orient entered scores back to
     /// the canonical side-1/side-2 axis when resuming a match the viewer didn't
     /// create. Defaults to side 1 (the match creator).
     var yourSideNumber: Int = 1
 
-    /// The viewer can resume entering scores. Relies solely on the server's
-    /// `canScore`, which is already false once a result is awaiting confirmation
-    /// (the BFF only exposes a next game while one exists) — so this stays
-    /// correct on the *list* surface too, where `awaitingConfirmation` is only a
-    /// games-won guess (the list row carries no signatures). Single source of
-    /// truth for the "Score" affordances on the list, detail, and dashboard.
+    /// The viewer can resume entering / editing scores. Relies solely on the
+    /// server's `canScore`, which is false once a result is signed (awaiting
+    /// confirmation) — so this stays correct on the *list* surface too, where
+    /// `awaitingConfirmation` is only a games-won guess (the list row carries no
+    /// signatures). Single source of truth for the "Score" affordances on the
+    /// list, detail, and dashboard.
     var canResume: Bool { canScore && inProgress }
 
     /// Context for resuming live scoring, or `nil` when the viewer can't (or

--- a/ios/Fortymm/MatchFlow/MatchService.swift
+++ b/ios/Fortymm/MatchFlow/MatchService.swift
@@ -258,10 +258,11 @@ struct MatchService {
             sideBGames: side2?.gamesWon ?? 0,
             viewerIsParticipant: viewerIsParticipant,
             inProgress: status == .inProgress,
-            // `canScore` is the server's authoritative "there's a next game to
-            // enter" signal (already false once a result is awaiting
-            // confirmation); `canResume` is built on it, so it stays correct on
-            // the list surface where `awaitingConfirmation` is only a heuristic.
+            // `canScore` is the server's authoritative "scores are editable"
+            // signal — true whenever no result is signed (the scratchpad is
+            // open), regardless of whether a next game remains. `canResume` is
+            // built on it, so it stays correct on the list surface where
+            // `awaitingConfirmation` is only a heuristic.
             canScore: canScore && viewerIsParticipant,
             canFinalize: canFinalize && viewerIsParticipant,
             yourSideNumber: mine?.sideNumber ?? 1

--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -850,4 +850,102 @@ describe('MatchDetailsView', () => {
       screen.queryByTestId('match-confirm-callout'),
     ).not.toBeInTheDocument()
   })
+
+  it('offers one-click "Post result" resubmit on a decided, unsigned board (post-dispute)', async () => {
+    // A dispute clears signatures but keeps the games. The board still decides
+    // the match (so there's no next game / Score CTA), but it's editable again
+    // (can_score) and re-postable as-is (can_finalize) — the resubmit path for
+    // a mistaken dispute.
+    const match = matchDetails({
+      id: 'm-resubmit',
+      status: 'in_progress',
+      status_label: 'Live',
+      sides: [
+        {
+          side_number: 1,
+          players: [{ user_id: 'u-me', username: 'me', is_current_user: true }],
+          games_won: 2,
+          won: null,
+          is_current_user_side: true,
+        },
+        {
+          side_number: 2,
+          players: [
+            { user_id: 'u-opp', username: 'nguyen.t', is_current_user: false },
+          ],
+          games_won: 0,
+          won: null,
+          is_current_user_side: false,
+        },
+      ],
+      games: [
+        {
+          id: 'g1',
+          game_number: 1,
+          score: {
+            id: 's1',
+            side_1_points: 11,
+            side_2_points: 4,
+            winner_side_number: 1,
+          },
+        },
+        {
+          id: 'g2',
+          game_number: 2,
+          score: {
+            id: 's2',
+            side_1_points: 11,
+            side_2_points: 7,
+            winner_side_number: 1,
+          },
+        },
+      ],
+      current_game: null,
+      can_score: true,
+      can_finalize: true,
+      can_confirm: false,
+      signatures: [],
+    })
+    let postedGames: unknown = null
+    server.use(
+      http.get('*/v1/matches/m-resubmit', () => HttpResponse.json(match)),
+      http.post('*/v1/matches/m-resubmit/results', async ({ request }) => {
+        postedGames = ((await request.json()) as { games: unknown }).games
+        return HttpResponse.json(
+          {
+            ...match,
+            can_finalize: false,
+            can_confirm: false,
+            signatures: [{ user_id: 'u-me', signed_at: '2026-05-26T12:00:00Z' }],
+            status_label: 'Awaiting confirmation',
+          },
+          { status: 201 },
+        )
+      }),
+    )
+
+    const user = userEvent.setup()
+    renderDetails('m-resubmit')
+
+    const callout = await screen.findByTestId('match-finalize-callout')
+    const postBtn = within(callout).getByRole('button', {
+      name: /post result/i,
+    })
+    await user.click(postBtn)
+
+    // Re-posts exactly the saved (canonical side-1/side-2) scores, unchanged.
+    await waitFor(() =>
+      expect(postedGames).toEqual([
+        { game_number: 1, side_1_points: 11, side_2_points: 4 },
+        { game_number: 2, side_1_points: 11, side_2_points: 7 },
+      ]),
+    )
+    // Once posted, the resubmit callout gives way to the awaiting-confirmation
+    // state (the finalize callout is gone).
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('match-finalize-callout'),
+      ).not.toBeInTheDocument(),
+    )
+  })
 })

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -23,6 +23,7 @@ import {
   scoringNewRoute,
   useConfirmMatch,
   useDisputeMatch,
+  useFinalizeMatch,
   useMatch,
 } from '@/api/matches'
 import type { components } from '@/api/schema'
@@ -32,6 +33,7 @@ import { SaveYourMatch } from './save-your-match'
 
 type MatchDetails = components['schemas']['app__schemas__match__MatchDetails']
 type MatchDetailsGame = components['schemas']['MatchDetailsGame']
+type MatchResultsGameWrite = components['schemas']['MatchResultsGameWrite']
 type MatchDetailsSide = components['schemas']['MatchDetailsSide']
 type MatchDetailsFormResult = components['schemas']['MatchDetailsFormResult']
 type MatchDetailsPlayerForm = components['schemas']['MatchDetailsPlayerForm']
@@ -122,6 +124,11 @@ export type MatchView = {
   // True when the caller can hit either ``POST /confirmation`` or
   // ``POST /dispute`` — surfaces the Confirm / Dispute CTAs.
   canConfirm: boolean
+  // The canonical games to re-post when the saved scores form a decided, valid,
+  // unsigned match (i.e. `can_finalize`). Non-null drives the "Post result"
+  // callout, which doubles as the one-click resubmit after a mistaken dispute;
+  // null when there's nothing postable.
+  resubmitGames: MatchResultsGameWrite[] | null
   // True when there's at least one signature AND the current user is among
   // the signers — surfaces the passive "Awaiting <opponent>'s confirmation"
   // indicator (we already signed; waiting on the other side).
@@ -297,6 +304,20 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
     pendingSignerName = missing?.username ?? 'your opponent'
   }
 
+  // The canonical games to re-post when the board is decided but unsigned.
+  // Built from the saved (perspective-agnostic) side-1/side-2 scores so a
+  // one-click "Post result" sends exactly what's on the board.
+  const resubmitGames: MatchResultsGameWrite[] | null = data.can_finalize
+    ? data.games
+        .filter((g) => g.score)
+        .sort((a, b) => a.game_number - b.game_number)
+        .map((g) => ({
+          game_number: g.game_number,
+          side_1_points: g.score!.side_1_points,
+          side_2_points: g.score!.side_2_points,
+        }))
+    : null
+
   return {
     state,
     statusLabel: data.status_label,
@@ -312,6 +333,7 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
     scoreCta,
     headToHead: projectHeadToHead(data.head_to_head, leftView.sideNumber),
     canConfirm: data.can_confirm,
+    resubmitGames,
     viewerIsAwaitingOther,
     pendingSignerName,
   }
@@ -457,6 +479,8 @@ function MatchDetailsPage({
         </div>
 
         <ConfirmationCallout view={view} matchId={matchId} />
+
+        <FinalizeCallout view={view} matchId={matchId} />
 
         <SaveYourMatch key={matchId} view={view} matchId={matchId} />
 
@@ -1355,6 +1379,64 @@ function ConfirmationCallout({
   }
 
   return null
+}
+
+function FinalizeCallout({
+  view,
+  matchId,
+}: {
+  view: MatchView
+  matchId: string
+}) {
+  const finalizeMutation = useFinalizeMatch(matchId)
+  // Only a participant on a decided-but-unsigned board gets here (the backend
+  // gates `can_finalize` on participation + validity + no signature). This is
+  // the recovery path for scores entered then left unposted, and the one-click
+  // resubmit after a mistaken dispute — the scratchpad scores survive a
+  // dispute, so re-posting them unchanged drops back into the sign-off flow.
+  if (!view.resubmitGames) return null
+  const games = view.resubmitGames
+  const error =
+    finalizeMutation.error instanceof ApiError ? finalizeMutation.error : null
+  return (
+    <section
+      className="md-confirm-callout md-confirm-callout--featured"
+      data-testid="match-finalize-callout"
+    >
+      <div className="md-confirm-callout__copy">
+        <div className="md-confirm-callout__kicker">
+          <span className="ball-dot" aria-hidden="true" /> Scores ready · not
+          yet posted
+        </div>
+        <h3 className="md-confirm-callout__headline">
+          Post this result for your opponent to confirm.
+        </h3>
+        <p className="md-confirm-callout__body">
+          These scores already decide the match but haven't been posted. Post
+          them as-is to send the result for sign-off, or edit any game in the
+          scoreboard below first.
+        </p>
+        {error && (
+          <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
+            {error.detail ?? error.message}
+          </p>
+        )}
+      </div>
+      <div className="md-confirm-callout__actions">
+        <button
+          type="button"
+          className="md-btn md-btn--primary"
+          disabled={finalizeMutation.isPending}
+          onClick={() => {
+            finalizeMutation.reset()
+            finalizeMutation.mutate({ games })
+          }}
+        >
+          {finalizeMutation.isPending ? 'Posting…' : 'Post result'}
+        </button>
+      </div>
+    </section>
+  )
 }
 
 function ShareModal({

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -114,6 +114,12 @@ function currentGameNumber(seed: SeedMatch): number | null {
   // A posted-but-unconfirmed result locks the scratchpad — no game is
   // "current" in a writable sense until the result is disputed.
   if (seed.signatures.length > 0) return null
+  // A decided board has no "next game to play" even if a slot in [1, best_of]
+  // is still un-scored (a bo3 won 2-0 has no game 3). Mirrors the server's
+  // decided-check so a disputed-but-decided board reports current_game = null.
+  const target = gamesToWin(seed.best_of)
+  const { side1, side2 } = sideWinCounts(seed)
+  if (side1 >= target || side2 >= target) return null
   const scored = new Set(
     seed.games.filter((g) => g.score !== null).map((g) => g.game_number),
   )
@@ -121,6 +127,19 @@ function currentGameNumber(seed: SeedMatch): number | null {
     if (!scored.has(n)) return n
   }
   return null
+}
+
+/** Whether the saved scores are editable — the no-signature scratchpad rule.
+ * Mirrors the server's ``_is_scorable``: a non-terminal match with no posted
+ * result, regardless of whether the board already decides the match. (The mock
+ * seeds always carry two sides and view the match as a participant.) */
+function scorableSeed(seed: SeedMatch): boolean {
+  return (
+    seed.status !== 'completed' &&
+    seed.status !== 'disputed' &&
+    seed.status !== 'voided' &&
+    seed.signatures.length === 0
+  )
 }
 
 /** Whether the currently-saved scores form a complete, validly-ordered,
@@ -289,7 +308,7 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
     sides: [mySide, opponentSide],
     games,
     current_game: nextNumber !== null ? { game_number: nextNumber } : null,
-    can_score: nextNumber !== null,
+    can_score: scorableSeed(seed),
     can_finalize: canFinalizeSeed(seed),
     can_confirm: canConfirmSeed(seed),
     signatures: seedSignatureViews(seed),
@@ -425,9 +444,6 @@ function projectHeadToHead(
 export function projectListRow(seed: SeedMatch): MatchListRow {
   const { mySide, opponentSide } = projectSides(seed)
   const nextNumber = currentGameNumber(seed)
-  const scorable =
-    (seed.status === 'pending' || seed.status === 'in_progress') &&
-    nextNumber !== null
   return {
     id: seed.id,
     status: seed.status,
@@ -436,8 +452,10 @@ export function projectListRow(seed: SeedMatch): MatchListRow {
     sides: [mySide, opponentSide],
     best_of: seed.best_of,
     created_at: seed.created_at,
-    current_game_number: scorable ? nextNumber : null,
-    can_score: scorable,
+    // The next-playable-game deep-link target (null when decided/signed); the
+    // editable flag follows the no-signature rule independently of it.
+    current_game_number: nextNumber,
+    can_score: scorableSeed(seed),
     can_confirm: canConfirmSeed(seed),
   }
 }


### PR DESCRIPTION
## Problem

Disputing a result never fully returned the match to "edit scores" mode. A dispute clears the signatures (by design) but **keeps the games**, so the board is still *decided* — and `can_score` was defined as *"a next un-played game exists"* (`current_game is not None`), which is `false` for a decided board. The write path (`_enforce_scorable`) already accepted the edits, so the flag the clients trust **contradicted what the API actually allowed**. On iOS this dead-ended the disputer to a lone "Post result" with no way to edit; on web the only edit affordance was the easy-to-miss per-cell scoreline links.

## The model

Treat the saved games as a **scratchpad until someone signs**: a match is scorable iff it has **no signature** (plus: participant, two sides, non-terminal status). The signature is the only editability gate.

## Changes

**Backend (`api/app/matches.py`)**
- Add `_is_scorable(match)` as the single source of truth. `_enforce_scorable` now delegates the *decision* to it and only picks the rejection message (catch-all 409 so a future gate fails safe instead of drifting). The BFF `can_score` flag (detail + list) is derived from it, decoupled from `current_game`.
- `current_game` stays the next-*playable*-game pointer (null when decided) so dashboards/lists never deep-link a phantom game.
- `can_finalize` unchanged — a match is signable only when the scores are valid.

**Web (`match-details-page.tsx`, mock store)**
- One-click **"Post result"** resubmit callout on the detail page for a decided-but-unsigned board.
- MSW mock mirrors the backend (decided-check + `scorableSeed`).

**iOS (`MatchDetailView`, models, service)**
- **"Edit scores"** button alongside "Post result" on a decided-but-unsigned board.

So a mistaken dispute is fixed by resubmitting the unchanged scores (straight back into the sign-off flow), or by editing a game first.

## Verification

- Backend: `ruff` + `mypy --strict` clean, full suite (363) green.
- Web: `tsc` + lint clean, full suite (137, incl. a new resubmit test) green.
- iOS: builds for the simulator; full dispute → edit / resubmit flow exercised live in the simulator against a local API.
- Web flow driven end-to-end in the browser (desktop + mobile 375×667), including post-dispute list cache invalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)