### PR TITLE
iOS dashboard: port the "Needs your attention" triage panel

### DIFF
--- a/ios/Fortymm/Dashboard/DashboardAttentionPanel.swift
+++ b/ios/Fortymm/Dashboard/DashboardAttentionPanel.swift
@@ -1,0 +1,215 @@
+import SwiftUI
+
+// MARK: - View model
+
+/// Where an attention row's button takes the user. Mirrors the web view-model's
+/// `routeOf`: a `score` row with a known game deep-links into scoring; every
+/// other row (review/dispute, or a decided-but-unposted board) goes to match
+/// detail, which holds the confirm/dispute/post-result actions.
+enum AttentionTarget: Equatable {
+    case scoring(gameNumber: Int)
+    case detail
+}
+
+/// One projected row of the "Needs your attention" panel — ready to render and
+/// route, with all ranking/labels/targets decided by `projectAttentionPanel`.
+struct AttentionRowView: Identifiable {
+    let matchId: UUID
+    /// Avatar/headline seed — nil renders the "No opponent" placeholder.
+    let opponentUsername: String?
+    /// Row headline, e.g. `vs nguyen.t` or `No opponent`.
+    let headline: String
+    /// Button copy: `Resolve dispute` | `Review result` | `Enter score`.
+    let actionLabel: String
+    /// Whether this row takes the primary (filled) button — true for every row
+    /// in the highest-priority bucket currently visible.
+    let primary: Bool
+    let target: AttentionTarget
+
+    var id: UUID { matchId }
+}
+
+/// The projected panel: the (≤3) rows to render plus the footer counts.
+struct AttentionPanelView {
+    let rows: [AttentionRowView]
+    /// Actionable items beyond the visible 3 — footer "N more need attention".
+    let overflowCount: Int
+    /// Matches waiting on someone else — footer "N waiting on others".
+    let waitingCount: Int
+}
+
+/// The panel never grows unbounded — show the top 3 rows, roll the rest into
+/// the footer (mirrors the web's `ATTENTION_VISIBLE_LIMIT`).
+private let attentionVisibleLimit = 3
+
+private let noOpponentLabel = "No opponent"
+
+// A row's attention "bucket" — the unit the primary-button rule operates on
+// (score rows split rated vs unrated; review/dispute are each their own
+// bucket). The priority *ordering* is the server's job: items arrive
+// pre-sorted, so the first visible row is the highest-priority bucket present,
+// and every row sharing its bucket takes the primary button.
+private func bucketKey(_ item: DashboardAttentionItem) -> String {
+    item.kind == .score ? "score-\(item.affectsRating)" : item.kind.rawValue
+}
+
+private func actionLabel(_ kind: AttentionKind) -> String {
+    switch kind {
+    case .dispute: return "Resolve dispute"
+    case .review: return "Review result"
+    case .score: return "Enter score"
+    case .unknown: return "View match"
+    }
+}
+
+private func target(_ item: DashboardAttentionItem) -> AttentionTarget {
+    if item.kind == .score, let game = item.currentGameNumber {
+        return .scoring(gameNumber: game)
+    }
+    return .detail
+}
+
+/// Project the BFF's pre-ranked attention items into the panel's view model:
+/// cap visible rows at 3, compute the footer counts, and mark the
+/// highest-priority *visible* bucket as primary (so a `Review result` beneath a
+/// `Resolve dispute` renders secondary). Items arrive already sorted by the
+/// server, so their order is preserved as-is. Mirrors the web's
+/// `projectAttentionPanelView`.
+func projectAttentionPanel(
+    items: [DashboardAttentionItem],
+    waitingCount: Int
+) -> AttentionPanelView {
+    let visible = Array(items.prefix(attentionVisibleLimit))
+    let topBucket = visible.first.map(bucketKey) ?? ""
+    return AttentionPanelView(
+        rows: visible.map { item in
+            AttentionRowView(
+                matchId: item.matchId,
+                opponentUsername: item.opponentUsername,
+                headline: item.opponentUsername.map { "vs \($0)" } ?? noOpponentLabel,
+                actionLabel: actionLabel(item.kind),
+                primary: bucketKey(item) == topBucket,
+                target: target(item)
+            )
+        },
+        overflowCount: max(0, items.count - attentionVisibleLimit),
+        waitingCount: waitingCount
+    )
+}
+
+// MARK: - View
+
+/// The dashboard's "Needs your attention" triage panel: up to three
+/// priority-ordered, action-only rows (avatar · `vs @opponent` · one button)
+/// plus a footer summarizing overflow + waiting counts and a "View all" link.
+/// Pure view-in — all ranking/labels/targets are decided by
+/// `projectAttentionPanel`. Buttons only route; they never finalize a result.
+/// Renders a calm empty state rather than disappearing when nothing is
+/// actionable. Mirrors the web dashboard's `AttentionPanel`.
+struct DashboardAttentionPanel: View {
+    let view: AttentionPanelView
+    /// Run the row's action — fetch the match and open scoring or detail.
+    let onAct: (AttentionRowView) -> Void
+    /// Footer "View all" — send the user to the Matches tab.
+    let onViewAll: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Needs your attention")
+                .font(FMFont.ui(FMFont.md, weight: .semibold))
+                .foregroundStyle(FMColor.fg1)
+                .padding(.horizontal, FMSpace.s4)
+                .padding(.top, FMSpace.s4)
+                .padding(.bottom, FMSpace.s3)
+
+            Rectangle().fill(FMColor.ink700).frame(height: 1)
+
+            if view.rows.isEmpty {
+                Text("You're all caught up.")
+                    .font(FMFont.ui(FMFont.sm))
+                    .foregroundStyle(FMColor.fg3)
+                    .padding(FMSpace.s4)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                ForEach(Array(view.rows.enumerated()), id: \.element.id) { i, row in
+                    if i > 0 { Rectangle().fill(FMColor.ink700).frame(height: 1) }
+                    AttentionRow(row: row) { onAct(row) }
+                }
+            }
+
+            Rectangle().fill(FMColor.ink700).frame(height: 1)
+            footer
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(FMColor.bgCard)
+        .fmRoundedBorder(radius: FMRadius.lg, color: FMColor.borderSubtle)
+    }
+
+    private var footer: some View {
+        HStack(spacing: FMSpace.s2) {
+            ForEach(footerParts, id: \.self) { part in
+                Text("\(part) ·")
+                    .font(FMFont.ui(FMFont.sm))
+                    .foregroundStyle(FMColor.fgMuted)
+            }
+            Button(action: onViewAll) {
+                Text("View all")
+                    .font(FMFont.ui(FMFont.sm, weight: .medium))
+                    .foregroundStyle(FMColor.fg3)
+            }
+            .buttonStyle(.plain)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, FMSpace.s4)
+        .padding(.vertical, FMSpace.s3)
+    }
+
+    private var footerParts: [String] {
+        var parts: [String] = []
+        if view.overflowCount > 0 {
+            let verb = view.overflowCount == 1 ? "needs" : "need"
+            parts.append("\(view.overflowCount) more \(verb) attention")
+        }
+        if view.waitingCount > 0 {
+            parts.append("\(view.waitingCount) waiting on others")
+        }
+        return parts
+    }
+}
+
+/// One actionable row: avatar · headline · the single routing button.
+private struct AttentionRow: View {
+    let row: AttentionRowView
+    let onAct: () -> Void
+
+    var body: some View {
+        HStack(spacing: FMSpace.s3) {
+            FMAvatar(
+                initials: (row.opponentUsername ?? "?").fmInitials,
+                size: 40,
+                color: avatarColor,
+                foreground: FMColor.fg1
+            )
+            Text(row.headline)
+                .font(FMFont.ui(FMFont.base, weight: .semibold))
+                .foregroundStyle(row.opponentUsername == nil ? FMColor.fgMuted : FMColor.fg1)
+                .italic(row.opponentUsername == nil)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            FMButton(
+                title: row.actionLabel,
+                variant: row.primary ? .primary : .outline,
+                size: .sm,
+                action: onAct
+            )
+        }
+        .padding(.horizontal, FMSpace.s4)
+        .padding(.vertical, FMSpace.s3)
+    }
+
+    private var avatarColor: Color {
+        guard let opponent = row.opponentUsername else { return FMColor.ink600 }
+        return MatchPlayer.avatarColor(for: opponent).color
+    }
+}

--- a/ios/Fortymm/Dashboard/DashboardModels.swift
+++ b/ios/Fortymm/Dashboard/DashboardModels.swift
@@ -5,24 +5,52 @@ import Foundation
 /// `.convertFromSnakeCase`, so `recent_results` / `spark_data` / `my_rating_change`
 /// arrive as `recentResults` / `sparkData` / `myRatingChange`.
 struct DashboardResponse: Decodable {
-    let scoreBanners: [DashboardScoreBanner]
-    let nextMatch: DashboardNextMatch?
+    /// Every actionable match for the current user, pre-ranked server-side by
+    /// attention priority (see `api/app/dashboard.py`). The UI renders the top
+    /// few as rows and rolls the remainder into the footer's overflow count.
+    let attention: [DashboardAttentionItem]
+    /// Matches that need *someone else's* move — a result we posted awaiting the
+    /// opponent's sign-off, plus pending/scheduled matches. Footer text only;
+    /// never a row.
+    let waitingCount: Int
     let recentResults: [DashboardRecentResult]
     let rating: DashboardRating?
     let completedMatchCount: Int
 }
 
-struct DashboardScoreBanner: Decodable {
-    let matchId: UUID
-    let opponentUsername: String?
-    let currentGameNumber: Int
+/// The actionable bucket a match falls in for the current user, in priority
+/// order (`dispute` > `review` > `score`). Mirrors the API's `AttentionKind`
+/// (`api/app/schemas/dashboard.py`). An unknown future kind decodes to
+/// `.unknown` so an older client doesn't fail the whole payload.
+enum AttentionKind: String, Decodable {
+    case dispute
+    case review
+    case score
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = AttentionKind(rawValue: raw) ?? .unknown
+    }
 }
 
-struct DashboardNextMatch: Decodable {
+/// One actionable row in the dashboard's "Needs your attention" panel,
+/// classified server-side and current-user-aware. Mirror of the API's
+/// `DashboardAttentionItem`. Carries only routing data — opponent handle and
+/// the action — never scores.
+struct DashboardAttentionItem: Decodable, Identifiable {
     let matchId: UUID
     let opponentUsername: String?
-    let bestOf: Int
-    let createdAt: Date
+    let kind: AttentionKind
+    /// `score` rows split rated-above-unrated by this flag; always true for
+    /// `review`/`dispute` (both only arise on rated matches).
+    let affectsRating: Bool
+    /// The next un-scored game for a `score` row, used to deep-link straight
+    /// into scoring. `nil` when the board is decided but unposted (route to
+    /// match detail to post instead), and always `nil` for `review`/`dispute`.
+    let currentGameNumber: Int?
+
+    var id: UUID { matchId }
 }
 
 /// One row of the "Recent matches" table.

--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -8,23 +8,23 @@ import SwiftUI
 /// environment, so the greeting reads the username from there rather than
 /// refetching it.
 struct DashboardView: View {
-    /// Most "Score needed" banners to show inline before collapsing the rest
-    /// into a "+N more" link (mirrors the web's primary + secondary + more).
-    private static let maxBanners = 2
-
     @EnvironmentObject private var session: SessionStore
     @StateObject private var store = DashboardStore()
     var service: MatchService = .shared
-    /// Called by the "+N more" banner overflow link to send the user to the
-    /// Matches tab, filtered to their live (score-needed) matches. The argument
-    /// is the current username, used as the list's search filter. Nil in previews.
-    var onShowAllScores: ((String?) -> Void)? = nil
+    /// Called by the attention panel's "View all" footer link to send the user
+    /// to the Matches tab, filtered to their matches. The argument is the
+    /// current username, used as the list's search filter. Nil in previews.
+    var onViewAll: ((String?) -> Void)? = nil
 
     /// Non-nil while the resume-scoring flow is presented over the dashboard;
-    /// `resumeLoading` covers the brief fetch of the full match (the banner
-    /// carries only the id, opponent, and current game number).
+    /// `resumeLoading` covers the brief fetch of the full match (the attention
+    /// row carries only the id, opponent, and current game number).
     @State private var resuming: ResumeScoring?
     @State private var resumeLoading = false
+    /// Non-nil while a match-detail screen is presented over the dashboard —
+    /// the destination for `review`/`dispute` rows (and a decided-but-unposted
+    /// `score` row), fetched from the row's match id.
+    @State private var selected: FinalMatch?
 
     private static let longDate: DateFormatter = {
         let f = DateFormatter()
@@ -58,19 +58,36 @@ struct DashboardView: View {
             if resumeLoading { FMBlockingSpinner() }
         }
         // The match just changed (result posted / games entered) — refetch so the
-        // score banner clears and the recent results update.
+        // attention panel clears the row and the recent results update.
         .resumeScoringCover($resuming) { Task { await store.load(force: true) } }
+        // Detail covers review/dispute (and decided-but-unposted) rows; refetch
+        // on dismissal so a resolved row drops off the panel.
+        .fullScreenCover(item: $selected) { match in
+            MatchDetailView(initial: match, onBack: {
+                selected = nil
+                Task { await store.load(force: true) }
+            })
+        }
     }
 
-    /// Fetch the full match behind a score banner and open the resume flow.
-    /// Falls back silently if the match can no longer be scored.
-    private func openResume(_ matchId: UUID) {
+    /// Run an attention row's action: fetch the full match, then deep-link into
+    /// scoring (a `score` row whose board is still live) or open match detail
+    /// (review/dispute, or a board that has since been decided). Mirrors the web
+    /// view-model's `routeOf` and the matches-list `openResume` fallback.
+    private func act(on row: AttentionRowView) {
         guard !resumeLoading else { return }
         resumeLoading = true
         Task {
-            let detail = try? await service.matchDetails(matchId)
+            let detail = try? await service.matchDetails(row.matchId)
             resumeLoading = false
-            if let ctx = detail?.resumeContext { resuming = ctx }
+            guard let detail else { return }
+            switch row.target {
+            case .scoring:
+                if let ctx = detail.resumeContext { resuming = ctx }
+                else { selected = detail }
+            case .detail:
+                selected = detail
+            }
         }
     }
 
@@ -95,7 +112,7 @@ struct DashboardView: View {
     }
 
     /// The signed-in username, used to filter the matches list when the user
-    /// taps "+N more to score". Nil if the session isn't resolved.
+    /// taps the attention panel's "View all". Nil if the session isn't resolved.
     private var currentUsername: String? {
         if case let .loaded(user) = session.state { return user.username }
         return nil
@@ -113,19 +130,19 @@ struct DashboardView: View {
     @ViewBuilder
     private func yourGame(_ data: DashboardResponse) -> some View {
         VStack(alignment: .leading, spacing: FMSpace.s4) {
-            // Top-priority: matches stranded mid-scoring that need the user to
-            // finish entering a result (issue #445). Mirrors the web dashboard's
-            // "Score needed" banners — capped so a backlog of stranded matches
-            // doesn't bury the rest of the dashboard; the overflow link sends the
-            // user to the Matches tab to work through the rest.
-            ForEach(data.scoreBanners.prefix(Self.maxBanners), id: \.matchId) { banner in
-                ScoreNeededBanner(banner: banner) { openResume(banner.matchId) }
-            }
-            if data.scoreBanners.count > Self.maxBanners {
-                MorePendingLink(count: data.scoreBanners.count - Self.maxBanners) {
-                    onShowAllScores?(currentUsername)
-                }
-            }
+            // Server-ranked triage of every match needing the user's move —
+            // disputes, results to review, matches to score (issue #445).
+            // Mirrors the web dashboard's "Needs your attention" panel: top 3
+            // rows + a footer rolling up the overflow / waiting counts, with a
+            // "View all" link into the Matches tab.
+            DashboardAttentionPanel(
+                view: projectAttentionPanel(
+                    items: data.attention,
+                    waitingCount: data.waitingCount
+                ),
+                onAct: { act(on: $0) },
+                onViewAll: { onViewAll?(currentUsername) }
+            )
 
             HStack(alignment: .firstTextBaseline, spacing: FMSpace.s3) {
                 Text("Your game")
@@ -187,68 +204,6 @@ struct DashboardView: View {
                 }
             }
         }
-    }
-}
-
-/// Dashboard banner for a match stranded mid-scoring — a one-tap path back into
-/// score entry so a Live match the user owns is never permanently stranded
-/// (issue #445). Mirrors the web dashboard's "Score needed" banner.
-private struct ScoreNeededBanner: View {
-    let banner: DashboardScoreBanner
-    let onResume: () -> Void
-
-    var body: some View {
-        FMCard(featured: true) {
-            HStack(alignment: .center, spacing: FMSpace.s4) {
-                VStack(alignment: .leading, spacing: FMSpace.s1) {
-                    HStack(spacing: 7) {
-                        Circle().fill(FMColor.ball500).frame(width: 7, height: 7)
-                            .shadow(color: FMColor.ball500.opacity(0.55), radius: 5)
-                        DashOverline(text: "Score needed")
-                    }
-                    Text(opponentLine)
-                        .font(FMFont.ui(FMFont.md, weight: .semibold))
-                        .foregroundStyle(FMColor.fg1)
-                        .lineLimit(1)
-                    Text("Game \(banner.currentGameNumber) is waiting on a score.")
-                        .font(FMFont.ui(FMFont.sm))
-                        .foregroundStyle(FMColor.fg3)
-                        .lineLimit(1)
-                }
-                Spacer(minLength: FMSpace.s3)
-                FMButton(title: "Enter score", variant: .primary, size: .sm, action: onResume)
-            }
-        }
-    }
-
-    private var opponentLine: String {
-        if let opponent = banner.opponentUsername { return "vs @\(opponent)" }
-        return "Solo match"
-    }
-}
-
-/// Overflow link shown under the capped score banners — "+N more to score" —
-/// routing the user to the Matches tab to clear the rest.
-private struct MorePendingLink: View {
-    let count: Int
-    let onTap: () -> Void
-
-    var body: some View {
-        Button(action: onTap) {
-            HStack(spacing: FMSpace.s2) {
-                Text("+\(count) more to score")
-                    .font(FMFont.ui(FMFont.sm, weight: .semibold))
-                    .foregroundStyle(FMColor.fgAccent)
-                Image(systemName: "arrow.right")
-                    .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(FMColor.fgAccent)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, FMSpace.s1)
-            .padding(.vertical, FMSpace.s1)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 }
 

--- a/ios/Fortymm/Navigation/MainTabView.swift
+++ b/ios/Fortymm/Navigation/MainTabView.swift
@@ -25,13 +25,13 @@ struct MainTabView: View {
     @State private var selection: FMTab = .home
     @State private var showingNewMatch = false
     /// A filter the Matches list should adopt when another tab routes to it
-    /// (the dashboard's "+N more to score" link → the user's live matches).
+    /// (the dashboard attention panel's "View all" link → the user's matches).
     @State private var matchesFilter: MatchesFilter?
 
     var body: some View {
         TabView(selection: $selection) {
-            DashboardView(onShowAllScores: { username in
-                matchesFilter = MatchesFilter(status: .inProgress, query: username ?? "")
+            DashboardView(onViewAll: { username in
+                matchesFilter = MatchesFilter(status: nil, query: username ?? "")
                 selection = .matches
             })
                 .fmTopBar(FMTab.home.title)


### PR DESCRIPTION
Ports the web dashboard's reworked callouts to the iOS app.

## Context
The web BFF (`GET /v1/dashboard`) was reworked (#547) to drop `score_banners`/`next_match` in favor of a unified, server-ranked `attention[]` (kinds `dispute` > `review` > `score`, score split rated-above-unrated) plus a `waiting_count`. **iOS still decoded `score_banners` as a non-optional field, so it failed to decode the live `/v1/dashboard` payload entirely** — this fixes that regression and ports the feature.

## Changes
- **DashboardModels**: replace `score_banners`/`next_match` with `attention: [DashboardAttentionItem]` + `waitingCount`; add `AttentionKind` (forward-compatible `.unknown`) and `DashboardAttentionItem`.
- **DashboardAttentionPanel** (new): faithful port of the web view-model (`projectAttentionPanel` — top-3 cap, bucket-based primary-button rule, action labels, scoring-vs-detail routing) + the SwiftUI panel (header, avatar/headline/action rows, footer with overflow + waiting counts + "View all", and the calm "You're all caught up." empty state).
- **DashboardView**: render the panel; `score` rows deep-link into the resume-scoring flow, `review`/`dispute` (and decided-but-unposted) rows open `MatchDetailView`; refetch on dismissal.
- **MainTabView**: `onShowAllScores` → `onViewAll`, filtering by username across all statuses (matches the web `?q=username` link).

## QA
Black-box on the iOS Simulator (iPhone 17, iOS 26.5) Debug build against **real UAT**:
- Panel renders real data: priority-ordered rows (avatar · `vs <opponent>` · action button), correct primary styling, footer `N more need attention · N waiting on others · View all`.
- Score row → opens match detail (board decided → Post result); back returns to dashboard.
- "View all" → Matches tab, search = username, **All** statuses.
- Decode regression fixed; no crash, no bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)