### PR TITLE
Observability stack (Prometheus/Grafana/Loki/Tempo) + Faro browser telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ node_modules/
 
 secrets
 .qa-review/
+
+# Helm chart dependencies are vendored at deploy time (helm dependency build
+# reads Chart.lock, which IS committed). Don't commit the downloaded tarballs.
+deploy/observability/charts/

--- a/deploy/observability/Chart.lock
+++ b/deploy/observability/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 86.3.2
+- name: loki-stack
+  repository: https://grafana.github.io/helm-charts
+  version: 2.10.3
+- name: tempo
+  repository: https://grafana.github.io/helm-charts
+  version: 1.24.4
+digest: sha256:6377989ded2e3c6a6bd03a1dfe53208133df4372cf45896a988ecb8ecd52c648
+generated: "2026-06-20T06:54:03.626299-05:00"

--- a/deploy/observability/Chart.yaml
+++ b/deploy/observability/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: observability
+description: |
+  Observability stack for FortyMM UAT on Kubernetes: kube-prometheus-stack
+  (Prometheus + Grafana + Alertmanager), loki-stack (Loki + Promtail), and
+  Tempo, deployed into the `monitoring` namespace. Grafana ships Loki + Tempo
+  datasources; Promtail redacts email addresses before they reach Loki. Each of
+  Grafana / Prometheus / Loki is fronted by a per-service `tailscale serve`
+  proxy (see templates/tailscale-proxies.yaml) so they're reachable privately
+  on the tailnet — mirrors deploy/uat's tailscale.yaml pattern, no operator.
+
+  Kept as a sibling chart (not a subchart of deploy/uat) so the cluster-scoped
+  CRDs + Prometheus operator have their own release lifecycle and so the stack
+  can live in its own `monitoring` namespace. scripts/redeploy-uat.sh installs
+  both releases.
+type: application
+version: 0.1.0
+appVersion: "uat"
+
+dependencies:
+  - name: kube-prometheus-stack
+    version: "86.3.2"
+    repository: https://prometheus-community.github.io/helm-charts
+  - name: loki-stack
+    version: "2.10.3"
+    repository: https://grafana.github.io/helm-charts
+  - name: tempo
+    version: "1.24.4"
+    repository: https://grafana.github.io/helm-charts

--- a/deploy/observability/templates/_helpers.tpl
+++ b/deploy/observability/templates/_helpers.tpl
@@ -1,0 +1,22 @@
+{{/* Common labels applied to objects this chart defines directly. */}}
+{{- define "observability.labels" -}}
+app.kubernetes.io/name: observability
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+tailscale serve config for one proxy. Pass the backend URL as the context.
+${TS_CERT_DOMAIN} is substituted by the container with the node's MagicDNS
+name at startup. Mirrors deploy/uat's fortymm-uat.tailscaleServe helper.
+*/}}
+{{- define "observability.tailscaleServe" -}}
+{
+  "TCP": { "443": { "HTTPS": true } },
+  "Web": {
+    "${TS_CERT_DOMAIN}:443": {
+      "Handlers": { "/": { "Proxy": {{ . | quote }} } }
+    }
+  }
+}
+{{- end -}}

--- a/deploy/observability/templates/alloy.yaml
+++ b/deploy/observability/templates/alloy.yaml
@@ -1,0 +1,123 @@
+{{- if .Values.alloy.enabled }}
+{{- $a := .Values.alloy }}
+{{/*
+Grafana Alloy running a faro.receiver: ingests browser telemetry from the
+@grafana/faro-web-sdk in the SPA and fans it out — logs -> Loki, traces ->
+Tempo. The browser reaches it same-origin at /faro/collect via the routing
+nginx (deploy/uat), so both public (uat.fortymm.com) and tailnet users are
+captured. Abuse controls live on the receiver itself: CORS origin allowlist,
+request rate limiting, and a max payload size (a browser endpoint is inherently
+public — these cap the blast radius rather than authenticate callers).
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy-config
+  labels:
+    {{- include "observability.labels" . | nindent 4 }}
+data:
+  config.alloy: |
+    faro.receiver "frontend" {
+      server {
+        listen_address           = "0.0.0.0"
+        listen_port              = {{ $a.faroPort }}
+        cors_allowed_origins     = {{ $a.corsAllowedOrigins | toJson }}
+        max_allowed_payload_size = {{ $a.maxPayloadSize | quote }}
+
+        rate_limiting {
+          enabled = true
+          rate    = {{ $a.rateLimitPerSecond }}
+        }
+      }
+
+      sourcemaps { }
+
+      output {
+        logs   = [loki.write.faro.receiver]
+        traces = [otelcol.exporter.otlp.tempo.input]
+      }
+    }
+
+    loki.write "faro" {
+      endpoint {
+        url = "http://loki:3100/loki/api/v1/push"
+      }
+      external_labels = {
+        source = "faro",
+        app    = "fortymm-web",
+      }
+    }
+
+    otelcol.exporter.otlp "tempo" {
+      client {
+        endpoint = "tempo:4317"
+        tls {
+          insecure = true
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alloy
+  labels:
+    {{- include "observability.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alloy
+  template:
+    metadata:
+      labels:
+        app: alloy
+      annotations:
+        # Roll the pod when the receiver config (derived from these values) changes.
+        checksum/config: {{ $a | toYaml | sha256sum }}
+    spec:
+      containers:
+        - name: alloy
+          image: {{ $a.image }}
+          imagePullPolicy: {{ .Values.tailscaleProxies.pullPolicy }}
+          args:
+            - run
+            - --server.http.listen-addr=0.0.0.0:12345
+            - --storage.path=/var/lib/alloy/data
+            - /etc/alloy/config.alloy
+          ports:
+            - name: faro
+              containerPort: {{ $a.faroPort }}
+            - name: http
+              containerPort: 12345
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 12345
+            initialDelaySeconds: 10
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+            - name: data
+              mountPath: /var/lib/alloy
+      volumes:
+        - name: config
+          configMap:
+            name: alloy-config
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alloy
+  labels:
+    {{- include "observability.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: alloy
+  ports:
+    - name: faro
+      port: {{ $a.faroPort }}
+      targetPort: {{ $a.faroPort }}
+{{- end }}

--- a/deploy/observability/templates/tailscale-proxies.yaml
+++ b/deploy/observability/templates/tailscale-proxies.yaml
@@ -1,0 +1,115 @@
+{{- if .Values.tailscaleProxies.enabled }}
+{{- $top := . }}
+{{- $p := .Values.tailscaleProxies }}
+{{/*
+One tailscale node per service (Grafana / Prometheus / Loki). Each registers a
+distinct MagicDNS hostname and `tailscale serve`s HTTPS:443 -> its backend
+Service. State persists in a per-node Secret so identity survives restarts.
+Userspace networking — no NET_ADMIN / /dev/net/tun needed on k3d.
+
+Prereqs (admin console): MagicDNS + HTTPS certs enabled, and a reusable
+non-ephemeral auth key in .env as TS_AUTHKEY (redeploy-uat.sh syncs it into the
+`{{ $p.authKeySecret }}` Secret in this namespace).
+*/}}
+{{- range $svc := $p.services }}
+{{- $name := printf "ts-%s" $svc.hostname }}
+{{- $stateSecret := printf "tailscale-state-%s" $svc.hostname }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "observability.labels" $top | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "observability.labels" $top | nindent 4 }}
+rules:
+  # Create the state secret on first run...
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  # ...then read/update only that one secret on subsequent runs.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["{{ $stateSecret }}"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "observability.labels" $top | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+roleRef:
+  kind: Role
+  name: {{ $name }}
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "ts-serve-%s" $svc.hostname }}
+  labels:
+    {{- include "observability.labels" $top | nindent 4 }}
+data:
+  serve.json: |
+    {{- include "observability.tailscaleServe" $svc.backend | nindent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "observability.labels" $top | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $name }}
+  # Only one node identity may be active at a time; don't run two side-by-side.
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: {{ $name }}
+      annotations:
+        checksum/serve: {{ include "observability.tailscaleServe" $svc.backend | sha256sum }}
+    spec:
+      serviceAccountName: {{ $name }}
+      containers:
+        - name: tailscale
+          image: {{ $p.image }}
+          imagePullPolicy: {{ $p.pullPolicy }}
+          env:
+            - name: TS_KUBE_SECRET
+              value: {{ $stateSecret | quote }}
+            - name: TS_USERSPACE
+              value: "true"
+            - name: TS_HOSTNAME
+              value: {{ $svc.hostname | quote }}
+            - name: TS_SERVE_CONFIG
+              value: /etc/tailscale/serve.json
+            - name: TS_AUTHKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $p.authKeySecret }}
+                  key: {{ $p.authKeySecretKey }}
+          volumeMounts:
+            - name: serve
+              mountPath: /etc/tailscale
+              readOnly: true
+      volumes:
+        - name: serve
+          configMap:
+            name: {{ printf "ts-serve-%s" $svc.hostname }}
+{{- end }}
+{{- end }}

--- a/deploy/observability/values.yaml
+++ b/deploy/observability/values.yaml
@@ -1,0 +1,124 @@
+# Values for the observability chart. Subchart values are nested under each
+# dependency's chart name. fullnameOverrides pin the Service names so the
+# Grafana datasource URLs and the tailscale proxy backends below stay stable
+# (otherwise Helm prefixes them with the umbrella release name).
+
+# --------------------------------------------------------------------------
+# kube-prometheus-stack: Prometheus + Grafana + Alertmanager + operator.
+# --------------------------------------------------------------------------
+kube-prometheus-stack:
+  fullnameOverride: kube-prometheus-stack
+  grafana:
+    fullnameOverride: kube-prometheus-stack-grafana
+    # Admin creds come from a Secret created out-of-band by redeploy-uat.sh
+    # from .env (GRAFANA_ADMIN_PASSWORD) — never committed to the chart.
+    admin:
+      existingSecret: grafana-admin
+      userKey: admin-user
+      passwordKey: admin-password
+    # Loki + Tempo datasources (Prometheus is auto-provisioned by the chart).
+    additionalDataSources:
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki:3100
+        isDefault: false
+      - name: Tempo
+        type: tempo
+        access: proxy
+        # grafana/tempo serves its HTTP/query API on 3200 (3100 is Loki's).
+        url: http://tempo:3200
+        isDefault: false
+
+# --------------------------------------------------------------------------
+# loki-stack: Loki + Promtail. Grafana/Prometheus subcharts disabled (we use
+# the ones from kube-prometheus-stack).
+# --------------------------------------------------------------------------
+loki-stack:
+  loki:
+    enabled: true
+    fullnameOverride: loki
+    # loki-stack pins Loki 2.6.1, which predates the log-volume feature
+    # (Grafana's "Logs volume" histogram + /loki/api/v1/index/volume, added in
+    # 2.8). Bump to 2.9.x and enable it so Explore shows volume.
+    image:
+      tag: 2.9.10
+    config:
+      limits_config:
+        volume_enabled: true
+  promtail:
+    enabled: true
+    config:
+      # loki service is pinned to `loki`, so point promtail at it explicitly
+      # (the chart default derives this from the umbrella release name).
+      clients:
+        - url: http://loki:3100/loki/api/v1/push
+      snippets:
+        # Keep cri parsing first, then redact email addresses before they ship.
+        pipelineStages:
+          - cri: {}
+          - replace:
+              expression: '(\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b)'
+              replace: '[REDACTED_EMAIL]'
+  grafana:
+    enabled: false
+    # Even with grafana disabled, loki-stack's sidecar.datasources defaults to
+    # enabled and emits a grafana_datasource ConfigMap with Loki as DEFAULT —
+    # that collides with kube-prometheus-stack's default (Prometheus) and
+    # duplicates the Loki datasource we provision above. Suppress it.
+    sidecar:
+      datasources:
+        enabled: false
+  prometheus:
+    enabled: false
+
+# --------------------------------------------------------------------------
+# Tempo (single binary). Note the doubled key: `tempo:` is the dependency,
+# the nested `tempo:` is the chart's own config block.
+# --------------------------------------------------------------------------
+tempo:
+  fullnameOverride: tempo
+  tempo:
+    metricsGenerator:
+      enabled: false
+
+# --------------------------------------------------------------------------
+# Grafana Alloy faro.receiver — ingests browser telemetry from the SPA's
+# @grafana/faro-web-sdk and forwards logs -> Loki, traces -> Tempo. Reached
+# same-origin at /faro/collect via the routing nginx (deploy/uat). The abuse
+# controls below run on the receiver itself (a browser endpoint can't be
+# authenticated — these cap volume/origin/size, see README/answer).
+# --------------------------------------------------------------------------
+alloy:
+  enabled: true
+  image: grafana/alloy:v1.17.0
+  faroPort: 12347
+  # Browser origins allowed cross-origin (CORS). The SPA posts SAME-origin via
+  # the routing nginx, so those aren't subject to CORS at all and the public
+  # origin alone suffices — don't commit the tailnet domain (per the repo's
+  # <tailnet>/${TS_CERT_DOMAIN} convention); add tailnet/extra origins here if
+  # a cross-origin client ever needs them.
+  corsAllowedOrigins:
+    - https://uat.fortymm.com
+  # Per-client request rate cap on the receiver.
+  rateLimitPerSecond: 50
+  maxPayloadSize: "5MiB"
+
+# --------------------------------------------------------------------------
+# Per-service tailscale serve proxies (option C — no Tailscale operator). One
+# tailnet node per service => one MagicDNS hostname each, auto-HTTPS, tailnet
+# only. TS_AUTHKEY is read from a Secret synced from .env by redeploy-uat.sh.
+# --------------------------------------------------------------------------
+tailscaleProxies:
+  enabled: true
+  image: tailscale/tailscale:stable
+  pullPolicy: IfNotPresent
+  authKeySecret: tailscale-authkey
+  authKeySecretKey: TS_AUTHKEY
+  services:
+    - hostname: grafana
+      backend: "http://kube-prometheus-stack-grafana:80"
+    - hostname: prometheus
+      backend: "http://kube-prometheus-stack-prometheus:9090"
+    - hostname: loki
+      backend: "http://loki:3100"

--- a/deploy/uat/templates/_helpers.tpl
+++ b/deploy/uat/templates/_helpers.tpl
@@ -86,6 +86,25 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Browser telemetry (Grafana Faro) -> Alloy faro.receiver in the
+    # `monitoring` namespace (deploy/observability). resolver + variable
+    # upstream so this nginx starts even before the observability release
+    # exists (serves 502 on /faro until it does) and picks up a new Alloy
+    # ClusterIP without an nginx restart. 10.43.0.10 is the k3d CoreDNS
+    # (kube-dns) ClusterIP. Telemetry payloads are small; cap the body size.
+    location /faro/ {
+        resolver 10.43.0.10 valid=10s;
+        set $faro_upstream alloy.monitoring.svc.cluster.local:12347;
+        client_max_body_size 5m;
+        rewrite ^/faro/(.*)$ /$1 break;
+        proxy_pass http://$faro_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Direct API paths — FastAPI mounts routes at /v1/*; /openapi.json,
     # /docs, /redoc are FastAPI's defaults.
     location ~ ^/(v1|openapi\.json|docs|redoc)(/|$) {

--- a/scripts/redeploy-uat.sh
+++ b/scripts/redeploy-uat.sh
@@ -98,7 +98,7 @@ WEB_BUILD_ARGS=()
 if [ "$DEPLOY_OBSERVABILITY" = "true" ]; then
   WEB_BUILD_ARGS+=(--build-arg "VITE_FARO_COLLECTOR_URL=/faro/collect")
 fi
-docker build -t "$WEB_IMAGE" "${WEB_BUILD_ARGS[@]}" -f web-client/Dockerfile.uat web-client
+docker build -t "$WEB_IMAGE" "${WEB_BUILD_ARGS[@]+"${WEB_BUILD_ARGS[@]}"}" -f web-client/Dockerfile.uat web-client
 
 echo
 echo "==> Importing images into k3d"

--- a/scripts/redeploy-uat.sh
+++ b/scripts/redeploy-uat.sh
@@ -31,6 +31,16 @@ WEB_IMAGE="fortymm/web:uat"
 APNS_KEY="secrets/AuthKey_68VYRLMWWR.p8"
 UAT_URL="${UAT_URL:-https://uat.fortymm.com}"
 
+# Observability stack (kube-prometheus-stack + loki-stack + tempo) in its own
+# namespace/release. Set DEPLOY_OBSERVABILITY=false to skip it.
+OBS_NAMESPACE="monitoring"
+OBS_RELEASE="observability"
+OBS_CHART="deploy/observability"
+DEPLOY_OBSERVABILITY="${DEPLOY_OBSERVABILITY:-true}"
+
+# Read a single value from .env, stripping one layer of surrounding quotes.
+read_env() { grep "^$1=" .env | head -1 | cut -d= -f2- | sed -e "s/^[\"']//" -e "s/[\"']\$//"; }
+
 for bin in docker kubectl helm k3d; do
   command -v "$bin" >/dev/null 2>&1 || { echo "ERROR: '$bin' not found on PATH." >&2; exit 1; }
 done
@@ -82,7 +92,13 @@ kubectl get namespace "$NAMESPACE" >/dev/null 2>&1 || kubectl create namespace "
 echo
 echo "==> Building images"
 docker build -t "$API_IMAGE" -f api/Dockerfile.dev api
-docker build -t "$WEB_IMAGE" -f web-client/Dockerfile.uat web-client
+# Enable Grafana Faro in the UAT bundle: telemetry posts same-origin to
+# /faro/collect, which the routing nginx forwards to Alloy in `monitoring`.
+WEB_BUILD_ARGS=()
+if [ "$DEPLOY_OBSERVABILITY" = "true" ]; then
+  WEB_BUILD_ARGS+=(--build-arg "VITE_FARO_COLLECTOR_URL=/faro/collect")
+fi
+docker build -t "$WEB_IMAGE" "${WEB_BUILD_ARGS[@]}" -f web-client/Dockerfile.uat web-client
 
 echo
 echo "==> Importing images into k3d"
@@ -108,6 +124,20 @@ if [ "$ts_enabled" = "true" ]; then
     echo "       set tailscale.enabled=false in deploy/uat/values.yaml to skip it." >&2
     exit 1
   }
+fi
+
+# The observability stack needs a Grafana admin password and (for its tailscale
+# proxies) the same TS_AUTHKEY. Fail fast here rather than mid-deploy.
+require_env() {
+  grep -qE "^$1=." .env || {
+    echo "ERROR: $1 missing/empty in .env ($2)." >&2
+    echo "       Add it to .env, or set DEPLOY_OBSERVABILITY=false." >&2
+    exit 1
+  }
+}
+if [ "$DEPLOY_OBSERVABILITY" = "true" ]; then
+  require_env GRAFANA_ADMIN_PASSWORD "Grafana admin password"
+  require_env TS_AUTHKEY "observability tailscale proxies"
 fi
 
 kubectl create secret generic fortymm-uat-env \
@@ -142,6 +172,47 @@ until curl -fsS --max-time 3 "$UAT_URL/api/v1/health" >/dev/null 2>&1; do
   fi
   sleep 2
 done
+
+# --- observability ----------------------------------------------------------
+# Separate release in the `monitoring` namespace: kube-prometheus-stack (Grafana
+# + Prometheus + Alertmanager), loki-stack (Loki + Promtail with email
+# redaction), Tempo. Each of Grafana/Prometheus/Loki gets a tailscale serve
+# proxy (private MagicDNS hostname). Chart deps are vendored at deploy time.
+if [ "$DEPLOY_OBSERVABILITY" = "true" ]; then
+  echo
+  echo "==> Deploying observability stack ($OBS_RELEASE -> $OBS_NAMESPACE)"
+  kubectl get namespace "$OBS_NAMESPACE" >/dev/null 2>&1 || kubectl create namespace "$OBS_NAMESPACE"
+
+  # Secrets from .env (never committed): Grafana admin creds + tailscale key.
+  kubectl create secret generic grafana-admin \
+    --namespace "$OBS_NAMESPACE" \
+    --from-literal=admin-user=admin \
+    --from-literal=admin-password="$(read_env GRAFANA_ADMIN_PASSWORD)" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  kubectl create secret generic tailscale-authkey \
+    --namespace "$OBS_NAMESPACE" \
+    --from-literal=TS_AUTHKEY="$(read_env TS_AUTHKEY)" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  # Vendor chart dependencies (helm dependency build reads Chart.lock).
+  helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null 2>&1 || true
+  helm repo add grafana https://grafana.github.io/helm-charts >/dev/null 2>&1 || true
+  helm repo update prometheus-community grafana >/dev/null
+  helm dependency build "$OBS_CHART"
+
+  echo
+  echo "==> helm upgrade --install $OBS_RELEASE"
+  helm upgrade --install "$OBS_RELEASE" "$OBS_CHART" \
+    --namespace "$OBS_NAMESPACE" \
+    --wait --timeout 10m
+
+  echo
+  echo "==> Observability pods"
+  kubectl get pods -n "$OBS_NAMESPACE"
+else
+  echo
+  echo "(skipping observability deploy; DEPLOY_OBSERVABILITY=$DEPLOY_OBSERVABILITY)"
+fi
 
 echo
 echo "==> Pod status"

--- a/web-client/Dockerfile.uat
+++ b/web-client/Dockerfile.uat
@@ -12,6 +12,13 @@ COPY package.json package-lock.json .npmrc ./
 RUN npm ci
 
 COPY . .
+
+# Grafana Faro browser telemetry collector URL, baked into the bundle at build
+# time. Empty by default => Faro is a no-op (so the QA stack, which also builds
+# this Dockerfile, stays off). The UAT deploy passes /faro/collect.
+ARG VITE_FARO_COLLECTOR_URL=""
+ENV VITE_FARO_COLLECTOR_URL=$VITE_FARO_COLLECTOR_URL
+
 RUN npm run build
 
 FROM nginx:1.31-alpine

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
+        "@grafana/faro-web-sdk": "^2.7.1",
+        "@grafana/faro-web-tracing": "^2.7.1",
         "@hookform/resolvers": "^5.4.0",
         "@tailwindcss/vite": "^4.3.1",
         "@tanstack/react-query": "^5.101.0",
@@ -2246,6 +2248,46 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@grafana/faro-core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-2.7.1.tgz",
+      "integrity": "sha512-qJOp0sPBAEsmUxhs11nVdGx5Dk+VJ4CN/4s9ek99m33FfzybmjQ9nPXLHWhwEeNJNiEwQdDl4HsNUlXBGT5YEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/otlp-transformer": "^0.218.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-sdk": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-2.7.1.tgz",
+      "integrity": "sha512-ZK3MuE6FWBmiT5tTivcMovTVe8fG1tPm1ctc84blVoJkpQXlgODxOX7/fNmDBOjaHZ3EWdoGplZmjoXQ3g0mDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grafana/faro-core": "^2.7.1",
+        "ua-parser-js": "1.0.41",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/@grafana/faro-web-tracing": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-web-tracing/-/faro-web-tracing-2.7.1.tgz",
+      "integrity": "sha512-BCgFfxme4geu3glzHTbgdQpt1foKLS7Vu+jtuTYtelmR6VWBNcgrmrrzzOfJKTEmruk3Sq7SLM6/iAQS4CV1zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grafana/faro-web-sdk": "^2.7.1",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+        "@opentelemetry/instrumentation": "^0.218.0",
+        "@opentelemetry/instrumentation-fetch": "^0.218.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.218.0",
+        "@opentelemetry/otlp-transformer": "^0.218.0",
+        "@opentelemetry/resources": "^2.0.0",
+        "@opentelemetry/sdk-trace-web": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.32.0"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "license": "MIT",
@@ -2900,6 +2942,491 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
+      "integrity": "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fetch": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.218.0.tgz",
+      "integrity": "sha512-eP/Y5hDupb+6MwZSaMw4ZdsDz8YgfJbJ4Ta86BMVeOmI2EArwXcd0v1nfNIvUzXTPi7nakidwqeuUa3FwRwECg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/instrumentation": "0.218.0",
+        "@opentelemetry/sdk-trace-web": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fetch/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fetch/node_modules/@opentelemetry/sdk-trace-web": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.7.1.tgz",
+      "integrity": "sha512-K806OouCSOjMd8Nr7+ZCq3QT22tdAzzS/7h8vprfiKjkgFQ99/dvwU8d12WJANA6D5Qtme65hyBAqAu9CkQuxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-xml-http-request": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.218.0.tgz",
+      "integrity": "sha512-KzqSO62lTiqbT1ihKbbdJSt6A3TngIkacHJHi0SNUJmlpS0/Jg8Sn8kneKffQGjjpScODjZJ6LLs640zWlOGIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/instrumentation": "0.218.0",
+        "@opentelemetry/sdk-trace-web": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-xml-http-request/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-xml-http-request/node_modules/@opentelemetry/sdk-trace-web": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.7.1.tgz",
+      "integrity": "sha512-K806OouCSOjMd8Nr7+ZCq3QT22tdAzzS/7h8vprfiKjkgFQ99/dvwU8d12WJANA6D5Qtme65hyBAqAu9CkQuxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-web": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.8.0.tgz",
+      "integrity": "sha512-P3ZM8BGJ5mwjtyfAxRyxsCyWHvaj+xahdhLoS3YiPsEyTHcWTVzx2691C8SrGkpvro3tNFCsWuNNrvM+spKODg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
@@ -6768,13 +7295,21 @@
     },
     "node_modules/acorn": {
       "version": "8.16.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -7313,6 +7848,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -9254,6 +9795,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.1.0.tgz",
+      "integrity": "sha512-c0AeAV8VcwZzfYE7euTZY3H+VXUPMVugiovdosq80lqEXJmOekg3zGUAYg6KImHMaMuBoTUfTv7xNpUFdy0hJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
@@ -10592,6 +11148,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "dev": true,
@@ -11902,6 +12464,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve": {
@@ -13238,6 +13813,32 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
+      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -13737,6 +14338,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -19,6 +19,8 @@
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.9",
+    "@grafana/faro-web-sdk": "^2.7.1",
+    "@grafana/faro-web-tracing": "^2.7.1",
     "@hookform/resolvers": "^5.4.0",
     "@tailwindcss/vite": "^4.3.1",
     "@tanstack/react-query": "^5.101.0",

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -10,7 +10,12 @@ import { NotFoundPage } from '@/components/not-found-page'
 import { setSessionEndedHandler } from '@/api/client'
 import { SESSION_QUERY_KEY } from '@/api/session'
 import { clearAppEntered } from '@/lib/landing-redirect'
+import { initFaro } from '@/observability/faro'
 import { routeTree } from './routeTree.gen'
+
+// Start browser telemetry as early as possible so startup errors are captured.
+// No-op unless VITE_FARO_COLLECTOR_URL is set (UAT build only).
+void initFaro()
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/web-client/src/observability/faro.ts
+++ b/web-client/src/observability/faro.ts
@@ -1,0 +1,35 @@
+let started = false
+
+/**
+ * Initialize Grafana Faro browser telemetry — uncaught errors, console logs,
+ * web-vitals, and traces (forwarded to Loki/Tempo by the Alloy faro.receiver).
+ *
+ * Enabled only when VITE_FARO_COLLECTOR_URL is set, which happens just in the
+ * UAT build (`/faro/collect`, routed same-origin to Alloy). In local dev,
+ * tests, and the QA build the var is empty, so this is a no-op — no telemetry
+ * leaves the browser. The SDK is dynamically imported behind that build-time
+ * gate so the heavy Faro/OpenTelemetry tree stays out of the entry chunk (and
+ * is dropped entirely from builds where the URL is empty).
+ */
+export async function initFaro(): Promise<void> {
+  if (started || typeof window === 'undefined') return
+  const url = import.meta.env.VITE_FARO_COLLECTOR_URL
+  if (!url) return
+  started = true
+
+  const [{ getWebInstrumentations, initializeFaro }, { TracingInstrumentation }] =
+    await Promise.all([
+      import('@grafana/faro-web-sdk'),
+      import('@grafana/faro-web-tracing'),
+    ])
+
+  initializeFaro({
+    url,
+    app: {
+      name: 'fortymm-web',
+      version: import.meta.env.VITE_APP_VERSION || 'uat',
+      environment: import.meta.env.VITE_FARO_ENVIRONMENT || 'uat',
+    },
+    instrumentations: [...getWebInstrumentations(), new TracingInstrumentation()],
+  })
+}


### PR DESCRIPTION
## What

Adds a full observability stack for UAT plus Grafana Faro browser telemetry for the React app.

### New `deploy/observability` Helm chart
Sibling to `deploy/uat` (its own `monitoring` namespace, so the cluster-scoped CRDs + Prometheus operator have a separate release lifecycle).

- **kube-prometheus-stack / loki-stack / tempo** as pinned dependencies (`Chart.lock` committed; vendored tarballs gitignored, built at deploy time).
- **Grafana** provisioned with **Loki** (`http://loki:3100`) and **Tempo** (`http://tempo:3200` — the chart serves its query API on 3200) datasources; admin password from a `grafana-admin` Secret synced from `.env` (never committed).
- **Promtail** redacts email addresses (`replace` stage → `[REDACTED_EMAIL]`) before logs reach Loki.
- **Loki bumped to 2.9.10** with `limits_config.volume_enabled: true` so Grafana's log-volume feature works (the pinned 2.6.1 predates it).
- **Tailscale exposure** without the operator: a per-service `tailscale serve` proxy for Grafana/Prometheus/Loki (private MagicDNS, state persisted across restarts), mirroring `deploy/uat`'s tailscale pattern.

### Grafana Faro (browser/React telemetry)
- **Alloy `faro.receiver`** (`templates/alloy.yaml`) forwards browser logs → Loki (`{source="faro"}`) and traces → Tempo, with CORS allowlist + rate-limit + payload-size caps (a browser endpoint can't be authenticated; these cap the blast radius).
- **web-client** uses `@grafana/faro-web-sdk` + `-web-tracing`, **dynamically imported behind a build-time gate** (`VITE_FARO_COLLECTOR_URL`), so the SDK is absent from dev/test/QA bundles entirely; only the UAT build enables it.
- Browser posts **same-origin** to `/faro/collect`; the routing nginx forwards to Alloy in `monitoring` via a `resolver` (tolerates Alloy not yet existing).

### Deploy
`scripts/redeploy-uat.sh` installs the observability release (toggle `DEPLOY_OBSERVABILITY`), syncs the `grafana-admin` / `tailscale-authkey` secrets from `.env`, and passes the Faro build-arg to the web image.

## Testing
- web-client **vitest**: 974 passed
- web-client **lint** (0 errors) + **build** (`tsc -b && vite build`): green; main bundle unchanged (Faro dynamically split out of non-UAT builds)
- web-client **Playwright e2e**: 128 passed
- Helm `lint` + `template` render verified; stack deployed to the live k3d UAT cluster and exercised end-to-end (api/web-client logs in Loki; synthetic Faro POST → `{source="faro"}` in Loki; log-volume endpoint returns 200)
- `api/`, `ios/`, and OpenAPI gates not applicable (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)