### PR TITLE
iOS: token-aware merged-session sign-out + human-readable 422 copy + sign-in VALID-chip fix

### DIFF
--- a/ios/Fortymm/Login/LoginComponents.swift
+++ b/ios/Fortymm/Login/LoginComponents.swift
@@ -437,14 +437,29 @@ struct LoginDivider: View {
     }
 }
 
-/// The email field: an "@" prefix box, a mono input, and a live VALID/FAILED
-/// status chip. `invalid` flips the accent to loss-red.
+/// The email field: an "@" prefix box, a mono input, and a live status chip.
+/// The chip is tri-state: green "VALID" only once the address actually passes
+/// validation (`valid`), red "FAILED" when flagged invalid, and a neutral dot
+/// while empty / not yet evaluated — so an untouched field never claims "VALID"
+/// for a blank or malformed address (#448). `invalid` flips the accent to
+/// loss-red.
 struct LoginEmailField: View {
     @Binding var text: String
+    var valid: Bool = false
     var invalid: Bool = false
     var focused: FocusState<Bool>.Binding
 
     private var tint: Color { invalid ? FMColor.loss : FMColor.ball500 }
+
+    // invalid wins over valid; neutral is the empty / not-yet-evaluated state.
+    private var chipText: String {
+        if invalid { return "● FAILED" }
+        return valid ? "● VALID" : "●"
+    }
+    private var chipColor: Color {
+        if invalid { return FMColor.loss }
+        return valid ? FMColor.serve500 : FMColor.fgMuted
+    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -469,10 +484,10 @@ struct LoginEmailField: View {
             .autocorrectionDisabled()
             .submitLabel(.go)
             .padding(.horizontal, 14)
-            Text(invalid ? "● FAILED" : "● VALID")
+            Text(chipText)
                 .font(FMFont.mono(11))
                 .tracking(1.4)
-                .foregroundStyle(invalid ? FMColor.loss : FMColor.serve500)
+                .foregroundStyle(chipColor)
                 .padding(.trailing, 14)
         }
         .background(FMColor.bgCard)

--- a/ios/Fortymm/Login/SignInView.swift
+++ b/ios/Fortymm/Login/SignInView.swift
@@ -38,7 +38,7 @@ struct SignInView: View {
                 + "We never made a password, so we can't lose yours."
         ) {
             VStack(alignment: .leading, spacing: 14) {
-                LoginEmailField(text: $email, invalid: invalid, focused: $focused)
+                LoginEmailField(text: $email, valid: validation.ok, invalid: invalid, focused: $focused)
                     .onChange(of: email) { _, _ in if serverError != nil { serverError = nil } }
 
                 TurnstileView(

--- a/ios/Fortymm/Networking/APIClient.swift
+++ b/ios/Fortymm/Networking/APIClient.swift
@@ -173,10 +173,14 @@ struct APIClient {
         }
         // Send the session and its CSRF companion as cookies. The server's
         // double-submit check compares the CSRF cookie against the header, so
-        // both must be present and equal on mutations.
+        // both must be present and equal on mutations. `sentToken` is captured
+        // so the response handling can tell whether a session-dropping reply
+        // pertains to the token *this* request used (vs. one a newer sign-in
+        // has since replaced).
+        let sentToken = await tokens.token()
         let csrf = await tokens.csrfToken()
         let cookieHeader = [
-            (await tokens.token()).map { "\(Self.sessionCookieName)=\($0)" },
+            sentToken.map { "\(Self.sessionCookieName)=\($0)" },
             csrf.map { "\(Self.csrfCookieName)=\($0)" },
         ].compactMap { $0 }.joined(separator: "; ")
         if !cookieHeader.isEmpty {
@@ -190,13 +194,14 @@ struct APIClient {
         guard let http = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
         }
-        await captureSessionCookie(from: http, url: url)
-        guard (200..<300).contains(http.statusCode) else {
-            // A merged-away guest's cookie still resolves server-side, so this
-            // can land on *any* request — broadcast it (and drop the dead token)
-            // so the app routes to sign-in instead of acting as the ghost.
-            if http.statusCode == 401, let info = Self.mergedSessionInfo(from: data) {
-                await tokens.clear()
+        // A merged-away guest's cookie still resolves server-side, so this 401
+        // can land on *any* request. Handle it before the generic cookie capture
+        // and make it token-aware: only drop the token + broadcast the sign-out
+        // if the cookie this request sent is still the one we hold. Otherwise a
+        // stale in-flight request — whose token a newer sign-in already replaced
+        // — would wipe the *new* token and kick the user out of a live session.
+        if http.statusCode == 401, let info = Self.mergedSessionInfo(from: data) {
+            if await tokens.clearIfCurrent(sentToken) {
                 var userInfo: [String: Any] = ["message": info.message]
                 if let email = info.email { userInfo["email"] = email }
                 NotificationCenter.default.post(
@@ -204,6 +209,12 @@ struct APIClient {
                 )
                 throw APIError.sessionMerged(message: info.message, email: info.email)
             }
+            // Token already superseded — fail this request without disturbing the
+            // current session.
+            throw APIError.http(status: http.statusCode, detail: Self.detail(from: data))
+        }
+        await captureSessionCookie(from: http, url: url, sentToken: sentToken)
+        guard (200..<300).contains(http.statusCode) else {
             throw APIError.http(status: http.statusCode, detail: Self.detail(from: data))
         }
         do {
@@ -269,7 +280,9 @@ struct APIClient {
     /// out of the response and persist them. The API sets both together and
     /// folds them into the comma-joined `Set-Cookie` header; both use `Max-Age`
     /// (no comma-bearing `Expires`), so `HTTPCookie` splits them cleanly.
-    private func captureSessionCookie(from http: HTTPURLResponse, url: URL) async {
+    private func captureSessionCookie(
+        from http: HTTPURLResponse, url: URL, sentToken: String?
+    ) async {
         guard let header = http.value(forHTTPHeaderField: "Set-Cookie") else {
             return
         }
@@ -279,10 +292,11 @@ struct APIClient {
         )
         if let session = cookies.first(where: { $0.name == Self.sessionCookieName }) {
             if session.value.isEmpty {
-                // A clearing Set-Cookie (e.g. the session-merged 401 clears the
-                // dead cookie). Drop the stored token (and CSRF companion) so the
-                // next call starts cookieless and mints a fresh guest.
-                await tokens.clear()
+                // A clearing Set-Cookie. Drop the token only if it's still the
+                // one this request sent, so a stale reply can't wipe a token a
+                // newer sign-in already installed. (The merged-401 clear is
+                // handled before this, token-aware; this guards any other path.)
+                _ = await tokens.clearIfCurrent(sentToken)
             } else {
                 await tokens.update(session.value)
             }

--- a/ios/Fortymm/Networking/APIClient.swift
+++ b/ios/Fortymm/Networking/APIClient.swift
@@ -246,14 +246,34 @@ struct APIClient {
         )
     }
 
-    /// FastAPI errors come back as `{"detail": "..."}` (or `{"detail": [...]}`
-    /// for validation errors). Pull a human string out when we can.
+    /// FastAPI errors come back as `{"detail": "..."}` for hand-raised
+    /// `HTTPException`s, or `{"detail": [{"loc": ..., "msg": "...", ...}]}` for
+    /// request-validation (422) errors. Pull a human string out of either shape
+    /// — mirrors `extractDetail` in web-client/src/api/client.ts; keep in
+    /// lockstep. Without the array branch a 422 (e.g. a scoring rule the client
+    /// doesn't mirror) leaks as the bare "HTTP 422" fallback (#446).
     private static func detail(from data: Data) -> String? {
         struct StringDetail: Decodable { let detail: String }
         if let parsed = try? JSONDecoder().decode(StringDetail.self, from: data) {
-            return parsed.detail
+            return humanize(parsed.detail)
+        }
+        struct ValidationDetail: Decodable {
+            struct Item: Decodable { let msg: String }
+            let detail: [Item]
+        }
+        if let parsed = try? JSONDecoder().decode(ValidationDetail.self, from: data),
+           let first = parsed.detail.first {
+            return humanize(first.msg)
         }
         return nil
+    }
+
+    /// Strip pydantic's `"Value error, "` prefix from a validator message so the
+    /// UI shows the rule ("A game cannot end in a tie.") rather than the raw
+    /// framework wrapper (the iOS face of #151).
+    private static func humanize(_ message: String) -> String {
+        let prefix = "Value error, "
+        return message.hasPrefix(prefix) ? String(message.dropFirst(prefix.count)) : message
     }
 
     /// Parse the structured `session_merged` 401 body — `{"detail":{"code":

--- a/ios/Fortymm/Networking/SessionTokenStore.swift
+++ b/ios/Fortymm/Networking/SessionTokenStore.swift
@@ -77,4 +77,20 @@ actor SessionTokenStore {
         didLoad = true
         keychain.delete()
     }
+
+    /// Clear the session only if `token` is still the one we hold, returning
+    /// whether it did. A response that drops the session (the merged-away 401)
+    /// belongs to the token the *request* sent; if a newer sign-in has since
+    /// replaced it, a stale in-flight request must not wipe the new token or
+    /// trigger a sign-out. Hydrate first so the comparison is against the real
+    /// stored token, not a not-yet-loaded `nil`.
+    func clearIfCurrent(_ token: String?) -> Bool {
+        if !didLoad {
+            cached = keychain.load()
+            didLoad = true
+        }
+        guard cached == token else { return false }
+        clear()
+        return true
+    }
 }

--- a/ios/Fortymm/Networking/SessionTokenStore.swift
+++ b/ios/Fortymm/Networking/SessionTokenStore.swift
@@ -31,12 +31,16 @@ actor SessionTokenStore {
         self.keychain = keychain
     }
 
+    /// Load the token from the Keychain into the cache once, on first access.
+    private func hydrate() {
+        guard !didLoad else { return }
+        cached = keychain.load()
+        didLoad = true
+    }
+
     /// The current token, lazily hydrated from the Keychain on first access.
     func token() -> String? {
-        if !didLoad {
-            cached = keychain.load()
-            didLoad = true
-        }
+        hydrate()
         retryPersistIfNeeded()
         return cached
     }
@@ -85,10 +89,7 @@ actor SessionTokenStore {
     /// trigger a sign-out. Hydrate first so the comparison is against the real
     /// stored token, not a not-yet-loaded `nil`.
     func clearIfCurrent(_ token: String?) -> Bool {
-        if !didLoad {
-            cached = keychain.load()
-            didLoad = true
-        }
+        hydrate()
         guard cached == token else { return false }
         clear()
         return true

--- a/ios/Fortymm/Session/SessionStore.swift
+++ b/ios/Fortymm/Session/SessionStore.swift
@@ -103,6 +103,12 @@ final class SessionStore: ObservableObject {
             guard case .loading = state else { return }
             state = .loaded(response.data.user)
         } catch let APIError.sessionMerged(message, email) {
+            // getSession sends the current token, and APIClient only raises this
+            // for a merge of the token it sent — so reaching here means *our*
+            // session was merged and signing out is right. Still gate on
+            // .loading for symmetry, so a state another task already resolved
+            // mid-flight isn't overwritten.
+            guard case .loading = state else { return }
             signedOut(reason: message, email: email)
         } catch {
             guard case .loading = state else { return }


### PR DESCRIPTION
Three unmerged iOS commits on this branch (the earlier #597 work landed via #603; these sit on top).

## Changes

**Merged-session sign-out is token-aware (`1dc86db`, `4ebaf82`)**
A stale in-flight request that 401s with `session_merged` no longer clobbers a *live* session: `clearIfCurrent(sentToken)` only drops the token + broadcasts sign-out when the cookie the request sent is still the one we hold. `SessionTokenStore.hydrate()` is extracted and shared by `token()`/`clearIfCurrent()`.

**Human-readable 422 copy (#446)**
`APIClient.detail(from:)` only decoded `{"detail": "<string>"}`, so a FastAPI 422 (`{"detail": [{"msg": ...}]}`) fell through to the bare "HTTP 422". Now decodes the validation-array shape too (mirroring web-client's `extractDetail`) and strips pydantic's `"Value error, "` prefix so scoring-rule rejections read as the rule.

**Sign-in field's false "VALID" chip (#448)**
`LoginEmailField`'s status chip was binary on `invalid`, so an empty/untouched email showed a green "● VALID". Made it tri-state (valid / invalid / neutral) fed by the real validation result.

## Testing
- iOS clean simulator build (`rm -rf ios/build/sim && xcodebuild ... build`) → **BUILD SUCCEEDED**. The app ships no XCTest target, so the compile is the gate.
- 422-parsing logic verified with a standalone `swiftc` harness (string detail, 422 array, prefix-strip, empty array, no-detail).

## Follow-up
The `"Value error, "` strip is iOS-only; the server-side fix that cleans it for web too is tracked in #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)