### PR TITLE
Fix inverted dashboard "Top N%" percentile (#632)

### DIFF
--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -389,14 +389,17 @@ async def _league_peak_rating(
 async def _league_percentile(
     db: AsyncSession, league_id: uuid.UUID, my_rating: float
 ) -> int | None:
-    """Percentile rank within the league: the share of rated members the user
-    is at or above. Returns None for leagues of one — nothing to compare to."""
-    total, at_or_below = (
+    """"Top N%" rank within the league: the share of rated members at or above
+    the user's rating, so the strongest player reads a *small* percentage (e.g.
+    "Top 1%") and weaker players a larger one. Clamped to at least 1 so the top
+    player never reads "Top 0%". Returns None for leagues of one — nothing to
+    compare to."""
+    total, at_or_above = (
         await db.execute(
             select(
                 func.count(UserLeagueRating.id),
                 func.count(UserLeagueRating.id).filter(
-                    UserLeagueRating.rating_value <= my_rating
+                    UserLeagueRating.rating_value >= my_rating
                 ),
             ).where(
                 UserLeagueRating.league_id == league_id,
@@ -406,7 +409,7 @@ async def _league_percentile(
     ).one()
     if total <= 1:
         return None
-    return round(int(at_or_below) / int(total) * 100)
+    return max(1, round(int(at_or_above) / int(total) * 100))
 
 
 async def _spark_and_delta(

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -389,7 +389,7 @@ async def _league_peak_rating(
 async def _league_percentile(
     db: AsyncSession, league_id: uuid.UUID, my_rating: float
 ) -> int | None:
-    """"Top N%" rank within the league: the share of rated members at or above
+    """ "Top N%" rank within the league: the share of rated members at or above
     the user's rating, so the strongest player reads a *small* percentage (e.g.
     "Top 1%") and weaker players a larger one. Clamped to at least 1 so the top
     player never reads "Top 0%". Returns None for leagues of one — nothing to

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -478,13 +478,18 @@ async def test_dashboard_percentile_shown_once_user_has_played(
 async def test_league_percentile_ranks_against_rated_members(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    """The percentile helper itself: a 1500 rating among 1200/1400/1600/1800
-    plus self is 3rd of 5 — 60th percentile."""
+    """The "Top N%" helper itself, against peers at 1200/1400/1600/1800 plus
+    self. "Top N%" counts the share at or above the rating, so a stronger
+    rating reads a *smaller* percentage:
+      - 1500 is 3rd of 5 (1500/1600/1800 at-or-above) → Top 60%
+      - the strongest rating reads Top 20% (1 of 5), not Top 100%
+      - the weakest reads Top 100% (5 of 5)."""
     me = await start_session(api_client, db_session)
     default_league = await _seed_rated_peers(db_session)
 
-    pct = await _league_percentile(db_session, default_league.id, 1500.0)
-    assert pct == 60
+    assert await _league_percentile(db_session, default_league.id, 1500.0) == 60
+    assert await _league_percentile(db_session, default_league.id, 1800.0) == 20
+    assert await _league_percentile(db_session, default_league.id, 1200.0) == 100
     _ = me
 
 


### PR DESCRIPTION
Closes #632.

## Problem

The dashboard rating card's **"Top N% in \<league\>"** line was inverted: it counted league members at or *below* the user's rating and divided by the total, so the strongest player read **"Top 100%"** (sounds like "worse than everyone") instead of "Top 1%".

## Fix

`_league_percentile` now counts members at or *above* the user's rating, so a higher rating yields a smaller percentage. Clamped to a minimum of 1 so the top player never reads "Top 0%". `None` for leagues of one is unchanged.

- Top player → low % (1 of N)
- Weakest player → 100%
- Median is unchanged (symmetric)

## Tests

The existing helper test used a median rating (1500 of 5), which is symmetric under the inversion and never caught the bug. Added top- and bottom-rating assertions to lock in the direction. All 19 dashboard tests pass; `ruff` + `mypy --strict` clean.

> Note: the other items the issue lists ("· last 0" empty header, unrated delta pill, mobile name truncation, best-of-1 finalization) are explicitly called out as separate/minor and are left for their own tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)