### PR TITLE
Land 20 web/API bug fixes (QA batch 2026-06-16)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -67,6 +67,7 @@ from app.schemas.match import (
     MatchDetailsSide,
     MatchGameScoreWrite,
     MatchLeague,
+    MatchListFilter,
     MatchListResponse,
     MatchListRow,
     MatchResultsGameWrite,
@@ -385,6 +386,15 @@ def participant_filter[SelectT: Select[Any]](
     return query.where(me_in_match)
 
 
+def _has_signature_exists() -> Any:
+    """``EXISTS`` correlated subquery: this match has at least one signature.
+    The "posted result" marker — an ``in_progress`` match with this true is the
+    derived "Awaiting confirmation" bucket (see ``_status_label``). Pulled into
+    a helper so the list filter and the status-count aggregate split the Live
+    vs awaiting buckets identically (issue #381)."""
+    return select(MatchSignature.id).where(MatchSignature.match_id == Match.id).exists()
+
+
 def _player_username_filter[SelectT: Select[Any]](query: SelectT, q: str) -> SelectT:
     """Restrict to matches that have *any* player whose username matches ``q``.
 
@@ -471,14 +481,33 @@ async def create_match(
     return _serialize_details(created, current_user.id)
 
 
+def _apply_list_filter[SelectT: Select[Any]](
+    query: SelectT, filter_: MatchListFilter
+) -> SelectT:
+    """Narrow ``query`` to one filter bucket. ``live`` and
+    ``awaiting_confirmation`` both sit on the ``in_progress`` status but split
+    on whether a result has been posted (any signature), so neither bucket
+    leaks into the other (issue #381). Every other bucket is a plain status
+    match."""
+    if filter_ is MatchListFilter.live:
+        return query.where(
+            Match.status == MatchStatus.in_progress, ~_has_signature_exists()
+        )
+    if filter_ is MatchListFilter.awaiting_confirmation:
+        return query.where(
+            Match.status == MatchStatus.in_progress, _has_signature_exists()
+        )
+    return query.where(Match.status == MatchStatus(filter_.value))
+
+
 def _filtered_matches_query(
-    q: str | None, status_: MatchStatus | None
+    q: str | None, filter_: MatchListFilter | None
 ) -> Select[tuple[Match]]:
-    """Shared base query for the matches list + CSV export (status + search)."""
+    """Shared base query for the matches list + CSV export (filter + search)."""
     base = select(Match)
     if q:
         base = _player_username_filter(base, q)
-    return base if status_ is None else base.where(Match.status == status_)
+    return base if filter_ is None else _apply_list_filter(base, filter_)
 
 
 # Open statuses the Attention filter ranges over — the only ones where the
@@ -523,7 +552,7 @@ def _attention_sort_key(
 
 @router.get("/matches.csv", response_class=Response)
 async def export_matches_csv(
-    status_: MatchStatus | None = Query(default=None, alias="status"),
+    status_: MatchListFilter | None = Query(default=None, alias="status"),
     q: str | None = Query(default=None),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
@@ -552,7 +581,7 @@ async def export_matches_csv(
 
 @router.get("/matches", response_model=MatchListResponse)
 async def list_matches(
-    status_: MatchStatus | None = Query(default=None, alias="status"),
+    status_: MatchListFilter | None = Query(default=None, alias="status"),
     attention: bool = Query(
         default=False,
         description=(
@@ -568,16 +597,27 @@ async def list_matches(
     db: AsyncSession = Depends(get_session),
 ) -> MatchListResponse:
     # status_counts honors `q` but ignores the status/attention filter, so it's
-    # built from its own aggregate and powers the All/Live/Up-next/Final badges
-    # (and the browsing `total`) for either filter mode.
+    # built from its own aggregate and powers the All/Live/Awaiting/Up-next/Final
+    # badges (and the browsing `total`) for either filter mode. The
+    # awaiting-confirmation bucket is an `in_progress` row with a signature, so
+    # it's counted separately and peeled out of the `in_progress` total — the
+    # `in_progress` count then reads as true-live (no posted result), keeping the
+    # two buckets disjoint (issue #381).
     counts_query = select(Match.status, func.count(Match.id))
+    awaiting_query = select(func.count(Match.id)).where(
+        Match.status == MatchStatus.in_progress, _has_signature_exists()
+    )
     if q:
         counts_query = _player_username_filter(counts_query, q)
+        awaiting_query = _player_username_filter(awaiting_query, q)
     status_counts: dict[MatchStatus, int] = {s: 0 for s in MatchStatus}
     for status_value, count in (
         await db.execute(counts_query.group_by(Match.status))
     ).all():
         status_counts[status_value] = count
+    awaiting_count = (await db.execute(awaiting_query)).scalar_one()
+    # Split the raw in_progress total into true-live + awaiting-confirmation.
+    status_counts[MatchStatus.in_progress] -= awaiting_count
 
     # The list is open to every signed-in user. Writes still gate on
     # `_is_participant` downstream.
@@ -622,11 +662,12 @@ async def list_matches(
             .all()
         )
         items = [_list_row(match, current_user.id) for match in matches]
-        total = (
-            status_counts[status_]
-            if status_ is not None
-            else sum(status_counts.values())
-        )
+        if status_ is None:
+            total = sum(status_counts.values()) + awaiting_count
+        elif status_ is MatchListFilter.awaiting_confirmation:
+            total = awaiting_count
+        else:
+            total = status_counts[MatchStatus(status_.value)]
         # The Attention badge must read its own count even while another tab is
         # active, so it's a dedicated participant-scoped aggregate (honoring `q`).
         attention_count = await _attention_count(db, q, current_user.id)
@@ -636,6 +677,7 @@ async def list_matches(
         page=page,
         page_size=page_size,
         total=total,
+        awaiting_confirmation_count=awaiting_count,
         status_counts=status_counts,
         attention_count=attention_count,
     )

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -63,6 +63,7 @@ from app.schemas.match import (
     MatchDetailsSide,
     MatchGameScoreWrite,
     MatchLeague,
+    MatchListFilter,
     MatchListResponse,
     MatchListRow,
     MatchResultsGameWrite,
@@ -381,6 +382,15 @@ def participant_filter[SelectT: Select[Any]](
     return query.where(me_in_match)
 
 
+def _has_signature_exists() -> Any:
+    """``EXISTS`` correlated subquery: this match has at least one signature.
+    The "posted result" marker — an ``in_progress`` match with this true is the
+    derived "Awaiting confirmation" bucket (see ``_status_label``). Pulled into
+    a helper so the list filter and the status-count aggregate split the Live
+    vs awaiting buckets identically (issue #381)."""
+    return select(MatchSignature.id).where(MatchSignature.match_id == Match.id).exists()
+
+
 def _player_username_filter[SelectT: Select[Any]](query: SelectT, q: str) -> SelectT:
     """Restrict to matches that have *any* player whose username matches ``q``.
 
@@ -467,19 +477,38 @@ async def create_match(
     return _serialize_details(created, current_user.id)
 
 
+def _apply_list_filter[SelectT: Select[Any]](
+    query: SelectT, filter_: MatchListFilter
+) -> SelectT:
+    """Narrow ``query`` to one filter bucket. ``live`` and
+    ``awaiting_confirmation`` both sit on the ``in_progress`` status but split
+    on whether a result has been posted (any signature), so neither bucket
+    leaks into the other (issue #381). Every other bucket is a plain status
+    match."""
+    if filter_ is MatchListFilter.live:
+        return query.where(
+            Match.status == MatchStatus.in_progress, ~_has_signature_exists()
+        )
+    if filter_ is MatchListFilter.awaiting_confirmation:
+        return query.where(
+            Match.status == MatchStatus.in_progress, _has_signature_exists()
+        )
+    return query.where(Match.status == MatchStatus(filter_.value))
+
+
 def _filtered_matches_query(
-    q: str | None, status_: MatchStatus | None
+    q: str | None, filter_: MatchListFilter | None
 ) -> Select[tuple[Match]]:
-    """Shared base query for the matches list + CSV export (status + search)."""
+    """Shared base query for the matches list + CSV export (filter + search)."""
     base = select(Match)
     if q:
         base = _player_username_filter(base, q)
-    return base if status_ is None else base.where(Match.status == status_)
+    return base if filter_ is None else _apply_list_filter(base, filter_)
 
 
 @router.get("/matches.csv", response_class=Response)
 async def export_matches_csv(
-    status_: MatchStatus | None = Query(default=None, alias="status"),
+    status_: MatchListFilter | None = Query(default=None, alias="status"),
     q: str | None = Query(default=None),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
@@ -508,7 +537,7 @@ async def export_matches_csv(
 
 @router.get("/matches", response_model=MatchListResponse)
 async def list_matches(
-    status_: MatchStatus | None = Query(default=None, alias="status"),
+    status_: MatchListFilter | None = Query(default=None, alias="status"),
     q: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=25, ge=1, le=MAX_PAGE_SIZE),
@@ -532,25 +561,41 @@ async def list_matches(
     )
 
     # status_counts honors `q` but ignores the status filter, so it's built
-    # from its own aggregate. `total` then falls out of the same counts — no
-    # separate count round-trip needed.
+    # from its own aggregate. The awaiting-confirmation bucket is an
+    # `in_progress` row with a signature, so it's counted separately and peeled
+    # out of the `in_progress` total — the `in_progress` count then reads as
+    # true-live (no posted result), keeping the two buckets disjoint (issue
+    # #381). `total` falls out of the same counts — no separate count
+    # round-trip needed.
     counts_query = select(Match.status, func.count(Match.id))
+    awaiting_query = select(func.count(Match.id)).where(
+        Match.status == MatchStatus.in_progress, _has_signature_exists()
+    )
     if q:
         counts_query = _player_username_filter(counts_query, q)
+        awaiting_query = _player_username_filter(awaiting_query, q)
     status_counts: dict[MatchStatus, int] = {s: 0 for s in MatchStatus}
     for status_value, count in (
         await db.execute(counts_query.group_by(Match.status))
     ).all():
         status_counts[status_value] = count
-    total = (
-        status_counts[status_] if status_ is not None else sum(status_counts.values())
-    )
+    awaiting_count = (await db.execute(awaiting_query)).scalar_one()
+    # Split the raw in_progress total into true-live + awaiting-confirmation.
+    status_counts[MatchStatus.in_progress] -= awaiting_count
+
+    if status_ is None:
+        total = sum(status_counts.values()) + awaiting_count
+    elif status_ is MatchListFilter.awaiting_confirmation:
+        total = awaiting_count
+    else:
+        total = status_counts[MatchStatus(status_.value)]
 
     return MatchListResponse(
         items=[_list_row(match, current_user.id) for match in matches],
         page=page,
         page_size=page_size,
         total=total,
+        awaiting_confirmation_count=awaiting_count,
         status_counts=status_counts,
     )
 

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -760,9 +760,16 @@ async def get_match(
     match_service: MatchService = Depends(get_match_service),
 ) -> MatchDetails:
     """Open to anyone, signed in or not. A signed-in caller gets
-    is_current_user / can_score flags; an anonymous caller gets the same view
-    with those flags off. Per-IP rate-limited (60/min) so an open URL can't be
-    scraped from one source.
+    is_current_user / can_score flags; an anonymous caller gets the same
+    scorecard with those flags off. Per-IP rate-limited (60/min) so an open URL
+    can't be scraped from one source.
+
+    The richer history payload — recent form, head-to-head, and per-side rating
+    changes — is *only* loaded for a caller who is a participant on this match
+    (see #515). Non-participants (anonymous holders of the share URL or
+    signed-in spectators) get the scorecard with those extras empty/null, so a
+    public link reveals the result but not the players' rivalry / rating
+    metadata.
 
     The serializer flags whether the current user is on a side; write paths
     below still gate on participation via `get_current_user`."""
@@ -772,7 +779,13 @@ async def get_match(
     domain_match = await match_service.get_match(match_id)
     if domain_match is None:
         raise HTTPException(status_code=404, detail="Match not found.")
-    extras = await _load_view_extras(db, match)
+    # Gate the history/rivalry/rating payload on participation. Anonymous and
+    # spectator callers never see another player's form or rating trajectory —
+    # they get the scorecard with empty extras (see #515).
+    is_participant = current_user is not None and _is_participant(
+        match, current_user.id
+    )
+    extras = await _load_view_extras(db, match) if is_participant else _EMPTY_EXTRAS
     return _serialize_details(
         match,
         current_user.id if current_user else None,

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -660,9 +660,16 @@ async def get_match(
     match_service: MatchService = Depends(get_match_service),
 ) -> MatchDetails:
     """Open to anyone, signed in or not. A signed-in caller gets
-    is_current_user / can_score flags; an anonymous caller gets the same view
-    with those flags off. Per-IP rate-limited (60/min) so an open URL can't be
-    scraped from one source.
+    is_current_user / can_score flags; an anonymous caller gets the same
+    scorecard with those flags off. Per-IP rate-limited (60/min) so an open URL
+    can't be scraped from one source.
+
+    The richer history payload — recent form, head-to-head, and per-side rating
+    changes — is *only* loaded for a caller who is a participant on this match
+    (see #515). Non-participants (anonymous holders of the share URL or
+    signed-in spectators) get the scorecard with those extras empty/null, so a
+    public link reveals the result but not the players' rivalry / rating
+    metadata.
 
     The serializer flags whether the current user is on a side; write paths
     below still gate on participation via `get_current_user`."""
@@ -672,7 +679,13 @@ async def get_match(
     domain_match = await match_service.get_match(match_id)
     if domain_match is None:
         raise HTTPException(status_code=404, detail="Match not found.")
-    extras = await _load_view_extras(db, match)
+    # Gate the history/rivalry/rating payload on participation. Anonymous and
+    # spectator callers never see another player's form or rating trajectory —
+    # they get the scorecard with empty extras (see #515).
+    is_participant = current_user is not None and _is_participant(
+        match, current_user.id
+    )
+    extras = await _load_view_extras(db, match) if is_participant else _EMPTY_EXTRAS
     return _serialize_details(
         match,
         current_user.id if current_user else None,

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -1,3 +1,4 @@
+import enum
 import uuid
 from datetime import datetime
 
@@ -6,6 +7,25 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from app.models.match import MatchStatus
 from app.schemas.rating import RatingChange
 from app.schemas.view.match_details import MatchDetails as MatchDetailsView
+
+
+class MatchListFilter(enum.Enum):
+    """The selectable buckets on the ``/matches`` list filter.
+
+    Mostly a 1:1 echo of ``MatchStatus``, but ``awaiting_confirmation`` is a
+    *derived* bucket with no DB status of its own — it's an ``in_progress``
+    match that already carries at least one signature (a posted result waiting
+    on the other side; see ``_status_label``). The ``live`` filter therefore
+    means "``in_progress`` with **no** signature yet", so a posted-but-unconfirmed
+    result no longer silently inflates the Live tab / count (issue #381)."""
+
+    pending = "pending"
+    live = "in_progress"
+    awaiting_confirmation = "awaiting_confirmation"
+    completed = "completed"
+    disputed = "disputed"
+    voided = "voided"
+
 
 # Match lengths the client offers. All odd so one side can always reach a
 # strict majority of games; the DB additionally enforces "odd and >= 1".
@@ -213,7 +233,16 @@ class MatchListResponse(BaseModel):
     page: int
     page_size: int
     total: int
+    # Per-status counts (honoring ``q``, ignoring the status filter). The
+    # ``in_progress`` count here is *true-live only* — posted-but-unconfirmed
+    # results are split out into ``awaiting_confirmation_count`` so the Live tab
+    # / count can't silently fold them in (issue #381). ``in_progress`` +
+    # ``awaiting_confirmation_count`` is the total of all ``in_progress`` rows.
     status_counts: dict[MatchStatus, int]
+    # Count of ``in_progress`` matches with at least one signature — a posted
+    # result waiting on the other side ("Awaiting confirmation"). Its own bucket
+    # so it neither inflates Live nor needs the FE to re-derive it.
+    awaiting_confirmation_count: int
 
 
 # ----- score write (POST/PUT body) -----------------------------------------

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -1,3 +1,4 @@
+import enum
 import uuid
 from datetime import datetime
 
@@ -7,6 +8,25 @@ from app.attention import ListAttentionKind
 from app.models.match import MatchStatus
 from app.schemas.rating import RatingChange
 from app.schemas.view.match_details import MatchDetails as MatchDetailsView
+
+
+class MatchListFilter(enum.Enum):
+    """The selectable buckets on the ``/matches`` list filter.
+
+    Mostly a 1:1 echo of ``MatchStatus``, but ``awaiting_confirmation`` is a
+    *derived* bucket with no DB status of its own — it's an ``in_progress``
+    match that already carries at least one signature (a posted result waiting
+    on the other side; see ``_status_label``). The ``live`` filter therefore
+    means "``in_progress`` with **no** signature yet", so a posted-but-unconfirmed
+    result no longer silently inflates the Live tab / count (issue #381)."""
+
+    pending = "pending"
+    live = "in_progress"
+    awaiting_confirmation = "awaiting_confirmation"
+    completed = "completed"
+    disputed = "disputed"
+    voided = "voided"
+
 
 # Match lengths the client offers. All odd so one side can always reach a
 # strict majority of games; the DB additionally enforces "odd and >= 1".
@@ -221,11 +241,20 @@ class MatchListResponse(BaseModel):
     page: int
     page_size: int
     total: int
+    # Per-status counts (honoring ``q``, ignoring the status filter). The
+    # ``in_progress`` count here is *true-live only* — posted-but-unconfirmed
+    # results are split out into ``awaiting_confirmation_count`` so the Live tab
+    # / count can't silently fold them in (issue #381). ``in_progress`` +
+    # ``awaiting_confirmation_count`` is the total of all ``in_progress`` rows.
     status_counts: dict[MatchStatus, int]
     # Count of the caller's *open* matches (any attention bucket) under the
     # active search, independent of which status tab is selected — powers the
     # Attention tab's badge even while another tab is showing. Always present.
     attention_count: int
+    # Count of ``in_progress`` matches with at least one signature — a posted
+    # result waiting on the other side ("Awaiting confirmation"). Its own bucket
+    # so it neither inflates Live nor needs the FE to re-derive it.
+    awaiting_confirmation_count: int
 
 
 # ----- score write (POST/PUT body) -----------------------------------------

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -455,6 +455,54 @@ async def test_list_filter_by_status(api_client: AsyncClient, db_session: AsyncS
     assert listing["status_counts"]["completed"] == 1
 
 
+async def test_list_live_filter_excludes_awaiting_confirmation(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Regression for #381: a posted-but-unconfirmed result is an in_progress
+    match with a signature ("Awaiting confirmation"). It must NOT count or list
+    under the Live filter — it has its own ``awaiting_confirmation`` bucket."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        live = await _create_match(api_client, opp.id, best_of=1)
+        # A second match with a posted (but unconfirmed) result: status stays
+        # in_progress, one signature recorded → "Awaiting confirmation".
+        awaiting = await _create_match(api_client, opp.id, best_of=1)
+        post = await api_client.post(
+            f"/v1/matches/{awaiting['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 5},
+                ]
+            },
+        )
+        assert post.status_code == 201
+        assert post.json()["status"] == "in_progress"
+        assert post.json()["status_label"] == "Awaiting confirmation"
+
+    # Live filter: only the signature-free in_progress match.
+    live_listing = (
+        await api_client.get("/v1/matches", params={"status": "in_progress"})
+    ).json()
+    assert [row["id"] for row in live_listing["items"]] == [live["id"]]
+    assert live_listing["total"] == 1
+    assert live_listing["status_counts"]["in_progress"] == 1
+    assert live_listing["awaiting_confirmation_count"] == 1
+
+    # Awaiting filter: only the posted-but-unconfirmed match.
+    awaiting_listing = (
+        await api_client.get("/v1/matches", params={"status": "awaiting_confirmation"})
+    ).json()
+    assert [row["id"] for row in awaiting_listing["items"]] == [awaiting["id"]]
+    assert awaiting_listing["total"] == 1
+    assert awaiting_listing["items"][0]["status_label"] == "Awaiting confirmation"
+
+    # Unfiltered: both rows present, and the total counts each exactly once.
+    full = (await api_client.get("/v1/matches")).json()
+    assert full["total"] == 2
+    assert full["status_counts"]["in_progress"] == 1
+    assert full["awaiting_confirmation_count"] == 1
+
+
 async def test_list_q_filter_matches_any_player_username(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -509,6 +509,54 @@ async def test_list_filter_by_status(api_client: AsyncClient, db_session: AsyncS
     assert listing["status_counts"]["completed"] == 1
 
 
+async def test_list_live_filter_excludes_awaiting_confirmation(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Regression for #381: a posted-but-unconfirmed result is an in_progress
+    match with a signature ("Awaiting confirmation"). It must NOT count or list
+    under the Live filter — it has its own ``awaiting_confirmation`` bucket."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        live = await _create_match(api_client, opp.id, best_of=1)
+        # A second match with a posted (but unconfirmed) result: status stays
+        # in_progress, one signature recorded → "Awaiting confirmation".
+        awaiting = await _create_match(api_client, opp.id, best_of=1)
+        post = await api_client.post(
+            f"/v1/matches/{awaiting['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 5},
+                ]
+            },
+        )
+        assert post.status_code == 201
+        assert post.json()["status"] == "in_progress"
+        assert post.json()["status_label"] == "Awaiting confirmation"
+
+    # Live filter: only the signature-free in_progress match.
+    live_listing = (
+        await api_client.get("/v1/matches", params={"status": "in_progress"})
+    ).json()
+    assert [row["id"] for row in live_listing["items"]] == [live["id"]]
+    assert live_listing["total"] == 1
+    assert live_listing["status_counts"]["in_progress"] == 1
+    assert live_listing["awaiting_confirmation_count"] == 1
+
+    # Awaiting filter: only the posted-but-unconfirmed match.
+    awaiting_listing = (
+        await api_client.get("/v1/matches", params={"status": "awaiting_confirmation"})
+    ).json()
+    assert [row["id"] for row in awaiting_listing["items"]] == [awaiting["id"]]
+    assert awaiting_listing["total"] == 1
+    assert awaiting_listing["items"][0]["status_label"] == "Awaiting confirmation"
+
+    # Unfiltered: both rows present, and the total counts each exactly once.
+    full = (await api_client.get("/v1/matches")).json()
+    assert full["total"] == 2
+    assert full["status_counts"]["in_progress"] == 1
+    assert full["awaiting_confirmation_count"] == 1
+
+
 async def test_list_q_filter_matches_any_player_username(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -348,6 +348,55 @@ async def test_get_match_is_open_to_anonymous_callers(
     assert user_ids == {str(creator.id), str(opponent.id)}
 
 
+async def test_history_extras_are_gated_to_participants(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Regression for #515: recent form / head-to-head / rating history is
+    rivalry metadata, not part of the public scorecard. A participant viewing
+    the match sees it; an anonymous holder of the share URL and a signed-in
+    spectator both get the scorecard with those extras empty/null."""
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "gated-rival") as (rival_client, rival):
+        # A prior completed meeting gives both players recent form and seeds a
+        # head-to-head between them.
+        await _play_match_to_completion(
+            api_client, rival_client, rival.id, best_of=3, side_1_wins=True
+        )
+        # The current match between the same two players is what we view.
+        current = await _create_match(api_client, rival.id, best_of=3)
+
+        # A participant (me) sees the rich history payload.
+        mine = (await api_client.get(f"/v1/matches/{current['id']}")).json()
+        assert mine["recent_form"], "participant should see recent form"
+        assert mine["head_to_head"] is not None
+        assert mine["head_to_head"]["total_meetings"] == 1
+
+        # The other participant (the rival) sees it too.
+        theirs = (await rival_client.get(f"/v1/matches/{current['id']}")).json()
+        assert theirs["recent_form"]
+        assert theirs["head_to_head"] is not None
+
+        # A signed-in spectator who is not on either side gets the scorecard
+        # only — no form, no head-to-head.
+        async with make_client() as spectator_client:
+            await start_session(spectator_client, db_session)
+            spec = (await spectator_client.get(f"/v1/matches/{current['id']}")).json()
+        assert spec["recent_form"] == []
+        assert spec["head_to_head"] is None
+        assert all(s["rating_change"] is None for s in spec["sides"])
+
+        # An anonymous holder of the share URL likewise sees no history.
+        async with make_client() as anon_client:
+            anon = (await anon_client.get(f"/v1/matches/{current['id']}")).json()
+        assert anon["recent_form"] == []
+        assert anon["head_to_head"] is None
+        assert all(s["rating_change"] is None for s in anon["sides"])
+
+        # The scorecard itself is unaffected — both players still appear.
+        anon_ids = {p["user_id"] for s in anon["sides"] for p in s["players"]}
+        assert anon_ids == {str(me.id), str(rival.id)}
+
+
 async def test_get_match_is_rate_limited_per_ip(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -353,6 +353,55 @@ async def test_get_match_is_open_to_anonymous_callers(
     assert user_ids == {str(creator.id), str(opponent.id)}
 
 
+async def test_history_extras_are_gated_to_participants(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Regression for #515: recent form / head-to-head / rating history is
+    rivalry metadata, not part of the public scorecard. A participant viewing
+    the match sees it; an anonymous holder of the share URL and a signed-in
+    spectator both get the scorecard with those extras empty/null."""
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "gated-rival") as (rival_client, rival):
+        # A prior completed meeting gives both players recent form and seeds a
+        # head-to-head between them.
+        await _play_match_to_completion(
+            api_client, rival_client, rival.id, best_of=3, side_1_wins=True
+        )
+        # The current match between the same two players is what we view.
+        current = await _create_match(api_client, rival.id, best_of=3)
+
+        # A participant (me) sees the rich history payload.
+        mine = (await api_client.get(f"/v1/matches/{current['id']}")).json()
+        assert mine["recent_form"], "participant should see recent form"
+        assert mine["head_to_head"] is not None
+        assert mine["head_to_head"]["total_meetings"] == 1
+
+        # The other participant (the rival) sees it too.
+        theirs = (await rival_client.get(f"/v1/matches/{current['id']}")).json()
+        assert theirs["recent_form"]
+        assert theirs["head_to_head"] is not None
+
+        # A signed-in spectator who is not on either side gets the scorecard
+        # only — no form, no head-to-head.
+        async with make_client() as spectator_client:
+            await start_session(spectator_client, db_session)
+            spec = (await spectator_client.get(f"/v1/matches/{current['id']}")).json()
+        assert spec["recent_form"] == []
+        assert spec["head_to_head"] is None
+        assert all(s["rating_change"] is None for s in spec["sides"])
+
+        # An anonymous holder of the share URL likewise sees no history.
+        async with make_client() as anon_client:
+            anon = (await anon_client.get(f"/v1/matches/{current['id']}")).json()
+        assert anon["recent_form"] == []
+        assert anon["head_to_head"] is None
+        assert all(s["rating_change"] is None for s in anon["sides"])
+
+        # The scorecard itself is unaffected — both players still appear.
+        anon_ids = {p["user_id"] for s in anon["sides"] for p in s["players"]}
+        assert anon_ids == {str(me.id), str(rival.id)}
+
+
 async def test_get_match_is_rate_limited_per_ip(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/web-client/e2e/page-objects/score-entry.page.ts
+++ b/web-client/e2e/page-objects/score-entry.page.ts
@@ -10,10 +10,15 @@ type NavigateOptions = {
   opponentUsername?: string
 }
 
-// Stable identifiers from `buildInitialSeeds()` in src/mocks/match-store.ts.
-// Hard-coded here so the e2e doesn't have to reach into the mock module.
+// Stable identifiers mirroring `m-2207` from src/mocks/match-store.ts (1-1
+// mid-match). Hard-coded here so the e2e doesn't have to reach into the mock
+// module. The match id is a real UUID, not the `m-2207` placeholder, because
+// the scoring routes guard the param shape and short-circuit to the friendly
+// not-found page for anything that isn't UUID-shaped (#385) — production match
+// ids are UUIDs (`gen_random_uuid()`), so the e2e seed must be too or the page
+// never renders.
 export const SEED = {
-  matchId: 'm-2207',
+  matchId: '22070000-0000-4000-8000-000000000000',
   // After the decouple-scoring refactor games 1 + 2 are scratchpad scores;
   // game 3 is the next un-scored slot. All addressing is by game number.
   nextGameNumber: 3,

--- a/web-client/e2e/score-entry.spec.ts
+++ b/web-client/e2e/score-entry.spec.ts
@@ -13,9 +13,10 @@ type Seed = {
 }
 
 // The seed shape exercised by the score-entry e2e. Mirrors `m-2207` from
-// `src/mocks/match-store.ts` (1-1 mid-match) so the asserts can rely on the
-// same stable id. Per the decouple-scoring refactor, only scored games have
-// rows — the next un-scored slot is exposed via current_game.game_number.
+// `src/mocks/match-store.ts` (1-1 mid-match), but under a UUID-shaped id (see
+// SEED.matchId) so it survives the scoring routes' param-shape guard (#385).
+// Per the decouple-scoring refactor, only scored games have rows — the next
+// un-scored slot is exposed via current_game.game_number.
 function buildSeed(): Seed {
   return {
     id: SEED.matchId,

--- a/web-client/src/App.test.tsx
+++ b/web-client/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   RouterProvider,
@@ -28,6 +28,56 @@ describe('App', () => {
         name: /play more\.\s*pay never\./i,
       }),
     ).toBeInTheDocument()
+  })
+
+  it('exposes the section links behind a mobile hamburger toggle', async () => {
+    // Regression for #375: at narrow widths the desktop `.nav-links` are
+    // hidden, so the only way to reach Product/Tournaments/Manifesto/FAQ is
+    // through a hamburger toggle + collapsible menu. Before the fix neither
+    // existed, leaving the nav unreachable on mobile.
+    const user = userEvent.setup()
+    renderApp()
+
+    // The toggle is `display:none` on desktop (jsdom applies the stylesheet),
+    // so it's hidden from the a11y tree until the mobile breakpoint — query it
+    // by its label, which ignores visibility.
+    const toggle = await screen.findByLabelText('Open menu')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(
+      document.querySelector('.fortymm-landing .nav-mobile-menu'),
+    ).toBeNull()
+
+    await user.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    const menu = document.querySelector('.fortymm-landing .nav-mobile-menu')
+    expect(menu).not.toBeNull()
+    // The collapsible menu is also stylesheet-hidden in jsdom (no media query),
+    // so include hidden elements when asserting its links are present.
+    const labels = ['Product', 'Tournaments', 'Manifesto', 'FAQ', 'Sign in']
+    for (const label of labels) {
+      expect(
+        within(menu as HTMLElement).getByRole('link', { name: label, hidden: true }),
+      ).toBeInTheDocument()
+    }
+    expect(
+      within(menu as HTMLElement).getByRole('link', {
+        name: /start playing/i,
+        hidden: true,
+      }),
+    ).toBeInTheDocument()
+
+    // Tapping a section link collapses the menu again.
+    await user.click(
+      within(menu as HTMLElement).getByRole('link', {
+        name: 'Tournaments',
+        hidden: true,
+      }),
+    )
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(
+      document.querySelector('.fortymm-landing .nav-mobile-menu'),
+    ).toBeNull()
   })
 
   it('switches the active product feature when a tab is clicked', async () => {

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import './landing.css'
 
+/** Public source repository — FortyMM is GPLv3 and open to contributors. */
+const GITHUB_URL = 'https://github.com/mightymoose/fortymm'
+
 function App() {
   return (
     <div className="fortymm-theme fortymm-landing">
@@ -738,11 +741,11 @@ function TournamentsBand() {
             <li><span className="mono tb-k">04</span> Score live from the scorers' table.</li>
           </ul>
           <div className="tb-ctas">
-            <a className="btn btn-primary" href="#">
+            <Link className="btn btn-primary" to="/tournaments">
               <span className="btn-dot" />
               Start a tournament
-            </a>
-            <a className="btn btn-ghost" href="#">
+            </Link>
+            <a className="btn btn-ghost" href="#tournaments">
               See a sample schedule →
             </a>
           </div>
@@ -1056,12 +1059,20 @@ function CtaBand() {
             <span className="btn-dot" />
             Start playing now
           </Link>
-          <a className="btn btn-secondary btn-xl" href="#">
+          <span
+            className="btn btn-secondary btn-xl btn-disabled"
+            aria-disabled="true"
+            title="Coming soon — iOS is in beta"
+          >
             Get the iOS app
-          </a>
-          <a className="btn btn-secondary btn-xl" href="#">
+          </span>
+          <span
+            className="btn btn-secondary btn-xl btn-disabled"
+            aria-disabled="true"
+            title="Coming soon — Android is in beta"
+          >
             Get the Android app
-          </a>
+          </span>
         </div>
         <div className="cta-foot mono">
           ● Web is live · iOS in beta · Android in beta
@@ -1087,19 +1098,40 @@ function Footer() {
         </div>
         <FooterCol
           h="Product"
-          items={['Web app', 'iOS (beta)', 'Android (beta)', 'Spectator view', 'Changelog']}
+          items={[
+            { label: 'Web app', to: '/matches/new' },
+            { label: 'iOS (beta)', disabled: true },
+            { label: 'Android (beta)', disabled: true },
+            { label: 'Spectator view', disabled: true },
+            { label: 'Changelog', disabled: true },
+          ]}
         />
         <FooterCol
           h="For directors"
-          items={['Run a tournament', 'Scheduler', 'Sample draws', "Scorers' guide"]}
+          items={[
+            { label: 'Run a tournament', to: '/tournaments' },
+            { label: 'Scheduler', href: '#tournaments' },
+            { label: 'Sample draws', disabled: true },
+            { label: "Scorers' guide", disabled: true },
+          ]}
         />
         <FooterCol
           h="Community"
-          items={['Discord', 'GitHub', 'Clubs map', 'Contribute']}
+          items={[
+            { label: 'Discord', disabled: true },
+            { label: 'GitHub', href: GITHUB_URL, external: true },
+            { label: 'Clubs map', disabled: true },
+            { label: 'Contribute', href: GITHUB_URL, external: true },
+          ]}
         />
         <FooterCol
           h="Never"
-          items={['Ads', 'Trackers', 'Premium', 'Cookie banners']}
+          items={[
+            { label: 'Ads', disabled: true },
+            { label: 'Trackers', disabled: true },
+            { label: 'Premium', disabled: true },
+            { label: 'Cookie banners', disabled: true },
+          ]}
         />
       </div>
       <div className="footer-bar">
@@ -1110,15 +1142,57 @@ function Footer() {
   )
 }
 
-function FooterCol({ h, items }: { h: string; items: string[] }) {
+type FooterItem = {
+  label: string
+  /** In-app route (renders a TanStack <Link>). */
+  to?: string
+  /** Raw href: an external URL (with `external`) or an in-page `#anchor`. */
+  href?: string
+  /** Open in a new tab (set for off-site links). */
+  external?: boolean
+  /** No destination yet — render as inert, visibly-dimmed text, not a link. */
+  disabled?: boolean
+}
+
+function FooterCol({ h, items }: { h: string; items: FooterItem[] }) {
   return (
     <div className="ft-col">
       <div className="ft-col-h">{h}</div>
-      {items.map((i) => (
-        <a key={i} href="#" className="ft-col-i">
-          {i}
-        </a>
+      {items.map((item) => (
+        <FooterLink key={item.label} item={item} />
       ))}
     </div>
+  )
+}
+
+function FooterLink({ item }: { item: FooterItem }) {
+  const { label, to, href, external, disabled } = item
+
+  if (disabled || (!to && !href)) {
+    return (
+      <span className="ft-col-i ft-col-i-disabled" aria-disabled="true">
+        {label}
+      </span>
+    )
+  }
+
+  if (to) {
+    return (
+      <Link to={to} className="ft-col-i">
+        {label}
+      </Link>
+    )
+  }
+
+  return (
+    <a
+      href={href}
+      className="ft-col-i"
+      {...(external
+        ? { target: '_blank', rel: 'noreferrer noopener' }
+        : {})}
+    >
+      {label}
+    </a>
   )
 }

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -56,27 +56,68 @@ function Logo({ size = 28 }: { size?: number }) {
 /*  Nav                                                               */
 /* ------------------------------------------------------------------ */
 function Nav() {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const closeMenu = () => setMenuOpen(false)
+
+  const sectionLinks = (
+    <>
+      <a className="nav-link" href="#product" onClick={closeMenu}>Product</a>
+      <a className="nav-link" href="#tournaments" onClick={closeMenu}>Tournaments</a>
+      <a className="nav-link" href="#manifesto" onClick={closeMenu}>Manifesto</a>
+      <a className="nav-link" href="#faq" onClick={closeMenu}>FAQ</a>
+    </>
+  )
+
   return (
-    <nav className="nav">
+    <nav className={`nav ${menuOpen ? 'is-open' : ''}`}>
       <Logo size={26} />
-      <div className="nav-links">
-        <a className="nav-link" href="#product">Product</a>
-        <a className="nav-link" href="#tournaments">Tournaments</a>
-        <a className="nav-link" href="#manifesto">Manifesto</a>
-        <a className="nav-link" href="#faq">FAQ</a>
-      </div>
+      <div className="nav-links">{sectionLinks}</div>
       <div style={{ flex: 1 }} />
       <Link
-        className="nav-link"
+        className="nav-link nav-signin"
         to="/login"
         search={{ error: undefined, email: undefined }}
       >
         Sign in
       </Link>
-      <Link className="btn btn-primary" to="/matches/new">
+      <Link className="btn btn-primary nav-cta" to="/matches/new">
         <span className="btn-dot" />
         Start playing
       </Link>
+      <button
+        type="button"
+        className="nav-toggle"
+        aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+        aria-expanded={menuOpen}
+        aria-controls="nav-mobile-menu"
+        onClick={() => setMenuOpen((open) => !open)}
+      >
+        <span className="nav-toggle-bar" />
+        <span className="nav-toggle-bar" />
+        <span className="nav-toggle-bar" />
+      </button>
+
+      {menuOpen && (
+        <div id="nav-mobile-menu" className="nav-mobile-menu">
+          {sectionLinks}
+          <Link
+            className="nav-link"
+            to="/login"
+            search={{ error: undefined, email: undefined }}
+            onClick={closeMenu}
+          >
+            Sign in
+          </Link>
+          <Link
+            className="btn btn-primary nav-mobile-cta"
+            to="/matches/new"
+            onClick={closeMenu}
+          >
+            <span className="btn-dot" />
+            Start playing
+          </Link>
+        </div>
+      )}
     </nav>
   )
 }

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import './landing.css'
 
+/** Public source repository — FortyMM is GPLv3 and open to contributors. */
+const GITHUB_URL = 'https://github.com/mightymoose/fortymm'
+
 function App() {
   return (
     <div className="fortymm-theme fortymm-landing">
@@ -779,11 +782,11 @@ function TournamentsBand() {
             <li><span className="mono tb-k">04</span> Score live from the scorers' table.</li>
           </ul>
           <div className="tb-ctas">
-            <a className="btn btn-primary" href="#">
+            <Link className="btn btn-primary" to="/tournaments">
               <span className="btn-dot" />
               Start a tournament
-            </a>
-            <a className="btn btn-ghost" href="#">
+            </Link>
+            <a className="btn btn-ghost" href="#tournaments">
               See a sample schedule →
             </a>
           </div>
@@ -1097,12 +1100,20 @@ function CtaBand() {
             <span className="btn-dot" />
             Start playing now
           </Link>
-          <a className="btn btn-secondary btn-xl" href="#">
+          <span
+            className="btn btn-secondary btn-xl btn-disabled"
+            aria-disabled="true"
+            title="Coming soon — iOS is in beta"
+          >
             Get the iOS app
-          </a>
-          <a className="btn btn-secondary btn-xl" href="#">
+          </span>
+          <span
+            className="btn btn-secondary btn-xl btn-disabled"
+            aria-disabled="true"
+            title="Coming soon — Android is in beta"
+          >
             Get the Android app
-          </a>
+          </span>
         </div>
         <div className="cta-foot mono">
           ● Web is live · iOS in beta · Android in beta
@@ -1128,19 +1139,40 @@ function Footer() {
         </div>
         <FooterCol
           h="Product"
-          items={['Web app', 'iOS (beta)', 'Android (beta)', 'Spectator view', 'Changelog']}
+          items={[
+            { label: 'Web app', to: '/matches/new' },
+            { label: 'iOS (beta)', disabled: true },
+            { label: 'Android (beta)', disabled: true },
+            { label: 'Spectator view', disabled: true },
+            { label: 'Changelog', disabled: true },
+          ]}
         />
         <FooterCol
           h="For directors"
-          items={['Run a tournament', 'Scheduler', 'Sample draws', "Scorers' guide"]}
+          items={[
+            { label: 'Run a tournament', to: '/tournaments' },
+            { label: 'Scheduler', href: '#tournaments' },
+            { label: 'Sample draws', disabled: true },
+            { label: "Scorers' guide", disabled: true },
+          ]}
         />
         <FooterCol
           h="Community"
-          items={['Discord', 'GitHub', 'Clubs map', 'Contribute']}
+          items={[
+            { label: 'Discord', disabled: true },
+            { label: 'GitHub', href: GITHUB_URL, external: true },
+            { label: 'Clubs map', disabled: true },
+            { label: 'Contribute', href: GITHUB_URL, external: true },
+          ]}
         />
         <FooterCol
           h="Never"
-          items={['Ads', 'Trackers', 'Premium', 'Cookie banners']}
+          items={[
+            { label: 'Ads', disabled: true },
+            { label: 'Trackers', disabled: true },
+            { label: 'Premium', disabled: true },
+            { label: 'Cookie banners', disabled: true },
+          ]}
         />
       </div>
       <div className="footer-bar">
@@ -1151,15 +1183,57 @@ function Footer() {
   )
 }
 
-function FooterCol({ h, items }: { h: string; items: string[] }) {
+type FooterItem = {
+  label: string
+  /** In-app route (renders a TanStack <Link>). */
+  to?: string
+  /** Raw href: an external URL (with `external`) or an in-page `#anchor`. */
+  href?: string
+  /** Open in a new tab (set for off-site links). */
+  external?: boolean
+  /** No destination yet — render as inert, visibly-dimmed text, not a link. */
+  disabled?: boolean
+}
+
+function FooterCol({ h, items }: { h: string; items: FooterItem[] }) {
   return (
     <div className="ft-col">
       <div className="ft-col-h">{h}</div>
-      {items.map((i) => (
-        <a key={i} href="#" className="ft-col-i">
-          {i}
-        </a>
+      {items.map((item) => (
+        <FooterLink key={item.label} item={item} />
       ))}
     </div>
+  )
+}
+
+function FooterLink({ item }: { item: FooterItem }) {
+  const { label, to, href, external, disabled } = item
+
+  if (disabled || (!to && !href)) {
+    return (
+      <span className="ft-col-i ft-col-i-disabled" aria-disabled="true">
+        {label}
+      </span>
+    )
+  }
+
+  if (to) {
+    return (
+      <Link to={to} className="ft-col-i">
+        {label}
+      </Link>
+    )
+  }
+
+  return (
+    <a
+      href={href}
+      className="ft-col-i"
+      {...(external
+        ? { target: '_blank', rel: 'noreferrer noopener' }
+        : {})}
+    >
+      {label}
+    </a>
   )
 }

--- a/web-client/src/api/matches.test.ts
+++ b/web-client/src/api/matches.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { QueryClient } from '@tanstack/react-query'
+
+import { server } from '@/mocks/server'
+import { matchDetails } from '@/test/factories'
+import {
+  type MatchDetails,
+  fireScoreSave,
+  matchQueryKey,
+  matchQueryOptions,
+  scoreMutationKey,
+} from './matches'
+
+let queryClient: QueryClient
+
+beforeEach(() => {
+  queryClient = new QueryClient({
+    // A long staleTime means a re-read only refetches if something explicitly
+    // invalidates the query — so the #564 test proves the error path is what
+    // re-syncs the cache, not an incidental "stale by default" refetch.
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
+})
+
+afterEach(() => {
+  queryClient.clear()
+  vi.restoreAllMocks()
+})
+
+/**
+ * Regression for #564: when a per-game score save loses a server-side race to
+ * a concurrent conflicting write, the server rejects it and the mutation lands
+ * in `error`. The match detail query must be re-synced to server truth so the
+ * "Games won" counter reconciles without a manual reload — while the failed
+ * mutation's scratch state survives to drive the failure banner / retry UI.
+ */
+it('re-syncs the match detail query after a rejected score save (#564)', async () => {
+  const matchId = 'm-564'
+  // Stale local view the losing client is staring at: it thinks it's up 1-0.
+  const stale: MatchDetails = matchDetails({
+    id: matchId,
+    sides: [
+      {
+        side_number: 1,
+        players: [
+          { user_id: 'u-me', username: 'rita.kovac', is_current_user: true },
+        ],
+        games_won: 1,
+        won: null,
+        is_current_user_side: true,
+      },
+      {
+        side_number: 2,
+        players: [
+          { user_id: 'u-op', username: 'opponent', is_current_user: false },
+        ],
+        games_won: 0,
+        won: null,
+        is_current_user_side: false,
+      },
+    ],
+  })
+  queryClient.setQueryData(matchQueryKey(matchId), stale)
+
+  // Server truth: the opponent's conflicting write won — it's actually 1-1.
+  const serverTruth: MatchDetails = matchDetails({
+    id: matchId,
+    sides: [
+      { ...stale.sides[0], games_won: 1 },
+      { ...stale.sides[1], games_won: 1 },
+    ],
+  })
+
+  server.use(
+    // Our conflicting save is rejected by the server.
+    http.post(
+      '*/v1/matches/:matchId/games/:gameNumber/scores/new',
+      () => HttpResponse.json({ detail: 'Conflicting score.' }, { status: 422 }),
+    ),
+    // The re-sync refetch returns server truth.
+    http.get('*/v1/matches/:matchId', () =>
+      HttpResponse.json(serverTruth),
+    ),
+  )
+
+  await fireScoreSave(queryClient, matchId, 1, {
+    side_1_points: 11,
+    side_2_points: 9,
+  })
+
+  // The failed-save scratch state survives so the banner / cell can drive retry.
+  const failed = queryClient
+    .getMutationCache()
+    .findAll({ mutationKey: scoreMutationKey(matchId, 1), exact: true })
+  expect(failed).toHaveLength(1)
+  expect(failed[0].state.status).toBe('error')
+
+  // Sanity: the options/queryKey wiring matches what the mutation invalidates.
+  expect(matchQueryOptions(matchId).queryKey).toEqual(matchQueryKey(matchId))
+  // The match detail query was invalidated, so the next read reconciles to
+  // server truth (the opponent's win counts: now 1-1, not the stale 1-0).
+  const synced = await queryClient.fetchQuery(matchQueryOptions(matchId))
+  expect(synced.sides[1].games_won).toBe(1)
+})
+
+it('marks the match detail query stale on a rejected save (#564)', async () => {
+  const matchId = 'm-564b'
+  // Seed an active (fetched, fresh) query so we can observe it being invalidated.
+  await queryClient.fetchQuery(matchQueryOptions(matchId)).catch(() => undefined)
+
+  server.use(
+    http.post(
+      '*/v1/matches/:matchId/games/:gameNumber/scores/new',
+      () => HttpResponse.json({ detail: 'Conflicting score.' }, { status: 422 }),
+    ),
+  )
+
+  const invalidations: unknown[] = []
+  const spy = vi
+    .spyOn(queryClient, 'invalidateQueries')
+    .mockImplementation((filters) => {
+      invalidations.push(filters?.queryKey)
+      return Promise.resolve()
+    })
+
+  await fireScoreSave(queryClient, matchId, 1, {
+    side_1_points: 11,
+    side_2_points: 9,
+  })
+
+  spy.mockRestore()
+  // The error path invalidated the canonical match query key.
+  expect(invalidations).toContainEqual(matchQueryKey(matchId))
+})

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -328,6 +328,23 @@ export function scoreSaveMutationOptions(
     },
     onSuccess: (data: MatchDetails) =>
       applyScoreMutationCache(queryClient, matchId, data),
+    // Re-sync server truth whenever a save settles in error. A per-game write
+    // can lose a server-side race to a concurrent conflicting write (e.g. the
+    // opponent saved game 1 the other way first), so the server rejects ours
+    // and the success path never primes the cache. Without this, the match
+    // detail query keeps the stale games-won it last saw (the "Games won"
+    // counter on the entry screen reads `mySide.games_won` from
+    // `matchQueryKey`) until a manual reload (#564). Only invalidate the
+    // server-canonical match queries to refetch the resolved truth —
+    // deliberately *not* touching the mutation cache, so this game's
+    // failed-save scratch state survives to drive the failure banner /
+    // "Not saved" cell + retry UI.
+    onError: () => {
+      queryClient.invalidateQueries({ queryKey: matchQueryKey(matchId) })
+      queryClient.invalidateQueries({
+        queryKey: matchDetailsQueryKey(matchId),
+      })
+    },
   }
 }
 

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -28,10 +28,15 @@ export type MatchGameScoreWrite = components['schemas']['MatchGameScoreWrite']
 export type MatchResultsWrite = components['schemas']['MatchResultsWrite']
 export type MatchResultsGameWrite = components['schemas']['MatchResultsGameWrite']
 export type MatchStatus = components['schemas']['MatchStatus']
+// The `/matches` list filter bucket. A superset of `MatchStatus`: it splits
+// `in_progress` into `in_progress` (true-live, no posted result) and
+// `awaiting_confirmation` (posted result, ≥1 signature) so the Live filter
+// can't silently fold in awaiting-confirmation rows (issue #381).
+export type MatchListFilter = components['schemas']['MatchListFilter']
 export type Scoreboard = components['schemas']['Scoreboard']
 
 export type MatchListParams = {
-  status?: MatchStatus
+  status?: MatchListFilter
   q?: string
   page: number
   page_size: number

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -28,10 +28,15 @@ export type MatchGameScoreWrite = components['schemas']['MatchGameScoreWrite']
 export type MatchResultsWrite = components['schemas']['MatchResultsWrite']
 export type MatchResultsGameWrite = components['schemas']['MatchResultsGameWrite']
 export type MatchStatus = components['schemas']['MatchStatus']
+// The `/matches` list filter bucket. A superset of `MatchStatus`: it splits
+// `in_progress` into `in_progress` (true-live, no posted result) and
+// `awaiting_confirmation` (posted result, ≥1 signature) so the Live filter
+// can't silently fold in awaiting-confirmation rows (issue #381).
+export type MatchListFilter = components['schemas']['MatchListFilter']
 export type Scoreboard = components['schemas']['Scoreboard']
 
 export type MatchListParams = {
-  status?: MatchStatus
+  status?: MatchListFilter
   /** When true, request the current user's attention-ranked open matches; the
    * server ignores `status` in this mode. */
   attention?: boolean

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -324,6 +324,23 @@ export function scoreSaveMutationOptions(
     },
     onSuccess: (data: MatchDetails) =>
       applyScoreMutationCache(queryClient, matchId, data),
+    // Re-sync server truth whenever a save settles in error. A per-game write
+    // can lose a server-side race to a concurrent conflicting write (e.g. the
+    // opponent saved game 1 the other way first), so the server rejects ours
+    // and the success path never primes the cache. Without this, the match
+    // detail query keeps the stale games-won it last saw (the "Games won"
+    // counter on the entry screen reads `mySide.games_won` from
+    // `matchQueryKey`) until a manual reload (#564). Only invalidate the
+    // server-canonical match queries to refetch the resolved truth —
+    // deliberately *not* touching the mutation cache, so this game's
+    // failed-save scratch state survives to drive the failure banner /
+    // "Not saved" cell + retry UI.
+    onError: () => {
+      queryClient.invalidateQueries({ queryKey: matchQueryKey(matchId) })
+      queryClient.invalidateQueries({
+        queryKey: matchDetailsQueryKey(matchId),
+      })
+    },
   }
 }
 

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1098,6 +1098,19 @@ export interface components {
             /** Name */
             name: string;
         };
+        /**
+         * MatchListFilter
+         * @description The selectable buckets on the ``/matches`` list filter.
+         *
+         *     Mostly a 1:1 echo of ``MatchStatus``, but ``awaiting_confirmation`` is a
+         *     *derived* bucket with no DB status of its own — it's an ``in_progress``
+         *     match that already carries at least one signature (a posted result waiting
+         *     on the other side; see ``_status_label``). The ``live`` filter therefore
+         *     means "``in_progress`` with **no** signature yet", so a posted-but-unconfirmed
+         *     result no longer silently inflates the Live tab / count (issue #381).
+         * @enum {string}
+         */
+        MatchListFilter: "pending" | "in_progress" | "awaiting_confirmation" | "completed" | "disputed" | "voided";
         /** MatchListResponse */
         MatchListResponse: {
             /** Items */
@@ -1112,6 +1125,8 @@ export interface components {
             status_counts: {
                 [key: string]: number;
             };
+            /** Awaiting Confirmation Count */
+            awaiting_confirmation_count: number;
         };
         /** MatchListRow */
         MatchListRow: {
@@ -2494,7 +2509,7 @@ export interface operations {
     list_matches_v1_matches_get: {
         parameters: {
             query?: {
-                status?: components["schemas"]["MatchStatus"] | null;
+                status?: components["schemas"]["MatchListFilter"] | null;
                 q?: string | null;
                 page?: number;
                 page_size?: number;
@@ -2565,7 +2580,7 @@ export interface operations {
     export_matches_csv_v1_matches_csv_get: {
         parameters: {
             query?: {
-                status?: components["schemas"]["MatchStatus"] | null;
+                status?: components["schemas"]["MatchListFilter"] | null;
                 q?: string | null;
             };
             header?: never;

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -379,9 +379,16 @@ export interface paths {
         /**
          * Get Match
          * @description Open to anyone, signed in or not. A signed-in caller gets
-         *     is_current_user / can_score flags; an anonymous caller gets the same view
-         *     with those flags off. Per-IP rate-limited (60/min) so an open URL can't be
-         *     scraped from one source.
+         *     is_current_user / can_score flags; an anonymous caller gets the same
+         *     scorecard with those flags off. Per-IP rate-limited (60/min) so an open URL
+         *     can't be scraped from one source.
+         *
+         *     The richer history payload — recent form, head-to-head, and per-side rating
+         *     changes — is *only* loaded for a caller who is a participant on this match
+         *     (see #515). Non-participants (anonymous holders of the share URL or
+         *     signed-in spectators) get the scorecard with those extras empty/null, so a
+         *     public link reveals the result but not the players' rivalry / rating
+         *     metadata.
          *
          *     The serializer flags whether the current user is on a side; write paths
          *     below still gate on participation via `get_current_user`.

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1105,6 +1105,19 @@ export interface components {
             /** Name */
             name: string;
         };
+        /**
+         * MatchListFilter
+         * @description The selectable buckets on the ``/matches`` list filter.
+         *
+         *     Mostly a 1:1 echo of ``MatchStatus``, but ``awaiting_confirmation`` is a
+         *     *derived* bucket with no DB status of its own — it's an ``in_progress``
+         *     match that already carries at least one signature (a posted result waiting
+         *     on the other side; see ``_status_label``). The ``live`` filter therefore
+         *     means "``in_progress`` with **no** signature yet", so a posted-but-unconfirmed
+         *     result no longer silently inflates the Live tab / count (issue #381).
+         * @enum {string}
+         */
+        MatchListFilter: "pending" | "in_progress" | "awaiting_confirmation" | "completed" | "disputed" | "voided";
         /** MatchListResponse */
         MatchListResponse: {
             /** Items */
@@ -1121,6 +1134,8 @@ export interface components {
             };
             /** Attention Count */
             attention_count: number;
+            /** Awaiting Confirmation Count */
+            awaiting_confirmation_count: number;
         };
         /** MatchListRow */
         MatchListRow: {
@@ -2506,7 +2521,7 @@ export interface operations {
     list_matches_v1_matches_get: {
         parameters: {
             query?: {
-                status?: components["schemas"]["MatchStatus"] | null;
+                status?: components["schemas"]["MatchListFilter"] | null;
                 /** @description When true, return only the caller's open matches that need attention (theirs or someone else's), ranked by urgency. This is its own dimension — ``status`` is ignored when it's set. */
                 attention?: boolean;
                 q?: string | null;
@@ -2579,7 +2594,7 @@ export interface operations {
     export_matches_csv_v1_matches_csv_get: {
         parameters: {
             query?: {
-                status?: components["schemas"]["MatchStatus"] | null;
+                status?: components["schemas"]["MatchListFilter"] | null;
                 q?: string | null;
             };
             header?: never;

--- a/web-client/src/components/login/login-screens.test.tsx
+++ b/web-client/src/components/login/login-screens.test.tsx
@@ -1,8 +1,9 @@
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { act, render, screen } from '@/test/utilities'
 
-import { ScreenSent } from './login-screens'
+import { ScreenEmail, ScreenSent } from './login-screens'
 
 describe('ScreenSent expiry countdown', () => {
   beforeEach(() => {
@@ -35,5 +36,44 @@ describe('ScreenSent expiry countdown', () => {
     })
     expect(screen.getByRole('timer')).toHaveTextContent('00:00')
     expect(screen.getByText(/link expired/i)).toBeInTheDocument()
+  })
+})
+
+describe('ScreenEmail over-long address (#377)', () => {
+  // An address over the RFC-5321 254-char cap used to test VALID client-side,
+  // then 422 with a raw pydantic string. The client now rejects it up front.
+  const overLong = `${'a'.repeat(250)}@example.com` // 262 chars
+
+  it('flips the badge from VALID to FAILED when the address exceeds the length cap', async () => {
+    const user = userEvent.setup()
+    render(<ScreenEmail onSubmit={vi.fn()} />)
+
+    const input = screen.getByLabelText('Email address')
+
+    // A normal address is VALID.
+    await user.type(input, 'rita@example.com')
+    expect(screen.getByText(/VALID/)).toBeInTheDocument()
+    expect(screen.queryByText(/FAILED/)).not.toBeInTheDocument()
+
+    // Appending past the 254-char cap must drop the misleading VALID badge.
+    await user.clear(input)
+    await user.type(input, overLong)
+    expect(screen.queryByText(/VALID/)).not.toBeInTheDocument()
+  })
+
+  it('does not submit an over-long address and surfaces friendly inline copy', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    render(<ScreenEmail onSubmit={onSubmit} />)
+
+    const input = screen.getByLabelText('Email address')
+    await user.type(input, overLong)
+    await user.click(screen.getByRole('button', { name: /send the link/i }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(
+      screen.getByText("That doesn't look like a valid email."),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/FAILED/)).toBeInTheDocument()
   })
 })

--- a/web-client/src/components/matches/match-details/match-details-query.test.ts
+++ b/web-client/src/components/matches/match-details/match-details-query.test.ts
@@ -4,15 +4,58 @@ import { ApiError } from "@/api/client";
 import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
 import { waitFor } from "@/test/utilities";
 
+import type { Query } from "@tanstack/react-query";
+
 import {
   matchDetailsQuery,
   matchDetailsResultFromPayload,
+  refetchWhileAwaitingConfirmation,
+  type MatchDetailsResult,
 } from "./match-details-query";
 import { matchDetailsQueryPage } from "./match-details-query.page";
+
+const queryWithStatusLabel = (
+  status_label: string,
+): Pick<Query<MatchDetailsResult>, "state"> => ({
+  state: {
+    data: matchDetailsResultFromPayload(buildMatchDetails({ status_label })),
+  } as Query<MatchDetailsResult>["state"],
+});
 
 describe("matchDetailsQuery", () => {
   it("throws on error so route-level error boundaries catch failures", () => {
     expect(matchDetailsQuery("m-1").throwOnError).toBe(true);
+  });
+
+  it("polls while awaiting the opponent's confirmation (#493)", () => {
+    // The reporter posts a result and leaves the page open; the opponent
+    // confirms in a different session, so nothing invalidates this cache.
+    // Polling is the only thing that flips the page off "Awaiting confirmation".
+    expect(matchDetailsQuery("m-1").refetchInterval).toBe(
+      refetchWhileAwaitingConfirmation,
+    );
+    expect(
+      refetchWhileAwaitingConfirmation(
+        queryWithStatusLabel("Awaiting confirmation"),
+      ),
+    ).toBeGreaterThan(0);
+  });
+
+  it.each(["Scheduled", "Live", "Final", "Disputed", "Voided"])(
+    "stops polling once the match settles (%s)",
+    (label) => {
+      expect(
+        refetchWhileAwaitingConfirmation(queryWithStatusLabel(label)),
+      ).toBe(false);
+    },
+  );
+
+  it("does not poll before any data has loaded", () => {
+    expect(
+      refetchWhileAwaitingConfirmation({
+        state: { data: undefined } as Query<MatchDetailsResult>["state"],
+      }),
+    ).toBe(false);
   });
 
   it("returns the parsed scoreboard view", async () => {

--- a/web-client/src/components/matches/match-details/match-details-query.ts
+++ b/web-client/src/components/matches/match-details/match-details-query.ts
@@ -1,6 +1,6 @@
 import { api, unwrap } from "@/api/client";
 import type { MatchDetails } from "@/api/matches";
-import type { QueryFunctionContext } from "@tanstack/react-query";
+import type { Query, QueryFunctionContext } from "@tanstack/react-query";
 import z from "zod";
 
 const scoreboardSchema = z.object({
@@ -51,8 +51,35 @@ export function matchDetailsResultFromPayload(payload: MatchDetails) {
 /** The resolved shape `matchDetailsQuery`'s `queryFn` returns. */
 export type MatchDetailsResult = ReturnType<typeof matchDetailsResultFromPayload>;
 
+/** The server's lifecycle label for a posted-but-unconfirmed result (mirrors
+ * `_status_label` in api/app/matches.py). While a match sits here it is waiting
+ * on the *other* side to confirm — a transition that happens in a different
+ * browser session and so triggers no cache invalidation on this page. */
+const AWAITING_CONFIRMATION = "Awaiting confirmation";
+
+/** How often (ms) to re-poll `GET /v1/matches/{id}` while a result is awaiting
+ * the opponent's confirmation. */
+const AWAITING_CONFIRMATION_POLL_MS = 5_000;
+
+/** Poll only while the match is awaiting the opponent's confirmation, and stop
+ * once it leaves that state (confirmed → Final, or contested → Disputed).
+ *
+ * The reporter posts a result, then leaves the match page open; the opponent
+ * confirms in their own session. Nothing invalidates the reporter's cache, and
+ * the global client disables `refetchOnWindowFocus` with a 30s `staleTime`, so
+ * without this the page is stuck on "Awaiting confirmation" until a manual
+ * reload (#493). Returning `false` outside that state means a settled match
+ * isn't polled, so the open page goes quiet again once it resolves. */
+export function refetchWhileAwaitingConfirmation(
+  query: Pick<Query<MatchDetailsResult>, "state">,
+): number | false {
+  const label = query.state.data?.unmigrated.status_label;
+  return label === AWAITING_CONFIRMATION ? AWAITING_CONFIRMATION_POLL_MS : false;
+}
+
 export const matchDetailsQuery = (matchId: string) => ({
   queryKey: queryKey(matchId),
   queryFn: fetchMatchDetails,
   throwOnError: true,
+  refetchInterval: refetchWhileAwaitingConfirmation,
 });

--- a/web-client/src/components/matches/match-details/save-your-match/save-your-match-fetcher/save-your-match-display.page.tsx
+++ b/web-client/src/components/matches/match-details/save-your-match/save-your-match-fetcher/save-your-match-display.page.tsx
@@ -66,6 +66,13 @@ const scoped = (container: Container) => ({
   getScoreBlips(): HTMLElement[] {
     return container.getAllByText(/^[0-9]+$/);
   },
+  /** The two avatar chips (viewer-first), so tests can assert win/loss tones. */
+  getAvatars(): HTMLElement[] {
+    const anchor = container.getByLabelText(/match summary/i) as HTMLElement;
+    return Array.from(
+      anchor.querySelectorAll<HTMLElement>(".md-save__avatar"),
+    );
+  },
 });
 
 /**

--- a/web-client/src/components/matches/match-details/save-your-match/save-your-match-fetcher/save-your-match-display.test.tsx
+++ b/web-client/src/components/matches/match-details/save-your-match/save-your-match-fetcher/save-your-match-display.test.tsx
@@ -42,6 +42,59 @@ describe("SaveYourMatchDisplay", () => {
     expect(saveYourMatchDisplayPage.getHint()).toHaveTextContent(/TAKES 20s/);
   });
 
+  it("highlights neither side mid-match when no winner is decided (Live 0–0)", async () => {
+    saveYourMatchDisplayPage.mockSession({
+      user: { email: null, confirmed_at: null },
+    });
+
+    saveYourMatchDisplayPage.render({
+      view: buildSaveYourMatchView({
+        leftWon: null,
+        leftGamesWon: 0,
+        rightGamesWon: 0,
+      }),
+    });
+
+    await saveYourMatchDisplayPage.findPrompt();
+
+    // Neither 0 may carry the winner tint — the old binary `!iWon` painted the
+    // opponent's score green at a 0–0 tie (#386).
+    const blips = saveYourMatchDisplayPage.getScoreBlips();
+    expect(blips.map((n) => n.textContent)).toEqual(["0", "0"]);
+    for (const blip of blips) {
+      expect(blip).not.toHaveClass("md-save__blip--win");
+    }
+    // …and neither avatar may be styled as the winner or the loser.
+    for (const avatar of saveYourMatchDisplayPage.getAvatars()) {
+      expect(avatar).not.toHaveClass("md-avatar--win");
+      expect(avatar).not.toHaveClass("md-avatar--loss");
+    }
+  });
+
+  it("highlights only the decided winner's score and avatar", async () => {
+    saveYourMatchDisplayPage.mockSession({
+      user: { email: null, confirmed_at: null },
+    });
+
+    saveYourMatchDisplayPage.render({
+      view: buildSaveYourMatchView({
+        leftWon: true,
+        leftGamesWon: 3,
+        rightGamesWon: 1,
+      }),
+    });
+
+    await saveYourMatchDisplayPage.findPrompt();
+
+    const [leftBlip, rightBlip] = saveYourMatchDisplayPage.getScoreBlips();
+    expect(leftBlip).toHaveClass("md-save__blip--win");
+    expect(rightBlip).not.toHaveClass("md-save__blip--win");
+
+    const [leftAvatar, rightAvatar] = saveYourMatchDisplayPage.getAvatars();
+    expect(leftAvatar).toHaveClass("md-avatar--win");
+    expect(rightAvatar).toHaveClass("md-avatar--loss");
+  });
+
   it("hides when the viewer already has a confirmed email", async () => {
     saveYourMatchDisplayPage.mockSession({
       user: { email: "rita@example.com", confirmed_at: "2026-05-01T00:00:00Z" },

--- a/web-client/src/components/matches/match-details/save-your-match/save-your-match-fetcher/save-your-match-display.tsx
+++ b/web-client/src/components/matches/match-details/save-your-match/save-your-match-fetcher/save-your-match-display.tsx
@@ -39,30 +39,37 @@ function writeDismissed(matchId: string, value: boolean) {
 /** Match score anchor: viewer avatar, game-score blips, opponent avatar, and
  * the match date — the win/loss tones key off the viewer's side. */
 function MatchAnchor({ view }: { view: SaveYourMatchView }) {
-  const iWon = view.leftWon === true;
+  // Tri-state, not a forced binary: `leftWon` is null mid-match (incl. a Live
+  // 0–0), so we must only paint a winner once a result is actually decided.
+  // The old `!iWon` fallthrough unconditionally greened the opponent's side
+  // (and avatar) on any undecided match (#386).
+  const leftWon = view.leftWon === true;
+  const rightWon = view.leftWon === false;
   return (
     <div className="md-save__anchor" aria-label="Match summary">
       <div
         className={cn(
           "md-avatar md-save__avatar",
-          iWon ? "md-avatar--win" : "md-avatar--loss",
+          leftWon && "md-avatar--win",
+          rightWon && "md-avatar--loss",
         )}
       >
         {view.leftInitials}
       </div>
       <div className="md-save__blips">
-        <span className={cn("md-save__blip", iWon && "md-save__blip--win")}>
+        <span className={cn("md-save__blip", leftWon && "md-save__blip--win")}>
           {view.leftGamesWon}
         </span>
         <span className="md-save__blip-dash">–</span>
-        <span className={cn("md-save__blip", !iWon && "md-save__blip--win")}>
+        <span className={cn("md-save__blip", rightWon && "md-save__blip--win")}>
           {view.rightGamesWon}
         </span>
       </div>
       <div
         className={cn(
           "md-avatar md-save__avatar",
-          iWon ? "md-avatar--loss" : "md-avatar--win",
+          rightWon && "md-avatar--win",
+          leftWon && "md-avatar--loss",
         )}
       >
         {view.rightInitials}

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/game-grid.page.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/game-grid.page.tsx
@@ -24,6 +24,15 @@ const scoped = (container: Container) => ({
   findGrid() {
     return container.findByTestId("scoreboard-game-grid");
   },
+  /** The inner grid track laying out the columns — the `.md-games__grid` child
+   * of the `.md-games` scroll container (the testid host). The track overflows
+   * the container on narrow viewports, which is what makes the trailing SETS
+   * column reachable by scroll instead of clipped off-screen (#509). */
+  getGridTrack() {
+    return container
+      .getByTestId("scoreboard-game-grid")
+      .querySelector(".md-games__grid") as HTMLElement | null;
+  },
   ...gameGridRowPage.within(container),
 });
 

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/game-grid.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display/game-grid.test.tsx
@@ -50,6 +50,41 @@ describe("GameGrid", () => {
     );
   });
 
+  it("renders all 7 game labels plus SETS for a BO7, inside the scroll container", async () => {
+    // Regression for #509: on a BO7 the columns can't shrink to fit a narrow
+    // viewport, so the trailing SETS column was clipped off-screen by the
+    // hero's `overflow: hidden`. The fix puts the grid track inside a
+    // horizontally scrollable `.md-games` boundary (the testid host) so every
+    // column — including SETS — stays in the DOM and reachable by scroll.
+    gameGridPage.render({
+      gameGrid: buildGameGridView({
+        bestOf: 7,
+        rows: [
+          buildGameGridRowView({
+            cells: Array.from({ length: 7 }, () => buildUnplayedCellView()),
+          }),
+          buildGameGridRowView({
+            name: "leo.mertens",
+            initials: "LM",
+            cells: Array.from({ length: 7 }, () => buildUnplayedCellView()),
+          }),
+        ],
+      }),
+    });
+
+    const grid = await gameGridPage.findGrid();
+    for (let g = 1; g <= 7; g += 1) {
+      expect(grid).toHaveTextContent(`G${g}`);
+    }
+    expect(grid).toHaveTextContent("SETS");
+
+    // The column track must live inside the `.md-games` scroll boundary so the
+    // overflow is scrollable rather than clipped by the hero section.
+    const track = gameGridPage.getGridTrack();
+    expect(track).not.toBeNull();
+    expect(grid).toContainElement(track);
+  });
+
   it("renders each row's cells and SETS total against the shared match id", async () => {
     gameGridPage.render({
       gameGrid: buildGameGridView({

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.test.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.test.ts
@@ -371,6 +371,41 @@ describe("scoreboardQuery", () => {
     expect(result.current.data?.outcome).toBe("rita.kovac leads by 3 games to 1");
   });
 
+  it("names the finishing player for a finished solo (no-opponent) match (#495)", async () => {
+    // A solo match has one played side stamped `won: true` and a playerless
+    // ghost opponent side; there is no losing player to pair, so the heading
+    // used to fall through to the null guard and read just "Match".
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          status_label: "Final",
+          sides: [
+            buildMatchDetailsSide({
+              won: true,
+              games_won: 3,
+              players: [buildMatchDetailsPlayer({ username: "rita.kovac" })],
+            }),
+            buildMatchDetailsSide({
+              side_number: 2,
+              won: false,
+              games_won: 0,
+              players: [],
+              is_current_user_side: false,
+            }),
+          ],
+          data: { scoreboard: { status: "final" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.outcome).toBe(
+      "rita.kovac finished, winning 3 games to 0",
+    );
+  });
+
   it("returns a null outcome when a side is missing entirely", async () => {
     scoreboardQueryPage.mockEndpoint(() =>
       HttpResponse.json(buildMatchDetails({ sides: [buildMatchDetailsSide()] })),

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.ts
@@ -124,6 +124,17 @@ const selectOutcome = (match: MatchDetailsResult): string | null => {
     return `${winner.players[0].username} defeated ${loser.players[0].username} by ${games(winner.games_won)} to ${loser.games_won}`;
   }
 
+  // Solo (no-opponent) match that has finished: the lone played side is stamped
+  // `won === true` but the ghost opponent side has no player, so the "defeated"
+  // branch above can't pair a loser. Without this branch the null guard below
+  // swallows the result and the hero heading reads just "Match" (#495). Trigger
+  // only when exactly one side carries a player — a real opponent whose side
+  // simply isn't stamped lost yet falls through to the in-progress copy.
+  const playeredSides = sides.filter((s) => s.players[0]);
+  if (winner?.players[0] && playeredSides.length === 1) {
+    return `${winner.players[0].username} finished, winning ${games(winner.games_won)} to 0`;
+  }
+
   // Still in progress (or posted, awaiting confirmation): describe the current
   // state from games won. Needs both sides' lead player to name them.
   const [side1, side2] = sides;

--- a/web-client/src/components/matches/match-list.tsx
+++ b/web-client/src/components/matches/match-list.tsx
@@ -172,6 +172,13 @@ export const MatchList = () => {
   // shows start > end during that frame.
   const displayPage = Math.min(page, totalPages)
 
+  // A search, a non-"all" status tab, or paging past the end all narrow the
+  // list — drive the empty-state copy so a filtered/no-result view reads "No
+  // matches match your filters" instead of the cold-start "No matches yet"
+  // (#373).
+  const isFiltered =
+    q.trim().length > 0 || status !== 'all' || page > totalPages
+
   // Project the raw payload rows into the presentational view models the table
   // consumes — perspective, status tone, side labels, short id, the relative
   // "started" label, and the current-user-aware label/CTA all resolve here,
@@ -212,6 +219,7 @@ export const MatchList = () => {
             isLoading={isLoading}
             isAttention={isAttention}
             query={q.trim()}
+            isFiltered={isFiltered}
             onClear={onClear}
             onClearSearch={onClearSearch}
             navigate={navigate}

--- a/web-client/src/components/matches/match-list.tsx
+++ b/web-client/src/components/matches/match-list.tsx
@@ -149,6 +149,9 @@ export const MatchList = () => {
   )
 
   const total = data?.total ?? 0
+  // True-live only: the server splits posted-but-unconfirmed results out of the
+  // `in_progress` count into `awaiting_confirmation_count`, so this no longer
+  // folds awaiting-confirmation matches into the Live headline (issue #381).
   const liveCount = data?.status_counts?.in_progress ?? 0
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
 
@@ -181,13 +184,15 @@ export const MatchList = () => {
   }, [data?.items])
   const tabs = useMemo(
     () =>
-      buildFilterTabs(
-        STATUS_TABS,
-        data?.status_counts,
-        TAB_TO_API,
-        data?.attention_count,
-      ),
-    [data?.status_counts, data?.attention_count],
+      buildFilterTabs(STATUS_TABS, data?.status_counts, TAB_TO_API, {
+        attentionCount: data?.attention_count,
+        awaitingCount: data?.awaiting_confirmation_count,
+      }),
+    [
+      data?.status_counts,
+      data?.attention_count,
+      data?.awaiting_confirmation_count,
+    ],
   )
 
   return (

--- a/web-client/src/components/matches/match-list.tsx
+++ b/web-client/src/components/matches/match-list.tsx
@@ -139,6 +139,9 @@ export const MatchList = () => {
   )
 
   const total = data?.total ?? 0
+  // True-live only: the server splits posted-but-unconfirmed results out of the
+  // `in_progress` count into `awaiting_confirmation_count`, so this no longer
+  // folds awaiting-confirmation matches into the Live headline (issue #381).
   const liveCount = data?.status_counts?.in_progress ?? 0
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
 
@@ -167,8 +170,14 @@ export const MatchList = () => {
     [data?.items],
   )
   const tabs = useMemo(
-    () => buildFilterTabs(STATUS_TABS, data?.status_counts, TAB_TO_API),
-    [data?.status_counts],
+    () =>
+      buildFilterTabs(
+        STATUS_TABS,
+        data?.status_counts,
+        TAB_TO_API,
+        data?.awaiting_confirmation_count,
+      ),
+    [data?.status_counts, data?.awaiting_confirmation_count],
   )
 
   return (

--- a/web-client/src/components/matches/match-list.tsx
+++ b/web-client/src/components/matches/match-list.tsx
@@ -159,6 +159,13 @@ export const MatchList = () => {
   // shows start > end during that frame.
   const displayPage = Math.min(page, totalPages)
 
+  // A search, a non-"all" status tab, or paging past the end all narrow the
+  // list — drive the empty-state copy so a filtered/no-result view reads "No
+  // matches match your filters" instead of the cold-start "No matches yet"
+  // (#373).
+  const isFiltered =
+    q.trim().length > 0 || status !== 'all' || page > totalPages
+
   // Project the raw payload rows into the presentational view models the table
   // consumes — perspective, status tone, side labels, short id, and the
   // relative "started" label all resolve here, never inside the children.
@@ -186,6 +193,7 @@ export const MatchList = () => {
           <MatchListTable
             rows={rowViews}
             isLoading={isLoading}
+            isFiltered={isFiltered}
             onClear={onClear}
             navigate={navigate}
           />

--- a/web-client/src/components/matches/match-list/filter-row.factory.tsx
+++ b/web-client/src/components/matches/match-list/filter-row.factory.tsx
@@ -25,8 +25,9 @@ export function buildFilterRowProps(
     tabs: [
       { value: "all", label: "All", isLive: false, count: 7 },
       { value: "live", label: "Live", isLive: true, count: 2 },
+      { value: "awaiting", label: "Awaiting", isLive: false, count: 1 },
       { value: "scheduled", label: "Up next", isLive: false, count: 3 },
-      { value: "final", label: "Final", isLive: false, count: 2 },
+      { value: "final", label: "Final", isLive: false, count: 1 },
     ],
     ...overrides,
   };

--- a/web-client/src/components/matches/match-list/filter-row.test.tsx
+++ b/web-client/src/components/matches/match-list/filter-row.test.tsx
@@ -42,9 +42,22 @@ describe("FilterRow", () => {
     filterRowPage.render(buildFilterRowProps());
 
     expect(filterRowPage.getTab(/^all/i)).toHaveTextContent("7");
-    expect(filterRowPage.getTab(/live/i)).toHaveTextContent("2");
+    expect(filterRowPage.getTab(/^live/i)).toHaveTextContent("2");
+    expect(filterRowPage.getTab(/awaiting/i)).toHaveTextContent("1");
     expect(filterRowPage.getTab(/up next/i)).toHaveTextContent("3");
-    expect(filterRowPage.getTab(/final/i)).toHaveTextContent("2");
+    expect(filterRowPage.getTab(/final/i)).toHaveTextContent("1");
+  });
+
+  it("renders an Awaiting tab distinct from Live (no live-dot)", async () => {
+    const user = userEvent.setup();
+    const setStatus = vi.fn();
+    filterRowPage.render(buildFilterRowProps({ setStatus }));
+
+    const awaiting = filterRowPage.getTab(/awaiting/i);
+    expect(awaiting.querySelector(".live-dot")).toBeNull();
+
+    await user.click(awaiting);
+    expect(setStatus).toHaveBeenCalledWith("awaiting");
   });
 
   it("omits the seg-count when a tab's count is null", () => {

--- a/web-client/src/components/matches/match-list/match-list-row-view.test.ts
+++ b/web-client/src/components/matches/match-list/match-list-row-view.test.ts
@@ -8,7 +8,7 @@ import {
 import type { components } from '@/api/schema'
 import { matchListRow } from '@/test/factories'
 import {
-  API_TO_TAB,
+  API_TO_TONE,
   STATUS_TABS,
   STATUS_TONE,
   TAB_TO_API,
@@ -137,10 +137,10 @@ describe('projectMatchListRow', () => {
     expect(projectMatchListRow(row).score.games).toBeNull()
   })
 
-  it('resolves the status tone from STATUS_TONE[API_TO_TAB[status]]', () => {
+  it('resolves the status tone from STATUS_TONE[API_TO_TONE[status]]', () => {
     const row = matchListRow({ status: 'disputed', status_label: 'Disputed' })
     const view = projectMatchListRow(row)
-    expect(view.status.toneClass).toBe(STATUS_TONE[API_TO_TAB.disputed])
+    expect(view.status.toneClass).toBe(STATUS_TONE[API_TO_TONE.disputed])
     expect(view.status.toneClass).toBe('status-tone-final')
     expect(view.status.label).toBe('Disputed')
   })
@@ -155,6 +155,29 @@ describe('projectMatchListRow', () => {
     expect(projectMatchListRow(matchListRow({ status: 'completed' })).status.isLive).toBe(
       false,
     )
+  })
+
+  // The #381 bug at the row level: a posted-but-unconfirmed result is an
+  // in_progress row labelled "Awaiting confirmation". It must NOT read as Live
+  // (no live-dot) and must take its own "called" tone, not the live tone.
+  it('does not mark an awaiting-confirmation row as live and re-tones it', () => {
+    const row = matchListRow({
+      status: 'in_progress',
+      status_label: 'Awaiting confirmation',
+    })
+    const view = projectMatchListRow(row)
+    expect(view.isLive).toBe(false)
+    expect(view.status.isLive).toBe(false)
+    expect(view.status.toneClass).toBe('status-tone-called')
+    expect(view.status.toneClass).not.toBe(STATUS_TONE.live)
+    expect(view.status.label).toBe('Awaiting confirmation')
+  })
+
+  it('still marks a signature-free in_progress row as live', () => {
+    const row = matchListRow({ status: 'in_progress', status_label: 'Live' })
+    const view = projectMatchListRow(row)
+    expect(view.isLive).toBe(true)
+    expect(view.status.toneClass).toBe('status-tone-live')
   })
 
   it('builds the aria label as "Open match: {s1} vs {s2}"', () => {
@@ -277,19 +300,19 @@ describe('topActionableKind', () => {
 })
 
 describe('buildFilterTabs', () => {
-  it('sums all status counts for the "all" tab', () => {
+  it('sums every status bucket plus the awaiting bucket for the "all" tab', () => {
     const tabs = buildFilterTabs(
       STATUS_TABS,
       { pending: 2, in_progress: 1, completed: 4 },
       TAB_TO_API,
-      0,
+      { awaitingCount: 3 },
     )
     const all = tabs.find((t) => t.value === 'all')
-    expect(all?.count).toBe(7)
+    expect(all?.count).toBe(10)
   })
 
-  it('uses statusCounts[TAB_TO_API[value]] ?? 0 for each named tab', () => {
-    const tabs = buildFilterTabs(STATUS_TABS, { in_progress: 3 }, TAB_TO_API, 0)
+  it('uses statusCounts[TAB_TO_API[value]] ?? 0 for each status-backed tab', () => {
+    const tabs = buildFilterTabs(STATUS_TABS, { in_progress: 3 }, TAB_TO_API)
     const live = tabs.find((t) => t.value === 'live')
     const scheduled = tabs.find((t) => t.value === 'scheduled')
     expect(live?.count).toBe(3)
@@ -298,22 +321,46 @@ describe('buildFilterTabs', () => {
   })
 
   it('reads the Attention tab from attentionCount, independent of status_counts', () => {
-    const tabs = buildFilterTabs(STATUS_TABS, { in_progress: 3 }, TAB_TO_API, 5)
+    const tabs = buildFilterTabs(STATUS_TABS, { in_progress: 3 }, TAB_TO_API, {
+      attentionCount: 5,
+    })
     const attention = tabs.find((t) => t.value === 'attention')
     expect(attention?.count).toBe(5)
   })
 
-  it('returns a null count for every tab when counts are undefined', () => {
-    const tabs = buildFilterTabs(STATUS_TABS, undefined, TAB_TO_API, undefined)
+  // The #381 fix at the count level: the Live count reads the (already
+  // awaiting-subtracted) in_progress count, the Awaiting count reads its own
+  // bucket. A posted-but-unconfirmed result is counted once, under Awaiting,
+  // never under Live.
+  it('reads the awaiting tab from awaitingCount, separate from live', () => {
+    const tabs = buildFilterTabs(STATUS_TABS, { in_progress: 2 }, TAB_TO_API, {
+      awaitingCount: 5,
+    })
+    expect(tabs.find((t) => t.value === 'live')?.count).toBe(2)
+    expect(tabs.find((t) => t.value === 'awaiting')?.count).toBe(5)
+  })
+
+  it('returns a null count for every tab when statusCounts is undefined', () => {
+    const tabs = buildFilterTabs(STATUS_TABS, undefined, TAB_TO_API, {
+      awaitingCount: 4,
+    })
     expect(tabs.every((t) => t.count === null)).toBe(true)
   })
 
+  it('treats a missing awaitingCount as 0', () => {
+    const tabs = buildFilterTabs(STATUS_TABS, { in_progress: 1 }, TAB_TO_API)
+    expect(tabs.find((t) => t.value === 'awaiting')?.count).toBe(0)
+  })
+
   it('carries the label and live flag through from the tab descriptors', () => {
-    const tabs = buildFilterTabs(STATUS_TABS, undefined, TAB_TO_API, undefined)
+    const tabs = buildFilterTabs(STATUS_TABS, undefined, TAB_TO_API)
     const live = tabs.find((t) => t.value === 'live')
     expect(live?.label).toBe('Live')
     expect(live?.isLive).toBe(true)
     const all = tabs.find((t) => t.value === 'all')
     expect(all?.isLive).toBe(false)
+    const awaiting = tabs.find((t) => t.value === 'awaiting')
+    expect(awaiting?.label).toBe('Awaiting')
+    expect(awaiting?.isLive).toBe(false)
   })
 })

--- a/web-client/src/components/matches/match-list/match-list-row-view.test.ts
+++ b/web-client/src/components/matches/match-list/match-list-row-view.test.ts
@@ -4,7 +4,7 @@ import { scoringNewRoute, type MatchListRow } from '@/api/matches'
 import type { components } from '@/api/schema'
 import { matchListRow } from '@/test/factories'
 import {
-  API_TO_TAB,
+  API_TO_TONE,
   STATUS_TABS,
   STATUS_TONE,
   TAB_TO_API,
@@ -132,10 +132,10 @@ describe('projectMatchListRow', () => {
     expect(projectMatchListRow(row).score.games).toBeNull()
   })
 
-  it('resolves the status tone from STATUS_TONE[API_TO_TAB[status]]', () => {
+  it('resolves the status tone from STATUS_TONE[API_TO_TONE[status]]', () => {
     const row = matchListRow({ status: 'disputed', status_label: 'Disputed' })
     const view = projectMatchListRow(row)
-    expect(view.status.toneClass).toBe(STATUS_TONE[API_TO_TAB.disputed])
+    expect(view.status.toneClass).toBe(STATUS_TONE[API_TO_TONE.disputed])
     expect(view.status.toneClass).toBe('status-tone-final')
     expect(view.status.label).toBe('Disputed')
   })
@@ -150,6 +150,29 @@ describe('projectMatchListRow', () => {
     expect(projectMatchListRow(matchListRow({ status: 'completed' })).status.isLive).toBe(
       false,
     )
+  })
+
+  // The #381 bug at the row level: a posted-but-unconfirmed result is an
+  // in_progress row labelled "Awaiting confirmation". It must NOT read as Live
+  // (no live-dot) and must take its own "called" tone, not the live tone.
+  it('does not mark an awaiting-confirmation row as live and re-tones it', () => {
+    const row = matchListRow({
+      status: 'in_progress',
+      status_label: 'Awaiting confirmation',
+    })
+    const view = projectMatchListRow(row)
+    expect(view.isLive).toBe(false)
+    expect(view.status.isLive).toBe(false)
+    expect(view.status.toneClass).toBe('status-tone-called')
+    expect(view.status.toneClass).not.toBe(STATUS_TONE.live)
+    expect(view.status.label).toBe('Awaiting confirmation')
+  })
+
+  it('still marks a signature-free in_progress row as live', () => {
+    const row = matchListRow({ status: 'in_progress', status_label: 'Live' })
+    const view = projectMatchListRow(row)
+    expect(view.isLive).toBe(true)
+    expect(view.status.toneClass).toBe('status-tone-live')
   })
 
   it('builds the aria label as "Open match: {s1} vs {s2}"', () => {
@@ -190,22 +213,19 @@ describe('projectMatchListRow', () => {
 })
 
 describe('buildFilterTabs', () => {
-  it('sums all status counts for the "all" tab', () => {
+  it('sums every status bucket plus the awaiting bucket for the "all" tab', () => {
     const tabs = buildFilterTabs(
       STATUS_TABS,
       { pending: 2, in_progress: 1, completed: 4 },
       TAB_TO_API,
+      3,
     )
     const all = tabs.find((t) => t.value === 'all')
-    expect(all?.count).toBe(7)
+    expect(all?.count).toBe(10)
   })
 
-  it('uses statusCounts[TAB_TO_API[value]] ?? 0 for each named tab', () => {
-    const tabs = buildFilterTabs(
-      STATUS_TABS,
-      { in_progress: 3 },
-      TAB_TO_API,
-    )
+  it('uses statusCounts[TAB_TO_API[value]] ?? 0 for each status-backed tab', () => {
+    const tabs = buildFilterTabs(STATUS_TABS, { in_progress: 3 }, TAB_TO_API, 0)
     const live = tabs.find((t) => t.value === 'live')
     const scheduled = tabs.find((t) => t.value === 'scheduled')
     expect(live?.count).toBe(3)
@@ -213,17 +233,40 @@ describe('buildFilterTabs', () => {
     expect(scheduled?.count).toBe(0)
   })
 
+  // The #381 fix at the count level: the Live count reads the (already
+  // awaiting-subtracted) in_progress count, the Awaiting count reads its own
+  // bucket. A posted-but-unconfirmed result is counted once, under Awaiting,
+  // never under Live.
+  it('reads the awaiting tab from awaitingCount, separate from live', () => {
+    const tabs = buildFilterTabs(
+      STATUS_TABS,
+      { in_progress: 2 },
+      TAB_TO_API,
+      5,
+    )
+    expect(tabs.find((t) => t.value === 'live')?.count).toBe(2)
+    expect(tabs.find((t) => t.value === 'awaiting')?.count).toBe(5)
+  })
+
   it('returns a null count for every tab when statusCounts is undefined', () => {
-    const tabs = buildFilterTabs(STATUS_TABS, undefined, TAB_TO_API)
+    const tabs = buildFilterTabs(STATUS_TABS, undefined, TAB_TO_API, 4)
     expect(tabs.every((t) => t.count === null)).toBe(true)
   })
 
+  it('treats a missing awaitingCount as 0', () => {
+    const tabs = buildFilterTabs(STATUS_TABS, { in_progress: 1 }, TAB_TO_API, undefined)
+    expect(tabs.find((t) => t.value === 'awaiting')?.count).toBe(0)
+  })
+
   it('carries the label and live flag through from the tab descriptors', () => {
-    const tabs = buildFilterTabs(STATUS_TABS, undefined, TAB_TO_API)
+    const tabs = buildFilterTabs(STATUS_TABS, undefined, TAB_TO_API, 0)
     const live = tabs.find((t) => t.value === 'live')
     expect(live?.label).toBe('Live')
     expect(live?.isLive).toBe(true)
     const all = tabs.find((t) => t.value === 'all')
     expect(all?.isLive).toBe(false)
+    const awaiting = tabs.find((t) => t.value === 'awaiting')
+    expect(awaiting?.label).toBe('Awaiting')
+    expect(awaiting?.isLive).toBe(false)
   })
 })

--- a/web-client/src/components/matches/match-list/match-list-row-view.ts
+++ b/web-client/src/components/matches/match-list/match-list-row-view.ts
@@ -1,11 +1,21 @@
-import type { MatchListRow, MatchStatus } from '@/api/matches'
+import type { MatchListFilter, MatchListRow } from '@/api/matches'
 import type { components } from '@/api/schema'
 import { matchDetailRoute, scoringNewRoute } from '@/api/matches'
-import { API_TO_TAB, STATUS_TONE } from './match-list-status'
+import {
+  API_TO_TONE,
+  STATUS_TONE,
+  type StatusKey,
+} from './match-list-status'
 import type { MatchListRowView } from './match-list-table/match-list-row'
 import type { FilterTabView } from './filter-row'
 
 type MatchListRowSide = components['schemas']['MatchDetailsSide']
+
+// The server-derived label for a posted-but-unconfirmed result (an in_progress
+// match with ≥1 signature; see `_status_label` in the API). The list re-tones
+// these rows to the dedicated "awaiting" treatment — they share the
+// `in_progress` DB status with true-live rows but aren't live anymore.
+export const AWAITING_CONFIRMATION_LABEL = 'Awaiting confirmation'
 
 /** Players joined by ' & ', or 'No opponent' for a null/empty side. (was sideLabel) */
 export function sideLabel(side: MatchListRowSide | null): string {
@@ -48,12 +58,19 @@ function projectPlayerChip(side: MatchListRowSide | null): {
 
 /** Project one raw row into the presentational view model the table renders. */
 export function projectMatchListRow(row: MatchListRow): MatchListRowView {
-  const tab = API_TO_TAB[row.status]
+  // An in_progress row with a posted result reads as "Awaiting confirmation",
+  // not Live — re-tone it and drop the live-dot so it stops masquerading as a
+  // live match (issue #381). The DB status is still in_progress, so the
+  // games-score still shows.
+  const isAwaiting =
+    row.status === 'in_progress' &&
+    row.status_label === AWAITING_CONFIRMATION_LABEL
+  const tone: StatusKey = isAwaiting ? 'awaiting' : API_TO_TONE[row.status]
   const side1 = row.sides.find((s) => s.side_number === 1) ?? row.sides[0]
   const side2 = row.sides.find((s) => s.side_number === 2) ?? null
   const showScore =
     row.status === 'in_progress' || row.status === 'completed'
-  const isLive = row.status === 'in_progress'
+  const isLive = row.status === 'in_progress' && !isAwaiting
 
   return {
     id: row.id,
@@ -71,7 +88,7 @@ export function projectMatchListRow(row: MatchListRow): MatchListRowView {
     },
     status: {
       label: row.status_label,
-      toneClass: STATUS_TONE[tab],
+      toneClass: STATUS_TONE[tone],
       isLive,
     },
     time: { when: formatCreatedAt(row.created_at) },
@@ -82,20 +99,38 @@ export function projectMatchListRow(row: MatchListRow): MatchListRowView {
   }
 }
 
-/** Build the FilterRow tab descriptors from the static tab list + status_counts. */
+/** Build the FilterRow tab descriptors from the static tab list + counts.
+ *
+ * Counts are bucketed exactly the way the server splits the list: `live` reads
+ * the (already awaiting-subtracted) `in_progress` count, the `awaiting` tab
+ * reads the dedicated `awaitingCount`, and `all` sums every status bucket plus
+ * the awaiting bucket — so a posted-but-unconfirmed result is counted once,
+ * under Awaiting, never under Live (issue #381). */
 export function buildFilterTabs(
   tabs: { value: FilterTabView['value']; label: string; live?: boolean }[],
   statusCounts: Record<string, number> | undefined,
-  tabToApi: Record<string, MatchStatus>,
+  tabToApi: Record<string, MatchListFilter>,
+  awaitingCount: number | undefined,
 ): FilterTabView[] {
-  return tabs.map((tab) => ({
-    value: tab.value,
-    label: tab.label,
-    isLive: tab.live ?? false,
-    count: !statusCounts
-      ? null
-      : tab.value === 'all'
-        ? Object.values(statusCounts).reduce((a, b) => a + b, 0)
-        : statusCounts[tabToApi[tab.value]] ?? 0,
-  }))
+  return tabs.map((tab) => {
+    const count = (): number | null => {
+      if (!statusCounts) return null
+      if (tab.value === 'all') {
+        return (
+          Object.values(statusCounts).reduce((a, b) => a + b, 0) +
+          (awaitingCount ?? 0)
+        )
+      }
+      if (tabToApi[tab.value] === 'awaiting_confirmation') {
+        return awaitingCount ?? 0
+      }
+      return statusCounts[tabToApi[tab.value]] ?? 0
+    }
+    return {
+      value: tab.value,
+      label: tab.label,
+      isLive: tab.live ?? false,
+      count: count(),
+    }
+  })
 }

--- a/web-client/src/components/matches/match-list/match-list-row-view.ts
+++ b/web-client/src/components/matches/match-list/match-list-row-view.ts
@@ -1,7 +1,7 @@
-import type { MatchListRow, MatchStatus } from '@/api/matches'
+import type { MatchListFilter, MatchListRow } from '@/api/matches'
 import type { components } from '@/api/schema'
 import { matchDetailRoute, scoringNewRoute } from '@/api/matches'
-import { API_TO_TAB, STATUS_TONE } from './match-list-status'
+import { API_TO_TONE, STATUS_TONE, type StatusKey } from './match-list-status'
 import type {
   MatchListRowView,
   RowActionView,
@@ -9,6 +9,13 @@ import type {
 import type { FilterTabView } from './filter-row'
 
 type MatchListRowSide = components['schemas']['MatchDetailsSide']
+
+// The server-derived label for a posted-but-unconfirmed result (an in_progress
+// match with ≥1 signature; see `_status_label` in the API). When the row has no
+// current-user-aware attention bucket, the list re-tones these rows to the
+// dedicated "awaiting" treatment — they share the `in_progress` DB status with
+// true-live rows but aren't live anymore (issue #381).
+export const AWAITING_CONFIRMATION_LABEL = 'Awaiting confirmation'
 
 // The current-user-aware attention bucket the server stamps on a row (or null).
 export type AttentionKind = NonNullable<MatchListRow['attention']>
@@ -144,12 +151,21 @@ export function projectMatchListRow(
   row: MatchListRow,
   primaryKind: ActionableKind | null = null,
 ): MatchListRowView {
-  const tab = API_TO_TAB[row.status]
+  const attention = row.attention
+  // An in_progress row with a posted result reads as "Awaiting confirmation",
+  // not Live — re-tone it and drop the live-dot so it stops masquerading as a
+  // live match (issue #381). The DB status is still in_progress, so the
+  // games-score still shows. A current-user-aware attention bucket takes
+  // precedence over this perspective-neutral re-toning (see the status chip
+  // below).
+  const isAwaiting =
+    row.status === 'in_progress' &&
+    row.status_label === AWAITING_CONFIRMATION_LABEL
+  const tone: StatusKey = isAwaiting ? 'awaiting' : API_TO_TONE[row.status]
   const side1 = row.sides.find((s) => s.side_number === 1) ?? row.sides[0]
   const side2 = row.sides.find((s) => s.side_number === 2) ?? null
   const showScore = row.status === 'in_progress' || row.status === 'completed'
-  const isLive = row.status === 'in_progress'
-  const attention = row.attention
+  const isLive = row.status === 'in_progress' && !isAwaiting
 
   return {
     id: row.id,
@@ -168,11 +184,12 @@ export function projectMatchListRow(
     status: {
       // A current-user-aware bucket overrides the perspective-neutral
       // status_label so a row says who must act; otherwise fall back to the
-      // server label + tab tone.
+      // server label + (awaiting-aware) status tone.
       label: attention ? ATTENTION_LABEL[attention] : row.status_label,
-      toneClass: attention ? ATTENTION_TONE[attention] : STATUS_TONE[tab],
+      toneClass: attention ? ATTENTION_TONE[attention] : STATUS_TONE[tone],
       // Only the plain "Live" chip pulses; an attention-labeled in-progress row
-      // (e.g. "Needs your review") shouldn't carry a live dot next to its copy.
+      // (e.g. "Needs your review") or an awaiting-confirmation row shouldn't
+      // carry a live dot next to its copy.
       isLive: attention === null && isLive,
     },
     time: { when: formatCreatedAt(row.created_at) },
@@ -180,9 +197,14 @@ export function projectMatchListRow(
   }
 }
 
-/** Build the FilterRow tab descriptors from the static tab list + counts. The
- * Attention tab reads its badge from `attentionCount`; `all` sums the status
- * counts; every other tab reads its own status bucket. */
+/** Build the FilterRow tab descriptors from the static tab list + counts.
+ *
+ * The Attention tab reads its badge from `attentionCount` (its own server
+ * dimension). The status-backed tabs bucket exactly the way the server splits
+ * the list: `live` reads the (already awaiting-subtracted) `in_progress` count,
+ * the `awaiting` tab reads the dedicated `awaitingCount`, and `all` sums every
+ * status bucket plus the awaiting bucket — so a posted-but-unconfirmed result is
+ * counted once, under Awaiting, never under Live (issue #381). */
 export function buildFilterTabs(
   tabs: {
     value: FilterTabView['value']
@@ -191,27 +213,39 @@ export function buildFilterTabs(
     attention?: boolean
   }[],
   statusCounts: Record<string, number> | undefined,
-  tabToApi: Record<string, MatchStatus>,
-  attentionCount: number | undefined,
+  tabToApi: Record<string, MatchListFilter>,
+  counts: { attentionCount?: number; awaitingCount?: number } = {},
 ): FilterTabView[] {
   return tabs.map((tab) => ({
     value: tab.value,
     label: tab.label,
     isLive: tab.live ?? false,
-    count: tabCount(tab, statusCounts, tabToApi, attentionCount),
+    count: tabCount(tab, statusCounts, tabToApi, counts),
   }))
 }
 
 function tabCount(
   tab: { value: FilterTabView['value']; attention?: boolean },
   statusCounts: Record<string, number> | undefined,
-  tabToApi: Record<string, MatchStatus>,
-  attentionCount: number | undefined,
+  tabToApi: Record<string, MatchListFilter>,
+  { attentionCount, awaitingCount }: { attentionCount?: number; awaitingCount?: number },
 ): number | null {
+  // The Attention tab is its own server dimension — its badge reads from
+  // `attentionCount`, independent of `status_counts`.
   if (tab.attention) return attentionCount ?? null
   if (!statusCounts) return null
+  // `all` sums every status bucket plus the awaiting bucket (the awaiting count
+  // is peeled out of the in_progress status count server-side, issue #381).
   if (tab.value === 'all') {
-    return Object.values(statusCounts).reduce((a, b) => a + b, 0)
+    return (
+      Object.values(statusCounts).reduce((a, b) => a + b, 0) +
+      (awaitingCount ?? 0)
+    )
+  }
+  // `awaiting` reads its dedicated bucket; `live` reads the
+  // (already awaiting-subtracted) in_progress count — disjoint (issue #381).
+  if (tabToApi[tab.value] === 'awaiting_confirmation') {
+    return awaitingCount ?? 0
   }
   return statusCounts[tabToApi[tab.value]] ?? 0
 }

--- a/web-client/src/components/matches/match-list/match-list-status.test.ts
+++ b/web-client/src/components/matches/match-list/match-list-status.test.ts
@@ -1,7 +1,7 @@
 import type { MatchStatus } from '@/api/matches'
 
 import {
-  API_TO_TAB,
+  API_TO_TONE,
   PAGE_SIZE,
   STATUS_KEYS,
   TAB_TO_API,
@@ -50,6 +50,18 @@ describe('listParamsFromSearch', () => {
     expect(listParamsFromSearch({ status: 'final' }).status).toBe('completed')
   })
 
+  // The bug in #381: the Live tab and the Awaiting tab must hit *distinct*
+  // server buckets — otherwise a posted-but-unconfirmed result rides under
+  // Live. `awaiting` maps to the dedicated `awaiting_confirmation` filter.
+  it('maps the awaiting tab to the awaiting_confirmation filter, distinct from live', () => {
+    expect(listParamsFromSearch({ status: 'awaiting' }).status).toBe(
+      'awaiting_confirmation',
+    )
+    expect(listParamsFromSearch({ status: 'awaiting' }).status).not.toBe(
+      listParamsFromSearch({ status: 'live' }).status,
+    )
+  })
+
   it('leaves status undefined when the search has none', () => {
     expect(listParamsFromSearch({}).status).toBe(undefined)
   })
@@ -72,17 +84,29 @@ describe('listParamsFromSearch', () => {
   })
 })
 
-describe('TAB_TO_API / API_TO_TAB', () => {
-  it('are mutual inverses for the three primary tabs', () => {
-    for (const tab of STATUS_KEYS) {
-      expect(API_TO_TAB[TAB_TO_API[tab]]).toBe(tab)
+describe('TAB_TO_API', () => {
+  it('maps the status-backed tabs to their DB status round-trip', () => {
+    // `awaiting` is the one tab with no DB status of its own (it's an
+    // in_progress row with a posted result), so it's excluded from the
+    // status↔tone round-trip.
+    const statusBacked = STATUS_KEYS.filter((k) => k !== 'awaiting')
+    for (const tab of statusBacked) {
+      expect(API_TO_TONE[TAB_TO_API[tab] as MatchStatus]).toBe(tab)
     }
   })
 
-  it('folds the terminal statuses to the final tab', () => {
+  it('maps live and awaiting to distinct filter buckets', () => {
+    expect(TAB_TO_API.live).toBe('in_progress')
+    expect(TAB_TO_API.awaiting).toBe('awaiting_confirmation')
+    expect(TAB_TO_API.live).not.toBe(TAB_TO_API.awaiting)
+  })
+})
+
+describe('API_TO_TONE', () => {
+  it('folds the terminal statuses to the final tone', () => {
     const terminal: MatchStatus[] = ['disputed', 'voided']
     for (const status of terminal) {
-      expect(API_TO_TAB[status]).toBe('final')
+      expect(API_TO_TONE[status]).toBe('final')
     }
   })
 })

--- a/web-client/src/components/matches/match-list/match-list-status.test.ts
+++ b/web-client/src/components/matches/match-list/match-list-status.test.ts
@@ -1,7 +1,7 @@
 import type { MatchStatus } from '@/api/matches'
 
 import {
-  API_TO_TAB,
+  API_TO_TONE,
   PAGE_SIZE,
   STATUS_KEYS,
   TAB_TO_API,
@@ -56,6 +56,18 @@ describe('listParamsFromSearch', () => {
     expect(listParamsFromSearch({ status: 'final' }).status).toBe('completed')
   })
 
+  // The bug in #381: the Live tab and the Awaiting tab must hit *distinct*
+  // server buckets — otherwise a posted-but-unconfirmed result rides under
+  // Live. `awaiting` maps to the dedicated `awaiting_confirmation` filter.
+  it('maps the awaiting tab to the awaiting_confirmation filter, distinct from live', () => {
+    expect(listParamsFromSearch({ status: 'awaiting' }).status).toBe(
+      'awaiting_confirmation',
+    )
+    expect(listParamsFromSearch({ status: 'awaiting' }).status).not.toBe(
+      listParamsFromSearch({ status: 'live' }).status,
+    )
+  })
+
   it('leaves status undefined when the search has none', () => {
     expect(listParamsFromSearch({}).status).toBe(undefined)
   })
@@ -89,17 +101,29 @@ describe('listParamsFromSearch', () => {
   })
 })
 
-describe('TAB_TO_API / API_TO_TAB', () => {
-  it('are mutual inverses for the three primary tabs', () => {
-    for (const tab of STATUS_KEYS) {
-      expect(API_TO_TAB[TAB_TO_API[tab]]).toBe(tab)
+describe('TAB_TO_API', () => {
+  it('maps the status-backed tabs to their DB status round-trip', () => {
+    // `awaiting` is the one tab with no DB status of its own (it's an
+    // in_progress row with a posted result), so it's excluded from the
+    // status↔tone round-trip.
+    const statusBacked = STATUS_KEYS.filter((k) => k !== 'awaiting')
+    for (const tab of statusBacked) {
+      expect(API_TO_TONE[TAB_TO_API[tab] as MatchStatus]).toBe(tab)
     }
   })
 
-  it('folds the terminal statuses to the final tab', () => {
+  it('maps live and awaiting to distinct filter buckets', () => {
+    expect(TAB_TO_API.live).toBe('in_progress')
+    expect(TAB_TO_API.awaiting).toBe('awaiting_confirmation')
+    expect(TAB_TO_API.live).not.toBe(TAB_TO_API.awaiting)
+  })
+})
+
+describe('API_TO_TONE', () => {
+  it('folds the terminal statuses to the final tone', () => {
     const terminal: MatchStatus[] = ['disputed', 'voided']
     for (const status of terminal) {
-      expect(API_TO_TAB[status]).toBe('final')
+      expect(API_TO_TONE[status]).toBe('final')
     }
   })
 })

--- a/web-client/src/components/matches/match-list/match-list-status.ts
+++ b/web-client/src/components/matches/match-list/match-list-status.ts
@@ -1,15 +1,24 @@
 import type { useNavigate } from '@tanstack/react-router'
 import { z } from 'zod'
 
-import type { MatchListParams, MatchStatus } from '@/api/matches'
+import type {
+  MatchListFilter,
+  MatchListParams,
+  MatchStatus,
+} from '@/api/matches'
 
-// Single source of truth for the API-backed filter-tab status values — the ones
-// that map straight onto a `MatchStatus` query. `attention` is a *separate*
-// dimension (its own server flag + ranking), so it lives in `FILTER_KEYS`
-// below, not here.
-export const STATUS_KEYS = ['scheduled', 'live', 'final'] as const
+// Single source of truth for the status-backed filter-tab values — the ones
+// that map onto a `MatchListFilter` query. `awaiting` is the
+// posted-but-unconfirmed bucket (in_progress + ≥1 signature), split out from
+// `live` so a posted result no longer inflates the Live tab / count (issue
+// #381). `attention` is a *separate* dimension (its own server flag + ranking),
+// so it lives in `FILTER_KEYS` below, not here.
+export const STATUS_KEYS = ['scheduled', 'live', 'awaiting', 'final'] as const
 export type StatusKey = (typeof STATUS_KEYS)[number]
-export type RowTab = StatusKey
+// A row's display classification, used for the status-pill tone. `awaiting`
+// shares the live/in_progress DB status but reads with its own "called" tone
+// (picked from `status_label`, see `projectMatchListRow`), so it's its own key.
+export type ToneKey = StatusKey
 
 // Every non-default tab value the URL can carry. `attention` leads the
 // ordering (Attention · All · Live · Up next · Final); `all` is the default and
@@ -30,14 +39,20 @@ export const matchesSearchSchema = z.object({
   page: z.coerce.number().int().min(2).optional().catch(undefined),
 })
 
-export const TAB_TO_API: Record<RowTab, MatchStatus> = {
+// Maps a selected tab to the API's `status` filter value. `live` and
+// `awaiting` both live on `in_progress` server-side but resolve to disjoint
+// `MatchListFilter` buckets (the server splits on whether a result is posted).
+export const TAB_TO_API: Record<StatusKey, MatchListFilter> = {
   scheduled: 'pending',
   live: 'in_progress',
+  awaiting: 'awaiting_confirmation',
   final: 'completed',
 }
 // Terminal statuses (disputed, voided) fall back to the `final` tone — they
 // share final's "no further action" semantics, not scheduled's pending one.
-export const API_TO_TAB: Record<MatchStatus, RowTab> = {
+// in_progress maps to the `live` tone; awaiting-confirmation rows (also
+// in_progress) are re-toned in `projectMatchListRow` from their `status_label`.
+export const API_TO_TONE: Record<MatchStatus, ToneKey> = {
   pending: 'scheduled',
   in_progress: 'live',
   completed: 'final',
@@ -56,14 +71,16 @@ export const STATUS_TABS: {
   { value: 'attention', label: 'Attention', attention: true },
   { value: 'all', label: 'All' },
   { value: 'live', label: 'Live', live: true },
+  { value: 'awaiting', label: 'Awaiting' },
   { value: 'scheduled', label: 'Up next' },
   { value: 'final', label: 'Final' },
 ]
 
 export const PAGE_SIZE = 25
 
-export const STATUS_TONE: Record<RowTab, string> = {
+export const STATUS_TONE: Record<ToneKey, string> = {
   live: 'status-tone-live',
+  awaiting: 'status-tone-called',
   final: 'status-tone-final',
   scheduled: 'status-tone-scheduled',
 }

--- a/web-client/src/components/matches/match-list/match-list-status.ts
+++ b/web-client/src/components/matches/match-list/match-list-status.ts
@@ -1,13 +1,23 @@
 import type { useNavigate } from '@tanstack/react-router'
 import { z } from 'zod'
 
-import type { MatchListParams, MatchStatus } from '@/api/matches'
+import type {
+  MatchListFilter,
+  MatchListParams,
+  MatchStatus,
+} from '@/api/matches'
 
 // Single source of truth for the filter-tab status values — the URL schema,
 // the row classification, and the tab list all derive from this tuple.
-export const STATUS_KEYS = ['scheduled', 'live', 'final'] as const
+// `awaiting` is the posted-but-unconfirmed bucket (in_progress + ≥1 signature),
+// split out from `live` so a posted result no longer inflates the Live tab /
+// count (issue #381).
+export const STATUS_KEYS = ['scheduled', 'live', 'awaiting', 'final'] as const
 export type StatusKey = (typeof STATUS_KEYS)[number]
-export type RowTab = StatusKey
+// A row's display classification, used for the status-pill tone. `awaiting`
+// shares the live/in_progress DB status but reads with its own "called" tone
+// (picked from `status_label`, see `projectMatchListRow`), so it's its own key.
+export type ToneKey = StatusKey
 
 // URL is the source of truth for filters. `.trim()` strips whitespace so a
 // junk query like `?q=%20%20%20` collapses to "no filter" instead of polluting
@@ -20,14 +30,20 @@ export const matchesSearchSchema = z.object({
   page: z.coerce.number().int().min(2).optional().catch(undefined),
 })
 
-export const TAB_TO_API: Record<RowTab, MatchStatus> = {
+// Maps a selected tab to the API's `status` filter value. `live` and
+// `awaiting` both live on `in_progress` server-side but resolve to disjoint
+// `MatchListFilter` buckets (the server splits on whether a result is posted).
+export const TAB_TO_API: Record<StatusKey, MatchListFilter> = {
   scheduled: 'pending',
   live: 'in_progress',
+  awaiting: 'awaiting_confirmation',
   final: 'completed',
 }
 // Terminal statuses (disputed, voided) fall back to the `final` tone — they
 // share final's "no further action" semantics, not scheduled's pending one.
-export const API_TO_TAB: Record<MatchStatus, RowTab> = {
+// in_progress maps to the `live` tone; awaiting-confirmation rows (also
+// in_progress) are re-toned in `projectMatchListRow` from their `status_label`.
+export const API_TO_TONE: Record<MatchStatus, ToneKey> = {
   pending: 'scheduled',
   in_progress: 'live',
   completed: 'final',
@@ -42,14 +58,16 @@ export const STATUS_TABS: {
 }[] = [
   { value: 'all', label: 'All' },
   { value: 'live', label: 'Live', live: true },
+  { value: 'awaiting', label: 'Awaiting' },
   { value: 'scheduled', label: 'Up next' },
   { value: 'final', label: 'Final' },
 ]
 
 export const PAGE_SIZE = 25
 
-export const STATUS_TONE: Record<RowTab, string> = {
+export const STATUS_TONE: Record<ToneKey, string> = {
   live: 'status-tone-live',
+  awaiting: 'status-tone-called',
   final: 'status-tone-final',
   scheduled: 'status-tone-scheduled',
 }

--- a/web-client/src/components/matches/match-list/match-list-table.factory.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table.factory.tsx
@@ -7,9 +7,11 @@ import type { NavigateFn } from './match-list-status'
 /**
  * Props for `MatchListTable` — a settled table with one viewer-won row.
  *
- * Drive the other two states by overriding `rows`:
+ * Drive the other states by overriding `rows` / `isFiltered`:
  * - `{ isLoading: true, rows: [] }` renders the loading skeleton.
- * - `{ isLoading: false, rows: [] }` renders the empty state.
+ * - `{ isLoading: false, rows: [] }` renders the unfiltered cold-start empty.
+ * - `{ isLoading: false, rows: [], isFiltered: true }` renders the filtered
+ *   no-result empty ("No matches match your filters").
  */
 export function buildMatchListTableProps(
   overrides: Partial<MatchListTableProps> = {},
@@ -17,6 +19,7 @@ export function buildMatchListTableProps(
   return {
     rows: [buildMatchListRowView()],
     isLoading: false,
+    isFiltered: false,
     onClear: vi.fn(),
     navigate: vi.fn() as unknown as NavigateFn,
     ...overrides,

--- a/web-client/src/components/matches/match-list/match-list-table.factory.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table.factory.tsx
@@ -7,9 +7,15 @@ import type { NavigateFn } from './match-list-status'
 /**
  * Props for `MatchListTable` — a settled table with one viewer-won row.
  *
- * Drive the other two states by overriding `rows`:
+ * Drive the other states by overriding `rows` / `isFiltered` / `isAttention` /
+ * `query`:
  * - `{ isLoading: true, rows: [] }` renders the loading skeleton.
- * - `{ isLoading: false, rows: [] }` renders the empty state.
+ * - `{ isLoading: false, rows: [] }` renders the unfiltered cold-start empty.
+ * - `{ isLoading: false, rows: [], isFiltered: true }` renders the filtered
+ *   no-result empty ("No matches match your filters") — a non-"all" status tab
+ *   or out-of-range page.
+ * - `{ isLoading: false, rows: [], isAttention: true }` renders the Attention
+ *   "all caught up" empty; add `query` for the "No matches for …" no-result.
  */
 export function buildMatchListTableProps(
   overrides: Partial<MatchListTableProps> = {},
@@ -19,6 +25,7 @@ export function buildMatchListTableProps(
     isLoading: false,
     isAttention: false,
     query: '',
+    isFiltered: false,
     onClear: vi.fn(),
     onClearSearch: vi.fn(),
     navigate: vi.fn() as unknown as NavigateFn,

--- a/web-client/src/components/matches/match-list/match-list-table.page.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table.page.tsx
@@ -19,16 +19,30 @@ const scoped = (container: Container) => ({
   getTable() {
     return container.getByRole('table')
   },
-  /** The empty-state copy heading, present only when not loading and no rows. */
+  /** The empty-state copy heading, present only when not loading and no rows.
+   * Matches either copy — the cold-start "No matches yet" or the filtered
+   * "No matches match your filters". */
   getEmptyState() {
-    return container.getByText(/no matches yet/i)
+    return container.getByText(/no matches (yet|match your filters)/i)
   },
   queryEmptyState() {
-    return container.queryByText(/no matches yet/i)
+    return container.queryByText(/no matches (yet|match your filters)/i)
   },
-  /** The empty-state "Clear filters" button. */
+  /** The cold-start (unfiltered) heading specifically. */
+  queryColdStartHeading() {
+    return container.queryByText(/^no matches yet$/i)
+  },
+  /** The filtered no-result heading specifically. */
+  queryFilteredHeading() {
+    return container.queryByText(/no matches match your filters/i)
+  },
+  /** The empty-state "Clear filters" button (filtered empty only). */
   getClearFiltersButton() {
     return container.getByRole('button', { name: /clear filters/i })
+  },
+  /** Nullable variant — the cold-start empty omits the Clear filters button. */
+  queryClearFiltersButton() {
+    return container.queryByRole('button', { name: /clear filters/i })
   },
   // Column headers (Match/Players/Score/Status/Started) read as this table's
   // own queries.
@@ -91,7 +105,7 @@ export const matchListTablePage = {
   /** Async-first accessor for the empty state — no `<table>` renders, so tests
    * await this instead of `findTable()` before reading synchronous accessors. */
   findEmptyState() {
-    return screen.findByText(/no matches yet/i)
+    return screen.findByText(/no matches (yet|match your filters)/i)
   },
 
   /**

--- a/web-client/src/components/matches/match-list/match-list-table.page.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table.page.tsx
@@ -19,16 +19,30 @@ const scoped = (container: Container) => ({
   getTable() {
     return container.getByRole('table')
   },
-  /** The empty-state copy heading, present only when not loading and no rows. */
+  /** The empty-state copy heading, present only when not loading and no rows.
+   * Matches either copy — the cold-start "No matches yet" or the filtered
+   * "No matches match your filters". */
   getEmptyState() {
-    return container.getByText(/no matches yet/i)
+    return container.getByText(/no matches (yet|match your filters)/i)
   },
   queryEmptyState() {
-    return container.queryByText(/no matches yet/i)
+    return container.queryByText(/no matches (yet|match your filters)/i)
   },
-  /** The empty-state "Clear filters" button. */
+  /** The cold-start (unfiltered) heading specifically. */
+  queryColdStartHeading() {
+    return container.queryByText(/^no matches yet$/i)
+  },
+  /** The filtered no-result heading specifically. */
+  queryFilteredHeading() {
+    return container.queryByText(/no matches match your filters/i)
+  },
+  /** The empty-state "Clear filters" button (filtered empty only). */
   getClearFiltersButton() {
     return container.getByRole('button', { name: /clear filters/i })
+  },
+  /** Nullable variant — the cold-start empty omits the Clear filters button. */
+  queryClearFiltersButton() {
+    return container.queryByRole('button', { name: /clear filters/i })
   },
   /** The Attention tab's calm "all caught up" empty-state heading. */
   getCaughtUpState() {
@@ -106,7 +120,7 @@ export const matchListTablePage = {
   /** Async-first accessor for the empty state — no `<table>` renders, so tests
    * await this instead of `findTable()` before reading synchronous accessors. */
   findEmptyState() {
-    return screen.findByText(/no matches yet/i)
+    return screen.findByText(/no matches (yet|match your filters)/i)
   },
 
   /** Async-first accessor for the Attention "all caught up" empty state. */

--- a/web-client/src/components/matches/match-list/match-list-table.test.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table.test.tsx
@@ -14,21 +14,42 @@ describe('MatchListTable', () => {
     expect(matchListTablePage.queryEmptyState()).toBeNull()
   })
 
-  it('renders the empty state (icon, "No matches yet", sub copy, Clear filters button) when not loading and rows empty', async () => {
-    matchListTablePage.render({ isLoading: false, rows: [] })
+  it('renders the cold-start empty ("No matches yet", no Clear filters) when not loading, rows empty, and unfiltered', async () => {
+    matchListTablePage.render({ isLoading: false, rows: [], isFiltered: false })
 
     const heading = await matchListTablePage.findEmptyState()
     expect(heading).toHaveTextContent('No matches yet')
     expect(heading.closest('.empty')).toHaveTextContent(
-      "Start a new match or clear the filters to see what's being played.",
+      'Start a new match to see what’s being played.',
+    )
+    // A first-run user has nothing to clear — the button would be a no-op, so
+    // it's omitted (#373).
+    expect(matchListTablePage.queryClearFiltersButton()).toBeNull()
+  })
+
+  it('renders the filtered no-result empty ("No matches match your filters" + Clear filters) when a filter is active and rows empty', async () => {
+    // Regression for #373: a filtered/out-of-range no-result view must not
+    // imply the user has never played.
+    matchListTablePage.render({ isLoading: false, rows: [], isFiltered: true })
+
+    const heading = await matchListTablePage.findEmptyState()
+    expect(heading).toHaveTextContent('No matches match your filters')
+    expect(matchListTablePage.queryColdStartHeading()).toBeNull()
+    expect(heading.closest('.empty')).toHaveTextContent(
+      'Try a different search or clear the filters to see what’s being played.',
     )
     expect(matchListTablePage.getClearFiltersButton()).toBeInTheDocument()
   })
 
-  it('calls onClear when Clear filters is clicked', async () => {
+  it('calls onClear when Clear filters is clicked (filtered empty)', async () => {
     const user = userEvent.setup()
     const onClear = buildMatchListTableProps().onClear
-    matchListTablePage.render({ isLoading: false, rows: [], onClear })
+    matchListTablePage.render({
+      isLoading: false,
+      rows: [],
+      isFiltered: true,
+      onClear,
+    })
 
     await matchListTablePage.findEmptyState()
     await user.click(matchListTablePage.getClearFiltersButton())

--- a/web-client/src/components/matches/match-list/match-list-table.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table.tsx
@@ -12,6 +12,16 @@ export interface MatchListTableProps {
   rows: MatchListRowView[]
   /** True while the first page is loading and there are no rows yet — render the skeleton. */
   isLoading: boolean
+  /**
+   * Whether a search, status tab, or out-of-range page is narrowing the list.
+   * Drives the empty-state copy: a filtered no-result reads "No matches match
+   * your filters" and offers a Clear filters button (the user has matches, just
+   * not here), while an unfiltered empty list reads "No matches yet" — a
+   * genuine first-run cold start where clearing filters is a no-op. Without
+   * this, a filtered/no-result view falsely implies the user has never played
+   * (#373).
+   */
+  isFiltered: boolean
   /** Clears all filters from the empty state's button. */
   onClear: () => void
   navigate: NavigateFn
@@ -20,6 +30,7 @@ export interface MatchListTableProps {
 export const MatchListTable = ({
   rows,
   isLoading,
+  isFiltered,
   onClear,
   navigate,
 }: MatchListTableProps) => {
@@ -30,18 +41,24 @@ export const MatchListTable = ({
         <div className="empty-icon">
           <Inbox size={56} strokeWidth={1.5} />
         </div>
-        <div className="empty-title">No matches yet</div>
-        <div className="empty-sub">
-          Start a new match or clear the filters to see what's being played.
+        <div className="empty-title">
+          {isFiltered ? 'No matches match your filters' : 'No matches yet'}
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="empty-clear"
-          onClick={onClear}
-        >
-          Clear filters
-        </Button>
+        <div className="empty-sub">
+          {isFiltered
+            ? 'Try a different search or clear the filters to see what’s being played.'
+            : 'Start a new match to see what’s being played.'}
+        </div>
+        {isFiltered && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="empty-clear"
+            onClick={onClear}
+          >
+            Clear filters
+          </Button>
+        )}
       </div>
     )
   }

--- a/web-client/src/components/matches/match-list/match-list-table.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table.tsx
@@ -16,6 +16,17 @@ export interface MatchListTableProps {
   isAttention: boolean
   /** The active (trimmed) search term, used to phrase the no-results state. */
   query: string
+  /**
+   * Whether a search, a non-"all" status tab, or an out-of-range page is
+   * narrowing the list. Drives the cold-start vs filtered empty copy when there
+   * is no search term: a filtered no-result reads "No matches match your
+   * filters" and offers a Clear filters button (the user has matches, just not
+   * here), while a genuinely empty list reads "No matches yet" — a first-run
+   * cold start where clearing filters is a no-op, so the button is omitted.
+   * Without this, a status-tab/out-of-range no-result view falsely implies the
+   * user has never played (#373).
+   */
+  isFiltered: boolean
   /** Clears all filters (used by "Clear filters" / "View all matches"). */
   onClear: () => void
   /** Clears only the search term, staying on the active tab. */
@@ -28,6 +39,7 @@ export const MatchListTable = ({
   isLoading,
   isAttention,
   query,
+  isFiltered,
   onClear,
   onClearSearch,
   navigate,
@@ -38,6 +50,7 @@ export const MatchListTable = ({
       <EmptyState
         isAttention={isAttention}
         query={query}
+        isFiltered={isFiltered}
         onClear={onClear}
         onClearSearch={onClearSearch}
       />
@@ -58,11 +71,13 @@ export const MatchListTable = ({
 function EmptyState({
   isAttention,
   query,
+  isFiltered,
   onClear,
   onClearSearch,
 }: {
   isAttention: boolean
   query: string
+  isFiltered: boolean
   onClear: () => void
   onClearSearch: () => void
 }) {
@@ -109,18 +124,33 @@ function EmptyState({
       </div>
     )
   }
+  // No search term, not the attention tab. A non-"all" status tab or an
+  // out-of-range page can still have narrowed the list to nothing (#373): say
+  // so and offer Clear filters. A genuinely empty list is a first-run cold
+  // start — clearing filters is a no-op, so the button is omitted.
   return (
     <div className="empty">
       <div className="empty-icon">
         <Inbox size={56} strokeWidth={1.5} />
       </div>
-      <div className="empty-title">No matches yet</div>
-      <div className="empty-sub">
-        Start a new match or clear the filters to see what's being played.
+      <div className="empty-title">
+        {isFiltered ? 'No matches match your filters' : 'No matches yet'}
       </div>
-      <Button variant="ghost" size="sm" className="empty-clear" onClick={onClear}>
-        Clear filters
-      </Button>
+      <div className="empty-sub">
+        {isFiltered
+          ? 'Try a different search or clear the filters to see what’s being played.'
+          : 'Start a new match to see what’s being played.'}
+      </div>
+      {isFiltered && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="empty-clear"
+          onClick={onClear}
+        >
+          Clear filters
+        </Button>
+      )}
     </div>
   )
 }

--- a/web-client/src/components/matches/save-banner.test.tsx
+++ b/web-client/src/components/matches/save-banner.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQueryClient,
+} from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { server } from '@/mocks/server'
+import { matchDetails } from '@/test/factories'
+import { fireScoreSave } from '@/api/matches'
+import { SaveBanner } from './save-banner'
+
+// Bo5, 1-1 on the board, game 3 next — a single game-3 failure can't decide the
+// match, so the banner stays in its plain "Game N didn't save." mode (not the
+// finalize variant) and exposes a Dismiss + Retry.
+const inProgressMatch = matchDetails({
+  id: 'm-1',
+  status: 'in_progress',
+  status_label: 'Live',
+  best_of: 5,
+  games_to_win: 3,
+  affects_rating: true,
+  games: [
+    {
+      id: 'g-1',
+      game_number: 1,
+      score: {
+        id: 's-1',
+        side_1_points: 11,
+        side_2_points: 8,
+        winner_side_number: 1,
+      },
+    },
+    {
+      id: 'g-2',
+      game_number: 2,
+      score: {
+        id: 's-2',
+        side_1_points: 9,
+        side_2_points: 11,
+        winner_side_number: 2,
+      },
+    },
+  ],
+  current_game: { game_number: 3 },
+  can_score: true,
+  can_finalize: false,
+})
+
+// Render the banner for an active game OTHER than the one that fails, so the
+// failure is surfaced (the active game's own failure is suppressed). A sibling
+// button re-fires game 3's scratch save imperatively — the same `fireScoreSave`
+// the banner's own Retry calls — so a re-failure happens WITHOUT unmounting the
+// banner (its dismiss state, the thing under test, must survive).
+function renderBanner() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute()
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: function Harness() {
+      const qc = useQueryClient()
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() =>
+              fireScoreSave(qc, 'm-1', 3, {
+                side_1_points: 11,
+                side_2_points: 4,
+              })
+            }
+          >
+            fail game 3
+          </button>
+          <SaveBanner matchId="m-1" activeGameNumber={4} />
+        </>
+      )
+    },
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('SaveBanner', () => {
+  // Regression for #528: the dismiss key folded only the failed game NUMBERS,
+  // so a same-game repeat failure (set still {3}) kept the signature unchanged
+  // and the dismissed banner stayed hidden — hiding the new failure. The key
+  // now also carries each failure's `submittedAt`, so a fresh failure of an
+  // already-listed game re-surfaces the banner.
+  it('re-surfaces after dismiss when the same single game fails to save again', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch)),
+      // Every game-3 save fails.
+      http.post('*/v1/matches/m-1/games/3/scores/new', () =>
+        HttpResponse.json({ detail: 'boom' }, { status: 500 }),
+      ),
+    )
+
+    renderBanner()
+
+    // First failure → banner surfaces.
+    await user.click(await screen.findByRole('button', { name: 'fail game 3' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      "Game 3 didn't save.",
+    )
+
+    // Dismiss it.
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+    // Same game fails AGAIN (the banner never unmounted). The failed set is
+    // unchanged ({3}); only the new failure's identity differs — and that must
+    // be enough to bring the dismissed banner back.
+    await user.click(screen.getByRole('button', { name: 'fail game 3' }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        "Game 3 didn't save.",
+      ),
+    )
+  })
+})

--- a/web-client/src/components/matches/save-banner.tsx
+++ b/web-client/src/components/matches/save-banner.tsx
@@ -99,7 +99,14 @@ export function SaveBanner({ matchId, activeGameNumber }: SaveBannerProps) {
   // the active game's score finishes the match: we stay on it instead of
   // advancing, so it must appear here (informational; see `decidedHere`).
   const failed = wouldFinalize ? allFailed : otherFailed
-  const signature = failed.map((entry) => entry.gameNumber).join(',')
+  // Key the dismiss by each failure's identity, not just its game number: a
+  // single game that fails, is dismissed, then fails again on retry keeps the
+  // same failed set ({N}) but a fresh `submittedAt`, so folding the timestamp
+  // in re-surfaces the banner for the new failure instead of staying hidden
+  // (#528).
+  const signature = failed
+    .map((entry) => `${entry.gameNumber}:${entry.submittedAt}`)
+    .join(',')
 
   if (failed.length === 0 || signature === dismissedSignature) return null
 

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -401,6 +401,38 @@ describe('ScoreEntry — create', () => {
     expect(posted).toBe(0)
   })
 
+  it('explains that both scores are required when only one field is filled (#387)', async () => {
+    // With exactly one score entered, Save is disabled with no reason given.
+    // Surface an inline hint and flag the still-empty field so the disabled
+    // button isn't a silent dead end.
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+
+    // Untouched: no hint, no red.
+    expect(screen.queryByText(/enter both scores/i)).not.toBeInTheDocument()
+
+    await user.type(meInput, '11')
+    // One side filled → hint appears, Save disabled, the empty field flagged.
+    expect(screen.getByText(/enter both scores to save this game/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
+    expect(oppInput).toHaveAttribute('aria-invalid', 'true')
+    expect(meInput).not.toHaveAttribute('aria-invalid', 'true')
+
+    // Filling the second score clears the hint and enables Save.
+    await user.type(oppInput, '9')
+    expect(screen.queryByText(/enter both scores/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+    expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
+  })
+
   it('keeps a 3-digit entry intact instead of silently truncating to 2 digits', async () => {
     // Regression for #442: typing "100" used to be cut to "10", then the
     // win-by-2 check fired against a value the user never entered. The input
@@ -528,9 +560,14 @@ describe('ScoreEntry — create', () => {
     expect(meInput).toHaveAttribute('aria-invalid', 'true')
     expect(oppInput).toHaveAttribute('aria-invalid', 'true')
 
-    // Editing either input clears the error.
+    // Editing either input clears the server error. (Clearing one field leaves
+    // exactly one score filled, so the lower-severity "both scores required"
+    // hint takes over — the 422 message itself is gone and the fields are no
+    // longer flagged for that error.)
     await user.clear(meInput)
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/rejected by the server/i),
+    ).not.toBeInTheDocument()
   })
 })
 
@@ -590,10 +627,42 @@ describe('ScoreEntry — edit', () => {
     // "Clear game N" labels and would otherwise collide with /clear/i.
     await user.click(screen.getByRole('button', { name: /^clear$/i }))
 
+    // Clearing now asks first (#387) — nothing is deleted until confirmed.
+    await screen.findByRole('alertdialog')
+    expect(deleted).toBe(false)
+    await user.click(screen.getByRole('button', { name: /clear game/i }))
+
     await waitFor(() =>
       expect(screen.getByText('scoring-new m-1 1')).toBeInTheDocument(),
     )
     expect(deleted).toBe(true)
+  })
+
+  it('cancelling the clear confirmation keeps the saved score (#387)', async () => {
+    const user = userEvent.setup()
+    let deleted = false
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      http.delete('*/v1/matches/m-1/games/1/scores', () => {
+        deleted = true
+        return HttpResponse.json(inProgressMatch())
+      }),
+    )
+
+    renderScoreEntry({ kind: 'edit', matchId: 'm-1', gameNumber: 1 })
+
+    await screen.findByRole('textbox', { name: 'rita.kovac score' })
+    await user.click(screen.getByRole('button', { name: /^clear$/i }))
+
+    const dialog = await screen.findByRole('alertdialog')
+    await user.click(within(dialog).getByRole('button', { name: /keep score/i }))
+
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument(),
+    )
+    expect(deleted).toBe(false)
+    // Still on the edit screen, score intact — no navigation away.
+    expect(screen.queryByText('scoring-new m-1 1')).not.toBeInTheDocument()
   })
 
   it("✕ on another game's cell clears that game in place without leaving the page", async () => {
@@ -624,6 +693,14 @@ describe('ScoreEntry — edit', () => {
     await user.type(oppInput, '7')
 
     await user.click(screen.getByRole('button', { name: /clear game 1/i }))
+
+    // Confirm first (#387): the ✕ opens a dialog scoped to game 1.
+    const dialog = await screen.findByRole('alertdialog')
+    expect(within(dialog).getByRole('heading')).toHaveTextContent(
+      /clear game 1\?/i,
+    )
+    expect(deletedGameNumber).toBeNull()
+    await user.click(within(dialog).getByRole('button', { name: /clear game/i }))
 
     await waitFor(() => expect(deletedGameNumber).toBe(1))
     // No redirect — still on the active game's entry route.

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -401,6 +401,38 @@ describe('ScoreEntry — create', () => {
     expect(posted).toBe(0)
   })
 
+  it('explains that both scores are required when only one field is filled (#387)', async () => {
+    // With exactly one score entered, Save is disabled with no reason given.
+    // Surface an inline hint and flag the still-empty field so the disabled
+    // button isn't a silent dead end.
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+
+    // Untouched: no hint, no red.
+    expect(screen.queryByText(/enter both scores/i)).not.toBeInTheDocument()
+
+    await user.type(meInput, '11')
+    // One side filled → hint appears, Save disabled, the empty field flagged.
+    expect(screen.getByText(/enter both scores to save this game/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
+    expect(oppInput).toHaveAttribute('aria-invalid', 'true')
+    expect(meInput).not.toHaveAttribute('aria-invalid', 'true')
+
+    // Filling the second score clears the hint and enables Save.
+    await user.type(oppInput, '9')
+    expect(screen.queryByText(/enter both scores/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+    expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
+  })
+
   it('keeps a 3-digit entry intact instead of silently truncating to 2 digits', async () => {
     // Regression for #442: typing "100" used to be cut to "10", then the
     // win-by-2 check fired against a value the user never entered. The input
@@ -528,9 +560,14 @@ describe('ScoreEntry — create', () => {
     expect(meInput).toHaveAttribute('aria-invalid', 'true')
     expect(oppInput).toHaveAttribute('aria-invalid', 'true')
 
-    // Editing either input clears the error.
+    // Editing either input clears the server error. (Clearing one field leaves
+    // exactly one score filled, so the lower-severity "both scores required"
+    // hint takes over — the 422 message itself is gone and the fields are no
+    // longer flagged for that error.)
     await user.clear(meInput)
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/rejected by the server/i),
+    ).not.toBeInTheDocument()
   })
 })
 
@@ -652,10 +689,42 @@ describe('ScoreEntry — edit', () => {
     // "Clear game N" labels and would otherwise collide with /clear/i.
     await user.click(screen.getByRole('button', { name: /^clear$/i }))
 
+    // Clearing now asks first (#387) — nothing is deleted until confirmed.
+    await screen.findByRole('alertdialog')
+    expect(deleted).toBe(false)
+    await user.click(screen.getByRole('button', { name: /clear game/i }))
+
     await waitFor(() =>
       expect(screen.getByText('scoring-new m-1 1')).toBeInTheDocument(),
     )
     expect(deleted).toBe(true)
+  })
+
+  it('cancelling the clear confirmation keeps the saved score (#387)', async () => {
+    const user = userEvent.setup()
+    let deleted = false
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      http.delete('*/v1/matches/m-1/games/1/scores', () => {
+        deleted = true
+        return HttpResponse.json(inProgressMatch())
+      }),
+    )
+
+    renderScoreEntry({ kind: 'edit', matchId: 'm-1', gameNumber: 1 })
+
+    await screen.findByRole('textbox', { name: 'rita.kovac score' })
+    await user.click(screen.getByRole('button', { name: /^clear$/i }))
+
+    const dialog = await screen.findByRole('alertdialog')
+    await user.click(within(dialog).getByRole('button', { name: /keep score/i }))
+
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument(),
+    )
+    expect(deleted).toBe(false)
+    // Still on the edit screen, score intact — no navigation away.
+    expect(screen.queryByText('scoring-new m-1 1')).not.toBeInTheDocument()
   })
 
   it("✕ on another game's cell clears that game in place without leaving the page", async () => {
@@ -686,6 +755,14 @@ describe('ScoreEntry — edit', () => {
     await user.type(oppInput, '7')
 
     await user.click(screen.getByRole('button', { name: /clear game 1/i }))
+
+    // Confirm first (#387): the ✕ opens a dialog scoped to game 1.
+    const dialog = await screen.findByRole('alertdialog')
+    expect(within(dialog).getByRole('heading')).toHaveTextContent(
+      /clear game 1\?/i,
+    )
+    expect(deletedGameNumber).toBeNull()
+    await user.click(within(dialog).getByRole('button', { name: /clear game/i }))
 
     await waitFor(() => expect(deletedGameNumber).toBe(1))
     // No redirect — still on the active game's entry route.

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -534,6 +534,68 @@ describe('ScoreEntry — create', () => {
   })
 })
 
+describe('ScoreEntry — name layout (#566)', () => {
+  // A long username used to overflow the score card on desktop: the desktop
+  // `.se-head .nm` rule had no clipping, and its flex parents didn't allow the
+  // text column to shrink. jsdom can't measure layout, so we assert the
+  // structural contract the CSS depends on: each name renders in `.se-head .nm`
+  // inside a `.se-head .id` shrink wrapper. Both must exist or the clipping
+  // (overflow/ellipsis + min-width:0) the CSS applies has nothing to bite on.
+  it('renders each username in a shrinkable .se-head .id > .nm wrapper', async () => {
+    const longName = 'this.is.a.really.long.username.that.overflows'
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          inProgressMatch({
+            sides: [
+              {
+                side_number: 1,
+                players: [
+                  { user_id: 'u-me', username: longName, is_current_user: true },
+                ],
+                games_won: 1,
+                won: null,
+                is_current_user_side: true,
+              },
+              {
+                side_number: 2,
+                players: [
+                  {
+                    user_id: 'u-opp',
+                    username: 'nguyen.t',
+                    is_current_user: false,
+                  },
+                ],
+                games_won: 1,
+                won: null,
+                is_current_user_side: false,
+              },
+            ],
+          }),
+        ),
+      ),
+    )
+
+    const { container } = renderScoreEntry({
+      kind: 'create',
+      matchId: 'm-1',
+      gameNumber: 3,
+    })
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+
+    const nameEl = screen.getByText(longName)
+    // The name lives in `.se-head .nm` — the element the desktop overflow rule
+    // targets — nested in the `.id` shrink wrapper (`min-width: 0`).
+    expect(nameEl).toHaveClass('nm')
+    const idWrapper = nameEl.parentElement
+    expect(idWrapper).toHaveClass('id')
+    expect(idWrapper?.closest('.se-head')).not.toBeNull()
+    // Both heads carry the shrink wrapper, so neither name can push its column
+    // out of the card.
+    expect(container.querySelectorAll('.se-head .id')).toHaveLength(2)
+  })
+})
+
 describe('ScoreEntry — edit', () => {
   it('pre-populates inputs from the stored score and PUTs the new value', async () => {
     const user = userEvent.setup()

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -1520,6 +1520,113 @@ describe('ScoreEntry — failed saves', () => {
   })
 })
 
+// ---------------------------------------------------------------------------
+// Unsaved-input guard (#441): typing a score and then leaving — via an in-app
+// route change — without pressing Save must prompt before discarding it. A
+// clean page (or input that matches the saved score) must not nag, and the
+// sanctioned Save/Clear paths must navigate without tripping the guard.
+// ---------------------------------------------------------------------------
+
+describe('ScoreEntry — unsaved-input guard', () => {
+  it('prompts before an in-app navigation away from unsaved typing, and "Keep editing" stays put', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+    )
+
+    renderScoringApp('/matches/m-1/games/3/scores/new')
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+
+    // Type a score but DON'T save it.
+    await user.type(
+      screen.getByRole('textbox', { name: 'rita.kovac score' }),
+      '11',
+    )
+
+    // Try to leave by tapping an already-scored game's scoreline cell.
+    await user.click(screen.getByRole('link', { name: /game 1, saved/i }))
+
+    // The leave prompt appears instead of navigating. (The modal dialog
+    // aria-hides the page behind it, so the heading isn't queryable here —
+    // we confirm we never left after dismissing the prompt below.)
+    const dialog = await screen.findByRole('alertdialog')
+    expect(dialog).toHaveTextContent(/leave without saving/i)
+
+    // "Keep editing" cancels the navigation — still on game 3 with the input.
+    await user.click(screen.getByRole('button', { name: /keep editing/i }))
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument(),
+    )
+    expect(
+      screen.getByRole('heading', { name: /enter game 3 score/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('textbox', { name: 'rita.kovac score' }),
+    ).toHaveValue('11')
+  })
+
+  it('"Discard & leave" proceeds with the blocked navigation', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+    )
+
+    renderScoringApp('/matches/m-1/games/3/scores/new')
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+    await user.type(
+      screen.getByRole('textbox', { name: 'rita.kovac score' }),
+      '11',
+    )
+
+    await user.click(screen.getByRole('link', { name: /game 1, saved/i }))
+    await screen.findByRole('alertdialog')
+    await user.click(screen.getByRole('button', { name: /discard & leave/i }))
+
+    // Navigation goes through — game 1 opens in edit mode.
+    await screen.findByRole('heading', { name: /edit game 1 score/i })
+  })
+
+  it('does not prompt when leaving a clean page (nothing typed)', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+    )
+
+    renderScoringApp('/matches/m-1/games/3/scores/new')
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+
+    // No typing — leaving must be friction-free.
+    await user.click(screen.getByRole('link', { name: /game 1, saved/i }))
+    await screen.findByRole('heading', { name: /edit game 1 score/i })
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+
+  it('does not prompt after the fire-and-forget Save navigates to the next game', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      http.post(
+        '*/v1/matches/m-1/games/3/scores/new',
+        () => new Promise<Response>(() => {}),
+      ),
+    )
+
+    renderScoringApp('/matches/m-1/games/3/scores/new')
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+    await user.type(
+      screen.getByRole('textbox', { name: 'rita.kovac score' }),
+      '11',
+    )
+    await user.type(screen.getByRole('textbox', { name: 'nguyen.t score' }), '4')
+
+    // Saving advances to game 4 with no leave prompt — the Save hop is
+    // sanctioned, not blocked.
+    await user.click(screen.getByRole('button', { name: /save game & next/i }))
+    await screen.findByRole('heading', { name: /enter game 4 score/i })
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+})
+
 afterEach(() => {
   // Restore connectivity so the offline test doesn't leak into others.
   onlineManager.setOnline(true)

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -1381,6 +1381,113 @@ describe('ScoreEntry — failed saves', () => {
   })
 })
 
+// ---------------------------------------------------------------------------
+// Unsaved-input guard (#441): typing a score and then leaving — via an in-app
+// route change — without pressing Save must prompt before discarding it. A
+// clean page (or input that matches the saved score) must not nag, and the
+// sanctioned Save/Clear paths must navigate without tripping the guard.
+// ---------------------------------------------------------------------------
+
+describe('ScoreEntry — unsaved-input guard', () => {
+  it('prompts before an in-app navigation away from unsaved typing, and "Keep editing" stays put', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+    )
+
+    renderScoringApp('/matches/m-1/games/3/scores/new')
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+
+    // Type a score but DON'T save it.
+    await user.type(
+      screen.getByRole('textbox', { name: 'rita.kovac score' }),
+      '11',
+    )
+
+    // Try to leave by tapping an already-scored game's scoreline cell.
+    await user.click(screen.getByRole('link', { name: /game 1, saved/i }))
+
+    // The leave prompt appears instead of navigating. (The modal dialog
+    // aria-hides the page behind it, so the heading isn't queryable here —
+    // we confirm we never left after dismissing the prompt below.)
+    const dialog = await screen.findByRole('alertdialog')
+    expect(dialog).toHaveTextContent(/leave without saving/i)
+
+    // "Keep editing" cancels the navigation — still on game 3 with the input.
+    await user.click(screen.getByRole('button', { name: /keep editing/i }))
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument(),
+    )
+    expect(
+      screen.getByRole('heading', { name: /enter game 3 score/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('textbox', { name: 'rita.kovac score' }),
+    ).toHaveValue('11')
+  })
+
+  it('"Discard & leave" proceeds with the blocked navigation', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+    )
+
+    renderScoringApp('/matches/m-1/games/3/scores/new')
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+    await user.type(
+      screen.getByRole('textbox', { name: 'rita.kovac score' }),
+      '11',
+    )
+
+    await user.click(screen.getByRole('link', { name: /game 1, saved/i }))
+    await screen.findByRole('alertdialog')
+    await user.click(screen.getByRole('button', { name: /discard & leave/i }))
+
+    // Navigation goes through — game 1 opens in edit mode.
+    await screen.findByRole('heading', { name: /edit game 1 score/i })
+  })
+
+  it('does not prompt when leaving a clean page (nothing typed)', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+    )
+
+    renderScoringApp('/matches/m-1/games/3/scores/new')
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+
+    // No typing — leaving must be friction-free.
+    await user.click(screen.getByRole('link', { name: /game 1, saved/i }))
+    await screen.findByRole('heading', { name: /edit game 1 score/i })
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+
+  it('does not prompt after the fire-and-forget Save navigates to the next game', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      http.post(
+        '*/v1/matches/m-1/games/3/scores/new',
+        () => new Promise<Response>(() => {}),
+      ),
+    )
+
+    renderScoringApp('/matches/m-1/games/3/scores/new')
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+    await user.type(
+      screen.getByRole('textbox', { name: 'rita.kovac score' }),
+      '11',
+    )
+    await user.type(screen.getByRole('textbox', { name: 'nguyen.t score' }), '4')
+
+    // Saving advances to game 4 with no leave prompt — the Save hop is
+    // sanctioned, not blocked.
+    await user.click(screen.getByRole('button', { name: /save game & next/i }))
+    await screen.findByRole('heading', { name: /enter game 4 score/i })
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+})
+
 afterEach(() => {
   // Restore connectivity so the offline test doesn't leak into others.
   onlineManager.setOnline(true)

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link, Navigate, useNavigate } from '@tanstack/react-router'
+import {
+  Link,
+  Navigate,
+  useBlocker,
+  useNavigate,
+} from '@tanstack/react-router'
 import { onlineManager, useQueryClient } from '@tanstack/react-query'
 import {
   Check,
@@ -111,6 +116,23 @@ function ScoreEntryInner({
     null,
   )
 
+  // Guard against losing un-submitted typing on refresh/close or an in-app
+  // navigation (#441). `isDirty` is driven by the score change handlers as the
+  // user types (set below, once `data`-derived baselines are in scope) — the
+  // blocker only reads it. `submittingRef` is flipped just before the
+  // fire-and-forget Save (or an explicit Clear) navigates so that intentional
+  // hop is never blocked; it's a ref since it's read inside the blocker
+  // callbacks, not rendered.
+  const [isDirty, setIsDirty] = useState(false)
+  const submittingRef = useRef(false)
+  const { status, proceed, reset } = useBlocker({
+    // Blocks browser refresh/close (beforeunload) only while genuinely dirty.
+    enableBeforeUnload: () => isDirty,
+    // Blocks in-app route changes the same way — but never the Save hop.
+    shouldBlockFn: () => isDirty && !submittingRef.current,
+    withResolver: true,
+  })
+
   if (isLoading || !data) {
     return (
       <AppShell>
@@ -206,6 +228,27 @@ function ScoreEntryInner({
         ? String(persistedOpp)
         : '')
 
+  // The baseline is what the inputs read with no local typing — the failed
+  // scratch save, else the persisted score, else empty. Input is "dirty"
+  // (worth guarding on exit) only when the user has actually typed something
+  // that diverges from that baseline: a clean page, or input that merely
+  // matches what's already saved, must not nag. Updating the ref here (rather
+  // than in an effect) keeps the blocker reading the current-render truth.
+  const baselineMe =
+    failedMe != null ? String(failedMe) : persistedMe != null ? String(persistedMe) : ''
+  const baselineOpp =
+    failedOpp != null
+      ? String(failedOpp)
+      : persistedOpp != null
+        ? String(persistedOpp)
+        : ''
+  // Whether the live inputs (me/opp) diverge from the baseline — i.e. there's
+  // genuinely-unsaved typing worth guarding on exit. Recomputed by the change
+  // handlers below as the user types (a clean page, or input matching the
+  // saved score, isn't dirty).
+  const computeDirty = (nextMe: string, nextOpp: string) =>
+    nextMe !== baselineMe || nextOpp !== baselineOpp
+
   // Strip non-digits and cap at 3 digits. Two digits silently turned "100"
   // into "10", then the deuce/win-by-2 check fired against a value the user
   // never typed (#442). Three digits covers any real table-tennis score
@@ -213,11 +256,15 @@ function ScoreEntryInner({
   // illegalScoreReason always references exactly what was entered.
   const sanitize = (value: string) => value.replace(/[^0-9]/g, '').slice(0, 3)
   const onMeChange = (value: string) => {
-    setMeTyped(sanitize(value))
+    const next = sanitize(value)
+    setMeTyped(next)
+    setIsDirty(computeDirty(next, opp))
     if (finalizeMutation.error) finalizeMutation.reset()
   }
   const onOppChange = (value: string) => {
-    setOppTyped(sanitize(value))
+    const next = sanitize(value)
+    setOppTyped(next)
+    setIsDirty(computeDirty(me, next))
     if (finalizeMutation.error) finalizeMutation.reset()
   }
 
@@ -321,6 +368,10 @@ function ScoreEntryInner({
     // double-click can land a second tap before React commits it — fire one
     // POST /results, not two (the second 409s on the already-posted result).
     if (finalizeMutation.isPending) return
+    // This is the sanctioned write path: any navigation it triggers (the
+    // synchronous next-game hop, or finalize's onSuccess to the match page)
+    // is intentional, so wave the unsaved-input blocker through it (#441).
+    submittingRef.current = true
     // Finalizing posts the canonical result — but that's the one write that
     // can't be faked offline. When offline we instead fall through to the
     // scratchpad save below, which stores the deciding game's score in the
@@ -382,7 +433,10 @@ function ScoreEntryInner({
     if (target === 'active') {
       if (mode.kind !== 'edit') return
       // Clearing is an explicit discard — drop any failed-save leftovers too,
-      // so a stale failure doesn't outlive the score it referred to.
+      // so a stale failure doesn't outlive the score it referred to. The
+      // edit→new hop it triggers is intentional, so the unsaved-input blocker
+      // stays out (#441).
+      submittingRef.current = true
       forgetScoreSaves(queryClient, matchId, gameNumber)
       deleteMutation.mutate(undefined, {
         // After clearing, land back on this game's create route so the user
@@ -603,7 +657,53 @@ function ScoreEntryInner({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <UnsavedScorePrompt
+        open={status === 'blocked'}
+        onLeave={proceed}
+        onStay={reset}
+      />
     </AppShell>
+  )
+}
+
+// The in-app leave confirmation for unsaved score input. A design-system
+// AlertDialog (not a bare confirm()), driven by the router blocker's resolver:
+// "Leave" proceeds with the blocked navigation, "Stay" cancels it. Browser
+// refresh/close is handled separately by the blocker's enableBeforeUnload.
+function UnsavedScorePrompt({
+  open,
+  onLeave,
+  onStay,
+}: {
+  open: boolean
+  onLeave?: () => void
+  onStay?: () => void
+}) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        // Dismissing via overlay/Esc is a "stay" — don't drop the score.
+        if (!next) onStay?.()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Leave without saving?</AlertDialogTitle>
+          <AlertDialogDescription>
+            You've entered a score for this game but haven't saved it yet.
+            Leaving now discards it.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onStay}>Keep editing</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={onLeave}>
+            Discard &amp; leave
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }
 

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -25,6 +25,16 @@ import {
   type MatchResultsGameWrite,
 } from '@/api/matches'
 import { AppShell } from '@/components/app-shell'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { cn, initialsOf } from '@/lib/utils'
 import { decidedSide, illegalScoreReason } from '@/lib/scoring'
 import { useGameSaveState } from './score-saves'
@@ -89,6 +99,17 @@ function ScoreEntryInner({
   const [oppTyped, setOppTyped] = useState<string | null>(null)
   const meRef = useRef<HTMLInputElement>(null)
   const oppRef = useRef<HTMLInputElement>(null)
+  // Set when a per-cell clear is confirmed: the dialog otherwise restores focus
+  // to its trigger (the now-removed ✕), so we re-grab focus for the first empty
+  // input in the dialog's close-focus hook instead.
+  const refocusAfterCloseRef = useRef(false)
+  // The game whose saved score is pending a clear-confirmation, or `'active'`
+  // for the in-page Clear button (which clears the game being edited above).
+  // `null` means no confirmation is open. Clearing discards a recorded game, so
+  // it asks first rather than firing instantly (#387).
+  const [pendingClear, setPendingClear] = useState<number | 'active' | null>(
+    null,
+  )
 
   if (isLoading || !data) {
     return (
@@ -201,6 +222,11 @@ function ScoreEntryInner({
   }
 
   const bothFilled = me !== '' && opp !== ''
+  // Exactly one side filled: the Save button is disabled, so without a word
+  // it's a dead end with no explanation (#387). Tell the user both scores are
+  // required and flag the still-empty field. Only after the user has started
+  // typing — a wholly-empty pair is the untouched initial state, not an error.
+  const oneSideFilled = (me !== '') !== (opp !== '')
   const localScoreError = bothFilled
     ? illegalScoreReason(Number(me), Number(opp))
     : null
@@ -250,6 +276,13 @@ function ScoreEntryInner({
     localScoreError !== null || finalizeApiError?.status === 422
   // The message line, though, surfaces every finalize error (409/500 included).
   const showScoreError = inputsInvalid || finalizeApiError !== null
+  // The "both scores required" hint is its own, lower-severity line — shown only
+  // when exactly one field is filled and there's no harder error to surface.
+  const showBothRequired = oneSideFilled && !showScoreError
+  // Per-side red flags: a genuine validation error paints both inputs; the
+  // both-required hint only flags the empty one.
+  const meInvalid = inputsInvalid || (showBothRequired && me === '')
+  const oppInvalid = inputsInvalid || (showBothRequired && opp === '')
 
   function predictNextScoringRoute() {
     if (!data) return matchDetailRoute(matchId)
@@ -338,27 +371,43 @@ function ScoreEntryInner({
     }
   }
 
-  function onClear() {
-    if (mode.kind !== 'edit') return
-    // Clearing is an explicit discard — drop any failed-save leftovers too, so
-    // a stale failure doesn't outlive the score it referred to.
-    forgetScoreSaves(queryClient, matchId, gameNumber)
-    deleteMutation.mutate(undefined, {
-      // After clearing, land back on this game's create route so the user
-      // can re-enter — same page, just with empty inputs and create-mode
-      // semantics. The remount's autoFocus puts focus on the me-input,
-      // which is the first empty input.
-      onSettled: () => navigate(scoringNewRoute(matchId, gameNumber)),
-    })
+  // Clearing discards a recorded game's score — an irreversible write. Both
+  // clear affordances (the in-page Clear button and the per-cell ✕) route
+  // through a confirmation dialog (#387); only on confirm do we actually fire
+  // the delete. `pendingClear` carries which game is being discarded.
+  function performClear() {
+    const target = pendingClear
+    setPendingClear(null)
+    if (target === null) return
+    if (target === 'active') {
+      if (mode.kind !== 'edit') return
+      // Clearing is an explicit discard — drop any failed-save leftovers too,
+      // so a stale failure doesn't outlive the score it referred to.
+      forgetScoreSaves(queryClient, matchId, gameNumber)
+      deleteMutation.mutate(undefined, {
+        // After clearing, land back on this game's create route so the user
+        // can re-enter — same page, just with empty inputs and create-mode
+        // semantics. The remount's autoFocus puts focus on the me-input,
+        // which is the first empty input.
+        onSettled: () => navigate(scoringNewRoute(matchId, gameNumber)),
+      })
+      return
+    }
+    // Per-cell ✕ — clears the score for any logged game from the scoreline
+    // strip. We refocus the first empty input on the current page so the user
+    // can keep typing (deferred to the dialog's close-focus hook).
+    forgetScoreSaves(queryClient, matchId, target)
+    cellDeleteMutation.mutate(target)
+    refocusAfterCloseRef.current = true
   }
 
-  // Per-cell ✕ — clears the score for any logged game from the scoreline
-  // strip. Fire-and-forget like the per-game writes; we just refocus the
-  // first empty input on the current page so the user can keep typing.
+  function onClear() {
+    if (mode.kind !== 'edit') return
+    setPendingClear('active')
+  }
+
   function onClearCell(n: number) {
-    forgetScoreSaves(queryClient, matchId, n)
-    cellDeleteMutation.mutate(n)
-    focusFirstEmpty()
+    setPendingClear(n)
   }
 
   function handleKey(
@@ -438,7 +487,7 @@ function ScoreEntryInner({
             inputRef={meRef}
             autoFocus
             disabled={inputsLocked}
-            invalid={inputsInvalid}
+            invalid={meInvalid}
             onChange={onMeChange}
             onKeyDown={(e) => handleKey(e, 'me')}
           />
@@ -458,7 +507,7 @@ function ScoreEntryInner({
             value={opp}
             inputRef={oppRef}
             disabled={inputsLocked}
-            invalid={inputsInvalid}
+            invalid={oppInvalid}
             onChange={onOppChange}
             onKeyDown={(e) => handleKey(e, 'opp')}
           />
@@ -469,6 +518,11 @@ function ScoreEntryInner({
             {localScoreError ??
               finalizeApiError?.detail ??
               finalizeApiError?.message}
+          </p>
+        )}
+        {showBothRequired && (
+          <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
+            Enter both scores to save this game.
           </p>
         )}
 
@@ -511,6 +565,44 @@ function ScoreEntryInner({
           clearDisabled={inputsLocked || cellDeleteMutation.isPending}
         />
       </div>
+
+      <AlertDialog
+        open={pendingClear !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingClear(null)
+        }}
+      >
+        <AlertDialogContent
+          onCloseAutoFocus={(e) => {
+            // A confirmed per-cell clear removed its own ✕ trigger; rather than
+            // letting Radix restore focus to a detached node, put focus on the
+            // first empty input so the user can keep typing.
+            if (refocusAfterCloseRef.current) {
+              refocusAfterCloseRef.current = false
+              e.preventDefault()
+              focusFirstEmpty()
+            }
+          }}
+        >
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingClear === 'active' || pendingClear === null
+                ? `Clear game ${gameNumber}?`
+                : `Clear game ${pendingClear}?`}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This deletes the saved score for this game. You can re-enter it
+              afterwards.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep score</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={performClear}>
+              Clear game
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </AppShell>
   )
 }

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -549,7 +549,7 @@ function ScoreSide({
     </div>
   )
   const identity = (
-    <div>
+    <div className="id">
       <div className="nm">{name}</div>
       <div className="rt">
         Games won · <b>{wins}</b>

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link, Navigate, useNavigate } from '@tanstack/react-router'
+import {
+  Link,
+  Navigate,
+  useBlocker,
+  useNavigate,
+} from '@tanstack/react-router'
 import { onlineManager, useQueryClient } from '@tanstack/react-query'
 import {
   Check,
@@ -25,6 +30,16 @@ import {
   type MatchResultsGameWrite,
 } from '@/api/matches'
 import { AppShell } from '@/components/app-shell'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { cn, initialsOf } from '@/lib/utils'
 import { decidedSide, illegalScoreReason } from '@/lib/scoring'
 import { useGameSaveState } from './score-saves'
@@ -89,6 +104,23 @@ function ScoreEntryInner({
   const [oppTyped, setOppTyped] = useState<string | null>(null)
   const meRef = useRef<HTMLInputElement>(null)
   const oppRef = useRef<HTMLInputElement>(null)
+
+  // Guard against losing un-submitted typing on refresh/close or an in-app
+  // navigation (#441). `isDirty` is driven by the score change handlers as the
+  // user types (set below, once `data`-derived baselines are in scope) — the
+  // blocker only reads it. `submittingRef` is flipped just before the
+  // fire-and-forget Save (or an explicit Clear) navigates so that intentional
+  // hop is never blocked; it's a ref since it's read inside the blocker
+  // callbacks, not rendered.
+  const [isDirty, setIsDirty] = useState(false)
+  const submittingRef = useRef(false)
+  const { status, proceed, reset } = useBlocker({
+    // Blocks browser refresh/close (beforeunload) only while genuinely dirty.
+    enableBeforeUnload: () => isDirty,
+    // Blocks in-app route changes the same way — but never the Save hop.
+    shouldBlockFn: () => isDirty && !submittingRef.current,
+    withResolver: true,
+  })
 
   if (isLoading || !data) {
     return (
@@ -185,6 +217,27 @@ function ScoreEntryInner({
         ? String(persistedOpp)
         : '')
 
+  // The baseline is what the inputs read with no local typing — the failed
+  // scratch save, else the persisted score, else empty. Input is "dirty"
+  // (worth guarding on exit) only when the user has actually typed something
+  // that diverges from that baseline: a clean page, or input that merely
+  // matches what's already saved, must not nag. Updating the ref here (rather
+  // than in an effect) keeps the blocker reading the current-render truth.
+  const baselineMe =
+    failedMe != null ? String(failedMe) : persistedMe != null ? String(persistedMe) : ''
+  const baselineOpp =
+    failedOpp != null
+      ? String(failedOpp)
+      : persistedOpp != null
+        ? String(persistedOpp)
+        : ''
+  // Whether the live inputs (me/opp) diverge from the baseline — i.e. there's
+  // genuinely-unsaved typing worth guarding on exit. Recomputed by the change
+  // handlers below as the user types (a clean page, or input matching the
+  // saved score, isn't dirty).
+  const computeDirty = (nextMe: string, nextOpp: string) =>
+    nextMe !== baselineMe || nextOpp !== baselineOpp
+
   // Strip non-digits and cap at 3 digits. Two digits silently turned "100"
   // into "10", then the deuce/win-by-2 check fired against a value the user
   // never typed (#442). Three digits covers any real table-tennis score
@@ -192,11 +245,15 @@ function ScoreEntryInner({
   // illegalScoreReason always references exactly what was entered.
   const sanitize = (value: string) => value.replace(/[^0-9]/g, '').slice(0, 3)
   const onMeChange = (value: string) => {
-    setMeTyped(sanitize(value))
+    const next = sanitize(value)
+    setMeTyped(next)
+    setIsDirty(computeDirty(next, opp))
     if (finalizeMutation.error) finalizeMutation.reset()
   }
   const onOppChange = (value: string) => {
-    setOppTyped(sanitize(value))
+    const next = sanitize(value)
+    setOppTyped(next)
+    setIsDirty(computeDirty(me, next))
     if (finalizeMutation.error) finalizeMutation.reset()
   }
 
@@ -288,6 +345,10 @@ function ScoreEntryInner({
     // double-click can land a second tap before React commits it — fire one
     // POST /results, not two (the second 409s on the already-posted result).
     if (finalizeMutation.isPending) return
+    // This is the sanctioned write path: any navigation it triggers (the
+    // synchronous next-game hop, or finalize's onSuccess to the match page)
+    // is intentional, so wave the unsaved-input blocker through it (#441).
+    submittingRef.current = true
     // Finalizing posts the canonical result — but that's the one write that
     // can't be faked offline. When offline we instead fall through to the
     // scratchpad save below, which stores the deciding game's score in the
@@ -341,7 +402,9 @@ function ScoreEntryInner({
   function onClear() {
     if (mode.kind !== 'edit') return
     // Clearing is an explicit discard — drop any failed-save leftovers too, so
-    // a stale failure doesn't outlive the score it referred to.
+    // a stale failure doesn't outlive the score it referred to. The edit→new
+    // hop it triggers is intentional, so the unsaved-input blocker stays out.
+    submittingRef.current = true
     forgetScoreSaves(queryClient, matchId, gameNumber)
     deleteMutation.mutate(undefined, {
       // After clearing, land back on this game's create route so the user
@@ -511,7 +574,53 @@ function ScoreEntryInner({
           clearDisabled={inputsLocked || cellDeleteMutation.isPending}
         />
       </div>
+
+      <UnsavedScorePrompt
+        open={status === 'blocked'}
+        onLeave={proceed}
+        onStay={reset}
+      />
     </AppShell>
+  )
+}
+
+// The in-app leave confirmation for unsaved score input. A design-system
+// AlertDialog (not a bare confirm()), driven by the router blocker's resolver:
+// "Leave" proceeds with the blocked navigation, "Stay" cancels it. Browser
+// refresh/close is handled separately by the blocker's enableBeforeUnload.
+function UnsavedScorePrompt({
+  open,
+  onLeave,
+  onStay,
+}: {
+  open: boolean
+  onLeave?: () => void
+  onStay?: () => void
+}) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        // Dismissing via overlay/Esc is a "stay" — don't drop the score.
+        if (!next) onStay?.()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Leave without saving?</AlertDialogTitle>
+          <AlertDialogDescription>
+            You've entered a score for this game but haven't saved it yet.
+            Leaving now discards it.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onStay}>Keep editing</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={onLeave}>
+            Discard &amp; leave
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }
 

--- a/web-client/src/components/matches/score-saves.ts
+++ b/web-client/src/components/matches/score-saves.ts
@@ -69,6 +69,11 @@ export function useGameSaveState(
 export interface FailedGameSave {
   gameNumber: number
   variables: MatchGameScoreWrite
+  /** When this failed save was fired. A re-failure of the same game produces a
+   * fresh timestamp, letting callers tell "the same game failed again" apart
+   * from "nothing changed" — the failed-save banner folds this into its dismiss
+   * key so a dismissed banner re-surfaces when a retry fails anew (#528). */
+  submittedAt: number
 }
 
 /**
@@ -98,5 +103,6 @@ export function useFailedGameSaves(matchId: string): FailedGameSave[] {
     .map((state) => ({
       gameNumber: state.gameNumber as number,
       variables: state.variables as MatchGameScoreWrite,
+      submittedAt: state.submittedAt,
     }))
 }

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2200,8 +2200,14 @@ body.dark.fortymm-theme {
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  /* Keep the "Games won · N" tally on mobile (#387): hiding it left the cramped
+     mobile header with no running score, and the big inputs already read as
+     blank panels — this is the only games-won readout near them. */
   .fortymm-theme .se-head .rt {
-    display: none;
+    display: block;
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    margin-top: 2px;
   }
   .fortymm-theme .se-mid {
     padding: 14px 6px;
@@ -2213,9 +2219,22 @@ body.dark.fortymm-theme {
   .fortymm-theme .se-games {
     font-size: 14px;
   }
+  /* On mobile the inputs sit edge-to-edge with no chrome, so an empty field
+     reads as a dark panel with only a faint "0" placeholder (#387). Give it a
+     visible field affordance — a subtle filled box with a border — so it's
+     legible as a tap target. */
   .fortymm-theme .big-input {
     font-size: 72px;
     padding: 6px 0 0;
+    background: var(--ink-900);
+    border: 1px solid var(--ink-600);
+    border-radius: 12px;
+  }
+  .fortymm-theme .big-input:focus {
+    border-color: var(--ball-500);
+  }
+  .fortymm-theme .big-input[aria-invalid='true'] {
+    border-color: var(--loss);
   }
 
   /* Single row of buttons, equal-width, full-bleed across the card. */

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2193,8 +2193,14 @@ body.dark.fortymm-theme {
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  /* Keep the "Games won · N" tally on mobile (#387): hiding it left the cramped
+     mobile header with no running score, and the big inputs already read as
+     blank panels — this is the only games-won readout near them. */
   .fortymm-theme .se-head .rt {
-    display: none;
+    display: block;
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    margin-top: 2px;
   }
   .fortymm-theme .se-mid {
     padding: 14px 6px;
@@ -2206,9 +2212,22 @@ body.dark.fortymm-theme {
   .fortymm-theme .se-games {
     font-size: 14px;
   }
+  /* On mobile the inputs sit edge-to-edge with no chrome, so an empty field
+     reads as a dark panel with only a faint "0" placeholder (#387). Give it a
+     visible field affordance — a subtle filled box with a border — so it's
+     legible as a tap target. */
   .fortymm-theme .big-input {
     font-size: 72px;
     padding: 6px 0 0;
+    background: var(--ink-900);
+    border: 1px solid var(--ink-600);
+    border-radius: 12px;
+  }
+  .fortymm-theme .big-input:focus {
+    border-color: var(--ball-500);
+  }
+  .fortymm-theme .big-input[aria-invalid='true'] {
+    border-color: var(--loss);
   }
 
   /* Single row of buttons, equal-width, full-bleed across the card. */

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1665,6 +1665,10 @@ body.dark.fortymm-theme {
   display: flex;
   align-items: center;
   gap: 14px;
+  min-width: 0;
+}
+.fortymm-theme .se-head .id {
+  min-width: 0;
 }
 .fortymm-theme .se-head.right {
   justify-content: flex-end;
@@ -1694,6 +1698,9 @@ body.dark.fortymm-theme {
 .fortymm-theme .se-head .nm {
   font: 600 20px var(--font-ui);
   color: var(--fg-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .fortymm-theme .se-head .rt {
   font: 500 11px var(--font-mono);

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -3001,15 +3001,25 @@ body.dark.fortymm-theme {
   margin-top: 32px;
   padding-top: 24px;
   border-top: 1px solid var(--border-subtle);
+  /* Scroll boundary for the grid: lives inside the .md-hero section (which is
+     overflow: hidden for its decorative grid-bg), so when the per-game columns
+     can't shrink to fit on narrow viewports (BO5/BO7) the trailing SETS column
+     stays reachable by horizontal scroll instead of being clipped off-screen.
+     See #509. */
+  overflow-x: auto;
+  scrollbar-width: thin;
 }
 .fortymm-theme .md-games__grid {
   display: grid;
   grid-template-columns:
     var(--md-games-kicker, 130px)
-    repeat(var(--md-games-count, 5), 1fr)
+    repeat(var(--md-games-count, 5), minmax(40px, 1fr))
     var(--md-games-total, 90px);
   gap: 8px;
   align-items: center;
+  /* Keep columns at their intrinsic width and let .md-games scroll, rather than
+     letting the grid overflow (and get clipped by) its ancestor. */
+  min-width: max-content;
 }
 .fortymm-theme .md-games__kicker {
   font: 600 11px var(--font-mono);

--- a/web-client/src/landing.css
+++ b/web-client/src/landing.css
@@ -114,6 +114,12 @@
 }
 .fortymm-landing .btn-secondary .btn-dot { background: var(--ball-500); }
 
+.fortymm-landing .btn-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 /* ---------- Shared ---------- */
 .fortymm-landing .eyebrow {
   display: inline-flex;
@@ -1364,12 +1370,19 @@
   text-transform: uppercase;
 }
 .fortymm-landing .ft-col-i {
+  display: block;
   font: 500 14px var(--font-ui);
   color: var(--fg-2);
   cursor: pointer;
   transition: color var(--dur-fast) var(--ease-out);
+  text-decoration: none;
 }
-.fortymm-landing .ft-col-i:hover { color: var(--ball-500); }
+.fortymm-landing a.ft-col-i:hover { color: var(--ball-500); }
+.fortymm-landing .ft-col-i-disabled {
+  color: var(--fg-3);
+  cursor: default;
+}
+.fortymm-landing .ft-col-i-disabled:hover { color: var(--fg-3); }
 .fortymm-landing .footer-bar {
   max-width: 1200px;
   margin: 56px auto 0;

--- a/web-client/src/landing.css
+++ b/web-client/src/landing.css
@@ -114,6 +114,12 @@
 }
 .fortymm-landing .btn-secondary .btn-dot { background: var(--ball-500); }
 
+.fortymm-landing .btn-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 /* ---------- Shared ---------- */
 .fortymm-landing .eyebrow {
   display: inline-flex;
@@ -1328,12 +1334,19 @@
   text-transform: uppercase;
 }
 .fortymm-landing .ft-col-i {
+  display: block;
   font: 500 14px var(--font-ui);
   color: var(--fg-2);
   cursor: pointer;
   transition: color var(--dur-fast) var(--ease-out);
+  text-decoration: none;
 }
-.fortymm-landing .ft-col-i:hover { color: var(--ball-500); }
+.fortymm-landing a.ft-col-i:hover { color: var(--ball-500); }
+.fortymm-landing .ft-col-i-disabled {
+  color: var(--fg-3);
+  cursor: default;
+}
+.fortymm-landing .ft-col-i-disabled:hover { color: var(--fg-3); }
 .fortymm-landing .footer-bar {
   max-width: 1200px;
   margin: 56px auto 0;

--- a/web-client/src/landing.css
+++ b/web-client/src/landing.css
@@ -178,6 +178,42 @@
 }
 .fortymm-landing .nav-link:hover { color: var(--fg-1); }
 
+/* Mobile nav toggle (hamburger) — hidden until the narrow breakpoint. */
+.fortymm-landing .nav-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 40px;
+  height: 40px;
+  padding: 0 9px;
+  background: transparent;
+  border: 1px solid var(--ink-600);
+  border-radius: 8px;
+  cursor: pointer;
+}
+.fortymm-landing .nav-toggle-bar {
+  display: block;
+  height: 2px;
+  width: 100%;
+  background: var(--fg-1);
+  border-radius: 2px;
+  transition: transform var(--dur-fast) var(--ease-out),
+    opacity var(--dur-fast) var(--ease-out);
+}
+.fortymm-landing .nav.is-open .nav-toggle-bar:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+.fortymm-landing .nav.is-open .nav-toggle-bar:nth-child(2) {
+  opacity: 0;
+}
+.fortymm-landing .nav.is-open .nav-toggle-bar:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+.fortymm-landing .nav-mobile-menu {
+  display: none;
+}
+
 /* ---------- Hero ---------- */
 .fortymm-landing .hero {
   position: relative;
@@ -1351,7 +1387,16 @@
   .fortymm-landing .hero-inner,
   .fortymm-landing .tb-inner,
   .fortymm-landing .feat-panel {
-    grid-template-columns: 1fr;
+    /* minmax(0, 1fr) — not bare 1fr — so the single column can shrink below
+       the min-content width of its children (e.g. the scheduler mockup),
+       otherwise the column blows past the viewport (#375). */
+    grid-template-columns: minmax(0, 1fr);
+  }
+  /* Grid items default to min-width:auto, which floors them at min-content
+     and reintroduces the overflow; let them shrink instead. */
+  .fortymm-landing .tb-inner > *,
+  .fortymm-landing .feat-panel > * {
+    min-width: 0;
   }
   .fortymm-landing .footer-inner {
     grid-template-columns: 1fr 1fr;
@@ -1379,7 +1424,42 @@
   }
 }
 @media (max-width: 680px) {
-  .fortymm-landing .nav-links { display: none; }
+  /* Collapse the desktop links + inline CTAs into the hamburger menu. */
+  .fortymm-landing .nav-links,
+  .fortymm-landing .nav-signin,
+  .fortymm-landing .nav-cta {
+    display: none;
+  }
+  .fortymm-landing .nav {
+    gap: 12px;
+    padding: 12px 22px;
+  }
+  .fortymm-landing .nav-toggle {
+    display: flex;
+  }
+  /* Off-canvas menu drops below the sticky bar, full-width, vertical. */
+  .fortymm-landing .nav-mobile-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 12px 22px 20px;
+    background: rgba(11, 13, 18, 0.97);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--ink-600);
+  }
+  .fortymm-landing .nav-mobile-menu .nav-link {
+    padding: 10px 0;
+    font-size: 16px;
+  }
+  .fortymm-landing .nav-mobile-cta {
+    margin-top: 8px;
+    justify-content: center;
+  }
   .fortymm-landing .hero-h1 { font-size: 64px; }
   .fortymm-landing .section-h2 { font-size: 42px; }
   .fortymm-landing .cta-h2 { font-size: 48px; }
@@ -1401,5 +1481,35 @@
   .fortymm-landing .feat-panel,
   .fortymm-landing .founder {
     padding: 28px;
+  }
+  /* Kill the horizontal overflow from the scheduler mockup + copy. The
+     solver's fixed-width inner grids (sv-line 18/80/1fr, sv-grid-row
+     40px+repeat(8,1fr)) can't fit ~331px of usable width, so shrink the
+     fixed columns and cap the copy block to the viewport. */
+  .fortymm-landing .tb-copy {
+    max-width: 100%;
+  }
+  /* The two CTAs sit side by side and overflow ~331px; let them wrap. */
+  .fortymm-landing .tb-ctas {
+    flex-wrap: wrap;
+  }
+  .fortymm-landing .sv-body {
+    padding: 16px 12px;
+  }
+  .fortymm-landing .sv-line {
+    grid-template-columns: 14px 56px minmax(0, 1fr);
+    gap: 8px;
+  }
+  /* The constraint text is the long token; let it wrap rather than push the
+     card wider than the viewport. */
+  .fortymm-landing .sv-txt {
+    overflow-wrap: anywhere;
+  }
+  .fortymm-landing .sv-grid-row {
+    grid-template-columns: 28px repeat(8, minmax(0, 1fr));
+    gap: 3px;
+  }
+  .fortymm-landing .sv-cell {
+    height: 16px;
   }
 }

--- a/web-client/src/lib/form-helpers.ts
+++ b/web-client/src/lib/form-helpers.ts
@@ -13,6 +13,12 @@ export const HONEYPOT_STYLE: CSSProperties = {
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/
 
+// RFC 5321 caps a forward-path address at 254 characters. The API enforces
+// this and 422s with a raw pydantic message ("...The email address is too
+// long (N characters too many)"); mirror the cap here so the badge flips to
+// FAILED before submit instead of leaking that server string.
+export const MAX_EMAIL_LENGTH = 254
+
 export interface Validation {
   ok: boolean
   err?: string
@@ -20,11 +26,11 @@ export interface Validation {
 
 export function validateEmail(e: string): Validation {
   if (!e) return { ok: false, err: 'Email is required to claim your account.' }
-  if (!EMAIL_RE.test(e))
+  if (!isValidEmail(e))
     return { ok: false, err: "That doesn't look like a valid email." }
   return { ok: true }
 }
 
 export function isValidEmail(e: string): boolean {
-  return EMAIL_RE.test(e)
+  return e.length <= MAX_EMAIL_LENGTH && EMAIL_RE.test(e)
 }

--- a/web-client/src/lib/match-id.ts
+++ b/web-client/src/lib/match-id.ts
@@ -1,0 +1,16 @@
+// Match ids are UUIDs. A malformed id (e.g. /matches/not-a-uuid) would 422 on
+// every self-fetching section and surface an `ApiError` in the console even
+// though the UI handles it (#494). Guarding the param shape client-side means
+// we never make the request: no 422, no console error — just the friendly
+// not-found state the boundary already renders for a 404/422.
+//
+// Shared by every route keyed on a match id (match details + the scoring
+// screens) so they all reject a malformed id the same way (#385) rather than
+// each duplicating the regex.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Whether `matchId` is shaped like the UUID the API expects. */
+export function isMatchId(matchId: string): boolean {
+  return UUID_RE.test(matchId)
+}

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -7,6 +7,8 @@ import {
   finalizeSeed,
   findMatch,
   MOCK_CURRENT_USER,
+  awaitingCountOf,
+  isAwaitingConfirmation,
   mockMatches,
   newMatchSeed,
   projectDashboardAttention,
@@ -55,6 +57,20 @@ function matchHasPlayerLike(m: SeedMatch, q: string): boolean {
     mockSession.data.user.username.toLowerCase().includes(q) ||
     (m.opponent?.username ?? '').toLowerCase().includes(q)
   )
+}
+
+/** Whether a seed falls in the requested `MatchListFilter` bucket. `in_progress`
+ * (Live) excludes posted-but-unconfirmed results; `awaiting_confirmation` is
+ * exactly those — mirrors the server split so a posted result never leaks into
+ * Live (issue #381). Shared by the list and CSV handlers. */
+function matchesListFilter(m: SeedMatch, statusFilter: string): boolean {
+  if (statusFilter === 'awaiting_confirmation') {
+    return isAwaitingConfirmation(m)
+  }
+  if (statusFilter === 'in_progress') {
+    return m.status === 'in_progress' && !isAwaitingConfirmation(m)
+  }
+  return m.status === statusFilter
 }
 
 // ----- /v1/players helpers --------------------------------------------------
@@ -555,7 +571,7 @@ export const handlers = [
       scoped = scoped.filter((m) => matchHasPlayerLike(m, q))
     }
     const filtered = statusFilter
-      ? scoped.filter((m) => m.status === statusFilter)
+      ? scoped.filter((m) => matchesListFilter(m, statusFilter))
       : scoped
 
     const esc = (v: string) =>
@@ -615,11 +631,12 @@ export const handlers = [
     // The Attention badge reads this regardless of the active tab.
     const attentionSeeds = rankAttentionSeeds(scoped)
     // Attention is its own dimension: rank the open matches by urgency and
-    // ignore the status filter. Otherwise apply the status filter as before.
+    // ignore the status filter. Otherwise apply the status filter — which splits
+    // Live from awaiting-confirmation, mirroring the server (issue #381).
     const filtered = attention
       ? attentionSeeds
       : statusFilter
-        ? scoped.filter((m) => m.status === statusFilter)
+        ? scoped.filter((m) => matchesListFilter(m, statusFilter))
         : scoped
 
     const start = (page - 1) * pageSize
@@ -631,6 +648,7 @@ export const handlers = [
       total: filtered.length,
       status_counts: statusCountsOf(scoped),
       attention_count: attentionSeeds.length,
+      awaiting_confirmation_count: awaitingCountOf(scoped),
     })
   }),
 

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -7,6 +7,8 @@ import {
   finalizeSeed,
   findMatch,
   MOCK_CURRENT_USER,
+  awaitingCountOf,
+  isAwaitingConfirmation,
   mockMatches,
   newMatchSeed,
   projectDashboardAttention,
@@ -54,6 +56,20 @@ function matchHasPlayerLike(m: SeedMatch, q: string): boolean {
     mockSession.data.user.username.toLowerCase().includes(q) ||
     (m.opponent?.username ?? '').toLowerCase().includes(q)
   )
+}
+
+/** Whether a seed falls in the requested `MatchListFilter` bucket. `in_progress`
+ * (Live) excludes posted-but-unconfirmed results; `awaiting_confirmation` is
+ * exactly those — mirrors the server split so a posted result never leaks into
+ * Live (issue #381). Shared by the list and CSV handlers. */
+function matchesListFilter(m: SeedMatch, statusFilter: string): boolean {
+  if (statusFilter === 'awaiting_confirmation') {
+    return isAwaitingConfirmation(m)
+  }
+  if (statusFilter === 'in_progress') {
+    return m.status === 'in_progress' && !isAwaitingConfirmation(m)
+  }
+  return m.status === statusFilter
 }
 
 // ----- /v1/players helpers --------------------------------------------------
@@ -554,7 +570,7 @@ export const handlers = [
       scoped = scoped.filter((m) => matchHasPlayerLike(m, q))
     }
     const filtered = statusFilter
-      ? scoped.filter((m) => m.status === statusFilter)
+      ? scoped.filter((m) => matchesListFilter(m, statusFilter))
       : scoped
 
     const esc = (v: string) =>
@@ -611,7 +627,7 @@ export const handlers = [
       scoped = scoped.filter((m) => matchHasPlayerLike(m, q))
     }
     const filtered = statusFilter
-      ? scoped.filter((m) => m.status === statusFilter)
+      ? scoped.filter((m) => matchesListFilter(m, statusFilter))
       : scoped
 
     const start = (page - 1) * pageSize
@@ -622,6 +638,7 @@ export const handlers = [
       page_size: pageSize,
       total: filtered.length,
       status_counts: statusCountsOf(scoped),
+      awaiting_confirmation_count: awaitingCountOf(scoped),
     })
   }),
 

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -628,13 +628,30 @@ export function projectStreak(seeds: SeedMatch[]): DashboardStreak | null {
   return kind === null ? null : { kind, n }
 }
 
+/** A posted-but-unconfirmed result: an in_progress seed with ≥1 signature.
+ * Mirrors the server's "Awaiting confirmation" bucket (issue #381). */
+export function isAwaitingConfirmation(seed: SeedMatch): boolean {
+  return seed.status === 'in_progress' && seed.signatures.length > 0
+}
+
+/** Count of awaiting-confirmation seeds — its own bucket, peeled out of the
+ * in_progress status count so Live reads as true-live. */
+export function awaitingCountOf(seeds: SeedMatch[]): number {
+  return seeds.filter(isAwaitingConfirmation).length
+}
+
 /** Single source of truth for the per-status histogram returned alongside
- * the paginated list — the FE renders pill counts from this. */
+ * the paginated list — the FE renders pill counts from this. The in_progress
+ * count is true-live only: awaiting-confirmation seeds are split out into
+ * `awaitingCountOf` (issue #381). */
 export function statusCountsOf(seeds: SeedMatch[]): Record<string, number> {
   const counts: Record<string, number> = Object.fromEntries(
     ALL_STATUSES.map((s) => [s, 0]),
   )
-  for (const s of seeds) counts[s.status] = (counts[s.status] ?? 0) + 1
+  for (const s of seeds) {
+    if (isAwaitingConfirmation(s)) continue
+    counts[s.status] = (counts[s.status] ?? 0) + 1
+  }
   return counts
 }
 

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -685,13 +685,30 @@ export function projectStreak(seeds: SeedMatch[]): DashboardStreak | null {
   return kind === null ? null : { kind, n }
 }
 
+/** A posted-but-unconfirmed result: an in_progress seed with ≥1 signature.
+ * Mirrors the server's "Awaiting confirmation" bucket (issue #381). */
+export function isAwaitingConfirmation(seed: SeedMatch): boolean {
+  return seed.status === 'in_progress' && seed.signatures.length > 0
+}
+
+/** Count of awaiting-confirmation seeds — its own bucket, peeled out of the
+ * in_progress status count so Live reads as true-live. */
+export function awaitingCountOf(seeds: SeedMatch[]): number {
+  return seeds.filter(isAwaitingConfirmation).length
+}
+
 /** Single source of truth for the per-status histogram returned alongside
- * the paginated list — the FE renders pill counts from this. */
+ * the paginated list — the FE renders pill counts from this. The in_progress
+ * count is true-live only: awaiting-confirmation seeds are split out into
+ * `awaitingCountOf` (issue #381). */
 export function statusCountsOf(seeds: SeedMatch[]): Record<string, number> {
   const counts: Record<string, number> = Object.fromEntries(
     ALL_STATUSES.map((s) => [s, 0]),
   )
-  for (const s of seeds) counts[s.status] = (counts[s.status] ?? 0) + 1
+  for (const s of seeds) {
+    if (isAwaitingConfirmation(s)) continue
+    counts[s.status] = (counts[s.status] ?? 0) + 1
+  }
   return counts
 }
 

--- a/web-client/src/routes/confirm-email.test.tsx
+++ b/web-client/src/routes/confirm-email.test.tsx
@@ -73,6 +73,26 @@ describe('/confirm-email token scrubbing (#521)', () => {
     })
   })
 
+  it('treats a duplicated ?token=a&token=b as a single (invalid) token, not a missing one', async () => {
+    // A repeated query param parses into an array. We take the first value, so
+    // the page confirms with it and surfaces the generic invalid-link error
+    // rather than the misleading "This link is missing its token." copy (#439).
+    server.use(
+      http.post('*/v1/me/email/confirm', () =>
+        HttpResponse.json(
+          { detail: 'That confirmation link is invalid or expired.' },
+          { status: 400 },
+        ),
+      ),
+    )
+    renderAt('/confirm-email?token=first&token=second')
+
+    await screen.findByText(/invalid or expired/i)
+    expect(
+      screen.queryByText(/this link is missing its token/i),
+    ).not.toBeInTheDocument()
+  })
+
   it('scrubs the token from the URL after a failed confirm', async () => {
     server.use(
       http.post('*/v1/me/email/confirm', () =>

--- a/web-client/src/routes/confirm-email.tsx
+++ b/web-client/src/routes/confirm-email.tsx
@@ -16,9 +16,15 @@ export const Route = createFileRoute('/confirm-email')({
   head: () => ({
     meta: [{ title: pageTitle('Confirm email') }],
   }),
-  validateSearch: (search: Record<string, unknown>) => ({
-    token: typeof search.token === 'string' ? search.token : '',
-  }),
+  validateSearch: (search: Record<string, unknown>) => {
+    // A duplicated `?token=a&token=b` is parsed into an array. Take the first
+    // value so the dedup case behaves like a single (likely-invalid) token and
+    // surfaces the generic invalid-link error, not a misleading "missing token".
+    const raw = Array.isArray(search.token) ? search.token[0] : search.token
+    return {
+      token: typeof raw === 'string' ? raw : '',
+    }
+  },
   component: ConfirmEmailPage,
 })
 

--- a/web-client/src/routes/index.test.tsx
+++ b/web-client/src/routes/index.test.tsx
@@ -75,4 +75,45 @@ describe('/ route', () => {
     renderAt('/?landing=1')
     await expectLandingVisible()
   })
+
+  it('has no inert href="#" anchors on the landing page', async () => {
+    const { container } = renderAt('/')
+    await expectLandingVisible()
+
+    // Every link must go somewhere real: an in-app route, an off-site URL, or
+    // an in-page section anchor (#product etc.). A bare href="#" is a no-op CTA
+    // and regresses issue #437.
+    const inert = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>('a[href="#"]'),
+    )
+    expect(inert).toHaveLength(0)
+  })
+
+  it('wires the footer GitHub links to the public repository', async () => {
+    renderAt('/')
+    await expectLandingVisible()
+
+    for (const link of screen.getAllByRole('link', { name: /github|contribute/i })) {
+      expect(link).toHaveAttribute(
+        'href',
+        'https://github.com/mightymoose/fortymm',
+      )
+      expect(link).toHaveAttribute('target', '_blank')
+      expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    }
+  })
+
+  it('renders affordances that do not exist yet as inert, non-link text', async () => {
+    renderAt('/')
+    await expectLandingVisible()
+
+    // "Get the iOS app" has no destination yet — it must not be a clickable link.
+    expect(
+      screen.queryByRole('link', { name: /get the ios app/i }),
+    ).not.toBeInTheDocument()
+    // Footer "Discord" has no invite URL yet — also not a link.
+    expect(
+      screen.queryByRole('link', { name: /^discord$/i }),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/web-client/src/routes/login.index.tsx
+++ b/web-client/src/routes/login.index.tsx
@@ -80,6 +80,14 @@ function LoginPage() {
               )
               return
             }
+            if (err.status === 422) {
+              // Pydantic's 422 detail leaks internals ("value is not a valid
+              // email address: The email address is too long (N characters
+              // too many)"). Show the same friendly copy the client-side
+              // validator uses instead of echoing it.
+              setServerError("That doesn't look like a valid email.")
+              return
+            }
             setServerError(err.detail ?? 'Something went wrong. Try again.')
             return
           }

--- a/web-client/src/routes/login.verifying.tsx
+++ b/web-client/src/routes/login.verifying.tsx
@@ -22,8 +22,12 @@ export const Route = createFileRoute('/login/verifying')({
   }),
   validateSearch: (search: Record<string, unknown>) => {
     const e = search.error
+    // A duplicated `?token=a&token=b` is parsed into an array. Take the first
+    // value so the dedup case behaves like a single (likely-invalid) token and
+    // surfaces the generic invalid-link error, not a misleading "missing token".
+    const raw = Array.isArray(search.token) ? search.token[0] : search.token
     return {
-      token: typeof search.token === 'string' ? search.token : '',
+      token: typeof raw === 'string' ? raw : '',
       error: e === 'expired' || e === 'net' ? (e as VerifyError) : undefined,
     }
   },

--- a/web-client/src/routes/matches.$matchId.games.$gameNumber.scores.edit.tsx
+++ b/web-client/src/routes/matches.$matchId.games.$gameNumber.scores.edit.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ScoreEntry } from '@/components/matches/score-entry'
+import { MatchDetailsError } from '@/components/matches/match-details'
+import { ApiError } from '@/api/client'
 import { pageTitle } from '@/lib/page-title'
+import { isMatchId } from '@/lib/match-id'
 
 export const Route = createFileRoute(
   '/matches/$matchId/games/$gameNumber/scores/edit',
@@ -9,10 +12,26 @@ export const Route = createFileRoute(
     meta: [{ title: pageTitle('Edit score') }],
   }),
   component: ScoreEditRoute,
+  // `ScoreEntry` fetches the match with `throwOnError`, so a 404 (no such
+  // match) or 422 (malformed id) on `GET /v1/matches/{id}` throws during
+  // render. Without a boundary that escaped to TanStack's generic "Something
+  // went wrong!" crash page (#385); reuse the match-details fallback so it maps
+  // to the same friendly "We couldn't find that match." dead end instead.
+  errorComponent: MatchDetailsError,
 })
 
 function ScoreEditRoute() {
   const { matchId, gameNumber } = Route.useParams()
+  if (!isMatchId(matchId)) {
+    // Reject a malformed id without ever hitting the API — same friendly
+    // not-found UI, no 422 and no console-noise `ApiError` (#385).
+    return (
+      <MatchDetailsError
+        error={new ApiError(404, null, `load match ${matchId}`)}
+        reset={() => {}}
+      />
+    )
+  }
   return (
     <ScoreEntry
       matchId={matchId}

--- a/web-client/src/routes/matches.$matchId.games.$gameNumber.scores.new.test.tsx
+++ b/web-client/src/routes/matches.$matchId.games.$gameNumber.scores.new.test.tsx
@@ -16,6 +16,57 @@ import { Route } from './matches.$matchId.games.$gameNumber.scores.new'
 // guard, so the route fetches and the API answers 404.
 const UNKNOWN_MATCH_ID = '00000000-0000-4000-8000-000000000000'
 
+// A well-formed UUID with a live match behind it — passes the guard and
+// renders the score-entry page (the positive case the e2e regression hit when
+// the param guard rejected the non-UUID mock id).
+const LIVE_MATCH_ID = '22070000-0000-4000-8000-000000000000'
+
+function liveMatchDetails() {
+  return {
+    id: LIVE_MATCH_ID,
+    status: 'in_progress',
+    status_label: 'Live',
+    best_of: 5,
+    games_to_win: 3,
+    team_size: 1,
+    affects_rating: true,
+    created_at: '2026-05-12T19:00:00Z',
+    sides: [
+      {
+        side_number: 1,
+        players: [{ user_id: 'u-me', username: 'rita.kovac', is_current_user: true }],
+        games_won: 1,
+        won: null,
+        is_current_user_side: true,
+      },
+      {
+        side_number: 2,
+        players: [{ user_id: 'u-opp', username: 'nguyen.t', is_current_user: false }],
+        games_won: 1,
+        won: null,
+        is_current_user_side: false,
+      },
+    ],
+    games: [
+      {
+        id: 'g-1',
+        game_number: 1,
+        score: { id: 's-1', side_1_points: 11, side_2_points: 8, winner_side_number: 1 },
+      },
+      {
+        id: 'g-2',
+        game_number: 2,
+        score: { id: 's-2', side_1_points: 9, side_2_points: 11, winner_side_number: 2 },
+      },
+    ],
+    current_game: { game_number: 3 },
+    can_score: true,
+    can_finalize: false,
+    can_confirm: false,
+    signatures: [],
+  }
+}
+
 const ScoreCreateRoute = Route.options.component!
 const ScoreCreateError = Route.options.errorComponent!
 
@@ -23,7 +74,7 @@ const ScoreCreateError = Route.options.errorComponent!
 // route's own param guard + error boundary (not just the inner component). The
 // detail/list stubs cover the `<Link to="/matches">`/redirect targets the
 // not-found fallback can resolve to.
-function renderScoreCreate(matchId: string) {
+function renderScoreCreate(matchId: string, gameNumber = 1) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
@@ -47,7 +98,7 @@ function renderScoreCreate(matchId: string) {
   const router = createRouter({
     routeTree: rootRoute.addChildren([route, matchesList, matchPage]),
     history: createMemoryHistory({
-      initialEntries: [`/matches/${matchId}/games/1/scores/new`],
+      initialEntries: [`/matches/${matchId}/games/${gameNumber}/scores/new`],
     }),
   })
   return render(
@@ -79,6 +130,25 @@ describe('scoring-create route — bad/nonexistent match id (#385)', () => {
     ).toHaveAttribute('href', '/matches')
     // The guard short-circuits before any fetch — no 422/404 round-trip.
     expect(requested).toBe(false)
+  })
+
+  it('renders the score-entry page for a well-formed id with a live match', async () => {
+    server.use(
+      http.get('*/v1/matches/:matchId', () =>
+        HttpResponse.json(liveMatchDetails()),
+      ),
+    )
+
+    renderScoreCreate(LIVE_MATCH_ID, 3)
+
+    // The param guard lets a UUID-shaped id through, the fetch resolves, and
+    // the entry screen renders its heading — never the not-found dead end.
+    expect(
+      await screen.findByRole('heading', { name: /enter game 3 score/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(/couldn.t find that match/i),
+    ).not.toBeInTheDocument()
   })
 
   it('catches a 404 from a valid-but-nonexistent id instead of crashing', async () => {

--- a/web-client/src/routes/matches.$matchId.games.$gameNumber.scores.new.test.tsx
+++ b/web-client/src/routes/matches.$matchId.games.$gameNumber.scores.new.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { server } from '@/mocks/server'
+import { Route } from './matches.$matchId.games.$gameNumber.scores.new'
+
+// A well-formed UUID the seed data doesn't know about — passes the param-shape
+// guard, so the route fetches and the API answers 404.
+const UNKNOWN_MATCH_ID = '00000000-0000-4000-8000-000000000000'
+
+const ScoreCreateRoute = Route.options.component!
+const ScoreCreateError = Route.options.errorComponent!
+
+// Mount the real scoring-create route under a memory router so we exercise the
+// route's own param guard + error boundary (not just the inner component). The
+// detail/list stubs cover the `<Link to="/matches">`/redirect targets the
+// not-found fallback can resolve to.
+function renderScoreCreate(matchId: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute()
+  const route = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches/$matchId/games/$gameNumber/scores/new',
+    component: ScoreCreateRoute,
+    errorComponent: ScoreCreateError,
+  })
+  const matchesList = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches',
+    component: () => <div>matches-list</div>,
+  })
+  const matchPage = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches/$matchId',
+    component: () => <div>match-page</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([route, matchesList, matchPage]),
+    history: createMemoryHistory({
+      initialEntries: [`/matches/${matchId}/games/1/scores/new`],
+    }),
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('scoring-create route — bad/nonexistent match id (#385)', () => {
+  it('renders the friendly not-found state for a malformed id without hitting the API', async () => {
+    let requested = false
+    server.use(
+      http.get('*/v1/matches/:matchId', () => {
+        requested = true
+        return HttpResponse.json({ detail: 'Match not found.' }, { status: 404 })
+      }),
+    )
+
+    renderScoreCreate('not-a-uuid')
+
+    expect(
+      await screen.findByText(/couldn.t find that match/i),
+    ).toBeInTheDocument()
+    // No raw crash page, and the back-to-matches dead end is offered.
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /back to matches/i }),
+    ).toHaveAttribute('href', '/matches')
+    // The guard short-circuits before any fetch — no 422/404 round-trip.
+    expect(requested).toBe(false)
+  })
+
+  it('catches a 404 from a valid-but-nonexistent id instead of crashing', async () => {
+    server.use(
+      http.get('*/v1/matches/:matchId', () =>
+        HttpResponse.json({ detail: 'Match not found.' }, { status: 404 }),
+      ),
+    )
+
+    renderScoreCreate(UNKNOWN_MATCH_ID)
+
+    expect(
+      await screen.findByText(/couldn.t find that match/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        screen.getByRole('link', { name: /back to matches/i }),
+      ).toBeInTheDocument(),
+    )
+  })
+})

--- a/web-client/src/routes/matches.$matchId.games.$gameNumber.scores.new.tsx
+++ b/web-client/src/routes/matches.$matchId.games.$gameNumber.scores.new.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ScoreEntry } from '@/components/matches/score-entry'
+import { MatchDetailsError } from '@/components/matches/match-details'
+import { ApiError } from '@/api/client'
 import { pageTitle } from '@/lib/page-title'
+import { isMatchId } from '@/lib/match-id'
 
 export const Route = createFileRoute(
   '/matches/$matchId/games/$gameNumber/scores/new',
@@ -9,10 +12,26 @@ export const Route = createFileRoute(
     meta: [{ title: pageTitle('Enter score') }],
   }),
   component: ScoreCreateRoute,
+  // `ScoreEntry` fetches the match with `throwOnError`, so a 404 (no such
+  // match) or 422 (malformed id) on `GET /v1/matches/{id}` throws during
+  // render. Without a boundary that escaped to TanStack's generic "Something
+  // went wrong!" crash page (#385); reuse the match-details fallback so it maps
+  // to the same friendly "We couldn't find that match." dead end instead.
+  errorComponent: MatchDetailsError,
 })
 
 function ScoreCreateRoute() {
   const { matchId, gameNumber } = Route.useParams()
+  if (!isMatchId(matchId)) {
+    // Reject a malformed id without ever hitting the API — same friendly
+    // not-found UI, no 422 and no console-noise `ApiError` (#385).
+    return (
+      <MatchDetailsError
+        error={new ApiError(404, null, `load match ${matchId}`)}
+        reset={() => {}}
+      />
+    )
+  }
   return (
     <ScoreEntry
       matchId={matchId}

--- a/web-client/src/routes/matches.$matchId.index.tsx
+++ b/web-client/src/routes/matches.$matchId.index.tsx
@@ -6,14 +6,7 @@ import {
 import { matchDetailsQuery } from '@/components/matches/match-details/match-details-query'
 import { ApiError } from '@/api/client'
 import { pageTitle } from '@/lib/page-title'
-
-// Match ids are UUIDs. A malformed id (e.g. /matches/not-a-uuid) would 422 on
-// every self-fetching section and surface an `ApiError` in the console even
-// though the UI handles it (#494). Guarding the param shape client-side means
-// we never make the request: no 422, no console error — just the friendly
-// not-found state the boundary already renders for a 404/422.
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+import { isMatchId } from '@/lib/match-id'
 
 export const Route = createFileRoute('/matches/$matchId/')({
   head: () => ({
@@ -23,7 +16,7 @@ export const Route = createFileRoute('/matches/$matchId/')({
   // page's self-fetching sections keep streaming in independently on a direct
   // load while a preceding hover/touch preload makes the click render instantly.
   loader: ({ context, params }) => {
-    if (!UUID_RE.test(params.matchId)) return
+    if (!isMatchId(params.matchId)) return
     void context.queryClient.prefetchQuery(matchDetailsQuery(params.matchId))
   },
   component: MatchDetailsRoute,
@@ -32,7 +25,7 @@ export const Route = createFileRoute('/matches/$matchId/')({
 
 function MatchDetailsRoute() {
   const { matchId } = Route.useParams()
-  if (!UUID_RE.test(matchId)) {
+  if (!isMatchId(matchId)) {
     // Reuse the page's not-found UI without ever hitting the API.
     return (
       <MatchDetailsError

--- a/web-client/src/routes/matches/index.test.tsx
+++ b/web-client/src/routes/matches/index.test.tsx
@@ -349,6 +349,65 @@ describe('MatchesPage', () => {
     })
   })
 
+  it('reads a non-"all" status tab with no results as filtered, not a cold start (#373)', async () => {
+    // A status tab that filters everything out is NOT a first-run user — the
+    // empty state must offer Clear filters and not imply "No matches yet".
+    server.use(
+      http.get('*/v1/matches', () =>
+        HttpResponse.json(
+          matchListResponse({
+            items: [],
+            total: 0,
+            status_counts: { in_progress: 0 },
+          }),
+        ),
+      ),
+    )
+    renderMatchesPage('/matches?status=live')
+
+    expect(
+      await screen.findByText(/no matches match your filters/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/^no matches yet$/i)).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /clear filters/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('reads an out-of-range ?page= no-result frame as filtered, not a cold start (#373)', async () => {
+    // The clamp (#541) snaps the page back asynchronously; until it does, the
+    // out-of-range page paints an empty table. That frame must read as filtered
+    // ("No matches match your filters" + Clear filters) — `page > totalPages`
+    // feeds `isFiltered` — so it never flashes the cold-start "No matches yet".
+    server.use(
+      http.get('*/v1/matches', ({ request }) => {
+        const page = Number(
+          new URL(request.url).searchParams.get('page') ?? '1',
+        )
+        // 16 matches → one page. page=2 is out of range and returns no items,
+        // but the real total is still reported (so totalPages stays 1).
+        const items = page === 1 ? [matchListRow({ opponent: 'nguyen.t' })] : []
+        return HttpResponse.json(
+          matchListResponse({
+            items,
+            total: 16,
+            page,
+            status_counts: { pending: 16 },
+          }),
+        )
+      }),
+    )
+    renderMatchesPage('/matches?page=2')
+
+    // The out-of-range frame reads as filtered ("No matches match your
+    // filters"), not the cold-start "No matches yet" — proving `page >
+    // totalPages` feeds `isFiltered`. (The clamp then recovers the page; that
+    // recovery is asserted by the #541 test below.)
+    expect(
+      await screen.findByText(/no matches match your filters/i),
+    ).toBeInTheDocument()
+  })
+
   it('snaps an out-of-range ?page= back to the last valid page (#541)', async () => {
     server.use(
       http.get('*/v1/matches', ({ request }) => {

--- a/web-client/src/routes/matches/new.css
+++ b/web-client/src/routes/matches/new.css
@@ -129,8 +129,12 @@
 }
 .nm-section-head {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   justify-content: space-between;
+  /* Keep a minimum gap so the bold .title and the uppercase muted .hint never
+     abut ("OpponentOPTIONAL…") when the row is narrow before it wraps/stacks. */
+  gap: 4px 12px;
   margin-bottom: 14px;
 }
 .nm-section-head .title {
@@ -531,6 +535,7 @@
 }
 .nm-field-label {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
   margin-bottom: 12px;
@@ -540,7 +545,10 @@
   color: var(--fg-3);
 }
 .nm-field-label .na {
+  /* Push to the row's right edge, but keep a min-gap from the "Rated match"
+     label so the two don't collide on a narrow row. */
   margin-left: auto;
+  padding-left: 12px;
   font: 500 11px var(--font-mono);
   letter-spacing: 0.14em;
   color: var(--fg-muted);
@@ -797,6 +805,13 @@
   }
   .nm-page-head h1 {
     font-size: 30px;
+  }
+  /* Stack the section head so the title and its hint each get a full line
+     instead of crowding into one narrow row. */
+  .nm-section-head {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
   }
   .nm-you-strip .stats {
     display: none;

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -86,13 +86,21 @@ function renderNewMatch() {
       scoringRoute,
       detailsRoute,
     ]),
-    history: createMemoryHistory({ initialEntries: ['/matches/new'] }),
+    history: createMemoryHistory({
+      // Seed a prior entry (the dashboard) so a Back from score entry has
+      // somewhere real to land — and the new-match form must not be it.
+      initialEntries: ['/dashboard', '/matches/new'],
+      initialIndex: 1,
+    }),
   })
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>,
-  )
+  return {
+    router,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    ),
+  }
 }
 
 function DetailsProbe({ matchId }: { matchId: string }) {
@@ -140,6 +148,36 @@ describe('NewMatchPage', () => {
       best_of: 5,
       rated: true,
     })
+  })
+
+  it('replaces the new-match form in history so Back from scoring does not re-open it (#441)', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/players/recent', () => HttpResponse.json([])),
+      http.post('*/v1/matches', () =>
+        HttpResponse.json(pendingMatch(), { status: 201 }),
+      ),
+    )
+    const { router } = renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /start match/i }),
+    )
+    await waitFor(() =>
+      expect(
+        screen.getByText('Scoring route m-test game 1'),
+      ).toBeInTheDocument(),
+    )
+
+    // Going Back must NOT return to the creation form (which would otherwise
+    // try to re-create the match) — it lands on the page before it.
+    router.history.back()
+    await waitFor(() =>
+      expect(screen.getByText('Dashboard route')).toBeInTheDocument(),
+    )
+    expect(
+      screen.queryByRole('button', { name: /start match/i }),
+    ).not.toBeInTheDocument()
   })
 
   it('seeds the details cache from the create response, so a redirect to /matches/{id} renders without the racing GET (#510)', async () => {

--- a/web-client/src/routes/matches/new.test.tsx
+++ b/web-client/src/routes/matches/new.test.tsx
@@ -551,3 +551,56 @@ describe('NewMatchPage — opponent search', () => {
     )
   })
 })
+
+describe('NewMatchPage — mobile label layout (#388)', () => {
+  // These guard the DOM contract the responsive CSS in new.css relies on to
+  // keep labels and captions from crowding on a 375px screen. jsdom doesn't
+  // lay out, so we assert structure rather than measure pixels: the section
+  // head keeps the title and hint as two separate elements (so the flex
+  // `gap` / mobile column-stack apply between them, instead of one fused
+  // "OpponentOPTIONAL…" text node), and the unavailable caption stays a child
+  // of the field label (so its `margin-left:auto`/`padding-left` breathing
+  // room and the label's `flex-wrap` keep it off the "Rated match" label).
+  function recentWithOne() {
+    return http.get('*/v1/players/recent', () =>
+      HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }]),
+    )
+  }
+
+  it('renders the opponent title and hint as separate section-head children', async () => {
+    server.use(recentWithOne())
+    const { container } = renderNewMatch()
+
+    await screen.findByRole('button', { name: /ada\.lovelace/i })
+
+    const head = container.querySelector('.nm-section-head')
+    expect(head).not.toBeNull()
+    const title = head!.querySelector('.title')
+    const hint = head!.querySelector('.hint')
+    expect(title).toHaveTextContent(/^Opponent$/)
+    // The hint is its own element — not concatenated into the title — so the
+    // gap/column-stack rules have two boxes to space apart.
+    expect(hint).not.toBeNull()
+    expect(hint).not.toBe(title)
+    expect(hint).toHaveTextContent(/optional/i)
+  })
+
+  it('keeps the "unavailable" caption inside the rated field label', async () => {
+    server.use(recentWithOne())
+    const { container } = renderNewMatch()
+
+    // No opponent picked yet → the rated control is unavailable and shows the
+    // "No opponent · unavailable" caption.
+    await screen.findByRole('button', { name: /ada\.lovelace/i })
+
+    const fieldLabels = container.querySelectorAll('.nm-field-label')
+    const na = container.querySelector('.nm-field-label .na')
+    expect(na).not.toBeNull()
+    expect(na).toHaveTextContent(/no opponent.*unavailable/i)
+    // It lives within a field label that also carries the "Rated match" text,
+    // so the label's flex layout (wrap + margin) governs both.
+    const owner = Array.from(fieldLabels).find((el) => el.contains(na!))
+    expect(owner).toBeDefined()
+    expect(owner).toHaveTextContent(/rated match/i)
+  })
+})

--- a/web-client/src/routes/matches/new.tsx
+++ b/web-client/src/routes/matches/new.tsx
@@ -125,7 +125,11 @@ function MatchCard() {
         best_of: bestOf,
         rated: opponent !== null && rated,
       })
-      navigate(nextScoringDestination(created))
+      // Replace, don't push: the new-match form is a one-shot step, so the
+      // history stack shouldn't keep it. Otherwise browser/mobile Back from
+      // score entry re-opens the creation form for a match that already
+      // exists, instead of returning to wherever the user came from (#441).
+      navigate({ ...nextScoringDestination(created), replace: true })
     } catch (err) {
       setApiError(
         err instanceof ApiError

--- a/web-client/src/routes/players/index.tsx
+++ b/web-client/src/routes/players/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { createFileRoute, useNavigate, useRouter } from '@tanstack/react-router'
 import { zodValidator } from '@tanstack/zod-adapter'
 import {
@@ -95,9 +95,10 @@ function PlayersPage() {
   )
   const data = list.data
   const isLoading = list.isPending
+  const isFetching = list.isFetching
   const items = data?.items ?? []
   const total = data?.total ?? 0
-  const startIndex = (page - 1) * PAGE_SIZE
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
 
   // Rewrite the URL — `replace: true` keeps each keystroke from filling
   // browser history. Defaults are stripped so the URL stays clean.
@@ -128,6 +129,25 @@ function PlayersPage() {
     [setSearch],
   )
 
+  // Snap an out-of-range `?page=` back to the last valid page once the real
+  // total is known — a stale bookmark or paging past the end would otherwise
+  // render an empty roster under a nonsensical "Showing 51–40 of 40" footer
+  // (#373). Only act on a settled, current total: `isLoading` covers the
+  // pending/session-gated window (total still 0), and `isFetching` covers a
+  // `keepPreviousData` refetch still serving the prior filter's total. Mirrors
+  // the matches list clamp.
+  useEffect(() => {
+    if (!isLoading && !isFetching && page > totalPages) {
+      setPage(totalPages)
+    }
+  }, [isLoading, isFetching, page, totalPages, setPage])
+
+  // The redirect runs in an effect, so an out-of-range page paints for one
+  // frame first. Clamp the page the footer + seed numbering render with so the
+  // range math never shows start > end during that frame.
+  const displayPage = Math.min(page, totalPages)
+  const startIndex = (displayPage - 1) * PAGE_SIZE
+
   return (
     <AppShell>
       <div className="match-list-page">
@@ -142,7 +162,7 @@ function PlayersPage() {
           />
         </div>
         <PaginationFooter
-          page={page}
+          page={displayPage}
           setPage={setPage}
           total={total}
           pageSize={PAGE_SIZE}

--- a/web-client/src/routes/settings.test.tsx
+++ b/web-client/src/routes/settings.test.tsx
@@ -212,6 +212,25 @@ describe('SettingsPage username section', () => {
     const section = input.closest('section') as HTMLElement
     expect(within(section).getByText(/no spaces/i)).toBeInTheDocument()
   })
+
+  it('keeps the public-profile URL preview wrappable so a long username cannot overflow (#376)', async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    const input = await screen.findByLabelText(/^username$/i)
+    await user.clear(input)
+    // A long, valid (lowercase, no-space) username — the case that forced
+    // ~51px of horizontal overflow at 375px before the wrap fix.
+    await user.type(input, 'a-really-long-public-username-that-is-valid')
+
+    const section = input.closest('section') as HTMLElement
+    const urlPreview = within(section).getByText(/\/p\/players\//i)
+
+    // The mono URL span must be allowed to wrap inside the panel rather than
+    // forcing the row (and the viewport) wider than 375px. jsdom has no real
+    // layout engine, so we assert the break-enabling styles directly.
+    expect(urlPreview).toHaveStyle({ overflowWrap: 'anywhere', minWidth: '0px' })
+  })
 })
 
 describe('SettingsPage footer sign out', () => {

--- a/web-client/src/routes/settings.test.tsx
+++ b/web-client/src/routes/settings.test.tsx
@@ -1,6 +1,9 @@
+import type React from 'react'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
+  Link,
+  Outlet,
   RouterProvider,
   createMemoryHistory,
   createRootRoute,
@@ -63,14 +66,35 @@ async function renderSettings(initialEntry = '/settings') {
       mutations: { retry: false },
     },
   })
-  const rootRoute = createRootRoute()
+  // A persistent left-nav-style link lives in the root layout so tests can
+  // exercise in-app navigation away from the page (the #440 guard target).
+  const rootRoute = createRootRoute({
+    component: () => (
+      <>
+        {/* This ad-hoc test route isn't in the generated route tree, so the
+            typed `to` prop doesn't know it. Cast to satisfy the checker. */}
+        <Link
+          {...({ to: '/elsewhere' } as React.ComponentProps<typeof Link>)}
+          data-testid="nav-elsewhere"
+        >
+          Go elsewhere
+        </Link>
+        <Outlet />
+      </>
+    ),
+  })
   const settingsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/settings',
     component: SettingsPage,
   })
+  const elsewhereRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/elsewhere',
+    component: () => <div data-testid="elsewhere-page">Elsewhere</div>,
+  })
   const router = createRouter({
-    routeTree: rootRoute.addChildren([settingsRoute]),
+    routeTree: rootRoute.addChildren([settingsRoute, elsewhereRoute]),
     history: createMemoryHistory({ initialEntries: [initialEntry] }),
   })
   return render(
@@ -297,5 +321,100 @@ describe('SettingsPage notifications section', () => {
     expect(
       await screen.findByText(/aren't configured on the server/i),
     ).toBeInTheDocument()
+  })
+})
+
+describe('SettingsPage unsaved-changes guard (#440)', () => {
+  it('navigates freely when nothing is dirty', async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    await screen.findByLabelText(/^username$/i)
+    await user.click(screen.getByTestId('nav-elsewhere'))
+
+    expect(await screen.findByTestId('elsewhere-page')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('unsaved-changes-dialog'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('blocks in-app navigation with a confirm dialog when an edit is unsaved', async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    const input = await screen.findByLabelText(/^username$/i)
+    await user.clear(input)
+    await user.type(input, 'rita.kovac-2')
+
+    await user.click(screen.getByTestId('nav-elsewhere'))
+
+    // Navigation is intercepted: the prompt shows and we're still on settings.
+    expect(
+      await screen.findByTestId('unsaved-changes-dialog'),
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId('elsewhere-page')).not.toBeInTheDocument()
+  })
+
+  it('stays on the page when the user cancels the discard prompt', async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    const input = await screen.findByLabelText(/^username$/i)
+    await user.clear(input)
+    await user.type(input, 'rita.kovac-2')
+    await user.click(screen.getByTestId('nav-elsewhere'))
+
+    await screen.findByTestId('unsaved-changes-dialog')
+    await user.click(screen.getByRole('button', { name: /stay on this page/i }))
+
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('unsaved-changes-dialog'),
+      ).not.toBeInTheDocument(),
+    )
+    expect(screen.queryByTestId('elsewhere-page')).not.toBeInTheDocument()
+    expect(screen.getByLabelText(/^username$/i)).toBeInTheDocument()
+  })
+
+  it('proceeds with navigation when the user confirms discarding', async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    const input = await screen.findByLabelText(/^username$/i)
+    await user.clear(input)
+    await user.type(input, 'rita.kovac-2')
+    await user.click(screen.getByTestId('nav-elsewhere'))
+
+    await screen.findByTestId('unsaved-changes-dialog')
+    await user.click(screen.getByRole('button', { name: /discard changes/i }))
+
+    expect(await screen.findByTestId('elsewhere-page')).toBeInTheDocument()
+  })
+
+  it('clears the guard after a save, allowing navigation without a prompt', async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    const input = (await screen.findByLabelText(
+      /^username$/i,
+    )) as HTMLInputElement
+    await user.clear(input)
+    await user.type(input, 'rita.kovac-2')
+
+    const section = input.closest('section') as HTMLElement
+    const save = within(section).getByRole('button', { name: /save changes/i })
+    await waitFor(() => expect(save).toBeEnabled())
+    await user.click(save)
+
+    // Session now reports the saved username, so the section is clean again.
+    await waitFor(() =>
+      expect(mockSession.data.user.username).toBe('rita.kovac-2'),
+    )
+
+    await user.click(screen.getByTestId('nav-elsewhere'))
+    expect(await screen.findByTestId('elsewhere-page')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('unsaved-changes-dialog'),
+    ).not.toBeInTheDocument()
   })
 })

--- a/web-client/src/routes/settings.test.tsx
+++ b/web-client/src/routes/settings.test.tsx
@@ -236,6 +236,25 @@ describe('SettingsPage username section', () => {
     const section = input.closest('section') as HTMLElement
     expect(within(section).getByText(/no spaces/i)).toBeInTheDocument()
   })
+
+  it('keeps the public-profile URL preview wrappable so a long username cannot overflow (#376)', async () => {
+    const user = userEvent.setup()
+    await renderSettings()
+
+    const input = await screen.findByLabelText(/^username$/i)
+    await user.clear(input)
+    // A long, valid (lowercase, no-space) username — the case that forced
+    // ~51px of horizontal overflow at 375px before the wrap fix.
+    await user.type(input, 'a-really-long-public-username-that-is-valid')
+
+    const section = input.closest('section') as HTMLElement
+    const urlPreview = within(section).getByText(/\/p\/players\//i)
+
+    // The mono URL span must be allowed to wrap inside the panel rather than
+    // forcing the row (and the viewport) wider than 375px. jsdom has no real
+    // layout engine, so we assert the break-enabling styles directly.
+    expect(urlPreview).toHaveStyle({ overflowWrap: 'anywhere', minWidth: '0px' })
+  })
 })
 
 describe('SettingsPage footer sign out', () => {

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -675,10 +675,11 @@ function UsernameSection({
           display: 'flex',
           alignItems: 'center',
           gap: 14,
+          minWidth: 0,
         }}
       >
         <UserAvatar name={val} size={36} dim={!clientV.ok} />
-        <div style={{ flex: 1 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
           <div
             style={{
               fontSize: 'var(--text-xs)',
@@ -695,6 +696,7 @@ function UsernameSection({
               fontFamily: 'var(--font-mono)',
               fontSize: 'var(--text-base)',
               color: 'var(--fg-1)',
+              overflowWrap: 'anywhere',
             }}
           >
             {clientV.ok ? `@${val}` : '—'}
@@ -706,6 +708,8 @@ function UsernameSection({
             fontSize: 'var(--text-xs)',
             color: 'var(--fg-muted)',
             letterSpacing: '0.08em',
+            minWidth: 0,
+            overflowWrap: 'anywhere',
           }}
         >
           {window.location.host}/p/players/{clientV.ok ? val : '—'}

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -650,10 +650,11 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
           display: 'flex',
           alignItems: 'center',
           gap: 14,
+          minWidth: 0,
         }}
       >
         <UserAvatar name={val} size={36} dim={!clientV.ok} />
-        <div style={{ flex: 1 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
           <div
             style={{
               fontSize: 'var(--text-xs)',
@@ -670,6 +671,7 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
               fontFamily: 'var(--font-mono)',
               fontSize: 'var(--text-base)',
               color: 'var(--fg-1)',
+              overflowWrap: 'anywhere',
             }}
           >
             {clientV.ok ? `@${val}` : '—'}
@@ -681,6 +683,8 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
             fontSize: 'var(--text-xs)',
             color: 'var(--fg-muted)',
             letterSpacing: '0.08em',
+            minWidth: 0,
+            overflowWrap: 'anywhere',
           }}
         >
           {window.location.host}/p/players/{clientV.ok ? val : '—'}

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -757,6 +757,13 @@ function EmailSection({
     } catch (err) {
       resetCaptcha()
       if (err instanceof ApiError && err.status && err.status < 500) {
+        // A 422 carries a raw pydantic message ("...The email address is too
+        // long (N characters too many)"); show friendly copy instead of
+        // echoing it. Other 4xx detail is already operator-safe.
+        if (err.status === 422) {
+          setServerErr("That doesn't look like a valid email.")
+          return
+        }
         setServerErr(err.detail ?? 'Server rejected this email.')
         return
       }

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -8,11 +8,23 @@ import {
 } from 'react'
 import {
   createFileRoute,
+  useBlocker,
   useNavigate,
   useRouterState,
 } from '@tanstack/react-router'
 import { Check, Mail } from 'lucide-react'
 import { toast } from 'sonner'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 import { ApiError } from '@/api/client'
 import { useSendTestNotification } from '@/api/notifications'
@@ -514,7 +526,13 @@ function ClaimBanner({
 /*  01 — Username                                                     */
 /* ------------------------------------------------------------------ */
 
-function UsernameSection({ currentUsername }: { currentUsername: string }) {
+function UsernameSection({
+  currentUsername,
+  onDirtyChange,
+}: {
+  currentUsername: string
+  onDirtyChange: (dirty: boolean) => void
+}) {
   const updateUsername = useUpdateUsername()
   const [val, setVal] = useState(currentUsername)
   const [touched, setTouched] = useState(false)
@@ -536,6 +554,13 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
 
   const clientV = useMemo(() => validateUsername(val), [val])
   const dirty = val !== currentUsername
+  // Report dirtiness up so the page can guard against reload / navigation
+  // away while an edit is in flight (#440). Reset to clean on unmount so a
+  // stale flag can't keep the guard armed after the section is gone.
+  useEffect(() => {
+    onDirtyChange(dirty)
+    return () => onDirtyChange(false)
+  }, [dirty, onDirtyChange])
   // If the value contains a disallowed character (e.g. uppercase, whitespace,
   // punctuation outside the allowed set), surface that immediately — the user
   // just typed it and we want them to know it's not going through. Length
@@ -698,10 +723,12 @@ function EmailSection({
   email,
   confirmedAt,
   pendingEmail,
+  onDirtyChange,
 }: {
   email: string | null
   confirmedAt: string | null
   pendingEmail: string | null
+  onDirtyChange: (dirty: boolean) => void
 }) {
   const setEmail = useSetEmail()
   const resendEmail = useResendEmailConfirmation()
@@ -728,6 +755,11 @@ function EmailSection({
 
   const v = useMemo(() => validateEmail(val), [val])
   const dirty = val !== displayAddress
+  // Report dirtiness up so the page can guard reload / navigation away (#440).
+  useEffect(() => {
+    onDirtyChange(dirty)
+    return () => onDirtyChange(false)
+  }, [dirty, onDirtyChange])
   const showErr = serverErr ?? (touched && !v.ok ? v.err : null)
 
   const status = deriveEmailStatus({ email, confirmedAt, pendingEmail })
@@ -1083,6 +1115,20 @@ function SettingsPage() {
     if (id === 'sec-email' && sessionLoaded && !claimed) focusEmailInput()
   }, [hash, sessionLoaded, claimed])
 
+  // Aggregate each section's dirtiness so we can warn before a reload, tab
+  // close, or in-app navigation silently discards an in-progress edit (#440).
+  const [usernameDirty, setUsernameDirty] = useState(false)
+  const [emailDirty, setEmailDirty] = useState(false)
+  const anyDirty = usernameDirty || emailDirty
+
+  // `enableBeforeUnload` arms the native reload/close prompt; `withResolver`
+  // lets us replace the in-app browser confirm() with a design-system dialog.
+  const blocker = useBlocker({
+    shouldBlockFn: () => anyDirty,
+    enableBeforeUnload: () => anyDirty,
+    withResolver: true,
+  })
+
   return (
     <AppShell>
       <div className="fmm-settings">
@@ -1100,11 +1146,15 @@ function SettingsPage() {
             />
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
-              <UsernameSection currentUsername={sessionUsername} />
+              <UsernameSection
+                currentUsername={sessionUsername}
+                onDirtyChange={setUsernameDirty}
+              />
               <EmailSection
                 email={sessionEmail}
                 confirmedAt={sessionConfirmedAt}
                 pendingEmail={sessionPendingEmail}
+                onDirtyChange={setEmailDirty}
               />
               <NotificationsSection />
             </div>
@@ -1170,6 +1220,35 @@ function SettingsPage() {
           </div>
         </TooltipProvider>
       </div>
+      <AlertDialog
+        open={blocker.status === 'blocked'}
+        onOpenChange={(open) => {
+          // Radix fires onOpenChange(false) on overlay click / Escape — treat
+          // that as "stay on the page" so a stray dismiss never discards edits.
+          if (!open) blocker.reset?.()
+        }}
+      >
+        <AlertDialogContent data-testid="unsaved-changes-dialog">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Discard unsaved changes?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You have changes that haven't been saved. If you leave now, they'll
+              be lost.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => blocker.reset?.()}>
+              Stay on this page
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => blocker.proceed?.()}
+            >
+              Discard changes
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </AppShell>
   )
 }

--- a/web-client/src/routes/settings.tsx
+++ b/web-client/src/routes/settings.tsx
@@ -793,6 +793,13 @@ function EmailSection({
     } catch (err) {
       resetCaptcha()
       if (err instanceof ApiError && err.status && err.status < 500) {
+        // A 422 carries a raw pydantic message ("...The email address is too
+        // long (N characters too many)"); show friendly copy instead of
+        // echoing it. Other 4xx detail is already operator-safe.
+        if (err.status === 422) {
+          setServerErr("That doesn't look like a valid email.")
+          return
+        }
         setServerErr(err.detail ?? 'Server rejected this email.')
         return
       }

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -273,8 +273,19 @@ export function matchListResponse(
   const baseCounts: Record<string, number> = Object.fromEntries(
     ALL_STATUSES.map((s) => [s, 0]),
   )
+  // Mirror the server: a posted-but-unconfirmed result is an in_progress row
+  // labelled "Awaiting confirmation". Count it under its own bucket and peel it
+  // out of in_progress so status_counts.in_progress reads as true-live (#381).
+  let awaiting = 0
   for (const item of items) {
-    baseCounts[item.status] = (baseCounts[item.status] ?? 0) + 1
+    if (
+      item.status === 'in_progress' &&
+      item.status_label === 'Awaiting confirmation'
+    ) {
+      awaiting += 1
+    } else {
+      baseCounts[item.status] = (baseCounts[item.status] ?? 0) + 1
+    }
   }
   const attention_count =
     overrides.attention_count ??
@@ -286,6 +297,7 @@ export function matchListResponse(
     total: items.length,
     status_counts: baseCounts,
     attention_count,
+    awaiting_confirmation_count: awaiting,
     ...overrides,
   }
 }

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -272,8 +272,19 @@ export function matchListResponse(
   const baseCounts: Record<string, number> = Object.fromEntries(
     ALL_STATUSES.map((s) => [s, 0]),
   )
+  // Mirror the server: a posted-but-unconfirmed result is an in_progress row
+  // labelled "Awaiting confirmation". Count it under its own bucket and peel it
+  // out of in_progress so status_counts.in_progress reads as true-live (#381).
+  let awaiting = 0
   for (const item of items) {
-    baseCounts[item.status] = (baseCounts[item.status] ?? 0) + 1
+    if (
+      item.status === 'in_progress' &&
+      item.status_label === 'Awaiting confirmation'
+    ) {
+      awaiting += 1
+    } else {
+      baseCounts[item.status] = (baseCounts[item.status] ?? 0) + 1
+    }
   }
   return {
     items,
@@ -281,6 +292,7 @@ export function matchListResponse(
     page_size: 25,
     total: items.length,
     status_counts: baseCounts,
+    awaiting_confirmation_count: awaiting,
     ...overrides,
   }
 }


### PR DESCRIPTION
Batch landing of 20 web/API bug fixes triaged + fixed via an automated workflow, then integrated onto latest `main` and verified together.

## Verification (full integrated tree)
- web-client: `tsc -b` clean · `vitest` **767 passed (127 files)** · `lint` 0 errors
- api: `mypy` clean · `pytest` **398 passed** · `ruff` clean
- `schema.d.ts` regenerated from the resolved API source.

Each fix is its own commit (reviewable individually); three required manual conflict resolution against the recent match-list refactor (#381, #441, #373) — both behaviors preserved, regression tests added.

## Fixes (closes)
Launch-blockers: Closes #385, Closes #375
Scoring / match-details: Closes #566, Closes #564, Closes #528, Closes #509, Closes #495, Closes #493, Closes #387, Closes #386
API: Closes #515, Closes #381
Forms / routes / layout: Closes #441, Closes #440, Closes #439, Closes #437, Closes #388, Closes #377, Closes #376, Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
