### PR TITLE
Keep the mobile keyboard open between games when scoring (#567)

### DIFF
--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -205,6 +205,38 @@ describe('ScoreEntry — create', () => {
     expect(captured).toEqual({ side_1_points: 11, side_2_points: 4 })
   })
 
+  it('advances to the next game immediately, without waiting for the save to settle (#567)', async () => {
+    // Mobile keyboard regression: navigation must happen synchronously in the
+    // Save tap, not from the save's `onSettled`. If it waited for the network
+    // round-trip, the soft keyboard would close and the next game's input would
+    // lose focus between games. Here the save POST never resolves, yet we must
+    // still land on the next un-scored game.
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      // Never resolves — stands in for a slow/in-flight save.
+      http.post(
+        '*/v1/matches/m-1/games/3/scores/new',
+        () => new Promise<Response>(() => {}),
+      ),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+    await user.type(
+      screen.getByRole('textbox', { name: 'rita.kovac score' }),
+      '11',
+    )
+    await user.type(screen.getByRole('textbox', { name: 'nguyen.t score' }), '4')
+    await user.click(screen.getByRole('button', { name: /save game & next/i }))
+
+    // Already on game 4 even though the game-3 save is still pending.
+    await waitFor(() =>
+      expect(screen.getByText('scoring-new m-1 4')).toBeInTheDocument(),
+    )
+  })
+
   it('treats a 409 on the create POST as a successful re-save (#538)', async () => {
     // A double-tapped Save fires the create POST twice; the second hits an
     // already-saved game and 409s. The mutation must fall back to an update

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -487,7 +487,7 @@ function ScoreEntryInner({
               // Don't let tapping Save blur the active input: on mobile that
               // dismisses the soft keyboard before the synchronous navigation
               // can hand focus to the next game's input, closing the keyboard
-              // between games (#567). Preventing the pointerdown default keeps
+              // between games (#567). Preventing the mousedown default keeps
               // focus on the input through the tap; the click still fires.
               onMouseDown={(e) => e.preventDefault()}
               onClick={onSubmit}

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -306,13 +306,19 @@ function ScoreEntryInner({
       return
     }
     const next = predictNextScoringRoute()
-    // Fire-and-forget — we navigate as soon as the request settles either way,
-    // since the canonical POST /results reconciles the score later. The save
-    // lands in the shared mutation cache under this game's key: on success the
-    // game's scoreline cell reads "saved"; on failure it stays there as the
-    // failed-save state (#369), so the cell flips to failed (keeping the
-    // entered points) and the next screen's banner names the game.
-    saveMutation.mutate(args, { onSettled: () => navigate(next) })
+    // Fire-and-forget — navigate to the next game *synchronously*, in the same
+    // user gesture, without waiting for the request to settle. The save lands
+    // in the shared mutation cache under this game's key (pending immediately),
+    // so the next screen's scoreline cell reads "saving" and the route
+    // prediction already counts it; on success the cell flips to "saved", on
+    // failure to the failed-save state (#369) with the entered points retained.
+    // Navigating inside the gesture — rather than from a later onSettled, after
+    // the network round-trip — is what keeps the mobile soft keyboard open: a
+    // browser only honours the next input's autofocus while still inside the
+    // tap that triggered it, so deferring to onSettled dropped focus and closed
+    // the keyboard between games (#567).
+    saveMutation.mutate(args)
+    navigate(next)
   }
 
   // After any clear, drop focus into the first input that's still empty so
@@ -478,6 +484,12 @@ function ScoreEntryInner({
               type="button"
               className="btn primary"
               disabled={!inputsValid || inputsLocked}
+              // Don't let tapping Save blur the active input: on mobile that
+              // dismisses the soft keyboard before the synchronous navigation
+              // can hand focus to the next game's input, closing the keyboard
+              // between games (#567). Preventing the pointerdown default keeps
+              // focus on the input through the tap; the click still fires.
+              onMouseDown={(e) => e.preventDefault()}
               onClick={onSubmit}
             >
               {submitLabel}


### PR DESCRIPTION
## What & why

Fixes #567. On mobile, after saving a game's score the soft keyboard closed and the next game's inputs lost focus — so you had to re-tap the field for every game (see the issue screenshot: game 1 saved, game 2 input blurred with the keyboard down).

**Root cause:** advancing to the next game was deferred to the per-game save's `onSettled` callback, which fires *after* the network round-trip. By then the user's tap is over, and mobile browsers only honour a freshly-mounted input's `autoFocus` (and keep the soft keyboard up) while still inside the originating gesture.

## Fix

`web-client/src/components/matches/score-entry.tsx`:
1. **Navigate synchronously inside the tap** instead of from `onSettled`. The fire-and-forget design already registers the save as `pending` in the shared mutation cache immediately, so the next screen's scoreline cell still reads "saving" and the route prediction still counts the game — nothing depended on awaiting the round-trip. (Bonus: snappier.)
2. **`onMouseDown` `preventDefault()` on the Save button** so tapping it doesn't blur the active input before navigation can hand focus to the next game's input.

## Testing

- Added a vitest regression test: with a never-resolving save POST, the screen must still advance to the next game. Verified it **fails on the old `onSettled` code** and passes with the fix.
- web-client unit: **695/695** · lint + `tsc -b` + build: clean · web-client Playwright e2e: **127/127** (incl. the score-entry suite).

Note: the iOS *native* app has its own `ScoreEntryView.swift` and is unaffected by this web change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)