### PR TITLE
list_recent_opponents: stable tiebreaker on recency ORDER BY

### DIFF
--- a/api/app/players.py
+++ b/api/app/players.py
@@ -119,7 +119,11 @@ async def list_recent_opponents(
                 )
                 .where(User.id != current_user.id)
                 .group_by(User.id)
-                .order_by(func.max(Match.created_at).desc())
+                # Stable tiebreaker so ties on created_at (seed data, tests,
+                # concurrent creates) don't reorder across requests. Matches
+                # the alphabetical backfill below, so the list reads as one
+                # coherent order.
+                .order_by(func.max(Match.created_at).desc(), User.username)
                 .limit(limit)
             )
         )

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -80,6 +80,25 @@ async def test_recent_opponents_orders_by_most_recent_match(
     assert _usernames(response) == ["bo", "cy", "ana"]
 
 
+async def test_recent_opponents_breaks_recency_ties_alphabetically(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await start_session(api_client, db_session)
+    # Inserted out of alphabetical order, all sharing one timestamp, so a
+    # missing tiebreaker would let Postgres return them in any order.
+    cy = await make_user(db_session, "cy")
+    ana = await make_user(db_session, "ana")
+    bo = await make_user(db_session, "bo")
+
+    await _record_match(db_session, me, cy, created_at=BASE_TIME)
+    await _record_match(db_session, me, ana, created_at=BASE_TIME)
+    await _record_match(db_session, me, bo, created_at=BASE_TIME)
+
+    response = await api_client.get("/v1/players/recent")
+    assert response.status_code == 200
+    assert _usernames(response) == ["ana", "bo", "cy"]
+
+
 async def test_recent_opponents_dedupes_repeated_opponents(
     api_client: AsyncClient, db_session: AsyncSession
 ):


### PR DESCRIPTION
Fixes #103.

## Problem
`list_recent_opponents` ordered only by `func.max(Match.created_at).desc()`. When two opponents share a `created_at` (seed data, tests with identical timestamps, high-concurrency match creation), Postgres returns them in arbitrary order — the picker grid reorders across reloads and tests are flake-prone.

## Fix
Add `User.username` as a stable secondary sort key. It matches the alphabetical backfill below it, so a single recent opponent followed by backfill reads as one coherent order.

## Test
New `test_recent_opponents_breaks_recency_ties_alphabetically` records three matches with identical timestamps (users inserted out of order) and asserts alphabetical ordering. Verified it fails without the tiebreaker and passes with it. Full `test_players.py` suite (36 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)