### PR TITLE
Fix "We couldn't find that match" race on nav to a just-created match (#510)

### DIFF
--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -7,7 +7,10 @@ import {
 } from '@tanstack/react-query'
 import { ApiError, api, resolveBaseUrl, unwrap } from './client'
 import { DASHBOARD_QUERY_KEY } from './dashboard'
-import { matchDetailsQueryKey } from '@/components/matches/match-details/match-details-query'
+import {
+  matchDetailsQueryKey,
+  matchDetailsResultFromPayload,
+} from '@/components/matches/match-details/match-details-query'
 import type { components } from './schema'
 
 export type Player = components['schemas']['PlayerRead']
@@ -130,9 +133,21 @@ export function usePlayerSearch(term: string) {
  * 4xx `detail` inline on the form — no global error toast is attached here.
  */
 export function useCreateMatch() {
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (input: MatchCreate): Promise<MatchDetails> =>
       unwrap('create match', await api.POST('/v1/matches', { body: input })),
+    // The create response already *is* the match-details payload, so seed the
+    // details cache from it. Navigating to the just-created match (directly, or
+    // via the scoring screen) then renders from this warm entry instead of
+    // racing a `GET /v1/matches/{id}` against the write we just committed — the
+    // read-after-write "We couldn't find that match" dead-end behind #510.
+    onSuccess: (created) => {
+      queryClient.setQueryData(
+        matchDetailsQueryKey(created.id),
+        matchDetailsResultFromPayload(created),
+      )
+    },
   })
 }
 

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -138,10 +138,11 @@ export function useCreateMatch() {
     mutationFn: async (input: MatchCreate): Promise<MatchDetails> =>
       unwrap('create match', await api.POST('/v1/matches', { body: input })),
     // The create response already *is* the match-details payload, so seed the
-    // details cache from it. Navigating to the just-created match (directly, or
-    // via the scoring screen) then renders from this warm entry instead of
-    // racing a `GET /v1/matches/{id}` against the write we just committed — the
-    // read-after-write "We couldn't find that match" dead-end behind #510.
+    // details query cache from it. The match-details page then renders from this
+    // warm entry — whether reached by an immediate redirect or later from the
+    // scoring screen — instead of racing a `GET /v1/matches/{id}` against the
+    // write we just committed: the read-after-write "We couldn't find that
+    // match" dead-end behind #510.
     onSuccess: (created) => {
       queryClient.setQueryData(
         matchDetailsQueryKey(created.id),

--- a/web-client/src/components/matches/match-details/match-details-query.test.ts
+++ b/web-client/src/components/matches/match-details/match-details-query.test.ts
@@ -4,7 +4,10 @@ import { ApiError } from "@/api/client";
 import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
 import { waitFor } from "@/test/utilities";
 
-import { matchDetailsQuery } from "./match-details-query";
+import {
+  matchDetailsQuery,
+  matchDetailsResultFromPayload,
+} from "./match-details-query";
 import { matchDetailsQueryPage } from "./match-details-query.page";
 
 describe("matchDetailsQuery", () => {
@@ -63,5 +66,26 @@ describe("matchDetailsQuery", () => {
     expect((result.current.error as ApiError).message).toBe(
       "Failed to load match m-1",
     );
+  });
+});
+
+describe("matchDetailsResultFromPayload", () => {
+  it("produces the same shape the queryFn resolves to, so a seeded cache reads identically", async () => {
+    const match = buildMatchDetails();
+    matchDetailsQueryPage.mockEndpoint(() => HttpResponse.json(match));
+
+    const { result } = matchDetailsQueryPage.render();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Seeding from the payload the create response already holds yields exactly
+    // what a fresh fetch would have cached — no GET required (#510).
+    expect(matchDetailsResultFromPayload(match)).toEqual(result.current.data);
+  });
+
+  it("throws on a malformed payload rather than priming a bad cache entry", () => {
+    const malformed = buildMatchDetails({
+      data: { scoreboard: { status: "not-a-real-status" as never } },
+    });
+    expect(() => matchDetailsResultFromPayload(malformed)).toThrow();
   });
 });

--- a/web-client/src/components/matches/match-details/match-details-query.ts
+++ b/web-client/src/components/matches/match-details/match-details-query.ts
@@ -1,4 +1,5 @@
 import { api, unwrap } from "@/api/client";
+import type { MatchDetails } from "@/api/matches";
 import type { QueryFunctionContext } from "@tanstack/react-query";
 import z from "zod";
 
@@ -35,14 +36,20 @@ const fetchMatchDetails = async ({
 
   const data = unwrap(`load match ${matchId}`, result);
 
-  return {
-    ...matchDetailsSchema.parse(data),
-    unmigrated: data,
-  };
+  return matchDetailsResultFromPayload(data);
 };
 
+/** Build the cache value `matchDetailsQuery` resolves to from a full
+ * `MatchDetails` payload the caller already holds. Used by the queryFn (from the
+ * GET response) and to seed the details cache from the `POST /v1/matches`
+ * response before navigating to a just-created match (#510). Runs the parse, so
+ * a malformed payload fails loudly rather than priming a bad cache entry. */
+export function matchDetailsResultFromPayload(payload: MatchDetails) {
+  return { ...matchDetailsSchema.parse(payload), unmigrated: payload };
+}
+
 /** The resolved shape `matchDetailsQuery`'s `queryFn` returns. */
-export type MatchDetailsResult = Awaited<ReturnType<typeof fetchMatchDetails>>;
+export type MatchDetailsResult = ReturnType<typeof matchDetailsResultFromPayload>;
 
 export const matchDetailsQuery = (matchId: string) => ({
   queryKey: queryKey(matchId),

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -7,11 +7,17 @@ import {
   createRoute,
   createRouter,
 } from '@tanstack/react-router'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClient,
+  QueryClientProvider,
+  useSuspenseQuery,
+} from '@tanstack/react-query'
+import { Suspense } from 'react'
 import { delay, http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 import { server } from '@/mocks/server'
 import { matchDetails, sessionResponse } from '@/test/factories'
+import { matchDetailsQuery } from '@/components/matches/match-details/match-details-query'
 import { Route } from './new'
 
 // The page component isn't exported (route files should only export `Route`,
@@ -28,7 +34,10 @@ function pendingMatch() {
 
 function renderNewMatch() {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    // Mirror the app's real client (`main.tsx`): a 30s staleTime is what keeps
+    // a freshly-primed match-details entry from being treated as stale and
+    // background-refetched the instant the page mounts (#510).
+    defaultOptions: { queries: { retry: false, staleTime: 30_000 } },
   })
   const rootRoute = createRootRoute()
   const newMatchRoute = createRoute({
@@ -54,12 +63,28 @@ function renderNewMatch() {
       return <div>Scoring route {matchId} game {gameNumber}</div>
     },
   })
+  // A stand-in for the real match-details page: it reads the same query the
+  // page does, so it renders from a primed cache and only hits the network on
+  // a cache miss.
+  const detailsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches/$matchId',
+    component: () => {
+      const { matchId } = detailsRoute.useParams()
+      return (
+        <Suspense fallback={<div>Loading match…</div>}>
+          <DetailsProbe matchId={matchId} />
+        </Suspense>
+      )
+    },
+  })
   const router = createRouter({
     routeTree: rootRoute.addChildren([
       newMatchRoute,
       dashboardRoute,
       settingsRoute,
       scoringRoute,
+      detailsRoute,
     ]),
     history: createMemoryHistory({ initialEntries: ['/matches/new'] }),
   })
@@ -67,6 +92,15 @@ function renderNewMatch() {
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
     </QueryClientProvider>,
+  )
+}
+
+function DetailsProbe({ matchId }: { matchId: string }) {
+  const { data } = useSuspenseQuery(matchDetailsQuery(matchId))
+  return (
+    <div>
+      Details route {matchId} status {data.data.scoreboard.status}
+    </div>
   )
 }
 
@@ -106,6 +140,42 @@ describe('NewMatchPage', () => {
       best_of: 5,
       rated: true,
     })
+  })
+
+  it('seeds the details cache from the create response, so a redirect to /matches/{id} renders without the racing GET (#510)', async () => {
+    const user = userEvent.setup()
+    // A match with no next game redirects straight to /matches/{id} rather than
+    // the scoring page — the exact path that hit the read-after-write 404.
+    const created = matchDetails({
+      id: 'm-test',
+      current_game: null,
+      data: { scoreboard: { status: 'final' } },
+    })
+    let detailsGetCalls = 0
+    server.use(
+      http.get('*/v1/players/recent', () => HttpResponse.json([])),
+      http.post('*/v1/matches', () =>
+        HttpResponse.json(created, { status: 201 }),
+      ),
+      // Stand in for the race: the just-created match still 404s if the page
+      // actually fetches it. The primed cache must make this unreachable.
+      http.get('*/v1/matches/:id', () => {
+        detailsGetCalls += 1
+        return HttpResponse.json({ detail: 'Match not found.' }, { status: 404 })
+      }),
+    )
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /start match/i }),
+    )
+
+    // The details page renders from the seeded cache — no "couldn't find that
+    // match" dead-end — and never touched the network.
+    expect(
+      await screen.findByText('Details route m-test status final'),
+    ).toBeInTheDocument()
+    expect(detailsGetCalls).toBe(0)
   })
 
   it('starts a single-sided unrated match when no opponent is chosen', async () => {


### PR DESCRIPTION
## Problem

Navigating to `/matches/{id}` immediately after creating a match (deep-link or programmatic redirect) could dead-end on the not-found boundary — **"We couldn't find that match."** — even though the match exists (its score-entry page loads, and a manual reload renders details fine). Fixes #510.

The match-details page is a BFF surface whose query fires `GET /v1/matches/{id}`. On the realistic **Matches list → Open** path the React Query cache is already warm, so it renders instantly. Right after creating a match the cache for that id is **cold**, so the redirect fires a fresh GET that loses a read-after-write race against the just-committed write.

## Fix

The `POST /v1/matches` response already *is* a complete `MatchDetails` payload (identical shape to the GET — empty extras/H2H for a brand-new match). So `useCreateMatch` now seeds the match-details cache from that response in `onSuccess`, mirroring the existing `applyScoreMutationCache` "prime the detail cache from the mutation response" convention in the same file. The app's 30s `staleTime` keeps the seeded entry fresh, so the follow-on hop to `/matches/{id}` (direct redirect, or via the scoring screen) renders from cache instead of racing the GET.

- New `matchDetailsResultFromPayload` helper — single source of truth for the query's resolved shape; the queryFn now delegates to it (no more duplicated `{ ...parse, unmigrated }` shaping).
- Priming lives in the mutation hook (not the page), so every create caller is race-immune. No inverted dependency — `api/matches.ts` already imported `matchDetailsQueryKey` from the component-layer query module.

## Testing

- **Unit** (`match-details-query.test.ts`): helper produces the exact shape a fresh fetch caches; throws on a malformed payload rather than priming garbage.
- **Integration** (`new.test.tsx`): create → redirect to `/matches/{id}` with the GET handler stubbed to **404** (simulating the race) — the details page renders from the seeded cache and the network is never touched (`detailsGetCalls === 0`).
- Web-client: vitest **698 passed**, lint clean, `tsc -b && vite build` ✓, Playwright e2e **127 passed**.

Client-only change — no API/contract change, so `schema.d.ts` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)