### PR TITLE
Make iOS merged-session sign-out token-aware (don't clobber a live session)

### DIFF
--- a/ios/Fortymm/Networking/APIClient.swift
+++ b/ios/Fortymm/Networking/APIClient.swift
@@ -173,10 +173,14 @@ struct APIClient {
         }
         // Send the session and its CSRF companion as cookies. The server's
         // double-submit check compares the CSRF cookie against the header, so
-        // both must be present and equal on mutations.
+        // both must be present and equal on mutations. `sentToken` is captured
+        // so the response handling can tell whether a session-dropping reply
+        // pertains to the token *this* request used (vs. one a newer sign-in
+        // has since replaced).
+        let sentToken = await tokens.token()
         let csrf = await tokens.csrfToken()
         let cookieHeader = [
-            (await tokens.token()).map { "\(Self.sessionCookieName)=\($0)" },
+            sentToken.map { "\(Self.sessionCookieName)=\($0)" },
             csrf.map { "\(Self.csrfCookieName)=\($0)" },
         ].compactMap { $0 }.joined(separator: "; ")
         if !cookieHeader.isEmpty {
@@ -190,13 +194,14 @@ struct APIClient {
         guard let http = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
         }
-        await captureSessionCookie(from: http, url: url)
-        guard (200..<300).contains(http.statusCode) else {
-            // A merged-away guest's cookie still resolves server-side, so this
-            // can land on *any* request — broadcast it (and drop the dead token)
-            // so the app routes to sign-in instead of acting as the ghost.
-            if http.statusCode == 401, let info = Self.mergedSessionInfo(from: data) {
-                await tokens.clear()
+        // A merged-away guest's cookie still resolves server-side, so this 401
+        // can land on *any* request. Handle it before the generic cookie capture
+        // and make it token-aware: only drop the token + broadcast the sign-out
+        // if the cookie this request sent is still the one we hold. Otherwise a
+        // stale in-flight request — whose token a newer sign-in already replaced
+        // — would wipe the *new* token and kick the user out of a live session.
+        if http.statusCode == 401, let info = Self.mergedSessionInfo(from: data) {
+            if await tokens.clearIfCurrent(sentToken) {
                 var userInfo: [String: Any] = ["message": info.message]
                 if let email = info.email { userInfo["email"] = email }
                 NotificationCenter.default.post(
@@ -204,6 +209,12 @@ struct APIClient {
                 )
                 throw APIError.sessionMerged(message: info.message, email: info.email)
             }
+            // Token already superseded — fail this request without disturbing the
+            // current session.
+            throw APIError.http(status: http.statusCode, detail: Self.detail(from: data))
+        }
+        await captureSessionCookie(from: http, url: url, sentToken: sentToken)
+        guard (200..<300).contains(http.statusCode) else {
             throw APIError.http(status: http.statusCode, detail: Self.detail(from: data))
         }
         do {
@@ -269,7 +280,9 @@ struct APIClient {
     /// out of the response and persist them. The API sets both together and
     /// folds them into the comma-joined `Set-Cookie` header; both use `Max-Age`
     /// (no comma-bearing `Expires`), so `HTTPCookie` splits them cleanly.
-    private func captureSessionCookie(from http: HTTPURLResponse, url: URL) async {
+    private func captureSessionCookie(
+        from http: HTTPURLResponse, url: URL, sentToken: String?
+    ) async {
         guard let header = http.value(forHTTPHeaderField: "Set-Cookie") else {
             return
         }
@@ -279,10 +292,11 @@ struct APIClient {
         )
         if let session = cookies.first(where: { $0.name == Self.sessionCookieName }) {
             if session.value.isEmpty {
-                // A clearing Set-Cookie (e.g. the session-merged 401 clears the
-                // dead cookie). Drop the stored token (and CSRF companion) so the
-                // next call starts cookieless and mints a fresh guest.
-                await tokens.clear()
+                // A clearing Set-Cookie. Drop the token only if it's still the
+                // one this request sent, so a stale reply can't wipe a token a
+                // newer sign-in already installed. (The merged-401 clear is
+                // handled before this, token-aware; this guards any other path.)
+                _ = await tokens.clearIfCurrent(sentToken)
             } else {
                 await tokens.update(session.value)
             }

--- a/ios/Fortymm/Networking/SessionTokenStore.swift
+++ b/ios/Fortymm/Networking/SessionTokenStore.swift
@@ -77,4 +77,20 @@ actor SessionTokenStore {
         didLoad = true
         keychain.delete()
     }
+
+    /// Clear the session only if `token` is still the one we hold, returning
+    /// whether it did. A response that drops the session (the merged-away 401)
+    /// belongs to the token the *request* sent; if a newer sign-in has since
+    /// replaced it, a stale in-flight request must not wipe the new token or
+    /// trigger a sign-out. Hydrate first so the comparison is against the real
+    /// stored token, not a not-yet-loaded `nil`.
+    func clearIfCurrent(_ token: String?) -> Bool {
+        if !didLoad {
+            cached = keychain.load()
+            didLoad = true
+        }
+        guard cached == token else { return false }
+        clear()
+        return true
+    }
 }

--- a/ios/Fortymm/Networking/SessionTokenStore.swift
+++ b/ios/Fortymm/Networking/SessionTokenStore.swift
@@ -31,12 +31,16 @@ actor SessionTokenStore {
         self.keychain = keychain
     }
 
+    /// Load the token from the Keychain into the cache once, on first access.
+    private func hydrate() {
+        guard !didLoad else { return }
+        cached = keychain.load()
+        didLoad = true
+    }
+
     /// The current token, lazily hydrated from the Keychain on first access.
     func token() -> String? {
-        if !didLoad {
-            cached = keychain.load()
-            didLoad = true
-        }
+        hydrate()
         retryPersistIfNeeded()
         return cached
     }
@@ -85,10 +89,7 @@ actor SessionTokenStore {
     /// trigger a sign-out. Hydrate first so the comparison is against the real
     /// stored token, not a not-yet-loaded `nil`.
     func clearIfCurrent(_ token: String?) -> Bool {
-        if !didLoad {
-            cached = keychain.load()
-            didLoad = true
-        }
+        hydrate()
         guard cached == token else { return false }
         clear()
         return true

--- a/ios/Fortymm/Session/SessionStore.swift
+++ b/ios/Fortymm/Session/SessionStore.swift
@@ -103,6 +103,12 @@ final class SessionStore: ObservableObject {
             guard case .loading = state else { return }
             state = .loaded(response.data.user)
         } catch let APIError.sessionMerged(message, email) {
+            // getSession sends the current token, and APIClient only raises this
+            // for a merge of the token it sent — so reaching here means *our*
+            // session was merged and signing out is right. Still gate on
+            // .loading for symmetry, so a state another task already resolved
+            // mid-flight isn't overwritten.
+            guard case .loading = state else { return }
             signedOut(reason: message, email: email)
         } catch {
             guard case .loading = state else { return }


### PR DESCRIPTION
Follow-up to #597, hardening the merge-race handling at its source.

## Problem
The merged-away 401 carries a clearing `Set-Cookie`, and `APIClient` cleared the token + broadcast the sign-out notification **unconditionally**. A stale in-flight request — one sent with a guest token that a just-completed sign-in had already replaced — would therefore wipe the **new** token and kick the user out of the session they'd just signed into. The SessionStore guards from #597 couldn't prevent it: the notification sink calls `signedOut` unconditionally, so the clobber happened regardless of `load()`'s state checks.

## Fix (at the source)
- `SessionTokenStore.clearIfCurrent(_:)` — atomic compare-and-clear inside the actor; clears only when the passed token is still the one held (no TOCTOU).
- `APIClient` captures the token each request **sent** and, on a merged 401, only clears + notifies when that token is still current. A superseded token fails the request benignly without touching the live session. The merged-401 is now handled before the generic cookie capture, and the capture's clearing-cookie path is likewise token-aware.
- Because the spurious notification no longer fires, the sink and `load()`'s `sessionMerged` branch become correct automatically; `load()` also gains the `.loading` guard its siblings have, for symmetry.

This also fixes a strictly-worse bug a SessionStore-only patch would have missed: the stale request wiping the freshly-signed-in account's token.

## Testing
- Clean `xcodebuild ... -sdk iphonesimulator` build — BUILD SUCCEEDED.
- Standalone logic test of the `clearIfCurrent` decision (8 cases): current-session merge → sign out; stale token → benign, new token preserved; cookieless/edge cases pass.
- Simulator QA confirms normal session/sign-in paths are unregressed (the race itself isn't UI-reproducible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)