### PR TITLE
iOS: refresh stale server state without relaunch (fixes #452)

### DIFF
--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -54,6 +54,14 @@ struct DashboardView: View {
             // Returning to the foreground may surface cross-device changes (a
             // match the other player just confirmed) — refetch in place.
             .refetchOnForeground { Task { await store.load(force: true) } }
+            // The signed-in identity just changed under us — an in-app sign-in /
+            // account merge folded a new user into the session. The dashboard
+            // payload (rating, opponent) is now for the wrong account; refetch so
+            // Home isn't stale until a relaunch. `.onChange` skips the initial
+            // value, so this fires only on a later merge, not first load.
+            .onChange(of: session.username) { _, _ in
+                Task { await store.load(force: true) }
+            }
 
             if resumeLoading { FMBlockingSpinner() }
         }

--- a/ios/Fortymm/MatchFlow/MatchDetailView.swift
+++ b/ios/Fortymm/MatchFlow/MatchDetailView.swift
@@ -44,6 +44,10 @@ struct MatchDetailView: View {
                 }
                 .padding(.bottom, 120)
             }
+            // Pull-to-refresh: the one in-foreground way to pick up a cross-device
+            // change (the opponent confirmed/disputed) while staring at this screen,
+            // since there's no live poll. Mirrors the dashboard/matches-list pulls.
+            .refreshable { await refresh(force: true) }
             footer
             if actioning { FMBlockingSpinner() }
         }

--- a/ios/Fortymm/Session/SessionStore.swift
+++ b/ios/Fortymm/Session/SessionStore.swift
@@ -53,6 +53,12 @@ final class SessionStore: ObservableObject {
         return nil
     }
 
+    /// The signed-in username, or nil before the session resolves. A stable
+    /// identity handle for screens that need to refetch when the signed-in user
+    /// changes (a sign-in/merge flips a guest username to the account's), since
+    /// `state` isn't `Equatable` and can't be observed with `.onChange`.
+    var username: String? { user?.username }
+
     private let client: APIClient
     private var cancellables = Set<AnyCancellable>()
 


### PR DESCRIPTION
## What

Closes #452. Two iOS staleness bugs from the 2026-06-05 QA pass. Most of the issue was already fixed by #460 (foreground + pull-to-refresh + post-mutation refetch on dashboard and matches list); this closes the two remaining gaps.

- **Match detail had no pull-to-refresh.** `MatchDetailView` got `.refetchOnForeground` in #460 but never `.refreshable`, so an "Awaiting confirmation" screen couldn't be pulled to pick up the other device's confirm/dispute while in the foreground. Added `.refreshable { await refresh(force: true) }` on the ScrollView (reuses the existing `refresh(force:)`).
- **Dashboard didn't refetch on in-app identity change.** After an in-app sign-in / account merge, `SessionStore` folded in the new user and the greeting updated, but `DashboardStore` was never told to refetch — rating + opponent stayed stale until relaunch. Added `.onChange(of: session.username)` → `store.load(force: true)`. `.onChange` skips the initial value, so it fires only on a later merge, not first load.
- Added a `SessionStore.username` convenience to observe (the `State` enum isn't `Equatable`).

The matches list needs no change — it self-heals via its existing `.onAppear { reload() }` on tab re-entry. Scope is event-driven refetch only (no live polling), matching the issue's "Expected" and the app's existing pattern.

## Testing

- `/simplify` — clean (reuse + altitude reviews both confirmed ship-as-is).
- Clean iOS simulator build (`rm -rf ios/build/sim && xcodebuild ...`) — **BUILD SUCCEEDED**.
- No API/schema/web changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)