### PR TITLE
match-details: extract players snapshot panel into strangler quartets

### DIFF
--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -438,41 +438,14 @@ describe("MatchDetailsView", () => {
         "Players · going into this match",
       ),
     );
-    // My side: 1 W and 1 L with the right opponent / score labels.
-    const myForm = screen.getByTestId("form-1");
-    expect(within(myForm).getByText("Form · 1–1")).toBeInTheDocument();
-    // The with-history half leads with a one-line "going in" summary, mirroring
-    // the empty half's "first one" sentence.
+    // Wiring only: each half's content (form rows, rating box, career strip)
+    // is pinned by the players-panel query and component tests. Here we prove
+    // the panel projected *this* payload — my history half and the rookie's
+    // empty half, side by side.
     expect(
-      within(myForm).getByText("12 prior matches · 75% win rate going in"),
+      screen.getByText("12 prior matches · 75% win rate going in"),
     ).toBeInTheDocument();
-    expect(within(myForm).getByText("silva.r")).toBeInTheDocument();
-    expect(within(myForm).getByText("3–1")).toBeInTheDocument();
-    expect(within(myForm).getByText("tanaka.y")).toBeInTheDocument();
-    expect(within(myForm).getByText("1–3")).toBeInTheDocument();
-    // Each form row carries the date the past match completed on.
-    expect(within(myForm).getByText("May 9")).toBeInTheDocument();
-    expect(within(myForm).getByText("May 7")).toBeInTheDocument();
-    // Pre-match rating shows (rounded) with a sparkline; career stats below.
-    const myRating = screen.getByTestId("rating-box-1");
-    expect(within(myRating).getByText("1612")).toBeInTheDocument();
-    expect(myRating.querySelector("svg")).not.toBeNull();
-    const myCareer = screen.getByTestId("career-1");
-    expect(within(myCareer).getByText("12")).toBeInTheDocument();
-    expect(within(myCareer).getByText("75%")).toBeInTheDocument();
-    // Rookie shows the empty state, not a result list.
-    const oppForm = screen.getByTestId("form-2");
-    expect(
-      within(oppForm).getByText(/No prior matches yet/),
-    ).toBeInTheDocument();
-    expect(within(oppForm).queryByText(/Form · /)).not.toBeInTheDocument();
-    // Unrated rookie: no rating number, no sparkline, no win rate.
-    const oppRating = screen.getByTestId("rating-box-2");
-    expect(within(oppRating).getByText("Unrated")).toBeInTheDocument();
-    expect(oppRating.querySelector("svg")).toBeNull();
-    const oppCareer = screen.getByTestId("career-2");
-    expect(within(oppCareer).getByText("0")).toBeInTheDocument();
-    expect(within(oppCareer).getByText("—")).toBeInTheDocument();
+    expect(screen.getByText(/No prior matches yet/)).toBeInTheDocument();
   });
 
   it("shows the head-to-head card with prior meetings counted per side", async () => {

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -8,15 +8,16 @@ import {
   Link2,
   Send,
   Share2,
-  User,
   X,
 } from 'lucide-react'
 
+import { PlayersPanel } from './match-details/players-panel'
+import { Sparkline } from './match-details/players-panel/sparkline'
 import { Scoreboard } from './match-details/scoreboard'
 import { AppShell } from '@/components/app-shell'
 import { Overline } from '@/components/overline'
 import { cn, initialsOf } from '@/lib/utils'
-import { fmtDateShort, fmtDateTimeShort } from '@/lib/dates'
+import { fmtDateShort } from '@/lib/dates'
 import { formatRatingDelta } from '@/lib/rating'
 import {
   scoringNewRoute,
@@ -33,17 +34,10 @@ import { SaveYourMatch } from './save-your-match'
 type MatchDetails = components['schemas']['app__schemas__match__MatchDetails']
 type MatchResultsGameWrite = components['schemas']['MatchResultsGameWrite']
 type MatchDetailsSide = components['schemas']['MatchDetailsSide']
-type MatchDetailsFormResult = components['schemas']['MatchDetailsFormResult']
 type MatchDetailsPlayerForm = components['schemas']['MatchDetailsPlayerForm']
 type MatchDetailsH2H = components['schemas']['MatchDetailsH2H']
 type MatchDetailsH2HMeeting = components['schemas']['MatchDetailsH2HMeeting']
 type RatingChange = components['schemas']['RatingChange']
-
-// A match with only the creator's side has no opponent and may never gain one
-// (solo / "start without opponent" matches). The empty side reads as this
-// rather than implying someone is on the way — mirrors the recent-form rows,
-// which already label a missing opponent "No opponent".
-const NO_OPPONENT_LABEL = 'No opponent'
 
 const EMPTY_FORM: MatchDetailsPlayerForm = {
   user_id: '',
@@ -68,11 +62,7 @@ type SideView = {
   won: boolean | null
   isCurrentUser: boolean
   ratingChange: RatingChange | null
-  recentForm: MatchDetailsFormResult[]
-  ratingBefore: number | null
   ratingHistory: number[]
-  careerMatchesBefore: number
-  careerWinsBefore: number
 }
 
 type H2HMeetingView = {
@@ -141,11 +131,7 @@ function projectSide(
     won: side.won,
     isCurrentUser: side.is_current_user_side,
     ratingChange: side.rating_change ?? null,
-    recentForm: form.recent_results,
-    ratingBefore: form.rating_before ?? null,
     ratingHistory: form.rating_history ?? [],
-    careerMatchesBefore: form.career_matches_before,
-    careerWinsBefore: form.career_wins_before,
   }
 }
 
@@ -443,7 +429,7 @@ function MatchDetailsPage({
 
         <div className="md-col-2">
           <div className="md-col-2__main">
-            <PlayersCard view={view} />
+            <PlayersPanel matchId={matchId} />
             {showAuxCards && <CommentsCard />}
           </div>
           <aside className="md-col-2__aside">
@@ -520,230 +506,6 @@ function Breadcrumb({
       <span>›</span>
       <span className="md-breadcrumb__current">Match {matchId.slice(0, 6)}</span>
     </div>
-  )
-}
-
-function PlayersCard({ view }: { view: MatchView }) {
-  return (
-    <div className="md-card">
-      <div className="md-card__hd">
-        <Overline as="h3">Players · going into this match</Overline>
-        <span className="md-card__hd-meta">
-          SNAPSHOT · {fmtDateTimeShort(view.createdAt).toUpperCase()}
-        </span>
-      </div>
-      <div className="md-players">
-        <PlayerProfile side={view.leftSide} won={view.leftSide.won === true} />
-        <div className="md-players__divider" />
-        {view.rightSide ? (
-          <PlayerProfile
-            side={view.rightSide}
-            won={view.rightSide.won === true}
-          />
-        ) : (
-          <NoOpponentProfile />
-        )}
-      </div>
-    </div>
-  )
-}
-
-function PlayerProfile({ side, won }: { side: SideView; won: boolean }) {
-  if (side.isGhost) return <NoOpponentProfile />
-  const form = side.recentForm
-  const wins = form.filter((r) => r.is_win).length
-  const losses = form.length - wins
-  // A one-line "going in" summary so the with-history half leads with a
-  // sentence, mirroring the empty half's "first one" line (no lone row list).
-  const careerMatches = side.careerMatchesBefore
-  const careerWinRate =
-    careerMatches > 0
-      ? Math.round((side.careerWinsBefore / careerMatches) * 100)
-      : null
-  const formSummary =
-    `${careerMatches} prior ${careerMatches === 1 ? 'match' : 'matches'}` +
-    (careerWinRate !== null ? ` · ${careerWinRate}% win rate going in` : '')
-  return (
-    <div className="md-profile">
-      <div className="md-profile__identity">
-        <div className={cn('md-avatar', won ? 'md-avatar--win' : 'md-avatar--loss')}>
-          {side.initials}
-        </div>
-        <div className="md-profile__id-text">
-          <div className="md-profile__name">{side.username}</div>
-        </div>
-      </div>
-      <RatingBox side={side} />
-      <div className="md-profile__form" data-testid={`form-${side.sideNumber}`}>
-        <div className="md-kicker">
-          {form.length === 0 ? 'Form' : `Form · ${wins}–${losses}`}
-        </div>
-        {form.length === 0 ? (
-          <div className="md-profile__empty">
-            No prior matches yet — this is{' '}
-            {side.isCurrentUser ? 'your' : 'their'} first one.
-          </div>
-        ) : (
-          <>
-            <div className="md-profile__form-summary">{formSummary}</div>
-            <ul className="md-profile__form-list">
-              {form.map((r) => (
-                <FormRow key={r.match_id} result={r} />
-              ))}
-            </ul>
-          </>
-        )}
-      </div>
-      <CareerStats side={side} />
-    </div>
-  )
-}
-
-function NoOpponentProfile() {
-  return (
-    <div className="md-profile">
-      <div className="md-profile__identity">
-        <div className="md-avatar md-avatar--ghost" aria-hidden="true">
-          <User size={20} strokeWidth={1.75} />
-        </div>
-        <div className="md-profile__id-text">
-          <div className="md-profile__name md-profile__name--ghost">
-            {NO_OPPONENT_LABEL}
-          </div>
-        </div>
-      </div>
-      <div className="md-profile__empty">
-        Solo match — no second player.
-      </div>
-    </div>
-  )
-}
-
-function RatingBox({ side }: { side: SideView }) {
-  const value = side.ratingBefore
-  return (
-    <div
-      className="md-profile__rating-box"
-      data-testid={`rating-box-${side.sideNumber}`}
-    >
-      <div>
-        <div className="md-kicker">Rating</div>
-        <div className="md-profile__rating-value">
-          {value === null ? <span className="dim">Unrated</span> : Math.round(value)}
-        </div>
-      </div>
-      {side.ratingHistory.length >= 2 && (
-        <Sparkline data={side.ratingHistory} />
-      )}
-    </div>
-  )
-}
-
-function Sparkline({
-  data,
-  w = 110,
-  h = 36,
-  downColor = 'var(--fg-3)',
-}: {
-  data: number[]
-  w?: number
-  h?: number
-  downColor?: string
-}) {
-  const min = Math.min(...data)
-  const max = Math.max(...data)
-  const range = max - min || 1
-  const pad = 2
-  const points = data.map((v, i) => {
-    const x = pad + (i / (data.length - 1)) * (w - pad * 2)
-    const y = h - pad - ((v - min) / range) * (h - pad * 2)
-    return [x, y] as const
-  })
-  const path = points
-    .map((p, i) => `${i === 0 ? 'M' : 'L'}${p[0].toFixed(1)} ${p[1].toFixed(1)}`)
-    .join(' ')
-  // The last point's trend picks the colour so a falling rating reads as a
-  // loss tone even before the user squints at the y-axis.
-  const trendUp = data[data.length - 1] >= data[0]
-  const color = trendUp ? 'var(--serve-500)' : downColor
-  const last = points[points.length - 1]
-  return (
-    <svg
-      width={w}
-      height={h}
-      style={{ display: 'block', overflow: 'visible' }}
-      aria-hidden="true"
-    >
-      <path
-        d={path}
-        fill="none"
-        stroke={color}
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <circle cx={last[0]} cy={last[1]} r="2.4" fill={color} />
-    </svg>
-  )
-}
-
-function CareerStats({ side }: { side: SideView }) {
-  const matches = side.careerMatchesBefore
-  const winRate =
-    matches > 0 ? Math.round((side.careerWinsBefore / matches) * 100) : null
-  return (
-    <div
-      className="md-profile__career"
-      data-testid={`career-${side.sideNumber}`}
-    >
-      <div>
-        <div className="md-kicker">Career matches</div>
-        <div className="md-profile__career-value">{matches}</div>
-      </div>
-      <div>
-        <div className="md-kicker">Win rate</div>
-        <div
-          className={cn(
-            'md-profile__career-value',
-            winRate !== null &&
-              winRate >= 50 &&
-              'md-profile__career-value--good',
-          )}
-        >
-          {winRate === null ? <span className="dim">—</span> : `${winRate}%`}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function FormRow({ result }: { result: MatchDetailsFormResult }) {
-  const win = result.is_win
-  const score = `${result.player_games_won}–${result.opponent_games_won}`
-  const opponentLabel = result.opponent_username ?? 'No opponent'
-  return (
-    <li className="md-form-row">
-      <span
-        className={cn(
-          'md-form-row__badge',
-          win ? 'md-form-row__badge--w' : 'md-form-row__badge--l',
-        )}
-      >
-        {win ? 'W' : 'L'}
-      </span>
-      <span className="md-form-row__opp" title={opponentLabel}>
-        <span className="md-form-row__opp-name">{opponentLabel}</span>
-        <span className="md-form-row__when">{fmtDateShort(result.completed_at)}</span>
-      </span>
-      <span
-        className={cn(
-          'md-form-row__score',
-          !win && 'md-form-row__score--loss',
-        )}
-      >
-        {score}
-      </span>
-    </li>
   )
 }
 

--- a/web-client/src/components/matches/match-details/ordered-sides.ts
+++ b/web-client/src/components/matches/match-details/ordered-sides.ts
@@ -1,0 +1,21 @@
+import type { MatchDetailsResult } from "./match-details-query";
+
+export type MatchDetailsSide =
+  MatchDetailsResult["unmigrated"]["sides"][number];
+
+/**
+ * Perspective ordering shared by the scoreboard (hero row, game grid) and the
+ * players panel: the viewer's side reads first when they're a participant,
+ * otherwise side 1 / side 2.
+ */
+export const orderedSides = (
+  details: MatchDetailsResult["unmigrated"],
+): [MatchDetailsSide | null, MatchDetailsSide | null] => {
+  const bySideNumber = [...details.sides].sort(
+    (a, b) => a.side_number - b.side_number,
+  );
+  const mine = bySideNumber.find((s) => s.is_current_user_side);
+  const first = mine ?? bySideNumber[0] ?? null;
+  const second = bySideNumber.find((s) => s !== first) ?? null;
+  return [first, second];
+};

--- a/web-client/src/components/matches/match-details/players-panel.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel.page.tsx
@@ -1,0 +1,79 @@
+import { ErrorBoundary } from "react-error-boundary";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import { server } from "@/mocks/server";
+import { render, screen, type Container } from "@/test/utilities";
+
+import { PlayersPanel, type PlayersPanelProps } from "./players-panel";
+import { playersPanelDisplayPage } from "./players-panel/players-panel-display.page";
+
+const DEFAULT_MATCH_ID = "m-1";
+
+const scoped = (container: Container) => ({
+  /** `PlayersPanel`'s own `<Suspense>` fallback while the query is pending. */
+  queryLoading() {
+    return container.queryByText("Loading...");
+  },
+  /**
+   * The fallback rendered by the *ancestor* error boundary. `PlayersPanel`
+   * owns no boundary of its own — a failed query is meant to propagate
+   * upward — so this models the boundary the match-details page supplies in
+   * production.
+   */
+  queryError() {
+    return container.queryByRole("alert");
+  },
+  /** The snapshot panel `PlayersPanelDisplay` renders once data arrives. */
+  ...playersPanelDisplayPage.within(container),
+});
+
+/**
+ * Test page-object for the public `PlayersPanel` wrapper. `PlayersPanel` adds
+ * only a `<Suspense>` boundary (with its real `Loading...` fallback) around
+ * `PlayersPanelFetcher` and forwards `matchId` through — it deliberately has
+ * *no* error boundary, delegating failures upward. This renders it beneath an
+ * `ErrorBoundary` standing in for that ancestor so a rejected query can be
+ * observed reaching the boundary, and stubs the same
+ * `GET /v1/matches/:matchId` endpoint the query reads.
+ */
+export const playersPanelPage = {
+  /**
+   * Stub `GET /v1/matches/:matchId` — `HttpResponse.json(buildMatchDetails())`
+   * for the happy path, a non-2xx to drive the ancestor boundary.
+   */
+  mockEndpoint(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  render(overrides: Partial<PlayersPanelProps> = {}) {
+    const props: PlayersPanelProps = {
+      matchId: DEFAULT_MATCH_ID,
+      ...overrides,
+    };
+
+    render(
+      <ErrorBoundary
+        fallbackRender={() => (
+          <div role="alert">Couldn’t load the players panel</div>
+        )}
+      >
+        <PlayersPanel {...props} />
+      </ErrorBoundary>,
+    );
+  },
+
+  /**
+   * Scope the panel accessors to a container — the whole `screen` (default)
+   * or a `within(node)` subtree. A page object that embeds a `PlayersPanel`
+   * (e.g. the match-details page) calls this to expose the same queries as
+   * its own, rather than re-deriving them.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/players-panel.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel.test.tsx
@@ -1,0 +1,56 @@
+import { HttpResponse } from "msw";
+
+import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
+import { waitForElementToBeRemoved } from "@/test/utilities";
+
+import { playersPanelPage } from "./players-panel.page";
+
+describe("PlayersPanel", () => {
+  it("shows its own Loading fallback until the query resolves, then the panel", async () => {
+    playersPanelPage.mockEndpoint(() => HttpResponse.json(buildMatchDetails()));
+
+    playersPanelPage.render();
+
+    // Pending: only PlayersPanel's real Suspense fallback, no panel yet.
+    expect(playersPanelPage.queryLoading()).toBeInTheDocument();
+    expect(playersPanelPage.queryError()).not.toBeInTheDocument();
+
+    await waitForElementToBeRemoved(playersPanelPage.queryLoading());
+    expect(playersPanelPage.getPanel()).toBeInTheDocument();
+  });
+
+  it("forwards matchId to the underlying match-details query", async () => {
+    let requestedMatchId: string | undefined;
+    playersPanelPage.mockEndpoint(({ params }) => {
+      requestedMatchId = params.matchId;
+      return HttpResponse.json(buildMatchDetails());
+    });
+
+    playersPanelPage.render({ matchId: "m-42" });
+
+    await waitForElementToBeRemoved(playersPanelPage.queryLoading());
+    expect(requestedMatchId).toBe("m-42");
+  });
+
+  it("displays both player profiles projected from the match details", async () => {
+    playersPanelPage.mockEndpoint(() => HttpResponse.json(buildMatchDetails()));
+
+    playersPanelPage.render();
+
+    await waitForElementToBeRemoved(playersPanelPage.queryLoading());
+    // Wiring only: profile content is pinned by the query and display tests.
+    const rita = playersPanelPage.profileFor("rita.kovac");
+    expect(rita.getName("rita.kovac")).toBeInTheDocument();
+    const leo = playersPanelPage.profileFor("leo.mertens");
+    expect(leo.getName("leo.mertens")).toBeInTheDocument();
+  });
+
+  it("owns no error boundary — a failed query propagates to an ancestor boundary", async () => {
+    playersPanelPage.mockEndpoint(() => new HttpResponse(null, { status: 500 }));
+
+    playersPanelPage.render();
+
+    await waitForElementToBeRemoved(playersPanelPage.queryLoading());
+    expect(playersPanelPage.queryError()).toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/players-panel.tsx
+++ b/web-client/src/components/matches/match-details/players-panel.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import { PlayersPanelFetcher } from './players-panel/players-panel-fetcher'
+
+export interface PlayersPanelProps {
+    matchId: string;
+}
+
+export function PlayersPanel({ matchId }: PlayersPanelProps) {
+    return <Suspense fallback={<div>Loading...</div>}>
+        <PlayersPanelFetcher matchId={matchId} />
+    </Suspense>
+}

--- a/web-client/src/components/matches/match-details/players-panel/career-stats.factory.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/career-stats.factory.tsx
@@ -1,0 +1,33 @@
+import type { CareerStatsProps } from "./career-stats";
+import type { CareerStatsView } from "./players-panel-query";
+
+/** A 12-match career at a highlighted 75% win rate. */
+export function buildCareerStatsView(
+  overrides: Partial<CareerStatsView> = {},
+): CareerStatsView {
+  return {
+    matches: 12,
+    winRateLabel: "75%",
+    highWinRate: true,
+    ...overrides,
+  };
+}
+
+/** A rookie career — no matches, no win rate. */
+export function buildRookieCareerStatsView(
+  overrides: Partial<CareerStatsView> = {},
+): CareerStatsView {
+  return buildCareerStatsView({
+    matches: 0,
+    winRateLabel: null,
+    highWinRate: false,
+    ...overrides,
+  });
+}
+
+/** Props for `CareerStats`. */
+export function buildCareerStatsProps(
+  overrides: Partial<CareerStatsProps> = {},
+): CareerStatsProps {
+  return { career: buildCareerStatsView(), ...overrides };
+}

--- a/web-client/src/components/matches/match-details/players-panel/career-stats.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/career-stats.page.tsx
@@ -1,0 +1,47 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { CareerStats, type CareerStatsProps } from "./career-stats";
+import { buildCareerStatsProps } from "./career-stats.factory";
+
+const scoped = (container: Container) => {
+  // Each stat cell pairs a kicker label with a value div — resolve the value
+  // through its label, the same way a reader pairs them.
+  const valueFor = (label: string) =>
+    container
+      .getByText(label, { selector: ".md-profile__career .md-kicker" })
+      .parentElement!.querySelector(".md-profile__career-value")!;
+
+  return {
+    /** The "Career matches" count. */
+    getCareerMatches() {
+      return valueFor("Career matches");
+    },
+    /** The "Win rate" value — a percentage, or the dim em dash with no
+     * career matches. */
+    getWinRate() {
+      return valueFor("Win rate");
+    },
+  };
+};
+
+/**
+ * Test page-object for `CareerStats` — the career strip at the bottom of a
+ * profile. Accessors resolve each value through its kicker label.
+ */
+export const careerStatsPage = {
+  render(overrides: Partial<CareerStatsProps> = {}) {
+    const props = buildCareerStatsProps(overrides);
+    render(<CareerStats {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed this component spread
+   * this to expose the same queries as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/players-panel/career-stats.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/career-stats.test.tsx
@@ -1,0 +1,42 @@
+import {
+  buildCareerStatsView,
+  buildRookieCareerStatsView,
+} from "./career-stats.factory";
+import { careerStatsPage } from "./career-stats.page";
+
+describe("CareerStats", () => {
+  it("shows the career match count", () => {
+    careerStatsPage.render({ career: buildCareerStatsView({ matches: 12 }) });
+
+    expect(careerStatsPage.getCareerMatches()).toHaveTextContent("12");
+  });
+
+  it("highlights a 50%+ win rate in the good tone", () => {
+    careerStatsPage.render({
+      career: buildCareerStatsView({ winRateLabel: "75%", highWinRate: true }),
+    });
+
+    const winRate = careerStatsPage.getWinRate();
+    expect(winRate).toHaveTextContent("75%");
+    expect(winRate).toHaveClass("md-profile__career-value--good");
+  });
+
+  it("leaves a sub-50% win rate untinted", () => {
+    careerStatsPage.render({
+      career: buildCareerStatsView({ winRateLabel: "40%", highWinRate: false }),
+    });
+
+    const winRate = careerStatsPage.getWinRate();
+    expect(winRate).toHaveTextContent("40%");
+    expect(winRate).not.toHaveClass("md-profile__career-value--good");
+  });
+
+  it("dims an em dash for a rookie with no win rate yet", () => {
+    careerStatsPage.render({ career: buildRookieCareerStatsView() });
+
+    expect(careerStatsPage.getCareerMatches()).toHaveTextContent("0");
+    const winRate = careerStatsPage.getWinRate();
+    expect(winRate).toHaveTextContent("—");
+    expect(winRate.querySelector(".dim")).not.toBeNull();
+  });
+});

--- a/web-client/src/components/matches/match-details/players-panel/career-stats.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/career-stats.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+
+import { type CareerStatsView } from "./players-panel-query";
+
+export interface CareerStatsProps {
+  career: CareerStatsView;
+}
+
+export const CareerStats = ({ career }: CareerStatsProps) => (
+  <div className="md-profile__career">
+    <div>
+      <div className="md-kicker">Career matches</div>
+      <div className="md-profile__career-value">{career.matches}</div>
+    </div>
+    <div>
+      <div className="md-kicker">Win rate</div>
+      <div
+        className={cn(
+          "md-profile__career-value",
+          career.highWinRate && "md-profile__career-value--good",
+        )}
+      >
+        {career.winRateLabel ?? <span className="dim">—</span>}
+      </div>
+    </div>
+  </div>
+);

--- a/web-client/src/components/matches/match-details/players-panel/form-row.factory.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/form-row.factory.tsx
@@ -1,0 +1,37 @@
+import type { FormRowProps } from "./form-row";
+import type { FormRowView } from "./players-panel-query";
+
+/** A 3–1 win over silva.r on May 9. */
+export function buildFormRowView(
+  overrides: Partial<FormRowView> = {},
+): FormRowView {
+  return {
+    matchId: "m-prev-1",
+    won: true,
+    opponentLabel: "silva.r",
+    dateLabel: "May 9",
+    scoreLabel: "3–1",
+    ...overrides,
+  };
+}
+
+/** A 1–3 loss to tanaka.y on May 7 — pair with the win for a mixed list. */
+export function buildLossFormRowView(
+  overrides: Partial<FormRowView> = {},
+): FormRowView {
+  return buildFormRowView({
+    matchId: "m-prev-2",
+    won: false,
+    opponentLabel: "tanaka.y",
+    dateLabel: "May 7",
+    scoreLabel: "1–3",
+    ...overrides,
+  });
+}
+
+/** Props for `FormRow`. */
+export function buildFormRowProps(
+  overrides: Partial<FormRowProps> = {},
+): FormRowProps {
+  return { result: buildFormRowView(), ...overrides };
+}

--- a/web-client/src/components/matches/match-details/players-panel/form-row.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/form-row.page.tsx
@@ -1,0 +1,66 @@
+import { render, screen, within, type Container } from "@/test/utilities";
+
+import { FormRow, type FormRowProps } from "./form-row";
+import { buildFormRowProps } from "./form-row.factory";
+
+const scoped = (container: Container) => {
+  const getRow = (opponentLabel: string) =>
+    container
+      .getByText(opponentLabel, { selector: ".md-form-row__opp-name" })
+      .closest("li")!;
+
+  return {
+    /** The whole `<li>` for the row naming `opponentLabel` — rows in a list
+     * are distinguished by their opponent, same as a reader scans them. */
+    getRow,
+    queryRow(opponentLabel: string) {
+      return (
+        container
+          .queryByText(opponentLabel, { selector: ".md-form-row__opp-name" })
+          ?.closest("li") ?? null
+      );
+    },
+    /** That row's W/L badge. */
+    getBadge(opponentLabel: string) {
+      return within(getRow(opponentLabel)).getByText(/^[WL]$/, {
+        selector: ".md-form-row__badge",
+      });
+    },
+    /** That row's completion date, e.g. "May 9". */
+    getDate(opponentLabel: string) {
+      return getRow(opponentLabel).querySelector(".md-form-row__when")!;
+    },
+    /** That row's player-perspective score, e.g. "3–1". */
+    getScore(opponentLabel: string) {
+      return getRow(opponentLabel).querySelector(".md-form-row__score")!;
+    },
+  };
+};
+
+/**
+ * Test page-object for `FormRow` — one past result in a profile's recent-form
+ * list. `render` mounts the `<li>` inside a bare `<ul>` so the markup stays
+ * valid; accessors take the row's opponent label, since that's how rows in a
+ * list differ.
+ */
+export const formRowPage = {
+  render(overrides: Partial<FormRowProps> = {}) {
+    const props = buildFormRowProps(overrides);
+    render(
+      <ul>
+        <FormRow {...props} />
+      </ul>,
+    );
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed this component spread
+   * this to expose the same queries as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/players-panel/form-row.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/form-row.test.tsx
@@ -1,0 +1,53 @@
+import { buildFormRowView, buildLossFormRowView } from "./form-row.factory";
+import { formRowPage } from "./form-row.page";
+
+describe("FormRow", () => {
+  it("badges a win with a W in the win tone", () => {
+    formRowPage.render({ result: buildFormRowView({ won: true }) });
+
+    const badge = formRowPage.getBadge("silva.r");
+    expect(badge).toHaveTextContent("W");
+    expect(badge).toHaveClass("md-form-row__badge--w");
+    expect(badge).not.toHaveClass("md-form-row__badge--l");
+  });
+
+  it("badges a loss with an L in the loss tone", () => {
+    formRowPage.render({ result: buildLossFormRowView() });
+
+    const badge = formRowPage.getBadge("tanaka.y");
+    expect(badge).toHaveTextContent("L");
+    expect(badge).toHaveClass("md-form-row__badge--l");
+  });
+
+  it("names the opponent, titled for truncation, with the completion date", () => {
+    formRowPage.render({
+      result: buildFormRowView({
+        opponentLabel: "silva.r",
+        dateLabel: "May 9",
+      }),
+    });
+
+    const row = formRowPage.getRow("silva.r");
+    expect(row.querySelector(".md-form-row__opp")).toHaveAttribute(
+      "title",
+      "silva.r",
+    );
+    expect(formRowPage.getDate("silva.r")).toHaveTextContent("May 9");
+  });
+
+  it("shows the score plainly on a win", () => {
+    formRowPage.render({ result: buildFormRowView({ scoreLabel: "3–1" }) });
+
+    const score = formRowPage.getScore("silva.r");
+    expect(score).toHaveTextContent("3–1");
+    expect(score).not.toHaveClass("md-form-row__score--loss");
+  });
+
+  it("dims the score on a loss", () => {
+    formRowPage.render({ result: buildLossFormRowView() });
+
+    expect(formRowPage.getScore("tanaka.y")).toHaveClass(
+      "md-form-row__score--loss",
+    );
+  });
+});

--- a/web-client/src/components/matches/match-details/players-panel/form-row.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/form-row.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+
+import { type FormRowView } from "./players-panel-query";
+
+export interface FormRowProps {
+  result: FormRowView;
+}
+
+export const FormRow = ({ result }: FormRowProps) => (
+  <li className="md-form-row">
+    <span
+      className={cn(
+        "md-form-row__badge",
+        result.won ? "md-form-row__badge--w" : "md-form-row__badge--l",
+      )}
+    >
+      {result.won ? "W" : "L"}
+    </span>
+    <span className="md-form-row__opp" title={result.opponentLabel}>
+      <span className="md-form-row__opp-name">{result.opponentLabel}</span>
+      <span className="md-form-row__when">{result.dateLabel}</span>
+    </span>
+    <span
+      className={cn(
+        "md-form-row__score",
+        !result.won && "md-form-row__score--loss",
+      )}
+    >
+      {result.scoreLabel}
+    </span>
+  </li>
+);

--- a/web-client/src/components/matches/match-details/players-panel/no-opponent-profile.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/no-opponent-profile.page.tsx
@@ -1,0 +1,47 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { NoOpponentProfile } from "./no-opponent-profile";
+
+const scoped = (container: Container) => ({
+  /** The ghost-toned "No opponent" name; absent when a real profile renders
+   * that half of the panel. */
+  getGhostName() {
+    return container.getByText("No opponent", {
+      selector: ".md-profile__name--ghost",
+    });
+  },
+  queryGhostName() {
+    return container.queryByText("No opponent", {
+      selector: ".md-profile__name--ghost",
+    });
+  },
+  /** The solo-match explainer line. */
+  getSoloNote() {
+    return container.getByText("Solo match — no second player.");
+  },
+  querySoloNote() {
+    return container.queryByText("Solo match — no second player.");
+  },
+});
+
+/**
+ * Test page-object for `NoOpponentProfile` — the static "No opponent"
+ * placeholder half of the players panel. The component takes no props, so
+ * there's no factory.
+ */
+export const noOpponentProfilePage = {
+  render() {
+    render(<NoOpponentProfile />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed this component spread
+   * this to expose the same queries as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/players-panel/no-opponent-profile.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/no-opponent-profile.test.tsx
@@ -1,0 +1,25 @@
+import { noOpponentProfilePage } from "./no-opponent-profile.page";
+
+describe("NoOpponentProfile", () => {
+  it('names the missing side "No opponent" in the ghost tone', () => {
+    noOpponentProfilePage.render();
+
+    expect(noOpponentProfilePage.getGhostName()).toBeInTheDocument();
+  });
+
+  it("explains the half as a solo match", () => {
+    noOpponentProfilePage.render();
+
+    expect(noOpponentProfilePage.getSoloNote()).toBeInTheDocument();
+  });
+
+  it("hides the dashed avatar from assistive tech — the name carries the info", () => {
+    noOpponentProfilePage.render();
+
+    const avatar = noOpponentProfilePage
+      .getGhostName()
+      .closest(".md-profile")!
+      .querySelector(".md-avatar--ghost");
+    expect(avatar).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/web-client/src/components/matches/match-details/players-panel/no-opponent-profile.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/no-opponent-profile.tsx
@@ -1,0 +1,22 @@
+import { User } from "lucide-react";
+
+/**
+ * The right half of the panel when the match has no second player — a real
+ * side row carrying no player, or no second side at all. Reads as "solo"
+ * rather than implying someone is on the way.
+ */
+export const NoOpponentProfile = () => (
+  <div className="md-profile">
+    <div className="md-profile__identity">
+      <div className="md-avatar md-avatar--ghost" aria-hidden="true">
+        <User size={20} strokeWidth={1.75} />
+      </div>
+      <div className="md-profile__id-text">
+        <div className="md-profile__name md-profile__name--ghost">
+          No opponent
+        </div>
+      </div>
+    </div>
+    <div className="md-profile__empty">Solo match — no second player.</div>
+  </div>
+);

--- a/web-client/src/components/matches/match-details/players-panel/player-profile.factory.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/player-profile.factory.tsx
@@ -1,0 +1,28 @@
+import { buildCareerStatsView } from "./career-stats.factory";
+import type { PlayerProfileProps } from "./player-profile";
+import type { PlayerProfileView } from "./players-panel-query";
+import { buildRatingBoxView } from "./rating-box.factory";
+import { buildHistoryRecentFormView } from "./recent-form.factory";
+
+/** rita.kovac going in rated 1612 with a 1–1 recent form over a 12-match,
+ * 75%-win-rate career; the match isn't decided, so `won` is false. */
+export function buildPlayerProfileView(
+  overrides: Partial<PlayerProfileView> = {},
+): PlayerProfileView {
+  return {
+    name: "rita.kovac",
+    initials: "RK",
+    won: false,
+    rating: buildRatingBoxView(),
+    form: buildHistoryRecentFormView(),
+    career: buildCareerStatsView(),
+    ...overrides,
+  };
+}
+
+/** Props for `PlayerProfile`. */
+export function buildPlayerProfileProps(
+  overrides: Partial<PlayerProfileProps> = {},
+): PlayerProfileProps {
+  return { profile: buildPlayerProfileView(), ...overrides };
+}

--- a/web-client/src/components/matches/match-details/players-panel/player-profile.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/player-profile.page.tsx
@@ -1,0 +1,51 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { careerStatsPage } from "./career-stats.page";
+import { PlayerProfile, type PlayerProfileProps } from "./player-profile";
+import { buildPlayerProfileProps } from "./player-profile.factory";
+import { ratingBoxPage } from "./rating-box.page";
+import { recentFormPage } from "./recent-form.page";
+
+const scoped = (container: Container) => ({
+  /** The profile's player-name line. */
+  getName(name: string) {
+    return container.getByText(name, { selector: ".md-profile__name" });
+  },
+  queryName(name: string) {
+    return container.queryByText(name, { selector: ".md-profile__name" });
+  },
+  /** The initials avatar — win/loss toned by the profile's `won`. */
+  getAvatar(initials: string) {
+    return container.getByText(initials, { selector: ".md-avatar" });
+  },
+  /** The pre-match rating box at the top of the profile. */
+  ...ratingBoxPage.within(container),
+  /** The recent-form block in the middle. */
+  ...recentFormPage.within(container),
+  /** The career strip at the bottom. */
+  ...careerStatsPage.within(container),
+});
+
+/**
+ * Test page-object for `PlayerProfile` — one player's half of the snapshot
+ * panel (identity, rating box, recent form, career strip). The child page
+ * objects' queries are spread in, so callers read rating/form/career through
+ * the same accessors the children's own tests use.
+ */
+export const playerProfilePage = {
+  render(overrides: Partial<PlayerProfileProps> = {}) {
+    const props = buildPlayerProfileProps(overrides);
+    render(<PlayerProfile {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. The panel display's page object scopes this to
+   * one profile at a time via `profileFor(name)`.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/players-panel/player-profile.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/player-profile.test.tsx
@@ -1,0 +1,63 @@
+import { buildPlayerProfileView } from "./player-profile.factory";
+import { playerProfilePage } from "./player-profile.page";
+import { buildUnratedRatingBoxView } from "./rating-box.factory";
+import { buildEmptyRecentFormView } from "./recent-form.factory";
+
+describe("PlayerProfile", () => {
+  it("names the player", () => {
+    playerProfilePage.render({
+      profile: buildPlayerProfileView({ name: "rita.kovac" }),
+    });
+
+    expect(playerProfilePage.getName("rita.kovac")).toBeInTheDocument();
+  });
+
+  it("tones the initials avatar as a win when the side won", () => {
+    playerProfilePage.render({
+      profile: buildPlayerProfileView({ won: true }),
+    });
+
+    const avatar = playerProfilePage.getAvatar("RK");
+    expect(avatar).toHaveClass("md-avatar--win");
+    expect(avatar).not.toHaveClass("md-avatar--loss");
+  });
+
+  it("tones the avatar as a loss while the side hasn't won", () => {
+    playerProfilePage.render({
+      profile: buildPlayerProfileView({ won: false }),
+    });
+
+    expect(playerProfilePage.getAvatar("RK")).toHaveClass("md-avatar--loss");
+  });
+
+  it("renders the rating box from the view's rating", () => {
+    // Wiring only: box content is pinned by the rating-box tests.
+    playerProfilePage.render({
+      profile: buildPlayerProfileView({
+        rating: buildUnratedRatingBoxView(),
+      }),
+    });
+
+    expect(playerProfilePage.getUnrated()).toBeInTheDocument();
+  });
+
+  it("renders the recent form from the view's form", () => {
+    // Wiring only: block content is pinned by the recent-form tests.
+    playerProfilePage.render({
+      profile: buildPlayerProfileView({
+        form: buildEmptyRecentFormView({ emptyText: "No prior matches yet — this is your first one." }),
+      }),
+    });
+
+    expect(
+      playerProfilePage.getFirstMatchNote(/this is your first one/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the career strip from the view's career", () => {
+    // Wiring only: strip content is pinned by the career-stats tests.
+    playerProfilePage.render();
+
+    expect(playerProfilePage.getCareerMatches()).toHaveTextContent("12");
+  });
+});

--- a/web-client/src/components/matches/match-details/players-panel/player-profile.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/player-profile.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/utils";
+
+import { CareerStats } from "./career-stats";
+import { type PlayerProfileView } from "./players-panel-query";
+import { RatingBox } from "./rating-box";
+import { RecentForm } from "./recent-form";
+
+export interface PlayerProfileProps {
+  profile: PlayerProfileView;
+}
+
+export const PlayerProfile = ({ profile }: PlayerProfileProps) => (
+  <div className="md-profile">
+    <div className="md-profile__identity">
+      <div
+        className={cn(
+          "md-avatar",
+          profile.won ? "md-avatar--win" : "md-avatar--loss",
+        )}
+      >
+        {profile.initials}
+      </div>
+      <div className="md-profile__id-text">
+        <div className="md-profile__name">{profile.name}</div>
+      </div>
+    </div>
+    <RatingBox rating={profile.rating} />
+    <RecentForm form={profile.form} />
+    <CareerStats career={profile.career} />
+  </div>
+);

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-display.factory.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-display.factory.tsx
@@ -1,0 +1,40 @@
+import { buildPlayerProfileView } from "./player-profile.factory";
+import type { PlayersPanelDisplayProps } from "./players-panel-display";
+import type { PlayersPanelView } from "./players-panel-query";
+import { buildRookieCareerStatsView } from "./career-stats.factory";
+import { buildUnratedRatingBoxView } from "./rating-box.factory";
+import { buildEmptyRecentFormView } from "./recent-form.factory";
+
+/** A first-match rookie profile — unrated, empty form, no career numbers. */
+export function buildRookiePlayerProfileView(
+  overrides: Partial<ReturnType<typeof buildPlayerProfileView>> = {},
+) {
+  return buildPlayerProfileView({
+    name: "leo.mertens",
+    initials: "LM",
+    rating: buildUnratedRatingBoxView(),
+    form: buildEmptyRecentFormView(),
+    career: buildRookieCareerStatsView(),
+    ...overrides,
+  });
+}
+
+/** A live match's snapshot: rita.kovac (rated, 1–1 form, 12-match career)
+ * against first-timer leo.mertens. */
+export function buildPlayersPanelView(
+  overrides: Partial<PlayersPanelView> = {},
+): PlayersPanelView {
+  return {
+    snapshotLabel: "SNAPSHOT · 8 JUN, 12:00",
+    left: buildPlayerProfileView(),
+    right: buildRookiePlayerProfileView(),
+    ...overrides,
+  };
+}
+
+/** Props for `PlayersPanelDisplay`. */
+export function buildPlayersPanelDisplayProps(
+  overrides: Partial<PlayersPanelDisplayProps> = {},
+): PlayersPanelDisplayProps {
+  return { panel: buildPlayersPanelView(), ...overrides };
+}

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-display.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-display.page.tsx
@@ -1,0 +1,69 @@
+import { render, screen, within, type Container } from "@/test/utilities";
+
+import { noOpponentProfilePage } from "./no-opponent-profile.page";
+import { playerProfilePage } from "./player-profile.page";
+import {
+  PlayersPanelDisplay,
+  type PlayersPanelDisplayProps,
+} from "./players-panel-display";
+import { buildPlayersPanelDisplayProps } from "./players-panel-display.factory";
+
+const scoped = (container: Container) => ({
+  /** The panel's `<section>` landmark, named by its visible heading. */
+  getPanel() {
+    return container.getByRole("region", {
+      name: "Players · going into this match",
+    });
+  },
+  queryPanel() {
+    return container.queryByRole("region", {
+      name: "Players · going into this match",
+    });
+  },
+  /** The visible card heading. */
+  getTitle() {
+    return container.getByRole("heading", {
+      level: 3,
+      name: "Players · going into this match",
+    });
+  },
+  /** The "SNAPSHOT · …" stamp in the card header. */
+  getSnapshotLabel(text: string) {
+    return container.getByText(text, { selector: ".md-card__hd-meta" });
+  },
+  /**
+   * One player's half of the panel, scoped by the player's name — the same
+   * way a reader tells the two halves apart. Exposes the profile page
+   * object's accessors bound to just that half.
+   */
+  profileFor(name: string) {
+    const profile = container
+      .getByText(name, { selector: ".md-profile__name" })
+      .closest(".md-profile") as HTMLElement;
+    return playerProfilePage.within(within(profile) as Container);
+  },
+  /** The "No opponent" placeholder half; absent with two real players. */
+  ...noOpponentProfilePage.within(container),
+});
+
+/**
+ * Test page-object for `PlayersPanelDisplay` — the pure view-in, DOM-out
+ * snapshot card. Use `profileFor(name)` to assert within one half.
+ */
+export const playersPanelDisplayPage = {
+  render(overrides: Partial<PlayersPanelDisplayProps> = {}) {
+    const props = buildPlayersPanelDisplayProps(overrides);
+    render(<PlayersPanelDisplay {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. The fetcher and wrapper page objects spread this
+   * to expose the same queries as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-display.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-display.test.tsx
@@ -1,0 +1,63 @@
+import { buildPlayerProfileView } from "./player-profile.factory";
+import {
+  buildPlayersPanelView,
+  buildRookiePlayerProfileView,
+} from "./players-panel-display.factory";
+import { playersPanelDisplayPage } from "./players-panel-display.page";
+
+describe("PlayersPanelDisplay", () => {
+  it("renders a region landmark named by the visible card heading", () => {
+    playersPanelDisplayPage.render();
+
+    const panel = playersPanelDisplayPage.getPanel();
+    expect(panel).toHaveClass("md-card");
+    const id = playersPanelDisplayPage.getTitle().getAttribute("id");
+    expect(id).toBeTruthy();
+    expect(panel).toHaveAttribute("aria-labelledby", id);
+  });
+
+  it("stamps the header with the view's snapshot label", () => {
+    playersPanelDisplayPage.render({
+      panel: buildPlayersPanelView({
+        snapshotLabel: "SNAPSHOT · 8 JUN, 12:00",
+      }),
+    });
+
+    expect(
+      playersPanelDisplayPage.getSnapshotLabel("SNAPSHOT · 8 JUN, 12:00"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a profile per side from the view", () => {
+    // Wiring only: profile content is pinned by the query and profile tests.
+    playersPanelDisplayPage.render({
+      panel: buildPlayersPanelView({
+        left: buildPlayerProfileView({ name: "rita.kovac" }),
+        right: buildRookiePlayerProfileView({ name: "leo.mertens" }),
+      }),
+    });
+
+    const rita = playersPanelDisplayPage.profileFor("rita.kovac");
+    expect(rita.getRating("1612")).toBeInTheDocument();
+    const leo = playersPanelDisplayPage.profileFor("leo.mertens");
+    expect(leo.getUnrated()).toBeInTheDocument();
+    expect(playersPanelDisplayPage.querySoloNote()).not.toBeInTheDocument();
+  });
+
+  it('renders the "No opponent" placeholder for a null right side', () => {
+    playersPanelDisplayPage.render({
+      panel: buildPlayersPanelView({ right: null }),
+    });
+
+    expect(playersPanelDisplayPage.getGhostName()).toBeInTheDocument();
+    expect(playersPanelDisplayPage.getSoloNote()).toBeInTheDocument();
+  });
+
+  it('renders the "No opponent" placeholder for a null left side too', () => {
+    playersPanelDisplayPage.render({
+      panel: buildPlayersPanelView({ left: null }),
+    });
+
+    expect(playersPanelDisplayPage.getGhostName()).toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-display.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-display.tsx
@@ -1,0 +1,39 @@
+import { useId } from "react";
+
+import { Overline } from "@/components/overline";
+
+import { NoOpponentProfile } from "./no-opponent-profile";
+import { PlayerProfile } from "./player-profile";
+import { type PlayersPanelView } from "./players-panel-query";
+
+export interface PlayersPanelDisplayProps {
+  panel: PlayersPanelView;
+}
+
+export const PlayersPanelDisplay = ({ panel }: PlayersPanelDisplayProps) => {
+  const id = useId();
+
+  return (
+    <section className="md-card" aria-labelledby={id}>
+      <div className="md-card__hd">
+        <Overline as="h3" id={id}>
+          Players · going into this match
+        </Overline>
+        <span className="md-card__hd-meta">{panel.snapshotLabel}</span>
+      </div>
+      <div className="md-players">
+        {panel.left ? (
+          <PlayerProfile profile={panel.left} />
+        ) : (
+          <NoOpponentProfile />
+        )}
+        <div className="md-players__divider" />
+        {panel.right ? (
+          <PlayerProfile profile={panel.right} />
+        ) : (
+          <NoOpponentProfile />
+        )}
+      </div>
+    </section>
+  );
+};

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher.page.tsx
@@ -1,0 +1,71 @@
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import { server } from "@/mocks/server";
+import { render, screen, type Container } from "@/test/utilities";
+
+import { playersPanelDisplayPage } from "./players-panel-display.page";
+import {
+  PlayersPanelFetcher,
+  type PlayersPanelProps,
+} from "./players-panel-fetcher";
+
+const DEFAULT_MATCH_ID = "m-1";
+
+const scoped = (container: Container) => ({
+  /** The Suspense fallback shown while the match-details query is pending. */
+  queryLoading() {
+    return container.queryByTestId("players-panel-loading");
+  },
+  /** The error-boundary fallback shown when the query rejects. */
+  queryError() {
+    return container.queryByRole("alert");
+  },
+  /** The panel `PlayersPanelDisplay` renders once data arrives. */
+  ...playersPanelDisplayPage.within(container),
+});
+
+/**
+ * Test page-object for `PlayersPanelFetcher`. The fetcher reads via
+ * `useSuspenseQuery`, so this mirrors the real `PlayersPanel` wrapper — a
+ * `<Suspense>` plus an `ErrorBoundary` — so tests can assert the
+ * fetch→`PlayersPanelDisplay` handoff and that a failed query reaches the
+ * boundary. Stubs the same `GET /v1/matches/:matchId` endpoint the query
+ * reads.
+ */
+export const playersPanelFetcherPage = {
+  /**
+   * Stub `GET /v1/matches/:matchId` — `HttpResponse.json(buildMatchDetails())`
+   * for the happy path, a non-2xx to drive the error boundary.
+   */
+  mockEndpoint(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  render(overrides: Partial<PlayersPanelProps> = {}) {
+    const props: PlayersPanelProps = {
+      matchId: DEFAULT_MATCH_ID,
+      ...overrides,
+    };
+
+    render(
+      <ErrorBoundary
+        fallbackRender={() => (
+          <div role="alert">Couldn’t load the players panel</div>
+        )}
+      >
+        <Suspense
+          fallback={<div data-testid="players-panel-loading">Loading…</div>}
+        >
+          <PlayersPanelFetcher {...props} />
+        </Suspense>
+      </ErrorBoundary>,
+    );
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher.test.tsx
@@ -1,0 +1,38 @@
+import { HttpResponse } from "msw";
+
+import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
+import { waitForElementToBeRemoved } from "@/test/utilities";
+
+import { playersPanelFetcherPage } from "./players-panel-fetcher.page";
+
+describe("PlayersPanelFetcher", () => {
+  it("suspends while the query is pending, then hands the view to the display", async () => {
+    playersPanelFetcherPage.mockEndpoint(() =>
+      HttpResponse.json(buildMatchDetails()),
+    );
+
+    playersPanelFetcherPage.render();
+
+    expect(playersPanelFetcherPage.queryLoading()).toBeInTheDocument();
+    expect(playersPanelFetcherPage.queryPanel()).not.toBeInTheDocument();
+
+    await waitForElementToBeRemoved(playersPanelFetcherPage.queryLoading());
+    expect(playersPanelFetcherPage.getPanel()).toBeInTheDocument();
+    // The default payload's current user, projected through the query.
+    expect(
+      playersPanelFetcherPage.profileFor("rita.kovac").getName("rita.kovac"),
+    ).toBeInTheDocument();
+  });
+
+  it("lets a failed query reach the error boundary", async () => {
+    playersPanelFetcherPage.mockEndpoint(
+      () => new HttpResponse(null, { status: 500 }),
+    );
+
+    playersPanelFetcherPage.render();
+
+    await waitForElementToBeRemoved(playersPanelFetcherPage.queryLoading());
+    expect(playersPanelFetcherPage.queryError()).toBeInTheDocument();
+    expect(playersPanelFetcherPage.queryPanel()).not.toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher.tsx
@@ -1,0 +1,14 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { PlayersPanelDisplay } from "./players-panel-display";
+import { playersPanelQuery } from "./players-panel-query";
+
+export interface PlayersPanelProps {
+  matchId: string;
+}
+
+export function PlayersPanelFetcher({ matchId }: PlayersPanelProps) {
+  const { data: panel } = useSuspenseQuery(playersPanelQuery(matchId));
+
+  return <PlayersPanelDisplay panel={panel} />;
+}

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-query.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-query.page.tsx
@@ -1,0 +1,42 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import { server } from "@/mocks/server";
+import { renderHook } from "@/test/utilities";
+
+import { playersPanelQuery } from "./players-panel-query";
+
+const DEFAULT_MATCH_ID = "m-1";
+
+/**
+ * Test page-object for `playersPanelQuery`. The query is built on top of
+ * `matchDetailsQuery` and projects a `PlayersPanelView` off the full
+ * match-details payload via `select`, so the test stubs the same
+ * `GET /v1/matches/:matchId` endpoint and asserts on the projected view.
+ */
+export const playersPanelQueryPage = {
+  /**
+   * Stub `GET /v1/matches/:matchId` with a full MSW resolver, so the test owns
+   * the response — `HttpResponse.json(buildMatchDetails())` for the happy
+   * path, a non-2xx for the error branch. It's the same endpoint
+   * `matchDetailsQuery` reads from; the panel view is derived client-side.
+   */
+  mockEndpoint(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  /**
+   * Run the query under the shared retry-free test client. `throwOnError` is
+   * disabled here so failures land on `result.current.error` rather than
+   * bubbling to an error boundary — boundary behavior is covered by the
+   * fetcher tests. `result.current.data` is the projected `PlayersPanelView`.
+   */
+  render(matchId: string = DEFAULT_MATCH_ID) {
+    return renderHook(() =>
+      useQuery({ ...playersPanelQuery(matchId), throwOnError: false }),
+    );
+  },
+};

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-query.test.ts
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-query.test.ts
@@ -1,0 +1,328 @@
+import { HttpResponse } from "msw";
+
+import { fmtDateTimeShort } from "@/lib/dates";
+import {
+  buildMatchDetails,
+  buildMatchDetailsFormResult,
+  buildMatchDetailsPlayer,
+  buildMatchDetailsPlayerForm,
+  buildMatchDetailsSide,
+} from "@/mocks/factories/matches/match-details.factory";
+import { waitFor } from "@/test/utilities";
+
+import { playersPanelQuery } from "./players-panel-query";
+import { playersPanelQueryPage } from "./players-panel-query.page";
+
+const renderPanel = async (matchId?: string) => {
+  const { result } = playersPanelQueryPage.render(matchId);
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  return result;
+};
+
+describe("playersPanelQuery", () => {
+  it("shares the match-details query key so the page's BFF fetch is reused", () => {
+    expect(playersPanelQuery("m-1").queryKey).toEqual([
+      { scope: "matches", version: "v1", entity: "details", matchId: "m-1" },
+    ]);
+  });
+
+  it("stamps the snapshot label with the uppercased match creation time", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(buildMatchDetails({ created_at: "2026-06-08T12:00:00Z" })),
+    );
+
+    const result = await renderPanel();
+
+    // The timestamp half renders in the machine's local zone, so derive it
+    // with the same formatter rather than hard-coding a TZ-fragile time.
+    expect(result.current.data?.snapshotLabel).toBe(
+      `SNAPSHOT · ${fmtDateTimeShort("2026-06-08T12:00:00Z").toUpperCase()}`,
+    );
+  });
+
+  it("projects a player's identity, rating, form, and career from their form entry", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          recent_form: [
+            buildMatchDetailsPlayerForm({
+              user_id: "u-me",
+              rating_before: 1612.4,
+              rating_history: [1580, 1601, 1612],
+              career_matches_before: 12,
+              career_wins_before: 9,
+              recent_results: [
+                buildMatchDetailsFormResult({
+                  match_id: "m-prev-1",
+                  is_win: true,
+                  player_games_won: 3,
+                  opponent_games_won: 1,
+                  opponent_username: "silva.r",
+                  completed_at: "2026-05-09T18:00:00Z",
+                }),
+                buildMatchDetailsFormResult({
+                  match_id: "m-prev-2",
+                  is_win: false,
+                  player_games_won: 1,
+                  opponent_games_won: 3,
+                  opponent_username: "tanaka.y",
+                  completed_at: "2026-05-07T18:00:00Z",
+                }),
+              ],
+            }),
+          ],
+        }),
+      ),
+    );
+
+    const result = await renderPanel();
+
+    expect(result.current.data?.left).toEqual({
+      name: "rita.kovac",
+      initials: "RK",
+      won: false,
+      rating: { value: 1612, sparkline: [1580, 1601, 1612] },
+      form: {
+        kind: "history",
+        kicker: "Form · 1–1",
+        summary: "12 prior matches · 75% win rate going in",
+        rows: [
+          {
+            matchId: "m-prev-1",
+            won: true,
+            opponentLabel: "silva.r",
+            dateLabel: "May 9",
+            scoreLabel: "3–1",
+          },
+          {
+            matchId: "m-prev-2",
+            won: false,
+            opponentLabel: "tanaka.y",
+            dateLabel: "May 7",
+            scoreLabel: "1–3",
+          },
+        ],
+      },
+      career: { matches: 12, winRateLabel: "75%", highWinRate: true },
+    });
+  });
+
+  it("uses the singular 'match' in the summary after exactly one career match", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          recent_form: [
+            buildMatchDetailsPlayerForm({
+              career_matches_before: 1,
+              career_wins_before: 0,
+            }),
+          ],
+        }),
+      ),
+    );
+
+    const result = await renderPanel();
+
+    const form = result.current.data?.left?.form;
+    expect(form?.kind).toBe("history");
+    if (form?.kind === "history") {
+      expect(form.summary).toBe("1 prior match · 0% win rate going in");
+    }
+  });
+
+  it("labels a form row's missing opponent as No opponent", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          recent_form: [
+            buildMatchDetailsPlayerForm({
+              recent_results: [
+                buildMatchDetailsFormResult({ opponent_username: null }),
+              ],
+            }),
+          ],
+        }),
+      ),
+    );
+
+    const result = await renderPanel();
+
+    const form = result.current.data?.left?.form;
+    if (form?.kind === "history") {
+      expect(form.rows[0].opponentLabel).toBe("No opponent");
+    }
+    expect(form?.kind).toBe("history");
+  });
+
+  it("addresses the empty-form sentence to the viewer on their own side", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(buildMatchDetails({ recent_form: [] })),
+    );
+
+    const result = await renderPanel();
+
+    expect(result.current.data?.left?.form).toEqual({
+      kind: "empty",
+      emptyText: "No prior matches yet — this is your first one.",
+    });
+    expect(result.current.data?.right?.form).toEqual({
+      kind: "empty",
+      emptyText: "No prior matches yet — this is their first one.",
+    });
+  });
+
+  it("marks a player with no form entry as Unrated with no sparkline and no win rate", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(buildMatchDetails({ recent_form: [] })),
+    );
+
+    const result = await renderPanel();
+
+    expect(result.current.data?.left?.rating).toEqual({
+      value: null,
+      sparkline: null,
+    });
+    expect(result.current.data?.left?.career).toEqual({
+      matches: 0,
+      winRateLabel: null,
+      highWinRate: false,
+    });
+  });
+
+  it("withholds the sparkline when the rating history has fewer than two points", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          recent_form: [
+            buildMatchDetailsPlayerForm({ rating_history: [1612] }),
+          ],
+        }),
+      ),
+    );
+
+    const result = await renderPanel();
+
+    expect(result.current.data?.left?.rating).toEqual({
+      value: 1612,
+      sparkline: null,
+    });
+  });
+
+  it("does not highlight a sub-50% career win rate", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          recent_form: [
+            buildMatchDetailsPlayerForm({
+              career_matches_before: 10,
+              career_wins_before: 4,
+            }),
+          ],
+        }),
+      ),
+    );
+
+    const result = await renderPanel();
+
+    expect(result.current.data?.left?.career).toEqual({
+      matches: 10,
+      winRateLabel: "40%",
+      highWinRate: false,
+    });
+  });
+
+  it("marks a winning side's profile as won", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          sides: [
+            buildMatchDetailsSide({ won: true }),
+            buildMatchDetailsSide({
+              side_number: 2,
+              won: false,
+              is_current_user_side: false,
+              players: [
+                buildMatchDetailsPlayer({
+                  user_id: "u-opponent",
+                  username: "leo.mertens",
+                  is_current_user: false,
+                }),
+              ],
+            }),
+          ],
+        }),
+      ),
+    );
+
+    const result = await renderPanel();
+
+    expect(result.current.data?.left?.won).toBe(true);
+    expect(result.current.data?.right?.won).toBe(false);
+  });
+
+  it("orders the viewer's side left even when they're side 2", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          sides: [
+            buildMatchDetailsSide({
+              side_number: 1,
+              is_current_user_side: false,
+              players: [
+                buildMatchDetailsPlayer({
+                  user_id: "u-opponent",
+                  username: "leo.mertens",
+                  is_current_user: false,
+                }),
+              ],
+            }),
+            buildMatchDetailsSide({
+              side_number: 2,
+              is_current_user_side: true,
+              players: [buildMatchDetailsPlayer()],
+            }),
+          ],
+        }),
+      ),
+    );
+
+    const result = await renderPanel();
+
+    expect(result.current.data?.left?.name).toBe("rita.kovac");
+    expect(result.current.data?.right?.name).toBe("leo.mertens");
+  });
+
+  it("projects a missing second side as a null right profile", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({ sides: [buildMatchDetailsSide()] }),
+      ),
+    );
+
+    const result = await renderPanel();
+
+    expect(result.current.data?.left?.name).toBe("rita.kovac");
+    expect(result.current.data?.right).toBeNull();
+  });
+
+  it("projects a playerless ghost side as a null profile", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          sides: [
+            buildMatchDetailsSide(),
+            buildMatchDetailsSide({
+              side_number: 2,
+              is_current_user_side: false,
+              players: [],
+            }),
+          ],
+        }),
+      ),
+    );
+
+    const result = await renderPanel();
+
+    expect(result.current.data?.right).toBeNull();
+  });
+});

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-query.test.ts
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-query.test.ts
@@ -208,6 +208,45 @@ describe("playersPanelQuery", () => {
     });
   });
 
+  it("shows the sparkline at exactly two history points — the minimum line", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          recent_form: [
+            buildMatchDetailsPlayerForm({ rating_history: [1601, 1612] }),
+          ],
+        }),
+      ),
+    );
+
+    const result = await renderPanel();
+
+    expect(result.current.data?.left?.rating.sparkline).toEqual([1601, 1612]);
+  });
+
+  it("highlights an exactly-50% career win rate", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          recent_form: [
+            buildMatchDetailsPlayerForm({
+              career_matches_before: 10,
+              career_wins_before: 5,
+            }),
+          ],
+        }),
+      ),
+    );
+
+    const result = await renderPanel();
+
+    expect(result.current.data?.left?.career).toEqual({
+      matches: 10,
+      winRateLabel: "50%",
+      highWinRate: true,
+    });
+  });
+
   it("does not highlight a sub-50% career win rate", async () => {
     playersPanelQueryPage.mockEndpoint(() =>
       HttpResponse.json(
@@ -290,6 +329,44 @@ describe("playersPanelQuery", () => {
 
     expect(result.current.data?.left?.name).toBe("rita.kovac");
     expect(result.current.data?.right?.name).toBe("leo.mertens");
+  });
+
+  it("orders a spectator's view side 1 first even when the payload lists side 2 first", async () => {
+    playersPanelQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          sides: [
+            buildMatchDetailsSide({
+              side_number: 2,
+              is_current_user_side: false,
+              players: [
+                buildMatchDetailsPlayer({
+                  user_id: "u-b",
+                  username: "bo.k",
+                  is_current_user: false,
+                }),
+              ],
+            }),
+            buildMatchDetailsSide({
+              side_number: 1,
+              is_current_user_side: false,
+              players: [
+                buildMatchDetailsPlayer({
+                  user_id: "u-a",
+                  username: "ada.l",
+                  is_current_user: false,
+                }),
+              ],
+            }),
+          ],
+        }),
+      ),
+    );
+
+    const result = await renderPanel();
+
+    expect(result.current.data?.left?.name).toBe("ada.l");
+    expect(result.current.data?.right?.name).toBe("bo.k");
   });
 
   it("projects a missing second side as a null right profile", async () => {

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-query.ts
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-query.ts
@@ -1,0 +1,182 @@
+import { fmtDateShort, fmtDateTimeShort } from "@/lib/dates";
+import { initialsOf } from "@/lib/utils";
+
+import {
+  matchDetailsQuery,
+  type MatchDetailsResult,
+} from "../match-details-query";
+import { orderedSides, type MatchDetailsSide } from "../ordered-sides";
+
+/** One past result in a player's recent-form list. */
+export type FormRowView = {
+  /** The past match's id — used as the list key; rows don't link anywhere. */
+  matchId: string;
+  won: boolean;
+  /** That match's opponent username, or "No opponent" when it had none. */
+  opponentLabel: string;
+  /** When the past match completed, e.g. "May 9". */
+  dateLabel: string;
+  /** Player-perspective games line, e.g. "3–1". */
+  scoreLabel: string;
+};
+
+/** The form block in the middle of a profile: the first-match sentence when
+ * the player has no history, otherwise a W–L kicker, a one-line career
+ * summary, and the recent result rows. */
+export type RecentFormView =
+  | {
+      kind: "empty";
+      /** e.g. "No prior matches yet — this is your first one." — "your" for
+       * the viewer's own side, "their" otherwise. */
+      emptyText: string;
+    }
+  | {
+      kind: "history";
+      /** W–L over the recent results shown, e.g. "Form · 3–2". */
+      kicker: string;
+      /** Career numbers, e.g. "8 prior matches · 75% win rate going in". */
+      summary: string;
+      rows: FormRowView[];
+    };
+
+/** The pre-match rating box at the top of a profile. */
+export type RatingBoxView = {
+  /** Rounded pre-match rating; null renders as "Unrated". */
+  value: number | null;
+  /** Rating history for the sparkline; null when there aren't at least two
+   * points to draw a line through. */
+  sparkline: number[] | null;
+};
+
+/** The career strip at the bottom of a profile. */
+export type CareerStatsView = {
+  /** Career matches completed before this one. */
+  matches: number;
+  /** e.g. "75%"; null renders as the dim em dash (no career matches yet). */
+  winRateLabel: string | null;
+  /** True at a 50%+ win rate — drives the green highlight. */
+  highWinRate: boolean;
+};
+
+/** One player's half of the snapshot panel. */
+export type PlayerProfileView = {
+  name: string;
+  initials: string;
+  /** True only when this side has won the match — picks the avatar tone. */
+  won: boolean;
+  rating: RatingBoxView;
+  form: RecentFormView;
+  career: CareerStatsView;
+};
+
+/** The "Players · going into this match" panel. Sides are perspective-ordered
+ * like the scoreboard: the viewer's side reads left when they're a
+ * participant, otherwise side 1 is left. A null side is a missing opponent —
+ * no second side, or a playerless ghost side — rendered as the "No opponent"
+ * placeholder. */
+export type PlayersPanelView = {
+  /** When these numbers were captured (match creation),
+   * e.g. "SNAPSHOT · 8 JUN, 12:00". */
+  snapshotLabel: string;
+  left: PlayerProfileView | null;
+  right: PlayerProfileView | null;
+};
+
+type MatchDetailsPlayerForm = NonNullable<
+  MatchDetailsResult["unmigrated"]["recent_form"]
+>[number];
+type MatchDetailsFormResult = MatchDetailsPlayerForm["recent_results"][number];
+
+// A player the API returned no form entry for has no history at all — the
+// projection below then lands on the empty/Unrated/em-dash branches.
+const EMPTY_FORM: MatchDetailsPlayerForm = {
+  user_id: "",
+  recent_results: [],
+  rating_before: null,
+  rating_history: [],
+  career_matches_before: 0,
+  career_wins_before: 0,
+};
+
+const careerWinRate = (form: MatchDetailsPlayerForm): number | null =>
+  form.career_matches_before > 0
+    ? Math.round((form.career_wins_before / form.career_matches_before) * 100)
+    : null;
+
+const selectFormRow = (result: MatchDetailsFormResult): FormRowView => ({
+  matchId: result.match_id,
+  won: result.is_win,
+  opponentLabel: result.opponent_username ?? "No opponent",
+  dateLabel: fmtDateShort(result.completed_at),
+  scoreLabel: `${result.player_games_won}–${result.opponent_games_won}`,
+});
+
+const selectRecentForm = (
+  form: MatchDetailsPlayerForm,
+  isCurrentUser: boolean,
+): RecentFormView => {
+  const results = form.recent_results;
+  if (results.length === 0) {
+    return {
+      kind: "empty",
+      emptyText: `No prior matches yet — this is ${isCurrentUser ? "your" : "their"} first one.`,
+    };
+  }
+  const wins = results.filter((r) => r.is_win).length;
+  const losses = results.length - wins;
+  // A one-line "going in" summary so the with-history half leads with a
+  // sentence, mirroring the empty half's "first one" line.
+  const matches = form.career_matches_before;
+  const winRate = careerWinRate(form);
+  return {
+    kind: "history",
+    kicker: `Form · ${wins}–${losses}`,
+    summary:
+      `${matches} prior ${matches === 1 ? "match" : "matches"}` +
+      (winRate !== null ? ` · ${winRate}% win rate going in` : ""),
+    rows: results.map(selectFormRow),
+  };
+};
+
+const selectProfile = (
+  side: MatchDetailsSide | null,
+  details: MatchDetailsResult["unmigrated"],
+): PlayerProfileView | null => {
+  const player = side?.players[0];
+  if (!side || !player) return null;
+  const form =
+    details.recent_form?.find((f) => f.user_id === player.user_id) ??
+    EMPTY_FORM;
+  const history = form.rating_history ?? [];
+  const winRate = careerWinRate(form);
+  return {
+    name: player.username,
+    initials: initialsOf(player.username),
+    won: side.won === true,
+    rating: {
+      value: form.rating_before == null ? null : Math.round(form.rating_before),
+      sparkline: history.length >= 2 ? history : null,
+    },
+    form: selectRecentForm(form, side.is_current_user_side),
+    career: {
+      matches: form.career_matches_before,
+      winRateLabel: winRate === null ? null : `${winRate}%`,
+      highWinRate: winRate !== null && winRate >= 50,
+    },
+  };
+};
+
+const selectPlayersPanel = (match: MatchDetailsResult): PlayersPanelView => {
+  const details = match.unmigrated;
+  const [first, second] = orderedSides(details);
+  return {
+    snapshotLabel: `SNAPSHOT · ${fmtDateTimeShort(details.created_at).toUpperCase()}`,
+    left: selectProfile(first, details),
+    right: selectProfile(second, details),
+  };
+};
+
+export const playersPanelQuery = (matchId: string) => ({
+  ...matchDetailsQuery(matchId),
+  select: selectPlayersPanel,
+});

--- a/web-client/src/components/matches/match-details/players-panel/rating-box.factory.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/rating-box.factory.tsx
@@ -1,0 +1,27 @@
+import type { RatingBoxView } from "./players-panel-query";
+import type { RatingBoxProps } from "./rating-box";
+
+/** A 1612-rated player with a rising history behind the sparkline. */
+export function buildRatingBoxView(
+  overrides: Partial<RatingBoxView> = {},
+): RatingBoxView {
+  return {
+    value: 1612,
+    sparkline: [1580, 1601, 1612],
+    ...overrides,
+  };
+}
+
+/** An unrated player — no value, no trend to draw. */
+export function buildUnratedRatingBoxView(
+  overrides: Partial<RatingBoxView> = {},
+): RatingBoxView {
+  return buildRatingBoxView({ value: null, sparkline: null, ...overrides });
+}
+
+/** Props for `RatingBox`. */
+export function buildRatingBoxProps(
+  overrides: Partial<RatingBoxProps> = {},
+): RatingBoxProps {
+  return { rating: buildRatingBoxView(), ...overrides };
+}

--- a/web-client/src/components/matches/match-details/players-panel/rating-box.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/rating-box.page.tsx
@@ -1,0 +1,50 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { RatingBox, type RatingBoxProps } from "./rating-box";
+import { buildRatingBoxProps } from "./rating-box.factory";
+import { sparklinePage } from "./sparkline.page";
+
+const scoped = (container: Container) => ({
+  /** The rating number, resolved by its value (e.g. "1612"). */
+  getRating(value: string) {
+    return container.getByText(value, {
+      selector: ".md-profile__rating-value",
+    });
+  },
+  /** The dimmed "Unrated" placeholder shown when there's no pre-match
+   * rating; absent for a rated player. */
+  getUnrated() {
+    return container.getByText("Unrated", {
+      selector: ".md-profile__rating-value .dim",
+    });
+  },
+  queryUnrated() {
+    return container.queryByText("Unrated", {
+      selector: ".md-profile__rating-value .dim",
+    });
+  },
+  // The trend svg next to the value; absent without enough history.
+  ...sparklinePage.within(container),
+});
+
+/**
+ * Test page-object for `RatingBox` — the pre-match rating box at the top of a
+ * profile: the rounded rating (or "Unrated") plus an optional trend sparkline.
+ */
+export const ratingBoxPage = {
+  render(overrides: Partial<RatingBoxProps> = {}) {
+    const props = buildRatingBoxProps(overrides);
+    render(<RatingBox {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed this component spread
+   * this to expose the same queries as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/players-panel/rating-box.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/rating-box.test.tsx
@@ -1,0 +1,35 @@
+import {
+  buildRatingBoxView,
+  buildUnratedRatingBoxView,
+} from "./rating-box.factory";
+import { ratingBoxPage } from "./rating-box.page";
+
+describe("RatingBox", () => {
+  it("shows the pre-match rating with its trend sparkline", () => {
+    ratingBoxPage.render({
+      rating: buildRatingBoxView({
+        value: 1612,
+        sparkline: [1580, 1601, 1612],
+      }),
+    });
+
+    expect(ratingBoxPage.getRating("1612")).toBeInTheDocument();
+    expect(ratingBoxPage.getSparkline()).toBeInTheDocument();
+  });
+
+  it('dims "Unrated" for a player without a rating', () => {
+    ratingBoxPage.render({ rating: buildUnratedRatingBoxView() });
+
+    expect(ratingBoxPage.getUnrated()).toBeInTheDocument();
+    expect(ratingBoxPage.querySparkline()).not.toBeInTheDocument();
+  });
+
+  it("omits the sparkline when the view carries no history", () => {
+    ratingBoxPage.render({
+      rating: buildRatingBoxView({ sparkline: null }),
+    });
+
+    expect(ratingBoxPage.getRating("1612")).toBeInTheDocument();
+    expect(ratingBoxPage.querySparkline()).not.toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/players-panel/rating-box.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/rating-box.tsx
@@ -1,0 +1,18 @@
+import { type RatingBoxView } from "./players-panel-query";
+import { Sparkline } from "./sparkline";
+
+export interface RatingBoxProps {
+  rating: RatingBoxView;
+}
+
+export const RatingBox = ({ rating }: RatingBoxProps) => (
+  <div className="md-profile__rating-box">
+    <div>
+      <div className="md-kicker">Rating</div>
+      <div className="md-profile__rating-value">
+        {rating.value ?? <span className="dim">Unrated</span>}
+      </div>
+    </div>
+    {rating.sparkline && <Sparkline data={rating.sparkline} />}
+  </div>
+);

--- a/web-client/src/components/matches/match-details/players-panel/recent-form.factory.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/recent-form.factory.tsx
@@ -1,0 +1,39 @@
+import {
+  buildFormRowView,
+  buildLossFormRowView,
+} from "./form-row.factory";
+import type {
+  RecentFormView,
+} from "./players-panel-query";
+import type { RecentFormProps } from "./recent-form";
+
+/** A 1–1 recent form over a 12-match, 75%-win-rate career. */
+export function buildHistoryRecentFormView(
+  overrides: Partial<Extract<RecentFormView, { kind: "history" }>> = {},
+): RecentFormView {
+  return {
+    kind: "history",
+    kicker: "Form · 1–1",
+    summary: "12 prior matches · 75% win rate going in",
+    rows: [buildFormRowView(), buildLossFormRowView()],
+    ...overrides,
+  };
+}
+
+/** The first-match empty state, addressed to a non-viewer side. */
+export function buildEmptyRecentFormView(
+  overrides: Partial<Extract<RecentFormView, { kind: "empty" }>> = {},
+): RecentFormView {
+  return {
+    kind: "empty",
+    emptyText: "No prior matches yet — this is their first one.",
+    ...overrides,
+  };
+}
+
+/** Props for `RecentForm` — the with-history scenario. */
+export function buildRecentFormProps(
+  overrides: Partial<RecentFormProps> = {},
+): RecentFormProps {
+  return { form: buildHistoryRecentFormView(), ...overrides };
+}

--- a/web-client/src/components/matches/match-details/players-panel/recent-form.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/recent-form.page.tsx
@@ -1,0 +1,66 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { formRowPage } from "./form-row.page";
+import { RecentForm, type RecentFormProps } from "./recent-form";
+import { buildRecentFormProps } from "./recent-form.factory";
+
+const scoped = (container: Container) => ({
+  /** The block's kicker — "Form" on the empty branch, "Form · W–L" with
+   * history. Scoped to the form block: a profile has sibling kickers
+   * (Rating, Career matches, Win rate). */
+  getFormKicker(text: string) {
+    return container.getByText(text, {
+      selector: ".md-profile__form > .md-kicker",
+    });
+  },
+  /** The one-line career summary above the rows; absent on the empty branch. */
+  getFormSummary(text: string) {
+    return container.getByText(text, {
+      selector: ".md-profile__form-summary",
+    });
+  },
+  queryFormSummary(text: string) {
+    return container.queryByText(text, {
+      selector: ".md-profile__form-summary",
+    });
+  },
+  /** The "No prior matches yet…" sentence; absent when history exists. */
+  getFirstMatchNote(text: string | RegExp) {
+    return container.getByText(text, {
+      selector: ".md-profile__form .md-profile__empty",
+    });
+  },
+  queryFirstMatchNote(text: string | RegExp) {
+    return container.queryByText(text, {
+      selector: ".md-profile__form .md-profile__empty",
+    });
+  },
+  /** The result list itself; absent on the empty branch. */
+  queryFormList() {
+    return container.queryByRole("list");
+  },
+  ...formRowPage.within(container),
+});
+
+/**
+ * Test page-object for `RecentForm` — the form block in the middle of a
+ * profile: the empty "first one" sentence, or the W–L kicker + career summary
+ * + recent result rows.
+ */
+export const recentFormPage = {
+  render(overrides: Partial<RecentFormProps> = {}) {
+    const props = buildRecentFormProps(overrides);
+    render(<RecentForm {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed this component spread
+   * this to expose the same queries as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/players-panel/recent-form.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/recent-form.test.tsx
@@ -1,0 +1,52 @@
+import {
+  buildEmptyRecentFormView,
+  buildHistoryRecentFormView,
+} from "./recent-form.factory";
+import { recentFormPage } from "./recent-form.page";
+
+describe("RecentForm", () => {
+  it("leads a history block with the W–L kicker and career summary", () => {
+    recentFormPage.render({
+      form: buildHistoryRecentFormView({
+        kicker: "Form · 1–1",
+        summary: "12 prior matches · 75% win rate going in",
+      }),
+    });
+
+    expect(recentFormPage.getFormKicker("Form · 1–1")).toBeInTheDocument();
+    expect(
+      recentFormPage.getFormSummary("12 prior matches · 75% win rate going in"),
+    ).toBeInTheDocument();
+  });
+
+  it("lists every recent result as a form row", () => {
+    recentFormPage.render({ form: buildHistoryRecentFormView() });
+
+    expect(recentFormPage.getScore("silva.r")).toHaveTextContent("3–1");
+    expect(recentFormPage.getScore("tanaka.y")).toHaveTextContent("1–3");
+  });
+
+  it('falls back to a plain "Form" kicker and the first-match sentence when empty', () => {
+    recentFormPage.render({
+      form: buildEmptyRecentFormView({
+        emptyText: "No prior matches yet — this is their first one.",
+      }),
+    });
+
+    expect(recentFormPage.getFormKicker("Form")).toBeInTheDocument();
+    expect(
+      recentFormPage.getFirstMatchNote(
+        "No prior matches yet — this is their first one.",
+      ),
+    ).toBeInTheDocument();
+    expect(recentFormPage.queryFormList()).not.toBeInTheDocument();
+  });
+
+  it("shows no first-match sentence when history exists", () => {
+    recentFormPage.render({ form: buildHistoryRecentFormView() });
+
+    expect(
+      recentFormPage.queryFirstMatchNote(/No prior matches yet/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/players-panel/recent-form.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/recent-form.tsx
@@ -1,0 +1,26 @@
+import { FormRow } from "./form-row";
+import { type RecentFormView } from "./players-panel-query";
+
+export interface RecentFormProps {
+  form: RecentFormView;
+}
+
+export const RecentForm = ({ form }: RecentFormProps) => (
+  <div className="md-profile__form">
+    <div className="md-kicker">
+      {form.kind === "history" ? form.kicker : "Form"}
+    </div>
+    {form.kind === "empty" ? (
+      <div className="md-profile__empty">{form.emptyText}</div>
+    ) : (
+      <>
+        <div className="md-profile__form-summary">{form.summary}</div>
+        <ul className="md-profile__form-list">
+          {form.rows.map((row) => (
+            <FormRow key={row.matchId} result={row} />
+          ))}
+        </ul>
+      </>
+    )}
+  </div>
+);

--- a/web-client/src/components/matches/match-details/players-panel/sparkline.factory.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/sparkline.factory.tsx
@@ -1,0 +1,12 @@
+import type { SparklineProps } from "./sparkline";
+
+/** Props for `Sparkline` — a rating dipping then climbing to a new high, so
+ * the default trend reads up. */
+export function buildSparklineProps(
+  overrides: Partial<SparklineProps> = {},
+): SparklineProps {
+  return {
+    data: [1480, 1465, 1490, 1510],
+    ...overrides,
+  };
+}

--- a/web-client/src/components/matches/match-details/players-panel/sparkline.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/sparkline.page.tsx
@@ -1,0 +1,50 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { Sparkline, type SparklineProps } from "./sparkline";
+import { buildSparklineProps } from "./sparkline.factory";
+
+const scoped = (container: Container) => ({
+  /** The decorative trend svg; absent when the owner withholds the sparkline
+   * (e.g. a rating box with fewer than two history points). The svg is
+   * aria-hidden with no role or name, so a testid is the only handle. */
+  getSparkline() {
+    return container.getByTestId("match-details-sparkline");
+  },
+  querySparkline() {
+    return container.queryByTestId("match-details-sparkline");
+  },
+  /** The trend line path inside the svg — its `stroke` carries the up/down
+   * tone. */
+  getTrendLine() {
+    return container.getByTestId("match-details-sparkline").querySelector("path")!;
+  },
+  /** The endpoint marker dot at the last data point. */
+  getEndpointDot() {
+    return container
+      .getByTestId("match-details-sparkline")
+      .querySelector("circle")!;
+  },
+});
+
+/**
+ * Test page-object for `Sparkline` — the decorative rating-trend line. The
+ * svg is aria-hidden, so accessors resolve it by testid; owners (the rating
+ * box, the legacy rating card) spread `within` to expose the same queries.
+ */
+export const sparklinePage = {
+  render(overrides: Partial<SparklineProps> = {}) {
+    const props = buildSparklineProps(overrides);
+    render(<Sparkline {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed this component spread
+   * this to expose the same queries as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/players-panel/sparkline.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/sparkline.test.tsx
@@ -1,0 +1,55 @@
+import { sparklinePage } from "./sparkline.page";
+
+describe("Sparkline", () => {
+  it("draws a line through every data point with a marker on the last one", () => {
+    sparklinePage.render({ data: [1480, 1465, 1490, 1510] });
+
+    const path = sparklinePage.getTrendLine();
+    // One M plus an L per remaining point.
+    expect(path.getAttribute("d")).toMatch(/^M[\d. ]+(L[\d. ]+){3}$/);
+    expect(sparklinePage.getEndpointDot()).not.toBeNull();
+  });
+
+  it("colors an upward trend with the serve tone", () => {
+    sparklinePage.render({ data: [1480, 1465, 1490, 1510] });
+
+    expect(sparklinePage.getTrendLine()).toHaveAttribute(
+      "stroke",
+      "var(--serve-500)",
+    );
+    expect(sparklinePage.getEndpointDot()).toHaveAttribute(
+      "fill",
+      "var(--serve-500)",
+    );
+  });
+
+  it("colors a downward trend with the muted default", () => {
+    sparklinePage.render({ data: [1510, 1490, 1480] });
+
+    expect(sparklinePage.getTrendLine()).toHaveAttribute(
+      "stroke",
+      "var(--fg-3)",
+    );
+  });
+
+  it("honors a custom down color", () => {
+    sparklinePage.render({
+      data: [1510, 1480],
+      downColor: "var(--loss)",
+    });
+
+    expect(sparklinePage.getTrendLine()).toHaveAttribute(
+      "stroke",
+      "var(--loss)",
+    );
+  });
+
+  it("stays out of the accessibility tree — the rating value carries the info", () => {
+    sparklinePage.render();
+
+    expect(sparklinePage.getSparkline()).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+});

--- a/web-client/src/components/matches/match-details/players-panel/sparkline.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/sparkline.test.tsx
@@ -10,6 +10,43 @@ describe("Sparkline", () => {
     expect(sparklinePage.getEndpointDot()).not.toBeNull();
   });
 
+  it("scales the points across the padded canvas, min to bottom and max to top", () => {
+    // Two points over the default 110×36 canvas with 2px padding: the min
+    // (0) sits at the bottom edge, the max (10) at the top, x spanning
+    // pad → w-pad. Exact coordinates pin the scaling math.
+    sparklinePage.render({ data: [0, 10] });
+
+    expect(sparklinePage.getTrendLine()).toHaveAttribute(
+      "d",
+      "M2.0 34.0 L108.0 2.0",
+    );
+    const dot = sparklinePage.getEndpointDot();
+    expect(dot).toHaveAttribute("cx", "108");
+    expect(dot).toHaveAttribute("cy", "2");
+    expect(dot).toHaveAttribute("r", "2.4");
+  });
+
+  it("renders at the requested dimensions", () => {
+    sparklinePage.render({ data: [0, 10], w: 80, h: 28 });
+
+    const svg = sparklinePage.getSparkline();
+    expect(svg).toHaveAttribute("width", "80");
+    expect(svg).toHaveAttribute("height", "28");
+    expect(sparklinePage.getTrendLine()).toHaveAttribute(
+      "d",
+      "M2.0 26.0 L78.0 2.0",
+    );
+  });
+
+  it("pins a flat series to the baseline instead of dividing by a zero range", () => {
+    sparklinePage.render({ data: [1500, 1500] });
+
+    expect(sparklinePage.getTrendLine()).toHaveAttribute(
+      "d",
+      "M2.0 34.0 L108.0 34.0",
+    );
+  });
+
   it("colors an upward trend with the serve tone", () => {
     sparklinePage.render({ data: [1480, 1465, 1490, 1510] });
 
@@ -19,6 +56,15 @@ describe("Sparkline", () => {
     );
     expect(sparklinePage.getEndpointDot()).toHaveAttribute(
       "fill",
+      "var(--serve-500)",
+    );
+  });
+
+  it("reads a flat trend as up, not down", () => {
+    sparklinePage.render({ data: [1500, 1480, 1500] });
+
+    expect(sparklinePage.getTrendLine()).toHaveAttribute(
+      "stroke",
       "var(--serve-500)",
     );
   });

--- a/web-client/src/components/matches/match-details/players-panel/sparkline.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/sparkline.tsx
@@ -1,0 +1,54 @@
+export interface SparklineProps {
+  data: number[];
+  w?: number;
+  h?: number;
+  downColor?: string;
+}
+
+/** A decorative rating-trend line; the adjacent rating value carries the
+ * actual information, so the svg is aria-hidden. */
+export const Sparkline = ({
+  data,
+  w = 110,
+  h = 36,
+  downColor = "var(--fg-3)",
+}: SparklineProps) => {
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+  const pad = 2;
+  const points = data.map((v, i) => {
+    const x = pad + (i / (data.length - 1)) * (w - pad * 2);
+    const y = h - pad - ((v - min) / range) * (h - pad * 2);
+    return [x, y] as const;
+  });
+  const path = points
+    .map(
+      (p, i) => `${i === 0 ? "M" : "L"}${p[0].toFixed(1)} ${p[1].toFixed(1)}`,
+    )
+    .join(" ");
+  // The last point's trend picks the colour so a falling rating reads as a
+  // loss tone even before the user squints at the y-axis.
+  const trendUp = data[data.length - 1] >= data[0];
+  const color = trendUp ? "var(--serve-500)" : downColor;
+  const last = points[points.length - 1];
+  return (
+    <svg
+      width={w}
+      height={h}
+      style={{ display: "block", overflow: "visible" }}
+      aria-hidden="true"
+      data-testid="match-details-sparkline"
+    >
+      <path
+        d={path}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx={last[0]} cy={last[1]} r="2.4" fill={color} />
+    </svg>
+  );
+};

--- a/web-client/src/components/matches/match-details/scoreboard.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard.page.tsx
@@ -27,9 +27,17 @@ const scoped = (container: Container) => ({
   queryError() {
     return container.queryByRole("alert");
   },
-  /** The `<section>` landmark `ScoreboardDisplay` renders once data arrives. */
+  /** The `<section>` landmark `ScoreboardDisplay` renders once data arrives.
+   * The page renders sibling region landmarks (e.g. the players panel), so
+   * this resolves the one carrying the hero class. */
   getRegion() {
-    return container.getByRole("region");
+    const region = container
+      .getAllByRole("region")
+      .find((el: HTMLElement) => el.classList.contains("md-hero"));
+    if (!region) {
+      throw new Error("Unable to find the scoreboard's md-hero region");
+    }
+    return region;
   },
   /** The `<h2>` `ScoreboardDisplay` labels the region with. */
   getHeading() {

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-query.ts
@@ -2,6 +2,7 @@ import {
   matchDetailsQuery,
   type MatchDetailsResult,
 } from "../match-details-query";
+import { orderedSides } from "../ordered-sides";
 import type { Scoreboard } from "@/api/matches";
 import { initialsOf } from "@/lib/utils";
 
@@ -165,20 +166,6 @@ type MatchDetailsSide = MatchDetailsResult["unmigrated"]["sides"][number];
 type MatchDetailsGame = MatchDetailsResult["unmigrated"]["games"][number];
 
 const NO_OPPONENT_LABEL = "No opponent";
-
-// Perspective ordering shared by the hero row and the game grid: the viewer's
-// side reads first when they're a participant, otherwise side 1 / side 2.
-const orderedSides = (
-  details: MatchDetailsResult["unmigrated"],
-): [MatchDetailsSide | null, MatchDetailsSide | null] => {
-  const bySideNumber = [...details.sides].sort(
-    (a, b) => a.side_number - b.side_number,
-  );
-  const mine = bySideNumber.find((s) => s.is_current_user_side);
-  const first = mine ?? bySideNumber[0] ?? null;
-  const second = bySideNumber.find((s) => s !== first) ?? null;
-  return [first, second];
-};
 
 const selectHeroSide = (side: MatchDetailsSide | null): HeroSideView => {
   const player = side?.players[0] ?? null;

--- a/web-client/src/components/overline.tsx
+++ b/web-client/src/components/overline.tsx
@@ -7,6 +7,7 @@ type OverlineProps = {
   children: ReactNode
   className?: string
   style?: CSSProperties
+  id?: string
 }
 
 export function Overline({
@@ -14,10 +15,11 @@ export function Overline({
   children,
   className,
   style,
+  id,
 }: OverlineProps) {
   const Tag = as ?? 'div'
   return (
-    <Tag className={cn('fortymm-overline', className)} style={style}>
+    <Tag className={cn('fortymm-overline', className)} style={style} id={id}>
       {children}
     </Tag>
   )

--- a/web-client/src/mocks/factories/matches/match-details.factory.ts
+++ b/web-client/src/mocks/factories/matches/match-details.factory.ts
@@ -10,6 +10,7 @@ type MatchDetailsScore = components['schemas']['MatchDetailsScore']
 type MatchDetailsCurrentGame = components['schemas']['MatchDetailsCurrentGame']
 type MatchSignatureView = components['schemas']['MatchSignatureView']
 type MatchDetailsPlayerForm = components['schemas']['MatchDetailsPlayerForm']
+type MatchDetailsFormResult = components['schemas']['MatchDetailsFormResult']
 type MatchDetailsH2H = components['schemas']['MatchDetailsH2H']
 type MatchLeague = components['schemas']['MatchLeague']
 
@@ -68,6 +69,39 @@ export function buildMatchDetailsGame(
     id: 'game-1',
     game_number: 1,
     score: null,
+    ...overrides,
+  }
+}
+
+/** One past result in a player's recent-form list — a 3–1 win over silva.r. */
+export function buildMatchDetailsFormResult(
+  overrides: Partial<MatchDetailsFormResult> = {},
+): MatchDetailsFormResult {
+  return {
+    match_id: 'm-prev-1',
+    is_win: true,
+    player_games_won: 3,
+    opponent_games_won: 1,
+    opponent_username: 'silva.r',
+    completed_at: '2026-05-09T18:00:00Z',
+    ...overrides,
+  }
+}
+
+/**
+ * A player's pre-match form entry as it appears in `recent_form` — rita.kovac
+ * (`u-me`) rated 1612 with a rising history and a 9–3 career going in.
+ */
+export function buildMatchDetailsPlayerForm(
+  overrides: Partial<MatchDetailsPlayerForm> = {},
+): MatchDetailsPlayerForm {
+  return {
+    user_id: 'u-me',
+    recent_results: [buildMatchDetailsFormResult()],
+    rating_before: 1612,
+    rating_history: [1580, 1601, 1612],
+    career_matches_before: 12,
+    career_wins_before: 9,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary

- Extracts the players snapshot panel from `match-details-page.tsx` into a standalone component tree under `match-details/players-panel/`
- Builds the full strangler quartet for each sub-component: `players-panel-display`, `players-panel-fetcher`, `players-panel-query`, `player-profile`, `career-stats`, `recent-form`, `form-row`, `rating-box`, `sparkline`, and `no-opponent-profile`
- Pins sparkline SVG geometry and selector boundaries so mutation-strength tests can reliably query rendered elements

## Test plan

- [ ] `npm run test:run` passes (vitest)
- [ ] Players panel renders correctly on the match details page
- [ ] Sparkline tests pass with pinned geometry/selectors
- [ ] No regressions in `match-details-page.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)