### PR TITLE
preview: capture outbound email in Mailpit on UAT + QA stacks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ Prod-like stacks (built artifacts, no dev server, isolated volumes; only nginx p
 - `docker compose -f docker-compose.uat.yml up -d --build` — `fortymm-uat`, nginx on **:8084**, fronted by host Caddy at uat.fortymm.com.
 - `docker compose -f docker-compose.qa.yml up -d --build` — `fortymm-qa`, nginx on **:8085**, local-only at http://127.0.0.1:8085. Same shape as UAT, separate project/port/volumes so the two run side by side. `down -v` to wipe its data.
 
+**Preview-stack email (Mailpit).** Both prod-like stacks run a `mailpit` service that captures *all* outbound email instead of relaying it through the real Postmark account in `.env`. The api/worker `environment:` blocks override `SMTP_*` (`SMTP_HOST=mailpit`, `:1025`, no TLS, blank creds) so a preview stack can never send real mail — the worker's RQ `email` jobs (confirmation / magic-link sign-in / account-merge, see `api/app/email.py`) land in Mailpit. Read them at the Mailpit web UI: **UAT → http://127.0.0.1:8086**, **QA → http://127.0.0.1:8087** (host-local only; not proxied by Caddy, since captured mail contains live sign-in links). QA also overrides `APP_BASE_URL` to `http://127.0.0.1:8085` so captured links are clickable. To verify a sign-in/confirmation flow on a preview stack, trigger it in the UI then open the Mailpit UI to grab the link.
+
 Workflow commands: `/land-the-plane` (ship the branch), `/qa-review` (adversarial "Quinn" QA pass in a subagent against the QA stack), `/strangle` (quartet extraction).
 
 ## Cross-cutting invariants

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -25,6 +25,22 @@ x-api-service: &api-service
   env_file:
     - .env
 
+# Preview stacks must never send real email. .env points SMTP_* at the live
+# Postmark account; these keys override it (compose `environment:` wins over
+# `env_file:`) so the worker delivers to the in-network Mailpit on :1025 with
+# no TLS and no auth. APP_BASE_URL is also overridden here: .env hardcodes
+# uat.fortymm.com, but QA is reached at http://127.0.0.1:8085, so captured
+# sign-in/confirmation links must point there to be clickable. Read captured
+# mail at the Mailpit web UI on the host port published by `mailpit` below.
+# See root CLAUDE.md "Preview-stack email (Mailpit)".
+x-mailpit-smtp: &mailpit-smtp
+  SMTP_HOST: mailpit
+  SMTP_PORT: "1025"
+  SMTP_USE_TLS: "false"
+  SMTP_USERNAME: ""
+  SMTP_PASSWORD: ""
+  APP_BASE_URL: http://127.0.0.1:8085
+
 services:
   postgres:
     image: postgres:16-alpine
@@ -51,6 +67,7 @@ services:
   api:
     <<: *api-service
     environment:
+      <<: *mailpit-smtp
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm
       REDIS_URL: redis://redis:6379/0
       SESSION_COOKIE_SECURE: "false"
@@ -73,12 +90,24 @@ services:
   worker:
     <<: *api-service
     environment:
+      <<: *mailpit-smtp
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm
       REDIS_URL: redis://redis:6379/0
     depends_on:
       redis:
         condition: service_healthy
+      mailpit:
+        condition: service_started
     command: rq worker --url redis://redis:6379/0 solver email ratings
+
+  # Catches every email the worker sends in this preview stack instead of
+  # relaying it to Postmark. SMTP on :1025 (internal); web UI on :8025,
+  # published to the host below (QA is local-only anyway).
+  mailpit:
+    image: axllent/mailpit:latest
+    restart: unless-stopped
+    ports:
+      - "8087:8025"  # Mailpit web UI — http://127.0.0.1:8087
 
   web-client:
     build:

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -2,10 +2,10 @@
 #
 # A prod-like stack (same shape as docker-compose.uat.yml) that runs
 # alongside the dev and UAT stacks. Project name `fortymm-qa` keeps
-# networks, containers, and volumes namespaced; `nginx` is the only
-# service with a host port (8085 — UAT holds 8084). Everything else is
-# reachable only on the internal docker network; use `docker exec` for
-# ad-hoc psql/redis-cli access.
+# networks, containers, and volumes namespaced. Only `nginx` (8085 — UAT
+# holds 8084) and `mailpit` (8087, the captured-email web UI) publish host
+# ports. Everything else is reachable only on the internal docker network;
+# use `docker exec` for ad-hoc psql/redis-cli access.
 #
 # Bring up:    docker compose -f docker-compose.qa.yml up -d --build
 # Bring down:  docker compose -f docker-compose.qa.yml down
@@ -104,7 +104,7 @@ services:
   # relaying it to Postmark. SMTP on :1025 (internal); web UI on :8025,
   # published to the host below (QA is local-only anyway).
   mailpit:
-    image: axllent/mailpit:latest
+    image: axllent/mailpit:v1.30
     restart: unless-stopped
     ports:
       - "8087:8025"  # Mailpit web UI — http://127.0.0.1:8087

--- a/docker-compose.uat.yml
+++ b/docker-compose.uat.yml
@@ -21,6 +21,19 @@ x-api-service: &api-service
   env_file:
     - .env
 
+# Preview stacks must never send real email. .env points SMTP_* at the live
+# Postmark account; these keys override it (compose `environment:` wins over
+# `env_file:`) so the worker delivers to the in-network Mailpit on :1025 with
+# no TLS and no auth. Read everything it captures at the Mailpit web UI on the
+# host port published by the `mailpit` service below. See root CLAUDE.md
+# "Preview-stack email (Mailpit)".
+x-mailpit-smtp: &mailpit-smtp
+  SMTP_HOST: mailpit
+  SMTP_PORT: "1025"
+  SMTP_USE_TLS: "false"
+  SMTP_USERNAME: ""
+  SMTP_PASSWORD: ""
+
 services:
   postgres:
     image: postgres:16-alpine
@@ -47,6 +60,7 @@ services:
   api:
     <<: *api-service
     environment:
+      <<: *mailpit-smtp
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm
       REDIS_URL: redis://redis:6379/0
       SESSION_COOKIE_SECURE: "false"
@@ -70,12 +84,26 @@ services:
   worker:
     <<: *api-service
     environment:
+      <<: *mailpit-smtp
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm
       REDIS_URL: redis://redis:6379/0
     depends_on:
       redis:
         condition: service_healthy
+      mailpit:
+        condition: service_started
     command: rq worker --url redis://redis:6379/0 solver email ratings
+
+  # Catches every email the worker sends in this preview stack instead of
+  # relaying it to Postmark. SMTP on :1025 (internal); web UI on :8025,
+  # published to the host below. Local-only — not proxied by Caddy, so
+  # captured mail (which contains live sign-in/confirmation links) is not
+  # exposed on uat.fortymm.com.
+  mailpit:
+    image: axllent/mailpit:latest
+    restart: unless-stopped
+    ports:
+      - "8086:8025"  # Mailpit web UI — http://127.0.0.1:8086
 
   web-client:
     build:

--- a/docker-compose.uat.yml
+++ b/docker-compose.uat.yml
@@ -1,9 +1,10 @@
 # UAT stack — built artifacts, no dev server, isolated volumes.
 #
 # Runs alongside the dev stack: project name `fortymm-uat` keeps networks,
-# containers, and volumes namespaced. `nginx` is the only service with a
-# host port; everything else is reachable only on the internal docker
-# network. Use `docker exec` for ad-hoc psql/redis-cli access.
+# containers, and volumes namespaced. Only `nginx` (8084) and `mailpit`
+# (8086, the captured-email web UI) publish host ports; everything else is
+# reachable only on the internal docker network. Use `docker exec` for
+# ad-hoc psql/redis-cli access.
 #
 # Bring up:    docker compose -f docker-compose.uat.yml up -d --build
 # Bring down:  docker compose -f docker-compose.uat.yml down
@@ -100,7 +101,7 @@ services:
   # captured mail (which contains live sign-in/confirmation links) is not
   # exposed on uat.fortymm.com.
   mailpit:
-    image: axllent/mailpit:latest
+    image: axllent/mailpit:v1.30
     restart: unless-stopped
     ports:
       - "8086:8025"  # Mailpit web UI — http://127.0.0.1:8086


### PR DESCRIPTION
## What

Both prod-like preview stacks (`docker-compose.uat.yml`, `docker-compose.qa.yml`) now run a **Mailpit** service that captures all outbound email instead of relaying it through the real Postmark account configured in the shared `.env`.

Before this, the UAT/QA stacks loaded `.env` (which sets `SMTP_HOST=smtp.postmarkapp.com` with live credentials), so any confirmation / magic-link sign-in / account-merge email a preview stack generated went out as **real** mail.

## How

- Add a `mailpit` service to each stack — SMTP on internal `:1025`, web UI published to the host (**UAT → http://127.0.0.1:8086**, **QA → http://127.0.0.1:8087**).
- Override `SMTP_*` on the `api`/`worker` services via a shared `&mailpit-smtp` YAML anchor (`SMTP_HOST=mailpit`, `:1025`, TLS off, blank creds). Compose `environment:` wins over `env_file:`, so this supersedes the Postmark config from `.env`. `api/app/email.py` skips `starttls()` when `SMTP_USE_TLS=false` and skips `login()` when creds are blank — a plain unauthenticated handoff, which Mailpit's `:1025` accepts.
- QA additionally overrides `APP_BASE_URL` to `http://127.0.0.1:8085` (the `.env` value hardcodes `uat.fortymm.com`) so captured sign-in/confirmation links are clickable on the QA host.
- The Mailpit UIs are **host-local only** (not proxied by Caddy) since captured mail contains live sign-in links.
- Document the setup in root `CLAUDE.md` ("Preview-stack email (Mailpit)") so it's loaded into every agent session.

## Testing

- Diff is docker-compose + docs only; no `api/`, `web-client/`, or `e2e/` source changed, so the code suites (pytest/vitest/Playwright) don't apply.
- `docker compose config` validated on **both** stacks — anchors merge and the resolved SMTP/`APP_BASE_URL` env is correct.
- SMTP delivery path verified by inspection against `api/app/email.py` (TLS-off + blank-creds → plain unauthenticated send to `mailpit:1025`).
- ⚠️ Not yet exercised with a live container — the Docker daemon is down on the dev machine. First real send (trigger a sign-in on the stack, open the Mailpit UI) remains to be confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)