### PR TITLE
Fix event editor side panel width (was stuck at 320px)

### DIFF
--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -70,7 +70,7 @@ export const EventEditor = ({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="right"
-        className="w-full gap-0 p-0 sm:max-w-[820px]"
+        className="!w-full gap-0 p-0 sm:!w-[820px] sm:!max-w-[820px]"
       >
         <SheetHeader className="border-b border-[color:var(--border-subtle)]">
           <SheetDescription className="text-[11px] font-semibold tracking-[0.14em] uppercase">


### PR DESCRIPTION
## What

The tournament **event editor** side panel was rendering at **320px wide** on every breakpoint — far too narrow, cramming the form (e.g. the Date/Start/End row).

## Why

`SheetContent` passed `className="w-full gap-0 p-0 sm:max-w-[820px]"`, but the base `Sheet` component (`ui/sheet.tsx`) sets the width with an **attribute-selector** rule: `data-[side=right]:w-[320px]`. Attribute selectors outrank plain Tailwind utility classes on CSS specificity, so the base 320px width won and the caller's `w-full` / `sm:max-w-[820px]` were silently ignored.

## Fix

Force the intended widths with the `!important` modifier so they beat the base rule:

```diff
- className="w-full gap-0 p-0 sm:max-w-[820px]"
+ className="!w-full gap-0 p-0 sm:!w-[820px] sm:!max-w-[820px]"
```

Verified in the browser: **mobile (390px) → full-width**, **desktop (1280px) → 820px**.

This is a targeted band-aid. The root cause — that *no* sheet can be widened without `!important` — is tracked in **#623** for a proper fix in `ui/sheet.tsx`.

## Testing

- vitest: 889 passed (incl. event-editor's 24)
- lint: 0 errors · build (tsc -b + vite build): green
- web-client Playwright e2e: 127 passed
- Manually verified panel width at mobile + desktop via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)