### PR TITLE
scoreboard: extract the hero row into HeroRow/HeroPlayer/HeroScore quartets

### DIFF
--- a/.claude/skills/react-component/SKILL.md
+++ b/.claude/skills/react-component/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: react-component
+description: Build or extract React components in web-client/ the fortymm way — one component per file with a colocated page object, factory, and vitest test, composed page-object query surfaces, query-selector view models, and MSW endpoint mocks. Use this skill whenever you create a new component, extract markup out of an existing page/component, add tests for a component, or touch anything under web-client/src/components — even if the request only says "add a widget", "split this up", or "test this".
+---
+
+# Building web-client React components
+
+Every component in `web-client/src` ships as a colocated quartet in its feature
+directory. The canonical exemplars live in
+`web-client/src/components/matches/match-details/scoreboard/` — when in doubt,
+open `game-grid-cell.{tsx,page.tsx,factory.tsx,test.tsx}` (leaf component) and
+`game-grid.{tsx,page.tsx,factory.tsx,test.tsx}` (composes the row, which
+composes the cell) and copy their shapes.
+
+```
+feature-dir/
+├── thing.tsx           # the component — props in, DOM out
+├── thing.page.tsx      # test page object — the only place tests touch the DOM
+├── thing.factory.tsx   # builders for the component's props/view types
+└── thing.test.tsx      # tests, written entirely against the page object
+```
+
+File names are kebab-case; components are PascalCase named exports (no default
+exports). One component per file — if a component grows a distinct sub-block
+(a row, a chip, a cell), extract it into its own quartet and compose.
+
+## The component (`thing.tsx`)
+
+- Export the props interface alongside the component:
+  `export interface ThingProps { ... }` + `export const Thing = ({ ... }: ThingProps) => ...`.
+- Props are **pre-projected view models**, not raw API payloads. The component
+  receives a `View` type produced by a query selector (see "Data-fed
+  components" below) and does no joining, mapping, or label derivation —
+  conditionals only on fields the view already provides. Keep nullability
+  decisions at the owner: if a child is absent when its view is null, the
+  *parent* does the null check and the child always receives a non-null view
+  (see how `Heading` guards `chip` rather than `StatusChip` accepting null).
+- Prefer semantic, role-queryable markup (a `<section aria-labelledby>` with an
+  `sr-only` heading, `role="status"`, real links) so page objects can query by
+  role and accessible name. A `data-testid` is a last resort for elements no
+  role/name can distinguish — and never add markup (wrappers, testids, props
+  like a `rowSide` discriminator) that exists *only* to serve tests; scope
+  queries with `within(row)` instead. (The GameGrid exemplars predate this
+  rule — their `scoreboard-game-grid-*` testids are slated for removal in
+  #475; don't copy that part.) When you do need one, namespace and
+  parameterize it: `feature-thing-${variant}`.
+- Conditional classes via `cn(...)` from `@/lib/utils`.
+- Prefer design-system components in `src/components/ui` over bespoke markup
+  (see `web-client/CLAUDE.md`).
+
+## The page object (`thing.page.tsx`)
+
+The page object is the component's *test query surface*. Tests never call
+`screen.getBy...` directly — every accessor lives here, once, and parent page
+objects reuse it. The shape is always:
+
+```tsx
+import { render, screen, type Container } from "@/test/utilities";
+import { Thing, type ThingProps } from "./thing";
+import { buildThingProps } from "./thing.factory";
+import { childPage } from "./child.page";
+
+const scoped = (container: Container) => ({
+  /** JSDoc every accessor: what it is, and when it's absent. */
+  getThing() {
+    return container.getByTestId("feature-thing");
+  },
+  queryThing() {
+    return container.queryByTestId("feature-thing");
+  },
+  // Reuse the child's queries instead of re-deriving them — either spread
+  // (same surface) or named (a sub-object):
+  ...childPage.within(container),        // when the child's queries read naturally as this component's
+  child: childPage.within(container),    // when a named grouping is clearer
+});
+
+/** Test page-object for `Thing` — one sentence on what it covers, plus any
+ * harness quirks (router, suspense) and how tests should start. */
+export const thingPage = {
+  render(overrides: Partial<ThingProps> = {}) {
+    const props = buildThingProps(overrides);
+    render(<Thing {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed this component spread
+   * this to expose the same queries as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};
+```
+
+Rules that make this composition work:
+
+- **`scoped` + `within` + spread-at-`screen`** is the load-bearing trio. Every
+  accessor closes over `container`, never `screen` directly. `Container` comes
+  from `@/test/utilities`.
+- Always `render` through `@/test/utilities` (it wraps in a fresh, retry-free
+  `QueryClient`), never raw `@testing-library/react`.
+- Provide `get`/`query`/`find` variants as tests need them: `get` for
+  must-exist, `query` for asserting absence, `find` when the first paint is
+  async.
+- **Typed `<Link>`s need a router harness.** If the component (or any
+  descendant) renders a TanStack `<Link>`, `render` must mount it under a
+  minimal memory router that registers a stub route for each link target —
+  copy the harness in `game-grid-cell.page.tsx`. The router resolves
+  asynchronously, so document that tests must start with `await page.find...()`
+  and write them that way. If sibling page objects need the same harness,
+  extract it into a shared helper rather than pasting it a third time (#475
+  tracks doing this for the game-grid trio).
+- Accessors take discriminating parameters (`gameNumber`, a row's player name)
+  and resolve them the same way the component distinguishes the elements —
+  by role/name within a scope where possible, by parameterized testid
+  otherwise.
+
+## The factory (`thing.factory.tsx`)
+
+Builders for the props and any view types the component consumes:
+
+```tsx
+/** One-line doc of the default scenario this builds. */
+export function buildThingView(
+  overrides: Partial<ThingView> = {},
+): ThingView {
+  return { /* realistic, internally consistent defaults */ ...overrides };
+}
+
+/** Props for `Thing`. */
+export function buildThingProps(
+  overrides: Partial<ThingProps> = {},
+): ThingProps {
+  return { thing: buildThingView(), ...overrides };
+}
+```
+
+- Defaults describe one **realistic, named scenario** (e.g. "a live BO5 one
+  game in, viewer's row first") — say which in the doc comment, and keep the
+  defaults internally consistent so a bare `page.render()` is a meaningful
+  case.
+- Factories compose child factories (`buildGameGridView` calls
+  `buildGameGridRowView`), and union view types get one builder per variant
+  (`buildScoredCellView` / `buildUnplayedCellView`), typed with
+  `Partial<Extract<View, { kind: "..." }>>`.
+- Pick defaults that avoid harness requirements where possible — e.g. the
+  scored-cell default carries no edit link so it renders without a router —
+  and note the exception in the doc comment.
+- The `.factory.tsx` / `.page.tsx` suffixes matter: Stryker excludes them from
+  mutation (`stryker.config.mjs` `mutate` globs). Don't invent new suffixes.
+
+## The test (`thing.test.tsx`)
+
+```tsx
+import { buildThingView } from "./thing.factory";
+import { thingPage } from "./thing.page";
+
+describe("Thing", () => {
+  it("states the behavior, not the implementation", async () => {
+    thingPage.render({ thing: buildThingView({ ... }) });
+
+    const el = await thingPage.findThing();   // find-first when a router/suspense is in play
+    expect(el).toHaveTextContent("...");
+  });
+});
+```
+
+- Vitest globals (`describe`/`it`/`expect`/`vi`) — no imports for them.
+- Tests touch the DOM **only** through the page object; the only other imports
+  are factories, `msw`'s `HttpResponse`, and occasional `@/test/utilities`
+  helpers (`within`, `waitForElementToBeRemoved`).
+- One behavior per test; names read as behavior sentences ("links an editable
+  scored cell to that game's scores/edit route").
+- **Test content at the layer that owns it.** A parent asserts it *wired* the
+  child in (the child's container is present/absent, rendered against the
+  right id), not the child's internals — leave a breadcrumb comment like
+  `// Wiring only: grid content is pinned by the query and game-grid tests.`
+  Conversely the leaf tests pin every branch of the leaf.
+- The suite is mutation-tested (`npm run test:mutation:changed`). Assert
+  specific values and class/attribute effects (`toHaveClass`,
+  `toHaveAttribute("href", ...)`, exact text), not just `toBeInTheDocument`,
+  so mutants die.
+
+## Data-fed components: the query → fetcher → display split
+
+When a component renders server data, split it into layers, each its own
+quartet (exemplar: `scoreboard-query.ts` → `scoreboard-fetcher.tsx` →
+`scoreboard-display.tsx`):
+
+1. **Query selector (`thing-query.ts` + `thing-query.test.ts`)** — exports the
+   `View` types and a query-options factory built on the page's BFF query
+   (e.g. `matchDetailsQuery`) with a `select` that projects the payload into
+   the view. All mapping, label text, ordering, and perspective logic lives
+   here, tested as pure functions in a plain `.test.ts` (no DOM). Document
+   each view field's semantics and null conditions on the type.
+2. **Fetcher (`thing-fetcher.tsx`)** — a thin `useSuspenseQuery(thingQuery(id))`
+   that hands the view to the display. Its page object supplies the
+   `<Suspense>` + `ErrorBoundary` harness and stubs the endpoint (see
+   `scoreboard-fetcher.page.tsx`); its tests cover pending → resolved handoff
+   and that a failed query reaches the boundary.
+3. **Display (`thing-display.tsx`)** — pure view-in, DOM-out, tested without
+   MSW.
+
+MSW pieces live under `src/mocks` and are typed off the generated API schema:
+
+- **Endpoint helper** (`src/mocks/endpoints/<area>/<name>.endpoint.ts`):
+  exports `mockThingEndpoint(backend, resolver)` and a typed `ThingResolver`,
+  so tests write `HttpResponse.json(buildThing(...))` with payload
+  type-checking. Page objects wrap it as `page.mockEndpoint(resolver)`.
+- **Payload factories** (`src/mocks/factories/<area>/<name>.factory.ts`):
+  `build*` functions over `components["schemas"][...]` from `@/api/schema` —
+  same overrides pattern as component factories, but producing wire payloads.
+
+Remember the vitest MSW server runs with `onUnhandledRequest: "error"`: any
+fetch a test triggers needs a handler (the page object's `mockEndpoint` or
+`src/mocks/handlers.ts`).
+
+## Definition of done
+
+From `web-client/`: `npm run lint`, `npm run build` (type-checks), and
+`npm run test:run` all pass. For meaningful new logic, sanity-check assertion
+strength with `npm run test:mutation:changed`.

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -439,7 +439,7 @@ function MatchDetailsPage({
 
         <SaveYourMatch key={matchId} view={view} matchId={matchId} />
 
-        <HeroScoreboard view={view} matchId={matchId} />
+        <Scoreboard matchId={matchId} />
 
         <div className="md-col-2">
           <div className="md-col-2__main">
@@ -519,106 +519,6 @@ function Breadcrumb({
       <Link to="/matches">Matches</Link>
       <span>›</span>
       <span className="md-breadcrumb__current">Match {matchId.slice(0, 6)}</span>
-    </div>
-  )
-}
-
-function HeroScoreboard({
-  view,
-  matchId,
-}: {
-  view: MatchView
-  matchId: string
-}) {
-  const isUpcoming = view.state === 'upcoming'
-
-  return (
-    <Scoreboard matchId={matchId}>
-      {() => (
-        <>
-      <div className="md-hero__row">
-        <PlayerSide side={view.leftSide} pos="l" />
-        <div className="md-hero__score-block">
-          {isUpcoming ? (
-            <>
-              <div className="md-hero__vs-label">VS</div>
-              <div className="md-hero__vs-dash">—</div>
-              <div className="md-hero__vs-label">{view.statusLabel}</div>
-            </>
-          ) : (
-            <div className="md-hero__score-row">
-              <div
-                className={cn(
-                  'md-hero__score md-hero__score--l',
-                  view.leftSide.won && 'md-hero__score--win',
-                )}
-              >
-                {view.leftSide.gamesWon}
-              </div>
-              <div className="md-hero__score-dash">—</div>
-              <div
-                className={cn(
-                  'md-hero__score md-hero__score--r',
-                  view.rightSide?.won && 'md-hero__score--win',
-                )}
-              >
-                {view.rightSide?.gamesWon ?? 0}
-              </div>
-            </div>
-          )}
-        </div>
-        {view.rightSide ? (
-          <PlayerSide side={view.rightSide} pos="r" />
-        ) : (
-          <NoOpponentSide pos="r" />
-        )}
-      </div>
-      </>
-      )}
-    </Scoreboard>
-  )
-}
-
-function PlayerSide({ side, pos }: { side: SideView; pos: 'l' | 'r' }) {
-  if (side.isGhost) return <NoOpponentSide pos={pos} />
-  const win = side.won === true
-  return (
-    <div className={`md-hero__player md-hero__player--${pos}`}>
-      <div className="md-hero__player-row">
-        <div
-          className={cn(
-            'md-avatar md-hero__avatar-singles',
-            win ? 'md-avatar--win' : 'md-avatar--loss',
-          )}
-        >
-          {side.initials}
-        </div>
-        <div className={`md-hero__player-text--${pos}`}>
-          <div className={cn('md-hero__name', win && 'md-hero__name--win')}>
-            {side.username}
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function NoOpponentSide({ pos }: { pos: 'l' | 'r' }) {
-  return (
-    <div className={`md-hero__player md-hero__player--${pos}`}>
-      <div className="md-hero__player-row">
-        <div
-          className="md-avatar md-avatar--ghost md-hero__avatar-singles"
-          aria-hidden="true"
-        >
-          <User size={26} strokeWidth={1.75} />
-        </div>
-        <div className={`md-hero__player-text--${pos}`}>
-          <div className="md-hero__name md-hero__name--ghost">
-            {NO_OPPONENT_LABEL}
-          </div>
-        </div>
-      </div>
     </div>
   )
 }

--- a/web-client/src/components/matches/match-details/scoreboard.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard.page.tsx
@@ -10,6 +10,7 @@ import { render, screen, type Container } from "@/test/utilities";
 import { Scoreboard, type ScoreboardProps } from "./scoreboard";
 import { gameGridPage } from "./scoreboard/game-grid.page";
 import { headingPage } from "./scoreboard/heading.page";
+import { heroRowPage } from "./scoreboard/hero-row.page";
 
 const DEFAULT_MATCH_ID = "m-1";
 
@@ -36,6 +37,8 @@ const scoped = (container: Container) => ({
   },
   /** The heading strip (status chip + format/race labels) the display renders. */
   headingStrip: headingPage.within(container),
+  /** The hero row (left player / score block / right player) the display renders. */
+  heroRow: heroRowPage.within(container),
   /** The per-game score grid the display renders at the bottom of the hero. */
   gameGrid: gameGridPage.within(container),
 });
@@ -43,10 +46,10 @@ const scoped = (container: Container) => ({
 /**
  * Test page-object for the public `Scoreboard` wrapper. `Scoreboard` adds only
  * a `<Suspense>` boundary (with its real `Loading...` fallback) around
- * `ScoreboardFetcher` and forwards `matchId`/`children` through — it
- * deliberately has *no* error boundary, delegating failures upward. This
- * renders it beneath an `ErrorBoundary` standing in for that ancestor so a
- * rejected query can be observed reaching the boundary, and stubs the same
+ * `ScoreboardFetcher` and forwards `matchId` through — it deliberately has
+ * *no* error boundary, delegating failures upward. This renders it beneath an
+ * `ErrorBoundary` standing in for that ancestor so a rejected query can be
+ * observed reaching the boundary, and stubs the same
  * `GET /v1/matches/:matchId` endpoint the query reads.
  */
 export const scoreboardPage = {
@@ -61,9 +64,6 @@ export const scoreboardPage = {
   render(overrides: Partial<ScoreboardProps> = {}) {
     const props: ScoreboardProps = {
       matchId: DEFAULT_MATCH_ID,
-      children: (scoreboard) => (
-        <div data-testid="scoreboard-children">{scoreboard.status}</div>
-      ),
       ...overrides,
     };
 

--- a/web-client/src/components/matches/match-details/scoreboard.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard.test.tsx
@@ -5,7 +5,7 @@ import {
   buildMatchDetailsPlayer,
   buildMatchDetailsSide,
 } from "@/mocks/factories/matches/match-details.factory";
-import { waitForElementToBeRemoved, within } from "@/test/utilities";
+import { waitForElementToBeRemoved } from "@/test/utilities";
 
 import { scoreboardPage } from "./scoreboard.page";
 
@@ -54,17 +54,15 @@ describe("Scoreboard", () => {
     expect(requestedMatchId).toBe("m-42");
   });
 
-  it("forwards children through to the rendered output", async () => {
+  it("displays the hero row projected from the match details", async () => {
     scoreboardPage.mockEndpoint(() => HttpResponse.json(decidedMatch()));
 
-    scoreboardPage.render({
-      children: () => <p data-testid="scoreboard-body">live</p>,
-    });
+    scoreboardPage.render();
 
     await waitForElementToBeRemoved(scoreboardPage.queryLoading());
-    expect(
-      within(scoreboardPage.getRegion()).getByTestId("scoreboard-body"),
-    ).toBeInTheDocument();
+    // Wiring only: row content is pinned by the query and hero-row tests.
+    const name = scoreboardPage.heroRow.getPlayerName("l", "rita.kovac");
+    expect(scoreboardPage.getRegion()).toContainElement(name);
   });
 
   it("displays the heading strip projected from the match details", async () => {

--- a/web-client/src/components/matches/match-details/scoreboard.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard.tsx
@@ -1,17 +1,12 @@
-import { Suspense, type ReactNode } from 'react'
+import { Suspense } from 'react'
 import { ScoreboardFetcher } from './scoreboard/scoreboard-fetcher'
-import type { ScoreboardView } from './scoreboard/scoreboard-query'
 
 export interface ScoreboardProps {
     matchId: string;
-    children: (scoreboard: ScoreboardView) => ReactNode;
 }
 
-export function Scoreboard({
-    matchId,
-    children,
-}: ScoreboardProps) {
+export function Scoreboard({ matchId }: ScoreboardProps) {
     return <Suspense fallback={<div>Loading...</div>}>
-        <ScoreboardFetcher matchId={matchId} children={children} />
+        <ScoreboardFetcher matchId={matchId} />
     </Suspense>
 }

--- a/web-client/src/components/matches/match-details/scoreboard/hero-player.factory.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/hero-player.factory.tsx
@@ -1,0 +1,39 @@
+import type { HeroPlayerProps } from "./hero-player";
+import type { HeroSideView } from "./scoreboard-query";
+
+/** A named side ("rita.kovac") that hasn't won — a match still in play. */
+export function buildHeroSideView(
+  overrides: Partial<HeroSideView> = {},
+): HeroSideView {
+  return {
+    name: "rita.kovac",
+    initials: "RK",
+    isGhost: false,
+    won: false,
+    ...overrides,
+  };
+}
+
+/** A ghost "No opponent" side — the dashed placeholder for a solo match. */
+export function buildGhostHeroSideView(
+  overrides: Partial<HeroSideView> = {},
+): HeroSideView {
+  return {
+    name: "No opponent",
+    initials: "NO",
+    isGhost: true,
+    won: false,
+    ...overrides,
+  };
+}
+
+/** Props for `HeroPlayer` — rita.kovac anchoring the left end of the row. */
+export function buildHeroPlayerProps(
+  overrides: Partial<HeroPlayerProps> = {},
+): HeroPlayerProps {
+  return {
+    side: buildHeroSideView(),
+    pos: "l",
+    ...overrides,
+  };
+}

--- a/web-client/src/components/matches/match-details/scoreboard/hero-player.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/hero-player.page.tsx
@@ -1,0 +1,58 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { HeroPlayer, type HeroPlayerProps } from "./hero-player";
+import { buildHeroPlayerProps } from "./hero-player.factory";
+
+const scoped = (container: Container) => ({
+  /**
+   * The side's name element, resolved within the `--l`/`--r` positioned
+   * block; a ghost side reads "No opponent". Absent when no side with that
+   * name sits at that end of the row.
+   */
+  getPlayerName(pos: "l" | "r", name: string) {
+    return container.getByText(name, {
+      selector: `.md-hero__player--${pos} .md-hero__player-text--${pos} .md-hero__name`,
+    });
+  },
+  queryPlayerName(pos: "l" | "r", name: string) {
+    return container.queryByText(name, {
+      selector: `.md-hero__player--${pos} .md-hero__player-text--${pos} .md-hero__name`,
+    });
+  },
+  /** The initials avatar badge; ghost sides render an icon-only placeholder
+   * with no initials, so this is absent for them. */
+  getPlayerAvatar(initials: string) {
+    return container.getByText(initials, {
+      selector: ".md-hero__avatar-singles",
+    });
+  },
+  queryPlayerAvatar(initials: string) {
+    return container.queryByText(initials, {
+      selector: ".md-hero__avatar-singles",
+    });
+  },
+});
+
+/**
+ * Test page-object for `HeroPlayer` — one side of the hero row (avatar +
+ * name, or the ghost "No opponent" placeholder). Accessors take the `pos`
+ * the component was given, mirroring how the row distinguishes its two ends.
+ */
+export const heroPlayerPage = {
+  render(overrides: Partial<HeroPlayerProps> = {}) {
+    const props = buildHeroPlayerProps(overrides);
+    render(<HeroPlayer {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed this component (the hero
+   * row and the scoreboard above it) spread this to expose the same queries
+   * as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/scoreboard/hero-player.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/hero-player.test.tsx
@@ -1,0 +1,59 @@
+import {
+  buildGhostHeroSideView,
+  buildHeroSideView,
+} from "./hero-player.factory";
+import { heroPlayerPage } from "./hero-player.page";
+
+describe("HeroPlayer", () => {
+  it("renders the player's name at the end of the row it was positioned on", () => {
+    heroPlayerPage.render({
+      side: buildHeroSideView({ name: "rita.kovac" }),
+      pos: "r",
+    });
+
+    expect(heroPlayerPage.getPlayerName("r", "rita.kovac")).toBeInTheDocument();
+    expect(
+      heroPlayerPage.queryPlayerName("l", "rita.kovac"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the player's initials in a win-toned avatar when the side won", () => {
+    heroPlayerPage.render({ side: buildHeroSideView({ won: true }) });
+
+    const avatar = heroPlayerPage.getPlayerAvatar("RK");
+    expect(avatar).toHaveClass("md-avatar--win");
+    expect(avatar).not.toHaveClass("md-avatar--loss");
+  });
+
+  it("tones the avatar as a loss when the side hasn't won", () => {
+    heroPlayerPage.render({ side: buildHeroSideView({ won: false }) });
+
+    const avatar = heroPlayerPage.getPlayerAvatar("RK");
+    expect(avatar).toHaveClass("md-avatar--loss");
+    expect(avatar).not.toHaveClass("md-avatar--win");
+  });
+
+  it("highlights a winning side's name", () => {
+    heroPlayerPage.render({ side: buildHeroSideView({ won: true }) });
+
+    expect(heroPlayerPage.getPlayerName("l", "rita.kovac")).toHaveClass(
+      "md-hero__name--win",
+    );
+  });
+
+  it("does not highlight the name of a side still playing", () => {
+    heroPlayerPage.render({ side: buildHeroSideView({ won: false }) });
+
+    expect(heroPlayerPage.getPlayerName("l", "rita.kovac")).not.toHaveClass(
+      "md-hero__name--win",
+    );
+  });
+
+  it('renders a ghost side as a "No opponent" placeholder without an initials avatar', () => {
+    heroPlayerPage.render({ side: buildGhostHeroSideView() });
+
+    const name = heroPlayerPage.getPlayerName("l", "No opponent");
+    expect(name).toHaveClass("md-hero__name--ghost");
+    expect(heroPlayerPage.queryPlayerAvatar("NO")).not.toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/hero-player.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/hero-player.tsx
@@ -1,0 +1,48 @@
+import { User } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { type HeroSideView } from "./scoreboard-query";
+
+export interface HeroPlayerProps {
+  side: HeroSideView;
+  /** Which end of the hero row this side anchors — picks the l/r alignment
+   * variants. */
+  pos: "l" | "r";
+}
+
+export const HeroPlayer = ({ side, pos }: HeroPlayerProps) => {
+  return (
+    <div className={`md-hero__player md-hero__player--${pos}`}>
+      <div className="md-hero__player-row">
+        {side.isGhost ? (
+          <div
+            className="md-avatar md-avatar--ghost md-hero__avatar-singles"
+            aria-hidden="true"
+          >
+            <User size={26} strokeWidth={1.75} />
+          </div>
+        ) : (
+          <div
+            className={cn(
+              "md-avatar md-hero__avatar-singles",
+              side.won ? "md-avatar--win" : "md-avatar--loss",
+            )}
+          >
+            {side.initials}
+          </div>
+        )}
+        <div className={`md-hero__player-text--${pos}`}>
+          <div
+            className={cn(
+              "md-hero__name",
+              side.won && "md-hero__name--win",
+              side.isGhost && "md-hero__name--ghost",
+            )}
+          >
+            {side.name}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/web-client/src/components/matches/match-details/scoreboard/hero-row.factory.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/hero-row.factory.tsx
@@ -1,0 +1,26 @@
+import { buildHeroSideView } from "./hero-player.factory";
+import { buildScorelineHeroScoreView } from "./hero-score.factory";
+import type { HeroRowProps } from "./hero-row";
+import type { HeroRowView } from "./scoreboard-query";
+
+/** A live BO5: rita.kovac (left) leading leo.mertens (right) 2 games to 1. */
+export function buildHeroRowView(
+  overrides: Partial<HeroRowView> = {},
+): HeroRowView {
+  return {
+    left: buildHeroSideView(),
+    score: buildScorelineHeroScoreView(),
+    right: buildHeroSideView({ name: "leo.mertens", initials: "LM" }),
+    ...overrides,
+  };
+}
+
+/** Props for `HeroRow`. */
+export function buildHeroRowProps(
+  overrides: Partial<HeroRowProps> = {},
+): HeroRowProps {
+  return {
+    heroRow: buildHeroRowView(),
+    ...overrides,
+  };
+}

--- a/web-client/src/components/matches/match-details/scoreboard/hero-row.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/hero-row.page.tsx
@@ -1,0 +1,37 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { heroPlayerPage } from "./hero-player.page";
+import { heroScorePage } from "./hero-score.page";
+import { HeroRow, type HeroRowProps } from "./hero-row";
+import { buildHeroRowProps } from "./hero-row.factory";
+
+const scoped = (container: Container) => ({
+  // The row is its two players plus the score block — reuse their queries
+  // as this component's own surface.
+  ...heroPlayerPage.within(container),
+  ...heroScorePage.within(container),
+});
+
+/**
+ * Test page-object for `HeroRow` — the hero strip's left player / score
+ * block / right player. Player accessors take the `pos` end of the row
+ * (`"l"`/`"r"`); score accessors mirror `heroScorePage`.
+ */
+export const heroRowPage = {
+  render(overrides: Partial<HeroRowProps> = {}) {
+    const props = buildHeroRowProps(overrides);
+    render(<HeroRow {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed the hero row (the
+   * scoreboard display, fetcher, and wrapper) call this to expose the same
+   * player/score queries as their own `.heroRow`, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/scoreboard/hero-row.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/hero-row.test.tsx
@@ -1,0 +1,46 @@
+import {
+  buildGhostHeroSideView,
+  buildHeroSideView,
+} from "./hero-player.factory";
+import { buildUpcomingHeroScoreView } from "./hero-score.factory";
+import { buildHeroRowView } from "./hero-row.factory";
+import { heroRowPage } from "./hero-row.page";
+
+// Wiring only: side and score-block content is pinned by the hero-player and
+// hero-score tests.
+describe("HeroRow", () => {
+  it("renders the left side on the left and the right side on the right", () => {
+    heroRowPage.render({
+      heroRow: buildHeroRowView({
+        left: buildHeroSideView({ name: "rita.kovac" }),
+        right: buildHeroSideView({ name: "leo.mertens", initials: "LM" }),
+      }),
+    });
+
+    expect(heroRowPage.getPlayerName("l", "rita.kovac")).toBeInTheDocument();
+    expect(heroRowPage.getPlayerName("r", "leo.mertens")).toBeInTheDocument();
+  });
+
+  it("renders the score block between the sides from the view's score", () => {
+    heroRowPage.render();
+
+    expect(heroRowPage.getScore("l")).toHaveTextContent("2");
+    expect(heroRowPage.getScore("r")).toHaveTextContent("1");
+  });
+
+  it("renders the VS placeholder when the view's score is upcoming", () => {
+    heroRowPage.render({
+      heroRow: buildHeroRowView({ score: buildUpcomingHeroScoreView() }),
+    });
+
+    expect(heroRowPage.getVsLabel()).toBeInTheDocument();
+  });
+
+  it("renders a ghost right side as the No-opponent placeholder", () => {
+    heroRowPage.render({
+      heroRow: buildHeroRowView({ right: buildGhostHeroSideView() }),
+    });
+
+    expect(heroRowPage.getPlayerName("r", "No opponent")).toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/hero-row.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/hero-row.tsx
@@ -1,0 +1,17 @@
+import { HeroPlayer } from "./hero-player";
+import { HeroScore } from "./hero-score";
+import { type HeroRowView } from "./scoreboard-query";
+
+export interface HeroRowProps {
+  heroRow: HeroRowView;
+}
+
+export const HeroRow = ({ heroRow }: HeroRowProps) => {
+  return (
+    <div className="md-hero__row">
+      <HeroPlayer side={heroRow.left} pos="l" />
+      <HeroScore score={heroRow.score} />
+      <HeroPlayer side={heroRow.right} pos="r" />
+    </div>
+  );
+};

--- a/web-client/src/components/matches/match-details/scoreboard/hero-score.factory.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/hero-score.factory.tsx
@@ -1,0 +1,35 @@
+import type { HeroScoreProps } from "./hero-score";
+import type { HeroScoreView } from "./scoreboard-query";
+
+/** A live scoreline with the left side ahead 2–1, nothing decided yet. */
+export function buildScorelineHeroScoreView(
+  overrides: Partial<Extract<HeroScoreView, { kind: "scoreline" }>> = {},
+): HeroScoreView {
+  return {
+    kind: "scoreline",
+    left: { gamesWon: 2, won: false },
+    right: { gamesWon: 1, won: false },
+    ...overrides,
+  };
+}
+
+/** The pre-match "VS" placeholder with its status line. */
+export function buildUpcomingHeroScoreView(
+  overrides: Partial<Extract<HeroScoreView, { kind: "upcoming" }>> = {},
+): HeroScoreView {
+  return {
+    kind: "upcoming",
+    statusLabel: "Awaiting opponent",
+    ...overrides,
+  };
+}
+
+/** Props for `HeroScore` — a live 2–1 scoreline. */
+export function buildHeroScoreProps(
+  overrides: Partial<HeroScoreProps> = {},
+): HeroScoreProps {
+  return {
+    score: buildScorelineHeroScoreView(),
+    ...overrides,
+  };
+}

--- a/web-client/src/components/matches/match-details/scoreboard/hero-score.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/hero-score.page.tsx
@@ -1,0 +1,55 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { HeroScore, type HeroScoreProps } from "./hero-score";
+import { buildHeroScoreProps } from "./hero-score.factory";
+
+const scoped = (container: Container) => ({
+  /** One side's games-won number in the scoreline; absent before the match
+   * starts (the block shows the VS placeholder instead). */
+  getScore(pos: "l" | "r") {
+    return container.getByText(/^\d+$/, {
+      selector: `.md-hero__score--${pos}`,
+    });
+  },
+  queryScore(pos: "l" | "r") {
+    return container.queryByText(/^\d+$/, {
+      selector: `.md-hero__score--${pos}`,
+    });
+  },
+  /** The "VS" placeholder shown before the match starts; absent once a
+   * scoreline exists. */
+  getVsLabel() {
+    return container.getByText("VS");
+  },
+  queryVsLabel() {
+    return container.queryByText("VS");
+  },
+  /** The status line under the VS placeholder (e.g. "Awaiting opponent"). */
+  getVsStatusLabel(label: string) {
+    return container.getByText(label, { selector: ".md-hero__vs-label" });
+  },
+});
+
+/**
+ * Test page-object for `HeroScore` — the center block of the hero row:
+ * either the pre-match "VS · <status>" placeholder or the games-won
+ * scoreline.
+ */
+export const heroScorePage = {
+  render(overrides: Partial<HeroScoreProps> = {}) {
+    const props = buildHeroScoreProps(overrides);
+    render(<HeroScore {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed this component (the hero
+   * row and the scoreboard above it) spread this to expose the same queries
+   * as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/scoreboard/hero-score.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/hero-score.test.tsx
@@ -1,0 +1,61 @@
+import {
+  buildScorelineHeroScoreView,
+  buildUpcomingHeroScoreView,
+} from "./hero-score.factory";
+import { heroScorePage } from "./hero-score.page";
+
+describe("HeroScore", () => {
+  it("shows each side's games won in the scoreline", () => {
+    heroScorePage.render({
+      score: buildScorelineHeroScoreView({
+        left: { gamesWon: 3, won: false },
+        right: { gamesWon: 1, won: false },
+      }),
+    });
+
+    expect(heroScorePage.getScore("l")).toHaveTextContent("3");
+    expect(heroScorePage.getScore("r")).toHaveTextContent("1");
+    expect(heroScorePage.queryVsLabel()).not.toBeInTheDocument();
+  });
+
+  it("highlights the left score when the left side won", () => {
+    heroScorePage.render({
+      score: buildScorelineHeroScoreView({
+        left: { gamesWon: 3, won: true },
+        right: { gamesWon: 1, won: false },
+      }),
+    });
+
+    expect(heroScorePage.getScore("l")).toHaveClass("md-hero__score--win");
+    expect(heroScorePage.getScore("r")).not.toHaveClass(
+      "md-hero__score--win",
+    );
+  });
+
+  it("highlights the right score when the right side won", () => {
+    heroScorePage.render({
+      score: buildScorelineHeroScoreView({
+        left: { gamesWon: 1, won: false },
+        right: { gamesWon: 3, won: true },
+      }),
+    });
+
+    expect(heroScorePage.getScore("r")).toHaveClass("md-hero__score--win");
+    expect(heroScorePage.getScore("l")).not.toHaveClass(
+      "md-hero__score--win",
+    );
+  });
+
+  it("shows the VS placeholder with the status label before the match starts", () => {
+    heroScorePage.render({
+      score: buildUpcomingHeroScoreView({ statusLabel: "Awaiting opponent" }),
+    });
+
+    expect(heroScorePage.getVsLabel()).toBeInTheDocument();
+    expect(
+      heroScorePage.getVsStatusLabel("Awaiting opponent"),
+    ).toBeInTheDocument();
+    expect(heroScorePage.queryScore("l")).not.toBeInTheDocument();
+    expect(heroScorePage.queryScore("r")).not.toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/scoreboard/hero-score.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/hero-score.tsx
@@ -1,0 +1,40 @@
+import { cn } from "@/lib/utils";
+import { type HeroScoreView } from "./scoreboard-query";
+
+export interface HeroScoreProps {
+  score: HeroScoreView;
+}
+
+export const HeroScore = ({ score }: HeroScoreProps) => {
+  return (
+    <div className="md-hero__score-block">
+      {score.kind === "upcoming" ? (
+        <>
+          <div className="md-hero__vs-label">VS</div>
+          <div className="md-hero__vs-dash">—</div>
+          <div className="md-hero__vs-label">{score.statusLabel}</div>
+        </>
+      ) : (
+        <div className="md-hero__score-row">
+          <div
+            className={cn(
+              "md-hero__score md-hero__score--l",
+              score.left.won && "md-hero__score--win",
+            )}
+          >
+            {score.left.gamesWon}
+          </div>
+          <div className="md-hero__score-dash">—</div>
+          <div
+            className={cn(
+              "md-hero__score md-hero__score--r",
+              score.right.won && "md-hero__score--win",
+            )}
+          >
+            {score.right.gamesWon}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.factory.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.factory.tsx
@@ -1,8 +1,9 @@
+import { buildHeroRowView } from "./hero-row.factory";
 import { buildScoreboardHeadingView } from "./heading.factory";
 import type { ScoreboardView } from "./scoreboard-query";
 import type { ScoreboardDisplayProps } from "./scoreboard-display";
 
-/** The projected `{ status, outcome, heading, gameGrid }` view the display renders around. */
+/** The projected `{ status, outcome, heading, heroRow, gameGrid }` view the display renders. */
 export function buildScoreboardView(
   overrides: Partial<ScoreboardView> = {},
 ): ScoreboardView {
@@ -10,6 +11,7 @@ export function buildScoreboardView(
     status: "scheduled",
     outcome: null,
     heading: buildScoreboardHeadingView(),
+    heroRow: buildHeroRowView(),
     // Null by default so the view renders without a router — scored grid
     // cells may carry typed <Link>s; see `gameGridPage.render`.
     gameGrid: null,
@@ -17,11 +19,7 @@ export function buildScoreboardView(
   };
 }
 
-/**
- * Props for `ScoreboardDisplay`. The default `children` renders a recognizable
- * marker so tests can assert the render-prop's output lands inside the section;
- * override it with a `vi.fn()` to inspect the argument it receives.
- */
+/** Props for `ScoreboardDisplay`. */
 export function buildScoreboardDisplayProps(
   overrides: Partial<ScoreboardDisplayProps> = {},
 ): ScoreboardDisplayProps {
@@ -29,7 +27,6 @@ export function buildScoreboardDisplayProps(
     scoreboard: buildScoreboardView({
       outcome: "rita.kovac leading, 2 games to 1",
     }),
-    children: () => <div data-testid="scoreboard-children">scoreboard body</div>,
     ...overrides,
   };
 }

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.page.tsx
@@ -2,6 +2,7 @@ import { render, screen, type Container } from "@/test/utilities";
 
 import { gameGridPage } from "./game-grid.page";
 import { headingPage } from "./heading.page";
+import { heroRowPage } from "./hero-row.page";
 import {
   ScoreboardDisplay,
   type ScoreboardDisplayProps,
@@ -17,6 +18,8 @@ const scoped = (container: Container) => ({
   },
   /** The heading strip (status chip + format/race labels) the display renders. */
   headingStrip: headingPage.within(container),
+  /** The hero row (left player / score block / right player) in the middle. */
+  heroRow: heroRowPage.within(container),
   /** The per-game score grid at the bottom; absent when `gameGrid` is null. */
   gameGrid: gameGridPage.within(container),
 });

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.test.tsx
@@ -1,6 +1,6 @@
-import { within } from "@/test/utilities";
-
 import { buildGameGridView } from "./game-grid.factory";
+import { buildHeroRowView } from "./hero-row.factory";
+import { buildHeroSideView } from "./hero-player.factory";
 import { buildScoreboardHeadingView } from "./heading.factory";
 import { buildScoreboardView } from "./scoreboard-display.factory";
 import { scoreboardDisplayPage } from "./scoreboard-display.page";
@@ -54,24 +54,21 @@ describe("ScoreboardDisplay", () => {
     );
   });
 
-  it("renders the children render-prop's output inside the region", () => {
+  it("renders the hero row inside the region from the view's heroRow", () => {
+    // Wiring only: row content is pinned by the query and hero-row tests.
     scoreboardDisplayPage.render({
-      children: () => <p data-testid="scoreboard-body">live scores</p>,
+      scoreboard: buildScoreboardView({
+        heroRow: buildHeroRowView({
+          left: buildHeroSideView({ name: "rita.kovac" }),
+        }),
+      }),
     });
 
-    const body = within(scoreboardDisplayPage.getContainer()).getByTestId(
-      "scoreboard-body",
+    const name = scoreboardDisplayPage.heroRow.getPlayerName(
+      "l",
+      "rita.kovac",
     );
-    expect(body).toHaveTextContent("live scores");
-  });
-
-  it("invokes children with the exact scoreboard prop it was given", () => {
-    const scoreboard = buildScoreboardView({ status: "live", outcome: "tied" });
-    const children = vi.fn(() => null);
-
-    scoreboardDisplayPage.render({ scoreboard, children });
-
-    expect(children).toHaveBeenCalledWith(scoreboard);
+    expect(scoreboardDisplayPage.getContainer()).toContainElement(name);
   });
 
   it("renders the game grid inside the region from the view's gameGrid", () => {

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-display.tsx
@@ -1,17 +1,14 @@
 import { useId } from "react";
 import { GameGrid } from "./game-grid";
 import { Heading } from "./heading";
+import { HeroRow } from "./hero-row";
 import { type ScoreboardView } from "./scoreboard-query";
 
 export interface ScoreboardDisplayProps {
   scoreboard: ScoreboardView;
-  children: (scoreboard: ScoreboardView) => React.ReactNode;
 }
 
-export const ScoreboardDisplay = ({
-  scoreboard,
-  children,
-}: ScoreboardDisplayProps) => {
+export const ScoreboardDisplay = ({ scoreboard }: ScoreboardDisplayProps) => {
   const id = useId();
 
   return (
@@ -21,7 +18,7 @@ export const ScoreboardDisplay = ({
       </h2>
       <div className="md-hero__grid-bg" aria-hidden="true" />
       <Heading heading={scoreboard.heading} />
-      {children(scoreboard)}
+      <HeroRow heroRow={scoreboard.heroRow} />
       {scoreboard.gameGrid && <GameGrid gameGrid={scoreboard.gameGrid} />}
     </section>
   );

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.page.tsx
@@ -10,6 +10,7 @@ import { render, screen, type Container } from "@/test/utilities";
 
 import { gameGridPage } from "./game-grid.page";
 import { headingPage } from "./heading.page";
+import { heroRowPage } from "./hero-row.page";
 import { ScoreboardFetcher, type ScoreboardProps } from "./scoreboard-fetcher";
 
 const DEFAULT_MATCH_ID = "m-1";
@@ -33,6 +34,8 @@ const scoped = (container: Container) => ({
   },
   /** The heading strip (status chip + format/race labels) the display renders. */
   headingStrip: headingPage.within(container),
+  /** The hero row (left player / score block / right player) the display renders. */
+  heroRow: heroRowPage.within(container),
   /** The per-game score grid the display renders at the bottom of the hero. */
   gameGrid: gameGridPage.within(container),
 });
@@ -56,9 +59,6 @@ export const scoreboardFetcherPage = {
   render(overrides: Partial<ScoreboardProps> = {}) {
     const props: ScoreboardProps = {
       matchId: DEFAULT_MATCH_ID,
-      children: (scoreboard) => (
-        <div data-testid="scoreboard-children">{scoreboard.status}</div>
-      ),
       ...overrides,
     };
 

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.test.tsx
@@ -6,7 +6,7 @@ import {
   buildMatchDetailsPlayer,
   buildMatchDetailsSide,
 } from "@/mocks/factories/matches/match-details.factory";
-import { waitForElementToBeRemoved, within } from "@/test/utilities";
+import { waitForElementToBeRemoved } from "@/test/utilities";
 
 import { scoreboardFetcherPage } from "./scoreboard-fetcher.page";
 
@@ -62,23 +62,20 @@ describe("ScoreboardFetcher", () => {
     );
   });
 
-  it("calls the children render-prop with the selected ScoreboardView", async () => {
-    const children = vi.fn(() => null);
+  it("renders the hero row from the selected view", async () => {
     scoreboardFetcherPage.mockEndpoint(() =>
       HttpResponse.json(decidedMatch()),
     );
 
-    scoreboardFetcherPage.render({ children });
+    scoreboardFetcherPage.render();
 
     await waitForElementToBeRemoved(scoreboardFetcherPage.queryLoading());
-    // Wiring only: the projected heading's content is pinned by the
-    // scoreboard-query tests, the resulting DOM by the display tests.
-    expect(children).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: "scheduled",
-        outcome: "rita.kovac defeated leo.mertens, 3 games to 1",
-      }),
+    // Wiring only: row content is pinned by the query and hero-row tests.
+    const name = scoreboardFetcherPage.heroRow.getPlayerName(
+      "l",
+      "rita.kovac",
     );
+    expect(scoreboardFetcherPage.getRegion()).toContainElement(name);
   });
 
   it("renders the heading strip from the selected view", async () => {
@@ -128,21 +125,6 @@ describe("ScoreboardFetcher", () => {
     expect(
       scoreboardFetcherPage.gameGrid.queryGrid(),
     ).not.toBeInTheDocument();
-  });
-
-  it("renders the children output inside the region", async () => {
-    scoreboardFetcherPage.mockEndpoint(() =>
-      HttpResponse.json(decidedMatch()),
-    );
-
-    scoreboardFetcherPage.render({
-      children: () => <p data-testid="scoreboard-body">live</p>,
-    });
-
-    await waitForElementToBeRemoved(scoreboardFetcherPage.queryLoading());
-    expect(
-      within(scoreboardFetcherPage.getRegion()).getByTestId("scoreboard-body"),
-    ).toBeInTheDocument();
   });
 
   it("propagates a query failure to the nearest error boundary", async () => {

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.tsx
@@ -1,18 +1,13 @@
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { type ReactNode } from 'react'
-import { scoreboardQuery, type ScoreboardView } from './scoreboard-query'
+import { scoreboardQuery } from './scoreboard-query'
 import { ScoreboardDisplay } from './scoreboard-display';
 
 export interface ScoreboardProps {
     matchId: string;
-    children: (scoreboard: ScoreboardView) => ReactNode;
 }
 
-export function ScoreboardFetcher({
-    matchId,
-    children,
-}: ScoreboardProps) {
+export function ScoreboardFetcher({ matchId }: ScoreboardProps) {
     const { data: scoreboard } = useSuspenseQuery(scoreboardQuery(matchId))
 
-    return <ScoreboardDisplay scoreboard={scoreboard} children={children} />
+    return <ScoreboardDisplay scoreboard={scoreboard} />
 }

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.test.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.test.ts
@@ -667,6 +667,128 @@ describe("scoreboardQuery", () => {
     expect(ghost).toMatchObject({ name: "No opponent", isGhost: true });
   });
 
+  it("projects the hero scoreline from the perspective-ordered sides", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          sides: [
+            buildMatchDetailsSide({
+              won: false,
+              games_won: 1,
+              players: [
+                buildMatchDetailsPlayer({
+                  user_id: "u-opponent",
+                  username: "leo.mertens",
+                  is_current_user: false,
+                }),
+              ],
+              is_current_user_side: false,
+            }),
+            buildMatchDetailsSide({
+              side_number: 2,
+              won: true,
+              games_won: 3,
+              players: [buildMatchDetailsPlayer({ username: "rita.kovac" })],
+            }),
+          ],
+          data: { scoreboard: { status: "final" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    // The viewer is side 2, so their side reads left.
+    expect(result.current.data?.heroRow).toEqual({
+      left: { name: "rita.kovac", initials: "RK", isGhost: false, won: true },
+      score: {
+        kind: "scoreline",
+        left: { gamesWon: 3, won: true },
+        right: { gamesWon: 1, won: false },
+      },
+      right: {
+        name: "leo.mertens",
+        initials: "LM",
+        isGhost: false,
+        won: false,
+      },
+    });
+  });
+
+  it("projects an upcoming VS block carrying the status label for a scheduled match", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          status_label: "Awaiting opponent",
+          data: { scoreboard: { status: "scheduled" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heroRow.score).toEqual({
+      kind: "upcoming",
+      statusLabel: "Awaiting opponent",
+    });
+    expect(result.current.data?.heroRow.left.name).toBe("rita.kovac");
+    expect(result.current.data?.heroRow.right.name).toBe("leo.mertens");
+  });
+
+  it("projects a ghost hero side scoring zero when the match has only one side", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          sides: [buildMatchDetailsSide({ games_won: 2 })],
+          data: { scoreboard: { status: "live" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heroRow.right).toEqual({
+      name: "No opponent",
+      initials: "NO",
+      isGhost: true,
+      won: false,
+    });
+    expect(result.current.data?.heroRow.score).toEqual({
+      kind: "scoreline",
+      left: { gamesWon: 2, won: false },
+      right: { gamesWon: 0, won: false },
+    });
+  });
+
+  it("projects a playerless side as a ghost hero side", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          sides: [
+            buildMatchDetailsSide(),
+            buildMatchDetailsSide({
+              side_number: 2,
+              players: [],
+              is_current_user_side: false,
+            }),
+          ],
+          data: { scoreboard: { status: "live" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heroRow.right).toMatchObject({
+      name: "No opponent",
+      isGhost: true,
+    });
+  });
+
   it("shares the matchDetailsQuery cache key so the request is not duplicated", () => {
     expect(scoreboardQuery("m-1").queryKey).toEqual(
       matchDetailsQuery("m-1").queryKey,

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.ts
@@ -55,10 +55,48 @@ export type GameGridView = {
   rows: [GameGridRowView, GameGridRowView];
 };
 
+/** One competitor in the hero row. A ghost side stands in for a missing
+ * opponent — a playerless side row, or no second side at all — and renders
+ * as the dashed "No opponent" placeholder instead of an avatar. */
+export type HeroSideView = {
+  /** Lead player's username, or "No opponent" for a ghost side. */
+  name: string;
+  initials: string;
+  isGhost: boolean;
+  won: boolean;
+};
+
+/** One side's half of the hero scoreline; `won` drives the win highlight. */
+export type HeroScorelineSideView = {
+  gamesWon: number;
+  won: boolean;
+};
+
+/** The center block between the two hero players: a "VS · <status>"
+ * placeholder until the match starts, then the games-won scoreline. */
+export type HeroScoreView =
+  | { kind: "upcoming"; statusLabel: string }
+  | {
+      kind: "scoreline";
+      left: HeroScorelineSideView;
+      right: HeroScorelineSideView;
+    };
+
+/** The hero row across the middle of the scoreboard: left player, center
+ * score block, right player. Sides are perspective-ordered like the game
+ * grid — the viewer's side reads left when they're a participant, otherwise
+ * side 1 is left. */
+export type HeroRowView = {
+  left: HeroSideView;
+  score: HeroScoreView;
+  right: HeroSideView;
+};
+
 export type ScoreboardView = {
   status: Scoreboard["status"];
   outcome: string | null;
   heading: ScoreboardHeadingView;
+  heroRow: HeroRowView;
   /** Null when there's nothing to tabulate: an upcoming match, or a match
    * without two sides. */
   gameGrid: GameGridView | null;
@@ -126,13 +164,57 @@ const selectHeading = (match: MatchDetailsResult): ScoreboardHeadingView => {
 type MatchDetailsSide = MatchDetailsResult["unmigrated"]["sides"][number];
 type MatchDetailsGame = MatchDetailsResult["unmigrated"]["games"][number];
 
+const NO_OPPONENT_LABEL = "No opponent";
+
+// Perspective ordering shared by the hero row and the game grid: the viewer's
+// side reads first when they're a participant, otherwise side 1 / side 2.
+const orderedSides = (
+  details: MatchDetailsResult["unmigrated"],
+): [MatchDetailsSide | null, MatchDetailsSide | null] => {
+  const bySideNumber = [...details.sides].sort(
+    (a, b) => a.side_number - b.side_number,
+  );
+  const mine = bySideNumber.find((s) => s.is_current_user_side);
+  const first = mine ?? bySideNumber[0] ?? null;
+  const second = bySideNumber.find((s) => s !== first) ?? null;
+  return [first, second];
+};
+
+const selectHeroSide = (side: MatchDetailsSide | null): HeroSideView => {
+  const player = side?.players[0] ?? null;
+  const name = player?.username ?? NO_OPPONENT_LABEL;
+  return {
+    name,
+    initials: initialsOf(name),
+    isGhost: player === null,
+    won: side?.won === true,
+  };
+};
+
+const selectHeroRow = (match: MatchDetailsResult): HeroRowView => {
+  const details = match.unmigrated;
+  const [first, second] = orderedSides(details);
+  const score: HeroScoreView =
+    match.data.scoreboard.status === "scheduled"
+      ? { kind: "upcoming", statusLabel: details.status_label }
+      : {
+          kind: "scoreline",
+          left: { gamesWon: first?.games_won ?? 0, won: first?.won === true },
+          right: {
+            gamesWon: second?.games_won ?? 0,
+            won: second?.won === true,
+          },
+        };
+  return { left: selectHeroSide(first), score, right: selectHeroSide(second) };
+};
+
 const selectGameGridRow = (
   side: MatchDetailsSide,
   slots: Array<MatchDetailsGame | null>,
   details: MatchDetailsResult["unmigrated"],
   editable: boolean,
 ): GameGridRowView => {
-  const name = side.players[0]?.username ?? "No opponent";
+  const name = side.players[0]?.username ?? NO_OPPONENT_LABEL;
   return {
     name,
     initials: initialsOf(name),
@@ -167,14 +249,7 @@ const selectGameGrid = (match: MatchDetailsResult): GameGridView | null => {
   if (match.data.scoreboard.status === "scheduled") return null;
 
   const details = match.unmigrated;
-  // Perspective ordering: the viewer's side reads first when they're a
-  // participant; otherwise side 1 / side 2.
-  const bySideNumber = [...details.sides].sort(
-    (a, b) => a.side_number - b.side_number,
-  );
-  const mine = bySideNumber.find((s) => s.is_current_user_side);
-  const first = mine ?? bySideNumber[0];
-  const second = bySideNumber.find((s) => s !== first);
+  const [first, second] = orderedSides(details);
   if (!first || !second) return null;
 
   // Pad to best_of so the grid always renders the same number of cells.
@@ -202,6 +277,7 @@ const selectScoreboard = (match: MatchDetailsResult): ScoreboardView => ({
   status: match.data.scoreboard.status,
   outcome: selectOutcome(match),
   heading: selectHeading(match),
+  heroRow: selectHeroRow(match),
   gameGrid: selectGameGrid(match),
 });
 


### PR DESCRIPTION
## Summary

- Extracts the match-details hero row (players + score block) out of `match-details-page.tsx` into component quartets (`.tsx` / `.page.tsx` / `.factory.tsx` / `.test.tsx`) under `match-details/scoreboard/`, per the react-component skill:
  - `hero-row` — the `md-hero__row` composition: left player, score block, right player
  - `hero-player` — one side's avatar + name; the old `PlayerSide`/`NoOpponentSide` pair merged into one component with a ghost branch, mirroring `GameGridRow`
  - `hero-score` — the center block: pre-match "VS · status" placeholder or the games-won scoreline
- Adds `HeroRowView`/`HeroSideView`/`HeroScoreView` projections to `scoreboard-query` with the perspective ordering shared with the game grid via a new `orderedSides` helper; all label/ordering logic lives in the selector
- Retires the `Scoreboard` children render-prop seam — the hero row was the last unmigrated content it carried, so `ScoreboardDisplay` now renders `HeroRow` directly and `match-details-page.tsx` just renders `<Scoreboard matchId={matchId} />` (~130 lines removed)
- Page objects resolve elements by text scoped to the `--l`/`--r` class variants — no new testids (the game-grid ones are slated for removal in #475)
- Checks in the `react-component` skill these quartets follow

The extracted markup is byte-identical to the original; the untouched legacy `match-details-page.test.tsx` hero assertions still pass.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:run` (242/242)
- [x] Mutation testing: 100% score on all production files under `scoreboard/`, including the new components and the extended query selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)