### PR TITLE
match-details: extract save-your-match into a self-fetching quartet

### DIFF
--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -17,7 +17,6 @@ import { Ratings } from './match-details/ratings'
 import { Scoreboard } from './match-details/scoreboard'
 import { AppShell } from '@/components/app-shell'
 import { Overline } from '@/components/overline'
-import { initialsOf } from '@/lib/utils'
 import {
   scoringNewRoute,
   useConfirmMatch,
@@ -39,28 +38,15 @@ type HeroState = 'live' | 'final' | 'upcoming'
 type SideView = {
   sideNumber: number
   username: string
-  userId: string | null
-  // A "no opponent" side: a real side row carrying no player. Rendered as the
-  // dashed-circle placeholder instead of an avatar/profile.
-  isGhost: boolean
-  initials: string
-  gamesWon: number
-  won: boolean | null
-  isCurrentUser: boolean
 }
 
 export type MatchView = {
-  state: HeroState
   statusLabel: string
   bestOf: number
   gamesToWin: number
   rated: boolean
-  // When the match was created — used to stamp the pre-match "snapshot" of
-  // player form/ratings with the moment those numbers were captured.
-  createdAt: string
   // Left/right are perspective-relative: when the current user is on a side
-  // they're left (and `leftSide.isCurrentUser` is true); otherwise left = side
-  // 1, right = side 2.
+  // they're left; otherwise left = side 1, right = side 2.
   leftSide: SideView
   rightSide: SideView | null
   scoreCta: { matchId: string; gameNumber: number } | null
@@ -83,17 +69,9 @@ export type MatchView = {
 
 function projectSide(side: MatchDetailsSide, fallbackLabel: string): SideView {
   const player = side.players[0]
-  const isGhost = side.players.length === 0
-  const username = player?.username ?? fallbackLabel
   return {
     sideNumber: side.side_number,
-    username,
-    userId: player?.user_id ?? null,
-    isGhost,
-    initials: initialsOf(username),
-    gamesWon: side.games_won,
-    won: side.won,
-    isCurrentUser: side.is_current_user_side,
+    username: player?.username ?? fallbackLabel,
   }
 }
 
@@ -182,12 +160,10 @@ function projectMatchView(data: MatchDetails, matchId: string): MatchView {
     : null
 
   return {
-    state,
     statusLabel: data.status_label,
     bestOf: data.best_of,
     gamesToWin: data.games_to_win,
     rated: data.affects_rating,
-    createdAt: data.created_at,
     leftSide: leftView,
     rightSide: rightView,
     scoreCta,
@@ -332,7 +308,7 @@ function MatchDetailsPage({
 
         <FinalizeCallout view={view} matchId={matchId} />
 
-        <SaveYourMatch key={matchId} view={view} matchId={matchId} />
+        <SaveYourMatch key={matchId} matchId={matchId} />
 
         <Scoreboard matchId={matchId} />
 

--- a/web-client/src/components/matches/match-details/save-your-match-query.page.tsx
+++ b/web-client/src/components/matches/match-details/save-your-match-query.page.tsx
@@ -1,0 +1,42 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import { server } from "@/mocks/server";
+import { renderHook } from "@/test/utilities";
+
+import { saveYourMatchQuery } from "./save-your-match-query";
+
+const DEFAULT_MATCH_ID = "m-1";
+
+/**
+ * Test page-object for `saveYourMatchQuery`. The query is built on top of
+ * `matchDetailsQuery` and projects a `SaveYourMatchView | null` off the full
+ * match-details payload via `select` (null = the guest prompt is hidden), so
+ * the test stubs the same `GET /v1/matches/:matchId` endpoint and asserts on
+ * the projected view.
+ */
+export const saveYourMatchQueryPage = {
+  /**
+   * Stub `GET /v1/matches/:matchId` with a full MSW resolver, so the test owns
+   * the response. It's the same endpoint `matchDetailsQuery` reads from; the
+   * save-your-match view is derived client-side.
+   */
+  mockEndpoint(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  /**
+   * Run the query under the shared retry-free test client. `throwOnError` is
+   * disabled so failures land on `result.current.error` rather than bubbling
+   * to an error boundary. `result.current.data` is the projected
+   * `SaveYourMatchView` (or null when the prompt shouldn't render).
+   */
+  render(matchId: string = DEFAULT_MATCH_ID) {
+    return renderHook(() =>
+      useQuery({ ...saveYourMatchQuery(matchId), throwOnError: false }),
+    );
+  },
+};

--- a/web-client/src/components/matches/match-details/save-your-match-query.test.ts
+++ b/web-client/src/components/matches/match-details/save-your-match-query.test.ts
@@ -1,0 +1,176 @@
+import { HttpResponse } from "msw";
+
+import {
+  buildMatchDetails,
+  buildMatchDetailsPlayer,
+  buildMatchDetailsSide,
+  type MatchDetails,
+} from "@/mocks/factories/matches/match-details.factory";
+import {
+  buildMatchDetailsData,
+  buildScoreboard,
+} from "@/mocks/factories/matches/scoreboard.factory";
+import { waitFor } from "@/test/utilities";
+
+import { saveYourMatchQuery } from "./save-your-match-query";
+import { saveYourMatchQueryPage } from "./save-your-match-query.page";
+
+/** A live match with the viewer (rita.kovac, side 1) up 3–1 on leo.mertens —
+ * the canonical "save this match" candidate. */
+const liveMatch = (overrides: Partial<MatchDetails> = {}): MatchDetails =>
+  buildMatchDetails({
+    status: "in_progress",
+    status_label: "Live",
+    sides: [
+      buildMatchDetailsSide({ games_won: 3, won: true }),
+      buildMatchDetailsSide({
+        side_number: 2,
+        players: [
+          buildMatchDetailsPlayer({
+            user_id: "u-opponent",
+            username: "leo.mertens",
+            is_current_user: false,
+          }),
+        ],
+        games_won: 1,
+        won: false,
+        is_current_user_side: false,
+      }),
+    ],
+    data: buildMatchDetailsData({
+      scoreboard: buildScoreboard({ status: "live" }),
+    }),
+    ...overrides,
+  });
+
+const renderView = async (matchId?: string) => {
+  const { result } = saveYourMatchQueryPage.render(matchId);
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  return result;
+};
+
+describe("saveYourMatchQuery", () => {
+  it("shares the match-details query key so the page's BFF fetch is reused", () => {
+    expect(saveYourMatchQuery("m-1").queryKey).toEqual([
+      { scope: "matches", version: "v1", entity: "details", matchId: "m-1" },
+    ]);
+  });
+
+  it("projects the viewer-first anchor with initials, scores, and createdAt", async () => {
+    saveYourMatchQueryPage.mockEndpoint(() =>
+      HttpResponse.json(liveMatch({ created_at: "2026-06-08T12:00:00Z" })),
+    );
+
+    const result = await renderView();
+
+    expect(result.current.data).toEqual({
+      leftWon: true,
+      leftInitials: "RK",
+      leftGamesWon: 3,
+      rightGamesWon: 1,
+      rightInitials: "LM",
+      rightUsername: "leo.mertens",
+      createdAt: "2026-06-08T12:00:00Z",
+      canConfirm: false,
+    });
+  });
+
+  it("puts the viewer's side first even when they're side 2", async () => {
+    saveYourMatchQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          status: "in_progress",
+          status_label: "Live",
+          sides: [
+            buildMatchDetailsSide({
+              players: [
+                buildMatchDetailsPlayer({
+                  user_id: "u-opponent",
+                  username: "leo.mertens",
+                  is_current_user: false,
+                }),
+              ],
+              games_won: 1,
+              won: false,
+              is_current_user_side: false,
+            }),
+            buildMatchDetailsSide({
+              side_number: 2,
+              games_won: 3,
+              won: true,
+              is_current_user_side: true,
+            }),
+          ],
+          data: buildMatchDetailsData({
+            scoreboard: buildScoreboard({ status: "live" }),
+          }),
+        }),
+      ),
+    );
+
+    const result = await renderView();
+
+    expect(result.current.data).toMatchObject({
+      leftInitials: "RK",
+      leftGamesWon: 3,
+      rightInitials: "LM",
+      rightGamesWon: 1,
+      rightUsername: "leo.mertens",
+    });
+  });
+
+  it("surfaces canConfirm so the card can soften under the confirmation callout", async () => {
+    saveYourMatchQueryPage.mockEndpoint(() =>
+      HttpResponse.json(liveMatch({ can_confirm: true })),
+    );
+
+    const result = await renderView();
+
+    expect(result.current.data?.canConfirm).toBe(true);
+  });
+
+  it("is null while the match is still scheduled — nothing to save yet", async () => {
+    // The default factory match is scheduled (scoreboard status "scheduled").
+    saveYourMatchQueryPage.mockEndpoint(() =>
+      HttpResponse.json(buildMatchDetails()),
+    );
+
+    const result = await renderView();
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it("is null for a spectator who isn't a participant", async () => {
+    const match = liveMatch();
+    saveYourMatchQueryPage.mockEndpoint(() =>
+      HttpResponse.json({
+        ...match,
+        sides: match.sides.map((s) => ({
+          ...s,
+          is_current_user_side: false,
+          players: s.players.map((p) => ({ ...p, is_current_user: false })),
+        })),
+      }),
+    );
+
+    const result = await renderView();
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it("is null when there's no real opponent (a player-less ghost side)", async () => {
+    const match = liveMatch();
+    saveYourMatchQueryPage.mockEndpoint(() =>
+      HttpResponse.json({
+        ...match,
+        sides: match.sides.map((s) =>
+          s.side_number === 2 ? { ...s, players: [] } : s,
+        ),
+      }),
+    );
+
+    const result = await renderView();
+
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/web-client/src/components/matches/match-details/save-your-match-query.ts
+++ b/web-client/src/components/matches/match-details/save-your-match-query.ts
@@ -1,0 +1,63 @@
+import { initialsOf } from "@/lib/utils";
+
+import {
+  matchDetailsQuery,
+  type MatchDetailsResult,
+} from "./match-details-query";
+import { orderedSides } from "./ordered-sides";
+
+/** The match anchor + body copy for the guest "save this match" nudge, shaped
+ * for the viewer's perspective (left side = the viewer). Null from the query
+ * means the prompt doesn't apply and nothing renders. */
+export type SaveYourMatchView = {
+  /** True only when the viewer's side won — picks the win/loss avatar tone.
+   * Null mid-match, before a result is decided. */
+  leftWon: boolean | null;
+  leftInitials: string;
+  leftGamesWon: number;
+  rightGamesWon: number;
+  rightInitials: string;
+  /** The opponent's name, used in the "your rivalry with X" body copy. */
+  rightUsername: string;
+  /** When the match was created — stamped onto the anchor. */
+  createdAt: string;
+  /** When the viewer can still confirm/dispute, soften the card so it doesn't
+   * compete with the confirmation callout above it. */
+  canConfirm: boolean;
+};
+
+const selectSaveYourMatch = (
+  match: MatchDetailsResult,
+): SaveYourMatchView | null => {
+  // Show as soon as the match is being played — we don't wait for the
+  // opponent's sign-off. The "save it before cookies clear" risk applies the
+  // moment the guest has invested real time, not just at the rated-finalized
+  // boundary (which can be hours later, after the guest has closed the tab).
+  if (match.data.scoreboard.status === "scheduled") return null;
+
+  const details = match.unmigrated;
+  const [left, right] = orderedSides(details);
+
+  // The viewer must be the participant on the left side, facing a real
+  // (non-ghost) opponent — the prompt is "save *your* rivalry with X".
+  if (!left?.is_current_user_side) return null;
+  if (!right || right.players.length === 0) return null;
+
+  const leftName = left.players[0]?.username ?? "You";
+  const rightName = right.players[0]?.username ?? "Opponent";
+  return {
+    leftWon: left.won,
+    leftInitials: initialsOf(leftName),
+    leftGamesWon: left.games_won,
+    rightGamesWon: right.games_won,
+    rightInitials: initialsOf(rightName),
+    rightUsername: rightName,
+    createdAt: details.created_at,
+    canConfirm: details.can_confirm,
+  };
+};
+
+export const saveYourMatchQuery = (matchId: string) => ({
+  ...matchDetailsQuery(matchId),
+  select: selectSaveYourMatch,
+});

--- a/web-client/src/components/matches/save-your-match.tsx
+++ b/web-client/src/components/matches/save-your-match.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { Suspense, useState } from 'react'
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { ChevronRight } from 'lucide-react'
 
@@ -6,7 +7,10 @@ import { deriveEmailStatus, useSession } from '@/api/session'
 import { fmtDate } from '@/lib/dates'
 import { cn } from '@/lib/utils'
 
-import type { MatchView } from './match-details-page'
+import {
+  saveYourMatchQuery,
+  type SaveYourMatchView,
+} from './match-details/save-your-match-query'
 
 // Per-match key. Dismissing on one finalized match doesn't quiet the prompt
 // on the next — a guest with multiple matches still gets the nudge once per
@@ -36,12 +40,8 @@ function writeDismissed(matchId: string, value: boolean) {
   }
 }
 
-function MatchAnchor({ view }: { view: MatchView }) {
-  // The outer gate guarantees a real opponent on the right side; we can
-  // dereference freely here.
-  const me = view.leftSide
-  const opp = view.rightSide!
-  const iWon = me.won === true
+function MatchAnchor({ view }: { view: SaveYourMatchView }) {
+  const iWon = view.leftWon === true
   return (
     <div className="md-save__anchor" aria-label="Match summary">
       <div
@@ -50,15 +50,15 @@ function MatchAnchor({ view }: { view: MatchView }) {
           iWon ? 'md-avatar--win' : 'md-avatar--loss',
         )}
       >
-        {me.initials}
+        {view.leftInitials}
       </div>
       <div className="md-save__blips">
         <span className={cn('md-save__blip', iWon && 'md-save__blip--win')}>
-          {me.gamesWon}
+          {view.leftGamesWon}
         </span>
         <span className="md-save__blip-dash">–</span>
         <span className={cn('md-save__blip', !iWon && 'md-save__blip--win')}>
-          {opp.gamesWon}
+          {view.rightGamesWon}
         </span>
       </div>
       <div
@@ -67,7 +67,7 @@ function MatchAnchor({ view }: { view: MatchView }) {
           iWon ? 'md-avatar--loss' : 'md-avatar--win',
         )}
       >
-        {opp.initials}
+        {view.rightInitials}
       </div>
       <span className="md-save__date">{fmtDate(view.createdAt).toUpperCase()}</span>
     </div>
@@ -97,24 +97,22 @@ function DismissedReceipt() {
   )
 }
 
-export function SaveYourMatch({
-  view,
-  matchId,
-}: {
-  view: MatchView
-  matchId: string
-}) {
-  // Cheap, props-only gates first so we never call useSession() (and thereby
-  // mint a guest user via GET /v1/session) on the standalone public-share
-  // route where the viewer is never the participant. The inner body owns the
-  // hook tree so the conditional return here doesn't change hook order.
-  // Show as soon as the match is being played — we don't wait for opponent
-  // sign-off. The "save it before cookies clear" risk applies the moment the
-  // guest has invested any real time, not just at the rated-finalized
-  // boundary (which can be hours later, after the guest has closed the tab).
-  if (view.state === 'upcoming') return null
-  if (!view.leftSide.isCurrentUser) return null
-  if (!view.rightSide || view.rightSide.isGhost) return null
+export function SaveYourMatch({ matchId }: { matchId: string }) {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <SaveYourMatchFetcher matchId={matchId} />
+    </Suspense>
+  )
+}
+
+function SaveYourMatchFetcher({ matchId }: { matchId: string }) {
+  const { data: view } = useSuspenseQuery(saveYourMatchQuery(matchId))
+  // A null projection means the prompt doesn't apply (match not yet started,
+  // the viewer isn't a participant, or there's no real opponent). We bail here,
+  // before SaveYourMatchActive, so we never call useSession() — and thereby
+  // mint a guest user via GET /v1/session — on the standalone public-share
+  // route where the viewer is never the participant.
+  if (!view) return null
   return <SaveYourMatchActive view={view} matchId={matchId} />
 }
 
@@ -122,7 +120,7 @@ function SaveYourMatchActive({
   view,
   matchId,
 }: {
-  view: MatchView
+  view: SaveYourMatchView
   matchId: string
 }) {
   const { data: session } = useSession()
@@ -173,7 +171,7 @@ function SaveYourMatchActive({
           Let&rsquo;s make sure this one sticks around.
         </h3>
         <p className="md-save__body">
-          Add an email and your rating and rivalry with {view.rightSide!.username}{' '}
+          Add an email and your rating and rivalry with {view.rightUsername}{' '}
           are saved across devices. Right now, clearing cookies erases this
           match.
         </p>


### PR DESCRIPTION
## What

Completes the strangler-quartet extraction of `SaveYourMatch`. The component took a `view: MatchView` prop computed by the page; it now takes only `matchId` and self-fetches a `SaveYourMatchView | null` via `saveYourMatchQuery` — a `select` over the shared `matchDetailsQuery` (same cache key as the other sidebar quartets) — wrapped in its own Suspense fetcher.

## Why

The page-level `projectMatchView` was the last thing feeding `SaveYourMatch`. Making it self-sufficient lets `MatchView`/`SideView` shrink to only the fields remaining consumers read, and brings the card in line with the `ratings`/`match-info` sidebar quartets.

## Changes

- **New** `match-details/save-your-match-query.ts` — selector returning `SaveYourMatchView | null`; null when the match is `scheduled`, the viewer isn't a participant, or there's no real opponent. Uses `orderedSides()` for perspective ordering.
- `save-your-match.tsx` — `SaveYourMatch({ matchId })` wraps a new `SaveYourMatchFetcher` (`useSuspenseQuery`) in `<Suspense>`; bails on a null view **before** `SaveYourMatchActive`, so `useSession()` is never reached on the public-share route where the viewer isn't a participant.
- `match-details-page.tsx` — drops the `view` prop; `MatchView` loses `state`/`createdAt`; `SideView` shrinks to `{ sideNumber, username }`.
- Tests: 7 selector unit tests (gates + perspective swap) + page object; existing `save-your-match.test.tsx` exercises the new fetcher end-to-end.

## Verification

- vitest 375/375, lint clean, build (tsc + vite) green, web-client e2e 127/127.
- Manual real-API QA (docker preview, MSW off): live card / perspective swap / dismiss→receipt / persisted dismissal / spectator / solo-ghost / mobile 375px — all correct, 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)