### PR TITLE
Fix five QA bugs in login + match-details flows (#520 #522 #521 #494 #513)

### DIFF
--- a/web-client/e2e/matches/match-details.spec.ts
+++ b/web-client/e2e/matches/match-details.spec.ts
@@ -19,6 +19,12 @@ const gameScore = (
     },
 });
 
+// The match-details route guards its `$matchId` param to the UUID shape (real
+// match ids are UUIDs; a non-UUID is a malformed URL the route short-circuits
+// to the not-found state without fetching). So fixtures driven through the
+// route must use a UUID-shaped id, not a readable `m-...` slug.
+const COMPLETED_WIN_ID = '00000000-0000-4000-8000-000000000001';
+
 /** A decided singles match: rita.kovac beat silva.r, 3 games to 1. */
 const decidedMatch = (id: string): MatchDetails =>
     matchDetails({
@@ -93,8 +99,8 @@ test.describe('Match Details', () => {
 
     test.describe('the scoreboard', () => {
         test('names the hero region with the decided-match outcome', async ({ page }) => {
-            await matchDetailsPage.mock(decidedMatch('m-completed-win-1'));
-            await matchDetailsPage.goTo('m-completed-win-1');
+            await matchDetailsPage.mock(decidedMatch(COMPLETED_WIN_ID));
+            await matchDetailsPage.goTo(COMPLETED_WIN_ID);
             await expect(page.getByRole('region', { name: 'rita.kovac defeated silva.r, 3 games to 1' })).toBeVisible();
         });
 
@@ -102,8 +108,8 @@ test.describe('Match Details', () => {
         // as edit links (<a>), and the `.match-details a { color: inherit }`
         // reset used to out-rank the win/loss colors, leaving the row colorless.
         test('colors the editable (current-user) row win/loss cells like the opponent row', async ({ page }) => {
-            await matchDetailsPage.mock(decidedMatch('m-completed-win-1'));
-            await matchDetailsPage.goTo('m-completed-win-1');
+            await matchDetailsPage.mock(decidedMatch(COMPLETED_WIN_ID));
+            await matchDetailsPage.goTo(COMPLETED_WIN_ID);
 
             const color = (testId: string) =>
                 page

--- a/web-client/src/components/login/link-check-page/link-check-page.tsx
+++ b/web-client/src/components/login/link-check-page/link-check-page.tsx
@@ -35,7 +35,8 @@ const DEFAULT_COPY: Record<
   },
   expired: {
     eyebrow: '● Link expired',
-    title: 'This link expired',
+    // Covers both a genuinely expired link and one that was never valid (#522).
+    title: "This link can't be used",
     subtitle:
       'Sign-in links last 15 minutes and work once. Send a fresh one and you’ll be straight in.',
   },

--- a/web-client/src/components/login/login-screens.tsx
+++ b/web-client/src/components/login/login-screens.tsx
@@ -238,11 +238,14 @@ function EmailField({
 }: {
   value: string
   onChange?: (next: string) => void
-  state?: 'valid' | 'error'
+  state?: 'valid' | 'error' | 'neutral'
   autoFocus?: boolean
   readOnly?: boolean
 }) {
   const error = state === 'error'
+  // A pristine/incomplete field is neutral — show no badge rather than a
+  // misleading green "VALID" on an empty input (#520).
+  const neutral = state === 'neutral'
   return (
     <div
       style={{
@@ -299,19 +302,21 @@ function EmailField({
           letterSpacing: '0.01em',
         }}
       />
-      <span
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          padding: '0 14px',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          color: error ? 'var(--loss)' : 'var(--serve-500)',
-          letterSpacing: '0.14em',
-        }}
-      >
-        ● {error ? 'FAILED' : 'VALID'}
-      </span>
+      {!neutral && (
+        <span
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            padding: '0 14px',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            color: error ? 'var(--loss)' : 'var(--serve-500)',
+            letterSpacing: '0.14em',
+          }}
+        >
+          ● {error ? 'FAILED' : 'VALID'}
+        </span>
+      )}
     </div>
   )
 }
@@ -906,7 +911,7 @@ export function ScreenEmail({
                 setEmail(next)
                 if (localError) setLocalError(null)
               }}
-              state={showError ? 'error' : 'valid'}
+              state={showError ? 'error' : valid ? 'valid' : 'neutral'}
               autoFocus
             />
             {showError && (

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -405,8 +405,8 @@ function ScoreEntryInner({
         <div className="entry-head">
           <h2>{heading}</h2>
           <div className="hint">
-            <kbd>0</kbd>–<kbd>9</kbd> score &nbsp;·&nbsp; <kbd>Enter</kbd> next
-            / save game
+            Type <kbd>0</kbd>–<kbd>9</kbd> &nbsp;·&nbsp; <kbd>Enter</kbd> for
+            next / save game
           </div>
         </div>
 

--- a/web-client/src/routes/confirm-email.tsx
+++ b/web-client/src/routes/confirm-email.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { Link, createFileRoute } from '@tanstack/react-router'
+import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
 import { ApiError } from '@/api/client'
@@ -39,6 +39,7 @@ const CONFIRM_COPY: Partial<
 
 function ConfirmEmailPage() {
   const { token } = Route.useSearch()
+  const navigate = useNavigate()
   const preview = useMergePreview()
   const confirm = useConfirmEmail()
   const fired = useRef(false)
@@ -71,19 +72,35 @@ function ConfirmEmailPage() {
     }
   }, [confirm.isSuccess, confirm.data])
 
+  // The token is a single-use bearer credential. Once the confirm settles,
+  // drop it from the URL so it doesn't linger in the address bar / history /
+  // Referer — mirroring how `/login/verifying` scrubs its token (#521). The
+  // displayed state is driven by the mutation result, not the search param, so
+  // clearing `token` here doesn't revert the page to "missing token".
+  useEffect(() => {
+    if ((confirm.isSuccess || confirm.isError) && token) {
+      navigate({ to: '/confirm-email', search: { token: '' }, replace: true })
+    }
+  }, [confirm.isSuccess, confirm.isError, token, navigate])
+
   const p = preview.data
   const showGate =
     confirm.status === 'idle' && !!p && p.is_merge && p.guest_matches_count > 0
 
-  const status: 'missing-token' | 'gate' | 'confirming' | 'ok' | 'error' = !token
-    ? 'missing-token'
-    : confirm.isSuccess
+  // Order matters: the confirm result wins over `!token`, because we scrub the
+  // token from the URL after the mutation settles (#521) — a cleared token on
+  // a settled mutation is "ok"/"error", not "missing-token". A genuine
+  // no-token visit falls through to "missing-token".
+  const status: 'missing-token' | 'gate' | 'confirming' | 'ok' | 'error' =
+    confirm.isSuccess
       ? 'ok'
       : confirm.isError
         ? 'error'
         : showGate
           ? 'gate'
-          : 'confirming'
+          : !token
+            ? 'missing-token'
+            : 'confirming'
 
   const errorMsg =
     status === 'missing-token'

--- a/web-client/src/routes/login.test.tsx
+++ b/web-client/src/routes/login.test.tsx
@@ -203,7 +203,7 @@ describe('/login/verifying flow', () => {
       expect(router.state.location.search).toMatchObject({ error: 'expired' })
     })
     expect(
-      await screen.findByRole('heading', { name: /this link expired/i }),
+      await screen.findByRole('heading', { name: /this link can't be used/i }),
     ).toBeInTheDocument()
   })
 
@@ -226,7 +226,7 @@ describe('/login/verifying flow', () => {
   it('shows the missing-token screen when no token is supplied', async () => {
     renderAt('/login/verifying')
     expect(
-      await screen.findByRole('heading', { name: /this link expired/i }),
+      await screen.findByRole('heading', { name: /this link can't be used/i }),
     ).toBeInTheDocument()
     expect(
       screen.getByText(/this link is missing its token/i),

--- a/web-client/src/routes/matches.$matchId.index.tsx
+++ b/web-client/src/routes/matches.$matchId.index.tsx
@@ -4,7 +4,16 @@ import {
   MatchDetailsError,
 } from '@/components/matches/match-details'
 import { matchDetailsQuery } from '@/components/matches/match-details/match-details-query'
+import { ApiError } from '@/api/client'
 import { pageTitle } from '@/lib/page-title'
+
+// Match ids are UUIDs. A malformed id (e.g. /matches/not-a-uuid) would 422 on
+// every self-fetching section and surface an `ApiError` in the console even
+// though the UI handles it (#494). Guarding the param shape client-side means
+// we never make the request: no 422, no console error — just the friendly
+// not-found state the boundary already renders for a 404/422.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export const Route = createFileRoute('/matches/$matchId/')({
   head: () => ({
@@ -14,6 +23,7 @@ export const Route = createFileRoute('/matches/$matchId/')({
   // page's self-fetching sections keep streaming in independently on a direct
   // load while a preceding hover/touch preload makes the click render instantly.
   loader: ({ context, params }) => {
+    if (!UUID_RE.test(params.matchId)) return
     void context.queryClient.prefetchQuery(matchDetailsQuery(params.matchId))
   },
   component: MatchDetailsRoute,
@@ -22,5 +32,14 @@ export const Route = createFileRoute('/matches/$matchId/')({
 
 function MatchDetailsRoute() {
   const { matchId } = Route.useParams()
+  if (!UUID_RE.test(matchId)) {
+    // Reuse the page's not-found UI without ever hitting the API.
+    return (
+      <MatchDetailsError
+        error={new ApiError(404, null, `load match ${matchId}`)}
+        reset={() => {}}
+      />
+    )
+  }
   return <MatchDetails matchId={matchId} />
 }


### PR DESCRIPTION
Five small, independently-scoped QA fixes, each reproduced on the QA preview stack (real API, MSW off) before and re-verified after.

## Fixes
- **#520** — Login email field showed a green `● VALID` badge while empty. `EmailField` gains a `neutral` state; the badge now only appears once the input is a valid email (`VALID`) or a submit fails (`FAILED`).
- **#522** — The link-check page said "This link expired" for tokens that were *never* valid. Default expired title reworded to **"This link can't be used"** (covers expired + never-valid). `/confirm-email` inherits this via the same component.
- **#521** — `/confirm-email` left the single-use token in the URL. It's now scrubbed via a `replace` navigation once the confirm mutation settles (mirroring `/login/verifying`); displayed state is driven off the mutation result, so scrubbing doesn't revert to "missing token".
- **#494** — A malformed match id (`/matches/not-a-uuid`) fired one request per self-fetching section, each `422`ing and logging an `ApiError` to the console. A client-side UUID guard in the route loader + component means we never fetch — just the existing not-found UI, no console noise.
- **#513** — Desktop score entry's keyboard hint read `0–9 score …`, misreadable as a live (stale) scoreline. Reworded to **"Type 0–9 · Enter for next / save game"**.

Note: **#516** (match-details footer inert anchors) is already fixed on `main` by #537 (footer dropped) — can be closed.

## Testing
- web-client vitest: 540 passed
- lint: clean · build (`tsc -b && vite build`): success
- web-client Playwright e2e: 127 passed
- root e2e (vs QA stack): 4 passed
- All five fixes manually verified on the QA preview stack (desktop + the score/login surfaces).
- API gates + OpenAPI drift check: N/A (web-client-only diff; no `api/**` or `web-client/src/api/**` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)