### PR TITLE
Enforce tournament RBAC: view/create perms, owner-only edit/delete/publish (#592)

### DIFF
--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -19,15 +19,20 @@ from app.schemas.tournament import (
 )
 from app.sessions import get_current_user
 
-# Every route here is gated on this permission (router-wide). PATCH, DELETE, and
-# all event mutations additionally require the caller to be the tournament's
-# creator.
-TOURNAMENT_PERMISSION = "tournament.manage"
+# Reads are gated on ``tournament.view`` and creation on ``tournament.create``
+# (both granted to the Beta-tester role in ``scripts/seed_rbac.py``). The
+# mutating routes — PATCH, DELETE, and every event mutation — carry NO
+# permission gate: they're owner-only, available solely to the user who created
+# the tournament (``_require_owner``). There is deliberately no
+# ``tournament.edit``/``tournament.delete``/``tournament.publish`` permission;
+# managing a tournament you created is a property of ownership, not a role grant.
+TOURNAMENT_VIEW = "tournament.view"
+TOURNAMENT_CREATE = "tournament.create"
 
-router = APIRouter(
-    prefix="/v1",
-    dependencies=[Depends(require_permission(TOURNAMENT_PERMISSION))],
-)
+require_view = require_permission(TOURNAMENT_VIEW)
+require_create = require_permission(TOURNAMENT_CREATE)
+
+router = APIRouter(prefix="/v1")
 
 
 # ----- helpers -------------------------------------------------------------
@@ -135,7 +140,11 @@ def _require_owner(t: Tournament, current_user: User) -> None:
 # ----- tournament routes ---------------------------------------------------
 
 
-@router.get("/tournaments", response_model=list[TournamentDetailRead])
+@router.get(
+    "/tournaments",
+    response_model=list[TournamentDetailRead],
+    dependencies=[Depends(require_view)],
+)
 async def list_tournaments(
     db: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
@@ -184,6 +193,7 @@ async def list_tournaments(
     "/tournaments",
     response_model=TournamentRead,
     status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_create)],
 )
 async def create_tournament(
     payload: TournamentCreate,
@@ -212,7 +222,11 @@ async def create_tournament(
     )
 
 
-@router.get("/tournaments/{tournament_id}", response_model=TournamentDetailRead)
+@router.get(
+    "/tournaments/{tournament_id}",
+    response_model=TournamentDetailRead,
+    dependencies=[Depends(require_view)],
+)
 async def get_tournament(
     tournament_id: uuid.UUID,
     db: AsyncSession = Depends(get_session),

--- a/api/scripts/seed_rbac.py
+++ b/api/scripts/seed_rbac.py
@@ -17,7 +17,8 @@ from app.models import Permission, Role, RolePermission
 PERMISSIONS = [
     ("administration.view", "Open the Administration area and see the overview."),
     ("authorization.manage", "Manage roles, permissions, and user role assignments."),
-    ("tournament.manage", "Create and manage tournaments (beta)."),
+    ("tournament.view", "See the tournament list and tournament details."),
+    ("tournament.create", "Create a new tournament."),
     ("notifications.broadcast", "Send broadcast notifications to players."),
 ]
 
@@ -29,8 +30,9 @@ ROLES = [
     ),
     (
         "Beta tester",
-        "Early-access testers who can create and manage tournaments.",
-        ["tournament.manage"],
+        "Early-access testers who can view and create tournaments. Editing,"
+        " publishing, and deleting a tournament is reserved for its creator.",
+        ["tournament.view", "tournament.create"],
     ),
 ]
 

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -2,13 +2,15 @@
 
 Unlike test_rbac (which bypasses the authz gate via dependency_overrides),
 these tests exercise the *real* permission gate: each client establishes a
-genuine session via ``GET /v1/session`` and is granted ``tournament.manage`` by
-inserting real Permission/Role/RolePermission/UserRole rows. Mutating requests
+genuine session via ``GET /v1/session`` and is granted ``tournament.view`` +
+``tournament.create`` by inserting real Permission/Role/RolePermission/UserRole
+rows. (Editing, deleting, and publishing are owner-only — no permission gates
+them — so there is nothing extra to grant for those.) Mutating requests
 carry the double-submit CSRF token via ``CSRF_EVENT_HOOKS`` (baked into both the
 ``api_client`` fixture and ``make_client``).
 """
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from typing import Any
 
 import pytest_asyncio
@@ -24,34 +26,31 @@ from app.models import (
     User,
     UserRole,
 )
-from app.tournaments import TOURNAMENT_PERMISSION
+from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
 from tests._helpers import make_client, start_session
 
 
-async def _grant_tournament_manage(db_session: AsyncSession, user: User) -> None:
-    """Grant ``tournament.manage`` to ``user`` via real RBAC rows, reusing the
-    permission/role if a prior call already created them in this test."""
-    permission = (
-        await db_session.execute(
-            select(Permission).where(Permission.name == TOURNAMENT_PERMISSION)
-        )
-    ).scalar_one_or_none()
-    if permission is None:
-        permission = Permission(
-            name=TOURNAMENT_PERMISSION, description="Create and manage tournaments."
-        )
-        db_session.add(permission)
-        await db_session.flush()
-
-    role = (
-        await db_session.execute(select(Role).where(Role.name == "Beta tester"))
-    ).scalar_one_or_none()
-    if role is None:
-        role = Role(name="Beta tester", description="Early-access testers.")
-        db_session.add(role)
-        await db_session.flush()
+async def _grant_tournament_perms(
+    db_session: AsyncSession,
+    user: User,
+    names: Sequence[str] = (TOURNAMENT_VIEW, TOURNAMENT_CREATE),
+) -> None:
+    """Grant ``names`` to ``user`` via real RBAC rows. Each permission row is
+    reused if a prior call already created it; the user gets a dedicated role
+    carrying exactly ``names`` so different users can hold different subsets
+    (e.g. view-only vs view+create)."""
+    role = Role(name=f"grant-{user.id}", description="Per-user test grant.")
+    db_session.add(role)
+    await db_session.flush()
+    for name in names:
+        permission = (
+            await db_session.execute(select(Permission).where(Permission.name == name))
+        ).scalar_one_or_none()
+        if permission is None:
+            permission = Permission(name=name, description=name)
+            db_session.add(permission)
+            await db_session.flush()
         db_session.add(RolePermission(role_id=role.id, permission_id=permission.id))
-
     db_session.add(UserRole(user_id=user.id, role_id=role.id))
     await db_session.commit()
 
@@ -61,9 +60,9 @@ async def authed_client(
     api_client: AsyncClient, db_session: AsyncSession
 ) -> AsyncIterator[tuple[AsyncClient, User]]:
     """The primary ``api_client`` with a real session whose user holds
-    ``tournament.manage``."""
+    ``tournament.view`` + ``tournament.create``."""
     user = await start_session(api_client, db_session)
-    await _grant_tournament_manage(db_session, user)
+    await _grant_tournament_perms(db_session, user)
     yield api_client, user
 
 
@@ -523,10 +522,12 @@ async def test_permission_gate_blocks_user_without_permission(
     db_session: AsyncSession,
     authed_client: tuple[AsyncClient, User],
 ):
-    """A user WITHOUT ``tournament.manage`` is 403 on every route, including the
-    event routes. The ``authed_client`` fixture supplies a tournament + event
-    owned by someone else so the parametrized routes have a real target (the
-    gate runs before the 404/ownership checks)."""
+    """A user with NO tournament permissions is 403 on every route, including the
+    event routes. Reads/create are blocked by the ``tournament.view`` /
+    ``tournament.create`` gates; the owner-only mutations are blocked by the
+    ownership check (the caller has a session but didn't create the target). The
+    ``authed_client`` fixture supplies a tournament + event owned by someone else
+    so the routes have a real target."""
     owner_client, _ = authed_client
     target = (await owner_client.post("/v1/tournaments", json=_create_payload())).json()
     target_event = (
@@ -536,7 +537,7 @@ async def test_permission_gate_blocks_user_without_permission(
     ).json()
 
     async with make_client() as client:
-        # A bare guest session — no tournament.manage granted.
+        # A bare guest session — no tournament permissions granted.
         await start_session(client, db_session)
 
         assert (await client.get("/v1/tournaments")).status_code == 403
@@ -570,6 +571,29 @@ async def test_permission_gate_blocks_user_without_permission(
         ).status_code == 403
 
 
+async def test_view_permission_alone_reads_but_cannot_create(
+    db_session: AsyncSession,
+    authed_client: tuple[AsyncClient, User],
+):
+    """``tournament.view`` is its own grant, separate from create: a viewer can
+    list and read tournaments but POST /v1/tournaments is 403 without
+    ``tournament.create``."""
+    owner_client, _ = authed_client
+    target = (await owner_client.post("/v1/tournaments", json=_create_payload())).json()
+
+    async with make_client() as viewer_client:
+        viewer = await start_session(viewer_client, db_session)
+        await _grant_tournament_perms(db_session, viewer, names=(TOURNAMENT_VIEW,))
+
+        assert (await viewer_client.get("/v1/tournaments")).status_code == 200
+        assert (
+            await viewer_client.get(f"/v1/tournaments/{target['id']}")
+        ).status_code == 200
+        assert (
+            await viewer_client.post("/v1/tournaments", json=_create_payload())
+        ).status_code == 403
+
+
 # ----- ownership (permitted non-creator) -----------------------------------
 
 
@@ -577,9 +601,9 @@ async def test_non_creator_with_permission_can_read_but_not_modify(
     db_session: AsyncSession,
     authed_client: tuple[AsyncClient, User],
 ):
-    """A SECOND user who HAS ``tournament.manage`` but did not create the
-    tournament: GET detail -> 200 with can_edit False; PATCH/DELETE and all
-    event mutations -> 403."""
+    """A SECOND user who HAS view+create but did not create the tournament:
+    GET detail -> 200 with can_edit False; PATCH/DELETE and all event mutations
+    -> 403 (owner-only)."""
     owner_client, _ = authed_client
     target = (await owner_client.post("/v1/tournaments", json=_create_payload())).json()
     target_event = (
@@ -590,7 +614,7 @@ async def test_non_creator_with_permission_can_read_but_not_modify(
 
     async with make_client() as other_client:
         other = await start_session(other_client, db_session)
-        await _grant_tournament_manage(db_session, other)
+        await _grant_tournament_perms(db_session, other)
 
         got = await other_client.get(f"/v1/tournaments/{target['id']}")
         assert got.status_code == 200

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -95,10 +95,10 @@ const NAV_SECTIONS: NavSection[] = [
       },
       {
         // Top-level (not nested under Administration, which requires
-        // ADMIN_VIEW) so a Beta tester with only `tournament.manage` sees it.
+        // ADMIN_VIEW) so a Beta tester with `tournament.view` sees it.
         label: 'Tournaments',
         to: '/tournaments',
-        requires: PERM.TOURNAMENT_MANAGE,
+        requires: PERM.TOURNAMENT_VIEW,
         icon: <Trophy size={18} strokeWidth={2} />,
       },
       {

--- a/web-client/src/components/tournaments/tournament-card.page.tsx
+++ b/web-client/src/components/tournaments/tournament-card.page.tsx
@@ -13,6 +13,10 @@ const scoped = (container: Container) => ({
   getDeleteButton(name: string) {
     return container.getByRole('button', { name: `Delete ${name}` })
   },
+  /** The delete control, or null when absent (a non-creator's card). */
+  queryDeleteButton(name: string) {
+    return container.queryByRole('button', { name: `Delete ${name}` })
+  },
   /** The card's status pill, reusing the badge's own query. */
   ...statusBadgePage.within(container),
 })

--- a/web-client/src/components/tournaments/tournament-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-card.test.tsx
@@ -44,4 +44,13 @@ describe('TournamentCard', () => {
     await userEvent.click(tournamentCardPage.getDeleteButton('Summer Slam'))
     expect(onDelete).toHaveBeenCalledTimes(1)
   })
+
+  it('hides the delete control for a non-creator (canEdit: false)', () => {
+    tournamentCardPage.render({
+      tournament: buildTournament({ name: 'Summer Slam', canEdit: false }),
+    })
+
+    expect(tournamentCardPage.getOpenButton('Summer Slam')).toBeInTheDocument()
+    expect(tournamentCardPage.queryDeleteButton('Summer Slam')).toBeNull()
+  })
 })

--- a/web-client/src/components/tournaments/tournament-card.tsx
+++ b/web-client/src/components/tournaments/tournament-card.tsx
@@ -28,7 +28,9 @@ function CardStat({ label, value }: { label: string; value: number }) {
 
 /** A tournament summary card for the list grid: status, dates, name, venue,
  * and an events/entries/tables stat row. The whole card opens the tournament;
- * a delete control surfaces on hover. */
+ * a delete control surfaces on hover, but only for the tournament's creator
+ * (`canEdit`) — deleting is owner-only on the server, so a non-creator never
+ * sees a button that would 403. */
 export const TournamentCard = ({
   tournament: t,
   onOpen,
@@ -76,14 +78,16 @@ export const TournamentCard = ({
         onClick={onOpen}
         className="absolute inset-0 z-0 rounded-xl outline-offset-2"
       />
-      <button
-        type="button"
-        aria-label={`Delete ${t.name}`}
-        onClick={onDelete}
-        className="absolute top-2.5 right-2.5 z-10 grid size-7 place-items-center rounded-md text-[color:var(--fg-3)] opacity-0 transition-opacity group-hover/tcard:opacity-100 hover:bg-[color:var(--bg-hover)] hover:text-[color:var(--loss)] focus-visible:opacity-100"
-      >
-        <Trash2 size={14} />
-      </button>
+      {t.canEdit && (
+        <button
+          type="button"
+          aria-label={`Delete ${t.name}`}
+          onClick={onDelete}
+          className="absolute top-2.5 right-2.5 z-10 grid size-7 place-items-center rounded-md text-[color:var(--fg-3)] opacity-0 transition-opacity group-hover/tcard:opacity-100 hover:bg-[color:var(--bg-hover)] hover:text-[color:var(--loss)] focus-visible:opacity-100"
+        >
+          <Trash2 size={14} />
+        </button>
+      )}
     </div>
   )
 }

--- a/web-client/src/components/tournaments/tournaments-list-page.factory.tsx
+++ b/web-client/src/components/tournaments/tournaments-list-page.factory.tsx
@@ -15,6 +15,7 @@ export function buildTournamentsListPageProps(
     onOpen: () => {},
     onCreate: () => {},
     onDelete: () => {},
+    canCreate: true,
     ...overrides,
   }
 }

--- a/web-client/src/components/tournaments/tournaments-list-page.page.tsx
+++ b/web-client/src/components/tournaments/tournaments-list-page.page.tsx
@@ -17,6 +17,10 @@ const scoped = (container: Container) => ({
   getNewButton() {
     return container.getAllByRole('button', { name: /New tournament/ })[0]
   },
+  /** All "New tournament" actions — empty when the caller can't create. */
+  queryNewButtons() {
+    return container.queryAllByRole('button', { name: /New tournament/ })
+  },
   getResultCount() {
     return container.getByText(/results?$/)
   },

--- a/web-client/src/components/tournaments/tournaments-list-page.test.tsx
+++ b/web-client/src/components/tournaments/tournaments-list-page.test.tsx
@@ -44,4 +44,14 @@ describe('TournamentsListPage', () => {
     await userEvent.click(tournamentsListPagePage.getConfirmDeleteButton())
     expect(onDelete).toHaveBeenCalledWith('bay')
   })
+
+  it('shows the New tournament action when the caller can create', () => {
+    tournamentsListPagePage.render({ canCreate: true })
+    expect(tournamentsListPagePage.queryNewButtons().length).toBeGreaterThan(0)
+  })
+
+  it('hides every New tournament action when the caller cannot create', () => {
+    tournamentsListPagePage.render({ canCreate: false })
+    expect(tournamentsListPagePage.queryNewButtons()).toHaveLength(0)
+  })
 })

--- a/web-client/src/components/tournaments/tournaments-list-page.tsx
+++ b/web-client/src/components/tournaments/tournaments-list-page.tsx
@@ -18,6 +18,9 @@ export interface TournamentsListPageProps {
   onOpen: (id: string) => void
   onCreate: (draft: Omit<Tournament, 'id'>) => void
   onDelete: (id: string) => void
+  /** Whether to surface the "New tournament" action — gated on the caller's
+   * `tournament.create` permission. Creating 403s without it, so hide it. */
+  canCreate: boolean
 }
 
 type StatusFilter = (typeof STATUS_FILTER_OPTIONS)[number]['value']
@@ -29,6 +32,7 @@ export const TournamentsListPage = ({
   onOpen,
   onCreate,
   onDelete,
+  canCreate,
 }: TournamentsListPageProps) => {
   const [query, setQuery] = useState('')
   const [filter, setFilter] = useState<StatusFilter>('all')
@@ -57,10 +61,12 @@ export const TournamentsListPage = ({
         title="Tournaments"
         subtitle={`${tournaments.length} total · ${activeCount} active. Create draws, schedule pools, publish to players.`}
         action={
-          <Button size="lg" onClick={() => setCreateOpen(true)}>
-            <Plus size={18} />
-            New tournament
-          </Button>
+          canCreate ? (
+            <Button size="lg" onClick={() => setCreateOpen(true)}>
+              <Plus size={18} />
+              New tournament
+            </Button>
+          ) : undefined
         }
       />
 
@@ -99,10 +105,12 @@ export const TournamentsListPage = ({
           title="No tournaments match"
           hint="Adjust the filters or create a new one."
           action={
-            <Button onClick={() => setCreateOpen(true)}>
-              <Plus size={16} />
-              New tournament
-            </Button>
+            canCreate ? (
+              <Button onClick={() => setCreateOpen(true)}>
+                <Plus size={16} />
+                New tournament
+              </Button>
+            ) : undefined
           }
         />
       ) : (

--- a/web-client/src/lib/permissions.ts
+++ b/web-client/src/lib/permissions.ts
@@ -6,7 +6,12 @@
 export const PERM = {
   ADMIN_VIEW: 'administration.view',
   AUTH_MANAGE: 'authorization.manage',
-  TOURNAMENT_MANAGE: 'tournament.manage',
+  // Tournaments split: viewing the area and creating tournaments are the only
+  // permission grants. Editing, deleting, and publishing a tournament are
+  // owner-only on the server (the creator), driven by the `canEdit` flag on the
+  // tournament payload — there is intentionally no edit/delete/publish perm.
+  TOURNAMENT_VIEW: 'tournament.view',
+  TOURNAMENT_CREATE: 'tournament.create',
   NOTIFICATIONS_BROADCAST: 'notifications.broadcast',
 } as const
 

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -41,9 +41,15 @@ export const mockSession = sessionResponse({
     username: 'rita.kovac',
     // The Administration nav *section* is gated on ADMIN_VIEW (app-shell), and
     // its children on their own permission. Grant ADMIN_VIEW so the section
-    // expands, AUTH_MANAGE for the RBAC pages, and TOURNAMENT_MANAGE so the
-    // Tournaments item appears and its page loads under `npm run dev`.
-    permissions: [PERM.ADMIN_VIEW, PERM.AUTH_MANAGE, PERM.TOURNAMENT_MANAGE],
+    // expands, AUTH_MANAGE for the RBAC pages, and TOURNAMENT_VIEW +
+    // TOURNAMENT_CREATE so the Tournaments item appears, its page loads, and the
+    // "New tournament" action shows under `npm run dev`.
+    permissions: [
+      PERM.ADMIN_VIEW,
+      PERM.AUTH_MANAGE,
+      PERM.TOURNAMENT_VIEW,
+      PERM.TOURNAMENT_CREATE,
+    ],
   },
 })
 export const mockHealthy = healthCheck()

--- a/web-client/src/routes/_app/tournaments.tsx
+++ b/web-client/src/routes/_app/tournaments.tsx
@@ -3,7 +3,7 @@ import { Outlet, createFileRoute } from '@tanstack/react-router'
 import { RbacBoundary } from '@/components/rbac/error-fallback'
 
 // Wrap both the list and the detail in the RbacBoundary so a server-side 403
-// (a user without `tournament.manage`) renders the "no access" UI rather than
+// (a user without `tournament.view`) renders the "no access" UI rather than
 // crashing the route — the list query's `throwOnError` surfaces the 403 here.
 export const Route = createFileRoute('/_app/tournaments')({
   component: TournamentsLayout,

--- a/web-client/src/routes/_app/tournaments/index.tsx
+++ b/web-client/src/routes/_app/tournaments/index.tsx
@@ -7,6 +7,8 @@ import {
   useDeleteTournament,
   useTournaments,
 } from '@/components/tournaments/data/api'
+import { useHasPermission } from '@/api/session'
+import { PERM } from '@/lib/permissions'
 import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute('/_app/tournaments/')({
@@ -21,10 +23,12 @@ function TournamentsRoute() {
   const tournaments = useTournaments()
   const createTournament = useCreateTournament()
   const deleteTournament = useDeleteTournament()
+  const canCreate = useHasPermission(PERM.TOURNAMENT_CREATE)
 
   return (
     <TournamentsListPage
       tournaments={tournaments}
+      canCreate={canCreate}
       onOpen={(tournamentId) =>
         navigate({
           to: '/tournaments/$tournamentId',


### PR DESCRIPTION
Closes #592.

## What

Replaces the single router-wide `tournament.manage` permission with granular permission gates plus an ownership model, per the issue — with one modification the requester asked for: **edit and publish (and, for consistency, delete) are owner-only, not permission-gated.**

- **Reads** (list + detail) require `tournament.view`.
- **Create** requires `tournament.create`.
- **Edit / delete / publish / event mutations** are owner-only — gated by the existing `_require_owner` check (the tournament's creator), with **no** permission. There is deliberately no `tournament.edit` / `tournament.delete` / `tournament.publish` permission; managing a tournament you created is a property of ownership, not a role grant.

## Changes

**API**
- `app/tournaments.py`: dropped the router-wide gate; reads now depend on `tournament.view`, create on `tournament.create`; mutations stay owner-only.
- `scripts/seed_rbac.py`: seed `tournament.view` + `tournament.create` (replacing `tournament.manage`); Beta-tester role gets both.
- `tests/test_tournaments.py`: grant helper now grants arbitrary permission subsets; added a view-only-cannot-create test; updated gate/non-creator tests.

**Web**
- `lib/permissions.ts`: `TOURNAMENT_MANAGE` → `TOURNAMENT_VIEW` + `TOURNAMENT_CREATE`.
- Nav gated on `tournament.view`; the "New tournament" action gated on a new `canCreate` prop (wired from `useHasPermission`); card delete control hidden for non-creators (`canEdit`). Component tests added.

## Testing

- API: `ruff check` ✓, `ruff format --check` ✓, `mypy --strict` ✓, `pytest` **477 passed**
- Web: `vitest` **878 passed**, `eslint` (0 errors), `tsc -b && vite build` ✓
- Web e2e: Playwright **127 passed**
- OpenAPI: regenerated and diffed — **no schema drift**
- Root e2e / iOS: not applicable (no specs touch tournaments; no `ios/**` changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)