### PR TITLE
Login: make "Resend" re-issue the link in place (#519)

### DIFF
--- a/web-client/src/routes/login.sent.tsx
+++ b/web-client/src/routes/login.sent.tsx
@@ -1,6 +1,9 @@
+import { useRef, useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
+import { useRequestLogin } from '@/api/session'
 import { ScreenSent, ScreenSentBounced } from '@/components/login/login-screens'
+import { Turnstile, type TurnstileHandle } from '@/components/turnstile'
 import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute('/login/sent')({
@@ -18,27 +21,85 @@ export const Route = createFileRoute('/login/sent')({
 function LoginSentPage() {
   const { error, email, sentAt } = Route.useSearch()
   const navigate = useNavigate()
+  const requestLogin = useRequestLogin()
+  // A fresh captcha token is kept on this page (the Turnstile widget below
+  // hands one over and replaces it after each use) so "Resend" can re-issue
+  // the link without bouncing through /login to re-run the challenge.
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null)
+  const [resendMessage, setResendMessage] = useState<string | null>(null)
+  const captchaRef = useRef<TurnstileHandle | null>(null)
+  const inFlight = useRef(false)
 
-  // Both "resend" and "start over" route back to /login with the email
-  // prefilled. The captcha can't replay across page loads, so we have to
-  // get the user through the challenge again to send a new link.
-  const back = () => {
+  // "Start over" (and bounce recovery) goes back to /login with the email
+  // prefilled to re-run the whole flow from scratch.
+  const startOver = () => {
     navigate({
       to: '/login',
       search: { email: email || undefined, error: undefined },
     })
   }
 
+  // "Resend" re-issues the link in place: POST a new request with the held
+  // captcha token, reset the expiry countdown (a new sentAt), and reset the
+  // widget so the next resend gets a fresh token. A captcha/network failure
+  // falls back to the full /login flow rather than stranding the user here.
+  const resend = () => {
+    if (inFlight.current || !email || !captchaToken) return
+    inFlight.current = true
+    setResendMessage(null)
+    requestLogin.mutate(
+      { email, captchaToken },
+      {
+        onSuccess: () => {
+          setResendMessage('New link sent — check your inbox.')
+          navigate({
+            to: '/login/sent',
+            replace: true,
+            search: { email, sentAt: Date.now(), error: undefined },
+          })
+        },
+        onError: () => startOver(),
+        onSettled: () => {
+          inFlight.current = false
+          // Turnstile tokens are single-use; drop the spent one and ask the
+          // widget for a fresh one for any subsequent resend.
+          setCaptchaToken(null)
+          captchaRef.current?.reset()
+        },
+      },
+    )
+  }
+
   if (error === 'bounce') {
-    return <ScreenSentBounced email={email} onChangeEmail={back} onRetry={back} />
+    return (
+      <ScreenSentBounced
+        email={email}
+        onChangeEmail={startOver}
+        onRetry={startOver}
+      />
+    )
   }
 
   return (
-    <ScreenSent
-      email={email || 'your inbox'}
-      sentAt={sentAt}
-      onStartOver={back}
-      onResend={back}
-    />
+    <>
+      <ScreenSent
+        email={email || 'your inbox'}
+        sentAt={sentAt}
+        onStartOver={startOver}
+        // Disabled until a captcha token is in hand (and there's an address to
+        // send to); the button shows the disabled state in the meantime.
+        onResend={email && captchaToken ? resend : undefined}
+        resending={requestLogin.isPending}
+        resendMessage={resendMessage}
+      />
+      <Turnstile
+        handleRef={(h) => {
+          captchaRef.current = h
+        }}
+        onToken={setCaptchaToken}
+        onExpire={() => setCaptchaToken(null)}
+        onError={() => setCaptchaToken(null)}
+      />
+    </>
   )
 }

--- a/web-client/src/routes/login.test.tsx
+++ b/web-client/src/routes/login.test.tsx
@@ -182,6 +182,48 @@ describe('/login flow', () => {
   })
 })
 
+describe('/login/sent flow', () => {
+  it('"Resend" re-issues the link in place and resets the countdown (#519)', async () => {
+    let requests = 0
+    server.use(
+      http.post('*/v1/login/request', async ({ request }) => {
+        requests += 1
+        const body = (await request.json()) as { email: string }
+        return HttpResponse.json({ email: body.email }, { status: 202 })
+      }),
+    )
+    const user = userEvent.setup()
+    const { router } = renderAt('/login/sent?email=rita@example.com&sentAt=1000')
+
+    // The hidden Turnstile hands over a token on mount, enabling Resend.
+    const resendBtn = await screen.findByRole('button', { name: /^resend$/i })
+    await waitFor(() => expect(resendBtn).toBeEnabled())
+    await user.click(resendBtn)
+
+    await waitFor(() => expect(requests).toBe(1))
+    // Stays on the sent page (does NOT route back to /login like Start over).
+    expect(router.state.location.pathname).toBe('/login/sent')
+    // Fresh send time → the expiry countdown restarts.
+    expect(router.state.location.search.sentAt).not.toBe(1000)
+    expect(await screen.findByText(/new link sent/i)).toBeInTheDocument()
+  })
+
+  it('"Start over" routes back to /login with the email prefilled', async () => {
+    const user = userEvent.setup()
+    const { router } = renderAt('/login/sent?email=rita@example.com&sentAt=1000')
+
+    const [startOver] = await screen.findAllByRole('button', {
+      name: /start over/i,
+    })
+    await user.click(startOver)
+
+    await waitFor(() => expect(router.state.location.pathname).toBe('/login'))
+    expect(router.state.location.search).toMatchObject({
+      email: 'rita@example.com',
+    })
+  })
+})
+
 describe('/login/verifying flow', () => {
   it('consumes the token and routes to /login/welcome on success', async () => {
     const { router } = renderAt('/login/verifying?token=good-token')


### PR DESCRIPTION
Closes #519.

On `/login/sent`, **Resend** and **Start over** both called the same `back()` — routing to `/login?email=…`, firing no new `POST /v1/login/request`, and dropping the live expiry countdown. So "Resend" was identical to "Start over" despite its distinct label and the "hit resend, we don't mind" helper copy. The captcha-can't-replay comment was the original reason, but `ScreenSent` already carries `resending`/`resendMessage` plumbing that was never connected — the in-place resend was the intended design.

This wires it up:
- Hosts a `Turnstile` widget on `/login/sent` (`appearance: 'interaction-only'`, so invisible unless a challenge is actually needed) that keeps a fresh captcha token in hand.
- **Resend** POSTs a new request with that token, sets a confirmation message, and re-navigates to `/login/sent` with a fresh `sentAt` so the countdown restarts — all without leaving the page.
- After each send the spent (single-use) token is dropped and the widget reset for the next resend.
- A captcha/network failure falls back to the full `/login` flow rather than stranding the user.
- **Start over** still routes back to `/login` with the email prefilled.

Tests: new `/login/sent` describe block — Resend fires exactly one request, stays on `/login/sent`, restarts the countdown (new `sentAt`), and shows the confirmation; Start over routes back to `/login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)