### PR TITLE
Cap dashboard attention rows; return exact actionable total (#216)

### DIFF
--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Literal
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -25,6 +25,7 @@ from app.models import (
     Match,
     MatchSide,
     MatchSidePlayer,
+    MatchSignature,
     MatchStatus,
     RatingHistory,
     User,
@@ -48,6 +49,21 @@ RECENT_RESULTS_LIMIT = 5
 SPARK_WINDOW_DAYS = 30
 SPARK_MAX_POINTS = 30
 STREAK_SCAN_LIMIT = 100
+# Most actionable attention rows we eager-load (and return) at once. A
+# tournament player can sit on dozens of simultaneous open matches (variant D:
+# back-to-back round-robin play), but the panel only renders a few rows and
+# rolls the rest into a "+N more" count — so loading every open match (each
+# fully eager-loaded: sides, players, games, scores) would cost O(matches ×
+# games) for no UX benefit. We cap the eager-load here and derive the exact
+# overflow/waiting totals from cheap COUNT(*) aggregates instead (#216).
+ATTENTION_BANNERS_LIMIT = 10
+# The open statuses an attention row can hold — the only ones where the user
+# still owes (or is owed) a move. Bounds the count scan to a handful of rows.
+_OPEN_STATUSES = (
+    MatchStatus.pending,
+    MatchStatus.in_progress,
+    MatchStatus.disputed,
+)
 
 
 @router.get("/dashboard", response_model=DashboardResponse)
@@ -55,22 +71,38 @@ async def get_dashboard(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> DashboardResponse:
-    # Open matches the user participates in are pulled in full (signatures + sides
-    # are needed to classify each into an attention bucket); completed matches
-    # feed the recent-results table. The attention panel is bounded by the user's
-    # *open* matches — a handful even for an active player — so loading them all
-    # and ranking in Python is safe.
+    # Actionable open matches the user participates in are pulled in full
+    # (signatures + sides are needed to classify each into an attention bucket
+    # and to deep-link a "score" row); completed matches feed the recent-results
+    # table. The eager-loaded set is capped at ATTENTION_BANNERS_LIMIT — the
+    # panel only renders a few rows, and the exact total/waiting counts come from
+    # the cheap aggregates below — so an active tournament player doesn't pay to
+    # load every open match (#216).
+    #
+    # An in_progress match the current user has *already signed* is "waiting on
+    # the opponent": it's never an attention row, only a waiting count, so we
+    # exclude it from the eager load entirely rather than load-then-discard it.
+    my_signature_exists = (
+        select(MatchSignature.id)
+        .where(
+            MatchSignature.match_id == Match.id,
+            MatchSignature.user_id == current_user.id,
+        )
+        .exists()
+    )
     in_progress_q = (
         participant_filter(select(Match), current_user.id)
-        .where(Match.status == MatchStatus.in_progress)
+        .where(Match.status == MatchStatus.in_progress, ~my_signature_exists)
         .options(*match_eager_options())
         .order_by(Match.updated_at.asc())
+        .limit(ATTENTION_BANNERS_LIMIT)
     )
     disputed_q = (
         participant_filter(select(Match), current_user.id)
         .where(Match.status == MatchStatus.disputed)
         .options(*match_eager_options())
         .order_by(Match.updated_at.asc())
+        .limit(ATTENTION_BANNERS_LIMIT)
     )
     completed_q = (
         participant_filter(select(Match), current_user.id)
@@ -79,16 +111,46 @@ async def get_dashboard(
         .order_by(Match.updated_at.desc())
         .limit(RECENT_RESULTS_LIMIT)
     )
-    # Pending/scheduled matches are always "waiting on others" (O3 default), so
-    # we only need their count, not their rows.
-    pending_count_q = participant_filter(
-        select(func.count(Match.id)), current_user.id
-    ).where(Match.status == MatchStatus.pending)
+    # Exact attention totals, independent of the eager-load cap above so the
+    # footer's "+N more" / "waiting on others" stay accurate past it. This split
+    # mirrors ``app.attention.list_attention_kind`` in SQL (COUNT can't run the
+    # Python classifier): actionable rows are every ``dispute`` plus every
+    # ``score``/``review`` (in_progress the user hasn't signed); the passive
+    # ``waiting_opponent`` (in_progress the user *has* signed) and
+    # ``waiting_others`` (pending/scheduled) fold into waiting. If that
+    # classifier's status routing ever changes, these filters must follow. Both
+    # counts ride one open-status scan (a handful of rows even for an active
+    # player) via FILTER, so the dashboard pays a single extra round-trip.
+    attention_counts_q = participant_filter(
+        select(
+            func.count(Match.id).filter(
+                or_(
+                    Match.status == MatchStatus.disputed,
+                    and_(
+                        Match.status == MatchStatus.in_progress,
+                        ~my_signature_exists,
+                    ),
+                )
+            ),
+            func.count(Match.id).filter(
+                or_(
+                    Match.status == MatchStatus.pending,
+                    and_(
+                        Match.status == MatchStatus.in_progress,
+                        my_signature_exists,
+                    ),
+                )
+            ),
+        ),
+        current_user.id,
+    ).where(Match.status.in_(_OPEN_STATUSES))
 
     in_progress = (await db.execute(in_progress_q)).scalars().all()
     disputed = (await db.execute(disputed_q)).scalars().all()
     completed = (await db.execute(completed_q)).scalars().all()
-    pending_count = int((await db.execute(pending_count_q)).scalar_one())
+    attention_total, waiting = (await db.execute(attention_counts_q)).one()
+    attention_total_count = int(attention_total)
+    waiting_count = int(waiting)
 
     # When completed_q didn't hit its LIMIT, we already have the exact count
     # and can skip the extra round-trip; only the user-with-history case pays
@@ -105,9 +167,7 @@ async def get_dashboard(
         db, current_user.id, [m.id for m in completed]
     )
 
-    attention, waiting_count = _build_attention(
-        in_progress, disputed, pending_count, current_user.id
-    )
+    attention = _build_attention(in_progress, disputed, current_user.id)
     recent_results = [
         _build_recent_result(match, current_user.id, rating_changes.get(match.id))
         for match in completed
@@ -116,6 +176,7 @@ async def get_dashboard(
 
     return DashboardResponse(
         attention=attention,
+        attention_total_count=attention_total_count,
         waiting_count=waiting_count,
         recent_results=recent_results,
         rating=rating,
@@ -152,36 +213,28 @@ async def _load_my_rating_changes(
 def _build_attention(
     in_progress: Sequence[Match],
     disputed: Sequence[Match],
-    pending_count: int,
     current_user_id: uuid.UUID,
-) -> tuple[list[DashboardAttentionItem], int]:
-    """Classify the user's open matches into priority-ranked attention rows plus
-    a count of matches waiting on someone else.
+) -> list[DashboardAttentionItem]:
+    """Rank the user's actionable open matches into priority-ordered attention
+    rows.
 
-    Current-user-aware: the poster and the reviewer of the same posted result
-    classify differently — the poster has signed, so the match is "waiting on
-    opponent" (footer) for them, while the reviewer hasn't signed and gets a
-    ``review`` row. Pending/scheduled matches (``pending_count``) and our own
-    posted-and-awaiting results are folded into ``waiting_count``; they never
-    render as rows. Classification + ranking come from the shared
-    ``app.attention`` module so this panel and the matches-list Attention filter
-    never disagree about who owes a move.
+    The caller pre-filters to actionable matches — disputed, plus in_progress
+    matches the user hasn't signed — and bounds the count, so passive "waiting"
+    matches (our posted-and-awaiting results, pending/scheduled) never reach
+    here; they feed ``waiting_count`` via a separate aggregate. Classification +
+    ranking come from the shared ``app.attention`` module so this panel and the
+    matches-list Attention filter never disagree about who owes a move.
     """
     # (priority, sort_ts, item) — sorted by priority then oldest-first so a
     # long-stalled match floats to the top of its bucket.
     ranked: list[tuple[int, datetime, DashboardAttentionItem]] = []
-    waiting = pending_count
 
     for match in (*disputed, *in_progress):
         kind = list_attention_kind(match, current_user_id)
-        # Passive "waiting" buckets are footer-only here; ``waiting_others``
-        # (pending) never reaches this loop — those matches are counted, not
-        # loaded — so only ``waiting_opponent`` (our posted-and-awaiting result)
-        # folds in.
-        if kind == "waiting_opponent" or kind == "waiting_others":
-            waiting += 1
-            continue
-        if kind is None:
+        # Only actionable kinds become rows. The caller filters out the passive
+        # "waiting" buckets, but we skip them (and the non-participant ``None``)
+        # defensively so a stray match can never produce a bogus row.
+        if kind is None or kind == "waiting_opponent" or kind == "waiting_others":
             continue
         # kind is now narrowed to AttentionKind (dispute / review / score).
         ranked.append(
@@ -193,7 +246,7 @@ def _build_attention(
         )
 
     ranked.sort(key=lambda row: (row[0], row[1]))
-    return [item for _, _, item in ranked], waiting
+    return [item for _, _, item in ranked]
 
 
 def _attention_item(

--- a/api/app/schemas/dashboard.py
+++ b/api/app/schemas/dashboard.py
@@ -80,10 +80,15 @@ class DashboardRating(BaseModel):
 
 
 class DashboardResponse(BaseModel):
-    # Every actionable match for the current user, pre-ranked by attention
-    # priority (§5 of the PRD). The FE renders the top 3 as rows and rolls the
-    # remainder into the footer's overflow count.
+    # The current user's most-urgent actionable matches, pre-ranked by attention
+    # priority (§5 of the PRD), capped server-side (``ATTENTION_BANNERS_LIMIT``)
+    # since the panel only renders the top few as rows. Not the full set — use
+    # ``attention_total_count`` for the true total and the footer overflow.
     attention: list[DashboardAttentionItem]
+    # Total actionable matches for the current user (disputes + in_progress the
+    # user hasn't signed), counted independently of the ``attention`` cap so the
+    # footer's "+N more need attention" stays accurate however many there are.
+    attention_total_count: int
     # Count of matches that need *someone else's* move (a result we posted
     # awaiting the opponent's sign-off, plus pending/scheduled matches). Shown
     # as footer text only — never a row.

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -45,6 +45,7 @@ async def test_dashboard_empty_when_user_has_no_matches(
     assert response.status_code == 200
     body = response.json()
     assert body["attention"] == []
+    assert body["attention_total_count"] == 0
     assert body["waiting_count"] == 0
     assert body["recent_results"] == []
     assert body["completed_match_count"] == 0
@@ -89,6 +90,7 @@ async def test_dashboard_returns_score_attention_for_in_progress_match(
     assert item["current_game_number"] == 2
     # Nothing is waiting on the opponent yet.
     assert body["waiting_count"] == 0
+    assert body["attention_total_count"] == 1
     assert body["recent_results"] == []
 
 
@@ -250,7 +252,28 @@ async def test_dashboard_my_posted_result_counts_as_waiting(
 
     body = (await api_client.get("/v1/dashboard")).json()
     assert body["attention"] == []
+    assert body["attention_total_count"] == 0
     assert body["waiting_count"] == 1
+
+
+async def test_dashboard_caps_attention_rows_but_counts_them_all(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A tournament player with more open matches than the banner cap gets the
+    most-urgent ATTENTION_BANNERS_LIMIT rows, while ``attention_total_count``
+    still reflects every actionable match so the footer's "+N more" is exact."""
+    from app.dashboard import ATTENTION_BANNERS_LIMIT
+
+    await start_session(api_client, db_session)
+    over_cap = ATTENTION_BANNERS_LIMIT + 2
+    for i in range(over_cap):
+        opp = await make_user(db_session, f"rival_{i}")
+        await _create_match(api_client, opp.id, best_of=5)
+
+    body = (await api_client.get("/v1/dashboard")).json()
+    assert len(body["attention"]) == ATTENTION_BANNERS_LIMIT
+    assert body["attention_total_count"] == over_cap
+    assert all(i["kind"] == "score" for i in body["attention"])
 
 
 async def test_dashboard_attention_priority_ranking(
@@ -299,6 +322,7 @@ async def test_dashboard_attention_priority_ranking(
         rated_score["id"],
         unrated_score["id"],
     ]
+    assert body["attention_total_count"] == 4
     assert body["waiting_count"] == 0
 
 

--- a/e2e/node_modules
+++ b/e2e/node_modules
@@ -1,0 +1,1 @@
+/Users/ryan/Development/fortymm/e2e/node_modules

--- a/e2e/node_modules
+++ b/e2e/node_modules
@@ -1,1 +1,0 @@
-/Users/ryan/Development/fortymm/e2e/node_modules

--- a/ios/Fortymm/Dashboard/DashboardAttentionPanel.swift
+++ b/ios/Fortymm/Dashboard/DashboardAttentionPanel.swift
@@ -86,10 +86,17 @@ private func target(_ item: DashboardAttentionItem) -> AttentionTarget {
 /// `Resolve dispute` renders secondary). Items arrive already sorted by the
 /// server, so their order is preserved as-is. Mirrors the web's
 /// `projectAttentionPanelView`.
+///
+/// `attentionTotalCount` is the server's exact actionable-match total. The
+/// `items` array is itself capped server-side, so overflow is derived from this
+/// total — not from `items.count`, which would under-count once the cap bites.
+/// Defaults to `items.count` for callers that pass an uncapped set.
 func projectAttentionPanel(
     items: [DashboardAttentionItem],
-    waitingCount: Int
+    waitingCount: Int,
+    attentionTotalCount: Int? = nil
 ) -> AttentionPanelView {
+    let total = attentionTotalCount ?? items.count
     let visible = Array(items.prefix(attentionVisibleLimit))
     let topBucket = visible.first.map(bucketKey) ?? ""
     return AttentionPanelView(
@@ -103,7 +110,7 @@ func projectAttentionPanel(
                 target: target(item)
             )
         },
-        overflowCount: max(0, items.count - attentionVisibleLimit),
+        overflowCount: max(0, total - attentionVisibleLimit),
         waitingCount: waitingCount
     )
 }

--- a/ios/Fortymm/Dashboard/DashboardModels.swift
+++ b/ios/Fortymm/Dashboard/DashboardModels.swift
@@ -5,10 +5,15 @@ import Foundation
 /// `.convertFromSnakeCase`, so `recent_results` / `spark_data` / `my_rating_change`
 /// arrive as `recentResults` / `sparkData` / `myRatingChange`.
 struct DashboardResponse: Decodable {
-    /// Every actionable match for the current user, pre-ranked server-side by
-    /// attention priority (see `api/app/dashboard.py`). The UI renders the top
-    /// few as rows and rolls the remainder into the footer's overflow count.
+    /// The current user's most-urgent actionable matches, pre-ranked server-side
+    /// by attention priority (see `api/app/dashboard.py`). Capped server-side, so
+    /// this is NOT the full set — the UI renders the top few as rows and uses
+    /// `attentionTotalCount` (not this array's length) for the footer overflow.
     let attention: [DashboardAttentionItem]
+    /// Total actionable matches for the current user, counted server-side
+    /// independently of the `attention` cap so the footer's "+N more" stays
+    /// accurate however many there are.
+    let attentionTotalCount: Int
     /// Matches that need *someone else's* move — a result we posted awaiting the
     /// opponent's sign-off, plus pending/scheduled matches. Footer text only;
     /// never a row.

--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -138,7 +138,8 @@ struct DashboardView: View {
             DashboardAttentionPanel(
                 view: projectAttentionPanel(
                     items: data.attention,
-                    waitingCount: data.waitingCount
+                    waitingCount: data.waitingCount,
+                    attentionTotalCount: data.attentionTotalCount
                 ),
                 onAct: { act(on: $0) },
                 onViewAll: { onViewAll?(currentUsername) }

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1216,6 +1216,8 @@ export interface components {
         DashboardResponse: {
             /** Attention */
             attention: components["schemas"]["DashboardAttentionItem"][];
+            /** Attention Total Count */
+            attention_total_count: number;
             /** Waiting Count */
             waiting_count: number;
             /** Recent Results */

--- a/web-client/src/components/dashboard/attention-panel-view.test.ts
+++ b/web-client/src/components/dashboard/attention-panel-view.test.ts
@@ -17,6 +17,20 @@ describe('projectAttentionPanelView', () => {
     expect(view.overflowCount).toBe(2)
   })
 
+  it('derives overflow from the server total, not the capped row list', () => {
+    // The server caps the returned rows (ATTENTION_BANNERS_LIMIT) but reports
+    // the true actionable total, so the footer "+N more" must subtract the
+    // visible 3 from that total — never from the truncated array length.
+    const items = Array.from({ length: 10 }, (_, i) =>
+      dashboardAttentionItem({ match_id: `m-${i}`, kind: 'score' }),
+    )
+
+    const view = projectAttentionPanelView(items, 0, 47)
+
+    expect(view.rows).toHaveLength(3)
+    expect(view.overflowCount).toBe(44)
+  })
+
   it('marks only the highest-priority visible bucket as primary', () => {
     const view = projectAttentionPanelView(
       [

--- a/web-client/src/components/dashboard/attention-panel-view.ts
+++ b/web-client/src/components/dashboard/attention-panel-view.ts
@@ -88,10 +88,17 @@ export function isAttentionPanelEmpty(view: AttentionPanelView): boolean {
  * highest-priority *visible* bucket as primary (so a `Review result` beneath a
  * `Resolve dispute` renders secondary). Items arrive already sorted by the
  * server (PRD §5), so their order is preserved as-is.
+ *
+ * `attentionTotalCount` is the server's exact actionable-match total. The
+ * `items` array is itself capped server-side (`ATTENTION_BANNERS_LIMIT`), so
+ * overflow is derived from this total — not from `items.length`, which would
+ * under-count once the cap bites. Defaults to `items.length` for callers that
+ * pass an uncapped set.
  */
 export function projectAttentionPanelView(
   items: DashboardAttentionItem[],
   waitingCount: number,
+  attentionTotalCount: number = items.length,
 ): AttentionPanelView {
   const visible = items.slice(0, ATTENTION_VISIBLE_LIMIT)
   // Items arrive pre-sorted by priority, so the first visible row defines the
@@ -108,7 +115,7 @@ export function projectAttentionPanelView(
       primary: bucketKey(item) === topBucket,
       route: routeOf(item),
     })),
-    overflowCount: Math.max(0, items.length - ATTENTION_VISIBLE_LIMIT),
+    overflowCount: Math.max(0, attentionTotalCount - ATTENTION_VISIBLE_LIMIT),
     waitingCount,
     viewAllSearch: { status: 'attention' },
   }

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -853,8 +853,12 @@ export function DashboardPage() {
   const showGuestPersistBanner = isGuest && (data?.completed_match_count ?? 0) >= 1
   const attentionView = useMemo(
     () =>
-      projectAttentionPanelView(data?.attention ?? [], data?.waiting_count ?? 0),
-    [data?.attention, data?.waiting_count],
+      projectAttentionPanelView(
+        data?.attention ?? [],
+        data?.waiting_count ?? 0,
+        data?.attention_total_count ?? 0,
+      ),
+    [data?.attention, data?.waiting_count, data?.attention_total_count],
   )
   return (
     <div

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -805,7 +805,8 @@ export const handlers = [
   // ----- dashboard -------------------------------------------------------
   http.get('*/v1/dashboard', async () => {
     await delay(300)
-    const { attention, waiting_count } = projectDashboardAttention(mockMatches)
+    const { attention, attention_total_count, waiting_count } =
+      projectDashboardAttention(mockMatches)
     // Match the real BFF's participant-filtered COUNT, which doesn't care
     // whether the opponent slot is registered — projectRecentResult drops
     // null-opponent matches from the *display* list, but they still count
@@ -820,6 +821,7 @@ export const handlers = [
       .slice(0, 5)
     return HttpResponse.json({
       attention,
+      attention_total_count,
       waiting_count,
       recent_results: recentResults,
       rating: projectRating(mockMatches),

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -565,10 +565,18 @@ export function isWaitingSeed(seed: SeedMatch): boolean {
   )
 }
 
+// Mirrors the BFF's `ATTENTION_BANNERS_LIMIT`: the panel only renders a few
+// rows, so the server caps the eager-loaded set and reports the true total
+// separately (see api/app/dashboard.py).
+const ATTENTION_BANNERS_LIMIT = 10
+
 /** Build the dashboard attention payload from all seeds, pre-ranked oldest-
- * first within each priority bucket — mirrors the BFF's `_build_attention`. */
+ * first within each priority bucket — mirrors the BFF's `_build_attention`.
+ * The row list is capped at `ATTENTION_BANNERS_LIMIT`; `attention_total_count`
+ * carries the full actionable total so the footer's "+N more" stays exact. */
 export function projectDashboardAttention(seeds: SeedMatch[]): {
   attention: DashboardAttentionItem[]
+  attention_total_count: number
   waiting_count: number
 } {
   const ranked = seeds
@@ -586,11 +594,13 @@ export function projectDashboardAttention(seeds: SeedMatch[]): {
         a.classified.priority - b.classified.priority ||
         a.seed.created_at.localeCompare(b.seed.created_at),
     )
+  const attention = ranked.flatMap((row) => {
+    const item = projectAttention(row.seed)
+    return item ? [item] : []
+  })
   return {
-    attention: ranked.flatMap((row) => {
-      const item = projectAttention(row.seed)
-      return item ? [item] : []
-    }),
+    attention: attention.slice(0, ATTENTION_BANNERS_LIMIT),
+    attention_total_count: attention.length,
     waiting_count: seeds.filter(isWaitingSeed).length,
   }
 }

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -307,8 +307,12 @@ export function dashboardResponse(
   overrides: Partial<DashboardResponse> = {},
 ): DashboardResponse {
   const recent_results = overrides.recent_results ?? []
+  const attention = overrides.attention ?? []
   return {
-    attention: [],
+    attention,
+    // Mirrors the returned rows by default (no server-side cap in play).
+    // Override to model a capped panel with extra "+N more" overflow.
+    attention_total_count: attention.length,
     waiting_count: 0,
     recent_results,
     rating: dashboardRating(),


### PR DESCRIPTION
Closes #216.

## Problem
PR #215 dropped `.limit(1)` from the dashboard BFF's `in_progress_q` so it could stack score banners, which left the query **unbounded**. Every open match is fully eager-loaded (sides, players, games, scores via `match_eager_options()`), so a tournament player with many simultaneous in-progress matches paid a cost growing as matches × games — for rows the panel never renders (it shows a few and rolls the rest into a "+N more" pill).

## Fix
- **Cap the eager-load** at `ATTENTION_BANNERS_LIMIT` (10) on the in_progress + disputed queries.
- **Stop loading already-signed (awaiting-opponent) in_progress matches** entirely — they're a waiting count, never an attention row, so there's no reason to eager-load then discard them.
- **Derive exact counts from one open-status `COUNT(*)` scan with `FILTER`** (the same `func.count().filter()` pattern used elsewhere in the API), mirroring `list_attention_kind`'s actionable-vs-waiting split in SQL. This keeps `waiting_count` and the new `attention_total_count` accurate past the cap. Net DB round-trips are unchanged vs. before.
- **New `attention_total_count` field** on `DashboardResponse`; the web panel now derives the footer overflow from it rather than the (now-capped) returned row count.

## Testing
- API: `ruff` + `ruff format --check` + `mypy` (strict, 77 files) + `pytest` → **479 passed** (added a cap test: 12 matches → 10 rows, `attention_total_count == 12`)
- Web: `lint` + `build` (tsc) + `vitest` → **879 passed** (added an overflow-from-total test); `schema.d.ts` regenerated (no drift)
- web-client Playwright e2e → **127 passed**
- root e2e (real compose stack, incl. both dashboard specs) → **4 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)