### PR TITLE
match-details: extract match info card into strangler quartets

### DIFF
--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -11,6 +11,7 @@ import {
   X,
 } from 'lucide-react'
 
+import { MatchInfo } from './match-details/match-info'
 import { PlayersPanel } from './match-details/players-panel'
 import { Sparkline } from './match-details/players-panel/sparkline'
 import { Scoreboard } from './match-details/scoreboard'
@@ -433,7 +434,7 @@ function MatchDetailsPage({
             {showAuxCards && <CommentsCard />}
           </div>
           <aside className="md-col-2__aside">
-            <MatchInfoCard view={view} />
+            <MatchInfo matchId={matchId} />
             {showRatingCard && <RatingCard view={view} />}
             {view.headToHead && (
               <H2HCard view={view} h2h={view.headToHead} />
@@ -505,27 +506,6 @@ function Breadcrumb({
       <Link to="/matches">Matches</Link>
       <span>›</span>
       <span className="md-breadcrumb__current">Match {matchId.slice(0, 6)}</span>
-    </div>
-  )
-}
-
-function MatchInfoCard({ view }: { view: MatchView }) {
-  const rows: Array<[string, string]> = [
-    ['Format', `Singles · Best of ${view.bestOf}, first to ${view.gamesToWin}`],
-    ['Status', view.statusLabel],
-    ['Rated', view.rated ? 'Yes' : 'No'],
-  ]
-  return (
-    <div className="md-card">
-      <div className="md-card__hd"><Overline as="h3">Match info</Overline></div>
-      <div className="md-card__body">
-        {rows.map(([k, v]) => (
-          <div key={k} className="md-info-row">
-            <span className="md-info-row__k">{k}</span>
-            <span className="md-info-row__v">{v}</span>
-          </div>
-        ))}
-      </div>
     </div>
   )
 }

--- a/web-client/src/components/matches/match-details/match-info.page.tsx
+++ b/web-client/src/components/matches/match-details/match-info.page.tsx
@@ -1,0 +1,79 @@
+import { ErrorBoundary } from "react-error-boundary";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import { server } from "@/mocks/server";
+import { render, screen, type Container } from "@/test/utilities";
+
+import { MatchInfo, type MatchInfoProps } from "./match-info";
+import { matchInfoDisplayPage } from "./match-info/match-info-display.page";
+
+const DEFAULT_MATCH_ID = "m-1";
+
+const scoped = (container: Container) => ({
+  /** `MatchInfo`'s own `<Suspense>` fallback while the query is pending. */
+  queryLoading() {
+    return container.queryByText("Loading...");
+  },
+  /**
+   * The fallback rendered by the *ancestor* error boundary. `MatchInfo`
+   * owns no boundary of its own — a failed query is meant to propagate
+   * upward — so this models the boundary the match-details page supplies in
+   * production.
+   */
+  queryError() {
+    return container.queryByRole("alert");
+  },
+  /** The card `MatchInfoDisplay` renders once data arrives. */
+  ...matchInfoDisplayPage.within(container),
+});
+
+/**
+ * Test page-object for the public `MatchInfo` wrapper. `MatchInfo` adds
+ * only a `<Suspense>` boundary (with its real `Loading...` fallback) around
+ * `MatchInfoFetcher` and forwards `matchId` through — it deliberately has
+ * *no* error boundary, delegating failures upward. This renders it beneath an
+ * `ErrorBoundary` standing in for that ancestor so a rejected query can be
+ * observed reaching the boundary, and stubs the same
+ * `GET /v1/matches/:matchId` endpoint the query reads.
+ */
+export const matchInfoPage = {
+  /**
+   * Stub `GET /v1/matches/:matchId` — `HttpResponse.json(buildMatchDetails())`
+   * for the happy path, a non-2xx to drive the ancestor boundary.
+   */
+  mockEndpoint(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  render(overrides: Partial<MatchInfoProps> = {}) {
+    const props: MatchInfoProps = {
+      matchId: DEFAULT_MATCH_ID,
+      ...overrides,
+    };
+
+    render(
+      <ErrorBoundary
+        fallbackRender={() => (
+          <div role="alert">Couldn’t load the match info</div>
+        )}
+      >
+        <MatchInfo {...props} />
+      </ErrorBoundary>,
+    );
+  },
+
+  /**
+   * Scope the card accessors to a container — the whole `screen` (default)
+   * or a `within(node)` subtree. A page object that embeds a `MatchInfo`
+   * (e.g. the match-details page) calls this to expose the same queries as
+   * its own, rather than re-deriving them.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/match-info.test.tsx
+++ b/web-client/src/components/matches/match-details/match-info.test.tsx
@@ -1,0 +1,53 @@
+import { HttpResponse } from "msw";
+
+import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
+import { waitForElementToBeRemoved } from "@/test/utilities";
+
+import { matchInfoPage } from "./match-info.page";
+
+describe("MatchInfo", () => {
+  it("shows its own Loading fallback until the query resolves, then the card", async () => {
+    matchInfoPage.mockEndpoint(() => HttpResponse.json(buildMatchDetails()));
+
+    matchInfoPage.render();
+
+    // Pending: only MatchInfo's real Suspense fallback, no card yet.
+    expect(matchInfoPage.queryLoading()).toBeInTheDocument();
+    expect(matchInfoPage.queryError()).not.toBeInTheDocument();
+
+    await waitForElementToBeRemoved(matchInfoPage.queryLoading());
+    expect(matchInfoPage.getCard()).toBeInTheDocument();
+  });
+
+  it("forwards matchId to the underlying match-details query", async () => {
+    let requestedMatchId: string | undefined;
+    matchInfoPage.mockEndpoint(({ params }) => {
+      requestedMatchId = params.matchId;
+      return HttpResponse.json(buildMatchDetails());
+    });
+
+    matchInfoPage.render({ matchId: "m-42" });
+
+    await waitForElementToBeRemoved(matchInfoPage.queryLoading());
+    expect(requestedMatchId).toBe("m-42");
+  });
+
+  it("displays the rows projected from the match details", async () => {
+    matchInfoPage.mockEndpoint(() => HttpResponse.json(buildMatchDetails()));
+
+    matchInfoPage.render();
+
+    await waitForElementToBeRemoved(matchInfoPage.queryLoading());
+    // Wiring only: row content is pinned by the query and display tests.
+    expect(matchInfoPage.getValue("Status")).toHaveTextContent(/^Scheduled$/);
+  });
+
+  it("owns no error boundary — a failed query propagates to an ancestor boundary", async () => {
+    matchInfoPage.mockEndpoint(() => new HttpResponse(null, { status: 500 }));
+
+    matchInfoPage.render();
+
+    await waitForElementToBeRemoved(matchInfoPage.queryLoading());
+    expect(matchInfoPage.queryError()).toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/match-info.tsx
+++ b/web-client/src/components/matches/match-details/match-info.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import { MatchInfoFetcher } from './match-info/match-info-fetcher'
+
+export interface MatchInfoProps {
+    matchId: string;
+}
+
+export function MatchInfo({ matchId }: MatchInfoProps) {
+    return <Suspense fallback={<div>Loading...</div>}>
+        <MatchInfoFetcher matchId={matchId} />
+    </Suspense>
+}

--- a/web-client/src/components/matches/match-details/match-info/info-row.factory.tsx
+++ b/web-client/src/components/matches/match-details/match-info/info-row.factory.tsx
@@ -1,0 +1,20 @@
+import type { InfoRowProps } from "./info-row";
+import type { InfoRowView } from "./match-info-query";
+
+/** The "Format" row of a rated best-of-5 singles match. */
+export function buildInfoRowView(
+  overrides: Partial<InfoRowView> = {},
+): InfoRowView {
+  return {
+    label: "Format",
+    value: "Singles · Best of 5, first to 3",
+    ...overrides,
+  };
+}
+
+/** Props for `InfoRow`. */
+export function buildInfoRowProps(
+  overrides: Partial<InfoRowProps> = {},
+): InfoRowProps {
+  return { row: buildInfoRowView(), ...overrides };
+}

--- a/web-client/src/components/matches/match-details/match-info/info-row.page.tsx
+++ b/web-client/src/components/matches/match-details/match-info/info-row.page.tsx
@@ -1,0 +1,51 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { InfoRow, type InfoRowProps } from "./info-row";
+import { buildInfoRowProps } from "./info-row.factory";
+
+const scoped = (container: Container) => ({
+  /** The row's label cell (the `<dt>`), found by its text, e.g. "Format". */
+  getLabel(label: string) {
+    return container.getByText(label, { selector: ".md-info-row__k" });
+  },
+  queryLabel(label: string) {
+    return container.queryByText(label, { selector: ".md-info-row__k" });
+  },
+  /** The value cell (the `<dd>`) paired with the row labelled `label`. */
+  getValue(label: string) {
+    const row = scoped(container)
+      .getLabel(label)
+      .closest(".md-info-row") as HTMLElement;
+    const value = row.querySelector(".md-info-row__v");
+    if (!value) {
+      throw new Error(`Row "${label}" has no value cell`);
+    }
+    return value as HTMLElement;
+  },
+});
+
+/**
+ * Test page-object for `InfoRow` — one label/value line of the match-info
+ * card. Rows are told apart by their label text, the same way a reader does.
+ */
+export const infoRowPage = {
+  render(overrides: Partial<InfoRowProps> = {}) {
+    const props = buildInfoRowProps(overrides);
+    render(
+      <dl>
+        <InfoRow {...props} />
+      </dl>,
+    );
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed rows (the display, the
+   * fetcher) spread this to expose the same queries as their own.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/match-info/info-row.test.tsx
+++ b/web-client/src/components/matches/match-details/match-info/info-row.test.tsx
@@ -1,0 +1,18 @@
+import { buildInfoRowView } from "./info-row.factory";
+import { infoRowPage } from "./info-row.page";
+
+describe("InfoRow", () => {
+  it("renders the row's label as its term", () => {
+    infoRowPage.render({ row: buildInfoRowView({ label: "Status" }) });
+
+    expect(infoRowPage.getLabel("Status")).toBeInTheDocument();
+  });
+
+  it("pairs the value with the row's label", () => {
+    infoRowPage.render({
+      row: buildInfoRowView({ label: "Rated", value: "Yes" }),
+    });
+
+    expect(infoRowPage.getValue("Rated")).toHaveTextContent(/^Yes$/);
+  });
+});

--- a/web-client/src/components/matches/match-details/match-info/info-row.tsx
+++ b/web-client/src/components/matches/match-details/match-info/info-row.tsx
@@ -1,0 +1,14 @@
+import { type InfoRowView } from "./match-info-query";
+
+export interface InfoRowProps {
+  row: InfoRowView;
+}
+
+/** One label/value line of the match-info card. Rendered as a `<dt>`/`<dd>`
+ * pair — the parent supplies the enclosing `<dl>`. */
+export const InfoRow = ({ row }: InfoRowProps) => (
+  <div className="md-info-row">
+    <dt className="md-info-row__k">{row.label}</dt>
+    <dd className="md-info-row__v">{row.value}</dd>
+  </div>
+);

--- a/web-client/src/components/matches/match-details/match-info/match-info-display.factory.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-display.factory.tsx
@@ -1,0 +1,24 @@
+import { buildInfoRowView } from "./info-row.factory";
+import type { MatchInfoDisplayProps } from "./match-info-display";
+import type { MatchInfoView } from "./match-info-query";
+
+/** The info card of a scheduled, rated best-of-5 singles match. */
+export function buildMatchInfoView(
+  overrides: Partial<MatchInfoView> = {},
+): MatchInfoView {
+  return {
+    rows: [
+      buildInfoRowView(),
+      buildInfoRowView({ label: "Status", value: "Scheduled" }),
+      buildInfoRowView({ label: "Rated", value: "Yes" }),
+    ],
+    ...overrides,
+  };
+}
+
+/** Props for `MatchInfoDisplay`. */
+export function buildMatchInfoDisplayProps(
+  overrides: Partial<MatchInfoDisplayProps> = {},
+): MatchInfoDisplayProps {
+  return { info: buildMatchInfoView(), ...overrides };
+}

--- a/web-client/src/components/matches/match-details/match-info/match-info-display.page.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-display.page.tsx
@@ -1,0 +1,47 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { infoRowPage } from "./info-row.page";
+import {
+  MatchInfoDisplay,
+  type MatchInfoDisplayProps,
+} from "./match-info-display";
+import { buildMatchInfoDisplayProps } from "./match-info-display.factory";
+
+const scoped = (container: Container) => ({
+  /** The card's `<section>` landmark, named by its visible heading. */
+  getCard() {
+    return container.getByRole("region", { name: "Match info" });
+  },
+  queryCard() {
+    return container.queryByRole("region", { name: "Match info" });
+  },
+  /** The visible card heading. */
+  getTitle() {
+    return container.getByRole("heading", { level: 3, name: "Match info" });
+  },
+  // Row lookups (`getLabel(label)` / `getValue(label)`) come from the row's
+  // own page object.
+  ...infoRowPage.within(container),
+});
+
+/**
+ * Test page-object for `MatchInfoDisplay` — the pure view-in, DOM-out
+ * sidebar card. Use `getValue(label)` to assert a row's value.
+ */
+export const matchInfoDisplayPage = {
+  render(overrides: Partial<MatchInfoDisplayProps> = {}) {
+    const props = buildMatchInfoDisplayProps(overrides);
+    render(<MatchInfoDisplay {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. The fetcher and wrapper page objects spread this
+   * to expose the same queries as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/match-info/match-info-display.test.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-display.test.tsx
@@ -1,0 +1,29 @@
+import { buildInfoRowView } from "./info-row.factory";
+import { matchInfoDisplayPage } from "./match-info-display.page";
+
+describe("MatchInfoDisplay", () => {
+  it("renders the card as a region named by its Match info heading", () => {
+    matchInfoDisplayPage.render();
+
+    expect(matchInfoDisplayPage.getCard()).toBeInTheDocument();
+    expect(matchInfoDisplayPage.getTitle()).toBeInTheDocument();
+  });
+
+  it("renders one row per view row, in order, with its value", () => {
+    matchInfoDisplayPage.render({
+      info: {
+        rows: [
+          buildInfoRowView({ label: "Status", value: "Live" }),
+          buildInfoRowView({ label: "Rated", value: "No" }),
+        ],
+      },
+    });
+
+    // Wiring only: each row's label/value pairing is pinned by info-row tests.
+    expect(matchInfoDisplayPage.getValue("Status")).toHaveTextContent(
+      /^Live$/,
+    );
+    expect(matchInfoDisplayPage.getValue("Rated")).toHaveTextContent(/^No$/);
+    expect(matchInfoDisplayPage.queryLabel("Format")).not.toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/match-info/match-info-display.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-display.tsx
@@ -1,0 +1,29 @@
+import { useId } from "react";
+
+import { Overline } from "@/components/overline";
+
+import { InfoRow } from "./info-row";
+import { type MatchInfoView } from "./match-info-query";
+
+export interface MatchInfoDisplayProps {
+  info: MatchInfoView;
+}
+
+export const MatchInfoDisplay = ({ info }: MatchInfoDisplayProps) => {
+  const id = useId();
+
+  return (
+    <section className="md-card" aria-labelledby={id}>
+      <div className="md-card__hd">
+        <Overline as="h3" id={id}>
+          Match info
+        </Overline>
+      </div>
+      <dl className="md-card__body">
+        {info.rows.map((row) => (
+          <InfoRow key={row.label} row={row} />
+        ))}
+      </dl>
+    </section>
+  );
+};

--- a/web-client/src/components/matches/match-details/match-info/match-info-fetcher.page.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-fetcher.page.tsx
@@ -1,0 +1,68 @@
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import { server } from "@/mocks/server";
+import { render, screen, type Container } from "@/test/utilities";
+
+import { matchInfoDisplayPage } from "./match-info-display.page";
+import { MatchInfoFetcher, type MatchInfoProps } from "./match-info-fetcher";
+
+const DEFAULT_MATCH_ID = "m-1";
+
+const scoped = (container: Container) => ({
+  /** The Suspense fallback shown while the match-details query is pending. */
+  queryLoading() {
+    return container.queryByTestId("match-info-loading");
+  },
+  /** The error-boundary fallback shown when the query rejects. */
+  queryError() {
+    return container.queryByRole("alert");
+  },
+  /** The card `MatchInfoDisplay` renders once data arrives. */
+  ...matchInfoDisplayPage.within(container),
+});
+
+/**
+ * Test page-object for `MatchInfoFetcher`. The fetcher reads via
+ * `useSuspenseQuery`, so this mirrors the real `MatchInfo` wrapper — a
+ * `<Suspense>` plus an `ErrorBoundary` — so tests can assert the
+ * fetch→`MatchInfoDisplay` handoff and that a failed query reaches the
+ * boundary. Stubs the same `GET /v1/matches/:matchId` endpoint the query
+ * reads.
+ */
+export const matchInfoFetcherPage = {
+  /**
+   * Stub `GET /v1/matches/:matchId` — `HttpResponse.json(buildMatchDetails())`
+   * for the happy path, a non-2xx to drive the error boundary.
+   */
+  mockEndpoint(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  render(overrides: Partial<MatchInfoProps> = {}) {
+    const props: MatchInfoProps = {
+      matchId: DEFAULT_MATCH_ID,
+      ...overrides,
+    };
+
+    render(
+      <ErrorBoundary
+        fallbackRender={() => (
+          <div role="alert">Couldn’t load the match info</div>
+        )}
+      >
+        <Suspense
+          fallback={<div data-testid="match-info-loading">Loading…</div>}
+        >
+          <MatchInfoFetcher {...props} />
+        </Suspense>
+      </ErrorBoundary>,
+    );
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/match-info/match-info-fetcher.test.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-fetcher.test.tsx
@@ -1,0 +1,38 @@
+import { HttpResponse } from "msw";
+
+import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
+import { waitForElementToBeRemoved } from "@/test/utilities";
+
+import { matchInfoFetcherPage } from "./match-info-fetcher.page";
+
+describe("MatchInfoFetcher", () => {
+  it("suspends while the query is pending, then hands the view to the display", async () => {
+    matchInfoFetcherPage.mockEndpoint(() =>
+      HttpResponse.json(buildMatchDetails()),
+    );
+
+    matchInfoFetcherPage.render();
+
+    expect(matchInfoFetcherPage.queryLoading()).toBeInTheDocument();
+    expect(matchInfoFetcherPage.queryCard()).not.toBeInTheDocument();
+
+    await waitForElementToBeRemoved(matchInfoFetcherPage.queryLoading());
+    expect(matchInfoFetcherPage.getCard()).toBeInTheDocument();
+    // The default payload's format line, projected through the query.
+    expect(matchInfoFetcherPage.getValue("Format")).toHaveTextContent(
+      /^Singles · Best of 5, first to 3$/,
+    );
+  });
+
+  it("lets a failed query reach the error boundary", async () => {
+    matchInfoFetcherPage.mockEndpoint(
+      () => new HttpResponse(null, { status: 500 }),
+    );
+
+    matchInfoFetcherPage.render();
+
+    await waitForElementToBeRemoved(matchInfoFetcherPage.queryLoading());
+    expect(matchInfoFetcherPage.queryError()).toBeInTheDocument();
+    expect(matchInfoFetcherPage.queryCard()).not.toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/match-info/match-info-fetcher.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-fetcher.tsx
@@ -1,0 +1,14 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { MatchInfoDisplay } from "./match-info-display";
+import { matchInfoQuery } from "./match-info-query";
+
+export interface MatchInfoProps {
+  matchId: string;
+}
+
+export function MatchInfoFetcher({ matchId }: MatchInfoProps) {
+  const { data: info } = useSuspenseQuery(matchInfoQuery(matchId));
+
+  return <MatchInfoDisplay info={info} />;
+}

--- a/web-client/src/components/matches/match-details/match-info/match-info-query.page.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-query.page.tsx
@@ -1,0 +1,42 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import { server } from "@/mocks/server";
+import { renderHook } from "@/test/utilities";
+
+import { matchInfoQuery } from "./match-info-query";
+
+const DEFAULT_MATCH_ID = "m-1";
+
+/**
+ * Test page-object for `matchInfoQuery`. The query is built on top of
+ * `matchDetailsQuery` and projects a `MatchInfoView` off the full
+ * match-details payload via `select`, so the test stubs the same
+ * `GET /v1/matches/:matchId` endpoint and asserts on the projected view.
+ */
+export const matchInfoQueryPage = {
+  /**
+   * Stub `GET /v1/matches/:matchId` with a full MSW resolver, so the test owns
+   * the response — `HttpResponse.json(buildMatchDetails())` for the happy
+   * path, a non-2xx for the error branch. It's the same endpoint
+   * `matchDetailsQuery` reads from; the info view is derived client-side.
+   */
+  mockEndpoint(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  /**
+   * Run the query under the shared retry-free test client. `throwOnError` is
+   * disabled here so failures land on `result.current.error` rather than
+   * bubbling to an error boundary — boundary behavior is covered by the
+   * fetcher tests. `result.current.data` is the projected `MatchInfoView`.
+   */
+  render(matchId: string = DEFAULT_MATCH_ID) {
+    return renderHook(() =>
+      useQuery({ ...matchInfoQuery(matchId), throwOnError: false }),
+    );
+  },
+};

--- a/web-client/src/components/matches/match-details/match-info/match-info-query.test.ts
+++ b/web-client/src/components/matches/match-details/match-info/match-info-query.test.ts
@@ -1,0 +1,84 @@
+import { HttpResponse } from "msw";
+
+import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
+import { waitFor } from "@/test/utilities";
+
+import { matchInfoQuery } from "./match-info-query";
+import { matchInfoQueryPage } from "./match-info-query.page";
+
+const renderInfo = async (matchId?: string) => {
+  const { result } = matchInfoQueryPage.render(matchId);
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  return result;
+};
+
+describe("matchInfoQuery", () => {
+  it("shares the match-details query key so the page's BFF fetch is reused", () => {
+    expect(matchInfoQuery("m-1").queryKey).toEqual([
+      { scope: "matches", version: "v1", entity: "details", matchId: "m-1" },
+    ]);
+  });
+
+  it("projects the format, status, and rated rows in card order", async () => {
+    matchInfoQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          team_size: 1,
+          best_of: 5,
+          games_to_win: 3,
+          status_label: "Scheduled",
+          affects_rating: true,
+        }),
+      ),
+    );
+
+    const result = await renderInfo();
+
+    expect(result.current.data?.rows).toEqual([
+      { label: "Format", value: "Singles · Best of 5, first to 3" },
+      { label: "Status", value: "Scheduled" },
+      { label: "Rated", value: "Yes" },
+    ]);
+  });
+
+  it("labels a two-player team size as Doubles with its own race line", async () => {
+    matchInfoQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({ team_size: 2, best_of: 3, games_to_win: 2 }),
+      ),
+    );
+
+    const result = await renderInfo();
+
+    expect(result.current.data?.rows[0]).toEqual({
+      label: "Format",
+      value: "Doubles · Best of 3, first to 2",
+    });
+  });
+
+  it("passes the server's status label through untouched", async () => {
+    matchInfoQueryPage.mockEndpoint(() =>
+      HttpResponse.json(buildMatchDetails({ status_label: "In progress" })),
+    );
+
+    const result = await renderInfo();
+
+    expect(result.current.data?.rows[1]).toEqual({
+      label: "Status",
+      value: "In progress",
+    });
+  });
+
+  it("reads an unrated match as Rated · No", async () => {
+    matchInfoQueryPage.mockEndpoint(() =>
+      HttpResponse.json(buildMatchDetails({ affects_rating: false })),
+    );
+
+    const result = await renderInfo();
+
+    expect(result.current.data?.rows[2]).toEqual({
+      label: "Rated",
+      value: "No",
+    });
+  });
+});

--- a/web-client/src/components/matches/match-details/match-info/match-info-query.ts
+++ b/web-client/src/components/matches/match-details/match-info/match-info-query.ts
@@ -1,0 +1,35 @@
+import {
+  matchDetailsQuery,
+  type MatchDetailsResult,
+} from "../match-details-query";
+
+/** One label/value line in the match-info card, e.g. "Status" / "Live". */
+export type InfoRowView = {
+  label: string;
+  value: string;
+};
+
+/** The "Match info" sidebar card: a fixed run of label/value rows — format,
+ * status, and whether the match is rated. All label text is derived here. */
+export type MatchInfoView = {
+  rows: InfoRowView[];
+};
+
+const selectMatchInfo = (match: MatchDetailsResult): MatchInfoView => {
+  const details = match.unmigrated;
+  return {
+    rows: [
+      {
+        label: "Format",
+        value: `${details.team_size === 1 ? "Singles" : "Doubles"} · Best of ${details.best_of}, first to ${details.games_to_win}`,
+      },
+      { label: "Status", value: details.status_label },
+      { label: "Rated", value: details.affects_rating ? "Yes" : "No" },
+    ],
+  };
+};
+
+export const matchInfoQuery = (matchId: string) => ({
+  ...matchDetailsQuery(matchId),
+  select: selectMatchInfo,
+});


### PR DESCRIPTION
## Summary

- Replaces the inline `MatchInfoCard` function (which read off the page-level `MatchView`) with a `<MatchInfo matchId={} />` wrapper that fetches independently via `useSuspenseQuery`, mirroring the scoreboard and players-panel extractions.
- Adds a `matchInfoQuery` projection off `matchDetailsQuery` with a `select` that produces `MatchInfoView` — an array of `{ label, value }` rows (Format, Status, Rated). One net improvement: Format now derives Singles/Doubles from `team_size` (consistent with the scoreboard) instead of the old hardcoded "Singles".
- Delivers the full four-layer strangler quartet: `match-info-query`, `match-info-fetcher`, `match-info-display`, and the `InfoRow` leaf, each with its page object, factory, and tests. The public `MatchInfo` wrapper (`match-info.tsx`) follows the same no-error-boundary / Suspense-only shape as `PlayersPanel`.
- The card markup is upgraded from bare divs/spans to a `<section aria-labelledby>` region with a `<dl>` body (semantic label/value pairs).

## Test plan

- [x] `npm run lint` — clean (one pre-existing warning in `mockServiceWorker.js`)
- [x] `npm run build` — passes type-check
- [x] `npm run test:run` — 321/321 pass (15 new tests)
- [x] `npm run test:mutation:changed` — 100% mutation score on all new source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)