### PR TITLE
Validate New-tournament name client-side with RHF + Zod (#614)

### DIFF
--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -38,6 +38,30 @@ custom element only when nothing in the design system is a reasonable fit.
 
 ## Forms
 
+**Every form that submits a mutation uses React Hook Form + Zod.** Drive the
+form with `useForm({ resolver: zodResolver(schema) })` and validate
+client-side against a Zod schema that **mirrors the server's constraints**
+(e.g. `z.string().trim().min(1).max(255)` for a column that is `VARCHAR(255)`
+and `NOT NULL`) — so the user gets an inline message instead of a bare 4xx.
+`EditRoleModal` (`src/components/rbac/roles-page.tsx`) and
+`NewTournamentModal` are the reference implementations.
+
+- **Surface server 4xx inline, don't swallow it.** Submit with
+  `handleSubmit(async (v) => { try { await mutateAsync(...) } catch (e) { ... } })`,
+  and in the catch map an `ApiError` with status 422/409 to
+  `form.setError('<field>', { type: 'server', message: e.detail ?? '…' })`;
+  toast anything else. A modal must close itself **only on success** — never
+  unconditionally after firing the mutation, or a rejected request becomes a
+  silent failure (#614).
+- **Don't attach a global `onError` toast to a mutation a form surfaces
+  inline.** The form owns its errors; a global toast would double up. (See the
+  convention note on the RBAC form mutations in `rbac/queries.ts`.)
+- **Don't gate the submit button on `formState.isValid`.** `handleSubmit`
+  already blocks an invalid submit and renders the inline error; a
+  `disabled={!isValid}` button forces a `useEffect(trigger)` workaround for
+  edit forms (defaults that start valid) and leaves the user staring at a dead
+  button with no explanation. Disable on `isSubmitting` only.
+
 Show field validation errors inline, directly below the field, in red. Set
 `aria-invalid` on the `<Input>` and render the message as a `<p>` beneath it:
 

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -240,14 +240,18 @@ export function useTables(id: string): TournamentTable[] {
 
 // ----- mutations -----------------------------------------------------------
 
-/** Create a bare tournament. Returns the created id for navigation. */
+/** Create a bare tournament. Returns the created id for navigation.
+ *
+ * No global `onError` toast: `NewTournamentModal` awaits this via `mutateAsync`
+ * and surfaces a 4xx inline on the name field (and toasts the rest itself), so
+ * a global toast here would double up. (Same convention as the RBAC form
+ * mutations — see `rbac/queries.ts`.) */
 export function useCreateTournament() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: async (body: TournamentCreate): Promise<TournamentRead> =>
       unwrap('create tournament', await api.POST('/v1/tournaments', { body })),
     onSuccess: () => qc.invalidateQueries({ queryKey: TOURNAMENTS_KEY }),
-    onError: notifyError('create the tournament'),
   })
 }
 

--- a/web-client/src/components/tournaments/new-tournament-modal.page.tsx
+++ b/web-client/src/components/tournaments/new-tournament-modal.page.tsx
@@ -19,11 +19,18 @@ const scoped = (container: Container) => ({
   queryDialog() {
     return container.queryByRole('dialog')
   },
+  /** The inline validation/error text under a field (the `Field` hint), once it
+   * appears — absent until a failed submit or an invalid edit. */
+  findError(message: string | RegExp) {
+    return container.findByText(message)
+  },
 })
 
 /**
  * Test page-object for `NewTournamentModal`. The dialog portals to the body, so
- * accessors resolve against `screen` rather than a wrapper subtree.
+ * accessors resolve against `screen` rather than a wrapper subtree. Inline
+ * errors are async (the zod resolver runs on submit), so assert them with
+ * `await page.findError(...)`.
  */
 export const newTournamentModalPage = {
   render(overrides: Partial<NewTournamentModalProps> = {}) {

--- a/web-client/src/components/tournaments/new-tournament-modal.test.tsx
+++ b/web-client/src/components/tournaments/new-tournament-modal.test.tsx
@@ -1,19 +1,14 @@
 import userEvent from '@testing-library/user-event'
 
+import { ApiError } from '@/api/client'
+
 import { newTournamentModalPage } from './new-tournament-modal.page'
 
 describe('NewTournamentModal', () => {
-  it('disables create until a name is entered', async () => {
-    newTournamentModalPage.render()
-    expect(newTournamentModalPage.getCreateButton()).toBeDisabled()
-
-    await userEvent.type(newTournamentModalPage.getNameInput(), 'Spring Open')
-    expect(newTournamentModalPage.getCreateButton()).toBeEnabled()
-  })
-
-  it('emits the draft with name and address on create', async () => {
+  it('emits the draft with name and address, then closes on success', async () => {
     const onCreate = vi.fn()
-    newTournamentModalPage.render({ onCreate })
+    const onOpenChange = vi.fn()
+    newTournamentModalPage.render({ onCreate, onOpenChange })
 
     await userEvent.type(newTournamentModalPage.getNameInput(), 'Spring Open')
     await userEvent.click(newTournamentModalPage.getCreateButton())
@@ -23,6 +18,67 @@ describe('NewTournamentModal', () => {
       name: 'Spring Open',
       status: 'draft',
     })
+    // The modal owns closing — only after onCreate resolves.
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('blocks an empty name with an inline error and does not submit', async () => {
+    const onCreate = vi.fn()
+    newTournamentModalPage.render({ onCreate })
+
+    await userEvent.click(newTournamentModalPage.getCreateButton())
+
+    expect(
+      await newTournamentModalPage.findError('Name is required.'),
+    ).toBeVisible()
+    expect(newTournamentModalPage.getNameInput()).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    )
+    expect(onCreate).not.toHaveBeenCalled()
+  })
+
+  it('blocks a name longer than 255 characters client-side', async () => {
+    const onCreate = vi.fn()
+    newTournamentModalPage.render({ onCreate })
+
+    const input = newTournamentModalPage.getNameInput()
+    await userEvent.click(input)
+    await userEvent.paste('A'.repeat(256))
+    await userEvent.click(newTournamentModalPage.getCreateButton())
+
+    expect(
+      await newTournamentModalPage.findError(
+        'Name must be 255 characters or fewer.',
+      ),
+    ).toBeVisible()
+    expect(onCreate).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a server rejection inline and keeps the dialog open', async () => {
+    const onCreate = vi
+      .fn()
+      .mockRejectedValue(
+        new ApiError(
+          422,
+          'String should have at most 255 characters',
+          'create',
+        ),
+      )
+    const onOpenChange = vi.fn()
+    newTournamentModalPage.render({ onCreate, onOpenChange })
+
+    await userEvent.type(newTournamentModalPage.getNameInput(), 'Spring Open')
+    await userEvent.click(newTournamentModalPage.getCreateButton())
+
+    expect(onCreate).toHaveBeenCalledTimes(1)
+    expect(
+      await newTournamentModalPage.findError(
+        'String should have at most 255 characters',
+      ),
+    ).toBeVisible()
+    // Failure must not close over the user's entry.
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
   })
 
   it('closes via cancel', async () => {

--- a/web-client/src/components/tournaments/new-tournament-modal.tsx
+++ b/web-client/src/components/tournaments/new-tournament-modal.tsx
@@ -1,6 +1,11 @@
-import { useState } from 'react'
+import { useEffect } from 'react'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import { z } from 'zod'
 import { Check } from 'lucide-react'
 
+import { ApiError } from '@/api/client'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -13,13 +18,47 @@ import {
 import { Input } from '@/components/ui/input'
 
 import { emptyTournament } from './data/helpers'
-import type { Address, Tournament } from './data/types'
+import type { Tournament } from './data/types'
 import { Field } from './field'
 
 export interface NewTournamentModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onCreate: (draft: Omit<Tournament, 'id'>) => void
+  /** Persist the draft. May be async — the modal awaits it, closes itself only
+   * on success, and surfaces a rejection inline (the dialog stays open) rather
+   * than closing over a silent failure. */
+  onCreate: (draft: Omit<Tournament, 'id'>) => void | Promise<void>
+}
+
+// Mirrors the server's `tournaments.name` constraint (VARCHAR(255)) so the
+// over-long name is caught client-side with an inline message instead of a
+// bare 422 (#614).
+const NAME_MAX = 255
+
+const schema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, { message: 'Name is required.' })
+    .max(NAME_MAX, {
+      message: `Name must be ${NAME_MAX} characters or fewer.`,
+    }),
+  venue: z.string(),
+  street: z.string(),
+  city: z.string(),
+  region: z.string(),
+  postal: z.string(),
+})
+
+type FormValues = z.infer<typeof schema>
+
+const DEFAULT_VALUES: FormValues = {
+  name: '',
+  venue: '',
+  street: '',
+  city: '',
+  region: '',
+  postal: '',
 }
 
 /** "New tournament" dialog — captures a name (required) and optional venue
@@ -29,19 +68,54 @@ export const NewTournamentModal = ({
   onOpenChange,
   onCreate,
 }: NewTournamentModalProps) => {
-  const [draft, setDraft] = useState<Omit<Tournament, 'id'>>(emptyTournament)
-  const [wasOpen, setWasOpen] = useState(open)
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: DEFAULT_VALUES,
+    mode: 'onChange',
+  })
+  const {
+    register,
+    formState: { errors },
+  } = form
 
-  // Reset to a blank draft each time the dialog transitions to open —
-  // adjusting state during render instead of in an effect.
-  if (open !== wasOpen) {
-    setWasOpen(open)
-    if (open) setDraft(emptyTournament())
-  }
+  // Reset to a blank draft each time the dialog (re)opens — the modal stays
+  // mounted, so without this a second open would show the prior attempt.
+  useEffect(() => {
+    if (open) form.reset(DEFAULT_VALUES)
+  }, [open, form])
 
-  const valid = draft.name.trim().length > 0
-  const setAddress = (patch: Partial<Address>) =>
-    setDraft((d) => ({ ...d, address: { ...d.address, ...patch } }))
+  const submit = form.handleSubmit(async (values) => {
+    const base = emptyTournament()
+    try {
+      await onCreate({
+        ...base,
+        name: values.name,
+        address: {
+          ...base.address,
+          venue: values.venue.trim(),
+          street: values.street.trim(),
+          city: values.city.trim(),
+          region: values.region.trim(),
+          postal: values.postal.trim(),
+        },
+      })
+      onOpenChange(false)
+    } catch (err) {
+      // The name is the only constrained field, so a 4xx here is a name the
+      // server rejected — show it on the field. Anything else is unexpected;
+      // toast it and keep the dialog open so the entry isn't lost.
+      if (err instanceof ApiError && (err.status === 422 || err.status === 409)) {
+        form.setError('name', {
+          type: 'server',
+          message: err.detail ?? 'The server rejected this name.',
+        })
+        return
+      }
+      toast.error("Couldn't create the tournament", {
+        description: err instanceof Error ? err.message : String(err),
+      })
+    }
+  })
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -53,90 +127,81 @@ export const NewTournamentModal = ({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex flex-col gap-3.5">
-          <Field label="Name" required>
-            {(id) => (
-              <Input
-                id={id}
-                autoFocus
-                value={draft.name}
-                placeholder="Spring Open 2026"
-                onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
-              />
-            )}
-          </Field>
+        <form onSubmit={submit} noValidate>
+          <div className="flex flex-col gap-3.5">
+            <Field
+              label="Name"
+              required
+              error={!!errors.name}
+              hint={errors.name?.message}
+            >
+              {(id) => (
+                <Input
+                  id={id}
+                  autoFocus
+                  aria-invalid={!!errors.name}
+                  placeholder="Spring Open 2026"
+                  {...register('name')}
+                />
+              )}
+            </Field>
 
-          <div className="my-1 flex items-center gap-3">
-            <span className="text-[11px] font-semibold tracking-[0.14em] text-[color:var(--fg-3)] uppercase">
-              Venue
-            </span>
-            <span className="h-px flex-1 bg-[color:var(--border-subtle)]" />
+            <div className="my-1 flex items-center gap-3">
+              <span className="text-[11px] font-semibold tracking-[0.14em] text-[color:var(--fg-3)] uppercase">
+                Venue
+              </span>
+              <span className="h-px flex-1 bg-[color:var(--border-subtle)]" />
+            </div>
+
+            <Field label="Venue name">
+              {(id) => (
+                <Input id={id} placeholder="Berkeley TT Club" {...register('venue')} />
+              )}
+            </Field>
+            <Field label="Street">
+              {(id) => (
+                <Input id={id} placeholder="2727 Milvia St" {...register('street')} />
+              )}
+            </Field>
+            <div className="grid grid-cols-[2fr_1fr_1fr] gap-3">
+              <Field label="City">
+                {(id) => (
+                  <Input id={id} placeholder="Berkeley" {...register('city')} />
+                )}
+              </Field>
+              <Field label="Region">
+                {(id) => <Input id={id} placeholder="CA" {...register('region')} />}
+              </Field>
+              <Field label="Postal">
+                {(id) => (
+                  <Input
+                    id={id}
+                    placeholder="94703"
+                    className="font-mono"
+                    {...register('postal')}
+                  />
+                )}
+              </Field>
+            </div>
           </div>
 
-          <Field label="Venue name">
-            {(id) => (
-              <Input
-                id={id}
-                value={draft.address.venue}
-                placeholder="Berkeley TT Club"
-                onChange={(e) => setAddress({ venue: e.target.value })}
-              />
-            )}
-          </Field>
-          <Field label="Street">
-            {(id) => (
-              <Input
-                id={id}
-                value={draft.address.street}
-                placeholder="2727 Milvia St"
-                onChange={(e) => setAddress({ street: e.target.value })}
-              />
-            )}
-          </Field>
-          <div className="grid grid-cols-[2fr_1fr_1fr] gap-3">
-            <Field label="City">
-              {(id) => (
-                <Input
-                  id={id}
-                  value={draft.address.city}
-                  placeholder="Berkeley"
-                  onChange={(e) => setAddress({ city: e.target.value })}
-                />
-              )}
-            </Field>
-            <Field label="Region">
-              {(id) => (
-                <Input
-                  id={id}
-                  value={draft.address.region}
-                  placeholder="CA"
-                  onChange={(e) => setAddress({ region: e.target.value })}
-                />
-              )}
-            </Field>
-            <Field label="Postal">
-              {(id) => (
-                <Input
-                  id={id}
-                  value={draft.address.postal}
-                  placeholder="94703"
-                  className="font-mono"
-                  onChange={(e) => setAddress({ postal: e.target.value })}
-                />
-              )}
-            </Field>
-          </div>
-        </div>
-
-        <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button disabled={!valid} onClick={() => onCreate(draft)}>
-            <Check size={16} />
-            Create tournament
-          </Button>
-        </DialogFooter>
+          <DialogFooter className="mt-6">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            {/* Not gated on form validity: handleSubmit already blocks an
+                invalid submit and renders the inline error, so an empty/over-long
+                name surfaces a message instead of a dead, disabled button. */}
+            <Button type="submit" disabled={form.formState.isSubmitting}>
+              <Check size={16} />
+              Create tournament
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   )

--- a/web-client/src/components/tournaments/tournaments-list-page.tsx
+++ b/web-client/src/components/tournaments/tournaments-list-page.tsx
@@ -16,7 +16,7 @@ import { TournamentCard } from './tournament-card'
 export interface TournamentsListPageProps {
   tournaments: Tournament[]
   onOpen: (id: string) => void
-  onCreate: (draft: Omit<Tournament, 'id'>) => void
+  onCreate: (draft: Omit<Tournament, 'id'>) => void | Promise<void>
   onDelete: (id: string) => void
   /** Whether to surface the "New tournament" action — gated on the caller's
    * `tournament.create` permission. Creating 403s without it, so hide it. */
@@ -126,13 +126,13 @@ export const TournamentsListPage = ({
         </div>
       )}
 
+      {/* The modal owns its submit lifecycle: it awaits onCreate and closes
+          itself (via onOpenChange) only on success, surfacing a failure inline
+          instead of closing over it (#614). */}
       <NewTournamentModal
         open={createOpen}
         onOpenChange={setCreateOpen}
-        onCreate={(draft) => {
-          onCreate(draft)
-          setCreateOpen(false)
-        }}
+        onCreate={onCreate}
       />
       <ConfirmDeleteDialog
         open={pendingDelete !== null}


### PR DESCRIPTION
Fixes #614.

## Problem
The create-tournament dialog had no client-side length cap, so a name over 255 chars passed the (empty-only) check, hit `POST /v1/tournaments`, and came back **422**. The failure was **silent**: `tournaments-list-page.tsx` fired the create mutation and immediately `setCreateOpen(false)` regardless of the result, so the rejected promise was swallowed and the dialog vanished with nothing created and no message.

## Fix
Reworked `NewTournamentModal` on **React Hook Form + Zod** (mirroring `EditRoleModal`):

- **Client-side validation** — Zod schema mirrors the server constraint (`name` min 1, max 255) and renders an inline error under the field (`aria-invalid` + red hint) instead of a bare 422.
- **Modal owns its submit lifecycle** — it `await`s `onCreate` and closes itself **only on success**; an `ApiError` 422/409 maps to an inline `form.setError('name', …)` with the dialog staying open so the entry isn't lost. The list page now passes `onCreate` straight through.
- **No double-surfacing** — dropped the global `onError` toast from `useCreateTournament` (same convention as the RBAC form mutations in `rbac/queries.ts`).
- **No validity-gated button** — `handleSubmit` already blocks an invalid submit and shows the inline error; the Create button disables only while submitting.
- **Docs** — added the RHF + Zod mutation-form convention to `web-client/CLAUDE.md`.

## Testing
- `npm run test:run` — 985 passed (modal tests rewritten: empty-name blocked, 256-char blocked client-side, server-422 surfaced inline with dialog open, success closes)
- `npm run lint` clean · `npm run build` (tsc) passes
- `npm run test:e2e` — 128 passed
- API/iOS/schema gates N/A (web-client-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)