### PR TITLE
Hide dashboard attention panel whenever there are no actionable rows

### DIFF
--- a/ios/Fortymm/Dashboard/DashboardAttentionPanel.swift
+++ b/ios/Fortymm/Dashboard/DashboardAttentionPanel.swift
@@ -38,13 +38,15 @@ struct AttentionPanelView {
     let waitingCount: Int
 }
 
-/// Whether the panel has nothing to show — no actionable rows, no overflow, and
-/// nobody waiting on others. The panel hides entirely in this case rather than
-/// rendering a standalone "all caught up" card (a calm empty state still shows
-/// when rows are empty but the footer has a waiting/overflow count to surface).
-/// Mirrors the web view-model's `isAttentionPanelEmpty`.
+/// Whether the panel has nothing actionable to show. The panel is purely a
+/// to-do list: it hides entirely whenever there are no actionable rows, even if
+/// matches are still waiting on others — there's nothing for the user to do, so
+/// the dashboard stays calm rather than showing a standing "all caught up" card.
+/// (`rows.isEmpty` already implies `overflowCount == 0`, since overflow only
+/// exists once the visible rows fill.) Mirrors the web view-model's
+/// `isAttentionPanelEmpty`.
 func isAttentionPanelEmpty(_ view: AttentionPanelView) -> Bool {
-    view.rows.isEmpty && view.overflowCount == 0 && view.waitingCount == 0
+    view.rows.isEmpty
 }
 
 /// The panel never grows unbounded — show the top 3 rows, roll the rest into
@@ -113,9 +115,9 @@ func projectAttentionPanel(
 /// plus a footer summarizing overflow + waiting counts and a "View all" link.
 /// Pure view-in — all ranking/labels/targets are decided by
 /// `projectAttentionPanel`. Buttons only route; they never finalize a result.
-/// Hides entirely when there's nothing to surface; falls back to a calm empty
-/// state when there are no rows but the footer still has a waiting/overflow
-/// count to show. Mirrors the web dashboard's `AttentionPanel`.
+/// Hides entirely when there are no actionable rows — it's purely a to-do list,
+/// so a user with nothing to do sees no panel at all. Mirrors the web
+/// dashboard's `AttentionPanel`.
 struct DashboardAttentionPanel: View {
     let view: AttentionPanelView
     /// Run the row's action — fetch the match and open scoring or detail.
@@ -142,17 +144,9 @@ struct DashboardAttentionPanel: View {
 
             Rectangle().fill(FMColor.ink700).frame(height: 1)
 
-            if view.rows.isEmpty {
-                Text("You're all caught up.")
-                    .font(FMFont.ui(FMFont.sm))
-                    .foregroundStyle(FMColor.fg3)
-                    .padding(FMSpace.s4)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            } else {
-                ForEach(Array(view.rows.enumerated()), id: \.element.id) { i, row in
-                    if i > 0 { Rectangle().fill(FMColor.ink700).frame(height: 1) }
-                    AttentionRow(row: row) { onAct(row) }
-                }
+            ForEach(Array(view.rows.enumerated()), id: \.element.id) { i, row in
+                if i > 0 { Rectangle().fill(FMColor.ink700).frame(height: 1) }
+                AttentionRow(row: row) { onAct(row) }
             }
 
             Rectangle().fill(FMColor.ink700).frame(height: 1)

--- a/web-client/src/components/dashboard/attention-panel-view.test.ts
+++ b/web-client/src/components/dashboard/attention-panel-view.test.ts
@@ -126,12 +126,14 @@ describe('projectAttentionPanelView', () => {
 })
 
 describe('isAttentionPanelEmpty', () => {
-  it('is empty when there are no rows, no overflow, and nobody waiting', () => {
+  it('is empty when there are no actionable rows', () => {
     expect(isAttentionPanelEmpty(projectAttentionPanelView([], 0))).toBe(true)
   })
 
-  it('is not empty when matches are waiting on others', () => {
-    expect(isAttentionPanelEmpty(projectAttentionPanelView([], 3))).toBe(false)
+  it('is still empty when matches are waiting on others but there is nothing to act on', () => {
+    // The panel is purely a to-do list — matches waiting on others don't keep
+    // it on screen when the user has nothing to do.
+    expect(isAttentionPanelEmpty(projectAttentionPanelView([], 3))).toBe(true)
   })
 
   it('is not empty when there are actionable rows', () => {

--- a/web-client/src/components/dashboard/attention-panel-view.ts
+++ b/web-client/src/components/dashboard/attention-panel-view.ts
@@ -71,17 +71,15 @@ function routeOf(item: DashboardAttentionItem): RowRoute {
 }
 
 /**
- * Whether the panel has nothing to show — no actionable rows, no overflow, and
- * nobody waiting on others. The panel hides entirely in this case rather than
- * rendering a standalone "all caught up" card (a calm empty state still shows
- * when rows are empty but the footer has a waiting/overflow count to surface).
+ * Whether the panel has nothing actionable to show. The panel is purely a
+ * to-do list: it hides entirely whenever there are no actionable rows, even if
+ * matches are still waiting on others — there's nothing for the user to do, so
+ * the dashboard stays calm rather than showing a standing "all caught up" card.
+ * (`rows.length === 0` already implies `overflowCount === 0`, since overflow
+ * only exists once the visible rows fill.)
  */
 export function isAttentionPanelEmpty(view: AttentionPanelView): boolean {
-  return (
-    view.rows.length === 0 &&
-    view.overflowCount === 0 &&
-    view.waitingCount === 0
-  )
+  return view.rows.length === 0
 }
 
 /**

--- a/web-client/src/components/dashboard/attention-panel.page.tsx
+++ b/web-client/src/components/dashboard/attention-panel.page.tsx
@@ -36,10 +36,6 @@ const scoped = (container: Container) => ({
     if (!row) throw new Error(`No attention row for "${headline}"`)
     return within(row).getByRole('link')
   },
-  /** The calm "all caught up" empty-state copy (absent when rows exist). */
-  queryEmptyState() {
-    return container.queryByText(/all caught up/i)
-  },
   /** The "View all" footer link to /matches. */
   getViewAllLink() {
     return container.getByRole('link', { name: /view all/i })

--- a/web-client/src/components/dashboard/attention-panel.test.tsx
+++ b/web-client/src/components/dashboard/attention-panel.test.tsx
@@ -57,15 +57,14 @@ describe('AttentionPanel', () => {
     await waitFor(() => expect(page.queryPanel()).not.toBeInTheDocument())
   })
 
-  it('shows a calm empty state when rows are empty but matches are waiting', async () => {
+  it('hides even when matches are waiting but there is nothing to act on', async () => {
+    // Purely a to-do list — "N waiting on others" never keeps it on screen
+    // when the user has no actionable rows.
     page.render({
       view: buildAttentionPanelView({ rows: [], waitingCount: 2 }),
     })
 
-    await page.findPanel()
-    expect(page.queryRows()).toHaveLength(0)
-    expect(page.queryEmptyState()).toBeInTheDocument()
-    expect(page.queryFooterText(/2 waiting on others/)).toBeInTheDocument()
+    await waitFor(() => expect(page.queryPanel()).not.toBeInTheDocument())
   })
 
   it('summarizes overflow and waiting counts in the footer', async () => {

--- a/web-client/src/components/dashboard/attention-panel.tsx
+++ b/web-client/src/components/dashboard/attention-panel.tsx
@@ -18,9 +18,8 @@ export interface AttentionPanelProps {
  * plus a footer summarizing overflow + waiting counts and a `View all` link.
  * Pure view-in — all ranking/labels/routing are decided by
  * `projectAttentionPanelView`. Buttons only route; they never finalize a
- * result. Hides entirely when there's nothing to surface; falls back to a calm
- * empty state when there are no rows but the footer still has a waiting/overflow
- * count to show.
+ * result. Hides entirely when there are no actionable rows — it's purely a
+ * to-do list, so a user with nothing to do sees no panel at all.
  */
 export const AttentionPanel = ({ view }: AttentionPanelProps) => {
   const { rows, overflowCount, waitingCount, viewAllSearch } = view
@@ -38,35 +37,29 @@ export const AttentionPanel = ({ view }: AttentionPanelProps) => {
         >
           Needs your attention
         </h2>
-        {rows.length > 0 ? (
-          <ul className="flex flex-col">
-            {rows.map((row) => (
-              <li
-                key={row.matchId}
-                className="flex items-center gap-3 border-t border-[color:var(--ink-700)] px-5 py-3"
+        <ul className="flex flex-col">
+          {rows.map((row) => (
+            <li
+              key={row.matchId}
+              className="flex items-center gap-3 border-t border-[color:var(--ink-700)] px-5 py-3"
+            >
+              <UserAvatar name={row.opponentName} size={40} />
+              <span className="min-w-0 flex-1 truncate text-[15px] font-semibold text-[color:var(--chalk-50)]">
+                {row.headline}
+              </span>
+              <Button
+                asChild
+                variant={row.primary ? 'default' : 'outline'}
+                size="sm"
               >
-                <UserAvatar name={row.opponentName} size={40} />
-                <span className="min-w-0 flex-1 truncate text-[15px] font-semibold text-[color:var(--chalk-50)]">
-                  {row.headline}
-                </span>
-                <Button
-                  asChild
-                  variant={row.primary ? 'default' : 'outline'}
-                  size="sm"
-                >
-                  <Link {...row.route}>
-                    {row.actionLabel}
-                    <ArrowRight size={14} strokeWidth={1.75} />
-                  </Link>
-                </Button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="border-t border-[color:var(--ink-700)] px-5 py-6 text-[13px] text-[color:var(--chalk-300)]">
-            You&rsquo;re all caught up.
-          </p>
-        )}
+                <Link {...row.route}>
+                  {row.actionLabel}
+                  <ArrowRight size={14} strokeWidth={1.75} />
+                </Link>
+              </Button>
+            </li>
+          ))}
+        </ul>
         <AttentionFooter
           overflowCount={overflowCount}
           waitingCount={waitingCount}


### PR DESCRIPTION
## Summary

The dashboard's **"Needs your attention"** panel is meant to be purely a to-do list, but its hide condition also checked `overflowCount` and `waitingCount`. So a user with nothing to *act on* still saw the panel — rendering "You're all caught up." — whenever a match was merely waiting on an opponent. That's why the earlier hide PRs (#563 web, #575 iOS) appeared not to have shipped.

This collapses the visibility check to "no actionable rows" in **both** clients:

- **web** — `attention-panel-view.ts` `isAttentionPanelEmpty` → `rows.length === 0`; removed the now-dead "You're all caught up" branch in `attention-panel.tsx` and the unused `queryEmptyState` page-object helper.
- **iOS** — `DashboardAttentionPanel.swift` same simplification + removed the dead empty-state branch.

`rows.length === 0` already implies `overflowCount === 0` (overflow only exists once the 3 visible rows fill), so the check is exact, not lossy. The separate `/matches` Attention-tab empty state is unaffected.

## Testing

- web vitest: 769 passed · lint clean · `tsc -b && vite build` succeeded
- web-client Playwright e2e: 127 passed
- root Playwright e2e (full compose stack): 4 passed
- iOS clean simulator build: **BUILD SUCCEEDED**
- API suites + OpenAPI schema regen skipped — no `api/**` or `web-client/src/api/**` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)