### PR TITLE
Fix #624: reject malformed score entry instead of silently coercing it

### DIFF
--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -1636,6 +1636,30 @@ describe('ScoreEntry — unsaved-input guard', () => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
   })
 
+  it('does not prompt for a stray "." typed over an already-saved score', async () => {
+    // Regression for #624 + #441: the field keeps malformed text verbatim now,
+    // so a trailing "." in "11." must not read as a change from the saved "11"
+    // and spuriously trip the unsaved-changes blocker — the dirty check
+    // compares digits only.
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+    )
+
+    renderScoringApp('/matches/m-1/games/1/scores/edit')
+    await screen.findByRole('heading', { name: /edit game 1 score/i })
+
+    const meInput = screen.getByRole('textbox', { name: 'rita.kovac score' })
+    expect(meInput).toHaveValue('11')
+    await user.type(meInput, '.')
+    expect(meInput).toHaveValue('11.')
+
+    // Leaving for another saved game goes through with no leave prompt.
+    await user.click(screen.getByRole('link', { name: /game 2, saved/i }))
+    await screen.findByRole('heading', { name: /edit game 2 score/i })
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+
   it('does not prompt after the fire-and-forget Save navigates to the next game', async () => {
     const user = userEvent.setup()
     server.use(

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -459,11 +459,45 @@ describe('ScoreEntry — create', () => {
     expect(oppInput).toHaveValue('97')
     expect(screen.getByRole('alert')).toHaveTextContent(/leads by exactly 2/i)
 
-    // The field still caps at 3 digits so it can't grow unbounded — a 4th
-    // digit typed in one pass is dropped rather than accepted.
+    // A 4th digit is no longer truncated to a plausible 3-digit score (#624):
+    // the over-long value is kept verbatim and flagged as malformed instead.
     await user.clear(meInput)
     await user.type(meInput, '1005')
-    expect(meInput).toHaveValue('100')
+    expect(meInput).toHaveValue('1005')
+    expect(meInput).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('flags malformed input instead of coercing it to a different number', async () => {
+    // Regression for #624: the field used to strip/truncate, so "11.5" became
+    // "115" and "999999" became "999" — values the user never typed that pass
+    // as real scores. The raw text is now kept and a malformed entry is flagged
+    // inline (with Save blocked) rather than silently transformed.
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+
+    // A decimal stays "11.5" — it never becomes "115" — and is flagged.
+    await user.type(meInput, '11.5')
+    expect(meInput).toHaveValue('11.5')
+    expect(meInput).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByRole('alert')).toHaveTextContent(/whole number/i)
+
+    // Overflowing digits stay "999999" — not capped to a plausible "999".
+    await user.clear(meInput)
+    await user.type(meInput, '999999')
+    expect(meInput).toHaveValue('999999')
+    expect(meInput).toHaveAttribute('aria-invalid', 'true')
+
+    // Letters are still rejected at the keystroke, as before.
+    await user.clear(meInput)
+    await user.type(meInput, '1a2')
+    expect(meInput).toHaveValue('12')
   })
 
   it('redirects to the existing score\'s edit page when landing on /scores/new for an already-scored game', async () => {

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -248,22 +248,24 @@ function ScoreEntryInner({
   const computeDirty = (nextMe: string, nextOpp: string) =>
     nextMe !== baselineMe || nextOpp !== baselineOpp
 
-  // Strip non-digits and cap at 3 digits. Two digits silently turned "100"
-  // into "10", then the deuce/win-by-2 check fired against a value the user
-  // never typed (#442). Three digits covers any real table-tennis score
-  // (a long deuce game tops out well under 100) without that mutation, so
-  // illegalScoreReason always references exactly what was entered.
-  const sanitize = (value: string) => value.replace(/[^0-9]/g, '').slice(0, 3)
+  // Take the typed value verbatim — no stripping, no truncating. We only block
+  // characters that can't begin a score (letters, sign) so non-numeric input
+  // stays rejected as before; digits and a "." are kept. Earlier we stripped
+  // non-digits and capped at 3, but that quietly turned "11.5" into "115" and
+  // "999999" into "999" — plausible-looking scores the user never typed (#624).
+  // Keeping the raw text lets a malformed entry stay visible and get flagged
+  // inline (see `formatError`) instead of masquerading as a real score.
+  const isAcceptable = (value: string) => !/[^\d.]/.test(value)
   const onMeChange = (value: string) => {
-    const next = sanitize(value)
-    setMeTyped(next)
-    setIsDirty(computeDirty(next, opp))
+    if (!isAcceptable(value)) return
+    setMeTyped(value)
+    setIsDirty(computeDirty(value, opp))
     if (finalizeMutation.error) finalizeMutation.reset()
   }
   const onOppChange = (value: string) => {
-    const next = sanitize(value)
-    setOppTyped(next)
-    setIsDirty(computeDirty(me, next))
+    if (!isAcceptable(value)) return
+    setOppTyped(value)
+    setIsDirty(computeDirty(me, value))
     if (finalizeMutation.error) finalizeMutation.reset()
   }
 
@@ -273,9 +275,20 @@ function ScoreEntryInner({
   // required and flag the still-empty field. Only after the user has started
   // typing — a wholly-empty pair is the untouched initial state, not an error.
   const oneSideFilled = (me !== '') !== (opp !== '')
-  const localScoreError = bothFilled
-    ? illegalScoreReason(Number(me), Number(opp))
-    : null
+  // A filled side is well-formed only as 1–3 digits. Since the inputs are no
+  // longer coerced (#624), a decimal ("11.5") or an over-long run ("999999")
+  // reaches here verbatim — caught as a format error rather than silently
+  // becoming "115"/"999". Flagged on its own, before the both-filled scoring
+  // check, so it surfaces the moment the bad side is typed.
+  const meMalformed = me !== '' && !/^\d{1,3}$/.test(me)
+  const oppMalformed = opp !== '' && !/^\d{1,3}$/.test(opp)
+  const formatError =
+    meMalformed || oppMalformed
+      ? 'Enter each score as a whole number from 0 to 999.'
+      : null
+  const localScoreError =
+    formatError ??
+    (bothFilled ? illegalScoreReason(Number(me), Number(opp)) : null)
   const inputsValid = bothFilled && localScoreError === null
 
   // Build the hypothetical full-match games list including the current input,
@@ -325,10 +338,17 @@ function ScoreEntryInner({
   // The "both scores required" hint is its own, lower-severity line — shown only
   // when exactly one field is filled and there's no harder error to surface.
   const showBothRequired = oneSideFilled && !showScoreError
-  // Per-side red flags: a genuine validation error paints both inputs; the
+  // Per-side red flags: a format error paints only the malformed side; a
+  // genuine scoring error (illegal score / 422 drift) paints both inputs; the
   // both-required hint only flags the empty one.
-  const meInvalid = inputsInvalid || (showBothRequired && me === '')
-  const oppInvalid = inputsInvalid || (showBothRequired && opp === '')
+  const meInvalid =
+    meMalformed ||
+    (formatError === null && inputsInvalid) ||
+    (showBothRequired && me === '')
+  const oppInvalid =
+    oppMalformed ||
+    (formatError === null && inputsInvalid) ||
+    (showBothRequired && opp === '')
 
   function predictNextScoringRoute() {
     if (!data) return matchDetailRoute(matchId)

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -244,9 +244,13 @@ function ScoreEntryInner({
   // Whether the live inputs (me/opp) diverge from the baseline — i.e. there's
   // genuinely-unsaved typing worth guarding on exit. Recomputed by the change
   // handlers below as the user types (a clean page, or input matching the
-  // saved score, isn't dirty).
+  // saved score, isn't dirty). Compared on digits only: the field now keeps
+  // malformed text verbatim (#624), and a stray "." in "11." over a saved "11"
+  // must not read as a change and spuriously trip the unsaved-changes blocker
+  // (#441) — the baseline is always a clean digit-string, so this matches it.
+  const digitsOnly = (value: string) => value.replace(/[^0-9]/g, '')
   const computeDirty = (nextMe: string, nextOpp: string) =>
-    nextMe !== baselineMe || nextOpp !== baselineOpp
+    digitsOnly(nextMe) !== baselineMe || digitsOnly(nextOpp) !== baselineOpp
 
   // Take the typed value verbatim — no stripping, no truncating. We only block
   // characters that can't begin a score (letters, sign) so non-numeric input


### PR DESCRIPTION
## What

Closes #624. The per-game score-entry input silently *coerced* malformed values instead of rejecting them: typing `11.5` produced `115` (decimal stripped, digits concatenated) and `999999` produced `999` (capped to 3 digits). Either way a fat-fingered or pasted value became a plausible-looking but wrong score with no feedback.

## Change

- **Stop mutating the field.** The change handlers now keep the typed value verbatim — no stripping, no truncating. Only characters that can't begin a score (letters, sign) are still rejected at the keystroke, preserving the existing "non-numeric rejected" behavior. Digits and `.` are kept so a decimal entry surfaces instead of recombining into a different number.
- **Flag malformed input inline.** A filled side that isn't 1–3 digits is now a format error ("Enter each score as a whole number from 0 to 999.") shown on its own line, with Save blocked. `11.5` stays `11.5` and `999999` stays `999999`, each flagged — never silently transformed.
- **Per-side flags refined.** A format error paints only the malformed side; a genuine scoring error (illegal score / 422 drift) still paints both, as before.

## Testing

- `web-client` vitest: **891 passed** (new test covers `11.5`/`999999` shown-and-flagged + letters still rejected; updated the #442 test whose 3-digit-cap assertion no longer holds).
- `npm run lint` + `npm run build` (tsc -b + vite): clean.
- `web-client` Playwright e2e: **127 passed** (incl. `score-entry.spec.ts`).
- `/simplify` ran clean — no changes needed.

## Notes

- Observed on web (desktop), as reported. iOS has a sibling coercion bug (`999999` → `40` via `suffix(2)` + cap) tracked separately in #627 — its `.numberPad` keyboard and `Int?` model make a faithful fix a real rework rather than a one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)