### PR TITLE
login: focused token-check page + real expiry countdown

### DIFF
--- a/web-client/src/components/login/atoms.tsx
+++ b/web-client/src/components/login/atoms.tsx
@@ -1,0 +1,109 @@
+// Shared brand atoms + style objects for the FortyMM login flow. Lifted out of
+// login-screens.tsx so the focused token-check page (link-check-page) can reuse
+// the exact same vocabulary without copy-paste. Importing this module also pulls
+// in login.css (the spin keyframe + decorative-chrome classes) for any consumer.
+
+import type { ReactNode } from 'react'
+
+import './login.css'
+
+export function BallLogo({ size = 26 }: { size?: number }) {
+  const gradId = `fmm-login-lg-${size}`
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+      <svg width={size} height={size} viewBox="0 0 80 80" aria-hidden="true">
+        <defs>
+          <radialGradient id={gradId} cx="35%" cy="35%" r="65%">
+            <stop offset="0%" stopColor="#FFB57A" />
+            <stop offset="55%" stopColor="#FF7A1A" />
+            <stop offset="100%" stopColor="#B94700" />
+          </radialGradient>
+        </defs>
+        <circle cx="40" cy="40" r="36" fill={`url(#${gradId})`} />
+        <ellipse cx="30" cy="28" rx="10" ry="6" fill="#FFF" fillOpacity="0.22" />
+      </svg>
+      <span
+        style={{
+          fontFamily: "'Bebas Neue', sans-serif",
+          fontSize: size * 0.95,
+          letterSpacing: '0.04em',
+          color: 'var(--fg-1)',
+          lineHeight: 1,
+        }}
+      >
+        FORTYMM<span style={{ color: 'var(--ball-500)' }}>.</span>
+      </span>
+    </div>
+  )
+}
+
+export function Eyebrow({
+  children,
+  color = 'var(--ball-500)',
+}: {
+  children: ReactNode
+  color?: string
+}) {
+  return (
+    <div
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 0,
+        fontFamily: 'var(--font-ui)',
+        fontSize: 11,
+        fontWeight: 600,
+        letterSpacing: '0.18em',
+        textTransform: 'uppercase',
+        color,
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+export function RedirectStrip({ dest }: { dest: string }) {
+  return (
+    <div
+      style={{
+        marginTop: 'auto',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '12px 16px',
+        borderRadius: 'var(--r-md)',
+        background: 'rgba(0,226,154,0.08)',
+        border: '1px solid rgba(0,226,154,0.3)',
+      }}
+    >
+      <span
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 10.5,
+          fontWeight: 700,
+          color: 'var(--serve-500)',
+          letterSpacing: '0.16em',
+        }}
+      >
+        ● REDIRECTING
+      </span>
+      <span
+        style={{ fontFamily: 'var(--font-mono)', fontSize: 13, color: 'var(--fg-2)' }}
+      >
+        {dest}
+      </span>
+      <span style={{ flex: 1 }} />
+      <span
+        style={{ fontFamily: 'var(--font-mono)', fontSize: 13, color: 'var(--fg-3)' }}
+      >
+        2s
+      </span>
+      <span
+        style={{ fontFamily: 'var(--font-mono)', fontSize: 18, color: 'var(--serve-500)' }}
+      >
+        →
+      </span>
+    </div>
+  )
+}

--- a/web-client/src/components/login/link-check-page/link-check-page.page.tsx
+++ b/web-client/src/components/login/link-check-page/link-check-page.page.tsx
@@ -1,0 +1,41 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { LinkCheckPage, type LinkCheckPageProps } from './link-check-page'
+
+const scoped = (container: Container) => ({
+  root() {
+    return container.queryByTestId('link-check-page')
+  },
+  /** The resolved state, read off the root's `data-state`. */
+  state() {
+    return this.root()?.getAttribute('data-state') ?? null
+  },
+  /** The status disc's kind: `spin` | `check` | `x`. */
+  discKind() {
+    return container.queryByTestId('link-check-disc')?.getAttribute('data-kind') ?? null
+  },
+  heading() {
+    return container.queryByRole('heading', { level: 1 })
+  },
+  /** All visible text — used to assert a token string never leaks into the UI. */
+  text() {
+    return this.root()?.textContent ?? ''
+  },
+})
+
+/**
+ * Test page-object for the presentational `LinkCheckPage`. No network — the
+ * route drives `state`/`footer`, so tests render the view directly and assert
+ * the disc kind, headline, and that no bearer token is ever shown.
+ */
+export const linkCheckPage = {
+  render(props: LinkCheckPageProps) {
+    render(<LinkCheckPage {...props} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/login/link-check-page/link-check-page.test.tsx
+++ b/web-client/src/components/login/link-check-page/link-check-page.test.tsx
@@ -1,0 +1,61 @@
+import { linkCheckPage } from './link-check-page.page'
+
+// A token-shaped string the design prototype used to print. Ryan's design
+// feedback was "let's not show the token", and it's a live bearer credential —
+// so every state must keep it out of the rendered output.
+const TOKEN_PATTERN = /t_[A-Za-z0-9·_-]{6,}/
+
+describe('LinkCheckPage', () => {
+  it('checking: spinner disc, checking headline, keep-tab hint, no token', () => {
+    linkCheckPage.render({ state: 'checking' })
+
+    expect(linkCheckPage.state()).toBe('checking')
+    expect(linkCheckPage.discKind()).toBe('spin')
+    expect(linkCheckPage.heading()).toHaveTextContent(/checking your link/i)
+    expect(linkCheckPage.text()).toMatch(/keep this tab open/i)
+    expect(linkCheckPage.text()).not.toMatch(TOKEN_PATTERN)
+  })
+
+  it('success: check disc, success headline, footer action, no token', () => {
+    linkCheckPage.render({
+      state: 'success',
+      footer: <a href="/dashboard">Go to dashboard</a>,
+    })
+
+    expect(linkCheckPage.state()).toBe('success')
+    expect(linkCheckPage.discKind()).toBe('check')
+    expect(linkCheckPage.heading()).toHaveTextContent(/you’re in/i)
+    expect(
+      linkCheckPage.within().root()?.querySelector('a[href="/dashboard"]'),
+    ).toBeTruthy()
+    expect(linkCheckPage.text()).not.toMatch(TOKEN_PATTERN)
+  })
+
+  it('expired: x disc, error detail surfaced, footer action, no token', () => {
+    linkCheckPage.render({
+      state: 'expired',
+      detail: 'That confirmation link is invalid or expired.',
+      footer: <a href="/login">Send a new link</a>,
+    })
+
+    expect(linkCheckPage.state()).toBe('expired')
+    expect(linkCheckPage.discKind()).toBe('x')
+    expect(linkCheckPage.text()).toMatch(/invalid or expired/i)
+    expect(
+      linkCheckPage.within().root()?.querySelector('a[href="/login"]'),
+    ).toBeTruthy()
+    expect(linkCheckPage.text()).not.toMatch(TOKEN_PATTERN)
+  })
+
+  it('lets the route override the default copy', () => {
+    linkCheckPage.render({
+      state: 'checking',
+      eyebrow: '● Confirming your email',
+      title: 'Confirming your email',
+      subtitle: 'One moment.',
+    })
+
+    expect(linkCheckPage.heading()).toHaveTextContent(/confirming your email/i)
+    expect(linkCheckPage.text()).toMatch(/one moment/i)
+  })
+})

--- a/web-client/src/components/login/link-check-page/link-check-page.test.tsx
+++ b/web-client/src/components/login/link-check-page/link-check-page.test.tsx
@@ -44,6 +44,13 @@ describe('LinkCheckPage', () => {
     expect(
       linkCheckPage.within().root()?.querySelector('a[href="/login"]'),
     ).toBeTruthy()
+    // Support escape hatch is always present on the expired state.
+    expect(
+      linkCheckPage
+        .within()
+        .root()
+        ?.querySelector('a[href="mailto:support@fortymm.com"]'),
+    ).toBeTruthy()
     expect(linkCheckPage.text()).not.toMatch(TOKEN_PATTERN)
   })
 

--- a/web-client/src/components/login/link-check-page/link-check-page.tsx
+++ b/web-client/src/components/login/link-check-page/link-check-page.tsx
@@ -1,0 +1,166 @@
+import type { ReactNode } from 'react'
+
+import { BallLogo, Eyebrow } from '../atoms'
+import { fineprint } from '../styles'
+
+export type LinkCheckState = 'checking' | 'success' | 'expired'
+
+const ACCENT: Record<LinkCheckState, string> = {
+  checking: 'var(--ball-500)',
+  success: 'var(--serve-500)',
+  expired: 'var(--loss)',
+}
+
+const HALO: Record<LinkCheckState, string> = {
+  checking: 'rgba(255,122,26,0.20)',
+  success: 'rgba(0,226,154,0.16)',
+  expired: 'rgba(255,77,109,0.14)',
+}
+
+const DEFAULT_COPY: Record<
+  LinkCheckState,
+  { eyebrow: string; title: string; subtitle: string }
+> = {
+  checking: {
+    eyebrow: '● Verifying your link',
+    title: 'Checking your link',
+    subtitle:
+      'Hang tight — confirming your sign-in token. This only takes a second.',
+  },
+  success: {
+    eyebrow: '● Verified',
+    title: 'You’re in.',
+    subtitle:
+      'Token confirmed and your email is verified. Taking you to the courts.',
+  },
+  expired: {
+    eyebrow: '● Link expired',
+    title: 'This link expired',
+    subtitle:
+      'Sign-in links last 15 minutes and work once. Send a fresh one and you’ll be straight in.',
+  },
+}
+
+export interface LinkCheckPageProps {
+  state: LinkCheckState
+  eyebrow?: ReactNode
+  title?: ReactNode
+  subtitle?: ReactNode
+  /** Extra detail rendered under the subtitle — e.g. the API error message. */
+  detail?: string
+  /** Footer action(s). Routes inject router-aware links/buttons here; when
+   *  omitted, the `checking` state shows a "keep this tab open" hint. */
+  footer?: ReactNode
+}
+
+/**
+ * The focused, single-column page a sign-in / email-confirmation link opens to.
+ * It checks the token and resolves to one of three states — `checking`,
+ * `success`, `expired` — reusing the FortyMM login vocabulary (ball logo, brand
+ * dot-grid texture, status disc, Bebas headline). Purely presentational: the
+ * owning route drives `state` from its query and supplies the `footer` action.
+ */
+export function LinkCheckPage({
+  state,
+  eyebrow,
+  title,
+  subtitle,
+  detail,
+  footer,
+}: LinkCheckPageProps) {
+  const accent = ACCENT[state]
+  const copy = DEFAULT_COPY[state]
+
+  return (
+    <div
+      className="fortymm-theme fmm-login fmm-linkcheck"
+      data-testid="link-check-page"
+      data-state={state}
+    >
+      <div className="fortymm-grid-bg fmm-linkcheck__grid" aria-hidden="true" />
+      <div
+        className="fmm-linkcheck__halo"
+        aria-hidden="true"
+        style={{
+          background: `radial-gradient(circle, ${HALO[state]}, transparent 65%)`,
+        }}
+      />
+
+      <header className="fmm-linkcheck__header">
+        <BallLogo size={22} />
+        <span className="fmm-linkcheck__pill" style={{ color: accent }}>
+          {state === 'expired' ? '!!' : '03'} · LINK
+        </span>
+      </header>
+
+      <main className="fmm-linkcheck__main">
+        <StatusDisc state={state} />
+        <div role="status" aria-live="polite">
+          <Eyebrow color={accent}>{eyebrow ?? copy.eyebrow}</Eyebrow>
+          <h1 className="fmm-linkcheck__title">{title ?? copy.title}</h1>
+          <p className="fmm-linkcheck__sub">{subtitle ?? copy.subtitle}</p>
+          {detail && (
+            <p
+              className="fmm-linkcheck__detail"
+              style={{ color: accent }}
+            >
+              {detail}
+            </p>
+          )}
+        </div>
+      </main>
+
+      <footer className="fmm-linkcheck__footer">
+        {footer ??
+          (state === 'checking' ? (
+            <p style={{ ...fineprint, textAlign: 'center', marginTop: 0 }}>
+              Keep this tab open while we verify.
+            </p>
+          ) : null)}
+      </footer>
+    </div>
+  )
+}
+
+function StatusDisc({ state }: { state: LinkCheckState }) {
+  if (state === 'checking') {
+    return (
+      <div
+        className="fmm-linkcheck__disc fmm-linkcheck__disc--spin"
+        data-testid="link-check-disc"
+        data-kind="spin"
+        aria-hidden="true"
+      />
+    )
+  }
+  const ok = state === 'success'
+  return (
+    <div
+      className={`fmm-linkcheck__disc ${
+        ok ? 'fmm-linkcheck__disc--ok' : 'fmm-linkcheck__disc--err'
+      }`}
+      data-testid="link-check-disc"
+      data-kind={ok ? 'check' : 'x'}
+      aria-hidden="true"
+    >
+      <svg width="36" height="36" viewBox="0 0 24 24" fill="none">
+        {ok ? (
+          <path
+            d="M5 12.5l4 4 10-10"
+            stroke="#00E29A"
+            strokeWidth="2.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        ) : (
+          <path
+            d="M6 6l12 12M18 6L6 18"
+            stroke="#FF4D6D"
+            strokeWidth="2.4"
+            strokeLinecap="round"
+          />
+        )}
+      </svg>
+    </div>
+  )
+}

--- a/web-client/src/components/login/link-check-page/link-check-page.tsx
+++ b/web-client/src/components/login/link-check-page/link-check-page.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 
 import { BallLogo, Eyebrow } from '../atoms'
-import { fineprint } from '../styles'
+import { fineprint, linkInline } from '../styles'
 
 export type LinkCheckState = 'checking' | 'success' | 'expired'
 
@@ -111,12 +111,21 @@ export function LinkCheckPage({
       </main>
 
       <footer className="fmm-linkcheck__footer">
-        {footer ??
-          (state === 'checking' ? (
-            <p style={{ ...fineprint, textAlign: 'center', marginTop: 0 }}>
-              Keep this tab open while we verify.
-            </p>
-          ) : null)}
+        {footer}
+        {!footer && state === 'checking' && (
+          <p style={{ ...fineprint, textAlign: 'center', marginTop: 0 }}>
+            Keep this tab open while we verify.
+          </p>
+        )}
+        {state === 'expired' && (
+          <p style={{ ...fineprint, textAlign: 'center', marginTop: 0 }}>
+            Still stuck?{' '}
+            <a href="mailto:support@fortymm.com" style={linkInline}>
+              Email support
+            </a>
+            .
+          </p>
+        )}
       </footer>
     </div>
   )

--- a/web-client/src/components/login/login-screens.test.tsx
+++ b/web-client/src/components/login/login-screens.test.tsx
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { act, render, screen } from '@/test/utilities'
+
+import { ScreenSent } from './login-screens'
+
+describe('ScreenSent expiry countdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('ticks down each second from the deadline and flips to expired at zero', () => {
+    const now = 1_700_000_000_000
+    vi.setSystemTime(now)
+
+    // 15-min link lifetime (mirrors the API); seed sentAt so only 3s remain.
+    const LINK_TTL_MS = 15 * 60 * 1000
+    render(
+      <ScreenSent email="rita@example.com" sentAt={now - (LINK_TTL_MS - 3000)} />,
+    )
+
+    const timer = screen.getByRole('timer')
+    expect(timer).toHaveTextContent('00:03')
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(screen.getByRole('timer')).toHaveTextContent('00:02')
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(screen.getByRole('timer')).toHaveTextContent('00:00')
+    expect(screen.getByText(/link expired/i)).toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/login/login-screens.tsx
+++ b/web-client/src/components/login/login-screens.tsx
@@ -1,73 +1,18 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { CSSProperties, FormEvent, ReactNode } from 'react'
 
 import { Turnstile, type TurnstileHandle } from '@/components/turnstile'
 import { HONEYPOT_STYLE, isValidEmail } from '@/lib/form-helpers'
 
+import { BallLogo, Eyebrow, RedirectStrip } from './atoms'
+import { btnGhost, btnPrimary, fineprint, linkInline } from './styles'
 import './login.css'
 
+// Sign-in / confirmation links live 15 minutes — mirrors the API's
+// LOGIN_TOKEN_LIFETIME. The countdown owns this so routes only pass send time.
+const LOGIN_LINK_TTL_MS = 15 * 60 * 1000
+
 /* ─── Brand atoms ───────────────────────────────────────────────────── */
-
-function BallLogo({ size = 26 }: { size?: number }) {
-  const gradId = `fmm-login-lg-${size}`
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-      <svg
-        width={size}
-        height={size}
-        viewBox="0 0 80 80"
-        aria-hidden="true"
-      >
-        <defs>
-          <radialGradient id={gradId} cx="35%" cy="35%" r="65%">
-            <stop offset="0%" stopColor="#FFB57A" />
-            <stop offset="55%" stopColor="#FF7A1A" />
-            <stop offset="100%" stopColor="#B94700" />
-          </radialGradient>
-        </defs>
-        <circle cx="40" cy="40" r="36" fill={`url(#${gradId})`} />
-        <ellipse cx="30" cy="28" rx="10" ry="6" fill="#FFF" fillOpacity="0.22" />
-      </svg>
-      <span
-        style={{
-          fontFamily: "'Bebas Neue', sans-serif",
-          fontSize: size * 0.95,
-          letterSpacing: '0.04em',
-          color: 'var(--fg-1)',
-          lineHeight: 1,
-        }}
-      >
-        FORTYMM<span style={{ color: 'var(--ball-500)' }}>.</span>
-      </span>
-    </div>
-  )
-}
-
-function Eyebrow({
-  children,
-  color = 'var(--ball-500)',
-}: {
-  children: ReactNode
-  color?: string
-}) {
-  return (
-    <div
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 0,
-        fontFamily: 'var(--font-ui)',
-        fontSize: 11,
-        fontWeight: 600,
-        letterSpacing: '0.18em',
-        textTransform: 'uppercase',
-        color,
-      }}
-    >
-      {children}
-    </div>
-  )
-}
 
 function Display({
   children,
@@ -394,66 +339,7 @@ function EmailReceipt({ email }: { email: string }) {
   )
 }
 
-function VerifyCard() {
-  return (
-    <div
-      style={{
-        ...receiptCard,
-        borderColor: 'rgba(255,122,26,0.35)',
-        boxShadow:
-          '0 0 0 1px rgba(255,122,26,0.18), 0 8px 24px rgba(255,122,26,0.10)',
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 14,
-          padding: '4px 0 14px',
-        }}
-      >
-        <Spinner />
-        <div>
-          <div
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 10.5,
-              fontWeight: 700,
-              color: 'var(--ball-500)',
-              letterSpacing: '0.18em',
-            }}
-          >
-            ● VERIFYING TOKEN
-          </div>
-          <div
-            style={{
-              fontFamily: 'var(--font-ui)',
-              fontSize: 14,
-              fontWeight: 500,
-              color: 'var(--fg-1)',
-              marginTop: 4,
-            }}
-          >
-            Confirming signature &amp; expiry…
-          </div>
-        </div>
-      </div>
-      <div style={receiptDiv} />
-      <div style={receiptRow}>
-        <span style={receiptK}>Issued</span>
-        <span style={receiptV}>2 min ago · device match</span>
-      </div>
-    </div>
-  )
-}
-
 type SolverLine = [string, string, string, string]
-
-const VERIFY_LOG: SolverLine[] = [
-  ['200', 'POST', '/auth/verify', 'token signature ok'],
-  ['200', 'GET', '/auth/session', 'device fingerprint match'],
-  ['…', '···', '/auth/grant', 'minting session…'],
-]
 
 const FAILED_VERIFY_LOG: SolverLine[] = [
   ['200', 'POST', '/auth/verify', 'token signature ok'],
@@ -691,64 +577,32 @@ function BounceReceipt({ email }: { email: string }) {
   )
 }
 
-function ErrorReceipt({ code, detail }: { code: string; detail?: string }) {
-  return (
-    <div
-      style={{
-        ...receiptCard,
-        borderColor: 'rgba(255,77,109,0.35)',
-        boxShadow:
-          '0 0 0 1px rgba(255,77,109,0.18), 0 8px 24px rgba(255,77,109,0.10)',
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 14,
-          padding: '4px 0 12px',
-        }}
-      >
-        <XBadge />
-        <div>
-          <div
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 10.5,
-              fontWeight: 700,
-              color: 'var(--loss)',
-              letterSpacing: '0.18em',
-            }}
-          >
-            ● {code}
-          </div>
-          {detail && (
-            <div
-              style={{
-                fontFamily: 'var(--font-ui)',
-                fontSize: 14,
-                fontWeight: 500,
-                color: 'var(--fg-1)',
-                marginTop: 4,
-              }}
-            >
-              {detail}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  )
-}
+/** Live countdown to a sign-in link's expiry. `sentAt` is the epoch-ms send
+ *  time; this owns the link lifetime (matches the API's LOGIN_TOKEN_LIFETIME),
+ *  ticks once a second, and at zero flips to a spent "Link expired" treatment
+ *  (the Resend control on the screen is the recovery path). */
+function ExpiresCountdown({ sentAt }: { sentAt: number }) {
+  const expiresAt = sentAt + LOGIN_LINK_TTL_MS
+  // Track "now" and derive the remaining time during render — that way a new
+  // send time reflects immediately, and there's no setState in the effect body.
+  const [now, setNow] = useState(() => Date.now())
 
-function ExpiresCountdown({
-  minutes,
-  seconds,
-}: {
-  minutes: number
-  seconds: number
-}) {
-  const t = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+  useEffect(() => {
+    const id = setInterval(() => {
+      const t = Date.now()
+      setNow(t)
+      if (t >= expiresAt) clearInterval(id)
+    }, 1000)
+    return () => clearInterval(id)
+  }, [expiresAt])
+
+  const remaining = Math.max(0, expiresAt - now)
+  const expired = remaining <= 0
+  const totalSeconds = Math.ceil(remaining / 1000)
+  const mm = String(Math.floor(totalSeconds / 60)).padStart(2, '0')
+  const ss = String(totalSeconds % 60).padStart(2, '0')
+  const pct = Math.max(0, Math.min(100, (remaining / LOGIN_LINK_TTL_MS) * 100))
+
   return (
     <div
       style={{
@@ -759,7 +613,7 @@ function ExpiresCountdown({
         padding: '12px 16px',
         borderRadius: 'var(--r-md)',
         background: 'var(--ink-900)',
-        border: '1px solid var(--ink-600)',
+        border: `1px solid ${expired ? 'var(--loss)' : 'var(--ink-600)'}`,
       }}
     >
       <span
@@ -771,84 +625,29 @@ function ExpiresCountdown({
           textTransform: 'uppercase',
         }}
       >
-        Link expires in
+        {expired ? 'Link expired' : 'Link expires in'}
       </span>
       <span
+        role="timer"
+        aria-label={expired ? 'Link expired' : `Link expires in ${mm}:${ss}`}
         style={{
           fontFamily: 'var(--font-mono)',
           fontSize: 18,
           fontWeight: 700,
-          color: 'var(--ball-500)',
+          color: expired ? 'var(--loss)' : 'var(--ball-500)',
           letterSpacing: '0.06em',
           fontVariantNumeric: 'tabular-nums',
         }}
       >
-        {t}
+        {`${mm}:${ss}`}
       </span>
       <span style={{ flex: 1 }} />
-      <ProgressBar pct={97} />
+      <ProgressBar pct={pct} expired={expired} />
     </div>
   )
 }
 
-function RedirectStrip({ dest }: { dest: string }) {
-  return (
-    <div
-      style={{
-        marginTop: 'auto',
-        display: 'flex',
-        alignItems: 'center',
-        gap: 12,
-        padding: '12px 16px',
-        borderRadius: 'var(--r-md)',
-        background: 'rgba(0,226,154,0.08)',
-        border: '1px solid rgba(0,226,154,0.3)',
-      }}
-    >
-      <span
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 10.5,
-          fontWeight: 700,
-          color: 'var(--serve-500)',
-          letterSpacing: '0.16em',
-        }}
-      >
-        ● REDIRECTING
-      </span>
-      <span
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 13,
-          color: 'var(--fg-2)',
-        }}
-      >
-        {dest}
-      </span>
-      <span style={{ flex: 1 }} />
-      <span
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 13,
-          color: 'var(--fg-3)',
-        }}
-      >
-        2s
-      </span>
-      <span
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 18,
-          color: 'var(--serve-500)',
-        }}
-      >
-        →
-      </span>
-    </div>
-  )
-}
-
-function ProgressBar({ pct }: { pct: number }) {
+function ProgressBar({ pct, expired = false }: { pct: number; expired?: boolean }) {
   return (
     <span
       style={{
@@ -865,27 +664,13 @@ function ProgressBar({ pct }: { pct: number }) {
           display: 'block',
           width: `${pct}%`,
           height: '100%',
-          background: 'linear-gradient(90deg, var(--ball-500), var(--ball-400))',
+          background: expired
+            ? 'var(--loss)'
+            : 'linear-gradient(90deg, var(--ball-500), var(--ball-400))',
+          transition: 'width 1s linear',
         }}
       />
     </span>
-  )
-}
-
-function Spinner() {
-  return (
-    <div
-      aria-hidden="true"
-      style={{
-        width: 36,
-        height: 36,
-        borderRadius: '50%',
-        border: '3px solid rgba(255,122,26,0.20)',
-        borderTopColor: 'var(--ball-500)',
-        borderRightColor: 'var(--ball-500)',
-        animation: 'fmm-login-spin 1s linear infinite',
-      }}
-    />
   )
 }
 
@@ -971,50 +756,6 @@ function Divider({ label }: { label: string }) {
 }
 
 /* ─── Shared style objects ──────────────────────────────────────────── */
-
-const btnPrimary: CSSProperties = {
-  appearance: 'none',
-  border: '1px solid var(--ball-500)',
-  background: 'var(--ball-500)',
-  color: 'var(--ink-950)',
-  fontFamily: 'var(--font-ui)',
-  fontSize: 15,
-  fontWeight: 700,
-  letterSpacing: '0.01em',
-  padding: '14px 18px',
-  borderRadius: 'var(--r-md)',
-  cursor: 'pointer',
-  boxShadow: 'var(--shadow-glow)',
-}
-
-const btnGhost: CSSProperties = {
-  appearance: 'none',
-  border: '1px solid var(--ink-500)',
-  background: 'transparent',
-  color: 'var(--fg-2)',
-  fontFamily: 'var(--font-ui)',
-  fontSize: 14,
-  fontWeight: 600,
-  padding: '14px 18px',
-  borderRadius: 'var(--r-md)',
-  cursor: 'pointer',
-}
-
-const fineprint: CSSProperties = {
-  fontFamily: 'var(--font-ui)',
-  fontSize: 12.5,
-  lineHeight: 1.55,
-  color: 'var(--fg-3)',
-  marginTop: 2,
-}
-
-const linkInline: CSSProperties = {
-  color: 'var(--ball-500)',
-  textDecoration: 'underline',
-  textDecorationColor: 'rgba(255,122,26,0.4)',
-  textUnderlineOffset: '2px',
-  cursor: 'pointer',
-}
 
 // Reset for <button> elements that should render as inline text-link. Lets
 // app actions live in <button> (correct semantics, no scroll-jump, no `#`
@@ -1232,6 +973,9 @@ export function ScreenEmail({
 
 export interface ScreenSentProps {
   email: string
+  /** Epoch-ms time the sign-in link was sent; drives the live expiry
+   *  countdown. Defaults to first render when the caller doesn't know it. */
+  sentAt?: number
   onResend?: () => void
   onStartOver?: () => void
   resending?: boolean
@@ -1240,11 +984,15 @@ export interface ScreenSentProps {
 
 export function ScreenSent({
   email,
+  sentAt,
   onResend,
   onStartOver,
   resending = false,
   resendMessage = null,
 }: ScreenSentProps) {
+  // Stable fallback so the countdown doesn't reset every render when no
+  // send time was threaded in.
+  const [fallbackSentAt] = useState(() => Date.now())
   return (
     <Shell
       left={
@@ -1312,32 +1060,7 @@ export function ScreenSent({
             </span>
           </div>
 
-          <ExpiresCountdown minutes={14} seconds={32} />
-        </FormCol>
-      }
-    />
-  )
-}
-
-export function ScreenVerify() {
-  return (
-    <Shell
-      left={
-        <HeroCol
-          eyebrow="● Checking the score"
-          h1a="Hold up."
-          h1b="Reading your link."
-        />
-      }
-      right={
-        <FormCol
-          stepNo="03"
-          stepLabel="Verifying link"
-          title="Confirming your sign-in"
-          subtitle="Just a sec — confirming you’re you."
-        >
-          <VerifyCard />
-          <SolverLog lines={VERIFY_LOG} />
+          <ExpiresCountdown sentAt={sentAt ?? fallbackSentAt} />
         </FormCol>
       }
     />
@@ -1374,51 +1097,6 @@ export function ScreenSuccess({
         >
           <SuccessReceipt username={username} email={email} />
           <RedirectStrip dest={redirectTo} />
-        </FormCol>
-      }
-    />
-  )
-}
-
-export interface ScreenErrorProps {
-  detail?: string
-  onRequestNew?: () => void
-}
-
-export function ScreenError({ detail, onRequestNew }: ScreenErrorProps) {
-  return (
-    <Shell
-      left={
-        <HeroCol
-          eyebrow="● Net out"
-          h1a="That one missed."
-          h1b="Try again."
-        />
-      }
-      right={
-        <FormCol
-          stepNo="!!"
-          stepLabel="Link invalid"
-          title="This link can’t be used"
-          subtitle="Your link expired or was already used. Links are good for 15 minutes and one tap — strict for a reason. We’ll send a fresh one."
-          accent="var(--loss)"
-        >
-          <ErrorReceipt code="ERR_TOKEN_EXPIRED" detail={detail} />
-          <button
-            type="button"
-            style={btnPrimary}
-            onClick={onRequestNew}
-            disabled={!onRequestNew}
-          >
-            Hit me with a new link
-          </button>
-          <div style={{ ...fineprint, marginTop: 6 }}>
-            Still stuck?{' '}
-            <a href="mailto:support@fortymm.com" style={linkInline}>
-              Email support
-            </a>{' '}
-            — we read every one.
-          </div>
         </FormCol>
       }
     />

--- a/web-client/src/components/login/login.css
+++ b/web-client/src/components/login/login.css
@@ -168,3 +168,128 @@
     left: -25%;
   }
 }
+
+/* ── Token-check page — focused single-column link landing ────────────── */
+/* The page a sign-in / email-confirm link opens to: not the marketing split
+   shell, a centered column that reads well on phone and desktop alike. */
+
+.fmm-linkcheck {
+  position: relative;
+  align-items: center;
+  overflow: hidden;
+}
+
+.fmm-linkcheck__grid {
+  position: absolute;
+  inset: 0;
+  opacity: 0.5;
+  -webkit-mask-image: radial-gradient(ellipse 70% 45% at 50% 32%, black, transparent 75%);
+          mask-image: radial-gradient(ellipse 70% 45% at 50% 32%, black, transparent 75%);
+  pointer-events: none;
+}
+
+.fmm-linkcheck__halo {
+  position: absolute;
+  top: -22%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 460px;
+  height: 460px;
+  pointer-events: none;
+}
+
+.fmm-linkcheck__header,
+.fmm-linkcheck__main,
+.fmm-linkcheck__footer {
+  position: relative;
+  width: 100%;
+  max-width: 460px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.fmm-linkcheck__header {
+  flex-shrink: 0;
+  padding: 22px 24px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.fmm-linkcheck__pill {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  border: 1px solid var(--ink-600);
+  border-radius: var(--r-pill);
+  padding: 4px 10px;
+}
+
+.fmm-linkcheck__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 18px;
+  padding: 0 24px;
+}
+
+.fmm-linkcheck__title {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: clamp(40px, 12vw, 64px);
+  line-height: 0.95;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  margin: 12px 0 0;
+  color: var(--fg-1);
+}
+
+.fmm-linkcheck__sub {
+  font: 400 14.5px/1.55 var(--font-ui);
+  color: var(--fg-3);
+  margin: 12px 0 0;
+  max-width: 340px;
+}
+
+.fmm-linkcheck__detail {
+  font: 600 13px/1.5 var(--font-mono);
+  margin: 12px 0 0;
+}
+
+.fmm-linkcheck__footer {
+  flex-shrink: 0;
+  padding: 0 24px 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.fmm-linkcheck__disc {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.fmm-linkcheck__disc--spin {
+  border: 5px solid rgba(255, 122, 26, 0.18);
+  border-top-color: var(--ball-500);
+  border-right-color: var(--ball-500);
+  animation: fmm-login-spin 1s linear infinite;
+}
+
+.fmm-linkcheck__disc--ok {
+  background: rgba(0, 226, 154, 0.16);
+  border: 2px solid var(--serve-500);
+  box-shadow: var(--shadow-live-glow);
+}
+
+.fmm-linkcheck__disc--err {
+  background: rgba(255, 77, 109, 0.16);
+  border: 2px solid var(--loss);
+  box-shadow: 0 0 24px rgba(255, 77, 109, 0.25);
+}

--- a/web-client/src/components/login/styles.ts
+++ b/web-client/src/components/login/styles.ts
@@ -1,0 +1,52 @@
+// Shared inline-style objects for the FortyMM login flow. Kept in a plain
+// (component-free) module so both login-screens.tsx and the token-check page
+// can reuse them without tripping react-refresh's "components only" rule.
+
+import type { CSSProperties } from 'react'
+
+export const btnPrimary: CSSProperties = {
+  appearance: 'none',
+  border: '1px solid var(--ball-500)',
+  background: 'var(--ball-500)',
+  color: 'var(--ink-950)',
+  fontFamily: 'var(--font-ui)',
+  fontSize: 15,
+  fontWeight: 700,
+  letterSpacing: '0.01em',
+  padding: '14px 18px',
+  borderRadius: 'var(--r-md)',
+  cursor: 'pointer',
+  boxShadow: 'var(--shadow-glow)',
+  textAlign: 'center',
+  textDecoration: 'none',
+  display: 'inline-block',
+}
+
+export const btnGhost: CSSProperties = {
+  appearance: 'none',
+  border: '1px solid var(--ink-500)',
+  background: 'transparent',
+  color: 'var(--fg-2)',
+  fontFamily: 'var(--font-ui)',
+  fontSize: 14,
+  fontWeight: 600,
+  padding: '14px 18px',
+  borderRadius: 'var(--r-md)',
+  cursor: 'pointer',
+}
+
+export const fineprint: CSSProperties = {
+  fontFamily: 'var(--font-ui)',
+  fontSize: 12.5,
+  lineHeight: 1.55,
+  color: 'var(--fg-3)',
+  marginTop: 2,
+}
+
+export const linkInline: CSSProperties = {
+  color: 'var(--ball-500)',
+  textDecoration: 'underline',
+  textDecorationColor: 'rgba(255,122,26,0.4)',
+  textUnderlineOffset: '2px',
+  cursor: 'pointer',
+}

--- a/web-client/src/routes/confirm-email.tsx
+++ b/web-client/src/routes/confirm-email.tsx
@@ -4,6 +4,11 @@ import { toast } from 'sonner'
 
 import { ApiError } from '@/api/client'
 import { useConfirmEmail, useMergePreview } from '@/api/session'
+import { btnPrimary } from '@/components/login/styles'
+import {
+  LinkCheckPage,
+  type LinkCheckState,
+} from '@/components/login/link-check-page/link-check-page'
 import { MergeGate } from '@/components/login/merge-gate'
 import { pageTitle } from '@/lib/page-title'
 
@@ -16,6 +21,21 @@ export const Route = createFileRoute('/confirm-email')({
   }),
   component: ConfirmEmailPage,
 })
+
+const CONFIRM_COPY: Partial<
+  Record<LinkCheckState, { eyebrow: string; title: string; subtitle: string }>
+> = {
+  success: {
+    eyebrow: '● Email confirmed',
+    title: 'You’re in.',
+    subtitle: 'Your email is verified — your FortyMM account is yours to keep.',
+  },
+  checking: {
+    eyebrow: '● Confirming your email',
+    title: 'Confirming your email',
+    subtitle: 'Hang tight — this only takes a second.',
+  },
+}
 
 function ConfirmEmailPage() {
   const { token } = Route.useSearch()
@@ -92,56 +112,35 @@ function ConfirmEmailPage() {
   // one orphan user + session-token row per click. The confirm endpoint
   // itself rotates the cookie to the token's owner, so the user lands on
   // the dashboard signed in as themselves.
+  const linkState: LinkCheckState =
+    status === 'ok' ? 'success' : status === 'confirming' ? 'checking' : 'expired'
+
+  // Email-confirm copy per state; `expired` falls through to LinkCheckPage's
+  // own defaults.
+  const copy = CONFIRM_COPY[linkState]
+
   return (
-    <div
-      style={{
-        maxWidth: 520,
-        margin: '64px auto',
-        padding: 24,
-        textAlign: 'center',
-      }}
-    >
-      <h1
-        style={{
-          fontFamily: 'var(--font-display)',
-          fontSize: 40,
-          margin: '0 0 12px',
-        }}
-      >
-        {status === 'ok' ? 'You’re in.' : 'Confirming your email…'}
-      </h1>
-      {status === 'confirming' && (
-        <p style={{ color: 'var(--fg-3)' }}>Hang tight, this only takes a second.</p>
-      )}
-      {status === 'ok' && (
-        <>
-          <p style={{ color: 'var(--fg-2)' }}>
-            Your email is verified. Your FortyMM account is now yours to keep.
-          </p>
-          <Link
-            to="/dashboard"
-            className="fmm-btn fmm-btn--primary"
-            style={{ marginTop: 24 }}
-          >
+    <LinkCheckPage
+      state={linkState}
+      eyebrow={copy?.eyebrow}
+      title={copy?.title}
+      subtitle={copy?.subtitle}
+      detail={linkState === 'expired' ? errorMsg : undefined}
+      footer={
+        linkState === 'success' ? (
+          <Link to="/dashboard" style={{ ...btnPrimary, width: '100%' }}>
             Go to dashboard
           </Link>
-        </>
-      )}
-      {(status === 'error' || status === 'missing-token') && (
-        <>
-          <p className="fmm-help fmm-help--err" role="alert">
-            {errorMsg}
-          </p>
+        ) : linkState === 'expired' ? (
           <Link
             to="/settings"
             hash="sec-email"
-            className="fmm-btn fmm-btn--quiet"
-            style={{ marginTop: 24 }}
+            style={{ ...btnPrimary, width: '100%' }}
           >
             Back to settings
           </Link>
-        </>
-      )}
-    </div>
+        ) : undefined
+      }
+    />
   )
 }

--- a/web-client/src/routes/login.index.tsx
+++ b/web-client/src/routes/login.index.tsx
@@ -58,7 +58,10 @@ function LoginPage() {
           await requestLogin.mutateAsync({ email, captchaToken, honeypot })
           navigate({
             to: '/login/sent',
-            search: { email, error: undefined },
+            // Stamp the send time so /login/sent can run a real expiry
+            // countdown anchored to when the link actually went out (survives
+            // refresh; a fresh send via resend re-stamps it).
+            search: { email, sentAt: Date.now(), error: undefined },
           })
         } catch (err) {
           if (err instanceof ApiError) {

--- a/web-client/src/routes/login.sent.tsx
+++ b/web-client/src/routes/login.sent.tsx
@@ -10,12 +10,13 @@ export const Route = createFileRoute('/login/sent')({
   validateSearch: (search: Record<string, unknown>) => ({
     error: search.error === 'bounce' ? ('bounce' as const) : undefined,
     email: typeof search.email === 'string' ? search.email : '',
+    sentAt: typeof search.sentAt === 'number' ? search.sentAt : undefined,
   }),
   component: LoginSentPage,
 })
 
 function LoginSentPage() {
-  const { error, email } = Route.useSearch()
+  const { error, email, sentAt } = Route.useSearch()
   const navigate = useNavigate()
 
   // Both "resend" and "start over" route back to /login with the email
@@ -35,6 +36,7 @@ function LoginSentPage() {
   return (
     <ScreenSent
       email={email || 'your inbox'}
+      sentAt={sentAt}
       onStartOver={back}
       onResend={back}
     />

--- a/web-client/src/routes/login.test.tsx
+++ b/web-client/src/routes/login.test.tsx
@@ -203,7 +203,7 @@ describe('/login/verifying flow', () => {
       expect(router.state.location.search).toMatchObject({ error: 'expired' })
     })
     expect(
-      await screen.findByRole('heading', { name: /this link can.t be used/i }),
+      await screen.findByRole('heading', { name: /this link expired/i }),
     ).toBeInTheDocument()
   })
 
@@ -226,7 +226,7 @@ describe('/login/verifying flow', () => {
   it('shows the missing-token screen when no token is supplied', async () => {
     renderAt('/login/verifying')
     expect(
-      await screen.findByRole('heading', { name: /this link can.t be used/i }),
+      await screen.findByRole('heading', { name: /this link expired/i }),
     ).toBeInTheDocument()
     expect(
       screen.getByText(/this link is missing its token/i),

--- a/web-client/src/routes/login.verifying.tsx
+++ b/web-client/src/routes/login.verifying.tsx
@@ -8,11 +8,9 @@ import {
   useConsumeLoginToken,
   useMergePreview,
 } from '@/api/session'
-import {
-  ScreenError,
-  ScreenVerify,
-  ScreenVerifyNetError,
-} from '@/components/login/login-screens'
+import { btnPrimary } from '@/components/login/styles'
+import { LinkCheckPage } from '@/components/login/link-check-page/link-check-page'
+import { ScreenVerifyNetError } from '@/components/login/login-screens'
 import { MergeGate } from '@/components/login/merge-gate'
 import { pageTitle } from '@/lib/page-title'
 
@@ -91,25 +89,31 @@ function LoginVerifyingPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token, error])
 
+  const sendNewLink = () =>
+    navigate({ to: '/login', search: { error: undefined, email: undefined } })
+
+  const sendNewLinkButton = (
+    <button
+      type="button"
+      style={{ ...btnPrimary, width: '100%' }}
+      onClick={sendNewLink}
+    >
+      Send a new link
+    </button>
+  )
+
   if (!token && !error) {
     return (
-      <ScreenError
+      <LinkCheckPage
+        state="expired"
         detail="This link is missing its token."
-        onRequestNew={() =>
-          navigate({ to: '/login', search: { error: undefined, email: undefined } })
-        }
+        footer={sendNewLinkButton}
       />
     )
   }
 
   if (error === 'expired') {
-    return (
-      <ScreenError
-        onRequestNew={() =>
-          navigate({ to: '/login', search: { error: undefined, email: undefined } })
-        }
-      />
-    )
+    return <LinkCheckPage state="expired" footer={sendNewLinkButton} />
   }
 
   if (error === 'net') {
@@ -141,5 +145,5 @@ function LoginVerifyingPage() {
     )
   }
 
-  return <ScreenVerify />
+  return <LinkCheckPage state="checking" />
 }


### PR DESCRIPTION
## What

Implements the **FortyMM "Login flow"** Claude Design handoff. Most of the design (the split-shell `email → sent → verify → success → error` screens) was already built; the genuinely new piece is the **focused, single-column page a sign-in / email-confirm link opens to** — it checks the token and signs the user in.

### `LinkCheckPage`
New presentational component (`src/components/login/link-check-page/`) with three states — **checking → success → expired** — reusing the login design vocabulary (ball logo, brand dot-grid texture, 72px status disc, Bebas headline). Colocated page object + vitest tests.

**Design adaptations (faithful, grounded in reality):**
- **Does not render the token** — your design-chat note said "let's not show the token", and it's a live bearer credential. Also drops the prototype's fake request-log / hardcoded token metadata.

### Wired into both token-check landings
- **`/confirm-email`** (email confirmation) — was a bare, unstyled page (the "CONFIRMING YOUR EMAIL… invalid or expired" screen).
- **`/login/verifying`** (magic-link sign-in) — replaces the older split-shell `ScreenVerify`. Net-error screen, merge gate, and `/login/welcome` redirect are preserved.

### Real expiry countdown
The "LINK EXPIRES IN 14:32" strip on `/login/sent` was static. It now ticks against the real **15-minute** link TTL (mirrors the API's `LOGIN_TOKEN_LIFETIME`), anchored to the send time threaded through the URL (survives refresh; re-stamped on resend), and flips to an expired treatment at `0:00`.

### Refactor
- Lifted shared atoms (`BallLogo`, `Eyebrow`) into `atoms.tsx` and style objects into `styles.ts` so the new page reuses them without copy-paste.
- Removed the now-dead `ScreenVerify` / `ScreenError` and their exclusive helpers.

## Testing
- **vitest:** 457 passed (incl. new `LinkCheckPage` 3-state tests asserting the token is never rendered, and a fake-timers countdown test that ticks to `0:00`).
- **lint + build (tsc):** clean.
- **web-client Playwright e2e:** 127 passed.
- API suite + OpenAPI schema-drift: N/A (web-client-only diff). No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)