### PR TITLE
Fix #559: send a "no account yet" email for unknown magic-link sign-ins

### DIFF
--- a/api/app/email.py
+++ b/api/app/email.py
@@ -158,6 +158,45 @@ def send_login_email(to_email: str, raw_token: str, username: str) -> None:
     )
 
 
+def send_no_account_email(to_email: str) -> None:
+    """Delivered when someone asks for a sign-in link for an address that has no
+    FortyMM account yet.
+
+    Sending *something* to every requested address is what keeps the uniform
+    202 from ``/v1/login/request`` enumeration-safe: a known and an unknown
+    address now get identical treatment (same status, same shape, a piece of
+    mail) so neither the response nor an empty inbox reveals which addresses
+    exist. It also tells a real person who typo'd their address — or never
+    signed up — why no sign-in link arrived, instead of leaving them staring at
+    an empty inbox. Carries no bearer token, so the URL is safe to log
+    anywhere."""
+    base = _app_base_url()
+    lines = [
+        "Hi,",
+        "",
+        "Someone — probably you — asked for a sign-in link for this email "
+        "address, but there's no FortyMM account tied to it yet.",
+        "",
+        "To get started, open FortyMM and start playing as a guest, then claim "
+        "this email address in Settings to keep your matches and rating.",
+    ]
+    if base is not None:
+        lines += ["", base]
+    lines += [
+        "",
+        "If you didn't request this, you can safely ignore this email.",
+        "",
+    ]
+    _deliver(
+        to_email=to_email,
+        subject="About your FortyMM sign-in request",
+        body="\n".join(lines),
+        log_event="email_no_account",
+        log_url=base or "(no link)",
+        dev_label="no-account",
+    )
+
+
 def send_notification_email(
     to_email: str, title: str, body: str, link: str | None = None
 ) -> None:

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -699,6 +699,23 @@ def _enqueue_merge_email(to_email: str, raw_token: str, username: str) -> Job:
     )
 
 
+def _enqueue_no_account_email(to_email: str) -> Job:
+    """The tokenless 'no account for this email yet' notice. Carries no
+    credential — the account doesn't exist — so it takes neither a token nor a
+    username.
+
+    Not routed through ``_enqueue_email_job`` (which threads a raw token +
+    username), but it mirrors that helper's ``result_ttl`` / ``failure_ttl`` so
+    every email job ages out of the RQ registries on the same schedule. There's
+    no token to protect here — the short TTLs are just registry hygiene."""
+    return queue_module.get_email_queue().enqueue(
+        "app.email.send_no_account_email",
+        to_email,
+        result_ttl=60,
+        failure_ttl=300,
+    )
+
+
 def _enqueue_rating_recompute_after_merge(user_id: uuid.UUID) -> None:
     """Fire-and-forget the rating recompute for ``user_id`` after a merge.
 
@@ -1067,7 +1084,11 @@ async def request_login_email(
     belongs to a known account. Differential responses would let an
     attacker enumerate the user base by cycling guest sessions for fresh
     rate-limit budgets — the same enumeration vector the email-change flow
-    guards against.
+    guards against. An address with no account still gets a (tokenless)
+    "no account yet" email, so a known and an unknown address are
+    indistinguishable from the outside — same status, same shape, and a
+    piece of mail either way — rather than the unknown case silently
+    delivering nothing.
 
     Accounts whose email hasn't been confirmed yet get the confirmation
     link re-sent instead of a sign-in link. The login token would let
@@ -1090,6 +1111,7 @@ async def request_login_email(
         await db.execute(select(User).where(User.email == email))
     ).scalar_one_or_none()
     if user is None:
+        await _send_no_account_email_or_503(email)
         return LoginRequestAccepted(email=email)
 
     if user.confirmed_at is None:
@@ -1118,6 +1140,21 @@ async def _requesting_guest_id(
     ):
         return None
     return requester.id
+
+
+async def _send_no_account_email_or_503(email: str) -> None:
+    """Enqueue the tokenless 'no account yet' notice for an unknown address.
+
+    There's no DB write to guard, but on an enqueue failure we raise the same
+    503 the known-account path raises — so a Redis flap fails both paths
+    identically and the outcome never reveals whether the address exists."""
+    try:
+        _enqueue_no_account_email(email)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Email service unavailable. Try again in a moment.",
+        ) from None
 
 
 async def _issue_and_send_login_email(

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -1131,6 +1131,29 @@ def test_send_notification_email_builds_subject_body_and_link(monkeypatch):
     assert "https://fortymm.test/matches/m-1" in body
 
 
+def test_send_no_account_email_builds_subject_and_body(monkeypatch):
+    from app import email as email_module
+
+    monkeypatch.setenv("SMTP_HOST", "smtp.test")
+    monkeypatch.setenv("APP_BASE_URL", "https://fortymm.test")
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        email_module, "_send_via_smtp", lambda message: captured.update(msg=message)
+    )
+
+    email_module.send_no_account_email("stranger@example.com")
+
+    message = captured["msg"]
+    assert message["Subject"] == "About your FortyMM sign-in request"  # type: ignore[index]
+    assert message["To"] == "stranger@example.com"  # type: ignore[index]
+    body = message.get_content()  # type: ignore[attr-defined]
+    assert "no FortyMM account" in body
+    assert "https://fortymm.test" in body
+    # Tokenless — it must never carry a sign-in/confirm bearer link.
+    assert "/login/verifying" not in body
+    assert "/confirm-email" not in body
+
+
 def test_send_notification_email_omits_the_link_when_absent(monkeypatch):
     from app import email as email_module
 

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -121,11 +121,16 @@ async def test_request_normalizes_email_to_lowercase(
     assert tokens[0].sent_to == "rita@example.com"
 
 
-async def test_request_for_unknown_email_returns_202_without_sending(
+async def test_request_for_unknown_email_sends_no_account_email_without_token(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
+    """An unknown address mints no login token (no account to sign into) but
+    still gets a tokenless 'no account yet' email, so it's indistinguishable
+    from a known address from the outside — same 202, and a piece of mail
+    either way."""
     response = await api_client.post("/v1/login/request", json=REQUEST_BODY)
     assert response.status_code == 202
+    assert response.json() == {"email": "rita@example.com"}
 
     tokens = (
         (
@@ -137,7 +142,14 @@ async def test_request_for_unknown_email_returns_202_without_sending(
         .all()
     )
     assert tokens == []
-    assert fake_email_queue.finished_job_registry.count == 0
+
+    assert fake_email_queue.finished_job_registry.count == 1
+    job = fake_email_queue.fetch_job(
+        fake_email_queue.finished_job_registry.get_job_ids()[0]
+    )
+    assert job is not None
+    assert job.func_name == "app.email.send_no_account_email"
+    assert job.args == ("rita@example.com",)
 
 
 async def test_request_for_unconfirmed_account_resends_confirmation(

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -133,7 +133,11 @@ export interface paths {
          *     belongs to a known account. Differential responses would let an
          *     attacker enumerate the user base by cycling guest sessions for fresh
          *     rate-limit budgets — the same enumeration vector the email-change flow
-         *     guards against.
+         *     guards against. An address with no account still gets a (tokenless)
+         *     "no account yet" email, so a known and an unknown address are
+         *     indistinguishable from the outside — same status, same shape, and a
+         *     piece of mail either way — rather than the unknown case silently
+         *     delivering nothing.
          *
          *     Accounts whose email hasn't been confirmed yet get the confirmation
          *     link re-sent instead of a sign-in link. The login token would let


### PR DESCRIPTION
## What & why

Fixes #559. On the magic-link sign-in endpoint (`POST /v1/login/request`), an email address with **no FortyMM account** returned `202 Accepted` but enqueued nothing — so a mistyped or never-registered address produced **zero mail**, which is indistinguishable from a broken system. A black-box QA pass filed exactly that ("202 but no email is ever enqueued/delivered").

Root cause: the handler is enumeration-safe by design (unknown email → uniform `202`, no token, no mail). On a fresh QA stack no account exists, so every address Quinn tried hit that silent path. Not a captcha/env bug — captcha passed.

## Change

Keep the uniform `202`, but make the unknown-address path enqueue a **tokenless** "there's no FortyMM account for this email yet, here's how to get started" email. Now a known and an unknown address are genuinely indistinguishable from the outside — same status, same shape, **and a piece of mail either way** — instead of the unknown case silently delivering nothing. It also helps a real person who typo'd their address or never signed up.

- **No account is created and no sign-in token is minted** — this is *not* auto-signup. Sign-in stays separate from the guest→claim signup flow.
- `api/app/email.py`: new `send_no_account_email` (carries no bearer token, so its URL is safe to log).
- `api/app/sessions.py`: `_enqueue_no_account_email` + `_send_no_account_email_or_503`, called from `request_login_email` when the user is unknown. The 503-on-enqueue-failure mirrors the known-account path so a Redis flap fails both paths identically (no enumeration leak via differential failure).
- Regenerated `schema.d.ts` (the route docstring flows into the OpenAPI description).

## Testing

- API: `ruff check` ✓, `ruff format --check` ✓, `mypy --strict` ✓, `pytest` (full) **477 passed** ✓
- web-client: `lint` ✓ (0 errors), `build`/typecheck ✓, `vitest` **875 passed** ✓
- OpenAPI drift check: committed `schema.d.ts` matches regen ✓
- New tests: `send_no_account_email` render (asserts tokenless — no `/login/verifying` or `/confirm-email` link) and the unknown-email enqueue path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)