### PR TITLE
claude config: add qa-review/strangle commands, QA stack, reorganize CLAUDE.md

### DIFF
--- a/.claude/commands/qa-review.md
+++ b/.claude/commands/qa-review.md
@@ -1,0 +1,107 @@
+---
+description: Adversarially QA the current branch as "Quinn" — stand up the prod-like QA stack (real API, MSW off) and dispatch a subagent that drives it through the browser with playwright-cli, desktop + mobile, screenshotting every bug.
+---
+
+# QA review as Quinn (subagent, real QA stack)
+
+Run a black-box QA pass against a real running build of the current branch. You
+(the orchestrator) prepare the stack, then hand the whole testing job to a
+**subagent** that role-plays Quinn — it never sees this repo's source, only the
+running app through a browser. Keep Quinn's context isolated so its "trust
+nothing, I can't read the code" stance is real, not pretend.
+
+Why a subagent: Quinn must reason purely from observed UI behavior. If the same
+context that wrote the code also "tests" it, it leaks implementation knowledge
+and stops finding the bugs a real user hits. The subagent boundary enforces the
+UI-only rule.
+
+Why the QA stack and not MSW: mocks are circular — a branch that edited its own
+MSW handlers will "pass" against them while real backend behavior goes
+untested. QA runs against the real API through nginx, never the MSW dev server.
+
+## 1. Stand up the QA stack (you do this, not Quinn)
+
+The QA stack is `docker-compose.qa.yml` — prod-like (built artifacts, no dev
+server), `fortymm-qa` project, nginx published on **:8085**. `up --build`
+rebuilds the images from the current worktree, so it always tests *this* branch.
+
+```bash
+# .env is gitignored and lives in the main checkout; the worktree won't have it.
+[ -f .env ] || cp /Users/ryan/Development/fortymm/.env .env
+
+docker compose -f docker-compose.qa.yml up -d --build
+
+# Wait for the api entrypoint (migrate + seed) and smoke the real backend.
+# /api/v1/health is a real solver round-trip — needs the worker container up.
+until curl -sf -o /dev/null http://127.0.0.1:8085/api/v1/health; do sleep 2; done
+curl -s -o /dev/null -w "SPA: %{http_code}\n" http://127.0.0.1:8085/
+```
+
+If 8085 is taken (`lsof -i :8085`), the stack is already running — reuse it. If
+`up --build` recreates a subset of services later, also `restart nginx` or it
+serves stale upstream IPs and 502s.
+
+Create a screenshots dir and note its **absolute** path — you'll pass it to
+Quinn and read the bugs back out of it. Keep it out of git (it's local scratch):
+
+```bash
+mkdir -p "$(pwd)/.qa-review"
+grep -qxF '.qa-review/' .gitignore || echo '.qa-review/' >> .gitignore
+```
+
+## 2. Dispatch the Quinn subagent
+
+Use the Agent tool (general-purpose). Tell Quinn it has the `playwright-cli`
+skill available. Pass it the base URL, the absolute screenshots dir, and the
+flows to exercise (derive these from what the user asked to QA; if they didn't
+say, give Quinn the app's primary flows — sign-in, create a match, enter
+scores). Give Quinn the identity and rules verbatim below as its prompt.
+
+```
+You are Quinn, a veteran QA engineer with 12 years of experience breaking
+software. You've seen it all — apps that crash on empty input, forms that lose
+data, buttons that do nothing.
+
+PHILOSOPHY
+- Trust nothing. The developer says it works? Prove it.
+- Users are creative. They'll do things no one anticipated.
+- Edge cases are where bugs hide. The happy path is boring.
+
+NON-NEGOTIABLE RULES
+1. UI ONLY. You interact through the browser like a real user, using the
+   playwright-cli skill. You do NOT read source code, grep the repo, or inspect
+   network internals to explain behavior — you only observe what a user sees.
+2. SCREENSHOT BUGS. Every bug gets a screenshot saved to <SCREENSHOTS_DIR>
+   with a descriptive --filename (e.g. score-form-loses-data.png).
+3. CONTINUE AFTER BUGS. Finding a bug is not the end. Document it, then KEEP
+   TESTING. Do not stop at the first failure.
+4. MOBILE MATTERS. Test every flow at both desktop (1280x800) and mobile
+   (375x667). Switch with `playwright-cli resize 375 667`.
+
+TARGET: <BASE_URL>  (the real app — real API, no mocks)
+FLOWS TO BREAK: <FLOWS>
+
+Use two named browser sessions (`playwright-cli -s=poster ...`,
+`-s=opponent ...`) when a flow needs two distinct users (two cookie jars).
+Probe empty input, over-long input, duplicate submits, back-button mid-flow,
+reload mid-flow, and concurrent actions from both users.
+
+Return a structured report: for each bug — title, exact repro steps, what you
+expected, what happened, viewport, and the screenshot filename. Then a one-line
+verdict per flow (pass / bugs found). Your final message IS the report; the
+orchestrator relays it to the user.
+```
+
+## 3. Relay and tear down
+
+Relay Quinn's report to the user as the deliverable, listing each bug with its
+screenshot path under `.qa-review/`. Surface the screenshots with SendUserFile
+when there are bugs worth showing.
+
+Tear down unless the user wants the stack left up for their own poking:
+
+```bash
+docker compose -f docker-compose.qa.yml down -v   # -v wipes QA data
+```
+
+Confirm teardown (and whether you removed the copied `.env`) in your summary.

--- a/.claude/commands/strangle.md
+++ b/.claude/commands/strangle.md
@@ -1,0 +1,34 @@
+---
+description: Extract a section of a legacy page/component into colocated strangler quartets (component + page object + factory + test).
+argument-hint: <component or page section to extract>
+---
+
+Extract the target ($ARGUMENTS) from its legacy host into the standard quartet
+structure. This is the strangler pattern the repo has been applying to
+match-details and friends — follow the precedent of recent `extract … into
+strangler quartets` commits (`git log --oneline --grep="strangler"`).
+
+## Process
+
+1. **Sync first:** `git fetch origin` and plan against `origin/main`, not stale
+   local files — the strangler work moves fast and plans built on stale reads
+   get rewritten.
+2. Read the legacy host component and identify the seam: the markup + logic
+   that becomes the new component, and the props it needs from the host.
+3. Invoke the `react-component` skill — it defines the quartet layout
+   (`.tsx`, `.page.tsx`, `.factory.tsx`, `.test.tsx`), page-object
+   composition, view models, and MSW mocking. Canonical exemplars live in
+   `web-client/src/components/matches/match-details/scoreboard/`.
+4. Replace the extracted markup in the host with the new component; the host's
+   page object should compose the new component's page object rather than
+   re-querying the DOM.
+5. Keep each extraction a small, reviewable step. If the user asked for
+   several sections, do them as separate commits.
+
+## Verification
+
+Per standing feedback: when slicing a refactor into steps, **defer
+verification to the end of the branch** — don't run the full suite after each
+staged extraction. Run the new/changed component tests as you go
+(`npm run test -- <file>`), and leave whole-branch verification to
+`/land-the-plane`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,27 +47,20 @@ E2E_BASE_URL=http://localhost:8080 npm run test     # against compose stack
 
 Full stack via Docker: `docker compose -f docker-compose.dev.yml up`. Nginx on **:8080** proxies `/api/*` → api, `/` → web-client. Use this URL when you want the web app to talk to the real API instead of MSW.
 
-## Architecture notes that span files
+Prod-like stacks (built artifacts, no dev server, isolated volumes; only nginx published):
+- `docker compose -f docker-compose.uat.yml up -d --build` — `fortymm-uat`, nginx on **:8084**, fronted by host Caddy at uat.fortymm.com.
+- `docker compose -f docker-compose.qa.yml up -d --build` — `fortymm-qa`, nginx on **:8085**, local-only at http://127.0.0.1:8085. Same shape as UAT, separate project/port/volumes so the two run side by side. `down -v` to wipe its data.
 
-**OpenAPI is the source of truth for client/server types.** The API generates `openapi.json` at runtime; `web-client/src/api/schema.d.ts` is generated from it via `npm run gen:api` (openapi-typescript) and consumed by `openapi-fetch` in `web-client/src/api/client.ts`. The `openapi-schema` CI workflow boots the API, regenerates the schema, and fails if the committed file drifts. Regenerate locally with `mise run regen-api-types` — it starts the API if it isn't already running. Whenever you change FastAPI routes or pydantic schemas, regenerate and commit `schema.d.ts` in the same PR.
+Workflow commands: `/land-the-plane` (ship the branch), `/qa-review` (adversarial "Quinn" QA pass in a subagent against the QA stack), `/strangle` (quartet extraction).
 
-**Solver health is a real round-trip.** `GET /v1/health` enqueues a job on the `solver` RQ queue and waits up to 10s for a worker to solve a tiny CP-SAT problem (`app/solver.py:solve_hello_world`). With no worker running, health fails. Tests sidestep this by replacing the queue with `fakeredis` + synchronous RQ in `tests/conftest.py` (`fake_solver_queue` autouse fixture).
+## Cross-cutting invariants
 
-**Ephemeral, cookie-based sessions.** `GET /v1/session` creates a `User` + `UserToken` (sha256-hashed) on first hit and sets an HTTP-only `session` cookie; subsequent hits resolve the user from that cookie. Tokens are namespaced by `context` so a single user table can back multiple credential types later. `SESSION_COOKIE_SECURE` defaults true; set to `false` for local non-HTTPS dev (compose already does this).
+**OpenAPI is the source of truth for client/server types.** `web-client/src/api/schema.d.ts` is generated from the API's `openapi.json` (`npm run gen:api`, consumed by `openapi-fetch` in `web-client/src/api/client.ts`). The `openapi-schema` CI workflow fails if the committed file drifts. Whenever you change FastAPI routes or pydantic schemas (docstrings count — they become OpenAPI descriptions), run `mise run regen-api-types` and commit `schema.d.ts` in the same PR.
 
-**Alembic discovers models via `app.models` import.** `api/migrations/env.py` and `tests/conftest.py` both import `app.models` for the side effect of registering on `Base.metadata`. New model files must be re-exported from `app/models/__init__.py` or autogenerate will miss them.
+**BFF endpoints — one per page.** Each page-level UI surface has a single backend endpoint that returns all the data it needs, pre-shaped for that page; joining, aggregation, and status-label mapping happen on the server, current-user-aware. Exception: independently-interactive widgets (typeaheads, infinite-scroll panels) keep their own endpoints. Rule of thumb: if the widget fetches in response to user input rather than on page load, it's its own endpoint.
 
-**Routing is file-based and generated.** `web-client/src/routes/*.tsx` files are compiled into `routeTree.gen.ts` by the `@tanstack/router-plugin/vite` plugin. Don't edit `routeTree.gen.ts` by hand.
-
-**BFF endpoints — one per page.** Each page-level UI surface has a single backend endpoint that returns all the data it needs, pre-shaped for that page. The frontend does no joining, aggregation, or status-label mapping — those happen on the server, current-user-aware. Examples: `GET /v1/matches` backs `/matches`; `GET /v1/matches/{id}` backs both `/matches/$matchId` and the scoring routes; `GET /v1/dashboard` backs the dynamic widgets on `/dashboard`. Exception: independently-interactive widgets (typeaheads, autocompletes, infinite-scroll panels) keep their own endpoints — e.g. `GET /v1/players/search` backs the new-match opponent picker. Rule of thumb: if the widget fetches in response to user input rather than on page load, it's its own endpoint.
-
-**MSW only intercepts in `import.meta.env.DEV`.** See `web-client/src/main.tsx`. The vitest setup (`src/test/setup.ts`) uses the Node MSW server with `onUnhandledRequest: 'error'` — every fetch in a test must have a matching handler in `src/mocks/handlers.ts` (or one added via `server.use(...)`). Production builds never load MSW.
-
-**`VITE_API_URL`** (web-client) overrides the API base URL; otherwise the client uses `window.location.origin`. In dev that means MSW handles everything; in the compose stack the web origin (`:8080`) is also where nginx proxies the API.
+Layer-specific architecture and conventions live in `api/CLAUDE.md` and `web-client/CLAUDE.md` (loaded automatically when working in those directories).
 
 ## Conventions
 
-- Web-client path alias: `@/*` → `src/*` (see `vite.config.ts`, `components.json`).
-- shadcn components go under `src/components/ui` (configured in `components.json`).
-- API tests use async pytest (`asyncio_mode = "auto"`, session-scoped loop) and the `db_session` fixture, which truncates all tables after each test.
 - Docker is required for the default API test run (testcontainers). Set `TEST_DATABASE_URL` to opt out.

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -19,6 +19,29 @@ change, run from `api/`:
 3. `mypy` — strict type check; settings live in `pyproject.toml`
 4. `pytest` — tests (needs Docker for testcontainers)
 
+## Architecture
+
+**Solver health is a real round-trip.** `GET /v1/health` enqueues a job on the
+`solver` RQ queue and waits up to 10s for a worker to solve a tiny CP-SAT
+problem (`app/solver.py:solve_hello_world`). With no worker running, health
+fails. Tests sidestep this by replacing the queue with `fakeredis` +
+synchronous RQ in `tests/conftest.py` (`fake_solver_queue` autouse fixture).
+
+**Ephemeral, cookie-based sessions.** `GET /v1/session` creates a `User` +
+`UserToken` (sha256-hashed) on first hit and sets an HTTP-only `session`
+cookie; subsequent hits resolve the user from that cookie. Tokens are
+namespaced by `context` so a single user table can back multiple credential
+types later. `SESSION_COOKIE_SECURE` defaults true; set to `false` for local
+non-HTTPS dev (compose already does this).
+
+**Alembic discovers models via `app.models` import.** `migrations/env.py` and
+`tests/conftest.py` both import `app.models` for the side effect of
+registering on `Base.metadata`. New model files must be re-exported from
+`app/models/__init__.py` or autogenerate will miss them.
+
+**Tests** use async pytest (`asyncio_mode = "auto"`, session-scoped loop) and
+the `db_session` fixture, which truncates all tables after each test.
+
 ## Datetimes are timezone-aware, always
 
 - **Migrations:** every `sa.Column(..., sa.DateTime(...), ...)` must use

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -1,0 +1,103 @@
+# QA stack — built artifacts, no dev server, isolated volumes.
+#
+# A prod-like stack (same shape as docker-compose.uat.yml) that runs
+# alongside the dev and UAT stacks. Project name `fortymm-qa` keeps
+# networks, containers, and volumes namespaced; `nginx` is the only
+# service with a host port (8085 — UAT holds 8084). Everything else is
+# reachable only on the internal docker network; use `docker exec` for
+# ad-hoc psql/redis-cli access.
+#
+# Bring up:    docker compose -f docker-compose.qa.yml up -d --build
+# Bring down:  docker compose -f docker-compose.qa.yml down
+# Wipe data:   docker compose -f docker-compose.qa.yml down -v
+#
+# Unlike UAT (fronted by host Caddy at uat.fortymm.com), QA is local-only:
+# hit it directly at http://127.0.0.1:8085.
+
+name: fortymm-qa
+
+# api and worker run the same image and load the same secrets; only their
+# environment/command/depends_on differ.
+x-api-service: &api-service
+  build:
+    context: ./api
+    dockerfile: Dockerfile.dev
+  env_file:
+    - .env
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: fortymm
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d fortymm"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  api:
+    <<: *api-service
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm
+      REDIS_URL: redis://redis:6379/0
+      SESSION_COOKIE_SECURE: "false"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    # Same image as dev but no --reload and no source volume mount —
+    # the image's COPY'd /app is what runs. Both seed scripts are
+    # idempotent (seed_rbac.py: additive; seed_leagues.py: upserts the
+    # default league), so chaining them after migrations is safe on
+    # every boot.
+    command: >
+      sh -c "alembic upgrade head &&
+             python scripts/seed_rbac.py &&
+             python scripts/seed_leagues.py &&
+             uvicorn app.main:app --host 0.0.0.0 --port 8000"
+
+  worker:
+    <<: *api-service
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      redis:
+        condition: service_healthy
+    command: rq worker --url redis://redis:6379/0 solver email ratings
+
+  web-client:
+    build:
+      context: ./web-client
+      dockerfile: Dockerfile.uat
+    depends_on:
+      - api
+
+  nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "8085:80"
+    # uat.conf only references internal service names (api:8000,
+    # web-client:80), so it is host-port-agnostic and shared as-is.
+    volumes:
+      - ./nginx/uat.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - api
+      - web-client
+
+volumes:
+  postgres-data:

--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -1,5 +1,28 @@
 # web-client
 
+## Architecture
+
+**Routing is file-based and generated.** `src/routes/*.tsx` files are compiled
+into `routeTree.gen.ts` by the `@tanstack/router-plugin/vite` plugin. Don't
+edit `routeTree.gen.ts` by hand.
+
+**MSW only intercepts in `import.meta.env.DEV`.** See `src/main.tsx` (and the
+`VITE_ENABLE_MSW=false` escape hatch for hitting a real API). The vitest setup
+(`src/test/setup.ts`) uses the Node MSW server with
+`onUnhandledRequest: 'error'` — every fetch in a test must have a matching
+handler in `src/mocks/handlers.ts` (or one added via `server.use(...)`).
+Production builds never load MSW.
+
+**`VITE_API_URL`** overrides the API base URL; otherwise the client uses
+`window.location.origin`. In dev that means MSW handles everything; in the
+compose stack the web origin is also where nginx proxies the API.
+
+## Conventions
+
+- Path alias: `@/*` → `src/*` (see `vite.config.ts`, `components.json`).
+- shadcn components go under `src/components/ui` (configured in
+  `components.json`).
+
 ## Design system
 
 Prefer the shared design-system components in `src/components/ui` (showcased on


### PR DESCRIPTION
Splits layer-specific architecture notes out of the root `CLAUDE.md` into `api/` and `web-client/` `CLAUDE.md`, distills the cross-cutting invariants, and documents the prod-like QA docker stack (`docker-compose.qa.yml`) alongside the new `/qa-review` and `/strangle` workflow commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)