### PR TITLE
Preload the matches list via a route loader

### DIFF
--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -136,16 +136,11 @@ export function useCreateMatch() {
   })
 }
 
-/**
- * Paginated /matches list. `placeholderData: keepPreviousData` keeps the
- * current page rendered while the next page or filter resolves, so the table
- * doesn't flash empty between requests. Throws to the surrounding boundary.
- */
-export function useMatchList(
-  params: MatchListParams,
-  options: { enabled?: boolean } = {},
-) {
-  return useQuery({
+/** Query options for the paginated /matches list. Shared by `useMatchList` and
+ * any caller that needs to prefetch the same query — the list route's loader
+ * warms this on hover/touch preload so a click renders instantly. */
+export function matchListQueryOptions(params: MatchListParams) {
+  return queryOptions({
     queryKey: matchListQueryKey(params),
     queryFn: async (): Promise<MatchListResponse> =>
       unwrap(
@@ -161,12 +156,26 @@ export function useMatchList(
           },
         }),
       ),
+    retry: false,
+    throwOnError: true,
+  })
+}
+
+/**
+ * Paginated /matches list. `placeholderData: keepPreviousData` keeps the
+ * current page rendered while the next page or filter resolves, so the table
+ * doesn't flash empty between requests. Throws to the surrounding boundary.
+ */
+export function useMatchList(
+  params: MatchListParams,
+  options: { enabled?: boolean } = {},
+) {
+  return useQuery({
+    ...matchListQueryOptions(params),
     // Gate on the session so a first-visit direct-load doesn't fire before the
     // session cookie lands and 401 into the error boundary (#144).
     enabled: options.enabled ?? true,
     placeholderData: keepPreviousData,
-    retry: false,
-    throwOnError: true,
   })
 }
 

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -20,14 +20,16 @@ import { z } from 'zod'
 
 import {
   matchDetailRoute,
+  matchListQueryOptions,
   matchesCsvUrl,
   scoringNewRoute,
   useMatchList,
+  type MatchListParams,
   type MatchListRow,
   type MatchStatus,
 } from '@/api/matches'
 import type { components } from '@/api/schema'
-import { useSession } from '@/api/session'
+import { SESSION_QUERY_KEY, useSession } from '@/api/session'
 import { AppShell } from '@/components/app-shell'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -70,8 +72,38 @@ export const Route = createFileRoute('/matches/')({
     meta: [{ title: pageTitle('Matches') }],
   }),
   validateSearch: zodValidator(matchesSearchSchema),
+  // The filters live in the URL, so the prefetched list must be keyed by them —
+  // expose the search to the loader.
+  loaderDeps: ({ search }) => search,
+  // Warm the React Query cache without blocking the route transition, so an
+  // intent preload (the router's `defaultPreload: 'intent'`, fired when any
+  // Link to /matches is hovered/touched) makes the click render instantly.
+  // Skip the prefetch on a cold direct load where the session isn't resolved
+  // yet — firing here would 401 into the error boundary ahead of the
+  // component's session-gated query (#144). Intra-app navigation and preloads
+  // always have the session cached, which is exactly when warming pays off.
+  loader: ({ context, deps }) => {
+    if (!context.queryClient.getQueryData(SESSION_QUERY_KEY)) return
+    void context.queryClient.prefetchQuery(
+      matchListQueryOptions(listParamsFromSearch(deps)),
+    )
+  },
   component: MatchesPage,
 })
+
+/** Map the validated URL search to the list query's params. Shared by the
+ * loader's prefetch and the component's live query so both hit the same cache
+ * key — a hover preload then renders straight from cache on click. */
+function listParamsFromSearch(
+  search: z.infer<typeof matchesSearchSchema>,
+): MatchListParams {
+  return {
+    status: search.status ? TAB_TO_API[search.status] : undefined,
+    q: search.q || undefined,
+    page: search.page ?? 1,
+    page_size: PAGE_SIZE,
+  }
+}
 
 const TAB_TO_API: Record<RowTab, MatchStatus> = {
   scheduled: 'pending',
@@ -118,14 +150,16 @@ function MatchesPage() {
   // click by 300ms. The URL still updates synchronously on every change.
   const debouncedQ = useDebouncedValue(q.trim(), 300)
   const apiStatus = status === 'all' ? undefined : TAB_TO_API[status]
+  // Built via the same helper the route loader uses, so a hover preload and the
+  // live query share one cache key and the click renders from cache.
   const queryParams = useMemo(
-    () => ({
-      status: apiStatus,
-      q: debouncedQ || undefined,
-      page,
-      page_size: PAGE_SIZE,
-    }),
-    [apiStatus, debouncedQ, page],
+    () =>
+      listParamsFromSearch({
+        status: urlSearch.status,
+        q: debouncedQ,
+        page: urlSearch.page,
+      }),
+    [urlSearch.status, debouncedQ, urlSearch.page],
   )
   // Wait for the session before firing the matches query — otherwise a
   // first-visit direct-load races the session cookie and 401s into the error


### PR DESCRIPTION
## What

Every `<Link to=\"/matches\">` already preloads on intent (the router sets `defaultPreload: 'intent'`), but the `/matches/` route had **no loader**, so that preload warmed nothing — the click still triggered a cold fetch. This adds a loader that prefetches the list query, mirroring the existing match-details route, so hovering any link to the matches list renders the page from cache on click.

Links that now benefit (no per-link change needed — all inherit the global intent preload): the app-shell **Matches** nav, the match-details **breadcrumb** and **\"Back to matches\"** error link, and the dashboard **\"Full history\"** / **\"+N more pending\"** links.

## How

- Extracted `matchListQueryOptions` from `useMatchList` so the loader and the hook share one query definition (and therefore one cache key).
- Added `loaderDeps`/`loader` to the route, keyed on the URL search via a shared `listParamsFromSearch` helper that the component's live query also uses — guaranteeing the preloaded key matches what the page requests (filters + page included).
- Gated the prefetch on the session already being cached, so a cold direct load doesn't fire the query before the session cookie lands and 401 into the error boundary (#144). Intra-app navigation and preloads always have the session cached — exactly when warming pays off.

## Testing

- web-client vitest: 539 passed (incl. the matches-list route test)
- web-client lint: clean; build (`tsc -b && vite build`): typecheck + build pass
- web-client Playwright e2e: 127 passed
- API suite / OpenAPI schema drift: N/A — diff is web-client only, no `api/**` or generated `schema.d.ts` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)