### PR TITLE
Omit redundant games tally from single-game score entry

### DIFF
--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -559,7 +559,6 @@ function ScoreEntryInner({
             side="me"
             name={meName}
             initials={meInitials}
-            wins={meWins}
             value={me}
             inputRef={meRef}
             autoFocus
@@ -571,16 +570,19 @@ function ScoreEntryInner({
 
           <div className="se-mid">
             <div className="se-vs">VS</div>
-            <div className="se-games">
-              {meWins} – {oppWins}
-            </div>
+            {/* Single-game matches: the games tally is always 0–0 until the one
+                game finalizes, so it's noise — drop it (#bridge-cse). */}
+            {bestOf > 1 && (
+              <div className="se-games">
+                {meWins} – {oppWins}
+              </div>
+            )}
           </div>
 
           <ScoreSide
             side="opp"
             name={oppName}
             initials={oppHasPlayer ? initialsOf(oppName) : null}
-            wins={oppWins}
             value={opp}
             inputRef={oppRef}
             disabled={inputsLocked}
@@ -734,7 +736,6 @@ function ScoreSide({
   side,
   name,
   initials,
-  wins,
   value,
   inputRef,
   autoFocus,
@@ -748,7 +749,6 @@ function ScoreSide({
   // `null` means there's no player on this side — render the ghost avatar
   // (dashed circle + person icon) instead of a contrived monogram.
   initials: string | null
-  wins: number
   value: string
   inputRef: React.RefObject<HTMLInputElement | null>
   autoFocus?: boolean
@@ -766,9 +766,6 @@ function ScoreSide({
   const identity = (
     <div className="id">
       <div className="nm">{name}</div>
-      <div className="rt">
-        Games won · <b>{wins}</b>
-      </div>
     </div>
   )
 

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1702,17 +1702,6 @@ body.dark.fortymm-theme {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.fortymm-theme .se-head .rt {
-  font: 500 11px var(--font-mono);
-  letter-spacing: 0.14em;
-  color: var(--fg-3);
-  text-transform: uppercase;
-}
-.fortymm-theme .se-head .rt b {
-  color: var(--fg-1);
-  font-weight: 700;
-}
-
 .fortymm-theme .big-input {
   width: 100%;
   background: transparent;
@@ -2199,15 +2188,6 @@ body.dark.fortymm-theme {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-  /* Keep the "Games won · N" tally on mobile (#387): hiding it left the cramped
-     mobile header with no running score, and the big inputs already read as
-     blank panels — this is the only games-won readout near them. */
-  .fortymm-theme .se-head .rt {
-    display: block;
-    font-size: 10px;
-    letter-spacing: 0.1em;
-    margin-top: 2px;
   }
   .fortymm-theme .se-mid {
     padding: 14px 6px;


### PR DESCRIPTION
## What

On the score-entry screen, the games-in-match score was shown twice in a way that's pure noise for single-game matches:

- A per-player **"Games won · N"** line under each player's name.
- A **center games-score** (`{meWins} – {oppWins}`) between the two big point inputs.

This PR:
- **Removes the per-player "Games won" tally** under each name — for *all* match lengths.
- **Hides the center games-score for single-game matches** (gated on `best_of > 1`), leaving just the `VS` divider. Multi-game matches still show the running games score in the middle.
- Cleans up the now-dead `.se-head .rt` CSS (desktop + mobile rules) and the unused `wins` prop on `ScoreSide`.

## Testing

- `npm run test:run` — 965 unit tests pass
- `npm run lint` — clean
- `npm run build` (tsc -b + vite) — typecheck + build pass
- `npm run test:e2e` — 128 Playwright tests pass (incl. score-entry specs)

Web-client-only change; no API/schema/iOS changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)