### PR TITLE
Add iOS push notification for match results awaiting confirmation

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -858,16 +858,13 @@ def _result_confirmation_copy(
     poster_games = wins.get(poster_side.side_number, 0)
     recipient_games = wins.get(recipient_side.side_number, 0)
 
+    # Score always reads winner-first; the verb tells the recipient which side
+    # the poster claims won.
     if poster_games >= recipient_games:
-        headline = (
-            f"{poster_name} reported beating you "
-            f"{poster_games}{_SCORE_DASH}{recipient_games}"
-        )
+        verb, hi, lo = "beating", poster_games, recipient_games
     else:
-        headline = (
-            f"{poster_name} reported losing to you "
-            f"{recipient_games}{_SCORE_DASH}{poster_games}"
-        )
+        verb, hi, lo = "losing", recipient_games, poster_games
+    headline = f"{poster_name} reported {verb} you {hi}{_SCORE_DASH}{lo}"
 
     games = _game_scores_text(match, poster_side.side_number)
     body = (

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -43,6 +43,9 @@ from app.models import (
     User,
     UserLeagueRating,
 )
+from app.notifications.apns import MATCH_RESULT_CONFIRMATION_CATEGORY
+from app.notifications.dependencies import get_notification_service
+from app.notifications.service import NotificationService
 from app.players import escape_like
 from app.rate_limiting import RedisRateLimiter
 from app.ratings import get_calculator, state_rating_value, validate_state
@@ -807,6 +810,96 @@ def _can_confirm(match: Match, user_id: uuid.UUID | None) -> bool:
     return True
 
 
+# ----- result-confirmation push -------------------------------------------
+
+# En-dash between scores reads better than a hyphen in notification copy.
+_SCORE_DASH = "–"
+
+
+def _game_scores_text(match: Match, poster_side_number: int) -> str:
+    """Compact per-game scores oriented poster-first (e.g. ``"11–7, 9–11"``),
+    so they line up with the games-won headline the recipient sees. Games with
+    no saved score are skipped."""
+    parts: list[str] = []
+    for game in sorted(match.games, key=lambda g: g.game_number):
+        if game.score is None:
+            continue
+        if poster_side_number == 1:
+            poster_pts, recipient_pts = (
+                game.score.side_1_points,
+                game.score.side_2_points,
+            )
+        else:
+            poster_pts, recipient_pts = (
+                game.score.side_2_points,
+                game.score.side_1_points,
+            )
+        parts.append(f"{poster_pts}{_SCORE_DASH}{recipient_pts}")
+    return ", ".join(parts)
+
+
+def _result_confirmation_copy(
+    match: Match, poster_id: uuid.UUID
+) -> tuple[str, str] | None:
+    """Title + body for the "confirm or dispute the result your opponent
+    posted" push, framed for the *recipient* (the side that didn't post).
+
+    The headline carries the games-won score and, where there's room, the
+    body lists the individual game scores — both oriented so the poster's
+    number comes first. Returns ``None`` when the match isn't a two-human
+    match (nothing to confirm)."""
+    poster_side = my_side(match, poster_id)
+    recipient_side = opponent_side(match, poster_id)
+    if poster_side is None or recipient_side is None or not poster_side.players:
+        return None
+
+    poster_name = poster_side.players[0].user.username
+    wins = side_win_counts(match)
+    poster_games = wins.get(poster_side.side_number, 0)
+    recipient_games = wins.get(recipient_side.side_number, 0)
+
+    if poster_games >= recipient_games:
+        headline = (
+            f"{poster_name} reported beating you "
+            f"{poster_games}{_SCORE_DASH}{recipient_games}"
+        )
+    else:
+        headline = (
+            f"{poster_name} reported losing to you "
+            f"{recipient_games}{_SCORE_DASH}{poster_games}"
+        )
+
+    games = _game_scores_text(match, poster_side.side_number)
+    body = (
+        f"{headline}. Games: {games}. Approve or dispute?"
+        if games
+        else f"{headline}. Approve or dispute?"
+    )
+    return "Confirm your match result", body
+
+
+async def _notify_result_posted(
+    notifications: NotificationService, match: Match, poster_id: uuid.UUID
+) -> None:
+    """Push a confirm/dispute prompt to every player on the side that now owes
+    a sign-off. Best-effort: ``send_to_user`` no-ops when push isn't
+    configured, and a delivery hiccup must not fail the result post (the
+    result is already committed by the time this runs)."""
+    copy = _result_confirmation_copy(match, poster_id)
+    recipient_side = opponent_side(match, poster_id)
+    if copy is None or recipient_side is None:
+        return
+    title, body = copy
+    for player in recipient_side.players:
+        await notifications.send_to_user(
+            player.user_id,
+            title=title,
+            body=body,
+            category=MATCH_RESULT_CONFIRMATION_CATEGORY,
+            data={"match_id": str(match.id)},
+        )
+
+
 async def _load_rating_changes(
     db: AsyncSession, match_id: uuid.UUID
 ) -> dict[uuid.UUID, RatingChange]:
@@ -1458,6 +1551,7 @@ async def post_match_result(
     payload: MatchResultsWrite,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
+    notifications: NotificationService = Depends(get_notification_service),
 ) -> MatchDetails:
     """Post the result of a match. Any previously-saved per-game scores are
     discarded; the payload's games (validated as a complete, decided match)
@@ -1480,7 +1574,11 @@ async def post_match_result(
 
     await _commit_canonical_games(db, match, payload, decided_side)
 
-    if not _all_sides_have_players(match):
+    # Drives the post-commit push: only a two-human match leaves the other
+    # side owing a confirm/dispute. Computed before commit; the recipient gets
+    # pinged once the result is durably saved.
+    awaiting_confirmation = _all_sides_have_players(match)
+    if not awaiting_confirmation:
         # Solo path: nobody else to sign — finalize immediately, no signature
         # row inserted. Preserves today's solo-match behavior end-to-end.
         match.status = MatchStatus.completed
@@ -1496,6 +1594,9 @@ async def post_match_result(
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None
+    # Notify the side that now owes a sign-off, with Approve/Dispute actions.
+    if awaiting_confirmation:
+        await _notify_result_posted(notifications, reloaded, current_user.id)
     extras = await _load_view_extras(db, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
 

--- a/api/app/notifications/apns.py
+++ b/api/app/notifications/apns.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
 from typing import Literal, Protocol
@@ -26,6 +27,11 @@ import jwt
 log = logging.getLogger(__name__)
 
 Environment = Literal["sandbox", "production"]
+
+# Category identifier shared with the iOS client (see
+# ``PushNotificationManager`` in the iOS app). A push carrying this category
+# renders the Approve / Dispute action buttons the app registered for it.
+MATCH_RESULT_CONFIRMATION_CATEGORY = "MATCH_RESULT_CONFIRMATION"
 
 _APNS_HOSTS: dict[str, str] = {
     "sandbox": "https://api.sandbox.push.apple.com",
@@ -57,7 +63,11 @@ class SendResult:
 
 class PushSender(Protocol):
     """The seam the service depends on. Real implementation talks to APNs;
-    tests inject a recording fake."""
+    tests inject a recording fake.
+
+    ``category`` selects an APNs notification category (the iOS app registers
+    one per set of action buttons); ``data`` is merged into the push payload
+    alongside ``aps`` so the device can route the tap (e.g. a ``match_id``)."""
 
     @property
     def is_configured(self) -> bool: ...
@@ -69,6 +79,8 @@ class PushSender(Protocol):
         environment: Environment,
         title: str,
         body: str,
+        category: str | None = None,
+        data: Mapping[str, str] | None = None,
     ) -> SendResult: ...
 
 
@@ -85,6 +97,8 @@ class NoopSender:
         environment: Environment,
         title: str,
         body: str,
+        category: str | None = None,
+        data: Mapping[str, str] | None = None,
     ) -> SendResult:
         return SendResult(SendOutcome.FAILED, "push not configured")
 
@@ -169,6 +183,8 @@ class APNsClient:
         environment: Environment,
         title: str,
         body: str,
+        category: str | None = None,
+        data: Mapping[str, str] | None = None,
     ) -> SendResult:
         url = f"{_APNS_HOSTS[environment]}/3/device/{token}"
         headers = {
@@ -176,7 +192,17 @@ class APNsClient:
             "apns-topic": self._config.bundle_id,
             "apns-push-type": "alert",
         }
-        payload = {"aps": {"alert": {"title": title, "body": body}, "sound": "default"}}
+        # ``object`` (not ``Any``) so the heterogeneous JSON payload still
+        # type-checks under mypy --strict without loosening the interior.
+        aps: dict[str, object] = {
+            "alert": {"title": title, "body": body},
+            "sound": "default",
+        }
+        if category is not None:
+            aps["category"] = category
+        payload: dict[str, object] = {"aps": aps}
+        if data:
+            payload.update(data)
         try:
             response = await self._client.post(url, headers=headers, json=payload)
         except httpx.HTTPError as exc:

--- a/api/app/notifications/service.py
+++ b/api/app/notifications/service.py
@@ -8,6 +8,7 @@ than an ``HTTPException`` so the HTTP mapping stays in the router.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Mapping, Sequence
 
 from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.postgresql import insert
@@ -74,11 +75,51 @@ class NotificationService:
         if not self._sender.is_configured:
             raise PushNotConfiguredError
 
-        rows = await self._db.execute(
-            select(DeviceToken).where(DeviceToken.user_id == user.id)
-        )
-        tokens = rows.scalars().all()
+        tokens = await self._tokens_for_user(user.id)
+        sent, pruned = await self._fan_out(tokens, title=_TEST_TITLE, body=_TEST_BODY)
+        return TestNotificationResponse(sent=sent, pruned=pruned)
 
+    async def send_to_user(
+        self,
+        user_id: uuid.UUID,
+        *,
+        title: str,
+        body: str,
+        category: str | None = None,
+        data: Mapping[str, str] | None = None,
+    ) -> int:
+        """Best-effort push to every device a user has registered. Returns the
+        number APNs accepted and prunes any gone tokens as a side effect.
+
+        Unlike ``send_test_notification`` this **silently no-ops** (returns 0)
+        when APNs isn't configured: an event-driven push fired from another
+        flow (e.g. a posted match result) must never fail that flow just
+        because this environment has no push credentials."""
+        if not self._sender.is_configured:
+            return 0
+        tokens = await self._tokens_for_user(user_id)
+        sent, _ = await self._fan_out(
+            tokens, title=title, body=body, category=category, data=data
+        )
+        return sent
+
+    async def _tokens_for_user(self, user_id: uuid.UUID) -> Sequence[DeviceToken]:
+        rows = await self._db.execute(
+            select(DeviceToken).where(DeviceToken.user_id == user_id)
+        )
+        return rows.scalars().all()
+
+    async def _fan_out(
+        self,
+        tokens: Sequence[DeviceToken],
+        *,
+        title: str,
+        body: str,
+        category: str | None = None,
+        data: Mapping[str, str] | None = None,
+    ) -> tuple[int, int]:
+        """Send one push per token, returning ``(sent, pruned)``. Tokens APNs
+        reports as gone are deleted in a single statement."""
         sent = 0
         gone_ids: list[uuid.UUID] = []
         for device in tokens:
@@ -88,8 +129,10 @@ class NotificationService:
             result = await self._sender.send(
                 device.token,
                 environment=environment,
-                title=_TEST_TITLE,
-                body=_TEST_BODY,
+                title=title,
+                body=body,
+                category=category,
+                data=data,
             )
             if result.outcome is SendOutcome.SUCCESS:
                 sent += 1
@@ -102,4 +145,4 @@ class NotificationService:
             )
             await self._db.commit()
 
-        return TestNotificationResponse(sent=sent, pruned=len(gone_ids))
+        return sent, len(gone_ids)

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -4,8 +4,9 @@ The leading underscore keeps pytest from auto-collecting this as a test module;
 fixtures still belong in ``conftest.py``.
 """
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
@@ -13,6 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.main import app as fastapi_app
 from app.models import User
+from app.notifications.apns import Environment, SendOutcome, SendResult
+from app.notifications.dependencies import get_push_sender
 
 
 async def start_session(api_client: AsyncClient, db_session: AsyncSession) -> User:
@@ -74,3 +77,53 @@ async def opponent_session(
         yield client, user
     finally:
         await client.aclose()
+
+
+# ----- push notifications ---------------------------------------------------
+
+
+@dataclass
+class SentPush:
+    """One recorded ``PushSender.send`` call."""
+
+    token: str
+    environment: str
+    title: str
+    body: str
+    category: str | None
+    data: Mapping[str, str] | None
+
+
+class FakeSender:
+    """Records every send and returns a per-token outcome (default success).
+
+    Drop-in for the ``PushSender`` protocol; install it with ``use_sender``."""
+
+    def __init__(
+        self,
+        *,
+        configured: bool = True,
+        outcomes: dict[str, SendOutcome] | None = None,
+    ) -> None:
+        self.is_configured = configured
+        self.sent: list[SentPush] = []
+        self._outcomes = outcomes or {}
+
+    async def send(
+        self,
+        token: str,
+        *,
+        environment: Environment,
+        title: str,
+        body: str,
+        category: str | None = None,
+        data: Mapping[str, str] | None = None,
+    ) -> SendResult:
+        self.sent.append(SentPush(token, environment, title, body, category, data))
+        return SendResult(self._outcomes.get(token, SendOutcome.SUCCESS))
+
+
+def use_sender(sender: FakeSender) -> None:
+    """Override the process-wide push sender for the duration of a test.
+    ``api_client`` clears ``dependency_overrides`` afterwards."""
+    fastapi_app.dependency_overrides[get_push_sender] = lambda: sender

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -20,7 +20,15 @@ from app.models import (
     MatchStatus,
     User,
 )
-from tests._helpers import make_client, make_user, opponent_session, start_session
+from app.notifications.apns import MATCH_RESULT_CONFIRMATION_CATEGORY
+from tests._helpers import (
+    FakeSender,
+    make_client,
+    make_user,
+    opponent_session,
+    start_session,
+    use_sender,
+)
 
 # ----- create -------------------------------------------------------------
 
@@ -1903,3 +1911,129 @@ async def test_concurrent_confirm_and_dispute_serialize(
                 assert final.status == MatchStatus.in_progress
                 assert final.signatures == []
                 assert [s.won for s in sides] == [None, None]
+
+
+# ----- result-confirmation push -------------------------------------------
+
+
+async def _register_device(
+    client: AsyncClient, token: str, *, environment: str = "sandbox"
+) -> None:
+    response = await client.post(
+        "/v1/device-tokens",
+        json={"token": token, "platform": "ios", "environment": environment},
+    )
+    assert response.status_code == 200, response.text
+
+
+async def test_posting_result_pushes_confirmation_to_opponent(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """When a player posts a result on a two-human match, the opponent gets a
+    push carrying the Approve/Dispute category, the match id, and copy with the
+    games-won score plus the individual game scores."""
+    me = await start_session(api_client, db_session)
+    me.username = "poster"
+    await db_session.commit()
+
+    sender = FakeSender()
+    use_sender(sender)
+
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        await _register_device(opp_client, "opp-device")
+        match = await _create_match(api_client, opp.id, best_of=3)
+
+        response = await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 7},
+                    {"game_number": 2, "side_1_points": 9, "side_2_points": 11},
+                    {"game_number": 3, "side_1_points": 11, "side_2_points": 8},
+                ]
+            },
+        )
+        assert response.status_code == 201
+
+    assert len(sender.sent) == 1
+    push = sender.sent[0]
+    assert push.token == "opp-device"
+    assert push.category == MATCH_RESULT_CONFIRMATION_CATEGORY
+    assert push.data == {"match_id": match["id"]}
+    # Recipient-framed games-won (poster won 2–1) and the per-game scores,
+    # oriented poster-first.
+    assert "poster reported beating you 2–1" in push.body
+    assert "11–7" in push.body
+    assert "9–11" in push.body
+    assert "11–8" in push.body
+
+
+async def test_posting_result_does_not_push_to_the_poster(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Only the side that owes a sign-off is notified — never the poster, even
+    when both players have a device registered."""
+    await start_session(api_client, db_session)
+    await _register_device(api_client, "poster-device")
+
+    sender = FakeSender()
+    use_sender(sender)
+
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        await _register_device(opp_client, "opp-device")
+        match = await _create_match(api_client, opp.id, best_of=1)
+
+        response = await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [{"game_number": 1, "side_1_points": 11, "side_2_points": 5}]
+            },
+        )
+        assert response.status_code == 201
+
+    assert [push.token for push in sender.sent] == ["opp-device"]
+
+
+async def test_solo_result_sends_no_push(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A solo (opponent-less) match finalizes on post with nobody to confirm —
+    so no confirmation push is fired."""
+    await start_session(api_client, db_session)
+
+    sender = FakeSender()
+    use_sender(sender)
+
+    created = await api_client.post("/v1/matches", json={"best_of": 1, "rated": False})
+    assert created.status_code == 201
+    match = created.json()
+
+    response = await api_client.post(
+        f"/v1/matches/{match['id']}/results",
+        json={"games": [{"game_number": 1, "side_1_points": 11, "side_2_points": 5}]},
+    )
+    assert response.status_code == 201
+    assert sender.sent == []
+
+
+async def test_posting_result_succeeds_when_opponent_has_no_device(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The push is best-effort: an opponent with no registered device just
+    means nothing is sent — the result post still succeeds."""
+    await start_session(api_client, db_session)
+
+    sender = FakeSender()
+    use_sender(sender)
+
+    async with opponent_session(db_session, "rival") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=1)
+        response = await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [{"game_number": 1, "side_1_points": 11, "side_2_points": 5}]
+            },
+        )
+        assert response.status_code == 201
+
+    assert sender.sent == []

--- a/api/tests/test_notifications.py
+++ b/api/tests/test_notifications.py
@@ -2,43 +2,13 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.main import app
 from app.models import DeviceToken
-from app.notifications.apns import Environment, SendOutcome, SendResult
-from app.notifications.dependencies import get_push_sender
-from tests._helpers import make_client, start_session
+from app.notifications.apns import SendOutcome
+from tests._helpers import FakeSender, make_client, start_session, use_sender
 
 # ``api_client`` (an ASGI client sharing the per-test ``db_session``) comes from
-# tests/conftest.py — no need to redefine it here.
-
-
-class FakeSender:
-    """Records every send and returns a per-token outcome (default success)."""
-
-    def __init__(
-        self,
-        *,
-        configured: bool = True,
-        outcomes: dict[str, SendOutcome] | None = None,
-    ) -> None:
-        self.is_configured = configured
-        self.sent: list[tuple[str, str, str, str]] = []
-        self._outcomes = outcomes or {}
-
-    async def send(
-        self,
-        token: str,
-        *,
-        environment: Environment,
-        title: str,
-        body: str,
-    ) -> SendResult:
-        self.sent.append((token, environment, title, body))
-        return SendResult(self._outcomes.get(token, SendOutcome.SUCCESS))
-
-
-def use_sender(sender: FakeSender) -> None:
-    app.dependency_overrides[get_push_sender] = lambda: sender
+# tests/conftest.py — no need to redefine it here. ``FakeSender`` / ``use_sender``
+# live in tests/_helpers so the match-result notification tests share them.
 
 
 async def register(
@@ -126,7 +96,7 @@ async def test_test_send_fans_out_to_all_user_tokens(
 
     assert response.status_code == 200
     assert response.json() == {"sent": 2, "pruned": 0}
-    by_token = {token: environment for (token, environment, _, _) in sender.sent}
+    by_token = {push.token: push.environment for push in sender.sent}
     assert by_token == {"tok-1": "sandbox", "tok-2": "production"}
 
 

--- a/ios/Fortymm/MatchFlow/MatchDetailLoaderView.swift
+++ b/ios/Fortymm/MatchFlow/MatchDetailLoaderView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// Presents a match's detail from just its id — the entry point for a tapped
+/// confirm/dispute push notification, where all we carry is the `match_id`.
+///
+/// `MatchDetailView` needs a `FinalMatch` in hand (it renders immediately, then
+/// refetches), so this fetches the match first and shows a spinner meanwhile.
+/// On failure it offers a retry rather than dropping the user on a blank screen.
+struct MatchDetailLoaderView: View {
+    let matchId: UUID
+    var service: MatchService = .shared
+    var onClose: () -> Void
+
+    @State private var match: FinalMatch?
+    @State private var loadError: String?
+
+    var body: some View {
+        ZStack {
+            FMColor.bgApp.ignoresSafeArea()
+            if let match {
+                MatchDetailView(initial: match, onBack: onClose)
+            } else if let loadError {
+                errorState(loadError)
+            } else {
+                ProgressView()
+                    .tint(FMColor.ball500)
+            }
+        }
+        .task { await load() }
+    }
+
+    private func load() async {
+        loadError = nil
+        do {
+            match = try await service.matchDetails(matchId)
+        } catch {
+            loadError = error.fmMessage
+        }
+    }
+
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: FMSpace.s5) {
+            FMLogo(size: 30)
+            VStack(spacing: FMSpace.s2) {
+                Text("Couldn't open that match")
+                    .font(FMFont.ui(FMFont.md, weight: .semibold))
+                    .foregroundStyle(FMColor.fg1)
+                Text(message)
+                    .font(FMFont.ui(FMFont.sm))
+                    .foregroundStyle(FMColor.fg3)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(2)
+            }
+            FMButton(title: "Try again", variant: .primary, size: .md) {
+                Task { await load() }
+            }
+            FMButton(title: "Close", variant: .ghost, size: .md, action: onClose)
+        }
+        .padding(.horizontal, FMSpace.s6)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/ios/Fortymm/Navigation/DeepLink.swift
+++ b/ios/Fortymm/Navigation/DeepLink.swift
@@ -12,11 +12,15 @@ enum DeepLink: Identifiable, Equatable {
     case login(token: String)
     /// Email confirmation — `/confirm-email?token=…`. Lands on `ConfirmEmailView`.
     case confirmEmail(token: String)
+    /// A match to open — not a URL, but a push-notification body tap
+    /// (`PushNotificationManager`). Lands on `MatchDetailLoaderView`.
+    case match(id: UUID)
 
     var id: String {
         switch self {
         case let .login(token): return "login:\(token)"
         case let .confirmEmail(token): return "confirm:\(token)"
+        case let .match(id): return "match:\(id.uuidString)"
         }
     }
 

--- a/ios/Fortymm/Navigation/RootView.swift
+++ b/ios/Fortymm/Navigation/RootView.swift
@@ -28,9 +28,15 @@ struct RootView: View {
                     deepLinkDestination(link)
                 }
                 // Now that a session exists to attach the device token to, ask
-                // for notification permission and register with APNs. Runs once
-                // the signed-in shell appears.
-                .task { PushNotificationManager.shared.requestAuthorizationAndRegister() }
+                // for notification permission and register with APNs, and route
+                // a tapped match notification to its detail. Runs once the
+                // signed-in shell appears.
+                .task {
+                    PushNotificationManager.shared.onOpenMatch = { id in
+                        Task { @MainActor in session.openMatch(id) }
+                    }
+                    PushNotificationManager.shared.requestAuthorizationAndRegister()
+                }
         case let .signedOut(reason, email):
             SessionEndedView(
                 reason: reason,
@@ -59,6 +65,11 @@ struct RootView: View {
             ConfirmEmailView(
                 token: token,
                 onConfirmed: { session.resolveDeepLink($0) },
+                onClose: { session.pendingDeepLink = nil }
+            )
+        case let .match(id):
+            MatchDetailLoaderView(
+                matchId: id,
                 onClose: { session.pendingDeepLink = nil }
             )
         }

--- a/ios/Fortymm/Notifications/PushNotificationManager.swift
+++ b/ios/Fortymm/Notifications/PushNotificationManager.swift
@@ -1,14 +1,33 @@
 import UIKit
 import UserNotifications
 
+/// Identifiers shared with the backend push payload (`api/app/notifications`).
+/// A push whose `aps.category` is `MATCH_RESULT_CONFIRMATION` renders the
+/// Approve / Dispute buttons registered below; the `match_id` userInfo key tells
+/// the app which match the buttons (and a tap) act on. Kept in one place so the
+/// device-side registration can't drift from what the server sends.
+enum MatchNotification {
+    /// Must equal `MATCH_RESULT_CONFIRMATION_CATEGORY` in `app/notifications/apns.py`.
+    static let category = "MATCH_RESULT_CONFIRMATION"
+    static let approveAction = "CONFIRM_MATCH_ACTION"
+    static let disputeAction = "DISPUTE_MATCH_ACTION"
+    /// Must equal the `data` key the server sends (`{"match_id": "<uuid>"}`).
+    static let matchIdKey = "match_id"
+}
+
 /// Owns the device side of remote (APNs) push notifications:
 ///
 /// 1. asks the user for permission and registers with APNs,
 /// 2. receives the APNs device token (via the app delegate, see
 ///    `FortymmApp.swift`), hex-encodes it, and POSTs it to the backend so the
 ///    server can push to this device,
-/// 3. presents pushes as a banner even while the app is foregrounded (otherwise
-///    a self-test looks like nothing happened).
+/// 3. registers the "match result" notification category so a confirm/dispute
+///    push carries Approve / Dispute action buttons,
+/// 4. presents pushes as a banner even while the app is foregrounded (otherwise
+///    a self-test looks like nothing happened),
+/// 5. handles a tapped action: Approve/Dispute call the match endpoints
+///    directly (no need to open the app); tapping the body deep-links to the
+///    match via `onOpenMatch`.
 ///
 /// A singleton because the `UIApplicationDelegate` token callbacks and the
 /// SwiftUI view that triggers registration must talk to the same instance, and
@@ -17,6 +36,21 @@ final class PushNotificationManager: NSObject {
     static let shared = PushNotificationManager()
 
     private let client: APIClient
+    private let matchService: MatchService
+
+    /// Set by `RootView` once the signed-in shell is up; invoked when the user
+    /// taps a match notification's body (not an action button) to route to that
+    /// match. A tap that lands before this is wired (cold launch) is buffered in
+    /// `pendingMatchOpen` and flushed when the callback is set.
+    var onOpenMatch: ((UUID) -> Void)? {
+        didSet {
+            guard onOpenMatch != nil, let pending = pendingMatchOpen else { return }
+            pendingMatchOpen = nil
+            onOpenMatch?(pending)
+        }
+    }
+
+    private var pendingMatchOpen: UUID?
 
     /// Whether the device-token POST should report a sandbox or production APNs
     /// token. Debug builds register against the APNs sandbox; release builds
@@ -30,10 +64,36 @@ final class PushNotificationManager: NSObject {
         #endif
     }
 
-    init(client: APIClient = .shared) {
+    init(client: APIClient = .shared, matchService: MatchService = .shared) {
         self.client = client
+        self.matchService = matchService
         super.init()
-        UNUserNotificationCenter.current().delegate = self
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+        center.setNotificationCategories([Self.matchConfirmationCategory()])
+    }
+
+    /// The "a result is waiting on you" category: Approve confirms the posted
+    /// result, Dispute rejects it. Both run without `.foreground` so a quick
+    /// tap acts in the background; Dispute is `.destructive` (red) since it
+    /// rewinds the opponent's posted result.
+    private static func matchConfirmationCategory() -> UNNotificationCategory {
+        let approve = UNNotificationAction(
+            identifier: MatchNotification.approveAction,
+            title: "Approve",
+            options: []
+        )
+        let dispute = UNNotificationAction(
+            identifier: MatchNotification.disputeAction,
+            title: "Dispute",
+            options: [.destructive]
+        )
+        return UNNotificationCategory(
+            identifier: MatchNotification.category,
+            actions: [approve, dispute],
+            intentIdentifiers: [],
+            options: []
+        )
     }
 
     /// Ask for notification permission (no-op prompt after the first time — iOS
@@ -98,6 +158,70 @@ extension PushNotificationManager: UNUserNotificationCenterDelegate {
             @escaping (UNNotificationPresentationOptions) -> Void
     ) {
         completionHandler([.banner, .sound, .badge])
+    }
+
+    /// The user acted on a notification. For a match-confirmation push:
+    /// Approve / Dispute hit the corresponding endpoint in the background;
+    /// tapping the body (the default action) routes to the match. Anything we
+    /// don't recognise — or a payload missing its `match_id` — just dismisses.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let userInfo = response.notification.request.content.userInfo
+        guard
+            let raw = userInfo[MatchNotification.matchIdKey] as? String,
+            let matchId = UUID(uuidString: raw)
+        else {
+            completionHandler()
+            return
+        }
+
+        switch response.actionIdentifier {
+        case MatchNotification.approveAction:
+            act(completionHandler) { try await self.matchService.confirmMatch(matchId) }
+        case MatchNotification.disputeAction:
+            act(completionHandler) { try await self.matchService.disputeMatch(matchId) }
+        case UNNotificationDefaultActionIdentifier:
+            // Body tap → open the match. Hop to the main actor: `onOpenMatch`
+            // drives SwiftUI state.
+            DispatchQueue.main.async {
+                self.openMatch(matchId)
+                completionHandler()
+            }
+        default:
+            completionHandler()
+        }
+    }
+
+    /// Run a confirm/dispute call, then signal completion regardless of outcome.
+    /// Best-effort: a failed sign-off (e.g. the opponent already confirmed)
+    /// shouldn't hang the notification — the match screen reconciles state on
+    /// next open. iOS gives this background action a short window; the single
+    /// round-trip fits comfortably.
+    private func act(
+        _ completionHandler: @escaping () -> Void,
+        _ work: @escaping () async throws -> FinalMatch
+    ) {
+        Task {
+            do {
+                _ = try await work()
+            } catch {
+                print("[push] match action failed: \(error.fmMessage)")
+            }
+            completionHandler()
+        }
+    }
+
+    /// Route a body tap to the match, buffering until `RootView` wires
+    /// `onOpenMatch` (a cold-launch tap can arrive before the shell is up).
+    private func openMatch(_ matchId: UUID) {
+        if let onOpenMatch {
+            onOpenMatch(matchId)
+        } else {
+            pendingMatchOpen = matchId
+        }
     }
 }
 

--- a/ios/Fortymm/Session/SessionStore.swift
+++ b/ios/Fortymm/Session/SessionStore.swift
@@ -40,6 +40,12 @@ final class SessionStore: ObservableObject {
         pendingDeepLink = nil
     }
 
+    /// Open a match deep link (a tapped confirm/dispute notification). Held like
+    /// any pending link so `RootView` presents it once the shell is up.
+    func openMatch(_ id: UUID) {
+        pendingDeepLink = .match(id: id)
+    }
+
     /// The signed-in user when the session has resolved, else nil. Lets screens
     /// read the user without re-switching over `state` at every call site.
     var user: SessionUser? {


### PR DESCRIPTION
## What

When a player posts a match result on a two-human match, the opponent now owes a confirm/dispute. This fires an APNs push to that opponent with **Approve** and **Dispute** action buttons directly on the notification, and copy describing the reported games-won score plus the individual game scores.

Example body (framed for the recipient): _"Confirm your match result — poster reported beating you 2–1. Games: 11–7, 9–11, 11–8. Approve or dispute?"_

## Trigger

`POST /v1/matches/{id}/results` on a non-solo match. That call records the poster's signature and leaves the other side owing a sign-off (`can_confirm`) — exactly the "needs to approve or dispute" state. Solo matches (no opponent) finalize immediately and send nothing. The push is symmetric: a re-post after a dispute notifies whoever now owes the sign-off.

## Backend

- **`notifications/apns.py`** — extend the `PushSender` seam (protocol, `APNsClient`, `NoopSender`) with an optional notification `category` (selects the action-button set) and a `data` payload (carries `match_id`). Adds the shared `MATCH_RESULT_CONFIRMATION_CATEGORY` constant.
- **`notifications/service.py`** — add `send_to_user` (best-effort fan-out that **no-ops** when APNs is unconfigured, unlike the test endpoint which 503s) and factor the shared fan-out/prune logic out of `send_test_notification`.
- **`matches.py`** — after a result is committed on a two-human match, build recipient-framed copy (games-won headline + per-game scores, poster-first) and push it to the side that owes the sign-off. Best-effort: a delivery hiccup never fails the already-committed result post.

No OpenAPI changes — the new service is injected as a FastAPI dependency, not a request/response field, so `schema.d.ts` is unaffected.

## iOS

- **`PushNotificationManager`** — register a `MATCH_RESULT_CONFIRMATION` category with Approve / Dispute actions; handle the action responses (Approve/Dispute call the confirm/dispute endpoints in the background, no app launch needed; Dispute is destructive/red). A body tap deep-links to the match.
- **`DeepLink` + `SessionStore` + `RootView`** — add a `.match(id:)` deep link wired through the existing pending-deep-link cover.
- **`MatchDetailLoaderView`** (new) — loads a match by id (with spinner + retry) and presents `MatchDetailView`, since that screen needs a `FinalMatch` in hand. A cold-launch tap that lands before the shell is up is buffered and flushed.

## Tests

- New API tests cover: opponent receives the push with the right category/`match_id`/copy; the poster is never notified; solo matches send nothing; and a result post still succeeds when the opponent has no registered device. Shared `FakeSender`/`use_sender` moved into `tests/_helpers.py`.
- Full API suite green (376 passed) under `ruff` + `mypy --strict`.

## Not covered / notes

- iOS has no test target in the repo, so the Swift changes are unit-tested only by the type checker / build (couldn't run `xcodebuild` here — worth a device smoke test).
- Requires APNs credentials configured server-side (`APNS_*` env). Without them the push silently no-ops; the result post is unaffected.

https://claude.ai/code/session_01FEdBeZyBDcSUDQ3ZSsneUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEdBeZyBDcSUDQ3ZSsneUQ)_