### PR TITLE
Pack notification channel cards into masonry columns

### DIFF
--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
@@ -51,7 +51,11 @@ export function PreferencesView({
       </p>
 
       <p className="ds-overline mb-3.5">Where we reach you</p>
-      <div className="mb-9 grid grid-cols-1 gap-3 sm:grid-cols-2">
+      {/* Masonry-style columns rather than a grid: each card carries an
+          optional setup nudge of its own height, and a row-aligned grid would
+          leave a tall gap beside any card whose neighbour has a nudge. Columns
+          let each card+nudge unit pack independently. */}
+      <div className="mb-9 columns-1 gap-3 sm:columns-2">
         {channels.map((channel) => {
           const { Icon } = CHANNEL_VISUAL[channel.channel]
           const label = channelLabel.get(channel.channel) ?? channel.channel
@@ -68,7 +72,7 @@ export function PreferencesView({
               ? 'Pending — check your inbox'
               : channel.destination
           return (
-            <div key={channel.channel} className="min-w-0">
+            <div key={channel.channel} className="mb-3 break-inside-avoid">
               <div
                 className={cn(
                   'flex items-center gap-3 rounded-xl border bg-[color:var(--bg-card)] p-4 transition-opacity',

--- a/web-client/src/mocks/notifications-store.ts
+++ b/web-client/src/mocks/notifications-store.ts
@@ -61,7 +61,19 @@ let feed: NotificationItem[] = [
   },
 ]
 
-let prefs: NotificationPreferences = notificationPreferences()
+// Seed the dev mock with push + email needing setup so the preferences page
+// exercises its channel-setup nudges (the all-set-up state hides them).
+let prefs: NotificationPreferences = (() => {
+  const p = notificationPreferences()
+  p.channels = p.channels.map((c) =>
+    c.channel === 'push'
+      ? { ...c, setup_required: true, destination: 'No devices yet — open the app' }
+      : c.channel === 'email'
+        ? { ...c, setup_required: true, destination: 'Pending — check your inbox' }
+        : c,
+  )
+  return p
+})()
 
 const RECIPIENTS: BroadcastRecipient[] = [
   { id: 'u-1', username: 'nguyen.t' },


### PR DESCRIPTION
## What

The notification **Preferences** page's "Where we reach you" channel cards used a row-aligned 2-column grid. Each card carries an optional *setup nudge* of its own height (e.g. "Turn on push…", "Confirm your email…"). Because CSS grid aligns every cell in a row to the tallest one, a nudge-less card (In-app, SMS) was stretched with a tall empty gap beside its nudge-bearing neighbour (Push, Email) — a ragged checkerboard on desktop width.

## Change

- Switch the channel container from `grid grid-cols-2` to a masonry-style multi-column flow (`columns-1 sm:columns-2`), with `break-inside-avoid` on each card+nudge unit so each packs independently with no dead space. Column balancing also groups the device channels (In-app, Push) left and address channels (Email, SMS) right.
- Mobile is unchanged (single column).
- Seed the dev MSW mock (`notifications-store.ts`) with push + email needing setup so the preferences page renders its nudges in dev (the all-set-up default hid them). Dev-only; never ships to prod.

### Before → After (desktop, nudge state)
Before: In-app and SMS each left a tall empty gap beside Push/Email's nudges.
After: each card+nudge unit packs tightly; columns end at roughly even heights.

## Testing
- `npm run test:run` — 899 passed
- `npm run lint` — 0 errors
- `npm run build` (tsc + vite) — ✓
- `npm run test:e2e` — 128 passed

Not applicable: root e2e (CSS-only, covered by web-client e2e), OpenAPI drift (no api changes), iOS (no ios changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)