### PR TITLE
Auto mark notifications read on screen (debounced batch) + feed polling

### DIFF
--- a/api/app/notifications/router.py
+++ b/api/app/notifications/router.py
@@ -17,6 +17,7 @@ from app.schemas.notification import (
     BroadcastResponse,
     DeviceTokenResponse,
     MarkAllReadResponse,
+    MarkReadRequest,
     NotificationFeed,
     NotificationItem,
     NotificationPreferences,
@@ -79,6 +80,18 @@ async def get_unread_count(
 ) -> UnreadCountResponse:
     """Just the unread total — the lightweight endpoint the bell badge polls."""
     return await service.unread_count(current_user.id)
+
+
+@router.post("/v1/notifications/read", response_model=MarkAllReadResponse)
+async def mark_notifications_read(
+    payload: MarkReadRequest,
+    service: NotificationService = Depends(get_notification_service),
+    current_user: User = Depends(get_current_user),
+) -> MarkAllReadResponse:
+    """Mark a batch of notifications read — the endpoint the client flushes its
+    debounced "seen on screen" ids to. Owner-scoped and idempotent; ``marked``
+    counts only the rows that were still unread."""
+    return await service.mark_many_read(current_user.id, payload)
 
 
 @router.post("/v1/notifications/read-all", response_model=MarkAllReadResponse)

--- a/api/app/notifications/service.py
+++ b/api/app/notifications/service.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, assert_never, cast
 
-from sqlalchemy import CursorResult, delete, func, select, update
+from sqlalchemy import ColumnElement, CursorResult, delete, func, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -47,6 +47,7 @@ from app.schemas.notification import (
     BroadcastRecipientList,
     BroadcastResponse,
     MarkAllReadResponse,
+    MarkReadRequest,
     NotificationCategoryCell,
     NotificationCategoryPreference,
     NotificationChannelInfo,
@@ -357,17 +358,37 @@ class NotificationService:
             await self._db.refresh(notification)
         return NotificationItem.model_validate(notification)
 
-    async def mark_all_read(self, user_id: uuid.UUID) -> MarkAllReadResponse:
+    async def _mark_read_where(
+        self, *conditions: ColumnElement[bool]
+    ) -> MarkAllReadResponse:
+        """Stamp ``read_at`` on every notification matching ``conditions`` in one
+        statement; ``marked`` is how many rows actually flipped. Shared by the
+        batch and mark-all endpoints — callers supply the owner/unread scoping."""
         result = await self._db.execute(
-            update(Notification)
-            .where(
-                Notification.user_id == user_id,
-                Notification.read_at.is_(None),
-            )
-            .values(read_at=datetime.now(UTC))
+            update(Notification).where(*conditions).values(read_at=datetime.now(UTC))
         )
         await self._db.commit()
         return MarkAllReadResponse(marked=cast(CursorResult[Any], result).rowcount or 0)
+
+    async def mark_many_read(
+        self, user_id: uuid.UUID, payload: MarkReadRequest
+    ) -> MarkAllReadResponse:
+        """Mark a batch of notifications read in one statement. Scoped to the
+        owner and to still-unread rows, so ids that aren't theirs, don't exist,
+        or are already read are silently skipped — ``marked`` reports how many
+        rows actually flipped. Lets the client coalesce many on-screen rows into
+        a single round-trip."""
+        return await self._mark_read_where(
+            Notification.user_id == user_id,
+            Notification.id.in_(payload.ids),
+            Notification.read_at.is_(None),
+        )
+
+    async def mark_all_read(self, user_id: uuid.UUID) -> MarkAllReadResponse:
+        return await self._mark_read_where(
+            Notification.user_id == user_id,
+            Notification.read_at.is_(None),
+        )
 
     # ----- display taxonomy (DB-backed labels + order) ---------------------
 

--- a/api/app/schemas/notification.py
+++ b/api/app/schemas/notification.py
@@ -72,8 +72,19 @@ class UnreadCountResponse(BaseModel):
     unread_count: int
 
 
+class MarkReadRequest(BaseModel):
+    """A batch of notification ids to mark read in one round-trip. The client
+    debounces visible-on-screen rows into a single call rather than firing one
+    request per row."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ids: list[uuid.UUID] = Field(min_length=1)
+
+
 class MarkAllReadResponse(BaseModel):
-    """How many previously-unread notifications were just marked read."""
+    """How many previously-unread notifications were just marked read — the
+    response shape for both ``read-all`` and the batched ``read`` endpoint."""
 
     marked: int
 

--- a/api/tests/test_notification_feed.py
+++ b/api/tests/test_notification_feed.py
@@ -140,6 +140,63 @@ async def test_mark_missing_notification_404(
     assert response.status_code == 404
 
 
+async def test_mark_batch_read(api_client: AsyncClient, db_session: AsyncSession):
+    user = await start_session(api_client, db_session)
+    a = await make_notification(db_session, user.id, read=False)
+    b = await make_notification(db_session, user.id, read=False)
+    await make_notification(db_session, user.id, read=False)
+
+    response = await api_client.post(
+        "/v1/notifications/read", json={"ids": [str(a.id), str(b.id)]}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"marked": 2}
+    # Only the two named were flipped; the third stays unread.
+    after = await api_client.get("/v1/notifications/unread-count")
+    assert after.json() == {"unread_count": 1}
+
+
+async def test_mark_batch_skips_foreign_already_read_and_missing(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    user = await start_session(api_client, db_session)
+    other = await make_user(db_session, "someone-else")
+    mine_unread = await make_notification(db_session, user.id, read=False)
+    mine_read = await make_notification(db_session, user.id, read=True)
+    theirs = await make_notification(db_session, other.id, read=False)
+
+    response = await api_client.post(
+        "/v1/notifications/read",
+        json={
+            "ids": [
+                str(mine_unread.id),
+                str(mine_read.id),
+                str(theirs.id),
+                str(uuid.uuid4()),
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    # Only the caller's still-unread row counts; foreign/read/missing are skipped.
+    assert response.json() == {"marked": 1}
+    still_theirs = (
+        await db_session.execute(
+            select(Notification).where(Notification.id == theirs.id)
+        )
+    ).scalar_one()
+    assert still_theirs.read_at is None
+
+
+async def test_mark_batch_rejects_empty_ids(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    response = await api_client.post("/v1/notifications/read", json={"ids": []})
+    assert response.status_code == 422
+
+
 async def test_mark_all_read(api_client: AsyncClient, db_session: AsyncSession):
     user = await start_session(api_client, db_session)
     await make_notification(db_session, user.id, read=False)
@@ -159,6 +216,11 @@ async def test_feed_requires_session(api_client: AsyncClient):
     assert (await api_client.get("/v1/notifications")).status_code == 401
     assert (await api_client.get("/v1/notifications/unread-count")).status_code == 401
     assert (await api_client.post("/v1/notifications/read-all")).status_code == 401
+    assert (
+        await api_client.post(
+            "/v1/notifications/read", json={"ids": [str(uuid.uuid4())]}
+        )
+    ).status_code == 401
 
 
 async def test_unknown_user_feed_is_independent(

--- a/web-client/src/api/notifications.test.tsx
+++ b/web-client/src/api/notifications.test.tsx
@@ -1,0 +1,115 @@
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { server } from '@/mocks/server'
+import {
+  NOTIFICATIONS_QUERY_KEY,
+  type NotificationFeed,
+  type UnreadCount,
+  useMarkNotificationsRead,
+} from './notifications'
+
+const feedKey = [...NOTIFICATIONS_QUERY_KEY, 'feed']
+const countKey = [...NOTIFICATIONS_QUERY_KEY, 'unread-count']
+
+let queryClient: QueryClient
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+function seedFeed(): NotificationFeed {
+  return {
+    items: [
+      buildItem('a', null),
+      buildItem('b', null),
+      buildItem('c', '2026-06-17T10:00:00.000Z'),
+    ],
+    unread_count: 2,
+  }
+}
+
+function buildItem(id: string, read_at: string | null): NotificationFeed['items'][number] {
+  return {
+    id,
+    category: 'tournament',
+    title: id,
+    body: id,
+    link: null,
+    action_label: null,
+    delta: null,
+    read_at,
+    created_at: '2026-06-17T09:00:00.000Z',
+  }
+}
+
+beforeEach(() => {
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  queryClient.setQueryData<NotificationFeed>(feedKey, seedFeed())
+  queryClient.setQueryData<UnreadCount>(countKey, { unread_count: 2 })
+})
+
+afterEach(() => {
+  queryClient.clear()
+})
+
+describe('useMarkNotificationsRead', () => {
+  it('optimistically clears the seen rows and drops the unread count', async () => {
+    // The server agrees one row flipped, and the re-read reflects the new truth,
+    // so the optimistic state and the reconciled state line up.
+    server.use(
+      http.post('*/v1/notifications/read', () =>
+        HttpResponse.json({ marked: 1 }),
+      ),
+      http.get('*/v1/notifications', () =>
+        HttpResponse.json({
+          items: [
+            buildItem('a', '2026-06-17T12:00:00.000Z'),
+            buildItem('b', null),
+            buildItem('c', '2026-06-17T10:00:00.000Z'),
+          ],
+          unread_count: 1,
+        }),
+      ),
+      http.get('*/v1/notifications/unread-count', () =>
+        HttpResponse.json({ unread_count: 1 }),
+      ),
+    )
+
+    const { result } = renderHook(() => useMarkNotificationsRead(), { wrapper })
+    result.current.mutate(['a'])
+
+    await waitFor(() => {
+      const feed = queryClient.getQueryData<NotificationFeed>(feedKey)
+      expect(feed?.items.find((n) => n.id === 'a')?.read_at).not.toBeNull()
+      expect(feed?.unread_count).toBe(1)
+      expect(queryClient.getQueryData<UnreadCount>(countKey)?.unread_count).toBe(1)
+    })
+  })
+
+  it('rolls the count back to server truth when the batch request fails', async () => {
+    server.use(
+      http.post('*/v1/notifications/read', () =>
+        HttpResponse.json({ detail: 'boom' }, { status: 500 }),
+      ),
+      // On settle the failed mutation re-reads, which restores the unread feed.
+      http.get('*/v1/notifications', () => HttpResponse.json(seedFeed())),
+      http.get('*/v1/notifications/unread-count', () =>
+        HttpResponse.json({ unread_count: 2 }),
+      ),
+    )
+
+    const { result } = renderHook(() => useMarkNotificationsRead(), { wrapper })
+    result.current.mutate(['a'])
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    await waitFor(() => {
+      expect(queryClient.getQueryData<UnreadCount>(countKey)?.unread_count).toBe(2)
+      const feed = queryClient.getQueryData<NotificationFeed>(feedKey)
+      expect(feed?.items.find((n) => n.id === 'a')?.read_at).toBeNull()
+    })
+  })
+})

--- a/web-client/src/api/notifications.ts
+++ b/web-client/src/api/notifications.ts
@@ -38,8 +38,14 @@ export const NOTIFICATION_TAXONOMY_QUERY_KEY = [
 ] as const
 
 // The bell badge polls this lightweight count so a notification that arrives in
-// another tab/device surfaces without a manual refresh.
+// another tab/device surfaces without a manual refresh. We poll rather than
+// long-poll/WebSocket deliberately: the feed is low-frequency and per-user, so a
+// cheap interval GET beats standing up socket/pub-sub infra.
 const UNREAD_POLL_MS = 1000 * 60
+// Whenever the full feed is actually on screen (bell open, notifications page
+// mounted) refresh it on a tighter cadence so it stays live without a reload.
+// Off-screen the query isn't mounted, so nothing polls.
+const FEED_POLL_MS = 1000 * 30
 
 /**
  * Fire a test push to the current user's registered iOS devices. The backend
@@ -62,6 +68,7 @@ export function notificationFeedQueryOptions() {
     queryKey: [...NOTIFICATIONS_QUERY_KEY, 'feed'] as const,
     queryFn: async (): Promise<NotificationFeed> =>
       unwrap('load notifications', await api.GET('/v1/notifications')),
+    refetchInterval: FEED_POLL_MS,
   })
 }
 
@@ -97,6 +104,64 @@ export function useMarkNotificationRead() {
         }),
       ),
     onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: NOTIFICATIONS_QUERY_KEY })
+    },
+  })
+}
+
+/**
+ * Mark a batch of notifications read in one request. The "auto-mark on screen"
+ * flow debounces the ids of rows that scroll into view and flushes them here, so
+ * a burst of newly-seen rows costs one round-trip instead of one-per-row.
+ *
+ * We optimistically clear those rows' `read_at` and drop the unread badge so the
+ * count falls the instant a notification is seen — the debounce would otherwise
+ * leave the badge stale for ~1s — then reconcile against the server on settle.
+ */
+export function useMarkNotificationsRead() {
+  const qc = useQueryClient()
+  const feedKey = [...NOTIFICATIONS_QUERY_KEY, 'feed'] as const
+  const countKey = [...NOTIFICATIONS_QUERY_KEY, 'unread-count'] as const
+  return useMutation({
+    mutationFn: async (ids: string[]) =>
+      unwrap(
+        'mark notifications read',
+        await api.POST('/v1/notifications/read', { body: { ids } }),
+      ),
+    onMutate: async (ids) => {
+      const idSet = new Set(ids)
+      await qc.cancelQueries({ queryKey: NOTIFICATIONS_QUERY_KEY })
+      const prevFeed = qc.getQueryData<NotificationFeed>(feedKey)
+      const prevCount = qc.getQueryData<UnreadCount>(countKey)
+      // Decrement by how many targeted rows are *currently* unread, so a re-seen
+      // (already-read) row doesn't drive the badge negative.
+      const newlyRead =
+        prevFeed?.items.filter((n) => idSet.has(n.id) && n.read_at == null)
+          .length ?? 0
+      const readAt = new Date().toISOString()
+      if (prevFeed) {
+        qc.setQueryData<NotificationFeed>(feedKey, {
+          ...prevFeed,
+          items: prevFeed.items.map((n) =>
+            idSet.has(n.id) && n.read_at == null ? { ...n, read_at: readAt } : n,
+          ),
+          unread_count: Math.max(0, prevFeed.unread_count - newlyRead),
+        })
+      }
+      if (prevCount) {
+        qc.setQueryData<UnreadCount>(countKey, {
+          unread_count: Math.max(0, prevCount.unread_count - newlyRead),
+        })
+      }
+      return { prevFeed, prevCount }
+    },
+    // On success the optimistic state is already correct and the background
+    // polls reconcile any drift, so we deliberately don't invalidate here —
+    // that would force two refetches per debounced batch while scrolling. Only
+    // a failed write needs to re-sync to server truth.
+    onError: (_err, _ids, context) => {
+      if (context?.prevFeed) qc.setQueryData(feedKey, context.prevFeed)
+      if (context?.prevCount) qc.setQueryData(countKey, context.prevCount)
       void qc.invalidateQueries({ queryKey: NOTIFICATIONS_QUERY_KEY })
     },
   })

--- a/web-client/src/api/notifications.ts
+++ b/web-client/src/api/notifications.ts
@@ -116,7 +116,9 @@ export function useMarkNotificationRead() {
  *
  * We optimistically clear those rows' `read_at` and drop the unread badge so the
  * count falls the instant a notification is seen — the debounce would otherwise
- * leave the badge stale for ~1s — then reconcile against the server on settle.
+ * leave the badge stale for ~1s. On success we leave the optimistic state in
+ * place (the background polls reconcile any drift); only a failed write rolls
+ * back and re-syncs to server truth.
  */
 export function useMarkNotificationsRead() {
   const qc = useQueryClient()

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -749,6 +749,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/notifications/read": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mark Notifications Read
+         * @description Mark a batch of notifications read — the endpoint the client flushes its
+         *     debounced "seen on screen" ids to. Owner-scoped and idempotent; ``marked``
+         *     counts only the rows that were still unread.
+         */
+        post: operations["mark_notifications_read_v1_notifications_read_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/notifications/read-all": {
         parameters: {
             query?: never;
@@ -1255,11 +1277,22 @@ export interface components {
         };
         /**
          * MarkAllReadResponse
-         * @description How many previously-unread notifications were just marked read.
+         * @description How many previously-unread notifications were just marked read — the
+         *     response shape for both ``read-all`` and the batched ``read`` endpoint.
          */
         MarkAllReadResponse: {
             /** Marked */
             marked: number;
+        };
+        /**
+         * MarkReadRequest
+         * @description A batch of notification ids to mark read in one round-trip. The client
+         *     debounces visible-on-screen rows into a single call rather than firing one
+         *     request per row.
+         */
+        MarkReadRequest: {
+            /** Ids */
+            ids: string[];
         };
         /**
          * MatchCreate
@@ -4056,6 +4089,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UnreadCountResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    mark_notifications_read_v1_notifications_read_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MarkReadRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MarkAllReadResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web-client/src/components/notifications/notification-bell.tsx
+++ b/web-client/src/components/notifications/notification-bell.tsx
@@ -10,6 +10,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
 import { NotificationDropdown } from './notification-bell/notification-dropdown'
+import { useAutoMarkRead } from './use-auto-mark-read'
 import { useFollowNotification } from './use-follow-notification'
 
 /**
@@ -25,6 +26,7 @@ export function NotificationBell() {
   const feed = useQuery({ ...notificationFeedQueryOptions(), enabled: open })
   const markAll = useMarkAllNotificationsRead()
   const follow = useFollowNotification()
+  const markSeen = useAutoMarkRead()
 
   const unreadCount = unread.data?.unread_count ?? 0
   const badgeLabel = unreadCount > 99 ? '99+' : String(unreadCount)
@@ -81,6 +83,7 @@ export function NotificationBell() {
             setOpen(false)
           }}
           onMarkAllRead={() => markAll.mutate()}
+          onSeen={markSeen}
           onSeeAll={() => {
             setOpen(false)
             void router.history.push('/notifications')

--- a/web-client/src/components/notifications/notification-bell/notification-dropdown.tsx
+++ b/web-client/src/components/notifications/notification-bell/notification-dropdown.tsx
@@ -12,6 +12,8 @@ export interface NotificationDropdownProps {
   onActivate: (notification: NotificationItem) => void
   onMarkAllRead: () => void
   onSeeAll: () => void
+  /** Called with a row's id when it scrolls into view (auto mark-read). */
+  onSeen?: (id: string) => void
 }
 
 /**
@@ -27,6 +29,7 @@ export function NotificationDropdown({
   onActivate,
   onMarkAllRead,
   onSeeAll,
+  onSeen,
 }: NotificationDropdownProps) {
   const shown = items.slice(0, DROPDOWN_LIMIT)
 
@@ -88,7 +91,12 @@ export function NotificationDropdown({
                     : undefined
                 }
               >
-                <NotificationRow notification={item} compact onActivate={onActivate} />
+                <NotificationRow
+                  notification={item}
+                  compact
+                  onActivate={onActivate}
+                  onSeen={onSeen}
+                />
               </li>
             ))}
           </ul>

--- a/web-client/src/components/notifications/notification-row.test.tsx
+++ b/web-client/src/components/notifications/notification-row.test.tsx
@@ -1,3 +1,5 @@
+import { render } from '@/test/utilities'
+import { NotificationRow } from './notification-row'
 import { buildNotificationItem } from './notification-row.factory'
 import { notificationRowPage } from './notification-row.page'
 
@@ -155,6 +157,35 @@ describe('NotificationRow', () => {
         notification: buildNotificationItem({ read_at: null }),
       })
       expect(MockIntersectionObserver.instances).toHaveLength(0)
+    })
+
+    it('does not re-fire after an optimistic read rolls back to unread', () => {
+      // Simulates the failed-mark rollback: unread -> read (optimistic) -> unread
+      // again. The row must not re-arm and re-report, or a failing endpoint would
+      // get hammered every debounce window.
+      const onSeen = vi.fn()
+      const unread = buildNotificationItem({ id: 'n-9', read_at: null })
+      const { rerender } = render(
+        <NotificationRow notification={unread} onSeen={onSeen} />,
+      )
+
+      MockIntersectionObserver.instances[0].enterView()
+      expect(onSeen).toHaveBeenCalledTimes(1)
+      expect(MockIntersectionObserver.instances).toHaveLength(1)
+
+      // Optimistic mark-read, then a rollback flips it back to unread.
+      rerender(
+        <NotificationRow
+          notification={{ ...unread, read_at: '2026-06-17T12:00:00.000Z' }}
+          onSeen={onSeen}
+        />,
+      )
+      rerender(<NotificationRow notification={unread} onSeen={onSeen} />)
+
+      // The once-ever guard means no new observer was armed by the rollback, so
+      // there's nothing left to re-fire onSeen.
+      expect(MockIntersectionObserver.instances).toHaveLength(1)
+      expect(onSeen).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/web-client/src/components/notifications/notification-row.test.tsx
+++ b/web-client/src/components/notifications/notification-row.test.tsx
@@ -86,4 +86,75 @@ describe('NotificationRow', () => {
     expect(onActivate).toHaveBeenCalledTimes(1)
     expect(onActivate).toHaveBeenCalledWith(notification)
   })
+
+  describe('onSeen (auto mark-read on scroll into view)', () => {
+    class MockIntersectionObserver {
+      static instances: MockIntersectionObserver[] = []
+      private elements: Element[] = []
+      private cb: IntersectionObserverCallback
+      constructor(cb: IntersectionObserverCallback) {
+        this.cb = cb
+        MockIntersectionObserver.instances.push(this)
+      }
+      observe(el: Element) {
+        this.elements.push(el)
+      }
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return []
+      }
+      /** Simulate the observed rows crossing the visibility threshold. */
+      enterView() {
+        this.cb(
+          this.elements.map(
+            (target) => ({ isIntersecting: true, target }) as IntersectionObserverEntry,
+          ),
+          this as unknown as IntersectionObserver,
+        )
+      }
+    }
+
+    beforeEach(() => {
+      MockIntersectionObserver.instances = []
+      vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+    })
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('fires onSeen with the id once an unread row scrolls into view', () => {
+      const onSeen = vi.fn()
+      notificationRowPage.render({
+        notification: buildNotificationItem({ id: 'n-7', read_at: null }),
+        onSeen,
+      })
+
+      expect(onSeen).not.toHaveBeenCalled() // not yet on screen
+      MockIntersectionObserver.instances[0].enterView()
+
+      expect(onSeen).toHaveBeenCalledTimes(1)
+      expect(onSeen).toHaveBeenCalledWith('n-7')
+    })
+
+    it('does not observe an already-read row', () => {
+      const onSeen = vi.fn()
+      notificationRowPage.render({
+        notification: buildNotificationItem({
+          read_at: '2026-06-17T11:00:00.000Z',
+        }),
+        onSeen,
+      })
+
+      expect(MockIntersectionObserver.instances).toHaveLength(0)
+      expect(onSeen).not.toHaveBeenCalled()
+    })
+
+    it('does not track when no onSeen handler is given', () => {
+      notificationRowPage.render({
+        notification: buildNotificationItem({ read_at: null }),
+      })
+      expect(MockIntersectionObserver.instances).toHaveLength(0)
+    })
+  })
 })

--- a/web-client/src/components/notifications/notification-row.tsx
+++ b/web-client/src/components/notifications/notification-row.tsx
@@ -2,6 +2,7 @@ import type { NotificationItem } from '@/api/notifications'
 import { cn } from '@/lib/utils'
 import { CATEGORY_VISUAL } from './notification-meta'
 import { relativeTime } from './relative-time'
+import { useSeenOnScreen } from './use-seen-on-screen'
 
 export interface NotificationRowProps {
   notification: NotificationItem
@@ -11,6 +12,12 @@ export interface NotificationRowProps {
   now?: Date
   /** Fired on click — the parent marks the row read and follows its link. */
   onActivate?: (notification: NotificationItem) => void
+  /**
+   * Fired once with the notification id when an unread row scrolls into view,
+   * so the parent can debounce-batch a "mark read" for everything seen. Omit it
+   * (e.g. in isolation tests) and the row does no viewport tracking.
+   */
+  onSeen?: (id: string) => void
 }
 
 /**
@@ -24,15 +31,21 @@ export function NotificationRow({
   compact = false,
   now,
   onActivate,
+  onSeen,
 }: NotificationRowProps) {
   const visual = CATEGORY_VISUAL[notification.category]
   const { Icon } = visual
   const unread = notification.read_at == null
   const delta = notification.delta
   const deltaUp = delta?.trim().startsWith('+') ?? false
+  // Only unread rows with a listening parent track visibility (auto mark-read).
+  const ref = useSeenOnScreen<HTMLButtonElement>(unread && onSeen != null, () =>
+    onSeen?.(notification.id),
+  )
 
   return (
     <button
+      ref={ref}
       type="button"
       onClick={() => onActivate?.(notification)}
       data-unread={unread}

--- a/web-client/src/components/notifications/notifications-page.tsx
+++ b/web-client/src/components/notifications/notifications-page.tsx
@@ -9,6 +9,7 @@ import {
   NotificationsView,
   type NotificationFilter,
 } from './notifications-page/notifications-view'
+import { useAutoMarkRead } from './use-auto-mark-read'
 import { useFollowNotification } from './use-follow-notification'
 
 /** Route container for the full notifications page — wires the feed query, the
@@ -19,6 +20,7 @@ export function NotificationsPage() {
   const [filter, setFilter] = useState<NotificationFilter>('all')
   const follow = useFollowNotification()
   const markAll = useMarkAllNotificationsRead()
+  const markSeen = useAutoMarkRead()
 
   if (feed.isPending || taxonomy.isPending) {
     return (
@@ -48,6 +50,7 @@ export function NotificationsPage() {
       onFilterChange={setFilter}
       onActivate={follow}
       onMarkAllRead={() => markAll.mutate()}
+      onSeen={markSeen}
     />
   )
 }

--- a/web-client/src/components/notifications/notifications-page/notifications-view.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.tsx
@@ -24,6 +24,8 @@ export interface NotificationsViewProps {
   onFilterChange: (filter: NotificationFilter) => void
   onActivate: (notification: NotificationItem) => void
   onMarkAllRead: () => void
+  /** Called with a row's id when it scrolls into view (auto mark-read). */
+  onSeen?: (id: string) => void
 }
 
 /** The full notifications page: a Bebas header, category filter pills, and the
@@ -36,6 +38,7 @@ export function NotificationsView({
   onFilterChange,
   onActivate,
   onMarkAllRead,
+  onSeen,
 }: NotificationsViewProps) {
   const shown = items.filter((item) => matchesFilter(item, filter))
   const filters: { key: NotificationFilter; label: string }[] = [
@@ -116,7 +119,11 @@ export function NotificationsView({
                     : undefined
                 }
               >
-                <NotificationRow notification={item} onActivate={onActivate} />
+                <NotificationRow
+                  notification={item}
+                  onActivate={onActivate}
+                  onSeen={onSeen}
+                />
               </li>
             ))}
           </ul>

--- a/web-client/src/components/notifications/use-auto-mark-read.test.ts
+++ b/web-client/src/components/notifications/use-auto-mark-read.test.ts
@@ -1,0 +1,89 @@
+import { act, renderHook } from '@/test/utilities'
+
+const { mutateMock } = vi.hoisted(() => ({ mutateMock: vi.fn() }))
+
+vi.mock('@/api/notifications', () => ({
+  useMarkNotificationsRead: () => ({ mutate: mutateMock }),
+}))
+
+// Imported after the mock is declared (vi.mock hoists above all imports).
+import { useAutoMarkRead } from './use-auto-mark-read'
+
+describe('useAutoMarkRead', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mutateMock.mockClear()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('coalesces several seen rows into one batched call after the debounce', () => {
+    const { result } = renderHook(() => useAutoMarkRead())
+
+    act(() => {
+      result.current('a')
+      result.current('b')
+      result.current('c')
+    })
+    // Nothing fires until the burst stops arriving.
+    expect(mutateMock).not.toHaveBeenCalled()
+
+    act(() => vi.advanceTimersByTime(800))
+
+    expect(mutateMock).toHaveBeenCalledTimes(1)
+    expect(mutateMock).toHaveBeenCalledWith(['a', 'b', 'c'])
+  })
+
+  it('keeps deferring the flush while rows keep arriving', () => {
+    const { result } = renderHook(() => useAutoMarkRead())
+
+    act(() => result.current('a'))
+    act(() => vi.advanceTimersByTime(500))
+    act(() => result.current('b')) // resets the window
+    act(() => vi.advanceTimersByTime(500))
+    expect(mutateMock).not.toHaveBeenCalled()
+
+    act(() => vi.advanceTimersByTime(300))
+    expect(mutateMock).toHaveBeenCalledWith(['a', 'b'])
+  })
+
+  it('dedupes a repeated id within a batch', () => {
+    const { result } = renderHook(() => useAutoMarkRead())
+
+    act(() => {
+      result.current('a')
+      result.current('a')
+    })
+    act(() => vi.advanceTimersByTime(800))
+
+    expect(mutateMock).toHaveBeenCalledWith(['a'])
+  })
+
+  it('starts a fresh batch after a flush', () => {
+    const { result } = renderHook(() => useAutoMarkRead())
+
+    act(() => result.current('a'))
+    act(() => vi.advanceTimersByTime(800))
+    act(() => result.current('b'))
+    act(() => vi.advanceTimersByTime(800))
+
+    expect(mutateMock).toHaveBeenNthCalledWith(1, ['a'])
+    expect(mutateMock).toHaveBeenNthCalledWith(2, ['b'])
+  })
+
+  it('flushes a still-pending batch on unmount', () => {
+    const { result, unmount } = renderHook(() => useAutoMarkRead())
+
+    act(() => result.current('a'))
+    unmount()
+
+    expect(mutateMock).toHaveBeenCalledWith(['a'])
+  })
+
+  it('does not fire an empty batch on unmount', () => {
+    const { unmount } = renderHook(() => useAutoMarkRead())
+    unmount()
+    expect(mutateMock).not.toHaveBeenCalled()
+  })
+})

--- a/web-client/src/components/notifications/use-auto-mark-read.ts
+++ b/web-client/src/components/notifications/use-auto-mark-read.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useMarkNotificationsRead } from '@/api/notifications'
+
+// How long a row must stop arriving on screen before we flush the batch. Long
+// enough to coalesce a scroll/open burst into one request, short enough that the
+// badge clears almost immediately after a row settles into view.
+const AUTO_MARK_DEBOUNCE_MS = 800
+
+/**
+ * Collects the ids of notifications that have come on screen and flushes them to
+ * the batch mark-read endpoint once they stop arriving for a short window — so
+ * scrolling past (or opening the bell on) a dozen rows fires one request, not a
+ * dozen. Returns a `markSeen(id)` callback to hand each row.
+ *
+ * `mutate` from `useMarkNotificationsRead` is referentially stable, so the
+ * returned callback is stable too and won't churn the rows' observers.
+ */
+export function useAutoMarkRead() {
+  const { mutate } = useMarkNotificationsRead()
+  const pending = useRef<Set<string>>(new Set())
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const flush = useCallback(() => {
+    if (timer.current) {
+      clearTimeout(timer.current)
+      timer.current = null
+    }
+    const ids = [...pending.current]
+    pending.current.clear()
+    if (ids.length > 0) mutate(ids)
+  }, [mutate])
+
+  const markSeen = useCallback(
+    (id: string) => {
+      pending.current.add(id)
+      if (timer.current) clearTimeout(timer.current)
+      timer.current = setTimeout(flush, AUTO_MARK_DEBOUNCE_MS)
+    },
+    [flush],
+  )
+
+  // Flush whatever's still queued when the surface unmounts (the bell closing,
+  // a route change) so a final batch isn't dropped on the floor.
+  useEffect(() => () => flush(), [flush])
+
+  return markSeen
+}

--- a/web-client/src/components/notifications/use-seen-on-screen.ts
+++ b/web-client/src/components/notifications/use-seen-on-screen.ts
@@ -4,11 +4,18 @@ import { useEffect, useRef } from 'react'
 const SEEN_THRESHOLD = 0.5
 
 /**
- * Returns a ref to attach to an element; calls `onSeen` once — the first time
- * the element crosses into view — but only while `active`. Inert in environments
- * without IntersectionObserver (jsdom in unit tests). Keeps the latest `onSeen`
- * in a ref so an inline arrow from the caller doesn't re-subscribe the observer
- * on every render; it only re-subscribes when `active` flips.
+ * Returns a ref to attach to an element; calls `onSeen` exactly once — the first
+ * time the element crosses into view, ever, for this mounted instance — but only
+ * while `active`. Inert in environments without IntersectionObserver (jsdom in
+ * unit tests). Keeps the latest `onSeen` in a ref so an inline arrow from the
+ * caller doesn't re-subscribe the observer on every render; it only re-subscribes
+ * when `active` flips.
+ *
+ * The once-ever guard matters because `active` can flip false→true again: an
+ * optimistic mark-read that the server later rejects rolls the row back to
+ * unread, which would otherwise re-arm the observer on a still-visible row and
+ * re-fire `onSeen` — an ~debounce-period retry loop against a failing endpoint.
+ * Once reported, we stay quiet until the row remounts.
  */
 export function useSeenOnScreen<T extends Element>(
   active: boolean,
@@ -16,17 +23,20 @@ export function useSeenOnScreen<T extends Element>(
 ) {
   const ref = useRef<T>(null)
   const onSeenRef = useRef(onSeen)
+  const reported = useRef(false)
   useEffect(() => {
     onSeenRef.current = onSeen
   })
 
   useEffect(() => {
-    if (!active || typeof IntersectionObserver === 'undefined') return
+    if (!active || reported.current || typeof IntersectionObserver === 'undefined')
+      return
     const el = ref.current
     if (!el) return
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
+          reported.current = true
           onSeenRef.current()
           observer.disconnect() // fire once
         }

--- a/web-client/src/components/notifications/use-seen-on-screen.ts
+++ b/web-client/src/components/notifications/use-seen-on-screen.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react'
+
+// Fire once an element is at least half visible.
+const SEEN_THRESHOLD = 0.5
+
+/**
+ * Returns a ref to attach to an element; calls `onSeen` once — the first time
+ * the element crosses into view — but only while `active`. Inert in environments
+ * without IntersectionObserver (jsdom in unit tests). Keeps the latest `onSeen`
+ * in a ref so an inline arrow from the caller doesn't re-subscribe the observer
+ * on every render; it only re-subscribes when `active` flips.
+ */
+export function useSeenOnScreen<T extends Element>(
+  active: boolean,
+  onSeen: () => void,
+) {
+  const ref = useRef<T>(null)
+  const onSeenRef = useRef(onSeen)
+  useEffect(() => {
+    onSeenRef.current = onSeen
+  })
+
+  useEffect(() => {
+    if (!active || typeof IntersectionObserver === 'undefined') return
+    const el = ref.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          onSeenRef.current()
+          observer.disconnect() // fire once
+        }
+      },
+      { threshold: SEEN_THRESHOLD },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [active])
+
+  return ref
+}

--- a/web-client/src/mocks/notifications-store.ts
+++ b/web-client/src/mocks/notifications-store.ts
@@ -138,6 +138,20 @@ export const notificationHandlers = [
     }),
   ),
 
+  http.post('*/v1/notifications/read', async ({ request }) => {
+    const { ids } = (await request.json()) as { ids: string[] }
+    const targeted = new Set(ids)
+    let marked = 0
+    feed = feed.map((n) => {
+      if (targeted.has(n.id) && n.read_at == null) {
+        marked += 1
+        return { ...n, read_at: '2026-06-17T12:00:00.000Z' }
+      }
+      return n
+    })
+    return HttpResponse.json({ marked })
+  }),
+
   http.post('*/v1/notifications/read-all', () => {
     let marked = 0
     feed = feed.map((n) => {


### PR DESCRIPTION
## What

Clears the in-app unread count **as soon as a notification is on screen**, instead of only on click / "mark all read". Calls are debounced and batched, and the open feed now polls so it stays live.

## How

- **On-screen detection** — each unread row sets up an `IntersectionObserver`, extracted into a `useSeenOnScreen` hook so `NotificationRow` stays a pure presentational view. When a row scrolls into view it reports its id.
- **Debounced batching** — `useAutoMarkRead` accumulates seen ids and flushes them after an 800ms idle window (and on unmount), so a scroll/open burst is one request, not one-per-row.
- **Batch endpoint** — new `POST /v1/notifications/read` `{ids: [...]}`, owner-scoped and idempotent; shares an `_mark_read_where` helper with `read-all`.
- **Instant badge** — the client mutation optimistically clears `read_at` and decrements the unread count (bell badge + "X unread"/"X new" chips) so it drops immediately; it re-syncs only on error (the polls reconcile otherwise).
- **Fetching = polling (deliberate ROI call)** — WebSocket/long-poll would need new push infra (Redis pub/sub, socket auth, connection lifecycle) for a low-frequency per-user feed. Kept polling: the open feed refreshes every 30s (only while mounted), the bell badge keeps its 60s lightweight count poll.

Wired into **both** the bell dropdown and the notifications page.

## Testing

- API: `ruff` + `ruff format --check` + `mypy --strict` clean, `pytest` 475 passed (incl. 4 new batch-endpoint tests).
- Web: `tsc -b` + `vite build` + `eslint` clean, vitest 874 passed (new: `useAutoMarkRead` debounce, `useSeenOnScreen` observer, optimistic-mutation reconcile/rollback), Playwright e2e 127 passed.
- Regenerated `schema.d.ts`; added MSW handler for the new endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)