### PR TITLE
Remove dead /v1/p/players public endpoint; re-gate matches behind auth

### DIFF
--- a/api/app/players.py
+++ b/api/app/players.py
@@ -2,8 +2,7 @@ import uuid
 from collections.abc import Iterable, Mapping
 from typing import Any, Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from pyrate_limiter import Duration, Rate
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import Select, and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
@@ -20,7 +19,6 @@ from app.models import (
     User,
     UserLeagueRating,
 )
-from app.rate_limiting import RedisRateLimiter
 from app.schemas.player import (
     PlayerDetail,
     PlayerListResponse,
@@ -199,23 +197,6 @@ async def search_players(
 # W-L, form, per-set scores), so the FE doesn't join sides + games + flip
 # perspective. See `web-client/CLAUDE.md` BFF section.
 # ---------------------------------------------------------------------------
-
-
-async def _public_player_ip_key(request: Request) -> str:
-    """Per-IP key for the unauthenticated public profile endpoint — there's
-    no session cookie to bucket against, so IP is all we have."""
-    client = request.client
-    ip = client.host if client else "unknown"
-    return f"public-player-ip:{ip}"
-
-
-# 60/min per IP: comfortably above a human browsing several profiles in quick
-# succession, well below the volume needed to scrape the user table.
-public_player_ip_rate_limit = RedisRateLimiter(
-    rates=[Rate(60, Duration.MINUTE)],
-    bucket_key="public-player-ip",
-    identifier=_public_player_ip_key,
-)
 
 
 def _username_substring_filter[SelectT: Select[Any]](query: SelectT, q: str) -> SelectT:
@@ -398,17 +379,6 @@ async def _load_player_by_id(db: AsyncSession, player_id: uuid.UUID) -> User | N
     ).scalar_one_or_none()
 
 
-async def _load_player_by_username(db: AsyncSession, username: str) -> User | None:
-    return (
-        await db.execute(
-            select(User).where(
-                User.username == username,
-                User.merged_into_user_id.is_(None),
-            )
-        )
-    ).scalar_one_or_none()
-
-
 async def _summarize_one_player(
     db: AsyncSession, user: User, league_id: uuid.UUID
 ) -> PlayerSummary:
@@ -419,8 +389,7 @@ async def _summarize_one_player(
 async def _player_detail(
     db: AsyncSession, user: User, league_id: uuid.UUID
 ) -> PlayerDetail:
-    """Shared body for both `/v1/players/{id}` and
-    `/v1/p/players/{username}` — bundles the hero summary with the first
+    """Body for `/v1/players/{id}` — bundles the hero summary with the first
     page of matches so the profile page paints in one round trip. The FE
     seeds the matches-query cache from the embedded ``matches`` field;
     page 2+ falls through to `/v1/players/{id}/matches`."""
@@ -441,27 +410,6 @@ async def get_player(
     """Authed profile bundle for `/players/$userId` — hero + first page of
     matches in one response."""
     user = await _load_player_by_id(db, player_id)
-    if user is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Player not found."
-        )
-    league = await resolve_league(db, league_id)
-    return await _player_detail(db, user, league.id)
-
-
-@router.get(
-    "/p/players/{username}",
-    response_model=PlayerDetail,
-    dependencies=[Depends(public_player_ip_rate_limit)],
-)
-async def get_public_player(
-    username: str,
-    league_id: uuid.UUID | None = Query(default=None),
-    db: AsyncSession = Depends(get_session),
-) -> PlayerDetail:
-    """Public profile bundle for `/p/players/$username` — same shape as
-    the authed endpoint. No session required, rate-limited per-IP."""
-    user = await _load_player_by_username(db, username)
     if user is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Player not found."
@@ -555,10 +503,9 @@ async def _paginated_player_matches(
     page: int,
     page_size: int,
 ) -> PlayerMatchListResponse:
-    """Shared body for both `/v1/players/{id}/matches` and
-    `/v1/p/players/{username}/matches`. The two endpoints differ only in
-    how they resolve the player; the matches list shape, ordering, and
-    perspective flip are identical."""
+    """Per-player matches list backing `/v1/players/{id}/matches`: list
+    shape, newest-first ordering, and the perspective flip onto the
+    headline player's side."""
     participant = (
         select(MatchSidePlayer.id)
         .where(
@@ -590,27 +537,19 @@ async def _paginated_player_matches(
     )
 
 
-@router.get(
-    "/players/{player_id}/matches",
-    response_model=PlayerMatchListResponse,
-    dependencies=[Depends(public_player_ip_rate_limit)],
-)
+@router.get("/players/{player_id}/matches", response_model=PlayerMatchListResponse)
 async def list_player_matches(
     player_id: uuid.UUID,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=LIST_DEFAULT_PAGE_SIZE, ge=1, le=LIST_MAX_PAGE_SIZE),
+    _current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> PlayerMatchListResponse:
-    """Paginated per-player match history backing the profile-page match
-    table on BOTH the authed (`/players/$userId`) and public
-    (`/p/players/$username`) surfaces — the public page has already
-    resolved username → id via `/v1/p/players/{username}`, so it has the
-    id to hit this endpoint with.
-
-    Public — no session required, IP-rate-limited (60/min) so the match
-    history can't be scraped from a single source. Newest-first by
-    ``created_at``. Sets are projected from the player's perspective so
-    the FE renders them without flipping sides.
+    """Paginated per-player match history backing page 2+ of the authed
+    profile page (`/players/$userId`); page 1 ships inline in the
+    `/v1/players/{id}` bundle. Newest-first by ``created_at``. Sets are
+    projected from the player's perspective so the FE renders them without
+    flipping sides.
     """
     user = await _load_player_by_id(db, player_id)
     if user is None:

--- a/api/app/schemas/player.py
+++ b/api/app/schemas/player.py
@@ -95,8 +95,8 @@ class PlayerMatchListResponse(BaseModel):
 class PlayerDetail(PlayerSummary):
     """Profile-page bundle: the hero (`PlayerSummary` fields) plus the
     first page of matches inline. Saves a round trip on initial load —
-    `GET /v1/players/{id}` (and the public `/v1/p/players/{username}`
-    variant) returns this so the profile page paints with one request.
+    `GET /v1/players/{id}` returns this so the profile page paints with one
+    request.
 
     Pagination beyond page 1 still hits `GET /v1/players/{id}/matches`
     directly; the FE seeds page 1's cache from this `matches` field via

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -518,51 +518,6 @@ async def test_get_player_404_when_missing(
     assert response.status_code == 404
 
 
-async def test_get_public_player_does_not_require_session(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    """Public profile bundle: same shape as the authed variant — hero
-    summary + first-page matches inline."""
-    target = await make_user(db_session, "public.player")
-    opponent = await make_user(db_session, "public.opp")
-    await _record_match_with_winner(db_session, target, opponent, created_at=BASE_TIME)
-    async with make_client() as client:
-        response = await client.get("/v1/p/players/public.player")
-    assert response.status_code == 200
-    body = response.json()
-    assert body["id"] == str(target.id)
-    assert body["username"] == "public.player"
-    assert "session" not in response.cookies
-    # Embedded matches let the public profile paint in one request.
-    assert body["matches"]["total"] == 1
-    assert body["matches"]["items"][0]["opponent"]["username"] == "public.opp"
-    assert api_client is not None
-
-
-async def test_get_public_player_404_when_missing(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    async with make_client() as client:
-        response = await client.get("/v1/p/players/nobody.here")
-    assert response.status_code == 404
-    assert api_client is not None
-    assert db_session is not None
-
-
-async def test_get_public_player_is_rate_limited_per_ip(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    """After 60 requests in the same minute from one IP, the 61st returns 429."""
-    await make_user(db_session, "rl.public.player")
-    async with make_client() as client:
-        for i in range(60):
-            response = await client.get("/v1/p/players/rl.public.player")
-            assert response.status_code == 200, (i, response.text)
-        over = await client.get("/v1/p/players/rl.public.player")
-    assert over.status_code == 429
-    assert api_client is not None
-
-
 async def test_list_player_matches_returns_perspective_paginated(
     api_client: AsyncClient, db_session: AsyncSession
 ):
@@ -645,37 +600,13 @@ async def test_list_player_matches_404_when_player_missing(
     assert response.status_code == 404
 
 
-async def test_list_player_matches_does_not_require_a_session(
+async def test_list_player_matches_requires_a_session(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    """The matches endpoint is public — both the authed
-    `/players/$userId` page and the public `/p/players/$username` page
-    hit it with the same id (the public page resolves username → id via
-    `/v1/p/players/{username}` first). Rate-limited per-IP for both."""
-    target = await make_user(db_session, "anon.viewer.target")
-    opp = await make_user(db_session, "anon.viewer.opp")
-    await _record_match_with_winner(db_session, target, opp, created_at=BASE_TIME)
+    """The matches endpoint backs page 2+ of the authed profile page, so it
+    requires a session like the rest of `/players`."""
+    target = await make_user(db_session, "needs.auth.matches")
     async with make_client() as client:
         response = await client.get(f"/v1/players/{target.id}/matches")
-    assert response.status_code == 200
-    body = response.json()
-    assert body["total"] == 1
-    assert body["items"][0]["result"] == "W"
-    assert body["items"][0]["opponent"]["username"] == "anon.viewer.opp"
-    assert "session" not in response.cookies
-    assert api_client is not None
-
-
-async def test_list_player_matches_is_rate_limited_per_ip(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    """Per-IP rate limit (60/min) keeps the matches endpoint from being
-    scraped from a single source, even though it's now public."""
-    target = await make_user(db_session, "rl.matches.target")
-    async with make_client() as client:
-        for i in range(60):
-            response = await client.get(f"/v1/players/{target.id}/matches")
-            assert response.status_code == 200, (i, response.text)
-        over = await client.get(f"/v1/players/{target.id}/matches")
-    assert over.status_code == 429
+    assert response.status_code == 401
     assert api_client is not None

--- a/web-client/src/api/players.ts
+++ b/web-client/src/api/players.ts
@@ -111,9 +111,9 @@ export function usePlayerById(
 }
 
 /** Per-player paginated match list — pre-shaped from the player's
- * perspective so the FE doesn't have to flip set scores. The backend
- * endpoint is public (no session required) and IP-rate-limited. The authed
- * `/players/$userId` route already has the id by the time it calls this.
+ * perspective so the FE doesn't have to flip set scores. Backs page 2+ of
+ * the authed `/players/$userId` profile page, which already has the id by
+ * the time it calls this.
  *
  * Intentionally NOT `throwOnError`: the profile page renders an inline
  * "Couldn't load matches · Try again" affordance for transient failures

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -611,27 +611,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/p/players/{username}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Public Player
-         * @description Public profile bundle for `/p/players/$username` — same shape as
-         *     the authed endpoint. No session required, rate-limited per-IP.
-         */
-        get: operations["get_public_player_v1_p_players__username__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v1/players/{player_id}/matches": {
         parameters: {
             query?: never;
@@ -641,16 +620,11 @@ export interface paths {
         };
         /**
          * List Player Matches
-         * @description Paginated per-player match history backing the profile-page match
-         *     table on BOTH the authed (`/players/$userId`) and public
-         *     (`/p/players/$username`) surfaces — the public page has already
-         *     resolved username → id via `/v1/p/players/{username}`, so it has the
-         *     id to hit this endpoint with.
-         *
-         *     Public — no session required, IP-rate-limited (60/min) so the match
-         *     history can't be scraped from a single source. Newest-first by
-         *     ``created_at``. Sets are projected from the player's perspective so
-         *     the FE renders them without flipping sides.
+         * @description Paginated per-player match history backing page 2+ of the authed
+         *     profile page (`/players/$userId`); page 1 ships inline in the
+         *     `/v1/players/{id}` bundle. Newest-first by ``created_at``. Sets are
+         *     projected from the player's perspective so the FE renders them without
+         *     flipping sides.
          */
         get: operations["list_player_matches_v1_players__player_id__matches_get"];
         put?: never;
@@ -1898,8 +1872,8 @@ export interface components {
          * PlayerDetail
          * @description Profile-page bundle: the hero (`PlayerSummary` fields) plus the
          *     first page of matches inline. Saves a round trip on initial load —
-         *     `GET /v1/players/{id}` (and the public `/v1/p/players/{username}`
-         *     variant) returns this so the profile page paints with one request.
+         *     `GET /v1/players/{id}` returns this so the profile page paints with one
+         *     request.
          *
          *     Pagination beyond page 1 still hits `GET /v1/players/{id}/matches`
          *     directly; the FE seeds page 1's cache from this `matches` field via
@@ -3894,39 +3868,6 @@ export interface operations {
             };
         };
     };
-    get_public_player_v1_p_players__username__get: {
-        parameters: {
-            query?: {
-                league_id?: string | null;
-            };
-            header?: never;
-            path: {
-                username: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PlayerDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     list_player_matches_v1_players__player_id__matches_get: {
         parameters: {
             query?: {
@@ -3937,7 +3878,9 @@ export interface operations {
             path: {
                 player_id: string;
             };
-            cookie?: never;
+            cookie?: {
+                session?: string | null;
+            };
         };
         requestBody?: never;
         responses: {

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -221,8 +221,8 @@ function playerDetail(p: {
   }
 }
 
-/** Shared by the authed and public per-player-matches handlers — projects
- * the player's matches and slices to the requested page. */
+/** Backs the per-player-matches handler — projects the player's matches and
+ * slices to the requested page. */
 function paginatedMatches(
   player: { id: string; username: string },
   request: Request,


### PR DESCRIPTION
## What

Removes the only `/p/` route in the codebase and cleans up everything it left orphaned.

- **Deletes `GET /v1/p/players/{username}`** — a public, username-keyed profile bundle that had **zero FE consumers** (no route, hook, or MSW handler ever called it). It was a dead twin of the authed `GET /v1/players/{id}`, the exact "don't twin `/v1/p/X`" anti-pattern called out in `api/CLAUDE.md`. Its only-caller helper `_load_player_by_username` goes with it.
- **Re-gates `GET /v1/players/{player_id}/matches` behind `get_current_user`.** It was made public + IP-rate-limited solely to feed the never-built public page; its actual consumer is page 2+ of the *authed* `/players/$userId` profile. Removes the now-orphaned `public_player_ip_rate_limit` limiter, `_public_player_ip_key`, and the four imports (`Request`, `Duration`, `Rate`, `RedisRateLimiter`) they alone used.
- Cleans `/p/` references from docstrings (`players.py`, `schemas/player.py`, `players.ts` JSDoc) and regenerates `schema.d.ts`.

## Tests

- Removed 5 public-surface tests; replaced with `test_list_player_matches_requires_a_session` (asserts 401).
- API: `ruff` ✓, `ruff format --check` ✓, `mypy --strict` ✓, `pytest` **480 passed**.
- Web: `vitest` **965 passed**, `lint` clean (one pre-existing unrelated warning), `build` (tsc -b) ✓, web-client Playwright e2e **128 passed**.
- OpenAPI schema regenerated and verified in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)