### PR TITLE
Add tournament admin (Tournament CRUD) UI

### DIFF
--- a/web-client/src/components/tournaments/confirm-delete-dialog.factory.tsx
+++ b/web-client/src/components/tournaments/confirm-delete-dialog.factory.tsx
@@ -1,0 +1,15 @@
+import type { ConfirmDeleteDialogProps } from './confirm-delete-dialog'
+
+/** Props for `ConfirmDeleteDialog` — an open "delete tournament" prompt. */
+export function buildConfirmDeleteDialogProps(
+  overrides: Partial<ConfirmDeleteDialogProps> = {},
+): ConfirmDeleteDialogProps {
+  return {
+    open: true,
+    onOpenChange: () => {},
+    kind: 'tournament',
+    name: 'Bay Area Open 2026',
+    onConfirm: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/confirm-delete-dialog.page.tsx
+++ b/web-client/src/components/tournaments/confirm-delete-dialog.page.tsx
@@ -1,0 +1,32 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import {
+  ConfirmDeleteDialog,
+  type ConfirmDeleteDialogProps,
+} from './confirm-delete-dialog'
+import { buildConfirmDeleteDialogProps } from './confirm-delete-dialog.factory'
+
+const scoped = (container: Container) => ({
+  queryDialog() {
+    return container.queryByRole('dialog')
+  },
+  getConfirmButton() {
+    return container.getByRole('button', { name: /^Delete$/ })
+  },
+  getCancelButton() {
+    return container.getByRole('button', { name: /Cancel/ })
+  },
+})
+
+/** Test page-object for `ConfirmDeleteDialog`. Portals to the body. */
+export const confirmDeleteDialogPage = {
+  render(overrides: Partial<ConfirmDeleteDialogProps> = {}) {
+    render(<ConfirmDeleteDialog {...buildConfirmDeleteDialogProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/confirm-delete-dialog.test.tsx
+++ b/web-client/src/components/tournaments/confirm-delete-dialog.test.tsx
@@ -1,0 +1,19 @@
+import userEvent from '@testing-library/user-event'
+
+import { confirmDeleteDialogPage } from './confirm-delete-dialog.page'
+
+describe('ConfirmDeleteDialog', () => {
+  it('names the entity and kind being deleted', () => {
+    confirmDeleteDialogPage.render({ kind: 'event', name: 'Open Singles' })
+    const dialog = confirmDeleteDialogPage.queryDialog()
+    expect(dialog).toHaveTextContent('Delete event?')
+    expect(dialog).toHaveTextContent('Open Singles')
+  })
+
+  it('confirms the deletion', async () => {
+    const onConfirm = vi.fn()
+    confirmDeleteDialogPage.render({ onConfirm })
+    await userEvent.click(confirmDeleteDialogPage.getConfirmButton())
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web-client/src/components/tournaments/confirm-delete-dialog.tsx
+++ b/web-client/src/components/tournaments/confirm-delete-dialog.tsx
@@ -1,0 +1,54 @@
+import { Trash2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+export interface ConfirmDeleteDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The kind of thing being deleted, e.g. "tournament" or "event". */
+  kind: string
+  /** The name of the specific entity, bolded in the body. */
+  name: string | undefined
+  onConfirm: () => void
+}
+
+/** Generic "are you sure?" delete confirmation, shared by the tournament list
+ * and the event editor. */
+export const ConfirmDeleteDialog = ({
+  open,
+  onOpenChange,
+  kind,
+  name,
+  onConfirm,
+}: ConfirmDeleteDialogProps) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>Delete {kind}?</DialogTitle>
+          <DialogDescription>
+            <span className="font-semibold text-[color:var(--fg-1)]">{name}</span>{' '}
+            will be removed. This can't be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={onConfirm}>
+            <Trash2 size={16} />
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web-client/src/components/tournaments/data/helpers.test.ts
+++ b/web-client/src/components/tournaments/data/helpers.test.ts
@@ -1,0 +1,107 @@
+import {
+  daysBetween,
+  effectiveDateRange,
+  fmtDateRange,
+  formatPredicate,
+  findPoolConflicts,
+} from './helpers'
+import { buildPool, buildTournament, buildEvent } from './seed.factory'
+import type { Predicate } from './types'
+
+describe('fmtDateRange', () => {
+  it('collapses a same-month span to one month label', () => {
+    expect(fmtDateRange('2026-06-13', '2026-06-14')).toBe('Jun 13–14, 2026')
+  })
+
+  it('spans months in full', () => {
+    expect(fmtDateRange('2026-06-30', '2026-07-01')).toBe('Jun 30 – Jul 1, 2026')
+  })
+
+  it('returns a single date when the days are equal', () => {
+    expect(fmtDateRange('2026-06-13', '2026-06-13')).toBe('Jun 13, 2026')
+  })
+})
+
+describe('daysBetween', () => {
+  it('counts inclusively', () => {
+    expect(daysBetween('2026-06-13', '2026-06-14')).toBe(2)
+  })
+
+  it('floors at one day', () => {
+    expect(daysBetween('2026-06-13', '2026-06-13')).toBe(1)
+  })
+})
+
+describe('effectiveDateRange', () => {
+  it('derives the span from event slots when events exist', () => {
+    const t = buildTournament({
+      startDate: '2030-01-01',
+      endDate: '2030-01-01',
+      events: [
+        buildEvent({ slot: { date: '2026-06-14', start: '09:00', end: '12:00' } }),
+        buildEvent({ slot: { date: '2026-06-13', start: '09:00', end: '12:00' } }),
+      ],
+    })
+    expect(effectiveDateRange(t)).toEqual({ start: '2026-06-13', end: '2026-06-14' })
+  })
+
+  it('falls back to the seeded dates with no events', () => {
+    const t = buildTournament({
+      startDate: '2026-08-22',
+      endDate: '2026-08-23',
+      events: [],
+    })
+    expect(effectiveDateRange(t)).toEqual({ start: '2026-08-22', end: '2026-08-23' })
+  })
+})
+
+describe('formatPredicate', () => {
+  it('labels a numeric less-than rule', () => {
+    const p: Predicate = { id: 'p', field: 'rating', op: '<', value: 1500 }
+    expect(formatPredicate(p)).toBe('USATT rating < 1500')
+  })
+
+  it('labels an enum equality rule with the option label', () => {
+    const p: Predicate = { id: 'p', field: 'gender', op: 'is', value: 'F' }
+    expect(formatPredicate(p)).toBe('Gender = Female')
+  })
+
+  it('labels a between rule with the range', () => {
+    const p: Predicate = { id: 'p', field: 'age', op: 'between', value: [13, 17] }
+    expect(formatPredicate(p)).toBe('Age in [13–17]')
+  })
+})
+
+describe('findPoolConflicts', () => {
+  it('flags a table shared by two overlapping same-day pools', () => {
+    const conflicts = findPoolConflicts([
+      buildPool({
+        name: 'Pool A',
+        slot: { date: '2026-06-13', start: '09:00', end: '12:00' },
+        tableIds: ['t1', 't2'],
+      }),
+      buildPool({
+        name: 'Pool B',
+        slot: { date: '2026-06-13', start: '11:00', end: '14:00' },
+        tableIds: ['t2', 't3'],
+      }),
+    ])
+    expect(conflicts).toEqual([{ table: 'T2', poolA: 'Pool A', poolB: 'Pool B' }])
+  })
+
+  it('ignores pools that do not overlap in time', () => {
+    const conflicts = findPoolConflicts([
+      buildPool({ slot: { date: '2026-06-13', start: '09:00', end: '11:00' }, tableIds: ['t1'] }),
+      buildPool({ slot: { date: '2026-06-13', start: '11:00', end: '13:00' }, tableIds: ['t1'] }),
+    ])
+    expect(conflicts).toEqual([])
+  })
+
+  it('ignores pools on different days', () => {
+    const conflicts = findPoolConflicts([
+      buildPool({ slot: { date: '2026-06-13', start: '09:00', end: '12:00' }, tableIds: ['t1'] }),
+      buildPool({ slot: { date: '2026-06-14', start: '09:00', end: '12:00' }, tableIds: ['t1'] }),
+    ])
+    expect(conflicts).toEqual([])
+  })
+})

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -1,0 +1,174 @@
+// Pure helpers for the tournament-admin UI: date-only formatting (the domain
+// uses `YYYY-MM-DD`, never wall-clock instants, so we parse to a local Date to
+// dodge timezone drift), derived date ranges, predicate labels, and table
+// double-booking detection.
+
+import { PRED_FIELDS } from './options'
+import type { Predicate, Pool, Tournament, TournamentEvent } from './types'
+
+/** Parse a date-only `YYYY-MM-DD` string into a local-midnight Date. */
+function parseDateOnly(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number)
+  return new Date(y, m - 1, d)
+}
+
+export function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  return parseDateOnly(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export function fmtDateShort(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  return parseDateOnly(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+/** A compact, human range: collapses same-day, same-month, and full spans. */
+export function fmtDateRange(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): string {
+  if (!a || !b) return '—'
+  if (a === b) return fmtDate(a)
+  const [ay, am] = a.split('-').map(Number)
+  const [by, bm] = b.split('-').map(Number)
+  if (ay === by && am === bm) {
+    return `${fmtDateShort(a)}–${b.split('-')[2]}, ${ay}`
+  }
+  return `${fmtDateShort(a)} – ${fmtDate(b)}`
+}
+
+/** Inclusive day count between two date-only strings (min 1). */
+export function daysBetween(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): number {
+  if (!a || !b) return 1
+  const da = parseDateOnly(a)
+  const db = parseDateOnly(b)
+  return Math.max(1, Math.round((db.getTime() - da.getTime()) / 86_400_000) + 1)
+}
+
+/** A tournament's real date span is the min/max of its events' slots; falls
+ * back to the seeded `startDate`/`endDate` when there are no events. */
+export function effectiveDateRange(t: Tournament): {
+  start: string | null
+  end: string | null
+} {
+  const dates = t.events.map((e) => e.slot?.date).filter(Boolean) as string[]
+  if (dates.length === 0) {
+    return { start: t.startDate, end: t.endDate }
+  }
+  dates.sort()
+  return { start: dates[0], end: dates[dates.length - 1] }
+}
+
+/** A human-readable summary of one eligibility predicate, e.g. `Age < 18`. */
+export function formatPredicate(p: Predicate): string {
+  const f = PRED_FIELDS[p.field]
+  if (!f) return '—'
+  if (f.type === 'number') {
+    const v = p.value
+    const ops: Record<string, string> = {
+      '<': '<',
+      '<=': '≤',
+      '>': '>',
+      '>=': '≥',
+      '=': '=',
+      '!=': '≠',
+    }
+    if (p.op === 'between' && Array.isArray(v)) {
+      return `${f.label} in [${v[0] ?? '?'}–${v[1] ?? '?'}]`
+    }
+    if (ops[p.op]) return `${f.label} ${ops[p.op]} ${v ?? '?'}`
+  }
+  if (f.type === 'enum') {
+    const label =
+      f.options?.find((o) => o.value === p.value)?.label ?? String(p.value)
+    return `${f.label} ${p.op === 'is' ? '=' : '≠'} ${label}`
+  }
+  if (f.type === 'bool') {
+    return p.op === 'true' ? `Must be ${f.label}` : `Must not be ${f.label}`
+  }
+  return '—'
+}
+
+export interface PoolConflict {
+  table: string
+  poolA: string
+  poolB: string
+}
+
+/** Tables double-booked across two pools whose time windows overlap on the
+ * same day — surfaced as a warning in the event editor's Table pools tab. */
+export function findPoolConflicts(pools: Pool[]): PoolConflict[] {
+  const conflicts: PoolConflict[] = []
+  for (let i = 0; i < pools.length; i++) {
+    for (let j = i + 1; j < pools.length; j++) {
+      const a = pools[i]
+      const b = pools[j]
+      if (a.slot.date !== b.slot.date) continue
+      if (a.slot.end <= b.slot.start || b.slot.end <= a.slot.start) continue
+      const shared = a.tableIds.filter((t) => b.tableIds.includes(t))
+      for (const t of shared) {
+        conflicts.push({ table: t.toUpperCase(), poolA: a.name, poolB: b.name })
+      }
+    }
+  }
+  return conflicts
+}
+
+let idCounter = 0
+/** Unique-enough id for in-session entities. Scope: a single tab — the counter
+ * resets on reload and isn't shared across tabs, which is fine for this
+ * front-end-only prototype but not for real persistence. */
+export function genId(prefix: string): string {
+  idCounter += 1
+  return `${prefix}-${idCounter}-${Date.now().toString(36)}`
+}
+
+/** A blank draft tournament for the "New tournament" modal. */
+export function emptyTournament(): Omit<Tournament, 'id'> {
+  return {
+    name: '',
+    status: 'draft',
+    startDate: null,
+    endDate: null,
+    description: '',
+    address: {
+      venue: '',
+      street: '',
+      city: '',
+      region: '',
+      postal: '',
+      country: 'USA',
+    },
+    tableIds: ['t1', 't2', 't3', 't4', 't5', 't6', 't7', 't8'],
+    events: [],
+  }
+}
+
+/** A blank draft event, defaulting its date to the tournament's first day. */
+export function emptyEvent(t: Tournament): TournamentEvent {
+  const range = effectiveDateRange(t)
+  const defaultDate = range.start ?? new Date().toISOString().slice(0, 10)
+  return {
+    id: genId('new'),
+    name: '',
+    format: 'singles',
+    drawType: 'single-elim',
+    maxPlayers: 32,
+    entryFee: 30,
+    entered: 0,
+    slot: { date: defaultDate, start: '09:00', end: '13:00' },
+    predicates: [],
+    match: { rated: true, lengthGames: 5 },
+    pools: [],
+  }
+}

--- a/web-client/src/components/tournaments/data/options.ts
+++ b/web-client/src/components/tournaments/data/options.ts
@@ -1,0 +1,88 @@
+// Select/segmented-control option lists and the eligibility predicate schema.
+// Shared by the event editor, the event cards, and the predicate formatter.
+
+import type { DrawType, EventFormat, MatchLength } from './types'
+
+export const FORMAT_OPTIONS: { value: EventFormat; label: string }[] = [
+  { value: 'singles', label: 'Singles' },
+  { value: 'doubles', label: 'Doubles' },
+  { value: 'teams', label: 'Teams' },
+]
+
+export const DRAW_TYPE_OPTIONS: { value: DrawType; label: string }[] = [
+  { value: 'single-elim', label: 'Single elimination' },
+  { value: 'double-elim', label: 'Double elimination' },
+  { value: 'round-robin', label: 'Round robin' },
+  { value: 'rr-then-ko', label: 'RR → KO' },
+  { value: 'swiss', label: 'Swiss' },
+]
+
+export const MATCH_LENGTH_OPTIONS: { value: MatchLength; label: string }[] = [
+  { value: 1, label: 'Bo1' },
+  { value: 3, label: 'Bo3' },
+  { value: 5, label: 'Bo5' },
+  { value: 7, label: 'Bo7' },
+]
+
+export const STATUS_FILTER_OPTIONS: {
+  value: 'all' | 'published' | 'draft' | 'archived'
+  label: string
+}[] = [
+  { value: 'all', label: 'All' },
+  { value: 'published', label: 'Published' },
+  { value: 'draft', label: 'Drafts' },
+  { value: 'archived', label: 'Archived' },
+]
+
+export type PredicateFieldType = 'number' | 'enum' | 'bool'
+
+export interface PredicateFieldSchema {
+  label: string
+  type: PredicateFieldType
+  unit?: string
+  placeholder?: string
+  options?: { value: string; label: string }[]
+}
+
+export const PRED_FIELDS: Record<string, PredicateFieldSchema> = {
+  age: { label: 'Age', type: 'number', unit: 'yrs', placeholder: '18' },
+  rating: {
+    label: 'USATT rating',
+    type: 'number',
+    unit: 'pts',
+    placeholder: '1500',
+  },
+  gender: {
+    label: 'Gender',
+    type: 'enum',
+    options: [
+      { value: 'F', label: 'Female' },
+      { value: 'M', label: 'Male' },
+      { value: 'X', label: 'Non-binary / open' },
+    ],
+  },
+  club: { label: 'Club member', type: 'bool' },
+}
+
+export const PRED_OPS_BY_TYPE: Record<
+  PredicateFieldType,
+  { value: string; label: string }[]
+> = {
+  number: [
+    { value: '<', label: 'is less than' },
+    { value: '<=', label: 'is at most' },
+    { value: '>', label: 'is greater than' },
+    { value: '>=', label: 'is at least' },
+    { value: '=', label: 'equals' },
+    { value: '!=', label: 'is not' },
+    { value: 'between', label: 'is between' },
+  ],
+  enum: [
+    { value: 'is', label: 'is' },
+    { value: 'isnt', label: 'is not' },
+  ],
+  bool: [
+    { value: 'true', label: 'must be' },
+    { value: 'false', label: 'must not be' },
+  ],
+}

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -1,0 +1,87 @@
+// Builders for the tournament domain objects. These are the shared factories
+// the component quartets compose — each produces one realistic, internally
+// consistent default (a published two-day open, an Open Singles event, etc.)
+// that callers tweak via overrides.
+
+import type {
+  Pool,
+  Predicate,
+  Tournament,
+  TournamentEvent,
+  TournamentTable,
+} from './types'
+
+/** A single physical table, `T1` on court 1. */
+export function buildTable(
+  overrides: Partial<TournamentTable> = {},
+): TournamentTable {
+  return { id: 't1', label: 'T1', court: '1', ...overrides }
+}
+
+/** Twelve tables, `t1`–`t12`, the catalogue the seed tournaments draw from. */
+export function buildTables(count = 12): TournamentTable[] {
+  return Array.from({ length: count }, (_, i) =>
+    buildTable({ id: `t${i + 1}`, label: `T${i + 1}`, court: String(i + 1) }),
+  )
+}
+
+/** A `rating < 1500` eligibility rule. */
+export function buildPredicate(overrides: Partial<Predicate> = {}): Predicate {
+  return { id: 'pr-1', field: 'rating', op: '<', value: 1500, ...overrides }
+}
+
+/** A four-table morning pool. */
+export function buildPool(overrides: Partial<Pool> = {}): Pool {
+  return {
+    id: 'p-1',
+    name: 'Pool A',
+    slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
+    tableIds: ['t1', 't2', 't3', 't4'],
+    ...overrides,
+  }
+}
+
+/** A rated Bo5 Open Singles event, half full, one pool. */
+export function buildEvent(
+  overrides: Partial<TournamentEvent> = {},
+): TournamentEvent {
+  return {
+    id: 'ev-open-singles',
+    name: 'Open Singles',
+    format: 'singles',
+    drawType: 'rr-then-ko',
+    maxPlayers: 64,
+    entryFee: 45,
+    entered: 52,
+    slot: { date: '2026-06-13', start: '09:00', end: '18:00' },
+    predicates: [],
+    match: { rated: true, lengthGames: 5 },
+    pools: [buildPool()],
+    ...overrides,
+  }
+}
+
+/** The published "Bay Area Open 2026" with a single Open Singles event. */
+export function buildTournament(
+  overrides: Partial<Tournament> = {},
+): Tournament {
+  return {
+    id: 'bay-area-open-2026',
+    name: 'Bay Area Open 2026',
+    status: 'published',
+    startDate: '2026-06-13',
+    endDate: '2026-06-14',
+    description: 'Two-day open. USATT-sanctioned, ratings-eligible.',
+    address: {
+      venue: 'Berkeley TT Club',
+      street: '2727 Milvia St',
+      city: 'Berkeley',
+      region: 'CA',
+      postal: '94703',
+      country: 'USA',
+    },
+    tableIds: ['t1', 't2', 't3', 't4', 't5', 't6', 't7', 't8'],
+    events: [buildEvent()],
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/data/seed.ts
+++ b/web-client/src/components/tournaments/data/seed.ts
@@ -1,0 +1,161 @@
+// In-memory seed data for the Tournament CRUD prototype: the populated
+// "Bay Area Open 2026", a draft, and an archived event. There is no backend —
+// the store (./store) loads these once and mutates them for the session.
+
+import { buildTables } from './seed.factory'
+import type { Tournament, TournamentTable } from './types'
+
+export function seedTables(): TournamentTable[] {
+  return buildTables(12)
+}
+
+export function seedTournaments(): Tournament[] {
+  return [
+    {
+      id: 'bay-area-open-2026',
+      name: 'Bay Area Open 2026',
+      status: 'published',
+      startDate: '2026-06-13',
+      endDate: '2026-06-14',
+      description: 'Two-day open. USATT-sanctioned, ratings-eligible.',
+      address: {
+        venue: 'Berkeley TT Club',
+        street: '2727 Milvia St',
+        city: 'Berkeley',
+        region: 'CA',
+        postal: '94703',
+        country: 'USA',
+      },
+      tableIds: ['t1', 't2', 't3', 't4', 't5', 't6', 't7', 't8', 't9', 't10', 't11', 't12'],
+      events: [
+        {
+          id: 'ev-open-singles',
+          name: 'Open Singles',
+          format: 'singles',
+          drawType: 'rr-then-ko',
+          maxPlayers: 64,
+          entryFee: 45,
+          entered: 52,
+          slot: { date: '2026-06-13', start: '09:00', end: '18:00' },
+          predicates: [],
+          match: { rated: true, lengthGames: 5 },
+          pools: [
+            { id: 'p-os-1', name: 'Pool A', slot: { date: '2026-06-13', start: '09:00', end: '12:30' }, tableIds: ['t1', 't2', 't3', 't4'] },
+            { id: 'p-os-2', name: 'Pool B', slot: { date: '2026-06-13', start: '13:30', end: '17:00' }, tableIds: ['t1', 't2', 't3', 't4', 't5', 't6'] },
+          ],
+        },
+        {
+          id: 'ev-womens',
+          name: "Women's Singles",
+          format: 'singles',
+          drawType: 'single-elim',
+          maxPlayers: 32,
+          entryFee: 35,
+          entered: 22,
+          slot: { date: '2026-06-13', start: '10:00', end: '16:00' },
+          predicates: [{ id: 'pr-1', field: 'gender', op: 'is', value: 'F' }],
+          match: { rated: true, lengthGames: 5 },
+          pools: [
+            { id: 'p-w-1', name: 'Main draw', slot: { date: '2026-06-13', start: '10:00', end: '16:00' }, tableIds: ['t5', 't6', 't7', 't8'] },
+          ],
+        },
+        {
+          id: 'ev-u1500',
+          name: 'U1500 Singles',
+          format: 'singles',
+          drawType: 'rr-then-ko',
+          maxPlayers: 48,
+          entryFee: 30,
+          entered: 41,
+          slot: { date: '2026-06-14', start: '09:00', end: '16:00' },
+          predicates: [{ id: 'pr-2', field: 'rating', op: '<', value: 1500 }],
+          match: { rated: true, lengthGames: 3 },
+          pools: [
+            { id: 'p-u15-1', name: 'Pool A', slot: { date: '2026-06-14', start: '09:00', end: '12:00' }, tableIds: ['t1', 't2', 't3', 't4', 't5', 't6'] },
+            { id: 'p-u15-2', name: 'Pool B', slot: { date: '2026-06-14', start: '13:00', end: '16:00' }, tableIds: ['t1', 't2', 't3', 't4'] },
+          ],
+        },
+        {
+          id: 'ev-u18',
+          name: 'U18 Singles',
+          format: 'singles',
+          drawType: 'single-elim',
+          maxPlayers: 24,
+          entryFee: 20,
+          entered: 18,
+          slot: { date: '2026-06-13', start: '09:30', end: '13:00' },
+          predicates: [{ id: 'pr-3', field: 'age', op: '<', value: 18 }],
+          match: { rated: true, lengthGames: 3 },
+          pools: [
+            { id: 'p-u18-1', name: 'Group stage', slot: { date: '2026-06-13', start: '09:30', end: '13:00' }, tableIds: ['t9', 't10', 't11', 't12'] },
+          ],
+        },
+        {
+          id: 'ev-doubles',
+          name: 'U2200 Doubles',
+          format: 'doubles',
+          drawType: 'single-elim',
+          maxPlayers: 16,
+          entryFee: 50,
+          entered: 12,
+          slot: { date: '2026-06-14', start: '10:00', end: '15:00' },
+          predicates: [{ id: 'pr-4', field: 'rating', op: '<', value: 2200 }],
+          match: { rated: false, lengthGames: 5 },
+          pools: [
+            { id: 'p-d-1', name: 'Doubles draw', slot: { date: '2026-06-14', start: '10:00', end: '15:00' }, tableIds: ['t7', 't8', 't9', 't10'] },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'summer-slam-2026',
+      name: 'Summer Slam 2026',
+      status: 'draft',
+      startDate: '2026-08-22',
+      endDate: '2026-08-23',
+      description: '',
+      address: {
+        venue: 'Palo Alto Community Center',
+        street: '1313 Newell Rd',
+        city: 'Palo Alto',
+        region: 'CA',
+        postal: '94303',
+        country: 'USA',
+      },
+      tableIds: ['t1', 't2', 't3', 't4', 't5', 't6', 't7', 't8'],
+      events: [
+        {
+          id: 'ev-ss-open',
+          name: 'Open Singles',
+          format: 'singles',
+          drawType: 'single-elim',
+          maxPlayers: 32,
+          entryFee: 40,
+          entered: 0,
+          slot: { date: '2026-08-22', start: '09:00', end: '17:00' },
+          predicates: [],
+          match: { rated: true, lengthGames: 5 },
+          pools: [],
+        },
+      ],
+    },
+    {
+      id: 'winter-classic-2025',
+      name: 'Winter Classic 2025',
+      status: 'archived',
+      startDate: '2025-12-13',
+      endDate: '2025-12-14',
+      description: 'Concluded December 2025.',
+      address: {
+        venue: 'San Jose Sports Hall',
+        street: '1500 Senter Rd',
+        city: 'San Jose',
+        region: 'CA',
+        postal: '95112',
+        country: 'USA',
+      },
+      tableIds: ['t1', 't2', 't3', 't4', 't5', 't6', 't7', 't8', 't9', 't10'],
+      events: [],
+    },
+  ]
+}

--- a/web-client/src/components/tournaments/data/store.ts
+++ b/web-client/src/components/tournaments/data/store.ts
@@ -1,0 +1,95 @@
+// In-memory, front-end-only store for the Tournament CRUD prototype. There is
+// no backend: the seed loads once, mutations rewrite module state and notify
+// subscribers, and everything resets on page reload. The route components read
+// through `useTournaments()` / `useTables()` and call the mutators below.
+
+import { useSyncExternalStore } from 'react'
+
+import { genId } from './helpers'
+import { seedTables, seedTournaments } from './seed'
+import type { Tournament, TournamentEvent } from './types'
+
+let tournaments: Tournament[] = seedTournaments()
+const tables = seedTables()
+const listeners = new Set<() => void>()
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+// Stable getter: returns the current array reference (which only changes on
+// mutation), so `useSyncExternalStore` sees a new snapshot exactly when it must.
+function getSnapshot() {
+  return tournaments
+}
+
+/** Subscribe a component to the tournament list; re-renders on any mutation. */
+export function useTournaments(): Tournament[] {
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/** The (static) table catalogue. */
+export function useTables() {
+  return tables
+}
+
+/** Derive a slug id from the tournament name plus a short random suffix. */
+function slugId(name: string): string {
+  const base =
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 40) || 'tournament'
+  return `${base}-${genId('').split('-').pop()}`
+}
+
+/** Create a tournament from a draft (no id yet) and return its new id. */
+export function createTournament(draft: Omit<Tournament, 'id'>): string {
+  const id = slugId(draft.name)
+  tournaments = [{ ...draft, id }, ...tournaments]
+  emit()
+  return id
+}
+
+export function updateTournament(next: Tournament): void {
+  tournaments = tournaments.map((t) => (t.id === next.id ? next : t))
+  emit()
+}
+
+export function deleteTournament(id: string): void {
+  tournaments = tournaments.filter((t) => t.id !== id)
+  emit()
+}
+
+export function createEvent(tournamentId: string, ev: TournamentEvent): void {
+  tournaments = tournaments.map((t) =>
+    t.id === tournamentId ? { ...t, events: [...t.events, ev] } : t,
+  )
+  emit()
+}
+
+export function updateEvent(tournamentId: string, ev: TournamentEvent): void {
+  tournaments = tournaments.map((t) =>
+    t.id === tournamentId
+      ? { ...t, events: t.events.map((e) => (e.id === ev.id ? ev : e)) }
+      : t,
+  )
+  emit()
+}
+
+export function deleteEvent(tournamentId: string, eventId: string): void {
+  tournaments = tournaments.map((t) =>
+    t.id === tournamentId
+      ? { ...t, events: t.events.filter((e) => e.id !== eventId) }
+      : t,
+  )
+  emit()
+}

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -1,0 +1,100 @@
+// Domain types for the tournament-admin (Tournament CRUD) UI. This is a
+// front-end-only prototype: the shapes mirror the design handoff, not a live
+// API. All data is seeded in-memory (see ./seed) and mutated through ./store.
+
+export type TournamentStatus = 'draft' | 'published' | 'live' | 'archived'
+
+export type EventFormat = 'singles' | 'doubles' | 'teams'
+
+export type DrawType =
+  | 'single-elim'
+  | 'double-elim'
+  | 'round-robin'
+  | 'rr-then-ko'
+  | 'swiss'
+
+export type MatchLength = 1 | 3 | 5 | 7
+
+/** A date-only (`YYYY-MM-DD`) window with `HH:MM` start/end. */
+export interface Slot {
+  date: string
+  start: string
+  end: string
+}
+
+export interface Address {
+  venue: string
+  street: string
+  city: string
+  region: string
+  postal: string
+  country: string
+}
+
+/** Eligibility-rule field keys understood by the predicate builder. */
+export type PredicateField = 'age' | 'rating' | 'gender' | 'club'
+
+/** A predicate's value: a number (most fields), an enum key (gender), a
+ * boolean (club), or a `[min, max]` pair for the `between` operator. */
+export type PredicateValue =
+  | number
+  | string
+  | boolean
+  | [number | null, number | null]
+  | null
+
+export interface Predicate {
+  id: string
+  field: PredicateField
+  op: string
+  value: PredicateValue
+}
+
+export interface MatchSettings {
+  rated: boolean
+  lengthGames: MatchLength
+}
+
+/** A slice of tables reserved for a window of time within an event. */
+export interface Pool {
+  id: string
+  name: string
+  slot: Slot
+  tableIds: string[]
+}
+
+export interface TournamentEvent {
+  id: string
+  name: string
+  format: EventFormat
+  drawType: DrawType
+  maxPlayers: number
+  entryFee: number
+  entered: number
+  slot: Slot
+  predicates: Predicate[]
+  match: MatchSettings
+  pools: Pool[]
+}
+
+/** A physical table in the venue catalogue, referenced by id from a
+ * tournament's `tableIds` and a pool's `tableIds`. */
+export interface TournamentTable {
+  id: string
+  label: string
+  court: string
+}
+
+export interface Tournament {
+  id: string
+  name: string
+  status: TournamentStatus
+  /** Authoritative dates are derived from the event schedule; these are the
+   * seeded fall-backs shown before any event exists. */
+  startDate: string | null
+  endDate: string | null
+  description: string
+  address: Address
+  tableIds: string[]
+  events: TournamentEvent[]
+}

--- a/web-client/src/components/tournaments/empty-state.factory.tsx
+++ b/web-client/src/components/tournaments/empty-state.factory.tsx
@@ -1,0 +1,8 @@
+import type { EmptyStateProps } from './empty-state'
+
+/** Props for `EmptyState` — the "no tournaments" case. */
+export function buildEmptyStateProps(
+  overrides: Partial<EmptyStateProps> = {},
+): EmptyStateProps {
+  return { title: 'No tournaments match', ...overrides }
+}

--- a/web-client/src/components/tournaments/empty-state.page.tsx
+++ b/web-client/src/components/tournaments/empty-state.page.tsx
@@ -1,0 +1,26 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { EmptyState, type EmptyStateProps } from './empty-state'
+import { buildEmptyStateProps } from './empty-state.factory'
+
+const scoped = (container: Container) => ({
+  queryTitle(title: string) {
+    return container.queryByText(title)
+  },
+  queryHint(hint: string) {
+    return container.queryByText(hint)
+  },
+})
+
+/** Test page-object for `EmptyState`. */
+export const emptyStatePage = {
+  render(overrides: Partial<EmptyStateProps> = {}) {
+    render(<EmptyState {...buildEmptyStateProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/empty-state.test.tsx
+++ b/web-client/src/components/tournaments/empty-state.test.tsx
@@ -1,0 +1,14 @@
+import { emptyStatePage } from './empty-state.page'
+
+describe('EmptyState', () => {
+  it('renders the title and hint', () => {
+    emptyStatePage.render({ title: 'No pools yet', hint: 'Add a pool to start.' })
+    expect(emptyStatePage.queryTitle('No pools yet')).toBeInTheDocument()
+    expect(emptyStatePage.queryHint('Add a pool to start.')).toBeInTheDocument()
+  })
+
+  it('renders an action when provided', () => {
+    emptyStatePage.render({ title: 'Empty', action: <button>Add</button> })
+    expect(emptyStatePage.queryTitle('Add')).toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/tournaments/empty-state.tsx
+++ b/web-client/src/components/tournaments/empty-state.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react'
+
+export interface EmptyStateProps {
+  /** Optional icon (rendered at 28px in the design); omit for a text-only state. */
+  icon?: ReactNode
+  title: string
+  hint?: ReactNode
+  /** Optional call-to-action, e.g. a `<Button>`. */
+  action?: ReactNode
+}
+
+/** The dashed-border "nothing here yet" panel shared across the tournament
+ * list, the detail tabs, and the event-editor sections. */
+export const EmptyState = ({ icon, title, hint, action }: EmptyStateProps) => {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-[10px] border border-dashed border-[color:var(--border-default)] bg-[color:var(--bg-card)] px-6 py-12 text-center">
+      {icon && <div className="text-[color:var(--fg-3)]">{icon}</div>}
+      <div className="text-[17px] font-semibold text-[color:var(--fg-1)]">
+        {title}
+      </div>
+      {hint && (
+        <p className="max-w-[320px] text-[13px] text-[color:var(--fg-3)]">
+          {hint}
+        </p>
+      )}
+      {action}
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/field.factory.tsx
+++ b/web-client/src/components/tournaments/field.factory.tsx
@@ -1,0 +1,13 @@
+import { Input } from '@/components/ui/input'
+
+import type { FieldProps } from './field'
+
+/** Props for `Field` — a required "Name" row wrapping a plain text input. */
+export function buildFieldProps(overrides: Partial<FieldProps> = {}): FieldProps {
+  return {
+    label: 'Name',
+    required: true,
+    children: (id) => <Input id={id} defaultValue="" />,
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/field.page.tsx
+++ b/web-client/src/components/tournaments/field.page.tsx
@@ -1,0 +1,28 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { Field, type FieldProps } from './field'
+import { buildFieldProps } from './field.factory'
+
+const scoped = (container: Container) => ({
+  /** The control wired to the field's label, by accessible name. */
+  getControl(label: string) {
+    return container.getByLabelText(new RegExp(label))
+  },
+  /** Hint / error text, when present. */
+  queryHint(text: string) {
+    return container.queryByText(text)
+  },
+})
+
+/** Test page-object for `Field` — the label/control/hint form row. */
+export const fieldPage = {
+  render(overrides: Partial<FieldProps> = {}) {
+    render(<Field {...buildFieldProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/field.test.tsx
+++ b/web-client/src/components/tournaments/field.test.tsx
@@ -1,0 +1,18 @@
+import { Input } from '@/components/ui/input'
+
+import { fieldPage } from './field.page'
+
+describe('Field', () => {
+  it('associates its label with the control via the generated id', () => {
+    fieldPage.render({
+      label: 'Venue name',
+      children: (id) => <Input id={id} />,
+    })
+    expect(fieldPage.getControl('Venue name')).toBeInTheDocument()
+  })
+
+  it('renders a hint as error text when error is set', () => {
+    fieldPage.render({ hint: 'Required', error: true })
+    expect(fieldPage.queryHint('Required')).toHaveClass('text-[color:var(--loss)]')
+  })
+})

--- a/web-client/src/components/tournaments/field.tsx
+++ b/web-client/src/components/tournaments/field.tsx
@@ -1,0 +1,51 @@
+import { useId, type ReactNode } from 'react'
+
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+
+export interface FieldProps {
+  label: string
+  required?: boolean
+  /** Helper or error text shown below the control. */
+  hint?: ReactNode
+  /** When true, `hint` is rendered as an error (red). */
+  error?: boolean
+  children: (controlId: string) => ReactNode
+  className?: string
+}
+
+/** Uppercase-overline label + control + hint, the standard form row used
+ * across the tournament forms. `children` receives the generated control id so
+ * the rendered input can wire `id`/`aria-describedby`. */
+export const Field = ({
+  label,
+  required,
+  hint,
+  error,
+  children,
+  className,
+}: FieldProps) => {
+  const id = useId()
+  return (
+    <div className={cn('flex flex-col gap-1.5', className)}>
+      <Label
+        htmlFor={id}
+        className="text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase"
+      >
+        {label}
+        {required && <span className="text-[color:var(--ball-500)]">*</span>}
+      </Label>
+      {children(id)}
+      {hint && (
+        <p
+          className={cn(
+            'text-[11px]',
+            error ? 'text-[color:var(--loss)]' : 'text-[color:var(--fg-3)]',
+          )}
+        >
+          {hint}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/field.tsx
+++ b/web-client/src/components/tournaments/field.tsx
@@ -15,8 +15,10 @@ export interface FieldProps {
 }
 
 /** Uppercase-overline label + control + hint, the standard form row used
- * across the tournament forms. `children` receives the generated control id so
- * the rendered input can wire `id`/`aria-describedby`. */
+ * across the tournament forms. `children` receives the generated control id:
+ * a real input wires it as `id` (the label's `htmlFor` targets it); a
+ * non-input control (e.g. a radio `ToggleGroup`) instead points
+ * `aria-labelledby` at the label's `${id}-label` id. */
 export const Field = ({
   label,
   required,
@@ -29,6 +31,7 @@ export const Field = ({
   return (
     <div className={cn('flex flex-col gap-1.5', className)}>
       <Label
+        id={`${id}-label`}
         htmlFor={id}
         className="text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase"
       >

--- a/web-client/src/components/tournaments/new-tournament-modal.factory.tsx
+++ b/web-client/src/components/tournaments/new-tournament-modal.factory.tsx
@@ -1,0 +1,13 @@
+import type { NewTournamentModalProps } from './new-tournament-modal'
+
+/** Props for `NewTournamentModal` — open, with no-op handlers. */
+export function buildNewTournamentModalProps(
+  overrides: Partial<NewTournamentModalProps> = {},
+): NewTournamentModalProps {
+  return {
+    open: true,
+    onOpenChange: () => {},
+    onCreate: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/new-tournament-modal.page.tsx
+++ b/web-client/src/components/tournaments/new-tournament-modal.page.tsx
@@ -1,0 +1,38 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import {
+  NewTournamentModal,
+  type NewTournamentModalProps,
+} from './new-tournament-modal'
+import { buildNewTournamentModalProps } from './new-tournament-modal.factory'
+
+const scoped = (container: Container) => ({
+  getNameInput() {
+    return container.getByLabelText(/Name/)
+  },
+  getCreateButton() {
+    return container.getByRole('button', { name: /Create tournament/ })
+  },
+  getCancelButton() {
+    return container.getByRole('button', { name: /Cancel/ })
+  },
+  queryDialog() {
+    return container.queryByRole('dialog')
+  },
+})
+
+/**
+ * Test page-object for `NewTournamentModal`. The dialog portals to the body, so
+ * accessors resolve against `screen` rather than a wrapper subtree.
+ */
+export const newTournamentModalPage = {
+  render(overrides: Partial<NewTournamentModalProps> = {}) {
+    render(<NewTournamentModal {...buildNewTournamentModalProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/new-tournament-modal.test.tsx
+++ b/web-client/src/components/tournaments/new-tournament-modal.test.tsx
@@ -1,0 +1,35 @@
+import userEvent from '@testing-library/user-event'
+
+import { newTournamentModalPage } from './new-tournament-modal.page'
+
+describe('NewTournamentModal', () => {
+  it('disables create until a name is entered', async () => {
+    newTournamentModalPage.render()
+    expect(newTournamentModalPage.getCreateButton()).toBeDisabled()
+
+    await userEvent.type(newTournamentModalPage.getNameInput(), 'Spring Open')
+    expect(newTournamentModalPage.getCreateButton()).toBeEnabled()
+  })
+
+  it('emits the draft with name and address on create', async () => {
+    const onCreate = vi.fn()
+    newTournamentModalPage.render({ onCreate })
+
+    await userEvent.type(newTournamentModalPage.getNameInput(), 'Spring Open')
+    await userEvent.click(newTournamentModalPage.getCreateButton())
+
+    expect(onCreate).toHaveBeenCalledTimes(1)
+    expect(onCreate.mock.calls[0][0]).toMatchObject({
+      name: 'Spring Open',
+      status: 'draft',
+    })
+  })
+
+  it('closes via cancel', async () => {
+    const onOpenChange = vi.fn()
+    newTournamentModalPage.render({ onOpenChange })
+
+    await userEvent.click(newTournamentModalPage.getCancelButton())
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/web-client/src/components/tournaments/new-tournament-modal.tsx
+++ b/web-client/src/components/tournaments/new-tournament-modal.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react'
+import { Check } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+
+import { emptyTournament } from './data/helpers'
+import type { Address, Tournament } from './data/types'
+import { Field } from './field'
+
+export interface NewTournamentModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onCreate: (draft: Omit<Tournament, 'id'>) => void
+}
+
+/** "New tournament" dialog — captures a name (required) and optional venue
+ * address. Dates are derived from events, so they're set later. */
+export const NewTournamentModal = ({
+  open,
+  onOpenChange,
+  onCreate,
+}: NewTournamentModalProps) => {
+  const [draft, setDraft] = useState<Omit<Tournament, 'id'>>(emptyTournament)
+  const [wasOpen, setWasOpen] = useState(open)
+
+  // Reset to a blank draft each time the dialog transitions to open —
+  // adjusting state during render instead of in an effect.
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open) setDraft(emptyTournament())
+  }
+
+  const valid = draft.name.trim().length > 0
+  const setAddress = (patch: Partial<Address>) =>
+    setDraft((d) => ({ ...d, address: { ...d.address, ...patch } }))
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>New tournament</DialogTitle>
+          <DialogDescription>
+            You'll set dates when you add events.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3.5">
+          <Field label="Name" required>
+            {(id) => (
+              <Input
+                id={id}
+                autoFocus
+                value={draft.name}
+                placeholder="Spring Open 2026"
+                onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+              />
+            )}
+          </Field>
+
+          <div className="my-1 flex items-center gap-3">
+            <span className="text-[11px] font-semibold tracking-[0.14em] text-[color:var(--fg-3)] uppercase">
+              Venue
+            </span>
+            <span className="h-px flex-1 bg-[color:var(--border-subtle)]" />
+          </div>
+
+          <Field label="Venue name">
+            {(id) => (
+              <Input
+                id={id}
+                value={draft.address.venue}
+                placeholder="Berkeley TT Club"
+                onChange={(e) => setAddress({ venue: e.target.value })}
+              />
+            )}
+          </Field>
+          <Field label="Street">
+            {(id) => (
+              <Input
+                id={id}
+                value={draft.address.street}
+                placeholder="2727 Milvia St"
+                onChange={(e) => setAddress({ street: e.target.value })}
+              />
+            )}
+          </Field>
+          <div className="grid grid-cols-[2fr_1fr_1fr] gap-3">
+            <Field label="City">
+              {(id) => (
+                <Input
+                  id={id}
+                  value={draft.address.city}
+                  placeholder="Berkeley"
+                  onChange={(e) => setAddress({ city: e.target.value })}
+                />
+              )}
+            </Field>
+            <Field label="Region">
+              {(id) => (
+                <Input
+                  id={id}
+                  value={draft.address.region}
+                  placeholder="CA"
+                  onChange={(e) => setAddress({ region: e.target.value })}
+                />
+              )}
+            </Field>
+            <Field label="Postal">
+              {(id) => (
+                <Input
+                  id={id}
+                  value={draft.address.postal}
+                  placeholder="94703"
+                  className="font-mono"
+                  onChange={(e) => setAddress({ postal: e.target.value })}
+                />
+              )}
+            </Field>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button disabled={!valid} onClick={() => onCreate(draft)}>
+            <Check size={16} />
+            Create tournament
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web-client/src/components/tournaments/page-heading.factory.tsx
+++ b/web-client/src/components/tournaments/page-heading.factory.tsx
@@ -1,0 +1,12 @@
+import type { PageHeadingProps } from './page-heading'
+
+/** Props for `PageHeading` — the tournaments list header. */
+export function buildPageHeadingProps(
+  overrides: Partial<PageHeadingProps> = {},
+): PageHeadingProps {
+  return {
+    breadcrumb: [{ label: 'Manage' }, { label: 'Tournaments' }],
+    title: 'Tournaments',
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/page-heading.page.tsx
+++ b/web-client/src/components/tournaments/page-heading.page.tsx
@@ -1,0 +1,26 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { PageHeading, type PageHeadingProps } from './page-heading'
+import { buildPageHeadingProps } from './page-heading.factory'
+
+const scoped = (container: Container) => ({
+  getTitle() {
+    return container.getByRole('heading', { level: 1 })
+  },
+  getCrumbLink(label: string) {
+    return container.getByRole('button', { name: label })
+  },
+})
+
+/** Test page-object for `PageHeading`. */
+export const pageHeadingPage = {
+  render(overrides: Partial<PageHeadingProps> = {}) {
+    render(<PageHeading {...buildPageHeadingProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/page-heading.test.tsx
+++ b/web-client/src/components/tournaments/page-heading.test.tsx
@@ -1,0 +1,20 @@
+import userEvent from '@testing-library/user-event'
+
+import { pageHeadingPage } from './page-heading.page'
+
+describe('PageHeading', () => {
+  it('renders the title', () => {
+    pageHeadingPage.render({ title: 'Tournaments' })
+    expect(pageHeadingPage.getTitle()).toHaveTextContent('Tournaments')
+  })
+
+  it('invokes a non-final breadcrumb crumb on click', async () => {
+    const onClick = vi.fn()
+    pageHeadingPage.render({
+      breadcrumb: [{ label: 'Tournaments', onClick }, { label: 'Bay Area Open' }],
+      title: 'Bay Area Open',
+    })
+    await userEvent.click(pageHeadingPage.getCrumbLink('Tournaments'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web-client/src/components/tournaments/page-heading.tsx
+++ b/web-client/src/components/tournaments/page-heading.tsx
@@ -1,0 +1,79 @@
+import { Fragment, type ReactNode } from 'react'
+
+export interface Crumb {
+  label: string
+  onClick?: () => void
+}
+
+export interface PageHeadingProps {
+  breadcrumb: Crumb[]
+  /** The big display title. A trailing accent dot is added automatically. */
+  title: string
+  subtitle?: ReactNode
+  action?: ReactNode
+}
+
+/** The FortyMM page header: a mono breadcrumb chain with a leading accent dot,
+ * a large Bebas display title (with a trailing orange period), an optional
+ * subtitle, and a right-aligned action slot. */
+export const PageHeading = ({
+  breadcrumb,
+  title,
+  subtitle,
+  action,
+}: PageHeadingProps) => {
+  return (
+    <div className="mb-8 flex items-start gap-6">
+      <div className="min-w-0 flex-1">
+        {breadcrumb.length > 0 && (
+          <nav
+            aria-label="Breadcrumb"
+            className="mb-5 flex items-center gap-3 font-mono text-[11px] font-bold tracking-[0.22em] uppercase"
+          >
+            <span
+              aria-hidden
+              className="size-2 shrink-0 rounded-full bg-[color:var(--ball-500)]"
+            />
+            {breadcrumb.map((c, i) => {
+              const last = i === breadcrumb.length - 1
+              return (
+                <Fragment key={`${c.label}-${i}`}>
+                  {i > 0 && <span className="text-[color:var(--fg-3)]">/</span>}
+                  {c.onClick && !last ? (
+                    <button
+                      type="button"
+                      onClick={c.onClick}
+                      className="text-[color:var(--fg-3)] uppercase hover:text-[color:var(--fg-1)]"
+                    >
+                      {c.label}
+                    </button>
+                  ) : (
+                    <span
+                      className={
+                        last
+                          ? 'max-w-[360px] truncate text-[color:var(--fg-1)]'
+                          : 'text-[color:var(--fg-3)]'
+                      }
+                    >
+                      {c.label}
+                    </span>
+                  )}
+                </Fragment>
+              )
+            })}
+          </nav>
+        )}
+        <h1 className="font-display text-[64px] leading-[0.92] tracking-[0.005em] break-words text-[color:var(--fg-1)] uppercase">
+          {title}
+          <span className="text-[color:var(--ball-500)]">.</span>
+        </h1>
+        {subtitle && (
+          <p className="mt-5 max-w-[760px] text-[16px] text-[color:var(--fg-3)]">
+            {subtitle}
+          </p>
+        )}
+      </div>
+      {action && <div className="shrink-0 pt-7">{action}</div>}
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/status-badge.factory.tsx
+++ b/web-client/src/components/tournaments/status-badge.factory.tsx
@@ -1,0 +1,8 @@
+import type { StatusBadgeProps } from './status-badge'
+
+/** Props for `StatusBadge` — a published tournament by default. */
+export function buildStatusBadgeProps(
+  overrides: Partial<StatusBadgeProps> = {},
+): StatusBadgeProps {
+  return { status: 'published', ...overrides }
+}

--- a/web-client/src/components/tournaments/status-badge.page.tsx
+++ b/web-client/src/components/tournaments/status-badge.page.tsx
@@ -1,0 +1,30 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { StatusBadge, type StatusBadgeProps } from './status-badge'
+import { buildStatusBadgeProps } from './status-badge.factory'
+
+const scoped = (container: Container) => ({
+  /** The status pill. Always present; `data-status` carries the raw status. */
+  getBadge() {
+    return container.getByTestId('tournament-status-badge')
+  },
+  queryBadge() {
+    return container.queryByTestId('tournament-status-badge')
+  },
+})
+
+/**
+ * Test page-object for `StatusBadge`. Owners (the card, the detail hero) spread
+ * `within` to expose the same pill query against their own subtree.
+ */
+export const statusBadgePage = {
+  render(overrides: Partial<StatusBadgeProps> = {}) {
+    render(<StatusBadge {...buildStatusBadgeProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/status-badge.test.tsx
+++ b/web-client/src/components/tournaments/status-badge.test.tsx
@@ -1,0 +1,26 @@
+import { statusBadgePage } from './status-badge.page'
+
+describe('StatusBadge', () => {
+  it('labels a published tournament', () => {
+    statusBadgePage.render({ status: 'published' })
+    expect(statusBadgePage.getBadge()).toHaveTextContent('Published')
+    expect(statusBadgePage.getBadge()).toHaveAttribute('data-status', 'published')
+  })
+
+  it('labels and marks a live tournament with the pulsing dot', () => {
+    statusBadgePage.render({ status: 'live' })
+    const badge = statusBadgePage.getBadge()
+    expect(badge).toHaveTextContent('Live')
+    expect(badge.querySelector('.ball-dot--live')).not.toBeNull()
+  })
+
+  it('labels a draft tournament', () => {
+    statusBadgePage.render({ status: 'draft' })
+    expect(statusBadgePage.getBadge()).toHaveTextContent('Draft')
+  })
+
+  it('labels an archived tournament', () => {
+    statusBadgePage.render({ status: 'archived' })
+    expect(statusBadgePage.getBadge()).toHaveTextContent('Archived')
+  })
+})

--- a/web-client/src/components/tournaments/status-badge.tsx
+++ b/web-client/src/components/tournaments/status-badge.tsx
@@ -1,0 +1,63 @@
+import { cn } from '@/lib/utils'
+
+import type { TournamentStatus } from './data/types'
+
+export interface StatusBadgeProps {
+  status: TournamentStatus
+}
+
+interface StatusMeta {
+  label: string
+  /** Tailwind classes for the pill's surface + text. */
+  pill: string
+  /** Inline dot colour (a CSS token). */
+  dot: string
+  pulse?: boolean
+}
+
+const STATUS_META: Record<TournamentStatus, StatusMeta> = {
+  draft: {
+    label: 'Draft',
+    pill: 'border-[color:var(--border-subtle)] bg-transparent text-[color:var(--fg-2)]',
+    dot: 'var(--fg-muted)',
+  },
+  published: {
+    label: 'Published',
+    pill: 'border-[color:var(--border-subtle)] bg-[color:var(--bg-raised)] text-[color:var(--fg-2)]',
+    dot: 'var(--info)',
+  },
+  live: {
+    label: 'Live',
+    pill: 'border-[color:rgba(0,226,154,0.3)] bg-[color:var(--bg-live-soft)] text-[color:var(--serve-500)]',
+    dot: 'var(--serve-500)',
+    pulse: true,
+  },
+  archived: {
+    label: 'Archived',
+    pill: 'border-[color:var(--border-subtle)] bg-transparent text-[color:var(--fg-2)]',
+    dot: 'var(--ink-500)',
+  },
+}
+
+/** The status pill shown on tournament cards and the detail hero. A coloured
+ * leading dot encodes status; the `live` dot pulses. */
+export const StatusBadge = ({ status }: StatusBadgeProps) => {
+  const meta = STATUS_META[status]
+  return (
+    <span
+      data-testid="tournament-status-badge"
+      data-status={status}
+      className={cn(
+        'inline-flex h-[22px] items-center gap-1.5 rounded-full border px-2 text-[11px] font-semibold tracking-[0.06em] uppercase',
+        meta.pill,
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn('size-1.5 rounded-full', meta.pulse && 'ball-dot--live')}
+        style={{ background: meta.dot }}
+      />
+      {meta.label}
+    </span>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-card.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-card.factory.tsx
@@ -1,0 +1,14 @@
+import { buildTournament } from './data/seed.factory'
+import type { TournamentCardProps } from './tournament-card'
+
+/** Props for `TournamentCard` — the seeded Bay Area Open, with no-op handlers. */
+export function buildTournamentCardProps(
+  overrides: Partial<TournamentCardProps> = {},
+): TournamentCardProps {
+  return {
+    tournament: buildTournament(),
+    onOpen: () => {},
+    onDelete: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-card.page.tsx
+++ b/web-client/src/components/tournaments/tournament-card.page.tsx
@@ -1,0 +1,34 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { TournamentCard, type TournamentCardProps } from './tournament-card'
+import { buildTournamentCardProps } from './tournament-card.factory'
+import { statusBadgePage } from './status-badge.page'
+
+const scoped = (container: Container) => ({
+  /** The full-card open target, named for the tournament. */
+  getOpenButton(name: string) {
+    return container.getByRole('button', { name })
+  },
+  /** The hover delete control, named `Delete <tournament>`. */
+  getDeleteButton(name: string) {
+    return container.getByRole('button', { name: `Delete ${name}` })
+  },
+  /** The card's status pill, reusing the badge's own query. */
+  ...statusBadgePage.within(container),
+})
+
+/**
+ * Test page-object for `TournamentCard`. The card exposes two buttons — the
+ * stretched open target (named for the tournament) and the delete control.
+ */
+export const tournamentCardPage = {
+  render(overrides: Partial<TournamentCardProps> = {}) {
+    render(<TournamentCard {...buildTournamentCardProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-card.test.tsx
@@ -1,0 +1,47 @@
+import userEvent from '@testing-library/user-event'
+
+import { buildTournament, buildEvent } from './data/seed.factory'
+import { tournamentCardPage } from './tournament-card.page'
+
+describe('TournamentCard', () => {
+  it('shows the name, venue, and derived stats', () => {
+    tournamentCardPage.render({
+      tournament: buildTournament({
+        name: 'Bay Area Open 2026',
+        tableIds: ['t1', 't2', 't3'],
+        events: [
+          buildEvent({ id: 'a', entered: 52 }),
+          buildEvent({ id: 'b', entered: 22 }),
+        ],
+      }),
+    })
+
+    expect(tournamentCardPage.getOpenButton('Bay Area Open 2026')).toBeInTheDocument()
+    expect(tournamentCardPage.getBadge()).toHaveTextContent('Published')
+    // 52 + 22 entries; 2 events; 3 tables.
+    expect(document.body).toHaveTextContent('74')
+    expect(document.body).toHaveTextContent('Berkeley TT Club')
+  })
+
+  it('opens the tournament when the card is clicked', async () => {
+    const onOpen = vi.fn()
+    tournamentCardPage.render({
+      tournament: buildTournament({ name: 'Summer Slam' }),
+      onOpen,
+    })
+
+    await userEvent.click(tournamentCardPage.getOpenButton('Summer Slam'))
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('deletes via the dedicated delete control', async () => {
+    const onDelete = vi.fn()
+    tournamentCardPage.render({
+      tournament: buildTournament({ name: 'Summer Slam' }),
+      onDelete,
+    })
+
+    await userEvent.click(tournamentCardPage.getDeleteButton('Summer Slam'))
+    expect(onDelete).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-card.tsx
+++ b/web-client/src/components/tournaments/tournament-card.tsx
@@ -1,0 +1,89 @@
+import { MapPin, Trash2 } from 'lucide-react'
+
+import { Card } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+import { effectiveDateRange, fmtDateRange } from './data/helpers'
+import type { Tournament } from './data/types'
+import { StatusBadge } from './status-badge'
+
+export interface TournamentCardProps {
+  tournament: Tournament
+  onOpen: () => void
+  onDelete: () => void
+}
+
+function CardStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <div className="font-mono text-[20px] leading-none font-bold tabular-nums text-[color:var(--fg-1)]">
+        {value}
+      </div>
+      <div className="mt-1 text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">
+        {label}
+      </div>
+    </div>
+  )
+}
+
+/** A tournament summary card for the list grid: status, dates, name, venue,
+ * and an events/entries/tables stat row. The whole card opens the tournament;
+ * a delete control surfaces on hover. */
+export const TournamentCard = ({
+  tournament: t,
+  onOpen,
+  onDelete,
+}: TournamentCardProps) => {
+  const range = effectiveDateRange(t)
+  const entries = t.events.reduce((sum, e) => sum + (e.entered || 0), 0)
+
+  return (
+    <div className="group/tcard relative">
+      <Card
+        className={cn(
+          'gap-3 px-4 ring-[color:var(--border-subtle)] transition-colors',
+          'group-hover/tcard:ring-[color:var(--border-default)]',
+        )}
+      >
+        <div className="flex flex-wrap items-center gap-2.5">
+          <StatusBadge status={t.status} />
+          <span className="font-mono text-[11px] tracking-[0.04em] text-[color:var(--fg-3)]">
+            {range.start ? fmtDateRange(range.start, range.end) : 'Dates TBD'}
+          </span>
+        </div>
+
+        <div>
+          <div className="text-[20px] leading-tight font-bold tracking-[-0.01em] text-[color:var(--fg-1)]">
+            {t.name}
+          </div>
+          <div className="mt-1 flex items-center gap-1 text-[13px] text-[color:var(--fg-3)]">
+            <MapPin size={12} />
+            {t.address.venue} · {t.address.city}, {t.address.region}
+          </div>
+        </div>
+
+        <div className="mt-1 grid grid-cols-3 gap-2.5 border-t border-[color:var(--border-subtle)] pt-3">
+          <CardStat label="Events" value={t.events.length} />
+          <CardStat label="Entries" value={entries} />
+          <CardStat label="Tables" value={t.tableIds.length} />
+        </div>
+      </Card>
+
+      {/* Full-card open target sits beneath the delete control. */}
+      <button
+        type="button"
+        aria-label={t.name}
+        onClick={onOpen}
+        className="absolute inset-0 z-0 rounded-xl outline-offset-2"
+      />
+      <button
+        type="button"
+        aria-label={`Delete ${t.name}`}
+        onClick={onDelete}
+        className="absolute top-2.5 right-2.5 z-10 grid size-7 place-items-center rounded-md text-[color:var(--fg-3)] opacity-0 transition-opacity group-hover/tcard:opacity-100 hover:bg-[color:var(--bg-hover)] hover:text-[color:var(--loss)] focus-visible:opacity-100"
+      >
+        <Trash2 size={14} />
+      </button>
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.factory.tsx
@@ -1,0 +1,19 @@
+import { buildTables, buildTournament } from './data/seed.factory'
+import type { TournamentDetailPageProps } from './tournament-detail-page'
+
+/** Props for `TournamentDetailPage` — the seeded Bay Area Open with no-op
+ * handlers and the full 12-table catalogue. */
+export function buildTournamentDetailPageProps(
+  overrides: Partial<TournamentDetailPageProps> = {},
+): TournamentDetailPageProps {
+  return {
+    tournament: buildTournament(),
+    allTables: buildTables(12),
+    onUpdate: () => {},
+    onCreateEvent: () => {},
+    onUpdateEvent: () => {},
+    onDeleteEvent: () => {},
+    onBack: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.page.tsx
@@ -1,0 +1,41 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import {
+  TournamentDetailPage,
+  type TournamentDetailPageProps,
+} from './tournament-detail-page'
+import { buildTournamentDetailPageProps } from './tournament-detail-page.factory'
+import { eventsTabPage } from './tournament-detail-page/events-tab.page'
+
+const scoped = (container: Container) => ({
+  getTab(name: string) {
+    return container.getByRole('tab', { name })
+  },
+  getBackCrumb() {
+    return container.getByRole('button', { name: 'Tournaments' })
+  },
+  getLifecycleButton(name: RegExp) {
+    return container.getByRole('button', { name })
+  },
+  queryLifecycleButton(name: RegExp) {
+    return container.queryByRole('button', { name })
+  },
+  ...eventsTabPage.within(container),
+})
+
+/** Test page-object for `TournamentDetailPage`. */
+export const tournamentDetailPagePage = {
+  render(overrides: Partial<TournamentDetailPageProps> = {}) {
+    render(<TournamentDetailPage {...buildTournamentDetailPageProps(overrides)} />)
+  },
+  /** The event editor's save button (the sheet portals to the body). */
+  getEditorSaveButton() {
+    return screen.getByRole('button', { name: /Create event|Save changes/ })
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.test.tsx
@@ -1,0 +1,52 @@
+import userEvent from '@testing-library/user-event'
+
+import { buildEvent, buildTournament } from './data/seed.factory'
+import { tournamentDetailPagePage } from './tournament-detail-page.page'
+
+describe('TournamentDetailPage', () => {
+  it('shows the lifecycle action matching the status', () => {
+    tournamentDetailPagePage.render({
+      tournament: buildTournament({ status: 'draft' }),
+    })
+    expect(
+      tournamentDetailPagePage.getLifecycleButton(/Publish/),
+    ).toBeInTheDocument()
+    expect(
+      tournamentDetailPagePage.queryLifecycleButton(/Start tournament/),
+    ).toBeNull()
+  })
+
+  it('publishes a draft tournament', async () => {
+    const onUpdate = vi.fn()
+    tournamentDetailPagePage.render({
+      tournament: buildTournament({ status: 'draft' }),
+      onUpdate,
+    })
+    await userEvent.click(tournamentDetailPagePage.getLifecycleButton(/Publish/))
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'published' }),
+    )
+  })
+
+  it('opens the event editor and creates a new event', async () => {
+    const onCreateEvent = vi.fn()
+    tournamentDetailPagePage.render({
+      tournament: buildTournament({ events: [] }),
+      onCreateEvent,
+    })
+
+    await userEvent.click(tournamentDetailPagePage.getNewEventButton())
+    await userEvent.click(tournamentDetailPagePage.getEditorSaveButton())
+    expect(onCreateEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('navigates back via the breadcrumb', async () => {
+    const onBack = vi.fn()
+    tournamentDetailPagePage.render({
+      tournament: buildTournament({ events: [buildEvent()] }),
+      onBack,
+    })
+    await userEvent.click(tournamentDetailPagePage.getBackCrumb())
+    expect(onBack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.tsx
@@ -1,0 +1,260 @@
+import { useState } from 'react'
+import {
+  Calendar,
+  Hash,
+  Layers,
+  MapPin,
+  Radio,
+  Rocket,
+  Square,
+  Table2,
+  Trophy,
+  Users,
+} from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+
+import { ConfirmDeleteDialog } from './confirm-delete-dialog'
+import {
+  daysBetween,
+  effectiveDateRange,
+  emptyEvent,
+  fmtDateRange,
+  genId,
+} from './data/helpers'
+import type {
+  Tournament,
+  TournamentEvent,
+  TournamentTable,
+} from './data/types'
+import { PageHeading } from './page-heading'
+import { StatusBadge } from './status-badge'
+import { DetailsTab } from './tournament-detail-page/details-tab'
+import { EventEditor } from './tournament-detail-page/event-editor'
+import { EventsTab } from './tournament-detail-page/events-tab'
+import { HeroStat } from './tournament-detail-page/hero-stat'
+import { ScheduleTab } from './tournament-detail-page/schedule-tab'
+import { TablesTab } from './tournament-detail-page/tables-tab'
+
+export interface TournamentDetailPageProps {
+  tournament: Tournament
+  /** The full table catalogue (for the Tables tab). */
+  allTables: TournamentTable[]
+  onUpdate: (tournament: Tournament) => void
+  onCreateEvent: (event: TournamentEvent) => void
+  onUpdateEvent: (event: TournamentEvent) => void
+  onDeleteEvent: (eventId: string) => void
+  onBack: () => void
+}
+
+function MetaItem({
+  icon,
+  children,
+}: {
+  icon: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <span className="inline-flex min-w-0 items-center gap-2 text-[14px] text-[color:var(--fg-2)]">
+      <span className="text-[color:var(--fg-3)]">{icon}</span>
+      {children}
+    </span>
+  )
+}
+
+/** The tournament detail page: hero header with status lifecycle actions, a
+ * meta strip, a five-up stat strip, and the Events / Tables / Schedule /
+ * Details tabs, plus the slide-in event editor. */
+export const TournamentDetailPage = ({
+  tournament,
+  allTables,
+  onUpdate,
+  onCreateEvent,
+  onUpdateEvent,
+  onDeleteEvent,
+  onBack,
+}: TournamentDetailPageProps) => {
+  const [tab, setTab] = useState('events')
+  const [editorOpen, setEditorOpen] = useState(false)
+  const [editorEvent, setEditorEvent] = useState<TournamentEvent | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<TournamentEvent | null>(null)
+
+  const tournamentTables = tournament.tableIds
+    .map((id) => allTables.find((t) => t.id === id))
+    .filter((t): t is TournamentTable => t !== undefined)
+
+  const range = effectiveDateRange(tournament)
+  const entries = tournament.events.reduce((s, e) => s + (e.entered || 0), 0)
+  const pools = tournament.events.reduce((s, e) => s + e.pools.length, 0)
+
+  const openEvent = (ev: TournamentEvent) => {
+    setEditorEvent(ev)
+    setEditorOpen(true)
+  }
+  const openNewEvent = () => {
+    setEditorEvent(emptyEvent(tournament))
+    setEditorOpen(true)
+  }
+  const saveEvent = (ev: TournamentEvent) => {
+    if (ev.id.startsWith('new')) onCreateEvent({ ...ev, id: genId('ev') })
+    else onUpdateEvent(ev)
+    setEditorOpen(false)
+  }
+
+  return (
+    <div>
+      <div className="mx-auto w-full max-w-[1320px] px-12 pt-11 pb-6">
+        <PageHeading
+          breadcrumb={[
+            { label: 'Tournaments', onClick: onBack },
+            { label: tournament.name },
+          ]}
+          title={tournament.name}
+          action={
+            <div className="flex items-center gap-2">
+              {tournament.status === 'draft' && (
+                <Button
+                  onClick={() => onUpdate({ ...tournament, status: 'published' })}
+                >
+                  <Rocket size={16} />
+                  Publish
+                </Button>
+              )}
+              {tournament.status === 'published' && (
+                <Button
+                  className="border border-[color:rgba(0,226,154,0.35)] bg-[color:rgba(0,226,154,0.1)] text-[color:var(--serve-500)] hover:bg-[color:rgba(0,226,154,0.18)]"
+                  onClick={() => onUpdate({ ...tournament, status: 'live' })}
+                >
+                  <Radio size={16} />
+                  Start tournament
+                </Button>
+              )}
+              {tournament.status === 'live' && (
+                <Button
+                  variant="ghost"
+                  onClick={() => onUpdate({ ...tournament, status: 'archived' })}
+                >
+                  <Square size={16} />
+                  End tournament
+                </Button>
+              )}
+            </div>
+          }
+        />
+
+        <div className="mb-5 flex flex-wrap items-center gap-6">
+          <StatusBadge status={tournament.status} />
+          <MetaItem icon={<Calendar size={14} />}>
+            {range.start ? (
+              <span className="font-mono tabular-nums text-[color:var(--fg-1)]">
+                {fmtDateRange(range.start, range.end)}
+              </span>
+            ) : (
+              <span className="text-[color:var(--fg-3)] italic">
+                Dates set by events — add one to begin.
+              </span>
+            )}
+          </MetaItem>
+          <MetaItem icon={<MapPin size={14} />}>
+            <span className="text-[color:var(--fg-1)]">
+              {tournament.address.venue}
+            </span>
+            <span className="mx-1.5 text-[color:var(--fg-3)]">·</span>
+            <span>
+              {tournament.address.city}, {tournament.address.region}
+            </span>
+          </MetaItem>
+          <MetaItem icon={<Hash size={14} />}>
+            <span className="font-mono text-[12px] text-[color:var(--fg-3)]">
+              {tournament.id}
+            </span>
+          </MetaItem>
+        </div>
+
+        <div className="grid grid-cols-5 gap-3">
+          <HeroStat label="Events" value={tournament.events.length} icon={<Trophy size={16} />} />
+          <HeroStat label="Entries" value={entries} icon={<Users size={16} />} />
+          <HeroStat label="Tables" value={tournament.tableIds.length} icon={<Table2 size={16} />} />
+          <HeroStat label="Pools" value={pools} icon={<Layers size={16} />} />
+          <HeroStat
+            label="Days"
+            value={range.start ? daysBetween(range.start, range.end) : '—'}
+            suffix={range.start ? 'days' : undefined}
+            icon={<Calendar size={16} />}
+          />
+        </div>
+      </div>
+
+      <Tabs value={tab} onValueChange={setTab}>
+        <div className="border-b border-[color:var(--border-subtle)]">
+          <div className="mx-auto w-full max-w-[1320px] px-12">
+            <TabsList className="h-auto gap-1 bg-transparent p-0">
+              <TabsTrigger value="events">
+                Events
+                <span className="ml-1.5 rounded-full bg-[color:var(--bg-card)] px-1.5 font-mono text-[11px] tabular-nums">
+                  {tournament.events.length}
+                </span>
+              </TabsTrigger>
+              <TabsTrigger value="tables">
+                Tables
+                <span className="ml-1.5 rounded-full bg-[color:var(--bg-card)] px-1.5 font-mono text-[11px] tabular-nums">
+                  {tournament.tableIds.length}
+                </span>
+              </TabsTrigger>
+              <TabsTrigger value="schedule">Schedule</TabsTrigger>
+              <TabsTrigger value="details">Details</TabsTrigger>
+            </TabsList>
+          </div>
+        </div>
+
+        <div className="mx-auto w-full max-w-[1320px] px-12 pt-7 pb-20">
+          <TabsContent value="events">
+            <EventsTab
+              tournament={tournament}
+              onOpenEvent={openEvent}
+              onNewEvent={openNewEvent}
+            />
+          </TabsContent>
+          <TabsContent value="tables">
+            <TablesTab
+              tournament={tournament}
+              allTables={allTables}
+              onUpdate={onUpdate}
+            />
+          </TabsContent>
+          <TabsContent value="schedule">
+            <ScheduleTab tournament={tournament} />
+          </TabsContent>
+          <TabsContent value="details">
+            <DetailsTab tournament={tournament} onUpdate={onUpdate} />
+          </TabsContent>
+        </div>
+      </Tabs>
+
+      <EventEditor
+        open={editorOpen}
+        onOpenChange={setEditorOpen}
+        event={editorEvent}
+        tables={tournamentTables}
+        onSave={saveEvent}
+        onDelete={(id) => {
+          const ev = tournament.events.find((e) => e.id === id) ?? null
+          setEditorOpen(false)
+          setPendingDelete(ev)
+        }}
+      />
+
+      <ConfirmDeleteDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => !open && setPendingDelete(null)}
+        kind="event"
+        name={pendingDelete?.name}
+        onConfirm={() => {
+          if (pendingDelete) onDeleteEvent(pendingDelete.id)
+          setPendingDelete(null)
+        }}
+      />
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/details-tab.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/details-tab.factory.tsx
@@ -1,0 +1,9 @@
+import { buildTournament } from '../data/seed.factory'
+import type { DetailsTabProps } from './details-tab'
+
+/** Props for `DetailsTab` — the seeded tournament. */
+export function buildDetailsTabProps(
+  overrides: Partial<DetailsTabProps> = {},
+): DetailsTabProps {
+  return { tournament: buildTournament(), onUpdate: () => {}, ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/details-tab.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/details-tab.page.tsx
@@ -1,0 +1,26 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { DetailsTab, type DetailsTabProps } from './details-tab'
+import { buildDetailsTabProps } from './details-tab.factory'
+
+const scoped = (container: Container) => ({
+  getNameInput() {
+    return container.getByLabelText(/Name/)
+  },
+  querySaveButton() {
+    return container.queryByRole('button', { name: /Save changes/ })
+  },
+})
+
+/** Test page-object for `DetailsTab`. */
+export const detailsTabPage = {
+  render(overrides: Partial<DetailsTabProps> = {}) {
+    render(<DetailsTab {...buildDetailsTabProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/details-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/details-tab.test.tsx
@@ -1,0 +1,24 @@
+import userEvent from '@testing-library/user-event'
+
+import { buildTournament } from '../data/seed.factory'
+import { detailsTabPage } from './details-tab.page'
+
+describe('DetailsTab', () => {
+  it('reveals save only after an edit, then commits the draft', async () => {
+    const onUpdate = vi.fn()
+    detailsTabPage.render({
+      tournament: buildTournament({ name: 'Bay Area Open 2026' }),
+      onUpdate,
+    })
+    expect(detailsTabPage.querySaveButton()).toBeNull()
+
+    await userEvent.type(detailsTabPage.getNameInput(), '!')
+    const save = detailsTabPage.querySaveButton()
+    expect(save).toBeInTheDocument()
+
+    await userEvent.click(save!)
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Bay Area Open 2026!' }),
+    )
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/details-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/details-tab.tsx
@@ -95,9 +95,10 @@ export const DetailsTab = ({ tournament, onUpdate }: DetailsTabProps) => {
               )}
             </Field>
             <Field label="Status">
-              {() => (
+              {(id) => (
                 <ToggleGroup
                   type="single"
+                  aria-labelledby={`${id}-label`}
                   value={draft.status}
                   onValueChange={(v) => v && update({ status: v as TournamentStatus })}
                   className="w-fit"

--- a/web-client/src/components/tournaments/tournament-detail-page/details-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/details-tab.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react'
+import { Check } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+
+import type { Address, Tournament, TournamentStatus } from '../data/types'
+import { Field } from '../field'
+import { SectionHeader } from './section-header'
+
+export interface DetailsTabProps {
+  tournament: Tournament
+  onUpdate: (tournament: Tournament) => void
+}
+
+const STATUS_OPTIONS: { value: TournamentStatus; label: string }[] = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'published', label: 'Published' },
+  { value: 'live', label: 'Live' },
+  { value: 'archived', label: 'Archived' },
+]
+
+/** The Details tab: edit the tournament's name, description, status, and venue
+ * address. Changes stage in a draft and commit on Save. */
+export const DetailsTab = ({ tournament, onUpdate }: DetailsTabProps) => {
+  const [draft, setDraft] = useState<Tournament>(tournament)
+  const [seen, setSeen] = useState(tournament)
+  // Dirtiness is derivable: the draft diverges from the committed tournament
+  // exactly when there are unsaved edits (saving/reverting realign the refs).
+  const dirty = draft !== tournament
+
+  // Re-seed the draft when a different tournament loads — adjusting state
+  // during render instead of in an effect.
+  if (tournament !== seen) {
+    setSeen(tournament)
+    setDraft(tournament)
+  }
+
+  const update = (patch: Partial<Tournament>) =>
+    setDraft((d) => ({ ...d, ...patch }))
+  const updateAddress = (patch: Partial<Address>) =>
+    setDraft((d) => ({ ...d, address: { ...d.address, ...patch } }))
+  const save = () => onUpdate(draft)
+
+  return (
+    <div>
+      <SectionHeader
+        title="Tournament details"
+        subtitle="Edit the basics. Players see this on the public page and registration emails."
+        action={
+          dirty && (
+            <div className="flex gap-2">
+              <Button variant="ghost" onClick={() => setDraft(tournament)}>
+                Revert
+              </Button>
+              <Button onClick={save}>
+                <Check size={16} />
+                Save changes
+              </Button>
+            </div>
+          )
+        }
+      />
+
+      <div className="grid grid-cols-2 gap-6">
+        <Card className="px-4">
+          <div className="flex flex-col gap-4">
+            <div className="text-[15px] font-bold text-[color:var(--fg-1)]">
+              About
+            </div>
+            <Field label="Name" required>
+              {(id) => (
+                <Input
+                  id={id}
+                  value={draft.name}
+                  onChange={(e) => update({ name: e.target.value })}
+                />
+              )}
+            </Field>
+            <Field
+              label="Description"
+              hint="Optional. Shown on the public registration page."
+            >
+              {(id) => (
+                <Textarea
+                  id={id}
+                  rows={4}
+                  value={draft.description}
+                  placeholder="Two-day open. USATT-sanctioned."
+                  onChange={(e) => update({ description: e.target.value })}
+                />
+              )}
+            </Field>
+            <Field label="Status">
+              {() => (
+                <ToggleGroup
+                  type="single"
+                  value={draft.status}
+                  onValueChange={(v) => v && update({ status: v as TournamentStatus })}
+                  className="w-fit"
+                >
+                  {STATUS_OPTIONS.map((o) => (
+                    <ToggleGroupItem key={o.value} value={o.value}>
+                      {o.label}
+                    </ToggleGroupItem>
+                  ))}
+                </ToggleGroup>
+              )}
+            </Field>
+          </div>
+        </Card>
+
+        <Card className="px-4">
+          <div className="flex flex-col gap-4">
+            <div className="text-[15px] font-bold text-[color:var(--fg-1)]">
+              Venue &amp; address
+            </div>
+            <Field label="Venue name">
+              {(id) => (
+                <Input
+                  id={id}
+                  value={draft.address.venue}
+                  onChange={(e) => updateAddress({ venue: e.target.value })}
+                />
+              )}
+            </Field>
+            <Field label="Street">
+              {(id) => (
+                <Input
+                  id={id}
+                  value={draft.address.street}
+                  onChange={(e) => updateAddress({ street: e.target.value })}
+                />
+              )}
+            </Field>
+            <div className="grid grid-cols-[2fr_1fr_1fr] gap-3">
+              <Field label="City">
+                {(id) => (
+                  <Input
+                    id={id}
+                    value={draft.address.city}
+                    onChange={(e) => updateAddress({ city: e.target.value })}
+                  />
+                )}
+              </Field>
+              <Field label="Region">
+                {(id) => (
+                  <Input
+                    id={id}
+                    value={draft.address.region}
+                    onChange={(e) => updateAddress({ region: e.target.value })}
+                  />
+                )}
+              </Field>
+              <Field label="Postal">
+                {(id) => (
+                  <Input
+                    id={id}
+                    className="font-mono"
+                    value={draft.address.postal}
+                    onChange={(e) => updateAddress({ postal: e.target.value })}
+                  />
+                )}
+              </Field>
+            </div>
+            <Field label="Country">
+              {(id) => (
+                <Input
+                  id={id}
+                  value={draft.address.country}
+                  onChange={(e) => updateAddress({ country: e.target.value })}
+                />
+              )}
+            </Field>
+          </div>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.factory.tsx
@@ -1,0 +1,17 @@
+import { buildEvent, buildTables } from '../data/seed.factory'
+import type { EventEditorProps } from './event-editor'
+
+/** Props for `EventEditor` — open, editing the seeded Open Singles event. */
+export function buildEventEditorProps(
+  overrides: Partial<EventEditorProps> = {},
+): EventEditorProps {
+  return {
+    open: true,
+    onOpenChange: () => {},
+    event: buildEvent(),
+    tables: buildTables(12),
+    onSave: () => {},
+    onDelete: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
@@ -1,0 +1,35 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { EventEditor, type EventEditorProps } from './event-editor'
+import { buildEventEditorProps } from './event-editor.factory'
+
+const scoped = (container: Container) => ({
+  getSectionTab(label: string) {
+    return container.getByRole('tab', { name: label })
+  },
+  getSaveButton() {
+    return container.getByRole('button', { name: /Create event|Save changes/ })
+  },
+  getCancelButton() {
+    return container.getByRole('button', { name: 'Cancel' })
+  },
+  queryDeleteButton() {
+    return container.queryByRole('button', { name: 'Delete event' })
+  },
+})
+
+/**
+ * Test page-object for `EventEditor`. The sheet portals to the body, so
+ * accessors run against `screen`.
+ */
+export const eventEditorPage = {
+  render(overrides: Partial<EventEditorProps> = {}) {
+    render(<EventEditor {...buildEventEditorProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -1,0 +1,36 @@
+import userEvent from '@testing-library/user-event'
+
+import { screen } from '@/test/utilities'
+
+import { buildEvent } from '../data/seed.factory'
+import { eventEditorPage } from './event-editor.page'
+
+describe('EventEditor', () => {
+  it('saves the working draft', async () => {
+    const onSave = vi.fn()
+    eventEditorPage.render({ event: buildEvent({ name: 'Open Singles' }), onSave })
+
+    await userEvent.click(eventEditorPage.getSaveButton())
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Open Singles' }),
+    )
+  })
+
+  it('offers delete only for an existing event', () => {
+    eventEditorPage.render({ event: buildEvent({ id: 'ev-1' }) })
+    expect(eventEditorPage.queryDeleteButton()).toBeInTheDocument()
+    expect(eventEditorPage.getSaveButton()).toHaveTextContent('Save changes')
+  })
+
+  it('labels a new event and hides delete', () => {
+    eventEditorPage.render({ event: buildEvent({ id: 'new-123' }) })
+    expect(eventEditorPage.queryDeleteButton()).toBeNull()
+    expect(eventEditorPage.getSaveButton()).toHaveTextContent('Create event')
+  })
+
+  it('switches sections via the tabs', async () => {
+    eventEditorPage.render({ event: buildEvent() })
+    await userEvent.click(eventEditorPage.getSectionTab('Match settings'))
+    expect(screen.getByRole('switch', { name: 'Rated' })).toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react'
+import { Check, Trash2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+
+import type { TournamentEvent, TournamentTable } from '../data/types'
+import { BasicsSection } from './event-editor/basics-section'
+import { EligibilitySection } from './event-editor/eligibility-section'
+import { MatchSection } from './event-editor/match-section'
+import { PoolsSection } from './event-editor/pools-section'
+
+export interface EventEditorProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The event to edit. A new event has an id beginning `new-`. */
+  event: TournamentEvent | null
+  /** The tables available to this tournament (for the pools tab). */
+  tables: TournamentTable[]
+  onSave: (event: TournamentEvent) => void
+  onDelete: (id: string) => void
+}
+
+const SECTIONS = [
+  { value: 'basics', label: 'Basics' },
+  { value: 'eligibility', label: 'Eligibility' },
+  { value: 'match', label: 'Match settings' },
+  { value: 'pools', label: 'Table pools' },
+]
+
+/** The slide-in event editor — a side sheet with four sections (Basics,
+ * Eligibility, Match settings, Table pools) over a working draft that only
+ * commits on save. */
+export const EventEditor = ({
+  open,
+  onOpenChange,
+  event,
+  tables,
+  onSave,
+  onDelete,
+}: EventEditorProps) => {
+  const [draft, setDraft] = useState<TournamentEvent | null>(event)
+  const [section, setSection] = useState('basics')
+  const [seenEvent, setSeenEvent] = useState(event)
+
+  // Re-seed the working draft and reset to the first section whenever the
+  // editor is (re)opened on a different event — adjusting state during render
+  // rather than in an effect (https://react.dev/learn/you-might-not-need-an-effect).
+  if (event !== seenEvent) {
+    setSeenEvent(event)
+    setDraft(event)
+    setSection('basics')
+  }
+
+  const isNew = !event || event.id.startsWith('new')
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="w-full gap-0 p-0 sm:max-w-[820px]"
+      >
+        <SheetHeader className="border-b border-[color:var(--border-subtle)]">
+          <SheetDescription className="text-[11px] font-semibold tracking-[0.14em] uppercase">
+            {isNew ? 'New event' : 'Edit event'}
+          </SheetDescription>
+          <SheetTitle className="truncate text-[20px]">
+            {draft?.name || 'Untitled event'}
+          </SheetTitle>
+        </SheetHeader>
+
+        {draft && (
+          <div className="flex-1 overflow-y-auto px-6 py-5">
+            <Tabs value={section} onValueChange={setSection}>
+              <TabsList className="mb-6 w-full">
+                {SECTIONS.map((s) => (
+                  <TabsTrigger key={s.value} value={s.value} className="flex-1">
+                    {s.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+              <TabsContent value="basics">
+                <BasicsSection event={draft} onChange={setDraft} />
+              </TabsContent>
+              <TabsContent value="eligibility">
+                <EligibilitySection event={draft} onChange={setDraft} />
+              </TabsContent>
+              <TabsContent value="match">
+                <MatchSection event={draft} onChange={setDraft} />
+              </TabsContent>
+              <TabsContent value="pools">
+                <PoolsSection event={draft} tables={tables} onChange={setDraft} />
+              </TabsContent>
+            </Tabs>
+          </div>
+        )}
+
+        <SheetFooter className="flex-row items-center border-t border-[color:var(--border-subtle)]">
+          {!isNew && draft && (
+            <Button variant="destructive" onClick={() => onDelete(draft.id)}>
+              <Trash2 size={16} />
+              Delete event
+            </Button>
+          )}
+          <span className="flex-1" />
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button disabled={!draft} onClick={() => draft && onSave(draft)}>
+            <Check size={16} />
+            {isNew ? 'Create event' : 'Save changes'}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.factory.tsx
@@ -1,0 +1,9 @@
+import { buildEvent } from '../../data/seed.factory'
+import type { BasicsSectionProps } from './basics-section'
+
+/** Props for `BasicsSection` — the seeded Open Singles event. */
+export function buildBasicsSectionProps(
+  overrides: Partial<BasicsSectionProps> = {},
+): BasicsSectionProps {
+  return { event: buildEvent(), onChange: () => {}, ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
@@ -1,0 +1,29 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { BasicsSection, type BasicsSectionProps } from './basics-section'
+import { buildBasicsSectionProps } from './basics-section.factory'
+
+const scoped = (container: Container) => ({
+  getNameInput() {
+    return container.getByLabelText(/Event name/)
+  },
+  getPlayerLimitInput() {
+    return container.getByLabelText(/Player limit/)
+  },
+  getFormatTrigger() {
+    return container.getByRole('combobox', { name: 'Format' })
+  },
+})
+
+/** Test page-object for `BasicsSection`. */
+export const basicsSectionPage = {
+  render(overrides: Partial<BasicsSectionProps> = {}) {
+    render(<BasicsSection {...buildBasicsSectionProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent } from '@/test/utilities'
+
+import { buildEvent } from '../../data/seed.factory'
+import { basicsSectionPage } from './basics-section.page'
+
+describe('BasicsSection', () => {
+  it('shows the event name and format', () => {
+    basicsSectionPage.render({
+      event: buildEvent({ name: 'Open Singles', format: 'singles' }),
+    })
+    expect(basicsSectionPage.getNameInput()).toHaveValue('Open Singles')
+    expect(basicsSectionPage.getFormatTrigger()).toHaveTextContent('Singles')
+  })
+
+  it('emits a numeric player limit', () => {
+    const onChange = vi.fn()
+    basicsSectionPage.render({ event: buildEvent({ maxPlayers: 32 }), onChange })
+    fireEvent.change(basicsSectionPage.getPlayerLimitInput(), {
+      target: { value: '48' },
+    })
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ maxPlayers: 48 }),
+    )
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
@@ -1,0 +1,132 @@
+import { Input } from '@/components/ui/input'
+
+import { DRAW_TYPE_OPTIONS, FORMAT_OPTIONS } from '../../data/options'
+import type { DrawType, EventFormat, TournamentEvent } from '../../data/types'
+import { Field } from '../../field'
+import { SectionHeader } from '../section-header'
+import { OptionSelect } from './option-select'
+
+export interface BasicsSectionProps {
+  event: TournamentEvent
+  onChange: (next: TournamentEvent) => void
+}
+
+/** The event editor's "Basics" tab: name, format, draw type, caps, and the
+ * time-slot window. */
+export const BasicsSection = ({ event, onChange }: BasicsSectionProps) => {
+  const set = (patch: Partial<TournamentEvent>) => onChange({ ...event, ...patch })
+  const setSlot = (patch: Partial<TournamentEvent['slot']>) =>
+    set({ slot: { ...event.slot, ...patch } })
+
+  return (
+    <div className="flex flex-col gap-5">
+      <SectionHeader
+        title="The basics"
+        subtitle="Name it, decide the format, set the window."
+      />
+
+      <Field label="Event name" required>
+        {(id) => (
+          <Input
+            id={id}
+            autoFocus
+            value={event.name}
+            placeholder="Open Singles"
+            onChange={(e) => set({ name: e.target.value })}
+          />
+        )}
+      </Field>
+
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Format" required>
+          {() => (
+            <OptionSelect
+              ariaLabel="Format"
+              value={event.format}
+              options={FORMAT_OPTIONS}
+              onChange={(v) => set({ format: v as EventFormat })}
+            />
+          )}
+        </Field>
+        <Field label="Draw type">
+          {() => (
+            <OptionSelect
+              ariaLabel="Draw type"
+              value={event.drawType}
+              options={DRAW_TYPE_OPTIONS}
+              onChange={(v) => set({ drawType: v as DrawType })}
+            />
+          )}
+        </Field>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Player limit" hint="Hard cap. Waitlist opens past this.">
+          {(id) => (
+            <Input
+              id={id}
+              type="number"
+              min={2}
+              max={512}
+              value={event.maxPlayers}
+              onChange={(e) => set({ maxPlayers: Number(e.target.value) })}
+            />
+          )}
+        </Field>
+        <Field label="Entry fee">
+          {(id) => (
+            <Input
+              id={id}
+              type="number"
+              min={0}
+              value={event.entryFee}
+              onChange={(e) => set({ entryFee: Number(e.target.value) })}
+            />
+          )}
+        </Field>
+      </div>
+
+      <div className="my-1 flex items-center gap-3">
+        <span className="text-[11px] font-semibold tracking-[0.14em] text-[color:var(--fg-3)] uppercase">
+          Time slot
+        </span>
+        <span className="h-px flex-1 bg-[color:var(--border-subtle)]" />
+      </div>
+
+      <div className="grid grid-cols-[1.4fr_1fr_1fr] gap-4">
+        <Field label="Date">
+          {(id) => (
+            <Input
+              id={id}
+              type="date"
+              value={event.slot.date}
+              onChange={(e) => setSlot({ date: e.target.value })}
+            />
+          )}
+        </Field>
+        <Field label="Start">
+          {(id) => (
+            <Input
+              id={id}
+              type="time"
+              className="font-mono"
+              value={event.slot.start}
+              onChange={(e) => setSlot({ start: e.target.value })}
+            />
+          )}
+        </Field>
+        <Field label="End">
+          {(id) => (
+            <Input
+              id={id}
+              type="time"
+              className="font-mono"
+              value={event.slot.end}
+              onChange={(e) => setSlot({ end: e.target.value })}
+            />
+          )}
+        </Field>
+      </div>
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.factory.tsx
@@ -1,0 +1,13 @@
+import { buildEvent } from '../../data/seed.factory'
+import type { EligibilitySectionProps } from './eligibility-section'
+
+/** Props for `EligibilitySection` — an open event (no rules) by default. */
+export function buildEligibilitySectionProps(
+  overrides: Partial<EligibilitySectionProps> = {},
+): EligibilitySectionProps {
+  return {
+    event: buildEvent({ predicates: [] }),
+    onChange: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.page.tsx
@@ -1,0 +1,32 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import {
+  EligibilitySection,
+  type EligibilitySectionProps,
+} from './eligibility-section'
+import { buildEligibilitySectionProps } from './eligibility-section.factory'
+import { predicateRowPage } from './eligibility-section/predicate-row.page'
+
+const scoped = (container: Container) => ({
+  getAddRuleButton() {
+    return container.getByRole('button', { name: /Add (a )?rule/ })
+  },
+  queryRows() {
+    return container.queryAllByTestId('predicate-row')
+  },
+  /** Reuse the predicate-row queries (scoped to the section). */
+  ...predicateRowPage.within(container),
+})
+
+/** Test page-object for `EligibilitySection`. */
+export const eligibilitySectionPage = {
+  render(overrides: Partial<EligibilitySectionProps> = {}) {
+    render(<EligibilitySection {...buildEligibilitySectionProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.test.tsx
@@ -1,0 +1,24 @@
+import userEvent from '@testing-library/user-event'
+
+import { buildEvent } from '../../data/seed.factory'
+import { buildPredicate } from '../../data/seed.factory'
+import { eligibilitySectionPage } from './eligibility-section.page'
+
+describe('EligibilitySection', () => {
+  it('shows the open-to-all empty state with no rules', () => {
+    eligibilitySectionPage.render({ event: buildEvent({ predicates: [] }) })
+    expect(eligibilitySectionPage.queryRows()).toHaveLength(0)
+    expect(document.body).toHaveTextContent('Open to all players')
+  })
+
+  it('appends a rule when Add rule is clicked', async () => {
+    const onChange = vi.fn()
+    eligibilitySectionPage.render({
+      event: buildEvent({ predicates: [buildPredicate()] }),
+      onChange,
+    })
+
+    await userEvent.click(eligibilitySectionPage.getAddRuleButton())
+    expect(onChange.mock.calls.at(-1)?.[0].predicates).toHaveLength(2)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.tsx
@@ -1,0 +1,87 @@
+import { Filter, Globe, Plus } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+import { genId } from '../../data/helpers'
+import type { Predicate, TournamentEvent } from '../../data/types'
+import { EmptyState } from '../../empty-state'
+import { SectionHeader } from '../section-header'
+import { PredicateRow } from './eligibility-section/predicate-row'
+
+export interface EligibilitySectionProps {
+  event: TournamentEvent
+  onChange: (next: TournamentEvent) => void
+}
+
+/** The event editor's "Eligibility" tab — a free-form, ANDed rule builder.
+ * No rules means the event is open to everyone. */
+export const EligibilitySection = ({
+  event,
+  onChange,
+}: EligibilitySectionProps) => {
+  const preds = event.predicates
+  const setPreds = (predicates: Predicate[]) => onChange({ ...event, predicates })
+
+  const addRule = () =>
+    setPreds([
+      ...preds,
+      { id: genId('pr'), field: 'rating', op: '<', value: 1500 },
+    ])
+
+  return (
+    <div className="flex flex-col gap-5">
+      <SectionHeader
+        title="Eligibility rules"
+        subtitle="Players must satisfy every rule to enter. Empty = open to all."
+        action={
+          <Button variant="outline" size="sm" onClick={addRule}>
+            <Plus size={14} />
+            Add rule
+          </Button>
+        }
+      />
+
+      {preds.length === 0 ? (
+        <EmptyState
+          icon={<Globe size={28} />}
+          title="Open to all players"
+          hint="No restrictions. Anyone in the system can register for this event."
+          action={
+            <Button variant="outline" onClick={addRule}>
+              <Plus size={16} />
+              Add a rule
+            </Button>
+          }
+        />
+      ) : (
+        <div className="flex flex-col gap-3">
+          <div className="grid grid-cols-[160px_180px_1fr_auto] gap-2 pb-1 text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">
+            <div>Field</div>
+            <div>Operator</div>
+            <div>Value</div>
+            <div />
+          </div>
+          {preds.map((p, i) => (
+            <PredicateRow
+              key={p.id}
+              predicate={p}
+              onChange={(np) =>
+                setPreds(preds.map((x, j) => (j === i ? np : x)))
+              }
+              onRemove={() => setPreds(preds.filter((_, j) => j !== i))}
+            />
+          ))}
+          <div className="mt-1 flex items-center gap-2.5 rounded-[6px] border border-[color:rgba(255,122,26,0.2)] bg-[color:var(--bg-accent-soft)] px-3.5 py-2.5">
+            <Filter size={14} className="text-[color:var(--ball-500)]" />
+            <span className="text-[13px] text-[color:var(--fg-2)]">
+              All{' '}
+              <strong className="text-[color:var(--fg-1)]">{preds.length}</strong>{' '}
+              {preds.length === 1 ? 'rule' : 'rules'} must match. Combine with{' '}
+              <code className="font-mono text-[color:var(--ball-500)]">AND</code>.
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.factory.tsx
@@ -1,0 +1,14 @@
+import { buildPredicate } from '../../../data/seed.factory'
+import type { PredicateRowProps } from './predicate-row'
+
+/** Props for `PredicateRow` — a `rating < 1500` numeric rule. */
+export function buildPredicateRowProps(
+  overrides: Partial<PredicateRowProps> = {},
+): PredicateRowProps {
+  return {
+    predicate: buildPredicate(),
+    onChange: () => {},
+    onRemove: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.page.tsx
@@ -1,0 +1,35 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { PredicateRow, type PredicateRowProps } from './predicate-row'
+import { buildPredicateRowProps } from './predicate-row.factory'
+
+const scoped = (container: Container) => ({
+  getRow() {
+    return container.getByTestId('predicate-row')
+  },
+  getValueInput() {
+    return container.getByLabelText('Value')
+  },
+  queryValueInput() {
+    return container.queryByLabelText('Value')
+  },
+  getRemoveButton() {
+    return container.getByRole('button', { name: 'Remove rule' })
+  },
+  getFieldTrigger() {
+    return container.getByRole('combobox', { name: 'Field' })
+  },
+})
+
+/** Test page-object for `PredicateRow`. */
+export const predicateRowPage = {
+  render(overrides: Partial<PredicateRowProps> = {}) {
+    render(<PredicateRow {...buildPredicateRowProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.test.tsx
@@ -1,0 +1,37 @@
+import userEvent from '@testing-library/user-event'
+
+import { fireEvent } from '@/test/utilities'
+
+import { buildPredicate } from '../../../data/seed.factory'
+import { predicateRowPage } from './predicate-row.page'
+
+describe('PredicateRow', () => {
+  it('parses a numeric rule value to a number', () => {
+    const onChange = vi.fn()
+    predicateRowPage.render({
+      predicate: buildPredicate({ field: 'rating', op: '<', value: 1500 }),
+      onChange,
+    })
+
+    // Controlled input whose prop never updates here, so assert one change.
+    fireEvent.change(predicateRowPage.getValueInput(), {
+      target: { value: '1800' },
+    })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ value: 1800 }))
+  })
+
+  it('renders no numeric value input for a boolean field', () => {
+    predicateRowPage.render({
+      predicate: buildPredicate({ field: 'club', op: 'true', value: true }),
+    })
+    expect(predicateRowPage.queryValueInput()).toBeNull()
+    expect(predicateRowPage.getRow()).toHaveTextContent('a club member')
+  })
+
+  it('removes the rule', async () => {
+    const onRemove = vi.fn()
+    predicateRowPage.render({ onRemove })
+    await userEvent.click(predicateRowPage.getRemoveButton())
+    expect(onRemove).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.tsx
@@ -1,0 +1,142 @@
+import { Trash2 } from 'lucide-react'
+
+import { Input } from '@/components/ui/input'
+
+import {
+  PRED_FIELDS,
+  PRED_OPS_BY_TYPE,
+} from '../../../data/options'
+import type { Predicate, PredicateValue } from '../../../data/types'
+import { OptionSelect } from '../option-select'
+
+export interface PredicateRowProps {
+  predicate: Predicate
+  onChange: (predicate: Predicate) => void
+  onRemove: () => void
+}
+
+const FIELD_OPTIONS = Object.entries(PRED_FIELDS).map(([value, schema]) => ({
+  value,
+  label: schema.label,
+}))
+
+function numberOrNull(raw: string): number | null {
+  if (raw === '') return null
+  const n = Number(raw)
+  return Number.isNaN(n) ? null : n
+}
+
+/** One ANDed eligibility rule: a field picker, an operator picker, a
+ * type-appropriate value control, and a remove button. Switching the field
+ * resets the operator and value to that field-type's defaults. */
+export const PredicateRow = ({
+  predicate,
+  onChange,
+  onRemove,
+}: PredicateRowProps) => {
+  const schema = PRED_FIELDS[predicate.field]
+  const ops = schema ? PRED_OPS_BY_TYPE[schema.type] : []
+
+  const setField = (field: string) => {
+    const next = PRED_FIELDS[field]
+    const value: PredicateValue =
+      next.type === 'enum'
+        ? (next.options?.[0]?.value ?? null)
+        : next.type === 'bool'
+          ? true
+          : null
+    onChange({
+      ...predicate,
+      field: field as Predicate['field'],
+      op: PRED_OPS_BY_TYPE[next.type][0].value,
+      value,
+    })
+  }
+
+  const between = Array.isArray(predicate.value)
+    ? predicate.value
+    : [null, null]
+
+  return (
+    <div
+      data-testid="predicate-row"
+      className="grid grid-cols-[160px_180px_1fr_auto] items-start gap-2"
+    >
+      <OptionSelect
+        ariaLabel="Field"
+        value={predicate.field}
+        options={FIELD_OPTIONS}
+        onChange={setField}
+      />
+      <OptionSelect
+        ariaLabel="Operator"
+        value={predicate.op}
+        options={ops}
+        onChange={(op) => onChange({ ...predicate, op })}
+      />
+
+      <div>
+        {schema?.type === 'number' && predicate.op === 'between' && (
+          <div className="flex items-center gap-2">
+            <Input
+              type="number"
+              aria-label="Lower bound"
+              value={between[0] ?? ''}
+              onChange={(e) =>
+                onChange({
+                  ...predicate,
+                  value: [numberOrNull(e.target.value), between[1]],
+                })
+              }
+            />
+            <span className="text-[13px] text-[color:var(--fg-3)]">and</span>
+            <Input
+              type="number"
+              aria-label="Upper bound"
+              value={between[1] ?? ''}
+              onChange={(e) =>
+                onChange({
+                  ...predicate,
+                  value: [between[0], numberOrNull(e.target.value)],
+                })
+              }
+            />
+          </div>
+        )}
+        {schema?.type === 'number' && predicate.op !== 'between' && (
+          <Input
+            type="number"
+            aria-label="Value"
+            placeholder={schema.placeholder}
+            value={typeof predicate.value === 'number' ? predicate.value : ''}
+            onChange={(e) =>
+              onChange({ ...predicate, value: numberOrNull(e.target.value) })
+            }
+          />
+        )}
+        {schema?.type === 'enum' && (
+          <OptionSelect
+            ariaLabel="Value"
+            value={String(predicate.value)}
+            options={schema.options ?? []}
+            onChange={(value) => onChange({ ...predicate, value })}
+          />
+        )}
+        {schema?.type === 'bool' && (
+          <div className="py-2.5 text-[13px] text-[color:var(--fg-3)]">
+            a club member
+          </div>
+        )}
+      </div>
+
+      <button
+        type="button"
+        aria-label="Remove rule"
+        onClick={onRemove}
+        className="grid size-9 place-items-center rounded-md border border-transparent text-[color:var(--loss)] hover:bg-[color:rgba(255,77,109,0.16)]"
+      >
+        <Trash2 size={16} />
+      </button>
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.factory.tsx
@@ -1,0 +1,13 @@
+import { buildEvent } from '../../data/seed.factory'
+import type { MatchSectionProps } from './match-section'
+
+/** Props for `MatchSection` — a rated Bo5 event. */
+export function buildMatchSectionProps(
+  overrides: Partial<MatchSectionProps> = {},
+): MatchSectionProps {
+  return {
+    event: buildEvent({ match: { rated: true, lengthGames: 5 } }),
+    onChange: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.page.tsx
@@ -1,0 +1,26 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { MatchSection, type MatchSectionProps } from './match-section'
+import { buildMatchSectionProps } from './match-section.factory'
+
+const scoped = (container: Container) => ({
+  getRatedSwitch() {
+    return container.getByRole('switch', { name: 'Rated' })
+  },
+  getLengthOption(label: string) {
+    return container.getByRole('radio', { name: label })
+  },
+})
+
+/** Test page-object for `MatchSection`. */
+export const matchSectionPage = {
+  render(overrides: Partial<MatchSectionProps> = {}) {
+    render(<MatchSection {...buildMatchSectionProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.test.tsx
@@ -1,0 +1,37 @@
+import userEvent from '@testing-library/user-event'
+
+import { buildEvent } from '../../data/seed.factory'
+import { matchSectionPage } from './match-section.page'
+
+describe('MatchSection', () => {
+  it('reflects the current rated state', () => {
+    matchSectionPage.render({
+      event: buildEvent({ match: { rated: false, lengthGames: 3 } }),
+    })
+    expect(matchSectionPage.getRatedSwitch()).not.toBeChecked()
+  })
+
+  it('toggles rated off', async () => {
+    const onChange = vi.fn()
+    matchSectionPage.render({
+      event: buildEvent({ match: { rated: true, lengthGames: 5 } }),
+      onChange,
+    })
+    await userEvent.click(matchSectionPage.getRatedSwitch())
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ match: { rated: false, lengthGames: 5 } }),
+    )
+  })
+
+  it('changes the best-of length', async () => {
+    const onChange = vi.fn()
+    matchSectionPage.render({
+      event: buildEvent({ match: { rated: true, lengthGames: 5 } }),
+      onChange,
+    })
+    await userEvent.click(matchSectionPage.getLengthOption('Bo7'))
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ match: { rated: true, lengthGames: 7 } }),
+    )
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.tsx
@@ -1,0 +1,110 @@
+import { Card } from '@/components/ui/card'
+import { Switch } from '@/components/ui/switch'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { cn } from '@/lib/utils'
+
+import { MATCH_LENGTH_OPTIONS } from '../../data/options'
+import type { MatchLength, TournamentEvent } from '../../data/types'
+import { SectionHeader } from '../section-header'
+
+export interface MatchSectionProps {
+  event: TournamentEvent
+  onChange: (next: TournamentEvent) => void
+}
+
+/** The event editor's "Match settings" tab — a rated toggle and a best-of
+ * length picker, with a per-length "first to N" breakdown. */
+export const MatchSection = ({ event, onChange }: MatchSectionProps) => {
+  const m = event.match
+  const setMatch = (patch: Partial<TournamentEvent['match']>) =>
+    onChange({ ...event, match: { ...m, ...patch } })
+
+  return (
+    <div className="flex flex-col gap-5">
+      <SectionHeader
+        title="Match settings"
+        subtitle="How each individual match is played in this event."
+      />
+
+      <Card className="px-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <div className="text-[15px] font-semibold text-[color:var(--fg-1)]">
+              Rated
+            </div>
+            <div className="mt-0.5 text-[13px] text-[color:var(--fg-3)]">
+              Results count toward player ratings. Turn off for casual events.
+            </div>
+          </div>
+          <Switch
+            aria-label="Rated"
+            checked={m.rated}
+            onCheckedChange={(rated) => setMatch({ rated })}
+          />
+        </div>
+      </Card>
+
+      <Card className="px-4">
+        <div>
+          <div className="text-[15px] font-semibold text-[color:var(--fg-1)]">
+            Match length
+          </div>
+          <div className="mt-0.5 text-[13px] text-[color:var(--fg-3)]">
+            Best of{' '}
+            <span className="font-mono text-[color:var(--fg-1)]">
+              {m.lengthGames}
+            </span>{' '}
+            games. First to ceil(N/2) wins the match.
+          </div>
+        </div>
+
+        <ToggleGroup
+          type="single"
+          value={String(m.lengthGames)}
+          onValueChange={(v) => {
+            if (v) setMatch({ lengthGames: Number(v) as MatchLength })
+          }}
+          className="w-fit"
+        >
+          {MATCH_LENGTH_OPTIONS.map((o) => (
+            <ToggleGroupItem key={o.value} value={String(o.value)}>
+              {o.label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+
+        <div className="grid grid-cols-4 gap-2">
+          {MATCH_LENGTH_OPTIONS.map((o) => {
+            const wins = Math.ceil(o.value / 2)
+            const active = m.lengthGames === o.value
+            return (
+              <div
+                key={o.value}
+                className={cn(
+                  'rounded-[6px] border px-2.5 py-2 text-[11px]',
+                  active
+                    ? 'border-[color:rgba(255,122,26,0.3)] bg-[color:var(--bg-accent-soft)]'
+                    : 'border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)]',
+                )}
+              >
+                <div
+                  className={cn(
+                    'font-mono font-semibold tracking-[0.08em] uppercase',
+                    active
+                      ? 'text-[color:var(--ball-500)]'
+                      : 'text-[color:var(--fg-3)]',
+                  )}
+                >
+                  {o.label}
+                </div>
+                <div className="mt-0.5 text-[color:var(--fg-2)]">
+                  First to {wins}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/option-select.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/option-select.factory.tsx
@@ -1,0 +1,18 @@
+import type { OptionSelectProps } from './option-select'
+
+/** Props for `OptionSelect` — a three-option format picker. */
+export function buildOptionSelectProps(
+  overrides: Partial<OptionSelectProps> = {},
+): OptionSelectProps {
+  return {
+    value: 'singles',
+    options: [
+      { value: 'singles', label: 'Singles' },
+      { value: 'doubles', label: 'Doubles' },
+      { value: 'teams', label: 'Teams' },
+    ],
+    onChange: () => {},
+    ariaLabel: 'Format',
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/option-select.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/option-select.page.tsx
@@ -1,0 +1,25 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { OptionSelect, type OptionSelectProps } from './option-select'
+import { buildOptionSelectProps } from './option-select.factory'
+
+const scoped = (container: Container) => ({
+  getTrigger(ariaLabel: string) {
+    return container.getByRole('combobox', { name: ariaLabel })
+  },
+})
+
+/** Test page-object for `OptionSelect`. The radix listbox portals to the body,
+ * so option queries resolve against `screen`. */
+export const optionSelectPage = {
+  render(overrides: Partial<OptionSelectProps> = {}) {
+    render(<OptionSelect {...buildOptionSelectProps(overrides)} />)
+  },
+  getOption(label: string) {
+    return screen.getByRole('option', { name: label })
+  },
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/option-select.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/option-select.test.tsx
@@ -1,0 +1,13 @@
+import { optionSelectPage } from './option-select.page'
+
+describe('OptionSelect', () => {
+  it('renders the selected option label on the trigger', () => {
+    optionSelectPage.render({ value: 'doubles', ariaLabel: 'Format' })
+    expect(optionSelectPage.getTrigger('Format')).toHaveTextContent('Doubles')
+  })
+
+  it('exposes the trigger by its accessible name', () => {
+    optionSelectPage.render({ ariaLabel: 'Draw type' })
+    expect(optionSelectPage.getTrigger('Draw type')).toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/option-select.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/option-select.tsx
@@ -1,0 +1,43 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+export interface OptionSelectProps {
+  value: string
+  options: { value: string; label: string }[]
+  onChange: (value: string) => void
+  /** Accessible name for the trigger (there's rarely a visible label). */
+  ariaLabel: string
+  placeholder?: string
+  className?: string
+}
+
+/** A thin, typed wrapper over the shadcn `Select` for the simple
+ * value/options/onChange shape the event-editor forms use. */
+export const OptionSelect = ({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  placeholder,
+  className,
+}: OptionSelectProps) => {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger aria-label={ariaLabel} className={className}>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((o) => (
+          <SelectItem key={o.value} value={o.value}>
+            {o.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.factory.tsx
@@ -1,0 +1,14 @@
+import { buildEvent, buildTables } from '../../data/seed.factory'
+import type { PoolsSectionProps } from './pools-section'
+
+/** Props for `PoolsSection` — the seeded one-pool event with 12 tables. */
+export function buildPoolsSectionProps(
+  overrides: Partial<PoolsSectionProps> = {},
+): PoolsSectionProps {
+  return {
+    event: buildEvent(),
+    tables: buildTables(12),
+    onChange: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
@@ -1,0 +1,31 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { PoolsSection, type PoolsSectionProps } from './pools-section'
+import { buildPoolsSectionProps } from './pools-section.factory'
+import { poolCardPage } from './pools-section/pool-card.page'
+
+const scoped = (container: Container) => ({
+  getAddPoolButton() {
+    return container.getByRole('button', { name: /Add (first )?pool/ })
+  },
+  queryPoolCards() {
+    return container.queryAllByTestId('pool-card')
+  },
+  queryConflictAlert() {
+    return container.queryByRole('alert')
+  },
+  ...poolCardPage.within(container),
+})
+
+/** Test page-object for `PoolsSection`. */
+export const poolsSectionPage = {
+  render(overrides: Partial<PoolsSectionProps> = {}) {
+    render(<PoolsSection {...buildPoolsSectionProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
@@ -1,0 +1,41 @@
+import userEvent from '@testing-library/user-event'
+
+import { buildEvent, buildPool } from '../../data/seed.factory'
+import { poolsSectionPage } from './pools-section.page'
+
+describe('PoolsSection', () => {
+  it('appends a pool when Add pool is clicked', async () => {
+    const onChange = vi.fn()
+    poolsSectionPage.render({ event: buildEvent({ pools: [buildPool()] }), onChange })
+    await userEvent.click(poolsSectionPage.getAddPoolButton())
+    expect(onChange.mock.calls.at(-1)?.[0].pools).toHaveLength(2)
+  })
+
+  it('warns when two overlapping pools share a table', () => {
+    poolsSectionPage.render({
+      event: buildEvent({
+        pools: [
+          buildPool({
+            id: 'a',
+            name: 'Pool A',
+            slot: { date: '2026-06-13', start: '09:00', end: '12:00' },
+            tableIds: ['t1'],
+          }),
+          buildPool({
+            id: 'b',
+            name: 'Pool B',
+            slot: { date: '2026-06-13', start: '11:00', end: '14:00' },
+            tableIds: ['t1'],
+          }),
+        ],
+      }),
+    })
+    expect(poolsSectionPage.queryConflictAlert()).toHaveTextContent('double-booked')
+  })
+
+  it('shows the empty state with no pools', () => {
+    poolsSectionPage.render({ event: buildEvent({ pools: [] }) })
+    expect(poolsSectionPage.queryPoolCards()).toHaveLength(0)
+    expect(document.body).toHaveTextContent('No pools yet')
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
@@ -11,6 +11,23 @@ describe('PoolsSection', () => {
     expect(onChange.mock.calls.at(-1)?.[0].pools).toHaveLength(2)
   })
 
+  it('counts distinct double-booked tables, not conflict pairs', () => {
+    // One table (t1) shared across three mutually-overlapping pools yields
+    // three conflict pairs but is still a single double-booked table.
+    poolsSectionPage.render({
+      event: buildEvent({
+        pools: [
+          buildPool({ id: 'a', name: 'A', slot: { date: '2026-06-13', start: '09:00', end: '12:00' }, tableIds: ['t1'] }),
+          buildPool({ id: 'b', name: 'B', slot: { date: '2026-06-13', start: '10:00', end: '13:00' }, tableIds: ['t1'] }),
+          buildPool({ id: 'c', name: 'C', slot: { date: '2026-06-13', start: '11:00', end: '14:00' }, tableIds: ['t1'] }),
+        ],
+      }),
+    })
+    const alert = poolsSectionPage.queryConflictAlert()
+    expect(alert).toHaveTextContent('1 table is double-booked')
+    expect(alert).not.toHaveTextContent('3 tables are')
+  })
+
   it('warns when two overlapping pools share a table', () => {
     poolsSectionPage.render({
       event: buildEvent({

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
@@ -1,0 +1,100 @@
+import { Plus, TriangleAlert } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+import { findPoolConflicts, genId } from '../../data/helpers'
+import type { Pool, TournamentEvent, TournamentTable } from '../../data/types'
+import { EmptyState } from '../../empty-state'
+import { SectionHeader } from '../section-header'
+import { PoolCard } from './pools-section/pool-card'
+
+export interface PoolsSectionProps {
+  event: TournamentEvent
+  /** The tables available to this tournament. */
+  tables: TournamentTable[]
+  onChange: (next: TournamentEvent) => void
+}
+
+/** The event editor's "Table pools" tab: each pool reserves a slice of tables
+ * for a window, with a warning when tables are double-booked across overlapping
+ * pools. */
+export const PoolsSection = ({ event, tables, onChange }: PoolsSectionProps) => {
+  const pools = event.pools
+  const setPools = (next: Pool[]) => onChange({ ...event, pools: next })
+  const conflicts = findPoolConflicts(pools)
+
+  const addPool = () =>
+    setPools([
+      ...pools,
+      {
+        id: genId('p'),
+        name: `Pool ${String.fromCharCode(65 + pools.length)}`,
+        slot: { ...event.slot },
+        tableIds: [],
+      },
+    ])
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SectionHeader
+        title="Table pools"
+        subtitle="Each pool reserves a slice of tables for a window of time."
+        action={
+          <Button size="sm" onClick={addPool}>
+            <Plus size={14} />
+            Add pool
+          </Button>
+        }
+      />
+
+      {conflicts.length > 0 && (
+        <div
+          role="alert"
+          className="flex items-start gap-2.5 rounded-[6px] border border-[color:rgba(255,196,61,0.3)] bg-[color:rgba(255,196,61,0.1)] px-3.5 py-2.5"
+        >
+          <TriangleAlert
+            size={16}
+            className="mt-0.5 text-[color:var(--warn)]"
+          />
+          <div className="text-[13px] text-[color:var(--fg-2)]">
+            <div className="font-semibold text-[color:var(--warn)]">
+              {conflicts.length}{' '}
+              {conflicts.length === 1 ? 'table is' : 'tables are'} double-booked
+              within this event
+            </div>
+            <div className="mt-0.5 text-[11px] text-[color:var(--fg-3)]">
+              {conflicts
+                .map((c) => `${c.table} (${c.poolA}↔${c.poolB})`)
+                .join(' · ')}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {pools.length === 0 ? (
+        <EmptyState
+          title="No pools yet"
+          hint="Add a pool to reserve tables for this event."
+          action={
+            <Button onClick={addPool}>
+              <Plus size={16} />
+              Add first pool
+            </Button>
+          }
+        />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {pools.map((p, i) => (
+            <PoolCard
+              key={p.id}
+              pool={p}
+              tables={tables}
+              onChange={(np) => setPools(pools.map((x, j) => (j === i ? np : x)))}
+              onRemove={() => setPools(pools.filter((_, j) => j !== i))}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
@@ -1,5 +1,6 @@
 import { Plus, TriangleAlert } from 'lucide-react'
 
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 
 import { findPoolConflicts, genId } from '../../data/helpers'
@@ -22,6 +23,9 @@ export const PoolsSection = ({ event, tables, onChange }: PoolsSectionProps) => 
   const pools = event.pools
   const setPools = (next: Pool[]) => onChange({ ...event, pools: next })
   const conflicts = findPoolConflicts(pools)
+  // Count distinct tables, not conflict pairs: one table double-booked across
+  // several overlapping pools yields multiple conflict entries.
+  const conflictTableCount = new Set(conflicts.map((c) => c.table)).size
 
   const addPool = () =>
     setPools([
@@ -48,27 +52,19 @@ export const PoolsSection = ({ event, tables, onChange }: PoolsSectionProps) => 
       />
 
       {conflicts.length > 0 && (
-        <div
-          role="alert"
-          className="flex items-start gap-2.5 rounded-[6px] border border-[color:rgba(255,196,61,0.3)] bg-[color:rgba(255,196,61,0.1)] px-3.5 py-2.5"
-        >
-          <TriangleAlert
-            size={16}
-            className="mt-0.5 text-[color:var(--warn)]"
-          />
-          <div className="text-[13px] text-[color:var(--fg-2)]">
-            <div className="font-semibold text-[color:var(--warn)]">
-              {conflicts.length}{' '}
-              {conflicts.length === 1 ? 'table is' : 'tables are'} double-booked
-              within this event
-            </div>
-            <div className="mt-0.5 text-[11px] text-[color:var(--fg-3)]">
-              {conflicts
-                .map((c) => `${c.table} (${c.poolA}↔${c.poolB})`)
-                .join(' · ')}
-            </div>
-          </div>
-        </div>
+        <Alert className="border-[color:var(--warn)]/40 bg-[color:var(--warn)]/10">
+          <TriangleAlert className="text-[color:var(--warn)]" />
+          <AlertTitle className="text-[color:var(--warn)]">
+            {conflictTableCount}{' '}
+            {conflictTableCount === 1 ? 'table is' : 'tables are'} double-booked
+            within this event
+          </AlertTitle>
+          <AlertDescription className="text-[11px] text-[color:var(--fg-3)]">
+            {conflicts
+              .map((c) => `${c.table} (${c.poolA}↔${c.poolB})`)
+              .join(' · ')}
+          </AlertDescription>
+        </Alert>
       )}
 
       {pools.length === 0 ? (

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.factory.tsx
@@ -1,0 +1,15 @@
+import { buildPool, buildTables } from '../../../data/seed.factory'
+import type { PoolCardProps } from './pool-card'
+
+/** Props for `PoolCard` — Pool A with four of six tables selected. */
+export function buildPoolCardProps(
+  overrides: Partial<PoolCardProps> = {},
+): PoolCardProps {
+  return {
+    pool: buildPool(),
+    tables: buildTables(6),
+    onChange: () => {},
+    onRemove: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.page.tsx
@@ -1,0 +1,35 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { PoolCard, type PoolCardProps } from './pool-card'
+import { buildPoolCardProps } from './pool-card.factory'
+
+const scoped = (container: Container) => ({
+  getCard() {
+    return container.getByTestId('pool-card')
+  },
+  getNameInput() {
+    return container.getByLabelText('Pool name')
+  },
+  getTableToggle(label: string) {
+    return container.getByRole('button', { name: label, pressed: false })
+  },
+  getSelectedTableToggle(label: string) {
+    return container.getByRole('button', { name: label, pressed: true })
+  },
+  getRemoveButton() {
+    return container.getByRole('button', { name: 'Remove pool' })
+  },
+})
+
+/** Test page-object for `PoolCard`. */
+export const poolCardPage = {
+  render(overrides: Partial<PoolCardProps> = {}) {
+    render(<PoolCard {...buildPoolCardProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.test.tsx
@@ -1,0 +1,28 @@
+import userEvent from '@testing-library/user-event'
+
+import { buildPool } from '../../../data/seed.factory'
+import { poolCardPage } from './pool-card.page'
+
+describe('PoolCard', () => {
+  it('marks the selected tables as pressed', () => {
+    poolCardPage.render({ pool: buildPool({ tableIds: ['t1', 't2'] }) })
+    expect(poolCardPage.getSelectedTableToggle('T1')).toBeInTheDocument()
+    expect(poolCardPage.getTableToggle('T5')).toBeInTheDocument()
+  })
+
+  it('adds an unselected table on click', async () => {
+    const onChange = vi.fn()
+    poolCardPage.render({ pool: buildPool({ tableIds: ['t1'] }), onChange })
+    await userEvent.click(poolCardPage.getTableToggle('T5'))
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ tableIds: ['t1', 't5'] }),
+    )
+  })
+
+  it('removes the pool', async () => {
+    const onRemove = vi.fn()
+    poolCardPage.render({ onRemove })
+    await userEvent.click(poolCardPage.getRemoveButton())
+    expect(onRemove).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.tsx
@@ -1,0 +1,119 @@
+import { Trash2 } from 'lucide-react'
+
+import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+import type { Pool, TournamentTable } from '../../../data/types'
+import { Field } from '../../../field'
+
+export interface PoolCardProps {
+  pool: Pool
+  /** The tables available to this tournament. */
+  tables: TournamentTable[]
+  onChange: (pool: Pool) => void
+  onRemove: () => void
+}
+
+/** A single table pool: a name, a date/start/end window, and a multi-select of
+ * the tournament's tables (rendered as toggle chips). */
+export const PoolCard = ({ pool, tables, onChange, onRemove }: PoolCardProps) => {
+  const setSlot = (patch: Partial<Pool['slot']>) =>
+    onChange({ ...pool, slot: { ...pool.slot, ...patch } })
+
+  const toggleTable = (id: string) =>
+    onChange({
+      ...pool,
+      tableIds: pool.tableIds.includes(id)
+        ? pool.tableIds.filter((x) => x !== id)
+        : [...pool.tableIds, id],
+    })
+
+  return (
+    <Card className="gap-0 p-0" data-testid="pool-card">
+      <div className="flex items-center gap-2.5 border-b border-[color:var(--border-subtle)] p-3.5">
+        <Input
+          aria-label="Pool name"
+          value={pool.name}
+          onChange={(e) => onChange({ ...pool, name: e.target.value })}
+          className="h-8 flex-1 border-transparent bg-transparent text-[15px] font-semibold shadow-none focus-visible:border-[color:var(--border-default)]"
+        />
+        <span className="rounded-full bg-[color:var(--bg-raised)] px-2 py-0.5 font-mono text-[11px] text-[color:var(--fg-2)]">
+          {pool.tableIds.length}{' '}
+          {pool.tableIds.length === 1 ? 'table' : 'tables'}
+        </span>
+        <button
+          type="button"
+          aria-label="Remove pool"
+          onClick={onRemove}
+          className="grid size-7 place-items-center rounded-md text-[color:var(--loss)] hover:bg-[color:rgba(255,77,109,0.16)]"
+        >
+          <Trash2 size={14} />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 p-3.5">
+        <Field label="Date">
+          {(id) => (
+            <Input
+              id={id}
+              type="date"
+              value={pool.slot.date}
+              onChange={(e) => setSlot({ date: e.target.value })}
+            />
+          )}
+        </Field>
+        <Field label="Start">
+          {(id) => (
+            <Input
+              id={id}
+              type="time"
+              className="font-mono"
+              value={pool.slot.start}
+              onChange={(e) => setSlot({ start: e.target.value })}
+            />
+          )}
+        </Field>
+        <Field label="End">
+          {(id) => (
+            <Input
+              id={id}
+              type="time"
+              className="font-mono"
+              value={pool.slot.end}
+              onChange={(e) => setSlot({ end: e.target.value })}
+            />
+          )}
+        </Field>
+      </div>
+
+      <div className="px-3.5 pb-3.5">
+        <div className="mb-1.5 text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">
+          Tables in pool
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {tables.map((t) => {
+            const selected = pool.tableIds.includes(t.id)
+            return (
+              <button
+                key={t.id}
+                type="button"
+                aria-pressed={selected}
+                aria-label={t.label}
+                onClick={() => toggleTable(t.id)}
+                className={cn(
+                  'rounded-full border px-2.5 py-1 font-mono text-[12px] transition-colors',
+                  selected
+                    ? 'border-[color:rgba(255,122,26,0.3)] bg-[color:var(--bg-accent-soft)] text-[color:var(--ball-500)]'
+                    : 'border-[color:var(--border-subtle)] text-[color:var(--fg-2)] hover:bg-[color:var(--bg-hover)]',
+                )}
+              >
+                {t.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab.factory.tsx
@@ -1,0 +1,14 @@
+import { buildTournament } from '../data/seed.factory'
+import type { EventsTabProps } from './events-tab'
+
+/** Props for `EventsTab` — the seeded one-event tournament. */
+export function buildEventsTabProps(
+  overrides: Partial<EventsTabProps> = {},
+): EventsTabProps {
+  return {
+    tournament: buildTournament(),
+    onOpenEvent: () => {},
+    onNewEvent: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab.page.tsx
@@ -1,0 +1,27 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { EventsTab, type EventsTabProps } from './events-tab'
+import { buildEventsTabProps } from './events-tab.factory'
+import { eventCardPage } from './events-tab/event-card.page'
+
+const scoped = (container: Container) => ({
+  getNewEventButton() {
+    // The header action and the empty-state CTA both create events; take the
+    // first so the accessor resolves whether or not the list is empty.
+    return container.getAllByRole('button', { name: /New event|Add an event/ })[0]
+  },
+  ...eventCardPage.within(container),
+})
+
+/** Test page-object for `EventsTab`. */
+export const eventsTabPage = {
+  render(overrides: Partial<EventsTabProps> = {}) {
+    render(<EventsTab {...buildEventsTabProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab.test.tsx
@@ -1,0 +1,27 @@
+import userEvent from '@testing-library/user-event'
+
+import { buildTournament, buildEvent } from '../data/seed.factory'
+import { eventsTabPage } from './events-tab.page'
+
+describe('EventsTab', () => {
+  it('opens an event from its card', async () => {
+    const onOpenEvent = vi.fn()
+    eventsTabPage.render({
+      tournament: buildTournament({ events: [buildEvent({ name: 'Open Singles' })] }),
+      onOpenEvent,
+    })
+    await userEvent.click(eventsTabPage.getOpenButton('Open Singles'))
+    expect(onOpenEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the empty state and creates a first event', async () => {
+    const onNewEvent = vi.fn()
+    eventsTabPage.render({
+      tournament: buildTournament({ events: [] }),
+      onNewEvent,
+    })
+    expect(document.body).toHaveTextContent('No events yet')
+    await userEvent.click(eventsTabPage.getNewEventButton())
+    expect(onNewEvent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab.tsx
@@ -1,0 +1,56 @@
+import { Plus, Trophy } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+import type { Tournament, TournamentEvent } from '../data/types'
+import { EmptyState } from '../empty-state'
+import { SectionHeader } from './section-header'
+import { EventCard } from './events-tab/event-card'
+
+export interface EventsTabProps {
+  tournament: Tournament
+  onOpenEvent: (event: TournamentEvent) => void
+  onNewEvent: () => void
+}
+
+/** The Events tab: a list of event row-cards with a "New event" action and an
+ * empty state. */
+export const EventsTab = ({
+  tournament,
+  onOpenEvent,
+  onNewEvent,
+}: EventsTabProps) => {
+  return (
+    <div>
+      <SectionHeader
+        title="Events"
+        subtitle="Singles, doubles, age- and rating-restricted brackets. Click any event to edit."
+        action={
+          <Button onClick={onNewEvent}>
+            <Plus size={16} />
+            New event
+          </Button>
+        }
+      />
+      {tournament.events.length === 0 ? (
+        <EmptyState
+          icon={<Trophy size={28} />}
+          title="No events yet"
+          hint="Add your first event — Open Singles, U1500, Women's, etc."
+          action={
+            <Button onClick={onNewEvent}>
+              <Plus size={16} />
+              Add an event
+            </Button>
+          }
+        />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {tournament.events.map((ev) => (
+            <EventCard key={ev.id} event={ev} onOpen={() => onOpenEvent(ev)} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.factory.tsx
@@ -1,0 +1,9 @@
+import { buildEvent } from '../../data/seed.factory'
+import type { EventCardProps } from './event-card'
+
+/** Props for `EventCard` — the seeded Open Singles event. */
+export function buildEventCardProps(
+  overrides: Partial<EventCardProps> = {},
+): EventCardProps {
+  return { event: buildEvent(), onOpen: () => {}, ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.page.tsx
@@ -1,0 +1,24 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { EventCard, type EventCardProps } from './event-card'
+import { buildEventCardProps } from './event-card.factory'
+
+const scoped = (container: Container) => ({
+  /** The full-card open target, named `Edit <event>`. */
+  getOpenButton(name: string) {
+    return container.getByRole('button', { name: `Edit ${name}` })
+  },
+})
+
+/** Test page-object for `EventCard`. */
+export const eventCardPage = {
+  render(overrides: Partial<EventCardProps> = {}) {
+    render(<EventCard {...buildEventCardProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.test.tsx
@@ -1,0 +1,35 @@
+import userEvent from '@testing-library/user-event'
+
+import { buildEvent, buildPredicate } from '../../data/seed.factory'
+import { eventCardPage } from './event-card.page'
+
+describe('EventCard', () => {
+  it('shows the name, best-of badge, and eligibility chips', () => {
+    eventCardPage.render({
+      event: buildEvent({
+        name: 'U1500 Singles',
+        match: { rated: true, lengthGames: 3 },
+        predicates: [buildPredicate({ field: 'rating', op: '<', value: 1500 })],
+      }),
+    })
+    const card = eventCardPage.getOpenButton('U1500 Singles')
+    expect(card).toBeInTheDocument()
+    expect(document.body).toHaveTextContent('Bo3')
+    expect(document.body).toHaveTextContent('USATT rating < 1500')
+  })
+
+  it('shows entries out of the player cap', () => {
+    eventCardPage.render({
+      event: buildEvent({ entered: 52, maxPlayers: 64 }),
+    })
+    expect(document.body).toHaveTextContent('52')
+    expect(document.body).toHaveTextContent('/ 64')
+  })
+
+  it('opens the editor when clicked', async () => {
+    const onOpen = vi.fn()
+    eventCardPage.render({ event: buildEvent({ name: 'Open Singles' }), onOpen })
+    await userEvent.click(eventCardPage.getOpenButton('Open Singles'))
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.tsx
@@ -1,0 +1,131 @@
+import { ChevronRight, Layers, Pencil, TrendingUp } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+import { fmtDateShort, formatPredicate } from '../../data/helpers'
+import { DRAW_TYPE_OPTIONS, FORMAT_OPTIONS } from '../../data/options'
+import type { TournamentEvent } from '../../data/types'
+
+export interface EventCardProps {
+  event: TournamentEvent
+  onOpen: () => void
+}
+
+/** A row card for one event on the tournament's Events tab: title with rated /
+ * best-of badges, eligibility chips, the time slot, pool/table counts, and an
+ * entries fill bar. The whole card opens the editor. */
+export const EventCard = ({ event: ev, onOpen }: EventCardProps) => {
+  const fillPct = ev.maxPlayers
+    ? Math.min(100, Math.round(((ev.entered || 0) / ev.maxPlayers) * 100))
+    : 0
+  const isFull = ev.entered >= ev.maxPlayers
+  const formatLabel =
+    FORMAT_OPTIONS.find((f) => f.value === ev.format)?.label ?? ev.format
+  const drawLabel =
+    DRAW_TYPE_OPTIONS.find((d) => d.value === ev.drawType)?.label ?? ev.drawType
+  const tableCount = new Set(ev.pools.flatMap((p) => p.tableIds)).size
+
+  return (
+    <div className="group/ecard relative">
+      <Card className="p-0 ring-[color:var(--border-subtle)] transition-colors group-hover/ecard:ring-[color:var(--border-default)]">
+        <div className="grid grid-cols-[minmax(0,2.4fr)_minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-6 p-[18px]">
+          <div className="min-w-0">
+            <div className="mb-1.5 flex flex-wrap items-center gap-2.5">
+              <span className="text-[20px] font-bold whitespace-nowrap text-[color:var(--fg-1)]">
+                {ev.name}
+              </span>
+              {ev.match.rated && (
+                <Badge
+                  variant="outline"
+                  className="border-[color:rgba(255,122,26,0.3)] bg-[color:var(--bg-accent-soft)] text-[color:var(--ball-500)]"
+                >
+                  <TrendingUp size={12} />
+                  Rated
+                </Badge>
+              )}
+              <Badge variant="outline" className="font-mono">
+                Bo{ev.match.lengthGames}
+              </Badge>
+            </div>
+            <div className="flex items-center gap-2 text-[13px] whitespace-nowrap text-[color:var(--fg-3)]">
+              <span>{formatLabel}</span>
+              <span>·</span>
+              <span>{drawLabel}</span>
+            </div>
+            {ev.predicates.length > 0 && (
+              <div className="mt-2.5 flex flex-wrap gap-1">
+                {ev.predicates.map((p) => (
+                  <Badge key={p.id} variant="ghost" className="border-[color:var(--border-subtle)]">
+                    {formatPredicate(p)}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="min-w-0">
+            <div className="text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">
+              Time slot
+            </div>
+            <div className="mt-1 font-mono text-[13px] tabular-nums text-[color:var(--fg-1)]">
+              {fmtDateShort(ev.slot.date)} · {ev.slot.start}–{ev.slot.end}
+            </div>
+            <div className="mt-1.5 flex items-center gap-1.5 text-[11px] whitespace-nowrap text-[color:var(--fg-3)]">
+              <Layers size={12} />
+              <span>
+                {ev.pools.length} {ev.pools.length === 1 ? 'pool' : 'pools'}
+              </span>
+              <span>·</span>
+              <span className="font-mono">{tableCount} tables</span>
+            </div>
+          </div>
+
+          <div className="min-w-0">
+            <div className="text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">
+              Entries
+            </div>
+            <div className="mt-1 flex items-baseline gap-1">
+              <span
+                className={cn(
+                  'font-mono text-[20px] font-bold tabular-nums',
+                  isFull ? 'text-[color:var(--warn)]' : 'text-[color:var(--fg-1)]',
+                )}
+              >
+                {ev.entered || 0}
+              </span>
+              <span className="font-mono text-[13px] text-[color:var(--fg-3)]">
+                / {ev.maxPlayers}
+              </span>
+            </div>
+            <div className="mt-1.5 h-1 overflow-hidden rounded-full bg-[color:var(--bg-panel)]">
+              <div
+                className={cn(
+                  'h-full',
+                  isFull ? 'bg-[color:var(--warn)]' : 'bg-[color:var(--ball-500)]',
+                )}
+                style={{ width: `${fillPct}%` }}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="pointer-events-none inline-flex h-8 items-center gap-1.5 rounded-[10px] border border-[color:var(--border-default)] px-3 text-[13px] font-medium text-[color:var(--fg-1)]">
+              <Pencil size={14} />
+              Edit
+            </span>
+            <ChevronRight size={16} className="text-[color:var(--fg-3)]" />
+          </div>
+        </div>
+      </Card>
+
+      <button
+        type="button"
+        aria-label={`Edit ${ev.name}`}
+        onClick={onOpen}
+        className="absolute inset-0 rounded-xl outline-offset-2"
+      />
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/hero-stat.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/hero-stat.factory.tsx
@@ -1,0 +1,15 @@
+import { Trophy } from 'lucide-react'
+
+import type { HeroStatProps } from './hero-stat'
+
+/** Props for `HeroStat` — the "Events" stat by default. */
+export function buildHeroStatProps(
+  overrides: Partial<HeroStatProps> = {},
+): HeroStatProps {
+  return {
+    label: 'Events',
+    value: 5,
+    icon: <Trophy size={16} />,
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/hero-stat.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/hero-stat.page.tsx
@@ -1,0 +1,23 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { HeroStat, type HeroStatProps } from './hero-stat'
+import { buildHeroStatProps } from './hero-stat.factory'
+
+const scoped = (container: Container) => ({
+  getByLabel(label: string) {
+    return container.getByText(label)
+  },
+})
+
+/** Test page-object for `HeroStat`. */
+export const heroStatPage = {
+  render(overrides: Partial<HeroStatProps> = {}) {
+    render(<HeroStat {...buildHeroStatProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/hero-stat.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/hero-stat.test.tsx
@@ -1,0 +1,10 @@
+import { heroStatPage } from './hero-stat.page'
+
+describe('HeroStat', () => {
+  it('renders the value, label, and optional suffix', () => {
+    heroStatPage.render({ label: 'Days', value: 2, suffix: 'days' })
+    expect(heroStatPage.getByLabel('Days')).toBeInTheDocument()
+    expect(document.body).toHaveTextContent('2')
+    expect(document.body).toHaveTextContent('days')
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/hero-stat.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/hero-stat.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react'
+
+import { Card } from '@/components/ui/card'
+
+export interface HeroStatProps {
+  label: string
+  /** The primary figure; a string so callers can pass an em-dash placeholder. */
+  value: ReactNode
+  icon: ReactNode
+  /** Optional trailing unit, e.g. "days". */
+  suffix?: string
+}
+
+/** One cell of the tournament-detail stat strip: an accent icon chip beside a
+ * mono figure and an uppercase label. */
+export const HeroStat = ({ label, value, icon, suffix }: HeroStatProps) => {
+  return (
+    <Card className="flex-row items-center gap-3 px-4">
+      <div className="grid size-9 shrink-0 place-items-center rounded-md bg-[color:var(--bg-accent-soft)] text-[color:var(--ball-500)]">
+        {icon}
+      </div>
+      <div className="min-w-0">
+        <div className="font-mono text-[20px] leading-none font-bold tabular-nums text-[color:var(--fg-1)]">
+          {value}
+          {suffix && (
+            <span className="ml-1 text-[13px] font-medium text-[color:var(--fg-3)]">
+              {suffix}
+            </span>
+          )}
+        </div>
+        <div className="mt-1 text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">
+          {label}
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.factory.tsx
@@ -1,0 +1,9 @@
+import { buildTournament } from '../data/seed.factory'
+import type { ScheduleTabProps } from './schedule-tab'
+
+/** Props for `ScheduleTab` — the seeded tournament with one scheduled pool. */
+export function buildScheduleTabProps(
+  overrides: Partial<ScheduleTabProps> = {},
+): ScheduleTabProps {
+  return { tournament: buildTournament(), ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.page.tsx
@@ -1,0 +1,23 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { ScheduleTab, type ScheduleTabProps } from './schedule-tab'
+import { buildScheduleTabProps } from './schedule-tab.factory'
+
+const scoped = (container: Container) => ({
+  queryText(text: string) {
+    return container.queryByText(text)
+  },
+})
+
+/** Test page-object for `ScheduleTab`. */
+export const scheduleTabPage = {
+  render(overrides: Partial<ScheduleTabProps> = {}) {
+    render(<ScheduleTab {...buildScheduleTabProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.test.tsx
@@ -1,0 +1,31 @@
+import { buildEvent, buildPool, buildTournament } from '../data/seed.factory'
+import { scheduleTabPage } from './schedule-tab.page'
+
+describe('ScheduleTab', () => {
+  it('lists each scheduled pool under its day', () => {
+    scheduleTabPage.render({
+      tournament: buildTournament({
+        events: [
+          buildEvent({
+            name: 'Open Singles',
+            pools: [
+              buildPool({
+                name: 'Pool A',
+                slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
+              }),
+            ],
+          }),
+        ],
+      }),
+    })
+    expect(scheduleTabPage.queryText('Open Singles')).toBeInTheDocument()
+    expect(scheduleTabPage.queryText('09:00–12:30')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when nothing is scheduled', () => {
+    scheduleTabPage.render({
+      tournament: buildTournament({ events: [buildEvent({ pools: [] })] }),
+    })
+    expect(scheduleTabPage.queryText('Nothing scheduled')).toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.tsx
@@ -1,0 +1,144 @@
+import { Calendar } from 'lucide-react'
+
+import { Card } from '@/components/ui/card'
+
+import { fmtDate } from '../data/helpers'
+import type { Pool, Tournament, TournamentEvent } from '../data/types'
+import { EmptyState } from '../empty-state'
+import { SectionHeader } from './section-header'
+
+export interface ScheduleTabProps {
+  tournament: Tournament
+}
+
+const DAY_START = 8 * 60
+const DAY_END = 22 * 60
+const HOURS = [8, 10, 12, 14, 16, 18, 20, 22]
+
+function timeToMin(t: string): number {
+  const [h, m] = t.split(':').map(Number)
+  return h * 60 + m
+}
+function pct(t: string): number {
+  return ((timeToMin(t) - DAY_START) / (DAY_END - DAY_START)) * 100
+}
+
+interface Slotted {
+  event: TournamentEvent
+  pool: Pool
+}
+
+/** The Schedule tab: a read-only timeline of how each event's pools land on the
+ * calendar, grouped by day, on an 8:00–22:00 scale. */
+export const ScheduleTab = ({ tournament }: ScheduleTabProps) => {
+  const byDay = new Map<string, Slotted[]>()
+  for (const event of tournament.events) {
+    for (const pool of event.pools) {
+      const list = byDay.get(pool.slot.date) ?? []
+      list.push({ event, pool })
+      byDay.set(pool.slot.date, list)
+    }
+  }
+  const days = [...byDay.keys()].sort()
+
+  return (
+    <div>
+      <SectionHeader
+        title="Schedule"
+        subtitle="Read-only view of how pools land on the calendar. Conflicts flag in events."
+      />
+
+      {days.length === 0 ? (
+        <EmptyState
+          icon={<Calendar size={28} />}
+          title="Nothing scheduled"
+          hint="Add pools to events to see them here."
+        />
+      ) : (
+        <div className="flex flex-col gap-6">
+          {days.map((date) => {
+            const rows = byDay.get(date) ?? []
+            return (
+              <div key={date}>
+                <div className="mb-2.5 flex items-center gap-2.5">
+                  <div className="font-display text-[28px] tracking-[0.02em] text-[color:var(--fg-1)] uppercase">
+                    {fmtDate(date)}
+                  </div>
+                  <span className="rounded-full bg-[color:var(--bg-raised)] px-2 py-0.5 font-mono text-[11px] text-[color:var(--fg-2)]">
+                    {rows.length} pools
+                  </span>
+                </div>
+                <Card className="gap-0 p-0">
+                  <div className="grid grid-cols-[180px_1fr] border-b border-[color:var(--border-subtle)] font-mono text-[11px] text-[color:var(--fg-3)]">
+                    <div className="px-4 py-2.5">Event / pool</div>
+                    <div className="relative py-2.5">
+                      {HOURS.map((h) => (
+                        <div
+                          key={h}
+                          className="absolute top-0 bottom-0 pl-1"
+                          style={{
+                            left: `${((h * 60 - DAY_START) / (DAY_END - DAY_START)) * 100}%`,
+                          }}
+                        >
+                          {h}:00
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  {rows.map(({ event, pool }, i) => (
+                    <div
+                      key={pool.id}
+                      className="grid min-h-14 grid-cols-[180px_1fr] items-center"
+                      style={{
+                        borderBottom:
+                          i === rows.length - 1
+                            ? 'none'
+                            : '1px solid var(--border-subtle)',
+                      }}
+                    >
+                      <div className="px-4 py-2.5">
+                        <div className="text-[13px] font-semibold text-[color:var(--fg-1)]">
+                          {event.name}
+                        </div>
+                        <div className="text-[11px] text-[color:var(--fg-3)]">
+                          {pool.name} · {pool.tableIds.length} tables
+                        </div>
+                      </div>
+                      <div className="relative mr-3 h-8">
+                        {HOURS.map((h) => (
+                          <div
+                            key={h}
+                            className="absolute top-0 bottom-0 w-px bg-[color:var(--border-subtle)]"
+                            style={{
+                              left: `${((h * 60 - DAY_START) / (DAY_END - DAY_START)) * 100}%`,
+                            }}
+                          />
+                        ))}
+                        <div
+                          className="absolute top-1 bottom-1 flex items-center gap-1.5 overflow-hidden rounded-[4px] border border-[color:rgba(255,122,26,0.5)] px-2 whitespace-nowrap"
+                          style={{
+                            left: `${pct(pool.slot.start)}%`,
+                            width: `${pct(pool.slot.end) - pct(pool.slot.start)}%`,
+                            background:
+                              'linear-gradient(90deg, rgba(255,122,26,0.3), rgba(255,122,26,0.15))',
+                          }}
+                        >
+                          <span className="font-mono text-[11px] font-bold text-[color:var(--ball-500)]">
+                            {pool.slot.start}–{pool.slot.end}
+                          </span>
+                          <span className="text-[11px] text-[color:var(--fg-2)]">
+                            {pool.tableIds.length}×
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </Card>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/section-header.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/section-header.factory.tsx
@@ -1,0 +1,8 @@
+import type { SectionHeaderProps } from './section-header'
+
+/** Props for `SectionHeader` — the Events section header. */
+export function buildSectionHeaderProps(
+  overrides: Partial<SectionHeaderProps> = {},
+): SectionHeaderProps {
+  return { title: 'Events', subtitle: 'Click any event to edit.', ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/section-header.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/section-header.page.tsx
@@ -1,0 +1,23 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { SectionHeader, type SectionHeaderProps } from './section-header'
+import { buildSectionHeaderProps } from './section-header.factory'
+
+const scoped = (container: Container) => ({
+  getTitle(title: string) {
+    return container.getByText(title)
+  },
+})
+
+/** Test page-object for `SectionHeader`. */
+export const sectionHeaderPage = {
+  render(overrides: Partial<SectionHeaderProps> = {}) {
+    render(<SectionHeader {...buildSectionHeaderProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/section-header.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/section-header.test.tsx
@@ -1,0 +1,9 @@
+import { sectionHeaderPage } from './section-header.page'
+
+describe('SectionHeader', () => {
+  it('renders the title and subtitle', () => {
+    sectionHeaderPage.render({ title: 'Table pools', subtitle: 'Reserve tables' })
+    expect(sectionHeaderPage.getTitle('Table pools')).toBeInTheDocument()
+    expect(sectionHeaderPage.getTitle('Reserve tables')).toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/section-header.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/section-header.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react'
+
+export interface SectionHeaderProps {
+  title: string
+  subtitle?: ReactNode
+  action?: ReactNode
+}
+
+/** An accent overline title with an optional subtitle and a right-aligned
+ * action — the header used atop each detail tab and editor section. */
+export const SectionHeader = ({ title, subtitle, action }: SectionHeaderProps) => {
+  return (
+    <div className="mb-3 flex items-end gap-4">
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] font-semibold tracking-[0.16em] text-[color:var(--ball-500)] uppercase">
+          {title}
+        </div>
+        {subtitle && (
+          <div className="mt-0.5 text-[13px] text-[color:var(--fg-3)]">
+            {subtitle}
+          </div>
+        )}
+      </div>
+      {action}
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.factory.tsx
@@ -1,0 +1,16 @@
+import { buildTables, buildTournament } from '../data/seed.factory'
+import type { TablesTabProps } from './tables-tab'
+
+/** Props for `TablesTab` — a tournament with 8 of 12 tables assigned. */
+export function buildTablesTabProps(
+  overrides: Partial<TablesTabProps> = {},
+): TablesTabProps {
+  return {
+    tournament: buildTournament({
+      tableIds: ['t1', 't2', 't3', 't4', 't5', 't6', 't7', 't8'],
+    }),
+    allTables: buildTables(12),
+    onUpdate: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.page.tsx
@@ -1,0 +1,29 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { TablesTab, type TablesTabProps } from './tables-tab'
+import { buildTablesTabProps } from './tables-tab.factory'
+
+const scoped = (container: Container) => ({
+  getRemoveButton(label: string) {
+    return container.getByRole('button', { name: `Remove ${label}` })
+  },
+  getAddButton(label: string) {
+    return container.getByRole('button', { name: `Add ${label}` })
+  },
+  queryAddButton(label: string) {
+    return container.queryByRole('button', { name: `Add ${label}` })
+  },
+})
+
+/** Test page-object for `TablesTab`. */
+export const tablesTabPage = {
+  render(overrides: Partial<TablesTabProps> = {}) {
+    render(<TablesTab {...buildTablesTabProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.test.tsx
@@ -1,0 +1,32 @@
+import userEvent from '@testing-library/user-event'
+
+import { buildTables, buildTournament } from '../data/seed.factory'
+import { tablesTabPage } from './tables-tab.page'
+
+describe('TablesTab', () => {
+  it('adds an available table to the tournament', async () => {
+    const onUpdate = vi.fn()
+    tablesTabPage.render({
+      tournament: buildTournament({ tableIds: ['t1'] }),
+      allTables: buildTables(3),
+      onUpdate,
+    })
+    await userEvent.click(tablesTabPage.getAddButton('T3'))
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ tableIds: ['t1', 't3'] }),
+    )
+  })
+
+  it('removes an assigned table', async () => {
+    const onUpdate = vi.fn()
+    tablesTabPage.render({
+      tournament: buildTournament({ tableIds: ['t1', 't2'], events: [] }),
+      allTables: buildTables(3),
+      onUpdate,
+    })
+    await userEvent.click(tablesTabPage.getRemoveButton('T1'))
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ tableIds: ['t2'] }),
+    )
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.tsx
@@ -1,0 +1,111 @@
+import { Plus, Trash2 } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
+
+import type { Tournament, TournamentTable } from '../data/types'
+import { SectionHeader } from './section-header'
+
+export interface TablesTabProps {
+  tournament: Tournament
+  /** The full table catalogue. */
+  allTables: TournamentTable[]
+  onUpdate: (tournament: Tournament) => void
+}
+
+/** The Tables tab: the venue tables assigned to this tournament, each with the
+ * events using it, plus a row of unassigned tables to add. */
+export const TablesTab = ({ tournament, allTables, onUpdate }: TablesTabProps) => {
+  const usage = tournament.tableIds
+    .map((id) => {
+      const table = allTables.find((t) => t.id === id)
+      const usingEvents = tournament.events
+        .filter((ev) => ev.pools.some((p) => p.tableIds.includes(id)))
+        .map((ev) => ev.name)
+      return table ? { table, usingEvents } : null
+    })
+    .filter((u): u is { table: TournamentTable; usingEvents: string[] } => u !== null)
+
+  const available = allTables.filter((t) => !tournament.tableIds.includes(t.id))
+
+  const removeTable = (id: string) =>
+    onUpdate({ ...tournament, tableIds: tournament.tableIds.filter((x) => x !== id) })
+  const addTable = (id: string) =>
+    onUpdate({ ...tournament, tableIds: [...tournament.tableIds, id] })
+
+  return (
+    <div>
+      <SectionHeader
+        title="Tables"
+        subtitle="The physical tables available at this venue. Add them to pools when configuring events."
+      />
+
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3">
+        {usage.map(({ table, usingEvents }) => (
+          <Card key={table.id} className="gap-2.5 px-4">
+            <div className="flex items-center gap-2.5">
+              <div className="relative h-7 w-11 shrink-0 rounded-[3px] border border-[color:rgba(255,122,26,0.3)] bg-[color:var(--bg-accent-soft)]">
+                <div className="absolute top-1/2 right-0 left-0 h-px bg-[color:var(--ball-500)] opacity-50" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="font-mono text-[15px] font-bold text-[color:var(--fg-1)]">
+                  {table.label}
+                </div>
+                <div className="text-[11px] text-[color:var(--fg-3)]">
+                  Court {table.court}
+                </div>
+              </div>
+              <button
+                type="button"
+                aria-label={`Remove ${table.label}`}
+                onClick={() => removeTable(table.id)}
+                className="grid size-7 place-items-center rounded-md text-[color:var(--fg-3)] hover:bg-[color:var(--bg-hover)] hover:text-[color:var(--loss)]"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+            {usingEvents.length > 0 ? (
+              <div className="flex flex-wrap gap-1">
+                {usingEvents.map((n, i) => (
+                  <Badge
+                    key={i}
+                    variant="ghost"
+                    className="border-[color:var(--border-subtle)]"
+                  >
+                    {n}
+                  </Badge>
+                ))}
+              </div>
+            ) : (
+              <div className="text-[11px] text-[color:var(--fg-3)] italic">
+                Unused
+              </div>
+            )}
+          </Card>
+        ))}
+      </div>
+
+      {available.length > 0 && (
+        <div className="mt-6">
+          <div className="mb-2 text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">
+            Add a table · {available.length} available
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {available.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                aria-label={`Add ${t.label}`}
+                onClick={() => addTable(t.id)}
+                className="inline-flex items-center gap-1.5 rounded-md border border-[color:var(--border-default)] bg-[color:var(--bg-card)] px-3 py-2 font-mono text-[13px] text-[color:var(--fg-1)] hover:bg-[color:var(--bg-hover)]"
+              >
+                <Plus size={12} />
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournaments-list-page.factory.tsx
+++ b/web-client/src/components/tournaments/tournaments-list-page.factory.tsx
@@ -1,0 +1,20 @@
+import { buildTournament } from './data/seed.factory'
+import type { TournamentsListPageProps } from './tournaments-list-page'
+
+/** Props for `TournamentsListPage` — a published, a draft, and an archived
+ * tournament, with no-op handlers. */
+export function buildTournamentsListPageProps(
+  overrides: Partial<TournamentsListPageProps> = {},
+): TournamentsListPageProps {
+  return {
+    tournaments: [
+      buildTournament({ id: 'bay', name: 'Bay Area Open 2026', status: 'published' }),
+      buildTournament({ id: 'slam', name: 'Summer Slam 2026', status: 'draft', events: [] }),
+      buildTournament({ id: 'winter', name: 'Winter Classic 2025', status: 'archived', events: [] }),
+    ],
+    onOpen: () => {},
+    onCreate: () => {},
+    onDelete: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournaments-list-page.page.tsx
+++ b/web-client/src/components/tournaments/tournaments-list-page.page.tsx
@@ -1,0 +1,49 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import {
+  TournamentsListPage,
+  type TournamentsListPageProps,
+} from './tournaments-list-page'
+import { buildTournamentsListPageProps } from './tournaments-list-page.factory'
+import { tournamentCardPage } from './tournament-card.page'
+
+const scoped = (container: Container) => ({
+  getSearch() {
+    return container.getByLabelText(/Search tournaments/)
+  },
+  getStatusTab(label: string) {
+    return container.getByRole('tab', { name: label })
+  },
+  getNewButton() {
+    return container.getAllByRole('button', { name: /New tournament/ })[0]
+  },
+  getResultCount() {
+    return container.getByText(/results?$/)
+  },
+  /** A card's open target, by tournament name. */
+  getCard(name: string) {
+    return container.getByRole('button', { name })
+  },
+  queryCard(name: string) {
+    return container.queryByRole('button', { name })
+  },
+  /** The confirm button inside the delete dialog (portaled to the body). */
+  getConfirmDeleteButton() {
+    return screen.getByRole('button', { name: /^Delete$/ })
+  },
+  /** Reuse the card delete control query. */
+  ...tournamentCardPage.within(container),
+})
+
+/** Test page-object for `TournamentsListPage`. */
+export const tournamentsListPagePage = {
+  render(overrides: Partial<TournamentsListPageProps> = {}) {
+    render(<TournamentsListPage {...buildTournamentsListPageProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournaments-list-page.test.tsx
+++ b/web-client/src/components/tournaments/tournaments-list-page.test.tsx
@@ -1,0 +1,47 @@
+import userEvent from '@testing-library/user-event'
+
+import { buildTournament } from './data/seed.factory'
+import { tournamentsListPagePage } from './tournaments-list-page.page'
+
+describe('TournamentsListPage', () => {
+  it('filters the grid by search query', async () => {
+    tournamentsListPagePage.render()
+    expect(tournamentsListPagePage.getCard('Bay Area Open 2026')).toBeInTheDocument()
+
+    await userEvent.type(tournamentsListPagePage.getSearch(), 'Winter')
+
+    expect(tournamentsListPagePage.queryCard('Bay Area Open 2026')).toBeNull()
+    expect(tournamentsListPagePage.getCard('Winter Classic 2025')).toBeInTheDocument()
+  })
+
+  it('filters the grid by status tab', async () => {
+    tournamentsListPagePage.render()
+    await userEvent.click(tournamentsListPagePage.getStatusTab('Drafts'))
+
+    expect(tournamentsListPagePage.queryCard('Bay Area Open 2026')).toBeNull()
+    expect(tournamentsListPagePage.getCard('Summer Slam 2026')).toBeInTheDocument()
+  })
+
+  it('opens a tournament when its card is clicked', async () => {
+    const onOpen = vi.fn()
+    tournamentsListPagePage.render({
+      tournaments: [buildTournament({ id: 'bay', name: 'Bay Area Open 2026' })],
+      onOpen,
+    })
+
+    await userEvent.click(tournamentsListPagePage.getCard('Bay Area Open 2026'))
+    expect(onOpen).toHaveBeenCalledWith('bay')
+  })
+
+  it('confirms then deletes from the card delete control', async () => {
+    const onDelete = vi.fn()
+    tournamentsListPagePage.render({
+      tournaments: [buildTournament({ id: 'bay', name: 'Bay Area Open 2026' })],
+      onDelete,
+    })
+
+    await userEvent.click(tournamentsListPagePage.getDeleteButton('Bay Area Open 2026'))
+    await userEvent.click(tournamentsListPagePage.getConfirmDeleteButton())
+    expect(onDelete).toHaveBeenCalledWith('bay')
+  })
+})

--- a/web-client/src/components/tournaments/tournaments-list-page.tsx
+++ b/web-client/src/components/tournaments/tournaments-list-page.tsx
@@ -1,0 +1,141 @@
+import { useMemo, useState } from 'react'
+import { Plus, Search, Trophy } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+
+import { ConfirmDeleteDialog } from './confirm-delete-dialog'
+import { EmptyState } from './empty-state'
+import { NewTournamentModal } from './new-tournament-modal'
+import { STATUS_FILTER_OPTIONS } from './data/options'
+import type { Tournament } from './data/types'
+import { PageHeading } from './page-heading'
+import { TournamentCard } from './tournament-card'
+
+export interface TournamentsListPageProps {
+  tournaments: Tournament[]
+  onOpen: (id: string) => void
+  onCreate: (draft: Omit<Tournament, 'id'>) => void
+  onDelete: (id: string) => void
+}
+
+type StatusFilter = (typeof STATUS_FILTER_OPTIONS)[number]['value']
+
+/** The tournament-admin list: search + status filter, a responsive grid of
+ * cards, the "New tournament" modal, and a delete confirmation. */
+export const TournamentsListPage = ({
+  tournaments,
+  onOpen,
+  onCreate,
+  onDelete,
+}: TournamentsListPageProps) => {
+  const [query, setQuery] = useState('')
+  const [filter, setFilter] = useState<StatusFilter>('all')
+  const [createOpen, setCreateOpen] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<Tournament | null>(null)
+
+  const filtered = useMemo(
+    () =>
+      tournaments.filter((t) => {
+        if (filter !== 'all' && t.status !== filter) return false
+        if (query && !t.name.toLowerCase().includes(query.toLowerCase()))
+          return false
+        return true
+      }),
+    [tournaments, filter, query],
+  )
+
+  const activeCount = tournaments.filter(
+    (t) => t.status === 'published' || t.status === 'live',
+  ).length
+
+  return (
+    <div className="mx-auto w-full max-w-[1320px] px-12 pt-11 pb-20">
+      <PageHeading
+        breadcrumb={[{ label: 'Manage' }, { label: 'Tournaments' }]}
+        title="Tournaments"
+        subtitle={`${tournaments.length} total · ${activeCount} active. Create draws, schedule pools, publish to players.`}
+        action={
+          <Button size="lg" onClick={() => setCreateOpen(true)}>
+            <Plus size={18} />
+            New tournament
+          </Button>
+        }
+      />
+
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <div className="relative w-[320px]">
+          <Search
+            size={16}
+            className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-[color:var(--fg-3)]"
+          />
+          <Input
+            aria-label="Search tournaments by name"
+            value={query}
+            placeholder="Search by name…"
+            className="h-9 pl-9"
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </div>
+        <Tabs value={filter} onValueChange={(v) => setFilter(v as StatusFilter)}>
+          <TabsList>
+            {STATUS_FILTER_OPTIONS.map((o) => (
+              <TabsTrigger key={o.value} value={o.value}>
+                {o.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+        <span className="flex-1" />
+        <span className="font-mono text-[11px] text-[color:var(--fg-3)]">
+          {filtered.length} {filtered.length === 1 ? 'result' : 'results'}
+        </span>
+      </div>
+
+      {filtered.length === 0 ? (
+        <EmptyState
+          icon={<Trophy size={28} />}
+          title="No tournaments match"
+          hint="Adjust the filters or create a new one."
+          action={
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus size={16} />
+              New tournament
+            </Button>
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(380px,1fr))] gap-3.5">
+          {filtered.map((t) => (
+            <TournamentCard
+              key={t.id}
+              tournament={t}
+              onOpen={() => onOpen(t.id)}
+              onDelete={() => setPendingDelete(t)}
+            />
+          ))}
+        </div>
+      )}
+
+      <NewTournamentModal
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreate={(draft) => {
+          onCreate(draft)
+          setCreateOpen(false)
+        }}
+      />
+      <ConfirmDeleteDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => !open && setPendingDelete(null)}
+        kind="tournament"
+        name={pendingDelete?.name}
+        onConfirm={() => {
+          if (pendingDelete) onDelete(pendingDelete.id)
+          setPendingDelete(null)
+        }}
+      />
+    </div>
+  )
+}

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -16,10 +16,12 @@ import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as ConfirmEmailRouteImport } from './routes/confirm-email'
 import { Route as AdminRouteImport } from './routes/admin'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as TournamentsIndexRouteImport } from './routes/tournaments/index'
 import { Route as PlayersIndexRouteImport } from './routes/players/index'
 import { Route as MatchesIndexRouteImport } from './routes/matches/index'
 import { Route as LoginIndexRouteImport } from './routes/login.index'
 import { Route as AdminIndexRouteImport } from './routes/admin.index'
+import { Route as TournamentsTournamentIdRouteImport } from './routes/tournaments.$tournamentId'
 import { Route as PlayersUserIdRouteImport } from './routes/players/$userId'
 import { Route as MatchesNewRouteImport } from './routes/matches/new'
 import { Route as LoginWelcomeRouteImport } from './routes/login.welcome'
@@ -69,6 +71,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const TournamentsIndexRoute = TournamentsIndexRouteImport.update({
+  id: '/tournaments/',
+  path: '/tournaments/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PlayersIndexRoute = PlayersIndexRouteImport.update({
   id: '/players/',
   path: '/players/',
@@ -88,6 +95,11 @@ const AdminIndexRoute = AdminIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AdminRoute,
+} as any)
+const TournamentsTournamentIdRoute = TournamentsTournamentIdRouteImport.update({
+  id: '/tournaments/$tournamentId',
+  path: '/tournaments/$tournamentId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PlayersUserIdRoute = PlayersUserIdRouteImport.update({
   id: '/players/$userId',
@@ -173,10 +185,12 @@ export interface FileRoutesByFullPath {
   '/login/welcome': typeof LoginWelcomeRoute
   '/matches/new': typeof MatchesNewRoute
   '/players/$userId': typeof PlayersUserIdRoute
+  '/tournaments/$tournamentId': typeof TournamentsTournamentIdRoute
   '/admin/': typeof AdminIndexRoute
   '/login/': typeof LoginIndexRoute
   '/matches/': typeof MatchesIndexRoute
   '/players/': typeof PlayersIndexRoute
+  '/tournaments/': typeof TournamentsIndexRoute
   '/p/matches/$matchId': typeof PMatchesMatchIdRoute
   '/p/players/$username': typeof PPlayersUsernameRoute
   '/matches/$matchId/': typeof MatchesMatchIdIndexRoute
@@ -198,10 +212,12 @@ export interface FileRoutesByTo {
   '/login/welcome': typeof LoginWelcomeRoute
   '/matches/new': typeof MatchesNewRoute
   '/players/$userId': typeof PlayersUserIdRoute
+  '/tournaments/$tournamentId': typeof TournamentsTournamentIdRoute
   '/admin': typeof AdminIndexRoute
   '/login': typeof LoginIndexRoute
   '/matches': typeof MatchesIndexRoute
   '/players': typeof PlayersIndexRoute
+  '/tournaments': typeof TournamentsIndexRoute
   '/p/matches/$matchId': typeof PMatchesMatchIdRoute
   '/p/players/$username': typeof PPlayersUsernameRoute
   '/matches/$matchId': typeof MatchesMatchIdIndexRoute
@@ -225,10 +241,12 @@ export interface FileRoutesById {
   '/login/welcome': typeof LoginWelcomeRoute
   '/matches/new': typeof MatchesNewRoute
   '/players/$userId': typeof PlayersUserIdRoute
+  '/tournaments/$tournamentId': typeof TournamentsTournamentIdRoute
   '/admin/': typeof AdminIndexRoute
   '/login/': typeof LoginIndexRoute
   '/matches/': typeof MatchesIndexRoute
   '/players/': typeof PlayersIndexRoute
+  '/tournaments/': typeof TournamentsIndexRoute
   '/p/matches/$matchId': typeof PMatchesMatchIdRoute
   '/p/players/$username': typeof PPlayersUsernameRoute
   '/matches/$matchId/': typeof MatchesMatchIdIndexRoute
@@ -253,10 +271,12 @@ export interface FileRouteTypes {
     | '/login/welcome'
     | '/matches/new'
     | '/players/$userId'
+    | '/tournaments/$tournamentId'
     | '/admin/'
     | '/login/'
     | '/matches/'
     | '/players/'
+    | '/tournaments/'
     | '/p/matches/$matchId'
     | '/p/players/$username'
     | '/matches/$matchId/'
@@ -278,10 +298,12 @@ export interface FileRouteTypes {
     | '/login/welcome'
     | '/matches/new'
     | '/players/$userId'
+    | '/tournaments/$tournamentId'
     | '/admin'
     | '/login'
     | '/matches'
     | '/players'
+    | '/tournaments'
     | '/p/matches/$matchId'
     | '/p/players/$username'
     | '/matches/$matchId'
@@ -304,10 +326,12 @@ export interface FileRouteTypes {
     | '/login/welcome'
     | '/matches/new'
     | '/players/$userId'
+    | '/tournaments/$tournamentId'
     | '/admin/'
     | '/login/'
     | '/matches/'
     | '/players/'
+    | '/tournaments/'
     | '/p/matches/$matchId'
     | '/p/players/$username'
     | '/matches/$matchId/'
@@ -328,9 +352,11 @@ export interface RootRouteChildren {
   LoginWelcomeRoute: typeof LoginWelcomeRoute
   MatchesNewRoute: typeof MatchesNewRoute
   PlayersUserIdRoute: typeof PlayersUserIdRoute
+  TournamentsTournamentIdRoute: typeof TournamentsTournamentIdRoute
   LoginIndexRoute: typeof LoginIndexRoute
   MatchesIndexRoute: typeof MatchesIndexRoute
   PlayersIndexRoute: typeof PlayersIndexRoute
+  TournamentsIndexRoute: typeof TournamentsIndexRoute
   PMatchesMatchIdRoute: typeof PMatchesMatchIdRoute
   PPlayersUsernameRoute: typeof PPlayersUsernameRoute
   MatchesMatchIdIndexRoute: typeof MatchesMatchIdIndexRoute
@@ -389,6 +415,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/tournaments/': {
+      id: '/tournaments/'
+      path: '/tournaments'
+      fullPath: '/tournaments/'
+      preLoaderRoute: typeof TournamentsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/players/': {
       id: '/players/'
       path: '/players'
@@ -416,6 +449,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/admin/'
       preLoaderRoute: typeof AdminIndexRouteImport
       parentRoute: typeof AdminRoute
+    }
+    '/tournaments/$tournamentId': {
+      id: '/tournaments/$tournamentId'
+      path: '/tournaments/$tournamentId'
+      fullPath: '/tournaments/$tournamentId'
+      preLoaderRoute: typeof TournamentsTournamentIdRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/players/$userId': {
       id: '/players/$userId'
@@ -540,9 +580,11 @@ const rootRouteChildren: RootRouteChildren = {
   LoginWelcomeRoute: LoginWelcomeRoute,
   MatchesNewRoute: MatchesNewRoute,
   PlayersUserIdRoute: PlayersUserIdRoute,
+  TournamentsTournamentIdRoute: TournamentsTournamentIdRoute,
   LoginIndexRoute: LoginIndexRoute,
   MatchesIndexRoute: MatchesIndexRoute,
   PlayersIndexRoute: PlayersIndexRoute,
+  TournamentsIndexRoute: TournamentsIndexRoute,
   PMatchesMatchIdRoute: PMatchesMatchIdRoute,
   PPlayersUsernameRoute: PPlayersUsernameRoute,
   MatchesMatchIdIndexRoute: MatchesMatchIdIndexRoute,

--- a/web-client/src/routes/tournaments.$tournamentId.tsx
+++ b/web-client/src/routes/tournaments.$tournamentId.tsx
@@ -1,0 +1,61 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+
+import { AppShell } from '@/components/app-shell'
+import { Button } from '@/components/ui/button'
+import { TournamentDetailPage } from '@/components/tournaments/tournament-detail-page'
+import {
+  createEvent,
+  deleteEvent,
+  updateEvent,
+  updateTournament,
+  useTables,
+  useTournaments,
+} from '@/components/tournaments/data/store'
+import { pageTitle } from '@/lib/page-title'
+
+export const Route = createFileRoute('/tournaments/$tournamentId')({
+  head: () => ({
+    meta: [{ title: pageTitle('Tournament') }],
+  }),
+  component: TournamentDetailRoute,
+})
+
+function TournamentDetailRoute() {
+  const { tournamentId } = Route.useParams()
+  const navigate = useNavigate()
+  const tournaments = useTournaments()
+  const allTables = useTables()
+  const tournament = tournaments.find((t) => t.id === tournamentId)
+
+  const back = () => navigate({ to: '/tournaments' })
+
+  if (!tournament) {
+    return (
+      <AppShell>
+        <div className="mx-auto flex max-w-[600px] flex-col items-center gap-4 px-12 py-24 text-center">
+          <h1 className="text-[20px] font-semibold text-[color:var(--fg-1)]">
+            Tournament not found
+          </h1>
+          <p className="text-[14px] text-[color:var(--fg-3)]">
+            It may have been deleted, or the link is wrong.
+          </p>
+          <Button onClick={back}>Back to tournaments</Button>
+        </div>
+      </AppShell>
+    )
+  }
+
+  return (
+    <AppShell>
+      <TournamentDetailPage
+        tournament={tournament}
+        allTables={allTables}
+        onUpdate={updateTournament}
+        onCreateEvent={(ev) => createEvent(tournament.id, ev)}
+        onUpdateEvent={(ev) => updateEvent(tournament.id, ev)}
+        onDeleteEvent={(id) => deleteEvent(tournament.id, id)}
+        onBack={back}
+      />
+    </AppShell>
+  )
+}

--- a/web-client/src/routes/tournaments/index.tsx
+++ b/web-client/src/routes/tournaments/index.tsx
@@ -1,0 +1,46 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+
+import { AppShell } from '@/components/app-shell'
+import { TournamentsListPage } from '@/components/tournaments/tournaments-list-page'
+import {
+  createTournament,
+  deleteTournament,
+  useTournaments,
+} from '@/components/tournaments/data/store'
+import { pageTitle } from '@/lib/page-title'
+
+// Tournament-admin (Tournament CRUD) routes are intentionally not linked from
+// the sidebar nav — they're reached directly by URL for now.
+export const Route = createFileRoute('/tournaments/')({
+  head: () => ({
+    meta: [{ title: pageTitle('Tournaments') }],
+  }),
+  component: TournamentsRoute,
+})
+
+function TournamentsRoute() {
+  const navigate = useNavigate()
+  const tournaments = useTournaments()
+
+  return (
+    <AppShell>
+      <TournamentsListPage
+        tournaments={tournaments}
+        onOpen={(tournamentId) =>
+          navigate({
+            to: '/tournaments/$tournamentId',
+            params: { tournamentId },
+          })
+        }
+        onCreate={(draft) => {
+          const tournamentId = createTournament(draft)
+          navigate({
+            to: '/tournaments/$tournamentId',
+            params: { tournamentId },
+          })
+        }}
+        onDelete={deleteTournament}
+      />
+    </AppShell>
+  )
+}


### PR DESCRIPTION
Implements the **Tournament CRUD** design handoff as a front-end-only admin flow in `web-client`, built on the existing `.fortymm-theme` tokens and shadcn `ui` primitives.

## What's here
- **`/tournaments`** — list with search + status filter (All / Published / Drafts / Archived), "New tournament" modal, delete confirmation, and status/dates/venue/stats cards.
- **`/tournaments/$tournamentId`** — detail page: hero with status-lifecycle actions (draft → published → live → archived), meta strip, five-up stat strip, and **Events / Tables / Schedule / Details** tabs.
- **Event editor** side sheet — **Basics**, **Eligibility** (free-form ANDed rule builder), **Match settings** (rated + Bo1/3/5/7), and **Table pools** with double-booking conflict detection.

## Scope / constraints
- **UI only, no backend.** Data is an in-memory seeded store (`data/store.ts`) that resets on reload — no API, MSW, or `schema.d.ts` changes.
- **No nav item** — the routes are intentionally *not* linked from the sidebar (`app-shell.tsx` untouched); reach them by URL.
- Components follow the colocated quartet convention (component + `.page.tsx` + `.factory.tsx` + `.test.tsx`); a shared `EmptyState` is reused across the list, tabs, and editor sections.
- **Excluded** (separate player-facing flow): public tournament page, registration cart, Browse, and the geo "Near me" filter.

## Testing
- `npm run lint` — clean
- `npm run build` (`tsc -b && vite build`) — clean
- `npm run test:run` — **526 passed** (98 files; 73 new tournament tests)
- `npm run test:e2e` — **127 passed**
- API / root e2e / OpenAPI drift — N/A (zero `api/**` or `src/api/**` changes; routes unlinked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)