### PR TITLE
Match-details: H2H temporal fix (#497) + hero/status label fixes (#491/#492/#561) + finalize debounce (#550)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1066,13 +1066,16 @@ def _build_form_result(past_match: Match, user_id: uuid.UUID) -> MatchDetailsFor
 async def _load_head_to_head(
     db: AsyncSession,
     user_ids: list[uuid.UUID],
-    current_match_id: uuid.UUID,
+    match: Match,
 ) -> MatchDetailsH2H | None:
     if len(user_ids) != 2:
         return None
+    current_match_id = match.id
     user_a, user_b = user_ids
     rows_query = participant_filter(
-        participant_filter(_history_base_query(current_match_id), user_a),
+        participant_filter(
+            _history_base_query(current_match_id, before=match.created_at), user_a
+        ),
         user_b,
     )
     rows = (await db.execute(rows_query.limit(H2H_MEETINGS_LIMIT))).scalars().all()
@@ -1098,9 +1101,10 @@ async def _load_head_to_head(
             )
         )
 
-    # Full-history aggregates so the displayed window doesn't undercount a
-    # long rivalry. Driven from MatchSide.won so a future void/dispute that
-    # leaves `won` null naturally drops out of both totals.
+    # Prior-meetings aggregates (completed before this match) so the displayed
+    # window doesn't undercount the rivalry going into this match. Driven from
+    # MatchSide.won so a future void/dispute that leaves `won` null naturally
+    # drops out of both totals.
     a_side = aliased(MatchSide)
     b_side = aliased(MatchSide)
     a_player = aliased(MatchSidePlayer)
@@ -1118,6 +1122,7 @@ async def _load_head_to_head(
         .where(
             Match.status == MatchStatus.completed,
             Match.id != current_match_id,
+            Match.updated_at < match.created_at,
             a_player.user_id == user_a,
             b_player.user_id == user_b,
             a_side.id != b_side.id,
@@ -1149,7 +1154,7 @@ async def _load_view_extras(db: AsyncSession, match: Match) -> ViewExtras:
         rating_changes=await _load_rating_changes(db, match.id),
         recent_form=await _load_recent_form(db, user_ids, match),
         head_to_head=await _load_head_to_head(
-            db, user_ids if len(user_ids) == 2 else [], match.id
+            db, user_ids if len(user_ids) == 2 else [], match
         ),
     )
 

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1332,6 +1332,40 @@ async def test_details_head_to_head_counts_prior_meetings_per_side(
     assert h2h["recent_meetings"][0]["winner_side_number"] == 2
 
 
+async def test_details_head_to_head_excludes_meetings_after_this_match(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Viewing a match shows the rivalry as it stood going into it: meetings
+    completed *after* the viewed match must not appear, and a match that starts
+    the rivalry shows no prior meetings (regression for #497)."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "h2h-temporal-rival") as (
+        rival_client,
+        rival,
+    ):
+        # The match we'll view — first meeting, so it starts the rivalry.
+        first = await _play_match_to_completion(
+            api_client, rival_client, rival.id, best_of=3, side_1_wins=True
+        )
+        # Two more meetings completed *after* the viewed match.
+        await _play_match_to_completion(
+            api_client, rival_client, rival.id, best_of=3, side_1_wins=False
+        )
+        await _play_match_to_completion(
+            api_client, rival_client, rival.id, best_of=3, side_1_wins=True
+        )
+
+    detail = (await api_client.get(f"/v1/matches/{first['id']}")).json()
+    h2h = detail["head_to_head"]
+    # Nothing precedes the first meeting — both rows and aggregates are empty.
+    assert h2h == {
+        "total_meetings": 0,
+        "side_1_wins": 0,
+        "side_2_wins": 0,
+        "recent_meetings": [],
+    }
+
+
 async def test_details_head_to_head_is_null_for_solo_match(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/web-client/src/components/matches/match-details/scoreboard.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard.test.tsx
@@ -12,6 +12,7 @@ import { scoreboardPage } from "./scoreboard.page";
 /** A decided match whose selected view is a stable, assertable outcome. */
 const decidedMatch = () =>
   buildMatchDetails({
+    status_label: "Final",
     sides: [
       buildMatchDetailsSide({
         won: true,

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher.test.tsx
@@ -13,6 +13,7 @@ import { scoreboardFetcherPage } from "./scoreboard-fetcher.page";
 /** A decided match whose selected view is a stable, assertable outcome. */
 const decidedMatch = () =>
   buildMatchDetails({
+    status_label: "Final",
     sides: [
       buildMatchDetailsSide({
         won: true,
@@ -81,7 +82,10 @@ describe("ScoreboardFetcher", () => {
   it("renders the heading strip from the selected view", async () => {
     scoreboardFetcherPage.mockEndpoint(() =>
       HttpResponse.json(
-        buildMatchDetails({ data: { scoreboard: { status: "final" } } }),
+        buildMatchDetails({
+          status_label: "Final",
+          data: { scoreboard: { status: "final" } },
+        }),
       ),
     );
 

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/heading.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/heading.page.tsx
@@ -5,7 +5,7 @@ import { buildHeadingProps } from "./heading.factory";
 import { statusChipPage } from "./heading/status-chip.page";
 
 const scoped = (container: Container) => ({
-  /** The status chip on the left of the strip; absent when `chip` is null. */
+  /** The status chip on the left of the strip — always present. */
   ...statusChipPage.within(container),
   /** The "SINGLES · BO5"-style format label on the right of the strip. */
   getFormatLabel() {

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/heading.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/heading.test.tsx
@@ -3,8 +3,8 @@ import { headingPage } from "./heading.page";
 
 describe("Heading", () => {
   it("renders the status chip from the heading view's chip", () => {
-    // Chip variants and the null case are covered by the StatusChip tests;
-    // this pins the composition only.
+    // Chip variants are covered by the StatusChip tests; this pins the
+    // composition only.
     headingPage.render({
       heading: buildScoreboardHeadingView({
         chip: { status: "final", label: "Final" },
@@ -12,14 +12,6 @@ describe("Heading", () => {
     });
 
     expect(headingPage.getChip()).toHaveTextContent("Final");
-  });
-
-  it("omits the chip when the heading view's chip is null", () => {
-    headingPage.render({
-      heading: buildScoreboardHeadingView({ chip: null }),
-    });
-
-    expect(headingPage.queryChip()).not.toBeInTheDocument();
   });
 
   it("renders the format label", () => {

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/heading.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/heading.tsx
@@ -11,7 +11,7 @@ export const Heading = ({ heading }: HeadingProps) => {
   return (
     <div className="md-hero__strip">
       <div className="md-hero__strip-l">
-        {heading.chip && <StatusChip chip={heading.chip} />}
+        <StatusChip chip={heading.chip} />
       </div>
       <div className="md-hero__strip-r">
         <span data-testid="scoreboard-heading-format" className="md-hero__strip-meta">

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/heading/status-chip.factory.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/heading/status-chip.factory.tsx
@@ -3,8 +3,8 @@ import type { StatusChipProps } from "./status-chip";
 
 /** The projected chip view the status chip renders. */
 export function buildStatusChipView(
-  overrides: Partial<NonNullable<StatusChipView>> = {},
-): NonNullable<StatusChipView> {
+  overrides: Partial<StatusChipView> = {},
+): StatusChipView {
   return {
     status: "final",
     label: "Final",

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/heading/status-chip.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/heading/status-chip.tsx
@@ -2,11 +2,11 @@ import { Badge } from "@/components/ui/badge";
 import { type StatusChipView } from "../../scoreboard-query";
 
 export interface StatusChipProps {
-  chip: NonNullable<StatusChipView>;
+  chip: StatusChipView;
 }
 
 const chipVariant: Record<
-  NonNullable<StatusChipView>["status"],
+  StatusChipView["status"],
   React.ComponentProps<typeof Badge>["variant"]
 > = {
   scheduled: "outline",

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.test.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.test.ts
@@ -127,10 +127,13 @@ describe("scoreboardQuery", () => {
     expect(result.current.data?.heading.raceLabel).toBe("First to 3");
   });
 
-  it("projects no chip for a live match with no current game", async () => {
+  it("falls back to the status label as the chip for a live match with no current game (#492)", async () => {
+    // A posted-but-unconfirmed board is `live` with no current game; the chip
+    // must still show the server's label rather than vanishing.
     scoreboardQueryPage.mockEndpoint(() =>
       HttpResponse.json(
         buildMatchDetails({
+          status_label: "Awaiting confirmation",
           current_game: null,
           data: { scoreboard: { status: "live" } },
         }),
@@ -140,13 +143,19 @@ describe("scoreboardQuery", () => {
     const { result } = scoreboardQueryPage.render();
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data?.heading.chip).toBeNull();
+    expect(result.current.data?.heading.chip).toEqual({
+      status: "live",
+      label: "Awaiting confirmation",
+    });
   });
 
   it("projects a Final chip for a final match", async () => {
     scoreboardQueryPage.mockEndpoint(() =>
       HttpResponse.json(
-        buildMatchDetails({ data: { scoreboard: { status: "final" } } }),
+        buildMatchDetails({
+          status_label: "Final",
+          data: { scoreboard: { status: "final" } },
+        }),
       ),
     );
 
@@ -156,6 +165,28 @@ describe("scoreboardQuery", () => {
     expect(result.current.data?.heading.chip).toEqual({
       status: "final",
       label: "Final",
+    });
+  });
+
+  it("projects the Disputed label, not 'Final', for a disputed match (#561)", async () => {
+    // A disputed board maps to the coarse `final` scoreboard status, but its
+    // chip must read the server's "Disputed" label so it agrees with the
+    // Match-info Status field.
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          status_label: "Disputed",
+          data: { scoreboard: { status: "final" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heading.chip).toEqual({
+      status: "final",
+      label: "Disputed",
     });
   });
 
@@ -253,6 +284,39 @@ describe("scoreboardQuery", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.outcome).toBe("leo.mertens leads by 2 games to 1");
+  });
+
+  it("describes a posted result awaiting confirmation as won, not leading (#491)", async () => {
+    // The board is decided (a result was posted) but `side.won` is still null
+    // until the other side confirms. The outcome must read "won … awaiting
+    // confirmation", not "leading", which implies play continues.
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          status_label: "Awaiting confirmation",
+          current_game: null,
+          data: { scoreboard: { status: "live" } },
+          sides: [
+            buildMatchDetailsSide({
+              games_won: 3,
+              players: [buildMatchDetailsPlayer({ username: "rita.kovac" })],
+            }),
+            buildMatchDetailsSide({
+              side_number: 2,
+              games_won: 0,
+              players: [buildMatchDetailsPlayer({ username: "leo.mertens" })],
+            }),
+          ],
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.outcome).toBe(
+      "rita.kovac won 3 games to 0 — awaiting confirmation",
+    );
   });
 
   it("treats a side still on zero as leading, not unstarted, when the other has won games", async () => {

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.ts
@@ -6,12 +6,15 @@ import { orderedSides } from "../../ordered-sides";
 import type { Scoreboard } from "@/api/matches";
 import { initialsOf } from "@/lib/utils";
 
-/** The status chip on the left of the strip; null when the match is live
- * but has no current game (nothing meaningful to announce). */
+/** The status chip on the left of the strip. Its label comes from the
+ * server's lifecycle `status_label` (Live / Awaiting confirmation / Final /
+ * Disputed / Voided / Scheduled), so it never contradicts the Match-info
+ * Status field — the one exception being a live match with a game in progress,
+ * which reads "Live · Game N". Always present. */
 export type StatusChipView = {
   status: Scoreboard["status"];
   label: string;
-} | null;
+};
 
 export type ScoreboardHeadingView = {
   chip: StatusChipView;
@@ -105,21 +108,37 @@ export type ScoreboardView = {
 
 const games = (n: number) => `${n} ${n === 1 ? "game" : "games"}`;
 
-const selectOutcome = (match: MatchDetailsResult): string | null => {
-  const sides = match.unmigrated.sides;
+/** Mirrors the server's `_status_label` for the posted-but-unconfirmed state
+ * (api/app/matches.py). The BFF owns lifecycle labels, so we key off the
+ * string rather than re-deriving the state from `signatures` on the client. */
+const AWAITING_CONFIRMATION = "Awaiting confirmation";
 
-  // Decided match: one side won, the other lost.
+const selectOutcome = (match: MatchDetailsResult): string | null => {
+  const details = match.unmigrated;
+  const sides = details.sides;
+
+  // Decided & confirmed: one side won, the other lost.
   const winner = sides.find((s) => s.won === true);
   const loser = sides.find((s) => s.won === false);
   if (winner?.players[0] && loser?.players[0]) {
     return `${winner.players[0].username} defeated ${loser.players[0].username} by ${games(winner.games_won)} to ${loser.games_won}`;
   }
 
-  // Still in progress: describe the current state from games won. Needs both
-  // sides' lead player to name them.
+  // Still in progress (or posted, awaiting confirmation): describe the current
+  // state from games won. Needs both sides' lead player to name them.
   const [side1, side2] = sides;
   if (!side1?.players[0] || !side2?.players[0]) {
     return null;
+  }
+
+  // Result posted, waiting on the other side to confirm: the board is
+  // mathematically decided, so call it "won" — not "leading", which implies
+  // play continues — and flag the pending sign-off (#491). The prospective
+  // winner is whichever side reached the games target.
+  if (details.status_label === AWAITING_CONFIRMATION) {
+    const [winner, loser] =
+      side1.games_won >= side2.games_won ? [side1, side2] : [side2, side1];
+    return `${winner.players[0].username} won ${games(winner.games_won)} to ${loser.games_won} — awaiting confirmation`;
   }
 
   if (side1.games_won === 0 && side2.games_won === 0) {
@@ -139,13 +158,14 @@ const selectChip = (
   status: Scoreboard["status"],
   details: MatchDetailsResult["unmigrated"],
 ): StatusChipView => {
-  if (status === "live") {
-    return details.current_game
-      ? { status, label: `Live · Game ${details.current_game.game_number}` }
-      : null;
-  }
-  if (status === "final") {
-    return { status, label: "Final" };
+  // A game is actively being played — name it. Otherwise defer to the server's
+  // lifecycle label, which already distinguishes the states the coarse
+  // scoreboard status flattens: "Awaiting confirmation" and "Live" both map to
+  // `live` (so a posted-but-unconfirmed or between-games board still gets a
+  // chip, #491/#492), and "Disputed"/"Voided"/"Final" all map to `final` (so a
+  // disputed board's chip reads "Disputed", not "Final", #561).
+  if (status === "live" && details.current_game) {
+    return { status, label: `Live · Game ${details.current_game.game_number}` };
   }
   return { status, label: details.status_label };
 };

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -283,6 +283,11 @@ function ScoreEntryInner({
     // idempotent server-side, so this is just to avoid the wasted round-trip —
     // the mutationFn also treats a 409 as a successful re-save as a backstop.
     if (saveMutation.isPending) return
+    // Same for a second submit while the finalize POST is in flight (#550). The
+    // submit button's `disabled` is only a render-time guard, so a fast
+    // double-click can land a second tap before React commits it — fire one
+    // POST /results, not two (the second 409s on the already-posted result).
+    if (finalizeMutation.isPending) return
     // Finalizing posts the canonical result — but that's the one write that
     // can't be faked offline. When offline we instead fall through to the
     // scratchpad save below, which stores the deciding game's score in the


### PR DESCRIPTION
## What

Two related slices on the match-details surface:

**API — #497 (already on branch):** H2H card no longer counts meetings played *after* the viewed match — `_history_base_query` now filters to `before=match.created_at`.

**Web-client — hero/status labels + finalize debounce:** the scoreboard chip and hero outcome are now driven off the server's lifecycle `status_label` instead of re-derived from the coarse `scheduled/live/final` tri-state (which threw away the posted/disputed distinctions):

- **#561** — a disputed board (coarse status `final`) now reads **"Disputed"**, not "Final", so the hero badge agrees with the Match-info Status field.
- **#492** — a live board with no current game (e.g. posted-awaiting-confirmation) now shows a chip from `status_label` instead of rendering nothing. `StatusChipView` is now always present; dead null-handling + its test removed.
- **#491** — `selectOutcome` describes a posted-but-unconfirmed result as **"X won N games to M — awaiting confirmation"** instead of "leading".
- **#550** — `onSubmit` now guards against a second finalize while one is in flight (mirrors the existing `saveMutation` guard), so a fast double-click can't fire a duplicate `POST /results` (409).

## Not included
- **#510** investigated and found to be a service-worker register/unregister contradiction (`ServiceWorkerUpdater` registers, `main.tsx` unregisters), **not** a backend race — create→immediate-GET returns 200 for all callers, and it doesn't reproduce in a clean profile. Out of scope here; tracked separately for its own branch/QA pass.

## Testing
- web-client vitest: **690 passed** (incl. new coverage for the disputed chip #561, awaiting-confirmation chip #492, and awaiting outcome copy #491)
- web-client lint + `tsc -b` + vite build: clean
- API ruff + ruff format + mypy: clean
- API pytest: **385 passed**
- Schema drift: #497's change is internal query logic (no route/schema/docstring surface) → `schema.d.ts` in sync
- Playwright e2e (web + root): skipped — label/projection + guard changes, fully unit-covered, no routing/flow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)