### PR TITLE
match-details: extract rating-change card into strangler quartets

### DIFF
--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react'
 import { Link, useRouter } from '@tanstack/react-router'
 import {
   Check,
-  ChevronRight,
   Copy,
   Download,
   Link2,
@@ -13,13 +12,12 @@ import {
 
 import { MatchInfo } from './match-details/match-info'
 import { PlayersPanel } from './match-details/players-panel'
-import { Sparkline } from './match-details/players-panel/sparkline'
+import { Ratings } from './match-details/ratings'
 import { Scoreboard } from './match-details/scoreboard'
 import { AppShell } from '@/components/app-shell'
 import { Overline } from '@/components/overline'
 import { cn, initialsOf } from '@/lib/utils'
 import { fmtDateShort } from '@/lib/dates'
-import { formatRatingDelta } from '@/lib/rating'
 import {
   scoringNewRoute,
   useConfirmMatch,
@@ -35,19 +33,8 @@ import { SaveYourMatch } from './save-your-match'
 type MatchDetails = components['schemas']['app__schemas__match__MatchDetails']
 type MatchResultsGameWrite = components['schemas']['MatchResultsGameWrite']
 type MatchDetailsSide = components['schemas']['MatchDetailsSide']
-type MatchDetailsPlayerForm = components['schemas']['MatchDetailsPlayerForm']
 type MatchDetailsH2H = components['schemas']['MatchDetailsH2H']
 type MatchDetailsH2HMeeting = components['schemas']['MatchDetailsH2HMeeting']
-type RatingChange = components['schemas']['RatingChange']
-
-const EMPTY_FORM: MatchDetailsPlayerForm = {
-  user_id: '',
-  recent_results: [],
-  rating_before: null,
-  rating_history: [],
-  career_matches_before: 0,
-  career_wins_before: 0,
-}
 
 type HeroState = 'live' | 'final' | 'upcoming'
 
@@ -62,8 +49,6 @@ type SideView = {
   gamesWon: number
   won: boolean | null
   isCurrentUser: boolean
-  ratingChange: RatingChange | null
-  ratingHistory: number[]
 }
 
 type H2HMeetingView = {
@@ -114,11 +99,7 @@ export type MatchView = {
   pendingSignerName: string | null
 }
 
-function projectSide(
-  side: MatchDetailsSide,
-  fallbackLabel: string,
-  form: MatchDetailsPlayerForm,
-): SideView {
+function projectSide(side: MatchDetailsSide, fallbackLabel: string): SideView {
   const player = side.players[0]
   const isGhost = side.players.length === 0
   const username = player?.username ?? fallbackLabel
@@ -131,8 +112,6 @@ function projectSide(
     gamesWon: side.games_won,
     won: side.won,
     isCurrentUser: side.is_current_user_side,
-    ratingChange: side.rating_change ?? null,
-    ratingHistory: form.rating_history ?? [],
   }
 }
 
@@ -152,14 +131,6 @@ function orderSides(sides: MatchDetailsSide[]): {
     leftSide: bySideNumber[0],
     rightSide: bySideNumber[1] ?? null,
   }
-}
-
-function formForUser(
-  data: MatchDetails,
-  userId: string | null,
-): MatchDetailsPlayerForm {
-  if (!userId) return EMPTY_FORM
-  return data.recent_form?.find((f) => f.user_id === userId) ?? EMPTY_FORM
 }
 
 function projectHeadToHead(
@@ -201,18 +172,8 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
   const viewerIsParticipant = leftSide.is_current_user_side
   const leftLabel = viewerIsParticipant ? 'You' : 'Side 1'
   const rightLabel = viewerIsParticipant ? 'Opponent' : 'Side 2'
-  const leftView = projectSide(
-    leftSide,
-    leftLabel,
-    formForUser(data, leftSide.players[0]?.user_id ?? null),
-  )
-  const rightView = rightSide
-    ? projectSide(
-        rightSide,
-        rightLabel,
-        formForUser(data, rightSide.players[0]?.user_id ?? null),
-      )
-    : null
+  const leftView = projectSide(leftSide, leftLabel)
+  const rightView = rightSide ? projectSide(rightSide, rightLabel) : null
   const scoreCta =
     data.can_score && data.current_game
       ? { matchId, gameNumber: data.current_game.game_number }
@@ -381,15 +342,6 @@ function MatchDetailsPage({
   // Comments + share modal are still part of the design handoff but have no
   // real data behind them yet; gate them off and flip when each lands.
   const showAuxCards = false
-  // Only an over-and-done match has a real rating change to show. A live match
-  // may carry seeded/projected ratings that look like a finished result — the
-  // snapshot panel already states the pre-match numbers, so a "result" card
-  // mid-match reads as a contradiction. Gate it to Final. (Flagged for design:
-  // a live "PROJECTED · IF … WINS" card could replace this later.)
-  const showRatingCard =
-    view.state === 'final' &&
-    (view.leftSide.ratingChange !== null ||
-      view.rightSide?.ratingChange != null)
 
   return (
     <div className="match-details">
@@ -435,7 +387,7 @@ function MatchDetailsPage({
           </div>
           <aside className="md-col-2__aside">
             <MatchInfo matchId={matchId} />
-            {showRatingCard && <RatingCard view={view} />}
+            <Ratings matchId={matchId} />
             {view.headToHead && (
               <H2HCard view={view} h2h={view.headToHead} />
             )}
@@ -508,94 +460,6 @@ function Breadcrumb({
       <span className="md-breadcrumb__current">Match {matchId.slice(0, 6)}</span>
     </div>
   )
-}
-
-function RatingCard({ view }: { view: MatchView }) {
-  const sides = [view.leftSide, view.rightSide].filter(
-    (s): s is SideView => s !== null,
-  )
-  return (
-    <div className="md-card">
-      <div className="md-card__hd">
-        <Overline as="h3">Result · rating change</Overline>
-      </div>
-      <div className="md-card__body md-rating-card__body">
-        {sides.map((side, i) => (
-          <RatingRow key={side.sideNumber} side={side} isFirst={i === 0} />
-        ))}
-      </div>
-    </div>
-  )
-}
-
-function RatingRow({ side, isFirst }: { side: SideView; isFirst: boolean }) {
-  const change = side.ratingChange
-  const won = side.won === true
-  return (
-    <>
-      {!isFirst && <hr className="md-rating-divider" />}
-      <div className="md-rating-row">
-        <div
-          className={cn(
-            'md-avatar',
-            won ? 'md-avatar--win' : 'md-avatar--loss',
-          )}
-        >
-          {side.initials}
-        </div>
-        <div className="md-rating-row__text">
-          <div className="md-rating-row__name">{side.username}</div>
-          {change ? (
-            <div className="md-rating-row__numbers">
-              {change.before !== null && (
-                <span className="from">{Math.round(change.before)}</span>
-              )}
-              <ChevronRight size={11} strokeWidth={1.75} />
-              <span className="to">{Math.round(change.after)}</span>
-            </div>
-          ) : (
-            <div className="md-rating-row__numbers">
-              <span className="from">Unrated player</span>
-            </div>
-          )}
-        </div>
-        {change && (
-          <div className="md-rating-row__delta">
-            <RatingRowSparkline
-              history={side.ratingHistory}
-              change={change}
-            />
-            <span
-              className={cn(
-                'md-rating-row__delta-num',
-                change.delta >= 0 ? 'md-delta-up' : 'md-delta-down',
-              )}
-            >
-              {formatRatingDelta(change.delta)}
-            </span>
-          </div>
-        )}
-      </div>
-    </>
-  )
-}
-
-function RatingRowSparkline({
-  history,
-  change,
-}: {
-  history: number[]
-  change: RatingChange
-}) {
-  // history is anchored "before this match"; append the post-match value so the
-  // line lands on the new rating.
-  const series = [...history]
-  if (series.length === 0 && change.before !== null) {
-    series.push(change.before)
-  }
-  series.push(change.after)
-  if (series.length < 2) return null
-  return <Sparkline data={series} w={80} h={28} downColor="var(--loss)" />
 }
 
 function H2HCard({ view, h2h }: { view: MatchView; h2h: H2HView }) {

--- a/web-client/src/components/matches/match-details/ratings.page.tsx
+++ b/web-client/src/components/matches/match-details/ratings.page.tsx
@@ -1,0 +1,80 @@
+import { ErrorBoundary } from "react-error-boundary";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import { server } from "@/mocks/server";
+import { render, screen, type Container } from "@/test/utilities";
+
+import { Ratings, type RatingsProps } from "./ratings";
+import { ratingsDisplayPage } from "./ratings/ratings-display.page";
+
+const DEFAULT_MATCH_ID = "m-1";
+
+const scoped = (container: Container) => ({
+  /** `Ratings`'s own `<Suspense>` fallback while the query is pending. */
+  queryLoading() {
+    return container.queryByText("Loading...");
+  },
+  /**
+   * The fallback rendered by the *ancestor* error boundary. `Ratings`
+   * owns no boundary of its own — a failed query is meant to propagate
+   * upward — so this models the boundary the match-details page supplies in
+   * production.
+   */
+  queryError() {
+    return container.queryByRole("alert");
+  },
+  /** The card the fetcher renders once data arrives — absent (with no error)
+   * when the match has no visible rating change. */
+  ...ratingsDisplayPage.within(container),
+});
+
+/**
+ * Test page-object for the public `Ratings` wrapper. `Ratings` adds only a
+ * `<Suspense>` boundary (with its real `Loading...` fallback) around
+ * `RatingsFetcher` and forwards `matchId` through — it deliberately has *no*
+ * error boundary, delegating failures upward. This renders it beneath an
+ * `ErrorBoundary` standing in for that ancestor so a rejected query can be
+ * observed reaching the boundary, and stubs the same
+ * `GET /v1/matches/:matchId` endpoint the query reads.
+ */
+export const ratingsPage = {
+  /**
+   * Stub `GET /v1/matches/:matchId` — `HttpResponse.json(buildMatchDetails())`
+   * for the happy path, a non-2xx to drive the ancestor boundary.
+   */
+  mockEndpoint(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  render(overrides: Partial<RatingsProps> = {}) {
+    const props: RatingsProps = {
+      matchId: DEFAULT_MATCH_ID,
+      ...overrides,
+    };
+
+    render(
+      <ErrorBoundary
+        fallbackRender={() => (
+          <div role="alert">Couldn’t load the rating change</div>
+        )}
+      >
+        <Ratings {...props} />
+      </ErrorBoundary>,
+    );
+  },
+
+  /**
+   * Scope the card accessors to a container — the whole `screen` (default)
+   * or a `within(node)` subtree. A page object that embeds a `Ratings`
+   * (e.g. the match-details page) calls this to expose the same queries as
+   * its own, rather than re-deriving them.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/ratings.test.tsx
+++ b/web-client/src/components/matches/match-details/ratings.test.tsx
@@ -1,0 +1,96 @@
+import { HttpResponse } from "msw";
+
+import {
+  buildMatchDetails,
+  buildMatchDetailsSide,
+} from "@/mocks/factories/matches/match-details.factory";
+import {
+  buildMatchDetailsData,
+  buildScoreboard,
+} from "@/mocks/factories/matches/scoreboard.factory";
+import { waitForElementToBeRemoved } from "@/test/utilities";
+
+import { ratingsPage } from "./ratings.page";
+
+/** A completed match whose viewer side moved +12 — enough to show the card. */
+const finalRatedMatch = () =>
+  buildMatchDetails({
+    status: "completed",
+    status_label: "Final",
+    sides: [
+      buildMatchDetailsSide({
+        games_won: 3,
+        won: true,
+        rating_change: { before: 1612, after: 1624, delta: 12 },
+      }),
+      buildMatchDetailsSide({
+        side_number: 2,
+        players: [],
+        games_won: 1,
+        won: false,
+        is_current_user_side: false,
+      }),
+    ],
+    data: buildMatchDetailsData({
+      scoreboard: buildScoreboard({ status: "final" }),
+    }),
+  });
+
+describe("Ratings", () => {
+  it("shows its own Loading fallback until the query resolves, then the card", async () => {
+    ratingsPage.mockEndpoint(() => HttpResponse.json(finalRatedMatch()));
+
+    ratingsPage.render();
+
+    // Pending: only Ratings's real Suspense fallback, no card yet.
+    expect(ratingsPage.queryLoading()).toBeInTheDocument();
+    expect(ratingsPage.queryError()).not.toBeInTheDocument();
+
+    await waitForElementToBeRemoved(ratingsPage.queryLoading());
+    expect(ratingsPage.getCard()).toBeInTheDocument();
+  });
+
+  it("forwards matchId to the underlying match-details query", async () => {
+    let requestedMatchId: string | undefined;
+    ratingsPage.mockEndpoint(({ params }) => {
+      requestedMatchId = params.matchId;
+      return HttpResponse.json(finalRatedMatch());
+    });
+
+    ratingsPage.render({ matchId: "m-42" });
+
+    await waitForElementToBeRemoved(ratingsPage.queryLoading());
+    expect(requestedMatchId).toBe("m-42");
+  });
+
+  it("displays the rows projected from the match details", async () => {
+    ratingsPage.mockEndpoint(() => HttpResponse.json(finalRatedMatch()));
+
+    ratingsPage.render();
+
+    await waitForElementToBeRemoved(ratingsPage.queryLoading());
+    // Wiring only: row content is pinned by the query and rating-row tests.
+    expect(ratingsPage.queryDelta("rita.kovac")).toHaveTextContent(/^\+12$/);
+  });
+
+  it("renders nothing for a match with no visible rating change", async () => {
+    // The page mounts <Ratings> unconditionally; the hide-the-card gate
+    // (not final / no movement) lives in the projection.
+    ratingsPage.mockEndpoint(() => HttpResponse.json(buildMatchDetails()));
+
+    ratingsPage.render();
+
+    await waitForElementToBeRemoved(ratingsPage.queryLoading());
+    expect(ratingsPage.queryCard()).not.toBeInTheDocument();
+    expect(ratingsPage.queryError()).not.toBeInTheDocument();
+  });
+
+  it("owns no error boundary — a failed query propagates to an ancestor boundary", async () => {
+    ratingsPage.mockEndpoint(() => new HttpResponse(null, { status: 500 }));
+
+    ratingsPage.render();
+
+    await waitForElementToBeRemoved(ratingsPage.queryLoading());
+    expect(ratingsPage.queryError()).toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/ratings.tsx
+++ b/web-client/src/components/matches/match-details/ratings.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import { RatingsFetcher } from './ratings/ratings-fetcher'
+
+export interface RatingsProps {
+    matchId: string;
+}
+
+export function Ratings({ matchId }: RatingsProps) {
+    return <Suspense fallback={<div>Loading...</div>}>
+        <RatingsFetcher matchId={matchId} />
+    </Suspense>
+}

--- a/web-client/src/components/matches/match-details/ratings/rating-row.factory.tsx
+++ b/web-client/src/components/matches/match-details/ratings/rating-row.factory.tsx
@@ -1,0 +1,36 @@
+import type { RatingRowProps } from "./rating-row";
+import type { RatingRowChangeView, RatingRowView } from "./ratings-query";
+
+/** A +12 move from 1612 to 1624 with a rising four-point trend line. */
+export function buildRatingRowChangeView(
+  overrides: Partial<RatingRowChangeView> = {},
+): RatingRowChangeView {
+  return {
+    from: 1612,
+    to: 1624,
+    deltaLabel: "+12",
+    deltaUp: true,
+    sparkline: [1580, 1601, 1612, 1624],
+    ...overrides,
+  };
+}
+
+/** The winning side's row: rita.kovac, up 12 points. */
+export function buildRatingRowView(
+  overrides: Partial<RatingRowView> = {},
+): RatingRowView {
+  return {
+    username: "rita.kovac",
+    initials: "RK",
+    won: true,
+    change: buildRatingRowChangeView(),
+    ...overrides,
+  };
+}
+
+/** Props for `RatingRow`. */
+export function buildRatingRowProps(
+  overrides: Partial<RatingRowProps> = {},
+): RatingRowProps {
+  return { row: buildRatingRowView(), ...overrides };
+}

--- a/web-client/src/components/matches/match-details/ratings/rating-row.page.tsx
+++ b/web-client/src/components/matches/match-details/ratings/rating-row.page.tsx
@@ -1,0 +1,72 @@
+import { render, screen, within, type Container } from "@/test/utilities";
+
+import { sparklinePage } from "../players-panel/sparkline.page";
+import { RatingRow, type RatingRowProps } from "./rating-row";
+import { buildRatingRowProps } from "./rating-row.factory";
+
+const scoped = (container: Container) => {
+  const getRow = (username: string) =>
+    container
+      .getByText(username, { selector: ".md-rating-row__name" })
+      .closest(".md-rating-row") as HTMLElement;
+
+  return {
+    /** The whole row for `username` — rows are told apart by player name,
+     * same as a reader scans them. */
+    getRow,
+    queryRow(username: string) {
+      return (
+        (container
+          .queryByText(username, { selector: ".md-rating-row__name" })
+          ?.closest(".md-rating-row") as HTMLElement | undefined) ?? null
+      );
+    },
+    /** That row's initials avatar — its class carries the win/loss tone. */
+    getAvatar(username: string) {
+      return getRow(username).querySelector(".md-avatar")!;
+    },
+    /** The before→after numbers line, or the "Unrated player" stand-in. */
+    getNumbers(username: string) {
+      return getRow(username).querySelector(".md-rating-row__numbers")!;
+    },
+    /** The pre-match number; absent when the player entered unrated (or for
+     * an unrated row, where the same class carries "Unrated player"). */
+    queryFrom(username: string) {
+      return getRow(username).querySelector(".from");
+    },
+    /** The post-match number; absent for an unrated row. */
+    queryTo(username: string) {
+      return getRow(username).querySelector(".to");
+    },
+    /** The signed delta figure; absent when the row has no rating change. */
+    queryDelta(username: string) {
+      return getRow(username).querySelector(".md-rating-row__delta-num");
+    },
+    /** The row's trend-sparkline queries, scoped to just that row. */
+    sparkline(username: string) {
+      return sparklinePage.within(within(getRow(username)) as Container);
+    },
+  };
+};
+
+/**
+ * Test page-object for `RatingRow` — one side's line in the rating-change
+ * card. Accessors take the row's username, since that's how the rows differ.
+ */
+export const ratingRowPage = {
+  render(overrides: Partial<RatingRowProps> = {}) {
+    const props = buildRatingRowProps(overrides);
+    render(<RatingRow {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed this component spread
+   * this to expose the same queries as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/ratings/rating-row.test.tsx
+++ b/web-client/src/components/matches/match-details/ratings/rating-row.test.tsx
@@ -1,0 +1,99 @@
+import {
+  buildRatingRowChangeView,
+  buildRatingRowView,
+} from "./rating-row.factory";
+import { ratingRowPage } from "./rating-row.page";
+
+describe("RatingRow", () => {
+  it("tones the avatar as a win for the winning side", () => {
+    ratingRowPage.render({
+      row: buildRatingRowView({ initials: "RK", won: true }),
+    });
+
+    const avatar = ratingRowPage.getAvatar("rita.kovac");
+    expect(avatar).toHaveTextContent("RK");
+    expect(avatar).toHaveClass("md-avatar--win");
+    expect(avatar).not.toHaveClass("md-avatar--loss");
+  });
+
+  it("tones the avatar as a loss for the losing side", () => {
+    ratingRowPage.render({ row: buildRatingRowView({ won: false }) });
+
+    expect(ratingRowPage.getAvatar("rita.kovac")).toHaveClass(
+      "md-avatar--loss",
+    );
+  });
+
+  it("shows the before and after numbers for a rated change", () => {
+    ratingRowPage.render();
+
+    expect(ratingRowPage.queryFrom("rita.kovac")).toHaveTextContent(/^1612$/);
+    expect(ratingRowPage.queryTo("rita.kovac")).toHaveTextContent(/^1624$/);
+  });
+
+  it("omits the before number when the player entered unrated", () => {
+    ratingRowPage.render({
+      row: buildRatingRowView({
+        change: buildRatingRowChangeView({ from: null, to: 1500 }),
+      }),
+    });
+
+    expect(ratingRowPage.queryFrom("rita.kovac")).toBeNull();
+    expect(ratingRowPage.queryTo("rita.kovac")).toHaveTextContent(/^1500$/);
+  });
+
+  it("tones a positive delta up and shows its label", () => {
+    ratingRowPage.render({
+      row: buildRatingRowView({
+        change: buildRatingRowChangeView({ deltaLabel: "+12", deltaUp: true }),
+      }),
+    });
+
+    const delta = ratingRowPage.queryDelta("rita.kovac");
+    expect(delta).toHaveTextContent(/^\+12$/);
+    expect(delta).toHaveClass("md-delta-up");
+    expect(delta).not.toHaveClass("md-delta-down");
+  });
+
+  it("tones a negative delta down", () => {
+    ratingRowPage.render({
+      row: buildRatingRowView({
+        change: buildRatingRowChangeView({ deltaLabel: "-8", deltaUp: false }),
+      }),
+    });
+
+    const delta = ratingRowPage.queryDelta("rita.kovac");
+    expect(delta).toHaveTextContent(/^-8$/);
+    expect(delta).toHaveClass("md-delta-down");
+  });
+
+  it("draws the trend sparkline when the view supplies a series", () => {
+    ratingRowPage.render();
+
+    expect(
+      ratingRowPage.sparkline("rita.kovac").querySparkline(),
+    ).toBeInTheDocument();
+  });
+
+  it("withholds the sparkline when the view has no series", () => {
+    ratingRowPage.render({
+      row: buildRatingRowView({
+        change: buildRatingRowChangeView({ sparkline: null }),
+      }),
+    });
+
+    expect(ratingRowPage.sparkline("rita.kovac").querySparkline()).toBeNull();
+    // The delta figure still shows; only the decorative line is withheld.
+    expect(ratingRowPage.queryDelta("rita.kovac")).toBeInTheDocument();
+  });
+
+  it("reads a row without a rating change as an unrated player with no delta", () => {
+    ratingRowPage.render({ row: buildRatingRowView({ change: null }) });
+
+    expect(ratingRowPage.getNumbers("rita.kovac")).toHaveTextContent(
+      /^Unrated player$/,
+    );
+    expect(ratingRowPage.queryDelta("rita.kovac")).toBeNull();
+    expect(ratingRowPage.sparkline("rita.kovac").querySparkline()).toBeNull();
+  });
+});

--- a/web-client/src/components/matches/match-details/ratings/rating-row.tsx
+++ b/web-client/src/components/matches/match-details/ratings/rating-row.tsx
@@ -1,0 +1,56 @@
+import { ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import { Sparkline } from "../players-panel/sparkline";
+import { type RatingRowView } from "./ratings-query";
+
+export interface RatingRowProps {
+  row: RatingRowView;
+}
+
+export const RatingRow = ({ row }: RatingRowProps) => (
+  <div className="md-rating-row">
+    <div
+      className={cn("md-avatar", row.won ? "md-avatar--win" : "md-avatar--loss")}
+    >
+      {row.initials}
+    </div>
+    <div className="md-rating-row__text">
+      <div className="md-rating-row__name">{row.username}</div>
+      {row.change ? (
+        <div className="md-rating-row__numbers">
+          {row.change.from !== null && (
+            <span className="from">{row.change.from}</span>
+          )}
+          <ChevronRight size={11} strokeWidth={1.75} />
+          <span className="to">{row.change.to}</span>
+        </div>
+      ) : (
+        <div className="md-rating-row__numbers">
+          <span className="from">Unrated player</span>
+        </div>
+      )}
+    </div>
+    {row.change && (
+      <div className="md-rating-row__delta">
+        {row.change.sparkline && (
+          <Sparkline
+            data={row.change.sparkline}
+            w={80}
+            h={28}
+            downColor="var(--loss)"
+          />
+        )}
+        <span
+          className={cn(
+            "md-rating-row__delta-num",
+            row.change.deltaUp ? "md-delta-up" : "md-delta-down",
+          )}
+        >
+          {row.change.deltaLabel}
+        </span>
+      </div>
+    )}
+  </div>
+);

--- a/web-client/src/components/matches/match-details/ratings/ratings-display.factory.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-display.factory.tsx
@@ -1,0 +1,37 @@
+import {
+  buildRatingRowChangeView,
+  buildRatingRowView,
+} from "./rating-row.factory";
+import type { RatingsDisplayProps } from "./ratings-display";
+import type { RatingsView } from "./ratings-query";
+
+/** A finished rated match: rita.kovac up 12, leo.mertens down 12. */
+export function buildRatingsView(
+  overrides: Partial<RatingsView> = {},
+): RatingsView {
+  return {
+    rows: [
+      buildRatingRowView(),
+      buildRatingRowView({
+        username: "leo.mertens",
+        initials: "LM",
+        won: false,
+        change: buildRatingRowChangeView({
+          from: 1540,
+          to: 1528,
+          deltaLabel: "-12",
+          deltaUp: false,
+          sparkline: [1551, 1546, 1540, 1528],
+        }),
+      }),
+    ],
+    ...overrides,
+  };
+}
+
+/** Props for `RatingsDisplay`. */
+export function buildRatingsDisplayProps(
+  overrides: Partial<RatingsDisplayProps> = {},
+): RatingsDisplayProps {
+  return { ratings: buildRatingsView(), ...overrides };
+}

--- a/web-client/src/components/matches/match-details/ratings/ratings-display.page.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-display.page.tsx
@@ -1,0 +1,57 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { ratingRowPage } from "./rating-row.page";
+import { RatingsDisplay, type RatingsDisplayProps } from "./ratings-display";
+import { buildRatingsDisplayProps } from "./ratings-display.factory";
+
+const scoped = (container: Container) => {
+  const getCard = () =>
+    container.getByRole("region", { name: "Result · rating change" });
+
+  return {
+    /** The card's `<section>` landmark, named by its visible heading. */
+    getCard,
+    queryCard() {
+      return container.queryByRole("region", {
+        name: "Result · rating change",
+      });
+    },
+    /** The visible card heading. */
+    getTitle() {
+      return container.getByRole("heading", {
+        level: 3,
+        name: "Result · rating change",
+      });
+    },
+    /** The hairline dividers between rows — one fewer than the row count. */
+    getDividers() {
+      return Array.from(getCard().querySelectorAll(".md-rating-divider"));
+    },
+    // Row lookups (`getRow(username)`, `queryDelta(username)`, …) come from
+    // the row's own page object.
+    ...ratingRowPage.within(container),
+  };
+};
+
+/**
+ * Test page-object for `RatingsDisplay` — the pure view-in, DOM-out
+ * rating-change card. Use the row accessors with a username to assert
+ * within one side's line.
+ */
+export const ratingsDisplayPage = {
+  render(overrides: Partial<RatingsDisplayProps> = {}) {
+    const props = buildRatingsDisplayProps(overrides);
+    render(<RatingsDisplay {...props} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. The fetcher and wrapper page objects spread this
+   * to expose the same queries as their own, rather than re-deriving.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/ratings/ratings-display.test.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-display.test.tsx
@@ -1,0 +1,36 @@
+import { buildRatingRowView } from "./rating-row.factory";
+import { buildRatingsView } from "./ratings-display.factory";
+import { ratingsDisplayPage } from "./ratings-display.page";
+
+describe("RatingsDisplay", () => {
+  it("renders the card as a region named by its heading", () => {
+    ratingsDisplayPage.render();
+
+    expect(ratingsDisplayPage.getCard()).toBeInTheDocument();
+    expect(ratingsDisplayPage.getTitle()).toHaveTextContent(
+      "Result · rating change",
+    );
+  });
+
+  it("renders one row per side in view order", () => {
+    ratingsDisplayPage.render();
+
+    // Wiring only: row content is pinned by the query and rating-row tests.
+    expect(ratingsDisplayPage.getRow("rita.kovac")).toBeInTheDocument();
+    expect(ratingsDisplayPage.getRow("leo.mertens")).toBeInTheDocument();
+  });
+
+  it("separates the rows with a single hairline divider", () => {
+    ratingsDisplayPage.render();
+
+    expect(ratingsDisplayPage.getDividers()).toHaveLength(1);
+  });
+
+  it("draws no divider for a single-row card", () => {
+    ratingsDisplayPage.render({
+      ratings: buildRatingsView({ rows: [buildRatingRowView()] }),
+    });
+
+    expect(ratingsDisplayPage.getDividers()).toHaveLength(0);
+  });
+});

--- a/web-client/src/components/matches/match-details/ratings/ratings-display.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-display.tsx
@@ -1,0 +1,32 @@
+import { Fragment, useId } from "react";
+
+import { Overline } from "@/components/overline";
+
+import { RatingRow } from "./rating-row";
+import { type RatingsView } from "./ratings-query";
+
+export interface RatingsDisplayProps {
+  ratings: RatingsView;
+}
+
+export const RatingsDisplay = ({ ratings }: RatingsDisplayProps) => {
+  const id = useId();
+
+  return (
+    <section className="md-card" aria-labelledby={id}>
+      <div className="md-card__hd">
+        <Overline as="h3" id={id}>
+          Result · rating change
+        </Overline>
+      </div>
+      <div className="md-card__body md-rating-card__body">
+        {ratings.rows.map((row, i) => (
+          <Fragment key={row.username}>
+            {i > 0 && <hr className="md-rating-divider" />}
+            <RatingRow row={row} />
+          </Fragment>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/web-client/src/components/matches/match-details/ratings/ratings-fetcher.page.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-fetcher.page.tsx
@@ -1,0 +1,67 @@
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import { server } from "@/mocks/server";
+import { render, screen, type Container } from "@/test/utilities";
+
+import { ratingsDisplayPage } from "./ratings-display.page";
+import { RatingsFetcher, type RatingsProps } from "./ratings-fetcher";
+
+const DEFAULT_MATCH_ID = "m-1";
+
+const scoped = (container: Container) => ({
+  /** The Suspense fallback shown while the match-details query is pending. */
+  queryLoading() {
+    return container.queryByTestId("ratings-loading");
+  },
+  /** The error-boundary fallback shown when the query rejects. */
+  queryError() {
+    return container.queryByRole("alert");
+  },
+  /** The card `RatingsDisplay` renders once data arrives — absent (with no
+   * error) when the projection is null and the fetcher renders nothing. */
+  ...ratingsDisplayPage.within(container),
+});
+
+/**
+ * Test page-object for `RatingsFetcher`. The fetcher reads via
+ * `useSuspenseQuery`, so this mirrors the real `Ratings` wrapper — a
+ * `<Suspense>` plus an `ErrorBoundary` — so tests can assert the
+ * fetch→`RatingsDisplay` handoff, the render-nothing branch for a null
+ * projection, and that a failed query reaches the boundary. Stubs the same
+ * `GET /v1/matches/:matchId` endpoint the query reads.
+ */
+export const ratingsFetcherPage = {
+  /**
+   * Stub `GET /v1/matches/:matchId` — `HttpResponse.json(buildMatchDetails())`
+   * for the happy path, a non-2xx to drive the error boundary.
+   */
+  mockEndpoint(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  render(overrides: Partial<RatingsProps> = {}) {
+    const props: RatingsProps = {
+      matchId: DEFAULT_MATCH_ID,
+      ...overrides,
+    };
+
+    render(
+      <ErrorBoundary
+        fallbackRender={() => (
+          <div role="alert">Couldn’t load the rating change</div>
+        )}
+      >
+        <Suspense fallback={<div data-testid="ratings-loading">Loading…</div>}>
+          <RatingsFetcher {...props} />
+        </Suspense>
+      </ErrorBoundary>,
+    );
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/ratings/ratings-fetcher.test.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-fetcher.test.tsx
@@ -1,0 +1,82 @@
+import { HttpResponse } from "msw";
+
+import {
+  buildMatchDetails,
+  buildMatchDetailsSide,
+} from "@/mocks/factories/matches/match-details.factory";
+import {
+  buildMatchDetailsData,
+  buildScoreboard,
+} from "@/mocks/factories/matches/scoreboard.factory";
+import { waitForElementToBeRemoved } from "@/test/utilities";
+
+import { ratingsFetcherPage } from "./ratings-fetcher.page";
+
+/** A completed match whose viewer side moved +12 — enough to show the card. */
+const finalRatedMatch = () =>
+  buildMatchDetails({
+    status: "completed",
+    status_label: "Final",
+    sides: [
+      buildMatchDetailsSide({
+        games_won: 3,
+        won: true,
+        rating_change: { before: 1612, after: 1624, delta: 12 },
+      }),
+      buildMatchDetailsSide({
+        side_number: 2,
+        players: [],
+        games_won: 1,
+        won: false,
+        is_current_user_side: false,
+      }),
+    ],
+    data: buildMatchDetailsData({
+      scoreboard: buildScoreboard({ status: "final" }),
+    }),
+  });
+
+describe("RatingsFetcher", () => {
+  it("suspends while the query is pending, then hands the view to the display", async () => {
+    ratingsFetcherPage.mockEndpoint(() =>
+      HttpResponse.json(finalRatedMatch()),
+    );
+
+    ratingsFetcherPage.render();
+
+    expect(ratingsFetcherPage.queryLoading()).toBeInTheDocument();
+    expect(ratingsFetcherPage.queryCard()).not.toBeInTheDocument();
+
+    await waitForElementToBeRemoved(ratingsFetcherPage.queryLoading());
+    expect(ratingsFetcherPage.getCard()).toBeInTheDocument();
+    // The default payload's winner delta, projected through the query.
+    expect(ratingsFetcherPage.queryDelta("rita.kovac")).toHaveTextContent(
+      /^\+12$/,
+    );
+  });
+
+  it("renders nothing — no card, no error — when the projection is null", async () => {
+    // The default match is scheduled with no rating movement.
+    ratingsFetcherPage.mockEndpoint(() =>
+      HttpResponse.json(buildMatchDetails()),
+    );
+
+    ratingsFetcherPage.render();
+
+    await waitForElementToBeRemoved(ratingsFetcherPage.queryLoading());
+    expect(ratingsFetcherPage.queryCard()).not.toBeInTheDocument();
+    expect(ratingsFetcherPage.queryError()).not.toBeInTheDocument();
+  });
+
+  it("lets a failed query reach the error boundary", async () => {
+    ratingsFetcherPage.mockEndpoint(
+      () => new HttpResponse(null, { status: 500 }),
+    );
+
+    ratingsFetcherPage.render();
+
+    await waitForElementToBeRemoved(ratingsFetcherPage.queryLoading());
+    expect(ratingsFetcherPage.queryError()).toBeInTheDocument();
+    expect(ratingsFetcherPage.queryCard()).not.toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/ratings/ratings-fetcher.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-fetcher.tsx
@@ -1,0 +1,17 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { RatingsDisplay } from "./ratings-display";
+import { ratingsQuery } from "./ratings-query";
+
+export interface RatingsProps {
+  matchId: string;
+}
+
+export function RatingsFetcher({ matchId }: RatingsProps) {
+  const { data: ratings } = useSuspenseQuery(ratingsQuery(matchId));
+
+  // A null projection means the card has nothing to say — the match isn't
+  // final yet, or no rating moved.
+  if (!ratings) return null;
+  return <RatingsDisplay ratings={ratings} />;
+}

--- a/web-client/src/components/matches/match-details/ratings/ratings-query.page.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-query.page.tsx
@@ -1,0 +1,44 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import { server } from "@/mocks/server";
+import { renderHook } from "@/test/utilities";
+
+import { ratingsQuery } from "./ratings-query";
+
+const DEFAULT_MATCH_ID = "m-1";
+
+/**
+ * Test page-object for `ratingsQuery`. The query is built on top of
+ * `matchDetailsQuery` and projects a `RatingsView | null` off the full
+ * match-details payload via `select` (null = card hidden), so the test stubs
+ * the same `GET /v1/matches/:matchId` endpoint and asserts on the projected
+ * view.
+ */
+export const ratingsQueryPage = {
+  /**
+   * Stub `GET /v1/matches/:matchId` with a full MSW resolver, so the test owns
+   * the response — `HttpResponse.json(buildMatchDetails())` for the happy
+   * path, a non-2xx for the error branch. It's the same endpoint
+   * `matchDetailsQuery` reads from; the ratings view is derived client-side.
+   */
+  mockEndpoint(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  /**
+   * Run the query under the shared retry-free test client. `throwOnError` is
+   * disabled here so failures land on `result.current.error` rather than
+   * bubbling to an error boundary — boundary behavior is covered by the
+   * fetcher tests. `result.current.data` is the projected `RatingsView` (or
+   * null when the card shouldn't render).
+   */
+  render(matchId: string = DEFAULT_MATCH_ID) {
+    return renderHook(() =>
+      useQuery({ ...ratingsQuery(matchId), throwOnError: false }),
+    );
+  },
+};

--- a/web-client/src/components/matches/match-details/ratings/ratings-query.test.ts
+++ b/web-client/src/components/matches/match-details/ratings/ratings-query.test.ts
@@ -1,0 +1,292 @@
+import { HttpResponse } from "msw";
+
+import {
+  buildMatchDetails,
+  buildMatchDetailsPlayer,
+  buildMatchDetailsPlayerForm,
+  buildMatchDetailsSide,
+  type MatchDetails,
+} from "@/mocks/factories/matches/match-details.factory";
+import {
+  buildMatchDetailsData,
+  buildScoreboard,
+} from "@/mocks/factories/matches/scoreboard.factory";
+import { waitFor } from "@/test/utilities";
+
+import { ratingsQuery } from "./ratings-query";
+import { ratingsQueryPage } from "./ratings-query.page";
+
+/** A completed, rated match the viewer won 3–1: +12 for rita.kovac (with a
+ * rating history), −12 for leo.mertens (no history beyond his before). */
+const finalRatedMatch = (overrides: Partial<MatchDetails> = {}): MatchDetails =>
+  buildMatchDetails({
+    status: "completed",
+    status_label: "Final",
+    sides: [
+      buildMatchDetailsSide({
+        games_won: 3,
+        won: true,
+        rating_change: { before: 1612, after: 1624.4, delta: 12.4 },
+      }),
+      buildMatchDetailsSide({
+        side_number: 2,
+        players: [
+          buildMatchDetailsPlayer({
+            user_id: "u-opponent",
+            username: "leo.mertens",
+            is_current_user: false,
+          }),
+        ],
+        games_won: 1,
+        won: false,
+        is_current_user_side: false,
+        rating_change: { before: 1540, after: 1527.6, delta: -12.4 },
+      }),
+    ],
+    recent_form: [
+      buildMatchDetailsPlayerForm({
+        user_id: "u-me",
+        rating_history: [1580, 1601, 1612],
+      }),
+      buildMatchDetailsPlayerForm({
+        user_id: "u-opponent",
+        rating_before: 1540,
+        rating_history: [],
+      }),
+    ],
+    data: buildMatchDetailsData({
+      scoreboard: buildScoreboard({ status: "final" }),
+    }),
+    ...overrides,
+  });
+
+const renderRatings = async (matchId?: string) => {
+  const { result } = ratingsQueryPage.render(matchId);
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  return result;
+};
+
+describe("ratingsQuery", () => {
+  it("shares the match-details query key so the page's BFF fetch is reused", () => {
+    expect(ratingsQuery("m-1").queryKey).toEqual([
+      { scope: "matches", version: "v1", entity: "details", matchId: "m-1" },
+    ]);
+  });
+
+  it("projects perspective-ordered rows with rounded numbers and a signed delta", async () => {
+    ratingsQueryPage.mockEndpoint(() => HttpResponse.json(finalRatedMatch()));
+
+    const result = await renderRatings();
+
+    expect(result.current.data).toEqual({
+      rows: [
+        {
+          username: "rita.kovac",
+          initials: "RK",
+          won: true,
+          change: {
+            from: 1612,
+            to: 1624,
+            deltaLabel: "+12",
+            deltaUp: true,
+            // History anchored before the match, post-match value appended.
+            sparkline: [1580, 1601, 1612, 1624.4],
+          },
+        },
+        {
+          username: "leo.mertens",
+          initials: "LM",
+          won: false,
+          change: {
+            from: 1540,
+            to: 1528,
+            deltaLabel: "-12",
+            deltaUp: false,
+            // No history — the line is anchored at the pre-match rating.
+            sparkline: [1540, 1527.6],
+          },
+        },
+      ],
+    });
+  });
+
+  it("is null until the match is final, even when seeded rating changes exist", async () => {
+    // A live match may carry projected ratings; a "result" card mid-match
+    // would contradict the pre-match snapshot panel.
+    ratingsQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        finalRatedMatch({
+          status: "in_progress",
+          status_label: "Live",
+          data: buildMatchDetailsData({
+            scoreboard: buildScoreboard({ status: "live" }),
+          }),
+        }),
+      ),
+    );
+
+    const result = await renderRatings();
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it("is null when a final match moved no ratings", async () => {
+    const match = finalRatedMatch();
+    ratingsQueryPage.mockEndpoint(() =>
+      HttpResponse.json({
+        ...match,
+        sides: match.sides.map((s) => ({ ...s, rating_change: null })),
+      }),
+    );
+
+    const result = await renderRatings();
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it("shows the card when only one side's rating moved, the other reading as unrated", async () => {
+    const match = finalRatedMatch();
+    ratingsQueryPage.mockEndpoint(() =>
+      HttpResponse.json({
+        ...match,
+        sides: match.sides.map((s) =>
+          s.side_number === 2 ? { ...s, rating_change: null } : s,
+        ),
+      }),
+    );
+
+    const result = await renderRatings();
+
+    expect(result.current.data?.rows[0].change).not.toBeNull();
+    expect(result.current.data?.rows[1]).toMatchObject({
+      username: "leo.mertens",
+      change: null,
+    });
+  });
+
+  it("withholds the sparkline for a first-rating player with no history", async () => {
+    // before: null and no history leaves only the post-match point — not
+    // enough to draw a line.
+    const match = finalRatedMatch();
+    ratingsQueryPage.mockEndpoint(() =>
+      HttpResponse.json({
+        ...match,
+        sides: match.sides.map((s) =>
+          s.side_number === 2
+            ? {
+                ...s,
+                rating_change: { before: null, after: 1500, delta: 0 },
+              }
+            : s,
+        ),
+      }),
+    );
+
+    const result = await renderRatings();
+
+    expect(result.current.data?.rows[1].change).toEqual({
+      from: null,
+      to: 1500,
+      deltaLabel: "0",
+      deltaUp: true,
+      sparkline: null,
+    });
+  });
+
+  it("orders side 1 first when the viewer is not a participant", async () => {
+    const match = finalRatedMatch();
+    ratingsQueryPage.mockEndpoint(() =>
+      HttpResponse.json({
+        ...match,
+        sides: [...match.sides]
+          .reverse()
+          .map((s) => ({ ...s, is_current_user_side: false })),
+      }),
+    );
+
+    const result = await renderRatings();
+
+    expect(result.current.data?.rows.map((r) => r.username)).toEqual([
+      "rita.kovac",
+      "leo.mertens",
+    ]);
+  });
+
+  it("labels a playerless side with its non-participant stand-in", async () => {
+    const match = finalRatedMatch();
+    ratingsQueryPage.mockEndpoint(() =>
+      HttpResponse.json({
+        ...match,
+        sides: match.sides.map((s) =>
+          s.side_number === 2
+            ? { ...s, players: [], rating_change: null }
+            : { ...s, is_current_user_side: false },
+        ),
+      }),
+    );
+
+    const result = await renderRatings();
+
+    expect(result.current.data?.rows[1]).toMatchObject({
+      username: "Side 2",
+      initials: "S2",
+    });
+  });
+
+  it("labels playerless sides Side 1 / Side 2 for a non-participant viewer", async () => {
+    const match = finalRatedMatch();
+    ratingsQueryPage.mockEndpoint(() =>
+      HttpResponse.json({
+        ...match,
+        sides: match.sides.map((s, i) => ({
+          ...s,
+          players: [],
+          is_current_user_side: false,
+          // Keep one change so the card still shows.
+          rating_change: i === 0 ? s.rating_change : null,
+        })),
+      }),
+    );
+
+    const result = await renderRatings();
+
+    expect(result.current.data?.rows.map((r) => r.username)).toEqual([
+      "Side 1",
+      "Side 2",
+    ]);
+  });
+
+  it("labels the viewer's own playerless side You", async () => {
+    const match = finalRatedMatch();
+    ratingsQueryPage.mockEndpoint(() =>
+      HttpResponse.json({
+        ...match,
+        sides: match.sides.map((s) =>
+          s.side_number === 1 ? { ...s, players: [] } : s,
+        ),
+      }),
+    );
+
+    const result = await renderRatings();
+
+    expect(result.current.data?.rows[0]).toMatchObject({ username: "You" });
+  });
+
+  it("labels a playerless side Opponent when the viewer participates", async () => {
+    const match = finalRatedMatch();
+    ratingsQueryPage.mockEndpoint(() =>
+      HttpResponse.json({
+        ...match,
+        sides: match.sides.map((s) =>
+          s.side_number === 2 ? { ...s, players: [], rating_change: null } : s,
+        ),
+      }),
+    );
+
+    const result = await renderRatings();
+
+    expect(result.current.data?.rows[1]).toMatchObject({
+      username: "Opponent",
+    });
+  });
+});

--- a/web-client/src/components/matches/match-details/ratings/ratings-query.ts
+++ b/web-client/src/components/matches/match-details/ratings/ratings-query.ts
@@ -1,0 +1,110 @@
+import { formatRatingDelta } from "@/lib/rating";
+import { initialsOf } from "@/lib/utils";
+
+import {
+  matchDetailsQuery,
+  type MatchDetailsResult,
+} from "../match-details-query";
+import { orderedSides, type MatchDetailsSide } from "../ordered-sides";
+
+/** The numbers half of a rated row — all values pre-formatted. */
+export type RatingRowChangeView = {
+  /** Rounded pre-match rating; null when the player entered unrated (the
+   * numbers line then leads straight with the arrow into `to`). */
+  from: number | null;
+  /** Rounded post-match rating. */
+  to: number;
+  /** Signed, rounded delta, e.g. "+12" / "-8". */
+  deltaLabel: string;
+  /** True for a non-negative delta — picks the delta figure's up/down tone. */
+  deltaUp: boolean;
+  /** Series for the trend sparkline: the pre-match rating history with the
+   * post-match value appended (anchored at `from` when there's no history).
+   * Null when that leaves fewer than two points to draw a line through. */
+  sparkline: number[] | null;
+};
+
+/** One side's row in the rating-change card. */
+export type RatingRowView = {
+  /** The side's player name, or a "You"/"Opponent"/"Side N" stand-in for a
+   * playerless side. */
+  username: string;
+  initials: string;
+  /** True only when this side won the match — picks the avatar tone. */
+  won: boolean;
+  /** The rating movement; null when this side's rating didn't move
+   * (renders as "Unrated player" with no delta block). */
+  change: RatingRowChangeView | null;
+};
+
+/** The "Result · rating change" sidebar card. Rows are perspective-ordered
+ * like the scoreboard: the viewer's side first when they're a participant,
+ * otherwise side 1 then side 2. */
+export type RatingsView = {
+  rows: RatingRowView[];
+};
+
+const selectChange = (
+  side: MatchDetailsSide,
+  history: number[],
+): RatingRowChangeView | null => {
+  const change = side.rating_change;
+  if (!change) return null;
+  // history is anchored "before this match"; append the post-match value so
+  // the line lands on the new rating.
+  const series = [...history];
+  if (series.length === 0 && change.before !== null) {
+    series.push(change.before);
+  }
+  series.push(change.after);
+  return {
+    from: change.before === null ? null : Math.round(change.before),
+    to: Math.round(change.after),
+    deltaLabel: formatRatingDelta(change.delta),
+    deltaUp: change.delta >= 0,
+    sparkline: series.length >= 2 ? series : null,
+  };
+};
+
+const selectRow = (
+  side: MatchDetailsSide,
+  fallbackLabel: string,
+  details: MatchDetailsResult["unmigrated"],
+): RatingRowView => {
+  const player = side.players[0];
+  const username = player?.username ?? fallbackLabel;
+  const history =
+    details.recent_form?.find((f) => f.user_id === player?.user_id)
+      ?.rating_history ?? [];
+  return {
+    username,
+    initials: initialsOf(username),
+    won: side.won === true,
+    change: selectChange(side, history),
+  };
+};
+
+const selectRatings = (match: MatchDetailsResult): RatingsView | null => {
+  // Only an over-and-done match has a real rating change to show. A live match
+  // may carry seeded/projected ratings that look like a finished result — the
+  // snapshot panel already states the pre-match numbers, so a "result" card
+  // mid-match reads as a contradiction. (Flagged for design: a live
+  // "PROJECTED · IF … WINS" card could replace this later.)
+  if (match.data.scoreboard.status !== "final") return null;
+  const details = match.unmigrated;
+  const [first, second] = orderedSides(details);
+  const sides = [first, second].filter((s): s is MatchDetailsSide => s !== null);
+  if (!sides.some((s) => s.rating_change != null)) return null;
+  const viewerIsParticipant = first?.is_current_user_side === true;
+  const fallbackLabels = viewerIsParticipant
+    ? ["You", "Opponent"]
+    : ["Side 1", "Side 2"];
+  return {
+    rows: sides.map((side, i) => selectRow(side, fallbackLabels[i], details)),
+  };
+};
+
+export const ratingsQuery = (matchId: string) => ({
+  ...matchDetailsQuery(matchId),
+  select: selectRatings,
+});


### PR DESCRIPTION
Continues the match-details strangler extraction (after #484 players snapshot, #488 match info card): pulls the **result · rating-change card** out of the page component into a self-contained quartet (component + page object + factory + test).

No intended behavior change.

## QA
Manually QA'd against a real-API docker preview (no MSW) on desktop (1440) and mobile (375):
- Rating-change card only renders on rated finals; absent on live / awaiting-confirmation / unrated / solo matches.
- Values verified across two consecutive matches (±162 at 1500/1500, then ±58 at 1662/1338 — uses real match-time snapshots).
- Full two-user post → confirm and post → dispute → re-post → confirm lifecycles.
- 353/353 vitest, lint clean (one pre-existing warning in generated mockServiceWorker.js), build clean.

QA findings (adjacent, not regressions from this PR) filed as #491 #492 #493 #494 #495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)