### PR TITLE
Gate the /admin Overview on administration.view (#622)

### DIFF
--- a/e2e/tests/admin-system-health.spec.ts
+++ b/e2e/tests/admin-system-health.spec.ts
@@ -1,31 +1,25 @@
 import { expect, test } from '@playwright/test'
 
 test.describe('Administration · System Health (live stack)', () => {
-  test('the admin page reports every dependency as healthy', async ({
+  test('denies a guest without administration.view and hides the dashboard', async ({
     page,
   }) => {
+    // Regression for #622, end-to-end against the real stack: the live session
+    // is a freshly-minted guest with no roles (so no `administration.view`).
+    // The Overview's only fetch — `GET /v1/health` — is public and never 403s,
+    // so before the client-side gate this page rendered the system-health
+    // dashboard (and its internal service hostnames) to anyone. It must now
+    // refuse to render the dashboard and show the access-denied panel instead.
     await page.goto('/admin')
 
     await expect(
-      page.getByRole('heading', { level: 1, name: 'Administration' }),
+      page.getByText("You don't have access to this page"),
     ).toBeVisible()
 
-    const widget = page.getByTestId('system-health')
-    await expect(widget).toBeVisible()
-    await expect(widget).toHaveAttribute('data-state', 'ok', { timeout: 30_000 })
-
-    for (const service of ['redis', 'database', 'solver'] as const) {
-      await expect(page.getByTestId(`system-health-row-${service}`)).toHaveAttribute(
-        'data-status',
-        'ok',
-      )
-      await expect(page.getByTestId(`system-health-pill-${service}`)).toHaveText(
-        'healthy',
-      )
-    }
-
-    await expect(page.getByTestId('system-health-eyebrow')).toHaveText(
-      'Operational',
-    )
+    // The dashboard (and the internal hostnames it lists) must stay out of the DOM.
+    await expect(page.getByTestId('system-health')).toHaveCount(0)
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Administration' }),
+    ).toHaveCount(0)
   })
 })

--- a/web-client/e2e/admin-system-health.spec.ts
+++ b/web-client/e2e/admin-system-health.spec.ts
@@ -7,6 +7,19 @@ test.describe('Administration · System Health', () => {
     await expect(admin.heading).toBeVisible()
   })
 
+  test('denies a visitor without administration.view, hiding the dashboard', async ({
+    page,
+  }) => {
+    // Regression for #622: the Overview leaked internal service hostnames to
+    // anyone who direct-navigated to /admin, because its only fetch (/v1/health)
+    // is public and never 403s to trip the reactive boundary.
+    const admin = await AdminPage.navigateTo(page, { permissions: [] })
+
+    await expect(admin.accessDenied).toBeVisible()
+    await expect(admin.widget).toHaveCount(0)
+    await expect(admin.heading).toHaveCount(0)
+  })
+
   test('shows operational state when every dependency is healthy', async ({
     page,
   }) => {

--- a/web-client/e2e/page-objects/admin.page.ts
+++ b/web-client/e2e/page-objects/admin.page.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page, Route } from '@playwright/test'
 import type { components } from '../../src/api/schema'
+import { PERM } from '../../src/lib/permissions'
 import {
   databaseCheck,
   healthCheck,
@@ -36,7 +37,12 @@ export const HEALTH_SCENARIOS: Record<
 
 export type ScenarioName = keyof typeof HEALTH_SCENARIOS
 
-const SESSION_RESPONSE = sessionResponse({ user: { username: 'rita.kovac' } })
+// The Overview page is gated on `administration.view`; grant it by default so
+// the system-health scenarios render. Tests that exercise the gate itself pass
+// `permissions: []` to mock an unauthorized visitor.
+function buildSession(permissions: string[]) {
+  return sessionResponse({ user: { username: 'rita.kovac', permissions } })
+}
 
 export class AdminPage {
   static async navigateTo(
@@ -45,10 +51,11 @@ export class AdminPage {
       scenario?: ScenarioName
       healthDelayMs?: number
       onHealthRequest?: () => void
+      permissions?: string[]
     } = {},
   ): Promise<AdminPage> {
     const admin = new AdminPage(page)
-    await admin.mockSession()
+    await admin.mockSession(options.permissions ?? [PERM.ADMIN_VIEW])
     await admin.mockHealth(
       options.scenario ?? 'healthy',
       options.healthDelayMs ?? 0,
@@ -60,12 +67,12 @@ export class AdminPage {
 
   constructor(public readonly page: Page) {}
 
-  async mockSession() {
+  async mockSession(permissions: string[] = [PERM.ADMIN_VIEW]) {
     await this.page.route('**/v1/session', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(SESSION_RESPONSE),
+        body: JSON.stringify(buildSession(permissions)),
       })
     })
   }
@@ -124,5 +131,9 @@ export class AdminPage {
 
   get heading(): Locator {
     return this.page.getByRole('heading', { level: 1, name: 'Administration' })
+  }
+
+  get accessDenied(): Locator {
+    return this.page.getByText("You don't have access to this page")
   }
 }

--- a/web-client/src/components/admin-overview.factory.tsx
+++ b/web-client/src/components/admin-overview.factory.tsx
@@ -1,0 +1,7 @@
+import { PERM } from '@/lib/permissions'
+
+/** The permissions an admin who can see the Overview carries — the default
+ * "authorized" scenario for the gate. */
+export function buildAdminPermissions(overrides: string[] = []): string[] {
+  return [PERM.ADMIN_VIEW, ...overrides]
+}

--- a/web-client/src/components/admin-overview.page.tsx
+++ b/web-client/src/components/admin-overview.page.tsx
@@ -1,0 +1,53 @@
+import { http, HttpResponse } from 'msw'
+import { render, screen, type Container } from '@/test/utilities'
+import { server } from '@/mocks/server'
+import { sessionResponse } from '@/test/factories'
+import { AdminOverview } from './admin-overview'
+import { buildAdminPermissions } from './admin-overview.factory'
+
+const scoped = (container: Container) => ({
+  /** The system-health dashboard — present only on the authorized branch. */
+  querySystemHealth() {
+    return container.queryByTestId('system-health')
+  },
+  /** Resolves once the authorized branch has mounted the dashboard. */
+  findSystemHealth() {
+    return container.findByTestId('system-health')
+  },
+  /** The "Administration" page heading — present only on the authorized branch. */
+  queryHeading() {
+    return container.queryByRole('heading', { name: 'Administration' })
+  },
+  /** The shared access-denied panel — present only on the unauthorized branch. */
+  queryAccessDenied() {
+    return container.queryByText("You don't have access to this page")
+  },
+  /** Resolves once the unauthorized branch has rendered the panel — lets a
+   * test await the gate's decision before asserting the dashboard stayed out. */
+  findAccessDenied() {
+    return container.findByText("You don't have access to this page")
+  },
+})
+
+/** Test page-object for `AdminOverview`, the Administration Overview gate. The
+ * gate reads `/v1/session` (stubbed here per scenario) and, when authorized,
+ * mounts `SystemHealth` which fetches the public `/v1/health` (left to the
+ * default MSW handler). Tests start by awaiting a find-accessor since the
+ * session resolves asynchronously. */
+export const adminOverviewPage = {
+  /** Stub the session with `permissions`, then render. Pass `[]` for a guest. */
+  render(permissions: string[] = buildAdminPermissions()) {
+    server.use(
+      http.get('*/v1/session', () =>
+        HttpResponse.json(sessionResponse({ user: { permissions } })),
+      ),
+    )
+    render(<AdminOverview />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/admin-overview.test.tsx
+++ b/web-client/src/components/admin-overview.test.tsx
@@ -1,0 +1,30 @@
+import { PERM } from '@/lib/permissions'
+import { buildAdminPermissions } from './admin-overview.factory'
+import { adminOverviewPage } from './admin-overview.page'
+
+describe('AdminOverview', () => {
+  it('renders the system-health dashboard for a user with administration.view', async () => {
+    adminOverviewPage.render(buildAdminPermissions())
+
+    // Wiring only: the dashboard's contents are pinned by the SystemHealth tests.
+    expect(await adminOverviewPage.findSystemHealth()).toBeInTheDocument()
+    expect(adminOverviewPage.queryHeading()).toBeInTheDocument()
+    expect(adminOverviewPage.queryAccessDenied()).not.toBeInTheDocument()
+  })
+
+  it('shows the access-denied panel to a guest, never mounting the dashboard', async () => {
+    adminOverviewPage.render([])
+
+    expect(await adminOverviewPage.findAccessDenied()).toBeInTheDocument()
+    // The internal service hostnames live in SystemHealth — keep it unmounted.
+    expect(adminOverviewPage.querySystemHealth()).not.toBeInTheDocument()
+    expect(adminOverviewPage.queryHeading()).not.toBeInTheDocument()
+  })
+
+  it('gates specifically on administration.view, not any admin permission', async () => {
+    adminOverviewPage.render([PERM.AUTH_MANAGE])
+
+    expect(await adminOverviewPage.findAccessDenied()).toBeInTheDocument()
+    expect(adminOverviewPage.querySystemHealth()).not.toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/admin-overview.tsx
+++ b/web-client/src/components/admin-overview.tsx
@@ -1,0 +1,30 @@
+import { AccessDenied } from '@/components/rbac/error-fallback'
+import { SystemHealth } from '@/components/system-health'
+import { useHasPermission, useSession } from '@/api/session'
+import { PERM } from '@/lib/permissions'
+
+/** Route gate for the Administration Overview. Unlike the RBAC and broadcast
+ * surfaces — whose data endpoints 403 for the unauthorized and trip the
+ * `RbacBoundary` — this page's only fetch is the *public* `/v1/health`, so
+ * nothing ever 403s. The page must therefore check `administration.view`
+ * itself before rendering the system-health dashboard, which otherwise
+ * discloses internal service hostnames to a signed-out guest (see #622). */
+export function AdminOverview() {
+  const { isPending } = useSession()
+  const canViewAdmin = useHasPermission(PERM.ADMIN_VIEW)
+  // `useHasPermission` reads false while the session is in flight; wait it out
+  // so an authorized user never flashes the access-denied panel.
+  if (isPending) return null
+  if (!canViewAdmin) return <AccessDenied />
+
+  return (
+    <div className="mx-auto max-w-[1200px] px-12 pt-16 pb-32">
+      <header className="mb-10">
+        <h1 className="font-display text-4xl text-foreground">Administration</h1>
+      </header>
+      <section aria-label="Operations" className="mb-12 max-w-[640px]">
+        <SystemHealth />
+      </section>
+    </div>
+  )
+}

--- a/web-client/src/routes/_app/admin.index.tsx
+++ b/web-client/src/routes/_app/admin.index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { SystemHealth } from '@/components/system-health'
+import { AdminOverview } from '@/components/admin-overview'
 import { pageTitle } from '@/lib/page-title'
 
 export const Route = createFileRoute('/_app/admin/')({
@@ -8,16 +8,3 @@ export const Route = createFileRoute('/_app/admin/')({
   }),
   component: AdminOverview,
 })
-
-function AdminOverview() {
-  return (
-    <div className="mx-auto max-w-[1200px] px-12 pt-16 pb-32">
-      <header className="mb-10">
-        <h1 className="font-display text-4xl text-foreground">Administration</h1>
-      </header>
-      <section aria-label="Operations" className="mb-12 max-w-[640px]">
-        <SystemHealth />
-      </section>
-    </div>
-  )
-}


### PR DESCRIPTION
Fixes #622.

## Problem
The Administration Overview (`/admin`) was the only admin surface with no client-side permission gate. The RBAC and broadcast pages refuse to render to the unauthorized because their data endpoints 403 and trip the reactive `RbacBoundary`. The Overview's only fetch is the **public** `/v1/health`, which never 403s — so a signed-out **guest** who direct-navigated to `/admin` got the full system-health dashboard, **leaking internal service hostnames** (`cache.fortymm.internal`, `pg-primary.fortymm.internal`, `smt-solver.fortymm.internal`) plus per-service health/latency.

## Fix
- Extract the 403 panel from `RbacErrorFallback` into a shared, exported `AccessDenied` component (reused by the boundary and the new gate).
- Move the Overview into an `AdminOverview` component that proactively checks `administration.view` (waiting out the session load to avoid a flash) and renders `AccessDenied` for the unauthorized — so `SystemHealth`, and the hostnames it lists, never mounts. The route just wires it, matching how `admin.broadcast`/`roles`/`users` render their page components.

Each admin child stays gated on its **own** permission (Roles/Users → `authorization.manage`, Broadcast → `notifications.broadcast`); the Overview is proactive only because its endpoint is public and can't rely on a reactive 403. Gating the whole `admin.tsx` layout on `ADMIN_VIEW` was considered and rejected — it would wrongly deny a user who holds `authorization.manage` but not `administration.view` from `/admin/roles`.

## Testing
- New `admin-overview` quartet (authorized / guest / wrong-permission).
- web-client e2e: granted `ADMIN_VIEW` in the admin session page-object + added a guest-denial spec.
- Root e2e: rewrote the live-stack spec — it was asserting the bug (a real guest seeing the dashboard); it now verifies a real roleless guest is denied.
- vitest **893**, web-client e2e **128**, root e2e **4**, lint, build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)