### PR TITLE
scoreboard: regression test for the live 0-0 hero scoreline

### DIFF
--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.test.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.test.ts
@@ -737,6 +737,31 @@ describe("scoreboardQuery", () => {
     expect(result.current.data?.heroRow.right.name).toBe("leo.mertens");
   });
 
+  // Regression test for #394: a live match whose first game is still being
+  // played (no completed game yet) must show the 0 — 0 scoreline, not the
+  // upcoming "VS" placeholder — that state disagreed with the Live chip.
+  it("projects a 0-0 scoreline, not the VS block, for a live match with no scored game", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          status: "in_progress",
+          games: [buildMatchDetailsGame()],
+          current_game: { game_number: 1 },
+          data: { scoreboard: { status: "live" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heroRow.score).toEqual({
+      kind: "scoreline",
+      left: { gamesWon: 0, won: false },
+      right: { gamesWon: 0, won: false },
+    });
+  });
+
   it("projects a ghost hero side scoring zero when the match has only one side", async () => {
     scoreboardQueryPage.mockEndpoint(() =>
       HttpResponse.json(


### PR DESCRIPTION
## Summary

While triaging #394 (live match with no scored game showed "VS" instead of "0 – 0"), I found it is **already fixed on main**: the HeroRow extraction in #477 rewrote the projection so `selectHeroRow` branches on `data.scoreboard.status === 'scheduled'` rather than on the scored-games count (`games.length`), which was the root cause called out in the issue.

This PR pins that behavior with an explicit regression test for the exact #394 scenario — `in_progress`, one unscored game record, `current_game = 1`, scoreboard status `live` — asserting the hero projects a `0 – 0` scoreline, not the upcoming VS block.

Closes #394

## Tests

- `scoreboard-query.test.ts`: 36/36 passed (1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)