### PR TITLE
/login/verifying: distinct state for a missing link token (#438)

### DIFF
--- a/web-client/src/components/login/link-check-page/link-check-page.test.tsx
+++ b/web-client/src/components/login/link-check-page/link-check-page.test.tsx
@@ -54,6 +54,25 @@ describe('LinkCheckPage', () => {
     expect(linkCheckPage.text()).not.toMatch(TOKEN_PATTERN)
   })
 
+  it('missing: distinct incomplete-link copy, not the expired wording, with support escape hatch', () => {
+    linkCheckPage.render({
+      state: 'missing',
+      footer: <a href="/login">Send a new link</a>,
+    })
+
+    expect(linkCheckPage.state()).toBe('missing')
+    expect(linkCheckPage.heading()).toHaveTextContent(/this link is incomplete/i)
+    expect(linkCheckPage.text()).toMatch(/missing its token/i)
+    expect(linkCheckPage.text()).not.toMatch(/can’t be used|can't be used/i)
+    expect(
+      linkCheckPage
+        .within()
+        .root()
+        ?.querySelector('a[href="mailto:support@fortymm.com"]'),
+    ).toBeTruthy()
+    expect(linkCheckPage.text()).not.toMatch(TOKEN_PATTERN)
+  })
+
   it('lets the route override the default copy', () => {
     linkCheckPage.render({
       state: 'checking',

--- a/web-client/src/components/login/link-check-page/link-check-page.tsx
+++ b/web-client/src/components/login/link-check-page/link-check-page.tsx
@@ -3,18 +3,29 @@ import type { ReactNode } from 'react'
 import { BallLogo, Eyebrow } from '../atoms'
 import { fineprint, linkInline } from '../styles'
 
-export type LinkCheckState = 'checking' | 'success' | 'expired'
+export type LinkCheckState = 'checking' | 'success' | 'expired' | 'missing'
 
 const ACCENT: Record<LinkCheckState, string> = {
   checking: 'var(--ball-500)',
   success: 'var(--serve-500)',
   expired: 'var(--loss)',
+  missing: 'var(--loss)',
 }
 
 const HALO: Record<LinkCheckState, string> = {
   checking: 'rgba(255,122,26,0.20)',
   success: 'rgba(0,226,154,0.16)',
   expired: 'rgba(255,77,109,0.14)',
+  missing: 'rgba(255,77,109,0.14)',
+}
+
+// The short code shown in the header pill. Distinct per failure so a missing
+// link doesn't read identically to an expired one.
+const PILL_CODE: Record<LinkCheckState, string> = {
+  checking: '03',
+  success: '03',
+  expired: '!!',
+  missing: '??',
 }
 
 const DEFAULT_COPY: Record<
@@ -39,6 +50,14 @@ const DEFAULT_COPY: Record<
     title: "This link can't be used",
     subtitle:
       'Sign-in links last 15 minutes and work once. Send a fresh one and you’ll be straight in.',
+  },
+  missing: {
+    eyebrow: '● Link incomplete',
+    // Distinct from `expired`: the link arrived without its token at all
+    // (often truncated when copied), so "expired or already used" is wrong.
+    title: 'This link is incomplete',
+    subtitle:
+      'This sign-in link is missing its token — it may have been cut off when it was copied. Open the most recent link in full, or send yourself a fresh one.',
   },
 }
 
@@ -90,7 +109,7 @@ export function LinkCheckPage({
       <header className="fmm-linkcheck__header">
         <BallLogo size={22} />
         <span className="fmm-linkcheck__pill" style={{ color: accent }}>
-          {state === 'expired' ? '!!' : '03'} · LINK
+          {PILL_CODE[state]} · LINK
         </span>
       </header>
 
@@ -118,7 +137,7 @@ export function LinkCheckPage({
             Keep this tab open while we verify.
           </p>
         )}
-        {state === 'expired' && (
+        {(state === 'expired' || state === 'missing') && (
           <p style={{ ...fineprint, textAlign: 'center', marginTop: 0 }}>
             Still stuck?{' '}
             <a href="mailto:support@fortymm.com" style={linkInline}>

--- a/web-client/src/routes/login.test.tsx
+++ b/web-client/src/routes/login.test.tsx
@@ -223,14 +223,16 @@ describe('/login/verifying flow', () => {
     ).toBeInTheDocument()
   })
 
-  it('shows the missing-token screen when no token is supplied', async () => {
+  it('shows a distinct missing-link screen (not "expired") when no token is supplied', async () => {
     renderAt('/login/verifying')
     expect(
-      await screen.findByRole('heading', { name: /this link can't be used/i }),
+      await screen.findByRole('heading', { name: /this link is incomplete/i }),
     ).toBeInTheDocument()
+    expect(screen.getByText(/missing its token/i)).toBeInTheDocument()
+    // It must not reuse the expired/already-used wording.
     expect(
-      screen.getByText(/this link is missing its token/i),
-    ).toBeInTheDocument()
+      screen.queryByRole('heading', { name: /this link can't be used/i }),
+    ).not.toBeInTheDocument()
   })
 
   it('toasts the merged-matches count when consume reports a merge', async () => {

--- a/web-client/src/routes/login.verifying.tsx
+++ b/web-client/src/routes/login.verifying.tsx
@@ -103,13 +103,7 @@ function LoginVerifyingPage() {
   )
 
   if (!token && !error) {
-    return (
-      <LinkCheckPage
-        state="expired"
-        detail="This link is missing its token."
-        footer={sendNewLinkButton}
-      />
-    )
+    return <LinkCheckPage state="missing" footer={sendNewLinkButton} />
   }
 
   if (error === 'expired') {


### PR DESCRIPTION
Closes #438.

Loading `/login/verifying` with **no** token rendered the `expired` state — "This link can't be used" / "expired or already used", `!!` pill code — with only an overridden detail line hinting at the real cause. An absent token is a different failure from an expired/used one and deserves its own message.

Added a dedicated `missing` `LinkCheckState`:
- **Headline:** "This link is incomplete"
- **Copy:** explains the token was likely cut off when copied; open the full link or send a fresh one
- **Pill code:** `??` (vs `!!` for expired)
- Keeps the "Email support" escape hatch and the err disc

The no-token branch in `login.verifying.tsx` now renders `state="missing"`.

Tests: new `missing`-state unit test in `link-check-page.test.tsx` (distinct copy, not the expired wording, support link present, no token leak); updated the verifying-flow test to assert the new screen and that it no longer reuses the "can't be used" headline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)