### PR TITLE
Notifications: nudge to add email / set up push when a channel isn't configured

### DIFF
--- a/api/app/notifications/service.py
+++ b/api/app/notifications/service.py
@@ -594,7 +594,7 @@ class NotificationService:
                 locked=channel in LOCKED_CHANNELS,
                 destination=self._channel_destination(channel, user, device_count),
                 setup_required=self._channel_setup_required(
-                    channel, user, device_count
+                    channel, user, device_count, availability[channel]
                 ),
             )
             for channel in channel_order
@@ -643,11 +643,18 @@ class NotificationService:
 
     @staticmethod
     def _channel_setup_required(
-        channel: NotificationChannel, user: User, device_count: int
+        channel: NotificationChannel,
+        user: User,
+        device_count: int,
+        available: bool,
     ) -> bool:
         """Whether the user still has to do something before this channel can
         deliver. Email needs a confirmed address; push needs a registered
-        device. In-app and (unavailable) SMS never prompt for setup."""
+        device. A channel the server can't deliver on at all (``available`` is
+        false, e.g. SMS today) never prompts for setup — there's nothing the
+        user can do to make it work — so the availability gate comes first."""
+        if not available:
+            return False
         # Exhaustive match (no catch-all) per api/CLAUDE.md's enum-mapping rule.
         match channel:
             case NotificationChannel.IN_APP:

--- a/api/app/notifications/service.py
+++ b/api/app/notifications/service.py
@@ -593,6 +593,9 @@ class NotificationService:
                 available=availability[channel],
                 locked=channel in LOCKED_CHANNELS,
                 destination=self._channel_destination(channel, user, device_count),
+                setup_required=self._channel_setup_required(
+                    channel, user, device_count
+                ),
             )
             for channel in channel_order
         ]
@@ -636,6 +639,25 @@ class NotificationService:
                 return "Add an email in settings"
             case NotificationChannel.SMS:
                 return "Not available yet"
+        assert_never(channel)
+
+    @staticmethod
+    def _channel_setup_required(
+        channel: NotificationChannel, user: User, device_count: int
+    ) -> bool:
+        """Whether the user still has to do something before this channel can
+        deliver. Email needs a confirmed address; push needs a registered
+        device. In-app and (unavailable) SMS never prompt for setup."""
+        # Exhaustive match (no catch-all) per api/CLAUDE.md's enum-mapping rule.
+        match channel:
+            case NotificationChannel.IN_APP:
+                return False
+            case NotificationChannel.PUSH:
+                return device_count == 0
+            case NotificationChannel.EMAIL:
+                return not (user.email and user.confirmed_at is not None)
+            case NotificationChannel.SMS:
+                return False
         assert_never(channel)
 
     async def _channel_overrides(

--- a/api/app/schemas/notification.py
+++ b/api/app/schemas/notification.py
@@ -133,13 +133,17 @@ class NotificationChannelState(BaseModel):
     server can deliver on this channel at all (SMS isn't wired up yet);
     ``locked`` means the user can't switch it off (in-app is the feed itself);
     ``destination`` is a human hint about where it lands (email address, device
-    count, ...), computed server-side."""
+    count, ...), computed server-side. ``setup_required`` is true when the
+    channel is available but the user hasn't completed the prerequisite to
+    actually receive on it (no confirmed email; no registered push devices), so
+    the UI can prompt them to finish setup."""
 
     channel: NotificationChannel
     enabled: bool
     available: bool
     locked: bool
     destination: str | None = None
+    setup_required: bool = False
 
 
 class NotificationCategoryCell(BaseModel):

--- a/api/tests/test_notification_preferences.py
+++ b/api/tests/test_notification_preferences.py
@@ -124,6 +124,25 @@ async def test_email_setup_required_until_confirmed(
     assert _channels(data)["email"]["setup_required"] is True
 
 
+async def test_setup_required_is_gated_on_availability(db_session: AsyncSession):
+    user = await make_user(db_session, "no-setup")
+    # Push's prerequisite is unmet (zero devices). If the channel is available,
+    # that's a nudge; if the server can't deliver on it at all, it isn't — there
+    # is nothing the user could do to make it work.
+    assert (
+        NotificationService._channel_setup_required(
+            NotificationChannel.PUSH, user, 0, available=True
+        )
+        is True
+    )
+    assert (
+        NotificationService._channel_setup_required(
+            NotificationChannel.PUSH, user, 0, available=False
+        )
+        is False
+    )
+
+
 # ----- updates --------------------------------------------------------------
 
 

--- a/api/tests/test_notification_preferences.py
+++ b/api/tests/test_notification_preferences.py
@@ -46,15 +46,21 @@ async def test_default_channels(api_client: AsyncClient, db_session: AsyncSessio
         "available": True,
         "locked": True,
         "destination": "Always on, in your feed",
+        "setup_required": False,
     }
     assert channels["push"]["enabled"] is True
     assert channels["push"]["locked"] is False
     assert channels["push"]["destination"] == "No devices yet — open the app"
+    # No devices and no confirmed email yet: both prompt for setup.
+    assert channels["push"]["setup_required"] is True
     assert channels["email"]["enabled"] is True
     assert channels["email"]["destination"] == "Add an email in settings"
-    # SMS isn't wired up: surfaced but unavailable + off.
+    assert channels["email"]["setup_required"] is True
+    # SMS isn't wired up: surfaced but unavailable + off. Unavailable channels
+    # don't nudge for setup.
     assert channels["sms"]["available"] is False
     assert channels["sms"]["enabled"] is False
+    assert channels["sms"]["setup_required"] is False
 
 
 async def test_default_matrix_locks_match_reminders(
@@ -86,6 +92,8 @@ async def test_push_destination_reflects_device_count(
 
     data = (await api_client.get("/v1/notification-preferences")).json()
     assert _channels(data)["push"]["destination"] == "1 device"
+    # A registered device means push is set up — no nudge.
+    assert _channels(data)["push"]["setup_required"] is False
 
 
 async def test_email_destination_shows_confirmed_address(
@@ -98,6 +106,22 @@ async def test_email_destination_shows_confirmed_address(
 
     data = (await api_client.get("/v1/notification-preferences")).json()
     assert _channels(data)["email"]["destination"] == "player@fortymm.club"
+    # A confirmed address means email is set up — no nudge.
+    assert _channels(data)["email"]["setup_required"] is False
+
+
+async def test_email_setup_required_until_confirmed(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    user = await start_session(api_client, db_session)
+    # Address on file but not yet confirmed: the channel still can't deliver, so
+    # the nudge stays up.
+    user.email = "player@fortymm.club"
+    user.confirmed_at = None
+    await db_session.commit()
+
+    data = (await api_client.get("/v1/notification-preferences")).json()
+    assert _channels(data)["email"]["setup_required"] is True
 
 
 # ----- updates --------------------------------------------------------------

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1730,7 +1730,10 @@ export interface components {
          *     server can deliver on this channel at all (SMS isn't wired up yet);
          *     ``locked`` means the user can't switch it off (in-app is the feed itself);
          *     ``destination`` is a human hint about where it lands (email address, device
-         *     count, ...), computed server-side.
+         *     count, ...), computed server-side. ``setup_required`` is true when the
+         *     channel is available but the user hasn't completed the prerequisite to
+         *     actually receive on it (no confirmed email; no registered push devices), so
+         *     the UI can prompt them to finish setup.
          */
         NotificationChannelState: {
             channel: components["schemas"]["NotificationChannel"];
@@ -1742,6 +1745,11 @@ export interface components {
             locked: boolean;
             /** Destination */
             destination?: string | null;
+            /**
+             * Setup Required
+             * @default false
+             */
+            setup_required: boolean;
         };
         /**
          * NotificationChannelUpdate

--- a/web-client/src/components/notifications/notification-preferences-page.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page.tsx
@@ -3,6 +3,7 @@ import {
   useNotificationTaxonomy,
   useUpdateNotificationPreferences,
 } from '@/api/notifications'
+import { useSession } from '@/api/session'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { PreferencesView } from './notification-preferences-page/preferences-view'
 
@@ -11,6 +12,7 @@ import { PreferencesView } from './notification-preferences-page/preferences-vie
 export function NotificationPreferencesPage() {
   const preferences = useNotificationPreferences()
   const taxonomy = useNotificationTaxonomy()
+  const session = useSession()
   const update = useUpdateNotificationPreferences()
 
   if (preferences.isPending || taxonomy.isPending) {
@@ -36,6 +38,7 @@ export function NotificationPreferencesPage() {
     <PreferencesView
       preferences={preferences.data}
       taxonomy={taxonomy.data}
+      pendingEmail={session.data?.data.user.pending_email ?? null}
       onToggleChannel={(channel, enabled) =>
         update.mutate({ channels: [{ channel, enabled }], cells: [] })
       }

--- a/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge-content.ts
+++ b/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge-content.ts
@@ -1,0 +1,26 @@
+import { Mail, Smartphone } from 'lucide-react'
+import type { NotificationChannel } from '@/api/notifications'
+import type { ChannelSetupNudgeProps } from './channel-setup-nudge'
+
+/** Per-channel nudge copy + deep-link target, keyed by channel. Only the
+ * channels a user can fail to set up appear here; the preferences view looks a
+ * channel up and renders the nudge when the server marks it `setup_required`.
+ *
+ * Both CTAs deep-link into the settings page rather than re-implementing the
+ * work: `sec-email` is the captcha-protected add-email form (which auto-focuses
+ * on the deep link), and `sec-notifications` carries the iOS install + allow
+ * instructions and the test-push button. */
+export const CHANNEL_SETUP_NUDGE: Partial<
+  Record<NotificationChannel, ChannelSetupNudgeProps>
+> = {
+  email: {
+    title: 'Add your email to get match results in your inbox.',
+    body: "We'll send a sign-in link to confirm it. No marketing — ever.",
+    cta: { label: 'Add email', hash: 'sec-email', Icon: Mail },
+  },
+  push: {
+    title: 'Turn on push to get pinged the second your match is called.',
+    body: 'Install the FortyMM app and allow notifications to start receiving pushes.',
+    cta: { label: 'Set up push', hash: 'sec-notifications', Icon: Smartphone },
+  },
+}

--- a/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge-content.ts
+++ b/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge-content.ts
@@ -2,25 +2,45 @@ import { Mail, Smartphone } from 'lucide-react'
 import type { NotificationChannel } from '@/api/notifications'
 import type { ChannelSetupNudgeProps } from './channel-setup-nudge'
 
-/** Per-channel nudge copy + deep-link target, keyed by channel. Only the
- * channels a user can fail to set up appear here; the preferences view looks a
- * channel up and renders the nudge when the server marks it `setup_required`.
- *
- * Both CTAs deep-link into the settings page rather than re-implementing the
- * work: `sec-email` is the captcha-protected add-email form (which auto-focuses
- * on the deep link), and `sec-notifications` carries the iOS install + allow
- * instructions and the test-push button. */
-export const CHANNEL_SETUP_NUDGE: Partial<
-  Record<NotificationChannel, ChannelSetupNudgeProps>
-> = {
-  email: {
-    title: 'Add your email to get match results in your inbox.',
-    body: "We'll send a sign-in link to confirm it. No marketing — ever.",
-    cta: { label: 'Add email', hash: 'sec-email', Icon: Mail },
-  },
-  push: {
-    title: 'Turn on push to get pinged the second your match is called.',
-    body: 'Install the FortyMM app and allow notifications to start receiving pushes.',
-    cta: { label: 'Set up push', hash: 'sec-notifications', Icon: Smartphone },
-  },
+/** Per-channel nudge copy + deep-link target. Both CTAs deep-link into the
+ * settings page rather than re-implementing the work: `sec-email` is the
+ * captcha-protected add-email form (which auto-focuses on the deep link), and
+ * `sec-notifications` carries the iOS install + allow instructions and the
+ * test-push button. */
+
+const PUSH_SETUP_NUDGE: ChannelSetupNudgeProps = {
+  title: 'Turn on push to get pinged the second your match is called.',
+  body: 'Install the FortyMM app and allow notifications to start receiving pushes.',
+  cta: { label: 'Set up push', hash: 'sec-notifications', Icon: Smartphone },
+}
+
+const EMAIL_ADD_NUDGE: ChannelSetupNudgeProps = {
+  title: 'Add your email to get match results in your inbox.',
+  body: "We'll send a sign-in link to confirm it. No marketing — ever.",
+  cta: { label: 'Add email', hash: 'sec-email', Icon: Mail },
+}
+
+/** When an address is on file but not yet confirmed, the channel still can't
+ * deliver — but "add an email" is wrong (they already did). Acknowledge the
+ * pending address and point them at the confirm/resend controls. */
+function emailPendingNudge(address: string): ChannelSetupNudgeProps {
+  return {
+    title: 'Confirm your email to start getting results.',
+    body: `We sent a link to ${address}. Click it to finish — or resend it from settings.`,
+    cta: { label: 'Manage email', hash: 'sec-email', Icon: Mail },
+  }
+}
+
+/** The setup nudge to show under a channel card, or `undefined` if the channel
+ * has no nudge. Email has two sub-states: no address (add) vs. an address
+ * awaiting confirmation (`pendingEmail`). In-app and SMS never nudge. */
+export function channelSetupNudge(
+  channel: NotificationChannel,
+  pendingEmail: string | null,
+): ChannelSetupNudgeProps | undefined {
+  if (channel === 'push') return PUSH_SETUP_NUDGE
+  if (channel === 'email') {
+    return pendingEmail ? emailPendingNudge(pendingEmail) : EMAIL_ADD_NUDGE
+  }
+  return undefined
 }

--- a/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge.factory.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge.factory.tsx
@@ -1,0 +1,10 @@
+import type { ChannelSetupNudgeProps } from './channel-setup-nudge'
+import { CHANNEL_SETUP_NUDGE } from './channel-setup-nudge-content'
+
+/** Default scenario: the real email setup nudge (no confirmed address on file),
+ * sourced from the production content map so the fixture can't drift from it. */
+export function buildChannelSetupNudgeProps(
+  overrides: Partial<ChannelSetupNudgeProps> = {},
+): ChannelSetupNudgeProps {
+  return { ...CHANNEL_SETUP_NUDGE.email!, ...overrides }
+}

--- a/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge.factory.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge.factory.tsx
@@ -1,10 +1,10 @@
 import type { ChannelSetupNudgeProps } from './channel-setup-nudge'
-import { CHANNEL_SETUP_NUDGE } from './channel-setup-nudge-content'
+import { channelSetupNudge } from './channel-setup-nudge-content'
 
-/** Default scenario: the real email setup nudge (no confirmed address on file),
- * sourced from the production content map so the fixture can't drift from it. */
+/** Default scenario: the real "add an email" nudge (no address on file),
+ * sourced from the production resolver so the fixture can't drift from it. */
 export function buildChannelSetupNudgeProps(
   overrides: Partial<ChannelSetupNudgeProps> = {},
 ): ChannelSetupNudgeProps {
-  return { ...CHANNEL_SETUP_NUDGE.email!, ...overrides }
+  return { ...channelSetupNudge('email', null)!, ...overrides }
 }

--- a/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge.page.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge.page.tsx
@@ -1,0 +1,73 @@
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+
+import { render, screen, type Container } from '@/test/utilities'
+
+import {
+  ChannelSetupNudge,
+  type ChannelSetupNudgeProps,
+} from './channel-setup-nudge'
+import { buildChannelSetupNudgeProps } from './channel-setup-nudge.factory'
+
+const scoped = (container: Container) => ({
+  /** The nudge container (a status-role Alert). */
+  get() {
+    return container.getByRole('status')
+  },
+  query() {
+    return container.queryByRole('status')
+  },
+  /** The call-to-action link, by its label. */
+  cta(label: string) {
+    return container.getByRole('link', { name: label })
+  },
+  queryText(text: string) {
+    return container.queryByText(text)
+  },
+})
+
+/**
+ * Test page-object for `ChannelSetupNudge`. It renders a typed
+ * `<Link to="/settings">`, so `render` mounts it under a minimal memory router
+ * that registers that route; the router resolves on first paint, so tests start
+ * with `await channelSetupNudgePage.find...()`.
+ */
+export const channelSetupNudgePage = {
+  render(overrides: Partial<ChannelSetupNudgeProps> = {}) {
+    const props = buildChannelSetupNudgeProps(overrides)
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => <ChannelSetupNudge {...props} />,
+    })
+    // The settings route the CTA deep-links to — registered so the typed
+    // <Link to="/settings"> resolves at render time.
+    const settingsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/settings',
+      component: () => <div>settings</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, settingsRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+    render(<RouterProvider router={router} />)
+  },
+
+  /** Async-first accessor — the router resolves the tree on first paint. */
+  findCta(label: string) {
+    return screen.findByRole('link', { name: label })
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge.test.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge.test.tsx
@@ -1,0 +1,35 @@
+import { Smartphone } from 'lucide-react'
+import { channelSetupNudgePage } from './channel-setup-nudge.page'
+
+describe('ChannelSetupNudge', () => {
+  it('renders the title and supporting body', async () => {
+    channelSetupNudgePage.render()
+    await channelSetupNudgePage.findCta('Add email')
+    expect(
+      channelSetupNudgePage.queryText(
+        'Add your email to get match results in your inbox.',
+      ),
+    ).toBeInTheDocument()
+    expect(
+      channelSetupNudgePage.queryText(
+        "We'll send a sign-in link to confirm it. No marketing — ever.",
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('deep-links the CTA to the matching settings section', async () => {
+    channelSetupNudgePage.render()
+    const cta = await channelSetupNudgePage.findCta('Add email')
+    expect(cta).toHaveAttribute('href', '/settings#sec-email')
+  })
+
+  it('renders the push variant with its own copy and target', async () => {
+    channelSetupNudgePage.render({
+      title: 'Turn on push to get pinged the second your match is called.',
+      body: 'Install the FortyMM app and allow notifications to start receiving pushes.',
+      cta: { label: 'Set up push', hash: 'sec-notifications', Icon: Smartphone },
+    })
+    const cta = await channelSetupNudgePage.findCta('Set up push')
+    expect(cta).toHaveAttribute('href', '/settings#sec-notifications')
+  })
+})

--- a/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/channel-setup-nudge.tsx
@@ -1,0 +1,49 @@
+import { Link } from '@tanstack/react-router'
+import type { LucideIcon } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+
+export interface ChannelSetupNudgeProps {
+  /** The payoff headline for finishing setup. */
+  title: string
+  /** One-line supporting detail under the headline. */
+  body: string
+  /** The call-to-action. It deep-links to the settings section that does the
+   * real work (the captcha-protected email form, or the push instructions) —
+   * we don't duplicate either flow here. */
+  cta: {
+    label: string
+    /** Settings-page section anchor, e.g. `sec-email`. The settings route
+     * honours `/settings#sec-*` deep links (and focuses the email field). */
+    hash: string
+    Icon: LucideIcon
+  }
+}
+
+/** An inline prompt under a channel "sign-up" card, shown when the channel is
+ * available but the user hasn't finished setting it up (no confirmed email; no
+ * registered push devices). Built on the design-system Alert — it's a status
+ * nudge, not a content panel — and tinted with the ball accent so it reads as
+ * an opportunity rather than an error. */
+export function ChannelSetupNudge({ title, body, cta }: ChannelSetupNudgeProps) {
+  const { Icon } = cta
+  return (
+    <Alert
+      role="status"
+      className="mt-3 border-[color:var(--ball-500)]/28 bg-[color:var(--ball-500)]/8"
+    >
+      <AlertTitle className="text-[13.5px] font-semibold text-[color:var(--ball-200)]">
+        {title}
+      </AlertTitle>
+      <AlertDescription className="text-[13px] text-[color:var(--fg-3)]">
+        {body}
+      </AlertDescription>
+      <Button asChild size="sm" className="mt-3 w-fit">
+        <Link to="/settings" hash={cta.hash}>
+          <Icon />
+          {cta.label}
+        </Link>
+      </Button>
+    </Alert>
+  )
+}

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.factory.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.factory.tsx
@@ -12,6 +12,7 @@ export function buildPreferencesViewProps(
   return {
     preferences: notificationPreferences(),
     taxonomy: notificationTaxonomy(),
+    pendingEmail: null,
     onToggleChannel: () => {},
     onToggleCell: () => {},
     ...overrides,

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.page.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.page.tsx
@@ -1,3 +1,10 @@
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
 import userEvent from '@testing-library/user-event'
 import { render, screen, type Container } from '@/test/utilities'
 import { PreferencesView, type PreferencesViewProps } from './preferences-view'
@@ -17,6 +24,13 @@ const scoped = (container: Container) => ({
       name: `${categoryLabel} via ${channelLabel}`,
     })
   },
+  /** A channel setup-nudge CTA link, by its label (e.g. "Add email"). */
+  nudgeCta(label: string) {
+    return container.getByRole('link', { name: label })
+  },
+  queryNudgeCta(label: string) {
+    return container.queryByRole('link', { name: label })
+  },
   queryText(text: string) {
     return container.queryByText(text)
   },
@@ -24,7 +38,31 @@ const scoped = (container: Container) => ({
 
 export const preferencesViewPage = {
   render(overrides: Partial<PreferencesViewProps> = {}) {
-    render(<PreferencesView {...buildPreferencesViewProps(overrides)} />)
+    const props = buildPreferencesViewProps(overrides)
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => <PreferencesView {...props} />,
+    })
+    // The settings route the setup nudges deep-link to — registered so the
+    // typed <Link to="/settings"> resolves at render time.
+    const settingsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/settings',
+      component: () => <div>settings</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, settingsRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+    render(<RouterProvider router={router} />)
+  },
+
+  /** Async-first accessor — the router resolves the tree on first paint, so
+   * tests await this before reading the synchronous accessors. */
+  findHeading() {
+    return screen.findByRole('heading', { name: 'NOTIFICATIONS' })
   },
 
   within(container: Container = screen) {

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.test.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.test.tsx
@@ -95,6 +95,25 @@ describe('PreferencesView', () => {
     expect(cta).toHaveAttribute('href', '/settings#sec-notifications')
   })
 
+  it('shows no nudge for an unavailable channel even if setup is required', async () => {
+    const base = notificationPreferences()
+    // A channel the server can't deliver on (available: false) shouldn't nudge —
+    // there's nothing the user can do — even if setup_required slips through.
+    const unavailable = {
+      ...base,
+      channels: base.channels.map((c) =>
+        c.channel === 'push'
+          ? { ...c, available: false, setup_required: true }
+          : c,
+      ),
+    }
+    preferencesViewPage.render({ preferences: unavailable })
+    await preferencesViewPage.findHeading()
+    expect(
+      preferencesViewPage.queryNudgeCta('Set up push'),
+    ).not.toBeInTheDocument()
+  })
+
   it('shows no setup nudge for a fully configured account', async () => {
     preferencesViewPage.render()
     await preferencesViewPage.findHeading()

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.test.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.test.tsx
@@ -1,41 +1,58 @@
+import type { NotificationChannel } from '@/api/notifications'
 import { notificationPreferences } from '@/test/factories'
 import { preferencesViewPage } from './preferences-view.page'
 
+/** Flip one channel's `setup_required` to surface (or clear) its nudge. */
+function withSetupRequired(channel: NotificationChannel, value: boolean) {
+  const base = notificationPreferences()
+  return {
+    ...base,
+    channels: base.channels.map((c) =>
+      c.channel === channel ? { ...c, setup_required: value } : c,
+    ),
+  }
+}
+
 describe('PreferencesView', () => {
-  it('renders the settings heading', () => {
+  it('renders the settings heading', async () => {
     preferencesViewPage.render()
-    expect(preferencesViewPage.getHeading()).toBeInTheDocument()
+    expect(await preferencesViewPage.findHeading()).toBeInTheDocument()
   })
 
-  it('locks the in-app channel on', () => {
+  it('locks the in-app channel on', async () => {
     preferencesViewPage.render()
+    await preferencesViewPage.findHeading()
     const inApp = preferencesViewPage.channelSwitch('In-app')
     expect(inApp).toBeChecked()
     expect(inApp).toBeDisabled()
   })
 
-  it('disables the unavailable SMS channel', () => {
+  it('disables the unavailable SMS channel', async () => {
     preferencesViewPage.render()
+    await preferencesViewPage.findHeading()
     const sms = preferencesViewPage.channelSwitch('SMS')
     expect(sms).not.toBeChecked()
     expect(sms).toBeDisabled()
   })
 
-  it('shows each channel destination', () => {
+  it('shows each channel destination', async () => {
     preferencesViewPage.render()
+    await preferencesViewPage.findHeading()
     expect(preferencesViewPage.queryText('you@fortymm.club')).toBeInTheDocument()
   })
 
   it('toggles a channel master', async () => {
     const onToggleChannel = vi.fn()
     preferencesViewPage.render({ onToggleChannel })
+    await preferencesViewPage.findHeading()
     // Push starts on, so a click turns it off.
     await preferencesViewPage.toggleChannel('Push')
     expect(onToggleChannel).toHaveBeenCalledWith('push', false)
   })
 
-  it('locks the match-reminder in-app cell on', () => {
+  it('locks the match-reminder in-app cell on', async () => {
     preferencesViewPage.render()
+    await preferencesViewPage.findHeading()
     const cell = preferencesViewPage.cell('Match reminders', 'In-app')
     expect(cell).toBeChecked()
     expect(cell).toBeDisabled()
@@ -44,12 +61,13 @@ describe('PreferencesView', () => {
   it('toggles a matrix cell', async () => {
     const onToggleCell = vi.fn()
     preferencesViewPage.render({ onToggleCell })
+    await preferencesViewPage.findHeading()
     // Rating-change email starts on; clicking mutes it.
     await preferencesViewPage.toggleCell('Rating changes', 'Email')
     expect(onToggleCell).toHaveBeenCalledWith('rating_change', 'email', false)
   })
 
-  it('greys out a column whose channel master is off', () => {
+  it('greys out a column whose channel master is off', async () => {
     const base = notificationPreferences()
     const pushOff = {
       ...base,
@@ -58,7 +76,31 @@ describe('PreferencesView', () => {
       ),
     }
     preferencesViewPage.render({ preferences: pushOff })
+    await preferencesViewPage.findHeading()
     // The cell keeps its own checked state but can't be toggled while muted.
     expect(preferencesViewPage.cell('Rating changes', 'Push')).toBeDisabled()
+  })
+
+  it('nudges to add an email when the email channel needs setup', async () => {
+    preferencesViewPage.render({ preferences: withSetupRequired('email', true) })
+    await preferencesViewPage.findHeading()
+    const cta = preferencesViewPage.nudgeCta('Add email')
+    expect(cta).toHaveAttribute('href', '/settings#sec-email')
+  })
+
+  it('nudges to set up push when no devices are registered', async () => {
+    preferencesViewPage.render({ preferences: withSetupRequired('push', true) })
+    await preferencesViewPage.findHeading()
+    const cta = preferencesViewPage.nudgeCta('Set up push')
+    expect(cta).toHaveAttribute('href', '/settings#sec-notifications')
+  })
+
+  it('shows no setup nudge for a fully configured account', async () => {
+    preferencesViewPage.render()
+    await preferencesViewPage.findHeading()
+    expect(preferencesViewPage.queryNudgeCta('Add email')).not.toBeInTheDocument()
+    expect(
+      preferencesViewPage.queryNudgeCta('Set up push'),
+    ).not.toBeInTheDocument()
   })
 })

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.test.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.test.tsx
@@ -88,6 +88,24 @@ describe('PreferencesView', () => {
     expect(cta).toHaveAttribute('href', '/settings#sec-email')
   })
 
+  it('switches to a confirm-email nudge when an address is pending', async () => {
+    preferencesViewPage.render({
+      preferences: withSetupRequired('email', true),
+      pendingEmail: 'quinn@example.com',
+    })
+    await preferencesViewPage.findHeading()
+    // The pending variant replaces "Add email" and the card subtitle reflects
+    // the unconfirmed address instead of "Add an email in settings".
+    expect(preferencesViewPage.nudgeCta('Manage email')).toHaveAttribute(
+      'href',
+      '/settings#sec-email',
+    )
+    expect(preferencesViewPage.queryNudgeCta('Add email')).not.toBeInTheDocument()
+    expect(
+      preferencesViewPage.queryText('Pending — check your inbox'),
+    ).toBeInTheDocument()
+  })
+
   it('nudges to set up push when no devices are registered', async () => {
     preferencesViewPage.render({ preferences: withSetupRequired('push', true) })
     await preferencesViewPage.findHeading()

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
@@ -52,9 +52,10 @@ export function PreferencesView({
           const { Icon } = CHANNEL_VISUAL[channel.channel]
           const label = channelLabel.get(channel.channel) ?? channel.channel
           const interactive = !channel.locked && channel.available
-          const nudge = channel.setup_required
-            ? CHANNEL_SETUP_NUDGE[channel.channel]
-            : undefined
+          const nudge =
+            channel.available && channel.setup_required
+              ? CHANNEL_SETUP_NUDGE[channel.channel]
+              : undefined
           return (
             <div key={channel.channel} className="min-w-0">
               <div

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
@@ -8,12 +8,15 @@ import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 import { CATEGORY_VISUAL, CHANNEL_VISUAL } from '../notification-meta'
 import { ChannelSetupNudge } from './channel-setup-nudge'
-import { CHANNEL_SETUP_NUDGE } from './channel-setup-nudge-content'
+import { channelSetupNudge } from './channel-setup-nudge-content'
 
 export interface PreferencesViewProps {
   preferences: NotificationPreferences
   /** Server-owned display labels for categories + channels. */
   taxonomy: NotificationTaxonomy
+  /** The address awaiting confirmation, if any (from the session). Switches the
+   * email card + nudge from "add an email" to "confirm your email". */
+  pendingEmail?: string | null
   onToggleChannel: (channel: NotificationChannel, enabled: boolean) => void
   onToggleCell: (
     category: NotificationPreferences['categories'][number]['category'],
@@ -27,6 +30,7 @@ export interface PreferencesViewProps {
 export function PreferencesView({
   preferences,
   taxonomy,
+  pendingEmail = null,
   onToggleChannel,
   onToggleCell,
 }: PreferencesViewProps) {
@@ -54,8 +58,15 @@ export function PreferencesView({
           const interactive = !channel.locked && channel.available
           const nudge =
             channel.available && channel.setup_required
-              ? CHANNEL_SETUP_NUDGE[channel.channel]
+              ? channelSetupNudge(channel.channel, pendingEmail)
               : undefined
+          // The server's email destination ("Add an email in settings") is
+          // wrong once an address is on file but unconfirmed — reflect the
+          // pending state instead.
+          const destination =
+            channel.channel === 'email' && pendingEmail
+              ? 'Pending — check your inbox'
+              : channel.destination
           return (
             <div key={channel.channel} className="min-w-0">
               <div
@@ -82,7 +93,7 @@ export function PreferencesView({
                     {label}
                   </span>
                   <span className="block truncate text-xs text-[color:var(--fg-3)]">
-                    {channel.destination}
+                    {destination}
                   </span>
                 </span>
                 <Switch

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
@@ -7,6 +7,8 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 import { CATEGORY_VISUAL, CHANNEL_VISUAL } from '../notification-meta'
+import { ChannelSetupNudge } from './channel-setup-nudge'
+import { CHANNEL_SETUP_NUDGE } from './channel-setup-nudge-content'
 
 export interface PreferencesViewProps {
   preferences: NotificationPreferences
@@ -50,45 +52,48 @@ export function PreferencesView({
           const { Icon } = CHANNEL_VISUAL[channel.channel]
           const label = channelLabel.get(channel.channel) ?? channel.channel
           const interactive = !channel.locked && channel.available
+          const nudge = channel.setup_required
+            ? CHANNEL_SETUP_NUDGE[channel.channel]
+            : undefined
           return (
-            <div
-              key={channel.channel}
-              className={cn(
-                'flex items-center gap-3 rounded-xl border bg-[color:var(--bg-card)] p-4 transition-opacity',
-                channel.enabled
-                  ? 'border-[color:var(--border-default)]'
-                  : 'border-[color:var(--border-subtle)] opacity-70',
-              )}
-            >
-              <span
-                className="flex size-9 shrink-0 items-center justify-center rounded-[10px]"
-                style={{
-                  background: channel.enabled
-                    ? 'rgba(255,122,26,0.12)'
-                    : 'var(--bg-raised)',
-                  color: channel.enabled
-                    ? 'var(--ball-500)'
-                    : 'var(--fg-3)',
-                }}
+            <div key={channel.channel} className="min-w-0">
+              <div
+                className={cn(
+                  'flex items-center gap-3 rounded-xl border bg-[color:var(--bg-card)] p-4 transition-opacity',
+                  channel.enabled
+                    ? 'border-[color:var(--border-default)]'
+                    : 'border-[color:var(--border-subtle)] opacity-70',
+                )}
               >
-                <Icon size={20} />
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="block text-[15px] font-semibold text-[color:var(--fg-1)]">
-                  {label}
+                <span
+                  className="flex size-9 shrink-0 items-center justify-center rounded-[10px]"
+                  style={{
+                    background: channel.enabled
+                      ? 'rgba(255,122,26,0.12)'
+                      : 'var(--bg-raised)',
+                    color: channel.enabled ? 'var(--ball-500)' : 'var(--fg-3)',
+                  }}
+                >
+                  <Icon size={20} />
                 </span>
-                <span className="block truncate text-xs text-[color:var(--fg-3)]">
-                  {channel.destination}
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[15px] font-semibold text-[color:var(--fg-1)]">
+                    {label}
+                  </span>
+                  <span className="block truncate text-xs text-[color:var(--fg-3)]">
+                    {channel.destination}
+                  </span>
                 </span>
-              </span>
-              <Switch
-                checked={channel.enabled}
-                disabled={!interactive}
-                onCheckedChange={(value) =>
-                  onToggleChannel(channel.channel, value === true)
-                }
-                aria-label={`${label} notifications`}
-              />
+                <Switch
+                  checked={channel.enabled}
+                  disabled={!interactive}
+                  onCheckedChange={(value) =>
+                    onToggleChannel(channel.channel, value === true)
+                  }
+                  aria-label={`${label} notifications`}
+                />
+              </div>
+              {nudge && <ChannelSetupNudge {...nudge} />}
             </div>
           )
         })}

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -437,6 +437,10 @@ function notifChannelState(
     available,
     locked,
     destination: notifChannelDestination(channel),
+    // The default scenario is a fully set-up account (email confirmed, a push
+    // device registered), matching the configured destinations above. The
+    // nudge tests flip this per channel.
+    setup_required: false,
   }
 }
 


### PR DESCRIPTION
## What

The notification preferences page (`/notifications/settings`) now nudges the user to finish setting up a delivery channel they haven't configured:

- **Email** — shown when there's no confirmed address on file.
- **Push** — shown when no devices are registered.

Both render as a ball-accent `Alert` directly under the relevant channel card, with a CTA that deep-links to the canonical settings section.

## How

**Server (BFF pattern).** `NotificationChannelState` gains a structured `setup_required: bool`, computed per-channel and current-user-aware in `NotificationService` (email → no confirmed address; push → zero devices; in-app/SMS → never). The client keys off this real state instead of matching display strings.

**Client.** A new presentational `ChannelSetupNudge` (built on the design-system `Alert`, mirroring `GuestPersistBanner`) is rendered conditionally in `PreferencesView` via a `CHANNEL_SETUP_NUDGE` content map. The CTAs deep-link to existing canonical flows rather than duplicating them:
- `Add email` → `/settings#sec-email` (the captcha-protected add-email form, which auto-focuses on deep-link)
- `Set up push` → `/settings#sec-notifications` (the iOS install + allow-notifications instructions)

### Deliberate deviations from the mockup
- The mockup's email nudge had an inline input; the real add-email flow is CAPTCHA-protected and already lives at `/settings#sec-email`, so the nudge links there instead of maintaining a second captcha form.
- The mockup's push nudge had "Install app / Allow notifications" buttons; there's no web-push or PWA-install handler in this client (push is iOS-only/APNs), so a single "Set up push" CTA points at the settings section that carries the real instructions — honest over non-functional buttons.

## Testing
- API: `ruff` + `ruff format --check` + `mypy --strict` clean; `pytest` **479 passed** (added `setup_required` coverage incl. unconfirmed-email).
- Web: `tsc -b` + `eslint` clean; `vitest` **884 passed** (3 new nudge tests + full component quartet); `vite build` ✓; Playwright e2e **127 passed**.
- OpenAPI: `schema.d.ts` regenerated, no drift.
- Not run: root docker-compose e2e (not applicable to this surface), iOS (no `ios/**` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)