### PR TITLE
Don't silently lose the iOS session on a failed Keychain write or a merge race

### DIFF
--- a/ios/Fortymm/Networking/KeychainStore.swift
+++ b/ios/Fortymm/Networking/KeychainStore.swift
@@ -17,14 +17,19 @@ struct KeychainStore {
         self.account = account
     }
 
-    func save(_ value: String) {
+    /// Persist `value`, returning whether the write succeeded. A write can fail
+    /// (e.g. `errSecInteractionNotAllowed` if attempted before the device's
+    /// first unlock, given `kSecAttrAccessibleAfterFirstUnlock`); the caller
+    /// must not assume the value is durably stored.
+    @discardableResult
+    func save(_ value: String) -> Bool {
         // Delete any existing item first so SecItemAdd can't fail with
         // errSecDuplicateItem.
         SecItemDelete(baseQuery as CFDictionary)
         var attributes = baseQuery
         attributes[kSecValueData as String] = Data(value.utf8)
         attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
-        _ = SecItemAdd(attributes as CFDictionary, nil)
+        return SecItemAdd(attributes as CFDictionary, nil) == errSecSuccess
     }
 
     func load() -> String? {

--- a/ios/Fortymm/Networking/SessionTokenStore.swift
+++ b/ios/Fortymm/Networking/SessionTokenStore.swift
@@ -49,22 +49,19 @@ actor SessionTokenStore {
     /// only for the process lifetime.
     func updateCSRF(_ value: String) { csrf = value }
 
-    /// Persist a freshly minted or rotated token. When unchanged, skip the
-    /// rewrite but still retry a prior failed persist, so a resumed session
-    /// eventually lands in the Keychain even if its first write was blocked.
+    /// Persist a freshly minted or rotated token. No-op if unchanged, so a
+    /// resumed session doesn't rewrite the Keychain on every call.
     func update(_ token: String) {
-        guard token != cached else {
-            retryPersistIfNeeded()
-            return
-        }
+        guard token != cached else { return }
         cached = token
         didLoad = true
         needsPersist = !keychain.save(token)
     }
 
-    /// Re-attempt a previously-failed Keychain write. Called on every access, so
-    /// once the device is unlocked the cached token gets persisted on the next
-    /// request rather than waiting for a token rotation.
+    /// Re-attempt a previously-failed Keychain write. Called from `token()`,
+    /// which runs at the start of every request, so once the device is unlocked
+    /// the cached token gets persisted on the next request rather than waiting
+    /// for a token rotation.
     private func retryPersistIfNeeded() {
         guard needsPersist, let token = cached else { return }
         needsPersist = !keychain.save(token)

--- a/ios/Fortymm/Networking/SessionTokenStore.swift
+++ b/ios/Fortymm/Networking/SessionTokenStore.swift
@@ -12,6 +12,14 @@ actor SessionTokenStore {
     private var cached: String?
     private var didLoad = false
 
+    /// Set when `cached` holds a token the Keychain write didn't persist — e.g.
+    /// a session minted on a background/locked launch, before the device's
+    /// first unlock, fails the `kSecAttrAccessibleAfterFirstUnlock`-gated write.
+    /// We retry the save on the next access so the token isn't silently lost on
+    /// the next cold launch (which would mint a brand-new guest, abandoning this
+    /// one's matches and rating).
+    private var needsPersist = false
+
     /// The double-submit CSRF token, captured from the server's non-HttpOnly
     /// `csrf_token` cookie. In-memory only: it isn't a secret, and the API
     /// reissues it on the `/v1/session` bootstrap the app makes on every launch
@@ -29,6 +37,7 @@ actor SessionTokenStore {
             cached = keychain.load()
             didLoad = true
         }
+        retryPersistIfNeeded()
         return cached
     }
 
@@ -40,13 +49,25 @@ actor SessionTokenStore {
     /// only for the process lifetime.
     func updateCSRF(_ value: String) { csrf = value }
 
-    /// Persist a freshly minted or rotated token. No-op if unchanged, so a
-    /// resumed session doesn't rewrite the Keychain on every call.
+    /// Persist a freshly minted or rotated token. When unchanged, skip the
+    /// rewrite but still retry a prior failed persist, so a resumed session
+    /// eventually lands in the Keychain even if its first write was blocked.
     func update(_ token: String) {
-        guard token != cached else { return }
+        guard token != cached else {
+            retryPersistIfNeeded()
+            return
+        }
         cached = token
         didLoad = true
-        keychain.save(token)
+        needsPersist = !keychain.save(token)
+    }
+
+    /// Re-attempt a previously-failed Keychain write. Called on every access, so
+    /// once the device is unlocked the cached token gets persisted on the next
+    /// request rather than waiting for a token rotation.
+    private func retryPersistIfNeeded() {
+        guard needsPersist, let token = cached else { return }
+        needsPersist = !keychain.save(token)
     }
 
     /// Forget the session (sign-out). Clears both the cache and the vault, plus
@@ -55,6 +76,7 @@ actor SessionTokenStore {
     func clear() {
         cached = nil
         csrf = nil
+        needsPersist = false
         didLoad = true
         keychain.delete()
     }

--- a/ios/Fortymm/Session/SessionStore.swift
+++ b/ios/Fortymm/Session/SessionStore.swift
@@ -95,10 +95,17 @@ final class SessionStore: ObservableObject {
         state = .loading
         do {
             let response = try await client.getSession()
+            // While this getSession was in flight, a concurrent request may have
+            // flipped us to .signedOut (its session was merged away → token
+            // cleared → this call ran cookieless and minted a *fresh* guest), or
+            // a deep link may have resolved the session. Don't clobber either:
+            // only commit if we're still the in-flight load.
+            guard case .loading = state else { return }
             state = .loaded(response.data.user)
         } catch let APIError.sessionMerged(message, email) {
             signedOut(reason: message, email: email)
         } catch {
+            guard case .loading = state else { return }
             state = .failed(error.fmMessage)
         }
     }


### PR DESCRIPTION
Two iOS session-integrity fixes (both verified against current `main`).

## A — Failed Keychain write no longer silently drops the session
`KeychainStore.save` discarded `SecItemAdd`'s result, and `SessionTokenStore` marked the in-memory cache as persisted regardless. A write blocked before the device's first unlock (`kSecAttrAccessibleAfterFirstUnlock`) therefore worked for the session but **vanished on the next cold launch** — minting a brand-new guest and abandoning the old one's matches/rating.

- `save()` now returns whether the write succeeded.
- `SessionTokenStore` tracks an unpersisted token (`needsPersist`) and **retries the write on the next access** (`token()`, which runs at the start of every request), so it lands once the device unlocks. `clear()` resets the flag.

## B — `signedOut` / deep-link state no longer clobbered by an in-flight `getSession()`
`SessionStore.load()` committed `.loaded(user)` unconditionally after `getSession`. If a concurrent request hit a `session_merged` 401 (clearing the token, posting the `signedOut` notification) while `getSession` was in flight, that call ran cookieless, minted a fresh guest, and `load()` overwrote `.signedOut` with `.loaded(newGuest)` — silently acting as a different guest.

- `load()` now commits only if it's still the in-flight load (`state == .loading`), matching the web client's guard. Also protects a deep-link-resolved session.

## Testing
- Clean `xcodebuild ... -sdk iphonesimulator` build — BUILD SUCCEEDED.
- These are timing-dependent defensive guards (locked-write window, merge race) that can't be reliably triggered through the Simulator UI; QA confirms the normal paths (session persists across relaunch; sign-in/merge routing) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)