### PR TITLE
Fix recent-opponents grid overflow on mobile (#93)

### DIFF
--- a/web-client/src/routes/_app/matches/new.css
+++ b/web-client/src/routes/_app/matches/new.css
@@ -13,6 +13,11 @@
   --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.55);
 
   position: relative;
+  /* Clip the decorative ::before glow, which bleeds 200px past the right edge
+     (right: -200px) and would otherwise add a constant 200px of horizontal
+     page scroll at every viewport (#93). overflow-x: clip contains it without
+     establishing a scroll container or affecting vertical layout. */
+  overflow-x: clip;
   width: 100%;
   max-width: 980px;
   margin: 0 auto;

--- a/web-client/src/routes/_app/matches/new.css
+++ b/web-client/src/routes/_app/matches/new.css
@@ -376,11 +376,12 @@
 }
 .nm-recent-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
 }
 .nm-chip {
   display: flex;
+  min-width: 0;
   align-items: center;
   gap: 10px;
   padding: 10px 12px;


### PR DESCRIPTION
Fixes #93.

## Problem
`/matches/new` had a constant ~200px of horizontal scroll on mobile. Two causes:

1. **Decorative glow (dominant):** `.nm-page::before` is `position:absolute` with `right:-200px; width:700px`, so it bleeds 200px past the page's right edge with nothing clipping it — a constant 200px overflow at every viewport.
2. **Recent-opponents grid (secondary):** `.nm-recent-grid` used `grid-template-columns: repeat(2, 1fr)`; plain `1fr` is `minmax(auto,1fr)`, so tracks refused to shrink below the nowrap username, overflowing on narrow screens.

The original issue attributed it to the grid, but QA against the real stack showed the grid was only secondary — the glow was the real cause.

## Fix
- `.nm-page`: add `overflow-x: clip` to contain the decorative glow (no scroll container created, vertical layout untouched, no sticky/fixed descendants).
- `.nm-recent-grid`: `repeat(2, 1fr)` → `repeat(2, minmax(0, 1fr))`.
- `.nm-chip`: add `min-width: 0` so the flex chip shrinks and the existing name ellipsis takes effect.

## Verification (real QA stack, MSW off)
Measured `documentElement.scrollWidth` vs `innerWidth` on `/matches/new`:
- With fix: 375→0, 414→0, 1280→0 overflow. Toggling `overflow-x` back to `visible` returns scrollWidth 575 at 375px, confirming the glow as the cause.
- Recent-opponents grid renders clean 2-column at desktop + mobile, long usernames ellipsize.

Note: a residual ~25px overflow remains at 320px wide, sourced from the AppShell top nav (`app-shell__actions`) — a separate pre-existing component, out of scope for this issue.

## Testing
- Web unit (vitest): 989 passed
- Lint + build (tsc + vite): clean
- Web e2e (Playwright): 128 passed
- Root e2e (Playwright + compose): 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)