### PR TITLE
Add iOS push notifications (web button → API → APNs)

### DIFF
--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -24,6 +24,7 @@ from sqlalchemy import CursorResult, delete, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import (
+    DeviceToken,
     LeagueMembership,
     Match,
     MatchSidePlayer,
@@ -118,6 +119,25 @@ async def merge_user(
         {"from_id": from_user_id, "to_id": to_user_id},
     )
 
+    # device_tokens.token is UNIQUE, so re-point only the guest's tokens the
+    # survivor doesn't already hold; the rare collision (same physical device
+    # registered under both users) is dropped with the rest below.
+    await db.execute(
+        text(
+            """
+            UPDATE device_tokens AS dt
+            SET user_id = :to_id
+            WHERE dt.user_id = :from_id
+              AND NOT EXISTS (
+                SELECT 1 FROM device_tokens other
+                WHERE other.user_id = :to_id
+                  AND other.token = dt.token
+              )
+            """
+        ),
+        {"from_id": from_user_id, "to_id": to_user_id},
+    )
+
     # match_side_players is RESTRICT, so any rows that didn't re-point would
     # block the final user delete. Re-point should always cover them; this is
     # a belt-and-braces drop in case the impossible collision ever fires.
@@ -134,6 +154,7 @@ async def merge_user(
     # none of these reference each other. Keep the guest's *session* tokens so
     # its cookie still resolves to this (now-tombstoned) row.
     await db.execute(delete(UserRole).where(UserRole.user_id == from_user_id))
+    await db.execute(delete(DeviceToken).where(DeviceToken.user_id == from_user_id))
     await db.execute(delete(RatingHistory).where(RatingHistory.user_id == from_user_id))
     await db.execute(
         delete(UserLeagueRating).where(UserLeagueRating.user_id == from_user_id)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -12,6 +12,7 @@ from sqlalchemy import text
 from app import db, queue
 from app.dashboard import router as dashboard_router
 from app.matches import router as matches_router
+from app.notifications.router import router as notifications_router
 from app.players import router as players_router
 from app.rate_limiting import init_rate_limit_redis, shutdown_rate_limit_redis
 from app.rbac import router as rbac_router
@@ -43,6 +44,7 @@ app.include_router(rbac_router)
 app.include_router(matches_router)
 app.include_router(players_router)
 app.include_router(dashboard_router)
+app.include_router(notifications_router)
 
 SOLVER_HEALTH_TIMEOUT = 10.0
 

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.device_token import DeviceToken
 from app.models.league import League, LeagueVisibility
 from app.models.league_membership import LeagueMembership
 from app.models.match import Match, MatchStatus
@@ -18,6 +19,7 @@ from app.models.user_role import UserRole
 from app.models.user_token import UserToken
 
 __all__ = [
+    "DeviceToken",
     "League",
     "LeagueMembership",
     "LeagueVisibility",

--- a/api/app/models/device_token.py
+++ b/api/app/models/device_token.py
@@ -1,0 +1,59 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+from app.models.user import User
+
+
+class DeviceToken(Base):
+    """An APNs device token registered by an installed iOS app, owned by the
+    user whose session registered it. The backend sends remote pushes to these.
+
+    ``token`` is unique on its own: an APNs token identifies a single
+    device+app install globally, so re-registration from a device that has
+    since signed into a different account re-points the existing row's
+    ``user_id`` rather than inserting a duplicate (see
+    ``NotificationService.register_device_token``).
+    """
+
+    __tablename__ = "device_tokens"
+    # Named explicitly (not via the column's ``unique=True``) so the constraint
+    # name is stable across both create_all (tests) and the migration, which is
+    # what the registration upsert targets in ``on_conflict_do_update``.
+    __table_args__ = (UniqueConstraint("token", name="uq_device_tokens_token"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    token: Mapped[str] = mapped_column(String(512), nullable=False)
+    # Open today (only "ios"), but kept a string rather than an enum so adding
+    # a platform later doesn't need a migration. The schema layer pins the
+    # accepted inbound values with a Literal.
+    platform: Mapped[str] = mapped_column(String(16), nullable=False)
+    # "sandbox" (Xcode/dev builds) or "production" (TestFlight/App Store) —
+    # decides which APNs host the push goes to. The device reports it at
+    # registration based on its build configuration.
+    environment: Mapped[str] = mapped_column(String(16), nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    user: Mapped[User] = relationship(User)

--- a/api/app/notifications/apns.py
+++ b/api/app/notifications/apns.py
@@ -1,0 +1,210 @@
+"""Apple Push Notification service (APNs) sender.
+
+Token-based (JWT) auth over HTTP/2. The interior of the app depends on the
+``PushSender`` protocol, not the concrete client, so handlers and tests can
+substitute a fake (mirrors the ``RatingCalculator`` protocol seam).
+
+Configuration comes from the environment (the ``os.environ.get`` pattern used
+by ``app/captcha.py`` / ``app/email.py``). When unset, ``push_sender_from_env``
+returns a ``NoopSender`` whose ``is_configured`` is ``False`` — the service
+turns that into a clean ``503`` rather than crashing, exactly as ``app/email.py``
+no-ops without ``SMTP_HOST``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal, Protocol
+
+import httpx
+import jwt
+
+log = logging.getLogger(__name__)
+
+Environment = Literal["sandbox", "production"]
+
+_APNS_HOSTS: dict[str, str] = {
+    "sandbox": "https://api.sandbox.push.apple.com",
+    "production": "https://api.push.apple.com",
+}
+
+# APNs accepts a provider JWT for up to 1 hour and rejects tokens younger than
+# ~20 minutes when refreshed too eagerly. Refresh well inside the window.
+_JWT_TTL_SECONDS = 50 * 60
+
+# APNs reasons that mean "this device token is dead — stop sending to it".
+_GONE_REASONS = {"BadDeviceToken", "Unregistered", "DeviceTokenNotForTopic"}
+
+
+class SendOutcome(Enum):
+    SUCCESS = "success"
+    # The token is permanently invalid (uninstalled app, wrong environment) and
+    # should be pruned from the database.
+    GONE = "gone"
+    # A transient or configuration failure — left in place to retry later.
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class SendResult:
+    outcome: SendOutcome
+    detail: str | None = None
+
+
+class PushSender(Protocol):
+    """The seam the service depends on. Real implementation talks to APNs;
+    tests inject a recording fake."""
+
+    @property
+    def is_configured(self) -> bool: ...
+
+    async def send(
+        self,
+        token: str,
+        *,
+        environment: Environment,
+        title: str,
+        body: str,
+    ) -> SendResult: ...
+
+
+class NoopSender:
+    """Stand-in used when APNs credentials aren't configured. The service
+    checks ``is_configured`` and returns 503 before ever calling ``send``."""
+
+    is_configured = False
+
+    async def send(
+        self,
+        token: str,
+        *,
+        environment: Environment,
+        title: str,
+        body: str,
+    ) -> SendResult:
+        return SendResult(SendOutcome.FAILED, "push not configured")
+
+
+@dataclass(frozen=True)
+class APNsConfig:
+    key_id: str
+    team_id: str
+    bundle_id: str
+    auth_key_pem: str
+
+    @staticmethod
+    def from_env() -> APNsConfig | None:
+        """Build config from the environment, or ``None`` if the required
+        pieces are missing. ``APNS_AUTH_KEY`` holds the .p8 PEM contents
+        directly; ``APNS_AUTH_KEY_PATH`` points at the .p8 file on disk."""
+        key_id = os.environ.get("APNS_KEY_ID")
+        team_id = os.environ.get("APNS_TEAM_ID")
+        bundle_id = os.environ.get("APNS_BUNDLE_ID", "com.fortymm.ios-client")
+        auth_key_pem = _read_auth_key()
+        if not (key_id and team_id and auth_key_pem):
+            return None
+        return APNsConfig(
+            key_id=key_id,
+            team_id=team_id,
+            bundle_id=bundle_id,
+            auth_key_pem=auth_key_pem,
+        )
+
+
+def _read_auth_key() -> str | None:
+    inline = os.environ.get("APNS_AUTH_KEY")
+    if inline:
+        return inline
+    path = os.environ.get("APNS_AUTH_KEY_PATH")
+    if path:
+        try:
+            with open(path, encoding="utf-8") as handle:
+                return handle.read()
+        except OSError as exc:
+            log.warning("APNS_AUTH_KEY_PATH set but unreadable: %s", exc)
+            return None
+    return None
+
+
+class APNsClient:
+    """Sends a single alert push per ``send`` call. Reuses one HTTP/2 client
+    (connection pooling) and caches the provider JWT for ~50 minutes."""
+
+    is_configured = True
+
+    def __init__(
+        self,
+        config: APNsConfig,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self._client = client or httpx.AsyncClient(http2=True, timeout=10.0)
+        self._cached_jwt: str | None = None
+        self._jwt_minted_at: float = 0.0
+
+    def _provider_jwt(self) -> str:
+        now = time.monotonic()
+        age = now - self._jwt_minted_at
+        if self._cached_jwt is not None and age < _JWT_TTL_SECONDS:
+            return self._cached_jwt
+        token = jwt.encode(
+            {"iss": self._config.team_id, "iat": int(time.time())},
+            self._config.auth_key_pem,
+            algorithm="ES256",
+            headers={"kid": self._config.key_id},
+        )
+        self._cached_jwt = token
+        self._jwt_minted_at = now
+        return token
+
+    async def send(
+        self,
+        token: str,
+        *,
+        environment: Environment,
+        title: str,
+        body: str,
+    ) -> SendResult:
+        url = f"{_APNS_HOSTS[environment]}/3/device/{token}"
+        headers = {
+            "authorization": f"bearer {self._provider_jwt()}",
+            "apns-topic": self._config.bundle_id,
+            "apns-push-type": "alert",
+        }
+        payload = {"aps": {"alert": {"title": title, "body": body}, "sound": "default"}}
+        try:
+            response = await self._client.post(url, headers=headers, json=payload)
+        except httpx.HTTPError as exc:
+            log.warning("APNs request failed: %s", exc)
+            return SendResult(SendOutcome.FAILED, str(exc) or exc.__class__.__name__)
+        return _classify(response)
+
+
+def _classify(response: httpx.Response) -> SendResult:
+    if response.status_code == 200:
+        return SendResult(SendOutcome.SUCCESS)
+    try:
+        body = response.json()
+    except ValueError:
+        body = None
+    raw = body.get("reason") if isinstance(body, dict) else None
+    reason = raw if isinstance(raw, str) else None
+    if response.status_code == 410 or reason in _GONE_REASONS:
+        return SendResult(SendOutcome.GONE, reason)
+    log.warning("APNs rejected push: %s %s", response.status_code, reason)
+    return SendResult(SendOutcome.FAILED, reason)
+
+
+def push_sender_from_env() -> PushSender:
+    """The single construction point for the process-wide sender: a real
+    ``APNsClient`` when configured, else a ``NoopSender``."""
+    config = APNsConfig.from_env()
+    if config is None:
+        log.info("APNs not configured — push notifications will return 503")
+        return NoopSender()
+    return APNsClient(config)

--- a/api/app/notifications/dependencies.py
+++ b/api/app/notifications/dependencies.py
@@ -1,0 +1,29 @@
+"""FastAPI wiring for the notifications domain — the single place that knows how
+to construct the push sender and service (api/CLAUDE.md service-layer rules).
+
+The sender is a process-wide singleton (it holds an HTTP/2 connection pool and a
+cached provider JWT, no request state) — unlike session-holding services, which
+must stay request-scoped.
+"""
+
+from __future__ import annotations
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_session
+from app.notifications.apns import PushSender, push_sender_from_env
+from app.notifications.service import NotificationService
+
+_sender: PushSender = push_sender_from_env()
+
+
+def get_push_sender() -> PushSender:
+    return _sender
+
+
+def get_notification_service(
+    db: AsyncSession = Depends(get_session),
+    sender: PushSender = Depends(get_push_sender),
+) -> NotificationService:
+    return NotificationService(db, sender)

--- a/api/app/notifications/router.py
+++ b/api/app/notifications/router.py
@@ -1,0 +1,41 @@
+"""HTTP layer for push notifications: register a device token, and fire a test
+push to the caller's devices. Parses, delegates to ``NotificationService``,
+shapes the response — no data/domain logic inline."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.models import User
+from app.notifications.dependencies import get_notification_service
+from app.notifications.service import NotificationService, PushNotConfiguredError
+from app.schemas.notification import (
+    DeviceTokenResponse,
+    RegisterDeviceTokenRequest,
+    TestNotificationResponse,
+)
+from app.sessions import get_current_user
+
+router = APIRouter()
+
+
+@router.post("/v1/device-tokens", response_model=DeviceTokenResponse)
+async def register_device_token(
+    payload: RegisterDeviceTokenRequest,
+    service: NotificationService = Depends(get_notification_service),
+    current_user: User = Depends(get_current_user),
+) -> DeviceTokenResponse:
+    await service.register_device_token(current_user, payload)
+    return DeviceTokenResponse()
+
+
+@router.post("/v1/notifications/test", response_model=TestNotificationResponse)
+async def send_test_notification(
+    service: NotificationService = Depends(get_notification_service),
+    current_user: User = Depends(get_current_user),
+) -> TestNotificationResponse:
+    try:
+        return await service.send_test_notification(current_user)
+    except PushNotConfiguredError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Push notifications are not configured on the server.",
+        ) from None

--- a/api/app/notifications/service.py
+++ b/api/app/notifications/service.py
@@ -1,0 +1,105 @@
+"""Domain + data logic for device-token registration and test pushes.
+
+Plain class wired by ``notifications/dependencies.py`` — no FastAPI imports
+(api/CLAUDE.md service-layer rules). It raises ``PushNotConfiguredError`` rather
+than an ``HTTPException`` so the HTTP mapping stays in the router.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import DeviceToken, User
+from app.notifications.apns import Environment, PushSender, SendOutcome
+from app.schemas.notification import (
+    RegisterDeviceTokenRequest,
+    TestNotificationResponse,
+)
+
+_TEST_TITLE = "FortyMM"
+_TEST_BODY = "🏓 Test notification — your push setup is working."
+
+
+class PushNotConfiguredError(Exception):
+    """Raised when a push is requested but no APNs credentials are configured.
+    The router maps this to a 503."""
+
+
+def _as_environment(value: str) -> Environment | None:
+    if value == "sandbox":
+        return "sandbox"
+    if value == "production":
+        return "production"
+    return None
+
+
+class NotificationService:
+    def __init__(self, db: AsyncSession, sender: PushSender) -> None:
+        self._db = db
+        self._sender = sender
+
+    async def register_device_token(
+        self, user: User, req: RegisterDeviceTokenRequest
+    ) -> None:
+        """Upsert keyed on the globally-unique APNs token: a device that has
+        since signed into a different account re-points to the new owner rather
+        than creating a duplicate row."""
+        stmt = insert(DeviceToken).values(
+            token=req.token,
+            platform=req.platform,
+            environment=req.environment,
+            user_id=user.id,
+        )
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_device_tokens_token",
+            set_={
+                "user_id": user.id,
+                "platform": req.platform,
+                "environment": req.environment,
+                "updated_at": func.now(),
+            },
+        )
+        await self._db.execute(stmt)
+        await self._db.commit()
+
+    async def send_test_notification(self, user: User) -> TestNotificationResponse:
+        """Fan a test push out to every device the user has registered, pruning
+        any token APNs reports as gone. Raises ``PushNotConfiguredError`` if no
+        credentials are set; returns ``sent=0`` (not an error) if the user has
+        no registered devices."""
+        if not self._sender.is_configured:
+            raise PushNotConfiguredError
+
+        rows = await self._db.execute(
+            select(DeviceToken).where(DeviceToken.user_id == user.id)
+        )
+        tokens = rows.scalars().all()
+
+        sent = 0
+        gone_ids: list[uuid.UUID] = []
+        for device in tokens:
+            environment = _as_environment(device.environment)
+            if environment is None:
+                continue
+            result = await self._sender.send(
+                device.token,
+                environment=environment,
+                title=_TEST_TITLE,
+                body=_TEST_BODY,
+            )
+            if result.outcome is SendOutcome.SUCCESS:
+                sent += 1
+            elif result.outcome is SendOutcome.GONE:
+                gone_ids.append(device.id)
+
+        if gone_ids:
+            await self._db.execute(
+                delete(DeviceToken).where(DeviceToken.id.in_(gone_ids))
+            )
+            await self._db.commit()
+
+        return TestNotificationResponse(sent=sent, pruned=len(gone_ids))

--- a/api/app/schemas/notification.py
+++ b/api/app/schemas/notification.py
@@ -1,0 +1,31 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RegisterDeviceTokenRequest(BaseModel):
+    """An installed iOS app registering its APNs device token against the
+    caller's session, so the backend can push to it later."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    token: str = Field(min_length=1, max_length=512)
+    platform: Literal["ios"]
+    environment: Literal["sandbox", "production"]
+
+
+class DeviceTokenResponse(BaseModel):
+    """Confirmation that the device token is registered to the current user."""
+
+    registered: bool = True
+
+
+class TestNotificationResponse(BaseModel):
+    """Outcome of firing a test push to the current user's devices.
+
+    ``sent`` counts deliveries APNs accepted; ``pruned`` counts tokens APNs
+    reported as gone (unregistered / bad), which are deleted as a side effect.
+    """
+
+    sent: int
+    pruned: int

--- a/api/migrations/versions/20260607_0000_0008_create_device_tokens_table.py
+++ b/api/migrations/versions/20260607_0000_0008_create_device_tokens_table.py
@@ -1,0 +1,63 @@
+"""create device_tokens table
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-06-07 00:00:00.000000
+
+Per the pre-deploy convention in api/CLAUDE.md, edits to this migration
+happen in place. No backfill — assumes a fresh / empty DB.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0008"
+down_revision: Union[str, None] = "0007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "device_tokens",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("token", sa.String(length=512), nullable=False),
+        sa.Column("platform", sa.String(length=16), nullable=False),
+        sa.Column("environment", sa.String(length=16), nullable=False),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # An APNs token is globally unique to one device+app install, so a
+        # re-registration re-points this row's user_id rather than inserting a
+        # duplicate. The unique constraint is what the upsert keys on.
+        sa.UniqueConstraint("token", name="uq_device_tokens_token"),
+    )
+    op.create_index("ix_device_tokens_user_id", "device_tokens", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_device_tokens_user_id", table_name="device_tokens")
+    op.drop_table("device_tokens")

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -15,8 +15,9 @@ dependencies = [
     "coolname>=2.2",
     "jsonschema>=4.21",
     "pydantic[email]>=2.0",
-    "httpx>=0.27.0",
+    "httpx[http2]>=0.27.0",
     "fastapi-limiter>=0.1.6,<0.3",
+    "pyjwt[crypto]>=2.9",
 ]
 
 [project.optional-dependencies]

--- a/api/tests/test_notifications.py
+++ b/api/tests/test_notifications.py
@@ -1,0 +1,180 @@
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.main import app
+from app.models import DeviceToken
+from app.notifications.apns import Environment, SendOutcome, SendResult
+from app.notifications.dependencies import get_push_sender
+from tests._helpers import make_client, start_session
+
+# ``api_client`` (an ASGI client sharing the per-test ``db_session``) comes from
+# tests/conftest.py — no need to redefine it here.
+
+
+class FakeSender:
+    """Records every send and returns a per-token outcome (default success)."""
+
+    def __init__(
+        self,
+        *,
+        configured: bool = True,
+        outcomes: dict[str, SendOutcome] | None = None,
+    ) -> None:
+        self.is_configured = configured
+        self.sent: list[tuple[str, str, str, str]] = []
+        self._outcomes = outcomes or {}
+
+    async def send(
+        self,
+        token: str,
+        *,
+        environment: Environment,
+        title: str,
+        body: str,
+    ) -> SendResult:
+        self.sent.append((token, environment, title, body))
+        return SendResult(self._outcomes.get(token, SendOutcome.SUCCESS))
+
+
+def use_sender(sender: FakeSender) -> None:
+    app.dependency_overrides[get_push_sender] = lambda: sender
+
+
+async def register(
+    client: AsyncClient,
+    token: str,
+    *,
+    environment: str = "sandbox",
+) -> None:
+    response = await client.post(
+        "/v1/device-tokens",
+        json={"token": token, "platform": "ios", "environment": environment},
+    )
+    assert response.status_code == 200, response.text
+
+
+# --- registration -----------------------------------------------------------
+
+
+async def test_register_inserts_token(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    user = await start_session(api_client, db_session)
+    await register(api_client, "tok-aaa")
+
+    rows = (await db_session.execute(select(DeviceToken))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].token == "tok-aaa"
+    assert rows[0].user_id == user.id
+    assert rows[0].environment == "sandbox"
+
+
+async def test_register_same_token_updates_in_place(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    await register(api_client, "tok-aaa", environment="sandbox")
+    await register(api_client, "tok-aaa", environment="production")
+
+    rows = (await db_session.execute(select(DeviceToken))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].environment == "production"
+
+
+async def test_register_repoints_token_to_new_user(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The same physical device signing into a different account re-points the
+    existing row rather than duplicating it (token is globally unique)."""
+    await start_session(api_client, db_session)
+    await register(api_client, "tok-shared")
+
+    other = make_client()
+    try:
+        user_b = await start_session(other, db_session)
+        await register(other, "tok-shared")
+    finally:
+        await other.aclose()
+
+    rows = (await db_session.execute(select(DeviceToken))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].user_id == user_b.id
+
+
+async def test_register_requires_session(api_client: AsyncClient):
+    response = await api_client.post(
+        "/v1/device-tokens",
+        json={"token": "tok", "platform": "ios", "environment": "sandbox"},
+    )
+    assert response.status_code == 401
+
+
+# --- test send --------------------------------------------------------------
+
+
+async def test_test_send_fans_out_to_all_user_tokens(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    await register(api_client, "tok-1")
+    await register(api_client, "tok-2", environment="production")
+
+    sender = FakeSender()
+    use_sender(sender)
+    response = await api_client.post("/v1/notifications/test")
+
+    assert response.status_code == 200
+    assert response.json() == {"sent": 2, "pruned": 0}
+    by_token = {token: environment for (token, environment, _, _) in sender.sent}
+    assert by_token == {"tok-1": "sandbox", "tok-2": "production"}
+
+
+async def test_test_send_prunes_gone_tokens(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    await register(api_client, "tok-live")
+    await register(api_client, "tok-dead")
+
+    sender = FakeSender(outcomes={"tok-dead": SendOutcome.GONE})
+    use_sender(sender)
+    response = await api_client.post("/v1/notifications/test")
+
+    assert response.status_code == 200
+    assert response.json() == {"sent": 1, "pruned": 1}
+
+    remaining = (await db_session.execute(select(DeviceToken))).scalars().all()
+    assert [r.token for r in remaining] == ["tok-live"]
+
+
+async def test_test_send_with_no_devices_is_not_an_error(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+
+    sender = FakeSender()
+    use_sender(sender)
+    response = await api_client.post("/v1/notifications/test")
+
+    assert response.status_code == 200
+    assert response.json() == {"sent": 0, "pruned": 0}
+    assert sender.sent == []
+
+
+async def test_test_send_returns_503_when_unconfigured(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    await register(api_client, "tok-1")
+
+    use_sender(FakeSender(configured=False))
+    response = await api_client.post("/v1/notifications/test")
+
+    assert response.status_code == 503
+
+
+async def test_test_send_requires_session(api_client: AsyncClient):
+    use_sender(FakeSender())
+    response = await api_client.post("/v1/notifications/test")
+    assert response.status_code == 401

--- a/ios/Fortymm/Fortymm.entitlements
+++ b/ios/Fortymm/Fortymm.entitlements
@@ -19,5 +19,17 @@
 	<array>
 		<string>applinks:uat.fortymm.com</string>
 	</array>
+	<!--
+	  Push notifications (APNs). `development` routes device tokens through the
+	  APNs *sandbox*, which is what Xcode debug builds register against — the
+	  app reports "sandbox" to the backend (POST /v1/device-tokens) so the
+	  server pushes via api.sandbox.push.apple.com. TestFlight / App Store
+	  builds need this set to `production` (and the app then reports
+	  "production"); flip both together when cutting a release build. The App ID
+	  com.fortymm.ios-client must have the Push Notifications capability enabled
+	  in the Apple Developer portal for token registration to succeed.
+	-->
+	<key>aps-environment</key>
+	<string>development</string>
 </dict>
 </plist>

--- a/ios/Fortymm/FortymmApp.swift
+++ b/ios/Fortymm/FortymmApp.swift
@@ -1,11 +1,35 @@
 import SwiftUI
+import UIKit
 
 @main
 struct FortymmApp: App {
+    // SwiftUI has no hook for the APNs device-token callbacks, so we bridge in a
+    // minimal UIApplicationDelegate that forwards them to PushNotificationManager.
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
     var body: some Scene {
         WindowGroup {
             RootView()
                 .preferredColorScheme(.dark)
         }
+    }
+}
+
+/// Bridges the remote-notification registration callbacks (which only arrive on
+/// the app delegate) to `PushNotificationManager`. Registration itself is
+/// triggered from `RootView` once the session has loaded.
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        PushNotificationManager.shared.didRegister(deviceToken: deviceToken)
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        PushNotificationManager.shared.didFailToRegister(error: error)
     }
 }

--- a/ios/Fortymm/Navigation/RootView.swift
+++ b/ios/Fortymm/Navigation/RootView.swift
@@ -27,6 +27,10 @@ struct RootView: View {
                 .fullScreenCover(item: $session.pendingDeepLink) { link in
                     deepLinkDestination(link)
                 }
+                // Now that a session exists to attach the device token to, ask
+                // for notification permission and register with APNs. Runs once
+                // the signed-in shell appears.
+                .task { PushNotificationManager.shared.requestAuthorizationAndRegister() }
         case let .signedOut(reason, email):
             SessionEndedView(
                 reason: reason,

--- a/ios/Fortymm/Notifications/PushNotificationManager.swift
+++ b/ios/Fortymm/Notifications/PushNotificationManager.swift
@@ -1,0 +1,115 @@
+import UIKit
+import UserNotifications
+
+/// Owns the device side of remote (APNs) push notifications:
+///
+/// 1. asks the user for permission and registers with APNs,
+/// 2. receives the APNs device token (via the app delegate, see
+///    `FortymmApp.swift`), hex-encodes it, and POSTs it to the backend so the
+///    server can push to this device,
+/// 3. presents pushes as a banner even while the app is foregrounded (otherwise
+///    a self-test looks like nothing happened).
+///
+/// A singleton because the `UIApplicationDelegate` token callbacks and the
+/// SwiftUI view that triggers registration must talk to the same instance, and
+/// it carries no per-view state.
+final class PushNotificationManager: NSObject {
+    static let shared = PushNotificationManager()
+
+    private let client: APIClient
+
+    /// Whether the device-token POST should report a sandbox or production APNs
+    /// token. Debug builds register against the APNs sandbox; release builds
+    /// (TestFlight / App Store) against production — kept in lockstep with the
+    /// `aps-environment` entitlement.
+    private static var environment: String {
+        #if DEBUG
+        return "sandbox"
+        #else
+        return "production"
+        #endif
+    }
+
+    init(client: APIClient = .shared) {
+        self.client = client
+        super.init()
+        UNUserNotificationCenter.current().delegate = self
+    }
+
+    /// Ask for notification permission (no-op prompt after the first time — iOS
+    /// returns the existing decision) and, if not denied, register with APNs.
+    /// Safe to call on every launch; Apple recommends re-registering each launch
+    /// so a rotated device token reaches the server.
+    func requestAuthorizationAndRegister() {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
+            if let error {
+                print("[push] authorization error: \(error.localizedDescription)")
+            }
+            guard granted else {
+                print("[push] notifications not granted")
+                return
+            }
+            // registerForRemoteNotifications must run on the main thread.
+            DispatchQueue.main.async {
+                UIApplication.shared.registerForRemoteNotifications()
+            }
+        }
+    }
+
+    /// Called by the app delegate when APNs hands us a device token. Hex-encode
+    /// it (the wire format APNs expects) and send it to the backend.
+    func didRegister(deviceToken: Data) {
+        let hex = deviceToken.map { String(format: "%02x", $0) }.joined()
+        Task { await register(token: hex) }
+    }
+
+    func didFailToRegister(error: Error) {
+        print("[push] remote registration failed: \(error.localizedDescription)")
+    }
+
+    private func register(token: String) async {
+        let body = RegisterDeviceTokenRequest(
+            token: token,
+            platform: "ios",
+            environment: Self.environment
+        )
+        do {
+            let _: DeviceTokenRegistration = try await client.post(
+                "/v1/device-tokens",
+                body: body
+            )
+        } catch {
+            // Best-effort: a failed registration just means this device won't
+            // receive pushes until the next successful launch. Don't surface it.
+            print("[push] device-token registration failed: \(error.fmMessage)")
+        }
+    }
+}
+
+extension PushNotificationManager: UNUserNotificationCenterDelegate {
+    /// Show the banner (and play the sound) even when the app is in the
+    /// foreground, so a push that arrives while the user is in the app is
+    /// actually visible.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler:
+            @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound, .badge])
+    }
+}
+
+/// Request body for `POST /v1/device-tokens`. Keys are sent snake_case by
+/// `APIClient`'s encoder; these are all single words so they map 1:1.
+private struct RegisterDeviceTokenRequest: Encodable {
+    let token: String
+    let platform: String
+    let environment: String
+}
+
+/// `POST /v1/device-tokens` response — `{ "registered": true }`.
+private struct DeviceTokenRegistration: Decodable {
+    let registered: Bool
+}

--- a/web-client/src/api/notifications.ts
+++ b/web-client/src/api/notifications.ts
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query'
+import { api, unwrap } from './client'
+import type { components } from './schema'
+
+export type TestNotificationResult =
+  components['schemas']['TestNotificationResponse']
+
+/**
+ * Fire a test push to the current user's registered iOS devices. The backend
+ * fans out to every device token the signed-in user has registered (so you must
+ * be signed into the same account in the iOS app) and reports how many were
+ * delivered. Callers await via `mutateAsync` and catch `ApiError` — a 503 means
+ * push isn't configured on the server.
+ */
+export function useSendTestNotification() {
+  return useMutation({
+    mutationFn: async (): Promise<TestNotificationResult> =>
+      unwrap('send test notification', await api.POST('/v1/notifications/test')),
+  })
+}

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -666,6 +666,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/device-tokens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Register Device Token */
+        post: operations["register_device_token_v1_device_tokens_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/notifications/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send Test Notification */
+        post: operations["send_test_notification_v1_notifications_test_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/health": {
         parameters: {
             query?: never;
@@ -832,6 +866,17 @@ export interface components {
             kind: "W" | "L";
             /** N */
             n: number;
+        };
+        /**
+         * DeviceTokenResponse
+         * @description Confirmation that the device token is registered to the current user.
+         */
+        DeviceTokenResponse: {
+            /**
+             * Registered
+             * @default true
+             */
+            registered: boolean;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -1425,6 +1470,25 @@ export interface components {
             /** Role Ids */
             role_ids: string[];
         };
+        /**
+         * RegisterDeviceTokenRequest
+         * @description An installed iOS app registering its APNs device token against the
+         *     caller's session, so the backend can push to it later.
+         */
+        RegisterDeviceTokenRequest: {
+            /** Token */
+            token: string;
+            /**
+             * Platform
+             * @constant
+             */
+            platform: "ios";
+            /**
+             * Environment
+             * @enum {string}
+             */
+            environment: "sandbox" | "production";
+        };
         /** RequestLoginRequest */
         RequestLoginRequest: {
             /** Captcha Token */
@@ -1540,6 +1604,19 @@ export interface components {
          * @enum {string}
          */
         Status: "scheduled" | "live" | "final";
+        /**
+         * TestNotificationResponse
+         * @description Outcome of firing a test push to the current user's devices.
+         *
+         *     ``sent`` counts deliveries APNs accepted; ``pruned`` counts tokens APNs
+         *     reported as gone (unregistered / bad), which are deleted as a side effect.
+         */
+        TestNotificationResponse: {
+            /** Sent */
+            sent: number;
+            /** Pruned */
+            pruned: number;
+        };
         /** UpdateCurrentUserRequest */
         UpdateCurrentUserRequest: {
             /** Username */
@@ -2992,6 +3069,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DashboardResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    register_device_token_v1_device_tokens_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegisterDeviceTokenRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeviceTokenResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    send_test_notification_v1_notifications_test_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TestNotificationResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -581,7 +581,7 @@ function HeroScoreboard({
 
   return (
     <ScoreboardProvider matchId={matchId}>
-      {(_scoreboard) => (
+      {() => (
     <section className="md-hero">
       <div className="md-hero__grid-bg" aria-hidden="true" />
 

--- a/web-client/src/routes/settings.test.tsx
+++ b/web-client/src/routes/settings.test.tsx
@@ -240,3 +240,62 @@ describe('SettingsPage footer sign out', () => {
     await waitFor(() => expect(deleteCalled).toBe(true))
   })
 })
+
+describe('SettingsPage notifications section', () => {
+  it('POSTs a test push and confirms delivery', async () => {
+    const user = userEvent.setup()
+    let called = false
+    server.use(
+      http.post('*/v1/notifications/test', () => {
+        called = true
+        return HttpResponse.json({ sent: 2, pruned: 0 })
+      }),
+    )
+
+    await renderSettings()
+    await user.click(
+      await screen.findByRole('button', { name: /send test notification/i }),
+    )
+
+    await waitFor(() => expect(called).toBe(true))
+    // No "no devices" / "not configured" note on a successful send.
+    expect(screen.queryByText(/no devices registered/i)).not.toBeInTheDocument()
+  })
+
+  it('shows a helper note when no devices are registered', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('*/v1/notifications/test', () =>
+        HttpResponse.json({ sent: 0, pruned: 0 }),
+      ),
+    )
+
+    await renderSettings()
+    await user.click(
+      await screen.findByRole('button', { name: /send test notification/i }),
+    )
+
+    expect(
+      await screen.findByText(/no devices registered yet/i),
+    ).toBeInTheDocument()
+  })
+
+  it('explains when push is not configured on the server (503)', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post(
+        '*/v1/notifications/test',
+        () => new HttpResponse(null, { status: 503 }),
+      ),
+    )
+
+    await renderSettings()
+    await user.click(
+      await screen.findByRole('button', { name: /send test notification/i }),
+    )
+
+    expect(
+      await screen.findByText(/aren't configured on the server/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -15,6 +15,7 @@ import { Check, Mail } from 'lucide-react'
 import { toast } from 'sonner'
 
 import { ApiError } from '@/api/client'
+import { useSendTestNotification } from '@/api/notifications'
 import {
   deriveEmailStatus,
   useLogout,
@@ -969,6 +970,72 @@ function EmailSection({
 }
 
 /* ------------------------------------------------------------------ */
+/*  03 — Notifications (test push to iOS)                             */
+/* ------------------------------------------------------------------ */
+
+function NotificationsSection() {
+  const sendTest = useSendTestNotification()
+  // Inline note for the non-error "nothing to send / not set up" outcomes;
+  // genuine delivery is confirmed with a toast.
+  const [note, setNote] = useState<string | null>(null)
+
+  const onSend = async () => {
+    setNote(null)
+    try {
+      const result = await sendTest.mutateAsync()
+      if (result.sent === 0) {
+        setNote(
+          'No devices registered yet. Install the FortyMM iOS app, sign in with this account and allow notifications, then try again.',
+        )
+        return
+      }
+      const plural = result.sent === 1 ? 'device' : 'devices'
+      toast.success(`Test notification sent to ${result.sent} ${plural}.`)
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 503) {
+        setNote("Push notifications aren't configured on the server yet.")
+        return
+      }
+      toast.error(
+        err instanceof Error
+          ? `Couldn't send test notification: ${err.message}`
+          : "Couldn't send test notification.",
+      )
+    }
+  }
+
+  return (
+    <SectionCard
+      id="sec-notifications"
+      num="03"
+      eyebrow="Devices"
+      title="Push notifications"
+      subtitle="Send a test notification to your iOS devices to confirm push is working. It goes to every device where you're signed into this account with the app installed."
+    >
+      <button
+        type="button"
+        className="fmm-btn fmm-btn--primary"
+        onClick={onSend}
+        disabled={sendTest.isPending}
+      >
+        {sendTest.isPending ? (
+          <>
+            <Spinner /> Sending…
+          </>
+        ) : (
+          'Send test notification'
+        )}
+      </button>
+      {note && (
+        <div className="fmm-help" style={{ marginTop: 12 }}>
+          {note}
+        </div>
+      )}
+    </SectionCard>
+  )
+}
+
+/* ------------------------------------------------------------------ */
 /*  Page                                                              */
 /* ------------------------------------------------------------------ */
 
@@ -1039,6 +1106,7 @@ function SettingsPage() {
                 confirmedAt={sessionConfirmedAt}
                 pendingEmail={sessionPendingEmail}
               />
+              <NotificationsSection />
             </div>
 
             <ComingSoon>


### PR DESCRIPTION
## What

End-to-end remote push to the iOS app: a **Send test notification** button on the web Settings page → `POST /v1/notifications/test` → backend sends via **APNs** → native iOS banner on the user's device(s).

Web and iOS are separate clients of the same API, so the test fans out to the **current user's** registered devices — to see it, sign into the same verified account on both web and the phone. This is the minimal test-harness slice; richer trigger surfaces will reuse the same plumbing.

## Changes

**Backend (`api/`)**
- `device_tokens` table — `DeviceToken` model + migration `0008`, with account-merge re-point/cleanup (per `api/CLAUDE.md`).
- `app/notifications/` — APNs sender behind a `PushSender` protocol (ES256 JWT over HTTP/2, prunes tokens APNs reports gone; `NoopSender` when unconfigured), service, DI wiring, router. Endpoints `POST /v1/device-tokens`, `POST /v1/notifications/test`.
- Deps: `httpx[http2]`, `pyjwt[crypto]`.

**iOS (`ios/Fortymm/`)**
- `aps-environment` entitlement; `PushNotificationManager` (permission + APNs registration + token POST + foreground banner); `AppDelegate` bridge in `FortymmApp`; registration triggered once the session has loaded.

**Web (`web-client/`)**
- `useSendTestNotification` hook + Notifications section in Settings; regenerated `schema.d.ts`.

## Verification

- Backend: `ruff` + `ruff format --check` + `mypy --strict` clean; **372 tests pass** (9 new in `test_notifications.py`); migration `0008` applies **and reverses** on a fresh Postgres.
- iOS: `xcodebuild` → BUILD SUCCEEDED.
- Web: **15 settings tests pass** (3 new); `tsc -b && vite build` succeeds.

## Follow-ups required to deliver pushes

- Supply APNs creds in the api `.env`: `APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_AUTH_KEY` (or `APNS_AUTH_KEY_PATH`). The APNs Auth Key is a **separate** `.p8` from the App Store Connect key.
- Enable **Push Notifications** capability on the App ID (`com.fortymm.ios-client`) in the Apple Developer portal.
- For TestFlight/App Store builds, flip `aps-environment` to `production` (documented in the entitlements file).

Until configured, the endpoint returns a clean `503` and the button shows "not configured".

🤖 Generated with [Claude Code](https://claude.com/claude-code)