### PR TITLE
Send CSRF token on iOS mutations (fix 403 on every write)

### DIFF
--- a/ios/Fortymm/Networking/APIClient.swift
+++ b/ios/Fortymm/Networking/APIClient.swift
@@ -49,6 +49,15 @@ struct APIClient {
     /// and capture sides can't drift.
     private static let sessionCookieName = "session"
 
+    /// Double-submit CSRF defense (see `csrf_protect` in api/app/main.py): the
+    /// API sets a non-HttpOnly `csrf_token` cookie alongside the session, and
+    /// rejects any unsafe-method request that doesn't echo that value back in
+    /// the `X-CSRF-Token` header. We capture the cookie and replay both on
+    /// mutations. Safe (non-mutating) methods are exempt server-side.
+    private static let csrfCookieName = "csrf_token"
+    private static let csrfHeaderName = "X-CSRF-Token"
+    private static let csrfSafeMethods: Set<String> = ["GET", "HEAD", "OPTIONS"]
+
     private let session: URLSession
     private let decoder: JSONDecoder
     private let encoder: JSONEncoder
@@ -162,11 +171,19 @@ struct APIClient {
                 throw APIError.decoding(error)
             }
         }
-        if let token = await tokens.token() {
-            request.setValue(
-                "\(Self.sessionCookieName)=\(token)",
-                forHTTPHeaderField: "Cookie"
-            )
+        // Send the session and its CSRF companion as cookies. The server's
+        // double-submit check compares the CSRF cookie against the header, so
+        // both must be present and equal on mutations.
+        let csrf = await tokens.csrfToken()
+        let cookieHeader = [
+            (await tokens.token()).map { "\(Self.sessionCookieName)=\($0)" },
+            csrf.map { "\(Self.csrfCookieName)=\($0)" },
+        ].compactMap { $0 }.joined(separator: "; ")
+        if !cookieHeader.isEmpty {
+            request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        }
+        if let csrf, !Self.csrfSafeMethods.contains(method) {
+            request.setValue(csrf, forHTTPHeaderField: Self.csrfHeaderName)
         }
 
         let (data, response) = try await session.data(for: request)
@@ -248,9 +265,10 @@ struct APIClient {
         )
     }
 
-    /// Pull a minted/rotated `session` cookie out of the response and persist
-    /// it. The API only ever sets the single `session` cookie, so folding
-    /// multiple Set-Cookie headers isn't a concern here.
+    /// Pull a minted/rotated `session` cookie (and its companion `csrf_token`)
+    /// out of the response and persist them. The API sets both together and
+    /// folds them into the comma-joined `Set-Cookie` header; both use `Max-Age`
+    /// (no comma-bearing `Expires`), so `HTTPCookie` splits them cleanly.
     private func captureSessionCookie(from http: HTTPURLResponse, url: URL) async {
         guard let header = http.value(forHTTPHeaderField: "Set-Cookie") else {
             return
@@ -259,15 +277,22 @@ struct APIClient {
             withResponseHeaderFields: ["Set-Cookie": header],
             for: url
         )
-        guard let cookie = cookies.first(where: { $0.name == Self.sessionCookieName })
-        else { return }
-        if cookie.value.isEmpty {
-            // A clearing Set-Cookie (e.g. the session-merged 401 clears the dead
-            // cookie). Drop the stored token so the next call starts cookieless
-            // and mints a fresh guest.
-            await tokens.clear()
-        } else {
-            await tokens.update(cookie.value)
+        if let session = cookies.first(where: { $0.name == Self.sessionCookieName }) {
+            if session.value.isEmpty {
+                // A clearing Set-Cookie (e.g. the session-merged 401 clears the
+                // dead cookie). Drop the stored token (and CSRF companion) so the
+                // next call starts cookieless and mints a fresh guest.
+                await tokens.clear()
+            } else {
+                await tokens.update(session.value)
+            }
+        }
+        // Capture the CSRF token whenever the server (re)issues it — including
+        // the self-heal reissue on a returning session, which carries no
+        // `session` cookie of its own.
+        if let csrf = cookies.first(where: { $0.name == Self.csrfCookieName }),
+           !csrf.value.isEmpty {
+            await tokens.updateCSRF(csrf.value)
         }
     }
 }

--- a/ios/Fortymm/Networking/SessionTokenStore.swift
+++ b/ios/Fortymm/Networking/SessionTokenStore.swift
@@ -12,6 +12,13 @@ actor SessionTokenStore {
     private var cached: String?
     private var didLoad = false
 
+    /// The double-submit CSRF token, captured from the server's non-HttpOnly
+    /// `csrf_token` cookie. In-memory only: it isn't a secret, and the API
+    /// reissues it on the `/v1/session` bootstrap the app makes on every launch
+    /// (see `get_session_endpoint`'s self-heal), so it needn't survive a cold
+    /// start in the Keychain the way the session token does.
+    private var csrf: String?
+
     init(keychain: KeychainStore = KeychainStore(account: "session-token")) {
         self.keychain = keychain
     }
@@ -25,6 +32,14 @@ actor SessionTokenStore {
         return cached
     }
 
+    /// The current CSRF token to echo back on mutating requests, or nil before
+    /// the session bootstrap has captured one.
+    func csrfToken() -> String? { csrf }
+
+    /// Capture the CSRF token from a `Set-Cookie`. No Keychain write — it lives
+    /// only for the process lifetime.
+    func updateCSRF(_ value: String) { csrf = value }
+
     /// Persist a freshly minted or rotated token. No-op if unchanged, so a
     /// resumed session doesn't rewrite the Keychain on every call.
     func update(_ token: String) {
@@ -34,9 +49,12 @@ actor SessionTokenStore {
         keychain.save(token)
     }
 
-    /// Forget the session (sign-out). Clears both the cache and the vault.
+    /// Forget the session (sign-out). Clears both the cache and the vault, plus
+    /// the companion CSRF token (the server clears its cookie alongside the
+    /// session, and a stale CSRF token is useless without the session anyway).
     func clear() {
         cached = nil
+        csrf = nil
         didLoad = true
         keychain.delete()
     }


### PR DESCRIPTION
## Problem

The API added double-submit CSRF protection (#405/#573): `csrf_protect` in `api/app/main.py` rejects any unsafe-method request that doesn't echo the non-HttpOnly `csrf_token` cookie back in the `X-CSRF-Token` header.

The iOS client manages cookie transport itself (cookie storage is disabled so the session token never lands on disk outside the Keychain) and only ever sent the `session` cookie. So **every iOS mutation** — create match, post result, confirm, dispute, change email/username — returned `403 "CSRF token missing or invalid."` against current `main`. The app was effectively read-only.

## Fix

Capture the `csrf_token` cookie the server sets alongside the session, and replay it as **both** a cookie and the `X-CSRF-Token` header on unsafe-method requests (safe methods are exempt server-side, mirroring `CSRF_SAFE_METHODS`).

- The token is held **in-memory** in `SessionTokenStore` (not the Keychain): it isn't a secret, and the API self-heals it on the `/v1/session` bootstrap the app makes every launch (`get_session_endpoint`), so it needn't survive a cold start.
- Both cookies arrive in one comma-folded `Set-Cookie` header and use `Max-Age` (no comma-bearing `Expires`), so `HTTPCookie` splits them cleanly. The CSRF capture sits *outside* the session-cookie branch so it also catches the session-less self-heal reissue.

## Testing
- Clean `xcodebuild ... -sdk iphonesimulator` build — **BUILD SUCCEEDED**.
- iOS Simulator against the QA stack (real API, MSW off): creating a match — a POST that previously returned 403 — now succeeds and advances to score entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)