### PR TITLE
Fix H2H card showing meetings played after the viewed match (#497)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1066,13 +1066,16 @@ def _build_form_result(past_match: Match, user_id: uuid.UUID) -> MatchDetailsFor
 async def _load_head_to_head(
     db: AsyncSession,
     user_ids: list[uuid.UUID],
-    current_match_id: uuid.UUID,
+    match: Match,
 ) -> MatchDetailsH2H | None:
     if len(user_ids) != 2:
         return None
+    current_match_id = match.id
     user_a, user_b = user_ids
     rows_query = participant_filter(
-        participant_filter(_history_base_query(current_match_id), user_a),
+        participant_filter(
+            _history_base_query(current_match_id, before=match.created_at), user_a
+        ),
         user_b,
     )
     rows = (await db.execute(rows_query.limit(H2H_MEETINGS_LIMIT))).scalars().all()
@@ -1098,9 +1101,10 @@ async def _load_head_to_head(
             )
         )
 
-    # Full-history aggregates so the displayed window doesn't undercount a
-    # long rivalry. Driven from MatchSide.won so a future void/dispute that
-    # leaves `won` null naturally drops out of both totals.
+    # Prior-meetings aggregates (completed before this match) so the displayed
+    # window doesn't undercount the rivalry going into this match. Driven from
+    # MatchSide.won so a future void/dispute that leaves `won` null naturally
+    # drops out of both totals.
     a_side = aliased(MatchSide)
     b_side = aliased(MatchSide)
     a_player = aliased(MatchSidePlayer)
@@ -1118,6 +1122,7 @@ async def _load_head_to_head(
         .where(
             Match.status == MatchStatus.completed,
             Match.id != current_match_id,
+            Match.updated_at < match.created_at,
             a_player.user_id == user_a,
             b_player.user_id == user_b,
             a_side.id != b_side.id,
@@ -1149,7 +1154,7 @@ async def _load_view_extras(db: AsyncSession, match: Match) -> ViewExtras:
         rating_changes=await _load_rating_changes(db, match.id),
         recent_form=await _load_recent_form(db, user_ids, match),
         head_to_head=await _load_head_to_head(
-            db, user_ids if len(user_ids) == 2 else [], match.id
+            db, user_ids if len(user_ids) == 2 else [], match
         ),
     )
 

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1332,6 +1332,40 @@ async def test_details_head_to_head_counts_prior_meetings_per_side(
     assert h2h["recent_meetings"][0]["winner_side_number"] == 2
 
 
+async def test_details_head_to_head_excludes_meetings_after_this_match(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Viewing a match shows the rivalry as it stood going into it: meetings
+    completed *after* the viewed match must not appear, and a match that starts
+    the rivalry shows no prior meetings (regression for #497)."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "h2h-temporal-rival") as (
+        rival_client,
+        rival,
+    ):
+        # The match we'll view — first meeting, so it starts the rivalry.
+        first = await _play_match_to_completion(
+            api_client, rival_client, rival.id, best_of=3, side_1_wins=True
+        )
+        # Two more meetings completed *after* the viewed match.
+        await _play_match_to_completion(
+            api_client, rival_client, rival.id, best_of=3, side_1_wins=False
+        )
+        await _play_match_to_completion(
+            api_client, rival_client, rival.id, best_of=3, side_1_wins=True
+        )
+
+    detail = (await api_client.get(f"/v1/matches/{first['id']}")).json()
+    h2h = detail["head_to_head"]
+    # Nothing precedes the first meeting — both rows and aggregates are empty.
+    assert h2h == {
+        "total_meetings": 0,
+        "side_1_wins": 0,
+        "side_2_wins": 0,
+        "recent_meetings": [],
+    }
+
+
 async def test_details_head_to_head_is_null_for_solo_match(
     api_client: AsyncClient, db_session: AsyncSession
 ):


### PR DESCRIPTION
## What

The head-to-head card on a match's details page was built from the players' *current* rivalry state (minus the viewed match). On a **completed** match this meant the card listed meetings played **after** that match and omitted the match itself — contradicting the adjacent "Players · going into this match" snapshot and the "No prior meetings — this match is the start of the rivalry" empty-state copy.

Fixes #497.

## Why

`_load_head_to_head` called `_history_base_query(current_match_id)` without the `before=` argument, unlike its sibling `_load_recent_form`, which already scopes form to `before=match.created_at`. The aggregate counts query had the same gap (no temporal filter).

## Change

- `_load_head_to_head` now takes the `Match` (not just its id) and threads `before=match.created_at` into the rows query via the existing `_history_base_query` filter.
- Added `Match.updated_at < match.created_at` to the aggregate counts query, mirroring `_load_career_before`.
- Updated the now-stale "full-history aggregates" comment.
- Regression test `test_details_head_to_head_excludes_meetings_after_this_match`: views a completed first meeting with two later meetings and asserts an empty H2H. Verified it fails without the fix (sees `total_meetings: 2`) and passes with it.

No route signatures or response models changed → no OpenAPI/`schema.d.ts` impact.

## Testing

- `ruff check` ✅ · `ruff format --check` ✅ · `mypy` (strict, 68 files) ✅
- `pytest` full suite ✅ **385 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)