### PR TITLE
Don't show the hand cursor on locked scores in the match details scoreboard

### DIFF
--- a/web-client/e2e/matches/match-details.spec.ts
+++ b/web-client/e2e/matches/match-details.spec.ts
@@ -24,6 +24,43 @@ const gameScore = (
 // to the not-found state without fetching). So fixtures driven through the
 // route must use a UUID-shaped id, not a readable `m-...` slug.
 const COMPLETED_WIN_ID = '00000000-0000-4000-8000-000000000001';
+const SCORABLE_ID = '00000000-0000-4000-8000-000000000002';
+
+/**
+ * A live, still-scorable singles match where the current user (side 1) has a
+ * won game (1, 11–7) and a lost game (2, 9–11). Because `can_score` is true,
+ * the current user's scored cells render as edit links (`<a>`) — the case the
+ * #472 color reset regresses on.
+ */
+const scorableMatch = (id: string): MatchDetails =>
+    matchDetails({
+        id,
+        status: 'in_progress',
+        status_label: 'Live',
+        sides: [
+            {
+                side_number: 1,
+                players: [
+                    { user_id: 'u-me', username: 'rita.kovac', is_current_user: true },
+                ],
+                games_won: 1,
+                won: null,
+                is_current_user_side: true,
+            },
+            {
+                side_number: 2,
+                players: [
+                    { user_id: 'pl-silva', username: 'silva.r', is_current_user: false },
+                ],
+                games_won: 1,
+                won: null,
+                is_current_user_side: false,
+            },
+        ],
+        games: [gameScore(1, 11, 7), gameScore(2, 9, 11)],
+        current_game: { game_number: 3 },
+        can_score: true,
+    });
 
 /** A decided singles match: rita.kovac beat silva.r, 3 games to 1. */
 const decidedMatch = (id: string): MatchDetails =>
@@ -108,8 +145,8 @@ test.describe('Match Details', () => {
         // as edit links (<a>), and the `.match-details a { color: inherit }`
         // reset used to out-rank the win/loss colors, leaving the row colorless.
         test('colors the editable (current-user) row win/loss cells like the opponent row', async ({ page }) => {
-            await matchDetailsPage.mock(decidedMatch(COMPLETED_WIN_ID));
-            await matchDetailsPage.goTo(COMPLETED_WIN_ID);
+            await matchDetailsPage.mock(scorableMatch(SCORABLE_ID));
+            await matchDetailsPage.goTo(SCORABLE_ID);
 
             const color = (testId: string) =>
                 page

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.test.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.test.ts
@@ -540,6 +540,7 @@ describe("scoreboardQuery", () => {
         buildMatchDetails({
           id: "m-99",
           best_of: 5,
+          can_score: true,
           games: [
             buildMatchDetailsGame({
               score: buildMatchDetailsScore({
@@ -655,6 +656,7 @@ describe("scoreboardQuery", () => {
     scoreboardQueryPage.mockEndpoint(() =>
       HttpResponse.json(
         buildMatchDetails({
+          can_score: true,
           sides: [
             buildMatchDetailsSide({
               players: [
@@ -692,6 +694,37 @@ describe("scoreboardQuery", () => {
     expect(mine).toMatchObject({ name: "rita.kovac" });
     expect(mine.cells[0]).toMatchObject({ points: 7, editGameNumber: 1 });
     expect(theirs.cells[0]).toMatchObject({
+      points: 11,
+      editGameNumber: null,
+    });
+  });
+
+  it("carries no edit link on the viewer's own scored cell once the board is locked (can_score false)", async () => {
+    // A posted/confirmed result flips `can_score` to false: the scores can no
+    // longer be edited, so the viewer's own cells must render as plain text
+    // rather than links — otherwise they'd show a hand cursor on hover.
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          can_score: false,
+          games: [
+            buildMatchDetailsGame({
+              score: buildMatchDetailsScore({
+                side_1_points: 11,
+                side_2_points: 7,
+              }),
+            }),
+          ],
+          data: { scoreboard: { status: "final" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const [mine] = result.current.data!.gameGrid!.rows;
+    expect(mine.cells[0]).toMatchObject({
       points: 11,
       editGameNumber: null,
     });

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.ts
@@ -277,10 +277,12 @@ const selectGameGrid = (match: MatchDetailsResult): GameGridView | null => {
     slots.push(gamesByNumber.get(n) ?? null);
   }
 
-  // Per-cell edit links are gated on participation — spectators can't write
-  // scores — and only the viewer's own row carries them, so the user doesn't
-  // see two stacked links over the same game.
-  const canEdit = first.is_current_user_side;
+  // Per-cell edit links are gated on the server's `can_score` flag — which is
+  // false once a result is posted/confirmed (the board is locked) or for a
+  // spectator — and only the viewer's own row carries them, so the user doesn't
+  // see two stacked links over the same game, nor a hand cursor on scores that
+  // can no longer be edited.
+  const canEdit = details.can_score && first.is_current_user_side;
   return {
     matchId: details.id,
     bestOf: details.best_of,


### PR DESCRIPTION
## What & why

On the match details page, scored cells in the scoreboard's game grid showed the "little hand" (pointer) cursor on hover even when the scores could no longer be edited.

### Root cause

`selectGameGrid` in `scoreboard-query.ts` gated per-cell edit links purely on `first.is_current_user_side`:

```ts
const canEdit = first.is_current_user_side;
```

`GameGridCell` renders an `<a>` (`<Link>`) when `editGameNumber !== null` and a plain `<div>` otherwise — and an anchor carries the native pointer cursor. Because `canEdit` ignored the match lifecycle, a participant's own scored cells kept rendering as links (hand cursor) even after the result was posted/confirmed and the board was locked.

The backend already exposes the correct signal: `can_score` (`is_participant AND _is_scorable`), which goes false once a result is signed (or for spectators). The mock store mirrors this via `scorableSeed`.

### Fix

Gate edit links on `can_score` in addition to the viewer's own row:

```ts
const canEdit = details.can_score && first.is_current_user_side;
```

Locked scores now render as plain text with the default cursor.

## Tests

- Updated the two scoreboard-query unit tests that expected edit links to set `can_score: true` (the factory defaults it to `false`).
- Added a unit regression test asserting the viewer's own scored cell carries `editGameNumber: null` once `can_score` is false.
- Repointed the #472 color regression e2e test at a new `scorableMatch` fixture (live, `can_score: true`, current user with a won + a lost game) so it still exercises the color-inherit reset on genuinely *linked* cells — the previous fixture was a completed match whose cells are now correctly non-links.
- Web-client vitest (879 tests), lint, and `tsc -b`/build all pass locally; all 6 CI workflows green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bu8ZyJu9PTMMDkGATadbF