### PR TITLE
Gate /admin/broadcast client-side; surface recipient-search errors (#605)

### DIFF
--- a/web-client/src/components/notifications/broadcast-page.page.tsx
+++ b/web-client/src/components/notifications/broadcast-page.page.tsx
@@ -1,0 +1,36 @@
+import { http, HttpResponse } from 'msw'
+import { render, screen, type Container } from '@/test/utilities'
+import { server } from '@/mocks/server'
+import { sessionResponse } from '@/test/factories'
+import { BroadcastPage } from './broadcast-page'
+
+const scoped = (container: Container) => ({
+  /** The compose heading only renders once the tool is mounted. */
+  queryComposeHeading() {
+    return container.queryByRole('heading', { name: 'Compose' })
+  },
+  queryAccessDenied() {
+    return container.queryByText("You don't have access to this page")
+  },
+})
+
+export const broadcastPageObject = {
+  render() {
+    render(<BroadcastPage />)
+  },
+
+  /** Make `GET /v1/session` return a user with the given permission list. */
+  signInWithPermissions(permissions: string[]) {
+    server.use(
+      http.get('*/v1/session', () =>
+        HttpResponse.json(sessionResponse({ user: { permissions } })),
+      ),
+    )
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/notifications/broadcast-page.test.tsx
+++ b/web-client/src/components/notifications/broadcast-page.test.tsx
@@ -1,0 +1,19 @@
+import { screen } from '@/test/utilities'
+import { PERM } from '@/lib/permissions'
+import { broadcastPageObject } from './broadcast-page.page'
+
+describe('BroadcastPage gate', () => {
+  it('renders the tool for a user with notifications.broadcast', async () => {
+    broadcastPageObject.signInWithPermissions([PERM.NOTIFICATIONS_BROADCAST])
+    broadcastPageObject.render()
+    expect(await screen.findByText('Compose')).toBeInTheDocument()
+    expect(broadcastPageObject.queryAccessDenied()).not.toBeInTheDocument()
+  })
+
+  it('refuses to render the tool without the permission', async () => {
+    broadcastPageObject.signInWithPermissions([])
+    broadcastPageObject.render()
+    expect(await screen.findByText(/don't have access/)).toBeInTheDocument()
+    expect(broadcastPageObject.queryComposeHeading()).not.toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/notifications/broadcast-page.tsx
+++ b/web-client/src/components/notifications/broadcast-page.tsx
@@ -7,6 +7,9 @@ import {
   type BroadcastResponse,
   type NotificationCategory,
 } from '@/api/notifications'
+import { useHasPermission, useSession } from '@/api/session'
+import { PERM } from '@/lib/permissions'
+import { AccessDenied } from '@/components/rbac/error-fallback'
 import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { BroadcastView } from './broadcast-page/broadcast-view'
 import {
@@ -22,10 +25,25 @@ function toggle<T>(set: ReadonlySet<T>, value: T): Set<T> {
   return next
 }
 
-/** Route container for the admin broadcast tool — owns the recipient/compose
- * state and the recipients query + send mutation, and hands a pure view the
- * data + handlers. */
+/** Route gate for the admin broadcast tool. The server enforces
+ * `notifications.broadcast` on every endpoint, but the route itself must refuse
+ * to render the tool to an unauthorized user (matching the other admin
+ * surfaces) — otherwise the full UI shows and the recipient search just 403s on
+ * every keystroke. */
 export function BroadcastPage() {
+  const { isPending } = useSession()
+  const canBroadcast = useHasPermission(PERM.NOTIFICATIONS_BROADCAST)
+  // Wait for the session before deciding: `useHasPermission` reads false while
+  // it's in flight, so checking it during load would flash access-denied.
+  if (isPending) return null
+  if (!canBroadcast) return <AccessDenied />
+  return <BroadcastTool />
+}
+
+/** The tool itself — owns the recipient/compose state and the recipients query
+ * + send mutation, and hands a pure view the data + handlers. Only mounted once
+ * the gate confirms permission, so its data fetches never 403. */
+function BroadcastTool() {
   const [audience, setAudience] = useState<BroadcastAudience>('selected')
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [search, setSearch] = useState('')
@@ -71,6 +89,7 @@ export function BroadcastPage() {
       recipients={recipients.data?.recipients ?? []}
       recipientTotal={total}
       recipientsLoading={recipients.isPending}
+      recipientsError={recipients.isError}
       search={search}
       onSearchChange={setSearch}
       audience={audience}

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.factory.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.factory.tsx
@@ -12,6 +12,7 @@ export function buildBroadcastViewProps(
     ],
     recipientTotal: 2,
     recipientsLoading: false,
+    recipientsError: false,
     search: '',
     onSearchChange: () => {},
     audience: 'selected',

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.page.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.page.tsx
@@ -34,6 +34,14 @@ const scoped = (container: Container) => ({
   queryHint(text: string) {
     return container.queryByText(text)
   },
+  /** The recipient-list error row shown when the search request fails. */
+  queryRecipientsError() {
+    return container.queryByText(/Couldn’t load players/)
+  },
+  /** The recipient-list empty row shown when a search matches nobody. */
+  queryNoMatch() {
+    return container.queryByText(/No players match/)
+  },
   /** The "Filed under <category> — …" compose caption. */
   queryFiledUnder(label: string) {
     return container.queryByText(

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.test.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.test.tsx
@@ -70,6 +70,18 @@ describe('BroadcastView', () => {
     expect(broadcastViewPage.queryHint('Add a title.')).toBeInTheDocument()
   })
 
+  it('surfaces an error in the recipient list when the search fails', () => {
+    broadcastViewPage.render({
+      recipients: [],
+      recipientTotal: 0,
+      recipientsError: true,
+      search: 'riko',
+    })
+    expect(broadcastViewPage.queryRecipientsError()).toBeInTheDocument()
+    // The error must not read as a misleading "no players" empty state.
+    expect(broadcastViewPage.queryNoMatch()).not.toBeInTheDocument()
+  })
+
   it('previews the in-app notification', () => {
     broadcastViewPage.render()
     expect(

--- a/web-client/src/components/notifications/broadcast-page/broadcast-view.tsx
+++ b/web-client/src/components/notifications/broadcast-page/broadcast-view.tsx
@@ -28,6 +28,7 @@ export interface BroadcastViewProps {
   recipients: BroadcastRecipient[]
   recipientTotal: number
   recipientsLoading: boolean
+  recipientsError: boolean
   search: string
   onSearchChange: (search: string) => void
   audience: BroadcastAudience
@@ -57,6 +58,7 @@ export function BroadcastView(props: BroadcastViewProps) {
     recipients,
     recipientTotal,
     recipientsLoading,
+    recipientsError,
     search,
     onSearchChange,
     audience,
@@ -119,7 +121,9 @@ export function BroadcastView(props: BroadcastViewProps) {
             Send to all players
           </span>
           <span className="font-mono text-xs text-[color:var(--fg-3)]">
-            {recipientTotal} {search ? 'matched' : 'players'}
+            {recipientsError
+              ? '— matched'
+              : `${recipientTotal} ${search ? 'matched' : 'players'}`}
           </span>
         </label>
 
@@ -147,7 +151,11 @@ export function BroadcastView(props: BroadcastViewProps) {
               </li>
             )
           })}
-          {!recipientsLoading && recipients.length === 0 ? (
+          {recipientsError ? (
+            <li className="px-4 py-10 text-center text-[13px] text-[color:var(--loss)]">
+              Couldn’t load players. Check your access and try again.
+            </li>
+          ) : !recipientsLoading && recipients.length === 0 ? (
             <li className="px-4 py-10 text-center text-[13px] text-[color:var(--fg-muted)]">
               No players match “{search}”.
             </li>

--- a/web-client/src/components/rbac/error-fallback.tsx
+++ b/web-client/src/components/rbac/error-fallback.tsx
@@ -31,24 +31,31 @@ const detailStyle = {
   margin: '0 auto 18px',
 }
 
+/** The "you don't have access" panel. Rendered both reactively (a child
+ * endpoint 403s and trips the boundary) and proactively (a page checks the
+ * session's permissions before rendering the tool, so unauthorized
+ * direct-navigation never sees it). Copy is permission-agnostic because this
+ * boundary wraps several admin pages, each gated on a different permission. */
+export function AccessDenied() {
+  return (
+    <div role="alert" style={containerStyle}>
+      <div style={{ ...iconWrap, background: 'rgba(110, 130, 255, 0.12)' }}>
+        <Lock size={22} color="var(--info, #6e82ff)" strokeWidth={1.75} />
+      </div>
+      <div style={titleStyle}>You don't have access to this page</div>
+      <div style={detailStyle}>
+        Ask an administrator to grant you access to this page.
+      </div>
+    </div>
+  )
+}
+
 function RbacErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
   // 403s come from a server-side permission gate — show a clearer message than
   // "something went wrong" so unauthorized direct-navigation reads as
-  // intentional rather than broken. This boundary wraps several admin pages
-  // (RBAC + tournaments), each gated on a different permission, so the copy is
-  // permission-agnostic rather than naming one specific permission.
+  // intentional rather than broken.
   if (error instanceof ApiError && error.status === 403) {
-    return (
-      <div role="alert" style={containerStyle}>
-        <div style={{ ...iconWrap, background: 'rgba(110, 130, 255, 0.12)' }}>
-          <Lock size={22} color="var(--info, #6e82ff)" strokeWidth={1.75} />
-        </div>
-        <div style={titleStyle}>You don't have access to this page</div>
-        <div style={detailStyle}>
-          Ask an administrator to grant you access to this page.
-        </div>
-      </div>
-    )
+    return <AccessDenied />
   }
   return (
     <div role="alert" style={containerStyle}>

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -41,14 +41,17 @@ export const mockSession = sessionResponse({
     username: 'rita.kovac',
     // The Administration nav *section* is gated on ADMIN_VIEW (app-shell), and
     // its children on their own permission. Grant ADMIN_VIEW so the section
-    // expands, AUTH_MANAGE for the RBAC pages, and TOURNAMENT_VIEW +
+    // expands, AUTH_MANAGE for the RBAC pages, TOURNAMENT_VIEW +
     // TOURNAMENT_CREATE so the Tournaments item appears, its page loads, and the
-    // "New tournament" action shows under `npm run dev`.
+    // "New tournament" action shows, and NOTIFICATIONS_BROADCAST so the
+    // Broadcast item appears and its (now permission-gated) tool renders under
+    // `npm run dev`.
     permissions: [
       PERM.ADMIN_VIEW,
       PERM.AUTH_MANAGE,
       PERM.TOURNAMENT_VIEW,
       PERM.TOURNAMENT_CREATE,
+      PERM.NOTIFICATIONS_BROADCAST,
     ],
   },
 })


### PR DESCRIPTION
Fixes #605.

## Problem
The `/admin/broadcast` route rendered its full UI to a signed-out guest. The backend correctly refused every endpoint with `403`, but the route never checked permission client-side. Worse, the recipient search (`GET /v1/notifications/broadcast/recipients`) swallowed those 403s into a misleading **"0 matched / no players"** empty state, while the console filled with 403s on every keystroke.

## Fix
- **Route gate.** `BroadcastPage` is split into a permission gate + `BroadcastTool`. The gate reads the session (via `useHasPermission`, waiting out `isPending` so it doesn't flash access-denied during load) and renders an **AccessDenied** panel unless the user holds `notifications.broadcast`. Because the tool only mounts when authorized, its recipient/taxonomy fetches never fire — and never 403 — for an unauthorized user (no more console spam).
- **Shared AccessDenied.** Extracted the existing 403 panel out of `RbacBoundary` into an exported `AccessDenied` component, reused by both the error boundary and the new gate.
- **Recipient-search errors surface.** The recipient list now shows a distinct error row ("Couldn't load players. Check your access and try again.") plus a `— matched` count when the search query fails, instead of the misleading "No players match" empty state.
- **Dev/test mock session** grants `NOTIFICATIONS_BROADCAST` so the Broadcast nav item and its now-gated tool stay visible under `npm run dev`.

### Why proactive gating (not `throwOnError` + RbacBoundary)
The RBAC pages trip the reactive `RbacBoundary` via `throwOnError:true` data loads. That doesn't fit here: `useNotificationTaxonomy` is a **shared** endpoint (preferences matrix + feed filters for all users), so making it throw would nuke non-admin pages on transient errors; and making the recipient **typeahead** throw would blow the whole page into an error boundary on a transient keystroke error. Proactive component-level gating is already the established pattern (`AdminBreadcrumbAndCounts` gates on `useHasPermission`), kills the 403 console-spam, and keeps the typeahead error inline.

## Testing
Purely client-side — no API change, `schema.d.ts` untouched.
- New `broadcast-page.test.tsx` (gate renders tool with the permission, refuses without it) + a `broadcast-view` error-vs-empty-state test.
- **vitest 892 pass · lint 0 errors · build · web-client e2e 127 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)