### PR TITLE
Add double-submit CSRF protection for cookie-auth mutations (#405)

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -18,14 +18,10 @@ from app.notifications.router import router as notifications_router
 from app.players import router as players_router
 from app.rate_limiting import init_rate_limit_redis, shutdown_rate_limit_redis
 from app.rbac import router as rbac_router
-from app.sessions import CSRF_COOKIE_NAME, CSRF_HEADER_NAME
+from app.sessions import CSRF_COOKIE_NAME, CSRF_HEADER_NAME, CSRF_SAFE_METHODS
 from app.sessions import router as sessions_router
 
 log = logging.getLogger(__name__)
-
-# Methods that can't mutate state are exempt from the CSRF check. Note OPTIONS
-# preflights carry no custom header and must pass through.
-CSRF_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 
 @asynccontextmanager

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,11 +1,13 @@
 import logging
 import os
+import secrets
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 
 import redis.asyncio as redis_asyncio
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import text
 
@@ -16,9 +18,14 @@ from app.notifications.router import router as notifications_router
 from app.players import router as players_router
 from app.rate_limiting import init_rate_limit_redis, shutdown_rate_limit_redis
 from app.rbac import router as rbac_router
+from app.sessions import CSRF_COOKIE_NAME, CSRF_HEADER_NAME
 from app.sessions import router as sessions_router
 
 log = logging.getLogger(__name__)
+
+# Methods that can't mutate state are exempt from the CSRF check. Note OPTIONS
+# preflights carry no custom header and must pass through.
+CSRF_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 
 @asynccontextmanager
@@ -39,6 +46,28 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 
 
 app = FastAPI(title="FortyMM API", lifespan=lifespan)
+
+
+@app.middleware("http")
+async def csrf_protect(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    """Double-submit CSRF guard: every unsafe-method request must echo the
+    non-HttpOnly ``csrf_token`` cookie back in the ``X-CSRF-Token`` header. A
+    cross-origin attacker's page can ride along the cookie but can neither read
+    its value nor set a custom header, so it can't produce a match. The cookie
+    is issued/rotated alongside the session cookie in ``app.sessions``."""
+    if request.method not in CSRF_SAFE_METHODS:
+        cookie = request.cookies.get(CSRF_COOKIE_NAME)
+        header = request.headers.get(CSRF_HEADER_NAME)
+        if not cookie or not header or not secrets.compare_digest(cookie, header):
+            return JSONResponse(
+                status_code=403,
+                content={"detail": "CSRF token missing or invalid."},
+            )
+    return await call_next(request)
+
+
 app.include_router(sessions_router)
 app.include_router(rbac_router)
 app.include_router(matches_router)

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -52,6 +52,14 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 SESSION_COOKIE_NAME = "session"
+# Non-HttpOnly companion cookie for the double-submit CSRF defense. The session
+# cookie is HttpOnly so a cross-origin attacker can't read it; this one is
+# readable by our own JS, which echoes it in the ``X-CSRF-Token`` header on
+# mutating requests. ``csrf_protect`` (app/main.py) rejects any unsafe-method
+# request whose header doesn't match this cookie. An attacker's page can ride
+# along the cookies but can neither read this value nor set the custom header.
+CSRF_COOKIE_NAME = "csrf_token"
+CSRF_HEADER_NAME = "x-csrf-token"
 SESSION_TOKEN_CONTEXT = "session"
 # Stable `code` on the 401 we raise when a cookie resolves to a tombstoned
 # (merged-away) guest, so clients can tell "your session was merged, sign in"
@@ -421,12 +429,30 @@ async def _create_session(db: AsyncSession) -> tuple[User, str]:
 
 
 def _set_session_cookie(response: Response, raw_token: str) -> None:
+    # Session cookie first so it leads the Set-Cookie list, then a fresh CSRF
+    # token. Every session rotation (create, merge sign-in, email confirm,
+    # magic-link consume) flows through here, so the CSRF token rotates with
+    # the session for free.
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=raw_token,
         max_age=int(SESSION_LIFETIME.total_seconds()),
         path="/",
         httponly=True,
+        secure=_cookie_secure(),
+        samesite="lax",
+    )
+    _set_csrf_cookie(response)
+
+
+def _set_csrf_cookie(response: Response) -> None:
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=secrets.token_urlsafe(32),
+        max_age=int(SESSION_LIFETIME.total_seconds()),
+        path="/",
+        # Intentionally readable by JS — the client must echo it in a header.
+        httponly=False,
         secure=_cookie_secure(),
         samesite="lax",
     )
@@ -440,6 +466,13 @@ def _clear_session_cookie(response: Response) -> None:
         key=SESSION_COOKIE_NAME,
         path="/",
         httponly=True,
+        secure=_cookie_secure(),
+        samesite="lax",
+    )
+    response.delete_cookie(
+        key=CSRF_COOKIE_NAME,
+        path="/",
+        httponly=False,
         secure=_cookie_secure(),
         samesite="lax",
     )

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -60,6 +60,11 @@ SESSION_COOKIE_NAME = "session"
 # along the cookies but can neither read this value nor set the custom header.
 CSRF_COOKIE_NAME = "csrf_token"
 CSRF_HEADER_NAME = "x-csrf-token"
+# Methods that can't mutate state are exempt from the CSRF check; OPTIONS
+# preflights in particular carry no custom header and must pass through. The
+# middleware (app/main.py) and the test request hook both read this set so they
+# can't drift.
+CSRF_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 SESSION_TOKEN_CONTEXT = "session"
 # Stable `code` on the 401 we raise when a cookie resolves to a tombstoned
 # (merged-away) guest, so clients can tell "your session was merged, sign in"
@@ -482,6 +487,7 @@ def _clear_session_cookie(response: Response) -> None:
 async def get_session_endpoint(
     response: Response,
     session_cookie: Annotated[str | None, Cookie(alias=SESSION_COOKIE_NAME)] = None,
+    csrf_cookie: Annotated[str | None, Cookie(alias=CSRF_COOKIE_NAME)] = None,
     db: AsyncSession = Depends(get_session),
 ) -> SessionResponse:
     user: User | None = None
@@ -496,6 +502,12 @@ async def get_session_endpoint(
     if user is None:
         user, raw_token = await _create_session(db)
         _set_session_cookie(response, raw_token)
+    elif csrf_cookie is None:
+        # Returning session whose (non-HttpOnly) CSRF cookie was dropped —
+        # reissue it so mutations don't permanently 403. Self-heals on the
+        # bootstrap the client makes on every load, without rotating the cookie
+        # (or re-setting the session cookie) when one is already present.
+        _set_csrf_cookie(response)
     return await _build_session_response(db, user)
 
 

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -16,9 +16,7 @@ from app.main import app as fastapi_app
 from app.models import User
 from app.notifications.apns import Environment, SendOutcome, SendResult
 from app.notifications.dependencies import get_push_sender
-from app.sessions import CSRF_COOKIE_NAME, CSRF_HEADER_NAME
-
-_CSRF_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+from app.sessions import CSRF_COOKIE_NAME, CSRF_HEADER_NAME, CSRF_SAFE_METHODS
 
 
 async def _attach_csrf_header(request: Request) -> None:
@@ -31,7 +29,7 @@ async def _attach_csrf_header(request: Request) -> None:
     inject a synthetic matching cookie/header pair — they still need to clear
     the middleware. Tests exercising the *rejection* path build a client
     without this hook."""
-    if request.method.upper() in _CSRF_SAFE_METHODS:
+    if request.method.upper() in CSRF_SAFE_METHODS:
         return
     cookie_header = request.headers.get("cookie")
     prefix = f"{CSRF_COOKIE_NAME}="

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
-from httpx import ASGITransport, AsyncClient
+from httpx import ASGITransport, AsyncClient, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,6 +16,42 @@ from app.main import app as fastapi_app
 from app.models import User
 from app.notifications.apns import Environment, SendOutcome, SendResult
 from app.notifications.dependencies import get_push_sender
+from app.sessions import CSRF_COOKIE_NAME, CSRF_HEADER_NAME
+
+_CSRF_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+async def _attach_csrf_header(request: Request) -> None:
+    """httpx request hook that satisfies the app's double-submit CSRF guard on
+    every mutating request, mirroring the browser client.
+
+    If the client carries a real ``csrf_token`` cookie (it called
+    ``/v1/session``), echo that value in the ``X-CSRF-Token`` header. Tests that
+    bypass the session via ``dependency_overrides`` have no such cookie, so
+    inject a synthetic matching cookie/header pair — they still need to clear
+    the middleware. Tests exercising the *rejection* path build a client
+    without this hook."""
+    if request.method.upper() in _CSRF_SAFE_METHODS:
+        return
+    cookie_header = request.headers.get("cookie")
+    prefix = f"{CSRF_COOKIE_NAME}="
+    token: str | None = None
+    for part in (cookie_header or "").split("; "):
+        if part.startswith(prefix):
+            token = part[len(prefix) :]
+            break
+    if token is None:
+        token = "test-csrf-token"
+        pair = f"{prefix}{token}"
+        request.headers["cookie"] = (
+            f"{cookie_header}; {pair}" if cookie_header else pair
+        )
+    request.headers[CSRF_HEADER_NAME] = token
+
+
+# Pass to every test ``AsyncClient`` so the existing mutating-request tests keep
+# passing under the double-submit CSRF guard.
+CSRF_EVENT_HOOKS = {"request": [_attach_csrf_header]}
 
 
 async def start_session(api_client: AsyncClient, db_session: AsyncSession) -> User:
@@ -47,6 +83,7 @@ def make_client() -> AsyncClient:
     return AsyncClient(
         transport=ASGITransport(app=fastapi_app),
         base_url="https://testserver",
+        event_hooks=CSRF_EVENT_HOOKS,
     )
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -18,6 +18,7 @@ from app import queue as queue_module
 from app.db import Base, get_session
 from app.main import app as fastapi_app
 from app.models import League, LeagueVisibility, RatingStrategy
+from tests._helpers import CSRF_EVENT_HOOKS
 
 
 @pytest.fixture(autouse=True)
@@ -215,7 +216,9 @@ async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
     fastapi_app.dependency_overrides[get_session] = _override
     transport = ASGITransport(app=fastapi_app)
     async with AsyncClient(
-        transport=transport, base_url="https://testserver"
+        transport=transport,
+        base_url="https://testserver",
+        event_hooks=CSRF_EVENT_HOOKS,
     ) as client:
         yield client
     fastapi_app.dependency_overrides.clear()

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -25,7 +25,7 @@ from app.sessions import (
     EMAIL_MERGE_CONTEXT_PREFIX,
     _pending_email_token_clause,
 )
-from tests._helpers import start_session
+from tests._helpers import CSRF_EVENT_HOOKS, start_session
 
 
 @pytest_asyncio.fixture
@@ -36,7 +36,9 @@ async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
     app.dependency_overrides[get_session] = _override
     transport = ASGITransport(app=app)
     async with AsyncClient(
-        transport=transport, base_url="https://testserver"
+        transport=transport,
+        base_url="https://testserver",
+        event_hooks=CSRF_EVENT_HOOKS,
     ) as client:
         yield client
     app.dependency_overrides.clear()

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -25,7 +25,12 @@ from app.sessions import (
     SESSION_COOKIE_NAME,
     SESSION_TOKEN_CONTEXT,
 )
-from tests._helpers import make_client, make_user, start_session
+from tests._helpers import (
+    CSRF_EVENT_HOOKS,
+    make_client,
+    make_user,
+    start_session,
+)
 
 
 @pytest_asyncio.fixture
@@ -36,7 +41,9 @@ async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
     app.dependency_overrides[get_session] = _override
     transport = ASGITransport(app=app)
     async with AsyncClient(
-        transport=transport, base_url="https://testserver"
+        transport=transport,
+        base_url="https://testserver",
+        event_hooks=CSRF_EVENT_HOOKS,
     ) as client:
         yield client
     app.dependency_overrides.clear()

--- a/api/tests/test_rbac.py
+++ b/api/tests/test_rbac.py
@@ -10,6 +10,7 @@ from app.main import app
 from app.models import Permission, Role, RolePermission, User, UserRole
 from app.rbac import _require_rbac
 from app.sessions import get_current_user
+from tests._helpers import CSRF_EVENT_HOOKS
 
 
 @pytest_asyncio.fixture
@@ -44,7 +45,9 @@ async def api_client(
     app.dependency_overrides[_require_rbac] = _bypass_rbac
     transport = ASGITransport(app=app)
     async with AsyncClient(
-        transport=transport, base_url="https://testserver"
+        transport=transport,
+        base_url="https://testserver",
+        event_hooks=CSRF_EVENT_HOOKS,
     ) as client:
         yield client
     app.dependency_overrides.clear()

--- a/api/tests/test_rbac_authz.py
+++ b/api/tests/test_rbac_authz.py
@@ -16,6 +16,7 @@ from app.db import get_session
 from app.main import app
 from app.models import Permission, Role, RolePermission, User, UserRole
 from app.sessions import get_current_user
+from tests._helpers import CSRF_EVENT_HOOKS
 
 
 @pytest_asyncio.fixture
@@ -61,7 +62,11 @@ def _build_client(db_session: AsyncSession, user: User | None) -> AsyncClient:
 
     app.dependency_overrides[get_session] = _override_session
     app.dependency_overrides[get_current_user] = _override_user
-    return AsyncClient(transport=ASGITransport(app=app), base_url="https://testserver")
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="https://testserver",
+        event_hooks=CSRF_EVENT_HOOKS,
+    )
 
 
 @pytest_asyncio.fixture

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -496,3 +496,20 @@ async def test_safe_methods_never_require_a_csrf_token(raw_client: AsyncClient):
     """GET (and other safe methods) must pass even with no token at all."""
     response = await raw_client.get("/v1/session")
     assert response.status_code == 200
+
+
+async def test_session_reissues_csrf_cookie_when_dropped(raw_client: AsyncClient):
+    """A returning session that lost its non-HttpOnly CSRF cookie gets a fresh
+    one on bootstrap, so mutations don't permanently 403."""
+    await raw_client.get("/v1/session")  # mints session + csrf cookies
+    # Simulate the CSRF cookie being dropped while the session persists.
+    raw_client.cookies.delete(CSRF_COOKIE_NAME)
+    assert raw_client.cookies.get(CSRF_COOKIE_NAME) is None
+
+    response = await raw_client.get("/v1/session")
+    assert response.status_code == 200
+    # The session cookie is untouched (still no re-set); only CSRF is reissued.
+    set_cookies = [h.lower() for h in response.headers.get_list("set-cookie")]
+    assert any(h.startswith(f"{CSRF_COOKIE_NAME}=") for h in set_cookies)
+    assert not any(h.startswith(f"{SESSION_COOKIE_NAME}=") for h in set_cookies)
+    assert raw_client.cookies.get(CSRF_COOKIE_NAME)

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -11,8 +11,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db import get_session
 from app.main import app
 from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
-from app.sessions import SESSION_COOKIE_NAME, SESSION_TOKEN_CONTEXT
-from tests._helpers import make_client, start_session
+from app.sessions import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    SESSION_COOKIE_NAME,
+    SESSION_TOKEN_CONTEXT,
+)
+from tests._helpers import CSRF_EVENT_HOOKS, make_client, start_session
 
 
 @pytest_asyncio.fixture
@@ -23,7 +28,9 @@ async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
     app.dependency_overrides[get_session] = _override
     transport = ASGITransport(app=app)
     async with AsyncClient(
-        transport=transport, base_url="https://testserver"
+        transport=transport,
+        base_url="https://testserver",
+        event_hooks=CSRF_EVENT_HOOKS,
     ) as client:
         yield client
     app.dependency_overrides.clear()
@@ -411,3 +418,81 @@ async def test_authed_endpoint_with_merged_cookie_401s(
     assert response.json()["detail"]["code"] == "session_merged"
     # (A garbage / no-token cookie still mints — see
     # test_creates_new_session_when_cookie_invalid — only tombstones 401.)
+
+
+# ----- CSRF double-submit guard ---------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def raw_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    """A client bound to the test app *without* the CSRF auto-attach hook, so
+    tests can drive the double-submit guard by hand."""
+
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    app.dependency_overrides[get_session] = _override
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="https://testserver"
+    ) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+async def test_session_issues_readable_csrf_cookie(raw_client: AsyncClient):
+    """GET /v1/session sets a non-HttpOnly csrf_token cookie the client JS can
+    read to echo back in the header."""
+    response = await raw_client.get("/v1/session")
+    assert response.status_code == 200
+
+    csrf_set_cookie = next(
+        h
+        for h in response.headers.get_list("set-cookie")
+        if h.lower().startswith(f"{CSRF_COOKIE_NAME}=")
+    )
+    assert "httponly" not in csrf_set_cookie.lower()
+    assert "samesite=lax" in csrf_set_cookie.lower()
+    assert raw_client.cookies.get(CSRF_COOKIE_NAME)
+
+
+async def test_mutating_request_without_csrf_header_is_rejected(
+    raw_client: AsyncClient,
+):
+    await raw_client.get("/v1/session")  # establishes both cookies
+    response = await raw_client.delete("/v1/session")
+    assert response.status_code == 403
+    assert "csrf" in response.json()["detail"].lower()
+
+
+async def test_mutating_request_with_mismatched_csrf_header_is_rejected(
+    raw_client: AsyncClient,
+):
+    await raw_client.get("/v1/session")
+    response = await raw_client.delete(
+        "/v1/session", headers={CSRF_HEADER_NAME: "not-the-cookie-value"}
+    )
+    assert response.status_code == 403
+
+
+async def test_mutating_request_with_matching_csrf_header_passes(
+    raw_client: AsyncClient,
+):
+    await raw_client.get("/v1/session")
+    token = raw_client.cookies.get(CSRF_COOKIE_NAME)
+    assert token
+    response = await raw_client.delete("/v1/session", headers={CSRF_HEADER_NAME: token})
+    assert response.status_code == 204
+    # Logout clears the CSRF cookie alongside the session cookie.
+    cleared = [
+        h
+        for h in response.headers.get_list("set-cookie")
+        if h.lower().startswith(f"{CSRF_COOKIE_NAME}=")
+    ]
+    assert cleared and "max-age=0" in cleared[0].lower()
+
+
+async def test_safe_methods_never_require_a_csrf_token(raw_client: AsyncClient):
+    """GET (and other safe methods) must pass even with no token at all."""
+    response = await raw_client.get("/v1/session")
+    assert response.status_code == 200

--- a/web-client/src/api/client.test.ts
+++ b/web-client/src/api/client.test.ts
@@ -5,7 +5,11 @@ import { server } from '@/mocks/server'
 import { sessionResponse } from '@/test/factories'
 import { api, setSessionEndedHandler } from './client'
 
-afterEach(() => setSessionEndedHandler(null))
+afterEach(() => {
+  setSessionEndedHandler(null)
+  // Drop any csrf cookie a test set so it can't leak into the next one.
+  document.cookie = 'csrf_token=; max-age=0; path=/'
+})
 
 /** Force the middleware's internal latch back to "not firing" via a 200. */
 async function resetLatch() {
@@ -71,4 +75,48 @@ it('latches so a burst of 401s redirects only once', async () => {
   await api.GET('/v1/session')
 
   expect(handler).toHaveBeenCalledTimes(1)
+})
+
+it('echoes the csrf cookie in the X-CSRF-Token header on a mutation', async () => {
+  document.cookie = 'csrf_token=tok-123; path=/'
+  let seen: string | null = 'unset'
+  server.use(
+    http.delete('*/v1/session', ({ request }) => {
+      seen = request.headers.get('X-CSRF-Token')
+      return new HttpResponse(null, { status: 204 })
+    }),
+  )
+
+  await api.DELETE('/v1/session')
+
+  expect(seen).toBe('tok-123')
+})
+
+it('does not attach the csrf header on safe (GET) requests', async () => {
+  document.cookie = 'csrf_token=tok-123; path=/'
+  let seen: string | null = 'unset'
+  server.use(
+    http.get('*/v1/session', ({ request }) => {
+      seen = request.headers.get('X-CSRF-Token')
+      return HttpResponse.json(sessionResponse())
+    }),
+  )
+
+  await api.GET('/v1/session')
+
+  expect(seen).toBeNull()
+})
+
+it('attaches no header when there is no csrf cookie', async () => {
+  let seen: string | null = 'unset'
+  server.use(
+    http.delete('*/v1/session', ({ request }) => {
+      seen = request.headers.get('X-CSRF-Token')
+      return new HttpResponse(null, { status: 204 })
+    }),
+  )
+
+  await api.DELETE('/v1/session')
+
+  expect(seen).toBeNull()
 })

--- a/web-client/src/api/client.ts
+++ b/web-client/src/api/client.ts
@@ -66,6 +66,35 @@ async function readSessionMerged(
   return null
 }
 
+const CSRF_COOKIE_NAME = 'csrf_token'
+const CSRF_HEADER_NAME = 'X-CSRF-Token'
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+/** Read a non-HttpOnly cookie value by name from `document.cookie`. */
+function readCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null
+  const prefix = `${name}=`
+  for (const part of document.cookie.split('; ')) {
+    if (part.startsWith(prefix)) {
+      return decodeURIComponent(part.slice(prefix.length))
+    }
+  }
+  return null
+}
+
+api.use({
+  // Double-submit CSRF: echo the server-set `csrf_token` cookie back in a
+  // header on every mutating request. The backend (app/main.py:csrf_protect)
+  // 403s any unsafe-method request whose header doesn't match the cookie.
+  onRequest({ request }) {
+    if (!SAFE_METHODS.has(request.method.toUpperCase())) {
+      const token = readCookie(CSRF_COOKIE_NAME)
+      if (token) request.headers.set(CSRF_HEADER_NAME, token)
+    }
+    return request
+  },
+})
+
 api.use({
   async onResponse({ response }) {
     // Reset the latch on any healthy response so a later genuine session-end

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1694,6 +1694,7 @@ export interface operations {
             path?: never;
             cookie?: {
                 session?: string | null;
+                csrf_token?: string | null;
             };
         };
         requestBody?: never;


### PR DESCRIPTION
Closes #405.

## What

Adds a stateless **double-submit cookie** CSRF defense for the HttpOnly-`session`-cookie auth model. SameSite=Lax was previously the only thing standing between a forged cross-origin request and a state change.

- **Issue** a non-HttpOnly `csrf_token` cookie alongside the session cookie (`_set_session_cookie`), so it rotates with the session for free across every session-set path (create / merge sign-in / email-confirm / magic-link consume) and is cleared on logout.
- **Self-heal:** `GET /v1/session` reissues the CSRF cookie when it's absent on a returning session, so a dropped non-HttpOnly cookie doesn't permanently 403 mutations (idempotent — never re-sets the session cookie).
- **Enforce** at the transport layer: a FastAPI middleware (`csrf_protect`) 403s any POST/PUT/PATCH/DELETE whose `X-CSRF-Token` header doesn't match the cookie (`secrets.compare_digest`). Safe methods (GET/HEAD/OPTIONS) pass untouched — chosen over a per-route dependency so a new mutating route can't silently forget the guard.
- **Web client** echoes the cookie in the header via an `openapi-fetch` `onRequest` middleware — transparent, no per-call changes; only parses `document.cookie` on unsafe methods.

Confirmed no mutating endpoint is exposed over GET (only `GET /v1/session` writes — an intentional guest mint, not an exploitable target). Left CORS out deliberately (the app is same-origin behind nginx).

## Testing

- **API:** ruff + `ruff format --check` + `mypy --strict` clean; `pytest` **391 passed**. New tests cover valid / missing / mismatched token, safe-method exemption, the readable-cookie contract, logout clearing, and the self-heal reissue. A shared httpx request hook mirrors the browser so the existing mutating-request suites pass under the guard.
- **Web:** `npm run lint` clean, `tsc -b && vite build` ✓, vitest **698 passed** (3 new client middleware tests), Playwright e2e **127 passed**.
- **OpenAPI:** regenerated `schema.d.ts` (the new `csrf_cookie` param surfaces `csrf_token` in the `GET /v1/session` cookie params).

🤖 Generated with [Claude Code](https://claude.com/claude-code)