### PR TITLE
Hide the dashboard attention panel when there's nothing to surface

### DIFF
--- a/web-client/src/components/dashboard/attention-panel-view.test.ts
+++ b/web-client/src/components/dashboard/attention-panel-view.test.ts
@@ -1,5 +1,8 @@
 import { dashboardAttentionItem } from '@/test/factories'
-import { projectAttentionPanelView } from './attention-panel-view'
+import {
+  isAttentionPanelEmpty,
+  projectAttentionPanelView,
+} from './attention-panel-view'
 
 describe('projectAttentionPanelView', () => {
   it('caps visible rows at 3 and reports the overflow', () => {
@@ -109,5 +112,37 @@ describe('projectAttentionPanelView', () => {
     expect(view.overflowCount).toBe(0)
     expect(view.waitingCount).toBe(4)
     expect(view.viewAllSearch).toEqual({ q: 'rita.kovac' })
+  })
+})
+
+describe('isAttentionPanelEmpty', () => {
+  it('is empty when there are no rows, no overflow, and nobody waiting', () => {
+    expect(isAttentionPanelEmpty(projectAttentionPanelView([], 0, 'rita'))).toBe(
+      true,
+    )
+  })
+
+  it('is not empty when matches are waiting on others', () => {
+    expect(isAttentionPanelEmpty(projectAttentionPanelView([], 3, 'rita'))).toBe(
+      false,
+    )
+  })
+
+  it('is not empty when there are actionable rows', () => {
+    const view = projectAttentionPanelView(
+      [dashboardAttentionItem({ kind: 'score' })],
+      0,
+      'rita',
+    )
+    expect(isAttentionPanelEmpty(view)).toBe(false)
+  })
+
+  it('is not empty when overflow rolls extra items into the footer', () => {
+    const items = Array.from({ length: 5 }, (_, i) =>
+      dashboardAttentionItem({ match_id: `m-${i}`, kind: 'score' }),
+    )
+    expect(isAttentionPanelEmpty(projectAttentionPanelView(items, 0, 'r'))).toBe(
+      false,
+    )
   })
 })

--- a/web-client/src/components/dashboard/attention-panel-view.ts
+++ b/web-client/src/components/dashboard/attention-panel-view.ts
@@ -67,6 +67,20 @@ function routeOf(item: DashboardAttentionItem): RowRoute {
 }
 
 /**
+ * Whether the panel has nothing to show — no actionable rows, no overflow, and
+ * nobody waiting on others. The panel hides entirely in this case rather than
+ * rendering a standalone "all caught up" card (a calm empty state still shows
+ * when rows are empty but the footer has a waiting/overflow count to surface).
+ */
+export function isAttentionPanelEmpty(view: AttentionPanelView): boolean {
+  return (
+    view.rows.length === 0 &&
+    view.overflowCount === 0 &&
+    view.waitingCount === 0
+  )
+}
+
+/**
  * Project the BFF's pre-ranked attention items into the panel's view model:
  * cap visible rows at 3, compute the footer counts, and mark the
  * highest-priority *visible* bucket as primary (so a `Review result` beneath a

--- a/web-client/src/components/dashboard/attention-panel.page.tsx
+++ b/web-client/src/components/dashboard/attention-panel.page.tsx
@@ -12,10 +12,14 @@ import { AttentionPanel, type AttentionPanelProps } from './attention-panel'
 import { buildAttentionPanelProps } from './attention-panel.factory'
 
 const scoped = (container: Container) => ({
-  /** The panel `<section>` (always present — it renders a calm empty state
-   * rather than disappearing). */
+  /** The panel `<section>` (absent when there's nothing to surface — the panel
+   * hides entirely rather than rendering a standalone empty card). */
   getPanel() {
     return container.getByRole('region', { name: /needs your attention/i })
+  },
+  /** The panel `<section>`, or null when it has hidden itself. */
+  queryPanel() {
+    return container.queryByRole('region', { name: /needs your attention/i })
   },
   /** Every action row (one `<li>` per visible item). */
   getRows() {

--- a/web-client/src/components/dashboard/attention-panel.test.tsx
+++ b/web-client/src/components/dashboard/attention-panel.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react'
 import { matchDetailRoute, scoringNewRoute } from '@/api/matches'
 import {
   buildAttentionPanelView,
@@ -44,12 +45,27 @@ describe('AttentionPanel', () => {
     )
   })
 
-  it('shows a calm empty state and no rows when nothing is actionable', async () => {
-    page.render({ view: buildAttentionPanelView({ rows: [] }) })
+  it('hides entirely when there is nothing to surface', async () => {
+    page.render({
+      view: buildAttentionPanelView({
+        rows: [],
+        overflowCount: 0,
+        waitingCount: 0,
+      }),
+    })
+
+    await waitFor(() => expect(page.queryPanel()).not.toBeInTheDocument())
+  })
+
+  it('shows a calm empty state when rows are empty but matches are waiting', async () => {
+    page.render({
+      view: buildAttentionPanelView({ rows: [], waitingCount: 2 }),
+    })
 
     await page.findPanel()
     expect(page.queryRows()).toHaveLength(0)
     expect(page.queryEmptyState()).toBeInTheDocument()
+    expect(page.queryFooterText(/2 waiting on others/)).toBeInTheDocument()
   })
 
   it('summarizes overflow and waiting counts in the footer', async () => {

--- a/web-client/src/components/dashboard/attention-panel.tsx
+++ b/web-client/src/components/dashboard/attention-panel.tsx
@@ -3,7 +3,10 @@ import { ArrowRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { UserAvatar } from '@/components/ui/user-avatar'
-import type { AttentionPanelView } from './attention-panel-view'
+import {
+  isAttentionPanelEmpty,
+  type AttentionPanelView,
+} from './attention-panel-view'
 
 export interface AttentionPanelProps {
   view: AttentionPanelView
@@ -15,11 +18,13 @@ export interface AttentionPanelProps {
  * plus a footer summarizing overflow + waiting counts and a `View all` link.
  * Pure view-in — all ranking/labels/routing are decided by
  * `projectAttentionPanelView`. Buttons only route; they never finalize a
- * result. Renders a calm empty state rather than disappearing when nothing is
- * actionable.
+ * result. Hides entirely when there's nothing to surface; falls back to a calm
+ * empty state when there are no rows but the footer still has a waiting/overflow
+ * count to show.
  */
 export const AttentionPanel = ({ view }: AttentionPanelProps) => {
   const { rows, overflowCount, waitingCount, viewAllSearch } = view
+  if (isAttentionPanelEmpty(view)) return null
   return (
     <section
       aria-labelledby="needs-attention-heading"

--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -140,7 +140,7 @@ describe('DashboardPage', () => {
     ).toBeInTheDocument()
   })
 
-  it('shows the attention panel empty state and the empty recent-results card when nothing is pending', async () => {
+  it('hides the attention panel and shows the empty recent-results card when nothing is pending', async () => {
     server.use(
       http.get('*/v1/dashboard', () =>
         HttpResponse.json(
@@ -155,10 +155,10 @@ describe('DashboardPage', () => {
     renderDashboard()
 
     await screen.findByText('No completed matches yet.')
-    // The panel stays put (a calm empty state) rather than disappearing.
+    // Nothing actionable and nobody waiting: the panel disappears entirely.
     expect(
-      screen.getByRole('region', { name: /needs your attention/i }),
-    ).toHaveTextContent(/all caught up/i)
+      screen.queryByRole('region', { name: /needs your attention/i }),
+    ).not.toBeInTheDocument()
   })
 
   it('Log a match navigates to /matches/new', async () => {


### PR DESCRIPTION
## What

The dashboard's **"Needs your attention"** triage panel previously always rendered, falling back to a calm "You're all caught up" card. Now it hides entirely when there's genuinely nothing to show.

- New `isAttentionPanelEmpty(view)` helper in `attention-panel-view.ts`: true when there are **no action rows, no overflow, and nobody waiting on others**.
- `AttentionPanel` returns `null` (disappears) in that case.
- **Kept** the calm empty state for the one non-trivial edge: rows are empty but the footer still has a `N waiting on others` / overflow count to surface — so that info isn't lost.

## Design note

This is the conservative read of "hide when empty": the panel still shows if matches are *waiting on others*. Flipping to hide-whenever-no-action-rows is a one-line change to `isAttentionPanelEmpty` (drop the `waitingCount`/`overflowCount` checks).

## Testing

- `npm run test:run` — 694/694 pass (incl. new `isAttentionPanelEmpty` view-model cases + updated component/integration tests)
- `npm run lint` — clean (one pre-existing unrelated `mockServiceWorker.js` warning)
- `npm run build` (tsc -b typecheck + vite build) — clean

FE-only change; no API or OpenAPI schema impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)