### PR TITLE
Deliver notifications via a background job; drop broadcast channel picker

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -76,6 +76,7 @@ from app.schemas.match import (
     MatchResultsWrite,
     MatchSignatureView,
 )
+from app.schemas.notification import NotificationJob
 from app.schemas.rating import RatingChange
 from app.services.dependencies import get_match_service
 from app.services.match_service import MatchService
@@ -1038,9 +1039,9 @@ def _result_confirmation_copy(
 async def _notify_result_posted(
     notifications: NotificationService, match: Match, poster_id: uuid.UUID
 ) -> None:
-    """Record + deliver a confirm/dispute prompt to every player on the side
-    that now owes a sign-off. ``notify`` persists the in-app record (the bell
-    feed) and fans out push/email per the recipient's preferences. The APNs
+    """Queue a confirm/dispute prompt to every player on the side that now owes
+    a sign-off. Each enqueued job persists the in-app record (the bell feed) and
+    fans out push/email per the recipient's preferences in the worker. The APNs
     ``category``/``data`` carry the Approve/Dispute action group and the match
     id so a tapped push deep-links to the right match."""
     copy = _result_confirmation_copy(match, poster_id)
@@ -1049,15 +1050,17 @@ async def _notify_result_posted(
         return
     title, body = copy
     for player in recipient_side.players:
-        await notifications.notify(
-            user_id=player.user_id,
-            category=NotificationCategory.RESULT_CONFIRM,
-            title=title,
-            body=body,
-            link=f"/matches/{match.id}",
-            action_label="Review",
-            push_category=MATCH_RESULT_CONFIRMATION_CATEGORY,
-            push_data={"match_id": str(match.id)},
+        notifications.enqueue_notification(
+            NotificationJob(
+                user_id=player.user_id,
+                category=NotificationCategory.RESULT_CONFIRM,
+                title=title,
+                body=body,
+                link=f"/matches/{match.id}",
+                action_label="Review",
+                push_category=MATCH_RESULT_CONFIRMATION_CATEGORY,
+                push_data={"match_id": str(match.id)},
+            )
         )
 
 

--- a/api/app/notifications/jobs.py
+++ b/api/app/notifications/jobs.py
@@ -1,0 +1,44 @@
+"""Background delivery for notifications. Invoked by RQ workers.
+
+``notify`` is async (async SQLAlchemy + APNs), but RQ workers are sync
+processes, so the entry point is a thin ``asyncio.run`` wrapper that opens its
+own ``async_sessionmaker`` from ``app.db.get_engine`` and constructs a
+process-local ``PushSender`` — mirroring ``app.ratings.jobs``.
+"""
+
+import asyncio
+import logging
+
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.db import get_engine
+from app.notifications.apns import push_sender_from_env
+from app.notifications.service import NotificationService
+from app.schemas.notification import NotificationJob
+
+log = logging.getLogger(__name__)
+
+DELIVER_NOTIFICATION_JOB = "app.notifications.jobs.deliver_notification"
+
+
+def deliver_notification(payload_json: str) -> None:
+    """RQ entry point. Deliver one notification to one recipient on whichever
+    channels that user's preferences allow for the notification's category."""
+    asyncio.run(_deliver(NotificationJob.model_validate_json(payload_json)))
+
+
+async def _deliver(job: NotificationJob) -> None:
+    sessionmaker = async_sessionmaker(get_engine(), expire_on_commit=False)
+    async with sessionmaker() as db:
+        service = NotificationService(db, push_sender_from_env())
+        await service.notify(
+            user_id=job.user_id,
+            category=job.category,
+            title=job.title,
+            body=job.body,
+            link=job.link,
+            action_label=job.action_label,
+            delta=job.delta,
+            push_category=job.push_category,
+            push_data=job.push_data,
+        )

--- a/api/app/notifications/router.py
+++ b/api/app/notifications/router.py
@@ -167,16 +167,16 @@ async def broadcast_notification(
     payload: BroadcastRequest,
     service: NotificationService = Depends(get_notification_service),
 ) -> BroadcastResponse:
-    """Send an announcement to all players or a hand-picked set. Filed as
-    tournament news, so each recipient only receives it on channels they
-    haven't muted for that category."""
+    """Queue an announcement to all players or a hand-picked set. Filed as
+    tournament news, so each recipient only receives it on the channels they
+    haven't muted for that category. Delivery runs in the background — the
+    response reports how many players were targeted, not per-channel counts."""
     recipients = payload.recipients
     all_users = recipients.mode == "all"
     user_ids = recipients.user_ids if recipients.mode == "selected" else []
-    return await service.broadcast(
+    return await service.enqueue_broadcast(
         all_users=all_users,
         user_ids=user_ids,
-        channels=payload.channels,
         title=payload.title,
         body=payload.body,
     )

--- a/api/app/notifications/service.py
+++ b/api/app/notifications/service.py
@@ -53,6 +53,7 @@ from app.schemas.notification import (
     NotificationChannelState,
     NotificationFeed,
     NotificationItem,
+    NotificationJob,
     NotificationPreferences,
     NotificationPreferencesUpdate,
     NotificationTaxonomy,
@@ -198,24 +199,24 @@ class NotificationService:
         link: str | None = None,
         action_label: str | None = None,
         delta: str | None = None,
-        channels: Collection[NotificationChannel] | None = None,
         push_category: str | None = None,
         push_data: Mapping[str, str] | None = None,
     ) -> NotifyResult:
         """Deliver one notification to one user across every channel the user's
-        preferences allow (intersected with ``channels`` when the caller
-        restricts the candidates, e.g. an admin broadcast).
+        preferences allow for the notification's category.
 
-        The in-app channel persists a ``Notification`` row — the durable record
-        the bell/feed read. Push reuses ``send_to_user`` (best-effort) and email
-        enqueues an RQ job (best-effort). A missing or tombstoned recipient is a
-        no-op."""
+        Runs in the RQ worker (enqueued via ``enqueue_notification`` /
+        ``enqueue_broadcast``). The in-app channel persists a ``Notification``
+        row — the durable record the bell/feed read. Push reuses ``send_to_user``
+        (best-effort) and email enqueues an RQ job (best-effort). A missing or
+        tombstoned recipient is a no-op."""
         user = await self._db.get(User, user_id)
         if user is None or user.merged_into_user_id is not None:
             return NotifyResult()
 
-        candidates = set(channels) if channels is not None else set(NotificationChannel)
-        effective = await self._effective_channels(user_id, category, candidates)
+        effective = await self._effective_channels(
+            user_id, category, set(NotificationChannel)
+        )
         result = NotifyResult()
 
         if NotificationChannel.IN_APP in effective:
@@ -270,6 +271,30 @@ class NotificationService:
             )
         except Exception:
             log.exception("Failed to enqueue notification email")
+            return False
+        return True
+
+    # ----- enqueueing background delivery ----------------------------------
+
+    def enqueue_notification(self, job: NotificationJob) -> bool:
+        """Hand one notification to the worker, which resolves the recipient's
+        preferences and delivers (see ``app.notifications.jobs``). Fire-and-
+        forget: a Redis hiccup must not fail the originating flow, so enqueue
+        failures are logged and swallowed (mirrors ``_enqueue_notification_email``)."""
+        # Imported lazily (not at module level) because app.notifications.jobs
+        # imports this service — a top-level import would be a cycle. The
+        # function-level import keeps the job name a single source of truth.
+        from app.notifications.jobs import DELIVER_NOTIFICATION_JOB
+
+        try:
+            queue_module.get_notifications_queue().enqueue(
+                DELIVER_NOTIFICATION_JOB,
+                job.model_dump_json(),
+                result_ttl=60,
+                failure_ttl=300,
+            )
+        except Exception:
+            log.exception("Failed to enqueue notification delivery")
             return False
         return True
 
@@ -665,42 +690,36 @@ class NotificationService:
 
     # ----- admin broadcast -------------------------------------------------
 
-    async def broadcast(
+    async def enqueue_broadcast(
         self,
         *,
         all_users: bool,
         user_ids: Sequence[uuid.UUID],
-        channels: Collection[NotificationChannel],
         title: str,
         body: str,
     ) -> BroadcastResponse:
-        """Fan a tournament-news notification out to the chosen recipients,
-        respecting each player's preferences. Counts users (not devices) who
-        actually got each delivery kind after preference filtering."""
-        targets = await self._broadcast_targets(all_users, user_ids)
-        in_app = pushed = emailed = 0
-        for target in targets:
-            result = await self.notify(
-                user_id=target.id,
-                category=BROADCAST_CATEGORY,
-                title=title,
-                body=body,
-                channels=channels,
+        """Resolve the target players and hand one delivery job per recipient to
+        the worker, which resolves *that* player's tournament-news preferences
+        and delivers accordingly. Returns the recipient count immediately —
+        actual delivery happens in the background."""
+        target_ids = await self._broadcast_target_ids(all_users, user_ids)
+        for target_id in target_ids:
+            self.enqueue_notification(
+                NotificationJob(
+                    user_id=target_id,
+                    category=BROADCAST_CATEGORY,
+                    title=title,
+                    body=body,
+                )
             )
-            in_app += int(result.in_app_created)
-            pushed += int(result.pushed > 0)
-            emailed += int(result.emailed)
-        return BroadcastResponse(
-            recipients=len(targets),
-            in_app_created=in_app,
-            pushed=pushed,
-            emailed=emailed,
-        )
+        return BroadcastResponse(recipients=len(target_ids))
 
-    async def _broadcast_targets(
+    async def _broadcast_target_ids(
         self, all_users: bool, user_ids: Sequence[uuid.UUID]
-    ) -> Sequence[User]:
-        query = select(User).where(User.merged_into_user_id.is_(None))
+    ) -> Sequence[uuid.UUID]:
+        # Only the ids are needed (one job per recipient), so don't hydrate
+        # full User rows — an "all users" broadcast would load the whole table.
+        query = select(User.id).where(User.merged_into_user_id.is_(None))
         if not all_users:
             if not user_ids:
                 return []

--- a/api/app/queue.py
+++ b/api/app/queue.py
@@ -6,6 +6,7 @@ from rq import Queue
 SOLVER_QUEUE = "solver"
 EMAIL_QUEUE = "email"
 RATINGS_QUEUE = "ratings"
+NOTIFICATIONS_QUEUE = "notifications"
 
 
 def _connection() -> Redis:
@@ -23,3 +24,7 @@ def get_email_queue() -> Queue:
 
 def get_ratings_queue() -> Queue:
     return Queue(RATINGS_QUEUE, connection=_connection())
+
+
+def get_notifications_queue() -> Queue:
+    return Queue(NOTIFICATIONS_QUEUE, connection=_connection())

--- a/api/app/schemas/notification.py
+++ b/api/app/schemas/notification.py
@@ -218,28 +218,44 @@ BroadcastRecipients = Annotated[
 
 
 class BroadcastRequest(BaseModel):
-    """An admin broadcast: pick recipients, the channels to try, and the copy.
+    """An admin broadcast: pick recipients and the copy.
 
     Broadcasts are filed under the *tournament* category, so each recipient only
-    receives it on a channel they haven't muted for tournament news — admin
-    reach still respects the player's preferences."""
+    receives it on the channels they haven't muted for tournament news — the
+    server delivers per each player's preferences (there is no admin channel
+    override)."""
 
     model_config = ConfigDict(extra="forbid")
 
     recipients: BroadcastRecipients
-    channels: list[NotificationChannel] = Field(min_length=1)
     title: str = Field(min_length=1, max_length=100)
     body: str = Field(min_length=1, max_length=280)
 
 
 class BroadcastResponse(BaseModel):
-    """What the broadcast did: how many players it targeted and, of those, how
-    many got an in-app record / push / email after preference filtering."""
+    """What the broadcast enqueued: how many players were targeted. Delivery
+    happens in the background (one job per recipient resolves that player's
+    preferences and delivers), so per-channel counts aren't known here."""
 
     recipients: int
-    in_app_created: int
-    pushed: int
-    emailed: int
+    queued: bool = True
+
+
+class NotificationJob(BaseModel):
+    """The queue payload for one background delivery: a category + copy for a
+    single recipient. The worker resolves *this user's* preferences and delivers
+    on the channels they opted into — there is no channel restriction on the
+    payload. Serialized as JSON onto the ``notifications`` RQ queue."""
+
+    user_id: uuid.UUID
+    category: NotificationCategory
+    title: str
+    body: str
+    link: str | None = None
+    action_label: str | None = None
+    delta: str | None = None
+    push_category: str | None = None
+    push_data: dict[str, str] | None = None
 
 
 class BroadcastRecipient(BaseModel):

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
 from httpx import ASGITransport, AsyncClient, Request
+from rq import Queue
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,7 +17,21 @@ from app.main import app as fastapi_app
 from app.models import User
 from app.notifications.apns import Environment, SendOutcome, SendResult
 from app.notifications.dependencies import get_push_sender
+from app.notifications.jobs import DELIVER_NOTIFICATION_JOB
+from app.schemas.notification import NotificationJob
 from app.sessions import CSRF_COOKIE_NAME, CSRF_HEADER_NAME, CSRF_SAFE_METHODS
+
+
+def enqueued_notification_jobs(queue: Queue) -> list[NotificationJob]:
+    """The notification-delivery payloads enqueued so far, decoded back into
+    ``NotificationJob``. Under the async-style ``fake_notifications_queue`` the
+    worker body never runs, so tests assert on what was enqueued; channel
+    delivery itself is covered by the ``NotificationService.notify`` tests."""
+    jobs: list[NotificationJob] = []
+    for job in queue.get_jobs():
+        assert job.func_name == DELIVER_NOTIFICATION_JOB
+        jobs.append(NotificationJob.model_validate_json(job.args[0]))
+    return jobs
 
 
 async def _attach_csrf_header(request: Request) -> None:

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -50,6 +50,20 @@ def fake_ratings_queue(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def fake_notifications_queue(monkeypatch):
+    """Async-style RQ queue against fakeredis: enqueues are recorded but the
+    ``deliver_notification`` body never runs (like ``fake_ratings_queue``, it
+    would open its own DB engine via ``app.db.get_engine()``, not the
+    testcontainers database). Delivery is covered by direct
+    ``NotificationService.notify`` tests; this fixture only lets callers assert
+    which jobs were enqueued."""
+    connection = fakeredis.FakeStrictRedis()
+    q = Queue(queue_module.NOTIFICATIONS_QUEUE, connection=connection, is_async=True)
+    monkeypatch.setattr(queue_module, "get_notifications_queue", lambda: q)
+    return q
+
+
+@pytest.fixture(autouse=True)
 def fake_email_queue(monkeypatch):
     """Sync RQ queue against fakeredis so enqueued jobs execute inline.
 

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable, Callable
 import pytest
 from fastapi import HTTPException
 from httpx import AsyncClient
+from rq import Queue
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
@@ -22,18 +23,16 @@ from app.models import (
     MatchGameScore,
     MatchSide,
     MatchStatus,
-    Notification,
     User,
 )
 from app.notifications.apns import MATCH_RESULT_CONFIRMATION_CATEGORY
 from app.schemas.match import MatchGameScoreWrite
 from tests._helpers import (
-    FakeSender,
+    enqueued_notification_jobs,
     make_client,
     make_user,
     opponent_session,
     start_session,
-    use_sender,
 )
 
 # ----- create -------------------------------------------------------------
@@ -2250,36 +2249,24 @@ async def test_concurrent_confirm_and_dispute_serialize(
                 assert [s.won for s in sides] == [None, None]
 
 
-# ----- result-confirmation push -------------------------------------------
+# ----- result-confirmation delivery (enqueued to the worker) --------------
 
 
-async def _register_device(
-    client: AsyncClient, token: str, *, environment: str = "sandbox"
-) -> None:
-    response = await client.post(
-        "/v1/device-tokens",
-        json={"token": token, "platform": "ios", "environment": environment},
-    )
-    assert response.status_code == 200, response.text
-
-
-async def test_posting_result_pushes_confirmation_to_opponent(
-    api_client: AsyncClient, db_session: AsyncSession
+async def test_posting_result_enqueues_confirmation_for_opponent(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    fake_notifications_queue: Queue,
 ):
-    """When a player posts a result on a two-human match, the opponent gets a
-    push carrying the Approve/Dispute category, the match id, and copy with the
-    games-won score plus the individual game scores."""
+    """Posting a result on a two-human match enqueues one confirm/dispute
+    delivery for the opponent — filed under the result-confirmation category,
+    deep-linked to the match, carrying the Approve/Dispute push category + match
+    id, with recipient-framed copy. The poster gets nothing."""
     me = await start_session(api_client, db_session)
     me.username = "poster"
     await db_session.commit()
 
-    sender = FakeSender()
-    use_sender(sender)
-
-    async with opponent_session(db_session, "rival") as (opp_client, opp):
-        await _register_device(opp_client, "opp-device")
+    async with opponent_session(db_session, "rival") as (_opp_client, opp):
         match = await _create_match(api_client, opp.id, best_of=3)
-
         response = await api_client.post(
             f"/v1/matches/{match['id']}/results",
             json={
@@ -2292,54 +2279,28 @@ async def test_posting_result_pushes_confirmation_to_opponent(
         )
         assert response.status_code == 201
 
-    assert len(sender.sent) == 1
-    push = sender.sent[0]
-    assert push.token == "opp-device"
-    assert push.category == MATCH_RESULT_CONFIRMATION_CATEGORY
-    assert push.data == {"match_id": match["id"]}
-    # Recipient-framed games-won (poster won 2–1) and the per-game scores,
-    # oriented poster-first.
-    assert "poster reported beating you 2–1" in push.body
-    assert "11–7" in push.body
-    assert "9–11" in push.body
-    assert "11–8" in push.body
+    jobs = enqueued_notification_jobs(fake_notifications_queue)
+    assert [job.user_id for job in jobs] == [opp.id]
+    job = jobs[0]
+    assert job.category.value == "result_confirm"
+    assert job.link == f"/matches/{match['id']}"
+    assert job.push_category == MATCH_RESULT_CONFIRMATION_CATEGORY
+    assert job.push_data == {"match_id": match["id"]}
+    # Recipient-framed games-won (poster won 2–1) and the per-game scores.
+    assert "poster reported beating you 2–1" in job.body
+    assert "11–7" in job.body
+    assert "9–11" in job.body
+    assert "11–8" in job.body
 
 
-async def test_posting_result_does_not_push_to_the_poster(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    """Only the side that owes a sign-off is notified — never the poster, even
-    when both players have a device registered."""
-    await start_session(api_client, db_session)
-    await _register_device(api_client, "poster-device")
-
-    sender = FakeSender()
-    use_sender(sender)
-
-    async with opponent_session(db_session, "rival") as (opp_client, opp):
-        await _register_device(opp_client, "opp-device")
-        match = await _create_match(api_client, opp.id, best_of=1)
-
-        response = await api_client.post(
-            f"/v1/matches/{match['id']}/results",
-            json={
-                "games": [{"game_number": 1, "side_1_points": 11, "side_2_points": 5}]
-            },
-        )
-        assert response.status_code == 201
-
-    assert [push.token for push in sender.sent] == ["opp-device"]
-
-
-async def test_solo_result_sends_no_push(
-    api_client: AsyncClient, db_session: AsyncSession
+async def test_solo_result_enqueues_no_confirmation(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    fake_notifications_queue: Queue,
 ):
     """A solo (opponent-less) match finalizes on post with nobody to confirm —
-    so no confirmation push is fired."""
+    so no confirmation delivery is enqueued."""
     await start_session(api_client, db_session)
-
-    sender = FakeSender()
-    use_sender(sender)
 
     created = await api_client.post("/v1/matches", json={"best_of": 1, "rated": False})
     assert created.status_code == 201
@@ -2350,22 +2311,19 @@ async def test_solo_result_sends_no_push(
         json={"games": [{"game_number": 1, "side_1_points": 11, "side_2_points": 5}]},
     )
     assert response.status_code == 201
-    assert sender.sent == []
+    assert enqueued_notification_jobs(fake_notifications_queue) == []
 
 
-async def test_unrated_result_sends_no_push(
-    api_client: AsyncClient, db_session: AsyncSession
+async def test_unrated_result_enqueues_no_confirmation(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    fake_notifications_queue: Queue,
 ):
     """An unrated match finalizes on post with nothing for the opponent to
-    confirm — so no confirmation push is fired, even with a device
-    registered."""
+    confirm — so no confirmation delivery is enqueued."""
     await start_session(api_client, db_session)
 
-    sender = FakeSender()
-    use_sender(sender)
-
-    async with opponent_session(db_session, "rival") as (opp_client, opp):
-        await _register_device(opp_client, "opp-device")
+    async with opponent_session(db_session, "rival") as (_opp_client, opp):
         created = await api_client.post(
             "/v1/matches",
             json={"opponent_user_id": str(opp.id), "best_of": 1, "rated": False},
@@ -2381,79 +2339,4 @@ async def test_unrated_result_sends_no_push(
         )
         assert response.status_code == 201
 
-    assert sender.sent == []
-
-
-async def test_posting_result_succeeds_when_opponent_has_no_device(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    """The push is best-effort: an opponent with no registered device just
-    means nothing is sent — the result post still succeeds."""
-    await start_session(api_client, db_session)
-
-    sender = FakeSender()
-    use_sender(sender)
-
-    async with opponent_session(db_session, "rival") as (_opp_client, opp):
-        match = await _create_match(api_client, opp.id, best_of=1)
-        response = await api_client.post(
-            f"/v1/matches/{match['id']}/results",
-            json={
-                "games": [{"game_number": 1, "side_1_points": 11, "side_2_points": 5}]
-            },
-        )
-        assert response.status_code == 201
-
-    assert sender.sent == []
-
-
-async def test_posting_result_records_in_app_notification_for_opponent(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    """Posting a rated result persists an in-app notification (the bell/feed
-    record) for the side that owes a sign-off — not just a transient push. It
-    deep-links to the match and is filed under the result-confirmation category;
-    the poster gets nothing."""
-    me = await start_session(api_client, db_session)
-    me.username = "poster"
-    await db_session.commit()
-
-    sender = FakeSender()
-    use_sender(sender)
-
-    async with opponent_session(db_session, "rival") as (_opp_client, opp):
-        match = await _create_match(api_client, opp.id, best_of=1)
-        response = await api_client.post(
-            f"/v1/matches/{match['id']}/results",
-            json={
-                "games": [{"game_number": 1, "side_1_points": 11, "side_2_points": 5}]
-            },
-        )
-        assert response.status_code == 201
-
-    opp_rows = (
-        (
-            await db_session.execute(
-                select(Notification).where(Notification.user_id == opp.id)
-            )
-        )
-        .scalars()
-        .all()
-    )
-    assert len(opp_rows) == 1
-    stored = opp_rows[0]
-    assert stored.category == "result_confirm"
-    assert stored.link == f"/matches/{match['id']}"
-    assert stored.read_at is None
-
-    # The poster is never notified.
-    poster_rows = (
-        (
-            await db_session.execute(
-                select(Notification).where(Notification.user_id == me.id)
-            )
-        )
-        .scalars()
-        .all()
-    )
-    assert poster_rows == []
+    assert enqueued_notification_jobs(fake_notifications_queue) == []

--- a/api/tests/test_notification_broadcast.py
+++ b/api/tests/test_notification_broadcast.py
@@ -1,28 +1,26 @@
 """The admin broadcast tool: the permission gate, the recipient picker, and the
-preference-respecting fan-out."""
+background fan-out (one delivery job enqueued per resolved recipient)."""
 
 from datetime import UTC, datetime
 
 from httpx import AsyncClient
-from sqlalchemy import select
+from rq import Queue
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import (
-    DeviceToken,
-    Notification,
     Permission,
     Role,
     RolePermission,
     User,
     UserRole,
 )
-from app.notifications.service import NotificationService
-from app.notifications.taxonomy import NotificationCategory, NotificationChannel
-from app.schemas.notification import (
-    NotificationCellUpdate,
-    NotificationPreferencesUpdate,
+from tests._helpers import (
+    FakeSender,
+    enqueued_notification_jobs,
+    make_user,
+    start_session,
+    use_sender,
 )
-from tests._helpers import FakeSender, make_user, start_session, use_sender
 
 BROADCAST_PERMISSION = "notifications.broadcast"
 
@@ -41,18 +39,6 @@ async def grant_broadcast(db_session: AsyncSession, user: User) -> None:
     await db_session.commit()
 
 
-async def _stored_for(db_session: AsyncSession, user_id) -> list[Notification]:
-    return list(
-        (
-            await db_session.execute(
-                select(Notification).where(Notification.user_id == user_id)
-            )
-        )
-        .scalars()
-        .all()
-    )
-
-
 # ----- permission gate ------------------------------------------------------
 
 
@@ -62,12 +48,7 @@ async def test_broadcast_requires_permission(
     await start_session(api_client, db_session)
     response = await api_client.post(
         "/v1/notifications/broadcast",
-        json={
-            "recipients": {"mode": "all"},
-            "channels": ["in_app"],
-            "title": "Hi",
-            "body": "Body",
-        },
+        json={"recipients": {"mode": "all"}, "title": "Hi", "body": "Body"},
     )
     assert response.status_code == 403
 
@@ -83,8 +64,10 @@ async def test_recipient_picker_requires_permission(
 # ----- fan-out --------------------------------------------------------------
 
 
-async def test_broadcast_all_records_in_app_for_every_player(
-    api_client: AsyncClient, db_session: AsyncSession
+async def test_broadcast_all_enqueues_a_job_for_every_player(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    fake_notifications_queue: Queue,
 ):
     admin = await start_session(api_client, db_session)
     await grant_broadcast(db_session, admin)
@@ -95,7 +78,6 @@ async def test_broadcast_all_records_in_app_for_every_player(
         "/v1/notifications/broadcast",
         json={
             "recipients": {"mode": "all"},
-            "channels": ["in_app"],
             "title": "Spring Open — R16 is live",
             "body": "Brackets just dropped.",
         },
@@ -104,17 +86,17 @@ async def test_broadcast_all_records_in_app_for_every_player(
     assert response.status_code == 200
     data = response.json()
     # Two live users: the admin and alice.
-    assert data["recipients"] == 2
-    assert data["in_app_created"] == 2
-    assert data["pushed"] == 0
-    alice_feed = await _stored_for(db_session, alice.id)
-    assert [(n.title, n.category) for n in alice_feed] == [
-        ("Spring Open — R16 is live", "tournament")
-    ]
+    assert data == {"recipients": 2, "queued": True}
+    jobs = enqueued_notification_jobs(fake_notifications_queue)
+    assert {job.user_id for job in jobs} == {admin.id, alice.id}
+    assert all(job.category.value == "tournament" for job in jobs)
+    assert all(job.title == "Spring Open — R16 is live" for job in jobs)
 
 
 async def test_broadcast_all_excludes_tombstoned_users(
-    api_client: AsyncClient, db_session: AsyncSession
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    fake_notifications_queue: Queue,
 ):
     admin = await start_session(api_client, db_session)
     await grant_broadcast(db_session, admin)
@@ -128,7 +110,6 @@ async def test_broadcast_all_excludes_tombstoned_users(
         "/v1/notifications/broadcast",
         json={
             "recipients": {"mode": "all"},
-            "channels": ["in_app"],
             "title": "Everyone",
             "body": "…except the ghost.",
         },
@@ -137,23 +118,25 @@ async def test_broadcast_all_excludes_tombstoned_users(
     assert response.status_code == 200
     # Only the live admin counts — the tombstoned guest is excluded.
     assert response.json()["recipients"] == 1
-    assert await _stored_for(db_session, ghost.id) == []
+    jobs = enqueued_notification_jobs(fake_notifications_queue)
+    assert [job.user_id for job in jobs] == [admin.id]
 
 
 async def test_broadcast_selected_targets_only_those_players(
-    api_client: AsyncClient, db_session: AsyncSession
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    fake_notifications_queue: Queue,
 ):
     admin = await start_session(api_client, db_session)
     await grant_broadcast(db_session, admin)
     alice = await make_user(db_session, "alice")
-    bob = await make_user(db_session, "bob")
+    await make_user(db_session, "bob")
     use_sender(FakeSender())
 
     response = await api_client.post(
         "/v1/notifications/broadcast",
         json={
             "recipients": {"mode": "selected", "user_ids": [str(alice.id)]},
-            "channels": ["in_app"],
             "title": "Heads up",
             "body": "Just you.",
         },
@@ -161,82 +144,8 @@ async def test_broadcast_selected_targets_only_those_players(
 
     assert response.status_code == 200
     assert response.json()["recipients"] == 1
-    assert len(await _stored_for(db_session, alice.id)) == 1
-    assert await _stored_for(db_session, bob.id) == []
-    assert await _stored_for(db_session, admin.id) == []
-
-
-async def test_broadcast_respects_recipient_preferences(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    admin = await start_session(api_client, db_session)
-    await grant_broadcast(db_session, admin)
-    alice = await make_user(db_session, "alice")
-    # Alice muted tournament news in-app.
-    await NotificationService(db_session, FakeSender()).update_preferences(
-        alice,
-        NotificationPreferencesUpdate(
-            cells=[
-                NotificationCellUpdate(
-                    category=NotificationCategory.TOURNAMENT,
-                    channel=NotificationChannel.IN_APP,
-                    enabled=False,
-                )
-            ]
-        ),
-    )
-    use_sender(FakeSender())
-
-    response = await api_client.post(
-        "/v1/notifications/broadcast",
-        json={
-            "recipients": {"mode": "selected", "user_ids": [str(alice.id)]},
-            "channels": ["in_app"],
-            "title": "Muted for alice",
-            "body": "She won't see this in her feed.",
-        },
-    )
-
-    assert response.status_code == 200
-    data = response.json()
-    assert data["recipients"] == 1
-    assert data["in_app_created"] == 0
-    assert await _stored_for(db_session, alice.id) == []
-
-
-async def test_broadcast_pushes_to_devices(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    admin = await start_session(api_client, db_session)
-    await grant_broadcast(db_session, admin)
-    alice = await make_user(db_session, "alice")
-    db_session.add(
-        DeviceToken(
-            token="alice-device",
-            platform="ios",
-            environment="sandbox",
-            user_id=alice.id,
-        )
-    )
-    await db_session.commit()
-    sender = FakeSender()
-    use_sender(sender)
-
-    response = await api_client.post(
-        "/v1/notifications/broadcast",
-        json={
-            "recipients": {"mode": "selected", "user_ids": [str(alice.id)]},
-            "channels": ["push"],
-            "title": "Court change",
-            "body": "Your QF moved to Court 1.",
-        },
-    )
-
-    assert response.status_code == 200
-    data = response.json()
-    assert data["pushed"] == 1
-    assert data["in_app_created"] == 0
-    assert [p.token for p in sender.sent] == ["alice-device"]
+    jobs = enqueued_notification_jobs(fake_notifications_queue)
+    assert [job.user_id for job in jobs] == [alice.id]
 
 
 # ----- recipient picker -----------------------------------------------------
@@ -285,16 +194,18 @@ async def test_recipient_picker_excludes_tombstoned_users(
 # ----- validation -----------------------------------------------------------
 
 
-async def test_broadcast_rejects_empty_channels(
+async def test_broadcast_rejects_unknown_channels_field(
     api_client: AsyncClient, db_session: AsyncSession
 ):
+    """The admin no longer picks channels — preferences decide. A stray
+    ``channels`` key is a client bug (extra="forbid")."""
     admin = await start_session(api_client, db_session)
     await grant_broadcast(db_session, admin)
     response = await api_client.post(
         "/v1/notifications/broadcast",
         json={
             "recipients": {"mode": "all"},
-            "channels": [],
+            "channels": ["in_app"],
             "title": "Hi",
             "body": "Body",
         },
@@ -311,7 +222,6 @@ async def test_broadcast_rejects_selected_with_no_ids(
         "/v1/notifications/broadcast",
         json={
             "recipients": {"mode": "selected", "user_ids": []},
-            "channels": ["in_app"],
             "title": "Hi",
             "body": "Body",
         },

--- a/api/tests/test_notification_preferences.py
+++ b/api/tests/test_notification_preferences.py
@@ -361,25 +361,6 @@ async def test_notify_skips_muted_cell_even_with_channel_on(
     assert other.pushed == 1
 
 
-async def test_notify_restricts_to_candidate_channels(db_session: AsyncSession):
-    user = await make_user(db_session, "candidate")
-    await _add_device(db_session, user.id)
-    sender = FakeSender()
-    service = NotificationService(db_session, sender)
-
-    result = await service.notify(
-        user_id=user.id,
-        category=NotificationCategory.TOURNAMENT,
-        title="t",
-        body="b",
-        channels=[NotificationChannel.IN_APP],
-    )
-    # Only in-app was a candidate, so no push despite a registered device.
-    assert result.in_app_created is True
-    assert result.pushed == 0
-    assert sender.sent == []
-
-
 async def test_notify_missing_user_is_noop(db_session: AsyncSession):
     import uuid
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -60,7 +60,7 @@ services:
         condition: service_healthy
     volumes:
       - ./api:/app
-    command: rq worker --url redis://redis:6379/0 solver email ratings
+    command: rq worker --url redis://redis:6379/0 solver email ratings notifications
 
   web-client:
     build:

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -98,7 +98,7 @@ services:
         condition: service_healthy
       mailpit:
         condition: service_started
-    command: rq worker --url redis://redis:6379/0 solver email ratings
+    command: rq worker --url redis://redis:6379/0 solver email ratings notifications
 
   # Catches every email the worker sends in this preview stack instead of
   # relaying it to Postmark. SMTP on :1025 (internal); web UI on :8025,

--- a/docker-compose.uat.yml
+++ b/docker-compose.uat.yml
@@ -83,7 +83,7 @@ services:
     depends_on:
       redis:
         condition: service_healthy
-    command: rq worker --url redis://redis:6379/0 solver email ratings
+    command: rq worker --url redis://redis:6379/0 solver email ratings notifications
 
   web-client:
     build:

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -863,9 +863,10 @@ export interface paths {
         put?: never;
         /**
          * Broadcast Notification
-         * @description Send an announcement to all players or a hand-picked set. Filed as
-         *     tournament news, so each recipient only receives it on channels they
-         *     haven't muted for that category.
+         * @description Queue an announcement to all players or a hand-picked set. Filed as
+         *     tournament news, so each recipient only receives it on the channels they
+         *     haven't muted for that category. Delivery runs in the background — the
+         *     response reports how many players were targeted, not per-channel counts.
          */
         post: operations["broadcast_notification_v1_notifications_broadcast_post"];
         delete?: never;
@@ -1035,17 +1036,16 @@ export interface components {
         };
         /**
          * BroadcastRequest
-         * @description An admin broadcast: pick recipients, the channels to try, and the copy.
+         * @description An admin broadcast: pick recipients and the copy.
          *
          *     Broadcasts are filed under the *tournament* category, so each recipient only
-         *     receives it on a channel they haven't muted for tournament news — admin
-         *     reach still respects the player's preferences.
+         *     receives it on the channels they haven't muted for tournament news — the
+         *     server delivers per each player's preferences (there is no admin channel
+         *     override).
          */
         BroadcastRequest: {
             /** Recipients */
             recipients: components["schemas"]["BroadcastRecipientsAll"] | components["schemas"]["BroadcastRecipientsSelected"];
-            /** Channels */
-            channels: components["schemas"]["NotificationChannel"][];
             /** Title */
             title: string;
             /** Body */
@@ -1053,18 +1053,18 @@ export interface components {
         };
         /**
          * BroadcastResponse
-         * @description What the broadcast did: how many players it targeted and, of those, how
-         *     many got an in-app record / push / email after preference filtering.
+         * @description What the broadcast enqueued: how many players were targeted. Delivery
+         *     happens in the background (one job per recipient resolves that player's
+         *     preferences and delivers), so per-channel counts aren't known here.
          */
         BroadcastResponse: {
             /** Recipients */
             recipients: number;
-            /** In App Created */
-            in_app_created: number;
-            /** Pushed */
-            pushed: number;
-            /** Emailed */
-            emailed: number;
+            /**
+             * Queued
+             * @default true
+             */
+            queued: boolean;
         };
         /** ComponentHealth */
         ComponentHealth: {

--- a/web-client/src/components/notifications/broadcast-page.tsx
+++ b/web-client/src/components/notifications/broadcast-page.tsx
@@ -2,12 +2,9 @@ import { useState } from 'react'
 import { ApiError } from '@/api/client'
 import {
   useBroadcastRecipients,
-  useNotificationTaxonomy,
   useSendBroadcast,
   type BroadcastResponse,
-  type NotificationChannel,
 } from '@/api/notifications'
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { BroadcastView } from './broadcast-page/broadcast-view'
 import {
@@ -30,9 +27,6 @@ export function BroadcastPage() {
   const [audience, setAudience] = useState<BroadcastAudience>('selected')
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [search, setSearch] = useState('')
-  const [channels, setChannels] = useState<Set<NotificationChannel>>(
-    new Set(['in_app', 'push']),
-  )
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
   const [result, setResult] = useState<BroadcastResponse | null>(null)
@@ -42,10 +36,9 @@ export function BroadcastPage() {
   // by `search`; only the query keys off the settled value.
   const debouncedSearch = useDebouncedValue(search, 300)
   const recipients = useBroadcastRecipients(debouncedSearch)
-  const taxonomy = useNotificationTaxonomy()
   const send = useSendBroadcast()
 
-  const draft = { audience, selectedIds, channels, title, body }
+  const draft = { audience, selectedIds, title, body }
   const canSend = canSendBroadcast(draft) && !send.isPending
   const total = recipients.data?.total ?? 0
   const selectedCount = audience === 'all' ? total : selectedIds.size
@@ -61,29 +54,6 @@ export function BroadcastPage() {
       ? send.error.detail
       : "Couldn't send the broadcast. Try again."
     : null
-
-  // The channel chips render from the server taxonomy, so gate the whole tool on
-  // it (recipients are allowed to stream in via their own loading state).
-  if (taxonomy.isPending) {
-    return (
-      <p className="px-6 py-6 text-sm text-[color:var(--fg-muted)]">
-        Loading…
-      </p>
-    )
-  }
-
-  if (taxonomy.isError) {
-    return (
-      <div className="px-6 py-6">
-        <Alert variant="destructive">
-          <AlertTitle>Couldn't load the broadcast tool</AlertTitle>
-          <AlertDescription>Refresh to try again.</AlertDescription>
-        </Alert>
-      </div>
-    )
-  }
-
-  const channelOrder = taxonomy.data.channels.map((c) => c.key)
 
   return (
     <BroadcastView
@@ -104,12 +74,6 @@ export function BroadcastPage() {
         setSelectedIds((prev) => toggle(prev, id))
       }}
       selectedCount={selectedCount}
-      channels={channels}
-      channelInfos={taxonomy.data.channels}
-      onToggleChannel={(channel) => {
-        clearResult()
-        setChannels((prev) => toggle(prev, channel))
-      }}
       title={title}
       onTitleChange={(value) => {
         clearResult()
@@ -123,7 +87,7 @@ export function BroadcastPage() {
       canSend={canSend}
       sending={send.isPending}
       onSend={() =>
-        send.mutate(buildBroadcastRequest(draft, channelOrder), {
+        send.mutate(buildBroadcastRequest(draft), {
           onSuccess: (response) => setResult(response),
         })
       }

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.factory.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.factory.tsx
@@ -1,8 +1,7 @@
-import { notificationTaxonomy } from '@/test/factories'
 import type { BroadcastViewProps } from './broadcast-view'
 
-/** Default scenario: two searchable players, in-app + push selected, nothing
- * picked yet, so the form is not yet sendable. */
+/** Default scenario: two searchable players, nothing picked yet, so the form is
+ * not yet sendable. */
 export function buildBroadcastViewProps(
   overrides: Partial<BroadcastViewProps> = {},
 ): BroadcastViewProps {
@@ -20,9 +19,6 @@ export function buildBroadcastViewProps(
     selectedIds: new Set<string>(),
     onToggleRecipient: () => {},
     selectedCount: 0,
-    channels: new Set(['in_app', 'push']),
-    channelInfos: notificationTaxonomy().channels,
-    onToggleChannel: () => {},
     title: '',
     onTitleChange: () => {},
     body: '',

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.page.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.page.tsx
@@ -13,10 +13,6 @@ const scoped = (container: Container) => ({
   getRecipient(username: string) {
     return container.getByRole('checkbox', { name: username })
   },
-  /** A channel toggle chip, by channel label (In-app/Push/Email/SMS). */
-  getChannelChip(label: string) {
-    return container.getByRole('button', { name: label })
-  },
   getTitleInput() {
     return container.getByLabelText('Title')
   },
@@ -27,7 +23,7 @@ const scoped = (container: Container) => ({
     return container.getByRole('button', { name: /send to/i })
   },
   querySuccess() {
-    return container.queryByText(/sent to \d+ players/i)
+    return container.queryByText(/queued for \d+ player/i)
   },
   queryError() {
     return container.queryByText('Broadcast failed')
@@ -35,7 +31,7 @@ const scoped = (container: Container) => ({
   queryHint(text: string) {
     return container.queryByText(text)
   },
-  /** A preview channel section label (IN-APP / BELL, PUSH, EMAIL, SMS). */
+  /** A preview section label (e.g. IN-APP / BELL). */
   queryPreviewSection(label: string) {
     return container.queryByText(label)
   },
@@ -55,9 +51,6 @@ export const broadcastViewPage = {
   },
   async clickRecipient(username: string) {
     await userEvent.click(this.getRecipient(username))
-  },
-  async clickChannel(label: string) {
-    await userEvent.click(this.getChannelChip(label))
   },
   async clickSend() {
     await userEvent.click(this.getSendButton())

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.test.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.test.tsx
@@ -33,21 +33,6 @@ describe('BroadcastView', () => {
     expect(onToggleRecipient).toHaveBeenCalledWith('u-2')
   })
 
-  it('marks selected channels pressed and toggles them', async () => {
-    const onToggleChannel = vi.fn()
-    broadcastViewPage.render({ channels: new Set(['in_app']), onToggleChannel })
-    expect(broadcastViewPage.getChannelChip('In-app')).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    )
-    expect(broadcastViewPage.getChannelChip('Email')).toHaveAttribute(
-      'aria-pressed',
-      'false',
-    )
-    await broadcastViewPage.clickChannel('Email')
-    expect(onToggleChannel).toHaveBeenCalledWith('email')
-  })
-
   it('disables send until the draft is valid', () => {
     broadcastViewPage.render({ canSend: false })
     expect(broadcastViewPage.getSendButton()).toBeDisabled()
@@ -61,14 +46,11 @@ describe('BroadcastView', () => {
     expect(onSend).toHaveBeenCalledTimes(1)
   })
 
-  it('shows a success summary with the returned counts', () => {
-    broadcastViewPage.render({
-      result: { recipients: 7, in_app_created: 7, pushed: 4, emailed: 2 },
-    })
-    expect(broadcastViewPage.querySuccess()).toHaveTextContent('Sent to 7 players')
-    expect(
-      broadcastViewPage.queryHint('In-app 7 · push 4 · email 2'),
-    ).toBeInTheDocument()
+  it('shows a queued summary with the recipient count', () => {
+    broadcastViewPage.render({ result: { recipients: 7, queued: true } })
+    expect(broadcastViewPage.querySuccess()).toHaveTextContent(
+      'Queued for 7 players',
+    )
   })
 
   it('shows an error alert on a failed send', () => {
@@ -84,26 +66,14 @@ describe('BroadcastView', () => {
       broadcastViewPage.queryHint('Pick at least one recipient.'),
     ).toBeInTheDocument()
 
-    broadcastViewPage.render({
-      canSend: false,
-      selectedCount: 2,
-      channels: new Set(),
-    })
-    expect(
-      broadcastViewPage.queryHint('Pick at least one channel.'),
-    ).toBeInTheDocument()
+    broadcastViewPage.render({ canSend: false, selectedCount: 2 })
+    expect(broadcastViewPage.queryHint('Add a title.')).toBeInTheDocument()
   })
 
-  it('previews only the selected channels', () => {
-    broadcastViewPage.render({ channels: new Set(['email']) })
-    expect(broadcastViewPage.queryPreviewSection('EMAIL')).toBeInTheDocument()
-    expect(broadcastViewPage.queryPreviewSection('IN-APP / BELL')).not.toBeInTheDocument()
-    expect(broadcastViewPage.queryPreviewSection('PUSH')).not.toBeInTheDocument()
-  })
-
-  it('previews in-app and push by default', () => {
+  it('previews the in-app notification', () => {
     broadcastViewPage.render()
-    expect(broadcastViewPage.queryPreviewSection('IN-APP / BELL')).toBeInTheDocument()
-    expect(broadcastViewPage.queryPreviewSection('PUSH')).toBeInTheDocument()
+    expect(
+      broadcastViewPage.queryPreviewSection('IN-APP / BELL'),
+    ).toBeInTheDocument()
   })
 })

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.tsx
@@ -2,9 +2,7 @@ import { CheckCircle2, Search, Send } from 'lucide-react'
 import type {
   BroadcastRecipient,
   BroadcastResponse,
-  NotificationChannel,
   NotificationItem,
-  NotificationTaxonomy,
 } from '@/api/notifications'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -12,7 +10,6 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/lib/utils'
-import { CHANNEL_VISUAL } from '../notification-meta'
 import { NotificationRow } from '../notification-row'
 import type { BroadcastAudience } from './build-broadcast-request'
 
@@ -30,10 +27,6 @@ export interface BroadcastViewProps {
   selectedIds: ReadonlySet<string>
   onToggleRecipient: (id: string) => void
   selectedCount: number
-  channels: ReadonlySet<NotificationChannel>
-  /** Server-ordered channel taxonomy — drives the channel chips. */
-  channelInfos: NotificationTaxonomy['channels']
-  onToggleChannel: (channel: NotificationChannel) => void
   title: string
   onTitleChange: (title: string) => void
   body: string
@@ -46,8 +39,8 @@ export interface BroadcastViewProps {
 }
 
 /** The standalone admin broadcast tool, presentational: recipient picker,
- * compose form, channel-aware live preview, and send/result/error feedback.
- * Pure — all state + handlers come in as props. */
+ * compose form, live preview, and send/result/error feedback. Pure — all state
+ * + handlers come in as props. */
 export function BroadcastView(props: BroadcastViewProps) {
   const {
     recipients,
@@ -60,9 +53,6 @@ export function BroadcastView(props: BroadcastViewProps) {
     selectedIds,
     onToggleRecipient,
     selectedCount,
-    channels,
-    channelInfos,
-    onToggleChannel,
     title,
     onTitleChange,
     body,
@@ -75,11 +65,7 @@ export function BroadcastView(props: BroadcastViewProps) {
   } = props
 
   const hint =
-    selectedCount === 0
-      ? 'Pick at least one recipient.'
-      : channels.size === 0
-        ? 'Pick at least one channel.'
-        : 'Add a title.'
+    selectedCount === 0 ? 'Pick at least one recipient.' : 'Add a title.'
 
   return (
     <div className="grid gap-8 px-6 py-6 lg:grid-cols-[360px_1fr]">
@@ -170,34 +156,10 @@ export function BroadcastView(props: BroadcastViewProps) {
             Compose
           </h2>
 
-          <p className="mb-2 text-xs font-semibold text-[color:var(--fg-3)]">
-            Channels
+          <p className="mb-6 text-xs text-[color:var(--fg-muted)]">
+            Filed as tournament news — each player receives it on the channels
+            they haven't muted for that category.
           </p>
-          <div className="mb-6 flex flex-wrap gap-2">
-            {channelInfos.map((info) => {
-              const channel = info.key
-              const { Icon } = CHANNEL_VISUAL[channel]
-              const on = channels.has(channel)
-              return (
-                <button
-                  key={channel}
-                  type="button"
-                  aria-pressed={on}
-                  onClick={() => onToggleChannel(channel)}
-                  className={cn(
-                    'inline-flex items-center gap-2 rounded-[10px] border px-3.5 py-2 text-[13px] font-semibold transition-colors',
-                    on
-                      ? 'border-[color:var(--ball-500)] text-[color:var(--ball-500)]'
-                      : 'border-[color:var(--border-default)] text-[color:var(--fg-3)]',
-                  )}
-                  style={on ? { background: 'rgba(255,122,26,0.12)' } : undefined}
-                >
-                  <Icon size={16} />
-                  {info.label}
-                </button>
-              )
-            })}
-          </div>
 
           <label
             htmlFor="broadcast-title"
@@ -254,10 +216,12 @@ export function BroadcastView(props: BroadcastViewProps) {
           ) : result ? (
             <Alert className="mt-4 border-[color:rgba(0,226,154,0.3)] bg-[color:var(--bg-live-soft)]">
               <CheckCircle2 className="text-[color:var(--serve-500)]" />
-              <AlertTitle>Sent to {result.recipients} players</AlertTitle>
+              <AlertTitle>
+                Queued for {result.recipients} player
+                {result.recipients === 1 ? '' : 's'}
+              </AlertTitle>
               <AlertDescription>
-                In-app {result.in_app_created} · push {result.pushed} · email{' '}
-                {result.emailed}
+                Delivering in the background on each player's chosen channels.
               </AlertDescription>
             </Alert>
           ) : !canSend ? (
@@ -269,22 +233,14 @@ export function BroadcastView(props: BroadcastViewProps) {
           <h2 id="broadcast-preview-heading" className="ds-overline mb-3.5">
             Preview
           </h2>
-          <BroadcastPreview channels={channels} title={title} body={body} />
+          <BroadcastPreview title={title} body={body} />
         </section>
       </div>
     </div>
   )
 }
 
-function BroadcastPreview({
-  channels,
-  title,
-  body,
-}: {
-  channels: ReadonlySet<NotificationChannel>
-  title: string
-  body: string
-}) {
+function BroadcastPreview({ title, body }: { title: string; body: string }) {
   const safeTitle = title || 'Notification title'
   const safeBody = body || 'Your message shows up here.'
   const previewNotification: NotificationItem = {
@@ -300,77 +256,13 @@ function BroadcastPreview({
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      {channels.has('in_app') ? (
-        <div>
-          <p className="mb-2 font-mono text-[11px] tracking-wider text-[color:var(--fg-muted)]">
-            IN-APP / BELL
-          </p>
-          <div className="overflow-hidden rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)]">
-            <NotificationRow notification={previewNotification} compact />
-          </div>
-        </div>
-      ) : null}
-
-      {channels.has('push') ? (
-        <div>
-          <p className="mb-2 font-mono text-[11px] tracking-wider text-[color:var(--fg-muted)]">
-            PUSH
-          </p>
-          <div className="flex gap-3 rounded-2xl border border-white/10 bg-[rgba(30,34,44,0.82)] p-3 shadow-lg backdrop-blur">
-            <span
-              className="size-9 shrink-0 rounded-[9px]"
-              style={{ background: 'var(--ball-500)' }}
-            />
-            <div className="min-w-0">
-              <p className="truncate text-[13px] font-bold text-white">
-                {safeTitle}
-              </p>
-              <p className="line-clamp-2 text-[12.5px] text-white/75">{safeBody}</p>
-            </div>
-          </div>
-        </div>
-      ) : null}
-
-      {channels.has('email') ? (
-        <div>
-          <p className="mb-2 font-mono text-[11px] tracking-wider text-[color:var(--fg-muted)]">
-            EMAIL
-          </p>
-          <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)] p-3.5">
-            <div className="mb-2 flex items-center gap-2 border-b border-[color:var(--ink-700)] pb-2">
-              <span
-                className="size-4 rounded-full"
-                style={{ background: 'var(--ball-500)' }}
-              />
-              <span className="text-xs font-semibold text-[color:var(--fg-2)]">
-                FortyMM
-              </span>
-              <span className="text-[11px] text-[color:var(--fg-muted)]">
-                · no-reply
-              </span>
-            </div>
-            <p className="mb-1 text-sm font-bold text-[color:var(--fg-1)]">
-              {safeTitle}
-            </p>
-            <p className="text-[12.5px] leading-relaxed text-[color:var(--fg-3)]">
-              {safeBody}
-            </p>
-          </div>
-        </div>
-      ) : null}
-
-      {channels.has('sms') ? (
-        <div>
-          <p className="mb-2 font-mono text-[11px] tracking-wider text-[color:var(--fg-muted)]">
-            SMS
-          </p>
-          <div className="max-w-[260px] rounded-2xl rounded-bl-sm bg-[#1d2733] px-3.5 py-2.5 text-[13px] leading-snug text-[color:var(--fg-1)]">
-            FortyMM: {safeTitle}
-            {body ? ` — ${safeBody}` : ''}
-          </div>
-        </div>
-      ) : null}
+    <div>
+      <p className="mb-2 font-mono text-[11px] tracking-wider text-[color:var(--fg-muted)]">
+        IN-APP / BELL
+      </p>
+      <div className="overflow-hidden rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)]">
+        <NotificationRow notification={previewNotification} compact />
+      </div>
     </div>
   )
 }

--- a/web-client/src/components/notifications/broadcast-page/build-broadcast-request.test.ts
+++ b/web-client/src/components/notifications/broadcast-page/build-broadcast-request.test.ts
@@ -1,29 +1,20 @@
-import type { NotificationChannel } from '@/api/notifications'
 import {
   buildBroadcastRequest,
   canSendBroadcast,
   type BroadcastDraft,
 } from './build-broadcast-request'
 
-// The canonical server channel order, as the taxonomy ships it.
-const CHANNEL_ORDER: NotificationChannel[] = ['in_app', 'push', 'email', 'sms']
-
 const draft = (overrides: Partial<BroadcastDraft> = {}): BroadcastDraft => ({
   audience: 'all',
   selectedIds: new Set(),
-  channels: new Set(['in_app']),
   title: 'Spring Open is live',
   body: 'Brackets dropped.',
   ...overrides,
 })
 
 describe('canSendBroadcast', () => {
-  it('is true for an "all" broadcast with a channel and a title', () => {
+  it('is true for an "all" broadcast with a title', () => {
     expect(canSendBroadcast(draft())).toBe(true)
-  })
-
-  it('is false without a channel', () => {
-    expect(canSendBroadcast(draft({ channels: new Set() }))).toBe(false)
   })
 
   it('is false without a title', () => {
@@ -47,14 +38,13 @@ describe('canSendBroadcast', () => {
 
 describe('buildBroadcastRequest', () => {
   it('sends mode "all" for everyone', () => {
-    const req = buildBroadcastRequest(draft(), CHANNEL_ORDER)
+    const req = buildBroadcastRequest(draft())
     expect(req.recipients).toEqual({ mode: 'all' })
   })
 
   it('sends the picked ids for a selected audience', () => {
     const req = buildBroadcastRequest(
       draft({ audience: 'selected', selectedIds: new Set(['u2', 'u1']) }),
-      CHANNEL_ORDER,
     )
     expect(req.recipients).toEqual({
       mode: 'selected',
@@ -62,18 +52,9 @@ describe('buildBroadcastRequest', () => {
     })
   })
 
-  it('emits channels in canonical order regardless of selection order', () => {
-    const req = buildBroadcastRequest(
-      draft({ channels: new Set(['email', 'in_app', 'push']) }),
-      CHANNEL_ORDER,
-    )
-    expect(req.channels).toEqual(['in_app', 'push', 'email'])
-  })
-
   it('trims the title and body', () => {
     const req = buildBroadcastRequest(
       draft({ title: '  Heads up  ', body: '  Be early.  ' }),
-      CHANNEL_ORDER,
     )
     expect(req.title).toBe('Heads up')
     expect(req.body).toBe('Be early.')

--- a/web-client/src/components/notifications/broadcast-page/build-broadcast-request.ts
+++ b/web-client/src/components/notifications/broadcast-page/build-broadcast-request.ts
@@ -1,37 +1,31 @@
-import type { BroadcastRequest, NotificationChannel } from '@/api/notifications'
+import type { BroadcastRequest } from '@/api/notifications'
 
 export type BroadcastAudience = 'all' | 'selected'
 
 export interface BroadcastDraft {
   audience: BroadcastAudience
   selectedIds: ReadonlySet<string>
-  channels: ReadonlySet<NotificationChannel>
   title: string
   body: string
 }
 
 /** A broadcast is sendable once it has an audience (everyone, or ≥1 picked
- * player), at least one channel, and a non-blank title. */
+ * player) and a non-blank title. The server delivers per each recipient's
+ * notification preferences — there's no channel selection. */
 export function canSendBroadcast(
-  draft: Pick<BroadcastDraft, 'audience' | 'selectedIds' | 'channels' | 'title'>,
+  draft: Pick<BroadcastDraft, 'audience' | 'selectedIds' | 'title'>,
 ): boolean {
   const hasAudience = draft.audience === 'all' || draft.selectedIds.size > 0
-  return hasAudience && draft.channels.size > 0 && draft.title.trim().length > 0
+  return hasAudience && draft.title.trim().length > 0
 }
 
-/** Build the wire request from the draft. Channels are emitted in the canonical
- * server order (`channelOrder`, from the notification taxonomy) rather than
- * Set-insertion order, so the payload is deterministic. */
-export function buildBroadcastRequest(
-  draft: BroadcastDraft,
-  channelOrder: readonly NotificationChannel[],
-): BroadcastRequest {
+/** Build the wire request from the draft. */
+export function buildBroadcastRequest(draft: BroadcastDraft): BroadcastRequest {
   return {
     recipients:
       draft.audience === 'all'
         ? { mode: 'all' }
         : { mode: 'selected', user_ids: [...draft.selectedIds] },
-    channels: channelOrder.filter((channel) => draft.channels.has(channel)),
     title: draft.title.trim(),
     body: draft.body.trim(),
   }

--- a/web-client/src/mocks/notifications-store.ts
+++ b/web-client/src/mocks/notifications-store.ts
@@ -126,14 +126,7 @@ export const notificationHandlers = [
       body.recipients.mode === 'all'
         ? RECIPIENTS.length
         : body.recipients.user_ids.length
-    const channels = new Set<string>(body.channels)
-    const has = (c: string) => channels.has(c)
-    return HttpResponse.json({
-      recipients,
-      in_app_created: has('in_app') ? recipients : 0,
-      pushed: has('push') ? recipients : 0,
-      emailed: has('email') ? recipients : 0,
-    })
+    return HttpResponse.json({ recipients, queued: true })
   }),
 
   http.get('*/v1/notifications', () =>

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -526,9 +526,7 @@ export function broadcastResponse(
 ): BroadcastResponse {
   return {
     recipients: 2,
-    in_app_created: 2,
-    pushed: 0,
-    emailed: 0,
+    queued: true,
     ...overrides,
   }
 }


### PR DESCRIPTION
## What & why

Notification sending (admin broadcast **and** match-result confirmation) ran synchronously inside the request, blocking on per-recipient APNs round-trips (an N-recipient × M-device broadcast serialized N×M HTTP/2 calls before responding).

This moves delivery to the existing RQ worker. A new `notifications` queue carries a per-recipient `deliver_notification` job that looks up **that** user's preferences and delivers on the channels they opted into. `notify()` already resolved preferences via `_effective_channels`; the admin-chosen channel set was just a redundant extra restriction layered on top.

Because preferences alone now decide channels, the admin broadcast no longer picks channels:
- `BroadcastRequest.channels` is removed; the broadcast page's channel-selector chips are gone.
- `BroadcastResponse` is now `{recipients, queued}` (delivery happens in the background, so per-channel delivered counts aren't known at response time). The success panel reads "Queued for N players."

## Backend (`api/`)
- New `notifications` RQ queue (`app/queue.py`) + worker job `app/notifications/jobs.py::deliver_notification` (sync entrypoint → `asyncio.run`, owns its own session + APNs sender, like `app/ratings/jobs.py`).
- `NotificationJob` typed queue payload (`app/schemas/notification.py`).
- `NotificationService`: `enqueue_notification` / `enqueue_broadcast`; `notify()` drops its channel-restriction param; `_broadcast_target_ids` selects only `User.id`.
- Match-result confirmation (`matches.py`) and broadcast endpoint now enqueue instead of delivering inline.
- Worker queue list updated in `docker-compose.{dev,qa,uat}.yml` (**deploy note:** the worker must run the `notifications` queue).

## Web (`web-client/`)
- Removed the channel chips/state and the per-channel preview gating; single in-app/bell preview.
- Regenerated `schema.d.ts`; updated MSW handler and the broadcast quartet (view/page-object/factory/tests + request builder).

## Testing
- **API:** `ruff check` ✓, `ruff format --check` ✓, `mypy` (strict) ✓, `pytest` **472 passed**.
- **Web:** `npm run test:run` **863 passed**, `npm run lint` ✓, `npm run build` (tsc) ✓, Playwright e2e **127 passed**.
- **OpenAPI schema:** regenerated, in sync (no drift).
- iOS: untouched. Root docker e2e: skipped (no spec references notifications/broadcast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)