### PR TITLE
score-entry: fix finalize copy for unrated matches

### DIFF
--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -356,7 +356,9 @@ function ScoreEntryInner({
     ? `Edit game ${gameNumber} score.`
     : `Enter game ${gameNumber} score.`
   const subtitle = wouldFinalize
-    ? 'This score finishes the match — submitting posts the result for your opponent to confirm.'
+    ? data.affects_rating
+      ? 'This score finishes the match — submitting posts the result for your opponent to confirm.'
+      : 'This score finishes the match — submitting will finalize the result immediately.'
     : isEdit
       ? 'Save updates the score for this game.'
       : gameNumber < bestOf
@@ -364,8 +366,8 @@ function ScoreEntryInner({
         : 'Final game. Save to post the result.'
   const submitLabel = wouldFinalize
     ? finalizeMutation.isPending
-      ? 'Posting result…'
-      : 'Post result'
+      ? data.affects_rating ? 'Posting result…' : 'Finalizing…'
+      : data.affects_rating ? 'Post result' : 'Finalize result'
     : isEdit
       ? 'Save changes →'
       : gameNumber < bestOf


### PR DESCRIPTION
## Summary

- Unrated matches finalize immediately without requiring the opponent to confirm, but the subtitle and submit button incorrectly said "posting the result for your opponent to confirm" / "Post result" for all matches
- Subtitle now reads "submitting will finalize the result immediately" for unrated matches
- Button label now reads "Finalize result" / "Finalizing…" for unrated matches, consistent with the subtitle

## Test plan

- [ ] Verify rated match still shows "submitting posts the result for your opponent to confirm" and "Post result"
- [ ] Verify unrated match shows "submitting will finalize the result immediately" and "Finalize result"
- All 444 vitest + 127 e2e + 378 API tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)