### PR TITLE
Fix MA4: count ghost side's games in solo-match sr-only headline

### DIFF
--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.test.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.test.ts
@@ -406,6 +406,41 @@ describe("scoreboardQuery", () => {
     );
   });
 
+  it("counts the games the ghost side won in a finished solo match (MA4)", async () => {
+    // In solo play the playerless ghost side can still take individual games, so
+    // it carries `won: false` with a non-zero games_won. The heading must report
+    // that tally rather than hardcoding "to 0", which dropped the ghost's wins.
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          status_label: "Final",
+          sides: [
+            buildMatchDetailsSide({
+              won: true,
+              games_won: 3,
+              players: [buildMatchDetailsPlayer({ username: "rita.kovac" })],
+            }),
+            buildMatchDetailsSide({
+              side_number: 2,
+              won: false,
+              games_won: 1,
+              players: [],
+              is_current_user_side: false,
+            }),
+          ],
+          data: { scoreboard: { status: "final" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.outcome).toBe(
+      "rita.kovac finished, winning 3 games to 1",
+    );
+  });
+
   it("returns a null outcome when a side is missing entirely", async () => {
     scoreboardQueryPage.mockEndpoint(() =>
       HttpResponse.json(buildMatchDetails({ sides: [buildMatchDetailsSide()] })),

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.ts
@@ -129,10 +129,13 @@ const selectOutcome = (match: MatchDetailsResult): string | null => {
   // branch above can't pair a loser. Without this branch the null guard below
   // swallows the result and the hero heading reads just "Match" (#495). Trigger
   // only when exactly one side carries a player — a real opponent whose side
-  // simply isn't stamped lost yet falls through to the in-progress copy.
+  // simply isn't stamped lost yet falls through to the in-progress copy. The
+  // ghost side is still stamped `won === false`, so `loser` already points at
+  // it; read its real games_won — in solo play the ghost can take games, so
+  // hardcoding "to 0" understated the loser's tally whenever it won ≥1 (MA4).
   const playeredSides = sides.filter((s) => s.players[0]);
   if (winner?.players[0] && playeredSides.length === 1) {
-    return `${winner.players[0].username} finished, winning ${games(winner.games_won)} to 0`;
+    return `${winner.players[0].username} finished, winning ${games(winner.games_won)} to ${loser?.games_won ?? 0}`;
   }
 
   // Still in progress (or posted, awaiting confirmation): describe the current


### PR DESCRIPTION
## What

The completed-match visually-hidden `<h2>` on the match-details scoreboard announced the wrong game count for **solo (no-opponent) matches**.

For a 3–1 solo result, the `sr-only` headline read "…winning **3 games to 0**" while the visible score, SETS column, and game list all correctly showed 3–1. Screen-reader users got a materially wrong result whenever the ghost side won ≥1 game.

## Why

A finished solo match takes the scoreboard "solo" outcome branch in `selectOutcome` (`scoreboard-query.ts`) because its ghost opponent side has no player, so the "defeated" branch can't pair a loser. That branch **hardcoded "to 0"** — but in solo play the ghost side can still take individual games; it's stamped `won === false` with a non-zero `games_won`.

## Fix

The `loser` variable (found via `won === false`) already points at that ghost side, so the headline now reads its real `games_won` (`loser?.games_won ?? 0`) instead of a hardcoded `0`. The zero-game solo case (#495) is unchanged.

## Testing

- `web-client` vitest: **974 passed** (added a regression test for a solo match where the ghost won a game → "winning 3 games to 1")
- `npm run lint` clean (only a pre-existing generated-file warning)
- `npm run build` (tsc typecheck + vite) OK
- `web-client` Playwright e2e: **128 passed**

No API or OpenAPI schema changes — pure web-client view-model logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)