### PR TITLE
Add a category selector to the admin notification broadcast

### DIFF
--- a/api/app/notifications/router.py
+++ b/api/app/notifications/router.py
@@ -180,8 +180,8 @@ async def broadcast_notification(
     payload: BroadcastRequest,
     service: NotificationService = Depends(get_notification_service),
 ) -> BroadcastResponse:
-    """Queue an announcement to all players or a hand-picked set. Filed as
-    tournament news, so each recipient only receives it on the channels they
+    """Queue an announcement to all players or a hand-picked set, filed under the
+    chosen category, so each recipient only receives it on the channels they
     haven't muted for that category. Delivery runs in the background — the
     response reports how many players were targeted, not per-channel counts."""
     recipients = payload.recipients
@@ -190,6 +190,7 @@ async def broadcast_notification(
     return await service.enqueue_broadcast(
         all_users=all_users,
         user_ids=user_ids,
+        category=payload.category,
         title=payload.title,
         body=payload.body,
     )

--- a/api/app/notifications/service.py
+++ b/api/app/notifications/service.py
@@ -77,10 +77,6 @@ FEED_LIMIT = 50
 # typeahead snappy while ``total`` still reports the true match count.
 RECIPIENT_LIMIT = 50
 
-# Admin broadcasts are filed as tournament news, so a player's tournament-news
-# preferences decide which channels actually reach them.
-BROADCAST_CATEGORY = NotificationCategory.TOURNAMENT
-
 
 class PushNotConfiguredError(Exception):
     """Raised when a push is requested but no APNs credentials are configured.
@@ -716,11 +712,12 @@ class NotificationService:
         *,
         all_users: bool,
         user_ids: Sequence[uuid.UUID],
+        category: NotificationCategory,
         title: str,
         body: str,
     ) -> BroadcastResponse:
         """Resolve the target players and hand one delivery job per recipient to
-        the worker, which resolves *that* player's tournament-news preferences
+        the worker, which resolves *that* player's preferences for ``category``
         and delivers accordingly. Returns the recipient count immediately —
         actual delivery happens in the background."""
         target_ids = await self._broadcast_target_ids(all_users, user_ids)
@@ -728,7 +725,7 @@ class NotificationService:
             self.enqueue_notification(
                 NotificationJob(
                     user_id=target_id,
-                    category=BROADCAST_CATEGORY,
+                    category=category,
                     title=title,
                     body=body,
                 )

--- a/api/app/schemas/notification.py
+++ b/api/app/schemas/notification.py
@@ -229,16 +229,17 @@ BroadcastRecipients = Annotated[
 
 
 class BroadcastRequest(BaseModel):
-    """An admin broadcast: pick recipients and the copy.
+    """An admin broadcast: pick recipients, a category, and the copy.
 
-    Broadcasts are filed under the *tournament* category, so each recipient only
-    receives it on the channels they haven't muted for tournament news — the
-    server delivers per each player's preferences (there is no admin channel
-    override)."""
+    The chosen ``category`` decides which preference each recipient is delivered
+    against — each player only receives it on the channels they haven't muted for
+    that category (there is no admin channel override). Defaults to *tournament*
+    news when omitted."""
 
     model_config = ConfigDict(extra="forbid")
 
     recipients: BroadcastRecipients
+    category: NotificationCategory = NotificationCategory.TOURNAMENT
     title: str = Field(min_length=1, max_length=100)
     body: str = Field(min_length=1, max_length=280)
 

--- a/api/tests/test_notification_broadcast.py
+++ b/api/tests/test_notification_broadcast.py
@@ -148,6 +148,67 @@ async def test_broadcast_selected_targets_only_those_players(
     assert [job.user_id for job in jobs] == [alice.id]
 
 
+async def test_broadcast_files_under_the_chosen_category(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    fake_notifications_queue: Queue,
+):
+    admin = await start_session(api_client, db_session)
+    await grant_broadcast(db_session, admin)
+    use_sender(FakeSender())
+
+    response = await api_client.post(
+        "/v1/notifications/broadcast",
+        json={
+            "recipients": {"mode": "all"},
+            "category": "rating_change",
+            "title": "New season ratings",
+            "body": "Your rating moved.",
+        },
+    )
+
+    assert response.status_code == 200
+    jobs = enqueued_notification_jobs(fake_notifications_queue)
+    assert jobs
+    assert all(job.category.value == "rating_change" for job in jobs)
+
+
+async def test_broadcast_defaults_to_tournament_when_category_omitted(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    fake_notifications_queue: Queue,
+):
+    admin = await start_session(api_client, db_session)
+    await grant_broadcast(db_session, admin)
+    use_sender(FakeSender())
+
+    response = await api_client.post(
+        "/v1/notifications/broadcast",
+        json={"recipients": {"mode": "all"}, "title": "Hi", "body": "Body"},
+    )
+
+    assert response.status_code == 200
+    jobs = enqueued_notification_jobs(fake_notifications_queue)
+    assert all(job.category.value == "tournament" for job in jobs)
+
+
+async def test_broadcast_rejects_an_unknown_category(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    admin = await start_session(api_client, db_session)
+    await grant_broadcast(db_session, admin)
+    response = await api_client.post(
+        "/v1/notifications/broadcast",
+        json={
+            "recipients": {"mode": "all"},
+            "category": "not_a_category",
+            "title": "Hi",
+            "body": "Body",
+        },
+    )
+    assert response.status_code == 422
+
+
 # ----- recipient picker -----------------------------------------------------
 
 

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -889,8 +889,8 @@ export interface paths {
         put?: never;
         /**
          * Broadcast Notification
-         * @description Queue an announcement to all players or a hand-picked set. Filed as
-         *     tournament news, so each recipient only receives it on the channels they
+         * @description Queue an announcement to all players or a hand-picked set, filed under the
+         *     chosen category, so each recipient only receives it on the channels they
          *     haven't muted for that category. Delivery runs in the background — the
          *     response reports how many players were targeted, not per-channel counts.
          */
@@ -1062,16 +1062,18 @@ export interface components {
         };
         /**
          * BroadcastRequest
-         * @description An admin broadcast: pick recipients and the copy.
+         * @description An admin broadcast: pick recipients, a category, and the copy.
          *
-         *     Broadcasts are filed under the *tournament* category, so each recipient only
-         *     receives it on the channels they haven't muted for tournament news — the
-         *     server delivers per each player's preferences (there is no admin channel
-         *     override).
+         *     The chosen ``category`` decides which preference each recipient is delivered
+         *     against — each player only receives it on the channels they haven't muted for
+         *     that category (there is no admin channel override). Defaults to *tournament*
+         *     news when omitted.
          */
         BroadcastRequest: {
             /** Recipients */
             recipients: components["schemas"]["BroadcastRecipientsAll"] | components["schemas"]["BroadcastRecipientsSelected"];
+            /** @default tournament */
+            category: components["schemas"]["NotificationCategory"];
             /** Title */
             title: string;
             /** Body */

--- a/web-client/src/components/notifications/broadcast-page.tsx
+++ b/web-client/src/components/notifications/broadcast-page.tsx
@@ -2,8 +2,10 @@ import { useState } from 'react'
 import { ApiError } from '@/api/client'
 import {
   useBroadcastRecipients,
+  useNotificationTaxonomy,
   useSendBroadcast,
   type BroadcastResponse,
+  type NotificationCategory,
 } from '@/api/notifications'
 import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { BroadcastView } from './broadcast-page/broadcast-view'
@@ -27,6 +29,7 @@ export function BroadcastPage() {
   const [audience, setAudience] = useState<BroadcastAudience>('selected')
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [search, setSearch] = useState('')
+  const [category, setCategory] = useState<NotificationCategory>('tournament')
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
   const [result, setResult] = useState<BroadcastResponse | null>(null)
@@ -36,9 +39,17 @@ export function BroadcastPage() {
   // by `search`; only the query keys off the settled value.
   const debouncedSearch = useDebouncedValue(search, 300)
   const recipients = useBroadcastRecipients(debouncedSearch)
+  const taxonomy = useNotificationTaxonomy()
   const send = useSendBroadcast()
 
-  const draft = { audience, selectedIds, title, body }
+  // The server owns the ordered category list + labels; fall back to the
+  // current category alone until the taxonomy loads so the select is never empty.
+  const categories = taxonomy.data?.types.map((t) => ({
+    value: t.key,
+    label: t.label,
+  })) ?? [{ value: category, label: category }]
+
+  const draft = { audience, selectedIds, category, title, body }
   const canSend = canSendBroadcast(draft) && !send.isPending
   const total = recipients.data?.total ?? 0
   const selectedCount = audience === 'all' ? total : selectedIds.size
@@ -74,6 +85,12 @@ export function BroadcastPage() {
         setSelectedIds((prev) => toggle(prev, id))
       }}
       selectedCount={selectedCount}
+      categories={categories}
+      category={category}
+      onCategoryChange={(value) => {
+        clearResult()
+        setCategory(value)
+      }}
       title={title}
       onTitleChange={(value) => {
         clearResult()

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.factory.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.factory.tsx
@@ -19,6 +19,12 @@ export function buildBroadcastViewProps(
     selectedIds: new Set<string>(),
     onToggleRecipient: () => {},
     selectedCount: 0,
+    categories: [
+      { value: 'tournament', label: 'Tournament' },
+      { value: 'rating_change', label: 'Rating change' },
+    ],
+    category: 'tournament',
+    onCategoryChange: () => {},
     title: '',
     onTitleChange: () => {},
     body: '',

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.page.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.page.tsx
@@ -13,6 +13,9 @@ const scoped = (container: Container) => ({
   getRecipient(username: string) {
     return container.getByRole('checkbox', { name: username })
   },
+  getCategoryTrigger() {
+    return container.getByRole('combobox', { name: 'Category' })
+  },
   getTitleInput() {
     return container.getByLabelText('Title')
   },
@@ -30,6 +33,14 @@ const scoped = (container: Container) => ({
   },
   queryHint(text: string) {
     return container.queryByText(text)
+  },
+  /** The "Filed under <category> — …" compose caption. */
+  queryFiledUnder(label: string) {
+    return container.queryByText(
+      (_content: string, el: Element | null) =>
+        el?.tagName === 'P' &&
+        (el.textContent ?? '').startsWith(`Filed under ${label} —`),
+    )
   },
   /** A preview section label (e.g. IN-APP / BELL). */
   queryPreviewSection(label: string) {

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.test.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.test.tsx
@@ -76,4 +76,18 @@ describe('BroadcastView', () => {
       broadcastViewPage.queryPreviewSection('IN-APP / BELL'),
     ).toBeInTheDocument()
   })
+
+  it('shows the selected category on the trigger', () => {
+    broadcastViewPage.render({ category: 'rating_change' })
+    expect(broadcastViewPage.getCategoryTrigger()).toHaveTextContent(
+      'Rating change',
+    )
+  })
+
+  it('files the message under the selected category', () => {
+    broadcastViewPage.render({ category: 'rating_change' })
+    expect(
+      broadcastViewPage.queryFiledUnder('Rating change'),
+    ).toBeInTheDocument()
+  })
 })

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.tsx
@@ -2,6 +2,7 @@ import { CheckCircle2, Search, Send } from 'lucide-react'
 import type {
   BroadcastRecipient,
   BroadcastResponse,
+  NotificationCategory,
   NotificationItem,
 } from '@/api/notifications'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -10,11 +11,18 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/lib/utils'
+import { OptionSelect } from '../../tournaments/tournament-detail-page/event-editor/option-select'
 import { NotificationRow } from '../notification-row'
 import type { BroadcastAudience } from './build-broadcast-request'
 
 const TITLE_MAX = 100
 const BODY_MAX = 280
+
+/** A selectable broadcast category: the wire value plus its display label. */
+export interface BroadcastCategoryOption {
+  value: NotificationCategory
+  label: string
+}
 
 export interface BroadcastViewProps {
   recipients: BroadcastRecipient[]
@@ -27,6 +35,9 @@ export interface BroadcastViewProps {
   selectedIds: ReadonlySet<string>
   onToggleRecipient: (id: string) => void
   selectedCount: number
+  categories: BroadcastCategoryOption[]
+  category: NotificationCategory
+  onCategoryChange: (category: NotificationCategory) => void
   title: string
   onTitleChange: (title: string) => void
   body: string
@@ -53,6 +64,9 @@ export function BroadcastView(props: BroadcastViewProps) {
     selectedIds,
     onToggleRecipient,
     selectedCount,
+    categories,
+    category,
+    onCategoryChange,
     title,
     onTitleChange,
     body,
@@ -66,6 +80,9 @@ export function BroadcastView(props: BroadcastViewProps) {
 
   const hint =
     selectedCount === 0 ? 'Pick at least one recipient.' : 'Add a title.'
+
+  const categoryLabel =
+    categories.find((c) => c.value === category)?.label ?? category
 
   return (
     <div className="grid gap-8 px-6 py-6 lg:grid-cols-[360px_1fr]">
@@ -157,9 +174,23 @@ export function BroadcastView(props: BroadcastViewProps) {
           </h2>
 
           <p className="mb-6 text-xs text-[color:var(--fg-muted)]">
-            Filed as tournament news — each player receives it on the channels
+            Filed under {categoryLabel} — each player receives it on the channels
             they haven't muted for that category.
           </p>
+
+          <label
+            htmlFor="broadcast-category"
+            className="mb-2 block text-xs font-semibold text-[color:var(--fg-3)]"
+          >
+            Category
+          </label>
+          <OptionSelect
+            value={category}
+            options={categories}
+            onChange={(value) => onCategoryChange(value as NotificationCategory)}
+            ariaLabel="Category"
+            className="mb-5 w-full"
+          />
 
           <label
             htmlFor="broadcast-title"
@@ -233,19 +264,27 @@ export function BroadcastView(props: BroadcastViewProps) {
           <h2 id="broadcast-preview-heading" className="ds-overline mb-3.5">
             Preview
           </h2>
-          <BroadcastPreview title={title} body={body} />
+          <BroadcastPreview title={title} body={body} category={category} />
         </section>
       </div>
     </div>
   )
 }
 
-function BroadcastPreview({ title, body }: { title: string; body: string }) {
+function BroadcastPreview({
+  title,
+  body,
+  category,
+}: {
+  title: string
+  body: string
+  category: NotificationCategory
+}) {
   const safeTitle = title || 'Notification title'
   const safeBody = body || 'Your message shows up here.'
   const previewNotification: NotificationItem = {
     id: 'preview',
-    category: 'tournament',
+    category,
     title: safeTitle,
     body: safeBody,
     link: null,

--- a/web-client/src/components/notifications/broadcast-page/build-broadcast-request.test.ts
+++ b/web-client/src/components/notifications/broadcast-page/build-broadcast-request.test.ts
@@ -7,6 +7,7 @@ import {
 const draft = (overrides: Partial<BroadcastDraft> = {}): BroadcastDraft => ({
   audience: 'all',
   selectedIds: new Set(),
+  category: 'tournament',
   title: 'Spring Open is live',
   body: 'Brackets dropped.',
   ...overrides,
@@ -58,5 +59,10 @@ describe('buildBroadcastRequest', () => {
     )
     expect(req.title).toBe('Heads up')
     expect(req.body).toBe('Be early.')
+  })
+
+  it('forwards the chosen category', () => {
+    const req = buildBroadcastRequest(draft({ category: 'rating_change' }))
+    expect(req.category).toBe('rating_change')
   })
 })

--- a/web-client/src/components/notifications/broadcast-page/build-broadcast-request.ts
+++ b/web-client/src/components/notifications/broadcast-page/build-broadcast-request.ts
@@ -1,10 +1,11 @@
-import type { BroadcastRequest } from '@/api/notifications'
+import type { BroadcastRequest, NotificationCategory } from '@/api/notifications'
 
 export type BroadcastAudience = 'all' | 'selected'
 
 export interface BroadcastDraft {
   audience: BroadcastAudience
   selectedIds: ReadonlySet<string>
+  category: NotificationCategory
   title: string
   body: string
 }
@@ -26,6 +27,7 @@ export function buildBroadcastRequest(draft: BroadcastDraft): BroadcastRequest {
       draft.audience === 'all'
         ? { mode: 'all' }
         : { mode: 'selected', user_ids: [...draft.selectedIds] },
+    category: draft.category,
     title: draft.title.trim(),
     body: draft.body.trim(),
   }


### PR DESCRIPTION
## What

The admin broadcast tool previously filed every announcement under the hardcoded **tournament** category. This adds a **category selector** so the admin chooses which category an announcement is filed under — each recipient is then delivered against *their* preferences for that category (no admin channel override, same as before).

## Changes

**API**
- `BroadcastRequest` gains a `category: NotificationCategory` field. It defaults to `tournament` when omitted (backward compatible), so the wire field is optional but the default now lives in exactly one place — the schema.
- The route threads `payload.category` through `enqueue_broadcast` to each per-recipient `NotificationJob`.
- Removed the now-redundant `BROADCAST_CATEGORY` constant and the duplicate service-param default.

**web-client**
- `BroadcastView` renders a category dropdown (reusing `OptionSelect`) populated from the server-owned `/v1/notification-taxonomy` (ordered labels).
- The "Filed under …" compose caption and the live in-app preview reflect the selected category.
- `buildBroadcastRequest` / `BroadcastDraft` carry the category; the page container holds the state and falls back to the current category until the taxonomy loads.
- Regenerated `schema.d.ts`.

## Testing

- API: `ruff` + `ruff format --check` + `mypy` (strict) + `pytest` (481 passed), incl. 3 new broadcast tests (chosen category honored, default-to-tournament, unknown category → 422).
- web-client: `vitest` (881 passed), `eslint`, `tsc -b && vite build` — all green. New tests cover the request builder forwarding the category and the view rendering/caption.
- OpenAPI schema: regenerated, no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)