### PR TITLE
Bucket attention rows by action kind so same-type buttons match (#565)

### DIFF
--- a/web-client/src/components/dashboard/attention-panel-view.test.ts
+++ b/web-client/src/components/dashboard/attention-panel-view.test.ts
@@ -44,6 +44,22 @@ describe('projectAttentionPanelView', () => {
     expect(view.rows.map((r) => r.primary)).toEqual([true, true])
   })
 
+  it('keeps rated and unrated score rows in the same primary bucket', () => {
+    // Both are `Enter score` actions; the rated/unrated split only governs
+    // ordering, never button emphasis (issue #565).
+    const view = projectAttentionPanelView(
+      [
+        dashboardAttentionItem({ kind: 'score', affects_rating: true }),
+        dashboardAttentionItem({ kind: 'score', affects_rating: true }),
+        dashboardAttentionItem({ kind: 'score', affects_rating: false }),
+      ],
+      0,
+      'rita.kovac',
+    )
+
+    expect(view.rows.map((r) => r.primary)).toEqual([true, true, true])
+  })
+
   it('routes a score row to the scoring page and review/dispute to match detail', () => {
     const view = projectAttentionPanelView(
       [

--- a/web-client/src/components/dashboard/attention-panel-view.ts
+++ b/web-client/src/components/dashboard/attention-panel-view.ts
@@ -40,14 +40,16 @@ export interface AttentionPanelView {
   viewAllSearch: { q: string | undefined }
 }
 
-// A row's attention "bucket" — the unit the primary-button rule operates on
-// (score rows split rated vs unrated; review/dispute are each their own
-// bucket). We deliberately do NOT re-encode the priority *ordering* here: the
-// server already sorts by it (PRD §5), so the first visible row is the
-// highest-priority bucket present, and every row sharing its bucket takes the
-// primary button (PRD §6.3).
+// A row's attention "bucket" — the unit the primary-button rule operates on.
+// It is keyed by the action *kind* (the button copy: dispute / review / score)
+// so same-type rows always share styling: all `Enter score` rows render primary
+// together or secondary together, regardless of rated-vs-unrated (PRD §6.3 —
+// "multiple same-type actionable items → all primary"). The rated/unrated split
+// only affects priority *ordering*, which the server already applies (PRD §5),
+// so the first visible row is the highest-priority bucket present and every row
+// sharing its kind takes the primary button.
 function bucketKey(item: DashboardAttentionItem): string {
-  return item.kind === 'score' ? `score-${item.affects_rating}` : item.kind
+  return item.kind
 }
 
 function actionLabelOf(kind: DashboardAttentionItem['kind']): string {


### PR DESCRIPTION
## What

Fixes #565. In the dashboard "Needs your attention" panel, rated and unrated "Enter score" rows rendered with different button emphasis — two filled (primary) and one outlined (secondary) — even though they're the same action.

## Why

`bucketKey()` split `score` rows into `score-true` (rated) vs `score-false` (unrated) buckets when deciding which rows get the primary button. Only the top bucket renders primary, so an unrated "Enter score" beneath rated ones dropped to a secondary outline button. The rated/unrated split is meant to govern *ordering* (already applied server-side), not button emphasis.

PRD §6.3: "multiple same-type actionable items → all primary."

## Change

- `bucketKey()` now keys by `item.kind` only, so all `Enter score` rows share a bucket and render consistently.
- Added a view-model test asserting rated + unrated score rows all render primary.

## Testing

- `web-client` vitest: 695 passed (incl. new + existing attention-panel-view/component tests)
- `web-client` lint + `tsc -b && vite build`: clean
- e2e suites skipped — not applicable (presentational button-emphasis change, no data/behavior impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)