### PR TITLE
Fix cold deep-link to /login: gate CSRF guard on session cookie

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -18,7 +18,12 @@ from app.notifications.router import router as notifications_router
 from app.players import router as players_router
 from app.rate_limiting import init_rate_limit_redis, shutdown_rate_limit_redis
 from app.rbac import router as rbac_router
-from app.sessions import CSRF_COOKIE_NAME, CSRF_HEADER_NAME, CSRF_SAFE_METHODS
+from app.sessions import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    CSRF_SAFE_METHODS,
+    SESSION_COOKIE_NAME,
+)
 from app.sessions import router as sessions_router
 from app.tournaments import router as tournaments_router
 
@@ -49,12 +54,28 @@ app = FastAPI(title="FortyMM API", lifespan=lifespan)
 async def csrf_protect(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]
 ) -> Response:
-    """Double-submit CSRF guard: every unsafe-method request must echo the
-    non-HttpOnly ``csrf_token`` cookie back in the ``X-CSRF-Token`` header. A
-    cross-origin attacker's page can ride along the cookie but can neither read
-    its value nor set a custom header, so it can't produce a match. The cookie
-    is issued/rotated alongside the session cookie in ``app.sessions``."""
-    if request.method not in CSRF_SAFE_METHODS:
+    """Double-submit CSRF guard: every unsafe-method request that rides an
+    established ``session`` cookie must echo the non-HttpOnly ``csrf_token``
+    cookie back in the ``X-CSRF-Token`` header. A cross-origin attacker's page
+    can ride along the cookie but can neither read its value nor set a custom
+    header, so it can't produce a match. The cookie is issued/rotated alongside
+    the session cookie in ``app.sessions``.
+
+    The guard only engages when a session cookie is present, because CSRF is
+    only meaningful against a request abusing a victim's *ambient authority* —
+    the session cookie the browser attaches automatically. A request with no
+    session cookie carries no such authority: it runs anonymously, so there is
+    nothing to forge. Exempting it is what lets the cold, cookieless auth flows
+    work — landing straight on ``/login`` to request a sign-in link, or opening
+    a magic-link / email-confirm on a device that never loaded the app (and so
+    was never issued a csrf_token cookie). Those endpoints are gated by their
+    own non-cookie credential — a captcha + rate limit on ``/login/request``, an
+    unguessable single-use token in the body on consume/confirm — so they don't
+    need (or get) CSRF cover. The moment a session cookie rides along, the
+    double-submit guard is enforced in full."""
+    if request.method not in CSRF_SAFE_METHODS and request.cookies.get(
+        SESSION_COOKIE_NAME
+    ):
         cookie = request.cookies.get(CSRF_COOKIE_NAME)
         header = request.headers.get(CSRF_HEADER_NAME)
         if not cookie or not header or not secrets.compare_digest(cookie, header):

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -56,8 +56,10 @@ SESSION_COOKIE_NAME = "session"
 # cookie is HttpOnly so a cross-origin attacker can't read it; this one is
 # readable by our own JS, which echoes it in the ``X-CSRF-Token`` header on
 # mutating requests. ``csrf_protect`` (app/main.py) rejects any unsafe-method
-# request whose header doesn't match this cookie. An attacker's page can ride
-# along the cookies but can neither read this value nor set the custom header.
+# request that carries a session cookie whose header doesn't match this cookie
+# (a cookieless request has no ambient authority to forge, so the guard skips
+# it). An attacker's page can ride along the cookies but can neither read this
+# value nor set the custom header.
 CSRF_COOKIE_NAME = "csrf_token"
 CSRF_HEADER_NAME = "x-csrf-token"
 # Methods that can't mutate state are exempt from the CSRF check; OPTIONS

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -100,6 +100,16 @@ def make_client() -> AsyncClient:
     )
 
 
+def make_raw_client() -> AsyncClient:
+    """Like ``make_client`` but *without* the CSRF auto-attach hook, so a test
+    can drive the double-submit guard by hand — or stand in for a cold,
+    cookieless browser that was never issued session/csrf cookies."""
+    return AsyncClient(
+        transport=ASGITransport(app=fastapi_app),
+        base_url="https://testserver",
+    )
+
+
 @asynccontextmanager
 async def opponent_session(
     db_session: AsyncSession, username: str

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -28,6 +28,7 @@ from app.sessions import (
 from tests._helpers import (
     CSRF_EVENT_HOOKS,
     make_client,
+    make_raw_client,
     make_user,
     start_session,
 )
@@ -787,3 +788,38 @@ async def test_consume_skip_merge_signs_in_without_folding(
         await db_session.execute(select(User).where(User.id == guest.id))
     ).scalar_one()
     assert survivor.merged_into_user_id is None
+
+
+# ----- Cold, cookieless sign-in (regression for the direct-to-/login bug) ----
+
+
+@pytest_asyncio.fixture
+async def cold_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    """A client with no session cookie and *without* the CSRF auto-attach hook,
+    standing in for a browser that landed straight on ``/login`` (or opened a
+    magic link on a device that never loaded the app), so it was never issued
+    session/csrf cookies."""
+
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    app.dependency_overrides[get_session] = _override
+    async with make_raw_client() as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+async def test_request_login_succeeds_without_session_or_csrf_cookie(
+    cold_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """Landing cold on ``/login`` and requesting a link must not 403: the
+    request carries no session cookie, so the CSRF double-submit guard doesn't
+    engage (there is no ambient authority to forge), and captcha + rate limiting
+    still gate the endpoint."""
+    await _make_confirmed_user(db_session, "rita@example.com")
+
+    response = await cold_client.post("/v1/login/request", json=REQUEST_BODY)
+
+    assert response.status_code == 202
+    assert response.json() == {"email": "rita@example.com"}
+    assert cold_client.cookies.get(SESSION_COOKIE_NAME) is None

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -17,7 +17,7 @@ from app.sessions import (
     SESSION_COOKIE_NAME,
     SESSION_TOKEN_CONTEXT,
 )
-from tests._helpers import CSRF_EVENT_HOOKS, make_client, start_session
+from tests._helpers import CSRF_EVENT_HOOKS, make_client, make_raw_client, start_session
 
 
 @pytest_asyncio.fixture
@@ -432,10 +432,7 @@ async def raw_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
         yield db_session
 
     app.dependency_overrides[get_session] = _override
-    transport = ASGITransport(app=app)
-    async with AsyncClient(
-        transport=transport, base_url="https://testserver"
-    ) as client:
+    async with make_raw_client() as client:
         yield client
     app.dependency_overrides.clear()
 
@@ -496,6 +493,19 @@ async def test_safe_methods_never_require_a_csrf_token(raw_client: AsyncClient):
     """GET (and other safe methods) must pass even with no token at all."""
     response = await raw_client.get("/v1/session")
     assert response.status_code == 200
+
+
+async def test_mutating_request_without_session_cookie_is_exempt(
+    raw_client: AsyncClient,
+):
+    """A cookieless mutation carries no ambient authority to forge, so the
+    double-submit guard doesn't engage — it must pass without a csrf token. (A
+    fresh logout is idempotent, so DELETE /v1/session returns 204 here.) This is
+    what lets a browser landing straight on /login, or opening a magic link on a
+    device that never loaded the app, reach the auth endpoints at all."""
+    assert raw_client.cookies.get(SESSION_COOKIE_NAME) is None
+    response = await raw_client.delete("/v1/session")
+    assert response.status_code == 204
 
 
 async def test_session_reissues_csrf_cookie_when_dropped(raw_client: AsyncClient):


### PR DESCRIPTION
## Problem

Landing **cold** (no cookies) directly on `/login` — a bookmark, a shared link, a returning user — then requesting a sign-in link failed:

```
POST /api/v1/login/request → 403 {"detail":"CSRF token missing or invalid."}
```

The `/login` route makes **no API calls on load**, so the `session` / `csrf_token` cookies (only ever issued by `GET /v1/session`, fired by the app shell on `/_app/*` routes) were never set. The double-submit CSRF guard then rejected the login POST. Bouncing through any other route first worked around it.

This is a **class** of bug, not just `/login`: cold magic-link sign-in (`/login/verifying` → `POST /v1/login/consume`) and email-confirm (`/confirm-email` → `POST /v1/me/email/confirm`) hit the same wall on any device that never loaded the app — and those routes *deliberately* must not mint a guest session (see `confirm-email.tsx:131`), so a "just call `GET /v1/session` first" client fix would be wrong for them.

## Fix

Engage the double-submit guard **only when a `session` cookie is present** (`api/app/main.py`).

CSRF only matters against a request abusing a victim's *ambient authority* — the session cookie the browser attaches automatically. A cookieless request runs anonymously; there is nothing to forge. The affected endpoints are each gated by their own non-cookie credential — captcha + rate-limit on `/login/request`, an unguessable single-use token on consume/confirm — so they don't need (or get) CSRF cover. The moment a session cookie rides along (any logged-in user), the guard is enforced in full.

One server-side change fixes all three cold flows, mints **no** orphan guest sessions, and needs **no** client change.

## Tests

- `test_request_login_succeeds_without_session_or_csrf_cookie` (the exact reported repro) and `test_mutating_request_without_session_cookie_is_exempt` (middleware contract). Existing CSRF rejection tests still pass — they establish a session cookie first, so the guard still engages.
- Extracted a shared `make_raw_client()` test helper to dedup the cookieless-client fixtures.

## Verification

- `ruff check` + `ruff format --check` clean; `mypy --strict` clean (77 files); `pytest` green (486 passed).
- OpenAPI schema regen produced no drift (middleware change, no route signature touched).
- No `web-client/**`, `e2e/**`, or `ios/**` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)