### PR TITLE
Notification types & channels as DB lookup tables (server-driven taxonomy)

### DIFF
--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -13,6 +13,8 @@ from app.models.notification import (
     NotificationChannelSetting,
     NotificationPreference,
 )
+from app.models.notification_channel import NotificationChannel
+from app.models.notification_type import NotificationType
 from app.models.permission import Permission
 from app.models.rating_history import RatingHistory, RatingHistorySource
 from app.models.rating_strategy import RatingStrategy
@@ -46,8 +48,10 @@ __all__ = [
     "MatchSignature",
     "MatchStatus",
     "Notification",
+    "NotificationChannel",
     "NotificationChannelSetting",
     "NotificationPreference",
+    "NotificationType",
     "Permission",
     "RatingHistory",
     "RatingHistorySource",

--- a/api/app/models/notification.py
+++ b/api/app/models/notification.py
@@ -21,7 +21,8 @@ class Notification(Base):
     ``category`` is a string (validated against
     ``app.notifications.taxonomy.NotificationCategory`` at the boundary) rather
     than a Postgres enum, matching ``DeviceToken.platform`` — adding a category
-    later needs no enum migration.
+    later needs no enum migration. It carries an FK to ``notification_types.key``
+    so a value off the taxonomy can't be stored.
     """
 
     __tablename__ = "notifications"
@@ -41,7 +42,11 @@ class Notification(Base):
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
     )
-    category: Mapped[str] = mapped_column(String(32), nullable=False)
+    category: Mapped[str] = mapped_column(
+        String(32),
+        ForeignKey("notification_types.key", ondelete="RESTRICT"),
+        nullable=False,
+    )
     title: Mapped[str] = mapped_column(String(200), nullable=False)
     body: Mapped[str] = mapped_column(String(500), nullable=False)
     # Optional in-app affordances mirrored from the design's notification row:
@@ -90,7 +95,11 @@ class NotificationChannelSetting(Base):
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
     )
-    channel: Mapped[str] = mapped_column(String(16), nullable=False)
+    channel: Mapped[str] = mapped_column(
+        String(16),
+        ForeignKey("notification_channels.key", ondelete="RESTRICT"),
+        nullable=False,
+    )
     enabled: Mapped[bool] = mapped_column(nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -135,8 +144,16 @@ class NotificationPreference(Base):
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
     )
-    category: Mapped[str] = mapped_column(String(32), nullable=False)
-    channel: Mapped[str] = mapped_column(String(16), nullable=False)
+    category: Mapped[str] = mapped_column(
+        String(32),
+        ForeignKey("notification_types.key", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    channel: Mapped[str] = mapped_column(
+        String(16),
+        ForeignKey("notification_channels.key", ondelete="RESTRICT"),
+        nullable=False,
+    )
     enabled: Mapped[bool] = mapped_column(nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/api/app/models/notification_channel.py
+++ b/api/app/models/notification_channel.py
@@ -1,0 +1,53 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class NotificationChannel(Base):
+    """Lookup row for one delivery channel — the DB backing for
+    ``app.notifications.taxonomy.NotificationChannel`` (the enum, which keeps the
+    same name).
+
+    The enum stays the code source of truth (validation + OpenAPI keys); this
+    table mirrors it for the FK on the ``channel`` columns and the server-driven
+    display taxonomy. ``is_available`` is whether the server can actually deliver
+    on this channel today (``sms`` is present but unavailable). Behavioural rules
+    (default-on, locked) stay in ``app.notifications.taxonomy``. One row per
+    channel ``key``.
+    """
+
+    __tablename__ = "notification_channels"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    key: Mapped[str] = mapped_column(
+        String(16), unique=True, nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    display_order: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("true")
+    )
+    is_available: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("true")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/api/app/models/notification_type.py
+++ b/api/app/models/notification_type.py
@@ -1,0 +1,48 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class NotificationType(Base):
+    """Lookup row for one notification category — the DB backing for
+    ``app.notifications.taxonomy.NotificationCategory``.
+
+    The enum stays the code source of truth (validation + OpenAPI keys); this
+    table mirrors it for joins, queryability, the FK on ``notifications.category``,
+    and the server-driven display taxonomy (``name`` / ``short_label`` /
+    ``description`` / ``display_order``). One row per category ``key``.
+    """
+
+    __tablename__ = "notification_types"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    key: Mapped[str] = mapped_column(
+        String(32), unique=True, nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    short_label: Mapped[str] = mapped_column(String(32), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    display_order: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("true")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/api/app/notifications/router.py
+++ b/api/app/notifications/router.py
@@ -21,6 +21,7 @@ from app.schemas.notification import (
     NotificationItem,
     NotificationPreferences,
     NotificationPreferencesUpdate,
+    NotificationTaxonomy,
     RegisterDeviceTokenRequest,
     TestNotificationResponse,
     UnreadCountResponse,
@@ -100,6 +101,20 @@ async def mark_notification_read(
     if item is None:
         raise HTTPException(status_code=404, detail="Notification not found.")
     return item
+
+
+# ----- display taxonomy -----------------------------------------------------
+
+
+@router.get("/v1/notification-taxonomy", response_model=NotificationTaxonomy)
+async def get_notification_taxonomy(
+    service: NotificationService = Depends(get_notification_service),
+    current_user: User = Depends(get_current_user),
+) -> NotificationTaxonomy:
+    """The shared display taxonomy: the ordered category/channel lists with their
+    labels, read from the lookup tables. The preferences page, feed filters, and
+    broadcast tool all render their labels/order from this."""
+    return await service.get_taxonomy()
 
 
 # ----- preferences ----------------------------------------------------------

--- a/api/app/notifications/service.py
+++ b/api/app/notifications/service.py
@@ -26,11 +26,12 @@ from app.models import (
     Notification,
     NotificationChannelSetting,
     NotificationPreference,
+    NotificationType,
     User,
 )
+from app.models import NotificationChannel as NotificationChannelModel
 from app.notifications.apns import Environment, PushSender, SendOutcome
 from app.notifications.taxonomy import (
-    CHANNEL_AVAILABLE,
     LOCKED_CELLS,
     LOCKED_CHANNELS,
     NotificationCategory,
@@ -48,11 +49,14 @@ from app.schemas.notification import (
     MarkAllReadResponse,
     NotificationCategoryCell,
     NotificationCategoryPreference,
+    NotificationChannelInfo,
     NotificationChannelState,
     NotificationFeed,
     NotificationItem,
     NotificationPreferences,
     NotificationPreferencesUpdate,
+    NotificationTaxonomy,
+    NotificationTypeInfo,
     RegisterDeviceTokenRequest,
     TestNotificationResponse,
     UnreadCountResponse,
@@ -333,14 +337,104 @@ class NotificationService:
         await self._db.commit()
         return MarkAllReadResponse(marked=cast(CursorResult[Any], result).rowcount or 0)
 
+    # ----- display taxonomy (DB-backed labels + order) ---------------------
+
+    async def get_taxonomy(self) -> NotificationTaxonomy:
+        """The shared display taxonomy: the ordered category/channel lists with
+        their labels, read from the lookup tables. Every notification surface
+        (preferences, feed filters, broadcast) renders from this."""
+        type_rows = await self._load_type_rows()
+        channel_rows = await self._load_channel_rows()
+        types = [
+            NotificationTypeInfo(
+                key=category,
+                label=row.name,
+                short=row.short_label,
+                description=row.description,
+            )
+            for row in type_rows
+            if (category := _parse_category(row.key)) is not None
+        ]
+        channels = [
+            NotificationChannelInfo(
+                key=channel,
+                label=row.name,
+                available=row.is_available,
+                description=row.description,
+            )
+            for row in channel_rows
+            if (channel := _parse_channel(row.key)) is not None
+        ]
+        return NotificationTaxonomy(types=types, channels=channels)
+
+    async def _load_type_rows(self) -> Sequence[NotificationType]:
+        """Active notification-type rows in display order."""
+        return (
+            (
+                await self._db.execute(
+                    select(NotificationType)
+                    .where(NotificationType.is_active.is_(True))
+                    .order_by(NotificationType.display_order)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    async def _load_channel_rows(self) -> Sequence[NotificationChannelModel]:
+        """Active notification-channel rows in display order."""
+        return (
+            (
+                await self._db.execute(
+                    select(NotificationChannelModel)
+                    .where(NotificationChannelModel.is_active.is_(True))
+                    .order_by(NotificationChannelModel.display_order)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    async def _channel_order_and_availability(
+        self,
+    ) -> tuple[list[NotificationChannel], dict[NotificationChannel, bool]]:
+        """The active channels in display order plus their availability map,
+        both sourced from ``notification_channels``."""
+        order: list[NotificationChannel] = []
+        availability: dict[NotificationChannel, bool] = {}
+        for row in await self._load_channel_rows():
+            channel = _parse_channel(row.key)
+            if channel is None:
+                continue
+            order.append(channel)
+            availability[channel] = row.is_available
+        return order, availability
+
+    async def _category_order(self) -> list[NotificationCategory]:
+        """The active categories in display order, from ``notification_types``."""
+        order: list[NotificationCategory] = []
+        for row in await self._load_type_rows():
+            category = _parse_category(row.key)
+            if category is not None:
+                order.append(category)
+        return order
+
     # ----- preferences -----------------------------------------------------
 
     async def get_preferences(self, user: User) -> NotificationPreferences:
         channel_overrides = await self._channel_overrides(user.id)
         cell_overrides = await self._cell_overrides(user.id)
         device_count = await self._device_count(user.id)
+        channel_order, availability = await self._channel_order_and_availability()
+        category_order = await self._category_order()
         return self._build_preferences(
-            user, channel_overrides, cell_overrides, device_count
+            user,
+            channel_overrides,
+            cell_overrides,
+            device_count,
+            channel_order,
+            availability,
+            category_order,
         )
 
     async def update_preferences(
@@ -350,17 +444,22 @@ class NotificationService:
         default (and deleting overrides that fall back to the default).
         Locked/unavailable channels and cells are ignored — the user can't
         change them. Returns the freshly re-resolved preferences."""
+        _, availability = await self._channel_order_and_availability()
         for channel_update in update_req.channels:
             channel = channel_update.channel
-            if channel in LOCKED_CHANNELS or not CHANNEL_AVAILABLE[channel]:
+            if channel in LOCKED_CHANNELS or not availability.get(channel, False):
                 continue
             await self._set_channel_override(user.id, channel, channel_update.enabled)
         for cell_update in update_req.cells:
             cell = (cell_update.category, cell_update.channel)
-            if cell in LOCKED_CELLS or not CHANNEL_AVAILABLE[cell_update.channel]:
+            if cell in LOCKED_CELLS or not availability.get(cell_update.channel, False):
                 continue
             await self._set_cell_override(
-                user.id, cell_update.category, cell_update.channel, cell_update.enabled
+                user.id,
+                cell_update.category,
+                cell_update.channel,
+                cell_update.enabled,
+                availability.get(cell_update.channel, False),
             )
         await self._db.commit()
         return await self.get_preferences(user)
@@ -394,8 +493,9 @@ class NotificationService:
         category: NotificationCategory,
         channel: NotificationChannel,
         enabled: bool,
+        available: bool,
     ) -> None:
-        if enabled == cell_default(category, channel):
+        if enabled == cell_default(category, channel, available):
             await self._db.execute(
                 delete(NotificationPreference).where(
                     NotificationPreference.user_id == user_id,
@@ -423,18 +523,21 @@ class NotificationService:
         channel_overrides: dict[NotificationChannel, bool],
         cell_overrides: dict[tuple[NotificationCategory, NotificationChannel], bool],
         device_count: int,
+        channel_order: Sequence[NotificationChannel],
+        availability: Mapping[NotificationChannel, bool],
+        category_order: Sequence[NotificationCategory],
     ) -> NotificationPreferences:
         channels = [
             NotificationChannelState(
                 channel=channel,
                 enabled=resolve_channel_enabled(
-                    channel, channel_overrides.get(channel)
+                    channel, availability[channel], channel_overrides.get(channel)
                 ),
-                available=CHANNEL_AVAILABLE[channel],
+                available=availability[channel],
                 locked=channel in LOCKED_CHANNELS,
                 destination=self._channel_destination(channel, user, device_count),
             )
-            for channel in NotificationChannel
+            for channel in channel_order
         ]
         categories = [
             NotificationCategoryPreference(
@@ -443,14 +546,17 @@ class NotificationService:
                     NotificationCategoryCell(
                         channel=channel,
                         enabled=resolve_cell_enabled(
-                            category, channel, cell_overrides.get((category, channel))
+                            category,
+                            channel,
+                            availability[channel],
+                            cell_overrides.get((category, channel)),
                         ),
                         locked=(category, channel) in LOCKED_CELLS,
                     )
-                    for channel in NotificationChannel
+                    for channel in channel_order
                 ],
             )
-            for category in NotificationCategory
+            for category in category_order
         ]
         return NotificationPreferences(channels=channels, categories=categories)
 
@@ -521,11 +627,15 @@ class NotificationService:
     ) -> set[NotificationChannel]:
         channel_overrides = await self._channel_overrides(user_id)
         cell_overrides = await self._cell_overrides(user_id, category)
+        _, availability = await self._channel_order_and_availability()
         effective: set[NotificationChannel] = set()
         for channel in candidates:
-            master = resolve_channel_enabled(channel, channel_overrides.get(channel))
+            available = availability.get(channel, False)
+            master = resolve_channel_enabled(
+                channel, available, channel_overrides.get(channel)
+            )
             cell = resolve_cell_enabled(
-                category, channel, cell_overrides.get((category, channel))
+                category, channel, available, cell_overrides.get((category, channel))
             )
             if master and cell:
                 effective.add(channel)

--- a/api/app/notifications/service.py
+++ b/api/app/notifications/service.py
@@ -113,6 +113,13 @@ class NotificationService:
     def __init__(self, db: AsyncSession, sender: PushSender) -> None:
         self._db = db
         self._sender = sender
+        # The notification_types / notification_channels lookup tables are
+        # deploy-stable (never written at runtime), and the service is
+        # request-scoped, so load each once and reuse it for the request — a
+        # broadcast to N recipients otherwise re-queries the same tiny tables N
+        # times via _effective_channels.
+        self._type_rows: Sequence[NotificationType] | None = None
+        self._channel_rows: Sequence[NotificationChannelModel] | None = None
 
     # ----- device tokens (unchanged) ---------------------------------------
 
@@ -368,32 +375,36 @@ class NotificationService:
         return NotificationTaxonomy(types=types, channels=channels)
 
     async def _load_type_rows(self) -> Sequence[NotificationType]:
-        """Active notification-type rows in display order."""
-        return (
-            (
-                await self._db.execute(
-                    select(NotificationType)
-                    .where(NotificationType.is_active.is_(True))
-                    .order_by(NotificationType.display_order)
+        """Active notification-type rows in display order (cached per request)."""
+        if self._type_rows is None:
+            self._type_rows = (
+                (
+                    await self._db.execute(
+                        select(NotificationType)
+                        .where(NotificationType.is_active.is_(True))
+                        .order_by(NotificationType.display_order)
+                    )
                 )
+                .scalars()
+                .all()
             )
-            .scalars()
-            .all()
-        )
+        return self._type_rows
 
     async def _load_channel_rows(self) -> Sequence[NotificationChannelModel]:
-        """Active notification-channel rows in display order."""
-        return (
-            (
-                await self._db.execute(
-                    select(NotificationChannelModel)
-                    .where(NotificationChannelModel.is_active.is_(True))
-                    .order_by(NotificationChannelModel.display_order)
+        """Active notification-channel rows in display order (cached per request)."""
+        if self._channel_rows is None:
+            self._channel_rows = (
+                (
+                    await self._db.execute(
+                        select(NotificationChannelModel)
+                        .where(NotificationChannelModel.is_active.is_(True))
+                        .order_by(NotificationChannelModel.display_order)
+                    )
                 )
+                .scalars()
+                .all()
             )
-            .scalars()
-            .all()
-        )
+        return self._channel_rows
 
     async def _channel_order_and_availability(
         self,

--- a/api/app/notifications/taxonomy.py
+++ b/api/app/notifications/taxonomy.py
@@ -39,10 +39,11 @@ class NotificationChannel(StrEnum):
 # up, so it's surfaced in the preferences matrix (the design includes it) but
 # greyed out and never delivered — rather than pretending it works.
 #
-# This is the *seed* source for ``notification_channels.is_available`` (migration
-# 0009 / the tests' conftest). At runtime, availability is read from that table
-# and passed into the resolvers below — the DB row is the source of truth, this
-# dict only initialises it so the two can't silently disagree.
+# At runtime, availability is read from ``notification_channels.is_available`` and
+# passed into the resolvers below — the DB row is the source of truth. This dict
+# mirrors those seeded values: the tests' conftest seeds the table straight from
+# it, and migration 0009 hardcodes the same booleans (migrations stay
+# self-contained and can't import app code).
 CHANNEL_AVAILABLE: dict[NotificationChannel, bool] = {
     NotificationChannel.IN_APP: True,
     NotificationChannel.PUSH: True,

--- a/api/app/notifications/taxonomy.py
+++ b/api/app/notifications/taxonomy.py
@@ -38,6 +38,11 @@ class NotificationChannel(StrEnum):
 # Channels the server can actually deliver on today. SMS has no provider wired
 # up, so it's surfaced in the preferences matrix (the design includes it) but
 # greyed out and never delivered — rather than pretending it works.
+#
+# This is the *seed* source for ``notification_channels.is_available`` (migration
+# 0009 / the tests' conftest). At runtime, availability is read from that table
+# and passed into the resolvers below — the DB row is the source of truth, this
+# dict only initialises it so the two can't silently disagree.
 CHANNEL_AVAILABLE: dict[NotificationChannel, bool] = {
     NotificationChannel.IN_APP: True,
     NotificationChannel.PUSH: True,
@@ -78,23 +83,27 @@ def channel_default(channel: NotificationChannel) -> bool:
     return DEFAULT_CHANNEL_ENABLED[channel]
 
 
-def cell_default(category: NotificationCategory, channel: NotificationChannel) -> bool:
+def cell_default(
+    category: NotificationCategory, channel: NotificationChannel, available: bool
+) -> bool:
     """The out-of-the-box per-category/per-channel state, before any override.
-    Available channels start on; the unavailable SMS column starts off."""
+    Available channels start on; an unavailable column (SMS) starts off.
+    ``available`` comes from the ``notification_channels`` row."""
     if (category, channel) in LOCKED_CELLS:
         return True
-    return CHANNEL_AVAILABLE[channel]
+    return available
 
 
 def resolve_channel_enabled(
-    channel: NotificationChannel, override: bool | None
+    channel: NotificationChannel, available: bool, override: bool | None
 ) -> bool:
     """The effective master toggle: a locked channel is always on, an
     unavailable channel is always off, otherwise the stored override (or the
-    default when none is stored)."""
+    default when none is stored). ``available`` comes from the
+    ``notification_channels`` row."""
     if channel in LOCKED_CHANNELS:
         return True
-    if not CHANNEL_AVAILABLE[channel]:
+    if not available:
         return False
     return channel_default(channel) if override is None else override
 
@@ -102,13 +111,15 @@ def resolve_channel_enabled(
 def resolve_cell_enabled(
     category: NotificationCategory,
     channel: NotificationChannel,
+    available: bool,
     override: bool | None,
 ) -> bool:
     """The effective per-cell toggle, before the master gate. Locked cells are
     always on; unavailable channels always off; otherwise the override (or the
-    default when none is stored)."""
+    default when none is stored). ``available`` comes from the
+    ``notification_channels`` row."""
     if (category, channel) in LOCKED_CELLS:
         return True
-    if not CHANNEL_AVAILABLE[channel]:
+    if not available:
         return False
-    return cell_default(category, channel) if override is None else override
+    return cell_default(category, channel, available) if override is None else override

--- a/api/app/schemas/notification.py
+++ b/api/app/schemas/notification.py
@@ -78,6 +78,40 @@ class MarkAllReadResponse(BaseModel):
     marked: int
 
 
+# ----- display taxonomy (labels + order, DB-backed) -------------------------
+
+
+class NotificationTypeInfo(BaseModel):
+    """One notification category for display: its key plus the human labels and
+    ordering the UI renders. Sourced from the ``notification_types`` table so the
+    server owns the labels/order (the client keeps only icons/colours)."""
+
+    key: NotificationCategory
+    label: str
+    short: str
+    description: str | None = None
+
+
+class NotificationChannelInfo(BaseModel):
+    """One delivery channel for display: its key, label, and whether the server
+    can deliver on it (SMS is shown but unavailable). Sourced from the
+    ``notification_channels`` table."""
+
+    key: NotificationChannel
+    label: str
+    available: bool
+    description: str | None = None
+
+
+class NotificationTaxonomy(BaseModel):
+    """The shared display taxonomy — the ordered lists of categories and channels
+    every notification surface (preferences, feed filters, broadcast) renders.
+    Reference data, fetched once and cached on the client."""
+
+    types: list[NotificationTypeInfo]
+    channels: list[NotificationChannelInfo]
+
+
 # ----- preferences (per-channel masters + per-cell matrix) ------------------
 
 

--- a/api/migrations/versions/20260607_0001_0009_create_notification_tables.py
+++ b/api/migrations/versions/20260607_0001_0009_create_notification_tables.py
@@ -4,11 +4,14 @@ Revision ID: 0009
 Revises: 0008
 Create Date: 2026-06-07 00:01:00.000000
 
-Persisted in-app notifications plus the two sparse preference tables (per-channel
-master toggles and per-(category, channel) cells). Per the pre-deploy convention
-in api/CLAUDE.md, edits to this migration happen in place. No backfill — assumes
-a fresh / empty DB.
+The notification lookup tables (notification_types, notification_channels) plus
+persisted in-app notifications and the two sparse preference tables (per-channel
+master toggles and per-(category, channel) cells). The lookup tables are created
+and seeded first so the category/channel columns can carry FKs to them. Per the
+pre-deploy convention in api/CLAUDE.md, edits to this migration happen in place.
+No backfill — assumes a fresh / empty DB.
 """
+import uuid
 from typing import Sequence, Union
 
 from alembic import op
@@ -22,7 +25,132 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+# Seeded lookup rows. Keys mirror app.notifications.taxonomy enums; names /
+# short labels mirror the (former) client-side CATEGORY_META / CHANNEL_META.
+NOTIFICATION_TYPE_SEED = [
+    ("33333333-3333-3333-3333-333333330001", "match_reminder", "Match reminders", "Match"),
+    ("33333333-3333-3333-3333-333333330002", "rating_change", "Rating changes", "Rating"),
+    ("33333333-3333-3333-3333-333333330003", "tournament", "Tournament news", "Tourney"),
+    ("33333333-3333-3333-3333-333333330004", "opponent", "Challenges & friends", "Social"),
+    ("33333333-3333-3333-3333-333333330005", "result_confirm", "Score confirmations", "Scores"),
+]
+
+NOTIFICATION_CHANNEL_SEED = [
+    ("44444444-4444-4444-4444-444444440001", "in_app", "In-app", True),
+    ("44444444-4444-4444-4444-444444440002", "push", "Push", True),
+    ("44444444-4444-4444-4444-444444440003", "email", "Email", True),
+    ("44444444-4444-4444-4444-444444440004", "sms", "SMS", False),
+]
+
+
 def upgrade() -> None:
+    notification_types = op.create_table(
+        "notification_types",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("key", sa.String(length=32), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("short_label", sa.String(length=32), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "display_order", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_notification_types_key", "notification_types", ["key"], unique=True
+    )
+    op.bulk_insert(
+        notification_types,
+        [
+            {
+                "id": uuid.UUID(row_id),
+                "key": key,
+                "name": name,
+                "short_label": short,
+                "display_order": order,
+                "is_active": True,
+            }
+            for order, (row_id, key, name, short) in enumerate(
+                NOTIFICATION_TYPE_SEED, start=1
+            )
+        ],
+    )
+
+    notification_channels = op.create_table(
+        "notification_channels",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("key", sa.String(length=16), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "display_order", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "is_available",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_notification_channels_key", "notification_channels", ["key"], unique=True
+    )
+    op.bulk_insert(
+        notification_channels,
+        [
+            {
+                "id": uuid.UUID(row_id),
+                "key": key,
+                "name": name,
+                "display_order": order,
+                "is_active": True,
+                "is_available": available,
+            }
+            for order, (row_id, key, name, available) in enumerate(
+                NOTIFICATION_CHANNEL_SEED, start=1
+            )
+        ],
+    )
+
     op.create_table(
         "notifications",
         sa.Column(
@@ -37,7 +165,12 @@ def upgrade() -> None:
             sa.ForeignKey("users.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("category", sa.String(length=32), nullable=False),
+        sa.Column(
+            "category",
+            sa.String(length=32),
+            sa.ForeignKey("notification_types.key", ondelete="RESTRICT"),
+            nullable=False,
+        ),
         sa.Column("title", sa.String(length=200), nullable=False),
         sa.Column("body", sa.String(length=500), nullable=False),
         sa.Column("link", sa.String(length=512), nullable=True),
@@ -72,7 +205,12 @@ def upgrade() -> None:
             sa.ForeignKey("users.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("channel", sa.String(length=16), nullable=False),
+        sa.Column(
+            "channel",
+            sa.String(length=16),
+            sa.ForeignKey("notification_channels.key", ondelete="RESTRICT"),
+            nullable=False,
+        ),
         sa.Column("enabled", sa.Boolean(), nullable=False),
         sa.Column(
             "created_at",
@@ -108,8 +246,18 @@ def upgrade() -> None:
             sa.ForeignKey("users.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("category", sa.String(length=32), nullable=False),
-        sa.Column("channel", sa.String(length=16), nullable=False),
+        sa.Column(
+            "category",
+            sa.String(length=32),
+            sa.ForeignKey("notification_types.key", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "channel",
+            sa.String(length=16),
+            sa.ForeignKey("notification_channels.key", ondelete="RESTRICT"),
+            nullable=False,
+        ),
         sa.Column("enabled", sa.Boolean(), nullable=False),
         sa.Column(
             "created_at",
@@ -138,3 +286,9 @@ def downgrade() -> None:
     op.drop_table("notification_channel_settings")
     op.drop_index("ix_notifications_user_id_created_at", table_name="notifications")
     op.drop_table("notifications")
+    op.drop_index(
+        "ix_notification_channels_key", table_name="notification_channels"
+    )
+    op.drop_table("notification_channels")
+    op.drop_index("ix_notification_types_key", table_name="notification_types")
+    op.drop_table("notification_types")

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -17,7 +17,13 @@ import app.models  # noqa: F401  -- ensures models register on Base.metadata
 from app import queue as queue_module
 from app.db import Base, get_session
 from app.main import app as fastapi_app
-from app.models import League, LeagueVisibility, RatingStrategy
+from app.models import League, LeagueVisibility, NotificationType, RatingStrategy
+from app.models import NotificationChannel as NotificationChannelModel
+from app.notifications.taxonomy import (
+    CHANNEL_AVAILABLE,
+    NotificationCategory,
+)
+from app.notifications.taxonomy import NotificationChannel as ChannelEnum
 from tests._helpers import CSRF_EVENT_HOOKS
 
 
@@ -180,6 +186,64 @@ async def rating_strategies(db_session: AsyncSession) -> dict[str, RatingStrateg
     db_session.add_all([glicko2, manual])
     await db_session.commit()
     return {"glicko2": glicko2, "manual": manual}
+
+
+# Display labels mirror the migration 0009 seed (and the former client-side
+# CATEGORY_META / CHANNEL_META). Migration 0009 inserts these in real
+# deployments; tests build via ``Base.metadata.create_all`` so we re-seed here.
+NOTIFICATION_TYPE_LABELS: dict[NotificationCategory, tuple[str, str]] = {
+    NotificationCategory.MATCH_REMINDER: ("Match reminders", "Match"),
+    NotificationCategory.RATING_CHANGE: ("Rating changes", "Rating"),
+    NotificationCategory.TOURNAMENT: ("Tournament news", "Tourney"),
+    NotificationCategory.OPPONENT: ("Challenges & friends", "Social"),
+    NotificationCategory.RESULT_CONFIRM: ("Score confirmations", "Scores"),
+}
+NOTIFICATION_CHANNEL_LABELS: dict[ChannelEnum, str] = {
+    ChannelEnum.IN_APP: "In-app",
+    ChannelEnum.PUSH: "Push",
+    ChannelEnum.EMAIL: "Email",
+    ChannelEnum.SMS: "SMS",
+}
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def notification_types(db_session: AsyncSession) -> list[NotificationType]:
+    """Seed the notification type lookup rows (one per NotificationCategory).
+    Autouse because the FK on notifications/preferences ``category`` requires the
+    parent rows to exist whenever a test creates a notification or preference."""
+    rows = [
+        NotificationType(
+            key=category.value,
+            name=NOTIFICATION_TYPE_LABELS[category][0],
+            short_label=NOTIFICATION_TYPE_LABELS[category][1],
+            display_order=order,
+        )
+        for order, category in enumerate(NotificationCategory, start=1)
+    ]
+    db_session.add_all(rows)
+    await db_session.commit()
+    return rows
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def notification_channels(
+    db_session: AsyncSession,
+) -> list[NotificationChannelModel]:
+    """Seed the notification channel lookup rows (one per NotificationChannel).
+    Autouse because the FK on the ``channel`` columns requires the parent rows.
+    ``is_available`` is seeded from ``CHANNEL_AVAILABLE`` so it can't drift."""
+    rows = [
+        NotificationChannelModel(
+            key=channel.value,
+            name=NOTIFICATION_CHANNEL_LABELS[channel],
+            display_order=order,
+            is_available=CHANNEL_AVAILABLE[channel],
+        )
+        for order, channel in enumerate(ChannelEnum, start=1)
+    ]
+    db_session.add_all(rows)
+    await db_session.commit()
+    return rows
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/api/tests/test_notification_channel_model.py
+++ b/api/tests/test_notification_channel_model.py
@@ -1,0 +1,58 @@
+"""The notification_channels lookup table: it's seeded (one row per channel,
+sms unavailable), its key is unique, and the channel-column FKs reference it."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import NotificationChannel, NotificationChannelSetting
+from app.notifications.taxonomy import NotificationChannel as ChannelEnum
+from tests._helpers import make_user
+
+
+async def test_seeded_rows_cover_every_channel(db_session: AsyncSession):
+    rows = (await db_session.execute(select(NotificationChannel))).scalars().all()
+    by_key = {row.key: row for row in rows}
+    assert set(by_key) == {c.value for c in ChannelEnum}
+
+    sample = rows[0]
+    assert isinstance(sample.id, uuid.UUID)
+    assert sample.created_at is not None
+    assert sample.updated_at is not None
+
+    # sms is present but not deliverable; the rest are available.
+    assert by_key["sms"].is_available is False
+    assert by_key["in_app"].is_available is True
+    assert by_key["push"].is_available is True
+    assert by_key["email"].is_available is True
+
+
+async def test_key_is_unique(db_session: AsyncSession):
+    # in_app is already seeded by the autouse fixture.
+    db_session.add(NotificationChannel(key="in_app", name="dupe"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_channel_setting_must_reference_a_channel(db_session: AsyncSession):
+    user = await make_user(db_session, "fk-channel")
+    db_session.add(
+        NotificationChannelSetting(
+            user_id=user.id, channel="carrier_pigeon", enabled=True
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_known_channel_inserts_cleanly(db_session: AsyncSession):
+    user = await make_user(db_session, "fk-channel-ok")
+    db_session.add(
+        NotificationChannelSetting(
+            user_id=user.id, channel=ChannelEnum.PUSH.value, enabled=False
+        )
+    )
+    await db_session.commit()

--- a/api/tests/test_notification_taxonomy.py
+++ b/api/tests/test_notification_taxonomy.py
@@ -1,0 +1,37 @@
+"""The shared display taxonomy endpoint: the ordered category/channel lists with
+their labels, read from the lookup tables."""
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.notifications.taxonomy import NotificationCategory, NotificationChannel
+from tests._helpers import start_session
+
+
+async def test_taxonomy_lists_types_in_display_order(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    data = (await api_client.get("/v1/notification-taxonomy")).json()
+
+    keys = [t["key"] for t in data["types"]]
+    assert keys == [c.value for c in NotificationCategory]
+
+    match = next(t for t in data["types"] if t["key"] == "match_reminder")
+    assert match["label"] == "Match reminders"
+    assert match["short"] == "Match"
+
+
+async def test_taxonomy_lists_channels_with_availability(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    data = (await api_client.get("/v1/notification-taxonomy")).json()
+
+    keys = [c["key"] for c in data["channels"]]
+    assert keys == [c.value for c in NotificationChannel]
+
+    by_key = {c["key"]: c for c in data["channels"]}
+    assert by_key["in_app"]["label"] == "In-app"
+    assert by_key["in_app"]["available"] is True
+    assert by_key["sms"]["available"] is False

--- a/api/tests/test_notification_type_model.py
+++ b/api/tests/test_notification_type_model.py
@@ -1,0 +1,60 @@
+"""The notification_types lookup table: it's seeded (one row per category), its
+key is unique, and the notifications.category FK references it."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Notification, NotificationType, User
+from app.notifications.taxonomy import NotificationCategory
+from tests._helpers import make_user
+
+
+async def test_seeded_rows_cover_every_category(db_session: AsyncSession):
+    rows = (await db_session.execute(select(NotificationType))).scalars().all()
+    assert {row.key for row in rows} == {c.value for c in NotificationCategory}
+    sample = rows[0]
+    assert isinstance(sample.id, uuid.UUID)
+    assert sample.created_at is not None
+    assert sample.updated_at is not None
+    assert sample.display_order >= 1
+    assert sample.is_active is True
+
+
+async def test_key_is_unique(db_session: AsyncSession):
+    # match_reminder is already seeded by the autouse fixture.
+    db_session.add(
+        NotificationType(key="match_reminder", name="dupe", short_label="dupe")
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_notification_category_must_reference_a_type(db_session: AsyncSession):
+    user = await make_user(db_session, "fk-type")
+    db_session.add(
+        Notification(
+            user_id=user.id,
+            category="not_a_real_category",
+            title="x",
+            body="y",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_known_category_inserts_cleanly(db_session: AsyncSession):
+    user: User = await make_user(db_session, "fk-type-ok")
+    db_session.add(
+        Notification(
+            user_id=user.id,
+            category=NotificationCategory.RESULT_CONFIRM.value,
+            title="x",
+            body="y",
+        )
+    )
+    await db_session.commit()

--- a/web-client/src/api/notifications.ts
+++ b/web-client/src/api/notifications.ts
@@ -23,6 +23,8 @@ export type BroadcastResponse = components['schemas']['BroadcastResponse']
 export type BroadcastRecipient = components['schemas']['BroadcastRecipient']
 export type BroadcastRecipientList =
   components['schemas']['BroadcastRecipientList']
+export type NotificationTaxonomy =
+  components['schemas']['NotificationTaxonomy']
 
 // All notification queries hang off this prefix so a single
 // `invalidateQueries({ queryKey: NOTIFICATIONS_QUERY_KEY })` refreshes the bell
@@ -30,6 +32,9 @@ export type BroadcastRecipientList =
 export const NOTIFICATIONS_QUERY_KEY = ['notifications'] as const
 export const NOTIFICATION_PREFERENCES_QUERY_KEY = [
   'notification-preferences',
+] as const
+export const NOTIFICATION_TAXONOMY_QUERY_KEY = [
+  'notification-taxonomy',
 ] as const
 
 // The bell badge polls this lightweight count so a notification that arrives in
@@ -125,6 +130,25 @@ export function notificationPreferencesQueryOptions() {
 
 export function useNotificationPreferences() {
   return useQuery(notificationPreferencesQueryOptions())
+}
+
+/** The notification "display taxonomy" — the ordered, server-owned labels for
+ * categories and channels every surface renders. Reference data: it changes only
+ * with a deploy, so we never refetch it within a session. */
+export function notificationTaxonomyQueryOptions() {
+  return queryOptions({
+    queryKey: NOTIFICATION_TAXONOMY_QUERY_KEY,
+    queryFn: async (): Promise<NotificationTaxonomy> =>
+      unwrap(
+        'load notification taxonomy',
+        await api.GET('/v1/notification-taxonomy'),
+      ),
+    staleTime: Infinity,
+  })
+}
+
+export function useNotificationTaxonomy() {
+  return useQuery(notificationTaxonomyQueryOptions())
 }
 
 export function useUpdateNotificationPreferences() {

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -783,6 +783,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/notification-taxonomy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Notification Taxonomy
+         * @description The shared display taxonomy: the ordered category/channel lists with their
+         *     labels, read from the lookup tables. The preferences page, feed filters, and
+         *     broadcast tool all render their labels/order from this.
+         */
+        get: operations["get_notification_taxonomy_v1_notification_taxonomy_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/notification-preferences": {
         parameters: {
             query?: never;
@@ -1647,6 +1669,21 @@ export interface components {
          */
         NotificationChannel: "in_app" | "push" | "email" | "sms";
         /**
+         * NotificationChannelInfo
+         * @description One delivery channel for display: its key, label, and whether the server
+         *     can deliver on it (SMS is shown but unavailable). Sourced from the
+         *     ``notification_channels`` table.
+         */
+        NotificationChannelInfo: {
+            key: components["schemas"]["NotificationChannel"];
+            /** Label */
+            label: string;
+            /** Available */
+            available: boolean;
+            /** Description */
+            description?: string | null;
+        };
+        /**
          * NotificationChannelState
          * @description One channel "sign-up" card at the top of the preferences page.
          *
@@ -1742,6 +1779,33 @@ export interface components {
             channels?: components["schemas"]["NotificationChannelUpdate"][];
             /** Cells */
             cells?: components["schemas"]["NotificationCellUpdate"][];
+        };
+        /**
+         * NotificationTaxonomy
+         * @description The shared display taxonomy — the ordered lists of categories and channels
+         *     every notification surface (preferences, feed filters, broadcast) renders.
+         *     Reference data, fetched once and cached on the client.
+         */
+        NotificationTaxonomy: {
+            /** Types */
+            types: components["schemas"]["NotificationTypeInfo"][];
+            /** Channels */
+            channels: components["schemas"]["NotificationChannelInfo"][];
+        };
+        /**
+         * NotificationTypeInfo
+         * @description One notification category for display: its key plus the human labels and
+         *     ordering the UI renders. Sourced from the ``notification_types`` table so the
+         *     server owns the labels/order (the client keeps only icons/colours).
+         */
+        NotificationTypeInfo: {
+            key: components["schemas"]["NotificationCategory"];
+            /** Label */
+            label: string;
+            /** Short */
+            short: string;
+            /** Description */
+            description?: string | null;
         };
         /** PermissionCreate */
         PermissionCreate: {
@@ -4056,6 +4120,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["NotificationItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_notification_taxonomy_v1_notification_taxonomy_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationTaxonomy"];
                 };
             };
             /** @description Validation Error */

--- a/web-client/src/components/notifications/broadcast-page.tsx
+++ b/web-client/src/components/notifications/broadcast-page.tsx
@@ -2,10 +2,12 @@ import { useState } from 'react'
 import { ApiError } from '@/api/client'
 import {
   useBroadcastRecipients,
+  useNotificationTaxonomy,
   useSendBroadcast,
   type BroadcastResponse,
   type NotificationChannel,
 } from '@/api/notifications'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { BroadcastView } from './broadcast-page/broadcast-view'
 import {
@@ -40,6 +42,7 @@ export function BroadcastPage() {
   // by `search`; only the query keys off the settled value.
   const debouncedSearch = useDebouncedValue(search, 300)
   const recipients = useBroadcastRecipients(debouncedSearch)
+  const taxonomy = useNotificationTaxonomy()
   const send = useSendBroadcast()
 
   const draft = { audience, selectedIds, channels, title, body }
@@ -58,6 +61,29 @@ export function BroadcastPage() {
       ? send.error.detail
       : "Couldn't send the broadcast. Try again."
     : null
+
+  // The channel chips render from the server taxonomy, so gate the whole tool on
+  // it (recipients are allowed to stream in via their own loading state).
+  if (taxonomy.isPending) {
+    return (
+      <p className="px-6 py-6 text-sm text-[color:var(--fg-muted)]">
+        Loading…
+      </p>
+    )
+  }
+
+  if (taxonomy.isError) {
+    return (
+      <div className="px-6 py-6">
+        <Alert variant="destructive">
+          <AlertTitle>Couldn't load the broadcast tool</AlertTitle>
+          <AlertDescription>Refresh to try again.</AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  const channelOrder = taxonomy.data.channels.map((c) => c.key)
 
   return (
     <BroadcastView
@@ -79,6 +105,7 @@ export function BroadcastPage() {
       }}
       selectedCount={selectedCount}
       channels={channels}
+      channelInfos={taxonomy.data.channels}
       onToggleChannel={(channel) => {
         clearResult()
         setChannels((prev) => toggle(prev, channel))
@@ -96,7 +123,7 @@ export function BroadcastPage() {
       canSend={canSend}
       sending={send.isPending}
       onSend={() =>
-        send.mutate(buildBroadcastRequest(draft), {
+        send.mutate(buildBroadcastRequest(draft, channelOrder), {
           onSuccess: (response) => setResult(response),
         })
       }

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.factory.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.factory.tsx
@@ -1,3 +1,4 @@
+import { notificationTaxonomy } from '@/test/factories'
 import type { BroadcastViewProps } from './broadcast-view'
 
 /** Default scenario: two searchable players, in-app + push selected, nothing
@@ -20,6 +21,7 @@ export function buildBroadcastViewProps(
     onToggleRecipient: () => {},
     selectedCount: 0,
     channels: new Set(['in_app', 'push']),
+    channelInfos: notificationTaxonomy().channels,
     onToggleChannel: () => {},
     title: '',
     onTitleChange: () => {},

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.tsx
@@ -4,6 +4,7 @@ import type {
   BroadcastResponse,
   NotificationChannel,
   NotificationItem,
+  NotificationTaxonomy,
 } from '@/api/notifications'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -11,7 +12,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/lib/utils'
-import { CHANNEL_META, CHANNEL_ORDER } from '../notification-meta'
+import { CHANNEL_VISUAL } from '../notification-meta'
 import { NotificationRow } from '../notification-row'
 import type { BroadcastAudience } from './build-broadcast-request'
 
@@ -30,6 +31,8 @@ export interface BroadcastViewProps {
   onToggleRecipient: (id: string) => void
   selectedCount: number
   channels: ReadonlySet<NotificationChannel>
+  /** Server-ordered channel taxonomy — drives the channel chips. */
+  channelInfos: NotificationTaxonomy['channels']
   onToggleChannel: (channel: NotificationChannel) => void
   title: string
   onTitleChange: (title: string) => void
@@ -58,6 +61,7 @@ export function BroadcastView(props: BroadcastViewProps) {
     onToggleRecipient,
     selectedCount,
     channels,
+    channelInfos,
     onToggleChannel,
     title,
     onTitleChange,
@@ -170,9 +174,9 @@ export function BroadcastView(props: BroadcastViewProps) {
             Channels
           </p>
           <div className="mb-6 flex flex-wrap gap-2">
-            {CHANNEL_ORDER.map((channel) => {
-              const meta = CHANNEL_META[channel]
-              const { Icon } = meta
+            {channelInfos.map((info) => {
+              const channel = info.key
+              const { Icon } = CHANNEL_VISUAL[channel]
               const on = channels.has(channel)
               return (
                 <button
@@ -189,7 +193,7 @@ export function BroadcastView(props: BroadcastViewProps) {
                   style={on ? { background: 'rgba(255,122,26,0.12)' } : undefined}
                 >
                   <Icon size={16} />
-                  {meta.label}
+                  {info.label}
                 </button>
               )
             })}

--- a/web-client/src/components/notifications/broadcast-page/build-broadcast-request.test.ts
+++ b/web-client/src/components/notifications/broadcast-page/build-broadcast-request.test.ts
@@ -1,8 +1,12 @@
+import type { NotificationChannel } from '@/api/notifications'
 import {
   buildBroadcastRequest,
   canSendBroadcast,
   type BroadcastDraft,
 } from './build-broadcast-request'
+
+// The canonical server channel order, as the taxonomy ships it.
+const CHANNEL_ORDER: NotificationChannel[] = ['in_app', 'push', 'email', 'sms']
 
 const draft = (overrides: Partial<BroadcastDraft> = {}): BroadcastDraft => ({
   audience: 'all',
@@ -43,13 +47,14 @@ describe('canSendBroadcast', () => {
 
 describe('buildBroadcastRequest', () => {
   it('sends mode "all" for everyone', () => {
-    const req = buildBroadcastRequest(draft())
+    const req = buildBroadcastRequest(draft(), CHANNEL_ORDER)
     expect(req.recipients).toEqual({ mode: 'all' })
   })
 
   it('sends the picked ids for a selected audience', () => {
     const req = buildBroadcastRequest(
       draft({ audience: 'selected', selectedIds: new Set(['u2', 'u1']) }),
+      CHANNEL_ORDER,
     )
     expect(req.recipients).toEqual({
       mode: 'selected',
@@ -60,6 +65,7 @@ describe('buildBroadcastRequest', () => {
   it('emits channels in canonical order regardless of selection order', () => {
     const req = buildBroadcastRequest(
       draft({ channels: new Set(['email', 'in_app', 'push']) }),
+      CHANNEL_ORDER,
     )
     expect(req.channels).toEqual(['in_app', 'push', 'email'])
   })
@@ -67,6 +73,7 @@ describe('buildBroadcastRequest', () => {
   it('trims the title and body', () => {
     const req = buildBroadcastRequest(
       draft({ title: '  Heads up  ', body: '  Be early.  ' }),
+      CHANNEL_ORDER,
     )
     expect(req.title).toBe('Heads up')
     expect(req.body).toBe('Be early.')

--- a/web-client/src/components/notifications/broadcast-page/build-broadcast-request.ts
+++ b/web-client/src/components/notifications/broadcast-page/build-broadcast-request.ts
@@ -1,5 +1,4 @@
 import type { BroadcastRequest, NotificationChannel } from '@/api/notifications'
-import { CHANNEL_ORDER } from '../notification-meta'
 
 export type BroadcastAudience = 'all' | 'selected'
 
@@ -20,15 +19,19 @@ export function canSendBroadcast(
   return hasAudience && draft.channels.size > 0 && draft.title.trim().length > 0
 }
 
-/** Build the wire request from the draft. Channels are emitted in canonical
- * order (not Set-insertion order) so the payload is deterministic. */
-export function buildBroadcastRequest(draft: BroadcastDraft): BroadcastRequest {
+/** Build the wire request from the draft. Channels are emitted in the canonical
+ * server order (`channelOrder`, from the notification taxonomy) rather than
+ * Set-insertion order, so the payload is deterministic. */
+export function buildBroadcastRequest(
+  draft: BroadcastDraft,
+  channelOrder: readonly NotificationChannel[],
+): BroadcastRequest {
   return {
     recipients:
       draft.audience === 'all'
         ? { mode: 'all' }
         : { mode: 'selected', user_ids: [...draft.selectedIds] },
-    channels: CHANNEL_ORDER.filter((channel) => draft.channels.has(channel)),
+    channels: channelOrder.filter((channel) => draft.channels.has(channel)),
     title: draft.title.trim(),
     body: draft.body.trim(),
   }

--- a/web-client/src/components/notifications/notification-meta.ts
+++ b/web-client/src/components/notifications/notification-meta.ts
@@ -15,11 +15,7 @@ import type { components } from '@/api/schema'
 export type NotificationCategory = components['schemas']['NotificationCategory']
 export type NotificationChannel = components['schemas']['NotificationChannel']
 
-export interface CategoryMeta {
-  /** Full label for the preferences matrix and settings. */
-  label: string
-  /** Compact label for the feed filter pills. */
-  short: string
+export interface CategoryVisual {
   Icon: LucideIcon
   /** Icon stroke colour (a FortyMM token). */
   color: string
@@ -27,72 +23,46 @@ export interface CategoryMeta {
   tint: string
 }
 
-// The product's visual taxonomy — labels, icons, and the one accent colour each
-// category "owns". Mirrors the design's NCATS. Kept on the client (the server
-// ships only the category key) so the look stays a frontend concern.
-export const CATEGORY_META: Record<NotificationCategory, CategoryMeta> = {
+// The product's visual taxonomy — the icon and the one accent colour each
+// category "owns". Labels + display order now come from the server taxonomy
+// (`/v1/notification-taxonomy`); only the look stays a frontend concern, since
+// icons and colour tokens can't live in the DB.
+export const CATEGORY_VISUAL: Record<NotificationCategory, CategoryVisual> = {
   match_reminder: {
-    label: 'Match reminders',
-    short: 'Match',
     Icon: Clock,
     color: 'var(--ball-500)',
     tint: 'rgba(255, 122, 26, 0.12)',
   },
   rating_change: {
-    label: 'Rating changes',
-    short: 'Rating',
     Icon: TrendingUp,
     color: 'var(--serve-500)',
     tint: 'rgba(0, 226, 154, 0.14)',
   },
   tournament: {
-    label: 'Tournament news',
-    short: 'Tourney',
     Icon: Flag,
     color: 'var(--info)',
     tint: 'rgba(111, 181, 255, 0.14)',
   },
   opponent: {
-    label: 'Challenges & friends',
-    short: 'Social',
     Icon: Swords,
     color: 'var(--ball-500)',
     tint: 'rgba(255, 122, 26, 0.12)',
   },
   result_confirm: {
-    label: 'Score confirmations',
-    short: 'Scores',
     Icon: CheckCircle2,
     color: 'var(--warn)',
     tint: 'rgba(255, 196, 61, 0.14)',
   },
 }
 
-// Display order for the feed filter pills and the preferences matrix rows.
-export const CATEGORY_ORDER: NotificationCategory[] = [
-  'match_reminder',
-  'rating_change',
-  'tournament',
-  'opponent',
-  'result_confirm',
-]
-
-export interface ChannelMeta {
-  label: string
+export interface ChannelVisual {
   Icon: LucideIcon
 }
 
-// Mirrors the design's NCHANNELS.
-export const CHANNEL_META: Record<NotificationChannel, ChannelMeta> = {
-  in_app: { label: 'In-app', Icon: Bell },
-  push: { label: 'Push', Icon: Smartphone },
-  email: { label: 'Email', Icon: Mail },
-  sms: { label: 'SMS', Icon: MessageSquare },
+// Per-channel icon. Labels + order come from the server taxonomy.
+export const CHANNEL_VISUAL: Record<NotificationChannel, ChannelVisual> = {
+  in_app: { Icon: Bell },
+  push: { Icon: Smartphone },
+  email: { Icon: Mail },
+  sms: { Icon: MessageSquare },
 }
-
-export const CHANNEL_ORDER: NotificationChannel[] = [
-  'in_app',
-  'push',
-  'email',
-  'sms',
-]

--- a/web-client/src/components/notifications/notification-preferences-page.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page.tsx
@@ -1,5 +1,6 @@
 import {
   useNotificationPreferences,
+  useNotificationTaxonomy,
   useUpdateNotificationPreferences,
 } from '@/api/notifications'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -9,9 +10,10 @@ import { PreferencesView } from './notification-preferences-page/preferences-vie
  * query + partial-update mutation to the pure matrix view. */
 export function NotificationPreferencesPage() {
   const preferences = useNotificationPreferences()
+  const taxonomy = useNotificationTaxonomy()
   const update = useUpdateNotificationPreferences()
 
-  if (preferences.isPending) {
+  if (preferences.isPending || taxonomy.isPending) {
     return (
       <p className="mx-auto max-w-[840px] px-6 pt-9 text-sm text-[color:var(--fg-muted)]">
         Loading preferences…
@@ -19,7 +21,7 @@ export function NotificationPreferencesPage() {
     )
   }
 
-  if (preferences.isError) {
+  if (preferences.isError || taxonomy.isError) {
     return (
       <div className="mx-auto max-w-[840px] px-6 pt-9">
         <Alert variant="destructive">
@@ -33,6 +35,7 @@ export function NotificationPreferencesPage() {
   return (
     <PreferencesView
       preferences={preferences.data}
+      taxonomy={taxonomy.data}
       onToggleChannel={(channel, enabled) =>
         update.mutate({ channels: [{ channel, enabled }], cells: [] })
       }

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.factory.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.factory.tsx
@@ -1,4 +1,7 @@
-import { notificationPreferences } from '@/test/factories'
+import {
+  notificationPreferences,
+  notificationTaxonomy,
+} from '@/test/factories'
 import type { PreferencesViewProps } from './preferences-view'
 
 /** Default scenario: the out-of-the-box preferences (in-app locked on, push +
@@ -8,6 +11,7 @@ export function buildPreferencesViewProps(
 ): PreferencesViewProps {
   return {
     preferences: notificationPreferences(),
+    taxonomy: notificationTaxonomy(),
     onToggleChannel: () => {},
     onToggleCell: () => {},
     ...overrides,

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
@@ -1,14 +1,17 @@
 import type {
   NotificationChannel,
   NotificationPreferences,
+  NotificationTaxonomy,
 } from '@/api/notifications'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
-import { CATEGORY_META, CHANNEL_META } from '../notification-meta'
+import { CATEGORY_VISUAL, CHANNEL_VISUAL } from '../notification-meta'
 
 export interface PreferencesViewProps {
   preferences: NotificationPreferences
+  /** Server-owned display labels for categories + channels. */
+  taxonomy: NotificationTaxonomy
   onToggleChannel: (channel: NotificationChannel, enabled: boolean) => void
   onToggleCell: (
     category: NotificationPreferences['categories'][number]['category'],
@@ -21,11 +24,14 @@ export interface PreferencesViewProps {
  * per-category × per-channel mute matrix. Pure — state + handlers come in. */
 export function PreferencesView({
   preferences,
+  taxonomy,
   onToggleChannel,
   onToggleCell,
 }: PreferencesViewProps) {
   const channels = preferences.channels
   const channelByKey = new Map(channels.map((c) => [c.channel, c]))
+  const channelLabel = new Map(taxonomy.channels.map((c) => [c.key, c.label]))
+  const categoryLabel = new Map(taxonomy.types.map((t) => [t.key, t.label]))
 
   return (
     <div className="mx-auto max-w-[840px] px-6 pt-9 pb-20">
@@ -41,8 +47,8 @@ export function PreferencesView({
       <p className="ds-overline mb-3.5">Where we reach you</p>
       <div className="mb-9 grid grid-cols-1 gap-3 sm:grid-cols-2">
         {channels.map((channel) => {
-          const meta = CHANNEL_META[channel.channel]
-          const { Icon } = meta
+          const { Icon } = CHANNEL_VISUAL[channel.channel]
+          const label = channelLabel.get(channel.channel) ?? channel.channel
           const interactive = !channel.locked && channel.available
           return (
             <div
@@ -69,7 +75,7 @@ export function PreferencesView({
               </span>
               <span className="min-w-0 flex-1">
                 <span className="block text-[15px] font-semibold text-[color:var(--fg-1)]">
-                  {meta.label}
+                  {label}
                 </span>
                 <span className="block truncate text-xs text-[color:var(--fg-3)]">
                   {channel.destination}
@@ -81,7 +87,7 @@ export function PreferencesView({
                 onCheckedChange={(value) =>
                   onToggleChannel(channel.channel, value === true)
                 }
-                aria-label={`${meta.label} notifications`}
+                aria-label={`${label} notifications`}
               />
             </div>
           )
@@ -102,8 +108,8 @@ export function PreferencesView({
         >
           <div className="ds-overline px-4 py-3.5">Category</div>
           {channels.map((channel) => {
-            const meta = CHANNEL_META[channel.channel]
-            const { Icon } = meta
+            const { Icon } = CHANNEL_VISUAL[channel.channel]
+            const label = channelLabel.get(channel.channel) ?? channel.channel
             return (
               <div
                 key={channel.channel}
@@ -112,7 +118,7 @@ export function PreferencesView({
               >
                 <Icon size={17} className="text-[color:var(--fg-2)]" />
                 <span className="font-mono text-[10px] tracking-wide text-[color:var(--fg-3)] uppercase">
-                  {meta.label}
+                  {label}
                 </span>
               </div>
             )
@@ -120,8 +126,9 @@ export function PreferencesView({
         </div>
 
         {preferences.categories.map((row, i) => {
-          const meta = CATEGORY_META[row.category]
-          const { Icon } = meta
+          const visual = CATEGORY_VISUAL[row.category]
+          const { Icon } = visual
+          const rowLabel = categoryLabel.get(row.category) ?? row.category
           return (
             <div
               key={row.category}
@@ -135,12 +142,12 @@ export function PreferencesView({
               <div className="flex items-center gap-3 px-4 py-3.5">
                 <span
                   className="flex size-8 shrink-0 items-center justify-center rounded-[9px]"
-                  style={{ background: meta.tint, color: meta.color }}
+                  style={{ background: visual.tint, color: visual.color }}
                 >
                   <Icon size={17} />
                 </span>
                 <span className="text-sm font-semibold text-[color:var(--fg-1)]">
-                  {meta.label}
+                  {rowLabel}
                 </span>
               </div>
               {row.cells.map((cell) => {
@@ -159,7 +166,9 @@ export function PreferencesView({
                       onCheckedChange={(value) =>
                         onToggleCell(row.category, cell.channel, value === true)
                       }
-                      aria-label={`${meta.label} via ${CHANNEL_META[cell.channel].label}`}
+                      aria-label={`${rowLabel} via ${
+                        channelLabel.get(cell.channel) ?? cell.channel
+                      }`}
                     />
                   </div>
                 )

--- a/web-client/src/components/notifications/notification-row.tsx
+++ b/web-client/src/components/notifications/notification-row.tsx
@@ -1,6 +1,6 @@
 import type { NotificationItem } from '@/api/notifications'
 import { cn } from '@/lib/utils'
-import { CATEGORY_META } from './notification-meta'
+import { CATEGORY_VISUAL } from './notification-meta'
 import { relativeTime } from './relative-time'
 
 export interface NotificationRowProps {
@@ -25,8 +25,8 @@ export function NotificationRow({
   now,
   onActivate,
 }: NotificationRowProps) {
-  const meta = CATEGORY_META[notification.category]
-  const { Icon } = meta
+  const visual = CATEGORY_VISUAL[notification.category]
+  const { Icon } = visual
   const unread = notification.read_at == null
   const delta = notification.delta
   const deltaUp = delta?.trim().startsWith('+') ?? false
@@ -50,7 +50,7 @@ export function NotificationRow({
           'flex shrink-0 items-center justify-center rounded-[10px]',
           compact ? 'size-9' : 'size-10',
         )}
-        style={{ background: meta.tint, color: meta.color }}
+        style={{ background: visual.tint, color: visual.color }}
       >
         <Icon size={compact ? 17 : 20} strokeWidth={1.9} />
       </span>
@@ -99,7 +99,7 @@ export function NotificationRow({
               compact ? 'text-xs' : 'text-[13px]',
             )}
             style={{
-              color: meta.color,
+              color: visual.color,
               borderColor: 'var(--border-default)',
             }}
           >

--- a/web-client/src/components/notifications/notifications-page.tsx
+++ b/web-client/src/components/notifications/notifications-page.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import {
   useMarkAllNotificationsRead,
   useNotificationFeed,
+  useNotificationTaxonomy,
 } from '@/api/notifications'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
@@ -14,11 +15,12 @@ import { useFollowNotification } from './use-follow-notification'
  * filter state, and the mark-read mutations to the pure view. */
 export function NotificationsPage() {
   const feed = useNotificationFeed()
+  const taxonomy = useNotificationTaxonomy()
   const [filter, setFilter] = useState<NotificationFilter>('all')
   const follow = useFollowNotification()
   const markAll = useMarkAllNotificationsRead()
 
-  if (feed.isPending) {
+  if (feed.isPending || taxonomy.isPending) {
     return (
       <p className="mx-auto max-w-[760px] px-6 pt-9 text-sm text-[color:var(--fg-muted)]">
         Loading notifications…
@@ -26,7 +28,7 @@ export function NotificationsPage() {
     )
   }
 
-  if (feed.isError) {
+  if (feed.isError || taxonomy.isError) {
     return (
       <div className="mx-auto max-w-[760px] px-6 pt-9">
         <Alert variant="destructive">
@@ -40,6 +42,7 @@ export function NotificationsPage() {
   return (
     <NotificationsView
       items={feed.data.items}
+      categoryTypes={taxonomy.data.types}
       unreadCount={feed.data.unread_count}
       filter={filter}
       onFilterChange={setFilter}

--- a/web-client/src/components/notifications/notifications-page/notifications-view.factory.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.factory.tsx
@@ -1,4 +1,5 @@
 import type { NotificationItem } from '@/api/notifications'
+import { notificationTaxonomy } from '@/test/factories'
 import { buildNotificationItem } from '../notification-row.factory'
 import type { NotificationsViewProps } from './notifications-view'
 
@@ -39,6 +40,7 @@ export function buildNotificationsViewProps(
 ): NotificationsViewProps {
   return {
     items: buildNotificationsItems(),
+    categoryTypes: notificationTaxonomy().types,
     unreadCount: 1,
     filter: 'all',
     onFilterChange: () => {},

--- a/web-client/src/components/notifications/notifications-page/notifications-view.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.tsx
@@ -1,23 +1,13 @@
 import { Inbox } from 'lucide-react'
-import type { NotificationItem } from '@/api/notifications'
+import type {
+  NotificationItem,
+  NotificationTaxonomy,
+} from '@/api/notifications'
 import { cn } from '@/lib/utils'
-import {
-  CATEGORY_META,
-  CATEGORY_ORDER,
-  type NotificationCategory,
-} from '../notification-meta'
+import type { NotificationCategory } from '../notification-meta'
 import { NotificationRow } from '../notification-row'
 
 export type NotificationFilter = 'all' | 'unread' | NotificationCategory
-
-const FILTERS: { key: NotificationFilter; label: string }[] = [
-  { key: 'all', label: 'All' },
-  { key: 'unread', label: 'Unread' },
-  ...CATEGORY_ORDER.map((category) => ({
-    key: category,
-    label: CATEGORY_META[category].short,
-  })),
-]
 
 function matchesFilter(item: NotificationItem, filter: NotificationFilter) {
   if (filter === 'all') return true
@@ -27,6 +17,8 @@ function matchesFilter(item: NotificationItem, filter: NotificationFilter) {
 
 export interface NotificationsViewProps {
   items: NotificationItem[]
+  /** Server-ordered category taxonomy — drives the filter pills. */
+  categoryTypes: NotificationTaxonomy['types']
   unreadCount: number
   filter: NotificationFilter
   onFilterChange: (filter: NotificationFilter) => void
@@ -38,6 +30,7 @@ export interface NotificationsViewProps {
  * filtered list (or an empty state). Pure — data + handlers come in as props. */
 export function NotificationsView({
   items,
+  categoryTypes,
   unreadCount,
   filter,
   onFilterChange,
@@ -45,6 +38,11 @@ export function NotificationsView({
   onMarkAllRead,
 }: NotificationsViewProps) {
   const shown = items.filter((item) => matchesFilter(item, filter))
+  const filters: { key: NotificationFilter; label: string }[] = [
+    { key: 'all', label: 'All' },
+    { key: 'unread', label: 'Unread' },
+    ...categoryTypes.map((type) => ({ key: type.key, label: type.short })),
+  ]
 
   return (
     <div className="mx-auto max-w-[760px] px-6 pt-9 pb-20">
@@ -72,7 +70,7 @@ export function NotificationsView({
       </div>
 
       <div className="my-4 flex flex-wrap gap-2" role="group" aria-label="Filter notifications">
-        {FILTERS.map(({ key, label }) => {
+        {filters.map(({ key, label }) => {
           const active = filter === key
           return (
             <button

--- a/web-client/src/mocks/notifications-store.ts
+++ b/web-client/src/mocks/notifications-store.ts
@@ -1,6 +1,9 @@
 import { http, HttpResponse } from 'msw'
 import type { components } from '@/api/schema'
-import { notificationPreferences } from '@/test/factories'
+import {
+  notificationPreferences,
+  notificationTaxonomy,
+} from '@/test/factories'
 
 type NotificationItem = components['schemas']['NotificationItem']
 type NotificationPreferences = components['schemas']['NotificationPreferences']
@@ -101,6 +104,10 @@ function applyPreferenceUpdate(update: NotificationPreferencesUpdate) {
 }
 
 export const notificationHandlers = [
+  http.get('*/v1/notification-taxonomy', () =>
+    HttpResponse.json(notificationTaxonomy()),
+  ),
+
   http.get('*/v1/notifications/unread-count', () =>
     HttpResponse.json({ unread_count: unreadCount() }),
   ),

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -378,6 +378,9 @@ type NotificationChannel = components['schemas']['NotificationChannel']
 type NotificationCategory = components['schemas']['NotificationCategory']
 type BroadcastRecipientList = components['schemas']['BroadcastRecipientList']
 type BroadcastResponse = components['schemas']['BroadcastResponse']
+type NotificationTaxonomy = components['schemas']['NotificationTaxonomy']
+type NotificationTypeInfo = components['schemas']['NotificationTypeInfo']
+type NotificationChannelInfo = components['schemas']['NotificationChannelInfo']
 
 const NOTIF_CHANNELS: NotificationChannel[] = ['in_app', 'push', 'email', 'sms']
 const NOTIF_CATEGORIES: NotificationCategory[] = [
@@ -459,6 +462,48 @@ export function notificationPreferences(
   return {
     channels: NOTIF_CHANNELS.map(notifChannelState),
     categories: NOTIF_CATEGORIES.map(notifCategoryPref),
+    ...overrides,
+  }
+}
+
+// The server taxonomy's labels/short/order, mirrored for tests. These MUST stay
+// in sync with the strings the old CATEGORY_META/CHANNEL_META carried, since the
+// page objects query by visible label text.
+const NOTIF_TYPE_INFOS: NotificationTypeInfo[] = [
+  { key: 'match_reminder', label: 'Match reminders', short: 'Match' },
+  { key: 'rating_change', label: 'Rating changes', short: 'Rating' },
+  { key: 'tournament', label: 'Tournament news', short: 'Tourney' },
+  { key: 'opponent', label: 'Challenges & friends', short: 'Social' },
+  { key: 'result_confirm', label: 'Score confirmations', short: 'Scores' },
+]
+
+const NOTIF_CHANNEL_INFOS: NotificationChannelInfo[] = [
+  { key: 'in_app', label: 'In-app', available: true },
+  { key: 'push', label: 'Push', available: true },
+  { key: 'email', label: 'Email', available: true },
+  { key: 'sms', label: 'SMS', available: false },
+]
+
+export function notificationTypeInfo(
+  overrides: Partial<NotificationTypeInfo> = {},
+): NotificationTypeInfo {
+  return { ...NOTIF_TYPE_INFOS[0], ...overrides }
+}
+
+export function notificationChannelInfo(
+  overrides: Partial<NotificationChannelInfo> = {},
+): NotificationChannelInfo {
+  return { ...NOTIF_CHANNEL_INFOS[0], ...overrides }
+}
+
+/** The display taxonomy — the server-owned, ordered category + channel labels
+ * every notification surface renders. */
+export function notificationTaxonomy(
+  overrides: Partial<NotificationTaxonomy> = {},
+): NotificationTaxonomy {
+  return {
+    types: NOTIF_TYPE_INFOS.map((t) => ({ ...t })),
+    channels: NOTIF_CHANNEL_INFOS.map((c) => ({ ...c })),
     ...overrides,
   }
 }


### PR DESCRIPTION
## What & why

Notification "types" and "channels" previously existed only as Python `StrEnum`s (`api/app/notifications/taxonomy.py`), with their human-facing labels and display order **hardcoded on the client** in `notification-meta.ts`. This promotes them to real DB **lookup tables** and makes the displayed taxonomy server-driven.

## API

- New models `NotificationType` + `NotificationChannel` (lookup tables), registered for Alembic.
- **Migration 0009 edited in place** (pre-deploy convention, no new revision): the lookup tables are created and **seeded first**, then the `category`/`channel` string columns carry **foreign keys** to them:
  - `notifications.category`, `notification_preferences.category` → `notification_types.key`
  - `notification_channel_settings.channel`, `notification_preferences.channel` → `notification_channels.key`
- All 4 channels are seeded; `sms` is present with `is_available = false`. Channel availability is now read from the DB at runtime — the taxonomy resolvers take `available` as a parameter; `CHANNEL_AVAILABLE` remains the seed source so the two can't drift. Behavioural rules (default-on, locked channels, locked cells) stay in `taxonomy.py`.
- New endpoint **`GET /v1/notification-taxonomy`** returns the ordered, labelled category/channel lists. `schema.d.ts` regenerated.

## Web client

- `notification-meta.ts` reduced to **visuals only** (`CATEGORY_VISUAL` / `CHANNEL_VISUAL` — icons + colours/tints; icons/colours can't live in the DB). Labels + order deleted.
- New `useNotificationTaxonomy()` hook; the preferences matrix, feed filter pills, and broadcast channel chips now render **server-owned labels in server order**. `buildBroadcastRequest` takes the taxonomy channel order as a parameter.
- MSW handler + factories for the new endpoint.

## Verification

- API: `ruff` + `mypy` clean; **478 tests pass**. Migration applies to a fresh DB and seeds correctly; all 4 FK constraints verified present.
- Web client: `npm run lint` (0 errors), `npm run build`, and `npm run test:run` (**867 tests**) all pass.

## Notes / out of scope

- Descriptions are stored + exposed in the taxonomy but not yet rendered.
- `LOCKED_CELLS` stays a `taxonomy.py` relation (not DB).
- No `users.id` FK added, so the account-merge service is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011rUpXEyhLujeyUpkb3vFUP)_