### PR TITLE
scoreboard: color win/loss cells on the editable (linked) grid row

### DIFF
--- a/web-client/e2e/matches/match-details.spec.ts
+++ b/web-client/e2e/matches/match-details.spec.ts
@@ -4,6 +4,21 @@ import type { components } from '../../src/api/schema';
 
 type MatchDetails = components['schemas']['MatchDetails'];
 
+const gameScore = (
+    gameNumber: number,
+    side1Points: number,
+    side2Points: number,
+): MatchDetails['games'][number] => ({
+    id: `g-${gameNumber}`,
+    game_number: gameNumber,
+    score: {
+        id: `s-${gameNumber}`,
+        side_1_points: side1Points,
+        side_2_points: side2Points,
+        winner_side_number: side1Points > side2Points ? 1 : 2,
+    },
+});
+
 /** A decided singles match: rita.kovac beat silva.r, 3 games to 1. */
 const decidedMatch = (id: string): MatchDetails =>
     matchDetails({
@@ -30,7 +45,12 @@ const decidedMatch = (id: string): MatchDetails =>
                 is_current_user_side: false,
             },
         ],
-        games: [],
+        games: [
+            gameScore(1, 11, 7),
+            gameScore(2, 9, 11),
+            gameScore(3, 11, 5),
+            gameScore(4, 11, 8),
+        ],
         current_game: null,
         can_score: false,
     });
@@ -76,6 +96,38 @@ test.describe('Match Details', () => {
             await matchDetailsPage.mock(decidedMatch('m-completed-win-1'));
             await matchDetailsPage.goTo('m-completed-win-1');
             await expect(page.getByRole('region', { name: 'rita.kovac defeated silva.r, 3 games to 1' })).toBeVisible();
+        });
+
+        // Regression test for #472: the current user's row renders its cells
+        // as edit links (<a>), and the `.match-details a { color: inherit }`
+        // reset used to out-rank the win/loss colors, leaving the row colorless.
+        test('colors the editable (current-user) row win/loss cells like the opponent row', async ({ page }) => {
+            await matchDetailsPage.mock(decidedMatch('m-completed-win-1'));
+            await matchDetailsPage.goTo('m-completed-win-1');
+
+            const color = (testId: string) =>
+                page
+                    .getByTestId(testId)
+                    .evaluate((el) => getComputedStyle(el).color);
+
+            const winColor = 'rgb(0, 226, 154)'; // --serve-500
+
+            // Current-user row, game 1 (won, rendered as an edit link).
+            const myWinCell = page.getByTestId('scoreboard-game-grid-cell-left-1');
+            await expect(myWinCell).toHaveText('11');
+            await expect(
+                myWinCell.locator('xpath=self::a'),
+                'editable cell renders as a link',
+            ).toBeVisible();
+            expect(await color('scoreboard-game-grid-cell-left-1')).toBe(winColor);
+
+            // Won and lost cells on the editable row must be distinguishable.
+            const myLossColor = await color('scoreboard-game-grid-cell-left-2');
+            expect(myLossColor).not.toBe(winColor);
+
+            // And the editable row must match the opponent (non-link) row.
+            expect(await color('scoreboard-game-grid-cell-right-2')).toBe(winColor);
+            expect(await color('scoreboard-game-grid-cell-right-1')).toBe(myLossColor);
         });
     });
 });

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2909,10 +2909,15 @@ body.dark.fortymm-theme {
   font-variant-numeric: tabular-nums;
   line-height: 1;
 }
-.fortymm-theme .md-games__cell--win {
+/* The a-qualified selectors match the specificity of the
+   `.match-details a { color: inherit }` reset so editable (linked) cells
+   still get their win/loss color. */
+.fortymm-theme .md-games__cell--win,
+.fortymm-theme a.md-games__cell--win {
   color: var(--serve-500);
 }
-.fortymm-theme .md-games__cell--loss {
+.fortymm-theme .md-games__cell--loss,
+.fortymm-theme a.md-games__cell--loss {
   color: var(--fg-3);
 }
 .fortymm-theme .md-games__cell--live {


### PR DESCRIPTION
## Summary

Fixes #472 — on the match-details game grid, the current user's row showed won and lost game scores in the same plain white, so a 3–1 victory read as if the opponent was ahead (the only colored cell on the board was the opponent's win).

## Root cause

Editable cells render as TanStack `<Link>`s (anchors), and the anchor reset in `index.css` out-ranked the win/loss color rules:

- `.fortymm-theme .match-details a { color: inherit }` — specificity (0,2,1)
- `.fortymm-theme .md-games__cell--win` / `--loss` — specificity (0,2,0)

So any cell the viewer could edit inherited `--fg-1` (white) instead of getting the win green / loss gray. Non-editable `<div>` cells were unaffected, which is why only the current-user row broke.

## Fix

Add `a.md-games__cell--win` / `a.md-games__cell--loss` qualified selectors alongside the existing rules so linked cells match the reset's specificity (0,2,1) and win by source order.

## Test

New Playwright regression test in `web-client/e2e/matches/match-details.spec.ts`: a decided 3–1 match with scored games asserts (via `getComputedStyle`) that the editable row's win cell is `--serve-500` green, its loss cell differs, and both match the opponent's non-link row. Verified the test fails with the CSS fix reverted.

- web-client e2e: 2/2 passed
- vitest: 226/226 passed
- lint: clean (one pre-existing warning in `public/mockServiceWorker.js`)
- build: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)