### PR TITLE
Fix #514: show retry guidance for rate-limited match details

### DIFF
--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -213,6 +213,30 @@ describe("MatchDetailsView", () => {
     ).toHaveAttribute("href", "/matches");
   });
 
+  it("shows retry guidance (not not-found) when the match endpoint is rate-limited (#514)", async () => {
+    server.use(
+      http.get("*/v1/matches/m-busy", () =>
+        HttpResponse.json({ detail: "Too Many Requests" }, { status: 429 }),
+      ),
+    );
+    renderDetails("m-busy");
+
+    const alert = await screen.findByRole("alert");
+    // 429 is transient — show retry copy, not the "couldn't find that match"
+    // dead end.
+    expect(within(alert).getByText(/too many requests/i)).toBeInTheDocument();
+    expect(
+      within(alert).queryByText(/couldn.t find that match/i),
+    ).not.toBeInTheDocument();
+    // Retrying the same URL is the right move, so keep the retry affordance.
+    expect(
+      within(alert).getByRole("button", { name: /try again/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(alert).queryByRole("link", { name: /back to matches/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it('renders no-opponent matches with a "No opponent" placeholder, still scorable', async () => {
     const game1 = { id: "g-solo-1", game_number: 1, score: null };
     const match = matchDetails({

--- a/web-client/src/components/matches/match-details-page.test.tsx
+++ b/web-client/src/components/matches/match-details-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import {
   RouterProvider,
   createMemoryHistory,
@@ -173,69 +173,9 @@ describe("MatchDetailsView", () => {
     );
   });
 
-  it("renders an error fallback when the match fails to load", async () => {
-    server.use(
-      http.get("*/v1/matches/m-missing", () =>
-        HttpResponse.json({ detail: "Match not found." }, { status: 404 }),
-      ),
-    );
-    renderDetails("m-missing");
-
-    const alert = await screen.findByRole("alert");
-    expect(
-      within(alert).getByText(/couldn.t find that match/i),
-    ).toBeInTheDocument();
-  });
-
-  it("shows friendly not-found copy (not the raw API detail) for a malformed match id (#152)", async () => {
-    server.use(
-      http.get("*/v1/matches/garbage", () =>
-        HttpResponse.json(
-          {
-            detail:
-              "Input should be a valid UUID, invalid character: found `g` at 1",
-          },
-          { status: 422 },
-        ),
-      ),
-    );
-    renderDetails("garbage");
-
-    const alert = await screen.findByRole("alert");
-    expect(
-      within(alert).getByText(/couldn.t find that match/i),
-    ).toBeInTheDocument();
-    // The raw pydantic validation message must not leak to the user.
-    expect(within(alert).queryByText(/valid UUID/i)).not.toBeInTheDocument();
-    // Retrying the same broken URL is pointless — offer a way back to the list.
-    expect(
-      within(alert).getByRole("link", { name: /back to matches/i }),
-    ).toHaveAttribute("href", "/matches");
-  });
-
-  it("shows retry guidance (not not-found) when the match endpoint is rate-limited (#514)", async () => {
-    server.use(
-      http.get("*/v1/matches/m-busy", () =>
-        HttpResponse.json({ detail: "Too Many Requests" }, { status: 429 }),
-      ),
-    );
-    renderDetails("m-busy");
-
-    const alert = await screen.findByRole("alert");
-    // 429 is transient — show retry copy, not the "couldn't find that match"
-    // dead end.
-    expect(within(alert).getByText(/too many requests/i)).toBeInTheDocument();
-    expect(
-      within(alert).queryByText(/couldn.t find that match/i),
-    ).not.toBeInTheDocument();
-    // Retrying the same URL is the right move, so keep the retry affordance.
-    expect(
-      within(alert).getByRole("button", { name: /try again/i }),
-    ).toBeInTheDocument();
-    expect(
-      within(alert).queryByRole("link", { name: /back to matches/i }),
-    ).not.toBeInTheDocument();
-  });
+  // The error-boundary fallback (404 not-found, #152 malformed-id no-leak, and
+  // the #514 429 retry path) is now owned by the `MatchDetailsError` quartet —
+  // see match-details/match-details-error.test.tsx.
 
   it('renders no-opponent matches with a "No opponent" placeholder, still scorable', async () => {
     const game1 = { id: "g-solo-1", game_number: 1, score: null };

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -44,14 +44,21 @@ export function MatchDetailsError({
 }) {
   const router = useRouter()
   const status = error instanceof ApiError ? error.status : 0
-  // Any client error (404 no-such-match, 422 malformed id, …) means there's no
-  // viewable match at this URL — show the friendly copy and never leak the raw
-  // API detail (e.g. the pydantic "Input should be a valid UUID" string, #152).
-  // Retrying the same URL won't help, so offer a way back to the list instead.
-  const notFound = status >= 400 && status < 500
+  // `GET /v1/matches/{id}` is public and per-IP rate-limited, so a valid shared
+  // URL can hit 429 under load/refresh bursts. That's transient — retrying the
+  // same URL is exactly the right move, so treat it like a transient failure
+  // (retry button) rather than the not-found dead end (#514).
+  const rateLimited = status === 429
+  // Any other client error (404 no-such-match, 422 malformed id, …) means
+  // there's no viewable match at this URL — show the friendly copy and never
+  // leak the raw API detail (e.g. the pydantic "Input should be a valid UUID"
+  // string, #152). Retrying won't help, so offer a way back to the list.
+  const notFound = !rateLimited && status >= 400 && status < 500
   const message = notFound
     ? "We couldn't find that match."
-    : 'Something went wrong loading this match.'
+    : rateLimited
+      ? 'Too many requests. Try again shortly.'
+      : 'Something went wrong loading this match.'
   const body = (
     <div role="alert" className="md-error-state">
       <div className="md-error-state__title">{message}</div>

--- a/web-client/src/components/matches/match-details-page.tsx
+++ b/web-client/src/components/matches/match-details-page.tsx
@@ -1,4 +1,4 @@
-import { Link, useRouter } from '@tanstack/react-router'
+import { Link } from '@tanstack/react-router'
 
 import { ConfirmationCallout } from './match-details/confirmation-callout'
 import { FinalizeCallout } from './match-details/finalize-callout'
@@ -9,9 +9,16 @@ import { Ratings } from './match-details/ratings'
 import { Scoreboard } from './match-details/scoreboard'
 import { ScoreCta } from './match-details/score-cta'
 import { AppShell } from '@/components/app-shell'
-import { ApiError } from '@/api/client'
 
 import { SaveYourMatch } from './save-your-match'
+
+// `MatchDetailsError` is the error-boundary fallback for this page; it now
+// lives in its own colocated quartet. Re-exported here so the routes can keep
+// importing both halves of the page from one module.
+export {
+  MatchDetailsError,
+  type MatchDetailsErrorProps,
+} from './match-details/match-details-error'
 
 export function MatchDetailsView({
   matchId,
@@ -27,63 +34,6 @@ export function MatchDetailsView({
   // Every section below is a self-fetching quartet, so the page renders
   // immediately and each piece suspends independently — no page-level fetch.
   const body = <MatchDetailsPage matchId={matchId} standalone={standalone} />
-  return standalone ? body : <AppShell>{body}</AppShell>
-}
-
-export function MatchDetailsError({
-  error,
-  reset,
-  standalone = false,
-}: {
-  error: Error
-  reset: () => void
-  /** Mirror of `MatchDetailsView`'s standalone — skip AppShell on the public
-   * route, and drop the "Back to matches" affordance (anonymous viewers
-   * can't reach /matches). */
-  standalone?: boolean
-}) {
-  const router = useRouter()
-  const status = error instanceof ApiError ? error.status : 0
-  // `GET /v1/matches/{id}` is public and per-IP rate-limited, so a valid shared
-  // URL can hit 429 under load/refresh bursts. That's transient — retrying the
-  // same URL is exactly the right move, so treat it like a transient failure
-  // (retry button) rather than the not-found dead end (#514).
-  const rateLimited = status === 429
-  // Any other client error (404 no-such-match, 422 malformed id, …) means
-  // there's no viewable match at this URL — show the friendly copy and never
-  // leak the raw API detail (e.g. the pydantic "Input should be a valid UUID"
-  // string, #152). Retrying won't help, so offer a way back to the list.
-  const notFound = !rateLimited && status >= 400 && status < 500
-  const message = notFound
-    ? "We couldn't find that match."
-    : rateLimited
-      ? 'Too many requests. Try again shortly.'
-      : 'Something went wrong loading this match.'
-  const body = (
-    <div role="alert" className="md-error-state">
-      <div className="md-error-state__title">{message}</div>
-      {notFound ? (
-        // The public route has no /matches index to send anonymous viewers
-        // to; for them the 404 page stops at the message.
-        standalone ? null : (
-          <Link to="/matches" className="md-btn md-btn--secondary">
-            Back to matches
-          </Link>
-        )
-      ) : (
-        <button
-          type="button"
-          className="md-btn md-btn--secondary"
-          onClick={() => {
-            reset()
-            router.invalidate()
-          }}
-        >
-          Try again
-        </button>
-      )}
-    </div>
-  )
   return standalone ? body : <AppShell>{body}</AppShell>
 }
 

--- a/web-client/src/components/matches/match-details/match-details-error.factory.tsx
+++ b/web-client/src/components/matches/match-details/match-details-error.factory.tsx
@@ -1,0 +1,27 @@
+import { ApiError } from '@/api/client'
+
+import type { MatchDetailsErrorProps } from './match-details-error'
+
+/** An `ApiError` carrying `status` — the field `MatchDetailsError` branches on.
+ * `detail` defaults to null; pass a raw API string to exercise the no-leak
+ * path (#152). */
+export function buildApiError(
+  status: number,
+  detail: string | null = null,
+): ApiError {
+  return new ApiError(status, detail, 'load match')
+}
+
+/** Props for `MatchDetailsError`. Default scenario: a 404 no-such-match on the
+ * in-app (non-standalone) route — the friendly not-found dead end with a
+ * "Back to matches" link and the AppShell chrome. */
+export function buildMatchDetailsErrorProps(
+  overrides: Partial<MatchDetailsErrorProps> = {},
+): MatchDetailsErrorProps {
+  return {
+    error: buildApiError(404, 'Match not found.'),
+    reset: () => {},
+    standalone: false,
+    ...overrides,
+  }
+}

--- a/web-client/src/components/matches/match-details/match-details-error.page.tsx
+++ b/web-client/src/components/matches/match-details/match-details-error.page.tsx
@@ -1,0 +1,84 @@
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+
+import { render, screen, type Container } from '@/test/utilities'
+
+import {
+  MatchDetailsError,
+  type MatchDetailsErrorProps,
+} from './match-details-error'
+import { buildMatchDetailsErrorProps } from './match-details-error.factory'
+
+const scoped = (container: Container) => ({
+  /** The error region. Always present once the boundary renders. */
+  getAlert() {
+    return container.getByRole('alert')
+  },
+  findAlert() {
+    return container.findByRole('alert')
+  },
+  /** The headline copy (e.g. "We couldn't find that match."). Use a
+   * substring/regex matcher; absent only if the alert hasn't rendered. */
+  queryMessage(text: string | RegExp) {
+    return container.queryByText(text)
+  },
+  /** The retry affordance — present for retryable errors (429, 5xx, network),
+   * absent for the not-found dead end. */
+  queryRetryButton() {
+    return container.queryByRole('button', { name: /try again/i })
+  },
+  getRetryButton() {
+    return container.getByRole('button', { name: /try again/i })
+  },
+  /** The "Back to matches" link — present only for the in-app not-found case
+   * (4xx, non-standalone); absent on the public standalone route. */
+  queryBackLink() {
+    return container.queryByRole('link', { name: /back to matches/i })
+  },
+})
+
+/**
+ * Test page-object for `MatchDetailsError`. The not-found case renders a typed
+ * `<Link to="/matches">`, so `render` mounts the component under a minimal
+ * memory router that registers that route. The router resolves asynchronously,
+ * so tests start with `await matchDetailsErrorPage.findAlert()`.
+ */
+export const matchDetailsErrorPage = {
+  render(overrides: Partial<MatchDetailsErrorProps> = {}) {
+    const props = buildMatchDetailsErrorProps(overrides)
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => <MatchDetailsError {...props} />,
+    })
+    // Route stub the "Back to matches" link navigates to — registered so the
+    // typed <Link> resolves at render time.
+    const matchesList = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/matches',
+      component: () => <div>matches-list</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, matchesList]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+    render(<RouterProvider router={router} />)
+  },
+
+  /**
+   * Scope the accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Parent page objects spread this to expose the same
+   * queries as their own rather than re-deriving them.
+   */
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/matches/match-details/match-details-error.page.tsx
+++ b/web-client/src/components/matches/match-details/match-details-error.page.tsx
@@ -16,9 +16,6 @@ import { buildMatchDetailsErrorProps } from './match-details-error.factory'
 
 const scoped = (container: Container) => ({
   /** The error region. Always present once the boundary renders. */
-  getAlert() {
-    return container.getByRole('alert')
-  },
   findAlert() {
     return container.findByRole('alert')
   },
@@ -31,9 +28,6 @@ const scoped = (container: Container) => ({
    * absent for the not-found dead end. */
   queryRetryButton() {
     return container.queryByRole('button', { name: /try again/i })
-  },
-  getRetryButton() {
-    return container.getByRole('button', { name: /try again/i })
   },
   /** The "Back to matches" link — present only for the in-app not-found case
    * (4xx, non-standalone); absent on the public standalone route. */

--- a/web-client/src/components/matches/match-details/match-details-error.test.tsx
+++ b/web-client/src/components/matches/match-details/match-details-error.test.tsx
@@ -1,0 +1,92 @@
+import { buildApiError } from './match-details-error.factory'
+import { matchDetailsErrorPage } from './match-details-error.page'
+
+describe('MatchDetailsError', () => {
+  it('shows the not-found dead end with a Back to matches link for a 404', async () => {
+    matchDetailsErrorPage.render({ error: buildApiError(404, 'Match not found.') })
+
+    await matchDetailsErrorPage.findAlert()
+    expect(
+      matchDetailsErrorPage.queryMessage(/couldn.t find that match/i),
+    ).toBeInTheDocument()
+    expect(matchDetailsErrorPage.queryBackLink()).toHaveAttribute(
+      'href',
+      '/matches',
+    )
+    // Retrying the same URL won't help — no retry affordance.
+    expect(matchDetailsErrorPage.queryRetryButton()).not.toBeInTheDocument()
+  })
+
+  it('shows friendly not-found copy without leaking the raw API detail for a malformed id (#152)', async () => {
+    matchDetailsErrorPage.render({
+      error: buildApiError(
+        422,
+        'Input should be a valid UUID, invalid character: found `g` at 1',
+      ),
+    })
+
+    await matchDetailsErrorPage.findAlert()
+    expect(
+      matchDetailsErrorPage.queryMessage(/couldn.t find that match/i),
+    ).toBeInTheDocument()
+    // The raw pydantic validation message must not reach the user.
+    expect(matchDetailsErrorPage.queryMessage(/valid UUID/i)).not.toBeInTheDocument()
+    expect(matchDetailsErrorPage.queryBackLink()).toHaveAttribute(
+      'href',
+      '/matches',
+    )
+  })
+
+  it('shows retry guidance (not the not-found dead end) when rate-limited with a 429 (#514)', async () => {
+    matchDetailsErrorPage.render({ error: buildApiError(429, 'Too Many Requests') })
+
+    await matchDetailsErrorPage.findAlert()
+    // 429 is transient — retry copy, not "couldn't find that match".
+    expect(
+      matchDetailsErrorPage.queryMessage(/too many requests/i),
+    ).toBeInTheDocument()
+    expect(
+      matchDetailsErrorPage.queryMessage(/couldn.t find that match/i),
+    ).not.toBeInTheDocument()
+    // Retrying the same URL is the right move, so keep the retry affordance and
+    // drop the back-to-list dead end.
+    expect(matchDetailsErrorPage.queryRetryButton()).toBeInTheDocument()
+    expect(matchDetailsErrorPage.queryBackLink()).not.toBeInTheDocument()
+  })
+
+  it('shows a generic retryable error for a 5xx', async () => {
+    matchDetailsErrorPage.render({ error: buildApiError(500, 'boom') })
+
+    await matchDetailsErrorPage.findAlert()
+    expect(
+      matchDetailsErrorPage.queryMessage(/something went wrong loading this match/i),
+    ).toBeInTheDocument()
+    expect(matchDetailsErrorPage.queryRetryButton()).toBeInTheDocument()
+    expect(matchDetailsErrorPage.queryBackLink()).not.toBeInTheDocument()
+  })
+
+  it('treats a non-ApiError (network failure) as a generic retryable error', async () => {
+    matchDetailsErrorPage.render({ error: new Error('NetworkError') })
+
+    await matchDetailsErrorPage.findAlert()
+    expect(
+      matchDetailsErrorPage.queryMessage(/something went wrong loading this match/i),
+    ).toBeInTheDocument()
+    expect(matchDetailsErrorPage.queryRetryButton()).toBeInTheDocument()
+  })
+
+  it('drops the Back to matches link on the public standalone route', async () => {
+    matchDetailsErrorPage.render({
+      error: buildApiError(404, 'Match not found.'),
+      standalone: true,
+    })
+
+    await matchDetailsErrorPage.findAlert()
+    // Anonymous viewers can't reach /matches, so the 404 stops at the message.
+    expect(
+      matchDetailsErrorPage.queryMessage(/couldn.t find that match/i),
+    ).toBeInTheDocument()
+    expect(matchDetailsErrorPage.queryBackLink()).not.toBeInTheDocument()
+    expect(matchDetailsErrorPage.queryRetryButton()).not.toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/matches/match-details/match-details-error.tsx
+++ b/web-client/src/components/matches/match-details/match-details-error.tsx
@@ -1,0 +1,65 @@
+import { Link, useRouter } from '@tanstack/react-router'
+
+import { AppShell } from '@/components/app-shell'
+import { ApiError } from '@/api/client'
+
+export interface MatchDetailsErrorProps {
+  error: Error
+  reset: () => void
+  /** Skip the AppShell chrome and drop the "Back to matches" affordance —
+   * used by the public `/p/matches` route, whose anonymous viewers have no
+   * nav sidebar and can't reach /matches. */
+  standalone?: boolean
+}
+
+/** Error boundary fallback for the match-details page. Translates the failing
+ * `GET /v1/matches/{id}` status into the right message + recovery affordance. */
+export function MatchDetailsError({
+  error,
+  reset,
+  standalone = false,
+}: MatchDetailsErrorProps) {
+  const router = useRouter()
+  const status = error instanceof ApiError ? error.status : 0
+  // `GET /v1/matches/{id}` is public and per-IP rate-limited, so a valid shared
+  // URL can hit 429 under load/refresh bursts. That's transient — retrying the
+  // same URL is exactly the right move, so treat it like a transient failure
+  // (retry button) rather than the not-found dead end (#514).
+  const rateLimited = status === 429
+  // Any other client error (404 no-such-match, 422 malformed id, …) means
+  // there's no viewable match at this URL — show the friendly copy and never
+  // leak the raw API detail (e.g. the pydantic "Input should be a valid UUID"
+  // string, #152). Retrying won't help, so offer a way back to the list.
+  const notFound = !rateLimited && status >= 400 && status < 500
+  const message = notFound
+    ? "We couldn't find that match."
+    : rateLimited
+      ? 'Too many requests. Try again shortly.'
+      : 'Something went wrong loading this match.'
+  const body = (
+    <div role="alert" className="md-error-state">
+      <div className="md-error-state__title">{message}</div>
+      {notFound ? (
+        // The public route has no /matches index to send anonymous viewers
+        // to; for them the 404 page stops at the message.
+        standalone ? null : (
+          <Link to="/matches" className="md-btn md-btn--secondary">
+            Back to matches
+          </Link>
+        )
+      ) : (
+        <button
+          type="button"
+          className="md-btn md-btn--secondary"
+          onClick={() => {
+            reset()
+            router.invalidate()
+          }}
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  )
+  return standalone ? body : <AppShell>{body}</AppShell>
+}


### PR DESCRIPTION
Closes #514.

## Problem
`GET /v1/matches/{id}` is public and per-IP rate-limited, but `MatchDetailsError` mapped **every** 4xx to the not-found state. A viewer who hit the rate limit on a valid shared match URL saw **"We couldn't find that match."** with no retry affordance — the page looked broken under load.

## Fix
Special-case `429` in `MatchDetailsError`:
- Copy: **"Too many requests. Try again shortly."** (distinct from the not-found / malformed-id message).
- Keeps the **Try again** retry button (`reset()` + `router.invalidate()`), since retrying the same URL is the right move for a transient limit — rather than the "Back to matches" dead end, which also wouldn't work for anonymous viewers on the public `/p/matches` route.

Other 4xx (404 no-such-match, 422 malformed id, #152) keep the existing friendly not-found copy and never leak raw API detail.

## Refactor (react-component conventions)
Extracted `MatchDetailsError` out of the monolithic `match-details-page.tsx` into its own colocated quartet under `match-details/`:
- `match-details-error.tsx` — the component (props in, DOM out)
- `match-details-error.page.tsx` — test page object (router harness + scoped accessors)
- `match-details-error.factory.tsx` — `buildApiError` / `buildMatchDetailsErrorProps`
- `match-details-error.test.tsx` — 6 unit tests, one per status branch

`match-details-page.tsx` re-exports it so the two routes keep importing both halves of the page from one module. The legacy error-state tests in `match-details-page.test.tsx` were removed (now owned by the quartet).

## Tests
The error component's `status → message/affordance` projection is now unit-tested in isolation: 404 not-found + back link, 422 malformed-id no-leak (#152), 429 retry (#514), 5xx generic, non-ApiError network failure, and the standalone (public) no-back-link case. Full web-client suite: **461 tests pass**; `eslint` clean; `tsc -b && vite build` clean. Playwright e2e suites not run in this environment (no browser/docker); behavior is unchanged by the refactor.

https://claude.ai/code/session_01RkqChnGqhYK4LusVNwEFPU