### PR TITLE
Login: friendly guidance for a rate-limited (429) sign-in (#444)

### DIFF
--- a/web-client/src/routes/login.index.tsx
+++ b/web-client/src/routes/login.index.tsx
@@ -72,6 +72,14 @@ function LoginPage() {
               })
               return
             }
+            if (err.status === 429) {
+              // The API's bare "Too Many Requests" detail is no guidance, so
+              // give the user a concrete what-now instead of echoing it.
+              setServerError(
+                'Too many sign-in attempts. Wait a minute, then try again.',
+              )
+              return
+            }
             setServerError(err.detail ?? 'Something went wrong. Try again.')
             return
           }

--- a/web-client/src/routes/login.test.tsx
+++ b/web-client/src/routes/login.test.tsx
@@ -180,6 +180,26 @@ describe('/login flow', () => {
       await screen.findByRole('heading', { name: /couldn.t send/i }),
     ).toBeInTheDocument()
   })
+
+  it('shows friendly guidance instead of the bare "Too Many Requests" on a 429', async () => {
+    server.use(
+      http.post('*/v1/login/request', () =>
+        HttpResponse.json({ detail: 'Too Many Requests' }, { status: 429 }),
+      ),
+    )
+    const user = userEvent.setup()
+    const { router } = renderAt('/login')
+
+    const input = await screen.findByLabelText('Email address')
+    await user.type(input, 'rita@example.com')
+    await user.click(screen.getByRole('button', { name: /send the link/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /too many sign-in attempts.*wait a minute/i,
+    )
+    expect(screen.queryByText(/too many requests/i)).not.toBeInTheDocument()
+    expect(router.state.location.pathname).toBe('/login')
+  })
 })
 
 describe('/login/verifying flow', () => {


### PR DESCRIPTION
Closes #444.

Hitting the login rate limit returned a 429 whose `detail` ("Too Many Requests") was shown verbatim as the inline error — no guidance, no retry hint.

Special-case `429` in the `/login` submit handler to show a concrete message instead of echoing the bare API detail:

> Too many sign-in attempts. Wait a minute, then try again.

All other 4xx still surface `err.detail`; 5xx/network still route to the send-failed screen. Added a vitest covering the 429 path (asserts the friendly copy shows, the bare "Too Many Requests" does not, and the user stays on `/login`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)