### PR TITLE
Reject RFC-5321-invalid oversize email local part (#615)

### DIFF
--- a/api/app/schemas/session.py
+++ b/api/app/schemas/session.py
@@ -1,6 +1,28 @@
 from datetime import datetime
+from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import AfterValidator, BaseModel, ConfigDict, EmailStr, Field
+
+# RFC 5321 §4.5.3.1.1 caps the local part (before the ``@``) at 64 octets and
+# the whole address at 254. ``EmailStr`` / email-validator enforces the 254
+# total but NOT the 64-char local part, so an oversize local part validates and
+# we'd enqueue mail to it (#615). Reject it explicitly on inbound addresses.
+EMAIL_LOCAL_PART_MAX_LENGTH = 64
+
+
+def _validate_local_part_length(value: str) -> str:
+    local_part, _, _ = value.rpartition("@")
+    if len(local_part) > EMAIL_LOCAL_PART_MAX_LENGTH:
+        raise ValueError(
+            "The email address's local part is too long "
+            f"(maximum {EMAIL_LOCAL_PART_MAX_LENGTH} characters)."
+        )
+    return value
+
+
+# Use for inbound addresses we'll act on (send mail / persist). Response echoes
+# can stay plain ``EmailStr`` — they re-emit an already-validated value.
+BoundedEmailStr = Annotated[EmailStr, AfterValidator(_validate_local_part_length)]
 
 # Lowercase alphanumerics with optional dots/hyphens/underscores between them.
 # Must start and end with an alphanumeric so we don't store names that look
@@ -60,7 +82,7 @@ class CaptchaProtectedRequest(BaseModel):
 
 
 class SetEmailRequest(CaptchaProtectedRequest):
-    email: EmailStr
+    email: BoundedEmailStr
 
 
 class ResendEmailRequest(CaptchaProtectedRequest):
@@ -76,7 +98,7 @@ class ConfirmEmailRequest(BaseModel):
 
 
 class RequestLoginRequest(CaptchaProtectedRequest):
-    email: EmailStr
+    email: BoundedEmailStr
 
 
 class LoginRequestAccepted(BaseModel):

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -282,6 +282,20 @@ async def test_request_rejects_invalid_email_format(api_client: AsyncClient):
     assert response.status_code == 422
 
 
+async def test_request_rejects_oversize_local_part(
+    api_client: AsyncClient, fake_email_queue
+):
+    """RFC 5321 caps the local part at 64 chars; a longer one is rejected
+    before any mail is enqueued (#615)."""
+    oversize = "a" * 65 + "@example.com"
+    response = await api_client.post(
+        "/v1/login/request",
+        json={**REQUEST_BODY, "email": oversize},
+    )
+    assert response.status_code == 422
+    assert fake_email_queue.finished_job_registry.count == 0
+
+
 # ---- consume endpoint ----------------------------------------------------
 
 

--- a/web-client/src/lib/form-helpers.test.ts
+++ b/web-client/src/lib/form-helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MAX_EMAIL_LENGTH,
+  MAX_EMAIL_LOCAL_PART_LENGTH,
+  isValidEmail,
+} from './form-helpers'
+
+describe('isValidEmail', () => {
+  it('accepts an ordinary address', () => {
+    expect(isValidEmail('rita@example.com')).toBe(true)
+  })
+
+  it('rejects a malformed address', () => {
+    expect(isValidEmail('not-an-email')).toBe(false)
+  })
+
+  it('rejects an address longer than the RFC 5321 cap', () => {
+    const tooLong = `${'a'.repeat(MAX_EMAIL_LENGTH)}@example.com`
+    expect(isValidEmail(tooLong)).toBe(false)
+  })
+
+  it('accepts a 64-char local part but rejects a 65-char one (#615)', () => {
+    const max = `${'a'.repeat(MAX_EMAIL_LOCAL_PART_LENGTH)}@example.com`
+    const over = `${'a'.repeat(MAX_EMAIL_LOCAL_PART_LENGTH + 1)}@example.com`
+    expect(isValidEmail(max)).toBe(true)
+    expect(isValidEmail(over)).toBe(false)
+  })
+})

--- a/web-client/src/lib/form-helpers.ts
+++ b/web-client/src/lib/form-helpers.ts
@@ -19,6 +19,11 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/
 // FAILED before submit instead of leaking that server string.
 export const MAX_EMAIL_LENGTH = 254
 
+// RFC 5321 §4.5.3.1.1 also caps the local part (before the @) at 64 chars. The
+// API rejects an oversize local part with a 422 (#615); mirror it so the badge
+// flips to FAILED before submit instead of leaking that server string.
+export const MAX_EMAIL_LOCAL_PART_LENGTH = 64
+
 export interface Validation {
   ok: boolean
   err?: string
@@ -32,5 +37,10 @@ export function validateEmail(e: string): Validation {
 }
 
 export function isValidEmail(e: string): boolean {
-  return e.length <= MAX_EMAIL_LENGTH && EMAIL_RE.test(e)
+  // EMAIL_RE guarantees a single '@', so the local part is everything before it.
+  return (
+    e.length <= MAX_EMAIL_LENGTH &&
+    EMAIL_RE.test(e) &&
+    e.slice(0, e.lastIndexOf('@')).length <= MAX_EMAIL_LOCAL_PART_LENGTH
+  )
 }


### PR DESCRIPTION
## Summary

Fixes #615. The magic-link `/login` endpoint (`POST /v1/login/request`) accepted an address whose local part exceeds 64 chars (e.g. a ~200-char local part) and went on to enqueue/deliver mail to it. pydantic's `EmailStr` / email-validator enforces the **254-char total** length but **not** the **64-char local-part** cap (RFC 5321 §4.5.3.1.1) — confirmed: a 200-char local part validates.

## Changes

**Server (`api/`)**
- Add a shared `BoundedEmailStr` = `Annotated[EmailStr, AfterValidator(...)]` that rejects a local part > 64 chars, and apply it to both **inbound** address schemas: `RequestLoginRequest` and `SetEmailRequest` (the email-change flow has the same gap). The `LoginRequestAccepted` **response** echo stays plain `EmailStr` — it re-emits an already-validated value.
- The `AfterValidator` leaves the JSON Schema unchanged (`format: email`), so no `schema.d.ts` regen is needed (verified — no drift).
- Test: `test_request_rejects_oversize_local_part` asserts a 65-char local part 422s **and** that no mail is enqueued.

**Client (`web-client/`)**
- Mirror the cap in `isValidEmail` (shared by the login form and the settings email-change form) so the badge flips to `FAILED` before submit instead of surfacing a bare 422.
- New unit test for the 64/65-char boundary.

## Testing
- API: `ruff check` / `ruff format --check` / `mypy --strict` / `pytest` → 485 passed
- Web: `vitest` → 989 passed · `lint` + `build` clean · Playwright e2e → 128 passed
- No OpenAPI schema drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)