### PR TITLE
Redesign match-details not-found/error page to match design-system states

### DIFF
--- a/web-client/src/components/matches/match-details/match-details-error.page.tsx
+++ b/web-client/src/components/matches/match-details/match-details-error.page.tsx
@@ -24,6 +24,14 @@ const scoped = (container: Container) => ({
   queryMessage(text: string | RegExp) {
     return container.queryByText(text)
   },
+  /** The mono eyebrow above the headline (e.g. "404 · Not found"). */
+  queryEyebrow(text: string | RegExp) {
+    return container.queryByText(text)
+  },
+  /** The Bebas display headline, exposed as a level-1 heading. */
+  queryHeadline() {
+    return container.queryByRole('heading', { level: 1 })
+  },
   /** The retry affordance — present for retryable errors (429, 5xx, network),
    * absent for the not-found dead end. */
   queryRetryButton() {

--- a/web-client/src/components/matches/match-details/match-details-error.test.tsx
+++ b/web-client/src/components/matches/match-details/match-details-error.test.tsx
@@ -17,6 +17,24 @@ describe('MatchDetailsError', () => {
     expect(matchDetailsErrorPage.queryRetryButton()).not.toBeInTheDocument()
   })
 
+  it('renders the page-level state shape: mono eyebrow, Bebas headline, supporting copy', async () => {
+    matchDetailsErrorPage.render({ error: buildApiError(404, 'Match not found.') })
+
+    await matchDetailsErrorPage.findAlert()
+    // Eyebrow code chip above the headline.
+    expect(
+      matchDetailsErrorPage.queryEyebrow(/404 · not found/i),
+    ).toBeInTheDocument()
+    // The message is the headline (a level-1 heading).
+    expect(matchDetailsErrorPage.queryHeadline()).toHaveTextContent(
+      /couldn.t find that match/i,
+    )
+    // Supporting copy beneath the headline.
+    expect(
+      matchDetailsErrorPage.queryMessage(/may have been deleted/i),
+    ).toBeInTheDocument()
+  })
+
   it('shows friendly not-found copy without leaking the raw API detail for a malformed id (#152)', async () => {
     matchDetailsErrorPage.render({
       error: buildApiError(

--- a/web-client/src/components/matches/match-details/match-details-error.tsx
+++ b/web-client/src/components/matches/match-details/match-details-error.tsx
@@ -23,30 +23,58 @@ export function MatchDetailsError({ error, reset }: MatchDetailsErrorProps) {
   // leak the raw API detail (e.g. the pydantic "Input should be a valid UUID"
   // string, #152). Retrying won't help, so offer a way back to the list.
   const notFound = !rateLimited && status >= 400 && status < 500
-  const message = notFound
-    ? "We couldn't find that match."
+  // Mono eyebrow + Bebas headline + supporting copy, mirroring the design
+  // system's page-level error/empty states ("Error and Empty States").
+  const { code, message, detail } = notFound
+    ? {
+        code: '404 · Not found',
+        message: "We couldn't find that match.",
+        detail:
+          "That match doesn't exist, or the link is wrong. It may have been deleted, or never finished being created.",
+      }
     : rateLimited
-      ? 'Too many requests. Try again shortly.'
-      : 'Something went wrong loading this match.'
+      ? {
+          code: 'Rate limited · 429',
+          message: 'Too many requests. Try again shortly.',
+          detail:
+            "You're refreshing faster than we can keep up. Give it a moment, then try the same link again.",
+        }
+      : {
+          code: 'Error',
+          message: 'Something went wrong loading this match.',
+          detail:
+            "Our server didn't answer in time — could be us, could be the network. Try again in a moment.",
+        }
   const body = (
-    <div role="alert" className="md-error-state">
-      <div className="md-error-state__title">{message}</div>
-      {notFound ? (
-        <Link to="/matches" className="md-btn md-btn--secondary">
-          Back to matches
-        </Link>
-      ) : (
-        <button
-          type="button"
-          className="md-btn md-btn--secondary"
-          onClick={() => {
-            reset()
-            router.invalidate()
-          }}
-        >
-          Try again
-        </button>
-      )}
+    <div
+      role="alert"
+      className="md-error-state"
+      data-tone={notFound ? 'neutral' : 'alert'}
+    >
+      <div className="md-error-state__code">
+        <span className="md-error-state__dot" aria-hidden="true" />
+        {code}
+      </div>
+      <h1 className="md-error-state__title">{message}</h1>
+      <p className="md-error-state__sub">{detail}</p>
+      <div className="md-error-state__actions">
+        {notFound ? (
+          <Link to="/matches" className="md-btn md-btn--primary">
+            Back to matches
+          </Link>
+        ) : (
+          <button
+            type="button"
+            className="md-btn md-btn--primary"
+            onClick={() => {
+              reset()
+              router.invalidate()
+            }}
+          >
+            Try again
+          </button>
+        )}
+      </div>
     </div>
   )
   return <AppShell>{body}</AppShell>

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2395,6 +2395,59 @@ body.dark.fortymm-theme {
   padding: 0;
 }
 
+/* ---------- Page-level error / empty state ---------- */
+.fortymm-theme .md-error-state {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  min-height: 60vh;
+  max-width: 760px;
+  padding: 48px clamp(24px, 6vw, 80px);
+}
+.fortymm-theme .md-error-state__code {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font: 600 11px var(--font-mono);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ball-500);
+  margin-bottom: 20px;
+}
+.fortymm-theme .md-error-state__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.fortymm-theme .md-error-state__title {
+  font-family: var(--font-display);
+  font-size: clamp(52px, 9vw, 104px);
+  line-height: 0.9;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  text-wrap: balance;
+  color: var(--fg-1);
+  margin: 0 0 20px;
+}
+.fortymm-theme .md-error-state[data-tone='alert'] .md-error-state__title {
+  color: var(--ball-500);
+}
+.fortymm-theme .md-error-state__sub {
+  font: 400 18px var(--font-ui);
+  line-height: 1.45;
+  color: var(--fg-2);
+  max-width: 520px;
+  margin: 0 0 32px;
+}
+.fortymm-theme .md-error-state__actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 /* ---------- Page header row ---------- */
 .fortymm-theme .md-header {
   display: flex;


### PR DESCRIPTION
## What

Restyles the **match-details error-boundary fallback** to mirror the design system's page-level *"Error and Empty States"*: a mono uppercase eyebrow chip (with status dot), a large Bebas display headline, supporting copy, and a primary action — applied across all three branches:

- **Not found (4xx)** — neutral white headline, `404 · Not found`, "Back to matches" link.
- **Rate limited (429)** — alert-orange headline, `Rate limited · 429`, "Try again".
- **Generic (5xx / network)** — alert-orange headline, `Error`, "Try again".

Copy and retry/back-link logic (including the 429-is-transient and #152 don't-leak-raw-detail behavior) are unchanged — this is a visual/structure redesign.

## Why it was broken

The `.md-error-state` / `.md-error-state__title` classes were referenced by the old component but **never defined in `index.css`**, so the fallback rendered essentially unstyled. The old action also used `md-btn--secondary`, which doesn't exist in the stylesheet. This PR adds the `.md-error-state*` rules under `.fortymm-theme` and switches to the defined `md-btn--primary`.

## Testing

- `npm run test:run` — 719/719 vitest pass (incl. updated `match-details-error` quartet)
- `npm run lint` — 0 errors
- `npm run build` — tsc + vite build clean
- `npm run test:e2e` — 127/127 Playwright pass
- `/simplify` pass applied (collapsed three parallel ternaries into one keyed lookup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)