### PR TITLE
scoreboard: scaffold ScoreboardProvider strangler on HeroScoreboard

### DIFF
--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -1,5 +1,6 @@
 import {
   keepPreviousData,
+  queryOptions,
   useMutation,
   useQuery,
   useQueryClient,
@@ -23,6 +24,7 @@ export type MatchGameScoreWrite = components['schemas']['MatchGameScoreWrite']
 export type MatchResultsWrite = components['schemas']['MatchResultsWrite']
 export type MatchResultsGameWrite = components['schemas']['MatchResultsGameWrite']
 export type MatchStatus = components['schemas']['MatchStatus']
+export type Scoreboard = components['schemas']['Scoreboard']
 
 export type MatchListParams = {
   status?: MatchStatus
@@ -158,9 +160,10 @@ export function matchesCsvUrl(
   return `${resolveBaseUrl()}/v1/matches.csv${query ? `?${query}` : ''}`
 }
 
-/** Throws on failure so the surrounding boundary can render a retry. */
-export function useMatch(matchId: string) {
-  return useQuery({
+/** Query options for a single match's detail. Shared by `useMatch` and any
+ * caller that needs to prefetch or read the same query (route loaders, etc.). */
+export function matchQueryOptions(matchId: string) {
+  return queryOptions({
     queryKey: matchQueryKey(matchId),
     queryFn: async (): Promise<MatchDetails> =>
       unwrap(
@@ -172,6 +175,11 @@ export function useMatch(matchId: string) {
     retry: false,
     throwOnError: true,
   })
+}
+
+/** Throws on failure so the surrounding boundary can render a retry. */
+export function useMatch(matchId: string) {
+  return useQuery(matchQueryOptions(matchId))
 }
 
 /** Cache work shared by both score mutations: prime the detail cache from the

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -13,6 +13,7 @@ import {
   X,
 } from 'lucide-react'
 
+import { ScoreboardProvider } from '@/components/matches/match-details/scoreboard'
 import { AppShell } from '@/components/app-shell'
 import { Overline } from '@/components/overline'
 import { cn, initialsOf } from '@/lib/utils'
@@ -555,6 +556,8 @@ function HeroScoreboard({
   const isUpcoming = view.state === 'upcoming'
 
   return (
+    <ScoreboardProvider matchId={matchId}>
+      {(_scoreboard) => (
     <section className="md-hero">
       <div className="md-hero__grid-bg" aria-hidden="true" />
 
@@ -637,6 +640,8 @@ function HeroScoreboard({
         <GameGrid view={view} matchId={matchId} />
       )}
     </section>
+      )}
+    </ScoreboardProvider>
   )
 }
 

--- a/web-client/src/components/matches/match-details/scoreboard.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard.tsx
@@ -1,0 +1,16 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { scoreboardQuery } from './scoreboard/scoreboard-query'
+import type { Scoreboard } from './scoreboard/scoreboard-query'
+
+export function ScoreboardProvider({
+    matchId,
+    children,
+}: {
+    matchId: string
+    children: (scoreboard: Scoreboard) => ReactNode
+}) {
+    const { data: scoreboard } = useSuspenseQuery(scoreboardQuery(matchId))
+
+    return children(scoreboard)
+}

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.ts
@@ -1,0 +1,12 @@
+import { matchQueryOptions } from '@/api/matches';
+import type { Scoreboard } from '@/api/matches';
+
+export type { Scoreboard };
+
+const selectScoreboard = ({ data }: { data: { scoreboard: Scoreboard } }): Scoreboard =>
+    data.scoreboard;
+
+export const scoreboardQuery = (matchId: string) => ({
+    ...matchQueryOptions(matchId),
+    select: selectScoreboard,
+});


### PR DESCRIPTION
## Summary

- Extracts `matchQueryOptions()` from `useMatch()` so the query key/fn can be shared by hook callers, route loaders, and selectors without re-specifying the fetch
- Exports `Scoreboard` type from `@/api/matches` (the canonical API layer) rather than reaching into raw `@/api/schema`
- Adds `scoreboardQuery` — a select-lens over the existing `['matches', 'detail', matchId]` cache entry with a stable hoisted selector, so TanStack Query doesn't re-run it on every render
- Adds `ScoreboardProvider` render-prop component that suspense-fetches the scoreboard and passes it to children; wired into `HeroScoreboard` as the first consumer — `_scoreboard` will replace the `MatchView` props incrementally as the strangler progresses

## Test plan

- [ ] Visit a match detail page — hero scoreboard renders as before
- [ ] No extra network requests (the scoreboard query hits the existing match cache entry)
- [ ] TypeScript build passes (`npm run build` in `web-client/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)