### PR TITLE
Preload data on all players pages

### DIFF
--- a/web-client/src/api/players.ts
+++ b/web-client/src/api/players.ts
@@ -43,19 +43,11 @@ export function playerMatchesQueryKey(
   return ['players', 'matches', playerId, params] as const
 }
 
-/**
- * Paginated /v1/players list backing the `/players` page. Gated on session
- * success so a first-visit direct-load doesn't race the session cookie and
- * 401 into the error boundary (same pattern as `useMatchList`).
- *
- * `placeholderData: keepPreviousData` keeps the current rows on screen while
- * the next page or filter resolves — no flash to empty.
- */
-export function usePlayerList(
-  params: PlayerListParams,
-  options: { enabled?: boolean } = {},
-) {
-  return useQuery({
+/** Query options for the paginated /v1/players list. Shared by `usePlayerList`
+ * and any caller that needs to prefetch the same query — the list route's
+ * loader warms this on hover/touch preload so a click renders instantly. */
+export function playerListQueryOptions(params: PlayerListParams) {
+  return queryOptions({
     queryKey: playerListQueryKey(params),
     queryFn: async (): Promise<PlayerListResponse> =>
       unwrap(
@@ -70,12 +62,29 @@ export function usePlayerList(
           },
         }),
       ),
-    enabled: options.enabled ?? true,
-    placeholderData: keepPreviousData,
     // Fail-fast to the surrounding error boundary's "Try again" affordance
     // rather than silently retrying behind the skeleton.
     retry: false,
     throwOnError: true,
+  })
+}
+
+/**
+ * Paginated /v1/players list backing the `/players` page. Gated on session
+ * success so a first-visit direct-load doesn't race the session cookie and
+ * 401 into the error boundary (same pattern as `useMatchList`).
+ *
+ * `placeholderData: keepPreviousData` keeps the current rows on screen while
+ * the next page or filter resolves — no flash to empty.
+ */
+export function usePlayerList(
+  params: PlayerListParams,
+  options: { enabled?: boolean } = {},
+) {
+  return useQuery({
+    ...playerListQueryOptions(params),
+    enabled: options.enabled ?? true,
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/web-client/src/routes/p.players.$username.tsx
+++ b/web-client/src/routes/p.players.$username.tsx
@@ -3,7 +3,10 @@ import { createFileRoute, useNavigate, useRouter } from '@tanstack/react-router'
 import { zodValidator } from '@tanstack/zod-adapter'
 import { z } from 'zod'
 
-import { usePublicPlayerByUsername } from '@/api/players'
+import {
+  publicPlayerByUsernameQueryOptions,
+  usePublicPlayerByUsername,
+} from '@/api/players'
 import { PlayerProfile } from '@/components/players/player-profile'
 import { Button } from '@/components/ui/button'
 import { pageTitle } from '@/lib/page-title'
@@ -17,6 +20,13 @@ export const Route = createFileRoute('/p/players/$username')({
     meta: [{ title: pageTitle('Player') }],
   }),
   validateSearch: zodValidator(profileSearchSchema),
+  // Public route — no session required, so warm the profile cache on hover/
+  // touch preload unconditionally; a click then renders instantly.
+  loader: ({ context, params }) => {
+    void context.queryClient.prefetchQuery(
+      publicPlayerByUsernameQueryOptions(params.username),
+    )
+  },
   component: PublicPlayerRoute,
   errorComponent: PublicPlayerError,
 })

--- a/web-client/src/routes/players/$userId.tsx
+++ b/web-client/src/routes/players/$userId.tsx
@@ -3,8 +3,8 @@ import { createFileRoute, useNavigate, useRouter } from '@tanstack/react-router'
 import { zodValidator } from '@tanstack/zod-adapter'
 import { z } from 'zod'
 
-import { usePlayerById } from '@/api/players'
-import { useSession } from '@/api/session'
+import { playerByIdQueryOptions, usePlayerById } from '@/api/players'
+import { SESSION_QUERY_KEY, useSession } from '@/api/session'
 import { AppShell } from '@/components/app-shell'
 import { PlayerProfile } from '@/components/players/player-profile'
 import { Button } from '@/components/ui/button'
@@ -20,6 +20,16 @@ export const Route = createFileRoute('/players/$userId')({
     meta: [{ title: pageTitle('Player') }],
   }),
   validateSearch: zodValidator(profileSearchSchema),
+  // Warm the profile cache on hover/touch preload without blocking navigation.
+  // Skip on a cold direct load where the session isn't resolved yet, so the
+  // prefetch can't 401 into the error boundary ahead of the component's
+  // session-gated query (same pattern as `/matches`).
+  loader: ({ context, params }) => {
+    if (!context.queryClient.getQueryData(SESSION_QUERY_KEY)) return
+    void context.queryClient.prefetchQuery(
+      playerByIdQueryOptions(params.userId),
+    )
+  },
   component: PlayerRoute,
   errorComponent: PlayerRouteError,
 })

--- a/web-client/src/routes/players/index.tsx
+++ b/web-client/src/routes/players/index.tsx
@@ -11,8 +11,12 @@ import {
 } from 'lucide-react'
 import { z } from 'zod'
 
-import { usePlayerList, type PlayerSummary } from '@/api/players'
-import { useSession } from '@/api/session'
+import {
+  playerListQueryOptions,
+  usePlayerList,
+  type PlayerSummary,
+} from '@/api/players'
+import { SESSION_QUERY_KEY, useSession } from '@/api/session'
 import { AppShell } from '@/components/app-shell'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -41,16 +45,36 @@ const playersSearchSchema = z.object({
   page: z.coerce.number().int().min(2).optional().catch(undefined),
 })
 
+const PAGE_SIZE = 25
+
 export const Route = createFileRoute('/players/')({
   head: () => ({
     meta: [{ title: pageTitle('Players') }],
   }),
   validateSearch: zodValidator(playersSearchSchema),
+  // The filter + page live in the URL, so the prefetched list must be keyed by
+  // them — expose the search to the loader.
+  loaderDeps: ({ search }) => search,
+  // Warm the React Query cache without blocking the route transition, so an
+  // intent preload makes the click render instantly. Skip the prefetch on a
+  // cold direct load where the session isn't resolved yet — firing here would
+  // 401 into the error boundary ahead of the component's session-gated query
+  // (same pattern as `/matches`). The query key matches the component's first
+  // render: `useDebouncedValue` seeds its initial value synchronously, so the
+  // debounced `q` equals the URL `q` on mount.
+  loader: ({ context, deps }) => {
+    if (!context.queryClient.getQueryData(SESSION_QUERY_KEY)) return
+    void context.queryClient.prefetchQuery(
+      playerListQueryOptions({
+        q: deps.q?.trim() || undefined,
+        page: deps.page ?? 1,
+        page_size: PAGE_SIZE,
+      }),
+    )
+  },
   component: PlayersPage,
   errorComponent: PlayersListError,
 })
-
-const PAGE_SIZE = 25
 
 function PlayersPage() {
   const search = Route.useSearch()


### PR DESCRIPTION
## What

Adds TanStack Router `loader`s that warm the React Query cache on **intent preload** (link hover/touch) for all three players surfaces, mirroring the established `/matches` pattern. With `defaultPreload: 'intent'` already configured, a click now renders instantly instead of waiting on a fetch.

- **`/players` (list)** — extracted `playerListQueryOptions` out of `usePlayerList` (which now spreads it, like `matchListQueryOptions`/`useMatchList`) so the list query can be prefetched. The loader is keyed by the URL's `q`/`page` via `loaderDeps`, and gated on `SESSION_QUERY_KEY` being in cache so a cold direct load can't 401 ahead of the component's session-gated query.
- **`/players/$userId`** — loader prefetches `playerByIdQueryOptions(userId)`, same session gate (authed endpoint).
- **`/p/players/$username`** — loader prefetches `publicPlayerByUsernameQueryOptions(username)` unconditionally (public endpoint, no session required).

Cache keys are guaranteed to match the components' first render (`useDebouncedValue` seeds its initial value synchronously), so the prefetch is a true cache hit, not a wasted double fetch.

## Testing

- `npm run test:run` — 653 passed
- `npm run lint` — clean
- `npm run build` (`tsc -b && vite build`) — success
- `npm run test:e2e` — 127 passed
- OpenAPI schema drift — regenerated, no change

API + root-e2e suites not run: this branch only touches `web-client/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)