### PR TITLE
match-details: extract Score CTA into a self-fetching strangler quartet

### DIFF
--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -112,47 +112,12 @@ describe("MatchDetailsView", () => {
     expect(rightScore).not.toHaveClass("md-hero__score--win");
   });
 
-  it("shows a Score CTA only when can_score is true and links to current_game", async () => {
-    const game1 = { id: "g-1", game_number: 1, score: null };
-    const match = matchDetails({
-      id: "m-2",
-      status: "pending",
-      status_label: "Scheduled",
-      games: [game1],
-      current_game: { game_number: 1 },
-      can_score: true,
-    });
-    server.use(http.get("*/v1/matches/m-2", () => HttpResponse.json(match)));
-
-    renderDetails("m-2");
-
-    const scoreLink = await screen.findByRole("link", { name: "Score" });
-    expect(scoreLink).toHaveAttribute(
-      "href",
-      "/matches/m-2/games/1/scores/new",
-    );
-  });
-
-  it("hides the Score CTA when can_score is false", async () => {
-    const match = matchDetails({
-      id: "m-3",
-      status: "completed",
-      can_score: false,
-      current_game: null,
-      games: [],
-    });
-    server.use(http.get("*/v1/matches/m-3", () => HttpResponse.json(match)));
-
-    const { container } = renderDetails("m-3");
-
-    // Wait for the players card to render (one of its name nodes).
-    await waitFor(() =>
-      expect(container.querySelector(".md-profile__name")).toBeInTheDocument(),
-    );
-    expect(
-      screen.queryByRole("link", { name: "Score" }),
-    ).not.toBeInTheDocument();
-  });
+  // The header "Score" CTA moved to the self-fetching `ScoreCta` quartet — see
+  // score-cta-query.test.ts (the can_score / current_game projection),
+  // score-cta-display.test.tsx (the link target), and score-cta-fetcher.test.tsx
+  // (the fetch → display handoff and null-projection bail). The no-opponent and
+  // spectator cases below still assert the CTA's presence/absence as incidental
+  // page-level wiring.
 
   it("links each scored game cell on my row to its scores/edit route", async () => {
     const match = matchDetails({

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -7,28 +7,11 @@ import { MatchInfo } from './match-details/match-info'
 import { PlayersPanel } from './match-details/players-panel'
 import { Ratings } from './match-details/ratings'
 import { Scoreboard } from './match-details/scoreboard'
+import { ScoreCta } from './match-details/score-cta'
 import { AppShell } from '@/components/app-shell'
-import { scoringNewRoute, useMatch } from '@/api/matches'
-import type { components } from '@/api/schema'
 import { ApiError } from '@/api/client'
 
 import { SaveYourMatch } from './save-your-match'
-
-type MatchDetails = components['schemas']['app__schemas__match__MatchDetails']
-
-// What's left of the legacy page-level projection now that every section is a
-// self-fetching quartet: just the header's "Score" CTA target.
-export type MatchView = {
-  scoreCta: { matchId: string; gameNumber: number } | null
-}
-
-function projectMatchView(data: MatchDetails, matchId: string): MatchView {
-  const scoreCta =
-    data.can_score && data.current_game
-      ? { matchId, gameNumber: data.current_game.game_number }
-      : null
-  return { scoreCta }
-}
 
 export function MatchDetailsView({
   matchId,
@@ -41,18 +24,9 @@ export function MatchDetailsView({
    * viewer. */
   standalone?: boolean
 }) {
-  const { data, isLoading } = useMatch(matchId)
-
-  const body =
-    isLoading || !data ? (
-      <MatchDetailsSkeleton />
-    ) : (
-      <MatchDetailsPage
-        view={projectMatchView(data, matchId)}
-        matchId={matchId}
-        standalone={standalone}
-      />
-    )
+  // Every section below is a self-fetching quartet, so the page renders
+  // immediately and each piece suspends independently — no page-level fetch.
+  const body = <MatchDetailsPage matchId={matchId} standalone={standalone} />
   return standalone ? body : <AppShell>{body}</AppShell>
 }
 
@@ -106,23 +80,10 @@ export function MatchDetailsError({
   return standalone ? body : <AppShell>{body}</AppShell>
 }
 
-function MatchDetailsSkeleton() {
-  return (
-    <div className="match-details" aria-busy="true">
-      <main className="md-page md-page--y">
-        <section className="md-hero md-hero--skeleton" />
-        <div className="md-card md-card--skeleton" />
-      </main>
-    </div>
-  )
-}
-
 function MatchDetailsPage({
-  view,
   matchId,
   standalone,
 }: {
-  view: MatchView
   matchId: string
   standalone: boolean
 }) {
@@ -132,17 +93,7 @@ function MatchDetailsPage({
         <div className="md-header">
           <Breadcrumb matchId={matchId} standalone={standalone} />
           <div className="md-header__right">
-            {view.scoreCta && (
-              <Link
-                {...scoringNewRoute(
-                  view.scoreCta.matchId,
-                  view.scoreCta.gameNumber,
-                )}
-                className="md-btn md-btn--primary md-btn--sm"
-              >
-                Score
-              </Link>
-            )}
+            <ScoreCta matchId={matchId} />
           </div>
         </div>
 

--- a/web-client/src/components/matches/match-details/score-cta.tsx
+++ b/web-client/src/components/matches/match-details/score-cta.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from "react";
+
+import { ScoreCtaFetcher } from "./score-cta/score-cta-fetcher";
+
+export interface ScoreCtaProps {
+  matchId: string;
+}
+
+/** The header's "Score" CTA: deep-links the viewer into score entry for the
+ * match's current game. Self-fetching; renders nothing when there's nothing
+ * to score (spectator, or no open game). */
+export function ScoreCta({ matchId }: ScoreCtaProps) {
+  return (
+    <Suspense fallback={null}>
+      <ScoreCtaFetcher matchId={matchId} />
+    </Suspense>
+  );
+}

--- a/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher.page.tsx
+++ b/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher.page.tsx
@@ -1,0 +1,105 @@
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import { server } from "@/mocks/server";
+import { render, screen, type Container } from "@/test/utilities";
+
+import { scoreCtaDisplayPage } from "./score-cta-fetcher/score-cta-display.page";
+import { ScoreCtaFetcher, type ScoreCtaProps } from "./score-cta-fetcher";
+
+const DEFAULT_MATCH_ID = "m-1";
+
+const scoped = (container: Container) => ({
+  /** The Suspense fallback shown while the match-details query is pending. */
+  queryLoading() {
+    return container.queryByTestId("score-cta-loading");
+  },
+  /** The error-boundary fallback shown when the query rejects. */
+  queryError() {
+    return container.queryByRole("alert");
+  },
+  /** The "Score" link the display renders once a scorable view arrives. */
+  ...scoreCtaDisplayPage.within(container),
+  /** Absence-friendly variant of the display's link query. */
+  queryScoreLink() {
+    return container.queryByRole("link", { name: "Score" });
+  },
+});
+
+/**
+ * Test page-object for `ScoreCtaFetcher`. The fetcher reads via
+ * `useSuspenseQuery` and the display renders a typed `<Link>`, so this mirrors
+ * the real `ScoreCta` wrapper — a `<Suspense>` plus an `ErrorBoundary` — and
+ * mounts it under a minimal router that registers the score-entry route the
+ * link targets. Tests can assert the fetch → display handoff, the
+ * null-projection bail, and that a failed query reaches the boundary. Stubs
+ * the same `GET /v1/matches/:matchId` endpoint the query reads.
+ */
+export const scoreCtaFetcherPage = {
+  /**
+   * Stub `GET /v1/matches/:matchId` — `HttpResponse.json(buildMatchDetails())`
+   * for the happy path, a non-2xx to drive the error boundary.
+   */
+  mockEndpoint(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  render(overrides: Partial<ScoreCtaProps> = {}) {
+    const props: ScoreCtaProps = {
+      matchId: DEFAULT_MATCH_ID,
+      ...overrides,
+    };
+
+    const rootRoute = createRootRoute();
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/",
+      component: () => (
+        <ErrorBoundary
+          fallbackRender={() => (
+            <div role="alert">Couldn’t load the score CTA</div>
+          )}
+        >
+          <Suspense
+            fallback={<div data-testid="score-cta-loading">Loading…</div>}
+          >
+            <ScoreCtaFetcher {...props} />
+          </Suspense>
+        </ErrorBoundary>
+      ),
+    });
+    // Route stub the "Score" link navigates to — registered so the typed
+    // <Link> resolves at render time.
+    const scoringNew = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/matches/$matchId/games/$gameNumber/scores/new",
+      component: () => <div>scoring-new</div>,
+    });
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, scoringNew]),
+      history: createMemoryHistory({ initialEntries: ["/"] }),
+    });
+    render(<RouterProvider router={router} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher.test.tsx
+++ b/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher.test.tsx
@@ -1,0 +1,48 @@
+import { HttpResponse } from "msw";
+
+import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
+import { waitFor } from "@/test/utilities";
+
+import { scoreCtaFetcherPage } from "./score-cta-fetcher.page";
+
+/** A scorable match: the viewer can score the open current game. */
+const scorableMatch = () =>
+  buildMatchDetails({ can_score: true, current_game: { game_number: 1 } });
+
+describe("ScoreCtaFetcher", () => {
+  it("resolves the query and hands the view to the display", async () => {
+    scoreCtaFetcherPage.mockEndpoint(() => HttpResponse.json(scorableMatch()));
+
+    scoreCtaFetcherPage.render();
+
+    // Wiring only: the link's target is pinned by the query and display tests.
+    expect(await scoreCtaFetcherPage.findScoreLink()).toBeInTheDocument();
+  });
+
+  it("renders nothing when the projection is null (nothing to score)", async () => {
+    scoreCtaFetcherPage.mockEndpoint(() =>
+      HttpResponse.json(buildMatchDetails({ can_score: false })),
+    );
+
+    scoreCtaFetcherPage.render();
+
+    // Settles to nothing: no loading, no CTA, no error.
+    await waitFor(() =>
+      expect(scoreCtaFetcherPage.queryLoading()).not.toBeInTheDocument(),
+    );
+    expect(scoreCtaFetcherPage.queryScoreLink()).not.toBeInTheDocument();
+    expect(scoreCtaFetcherPage.queryError()).not.toBeInTheDocument();
+  });
+
+  it("propagates a query failure to the nearest error boundary", async () => {
+    scoreCtaFetcherPage.mockEndpoint(
+      () => new HttpResponse(null, { status: 500 }),
+    );
+
+    scoreCtaFetcherPage.render();
+
+    await waitFor(() =>
+      expect(scoreCtaFetcherPage.queryError()).toBeInTheDocument(),
+    );
+  });
+});

--- a/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher.tsx
+++ b/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher.tsx
@@ -1,0 +1,16 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { ScoreCtaDisplay } from "./score-cta-fetcher/score-cta-display";
+import { scoreCtaQuery } from "./score-cta-fetcher/score-cta-query";
+
+export interface ScoreCtaProps {
+  matchId: string;
+}
+
+export function ScoreCtaFetcher({ matchId }: ScoreCtaProps) {
+  const { data: scoreCta } = useSuspenseQuery(scoreCtaQuery(matchId));
+  // A null projection means there's nothing to score right now — the CTA
+  // doesn't apply.
+  if (!scoreCta) return null;
+  return <ScoreCtaDisplay scoreCta={scoreCta} />;
+}

--- a/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-display.factory.tsx
+++ b/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-display.factory.tsx
@@ -1,0 +1,23 @@
+import type { ScoreCtaView } from "./score-cta-query";
+import type { ScoreCtaDisplayProps } from "./score-cta-display";
+
+/** A scorable match: game 1 of `match-1` is open and the viewer can score it. */
+export function buildScoreCtaView(
+  overrides: Partial<ScoreCtaView> = {},
+): ScoreCtaView {
+  return {
+    matchId: "match-1",
+    gameNumber: 1,
+    ...overrides,
+  };
+}
+
+/** Props for `ScoreCtaDisplay`. */
+export function buildScoreCtaDisplayProps(
+  overrides: Partial<ScoreCtaDisplayProps> = {},
+): ScoreCtaDisplayProps {
+  return {
+    scoreCta: buildScoreCtaView(),
+    ...overrides,
+  };
+}

--- a/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-display.page.tsx
+++ b/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-display.page.tsx
@@ -1,0 +1,63 @@
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+
+import { render, screen, type Container } from "@/test/utilities";
+
+import { ScoreCtaDisplay, type ScoreCtaDisplayProps } from "./score-cta-display";
+import { buildScoreCtaDisplayProps } from "./score-cta-display.factory";
+
+const scoped = (container: Container) => ({
+  /** The "Score" button — a typed `<Link>` into the score-entry route. */
+  getScoreLink() {
+    return container.getByRole("link", { name: "Score" });
+  },
+  findScoreLink() {
+    return container.findByRole("link", { name: "Score" });
+  },
+});
+
+/**
+ * Test page-object for `ScoreCtaDisplay`. The CTA is a typed `<Link>`, so
+ * `render` mounts it under a minimal router that registers the score-entry
+ * route the link targets. The router resolves asynchronously, so tests start
+ * with `await scoreCtaDisplayPage.findScoreLink()`.
+ */
+export const scoreCtaDisplayPage = {
+  render(overrides: Partial<ScoreCtaDisplayProps> = {}) {
+    const props = buildScoreCtaDisplayProps(overrides);
+    const rootRoute = createRootRoute();
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/",
+      component: () => <ScoreCtaDisplay {...props} />,
+    });
+    // Route stub the "Score" link navigates to — registered so the typed
+    // <Link> resolves at render time.
+    const scoringNew = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/matches/$matchId/games/$gameNumber/scores/new",
+      component: () => <div>scoring-new</div>,
+    });
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, scoringNew]),
+      history: createMemoryHistory({ initialEntries: ["/"] }),
+    });
+    render(<RouterProvider router={router} />);
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Parent page objects spread this to expose the
+   * same queries as their own.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-display.test.tsx
+++ b/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-display.test.tsx
@@ -1,0 +1,14 @@
+import { buildScoreCtaView } from "./score-cta-display.factory";
+import { scoreCtaDisplayPage } from "./score-cta-display.page";
+
+describe("ScoreCtaDisplay", () => {
+  it("links the Score button to the score-entry route for the current game", async () => {
+    scoreCtaDisplayPage.render({
+      scoreCta: buildScoreCtaView({ matchId: "m-7", gameNumber: 3 }),
+    });
+
+    const link = await scoreCtaDisplayPage.findScoreLink();
+    expect(link).toHaveAttribute("href", "/matches/m-7/games/3/scores/new");
+    expect(link).toHaveClass("md-btn--primary");
+  });
+});

--- a/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-display.tsx
+++ b/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-display.tsx
@@ -1,0 +1,22 @@
+import { Link } from "@tanstack/react-router";
+
+import { scoringNewRoute } from "@/api/matches";
+
+import { type ScoreCtaView } from "./score-cta-query";
+
+export interface ScoreCtaDisplayProps {
+  scoreCta: ScoreCtaView;
+}
+
+/** The header's primary "Score" button — a typed link into the score-entry
+ * route for the match's current game. */
+export const ScoreCtaDisplay = ({ scoreCta }: ScoreCtaDisplayProps) => {
+  return (
+    <Link
+      {...scoringNewRoute(scoreCta.matchId, scoreCta.gameNumber)}
+      className="md-btn md-btn--primary md-btn--sm"
+    >
+      Score
+    </Link>
+  );
+};

--- a/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-query.page.tsx
+++ b/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-query.page.tsx
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import { server } from "@/mocks/server";
+import { renderHook } from "@/test/utilities";
+
+import { scoreCtaQuery } from "./score-cta-query";
+
+const DEFAULT_MATCH_ID = "m-1";
+
+/**
+ * Test page-object for `scoreCtaQuery`. The query is built on top of
+ * `matchDetailsQuery` and projects a `ScoreCtaView | null` off the full
+ * match-details payload via `select`, so the test stubs the same
+ * `GET /v1/matches/:matchId` endpoint and asserts on the projected view.
+ */
+export const scoreCtaQueryPage = {
+  /**
+   * Stub `GET /v1/matches/:matchId` with a full MSW resolver, so the test owns
+   * the response — `HttpResponse.json(buildMatchDetails())` for the happy
+   * path, a non-2xx for the error branch. It's the same endpoint
+   * `matchDetailsQuery` reads from; the score CTA is derived client-side.
+   */
+  mockEndpoint(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  /**
+   * Run the query under the shared retry-free test client. `throwOnError` is
+   * disabled here so failures land on `result.current.error` rather than
+   * bubbling to an error boundary — boundary behavior is covered at the
+   * fetcher level. `result.current.data` is the projected `ScoreCtaView` (or
+   * null).
+   */
+  render(matchId: string = DEFAULT_MATCH_ID) {
+    return renderHook(() =>
+      useQuery({ ...scoreCtaQuery(matchId), throwOnError: false }),
+    );
+  },
+};

--- a/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-query.test.ts
+++ b/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-query.test.ts
@@ -1,0 +1,54 @@
+import { HttpResponse } from "msw";
+
+import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
+import { waitFor } from "@/test/utilities";
+
+import { scoreCtaQueryPage } from "./score-cta-query.page";
+
+describe("scoreCtaQuery", () => {
+  it("projects the match id and current game when the viewer can score", async () => {
+    scoreCtaQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          id: "m-9",
+          can_score: true,
+          current_game: { game_number: 2 },
+        }),
+      ),
+    );
+
+    const { result } = scoreCtaQueryPage.render();
+
+    await waitFor(() => expect(result.current.data).not.toBeUndefined());
+    expect(result.current.data).toEqual({ matchId: "m-9", gameNumber: 2 });
+  });
+
+  it("projects null when the viewer cannot score", async () => {
+    scoreCtaQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          can_score: false,
+          current_game: { game_number: 2 },
+        }),
+      ),
+    );
+
+    const { result } = scoreCtaQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("projects null when there is no current game to score", async () => {
+    scoreCtaQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({ can_score: true, current_game: null }),
+      ),
+    );
+
+    const { result } = scoreCtaQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-query.ts
+++ b/web-client/src/components/matches/match-details/score-cta/score-cta-fetcher/score-cta-query.ts
@@ -1,0 +1,30 @@
+import {
+  matchDetailsQuery,
+  type MatchDetailsResult,
+} from "../../match-details-query";
+
+/** The header's "Score" CTA target: the match + current game to send the
+ * viewer to the score-entry route. Null from the query means there's nothing
+ * to score right now (the viewer can't score, or there's no current game) and
+ * the CTA doesn't render. */
+export type ScoreCtaView = {
+  matchId: string;
+  /** The game the "Score" button deep-links to — the match's current game. */
+  gameNumber: number;
+};
+
+const selectScoreCta = (match: MatchDetailsResult): ScoreCtaView | null => {
+  const details = match.unmigrated;
+  // The backend gates `can_score` on participation + an open, scorable game;
+  // `current_game` is the slot the button deep-links to. Both must be present.
+  if (!details.can_score || !details.current_game) return null;
+  return {
+    matchId: details.id,
+    gameNumber: details.current_game.game_number,
+  };
+};
+
+export const scoreCtaQuery = (matchId: string) => ({
+  ...matchDetailsQuery(matchId),
+  select: selectScoreCta,
+});


### PR DESCRIPTION
## What

The header **"Score" CTA** was the last consumer of the legacy page-level `useMatch` fetch in `match-details-page.tsx`. This extracts it into a self-fetching strangler quartet under `match-details/score-cta/`, completing the match-details quartet migration.

- **New quartet** (`score-cta.tsx` Suspense wrapper → `score-cta-fetcher.tsx` → `score-cta-query.ts` with `select` → `score-cta-display.tsx`), mirroring the `scoreboard`/`finalize-callout` precedent. The `can_score && current_game` projection that used to live in `projectMatchView` now lives in the query `select`, returning `{ matchId, gameNumber } | null`.
- **Host cleanup:** dropped `useMatch`, `projectMatchView`, the `MatchView` type, and `MatchDetailsSkeleton`. `MatchDetailsView` now renders `MatchDetailsPage` directly — every section self-fetches and suspends independently, and query failures bubble to the route's `errorComponent` (`MatchDetailsError`), unchanged.
- **Tests:** the two CTA-dedicated assertions moved out of the page-level integration test into the quartet (query/display/fetcher); the incidental no-opponent/spectator CTA checks stay green since the quartet self-fetches the same stubbed endpoint and shares the `matchDetailsQuery` cache key.

## Testing

- `npm run test:run` — 452 passed
- `npm run lint` — clean (lone warning is pre-existing in `public/mockServiceWorker.js`)
- `npm run build` (tsc + vite) — passes
- `npm run test:e2e` — 127 passed
- API gates / root e2e / OpenAPI drift skipped: diff is web-client-only (no `api/**` or `web-client/src/api/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)