### PR TITLE
Matches list: clamp out-of-range ?page= to the last valid page (#541)

### DIFF
--- a/web-client/src/routes/matches/index.test.tsx
+++ b/web-client/src/routes/matches/index.test.tsx
@@ -276,7 +276,9 @@ describe('MatchesPage', () => {
         return HttpResponse.json(
           matchListResponse({
             items: [matchListRow({ opponent: 'nguyen.t' })],
-            total: 1,
+            // Enough total for page 2 to be in range, so the deep-linked page
+            // isn't snapped back by the out-of-range clamp (#541).
+            total: 50,
             page: 2,
             status_counts: { in_progress: 1 },
           }),
@@ -345,6 +347,34 @@ describe('MatchesPage', () => {
         expect.objectContaining({ q: 'ngu' }),
       )
     })
+  })
+
+  it('snaps an out-of-range ?page= back to the last valid page (#541)', async () => {
+    server.use(
+      http.get('*/v1/matches', ({ request }) => {
+        const page = Number(new URL(request.url).searchParams.get('page') ?? '1')
+        // 16 matches → a single page. Any page > 1 is out of range and the
+        // API returns no items (but still the real total).
+        const items =
+          page === 1 ? [matchListRow({ opponent: 'nguyen.t' })] : []
+        return HttpResponse.json(
+          matchListResponse({ items, total: 16, page, status_counts: { pending: 16 } }),
+        )
+      }),
+    )
+    const { router } = renderMatchesPage('/matches?page=2')
+
+    // The page redirects to the last valid page, so the real rows render
+    // rather than an empty table under a broken "Showing 26–16" footer.
+    expect(await screen.findByText('nguyen.t')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(router.state.location.search).not.toEqual(
+        expect.objectContaining({ page: 2 }),
+      )
+    })
+    // The footer range is sane — start never exceeds end.
+    expect(screen.getByText(/showing/i).textContent).toContain('1–16')
+    expect(screen.queryByText(/26–16/)).not.toBeInTheDocument()
   })
 
   it('Export CSV links straight to /v1/matches.csv with the active filter (#149)', async () => {

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -169,6 +169,7 @@ function MatchesPage() {
   const matchList = useMatchList(queryParams, { enabled: session.isSuccess })
   const data = matchList.data
   const isLoading = matchList.isPending
+  const isFetching = matchList.isFetching
 
   // Rewrite the URL — `replace: true` keeps each keystroke from filling
   // browser history. Defaults are stripped so the URL stays clean.
@@ -235,13 +236,14 @@ function MatchesPage() {
   // Snap an out-of-range `?page=` back to the last valid page once the real
   // total is known — a stale bookmark or paging past the end would otherwise
   // render an empty table under a nonsensical "Showing 26–16 of 16" footer
-  // (#541). Wait for the first load to settle; `total` isn't trustworthy while
-  // the query is still pending.
+  // (#541). Only act on a settled, current total: `isLoading` covers the
+  // pending/session-gated window (where `total` is still 0), and `isFetching`
+  // covers a `keepPreviousData` refetch still serving the prior filter's total.
   useEffect(() => {
-    if (!isLoading && page > totalPages) {
+    if (!isLoading && !isFetching && page > totalPages) {
       setPage(totalPages)
     }
-  }, [isLoading, page, totalPages, setPage])
+  }, [isLoading, isFetching, page, totalPages, setPage])
 
   // The redirect runs in an effect, so an out-of-range page paints for one
   // frame first. Clamp the page the footer renders with so its range math never

--- a/web-client/src/routes/matches/index.tsx
+++ b/web-client/src/routes/matches/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import {
   Link,
   createFileRoute,
@@ -230,6 +230,23 @@ function MatchesPage() {
   const items = data?.items ?? []
   const total = data?.total ?? 0
   const liveCount = data?.status_counts?.in_progress ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  // Snap an out-of-range `?page=` back to the last valid page once the real
+  // total is known — a stale bookmark or paging past the end would otherwise
+  // render an empty table under a nonsensical "Showing 26–16 of 16" footer
+  // (#541). Wait for the first load to settle; `total` isn't trustworthy while
+  // the query is still pending.
+  useEffect(() => {
+    if (!isLoading && page > totalPages) {
+      setPage(totalPages)
+    }
+  }, [isLoading, page, totalPages, setPage])
+
+  // The redirect runs in an effect, so an out-of-range page paints for one
+  // frame first. Clamp the page the footer renders with so its range math never
+  // shows start > end during that frame.
+  const displayPage = Math.min(page, totalPages)
 
   return (
     <AppShell>
@@ -251,10 +268,11 @@ function MatchesPage() {
           />
         </div>
         <PaginationFooter
-          page={page}
+          page={displayPage}
           setPage={setPage}
           total={total}
           pageSize={PAGE_SIZE}
+          totalPages={totalPages}
         />
       </div>
     </AppShell>
@@ -609,13 +627,14 @@ function PaginationFooter({
   setPage,
   total,
   pageSize,
+  totalPages,
 }: {
   page: number
   setPage: (n: number) => void
   total: number
   pageSize: number
+  totalPages: number
 }) {
-  const totalPages = Math.max(1, Math.ceil(total / pageSize))
   const first = total === 0 ? 0 : (page - 1) * pageSize + 1
   const last = Math.min(total, page * pageSize)
   const tokens = paginationRange(page, totalPages)


### PR DESCRIPTION
## What

Fixes #541. On the matches list (`/matches`), navigating to a page beyond the last valid page (a stale bookmark, or `?page=2` when there's only one page of results) rendered an empty table under a nonsensical **"Showing 26–16 of 16 matches"** footer plus a misleading "No matches yet" empty state.

## How

In `MatchesPage` (`web-client/src/routes/matches/index.tsx`):
- Compute `totalPages` once and, in an effect, snap an out-of-range `page` back to the last valid page once the real `total` is known (it's only knowable after the response lands). This shows the user actual rows instead of a phantom empty page.
- Render the footer with a clamped `displayPage = Math.min(page, totalPages)` so its range math never shows `start > end` during the single frame before the redirect effect fires.
- Pass `totalPages` into `PaginationFooter` as a prop so it isn't computed twice.

Out-of-range is the only gap: zero/negative/non-numeric pages already fall back to page 1 via the zod schema.

## Testing

- web-client vitest: 540 passed, incl. a new regression test (`snaps an out-of-range ?page= back to the last valid page (#541)`)
- web-client lint: clean; build (`tsc -b && vite build`): typecheck + build pass
- web-client Playwright e2e: 127 passed
- API suite / OpenAPI schema drift: N/A — web-client-only diff, no `api/**` or `web-client/src/api/**` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)