### PR TITLE
iOS: normalize leading zeros in score entry (#446)

### DIFF
--- a/ios/Fortymm/MatchFlow/ScoreEntryView.swift
+++ b/ios/Fortymm/MatchFlow/ScoreEntryView.swift
@@ -273,8 +273,9 @@ struct ScoreEntryView: View {
         Binding(
             get: { side == .you ? rawYou : rawOpp },
             set: { raw in
-                if side == .you { rawYou = raw } else { rawOpp = raw }
-                let n = Self.parseScore(raw)
+                let cleaned = Self.normalizeScoreText(raw)
+                if side == .you { rawYou = cleaned } else { rawOpp = cleaned }
+                let n = Self.parseScore(cleaned)
                 setCurrent { side == .you ? ($0.a = n) : ($0.b = n) }
             }
         )
@@ -289,6 +290,16 @@ struct ScoreEntryView: View {
         guard !raw.isEmpty, raw.count <= 3,
               raw.allSatisfy({ $0 >= "0" && $0 <= "9" }) else { return nil }
         return Int(raw)
+    }
+
+    /// Collapse a clean digit run to its canonical form so the field shows the
+    /// same number it evaluates to: "011" → "11", "00" → "0". A lone "0" and the
+    /// empty field are left as-is, and a malformed entry (non-digits, >3 digits)
+    /// is returned verbatim so `scoreError` still flags it rather than being
+    /// silently rewritten. Fixes the leading-zeros half of #446.
+    private static func normalizeScoreText(_ raw: String) -> String {
+        guard let n = parseScore(raw) else { return raw }
+        return String(n)
     }
 
     /// True when the field holds something the user typed/pasted that isn't a


### PR DESCRIPTION
## What & why

Closes the last open part of **#446** (iOS impossible-score entry). The other three sub-bugs were already fixed by later PRs:

- `15-8` accepted then 422 → fixed by `illegalScoreReason` client-side rejection (#578)
- `999999` truncated to 40 → fixed by `parseScore` rejecting >3 digits (#629)
- raw "HTTP 422" leaked to the user → fixed by the 422-detail extraction in `APIClient`

The remaining gap: the score fields kept input **verbatim**, so a leading-zero run like `011` displayed literally while editing even though it parsed and posted as `11`.

## Change

`ScoreEntryView`: route the field binding's setter through a new `normalizeScoreText()` that collapses a clean digit run to canonical form (`011` → `11`, `00` → `0`), while leaving a lone `0`, the empty field, and any **malformed** entry (non-digits, `>3` digits) verbatim so the existing inline `scoreError` flag still fires.

## Testing

- iOS clean simulator build (`xcodebuild … -sdk iphonesimulator`): **BUILD SUCCEEDED**. The app ships no XCTest target, so the compile is the CI gate.
- `/simplify` reviewed the diff: already clean, no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)