### PR TITLE
Fix ~25px mobile overflow from AppShell top nav at 320px (#661)

### DIFF
--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1075,9 +1075,20 @@ body.dark.fortymm-theme {
 @media (max-width: 520px) {
   .app-shell__topbar {
     padding: 0 12px;
+    gap: 8px;
   }
   .app-shell__brand .app-shell__wordmark {
     font-size: 18px;
+  }
+  .app-shell__actions {
+    gap: 6px;
+  }
+  /* At the narrowest phones the actions cluster (Alpha badge + bell + user
+     menu) overflows the 320px viewport. The user-name is already hidden on
+     mobile, leaving the chevron beside a bare avatar — drop it here to reclaim
+     the width and keep the top nav inside the viewport (#661). */
+  .app-shell__user-menu-chev {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #661 — at a 320px-wide viewport, the shared AppShell top nav overflowed `document.documentElement.scrollWidth` by ~25px, producing horizontal scroll on every authenticated page. The overflow came from the header actions cluster (`app-shell__actions`: Alpha badge + notification bell + user menu), which ended at x=345 in a 320px viewport.

## Change

CSS-only, scoped to the existing `@media (max-width: 520px)` breakpoint in `web-client/src/index.css`:

- Tighten the topbar flex `gap` (12px → 8px) and actions `gap` (8px → 6px).
- Hide the user-menu chevron (`.app-shell__user-menu-chev`). The user-name is already hidden on mobile, so the chevron just sat beside a bare avatar — dropping it reclaims ~22px while the avatar remains an obvious menu trigger.

375px+ was already overflow-free and is unaffected aside from slightly tighter spacing.

## Testing

- Measured with Playwright before/after: `scrollWidth == innerWidth` (overflow 0) at **320 / 375 / 414px** (was 25px at 320).
- Visual check at 320px: full nav (hamburger · FORTYMM · ALPHA · bell · avatar) fits with no clipping.
- `npm run test:run` — 989 passed
- `npm run lint` — clean (lone pre-existing warning in mockServiceWorker.js)
- `npm run build` — green (tsc + vite)
- `npm run test:e2e` — 128 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)