### PR TITLE
Add "Needs your attention" dashboard triage panel

### DIFF
--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -30,12 +30,12 @@ from app.models import (
     UserLeagueRating,
 )
 from app.schemas.dashboard import (
-    DashboardNextMatch,
+    AttentionKind,
+    DashboardAttentionItem,
     DashboardRating,
     DashboardRatingStat,
     DashboardRecentResult,
     DashboardResponse,
-    DashboardScoreBanner,
     DashboardStreak,
 )
 from app.schemas.rating import RatingChange
@@ -54,24 +54,22 @@ async def get_dashboard(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> DashboardResponse:
-    # One query pulls every match the user participates in across the three
-    # statuses we surface; per-status bucketing happens in Python below. The
-    # dashboard always shows at most 1 + 1 + 5 = 7 matches, so the bound is
-    # safe even for an active user with thousands of completed matches.
-    pending_q = (
-        participant_filter(select(Match), current_user.id)
-        .where(Match.status == MatchStatus.pending)
-        .options(*match_eager_options())
-        .order_by(Match.created_at.desc())
-        .limit(1)
-    )
-    # Oldest first — the most-urgent banner heads the stack, and the
-    # frontend collapses anything past the second into a "+N more" pill.
+    # Open matches the user participates in are pulled in full (signatures + sides
+    # are needed to classify each into an attention bucket); completed matches
+    # feed the recent-results table. The attention panel is bounded by the user's
+    # *open* matches — a handful even for an active player — so loading them all
+    # and ranking in Python is safe.
     in_progress_q = (
         participant_filter(select(Match), current_user.id)
         .where(Match.status == MatchStatus.in_progress)
         .options(*match_eager_options())
-        .order_by(Match.created_at.asc())
+        .order_by(Match.updated_at.asc())
+    )
+    disputed_q = (
+        participant_filter(select(Match), current_user.id)
+        .where(Match.status == MatchStatus.disputed)
+        .options(*match_eager_options())
+        .order_by(Match.updated_at.asc())
     )
     completed_q = (
         participant_filter(select(Match), current_user.id)
@@ -80,10 +78,16 @@ async def get_dashboard(
         .order_by(Match.updated_at.desc())
         .limit(RECENT_RESULTS_LIMIT)
     )
+    # Pending/scheduled matches are always "waiting on others" (O3 default), so
+    # we only need their count, not their rows.
+    pending_count_q = participant_filter(
+        select(func.count(Match.id)), current_user.id
+    ).where(Match.status == MatchStatus.pending)
 
-    pending = (await db.execute(pending_q)).scalars().all()
     in_progress = (await db.execute(in_progress_q)).scalars().all()
+    disputed = (await db.execute(disputed_q)).scalars().all()
     completed = (await db.execute(completed_q)).scalars().all()
+    pending_count = int((await db.execute(pending_count_q)).scalar_one())
 
     # When completed_q didn't hit its LIMIT, we already have the exact count
     # and can skip the extra round-trip; only the user-with-history case pays
@@ -100,8 +104,9 @@ async def get_dashboard(
         db, current_user.id, [m.id for m in completed]
     )
 
-    score_banners = _build_score_banners(in_progress, current_user.id)
-    next_match = _build_next_match(pending, current_user.id)
+    attention, waiting_count = _build_attention(
+        in_progress, disputed, pending_count, current_user.id
+    )
     recent_results = [
         _build_recent_result(match, current_user.id, rating_changes.get(match.id))
         for match in completed
@@ -109,8 +114,8 @@ async def get_dashboard(
     rating = await _build_rating(db, current_user.id)
 
     return DashboardResponse(
-        score_banners=score_banners,
-        next_match=next_match,
+        attention=attention,
+        waiting_count=waiting_count,
         recent_results=recent_results,
         rating=rating,
         completed_match_count=completed_match_count,
@@ -143,35 +148,87 @@ async def _load_my_rating_changes(
     return changes
 
 
-def _build_score_banners(
-    in_progress: Sequence[Match], current_user_id: uuid.UUID
-) -> list[DashboardScoreBanner]:
-    banners: list[DashboardScoreBanner] = []
-    for match in in_progress:
-        next_number = current_game_number(match)
-        if next_number is None:
-            continue
-        banners.append(
-            DashboardScoreBanner(
-                match_id=match.id,
-                opponent_username=opponent_username(match, current_user_id),
-                current_game_number=next_number,
+# Attention-priority ranking (PRD §5): lower number = more urgent. ``score``
+# splits into rated (2) vs unrated (3) by ``affects_rating``.
+_DISPUTE_PRIORITY = 0
+_REVIEW_PRIORITY = 1
+_RATED_SCORE_PRIORITY = 2
+_UNRATED_SCORE_PRIORITY = 3
+
+
+def _build_attention(
+    in_progress: Sequence[Match],
+    disputed: Sequence[Match],
+    pending_count: int,
+    current_user_id: uuid.UUID,
+) -> tuple[list[DashboardAttentionItem], int]:
+    """Classify the user's open matches into priority-ranked attention rows plus
+    a count of matches waiting on someone else.
+
+    Current-user-aware: the poster and the reviewer of the same posted result
+    classify differently — the poster has signed, so the match is "waiting on
+    opponent" (footer) for them, while the reviewer hasn't signed and gets a
+    ``review`` row. Pending/scheduled matches (``pending_count``) and our own
+    posted-and-awaiting results are folded into ``waiting_count``; they never
+    render as rows.
+    """
+    # (priority, sort_ts, item) — sorted by priority then oldest-first so a
+    # long-stalled match floats to the top of its bucket.
+    ranked: list[tuple[int, datetime, DashboardAttentionItem]] = []
+    waiting = pending_count
+
+    for match in disputed:
+        ranked.append(
+            (
+                _DISPUTE_PRIORITY,
+                match.updated_at,
+                _attention_item(match, current_user_id, "dispute"),
             )
         )
-    return banners
+
+    for match in in_progress:
+        if match.signatures:
+            i_signed = any(sig.user_id == current_user_id for sig in match.signatures)
+            if i_signed:
+                # We posted the result; it's awaiting the opponent's sign-off.
+                waiting += 1
+            else:
+                ranked.append(
+                    (
+                        _REVIEW_PRIORITY,
+                        match.updated_at,
+                        _attention_item(match, current_user_id, "review"),
+                    )
+                )
+        else:
+            priority = (
+                _RATED_SCORE_PRIORITY
+                if match.match_settings.affects_rating
+                else _UNRATED_SCORE_PRIORITY
+            )
+            ranked.append(
+                (
+                    priority,
+                    match.updated_at,
+                    _attention_item(match, current_user_id, "score"),
+                )
+            )
+
+    ranked.sort(key=lambda row: (row[0], row[1]))
+    return [item for _, _, item in ranked], waiting
 
 
-def _build_next_match(
-    pending: Sequence[Match], current_user_id: uuid.UUID
-) -> DashboardNextMatch | None:
-    if not pending:
-        return None
-    match = pending[0]
-    return DashboardNextMatch(
+def _attention_item(
+    match: Match, current_user_id: uuid.UUID, kind: AttentionKind
+) -> DashboardAttentionItem:
+    return DashboardAttentionItem(
         match_id=match.id,
         opponent_username=opponent_username(match, current_user_id),
-        best_of=match.match_settings.best_of,
-        created_at=match.created_at,
+        kind=kind,
+        affects_rating=match.match_settings.affects_rating,
+        # Only ``score`` rows deep-link to the scoring page; review/dispute rows
+        # route to match detail and carry no game number.
+        current_game_number=current_game_number(match) if kind == "score" else None,
     )
 
 

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -228,9 +228,9 @@ def side_win_counts(match: Match) -> dict[int, int]:
 
 
 def current_game_number(match: Match) -> int | None:
-    """The next un-scored game number for an in-progress match. ``None`` when:
+    """The next un-scored game number for an open match. ``None`` when:
 
-    - the match isn't in progress (finalized / disputed / voided);
+    - the match is finalized / voided / pending (not in progress or disputed);
     - a result is posted and awaiting confirmation (``match.signatures``
       non-empty — score writes are locked);
     - the currently-saved games already decide the match — even if some game
@@ -242,7 +242,7 @@ def current_game_number(match: Match) -> int | None:
     Game rows are created lazily by the score-write endpoints, so the next
     game to score may not have a ``MatchGame`` row yet — this helper exposes
     the number rather than an object so deeplinks work either way."""
-    if match.status != MatchStatus.in_progress:
+    if match.status not in (MatchStatus.in_progress, MatchStatus.disputed):
         return None
     if match.signatures:
         return None
@@ -685,9 +685,11 @@ async def get_match(
 
 
 # A match that has reached one of these states is read-only — never scorable.
+# ``disputed`` is deliberately absent: a dispute reopens the match for score
+# correction (either side may edit — see ``dispute_match_result``), so a
+# disputed match is scorable again with its games intact.
 _TERMINAL_STATUSES = {
     MatchStatus.completed,
-    MatchStatus.disputed,
     MatchStatus.voided,
 }
 
@@ -1330,8 +1332,10 @@ def _can_finalize(match: Match) -> bool:
     ``can_finalize`` flag and the submit button's adaptive label.
 
     Returns False once anyone has posted a result — the next action on a
-    signed match is /confirmation or /dispute, not another /results."""
-    if match.status != MatchStatus.in_progress:
+    signed match is /confirmation or /dispute, not another /results. A
+    ``disputed`` match has no signatures and stays finalizable so the disputer
+    can re-post a corrected (or unchanged) board back into the sign-off flow."""
+    if match.status not in (MatchStatus.in_progress, MatchStatus.disputed):
         return False
     if match.signatures:
         return False
@@ -1613,9 +1617,11 @@ async def post_match_result(
         _set_side_won(match, decided_side)
         await _apply_rating_update(db, match)
     else:
-        # Rated path: caller is the first signer. Status remains in_progress
-        # (and side.won unset) until /confirmation lands the last needed
-        # signature.
+        # Rated path: caller is the first signer. Status is (re)set to
+        # in_progress — load-bearing when re-posting a ``disputed`` match, a
+        # no-op otherwise — and side.won stays unset until /confirmation lands
+        # the last needed signature.
+        match.status = MatchStatus.in_progress
         await _add_signature_or_409(
             db, match, current_user.id, "Result already posted; use /confirmation."
         )
@@ -1687,6 +1693,12 @@ async def dispute_match_result(
     _enforce_confirmable(match, current_user.id)
 
     match.signatures.clear()
+    # Move out of ``in_progress`` into the dedicated ``disputed`` state so a
+    # reopened match is unambiguous to the dashboard classifier and the matches
+    # list, instead of being indistinguishable from a never-posted live match.
+    # Scoring is reopened anyway (no signatures + ``disputed`` is non-terminal),
+    # and re-posting via /results flips it back to ``in_progress``.
+    match.status = MatchStatus.disputed
     for side in match.sides:
         # ``side.won`` is only stamped at completion now, so it's still None
         # on an awaiting-confirmation match — nulling it here is defensive.

--- a/api/app/schemas/dashboard.py
+++ b/api/app/schemas/dashboard.py
@@ -6,21 +6,32 @@ from pydantic import BaseModel
 
 from app.schemas.rating import RatingChange
 
+# The actionable bucket a match falls in for the current user, in priority
+# order: a disputed match reopened for correction (``dispute``) outranks a
+# rated result the opponent posted and is awaiting our review (``review``),
+# which outranks a match we still need to score (``score``). Passive states —
+# a result we posted awaiting the opponent, or a pending/scheduled match — are
+# never rows; they only feed ``waiting_count``.
+AttentionKind = Literal["dispute", "review", "score"]
 
-class DashboardScoreBanner(BaseModel):
+
+class DashboardAttentionItem(BaseModel):
+    """One actionable row in the dashboard's "Needs your attention" panel,
+    classified server-side and current-user-aware (see ``dashboard.py``). Rows
+    carry only routing data — opponent handle and the action — never scores."""
+
     match_id: uuid.UUID
     opponent_username: str | None
-    # The next game to score (1..best_of). Game rows are created lazily by the
-    # score-write endpoints, so the dashboard surfaces the number — the FE
-    # builds the deeplink ``/matches/{id}/games/{n}/scores/new`` from it.
-    current_game_number: int
-
-
-class DashboardNextMatch(BaseModel):
-    match_id: uuid.UUID
-    opponent_username: str | None
-    best_of: int
-    created_at: datetime
+    kind: AttentionKind
+    # ``score`` rows split rated-above-unrated by this flag (the FE derives the
+    # primary-button priority from ``kind`` + ``affects_rating``). It is always
+    # True for ``review``/``dispute`` (both only arise on rated matches).
+    affects_rating: bool
+    # The next un-scored game for a ``score`` row, used to deep-link straight to
+    # the scoring page. ``None`` when the board is already decided but unposted
+    # (the FE routes to match detail to post the result instead), and always
+    # ``None`` for ``review``/``dispute`` rows (which route to match detail).
+    current_game_number: int | None
 
 
 class DashboardRecentResult(BaseModel):
@@ -69,8 +80,14 @@ class DashboardRating(BaseModel):
 
 
 class DashboardResponse(BaseModel):
-    score_banners: list[DashboardScoreBanner]
-    next_match: DashboardNextMatch | None
+    # Every actionable match for the current user, pre-ranked by attention
+    # priority (§5 of the PRD). The FE renders the top 3 as rows and rolls the
+    # remainder into the footer's overflow count.
+    attention: list[DashboardAttentionItem]
+    # Count of matches that need *someone else's* move (a result we posted
+    # awaiting the opponent's sign-off, plus pending/scheduled matches). Shown
+    # as footer text only — never a row.
+    waiting_count: int
     recent_results: list[DashboardRecentResult]
     rating: DashboardRating | None = None
     # Total completed matches the current user participated in. The guest

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -43,8 +43,8 @@ async def test_dashboard_empty_when_user_has_no_matches(
     response = await api_client.get("/v1/dashboard")
     assert response.status_code == 200
     body = response.json()
-    assert body["score_banners"] == []
-    assert body["next_match"] is None
+    assert body["attention"] == []
+    assert body["waiting_count"] == 0
     assert body["recent_results"] == []
     assert body["completed_match_count"] == 0
     # A fresh signup is auto-joined to the default Glicko-2 league with
@@ -66,7 +66,7 @@ async def test_dashboard_empty_when_user_has_no_matches(
     ]
 
 
-async def test_dashboard_returns_score_banner_for_in_progress_match(
+async def test_dashboard_returns_score_attention_for_in_progress_match(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
@@ -78,24 +78,26 @@ async def test_dashboard_returns_score_banner_for_in_progress_match(
     )
 
     body = (await api_client.get("/v1/dashboard")).json()
-    assert len(body["score_banners"]) == 1
-    banner = body["score_banners"][0]
-    assert banner["match_id"] == match["id"]
-    assert banner["opponent_username"] == "rival"
+    assert len(body["attention"]) == 1
+    item = body["attention"][0]
+    assert item["match_id"] == match["id"]
+    assert item["opponent_username"] == "rival"
+    assert item["kind"] == "score"
+    assert item["affects_rating"] is True
     # Game rows are created lazily; the dashboard deeplinks by game number.
-    assert banner["current_game_number"] == 2
-    # An in-progress match is not "pending" so the next_match slot is empty.
-    assert body["next_match"] is None
+    assert item["current_game_number"] == 2
+    # Nothing is waiting on the opponent yet.
+    assert body["waiting_count"] == 0
     assert body["recent_results"] == []
 
 
-async def test_dashboard_returns_multiple_banners_oldest_first(
+async def test_dashboard_orders_score_items_oldest_first(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     # Variant D: back-to-back tournament play means a player can have two (or
-    # more) matches sitting in_progress at once. The frontend stacks them, but
-    # only if the API returns them in priority order — oldest first, since the
-    # one that's been waiting longest is the most urgent to score.
+    # more) matches sitting in_progress at once. The panel stacks them, but
+    # only if the API returns them in priority order — within the score bucket,
+    # oldest first, since the one waiting longest is the most urgent to score.
     await start_session(api_client, db_session)
     opp_a = await make_user(db_session, "rival_a")
     opp_b = await make_user(db_session, "rival_b")
@@ -105,19 +107,20 @@ async def test_dashboard_returns_multiple_banners_oldest_first(
     match_c = await _create_match(api_client, opp_c.id, best_of=5)
 
     body = (await api_client.get("/v1/dashboard")).json()
-    assert [b["match_id"] for b in body["score_banners"]] == [
+    assert [i["match_id"] for i in body["attention"]] == [
         match_a["id"],
         match_b["id"],
         match_c["id"],
     ]
-    assert [b["opponent_username"] for b in body["score_banners"]] == [
+    assert [i["opponent_username"] for i in body["attention"]] == [
         "rival_a",
         "rival_b",
         "rival_c",
     ]
+    assert all(i["kind"] == "score" for i in body["attention"])
 
 
-async def test_dashboard_returns_next_match_for_pending_match(
+async def test_dashboard_pending_match_counts_as_waiting(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
@@ -129,11 +132,11 @@ async def test_dashboard_returns_next_match_for_pending_match(
     db_match.status = MatchStatus.pending
     await db_session.commit()
 
+    # Pending/scheduled matches need the *other* side's move first (O3 default),
+    # so they're footer-only, never a row.
     body = (await api_client.get("/v1/dashboard")).json()
-    assert body["score_banners"] == []
-    assert body["next_match"]["match_id"] == created["id"]
-    assert body["next_match"]["opponent_username"] == "rival"
-    assert body["next_match"]["best_of"] == 5
+    assert body["attention"] == []
+    assert body["waiting_count"] == 1
 
 
 async def test_dashboard_returns_recent_results_for_completed_matches(
@@ -181,8 +184,8 @@ async def test_dashboard_scoped_to_current_user(
         await _create_match(other_client, bystander.id)
 
     body = (await api_client.get("/v1/dashboard")).json()
-    assert body["score_banners"] == []
-    assert body["next_match"] is None
+    assert body["attention"] == []
+    assert body["waiting_count"] == 0
     assert body["recent_results"] == []
     # Pin that completed_match_count also follows the participant filter —
     # Bob's completed match must not bleed into Alice's history total.
@@ -192,6 +195,110 @@ async def test_dashboard_scoped_to_current_user(
     # match.
     assert body["rating"]["current"] == 1500.0
     assert body["rating"]["streak"] is None
+
+
+async def _post_result(client: AsyncClient, match_id: str, *, best_of: int = 1) -> None:
+    """Post a decided result for ``match_id`` (no confirmation). For a rated
+    match this leaves it ``in_progress`` with the poster's lone signature —
+    awaiting the other side's review."""
+    games_to_win = best_of // 2 + 1
+    post = await client.post(
+        f"/v1/matches/{match_id}/results",
+        json={
+            "games": [
+                {"game_number": n, "side_1_points": 11, "side_2_points": 4}
+                for n in range(1, games_to_win + 1)
+            ]
+        },
+    )
+    assert post.status_code == 201
+
+
+async def test_dashboard_review_item_when_opponent_posted_result(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The opponent posts a rated result; the current user (who hasn't signed)
+    sees a ``review`` row — the in-app surface for confirmation that doesn't
+    depend on the push notification."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "poster") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=1)
+        # The OPPONENT posts, so it's the current user's turn to review.
+        await _post_result(opp_client, match["id"], best_of=1)
+
+    body = (await api_client.get("/v1/dashboard")).json()
+    assert len(body["attention"]) == 1
+    item = body["attention"][0]
+    assert item["match_id"] == match["id"]
+    assert item["kind"] == "review"
+    assert item["opponent_username"] == "poster"
+    # Review/dispute rows route to match detail, never deep-link to scoring.
+    assert item["current_game_number"] is None
+    assert body["waiting_count"] == 0
+
+
+async def test_dashboard_my_posted_result_counts_as_waiting(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The flip side of review: when *I* posted and the opponent owes the
+    sign-off, the match is waiting on them — footer count, never a row."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "reviewer") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=1)
+        await _post_result(api_client, match["id"], best_of=1)
+
+    body = (await api_client.get("/v1/dashboard")).json()
+    assert body["attention"] == []
+    assert body["waiting_count"] == 1
+
+
+async def test_dashboard_attention_priority_ranking(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """P0-4: a dispute ranks above a review, which ranks above a rated score,
+    which ranks above an unrated score."""
+    await start_session(api_client, db_session)
+    # Unrated + rated score matches: nobody has posted, so they sit in the
+    # score bucket; the current user is the one who'd score them.
+    rated_opp = await make_user(db_session, "rated_opp")
+    unrated_opp = await make_user(db_session, "unrated_opp")
+    rated_score = await _create_match(api_client, rated_opp.id, best_of=5)
+    unrated_create = await api_client.post(
+        "/v1/matches",
+        json={"opponent_user_id": str(unrated_opp.id), "best_of": 5, "rated": False},
+    )
+    assert unrated_create.status_code == 201
+    unrated_score = unrated_create.json()
+
+    async with opponent_session(db_session, "reviewer_opp") as (rev_client, rev_opp):
+        # Review row: the opponent posts, current user must review.
+        review_match = await _create_match(api_client, rev_opp.id, best_of=1)
+        await _post_result(rev_client, review_match["id"], best_of=1)
+
+        async with opponent_session(db_session, "dispute_opp") as (dis_client, dis_opp):
+            # Dispute row: current user posts, opponent disputes → disputed.
+            dispute_match = await _create_match(api_client, dis_opp.id, best_of=1)
+            await _post_result(api_client, dispute_match["id"], best_of=1)
+            dispute = await dis_client.post(
+                f"/v1/matches/{dispute_match['id']}/dispute"
+            )
+            assert dispute.status_code == 200
+
+            body = (await api_client.get("/v1/dashboard")).json()
+
+    assert [(i["kind"], i["affects_rating"]) for i in body["attention"]] == [
+        ("dispute", True),
+        ("review", True),
+        ("score", True),
+        ("score", False),
+    ]
+    assert [i["match_id"] for i in body["attention"]] == [
+        dispute_match["id"],
+        review_match["id"],
+        rated_score["id"],
+        unrated_score["id"],
+    ]
+    assert body["waiting_count"] == 0
 
 
 async def _play_match(

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1511,12 +1511,13 @@ async def test_confirmation_finalizes_and_lands_second_signature(
         assert body["can_confirm"] is False
 
 
-async def test_dispute_clears_signatures_and_rewinds_to_in_progress(
+async def test_dispute_clears_signatures_and_moves_to_disputed(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    """``POST /dispute`` deletes every signature on the match, drops the
-    side.won flags back to None, and leaves the canonical games in place so
-    the disputer can navigate to the contested game and PUT a correction."""
+    """``POST /dispute`` deletes every signature on the match, moves it to the
+    ``disputed`` status, drops the side.won flags back to None, and leaves the
+    canonical games in place so the disputer can navigate to the contested game
+    and PUT a correction."""
     await start_session(api_client, db_session)
     async with opponent_session(db_session, "dispute-opp") as (opp_client, opp):
         match = await _create_match(api_client, opp.id, best_of=3)
@@ -1525,8 +1526,8 @@ async def test_dispute_clears_signatures_and_rewinds_to_in_progress(
         dispute = await opp_client.post(f"/v1/matches/{match['id']}/dispute")
         assert dispute.status_code == 200
         body = dispute.json()
-        assert body["status"] == "in_progress"
-        assert body["status_label"] == "Live"
+        assert body["status"] == "disputed"
+        assert body["status_label"] == "Disputed"
         assert body["signatures"] == []
         sides = sorted(body["sides"], key=lambda s: s["side_number"])
         assert [s["won"] for s in sides] == [None, None]
@@ -1939,9 +1940,9 @@ async def test_concurrent_confirm_and_dispute_serialize(
                 assert {s.won for s in sides} == {True, False}, [s.won for s in sides]
                 assert len(final.signatures) == 2
             else:
-                # Dispute won: rewound to in_progress with no live signatures
-                # and no recorded winner.
-                assert final.status == MatchStatus.in_progress
+                # Dispute won: moved to disputed with no live signatures and no
+                # recorded winner.
+                assert final.status == MatchStatus.disputed
                 assert final.signatures == []
                 assert [s.won for s in sides] == [None, None]
 

--- a/e2e/tests/dashboard-matches.spec.ts
+++ b/e2e/tests/dashboard-matches.spec.ts
@@ -7,7 +7,7 @@ test.describe('Dashboard match widgets', () => {
 
         await expect(page.getByText('No completed matches yet.')).toBeVisible();
 
-        await expect(page.getByRole('status', { name: 'Loading score banner' })).toHaveCount(0);
+        await expect(page.getByRole('status', { name: 'Loading attention panel' })).toHaveCount(0);
         await expect(page.getByRole('status', { name: 'Loading recent matches' })).toHaveCount(0);
     });
 });

--- a/web-client/src/api/dashboard.ts
+++ b/web-client/src/api/dashboard.ts
@@ -3,9 +3,8 @@ import { api, unwrap } from './client'
 import type { components } from './schema'
 
 export type DashboardResponse = components['schemas']['DashboardResponse']
-export type DashboardScoreBanner =
-  components['schemas']['DashboardScoreBanner']
-export type DashboardNextMatch = components['schemas']['DashboardNextMatch']
+export type DashboardAttentionItem =
+  components['schemas']['DashboardAttentionItem']
 export type DashboardRecentResult =
   components['schemas']['DashboardRecentResult']
 export type DashboardRating = components['schemas']['DashboardRating']

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -751,8 +751,13 @@ export interface components {
              */
             skip_merge: boolean;
         };
-        /** DashboardNextMatch */
-        DashboardNextMatch: {
+        /**
+         * DashboardAttentionItem
+         * @description One actionable row in the dashboard's "Needs your attention" panel,
+         *     classified server-side and current-user-aware (see ``dashboard.py``). Rows
+         *     carry only routing data — opponent handle and the action — never scores.
+         */
+        DashboardAttentionItem: {
             /**
              * Match Id
              * Format: uuid
@@ -760,13 +765,15 @@ export interface components {
             match_id: string;
             /** Opponent Username */
             opponent_username: string | null;
-            /** Best Of */
-            best_of: number;
             /**
-             * Created At
-             * Format: date-time
+             * Kind
+             * @enum {string}
              */
-            created_at: string;
+            kind: "dispute" | "review" | "score";
+            /** Affects Rating */
+            affects_rating: boolean;
+            /** Current Game Number */
+            current_game_number: number | null;
         };
         /**
          * DashboardRating
@@ -837,26 +844,15 @@ export interface components {
         };
         /** DashboardResponse */
         DashboardResponse: {
-            /** Score Banners */
-            score_banners: components["schemas"]["DashboardScoreBanner"][];
-            next_match: components["schemas"]["DashboardNextMatch"] | null;
+            /** Attention */
+            attention: components["schemas"]["DashboardAttentionItem"][];
+            /** Waiting Count */
+            waiting_count: number;
             /** Recent Results */
             recent_results: components["schemas"]["DashboardRecentResult"][];
             rating?: components["schemas"]["DashboardRating"] | null;
             /** Completed Match Count */
             completed_match_count: number;
-        };
-        /** DashboardScoreBanner */
-        DashboardScoreBanner: {
-            /**
-             * Match Id
-             * Format: uuid
-             */
-            match_id: string;
-            /** Opponent Username */
-            opponent_username: string | null;
-            /** Current Game Number */
-            current_game_number: number;
         };
         /** DashboardStreak */
         DashboardStreak: {

--- a/web-client/src/components/dashboard/attention-panel-view.test.ts
+++ b/web-client/src/components/dashboard/attention-panel-view.test.ts
@@ -1,0 +1,113 @@
+import { dashboardAttentionItem } from '@/test/factories'
+import { projectAttentionPanelView } from './attention-panel-view'
+
+describe('projectAttentionPanelView', () => {
+  it('caps visible rows at 3 and reports the overflow', () => {
+    const items = Array.from({ length: 5 }, (_, i) =>
+      dashboardAttentionItem({ match_id: `m-${i}`, kind: 'score' }),
+    )
+
+    const view = projectAttentionPanelView(items, 0, 'rita.kovac')
+
+    expect(view.rows).toHaveLength(3)
+    expect(view.rows.map((r) => r.matchId)).toEqual(['m-0', 'm-1', 'm-2'])
+    expect(view.overflowCount).toBe(2)
+  })
+
+  it('marks only the highest-priority visible bucket as primary', () => {
+    const view = projectAttentionPanelView(
+      [
+        dashboardAttentionItem({ match_id: 'm-dispute', kind: 'dispute' }),
+        dashboardAttentionItem({ match_id: 'm-review', kind: 'review' }),
+        dashboardAttentionItem({ match_id: 'm-score', kind: 'score' }),
+      ],
+      0,
+      'rita.kovac',
+    )
+
+    expect(view.rows.map((r) => r.primary)).toEqual([true, false, false])
+  })
+
+  it('makes every same-type row primary', () => {
+    const view = projectAttentionPanelView(
+      [
+        dashboardAttentionItem({ kind: 'score', affects_rating: true }),
+        dashboardAttentionItem({ kind: 'score', affects_rating: true }),
+      ],
+      0,
+      'rita.kovac',
+    )
+
+    expect(view.rows.map((r) => r.primary)).toEqual([true, true])
+  })
+
+  it('routes a score row to the scoring page and review/dispute to match detail', () => {
+    const view = projectAttentionPanelView(
+      [
+        dashboardAttentionItem({
+          match_id: 'm-score',
+          kind: 'score',
+          current_game_number: 3,
+        }),
+        dashboardAttentionItem({
+          match_id: 'm-review',
+          kind: 'review',
+          current_game_number: null,
+        }),
+      ],
+      0,
+      'rita.kovac',
+    )
+
+    expect(view.rows[0].route).toEqual({
+      to: '/matches/$matchId/games/$gameNumber/scores/new',
+      params: { matchId: 'm-score', gameNumber: '3' },
+    })
+    expect(view.rows[1].route).toEqual({
+      to: '/matches/$matchId',
+      params: { matchId: 'm-review' },
+    })
+  })
+
+  it('routes a decided-but-unposted score row (no game number) to match detail', () => {
+    const view = projectAttentionPanelView(
+      [
+        dashboardAttentionItem({
+          match_id: 'm-decided',
+          kind: 'score',
+          current_game_number: null,
+        }),
+      ],
+      0,
+      'rita.kovac',
+    )
+
+    expect(view.rows[0].route).toEqual({
+      to: '/matches/$matchId',
+      params: { matchId: 'm-decided' },
+    })
+  })
+
+  it('builds the headline from the opponent handle, falling back to "No opponent"', () => {
+    const view = projectAttentionPanelView(
+      [
+        dashboardAttentionItem({ opponent_username: 'lively.otter' }),
+        dashboardAttentionItem({ opponent_username: null }),
+      ],
+      0,
+      'rita.kovac',
+    )
+
+    expect(view.rows[0].headline).toBe('vs lively.otter')
+    expect(view.rows[1].headline).toBe('No opponent')
+  })
+
+  it('passes through the waiting count and scopes "View all" to the user', () => {
+    const view = projectAttentionPanelView([], 4, 'rita.kovac')
+
+    expect(view.rows).toHaveLength(0)
+    expect(view.overflowCount).toBe(0)
+    expect(view.waitingCount).toBe(4)
+    expect(view.viewAllSearch).toEqual({ q: 'rita.kovac' })
+  })
+})

--- a/web-client/src/components/dashboard/attention-panel-view.ts
+++ b/web-client/src/components/dashboard/attention-panel-view.ts
@@ -1,0 +1,100 @@
+import { matchDetailRoute, scoringNewRoute } from '@/api/matches'
+import type { DashboardAttentionItem } from '@/api/dashboard'
+
+// Used wherever an opponent slot has no registered player — matches the label
+// the rest of the dashboard uses for solo matches.
+const NO_OPPONENT_LABEL = 'No opponent'
+
+// The panel never grows unbounded — show the top 3 rows, roll the rest into
+// the footer (PRD §6.4).
+export const ATTENTION_VISIBLE_LIMIT = 3
+
+type RowRoute =
+  | ReturnType<typeof matchDetailRoute>
+  | ReturnType<typeof scoringNewRoute>
+
+export interface AttentionRowView {
+  matchId: string
+  /** Avatar seed — null renders the "no opponent" placeholder avatar. */
+  opponentName: string | null
+  /** Row headline, e.g. `vs nguyen.t` or `No opponent`. */
+  headline: string
+  /** Button copy: `Resolve dispute` | `Review result` | `Enter score`. */
+  actionLabel: string
+  /** Whether this row takes the primary (filled) button — true for every row
+   * in the highest-priority bucket currently visible (PRD §6.3). */
+  primary: boolean
+  /** Where the button routes: match detail for dispute/review, the scoring
+   * page for a score row (or match detail when the board is already decided). */
+  route: RowRoute
+}
+
+export interface AttentionPanelView {
+  /** The (≤3) rows to render, in server-supplied priority order. */
+  rows: AttentionRowView[]
+  /** Actionable items beyond the visible 3 — footer "N more need attention". */
+  overflowCount: number
+  /** Matches waiting on someone else — footer "N waiting on others". */
+  waitingCount: number
+  /** Search params for the "View all" link to /matches. */
+  viewAllSearch: { q: string | undefined }
+}
+
+// A row's attention "bucket" — the unit the primary-button rule operates on
+// (score rows split rated vs unrated; review/dispute are each their own
+// bucket). We deliberately do NOT re-encode the priority *ordering* here: the
+// server already sorts by it (PRD §5), so the first visible row is the
+// highest-priority bucket present, and every row sharing its bucket takes the
+// primary button (PRD §6.3).
+function bucketKey(item: DashboardAttentionItem): string {
+  return item.kind === 'score' ? `score-${item.affects_rating}` : item.kind
+}
+
+function actionLabelOf(kind: DashboardAttentionItem['kind']): string {
+  if (kind === 'dispute') return 'Resolve dispute'
+  if (kind === 'review') return 'Review result'
+  return 'Enter score'
+}
+
+function routeOf(item: DashboardAttentionItem): RowRoute {
+  // A score row deep-links to the next un-played game; review/dispute rows (and
+  // a decided-but-unposted board, current_game_number === null) route to match
+  // detail, which holds the confirm/dispute/post-result actions.
+  if (item.kind === 'score' && item.current_game_number !== null) {
+    return scoringNewRoute(item.match_id, item.current_game_number)
+  }
+  return matchDetailRoute(item.match_id)
+}
+
+/**
+ * Project the BFF's pre-ranked attention items into the panel's view model:
+ * cap visible rows at 3, compute the footer counts, and mark the
+ * highest-priority *visible* bucket as primary (so a `Review result` beneath a
+ * `Resolve dispute` renders secondary). Items arrive already sorted by the
+ * server (PRD §5), so their order is preserved as-is.
+ */
+export function projectAttentionPanelView(
+  items: DashboardAttentionItem[],
+  waitingCount: number,
+  username: string | undefined,
+): AttentionPanelView {
+  const visible = items.slice(0, ATTENTION_VISIBLE_LIMIT)
+  // Items arrive pre-sorted by priority, so the first visible row defines the
+  // top bucket; rows sharing it render primary.
+  const topBucket = visible.length ? bucketKey(visible[0]) : ''
+  return {
+    rows: visible.map((item) => ({
+      matchId: item.match_id,
+      opponentName: item.opponent_username,
+      headline: item.opponent_username
+        ? `vs ${item.opponent_username}`
+        : NO_OPPONENT_LABEL,
+      actionLabel: actionLabelOf(item.kind),
+      primary: bucketKey(item) === topBucket,
+      route: routeOf(item),
+    })),
+    overflowCount: Math.max(0, items.length - ATTENTION_VISIBLE_LIMIT),
+    waitingCount,
+    viewAllSearch: { q: username },
+  }
+}

--- a/web-client/src/components/dashboard/attention-panel.factory.tsx
+++ b/web-client/src/components/dashboard/attention-panel.factory.tsx
@@ -1,0 +1,42 @@
+import { scoringNewRoute } from '@/api/matches'
+import type { AttentionPanelProps } from './attention-panel'
+import type {
+  AttentionPanelView,
+  AttentionRowView,
+} from './attention-panel-view'
+
+/** One primary "Enter score" row routing to game 1's scoring page. */
+export function buildAttentionRowView(
+  overrides: Partial<AttentionRowView> = {},
+): AttentionRowView {
+  return {
+    matchId: 'm-1',
+    opponentName: 'nguyen.t',
+    headline: 'vs nguyen.t',
+    actionLabel: 'Enter score',
+    primary: true,
+    route: scoringNewRoute('m-1', 1),
+    ...overrides,
+  }
+}
+
+/** A panel with a single primary "Enter score" row, no overflow, nobody
+ * waiting, and a "View all" link scoped to rita.kovac's matches. */
+export function buildAttentionPanelView(
+  overrides: Partial<AttentionPanelView> = {},
+): AttentionPanelView {
+  return {
+    rows: [buildAttentionRowView()],
+    overflowCount: 0,
+    waitingCount: 0,
+    viewAllSearch: { q: 'rita.kovac' },
+    ...overrides,
+  }
+}
+
+/** Props for `AttentionPanel`. */
+export function buildAttentionPanelProps(
+  overrides: Partial<AttentionPanelProps> = {},
+): AttentionPanelProps {
+  return { view: buildAttentionPanelView(), ...overrides }
+}

--- a/web-client/src/components/dashboard/attention-panel.page.tsx
+++ b/web-client/src/components/dashboard/attention-panel.page.tsx
@@ -1,0 +1,104 @@
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import { AttentionPanel, type AttentionPanelProps } from './attention-panel'
+import { buildAttentionPanelProps } from './attention-panel.factory'
+
+const scoped = (container: Container) => ({
+  /** The panel `<section>` (always present — it renders a calm empty state
+   * rather than disappearing). */
+  getPanel() {
+    return container.getByRole('region', { name: /needs your attention/i })
+  },
+  /** Every action row (one `<li>` per visible item). */
+  getRows() {
+    return container.getAllByRole('listitem')
+  },
+  queryRows() {
+    return container.queryAllByRole('listitem')
+  },
+  /** The action button/link in the row whose headline matches `headline`
+   * (e.g. "vs nguyen.t"). Resolved by walking up to the row, then querying the
+   * link within it — no test-only markup needed. */
+  getRowAction(headline: string) {
+    const row = container.getByText(headline).closest('li')
+    if (!row) throw new Error(`No attention row for "${headline}"`)
+    return within(row).getByRole('link')
+  },
+  /** The calm "all caught up" empty-state copy (absent when rows exist). */
+  queryEmptyState() {
+    return container.queryByText(/all caught up/i)
+  },
+  /** The "View all" footer link to /matches. */
+  getViewAllLink() {
+    return container.getByRole('link', { name: /view all/i })
+  },
+  /** Footer summary line (overflow / waiting counts), or null when empty. */
+  queryFooterText(pattern: RegExp) {
+    return container.queryByText(pattern)
+  },
+})
+
+/**
+ * Test page-object for `AttentionPanel`. The rows and footer render typed
+ * `<Link>`s (match detail, scoring, /matches), so `render` mounts the panel
+ * under a minimal memory router registering those routes. The router resolves
+ * asynchronously, so tests start with `await attentionPanelPage.findPanel()`.
+ */
+export const attentionPanelPage = {
+  render(overrides: Partial<AttentionPanelProps> = {}) {
+    const props = buildAttentionPanelProps(overrides)
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => <AttentionPanel {...props} />,
+    })
+    const matchesRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/matches',
+      component: () => <div>matches</div>,
+    })
+    const matchDetailRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/matches/$matchId',
+      component: () => <div>match-detail</div>,
+    })
+    const scoringNewRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/matches/$matchId/games/$gameNumber/scores/new',
+      component: () => <div>scoring-new</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        matchesRoute,
+        matchDetailRoute,
+        scoringNewRoute,
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+    render(<RouterProvider router={router} />)
+  },
+
+  /** Async-first accessor — the router resolves the route tree on first paint,
+   * so tests await this before reading the synchronous accessors. */
+  findPanel() {
+    return screen.findByRole('region', { name: /needs your attention/i })
+  },
+
+  /** Scope the accessors to a subtree so a parent page object can expose these
+   * queries as its own. */
+  within(node: HTMLElement) {
+    return scoped(within(node))
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/dashboard/attention-panel.test.tsx
+++ b/web-client/src/components/dashboard/attention-panel.test.tsx
@@ -66,6 +66,19 @@ describe('AttentionPanel', () => {
     expect(page.queryFooterText(/2 waiting on others/)).toBeInTheDocument()
   })
 
+  it('uses the singular verb for a single overflow item', async () => {
+    page.render({
+      view: buildAttentionPanelView({
+        rows: [buildAttentionRowView()],
+        overflowCount: 1,
+      }),
+    })
+
+    await page.findPanel()
+    expect(page.queryFooterText(/1 more needs attention/)).toBeInTheDocument()
+    expect(page.queryFooterText(/need attention/)).not.toBeInTheDocument()
+  })
+
   it('links "View all" to /matches scoped to the current user', async () => {
     page.render({
       view: buildAttentionPanelView({ viewAllSearch: { q: 'rita.kovac' } }),

--- a/web-client/src/components/dashboard/attention-panel.test.tsx
+++ b/web-client/src/components/dashboard/attention-panel.test.tsx
@@ -1,0 +1,80 @@
+import { matchDetailRoute, scoringNewRoute } from '@/api/matches'
+import {
+  buildAttentionPanelView,
+  buildAttentionRowView,
+} from './attention-panel.factory'
+import { attentionPanelPage as page } from './attention-panel.page'
+
+describe('AttentionPanel', () => {
+  it('renders each row with its headline and action button', async () => {
+    page.render({
+      view: buildAttentionPanelView({
+        rows: [
+          buildAttentionRowView({
+            matchId: 'm-dispute',
+            opponentName: 'congenial.wallaby',
+            headline: 'vs congenial.wallaby',
+            actionLabel: 'Resolve dispute',
+            primary: true,
+            route: matchDetailRoute('m-dispute'),
+          }),
+          buildAttentionRowView({
+            matchId: 'm-score',
+            headline: 'vs nguyen.t',
+            actionLabel: 'Enter score',
+            primary: false,
+            route: scoringNewRoute('m-score', 2),
+          }),
+        ],
+      }),
+    })
+
+    await page.findPanel()
+    expect(page.getRows()).toHaveLength(2)
+
+    const dispute = page.getRowAction('vs congenial.wallaby')
+    expect(dispute).toHaveTextContent('Resolve dispute')
+    expect(dispute).toHaveAttribute('href', '/matches/m-dispute')
+
+    const score = page.getRowAction('vs nguyen.t')
+    expect(score).toHaveTextContent('Enter score')
+    expect(score).toHaveAttribute(
+      'href',
+      '/matches/m-score/games/2/scores/new',
+    )
+  })
+
+  it('shows a calm empty state and no rows when nothing is actionable', async () => {
+    page.render({ view: buildAttentionPanelView({ rows: [] }) })
+
+    await page.findPanel()
+    expect(page.queryRows()).toHaveLength(0)
+    expect(page.queryEmptyState()).toBeInTheDocument()
+  })
+
+  it('summarizes overflow and waiting counts in the footer', async () => {
+    page.render({
+      view: buildAttentionPanelView({
+        rows: [buildAttentionRowView()],
+        overflowCount: 3,
+        waitingCount: 2,
+      }),
+    })
+
+    await page.findPanel()
+    expect(page.queryFooterText(/3 more need attention/)).toBeInTheDocument()
+    expect(page.queryFooterText(/2 waiting on others/)).toBeInTheDocument()
+  })
+
+  it('links "View all" to /matches scoped to the current user', async () => {
+    page.render({
+      view: buildAttentionPanelView({ viewAllSearch: { q: 'rita.kovac' } }),
+    })
+
+    await page.findPanel()
+    expect(page.getViewAllLink()).toHaveAttribute(
+      'href',
+      '/matches?q=rita.kovac',
+    )
+  })
+})

--- a/web-client/src/components/dashboard/attention-panel.tsx
+++ b/web-client/src/components/dashboard/attention-panel.tsx
@@ -82,7 +82,11 @@ function AttentionFooter({
   viewAllSearch: { q: string | undefined }
 }) {
   const parts: string[] = []
-  if (overflowCount > 0) parts.push(`${overflowCount} more need attention`)
+  if (overflowCount > 0) {
+    parts.push(
+      `${overflowCount} more ${overflowCount === 1 ? 'needs' : 'need'} attention`,
+    )
+  }
   if (waitingCount > 0) parts.push(`${waitingCount} waiting on others`)
   return (
     <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-[color:var(--ink-700)] px-5 py-3 text-[13px] text-[color:var(--chalk-500)]">

--- a/web-client/src/components/dashboard/attention-panel.tsx
+++ b/web-client/src/components/dashboard/attention-panel.tsx
@@ -1,0 +1,101 @@
+import { Link } from '@tanstack/react-router'
+import { ArrowRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { UserAvatar } from '@/components/ui/user-avatar'
+import type { AttentionPanelView } from './attention-panel-view'
+
+export interface AttentionPanelProps {
+  view: AttentionPanelView
+}
+
+/**
+ * The dashboard's "Needs your attention" triage panel: up to three
+ * priority-ordered, action-only rows (avatar · `vs @opponent` · one button)
+ * plus a footer summarizing overflow + waiting counts and a `View all` link.
+ * Pure view-in — all ranking/labels/routing are decided by
+ * `projectAttentionPanelView`. Buttons only route; they never finalize a
+ * result. Renders a calm empty state rather than disappearing when nothing is
+ * actionable.
+ */
+export const AttentionPanel = ({ view }: AttentionPanelProps) => {
+  const { rows, overflowCount, waitingCount, viewAllSearch } = view
+  return (
+    <section
+      aria-labelledby="needs-attention-heading"
+      className="mb-8"
+      data-testid="dashboard-attention-panel"
+    >
+      <Card className="flex flex-col gap-0 p-0">
+        <h2
+          id="needs-attention-heading"
+          className="px-5 pt-4 pb-3 text-[18px] font-semibold tracking-tight text-[color:var(--chalk-50)]"
+        >
+          Needs your attention
+        </h2>
+        {rows.length > 0 ? (
+          <ul className="flex flex-col">
+            {rows.map((row) => (
+              <li
+                key={row.matchId}
+                className="flex items-center gap-3 border-t border-[color:var(--ink-700)] px-5 py-3"
+              >
+                <UserAvatar name={row.opponentName} size={40} />
+                <span className="min-w-0 flex-1 truncate text-[15px] font-semibold text-[color:var(--chalk-50)]">
+                  {row.headline}
+                </span>
+                <Button
+                  asChild
+                  variant={row.primary ? 'default' : 'outline'}
+                  size="sm"
+                >
+                  <Link {...row.route}>
+                    {row.actionLabel}
+                    <ArrowRight size={14} strokeWidth={1.75} />
+                  </Link>
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="border-t border-[color:var(--ink-700)] px-5 py-6 text-[13px] text-[color:var(--chalk-300)]">
+            You&rsquo;re all caught up.
+          </p>
+        )}
+        <AttentionFooter
+          overflowCount={overflowCount}
+          waitingCount={waitingCount}
+          viewAllSearch={viewAllSearch}
+        />
+      </Card>
+    </section>
+  )
+}
+
+function AttentionFooter({
+  overflowCount,
+  waitingCount,
+  viewAllSearch,
+}: {
+  overflowCount: number
+  waitingCount: number
+  viewAllSearch: { q: string | undefined }
+}) {
+  const parts: string[] = []
+  if (overflowCount > 0) parts.push(`${overflowCount} more need attention`)
+  if (waitingCount > 0) parts.push(`${waitingCount} waiting on others`)
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-[color:var(--ink-700)] px-5 py-3 text-[13px] text-[color:var(--chalk-500)]">
+      {parts.map((part) => (
+        <span key={part}>{part} ·</span>
+      ))}
+      <Link
+        to="/matches"
+        search={viewAllSearch}
+        className="font-medium text-[color:var(--chalk-300)] hover:text-[color:var(--chalk-50)]"
+      >
+        View all
+      </Link>
+    </div>
+  )
+}

--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -13,10 +13,10 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { mockSession } from '@/mocks/handlers'
 import { server } from '@/mocks/server'
 import {
+  dashboardAttentionItem,
   dashboardRating,
   dashboardRecentResult,
   dashboardResponse,
-  dashboardScoreBanner,
 } from '@/test/factories'
 import { GUEST_PERSIST_DISMISS_KEY } from './guest-persist-banner'
 import { DashboardPage } from './dashboard-page'
@@ -81,9 +81,13 @@ describe('DashboardPage', () => {
       http.get('*/v1/dashboard', () =>
         HttpResponse.json(
           dashboardResponse({
-            score_banners: [
-              dashboardScoreBanner({
-                match_id: 'm-banner',
+            // Wiring only: the panel's rows/footer/routing are pinned by the
+            // attention-panel and attention-panel-view tests. Here we just
+            // confirm the dashboard feeds the response into the panel.
+            attention: [
+              dashboardAttentionItem({
+                match_id: 'm-attn',
+                kind: 'score',
                 current_game_number: 1,
                 opponent_username: 'nguyen.t',
               }),
@@ -110,9 +114,10 @@ describe('DashboardPage', () => {
     )
     renderDashboard()
 
-    expect(await screen.findByTestId('dashboard-score-banner')).toHaveTextContent(
-      'vs nguyen.t',
-    )
+    const panel = await screen.findByRole('region', {
+      name: /needs your attention/i,
+    })
+    expect(panel).toHaveTextContent('vs nguyen.t')
     const recent = await screen.findByTestId('dashboard-recent-results')
     const table = recent.parentElement?.querySelector('table')
     expect(table).not.toBeNull()
@@ -135,12 +140,13 @@ describe('DashboardPage', () => {
     ).toBeInTheDocument()
   })
 
-  it('omits the score banner when none is active and shows the empty recent-results card', async () => {
+  it('shows the attention panel empty state and the empty recent-results card when nothing is pending', async () => {
     server.use(
       http.get('*/v1/dashboard', () =>
         HttpResponse.json(
           dashboardResponse({
-            score_banners: [],
+            attention: [],
+            waiting_count: 0,
             recent_results: [],
           }),
         ),
@@ -149,7 +155,10 @@ describe('DashboardPage', () => {
     renderDashboard()
 
     await screen.findByText('No completed matches yet.')
-    expect(screen.queryByTestId('dashboard-score-banner')).not.toBeInTheDocument()
+    // The panel stays put (a calm empty state) rather than disappearing.
+    expect(
+      screen.getByRole('region', { name: /needs your attention/i }),
+    ).toHaveTextContent(/all caught up/i)
   })
 
   it('Log a match navigates to /matches/new', async () => {
@@ -227,103 +236,6 @@ describe('DashboardPage', () => {
     expect(screen.queryByText('RD')).not.toBeInTheDocument()
   })
 
-  it('Enter final score links to the current-game scoring route', async () => {
-    server.use(
-      http.get('*/v1/dashboard', () =>
-        HttpResponse.json(
-          dashboardResponse({
-            score_banners: [
-              dashboardScoreBanner({
-                match_id: 'm-banner',
-                current_game_number: 1,
-                opponent_username: 'nguyen.t',
-              }),
-            ],
-          }),
-        ),
-      ),
-    )
-    renderDashboard()
-
-    const link = await screen.findByRole('link', { name: /enter final score/i })
-    expect(link).toHaveAttribute(
-      'href',
-      '/matches/m-banner/games/1/scores/new',
-    )
-  })
-
-  it('stacks a compact banner when a second match is pending scoring', async () => {
-    server.use(
-      http.get('*/v1/dashboard', () =>
-        HttpResponse.json(
-          dashboardResponse({
-            score_banners: [
-              dashboardScoreBanner({
-                match_id: 'm-primary',
-                current_game_number: 1,
-                opponent_username: 'nguyen.t',
-              }),
-              dashboardScoreBanner({
-                match_id: 'm-secondary',
-                current_game_number: 1,
-                opponent_username: 'holm.s',
-              }),
-            ],
-          }),
-        ),
-      ),
-    )
-    renderDashboard()
-
-    expect(await screen.findByTestId('dashboard-score-banner')).toHaveTextContent(
-      'vs nguyen.t',
-    )
-    const compact = await screen.findByTestId('dashboard-score-banner-compact')
-    expect(compact).toHaveTextContent('vs holm.s')
-    expect(compact).toHaveTextContent(/also pending/i)
-    expect(within(compact).getByRole('link', { name: /enter score/i })).toHaveAttribute(
-      'href',
-      '/matches/m-secondary/games/1/scores/new',
-    )
-    expect(
-      screen.queryByTestId('dashboard-score-banner-more'),
-    ).not.toBeInTheDocument()
-  })
-
-  it('collapses 3+ pending matches into a "+N more pending" link to the current user\'s live matches', async () => {
-    server.use(
-      http.get('*/v1/dashboard', () =>
-        HttpResponse.json(
-          dashboardResponse({
-            score_banners: [
-              dashboardScoreBanner({
-                match_id: 'm-1',
-                opponent_username: 'nguyen.t',
-              }),
-              dashboardScoreBanner({
-                match_id: 'm-2',
-                opponent_username: 'holm.s',
-              }),
-              dashboardScoreBanner({
-                match_id: 'm-3',
-                opponent_username: 'okafor.m',
-              }),
-              dashboardScoreBanner({
-                match_id: 'm-4',
-                opponent_username: 'silva.r',
-              }),
-            ],
-          }),
-        ),
-      ),
-    )
-    renderDashboard()
-
-    const more = await screen.findByTestId('dashboard-score-banner-more')
-    expect(more).toHaveTextContent('+2')
-    expect(more).toHaveTextContent(/more pending/i)
-    expect(more).toHaveAttribute('href', '/matches?q=rita.kovac&status=live')
-  })
 })
 
 describe('DashboardPage · guest persistence banner', () => {

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -1,18 +1,15 @@
+import { useMemo } from 'react'
 import type { ComponentProps, CSSProperties, ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
-import { ArrowRight, ChevronRight, Plus, X } from 'lucide-react'
+import { ChevronRight, Plus } from 'lucide-react'
 import { useDashboard } from '@/api/dashboard'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import { Card as UICard } from '@/components/ui/card'
-import { cn } from '@/lib/utils'
-import type {
-  DashboardRating,
-  DashboardRecentResult,
-  DashboardScoreBanner,
-} from '@/api/dashboard'
-import { scoringNewRoute } from '@/api/matches'
+import type { DashboardRating, DashboardRecentResult } from '@/api/dashboard'
 import { deriveEmailStatus, useSession } from '@/api/session'
 import { Overline } from '@/components/overline'
+import { AttentionPanel } from '@/components/dashboard/attention-panel'
+import { projectAttentionPanelView } from '@/components/dashboard/attention-panel-view'
 import { GuestPersistBanner } from '@/components/dashboard/guest-persist-banner'
 import { fmtDateShort, fmtLongDate } from '@/lib/dates'
 import { formatRatingDelta } from '@/lib/rating'
@@ -125,34 +122,6 @@ function Pill({
     </span>
   )
 }
-
-function BallDot({
-  live = false,
-  color = C.ball500,
-  size = 8,
-}: {
-  live?: boolean
-  color?: string
-  size?: number
-}) {
-  const isGreen = color === C.serve500
-  const glow = isGreen ? 'rgba(0,226,154,0.65)' : 'rgba(255,122,26,0.55)'
-  return (
-    <span
-      style={{
-        display: 'inline-block',
-        width: size,
-        height: size,
-        borderRadius: '50%',
-        background: color,
-        boxShadow: `0 0 ${size + 2}px ${glow}`,
-        animation: live ? 'ball-pulse 1.4s ease-in-out infinite' : 'none',
-        flexShrink: 0,
-      }}
-    />
-  )
-}
-
 
 function Sparkline({
   data,
@@ -360,29 +329,24 @@ function Button({
 // The shared design-system Card (`@/components/ui/card`). `display: 'block'`
 // neutralizes the shadcn Card's default flex/gap so callers keep full control of
 // their inner layout (e.g. RatingCard re-enables flex via its own style;
-// RecentResultsCard stays block). Pass `highlight` for the design-system
-// "Featured" treatment — an orange ring plus the accent glow shadow, and
-// nothing else.
+// RecentResultsCard stays block).
 function Card({
   children,
   padding = 20,
   style,
-  highlight = false,
   className,
   ...rest
 }: {
   children: ReactNode
   padding?: number | string
-  highlight?: boolean
 } & Omit<ComponentProps<'div'>, 'children'>) {
   return (
     <UICard
-      className={cn(highlight && 'ring-2 ring-[color:var(--ball-500)]', className)}
+      className={className}
       style={{
         display: 'block',
         padding,
         position: 'relative',
-        ...(highlight ? { boxShadow: 'var(--shadow-glow)' } : null),
         ...style,
       }}
       {...rest}
@@ -541,249 +505,6 @@ function PageTitle({
       >
         Log a match
       </Button>
-    </div>
-  )
-}
-
-// Shared derivation for both the primary and compact score banners: the orange
-// accent, the "vs <opponent>" headline, and the route into scoring.
-function scoreBannerView(banner: DashboardScoreBanner) {
-  const opponent = banner.opponent_username
-  return {
-    accent: C.ball500,
-    opponent,
-    headline: opponent ? `vs ${opponent}` : NO_OPPONENT_LABEL,
-    scoringRoute: scoringNewRoute(banner.match_id, banner.current_game_number),
-  }
-}
-
-function ScoreBanner({
-  banner,
-  compact,
-}: {
-  banner: DashboardScoreBanner
-  compact: boolean
-}) {
-  const { accent, opponent, headline, scoringRoute } = scoreBannerView(banner)
-  return (
-    <Card highlight padding={0} data-testid="dashboard-score-banner">
-      <div style={{ position: 'relative', padding: compact ? '20px 18px' : '22px 26px' }}>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-            marginBottom: 14,
-            flexWrap: 'wrap',
-          }}
-        >
-          <BallDot live size={9} />
-          <span
-            style={{
-              font: `700 11px ${MONO}`,
-              letterSpacing: '0.18em',
-              color: accent,
-              fontVariantNumeric: 'tabular-nums',
-            }}
-          >
-            SCORE NEEDED
-          </span>
-        </div>
-
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 24,
-            flexWrap: 'wrap',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 18,
-              flex: '1 1 360px',
-              minWidth: 0,
-            }}
-          >
-            <UserAvatar name={opponent} size={64} ring ringColor={accent} />
-            <div style={{ minWidth: 0, flex: 1 }}>
-              <h1
-                style={{
-                  margin: 0,
-                  font: `700 28px ${UI}`,
-                  letterSpacing: '-0.01em',
-                  color: C.chalk50,
-                  lineHeight: 1.1,
-                }}
-              >
-                {headline}
-              </h1>
-            </div>
-          </div>
-
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'flex-end',
-              gap: 8,
-              flex: compact ? '1 1 100%' : '0 0 auto',
-            }}
-          >
-            <Button
-              kind="primary"
-              size="lg"
-              iconRight={<ArrowRight size={18} strokeWidth={1.75} />}
-              fullWidth={compact}
-              style={compact ? undefined : { minWidth: 220 }}
-              {...scoringRoute}
-            >
-              Enter final score
-            </Button>
-          </div>
-        </div>
-      </div>
-
-      <button
-        type="button"
-        aria-label="Dismiss"
-        style={{
-          position: 'absolute',
-          top: 12,
-          right: 12,
-          width: 28,
-          height: 28,
-          background: 'transparent',
-          border: 'none',
-          color: C.chalk500,
-          cursor: 'pointer',
-          borderRadius: 6,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <X size={14} strokeWidth={1.75} />
-      </button>
-    </Card>
-  )
-}
-
-// Used when a player has more than one match waiting for their score. Wraps the
-// shared design-system Card with the same "Featured" highlight (orange ring +
-// glow) as the primary ScoreBanner above, just in a compact single-row layout.
-function CompactScoreBanner({ banner }: { banner: DashboardScoreBanner }) {
-  const { accent, opponent, headline, scoringRoute } = scoreBannerView(banner)
-  return (
-    <Card
-      highlight
-      padding="14px 18px"
-      data-testid="dashboard-score-banner-compact"
-      style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 16 }}
-    >
-      <BallDot live color={accent} size={8} />
-      <UserAvatar name={opponent} size={36} ring ringColor={accent} />
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div
-          style={{
-            font: `700 10px ${MONO}`,
-            color: accent,
-            letterSpacing: '0.16em',
-            marginBottom: 2,
-          }}
-        >
-          ALSO PENDING
-        </div>
-        <div
-          style={{
-            font: `600 15px ${UI}`,
-            color: C.chalk50,
-            lineHeight: 1.2,
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {headline}
-        </div>
-      </div>
-      <Button
-        kind="secondary"
-        size="md"
-        iconRight={<ArrowRight size={14} strokeWidth={1.75} />}
-        {...scoringRoute}
-      >
-        Enter score
-      </Button>
-    </Card>
-  )
-}
-
-// 3+ pending: a single quiet link that funnels the rest into /matches,
-// pre-filtered to the current user's live (in-progress) matches so the
-// destination opens straight on the same pile the pill is summarizing.
-function MorePendingLink({
-  count,
-  username,
-}: {
-  count: number
-  username?: string
-}) {
-  return (
-    <Link
-      to="/matches"
-      search={{ q: username, status: 'live' }}
-      data-testid="dashboard-score-banner-more"
-      style={{
-        display: 'inline-flex',
-        alignSelf: 'flex-start',
-        alignItems: 'center',
-        gap: 8,
-        padding: '6px 12px',
-        borderRadius: 999,
-        border: `1px solid ${C.ink500}`,
-        background: 'transparent',
-        font: `500 12px ${UI}`,
-        color: C.chalk300,
-        textDecoration: 'none',
-      }}
-    >
-      <Mono size={12} weight={600} color={C.chalk100}>
-        +{count}
-      </Mono>
-      more pending
-      <ChevronRight size={14} strokeWidth={1.75} />
-    </Link>
-  )
-}
-
-function ScoreBannerStack({
-  banners,
-  username,
-  compact,
-}: {
-  banners: DashboardScoreBanner[]
-  username?: string
-  compact: boolean
-}) {
-  if (banners.length === 0) return null
-  const [primary, secondary, ...rest] = banners
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 12,
-        marginBottom: 32,
-      }}
-    >
-      <ScoreBanner banner={primary} compact={compact} />
-      {secondary && <CompactScoreBanner banner={secondary} />}
-      {rest.length > 0 && (
-        <MorePendingLink count={rest.length} username={username} />
-      )}
     </div>
   )
 }
@@ -1130,6 +851,15 @@ export function DashboardPage() {
       pendingEmail: user.pending_email ?? null,
     }) === 'guest'
   const showGuestPersistBanner = isGuest && (data?.completed_match_count ?? 0) >= 1
+  const attentionView = useMemo(
+    () =>
+      projectAttentionPanelView(
+        data?.attention ?? [],
+        data?.waiting_count ?? 0,
+        username,
+      ),
+    [data?.attention, data?.waiting_count, username],
+  )
   return (
     <div
       style={{
@@ -1148,14 +878,14 @@ export function DashboardPage() {
       )}
       <PageTitle greeting={greeting} compact={compact} />
       {isLoading ? (
-        <SkeletonCard label="Loading score banner" height={140} />
-      ) : data?.score_banners?.length ? (
-        <ScoreBannerStack
-          banners={data.score_banners}
-          username={username}
-          compact={compact}
+        <div style={{ marginBottom: 32 }}>
+          <SkeletonCard label="Loading attention panel" height={160} />
+        </div>
+      ) : (
+        <AttentionPanel
+          view={attentionView}
         />
-      ) : null}
+      )}
       <YourGameRow
         rating={data?.rating ?? null}
         recent={data?.recent_results ?? []}

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -9,12 +9,11 @@ import {
   MOCK_CURRENT_USER,
   mockMatches,
   newMatchSeed,
+  projectDashboardAttention,
   projectListRow,
   projectMatchDetails,
-  projectNextMatch,
   projectRating,
   projectRecentResult,
-  projectScoreBanner,
   statusCountsOf,
   validateScore,
   type SeedMatch,
@@ -764,9 +763,7 @@ export const handlers = [
   // ----- dashboard -------------------------------------------------------
   http.get('*/v1/dashboard', async () => {
     await delay(300)
-    const scoreBanners = mockMatches.map(projectScoreBanner).filter(notNull)
-    const nextMatch =
-      mockMatches.map(projectNextMatch).find(notNull) ?? null
+    const { attention, waiting_count } = projectDashboardAttention(mockMatches)
     // Match the real BFF's participant-filtered COUNT, which doesn't care
     // whether the opponent slot is registered — projectRecentResult drops
     // null-opponent matches from the *display* list, but they still count
@@ -780,8 +777,8 @@ export const handlers = [
       .sort((a, b) => b.completed_at.localeCompare(a.completed_at))
       .slice(0, 5)
     return HttpResponse.json({
-      score_banners: scoreBanners,
-      next_match: nextMatch,
+      attention,
+      waiting_count,
       recent_results: recentResults,
       rating: projectRating(mockMatches),
       completed_match_count: completedMatchCount,

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -11,8 +11,7 @@ type MatchDetailsH2HMeeting = components['schemas']['MatchDetailsH2HMeeting']
 type MatchListRow = components['schemas']['MatchListRow']
 type MatchLeague = components['schemas']['MatchLeague']
 type MatchSignatureView = components['schemas']['MatchSignatureView']
-type DashboardScoreBanner = components['schemas']['DashboardScoreBanner']
-type DashboardNextMatch = components['schemas']['DashboardNextMatch']
+type DashboardAttentionItem = components['schemas']['DashboardAttentionItem']
 type DashboardRecentResult = components['schemas']['DashboardRecentResult']
 type DashboardRating = components['schemas']['DashboardRating']
 type DashboardStreak = components['schemas']['DashboardStreak']
@@ -110,7 +109,7 @@ function sideWinCounts(seed: SeedMatch): { side1: number; side2: number } {
  * game in [1, best_of] is scored / the match isn't in progress. Mirrors the
  * server's ``current_game_number`` derivation in api/app/matches.py. */
 function currentGameNumber(seed: SeedMatch): number | null {
-  if (seed.status !== 'in_progress') return null
+  if (seed.status !== 'in_progress' && seed.status !== 'disputed') return null
   // A posted-but-unconfirmed result locks the scratchpad — no game is
   // "current" in a writable sense until the result is disputed.
   if (seed.signatures.length > 0) return null
@@ -134,9 +133,11 @@ function currentGameNumber(seed: SeedMatch): number | null {
  * result, regardless of whether the board already decides the match. (The mock
  * seeds always carry two sides and view the match as a participant.) */
 function scorableSeed(seed: SeedMatch): boolean {
+  // ``disputed`` is deliberately scorable — a dispute reopens the board for
+  // correction (mirrors the server's ``_TERMINAL_STATUSES``, which no longer
+  // includes disputed).
   return (
     seed.status !== 'completed' &&
-    seed.status !== 'disputed' &&
     seed.status !== 'voided' &&
     seed.signatures.length === 0
   )
@@ -146,7 +147,7 @@ function scorableSeed(seed: SeedMatch): boolean {
  * decided match — i.e. POST /results would succeed against the current
  * scratchpad state. Mirrors the server's ``_can_finalize`` predicate. */
 function canFinalizeSeed(seed: SeedMatch): boolean {
-  if (seed.status !== 'in_progress') return false
+  if (seed.status !== 'in_progress' && seed.status !== 'disputed') return false
   // Once a result is posted, /confirmation or /dispute is the next action,
   // not another /results.
   if (seed.signatures.length > 0) return false
@@ -460,23 +461,79 @@ export function projectListRow(seed: SeedMatch): MatchListRow {
   }
 }
 
-export function projectScoreBanner(seed: SeedMatch): DashboardScoreBanner | null {
-  const nextNumber = currentGameNumber(seed)
-  if (seed.status !== 'in_progress' || nextNumber === null) return null
+// Attention classification — mirrors api/app/dashboard.py (PRD §5). Returns the
+// bucket plus its priority (lower = more urgent) in one pass, or null when the
+// seed isn't an actionable row for the current user (waiting / pending /
+// finished).
+function classifyAttention(
+  seed: SeedMatch,
+): { kind: DashboardAttentionItem['kind']; priority: number } | null {
+  if (seed.status === 'disputed') return { kind: 'dispute', priority: 0 }
+  if (seed.status === 'in_progress' && seed.signatures.length > 0) {
+    const iSigned = seed.signatures.some(
+      (sig) => sig.user_id === MOCK_CURRENT_USER.id,
+    )
+    // Posted by me → waiting on opponent (footer); posted by them → my review.
+    return iSigned ? null : { kind: 'review', priority: 1 }
+  }
+  if (seed.status === 'in_progress') {
+    return { kind: 'score', priority: seed.affects_rating ? 2 : 3 }
+  }
+  return null
+}
+
+/** Classify a single seed into a dashboard attention row, or null when it's
+ * not actionable for the current user (waiting / pending / finished). */
+export function projectAttention(seed: SeedMatch): DashboardAttentionItem | null {
+  const classified = classifyAttention(seed)
+  if (classified === null) return null
   return {
     match_id: seed.id,
     opponent_username: seed.opponent?.username ?? null,
-    current_game_number: nextNumber,
+    kind: classified.kind,
+    affects_rating: seed.affects_rating,
+    current_game_number:
+      classified.kind === 'score' ? currentGameNumber(seed) : null,
   }
 }
 
-export function projectNextMatch(seed: SeedMatch): DashboardNextMatch | null {
-  if (seed.status !== 'pending') return null
+/** Whether a seed is "waiting on others" — a result I posted awaiting the
+ * opponent, or a pending/scheduled match. Footer count only, never a row. */
+export function isWaitingSeed(seed: SeedMatch): boolean {
+  if (seed.status === 'pending') return true
+  return (
+    seed.status === 'in_progress' &&
+    seed.signatures.some((sig) => sig.user_id === MOCK_CURRENT_USER.id)
+  )
+}
+
+/** Build the dashboard attention payload from all seeds, pre-ranked oldest-
+ * first within each priority bucket — mirrors the BFF's `_build_attention`. */
+export function projectDashboardAttention(seeds: SeedMatch[]): {
+  attention: DashboardAttentionItem[]
+  waiting_count: number
+} {
+  const ranked = seeds
+    .map((seed) => ({ seed, classified: classifyAttention(seed) }))
+    .filter(
+      (
+        row,
+      ): row is {
+        seed: SeedMatch
+        classified: { kind: DashboardAttentionItem['kind']; priority: number }
+      } => row.classified !== null,
+    )
+    .sort(
+      (a, b) =>
+        a.classified.priority - b.classified.priority ||
+        a.seed.created_at.localeCompare(b.seed.created_at),
+    )
   return {
-    match_id: seed.id,
-    opponent_username: seed.opponent?.username ?? null,
-    best_of: seed.best_of,
-    created_at: seed.created_at,
+    attention: ranked.flatMap((row) => {
+      const item = projectAttention(row.seed)
+      return item ? [item] : []
+    }),
+    waiting_count: seeds.filter(isWaitingSeed).length,
   }
 }
 
@@ -848,6 +905,9 @@ export function finalizeSeed(
     seed.status = 'completed'
     seed.completed_at = new Date().toISOString()
   } else {
+    // Rated path: (re)open into the sign-off flow. Setting status is
+    // load-bearing when re-posting a disputed match — a no-op otherwise.
+    seed.status = 'in_progress'
     seed.signatures.push({
       user_id: MOCK_CURRENT_USER.id,
       signed_at: new Date().toISOString(),
@@ -874,14 +934,15 @@ export function confirmSeed(seed: SeedMatch, userId: string): string | null {
   return null
 }
 
-/** POST /v1/matches/{id}/dispute: clear every signature; reset side win
- * flags (derived in ``projectSides`` from ``signatures.length``, so just
- * clearing signatures is enough). Returns null on success, or a 409-suitable
- * detail string. */
+/** POST /v1/matches/{id}/dispute: move the seed to ``disputed`` and clear
+ * every signature; reset side win flags (derived in ``projectSides`` from
+ * ``signatures.length``, so just clearing signatures is enough). Returns null
+ * on success, or a 409-suitable detail string. */
 export function disputeSeed(seed: SeedMatch, userId: string): string | null {
   const guard = confirmableGuard(seed, userId)
   if (guard) return guard
   seed.signatures = []
+  seed.status = 'disputed'
   return null
 }
 

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -16,8 +16,7 @@ type MatchListRow = components['schemas']['MatchListRow']
 type MatchListResponse = components['schemas']['MatchListResponse']
 type MatchStatus = components['schemas']['MatchStatus']
 type DashboardResponse = components['schemas']['DashboardResponse']
-type DashboardScoreBanner = components['schemas']['DashboardScoreBanner']
-type DashboardNextMatch = components['schemas']['DashboardNextMatch']
+type DashboardAttentionItem = components['schemas']['DashboardAttentionItem']
 type DashboardRecentResult = components['schemas']['DashboardRecentResult']
 type DashboardRating = components['schemas']['DashboardRating']
 
@@ -291,8 +290,8 @@ export function dashboardResponse(
 ): DashboardResponse {
   const recent_results = overrides.recent_results ?? []
   return {
-    score_banners: [],
-    next_match: null,
+    attention: [],
+    waiting_count: 0,
     recent_results,
     rating: dashboardRating(),
     // Default mirrors the visible list. Override directly to model the
@@ -323,25 +322,15 @@ export function dashboardRating(
   }
 }
 
-export function dashboardScoreBanner(
-  overrides: Partial<DashboardScoreBanner> = {},
-): DashboardScoreBanner {
+export function dashboardAttentionItem(
+  overrides: Partial<DashboardAttentionItem> = {},
+): DashboardAttentionItem {
   return {
     match_id: nextId('m'),
     opponent_username: faker.internet.username().toLowerCase(),
+    kind: 'score',
+    affects_rating: true,
     current_game_number: 1,
-    ...overrides,
-  }
-}
-
-export function dashboardNextMatch(
-  overrides: Partial<DashboardNextMatch> = {},
-): DashboardNextMatch {
-  return {
-    match_id: nextId('m'),
-    opponent_username: faker.internet.username().toLowerCase(),
-    best_of: 5,
-    created_at: ISO,
     ...overrides,
   }
 }


### PR DESCRIPTION
## What

Implements the **"Needs your attention" triage panel** PRD (`docs/prd/needs-your-attention-triage.md` / Obsidian PRD). Replaces the dashboard's score-only banners with a single ranked panel consolidating score-entry, rated-result review, and dispute resolution, plus a footer "waiting on others" count and a `View all` link.

## Backend (BFF)
- **New current-user-aware attention classifier** on `GET /v1/dashboard` (`_build_attention`): ranks open matches `dispute (0) > review (1) > rated score (2) > unrated score (3)`, oldest-first within a bucket. Poster vs. reviewer of the same posted result classify differently — poster → `waiting_count`, reviewer → `review` row. Pending + self-posted results feed `waiting_count` only.
- Replaced `score_banners`/`next_match` on `DashboardResponse` with `attention: DashboardAttentionItem[]` + `waiting_count`; dropped the never-rendered `next_match`.
- **Dispute now sets `MatchStatus.disputed`** (removed from `_TERMINAL_STATUSES`); `current_game_number` / `_can_finalize` accept disputed, and re-posting flips it back to `in_progress` — so a reopened match is unambiguous to the classifier (PRD O2).
- Regenerated `web-client/src/api/schema.d.ts`.

## Frontend
- New colocated **quartet + pure projection** under `components/dashboard/`: `attention-panel` + `attention-panel-view` (3-row cap, overflow/waiting counts, primary button derived from the top *visible* bucket, routing — score → scoring page, review/dispute → match detail).
- Wired into `dashboard-page.tsx`; deleted the old `ScoreBanner` stack. Panel always renders a calm empty state.
- Mirrored the dispute-status + classifier changes in the MSW mock store, factories, and handlers.

## Out of scope (deferred per PRD §7)
Matches-list current-user-aware labels / `Attention` filter and match-detail review/dispute UX. `View all` routes to the standard list. The matches-list `disputed→final` tab tone is intentionally left for that phase.

### Deviation worth noting
The `Resolve dispute` row routes to **match detail** (not the scoring page the PRD illustrates) — a disputed-but-decided board has no "next game" to deep-link, and match detail is where the user picks the contested game to correct. P0-3's pinned ACs (`Enter score`→scoring, `Review result`→match detail) are unaffected.

## Testing
- **api**: ruff + `ruff format --check` + `mypy --strict` clean; **381 pytest pass**
- **web-client**: lint + build clean; **648 vitest pass**; **127 Playwright e2e pass**
- **OpenAPI**: schema.d.ts regenerated, deterministic, no drift
- **root e2e**: both dashboard specs pass; `admin-system-health` fails on a pre-existing cold-start race in the harness (warm stack reports all deps healthy) — unrelated to this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)