### PR TITLE
Map concurrent game-score race to 409 instead of 500 (#362)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1510,7 +1510,19 @@ async def create_game_score(
         side_2_points=payload.side_2_points,
     )
 
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        # Two participants on the same game-entry page submitting at once both
+        # lazily insert the same game row (uq_match_games_match_id_game_number)
+        # and/or its score (uq_match_game_scores_match_game_id). The
+        # pre-checks above pass for both before either commits, so the loser of
+        # the race trips a unique constraint. Surface it as the same clean 409
+        # the sequential already-scored path returns, not a 500.
+        await db.rollback()
+        raise HTTPException(
+            status_code=409, detail="This game has already been scored."
+        ) from exc
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -9,7 +9,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
-from app.matches import confirm_match_result, dispute_match_result
+from app.matches import (
+    confirm_match_result,
+    create_game_score,
+    dispute_match_result,
+)
 from app.models import (
     League,
     LeagueVisibility,
@@ -21,6 +25,7 @@ from app.models import (
     User,
 )
 from app.notifications.apns import MATCH_RESULT_CONFIRMATION_CATEGORY
+from app.schemas.match import MatchGameScoreWrite
 from tests._helpers import (
     FakeSender,
     make_client,
@@ -617,6 +622,69 @@ async def test_score_create_409_when_game_already_scored(
     )
     assert second.status_code == 409
     assert second.json()["detail"] == "This game has already been scored."
+
+
+async def test_concurrent_score_create_returns_409_not_500(
+    api_client: AsyncClient, db_session: AsyncSession, engine: AsyncEngine
+):
+    """Regression for #362. Two participants sitting on the same
+    game-score-entry page who submit at the same instant both lazily insert
+    the same game row (``uq_match_games_match_id_game_number``); the loser of
+    the race trips the unique constraint at commit. Before the guard that
+    surfaced as a raw 500 — it must be the same clean 409 the sequential
+    already-scored path returns.
+
+    Driven on two *separate* DB sessions (real distinct Postgres connections)
+    via ``asyncio.gather`` so the constraint actually arbitrates — the shared
+    ``db_session`` override can't surface the race. An un-mapped
+    ``IntegrityError`` would escape ``run``'s ``HTTPException``-only ``except``
+    and fail the test loudly, which is exactly the 500 we're guarding against.
+    """
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "race-opp") as (_opp_client, opp):
+        # A fresh rated match: both participants may score game 1, and the
+        # game row doesn't exist yet, so each request inserts it.
+        match = await _create_match(api_client, opp.id, best_of=5)
+        match_id = uuid.UUID(match["id"])
+        me_id, opp_id = me.id, opp.id
+
+        make_session = async_sessionmaker(engine, expire_on_commit=False)
+
+        async def run(user_id: uuid.UUID, side_1: int, side_2: int) -> object:
+            async with make_session() as session:
+                user = (
+                    await session.execute(select(User).where(User.id == user_id))
+                ).scalar_one()
+                payload = MatchGameScoreWrite(
+                    side_1_points=side_1, side_2_points=side_2
+                )
+                try:
+                    await create_game_score(match_id, payload, 1, user, session)
+                    return "ok"
+                except HTTPException as exc:
+                    return exc.status_code
+
+        outcomes = await asyncio.gather(run(me_id, 11, 9), run(opp_id, 5, 11))
+
+        # Exactly one write wins; the other is cleanly rejected with 409,
+        # never a 500 and never a second silent success.
+        assert sorted(str(o) for o in outcomes) == ["409", "ok"], outcomes
+        assert all(o != 500 for o in outcomes), outcomes
+
+        # The committed match holds exactly one score for game 1.
+        async with make_session() as verify:
+            scores = (
+                (
+                    await verify.execute(
+                        select(MatchGameScore)
+                        .join(MatchGame, MatchGameScore.match_game_id == MatchGame.id)
+                        .where(MatchGame.match_id == match_id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(scores) == 1, scores
 
 
 async def test_score_create_422_when_game_number_exceeds_best_of(


### PR DESCRIPTION
## What

Fixes #362 — a **500 on `POST /v1/matches/{id}/games/{n}/scores/new`** when two participants on the same game-score-entry page submit simultaneously.

## Root cause

`create_game_score` pre-checks `game.score is not None`, but under a concurrent race both requests read the same pre-image, both pass the check, and both lazily insert the same `MatchGame(game_number=N)`. The loser trips `uq_match_games_match_id_game_number` at commit (or `uq_match_game_scores_match_game_id` when the game row already exists), which bubbled up as an unhandled `IntegrityError` → 500. The sequential / single-user case already returns a clean 409.

## Fix

Wrap the commit and translate `IntegrityError` into the same **409 "This game has already been scored."** the sequential path returns — mirroring the existing `_add_signature_or_409` and `confirm_email` race guards in this codebase.

## Test

`test_concurrent_score_create_returns_409_not_500` drives `create_game_score` on two **real, distinct Postgres connections** via `asyncio.gather` (the shared `db_session` override can't surface the race). One write wins, the other gets 409, and exactly one score row lands. An un-mapped `IntegrityError` escapes the handler's `HTTPException`-only `except` and fails the test — verified by temporarily removing the guard (test failed with the exact `uq_match_games_match_id_game_number` violation), then restoring it.

## Verification

- `ruff check` / `ruff format --check` clean
- `mypy` clean (68 files)
- `pytest tests/test_matches.py` — 94 passed

No OpenAPI change (handler signature, docstring, and `response_model` unchanged), so `schema.d.ts` doesn't drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)