### PR TITLE
Fix mobile clipping of matches tables + filter chips (#642, #643)

### DIFF
--- a/web-client/src/components/matches/match-list/match-list.css
+++ b/web-client/src/components/matches/match-list/match-list.css
@@ -114,6 +114,28 @@
   flex: 1;
 }
 
+/* On a phone the search box and the status tabs each wrap onto their own row
+ * (`.filter-row` is `flex-wrap: wrap`). The shadcn `TabsList` is
+ * `inline-flex w-fit` with no wrapping or scrolling, so the rightmost chip
+ * ("Up next" / "Final") clips off the edge. Let the tab strip take the full
+ * wrapped row and scroll horizontally instead of clipping. Desktop is
+ * untouched — there the whole row fits on one line. */
+@media (max-width: 640px) {
+  .match-list-page .filter-row [data-slot='tabs'] {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+  .match-list-page .filter-row [data-slot='tabs-list'] {
+    max-width: 100%;
+    justify-content: flex-start;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .match-list-page .filter-row [data-slot='tabs-list']::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 .match-list-page .filter-label {
   font-family: var(--font-ui);
   font-size: 10px;
@@ -132,6 +154,14 @@
 }
 .match-list-page table.matches {
   width: 100%;
+  /* `white-space: nowrap` cells plus fixed-width Score/Status/Started columns
+   * exceed a phone viewport. Without a min-width the table stays capped at
+   * 100% and the rightmost Status/action columns overflow their cells
+   * (clipped) instead of widening the table, so the `overflow: auto`
+   * `.table-wrap` never gets a horizontal scrollbar. Forcing the table to its
+   * content width makes the wrap scroll on mobile; `width: 100%` still fills
+   * it on desktop. */
+  min-width: max-content;
   border-collapse: separate;
   border-spacing: 0;
   font-family: var(--font-ui);

--- a/web-client/src/components/matches/match-list/match-list.css
+++ b/web-client/src/components/matches/match-list/match-list.css
@@ -151,20 +151,31 @@
   flex: 1;
   min-width: 0;
   overflow: auto;
+  /* Query the wrap's own width (not the viewport) below, so the table reacts
+   * to its real available space — the sidebar collapses at 960px, so the same
+   * viewport maps to different table widths and a viewport media query can't
+   * tell when the table is actually too narrow. */
+  container-type: inline-size;
 }
 .match-list-page table.matches {
   width: 100%;
-  /* `white-space: nowrap` cells plus fixed-width Score/Status/Started columns
-   * exceed a phone viewport. Without a min-width the table stays capped at
-   * 100% and the rightmost Status/action columns overflow their cells
-   * (clipped) instead of widening the table, so the `overflow: auto`
-   * `.table-wrap` never gets a horizontal scrollbar. Forcing the table to its
-   * content width makes the wrap scroll on mobile; `width: 100%` still fills
-   * it on desktop. */
-  min-width: max-content;
   border-collapse: separate;
   border-spacing: 0;
   font-family: var(--font-ui);
+}
+/* `white-space: nowrap` cells plus fixed-width Score/Status/Started columns
+ * exceed a phone viewport. Without a min-width the table stays capped at 100%
+ * and the rightmost Status/action columns overflow their cells (clipped)
+ * instead of widening the table, so the `overflow: auto` wrap never gets a
+ * horizontal scrollbar. When the wrap is narrower than the table's content
+ * (≤960px — phones, tablets, and the narrow-desktop band just after the
+ * sidebar reappears), force the table to its content width so the wrap scrolls.
+ * Above 960px the wrap fits the table's ~910px normal content, so `width: 100%`
+ * fills it with no scrollbar. */
+@container (max-width: 960px) {
+  .match-list-page table.matches {
+    min-width: max-content;
+  }
 }
 .match-list-page table.matches thead th {
   position: sticky;

--- a/web-client/src/components/players/player-profile.css
+++ b/web-client/src/components/players/player-profile.css
@@ -260,6 +260,10 @@
   flex: 1;
   min-height: 0;
   overflow: auto;
+  /* Query the wrap's own width (not the viewport) for the mobile horizontal
+   * scroll below — keeps the table responsive to its real available space
+   * regardless of the surrounding layout. */
+  container-type: inline-size;
 }
 
 .player-profile__section-title {
@@ -370,17 +374,23 @@
 
 .player-profile table.matches {
   width: 100%;
-  /* The cells are `white-space: nowrap` with fixed-width Date/Score/Result
-   * columns whose total exceeds a phone viewport. Without a min-width the
-   * table stays capped at 100% and the rightmost Result column overflows its
-   * cell (clipped) instead of widening the table — so the `overflow: auto`
-   * `.player-profile__table-wrap` never gets a horizontal scrollbar. Forcing
-   * the table to its content width makes the wrap scroll on mobile while
-   * `width: 100%` still fills the table on desktop. */
-  min-width: max-content;
   border-collapse: separate;
   border-spacing: 0;
   font-family: var(--font-ui);
+}
+/* The cells are `white-space: nowrap` with fixed-width Date/Score/Result
+ * columns whose total exceeds a phone viewport. Without a min-width the table
+ * stays capped at 100% and the rightmost Result column overflows its cell
+ * (clipped) instead of widening the table — so the `overflow: auto` wrap never
+ * gets a horizontal scrollbar. When the wrap is narrower than the table's
+ * content, force the table to its content width so the wrap scrolls; above
+ * 960px `width: 100%` fills it with no scrollbar. Keyed on the wrap's own width
+ * (container query) rather than the viewport so it tracks real available
+ * space. */
+@container (max-width: 960px) {
+  .player-profile table.matches {
+    min-width: max-content;
+  }
 }
 
 .player-profile table.matches thead th {

--- a/web-client/src/components/players/player-profile.css
+++ b/web-client/src/components/players/player-profile.css
@@ -370,6 +370,14 @@
 
 .player-profile table.matches {
   width: 100%;
+  /* The cells are `white-space: nowrap` with fixed-width Date/Score/Result
+   * columns whose total exceeds a phone viewport. Without a min-width the
+   * table stays capped at 100% and the rightmost Result column overflows its
+   * cell (clipped) instead of widening the table — so the `overflow: auto`
+   * `.player-profile__table-wrap` never gets a horizontal scrollbar. Forcing
+   * the table to its content width makes the wrap scroll on mobile while
+   * `width: 100%` still fills the table on desktop. */
+  min-width: max-content;
   border-collapse: separate;
   border-spacing: 0;
   font-family: var(--font-ui);


### PR DESCRIPTION
## Summary

Two pre-existing, sibling mobile bugs — both surfaced by adversarial QA during the #638 land-the-plane.

- **#642 — player profile** (`/players/<id>`): the embedded matches table clipped the **RESULT** column off-screen at 375px with no horizontal scroll ("RESU…", WIN/LOSS badge cut off).
- **#643 — matches list** (`/matches`): the **STATUS** column + the rightmost **filter chip** clipped off the right edge, no horizontal scroll.

## Root cause

`table.matches { width: 100% }` with default auto table-layout caps the table at the container width. The cells are `white-space: nowrap`, so the fixed-width Date/Score/Result/Status columns overflow *within their own cells* (clipped) instead of widening the table — meaning the `overflow: auto` scroll wrappers never actually overflow and never get a horizontal scrollbar.

## Fix (CSS only)

- Add `min-width: max-content` to both `table.matches` rules (`player-profile.css`, `match-list.css`). The table now grows to its content width on mobile so the wrapper scrolls; `width: 100%` still fills it on desktop. Mirrors the codebase's existing intentional per-page duplication of the `table.matches` chrome.
- `#643` filter chips: shadcn's `TabsList` is `inline-flex w-fit` with no wrap/scroll, so on its wrapped `.filter-row` line the last chip clips. A `@media (max-width: 640px)` block lets the strip take the full row and scroll horizontally (`max-width: 100%`, `overflow-x: auto`, hidden scrollbar, `justify-content: flex-start` so the first chip stays reachable). Desktop unchanged.

## Testing

- Verified in-browser at **375×667** (Chrome via Playwright): page no longer overflows (`document.scrollWidth == 375`); both table wrappers and the tab strip scroll to reveal the previously-clipped RESULT/STATUS/STARTED columns, action button, and last filter chip.
- `npm run test:run` — 989 passed
- `npm run lint` — clean · `npm run build` (tsc -b + vite) — green
- `npm run test:e2e` — 128 passed

Not applicable to this CSS-only `web-client/**` change: API gates, OpenAPI drift, iOS build, root `e2e/` compose suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)