### PR TITLE
login: guard "Send the link" against rapid multi-click duplicate POSTs

### DIFF
--- a/web-client/src/components/login/login-screens.tsx
+++ b/web-client/src/components/login/login-screens.tsx
@@ -1127,6 +1127,7 @@ export function ScreenEmail({
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    if (submitting) return
     setTouched(true)
     if (!valid) return
     if (!captchaToken) {

--- a/web-client/src/routes/login.index.tsx
+++ b/web-client/src/routes/login.index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
 import { ApiError } from '@/api/client'
@@ -25,6 +25,10 @@ function LoginPage() {
   const navigate = useNavigate()
   const requestLogin = useRequestLogin()
   const [serverError, setServerError] = useState<string | null>(null)
+  // Synchronous in-flight guard: the mutation's isPending flips on a batched
+  // re-render, so a rapid click burst can dispatch duplicate requests (and
+  // duplicate sign-in emails) before the button disables.
+  const inFlight = useRef(false)
 
   if (error === 'send-failed') {
     return (
@@ -47,6 +51,8 @@ function LoginPage() {
       submitting={requestLogin.isPending}
       errorMessage={serverError}
       onSubmit={async ({ email, captchaToken, honeypot }) => {
+        if (inFlight.current) return
+        inFlight.current = true
         setServerError(null)
         try {
           await requestLogin.mutateAsync({ email, captchaToken, honeypot })
@@ -67,6 +73,8 @@ function LoginPage() {
             return
           }
           setServerError('Something went wrong. Try again.')
+        } finally {
+          inFlight.current = false
         }
       }}
     />

--- a/web-client/src/routes/login.test.tsx
+++ b/web-client/src/routes/login.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   RouterProvider,
@@ -109,6 +109,39 @@ describe('/login flow', () => {
     expect(router.state.location.search).toMatchObject({
       email: 'rita@example.com',
     })
+  })
+
+  // Regression test for #436: the mutation's isPending only disables the
+  // button on a batched re-render, so a synchronous click burst used to
+  // dispatch one POST (and one sign-in email) per click.
+  it('fires exactly one POST /login/request for a rapid multi-click', async () => {
+    let requests = 0
+    server.use(
+      http.post('*/v1/login/request', async ({ request }) => {
+        requests += 1
+        const body = (await request.json()) as { email: string }
+        // Stay in flight long enough for the burst to land while pending.
+        await new Promise((resolve) => setTimeout(resolve, 25))
+        return HttpResponse.json({ email: body.email }, { status: 202 })
+      }),
+    )
+    const user = userEvent.setup()
+    const { router } = renderAt('/login')
+
+    const input = await screen.findByLabelText('Email address')
+    await user.type(input, 'rita@example.com')
+
+    // fireEvent (not userEvent) so all three clicks land in one synchronous
+    // burst, before React re-renders with the disabled submitting button.
+    const button = screen.getByRole('button', { name: /send the link/i })
+    fireEvent.click(button)
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/login/sent')
+    })
+    expect(requests).toBe(1)
   })
 
   it('keeps the user on /login and surfaces an inline error for bad emails', async () => {


### PR DESCRIPTION
## Summary

Fixes #436 — a rapid double/triple-click on "Send the link" fired one `POST /v1/login/request` per click (→ duplicate magic-link emails on a fresh IP).

## Root cause

The button is disabled via `requestLogin.isPending`, but TanStack Query dispatches that state change through its batched notify manager, so React only disables the button on the next re-render — after the synchronous click burst has already run the submit handler multiple times.

## Fix

- `login.index.tsx`: synchronous `useRef` in-flight guard around the submit handler (`try/finally` so failures re-enable submission).
- `login-screens.tsx` (`ScreenEmail`): early return from `handleSubmit` while `submitting` — belt-and-suspenders for any other consumer of the form.

## Test

New regression test in `login.test.tsx` fires a three-click `fireEvent` burst (synchronous, unlike `userEvent`) against a delayed MSW handler and asserts exactly one request lands, then the flow still navigates to `/login/sent`. Without the guard the test fails with 3 requests — matching the QA observation.

- vitest: 243/243 passed
- lint: clean (one pre-existing warning in `public/mockServiceWorker.js`)
- build: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)