### PR TITLE
Fix iOS score-entry accepting games the server rejects

### DIFF
--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -220,11 +220,30 @@ enum MatchRules {
     /// 1→1, 3→2, 5→3, 7→4
     static func gamesToWin(bestOf: Int) -> Int { Int(ceil(Double(bestOf) / 2)) }
 
-    /// To 11, win by 2 (deuce continues past 10–10).
+    /// The reason a completed game's score is illegal under table-tennis rules,
+    /// or nil when it's a legal final score. Mirrors `validate_game_score` in
+    /// api/app/schemas/match.py (and `illegalScoreReason` in
+    /// web-client/src/lib/scoring.ts) — keep in lockstep so the client never
+    /// lights up Post for a score the server will reject with a 422.
+    static func illegalScoreReason(_ a: Int, _ b: Int) -> String? {
+        let winner = max(a, b), loser = min(a, b)
+        if winner < 11 { return "The winning side must reach at least 11 points." }
+        if a == b { return "A game cannot end in a tie." }
+        if winner == 11 && loser > 9 {
+            return "At 10–10 the game enters deuce — the winner must lead by 2."
+        }
+        if winner > 11 {
+            if loser < 10 { return "A game can only go past 11 once both sides reach 10." }
+            if winner - loser != 2 { return "In a deuce game the winner leads by exactly 2 points." }
+        }
+        return nil
+    }
+
+    /// To 11, win by 2 (deuce continues past 10–10). A game is complete only
+    /// when both scores are entered and form a legal final score.
     static func gameComplete(_ g: Game) -> Bool {
         guard let a = g.a, let b = g.b else { return false }
-        let hi = max(a, b), lo = min(a, b)
-        return a != b && hi >= 11 && (hi - lo) >= 2
+        return illegalScoreReason(a, b) == nil
     }
 
     /// The winning side, only if the game is complete.
@@ -249,6 +268,29 @@ enum MatchRules {
         let sw = setsWon(games)
         let need = gamesToWin(bestOf: bestOf)
         return sw.a >= need || sw.b >= need
+    }
+
+    /// The canonical postable games: the gap-free run of completed games from
+    /// game 1 up to *and including* the game that decides the match, dropping
+    /// anything entered past the decider. Returns nil when the games entered so
+    /// far don't yet form a complete, validly-ordered, decided match — in which
+    /// case Post must not be offered. Mirrors `decidedSide` in
+    /// web-client/src/lib/scoring.ts and the finalize validator in
+    /// api/app/matches.py (no illegal scores, contiguous from game 1, no scored
+    /// games past the decider).
+    static func gamesThroughDecider(_ games: [Game], bestOf: Int) -> [Game]? {
+        let need = gamesToWin(bestOf: bestOf)
+        var a = 0, b = 0
+        for (i, g) in games.enumerated() {
+            // A gap (incomplete game) before the match is decided ⇒ not postable.
+            guard let winner = gameWinner(g) else { return nil }
+            switch winner {
+            case .you: a += 1
+            case .opponent: b += 1
+            }
+            if a >= need || b >= need { return Array(games.prefix(i + 1)) }
+        }
+        return nil
     }
 
     /// Elo delta, K = 26. Caller passes `won`; returns the signed change.

--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -273,11 +273,17 @@ enum MatchRules {
     /// The canonical postable games: the gap-free run of completed games from
     /// game 1 up to *and including* the game that decides the match, dropping
     /// anything entered past the decider. Returns nil when the games entered so
-    /// far don't yet form a complete, validly-ordered, decided match — in which
-    /// case Post must not be offered. Mirrors `decidedSide` in
-    /// web-client/src/lib/scoring.ts and the finalize validator in
-    /// api/app/matches.py (no illegal scores, contiguous from game 1, no scored
-    /// games past the decider).
+    /// far don't yet form a complete, decided match — in which case Post must
+    /// not be offered.
+    ///
+    /// Assumes `games` is the dense, position-indexed slot array the score-entry
+    /// screen builds (index i ⇒ game i+1, length == bestOf). Contiguity, the
+    /// no-duplicate-game-numbers rule, and the bestOf bound that the server's
+    /// finalize validator (api/app/matches.py) and the web client's `decidedSide`
+    /// (web-client/src/lib/scoring.ts) check explicitly are guaranteed here by
+    /// that array shape rather than re-validated: a gap (incomplete slot) before
+    /// the decider yields nil, and games past the decider are truncated rather
+    /// than rejected (the client simply never posts them).
     static func gamesThroughDecider(_ games: [Game], bestOf: Int) -> [Game]? {
         let need = gamesToWin(bestOf: bestOf)
         var a = 0, b = 0

--- a/ios/Fortymm/MatchFlow/ScoreEntryView.swift
+++ b/ios/Fortymm/MatchFlow/ScoreEntryView.swift
@@ -24,26 +24,22 @@ struct ScoreEntryView: View {
 
     private var you: MatchPlayer { MatchSeed.me }
     private var opp: MatchPlayer { config.opponent ?? .guest }
-    private var need: Int { MatchRules.gamesToWin(bestOf: config.bestOf) }
 
     private var current: Game { games.indices.contains(active) ? games[active] : Game() }
     private var currentValid: Bool { MatchRules.gameComplete(current) }
 
-    /// Tally over all games except the one being entered (so editing recomputes).
-    private var setsBefore: SetScore {
-        MatchRules.setsWon(games.enumerated().filter { $0.offset != active }.map(\.element))
-    }
     /// Tally shown in the VS column — includes the current game if it's complete.
     private var setsDisplay: SetScore {
         var games = self.games.enumerated().filter { $0.offset != active }.map(\.element)
         if currentValid { games.append(current) }
         return MatchRules.setsWon(games)
     }
-    /// True when the in-progress game's valid result reaches `need` for a side.
+    /// True when the games entered so far form a complete, decided match — i.e.
+    /// there's a valid result to Post. Uses the same canonical rule as `post()`
+    /// so the Post button never appears for games the server would reject, and
+    /// never goes dead when it does appear.
     private var deciding: Bool {
-        guard currentValid, let w = MatchRules.gameWinner(current) else { return false }
-        let prospective = (w == .you ? setsBefore.a : setsBefore.b) + 1
-        return prospective >= need
+        MatchRules.gamesThroughDecider(games, bestOf: config.bestOf) != nil
     }
 
     var body: some View {
@@ -307,11 +303,12 @@ struct ScoreEntryView: View {
     }
 
     private func post() {
-        guard currentValid else { return }
-        // The completed games in play order (game 1…N). The coordinator posts
-        // these to `POST /v1/matches/{id}/results`; the server computes sets
-        // won, the winner, and any rating change — so we don't here.
-        let finalGames = games.filter(MatchRules.gameComplete)
+        // The completed games in play order, game 1 up to and including the
+        // decider — anything entered past the decider is dropped, matching the
+        // server's finalize rules. The coordinator posts these to
+        // `POST /v1/matches/{id}/results`; the server computes sets won, the
+        // winner, and any rating change — so we don't here.
+        guard let finalGames = MatchRules.gamesThroughDecider(games, bestOf: config.bestOf) else { return }
         focus = nil
         onPost(finalGames)
     }

--- a/ios/Fortymm/MatchFlow/ScoreEntryView.swift
+++ b/ios/Fortymm/MatchFlow/ScoreEntryView.swift
@@ -28,12 +28,9 @@ struct ScoreEntryView: View {
     private var current: Game { games.indices.contains(active) ? games[active] : Game() }
     private var currentValid: Bool { MatchRules.gameComplete(current) }
 
-    /// Tally shown in the VS column — includes the current game if it's complete.
-    private var setsDisplay: SetScore {
-        var games = self.games.enumerated().filter { $0.offset != active }.map(\.element)
-        if currentValid { games.append(current) }
-        return MatchRules.setsWon(games)
-    }
+    /// Tally shown in the VS column. `setsWon` already ignores incomplete games,
+    /// so counting over all slots (including the one being entered) is correct.
+    private var setsDisplay: SetScore { MatchRules.setsWon(games) }
     /// True when the games entered so far form a complete, decided match — i.e.
     /// there's a valid result to Post. Uses the same canonical rule as `post()`
     /// so the Post button never appears for games the server would reject, and


### PR DESCRIPTION
## Problem

The iOS match-scoring screen's notion of a *complete/postable* match was looser than the server's, so legitimately-entered scores could light up the **Post** button and then fail server validation with a generic "Something went wrong" — stranding the user mid-match. Two release blockers, one root cause.

## Fixes

**1. Client accepted game scores the server rejects** (`MatchModels.swift`)
`MatchRules.gameComplete` accepted any `hi>=11, lead>=2` result, so scores like `12–9` or `13–10` passed the client gate but 422'd on the server. Added `illegalScoreReason`, a direct port of `validate_game_score` in `api/app/schemas/match.py` (and `illegalScoreReason` in `web-client/src/lib/scoring.ts`); `gameComplete` now defers to it.

**2. `post()` sent games past the decider** (`MatchModels.swift` + `ScoreEntryView.swift`)
`post()` sent *every* complete game, so overfilling a best-of-N (e.g. all 5 games of a BO5 already won 3–0) was rejected by the server's "scored games extend past the deciding game" check. Added `gamesThroughDecider`, mirroring `decidedSide` in the web client and the finalize validator in `api/app/matches.py`. Both `post()` and the `deciding` flag (which gates the Post button) now use it, so the button never appears for games the server would reject and never goes dead when it does.

Also removed the now-dead `setsBefore`/`need` helpers and collapsed a redundant `setsDisplay` traversal (via `/simplify`).

## Testing
- Standalone Swift logic test, 15 cases (legal/illegal scores, BO5 3–0 truncation, BO5 3–2 keep-all, gaps, illegal trailing game, BO1) — all pass.
- Clean `xcodebuild ... -sdk iphonesimulator` build — **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)