### PR TITLE
score-entry: stop truncating 3-digit scores to 2 digits (#442)

### DIFF
--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -316,6 +316,38 @@ describe('ScoreEntry — create', () => {
     expect(posted).toBe(0)
   })
 
+  it('keeps a 3-digit entry intact instead of silently truncating to 2 digits', async () => {
+    // Regression for #442: typing "100" used to be cut to "10", then the
+    // win-by-2 check fired against a value the user never entered. The input
+    // now keeps up to 3 digits, so the score the user sees is the score the
+    // validation reasons about.
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+
+    await user.type(meInput, '100')
+    expect(meInput).toHaveValue('100')
+
+    // The illegal-score hint references the typed value, not a mutated one:
+    // 100–97 is a deuce game that doesn't lead by exactly 2.
+    await user.type(oppInput, '97')
+    expect(oppInput).toHaveValue('97')
+    expect(screen.getByRole('alert')).toHaveTextContent(/leads by exactly 2/i)
+
+    // The field still caps at 3 digits so it can't grow unbounded — a 4th
+    // digit typed in one pass is dropped rather than accepted.
+    await user.clear(meInput)
+    await user.type(meInput, '1005')
+    expect(meInput).toHaveValue('100')
+  })
+
   it('redirects to the existing score\'s edit page when landing on /scores/new for an already-scored game', async () => {
     // Browser-Back-after-save flow: the user advanced to game 3, pressed
     // Back to /games/1/scores/new, but game 1 already has a score. Without

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -142,7 +142,12 @@ function ScoreEntryInner({
   const me = meTyped ?? (persistedMe !== null ? String(persistedMe) : '')
   const opp = oppTyped ?? (persistedOpp !== null ? String(persistedOpp) : '')
 
-  const sanitize = (value: string) => value.replace(/[^0-9]/g, '').slice(0, 2)
+  // Strip non-digits and cap at 3 digits. Two digits silently turned "100"
+  // into "10", then the deuce/win-by-2 check fired against a value the user
+  // never typed (#442). Three digits covers any real table-tennis score
+  // (a long deuce game tops out well under 100) without that mutation, so
+  // illegalScoreReason always references exactly what was entered.
+  const sanitize = (value: string) => value.replace(/[^0-9]/g, '').slice(0, 3)
   const onMeChange = (value: string) => {
     setMeTyped(sanitize(value))
     if (finalizeMutation.error) finalizeMutation.reset()


### PR DESCRIPTION
## What

The score-entry input sanitizer capped values at **2 digits** (`.slice(0, 2)`), so typing `100` was silently rewritten to `10`. Combined with the opponent's score, the client-side deuce/win-by-2 validator then surfaced an error referencing a value the user never entered (#442).

## Fix

Cap the input at **3 digits** instead of 2. Real table-tennis scores — including a long deuce game — sit well under 100, so the value is no longer mutated and `illegalScoreReason` always reasons about exactly what the user typed. The field still bounds growth (a 4th digit is dropped).

## Tests

Added a regression test in `score-entry.test.tsx` that types `100`, asserts the field keeps `100` (not `10`), confirms the illegal-score hint references the typed value, and that a 4th digit is still rejected. Full file (11 tests) passes; lint clean.

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)