### PR TITLE
Add an Attention filter + current-user-aware rows to the Matches list

### DIFF
--- a/api/app/attention.py
+++ b/api/app/attention.py
@@ -1,0 +1,108 @@
+"""Current-user-aware attention classification.
+
+A single source of truth, shared by the dashboard's "Needs your attention"
+panel (``app.dashboard``) and the matches list's Attention filter
+(``app.matches``), for two questions about one of the current user's *open*
+matches:
+
+- which actionable bucket does it fall in for this user, and
+- how urgent is that bucket relative to the others.
+
+The classification is current-user-aware: the poster and the reviewer of the
+same posted result land in different buckets (the poster has signed, so for
+them the match is *waiting on the opponent*; the reviewer hasn't, so they get a
+``review``). Keeping this here — rather than re-deriving it in each router —
+means the list and the dashboard can never disagree about who owes a move.
+"""
+
+import uuid
+from typing import Literal
+
+from app.models import Match, MatchStatus
+
+# The bucket an open match falls in for the current user. A superset of the
+# dashboard's narrower ``AttentionKind``: the list also surfaces the passive
+# "waiting" rows the dashboard folds into a count, so a user can see *why* a
+# match is parked, not just that it needs someone else.
+#
+#   dispute          — a disputed match, reopened for correction (either side
+#                      may re-score and re-post).
+#   review           — the opponent posted a result; the current user must
+#                      confirm or dispute it.
+#   score            — an in-progress match with no posted result; the current
+#                      user can still enter scores.
+#   waiting_opponent — the current user posted a result; it's awaiting the
+#                      opponent's sign-off.
+#   waiting_others   — a pending/scheduled match (nobody has started scoring).
+ListAttentionKind = Literal[
+    "dispute",
+    "review",
+    "score",
+    "waiting_opponent",
+    "waiting_others",
+]
+
+
+def list_attention_kind(
+    match: Match, current_user_id: uuid.UUID
+) -> ListAttentionKind | None:
+    """Classify one of the current user's matches into an attention bucket, or
+    ``None`` when it isn't an attention row at all.
+
+    ``None`` covers a non-participant (a spectator browsing the list), a
+    completed/voided match (nothing left to do), and — defensively — any future
+    status that isn't open. Only matches the user actually plays in and that are
+    still live in some sense produce a bucket.
+    """
+    if not _is_participant(match, current_user_id):
+        return None
+
+    match match.status:
+        case MatchStatus.disputed:
+            return "dispute"
+        case MatchStatus.pending:
+            return "waiting_others"
+        case MatchStatus.in_progress:
+            if match.signatures:
+                i_signed = any(
+                    sig.user_id == current_user_id for sig in match.signatures
+                )
+                return "waiting_opponent" if i_signed else "review"
+            return "score"
+        case MatchStatus.completed | MatchStatus.voided:
+            return None
+
+
+# Attention-priority ranking (PRD §"Sort Behavior"): lower number = more
+# urgent. ``score`` splits rated-above-unrated by ``affects_rating``; the
+# passive ``waiting`` buckets sink to the bottom. Within a bucket the caller
+# orders oldest-first so a long-stalled match floats to the top.
+_DISPUTE_PRIORITY = 0
+_REVIEW_PRIORITY = 1
+_RATED_SCORE_PRIORITY = 2
+_UNRATED_SCORE_PRIORITY = 3
+_WAITING_OPPONENT_PRIORITY = 4
+_WAITING_OTHERS_PRIORITY = 5
+
+
+def attention_priority(kind: ListAttentionKind, affects_rating: bool) -> int:
+    """Sort rank for an attention row. Exhaustive over ``ListAttentionKind`` —
+    adding a member is a type error until it's handled here."""
+    match kind:
+        case "dispute":
+            return _DISPUTE_PRIORITY
+        case "review":
+            return _REVIEW_PRIORITY
+        case "score":
+            return _RATED_SCORE_PRIORITY if affects_rating else _UNRATED_SCORE_PRIORITY
+        case "waiting_opponent":
+            return _WAITING_OPPONENT_PRIORITY
+        case "waiting_others":
+            return _WAITING_OTHERS_PRIORITY
+
+
+def _is_participant(match: Match, user_id: uuid.UUID) -> bool:
+    # Inlined rather than imported from ``app.matches`` to keep this module
+    # free of the 1700-line router (and the import cycle that would create:
+    # matches imports attention).
+    return any(any(p.user_id == user_id for p in side.players) for side in match.sides)

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -8,6 +8,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.attention import attention_priority, list_attention_kind
 from app.db import get_session
 from app.matches import (
     current_game_number,
@@ -148,14 +149,6 @@ async def _load_my_rating_changes(
     return changes
 
 
-# Attention-priority ranking (PRD §5): lower number = more urgent. ``score``
-# splits into rated (2) vs unrated (3) by ``affects_rating``.
-_DISPUTE_PRIORITY = 0
-_REVIEW_PRIORITY = 1
-_RATED_SCORE_PRIORITY = 2
-_UNRATED_SCORE_PRIORITY = 3
-
-
 def _build_attention(
     in_progress: Sequence[Match],
     disputed: Sequence[Match],
@@ -170,49 +163,34 @@ def _build_attention(
     opponent" (footer) for them, while the reviewer hasn't signed and gets a
     ``review`` row. Pending/scheduled matches (``pending_count``) and our own
     posted-and-awaiting results are folded into ``waiting_count``; they never
-    render as rows.
+    render as rows. Classification + ranking come from the shared
+    ``app.attention`` module so this panel and the matches-list Attention filter
+    never disagree about who owes a move.
     """
     # (priority, sort_ts, item) — sorted by priority then oldest-first so a
     # long-stalled match floats to the top of its bucket.
     ranked: list[tuple[int, datetime, DashboardAttentionItem]] = []
     waiting = pending_count
 
-    for match in disputed:
+    for match in (*disputed, *in_progress):
+        kind = list_attention_kind(match, current_user_id)
+        # Passive "waiting" buckets are footer-only here; ``waiting_others``
+        # (pending) never reaches this loop — those matches are counted, not
+        # loaded — so only ``waiting_opponent`` (our posted-and-awaiting result)
+        # folds in.
+        if kind == "waiting_opponent" or kind == "waiting_others":
+            waiting += 1
+            continue
+        if kind is None:
+            continue
+        # kind is now narrowed to AttentionKind (dispute / review / score).
         ranked.append(
             (
-                _DISPUTE_PRIORITY,
+                attention_priority(kind, match.match_settings.affects_rating),
                 match.updated_at,
-                _attention_item(match, current_user_id, "dispute"),
+                _attention_item(match, current_user_id, kind),
             )
         )
-
-    for match in in_progress:
-        if match.signatures:
-            i_signed = any(sig.user_id == current_user_id for sig in match.signatures)
-            if i_signed:
-                # We posted the result; it's awaiting the opponent's sign-off.
-                waiting += 1
-            else:
-                ranked.append(
-                    (
-                        _REVIEW_PRIORITY,
-                        match.updated_at,
-                        _attention_item(match, current_user_id, "review"),
-                    )
-                )
-        else:
-            priority = (
-                _RATED_SCORE_PRIORITY
-                if match.match_settings.affects_rating
-                else _UNRATED_SCORE_PRIORITY
-            )
-            ranked.append(
-                (
-                    priority,
-                    match.updated_at,
-                    _attention_item(match, current_user_id, "score"),
-                )
-            )
 
     ranked.sort(key=lambda row: (row[0], row[1]))
     return [item for _, _, item in ranked], waiting

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -23,6 +23,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
 from sqlalchemy.sql.base import ExecutableOption
 
+from app.attention import (
+    attention_priority,
+    list_attention_kind,
+)
 from app.db import get_session
 from app.domain.match.models import Match as MatchModel
 from app.leagues import resolve_league
@@ -477,6 +481,46 @@ def _filtered_matches_query(
     return base if status_ is None else base.where(Match.status == status_)
 
 
+# Open statuses the Attention filter ranges over — the only ones where the
+# current user can still owe (or be owed) a move. Completed/voided drop out.
+_ATTENTION_STATUSES = (
+    MatchStatus.pending,
+    MatchStatus.in_progress,
+    MatchStatus.disputed,
+)
+
+
+def _attention_matches_query(
+    q: str | None, current_user_id: uuid.UUID
+) -> Select[tuple[Match]]:
+    """The caller's own open matches (optionally search-narrowed) — the row set
+    behind the Attention tab and its tab-badge count. Restricted to
+    participation, unlike the perspective-neutral browsing query."""
+    base = participant_filter(select(Match), current_user_id).where(
+        Match.status.in_(_ATTENTION_STATUSES)
+    )
+    if q:
+        base = _player_username_filter(base, q)
+    return base
+
+
+def _attention_sort_key(
+    match: Match, current_user_id: uuid.UUID
+) -> tuple[int, datetime]:
+    """Priority then oldest-first, so the most urgent (and most-stalled within a
+    bucket) attention rows float to the top — the same order the dashboard
+    panel uses."""
+    kind = list_attention_kind(match, current_user_id)
+    if kind is None:
+        # Defensive: an open participant match always classifies. Sink any
+        # surprise to the bottom rather than crash the page.
+        return (len(_ATTENTION_STATUSES) + 99, match.updated_at)
+    return (
+        attention_priority(kind, match.match_settings.affects_rating),
+        match.updated_at,
+    )
+
+
 @router.get("/matches.csv", response_class=Response)
 async def export_matches_csv(
     status_: MatchStatus | None = Query(default=None, alias="status"),
@@ -509,31 +553,23 @@ async def export_matches_csv(
 @router.get("/matches", response_model=MatchListResponse)
 async def list_matches(
     status_: MatchStatus | None = Query(default=None, alias="status"),
+    attention: bool = Query(
+        default=False,
+        description=(
+            "When true, return only the caller's open matches that need "
+            "attention (theirs or someone else's), ranked by urgency. This is "
+            "its own dimension — ``status`` is ignored when it's set."
+        ),
+    ),
     q: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=25, ge=1, le=MAX_PAGE_SIZE),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> MatchListResponse:
-    # The list is open to every signed-in user. Writes still gate on
-    # `_is_participant` downstream.
-    matches = (
-        (
-            await db.execute(
-                _filtered_matches_query(q, status_)
-                .options(*match_eager_options())
-                .order_by(Match.created_at.desc())
-                .offset((page - 1) * page_size)
-                .limit(page_size)
-            )
-        )
-        .scalars()
-        .all()
-    )
-
-    # status_counts honors `q` but ignores the status filter, so it's built
-    # from its own aggregate. `total` then falls out of the same counts — no
-    # separate count round-trip needed.
+    # status_counts honors `q` but ignores the status/attention filter, so it's
+    # built from its own aggregate and powers the All/Live/Up-next/Final badges
+    # (and the browsing `total`) for either filter mode.
     counts_query = select(Match.status, func.count(Match.id))
     if q:
         counts_query = _player_username_filter(counts_query, q)
@@ -542,17 +578,80 @@ async def list_matches(
         await db.execute(counts_query.group_by(Match.status))
     ).all():
         status_counts[status_value] = count
-    total = (
-        status_counts[status_] if status_ is not None else sum(status_counts.values())
-    )
+
+    # The list is open to every signed-in user. Writes still gate on
+    # `_is_participant` downstream.
+    if attention:
+        # The Attention set is bounded by the caller's *open* matches — a handful
+        # even for an active player — so we load them all, rank by attention
+        # priority in Python (no SQL ordering captures the per-user bucketing),
+        # and paginate the sorted list. Its length *is* the tab-badge count, so
+        # no separate aggregate is needed on this path.
+        open_matches = (
+            (
+                await db.execute(
+                    _attention_matches_query(q, current_user.id).options(
+                        *match_eager_options()
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        ranked = sorted(
+            open_matches, key=lambda m: _attention_sort_key(m, current_user.id)
+        )
+        total = attention_count = len(ranked)
+        start = (page - 1) * page_size
+        items = [
+            _list_row(match, current_user.id)
+            for match in ranked[start : start + page_size]
+        ]
+    else:
+        matches = (
+            (
+                await db.execute(
+                    _filtered_matches_query(q, status_)
+                    .options(*match_eager_options())
+                    .order_by(Match.created_at.desc())
+                    .offset((page - 1) * page_size)
+                    .limit(page_size)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        items = [_list_row(match, current_user.id) for match in matches]
+        total = (
+            status_counts[status_]
+            if status_ is not None
+            else sum(status_counts.values())
+        )
+        # The Attention badge must read its own count even while another tab is
+        # active, so it's a dedicated participant-scoped aggregate (honoring `q`).
+        attention_count = await _attention_count(db, q, current_user.id)
 
     return MatchListResponse(
-        items=[_list_row(match, current_user.id) for match in matches],
+        items=items,
         page=page,
         page_size=page_size,
         total=total,
         status_counts=status_counts,
+        attention_count=attention_count,
     )
+
+
+async def _attention_count(
+    db: AsyncSession, q: str | None, current_user_id: uuid.UUID
+) -> int:
+    """Count of the caller's open matches under the active search — the Attention
+    tab's badge when a different tab is showing."""
+    query = participant_filter(select(func.count(Match.id)), current_user_id).where(
+        Match.status.in_(_ATTENTION_STATUSES)
+    )
+    if q:
+        query = _player_username_filter(query, q)
+    return int((await db.execute(query)).scalar_one())
 
 
 def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
@@ -577,6 +676,7 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
         current_game_number=next_number if is_participant else None,
         can_score=can_score,
         can_confirm=_can_confirm(match, current_user_id),
+        attention=list_attention_kind(match, current_user_id),
     )
 
 

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from app.attention import ListAttentionKind
 from app.models.match import MatchStatus
 from app.schemas.rating import RatingChange
 from app.schemas.view.match_details import MatchDetails as MatchDetailsView
@@ -206,6 +207,13 @@ class MatchListRow(BaseModel):
     # surface an "Awaiting your confirmation" CTA on rows the caller owes a
     # signature on.
     can_confirm: bool
+    # The current-user-aware attention bucket this row falls in (see
+    # ``app.attention``), or ``None`` when the row isn't an attention item for
+    # the caller — a completed/voided match, or a match the caller only
+    # spectates. The FE derives the row's current-user-aware status label and
+    # primary/secondary CTA from this (plus ``current_game_number`` for the
+    # scoring deep-link), falling back to ``status_label`` when it's ``None``.
+    attention: ListAttentionKind | None
 
 
 class MatchListResponse(BaseModel):
@@ -214,6 +222,10 @@ class MatchListResponse(BaseModel):
     page_size: int
     total: int
     status_counts: dict[MatchStatus, int]
+    # Count of the caller's *open* matches (any attention bucket) under the
+    # active search, independent of which status tab is selected — powers the
+    # Attention tab's badge even while another tab is showing. Always present.
+    attention_count: int
 
 
 # ----- score write (POST/PUT body) -----------------------------------------

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -527,6 +527,109 @@ async def test_list_row_hides_scoring_affordance_from_spectators(
     assert row["can_score"] is False
 
 
+# ----- attention filter ---------------------------------------------------
+
+
+async def _post_bo1_result(
+    client: AsyncClient, match_id: str, *, s1: int = 11, s2: int = 5
+) -> dict:
+    response = await client.post(
+        f"/v1/matches/{match_id}/results",
+        json={"games": [{"game_number": 1, "side_1_points": s1, "side_2_points": s2}]},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+async def test_list_attention_ranks_review_above_score(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        # A fresh rated match I still need to score.
+        scoring = await _create_match(api_client, opp.id, best_of=1)
+        # A match the opponent has posted a result on — now awaiting *my* review.
+        to_review = await _create_match(api_client, opp.id, best_of=1)
+        await _post_bo1_result(opp_client, to_review["id"])
+
+    listing = (await api_client.get("/v1/matches", params={"attention": "true"})).json()
+    rows = listing["items"]
+    # Review (priority 1) ranks above the rated score (priority 2).
+    assert [row["id"] for row in rows] == [to_review["id"], scoring["id"]]
+    assert [row["attention"] for row in rows] == ["review", "score"]
+    assert listing["total"] == 2
+    assert listing["attention_count"] == 2
+
+
+async def test_list_attention_excludes_finished_and_spectated_matches(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        open_match = await _create_match(api_client, opp.id, best_of=1)
+        # A finished match (post + confirm) — no longer an attention row.
+        done = await _create_match(api_client, opp.id, best_of=1)
+        await _post_bo1_result(api_client, done["id"])
+        assert (
+            await opp_client.post(f"/v1/matches/{done['id']}/confirmation")
+        ).status_code == 201
+    # A match between two strangers — visible when browsing, never in *my*
+    # attention list.
+    async with make_client() as other_client:
+        await start_session(other_client, db_session)
+        bystander = await make_user(db_session, "bystander")
+        spectated = await _create_match(other_client, bystander.id, best_of=1)
+
+    listing = (await api_client.get("/v1/matches", params={"attention": "true"})).json()
+    ids = {row["id"] for row in listing["items"]}
+    assert ids == {open_match["id"]}
+    assert done["id"] not in ids
+    assert spectated["id"] not in ids
+    assert listing["attention_count"] == 1
+
+
+async def test_list_attention_count_is_present_on_other_tabs(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # The Attention badge must read its own count even while another tab is
+    # active, so attention_count rides every response.
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    await _create_match(api_client, opp.id, best_of=1)
+    await _create_match(api_client, opp.id, best_of=1)
+
+    listing = (
+        await api_client.get("/v1/matches", params={"status": "completed"})
+    ).json()
+    assert listing["items"] == []
+    assert listing["attention_count"] == 2
+
+
+async def test_list_row_attention_kind_reflects_who_must_act(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        # I posted a result — it's waiting on the opponent's sign-off.
+        waiting = await _create_match(api_client, opp.id, best_of=1)
+        await _post_bo1_result(api_client, waiting["id"])
+        # A result the opponent posted, then I disputed — reopened.
+        disputed = await _create_match(api_client, opp.id, best_of=1)
+        await _post_bo1_result(opp_client, disputed["id"])
+        assert (
+            await api_client.post(f"/v1/matches/{disputed['id']}/dispute")
+        ).status_code == 200
+
+    listing = (await api_client.get("/v1/matches")).json()
+    by_id = {row["id"]: row["attention"] for row in listing["items"]}
+    assert by_id[waiting["id"]] == "waiting_opponent"
+    assert by_id[disputed["id"]] == "dispute"
+    # A disputed match is waiting on no one in particular — it's actionable for
+    # both sides — but the poster's awaiting-confirmation match reads as passive
+    # for them. Both still ride the attention set.
+    assert listing["attention_count"] == 2
+
+
 # ----- TT scoring rules ---------------------------------------------------
 
 

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -29,6 +29,9 @@ export type Scoreboard = components['schemas']['Scoreboard']
 
 export type MatchListParams = {
   status?: MatchStatus
+  /** When true, request the current user's attention-ranked open matches; the
+   * server ignores `status` in this mode. */
+  attention?: boolean
   q?: string
   page: number
   page_size: number
@@ -149,6 +152,7 @@ export function matchListQueryOptions(params: MatchListParams) {
           params: {
             query: {
               status: params.status,
+              attention: params.attention,
               q: params.q,
               page: params.page,
               page_size: params.page_size,

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1112,6 +1112,8 @@ export interface components {
             status_counts: {
                 [key: string]: number;
             };
+            /** Attention Count */
+            attention_count: number;
         };
         /** MatchListRow */
         MatchListRow: {
@@ -1139,6 +1141,8 @@ export interface components {
             can_score: boolean;
             /** Can Confirm */
             can_confirm: boolean;
+            /** Attention */
+            attention: ("dispute" | "review" | "score" | "waiting_opponent" | "waiting_others") | null;
         };
         /**
          * MatchResultsGameWrite
@@ -2495,6 +2499,8 @@ export interface operations {
         parameters: {
             query?: {
                 status?: components["schemas"]["MatchStatus"] | null;
+                /** @description When true, return only the caller's open matches that need attention (theirs or someone else's), ranked by urgency. This is its own dimension — ``status`` is ignored when it's set. */
+                attention?: boolean;
                 q?: string | null;
                 page?: number;
                 page_size?: number;

--- a/web-client/src/components/dashboard/attention-panel-view.test.ts
+++ b/web-client/src/components/dashboard/attention-panel-view.test.ts
@@ -10,7 +10,7 @@ describe('projectAttentionPanelView', () => {
       dashboardAttentionItem({ match_id: `m-${i}`, kind: 'score' }),
     )
 
-    const view = projectAttentionPanelView(items, 0, 'rita.kovac')
+    const view = projectAttentionPanelView(items, 0)
 
     expect(view.rows).toHaveLength(3)
     expect(view.rows.map((r) => r.matchId)).toEqual(['m-0', 'm-1', 'm-2'])
@@ -25,7 +25,6 @@ describe('projectAttentionPanelView', () => {
         dashboardAttentionItem({ match_id: 'm-score', kind: 'score' }),
       ],
       0,
-      'rita.kovac',
     )
 
     expect(view.rows.map((r) => r.primary)).toEqual([true, false, false])
@@ -38,7 +37,6 @@ describe('projectAttentionPanelView', () => {
         dashboardAttentionItem({ kind: 'score', affects_rating: true }),
       ],
       0,
-      'rita.kovac',
     )
 
     expect(view.rows.map((r) => r.primary)).toEqual([true, true])
@@ -54,7 +52,6 @@ describe('projectAttentionPanelView', () => {
         dashboardAttentionItem({ kind: 'score', affects_rating: false }),
       ],
       0,
-      'rita.kovac',
     )
 
     expect(view.rows.map((r) => r.primary)).toEqual([true, true, true])
@@ -75,7 +72,6 @@ describe('projectAttentionPanelView', () => {
         }),
       ],
       0,
-      'rita.kovac',
     )
 
     expect(view.rows[0].route).toEqual({
@@ -98,7 +94,6 @@ describe('projectAttentionPanelView', () => {
         }),
       ],
       0,
-      'rita.kovac',
     )
 
     expect(view.rows[0].route).toEqual({
@@ -114,41 +109,35 @@ describe('projectAttentionPanelView', () => {
         dashboardAttentionItem({ opponent_username: null }),
       ],
       0,
-      'rita.kovac',
     )
 
     expect(view.rows[0].headline).toBe('vs lively.otter')
     expect(view.rows[1].headline).toBe('No opponent')
   })
 
-  it('passes through the waiting count and scopes "View all" to the user', () => {
-    const view = projectAttentionPanelView([], 4, 'rita.kovac')
+  it('passes through the waiting count and points "View all" at the Attention tab', () => {
+    const view = projectAttentionPanelView([], 4)
 
     expect(view.rows).toHaveLength(0)
     expect(view.overflowCount).toBe(0)
     expect(view.waitingCount).toBe(4)
-    expect(view.viewAllSearch).toEqual({ q: 'rita.kovac' })
+    expect(view.viewAllSearch).toEqual({ status: 'attention' })
   })
 })
 
 describe('isAttentionPanelEmpty', () => {
   it('is empty when there are no rows, no overflow, and nobody waiting', () => {
-    expect(isAttentionPanelEmpty(projectAttentionPanelView([], 0, 'rita'))).toBe(
-      true,
-    )
+    expect(isAttentionPanelEmpty(projectAttentionPanelView([], 0))).toBe(true)
   })
 
   it('is not empty when matches are waiting on others', () => {
-    expect(isAttentionPanelEmpty(projectAttentionPanelView([], 3, 'rita'))).toBe(
-      false,
-    )
+    expect(isAttentionPanelEmpty(projectAttentionPanelView([], 3))).toBe(false)
   })
 
   it('is not empty when there are actionable rows', () => {
     const view = projectAttentionPanelView(
       [dashboardAttentionItem({ kind: 'score' })],
       0,
-      'rita',
     )
     expect(isAttentionPanelEmpty(view)).toBe(false)
   })
@@ -157,7 +146,7 @@ describe('isAttentionPanelEmpty', () => {
     const items = Array.from({ length: 5 }, (_, i) =>
       dashboardAttentionItem({ match_id: `m-${i}`, kind: 'score' }),
     )
-    expect(isAttentionPanelEmpty(projectAttentionPanelView(items, 0, 'r'))).toBe(
+    expect(isAttentionPanelEmpty(projectAttentionPanelView(items, 0))).toBe(
       false,
     )
   })

--- a/web-client/src/components/dashboard/attention-panel-view.ts
+++ b/web-client/src/components/dashboard/attention-panel-view.ts
@@ -36,8 +36,10 @@ export interface AttentionPanelView {
   overflowCount: number
   /** Matches waiting on someone else — footer "N waiting on others". */
   waitingCount: number
-  /** Search params for the "View all" link to /matches. */
-  viewAllSearch: { q: string | undefined }
+  /** Search params for the "View all" link — opens /matches on the Attention
+   * tab so the same priority-ranked set the panel previews fills the page
+   * (PRD §"Dashboard Integration"). */
+  viewAllSearch: { status: 'attention' }
 }
 
 // A row's attention "bucket" — the unit the primary-button rule operates on.
@@ -92,7 +94,6 @@ export function isAttentionPanelEmpty(view: AttentionPanelView): boolean {
 export function projectAttentionPanelView(
   items: DashboardAttentionItem[],
   waitingCount: number,
-  username: string | undefined,
 ): AttentionPanelView {
   const visible = items.slice(0, ATTENTION_VISIBLE_LIMIT)
   // Items arrive pre-sorted by priority, so the first visible row defines the
@@ -111,6 +112,6 @@ export function projectAttentionPanelView(
     })),
     overflowCount: Math.max(0, items.length - ATTENTION_VISIBLE_LIMIT),
     waitingCount,
-    viewAllSearch: { q: username },
+    viewAllSearch: { status: 'attention' },
   }
 }

--- a/web-client/src/components/dashboard/attention-panel.factory.tsx
+++ b/web-client/src/components/dashboard/attention-panel.factory.tsx
@@ -21,7 +21,7 @@ export function buildAttentionRowView(
 }
 
 /** A panel with a single primary "Enter score" row, no overflow, nobody
- * waiting, and a "View all" link scoped to rita.kovac's matches. */
+ * waiting, and a "View all" link to the matches Attention tab. */
 export function buildAttentionPanelView(
   overrides: Partial<AttentionPanelView> = {},
 ): AttentionPanelView {
@@ -29,7 +29,7 @@ export function buildAttentionPanelView(
     rows: [buildAttentionRowView()],
     overflowCount: 0,
     waitingCount: 0,
-    viewAllSearch: { q: 'rita.kovac' },
+    viewAllSearch: { status: 'attention' },
     ...overrides,
   }
 }

--- a/web-client/src/components/dashboard/attention-panel.test.tsx
+++ b/web-client/src/components/dashboard/attention-panel.test.tsx
@@ -95,15 +95,15 @@ describe('AttentionPanel', () => {
     expect(page.queryFooterText(/need attention/)).not.toBeInTheDocument()
   })
 
-  it('links "View all" to /matches scoped to the current user', async () => {
+  it('links "View all" to the matches Attention tab', async () => {
     page.render({
-      view: buildAttentionPanelView({ viewAllSearch: { q: 'rita.kovac' } }),
+      view: buildAttentionPanelView({ viewAllSearch: { status: 'attention' } }),
     })
 
     await page.findPanel()
     expect(page.getViewAllLink()).toHaveAttribute(
       'href',
-      '/matches?q=rita.kovac',
+      '/matches?status=attention',
     )
   })
 })

--- a/web-client/src/components/dashboard/attention-panel.tsx
+++ b/web-client/src/components/dashboard/attention-panel.tsx
@@ -84,7 +84,7 @@ function AttentionFooter({
 }: {
   overflowCount: number
   waitingCount: number
-  viewAllSearch: { q: string | undefined }
+  viewAllSearch: { status: 'attention' }
 }) {
   const parts: string[] = []
   if (overflowCount > 0) {

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -853,12 +853,8 @@ export function DashboardPage() {
   const showGuestPersistBanner = isGuest && (data?.completed_match_count ?? 0) >= 1
   const attentionView = useMemo(
     () =>
-      projectAttentionPanelView(
-        data?.attention ?? [],
-        data?.waiting_count ?? 0,
-        username,
-      ),
-    [data?.attention, data?.waiting_count, username],
+      projectAttentionPanelView(data?.attention ?? [], data?.waiting_count ?? 0),
+    [data?.attention, data?.waiting_count],
   )
   return (
     <div

--- a/web-client/src/components/matches/match-list.test.tsx
+++ b/web-client/src/components/matches/match-list.test.tsx
@@ -41,6 +41,34 @@ describe('MatchList', () => {
     )
   })
 
+  it('renders the Attention tab and the action CTA for an attention row when deep-linked', async () => {
+    matchListPage.mockEndpoint(
+      matchListResponse({
+        items: [
+          matchListRow({
+            id: 'm-att',
+            opponent: 'nguyen.t',
+            status: 'in_progress',
+            attention: 'score',
+            current_game_number: 2,
+          }),
+        ],
+        total: 1,
+        status_counts: { in_progress: 1 },
+        attention_count: 1,
+      }),
+    )
+    matchListPage.render('/matches?status=attention')
+
+    await matchListPage.findRow('Open match: rita.kovac vs nguyen.t')
+    // The Attention tab exists in the filter row…
+    expect(matchListPage.filterRow.getTab(/attention/i)).toBeInTheDocument()
+    // …and the score row exposes an "Enter score" CTA into the scoring flow.
+    expect(
+      matchListPage.table.rows.getActionLink('Enter score'),
+    ).toHaveAttribute('href', '/matches/m-att/games/2/scores/new')
+  })
+
   it('projects raw rows into row view models before handing them to the table (a known opponent renders)', async () => {
     // Wiring only: the projection branches (perspective, score, tone, time) are
     // pinned by match-list-row-view.test.ts — here we only confirm the

--- a/web-client/src/components/matches/match-list.tsx
+++ b/web-client/src/components/matches/match-list.tsx
@@ -20,11 +20,12 @@ import {
   PAGE_SIZE,
   listParamsFromSearch,
   matchesSearchSchema,
-  type StatusKey,
+  type TabValue,
 } from './match-list/match-list-status'
 import {
   projectMatchListRow,
   buildFilterTabs,
+  topActionableKind,
 } from './match-list/match-list-row-view'
 import './match-list/match-list.css'
 
@@ -52,14 +53,18 @@ export const MatchList = () => {
   const navigate = useNavigate()
 
   const q = urlSearch.q ?? ''
-  const status: 'all' | StatusKey = urlSearch.status ?? 'all'
+  const status: TabValue = urlSearch.status ?? 'all'
+  const isAttention = status === 'attention'
   const page = urlSearch.page ?? 1
 
   // Debounce only the text search — tab and pagination clicks aren't a
   // hammer risk and should fire immediately so the table doesn't lag the
   // click by 300ms. The URL still updates synchronously on every change.
   const debouncedQ = useDebouncedValue(q.trim(), 300)
-  const apiStatus = status === 'all' ? undefined : TAB_TO_API[status]
+  // `all` and `attention` aren't API status values — both export the whole
+  // q-filtered set (the CSV endpoint has no attention dimension).
+  const apiStatus =
+    status === 'all' || status === 'attention' ? undefined : TAB_TO_API[status]
   // Built via the same helper the route loader uses, so a hover preload and the
   // live query share one cache key and the click renders from cache.
   const queryParams = useMemo(
@@ -102,7 +107,7 @@ export const MatchList = () => {
   )
 
   const changeStatus = useCallback(
-    (next: 'all' | StatusKey) => {
+    (next: TabValue) => {
       setSearch({
         status: next === 'all' ? undefined : next,
         page: undefined,
@@ -118,6 +123,11 @@ export const MatchList = () => {
   )
   const onClear = useCallback(() => {
     setSearch({ q: undefined, status: undefined, page: undefined })
+  }, [setSearch])
+  // Drop only the search term, staying on the active tab — used by the
+  // attention "No matches for …" empty state.
+  const onClearSearch = useCallback(() => {
+    setSearch({ q: undefined, page: undefined })
   }, [setSearch])
   const setPage = useCallback(
     (next: number) => {
@@ -160,15 +170,24 @@ export const MatchList = () => {
   const displayPage = Math.min(page, totalPages)
 
   // Project the raw payload rows into the presentational view models the table
-  // consumes — perspective, status tone, side labels, short id, and the
-  // relative "started" label all resolve here, never inside the children.
-  const rowViews = useMemo(
-    () => (data?.items ?? []).map((row) => projectMatchListRow(row)),
-    [data?.items],
-  )
+  // consumes — perspective, status tone, side labels, short id, the relative
+  // "started" label, and the current-user-aware label/CTA all resolve here,
+  // never inside the children. The page's top actionable bucket (computed once
+  // over all rows) decides which rows take the primary orange CTA.
+  const rowViews = useMemo(() => {
+    const items = data?.items ?? []
+    const primaryKind = topActionableKind(items)
+    return items.map((row) => projectMatchListRow(row, primaryKind))
+  }, [data?.items])
   const tabs = useMemo(
-    () => buildFilterTabs(STATUS_TABS, data?.status_counts, TAB_TO_API),
-    [data?.status_counts],
+    () =>
+      buildFilterTabs(
+        STATUS_TABS,
+        data?.status_counts,
+        TAB_TO_API,
+        data?.attention_count,
+      ),
+    [data?.status_counts, data?.attention_count],
   )
 
   return (
@@ -186,7 +205,10 @@ export const MatchList = () => {
           <MatchListTable
             rows={rowViews}
             isLoading={isLoading}
+            isAttention={isAttention}
+            query={q.trim()}
             onClear={onClear}
+            onClearSearch={onClearSearch}
             navigate={navigate}
           />
         </div>

--- a/web-client/src/components/matches/match-list/filter-row.tsx
+++ b/web-client/src/components/matches/match-list/filter-row.tsx
@@ -3,12 +3,12 @@ import { Search, X } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
-import type { StatusKey } from './match-list-status'
+import type { TabValue } from './match-list-status'
 
 export interface FilterTabView {
-  /** Tab value passed back to setStatus: 'all' | StatusKey. */
-  value: 'all' | StatusKey
-  /** Visible label, e.g. 'All', 'Live', 'Up next', 'Final'. */
+  /** Tab value passed back to setStatus, e.g. 'attention' | 'all' | 'live'. */
+  value: TabValue
+  /** Visible label, e.g. 'Attention', 'All', 'Live', 'Up next', 'Final'. */
   label: string
   /** True for the Live tab — renders the leading live-dot. */
   isLive: boolean
@@ -21,8 +21,8 @@ export interface FilterRowProps {
   q: string
   setQ: (v: string) => void
   /** Currently-selected tab. */
-  status: 'all' | StatusKey
-  setStatus: (v: 'all' | StatusKey) => void
+  status: TabValue
+  setStatus: (v: TabValue) => void
   /** Pre-built tab descriptors with resolved counts. */
   tabs: FilterTabView[]
 }
@@ -52,7 +52,7 @@ export const FilterRow = ({ q, setQ, status, setStatus, tabs }: FilterRowProps) 
 
       <Tabs
         value={status}
-        onValueChange={(v) => setStatus(v as 'all' | StatusKey)}
+        onValueChange={(v) => setStatus(v as TabValue)}
       >
         <TabsList>
           {tabs.map((t) => (

--- a/web-client/src/components/matches/match-list/match-list-row-view.test.ts
+++ b/web-client/src/components/matches/match-list/match-list-row-view.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { scoringNewRoute, type MatchListRow } from '@/api/matches'
+import {
+  matchDetailRoute,
+  scoringNewRoute,
+  type MatchListRow,
+} from '@/api/matches'
 import type { components } from '@/api/schema'
 import { matchListRow } from '@/test/factories'
 import {
@@ -15,6 +19,7 @@ import {
   projectMatchListRow,
   shortId,
   sideLabel,
+  topActionableKind,
 } from './match-list-row-view'
 
 type MatchListRowSide = components['schemas']['MatchDetailsSide']
@@ -173,19 +178,101 @@ describe('projectMatchListRow', () => {
     expect(view.side2.isWinner).toBe(false)
   })
 
-  it('omits the score route when current_game_number is null', () => {
-    const row = matchListRow({ current_game_number: null })
-    expect(projectMatchListRow(row).scoreRoute).toBeNull()
+  it('omits the action when the row has no attention bucket', () => {
+    const row = matchListRow({ attention: null, current_game_number: null })
+    expect(projectMatchListRow(row).action).toBeNull()
   })
 
-  it('links the score route to the current game otherwise', () => {
+  it('links a score action to the current game', () => {
     const row: MatchListRow = matchListRow({
       id: 'm-live',
+      attention: 'score',
       current_game_number: 3,
     })
-    expect(projectMatchListRow(row).scoreRoute).toEqual(
-      scoringNewRoute('m-live', 3),
+    const action = projectMatchListRow(row).action
+    expect(action?.label).toBe('Enter score')
+    expect(action?.route).toEqual(scoringNewRoute('m-live', 3))
+  })
+
+  it('routes a score action to detail when the board is decided but unposted', () => {
+    const row = matchListRow({
+      id: 'm-decided',
+      attention: 'score',
+      current_game_number: null,
+    })
+    const action = projectMatchListRow(row).action
+    expect(action?.label).toBe('Enter score')
+    expect(action?.route).toEqual(matchDetailRoute('m-decided'))
+  })
+
+  it('routes review and dispute actions to match detail', () => {
+    const review = matchListRow({ id: 'm-r', attention: 'review' })
+    expect(projectMatchListRow(review).action).toMatchObject({
+      label: 'Review result',
+      route: matchDetailRoute('m-r'),
+    })
+    const dispute = matchListRow({ id: 'm-d', attention: 'dispute' })
+    expect(projectMatchListRow(dispute).action).toMatchObject({
+      label: 'Resolve dispute',
+      route: matchDetailRoute('m-d'),
+    })
+  })
+
+  it('gives passive waiting rows no action', () => {
+    expect(
+      projectMatchListRow(matchListRow({ attention: 'waiting_opponent' }))
+        .action,
+    ).toBeNull()
+    expect(
+      projectMatchListRow(matchListRow({ attention: 'waiting_others' })).action,
+    ).toBeNull()
+  })
+
+  it('uses current-user-aware labels + tones for attention rows', () => {
+    const score = projectMatchListRow(matchListRow({ attention: 'score' }))
+    expect(score.status.label).toBe('Needs score')
+    expect(score.status.toneClass).toBe('status-tone-attention')
+
+    const review = projectMatchListRow(matchListRow({ attention: 'review' }))
+    expect(review.status.label).toBe('Needs your review')
+
+    const waiting = projectMatchListRow(
+      matchListRow({ attention: 'waiting_opponent' }),
     )
+    expect(waiting.status.label).toBe('Waiting on opponent')
+    expect(waiting.status.toneClass).toBe('status-tone-waiting')
+    // A passive waiting row never pulses, even though it's in_progress.
+    expect(waiting.status.isLive).toBe(false)
+  })
+
+  it('marks a row primary only when its bucket matches the page top kind', () => {
+    const row = matchListRow({ attention: 'score' })
+    expect(projectMatchListRow(row, 'score').action?.primary).toBe(true)
+    expect(projectMatchListRow(row, 'review').action?.primary).toBe(false)
+    expect(projectMatchListRow(row).action?.primary).toBe(false)
+  })
+})
+
+describe('topActionableKind', () => {
+  it('returns the most urgent actionable bucket present (dispute > review > score)', () => {
+    const rows = [
+      matchListRow({ attention: 'score' }),
+      matchListRow({ attention: 'review' }),
+      matchListRow({ attention: 'waiting_others' }),
+    ]
+    expect(topActionableKind(rows)).toBe('review')
+    expect(
+      topActionableKind([...rows, matchListRow({ attention: 'dispute' })]),
+    ).toBe('dispute')
+  })
+
+  it('ignores passive and non-attention rows, returning null when none are actionable', () => {
+    const rows = [
+      matchListRow({ attention: 'waiting_opponent' }),
+      matchListRow({ attention: 'waiting_others' }),
+      matchListRow({ attention: null }),
+    ]
+    expect(topActionableKind(rows)).toBeNull()
   })
 })
 
@@ -195,17 +282,14 @@ describe('buildFilterTabs', () => {
       STATUS_TABS,
       { pending: 2, in_progress: 1, completed: 4 },
       TAB_TO_API,
+      0,
     )
     const all = tabs.find((t) => t.value === 'all')
     expect(all?.count).toBe(7)
   })
 
   it('uses statusCounts[TAB_TO_API[value]] ?? 0 for each named tab', () => {
-    const tabs = buildFilterTabs(
-      STATUS_TABS,
-      { in_progress: 3 },
-      TAB_TO_API,
-    )
+    const tabs = buildFilterTabs(STATUS_TABS, { in_progress: 3 }, TAB_TO_API, 0)
     const live = tabs.find((t) => t.value === 'live')
     const scheduled = tabs.find((t) => t.value === 'scheduled')
     expect(live?.count).toBe(3)
@@ -213,13 +297,19 @@ describe('buildFilterTabs', () => {
     expect(scheduled?.count).toBe(0)
   })
 
-  it('returns a null count for every tab when statusCounts is undefined', () => {
-    const tabs = buildFilterTabs(STATUS_TABS, undefined, TAB_TO_API)
+  it('reads the Attention tab from attentionCount, independent of status_counts', () => {
+    const tabs = buildFilterTabs(STATUS_TABS, { in_progress: 3 }, TAB_TO_API, 5)
+    const attention = tabs.find((t) => t.value === 'attention')
+    expect(attention?.count).toBe(5)
+  })
+
+  it('returns a null count for every tab when counts are undefined', () => {
+    const tabs = buildFilterTabs(STATUS_TABS, undefined, TAB_TO_API, undefined)
     expect(tabs.every((t) => t.count === null)).toBe(true)
   })
 
   it('carries the label and live flag through from the tab descriptors', () => {
-    const tabs = buildFilterTabs(STATUS_TABS, undefined, TAB_TO_API)
+    const tabs = buildFilterTabs(STATUS_TABS, undefined, TAB_TO_API, undefined)
     const live = tabs.find((t) => t.value === 'live')
     expect(live?.label).toBe('Live')
     expect(live?.isLive).toBe(true)

--- a/web-client/src/components/matches/match-list/match-list-row-view.ts
+++ b/web-client/src/components/matches/match-list/match-list-row-view.ts
@@ -2,10 +2,80 @@ import type { MatchListRow, MatchStatus } from '@/api/matches'
 import type { components } from '@/api/schema'
 import { matchDetailRoute, scoringNewRoute } from '@/api/matches'
 import { API_TO_TAB, STATUS_TONE } from './match-list-status'
-import type { MatchListRowView } from './match-list-table/match-list-row'
+import type {
+  MatchListRowView,
+  RowActionView,
+} from './match-list-table/match-list-row'
 import type { FilterTabView } from './filter-row'
 
 type MatchListRowSide = components['schemas']['MatchDetailsSide']
+
+// The current-user-aware attention bucket the server stamps on a row (or null).
+export type AttentionKind = NonNullable<MatchListRow['attention']>
+// The subset where the user has a move to make — these get a row CTA.
+export type ActionableKind = 'dispute' | 'review' | 'score'
+
+const ACTIONABLE_KINDS = new Set<AttentionKind>(['dispute', 'review', 'score'])
+
+function isActionable(kind: AttentionKind | null): kind is ActionableKind {
+  return kind !== null && ACTIONABLE_KINDS.has(kind)
+}
+
+// Current-user-aware status-chip labels. They replace the ambiguous
+// "Awaiting confirmation" with copy that says *who* must act (PRD §"Row Status
+// Labels").
+const ATTENTION_LABEL: Record<AttentionKind, string> = {
+  dispute: 'Disputed',
+  review: 'Needs your review',
+  score: 'Needs score',
+  waiting_opponent: 'Waiting on opponent',
+  waiting_others: 'Scheduled',
+}
+
+// Chip tone: actionable buckets read as warm/attention; the passive waiting
+// rows stay visually quiet so they don't compete with rows that need the user
+// (PRD §"Visual Hierarchy").
+const ATTENTION_TONE: Record<AttentionKind, string> = {
+  dispute: 'status-tone-attention',
+  review: 'status-tone-attention',
+  score: 'status-tone-attention',
+  waiting_opponent: 'status-tone-waiting',
+  waiting_others: 'status-tone-scheduled',
+}
+
+// Button copy per actionable bucket (PRD §"Row Actions").
+const ACTION_LABEL: Record<ActionableKind, string> = {
+  dispute: 'Resolve dispute',
+  review: 'Review result',
+  score: 'Enter score',
+}
+
+// Relative urgency among actionable buckets, used to pick the single bucket
+// that earns the primary (orange) CTA. Mirrors the server's priority order:
+// dispute > review > score. Lower wins.
+const ACTIONABLE_RANK: Record<ActionableKind, number> = {
+  dispute: 0,
+  review: 1,
+  score: 2,
+}
+
+/** The highest-priority actionable bucket present in a page of rows, or null
+ * when none are actionable. Only rows sharing this bucket take the primary CTA;
+ * the rest render secondary, so a page never lights up multiple orange buttons
+ * for different action types (PRD §"Visual Hierarchy"). */
+export function topActionableKind(rows: MatchListRow[]): ActionableKind | null {
+  let best: ActionableKind | null = null
+  for (const row of rows) {
+    const kind = row.attention
+    if (
+      isActionable(kind) &&
+      (best === null || ACTIONABLE_RANK[kind] < ACTIONABLE_RANK[best])
+    ) {
+      best = kind
+    }
+  }
+  return best
+}
 
 /** Players joined by ' & ', or 'No opponent' for a null/empty side. (was sideLabel) */
 export function sideLabel(side: MatchListRowSide | null): string {
@@ -46,14 +116,40 @@ function projectPlayerChip(side: MatchListRowSide | null): {
   }
 }
 
-/** Project one raw row into the presentational view model the table renders. */
-export function projectMatchListRow(row: MatchListRow): MatchListRowView {
+/** The trailing-cell action for a row, or null for a passive row (waiting /
+ * non-participant / final). `score` deep-links to the next un-played game, or
+ * to match detail when the board is already decided-but-unposted; review and
+ * dispute route to detail, which holds the confirm/dispute/post-result CTAs. */
+function projectAction(
+  row: MatchListRow,
+  primaryKind: ActionableKind | null,
+): RowActionView | null {
+  const kind = row.attention
+  if (!isActionable(kind)) return null
+  const route =
+    kind === 'score' && row.current_game_number !== null
+      ? scoringNewRoute(row.id, row.current_game_number)
+      : matchDetailRoute(row.id)
+  return { label: ACTION_LABEL[kind], route, primary: kind === primaryKind }
+}
+
+/**
+ * Project one raw row into the presentational view model the table renders.
+ *
+ * `primaryKind` (the page's top actionable bucket, from `topActionableKind`)
+ * decides which rows' CTAs render primary; pass `null` (the default) when no
+ * row is actionable.
+ */
+export function projectMatchListRow(
+  row: MatchListRow,
+  primaryKind: ActionableKind | null = null,
+): MatchListRowView {
   const tab = API_TO_TAB[row.status]
   const side1 = row.sides.find((s) => s.side_number === 1) ?? row.sides[0]
   const side2 = row.sides.find((s) => s.side_number === 2) ?? null
-  const showScore =
-    row.status === 'in_progress' || row.status === 'completed'
+  const showScore = row.status === 'in_progress' || row.status === 'completed'
   const isLive = row.status === 'in_progress'
+  const attention = row.attention
 
   return {
     id: row.id,
@@ -70,32 +166,52 @@ export function projectMatchListRow(row: MatchListRow): MatchListRowView {
           : null,
     },
     status: {
-      label: row.status_label,
-      toneClass: STATUS_TONE[tab],
-      isLive,
+      // A current-user-aware bucket overrides the perspective-neutral
+      // status_label so a row says who must act; otherwise fall back to the
+      // server label + tab tone.
+      label: attention ? ATTENTION_LABEL[attention] : row.status_label,
+      toneClass: attention ? ATTENTION_TONE[attention] : STATUS_TONE[tab],
+      // Only the plain "Live" chip pulses; an attention-labeled in-progress row
+      // (e.g. "Needs your review") shouldn't carry a live dot next to its copy.
+      isLive: attention === null && isLive,
     },
     time: { when: formatCreatedAt(row.created_at) },
-    scoreRoute:
-      row.current_game_number === null
-        ? null
-        : scoringNewRoute(row.id, row.current_game_number),
+    action: projectAction(row, primaryKind),
   }
 }
 
-/** Build the FilterRow tab descriptors from the static tab list + status_counts. */
+/** Build the FilterRow tab descriptors from the static tab list + counts. The
+ * Attention tab reads its badge from `attentionCount`; `all` sums the status
+ * counts; every other tab reads its own status bucket. */
 export function buildFilterTabs(
-  tabs: { value: FilterTabView['value']; label: string; live?: boolean }[],
+  tabs: {
+    value: FilterTabView['value']
+    label: string
+    live?: boolean
+    attention?: boolean
+  }[],
   statusCounts: Record<string, number> | undefined,
   tabToApi: Record<string, MatchStatus>,
+  attentionCount: number | undefined,
 ): FilterTabView[] {
   return tabs.map((tab) => ({
     value: tab.value,
     label: tab.label,
     isLive: tab.live ?? false,
-    count: !statusCounts
-      ? null
-      : tab.value === 'all'
-        ? Object.values(statusCounts).reduce((a, b) => a + b, 0)
-        : statusCounts[tabToApi[tab.value]] ?? 0,
+    count: tabCount(tab, statusCounts, tabToApi, attentionCount),
   }))
+}
+
+function tabCount(
+  tab: { value: FilterTabView['value']; attention?: boolean },
+  statusCounts: Record<string, number> | undefined,
+  tabToApi: Record<string, MatchStatus>,
+  attentionCount: number | undefined,
+): number | null {
+  if (tab.attention) return attentionCount ?? null
+  if (!statusCounts) return null
+  if (tab.value === 'all') {
+    return Object.values(statusCounts).reduce((a, b) => a + b, 0)
+  }
+  return statusCounts[tabToApi[tab.value]] ?? 0
 }

--- a/web-client/src/components/matches/match-list/match-list-status.test.ts
+++ b/web-client/src/components/matches/match-list/match-list-status.test.ts
@@ -22,6 +22,12 @@ describe('matchesSearchSchema', () => {
     }
   })
 
+  it('keeps the attention status', () => {
+    expect(matchesSearchSchema.parse({ status: 'attention' }).status).toBe(
+      'attention',
+    )
+  })
+
   it('drops a non-numeric page back to undefined', () => {
     expect(matchesSearchSchema.parse({ page: 'NaN' }).page).toBe(undefined)
   })
@@ -52,6 +58,17 @@ describe('listParamsFromSearch', () => {
 
   it('leaves status undefined when the search has none', () => {
     expect(listParamsFromSearch({}).status).toBe(undefined)
+  })
+
+  it('maps the attention tab to the attention flag with no status', () => {
+    const params = listParamsFromSearch({ status: 'attention' })
+    expect(params.attention).toBe(true)
+    expect(params.status).toBe(undefined)
+  })
+
+  it('leaves the attention flag unset for non-attention tabs', () => {
+    expect(listParamsFromSearch({ status: 'live' }).attention).toBe(undefined)
+    expect(listParamsFromSearch({}).attention).toBe(undefined)
   })
 
   it('passes a non-empty query through and drops an empty one', () => {

--- a/web-client/src/components/matches/match-list/match-list-status.ts
+++ b/web-client/src/components/matches/match-list/match-list-status.ts
@@ -3,11 +3,21 @@ import { z } from 'zod'
 
 import type { MatchListParams, MatchStatus } from '@/api/matches'
 
-// Single source of truth for the filter-tab status values — the URL schema,
-// the row classification, and the tab list all derive from this tuple.
+// Single source of truth for the API-backed filter-tab status values — the ones
+// that map straight onto a `MatchStatus` query. `attention` is a *separate*
+// dimension (its own server flag + ranking), so it lives in `FILTER_KEYS`
+// below, not here.
 export const STATUS_KEYS = ['scheduled', 'live', 'final'] as const
 export type StatusKey = (typeof STATUS_KEYS)[number]
 export type RowTab = StatusKey
+
+// Every non-default tab value the URL can carry. `attention` leads the
+// ordering (Attention · All · Live · Up next · Final); `all` is the default and
+// is represented by an absent `status`, so it isn't a member here.
+export const FILTER_KEYS = ['attention', ...STATUS_KEYS] as const
+export type FilterKey = (typeof FILTER_KEYS)[number]
+// The full selectable tab dimension, including the default `all`.
+export type TabValue = 'all' | FilterKey
 
 // URL is the source of truth for filters. `.trim()` strips whitespace so a
 // junk query like `?q=%20%20%20` collapses to "no filter" instead of polluting
@@ -16,7 +26,7 @@ export type RowTab = StatusKey
 // defaults instead of throwing.
 export const matchesSearchSchema = z.object({
   q: z.string().trim().min(1).optional().catch(undefined),
-  status: z.enum(STATUS_KEYS).optional().catch(undefined),
+  status: z.enum(FILTER_KEYS).optional().catch(undefined),
   page: z.coerce.number().int().min(2).optional().catch(undefined),
 })
 
@@ -36,10 +46,14 @@ export const API_TO_TAB: Record<MatchStatus, RowTab> = {
 }
 
 export const STATUS_TABS: {
-  value: 'all' | StatusKey
+  value: TabValue
   label: string
   live?: boolean
+  /** True for the Attention tab — its count comes from `attention_count`, not
+   * `status_counts`, and it selects the dedicated attention query dimension. */
+  attention?: boolean
 }[] = [
+  { value: 'attention', label: 'Attention', attention: true },
   { value: 'all', label: 'All' },
   { value: 'live', label: 'Live', live: true },
   { value: 'scheduled', label: 'Up next' },
@@ -58,12 +72,21 @@ export type NavigateFn = ReturnType<typeof useNavigate>
 
 /** Map the validated URL search to the list query's params. Shared by the
  * loader's prefetch and the component's live query so both hit the same cache
- * key — a hover preload then renders straight from cache on click. */
+ * key — a hover preload then renders straight from cache on click.
+ *
+ * `attention` is its own dimension: when the tab is `attention` we set the
+ * server flag and leave `status` unset (the server ignores `status` then);
+ * every other tab maps through `TAB_TO_API` as before. */
 export function listParamsFromSearch(
   search: z.infer<typeof matchesSearchSchema>,
 ): MatchListParams {
+  const isAttention = search.status === 'attention'
   return {
-    status: search.status ? TAB_TO_API[search.status] : undefined,
+    status:
+      search.status && search.status !== 'attention'
+        ? TAB_TO_API[search.status]
+        : undefined,
+    attention: isAttention ? true : undefined,
     q: search.q || undefined,
     page: search.page ?? 1,
     page_size: PAGE_SIZE,

--- a/web-client/src/components/matches/match-list/match-list-table.factory.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table.factory.tsx
@@ -17,7 +17,10 @@ export function buildMatchListTableProps(
   return {
     rows: [buildMatchListRowView()],
     isLoading: false,
+    isAttention: false,
+    query: '',
     onClear: vi.fn(),
+    onClearSearch: vi.fn(),
     navigate: vi.fn() as unknown as NavigateFn,
     ...overrides,
   }

--- a/web-client/src/components/matches/match-list/match-list-table.page.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table.page.tsx
@@ -30,6 +30,21 @@ const scoped = (container: Container) => ({
   getClearFiltersButton() {
     return container.getByRole('button', { name: /clear filters/i })
   },
+  /** The Attention tab's calm "all caught up" empty-state heading. */
+  getCaughtUpState() {
+    return container.getByText(/all caught up/i)
+  },
+  /** The search-with-no-results heading (either tab). */
+  getNoResultsState() {
+    return container.getByText(/no (attention )?matches for/i)
+  },
+  /** Buttons offered by the attention empty states. */
+  getViewAllMatchesButton() {
+    return container.getByRole('button', { name: /view all matches/i })
+  },
+  getClearSearchButton() {
+    return container.getByRole('button', { name: /clear search/i })
+  },
   // Column headers (Match/Players/Score/Status/Started) read as this table's
   // own queries.
   ...matchListTableHeadPage.within(container),
@@ -92,6 +107,16 @@ export const matchListTablePage = {
    * await this instead of `findTable()` before reading synchronous accessors. */
   findEmptyState() {
     return screen.findByText(/no matches yet/i)
+  },
+
+  /** Async-first accessor for the Attention "all caught up" empty state. */
+  findCaughtUpState() {
+    return screen.findByText(/all caught up/i)
+  },
+
+  /** Async-first accessor for the "no results for <query>" empty state. */
+  findNoResultsState() {
+    return screen.findByText(/no (attention )?matches for/i)
   },
 
   /**

--- a/web-client/src/components/matches/match-list/match-list-table.test.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table.test.tsx
@@ -35,6 +35,55 @@ describe('MatchListTable', () => {
     expect(onClear).toHaveBeenCalledTimes(1)
   })
 
+  it('renders the "all caught up" state on the Attention tab with no rows and no search', async () => {
+    matchListTablePage.render({
+      isLoading: false,
+      rows: [],
+      isAttention: true,
+      query: '',
+    })
+
+    const heading = await matchListTablePage.findCaughtUpState()
+    expect(heading.closest('.empty')).toHaveTextContent(
+      'No matches need your attention right now.',
+    )
+    expect(matchListTablePage.getViewAllMatchesButton()).toBeInTheDocument()
+  })
+
+  it('calls onClear when "View all matches" is clicked from the caught-up state', async () => {
+    const user = userEvent.setup()
+    const onClear = vi.fn()
+    matchListTablePage.render({
+      isLoading: false,
+      rows: [],
+      isAttention: true,
+      query: '',
+      onClear,
+    })
+
+    await matchListTablePage.findCaughtUpState()
+    await user.click(matchListTablePage.getViewAllMatchesButton())
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+
+  it('names the searched term and offers Clear search on the Attention tab when a query filters everything out', async () => {
+    const user = userEvent.setup()
+    const onClearSearch = vi.fn()
+    matchListTablePage.render({
+      isLoading: false,
+      rows: [],
+      isAttention: true,
+      query: 'silva',
+      onClearSearch,
+    })
+
+    const heading = await matchListTablePage.findNoResultsState()
+    expect(heading).toHaveTextContent('No attention matches for')
+    expect(heading).toHaveTextContent('silva')
+    await user.click(matchListTablePage.getClearSearchButton())
+    expect(onClearSearch).toHaveBeenCalledTimes(1)
+  })
+
   it('renders a table with one MatchListRow per row when rows are present', async () => {
     // Wiring only: row internals are pinned by match-list-row tests.
     const rows = [

--- a/web-client/src/components/matches/match-list/match-list-table.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table.tsx
@@ -1,4 +1,4 @@
-import { Inbox } from 'lucide-react'
+import { CheckCircle2, Inbox, SearchX } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 
@@ -12,37 +12,35 @@ export interface MatchListTableProps {
   rows: MatchListRowView[]
   /** True while the first page is loading and there are no rows yet — render the skeleton. */
   isLoading: boolean
-  /** Clears all filters from the empty state's button. */
+  /** True when the Attention tab is active — swaps in the attention-flavored empty states. */
+  isAttention: boolean
+  /** The active (trimmed) search term, used to phrase the no-results state. */
+  query: string
+  /** Clears all filters (used by "Clear filters" / "View all matches"). */
   onClear: () => void
+  /** Clears only the search term, staying on the active tab. */
+  onClearSearch: () => void
   navigate: NavigateFn
 }
 
 export const MatchListTable = ({
   rows,
   isLoading,
+  isAttention,
+  query,
   onClear,
+  onClearSearch,
   navigate,
 }: MatchListTableProps) => {
   if (isLoading && rows.length === 0) return <MatchListSkeletonRows />
   if (rows.length === 0) {
     return (
-      <div className="empty">
-        <div className="empty-icon">
-          <Inbox size={56} strokeWidth={1.5} />
-        </div>
-        <div className="empty-title">No matches yet</div>
-        <div className="empty-sub">
-          Start a new match or clear the filters to see what's being played.
-        </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="empty-clear"
-          onClick={onClear}
-        >
-          Clear filters
-        </Button>
-      </div>
+      <EmptyState
+        isAttention={isAttention}
+        query={query}
+        onClear={onClear}
+        onClearSearch={onClearSearch}
+      />
     )
   }
   return (
@@ -54,5 +52,75 @@ export const MatchListTable = ({
         ))}
       </tbody>
     </table>
+  )
+}
+
+function EmptyState({
+  isAttention,
+  query,
+  onClear,
+  onClearSearch,
+}: {
+  isAttention: boolean
+  query: string
+  onClear: () => void
+  onClearSearch: () => void
+}) {
+  // A search that filtered everything out reads the same on either tab: tell the
+  // user what they searched for and offer to clear just the search.
+  if (query) {
+    return (
+      <div className="empty">
+        <div className="empty-icon">
+          <SearchX size={56} strokeWidth={1.5} />
+        </div>
+        <div className="empty-title">
+          {isAttention
+            ? `No attention matches for “${query}”.`
+            : `No matches for “${query}”.`}
+        </div>
+        <div className="empty-sub">Try a different name or clear the search.</div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="empty-clear"
+          onClick={onClearSearch}
+        >
+          Clear search
+        </Button>
+      </div>
+    )
+  }
+  // Attention with no search and nothing pending: the calm "all caught up"
+  // state, with a way back to the full list (PRD §"Empty States").
+  if (isAttention) {
+    return (
+      <div className="empty">
+        <div className="empty-icon">
+          <CheckCircle2 size={56} strokeWidth={1.5} />
+        </div>
+        <div className="empty-title">You&rsquo;re all caught up.</div>
+        <div className="empty-sub">
+          No matches need your attention right now.
+        </div>
+        <Button variant="ghost" size="sm" className="empty-clear" onClick={onClear}>
+          View all matches
+        </Button>
+      </div>
+    )
+  }
+  return (
+    <div className="empty">
+      <div className="empty-icon">
+        <Inbox size={56} strokeWidth={1.5} />
+      </div>
+      <div className="empty-title">No matches yet</div>
+      <div className="empty-sub">
+        Start a new match or clear the filters to see what's being played.
+      </div>
+      <Button variant="ghost" size="sm" className="empty-clear" onClick={onClear}>
+        Clear filters
+      </Button>
+    </div>
   )
 }

--- a/web-client/src/components/matches/match-list/match-list-table/match-list-row.factory.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table/match-list-row.factory.tsx
@@ -11,9 +11,9 @@ import { buildTimeCellView } from './match-list-row/time-cell.factory'
 
 /**
  * A final, viewer-won singles row: rita.kovac (winner) vs nguyen.t, showing a
- * final 2–1 score, no in-progress Score button (`scoreRoute: null`). The
- * default still mounts under the router harness (the row click + detail link),
- * but renders without the Score-Link branch.
+ * final 2–1 score, no action button (`action: null`). The default still mounts
+ * under the router harness (the row click + detail link), but renders without
+ * the action-Link branch.
  */
 export function buildMatchListRowView(
   overrides: Partial<MatchListRowView> = {},
@@ -29,7 +29,7 @@ export function buildMatchListRowView(
     status: buildStatusBadgeView(),
     time: buildTimeCellView(),
     detailRoute: matchDetailRoute('m-1'),
-    scoreRoute: null,
+    action: null,
     ...overrides,
   }
 }

--- a/web-client/src/components/matches/match-list/match-list-table/match-list-row.page.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table/match-list-row.page.tsx
@@ -34,13 +34,14 @@ const scoped = (container: Container) => ({
   getPlayerName(name: string) {
     return container.getByText(name)
   },
-  /** The trailing "Score" Link — present only when the row's `scoreRoute` is
-   * non-null. Absent otherwise. */
-  getScoreLink() {
-    return container.getByRole('link', { name: 'Score' })
+  /** The trailing action Link (e.g. "Enter score" / "Review result" / "Resolve
+   * dispute") — present only when the row's `action` is non-null. Pass the
+   * action label the row was built with. */
+  getActionLink(label: string) {
+    return container.getByRole('link', { name: label })
   },
-  queryScoreLink() {
-    return container.queryByRole('link', { name: 'Score' })
+  queryActionLink(label: string) {
+    return container.queryByRole('link', { name: label })
   },
   // Child query surfaces, scoped to the row, for wiring assertions. Each child's
   // internals are pinned by its own tests.

--- a/web-client/src/components/matches/match-list/match-list-table/match-list-row.test.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table/match-list-row.test.tsx
@@ -106,16 +106,19 @@ describe('MatchListRow', () => {
     expect(scoped.getWhen('5d ago')).toHaveTextContent('5d ago')
   })
 
-  it('renders a Score Link to scoreRoute when scoreRoute is non-null, stopping row-click propagation from that cell', async () => {
+  it('renders the action Link to its route when action is non-null, stopping row-click propagation from that cell', async () => {
     const navigate = vi.fn() as unknown as NavigateFn
-    const scoreRoute = scoringNewRoute('m-9', 3)
+    const route = scoringNewRoute('m-9', 3)
     matchListRowPage.render({
       navigate,
-      row: buildMatchListRowView({ id: 'm-9', scoreRoute }),
+      row: buildMatchListRowView({
+        id: 'm-9',
+        action: { label: 'Enter score', route, primary: true },
+      }),
     })
 
     await matchListRowPage.findRow()
-    const link = matchListRowPage.getScoreLink()
+    const link = matchListRowPage.getActionLink('Enter score')
     expect(link).toHaveAttribute('href', '/matches/m-9/games/3/scores/new')
 
     // Clicking the trailing cell must not bubble up to the row's navigate.
@@ -123,12 +126,12 @@ describe('MatchListRow', () => {
     expect(navigate).not.toHaveBeenCalled()
   })
 
-  it('renders no Score Link when scoreRoute is null', async () => {
+  it('renders no action Link when action is null', async () => {
     matchListRowPage.render({
-      row: buildMatchListRowView({ scoreRoute: null }),
+      row: buildMatchListRowView({ action: null }),
     })
 
     await matchListRowPage.findRow()
-    expect(matchListRowPage.queryScoreLink()).toBeNull()
+    expect(matchListRowPage.queryActionLink('Enter score')).toBeNull()
   })
 })

--- a/web-client/src/components/matches/match-list/match-list-table/match-list-row.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table/match-list-row.tsx
@@ -10,6 +10,22 @@ import { StatusBadge, type StatusBadgeView } from './match-list-row/status-badge
 import { TimeCell, type TimeCellView } from './match-list-row/time-cell'
 import type { NavigateFn } from '../match-list-status'
 
+/** The trailing-cell CTA for an actionable row (Enter score / Review result /
+ * Resolve dispute). Passive rows (waiting / final / non-participant) carry
+ * `action: null` and render no button. `primary` is true only for the page's
+ * top actionable bucket, which takes the filled orange button. */
+export interface RowActionView {
+  /** Button copy. */
+  label: string
+  /** Navigation target — the scoring page (score rows with a next game) or
+   * match detail (review/dispute, or a decided-but-unposted board). */
+  route:
+    | ReturnType<typeof matchDetailRoute>
+    | ReturnType<typeof scoringNewRoute>
+  /** Whether this row takes the primary (filled) button vs. the secondary one. */
+  primary: boolean
+}
+
 export interface MatchListRowView {
   /** Stable React key + used for navigation/preload targets. The raw match id. */
   id: string
@@ -26,8 +42,8 @@ export interface MatchListRowView {
   time: TimeCellView
   /** The {to,params} navigation target for the whole-row click + hover preload. */
   detailRoute: ReturnType<typeof matchDetailRoute>
-  /** The {to,params} for the Score Link in the trailing cell, or null when current_game_number is null (no Score button). */
-  scoreRoute: ReturnType<typeof scoringNewRoute> | null
+  /** The trailing-cell action, or null for a passive row (no button). */
+  action: RowActionView | null
 }
 
 export interface MatchListRowProps {
@@ -82,9 +98,13 @@ export const MatchListRow = ({ row, navigate }: MatchListRowProps) => {
         <TimeCell time={row.time} />
       </td>
       <td onClick={(e) => e.stopPropagation()}>
-        {row.scoreRoute !== null ? (
-          <Button asChild variant="default" size="sm">
-            <Link {...row.scoreRoute}>Score</Link>
+        {row.action !== null ? (
+          <Button
+            asChild
+            variant={row.action.primary ? 'default' : 'outline'}
+            size="sm"
+          >
+            <Link {...row.action.route}>{row.action.label}</Link>
           </Button>
         ) : null}
       </td>

--- a/web-client/src/components/matches/match-list/match-list.css
+++ b/web-client/src/components/matches/match-list/match-list.css
@@ -334,6 +334,17 @@
   color: var(--info);
   background: rgba(111, 181, 255, 0.12);
 }
+/* Actionable attention rows (needs score / your review / disputed) — warm
+   accent so they read as "you have a move here". */
+.match-list-page .status-tone-attention {
+  color: var(--ball-400);
+  background: var(--bg-accent-soft);
+}
+/* Passive "waiting on someone else" rows — quiet, muted, never orange. */
+.match-list-page .status-tone-waiting {
+  color: var(--fg-2);
+  background: var(--bg-raised);
+}
 .match-list-page .status-pill .live-dot {
   width: 6px;
   height: 6px;

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -14,6 +14,7 @@ import {
   projectMatchDetails,
   projectRating,
   projectRecentResult,
+  rankAttentionSeeds,
   statusCountsOf,
   validateScore,
   type SeedMatch,
@@ -599,6 +600,7 @@ export const handlers = [
     await delay(250)
     const url = new URL(request.url)
     const statusFilter = url.searchParams.get('status') ?? null
+    const attention = url.searchParams.get('attention') === 'true'
     const q = url.searchParams.get('q')?.trim().toLowerCase() ?? ''
     const page = Math.max(1, Number(url.searchParams.get('page') ?? '1'))
     const pageSize = Math.max(
@@ -610,9 +612,15 @@ export const handlers = [
     if (q) {
       scoped = scoped.filter((m) => matchHasPlayerLike(m, q))
     }
-    const filtered = statusFilter
-      ? scoped.filter((m) => m.status === statusFilter)
-      : scoped
+    // The Attention badge reads this regardless of the active tab.
+    const attentionSeeds = rankAttentionSeeds(scoped)
+    // Attention is its own dimension: rank the open matches by urgency and
+    // ignore the status filter. Otherwise apply the status filter as before.
+    const filtered = attention
+      ? attentionSeeds
+      : statusFilter
+        ? scoped.filter((m) => m.status === statusFilter)
+        : scoped
 
     const start = (page - 1) * pageSize
     const slice = filtered.slice(start, start + pageSize)
@@ -622,6 +630,7 @@ export const handlers = [
       page_size: pageSize,
       total: filtered.length,
       status_counts: statusCountsOf(scoped),
+      attention_count: attentionSeeds.length,
     })
   }),
 

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -442,6 +442,62 @@ function projectHeadToHead(
   }
 }
 
+type ListAttentionKind = NonNullable<MatchListRow['attention']>
+
+/** The matches-list attention bucket for a seed — mirrors
+ * `api/app/attention.py:list_attention_kind`. Unlike the dashboard classifier
+ * it also surfaces the passive `waiting_*` buckets (the list shows them as quiet
+ * rows). Null for a finished match (the mock treats every seed as the current
+ * user's). */
+export function listAttentionKind(seed: SeedMatch): ListAttentionKind | null {
+  switch (seed.status) {
+    case 'disputed':
+      return 'dispute'
+    case 'pending':
+      return 'waiting_others'
+    case 'in_progress':
+      if (seed.signatures.length > 0) {
+        const iSigned = seed.signatures.some(
+          (sig) => sig.user_id === MOCK_CURRENT_USER.id,
+        )
+        return iSigned ? 'waiting_opponent' : 'review'
+      }
+      return 'score'
+    default:
+      return null
+  }
+}
+
+// Priority for ranking the Attention tab — mirrors `attention_priority`.
+const LIST_ATTENTION_PRIORITY: Record<ListAttentionKind, number> = {
+  dispute: 0,
+  review: 1,
+  // score splits rated (2) / unrated (3) — handled in `listAttentionRank`.
+  score: 2,
+  waiting_opponent: 4,
+  waiting_others: 5,
+}
+
+function listAttentionRank(seed: SeedMatch, kind: ListAttentionKind): number {
+  if (kind === 'score' && !seed.affects_rating) return 3
+  return LIST_ATTENTION_PRIORITY[kind]
+}
+
+/** The Attention tab's row set: the current user's open matches, ranked by
+ * urgency then oldest-first — mirrors the BFF's attention path. */
+export function rankAttentionSeeds(seeds: SeedMatch[]): SeedMatch[] {
+  return seeds
+    .flatMap((seed) => {
+      const kind = listAttentionKind(seed)
+      return kind ? [{ seed, rank: listAttentionRank(seed, kind) }] : []
+    })
+    .sort(
+      (a, b) =>
+        a.rank - b.rank || a.seed.created_at.localeCompare(b.seed.created_at),
+    )
+    .map((row) => row.seed)
+}
+
 export function projectListRow(seed: SeedMatch): MatchListRow {
   const { mySide, opponentSide } = projectSides(seed)
   const nextNumber = currentGameNumber(seed)
@@ -458,6 +514,7 @@ export function projectListRow(seed: SeedMatch): MatchListRow {
     current_game_number: nextNumber,
     can_score: scorableSeed(seed),
     can_confirm: canConfirmSeed(seed),
+    attention: listAttentionKind(seed),
   }
 }
 

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -253,6 +253,7 @@ export function matchListRow(
     current_game_number: 1,
     can_score: true,
     can_confirm: false,
+    attention: null,
     ...rest,
   }
 }
@@ -275,12 +276,16 @@ export function matchListResponse(
   for (const item of items) {
     baseCounts[item.status] = (baseCounts[item.status] ?? 0) + 1
   }
+  const attention_count =
+    overrides.attention_count ??
+    items.filter((item) => item.attention !== null).length
   return {
     items,
     page: 1,
     page_size: 25,
     total: items.length,
     status_counts: baseCounts,
+    attention_count,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Problem
The match list showed statuses like *Live* or *Awaiting confirmation*, but it wasn't clear whether **you** need to act, your opponent does, or the match is just informational — especially after arriving from the dashboard's *View all pending* link.

## What this does
Adds an **Attention** workflow to the Matches screen so it answers: *which matches need me, which are waiting on someone else, and what can I do from this row?*

### Backend
- New `app/attention.py` — one current-user-aware classifier (`dispute` / `review` / `score` / `waiting_opponent` / `waiting_others`) + priority ranking, **shared** by the dashboard panel and the list so they can never disagree about who owes a move. `dashboard.py` refactored to route through it.
- `GET /v1/matches?attention=true` returns the caller's open matches ranked by urgency (dispute > review > rated score > unrated score > waiting), paginated in Python. `MatchListRow.attention` + `MatchListResponse.attention_count` added (the attention path reuses `total` as the count; other tabs run a single aggregate).

### Frontend
- Tab order **Attention · All · Live · Up next · Final** (URL `?status=attention`). Normal tabs keep their existing sort/behavior.
- Current-user-aware row labels + tones (Needs score / Needs your review / Waiting on opponent / Disputed / Scheduled) — actionable rows warm, passive rows quiet.
- Row CTAs: **Enter score** → scoring flow, **Review result** / **Resolve dispute** → match detail; waiting rows get no button. Primary orange only on the page's top actionable bucket. No confirm/dispute in the list.
- Attention-specific empty + search-empty states; dashboard **View all pending** now opens `/matches?status=attention`.
- MSW mocks mirror the new shape.

## Acceptance criteria
- [x] Attention filter on the Matches screen
- [x] Dashboard *View all pending* opens Matches with Attention active
- [x] Normal filters retain existing sort/behavior
- [x] Attention rows use current-user-aware labels
- [x] Score-needed → scoring flow; review-needed → match detail
- [x] Passive waiting rows are quieter, no primary CTA
- [x] No confirm/dispute in the list
- [x] Clear empty + search states

## Testing
- API: `ruff` + `mypy --strict` clean; **389 pytest** pass (4 new attention tests)
- Web: **710 vitest** + **127 Playwright e2e** pass; `eslint` + `tsc -b && vite build` clean
- `web-client/src/api/schema.d.ts` regenerated — no drift
- Root e2e (full docker-compose build) skipped as disproportionate; covered by the above + qa-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)