### PR TITLE
iOS: label rated matches correctly on the Matches list (#453)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -719,6 +719,7 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
         league=MatchLeague(id=match.league.id, name=match.league.name),
         sides=[_side_schema(side, side_wins, current_user_id) for side in sides_sorted],
         best_of=match.match_settings.best_of,
+        affects_rating=match.match_settings.affects_rating,
         created_at=match.created_at,
         current_game_number=next_number if is_participant else None,
         can_score=can_score,

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -217,6 +217,10 @@ class MatchListRow(BaseModel):
     league: MatchLeague
     sides: list[MatchDetailsSide]
     best_of: int
+    # Whether this match counts toward player ratings. The authoritative flag
+    # (from match settings) so the list can label rated vs. friendly without
+    # loading rating history — list rows don't carry ``rating_change``.
+    affects_rating: bool
     created_at: datetime
     # Game rows are created lazily on the first score write, so the deeplink
     # target may not have an id yet. The list passes the game number; the FE

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -461,6 +461,32 @@ async def test_list_matches_shows_every_match_on_the_system(
     assert me.username not in usernames
 
 
+async def test_list_rows_carry_affects_rating(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # The list row exposes the authoritative rated flag so a client can label
+    # rated vs. friendly without a rating delta (#453 — iOS mislabelled
+    # finalized rated matches as "Friendly" because list rows omit rating_change).
+    await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "opponent")
+    rated = await _create_match(api_client, opponent.id)
+    unrated = (
+        await api_client.post(
+            "/v1/matches",
+            json={
+                "opponent_user_id": str(opponent.id),
+                "best_of": 5,
+                "rated": False,
+            },
+        )
+    ).json()
+
+    body = (await api_client.get("/v1/matches")).json()
+    by_id = {row["id"]: row for row in body["items"]}
+    assert by_id[rated["id"]]["affects_rating"] is True
+    assert by_id[unrated["id"]]["affects_rating"] is False
+
+
 async def test_list_q_filter_matches_caller_username(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/ios/Fortymm/MatchFlow/MatchAPI.swift
+++ b/ios/Fortymm/MatchFlow/MatchAPI.swift
@@ -114,6 +114,10 @@ struct MatchListRowDTO: Decodable {
     let league: MatchLeagueDTO
     let sides: [MatchSideDTO]
     let bestOf: Int
+    /// Whether the match counts toward ratings. Authoritative (from match
+    /// settings), so the row labels rated vs. friendly without needing a
+    /// rating delta — list rows omit `rating_change`.
+    let affectsRating: Bool
     let createdAt: Date
     /// Next game to score; nil once every game is scored or the match is
     /// finalized. Game rows are created lazily, so this is a number, not an id.

--- a/ios/Fortymm/MatchFlow/MatchService.swift
+++ b/ios/Fortymm/MatchFlow/MatchService.swift
@@ -153,7 +153,10 @@ struct MatchService {
             // The list row omits can_finalize; the detail refetch (on open) fills
             // in the authoritative value and surfaces the "Post result" path.
             canFinalize: false,
-            ratedHint: nil, games: nil, h2h: nil,
+            // The list row carries the authoritative rated flag (rating_change is
+            // omitted on list rows), so don't infer rated from a missing delta —
+            // that mislabels finalized rated matches as "Friendly" (#453).
+            ratedHint: r.affectsRating, games: nil, h2h: nil,
             // The list row omits signatures; fall back to the games-won heuristic.
             // This row is transient anyway — the detail view refetches on open and
             // replaces it with the signature-accurate copy.

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1507,6 +1507,8 @@ export interface components {
             sides: components["schemas"]["MatchDetailsSide"][];
             /** Best Of */
             best_of: number;
+            /** Affects Rating */
+            affects_rating: boolean;
             /**
              * Created At
              * Format: date-time

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -508,6 +508,7 @@ export function projectListRow(seed: SeedMatch): MatchListRow {
     league: MOCK_DEFAULT_LEAGUE,
     sides: [mySide, opponentSide],
     best_of: seed.best_of,
+    affects_rating: seed.affects_rating,
     created_at: seed.created_at,
     // The next-playable-game deep-link target (null when decided/signed); the
     // editable flag follows the no-signature rule independently of it.

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -249,6 +249,7 @@ export function matchListRow(
     league: MOCK_DEFAULT_LEAGUE,
     sides: [mySide, opponentSide],
     best_of: 5,
+    affects_rating: true,
     created_at: ISO,
     current_game_number: 1,
     can_score: true,


### PR DESCRIPTION
## Problem (#453)

After completing + confirming a **rated** match on iOS, the Matches row read **"· Friendly · 3-0"** even though the detail showed Rated: Yes (+229). The list used "Friendly" as a catch-all finalized label.

## Root cause

`_list_row` (`api/app/matches.py`) builds its sides **without** `rating_changes`, so every list row's `rating_change` is `null` (the list deliberately skips the rating-history load). iOS then computed:

```swift
let rated = ratedHint ?? (mine?.ratingChange != nil)   // ratedHint was nil
```

so **every** decided match resolved to `rated == false` → context `"Casual"` → subtitle `"Friendly"`. Casual matches were correct by accident; finalized rated matches were wrong. The match **detail** view was always correct because it passes the authoritative `affects_rating` flag.

## Fix

Carry the authoritative `affects_rating` flag on the list row (same source the detail BFF uses) and stop inferring rated from an always-absent delta:

- **API** — add `affects_rating: bool` to `MatchListRow`; populate it in `_list_row` from `match.match_settings.affects_rating` (no extra query — settings are already loaded).
- **iOS** — decode `affectsRating` on `MatchListRowDTO`; pass `ratedHint: r.affectsRating` (was `nil`).
- **Generated/mocks** — regen `schema.d.ts` (+1 field); add the field to the web MSW list-row mock and the test factory.

## Testing

- New API regression test `test_list_rows_carry_affects_rating` (rated → `true`, unrated → `false`).
- API: 473 passed; ruff + mypy clean.
- Web: 863 vitest passed; `tsc -b && vite build` clean; lint clean.
- iOS: clean `xcodebuild` (`rm -rf` first) → **BUILD SUCCEEDED**.
- OpenAPI: `schema.d.ts` regenerated from the live app — only the intended field, no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)