### PR TITLE
Reword scoreboard outcome copy for grammar + a11y (#471)

### DIFF
--- a/web-client/e2e/matches/match-details.spec.ts
+++ b/web-client/e2e/matches/match-details.spec.ts
@@ -101,7 +101,7 @@ test.describe('Match Details', () => {
         test('names the hero region with the decided-match outcome', async ({ page }) => {
             await matchDetailsPage.mock(decidedMatch(COMPLETED_WIN_ID));
             await matchDetailsPage.goTo(COMPLETED_WIN_ID);
-            await expect(page.getByRole('region', { name: 'rita.kovac defeated silva.r, 3 games to 1' })).toBeVisible();
+            await expect(page.getByRole('region', { name: 'rita.kovac defeated silva.r by 3 games to 1' })).toBeVisible();
         });
 
         // Regression test for #472: the current user's row renders its cells

--- a/web-client/src/components/matches/match-details.test.tsx
+++ b/web-client/src/components/matches/match-details.test.tsx
@@ -105,12 +105,12 @@ describe("MatchDetails — scoreboard seam", () => {
     // an accessible name the old bare <section className="md-hero"> never had.
     await waitFor(() =>
       expect(matchDetailsPage.scoreboard.getHeading()).toHaveTextContent(
-        "me defeated nguyen.t, 3 games to 1",
+        "me defeated nguyen.t by 3 games to 1",
       ),
     );
     expect(
       matchDetailsPage.scoreboard.getRegion(),
-    ).toHaveAccessibleName("me defeated nguyen.t, 3 games to 1");
+    ).toHaveAccessibleName("me defeated nguyen.t by 3 games to 1");
   });
 
   it("renders the hero content inside that region", async () => {

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.test.tsx
@@ -53,7 +53,7 @@ describe("ScoreboardFetcher", () => {
 
     await waitForElementToBeRemoved(scoreboardFetcherPage.queryLoading());
     expect(scoreboardFetcherPage.getHeading()).toHaveTextContent(
-      "rita.kovac defeated leo.mertens, 3 games to 1",
+      "rita.kovac defeated leo.mertens by 3 games to 1",
     );
     // The region is labelled by that heading — the full display handoff.
     expect(scoreboardFetcherPage.getRegion()).toHaveAttribute(

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display.factory.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display.factory.tsx
@@ -25,7 +25,7 @@ export function buildScoreboardDisplayProps(
 ): ScoreboardDisplayProps {
   return {
     scoreboard: buildScoreboardView({
-      outcome: "rita.kovac leading, 2 games to 1",
+      outcome: "rita.kovac leads by 2 games to 1",
     }),
     ...overrides,
   };

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display.test.tsx
@@ -15,13 +15,13 @@ describe("ScoreboardDisplay", () => {
   it("names the heading with the outcome when one is provided", () => {
     scoreboardDisplayPage.render({
       scoreboard: buildScoreboardView({
-        outcome: "rita.kovac defeated leo.mertens, 3 games to 1",
+        outcome: "rita.kovac defeated leo.mertens by 3 games to 1",
       }),
     });
 
     const heading = scoreboardDisplayPage.getHeading();
     expect(heading).toHaveTextContent(
-      "rita.kovac defeated leo.mertens, 3 games to 1",
+      "rita.kovac defeated leo.mertens by 3 games to 1",
     );
     expect(heading).toHaveClass("sr-only");
   });

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.test.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.test.ts
@@ -40,7 +40,7 @@ describe("scoreboardQuery", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.outcome).toBe(
-      "rita.kovac defeated leo.mertens, 3 games to 1",
+      "rita.kovac defeated leo.mertens by 3 games to 1",
     );
   });
 
@@ -69,7 +69,7 @@ describe("scoreboardQuery", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.outcome).toBe(
-      "rita.kovac defeated leo.mertens, 1 game to 0",
+      "rita.kovac defeated leo.mertens by 1 game to 0",
     );
   });
 
@@ -226,7 +226,7 @@ describe("scoreboardQuery", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.outcome).toBe(
-      "rita.kovac and leo.mertens are tied, 2 games all",
+      "rita.kovac and leo.mertens are tied at 2 games apiece",
     );
   });
 
@@ -252,7 +252,7 @@ describe("scoreboardQuery", () => {
     const { result } = scoreboardQueryPage.render();
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data?.outcome).toBe("leo.mertens leading, 2 games to 1");
+    expect(result.current.data?.outcome).toBe("leo.mertens leads by 2 games to 1");
   });
 
   it("treats a side still on zero as leading, not unstarted, when the other has won games", async () => {
@@ -277,7 +277,7 @@ describe("scoreboardQuery", () => {
     const { result } = scoreboardQueryPage.render();
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data?.outcome).toBe("leo.mertens leading, 2 games to 0");
+    expect(result.current.data?.outcome).toBe("leo.mertens leads by 2 games to 0");
   });
 
   it("falls back to in-progress copy when one side is won but the other is not yet lost", async () => {
@@ -304,7 +304,7 @@ describe("scoreboardQuery", () => {
     const { result } = scoreboardQueryPage.render();
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data?.outcome).toBe("rita.kovac leading, 3 games to 1");
+    expect(result.current.data?.outcome).toBe("rita.kovac leads by 3 games to 1");
   });
 
   it("returns a null outcome when a side is missing entirely", async () => {
@@ -377,7 +377,7 @@ describe("scoreboardQuery", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     // No side `won: true`, so it is not "defeated" — just the current lead.
-    expect(result.current.data?.outcome).toBe("rita.kovac leading, 1 game to 0");
+    expect(result.current.data?.outcome).toBe("rita.kovac leads by 1 game to 0");
   });
 
   it("surfaces an error when data.scoreboard.status fails validation", async () => {

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.ts
@@ -112,7 +112,7 @@ const selectOutcome = (match: MatchDetailsResult): string | null => {
   const winner = sides.find((s) => s.won === true);
   const loser = sides.find((s) => s.won === false);
   if (winner?.players[0] && loser?.players[0]) {
-    return `${winner.players[0].username} defeated ${loser.players[0].username}, ${games(winner.games_won)} to ${loser.games_won}`;
+    return `${winner.players[0].username} defeated ${loser.players[0].username} by ${games(winner.games_won)} to ${loser.games_won}`;
   }
 
   // Still in progress: describe the current state from games won. Needs both
@@ -127,12 +127,12 @@ const selectOutcome = (match: MatchDetailsResult): string | null => {
   }
 
   if (side1.games_won === side2.games_won) {
-    return `${side1.players[0].username} and ${side2.players[0].username} are tied, ${games(side1.games_won)} all`;
+    return `${side1.players[0].username} and ${side2.players[0].username} are tied at ${games(side1.games_won)} apiece`;
   }
 
   const [leader, trailer] =
     side1.games_won > side2.games_won ? [side1, side2] : [side2, side1];
-  return `${leader.players[0].username} leading, ${games(leader.games_won)} to ${trailer.games_won}`;
+  return `${leader.players[0].username} leads by ${games(leader.games_won)} to ${trailer.games_won}`;
 };
 
 const selectChip = (


### PR DESCRIPTION
Closes #471.

The scoreboard hero's outcome string is rendered as the hero region's accessible name **and** an sr-only `<h2>`, so screen readers announce the whole string. The old wording (`X defeated Y, 3 games to 1`) joined a full clause to a bare score phrase with a comma splice.

Reworded all three cases consistently in the "games to" register, dropping the comma:

| case | before | after |
|------|--------|-------|
| decided | `X defeated Y, 3 games to 1` | `X defeated Y by 3 games to 1` |
| tied | `X and Y are tied, 2 games all` | `X and Y are tied at 2 games apiece` |
| leading | `X leading, 2 games to 1` | `X leads by 2 games to 1` |

Source: `scoreboard-query.ts`. Updated every test/fixture asserting these strings (query/display/fetcher unit tests, factories, the match-details hero accessible-name test, and the root e2e region-name assertion).

Surfacing/accessible-name copy only — no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)