### PR TITLE
scoreboard: extract and refine the Heading component for the hero strip

### DIFF
--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -3,7 +3,6 @@ import { Link, useRouter } from '@tanstack/react-router'
 import {
   Check,
   ChevronRight,
-  Clock,
   Copy,
   Download,
   Link2,
@@ -576,49 +575,12 @@ function HeroScoreboard({
   view: MatchView
   matchId: string
 }) {
-  const isLive = view.state === 'live'
   const isUpcoming = view.state === 'upcoming'
 
   return (
     <Scoreboard matchId={matchId}>
       {() => (
         <>
-      <div className="md-hero__grid-bg" aria-hidden="true" />
-
-      <div className="md-hero__strip">
-        <div className="md-hero__strip-l">
-          {isLive && view.currentGameNumber !== null && (
-            <span className="md-chip md-chip--live">
-              <span className="dot" />
-              Live · Game {view.currentGameNumber}
-            </span>
-          )}
-          {view.state === 'final' && (
-            <span className="md-chip md-chip--final">
-              <span className="dot" />
-              Final
-            </span>
-          )}
-          {isUpcoming && (
-            <span className="md-chip md-chip--upcoming">
-              <span className="dot" />
-              {view.statusLabel}
-            </span>
-          )}
-        </div>
-        <div className="md-hero__strip-r">
-          <span className="md-hero__strip-meta">
-            SINGLES · BO{view.bestOf}
-          </span>
-          {!isUpcoming && (
-            <span className="md-hero__strip-meta md-hero__strip-meta--with-icon">
-              <Clock size={13} strokeWidth={1.75} />
-              First to {view.gamesToWin}
-            </span>
-          )}
-        </div>
-      </div>
-
       <div className="md-hero__row">
         <PlayerSide side={view.leftSide} pos="l" />
         <div className="md-hero__score-block">
@@ -629,28 +591,25 @@ function HeroScoreboard({
               <div className="md-hero__vs-label">{view.statusLabel}</div>
             </>
           ) : (
-            <>
-              <div className="md-hero__score-row">
-                <div
-                  className={cn(
-                    'md-hero__score md-hero__score--l',
-                    view.leftSide.won && 'md-hero__score--win',
-                  )}
-                >
-                  {view.leftSide.gamesWon}
-                </div>
-                <div className="md-hero__score-dash">—</div>
-                <div
-                  className={cn(
-                    'md-hero__score md-hero__score--r',
-                    view.rightSide?.won && 'md-hero__score--win',
-                  )}
-                >
-                  {view.rightSide?.gamesWon ?? 0}
-                </div>
+            <div className="md-hero__score-row">
+              <div
+                className={cn(
+                  'md-hero__score md-hero__score--l',
+                  view.leftSide.won && 'md-hero__score--win',
+                )}
+              >
+                {view.leftSide.gamesWon}
               </div>
-              <div className="md-hero__score-caption">{view.statusLabel}</div>
-            </>
+              <div className="md-hero__score-dash">—</div>
+              <div
+                className={cn(
+                  'md-hero__score md-hero__score--r',
+                  view.rightSide?.won && 'md-hero__score--win',
+                )}
+              >
+                {view.rightSide?.gamesWon ?? 0}
+              </div>
+            </div>
           )}
         </div>
         {view.rightSide ? (

--- a/web-client/src/components/matches/match-details/scoreboard.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard.page.tsx
@@ -8,6 +8,7 @@ import { server } from "@/mocks/server";
 import { render, screen, type Container } from "@/test/utilities";
 
 import { Scoreboard, type ScoreboardProps } from "./scoreboard";
+import { headingPage } from "./scoreboard/heading.page";
 
 const DEFAULT_MATCH_ID = "m-1";
 
@@ -32,6 +33,8 @@ const scoped = (container: Container) => ({
   getHeading() {
     return container.getByRole("heading", { level: 2 });
   },
+  /** The heading strip (status chip + format/race labels) the display renders. */
+  headingStrip: headingPage.within(container),
 });
 
 /**

--- a/web-client/src/components/matches/match-details/scoreboard.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard.test.tsx
@@ -67,6 +67,23 @@ describe("Scoreboard", () => {
     ).toBeInTheDocument();
   });
 
+  it("displays the heading strip projected from the match details", async () => {
+    scoreboardPage.mockEndpoint(() =>
+      HttpResponse.json({
+        ...decidedMatch(),
+        data: { scoreboard: { status: "final" } },
+      }),
+    );
+
+    scoreboardPage.render();
+
+    await waitForElementToBeRemoved(scoreboardPage.queryLoading());
+    // Wiring only: heading content is pinned by the query and display tests.
+    const chip = scoreboardPage.headingStrip.getChip();
+    expect(chip).toHaveTextContent("Final");
+    expect(scoreboardPage.getRegion()).toContainElement(chip);
+  });
+
   it("owns no error boundary — a failed query propagates to an ancestor boundary", async () => {
     scoreboardPage.mockEndpoint(() => new HttpResponse(null, { status: 500 }));
 

--- a/web-client/src/components/matches/match-details/scoreboard/heading.factory.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/heading.factory.tsx
@@ -1,0 +1,25 @@
+import type { ScoreboardHeadingView } from "./scoreboard-query";
+import type { HeadingProps } from "./heading";
+import { buildStatusChipView } from "./status-chip.factory";
+
+/** The projected heading-strip view the display renders. */
+export function buildScoreboardHeadingView(
+  overrides: Partial<ScoreboardHeadingView> = {},
+): ScoreboardHeadingView {
+  return {
+    chip: buildStatusChipView(),
+    formatLabel: "SINGLES · BO5",
+    raceLabel: "First to 3",
+    ...overrides,
+  };
+}
+
+/** Props for `Heading`. */
+export function buildHeadingProps(
+  overrides: Partial<HeadingProps> = {},
+): HeadingProps {
+  return {
+    heading: buildScoreboardHeadingView(),
+    ...overrides,
+  };
+}

--- a/web-client/src/components/matches/match-details/scoreboard/heading.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/heading.page.tsx
@@ -1,0 +1,44 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { Heading, type HeadingProps } from "./heading";
+import { buildHeadingProps } from "./heading.factory";
+import { statusChipPage } from "./status-chip.page";
+
+const scoped = (container: Container) => ({
+  /** The status chip on the left of the strip; absent when `chip` is null. */
+  ...statusChipPage.within(container),
+  /** The "SINGLES · BO5"-style format label on the right of the strip. */
+  getFormatLabel() {
+    return container.getByTestId("scoreboard-heading-format");
+  },
+  /** The "First to N" race label; absent when `raceLabel` is null. */
+  queryRaceLabel() {
+    return container.queryByTestId("scoreboard-heading-race");
+  },
+  getRaceLabel() {
+    return container.getByTestId("scoreboard-heading-race");
+  },
+});
+
+/**
+ * Test page-object for the `Heading` strip — the status chip plus the
+ * format/race meta labels along the top of the scoreboard.
+ */
+export const headingPage = {
+  render(overrides: Partial<HeadingProps> = {}) {
+    const props = buildHeadingProps(overrides);
+    render(<Heading {...props} />);
+  },
+
+  /**
+   * Scope the heading accessors to a container — the whole `screen` (default)
+   * or a `within(node)` subtree. Page objects that embed the heading (the
+   * scoreboard display, fetcher, and wrapper) call this to expose the same
+   * chip/label queries as their own `.heading`, rather than re-deriving them.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/scoreboard/heading.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/heading.test.tsx
@@ -1,0 +1,48 @@
+import { buildScoreboardHeadingView } from "./heading.factory";
+import { headingPage } from "./heading.page";
+
+describe("Heading", () => {
+  it("renders the status chip from the heading view's chip", () => {
+    // Chip variants and the null case are covered by the StatusChip tests;
+    // this pins the composition only.
+    headingPage.render({
+      heading: buildScoreboardHeadingView({
+        chip: { status: "final", label: "Final" },
+      }),
+    });
+
+    expect(headingPage.getChip()).toHaveTextContent("Final");
+  });
+
+  it("omits the chip when the heading view's chip is null", () => {
+    headingPage.render({
+      heading: buildScoreboardHeadingView({ chip: null }),
+    });
+
+    expect(headingPage.queryChip()).not.toBeInTheDocument();
+  });
+
+  it("renders the format label", () => {
+    headingPage.render({
+      heading: buildScoreboardHeadingView({ formatLabel: "DOUBLES · BO3" }),
+    });
+
+    expect(headingPage.getFormatLabel()).toHaveTextContent("DOUBLES · BO3");
+  });
+
+  it("renders the race label when one is provided", () => {
+    headingPage.render({
+      heading: buildScoreboardHeadingView({ raceLabel: "First to 2" }),
+    });
+
+    expect(headingPage.getRaceLabel()).toHaveTextContent("First to 2");
+  });
+
+  it("omits the race label when raceLabel is null", () => {
+    headingPage.render({
+      heading: buildScoreboardHeadingView({ raceLabel: null }),
+    });
+
+    expect(headingPage.queryRaceLabel()).not.toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/heading.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/heading.tsx
@@ -1,0 +1,32 @@
+import { Clock } from "lucide-react";
+
+import { type ScoreboardHeadingView } from "./scoreboard-query";
+import { StatusChip } from "./status-chip";
+
+export interface HeadingProps {
+  heading: ScoreboardHeadingView;
+}
+
+export const Heading = ({ heading }: HeadingProps) => {
+  return (
+    <div className="md-hero__strip">
+      <div className="md-hero__strip-l">
+        {heading.chip && <StatusChip chip={heading.chip} />}
+      </div>
+      <div className="md-hero__strip-r">
+        <span data-testid="scoreboard-heading-format" className="md-hero__strip-meta">
+          {heading.formatLabel}
+        </span>
+        {heading.raceLabel && (
+          <span
+            data-testid="scoreboard-heading-race"
+            className="md-hero__strip-meta md-hero__strip-meta--with-icon"
+          >
+            <Clock size={13} strokeWidth={1.75} />
+            {heading.raceLabel}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.factory.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.factory.tsx
@@ -1,13 +1,15 @@
+import { buildScoreboardHeadingView } from "./heading.factory";
 import type { ScoreboardView } from "./scoreboard-query";
 import type { ScoreboardDisplayProps } from "./scoreboard-display";
 
-/** The projected `{ status, outcome }` view the display renders around. */
+/** The projected `{ status, outcome, heading }` view the display renders around. */
 export function buildScoreboardView(
   overrides: Partial<ScoreboardView> = {},
 ): ScoreboardView {
   return {
     status: "scheduled",
     outcome: null,
+    heading: buildScoreboardHeadingView(),
     ...overrides,
   };
 }

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.page.tsx
@@ -1,5 +1,6 @@
 import { render, screen, type Container } from "@/test/utilities";
 
+import { headingPage } from "./heading.page";
 import {
   ScoreboardDisplay,
   type ScoreboardDisplayProps,
@@ -13,6 +14,8 @@ const scoped = (container: Container) => ({
   getContainer() {
     return container.getByRole("region");
   },
+  /** The heading strip (status chip + format/race labels) the display renders. */
+  headingStrip: headingPage.within(container),
 });
 
 export const scoreboardDisplayPage = {

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.test.tsx
@@ -1,5 +1,6 @@
 import { within } from "@/test/utilities";
 
+import { buildScoreboardHeadingView } from "./heading.factory";
 import { buildScoreboardView } from "./scoreboard-display.factory";
 import { scoreboardDisplayPage } from "./scoreboard-display.page";
 
@@ -30,6 +31,26 @@ describe("ScoreboardDisplay", () => {
     });
 
     expect(scoreboardDisplayPage.getHeading()).toHaveTextContent("Match");
+  });
+
+  it("renders the heading strip inside the region from the view's heading", () => {
+    scoreboardDisplayPage.render({
+      scoreboard: buildScoreboardView({
+        heading: buildScoreboardHeadingView({
+          chip: { status: "final", label: "Final" },
+          formatLabel: "SINGLES · BO5",
+          raceLabel: "First to 3",
+        }),
+      }),
+    });
+
+    const strip = scoreboardDisplayPage.headingStrip;
+    expect(strip.getChip()).toHaveTextContent("Final");
+    expect(strip.getFormatLabel()).toHaveTextContent("SINGLES · BO5");
+    expect(strip.getRaceLabel()).toHaveTextContent("First to 3");
+    expect(scoreboardDisplayPage.getContainer()).toContainElement(
+      strip.getChip(),
+    );
   });
 
   it("renders the children render-prop's output inside the region", () => {

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.tsx
@@ -1,4 +1,5 @@
 import { useId } from "react";
+import { Heading } from "./heading";
 import { type ScoreboardView } from "./scoreboard-query";
 
 export interface ScoreboardDisplayProps {
@@ -17,6 +18,8 @@ export const ScoreboardDisplay = ({
       <h2 id={id} className="sr-only">
         {scoreboard.outcome ?? "Match"}
       </h2>
+      <div className="md-hero__grid-bg" aria-hidden="true" />
+      <Heading heading={scoreboard.heading} />
       {children(scoreboard)}
     </section>
   );

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.page.tsx
@@ -8,6 +8,7 @@ import {
 import { server } from "@/mocks/server";
 import { render, screen, type Container } from "@/test/utilities";
 
+import { headingPage } from "./heading.page";
 import { ScoreboardFetcher, type ScoreboardProps } from "./scoreboard-fetcher";
 
 const DEFAULT_MATCH_ID = "m-1";
@@ -29,6 +30,8 @@ const scoped = (container: Container) => ({
   getHeading() {
     return container.getByRole("heading", { level: 2 });
   },
+  /** The heading strip (status chip + format/race labels) the display renders. */
+  headingStrip: headingPage.within(container),
 });
 
 /**

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.test.tsx
@@ -70,10 +70,29 @@ describe("ScoreboardFetcher", () => {
     scoreboardFetcherPage.render({ children });
 
     await waitForElementToBeRemoved(scoreboardFetcherPage.queryLoading());
-    expect(children).toHaveBeenCalledWith({
-      status: "scheduled",
-      outcome: "rita.kovac defeated leo.mertens, 3 games to 1",
-    });
+    // Wiring only: the projected heading's content is pinned by the
+    // scoreboard-query tests, the resulting DOM by the display tests.
+    expect(children).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "scheduled",
+        outcome: "rita.kovac defeated leo.mertens, 3 games to 1",
+      }),
+    );
+  });
+
+  it("renders the heading strip from the selected view", async () => {
+    scoreboardFetcherPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({ data: { scoreboard: { status: "final" } } }),
+      ),
+    );
+
+    scoreboardFetcherPage.render();
+
+    await waitForElementToBeRemoved(scoreboardFetcherPage.queryLoading());
+    expect(scoreboardFetcherPage.headingStrip.getChip()).toHaveTextContent(
+      "Final",
+    );
   });
 
   it("renders the children output inside the region", async () => {

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.test.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.test.ts
@@ -85,6 +85,108 @@ describe("scoreboardQuery", () => {
     },
   );
 
+  it("projects an upcoming chip from status_label for a scheduled match, with no race label", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          status_label: "Awaiting opponent",
+          data: { scoreboard: { status: "scheduled" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heading).toEqual({
+      chip: { status: "scheduled", label: "Awaiting opponent" },
+      formatLabel: "SINGLES · BO5",
+      raceLabel: null,
+    });
+  });
+
+  it("projects a live chip naming the current game, and the race label", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          current_game: { game_number: 3 },
+          data: { scoreboard: { status: "live" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heading.chip).toEqual({
+      status: "live",
+      label: "Live · Game 3",
+    });
+    expect(result.current.data?.heading.raceLabel).toBe("First to 3");
+  });
+
+  it("projects no chip for a live match with no current game", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          current_game: null,
+          data: { scoreboard: { status: "live" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heading.chip).toBeNull();
+  });
+
+  it("projects a Final chip for a final match", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({ data: { scoreboard: { status: "final" } } }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heading.chip).toEqual({
+      status: "final",
+      label: "Final",
+    });
+  });
+
+  it("builds the format label from team_size and best_of", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({ team_size: 2, best_of: 3, games_to_win: 2 }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heading.formatLabel).toBe("DOUBLES · BO3");
+  });
+
+  it("builds the race label from games_to_win", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          best_of: 1,
+          games_to_win: 1,
+          data: { scoreboard: { status: "final" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heading.raceLabel).toBe("First to 1");
+  });
+
   it("reports no games recorded for a match that has not started", async () => {
     // The default factory leaves both sides at `won: null`, `games_won: 0`.
     scoreboardQueryPage.mockEndpoint(() =>

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.ts
@@ -4,47 +4,92 @@ import {
 } from "../match-details-query";
 import type { Scoreboard } from "@/api/matches";
 
+/** The status chip on the left of the strip; null when the match is live
+ * but has no current game (nothing meaningful to announce). */
+export type StatusChipView = {
+  status: Scoreboard["status"];
+  label: string;
+} | null;
+
+export type ScoreboardHeadingView = {
+  chip: StatusChipView;
+  /** e.g. "SINGLES · BO5" */
+  formatLabel: string;
+  /** e.g. "First to 3"; null for an upcoming match, where the race to a
+   * games target hasn't started. */
+  raceLabel: string | null;
+};
+
 export type ScoreboardView = {
   status: Scoreboard["status"];
   outcome: string | null;
+  heading: ScoreboardHeadingView;
 };
 
 const games = (n: number) => `${n} ${n === 1 ? "game" : "games"}`;
 
-const selectScoreboard = (match: MatchDetailsResult) => {
-  const status = match.data.scoreboard.status;
+const selectOutcome = (match: MatchDetailsResult): string | null => {
   const sides = match.unmigrated.sides;
 
   // Decided match: one side won, the other lost.
   const winner = sides.find((s) => s.won === true);
   const loser = sides.find((s) => s.won === false);
   if (winner?.players[0] && loser?.players[0]) {
-    const outcome = `${winner.players[0].username} defeated ${loser.players[0].username}, ${games(winner.games_won)} to ${loser.games_won}`;
-    return { status, outcome };
+    return `${winner.players[0].username} defeated ${loser.players[0].username}, ${games(winner.games_won)} to ${loser.games_won}`;
   }
 
   // Still in progress: describe the current state from games won. Needs both
   // sides' lead player to name them.
   const [side1, side2] = sides;
   if (!side1?.players[0] || !side2?.players[0]) {
-    return { status, outcome: null };
+    return null;
   }
 
   if (side1.games_won === 0 && side2.games_won === 0) {
-    const outcome = `${side1.players[0].username} and ${side2.players[0].username} have not started yet`;
-    return { status, outcome };
+    return `${side1.players[0].username} and ${side2.players[0].username} have not started yet`;
   }
 
   if (side1.games_won === side2.games_won) {
-    const outcome = `${side1.players[0].username} and ${side2.players[0].username} are tied, ${games(side1.games_won)} all`;
-    return { status, outcome };
+    return `${side1.players[0].username} and ${side2.players[0].username} are tied, ${games(side1.games_won)} all`;
   }
 
   const [leader, trailer] =
     side1.games_won > side2.games_won ? [side1, side2] : [side2, side1];
-  const outcome = `${leader.players[0].username} leading, ${games(leader.games_won)} to ${trailer.games_won}`;
-  return { status, outcome };
+  return `${leader.players[0].username} leading, ${games(leader.games_won)} to ${trailer.games_won}`;
 };
+
+const selectChip = (
+  status: Scoreboard["status"],
+  details: MatchDetailsResult["unmigrated"],
+): StatusChipView => {
+  if (status === "live") {
+    return details.current_game
+      ? { status, label: `Live · Game ${details.current_game.game_number}` }
+      : null;
+  }
+  if (status === "final") {
+    return { status, label: "Final" };
+  }
+  return { status, label: details.status_label };
+};
+
+const selectHeading = (match: MatchDetailsResult): ScoreboardHeadingView => {
+  const status = match.data.scoreboard.status;
+  const details = match.unmigrated;
+
+  return {
+    chip: selectChip(status, details),
+    formatLabel: `${details.team_size === 1 ? "SINGLES" : "DOUBLES"} · BO${details.best_of}`,
+    raceLabel:
+      status === "scheduled" ? null : `First to ${details.games_to_win}`,
+  };
+};
+
+const selectScoreboard = (match: MatchDetailsResult): ScoreboardView => ({
+  status: match.data.scoreboard.status,
+  outcome: selectOutcome(match),
+  heading: selectHeading(match),
+});
 
 export const scoreboardQuery = (matchId: string) => ({
   ...matchDetailsQuery(matchId),

--- a/web-client/src/components/matches/match-details/scoreboard/status-chip.factory.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/status-chip.factory.tsx
@@ -1,0 +1,23 @@
+import type { StatusChipView } from "./scoreboard-query";
+import type { StatusChipProps } from "./status-chip";
+
+/** The projected chip view the status chip renders. */
+export function buildStatusChipView(
+  overrides: Partial<NonNullable<StatusChipView>> = {},
+): NonNullable<StatusChipView> {
+  return {
+    status: "final",
+    label: "Final",
+    ...overrides,
+  };
+}
+
+/** Props for `StatusChip`. */
+export function buildStatusChipProps(
+  overrides: Partial<StatusChipProps> = {},
+): StatusChipProps {
+  return {
+    chip: buildStatusChipView(),
+    ...overrides,
+  };
+}

--- a/web-client/src/components/matches/match-details/scoreboard/status-chip.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/status-chip.page.tsx
@@ -1,0 +1,36 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { StatusChip, type StatusChipProps } from "./status-chip";
+import { buildStatusChipProps } from "./status-chip.factory";
+
+const scoped = (container: Container) => ({
+  queryChip() {
+    return container.queryByRole("status");
+  },
+  getChip() {
+    return container.getByRole("status");
+  },
+});
+
+/**
+ * Test page-object for `StatusChip` — the Badge announcing the match status
+ * on the left of the scoreboard heading strip.
+ */
+export const statusChipPage = {
+  render(overrides: Partial<StatusChipProps> = {}) {
+    const props = buildStatusChipProps(overrides);
+    render(<StatusChip {...props} />);
+  },
+
+  /**
+   * Scope the chip accessors to a container — the whole `screen` (default) or
+   * a `within(node)` subtree. Page objects that embed the chip (the heading
+   * strip and everything above it) call this to expose the same queries,
+   * rather than re-deriving them.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/scoreboard/status-chip.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/status-chip.test.tsx
@@ -1,0 +1,22 @@
+import { buildStatusChipView } from "./status-chip.factory";
+import { statusChipPage } from "./status-chip.page";
+
+describe("StatusChip", () => {
+  it.each([
+    ["scheduled", "outline"],
+    ["live", "default"],
+    ["final", "secondary"],
+  ] as const)(
+    "renders the chip for a %s match with its label as a %s Badge",
+    (status, variant) => {
+      statusChipPage.render({
+        chip: buildStatusChipView({ status, label: "chip label" }),
+      });
+
+      const chip = statusChipPage.getChip();
+      expect(chip).toHaveTextContent("chip label");
+      expect(chip).toHaveAttribute("data-variant", variant);
+    },
+  );
+
+});

--- a/web-client/src/components/matches/match-details/scoreboard/status-chip.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/status-chip.tsx
@@ -1,0 +1,23 @@
+import { Badge } from "@/components/ui/badge";
+import { type StatusChipView } from "./scoreboard-query";
+
+export interface StatusChipProps {
+  chip: NonNullable<StatusChipView>;
+}
+
+const chipVariant: Record<
+  NonNullable<StatusChipView>["status"],
+  React.ComponentProps<typeof Badge>["variant"]
+> = {
+  scheduled: "outline",
+  live: "default",
+  final: "secondary",
+};
+
+export const StatusChip = ({ chip }: StatusChipProps) => {
+  return (
+    <Badge role="status" variant={chipVariant[chip.status]}>
+      {chip.label}
+    </Badge>
+  );
+};

--- a/web-client/src/components/matches/save-your-match.test.tsx
+++ b/web-client/src/components/matches/save-your-match.test.tsx
@@ -253,7 +253,7 @@ describe('SaveYourMatch', () => {
     expect(
       screen.queryByRole('region', { name: PROMPT_REGION }),
     ).not.toBeInTheDocument()
-    const receipt = screen.getByRole('status')
+    const receipt = screen.getByRole('status', { name: /match save receipt/i })
     expect(receipt).toHaveTextContent(/lives on your device only/i)
     // The receipt's "Save it" is a real CTA — it links straight to the email
     // section, not a re-surface of the prompt.

--- a/web-client/src/components/matches/save-your-match.tsx
+++ b/web-client/src/components/matches/save-your-match.tsx
@@ -80,7 +80,7 @@ function DismissedReceipt() {
   // routes straight to the email flow — the label promises a commit, not an
   // undo, so we navigate rather than restore the prompt.
   return (
-    <div className="md-save-receipt" role="status">
+    <div className="md-save-receipt" role="status" aria-label="Match save receipt">
       <span aria-hidden="true">—</span>
       <span>
         This match lives on your device only.{' '}

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2829,12 +2829,6 @@ body.dark.fortymm-theme {
   color: var(--fg-3);
   letter-spacing: 0.1em;
 }
-.fortymm-theme .md-hero__score-caption {
-  font: 500 11px var(--font-mono);
-  color: var(--fg-3);
-  letter-spacing: 0.18em;
-  margin-top: 4px;
-}
 .fortymm-theme .md-hero__vs-label {
   font: 500 11px var(--font-mono);
   color: var(--fg-3);
@@ -2858,46 +2852,6 @@ body.dark.fortymm-theme {
   align-items: center;
   gap: 6px;
   letter-spacing: 0.1em;
-}
-
-/* ---------- Chips ---------- */
-.fortymm-theme .md-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  height: 24px;
-  padding: 0 10px;
-  border-radius: var(--r-pill);
-  font: 600 11px var(--font-ui);
-  letter-spacing: 0.04em;
-  background: var(--bg-panel);
-  color: var(--fg-2);
-  border: 1px solid var(--border-subtle);
-}
-.fortymm-theme .md-chip--live {
-  background: rgba(0, 226, 154, 0.12);
-  color: var(--serve-500);
-  border-color: rgba(0, 226, 154, 0.3);
-}
-.fortymm-theme .md-chip--final {
-  background: rgba(255, 122, 26, 0.1);
-  color: var(--ball-500);
-  border-color: rgba(255, 122, 26, 0.3);
-}
-.fortymm-theme .md-chip--upcoming {
-  background: rgba(255, 196, 61, 0.1);
-  color: var(--warn);
-  border-color: rgba(255, 196, 61, 0.3);
-}
-.fortymm-theme .md-chip .dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentColor;
-}
-.fortymm-theme .md-chip--live .dot {
-  box-shadow: 0 0 8px currentColor;
-  animation: ball-pulse 1.4s ease-in-out infinite;
 }
 
 /* ---------- Per-game grid ---------- */

--- a/web-client/stryker.config.mjs
+++ b/web-client/stryker.config.mjs
@@ -33,7 +33,7 @@ export default {
     "src/**/*.{ts,tsx}",
     "!src/**/*.test.{ts,tsx}",
     "!src/**/*.page.tsx", // page objects (test-only DOM access)
-    "!src/**/*.factory.ts", // test data builders
+    "!src/**/*.factory.{ts,tsx}", // test data builders
     "!src/**/*-skeleton.tsx", // pure <Suspense> fallbacks, no logic
     "!src/components/ui/**", // shadcn primitives (vendored)
     "!src/mocks/**", // MSW handlers + fixtures


### PR DESCRIPTION
## Summary

- Strangles the inline heading markup out of `scoreboard-display` into a tested `Heading` + `StatusChip` decomposition
- Null check for a missing chip lives in `Heading` (not `StatusChip`), so `StatusChip` always receives a non-nullable prop
- `StatusChip` uses `role="status"` — queryable by role without a test ID, and tells screen readers this is advisory match state
- Labels the `save-your-match` receipt live region (`aria-label`) so both `role="status"` regions on the match page are distinguishable

## Test plan

- [ ] `npm run test:run` passes (197 tests across 23 files)
- [ ] Scoreboard heading renders correctly for scheduled / live / final matches
- [ ] No chip renders when `heading.chip` is null (e.g. live match with no current game)

🤖 Generated with [Claude Code](https://claude.com/claude-code)