### PR TITLE
Fix profile LIVE-mislabel (#364) + dashboard/match-list footer bugs

### DIFF
--- a/api/app/players.py
+++ b/api/app/players.py
@@ -427,6 +427,10 @@ def _player_matches_eager() -> tuple[ExecutableOption, ...]:
         .selectinload(MatchSide.players)
         .selectinload(MatchSidePlayer.user),
         selectinload(Match.games).selectinload(MatchGame.score),
+        # Needed to derive the "Awaiting confirmation" boolean (#364): an
+        # ``in_progress`` match with a posted-but-unconfirmed result carries
+        # at least one signature.
+        selectinload(Match.signatures),
     )
 
 
@@ -487,6 +491,16 @@ def _serialize_player_match(match: Match, player_id: uuid.UUID) -> PlayerMatchRo
     elif mine.won is False:
         result = "L"
 
+    # A result has been posted but the opponent hasn't ratified it yet. This
+    # mirrors matches.py's ``_status_label`` ("Awaiting confirmation") bucket
+    # — computed inline here so players.py doesn't import the matches router's
+    # internals (api/CLAUDE.md: routers must not depend on each other). The FE
+    # uses this to render a distinct chip instead of the green "LIVE" one a
+    # genuinely-live ``in_progress`` match gets (#364).
+    awaiting_confirmation = match.status == MatchStatus.in_progress and bool(
+        match.signatures
+    )
+
     return PlayerMatchRow(
         id=match.id,
         status=match.status,
@@ -494,6 +508,7 @@ def _serialize_player_match(match: Match, player_id: uuid.UUID) -> PlayerMatchRo
         opponent=opponent,
         sets=sets,
         result=result,
+        awaiting_confirmation=awaiting_confirmation,
     )
 
 

--- a/api/app/schemas/player.py
+++ b/api/app/schemas/player.py
@@ -80,6 +80,14 @@ class PlayerMatchRow(BaseModel):
     # ``None`` while the match is still pending / in_progress / disputed /
     # voided. The FE keys the WIN/LOSS/LIVE/UP NEXT chip off `status` + this.
     result: Literal["W", "L"] | None = None
+    # True when a result has been posted but not yet confirmed by the
+    # opponent — i.e. ``status`` is still ``in_progress`` *and* the match
+    # carries at least one signature. This is the same "Awaiting confirmation"
+    # bucket matches.py derives via ``_status_label``; it's surfaced as a
+    # boolean here so the profile chip can distinguish a posted-but-unconfirmed
+    # result from a genuinely-live match (both sit at ``in_progress``) without
+    # the FE having to load signatures (#364).
+    awaiting_confirmation: bool = False
 
 
 class PlayerMatchListResponse(BaseModel):

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -9,6 +9,7 @@ from app.models import (
     MatchSettings,
     MatchSide,
     MatchSidePlayer,
+    MatchSignature,
     MatchStatus,
     User,
     UserLeagueRating,
@@ -339,12 +340,17 @@ async def _record_match_with_winner(
     *,
     created_at: datetime,
     status: MatchStatus = MatchStatus.completed,
+    signed_by: User | None = None,
 ) -> Match:
     """Persist a singles match with explicit winner/loser so W-L and form
     assertions are deterministic. Same shape as `_record_match` but flips
     `MatchSide.won` on the right side. ``won`` is stamped only for completed
     matches, mirroring the API: since #485 it's written at the moment a match
-    becomes final, never while one is still in progress."""
+    becomes final, never while one is still in progress.
+
+    ``signed_by`` seeds a single ``MatchSignature`` from that user (a
+    posted-but-unconfirmed result), so an ``in_progress`` match can be put in
+    the "Awaiting confirmation" bucket (#364)."""
     settings = MatchSettings(team_size=1, best_of=5, affects_rating=False)
     league = await get_default_league(db_session)
     match = Match(
@@ -360,6 +366,8 @@ async def _record_match_with_winner(
     side1.players.append(MatchSidePlayer(match=match, user=winner))
     side2 = MatchSide(match=match, side_number=2, won=False if completed else None)
     side2.players.append(MatchSidePlayer(match=match, user=loser))
+    if signed_by is not None:
+        match.signatures.append(MatchSignature(user_id=signed_by.id))
     db_session.add(match)
     await db_session.commit()
     return match
@@ -571,6 +579,53 @@ async def test_list_player_matches_result_hidden_while_awaiting_confirmation(
     row = body["items"][0]
     assert row["status"] == "in_progress"
     assert row["result"] is None
+    # No signature posted yet → genuinely live, not awaiting confirmation.
+    assert row["awaiting_confirmation"] is False
+
+
+async def test_list_player_matches_flags_awaiting_confirmation(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """An ``in_progress`` match with a posted-but-unconfirmed result (at least
+    one signature) reports ``awaiting_confirmation: true`` so the profile chip
+    can distinguish it from a genuinely-live match — both sit at
+    ``in_progress`` (#364). A true-live match (no signature) and a completed
+    match both report false."""
+    await start_session(api_client, db_session)
+    target = await make_user(db_session, "await.flag.target")
+    rival = await make_user(db_session, "await.flag.rival")
+
+    # Awaiting: in_progress with a signature from the result-poster.
+    await _record_match_with_winner(
+        db_session,
+        target,
+        rival,
+        created_at=BASE_TIME + timedelta(days=2),
+        status=MatchStatus.in_progress,
+        signed_by=target,
+    )
+    # True-live: in_progress, no signature.
+    await _record_match_with_winner(
+        db_session,
+        target,
+        rival,
+        created_at=BASE_TIME + timedelta(days=1),
+        status=MatchStatus.in_progress,
+    )
+    # Completed: never awaiting.
+    await _record_match_with_winner(db_session, target, rival, created_at=BASE_TIME)
+
+    response = await api_client.get(f"/v1/players/{target.id}/matches")
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 3
+    # Newest-first: awaiting, then live, then completed.
+    assert items[0]["status"] == "in_progress"
+    assert items[0]["awaiting_confirmation"] is True
+    assert items[1]["status"] == "in_progress"
+    assert items[1]["awaiting_confirmation"] is False
+    assert items[2]["status"] == "completed"
+    assert items[2]["awaiting_confirmation"] is False
 
 
 async def test_list_player_matches_excludes_other_players_matches(

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -2002,6 +2002,11 @@ export interface components {
             sets: components["schemas"]["PlayerMatchSet"][];
             /** Result */
             result?: ("W" | "L") | null;
+            /**
+             * Awaiting Confirmation
+             * @default false
+             */
+            awaiting_confirmation: boolean;
         };
         /**
          * PlayerMatchSet

--- a/web-client/src/components/dashboard/attention-panel.test.tsx
+++ b/web-client/src/components/dashboard/attention-panel.test.tsx
@@ -6,6 +6,20 @@ import {
 } from './attention-panel.factory'
 import { attentionPanelPage as page } from './attention-panel.page'
 
+/**
+ * The footer's visible text. Its summary spans and the "View all" link are
+ * separated only by flex `gap-x-2` (no literal whitespace in the DOM), so
+ * `textContent` would jam them together; join the direct children's text with
+ * a single space to reflect what the user actually reads.
+ */
+function footerText(p: typeof page) {
+  const footer = p.getViewAllLink().closest('div')!
+  return Array.from<Element>(footer.children)
+    .map((child) => child.textContent?.replace(/\s+/g, ' ').trim() ?? '')
+    .filter(Boolean)
+    .join(' ')
+}
+
 describe('AttentionPanel', () => {
   it('renders each row with its headline and action button', async () => {
     page.render({
@@ -79,6 +93,48 @@ describe('AttentionPanel', () => {
     await page.findPanel()
     expect(page.queryFooterText(/3 more need attention/)).toBeInTheDocument()
     expect(page.queryFooterText(/2 waiting on others/)).toBeInTheDocument()
+  })
+
+  it('does not leave a trailing separator before "View all" (waiting only)', async () => {
+    page.render({
+      view: buildAttentionPanelView({
+        rows: [buildAttentionRowView()],
+        overflowCount: 0,
+        waitingCount: 3,
+      }),
+    })
+
+    await page.findPanel()
+    // No separator dot may sit between the summary and the "View all" link.
+    expect(footerText(page)).toBe('3 waiting on others View all')
+  })
+
+  it('does not leave a trailing separator before "View all" (overflow only)', async () => {
+    page.render({
+      view: buildAttentionPanelView({
+        rows: [buildAttentionRowView()],
+        overflowCount: 2,
+        waitingCount: 0,
+      }),
+    })
+
+    await page.findPanel()
+    expect(footerText(page)).toBe('2 more need attention View all')
+  })
+
+  it('joins overflow and waiting with a single separator, none before "View all"', async () => {
+    page.render({
+      view: buildAttentionPanelView({
+        rows: [buildAttentionRowView()],
+        overflowCount: 2,
+        waitingCount: 3,
+      }),
+    })
+
+    await page.findPanel()
+    expect(footerText(page)).toBe(
+      '2 more need attention · 3 waiting on others View all',
+    )
   })
 
   it('uses the singular verb for a single overflow item', async () => {

--- a/web-client/src/components/dashboard/attention-panel.tsx
+++ b/web-client/src/components/dashboard/attention-panel.tsx
@@ -88,8 +88,11 @@ function AttentionFooter({
   if (waitingCount > 0) parts.push(`${waitingCount} waiting on others`)
   return (
     <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-[color:var(--ink-700)] px-5 py-3 text-[13px] text-[color:var(--chalk-500)]">
-      {parts.map((part) => (
-        <span key={part}>{part} ·</span>
+      {parts.map((part, index) => (
+        <span key={part}>
+          {index > 0 && <span aria-hidden="true">·&nbsp;</span>}
+          {part}
+        </span>
       ))}
       <Link
         to="/matches"

--- a/web-client/src/components/matches/match-list/pagination-footer.test.tsx
+++ b/web-client/src/components/matches/match-list/pagination-footer.test.tsx
@@ -11,6 +11,35 @@ describe('PaginationFooter', () => {
     )
   })
 
+  it('renders an in-range page range correctly', () => {
+    // Page 2 of 4, 100 results, 25/page => Showing 26–50.
+    paginationFooterPage.render({
+      page: 2,
+      total: 100,
+      pageSize: 25,
+      totalPages: 4,
+    })
+
+    expect(paginationFooterPage.getInfo()).toHaveTextContent(
+      'Showing 26–50 of 100 matches',
+    )
+  })
+
+  it('clamps an out-of-range page to the last page range (start <= end)', () => {
+    // A deep-linked ?page=999 against a 25-result list (1 page) must not render
+    // "Showing 24951–25000 of 25" — the footer clamps to the last valid page.
+    paginationFooterPage.render({
+      page: 999,
+      total: 25,
+      pageSize: 25,
+      totalPages: 1,
+    })
+
+    expect(paginationFooterPage.getInfo()).toHaveTextContent(
+      'Showing 1–25 of 25 matches',
+    )
+  })
+
   it('shows a 0 range when there are no matches', () => {
     paginationFooterPage.render({ page: 1, total: 0, pageSize: 25, totalPages: 1 })
 

--- a/web-client/src/components/matches/match-list/pagination-footer.tsx
+++ b/web-client/src/components/matches/match-list/pagination-footer.tsx
@@ -31,11 +31,16 @@ export const PaginationFooter = ({
   pageSize,
   totalPages,
 }: PaginationFooterProps) => {
-  const first = total === 0 ? 0 : (page - 1) * pageSize + 1
-  const last = Math.min(total, page * pageSize)
-  const tokens = paginationRange(page, totalPages)
-  const atFirst = page <= 1
-  const atLast = page >= totalPages
+  // Clamp a stale/out-of-range `page` to a valid one so the range math can
+  // never render start > end — e.g. the frame before the parent's redirect
+  // effect snaps a deep-linked `?page=999` back to the last page (#637). The
+  // footer is self-protecting regardless of what the caller passes.
+  const safePage = Math.min(Math.max(1, page), totalPages)
+  const first = total === 0 ? 0 : (safePage - 1) * pageSize + 1
+  const last = Math.min(total, safePage * pageSize)
+  const tokens = paginationRange(safePage, totalPages)
+  const atFirst = safePage <= 1
+  const atLast = safePage >= totalPages
 
   return (
     <div className="footer">
@@ -62,7 +67,7 @@ export const PaginationFooter = ({
               variant="ghost"
               size="icon-sm"
               disabled={atFirst}
-              onClick={() => setPage(page - 1)}
+              onClick={() => setPage(safePage - 1)}
               aria-label="Previous page"
             >
               <ChevronLeft size={14} strokeWidth={2.4} />
@@ -77,7 +82,7 @@ export const PaginationFooter = ({
               <PaginationItem key={i}>
                 <PaginationLink
                   href="#"
-                  isActive={t === page}
+                  isActive={t === safePage}
                   onClick={(e) => {
                     e.preventDefault()
                     setPage(t)
@@ -93,7 +98,7 @@ export const PaginationFooter = ({
               variant="ghost"
               size="icon-sm"
               disabled={atLast}
-              onClick={() => setPage(page + 1)}
+              onClick={() => setPage(safePage + 1)}
               aria-label="Next page"
             >
               <ChevronRight size={14} strokeWidth={2.4} />

--- a/web-client/src/components/players/player-profile.css
+++ b/web-client/src/components/players/player-profile.css
@@ -307,6 +307,14 @@
   border-color: rgba(255, 77, 109, 0.4);
 }
 
+/* A result posted but not yet confirmed by the opponent (#364). Distinct
+   amber/"warn" tone so it never reads as the green "LIVE" chip or a W/L. */
+.player-profile__result-chip--awaiting {
+  color: var(--warn);
+  background: rgba(255, 196, 61, 0.1);
+  border-color: rgba(255, 196, 61, 0.4);
+}
+
 /* ----- Per-set score chips ----- */
 .player-profile__sets {
   display: inline-flex;

--- a/web-client/src/components/players/player-profile.tsx
+++ b/web-client/src/components/players/player-profile.tsx
@@ -400,7 +400,12 @@ function MatchRowComponent({
         )}
       </td>
       <td>
-        <ResultChip status={m.status} won={won} lost={lost} />
+        <ResultChip
+          status={m.status}
+          awaitingConfirmation={m.awaiting_confirmation}
+          won={won}
+          lost={lost}
+        />
       </td>
     </tr>
   )
@@ -408,13 +413,26 @@ function MatchRowComponent({
 
 function ResultChip({
   status,
+  awaitingConfirmation,
   won,
   lost,
 }: {
   status: PlayerMatchRow['status']
+  awaitingConfirmation: boolean
   won: boolean
   lost: boolean
 }) {
+  // A posted-but-unconfirmed result and a genuinely-live match both sit at
+  // `in_progress`; check the awaiting flag first so the former gets its own
+  // "AWAITING" chip instead of the green "LIVE" one (#364). Mirrors the
+  // matches list's "Awaiting" bucket.
+  if (awaitingConfirmation) {
+    return (
+      <span className="player-profile__result-chip player-profile__result-chip--awaiting">
+        AWAITING
+      </span>
+    )
+  }
   if (status === 'in_progress') {
     return (
       <span className="player-profile__result-chip player-profile__result-chip--live">

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -294,6 +294,7 @@ function projectPlayerMatches(player: {
         opponent: { id: opponentId, username: opponentUsername },
         sets,
         result,
+        awaiting_confirmation: false,
       }
     })
 }

--- a/web-client/src/routes/_app/players/$userId.test.tsx
+++ b/web-client/src/routes/_app/players/$userId.test.tsx
@@ -27,6 +27,7 @@ function matchRows(count: number, page: number, pageSize: number) {
       result: 'W' as const,
       status: 'completed' as const,
       created_at: '2026-06-01T12:00:00Z',
+      awaiting_confirmation: false,
     }))
 }
 
@@ -165,5 +166,55 @@ describe('player profile match-history pagination', () => {
     })
     expect(await screen.findByText('opp.25')).toBeInTheDocument()
     expect(screen.queryByText(/no matches yet/i)).not.toBeInTheDocument()
+  })
+
+  it('labels an awaiting-confirmation match "AWAITING", not "LIVE" (#364)', async () => {
+    // Two in_progress rows: one genuinely live (no signature), one with a
+    // posted-but-unconfirmed result. They must render distinct chips.
+    const rows = [
+      {
+        id: 'm-awaiting',
+        opponent: { id: 'opp-a', username: 'opp.awaiting' },
+        sets: [{ mine: 11, theirs: 9 }],
+        result: null,
+        status: 'in_progress' as const,
+        created_at: '2026-06-02T12:00:00Z',
+        awaiting_confirmation: true,
+      },
+      {
+        id: 'm-live',
+        opponent: { id: 'opp-l', username: 'opp.live' },
+        sets: [],
+        result: null,
+        status: 'in_progress' as const,
+        created_at: '2026-06-01T12:00:00Z',
+        awaiting_confirmation: false,
+      },
+    ]
+    const bundle = { items: rows, page: 1, page_size: 25, total: rows.length }
+    server.use(
+      http.get('*/v1/session', () => HttpResponse.json(sessionResponse())),
+      http.get('*/v1/players/:playerId', () =>
+        HttpResponse.json({
+          id: 'p-1',
+          username: 'rallymaster',
+          rating: 1234,
+          wins: 20,
+          losses: 8,
+          matches: bundle,
+        }),
+      ),
+      http.get('*/v1/players/:playerId/matches', () =>
+        HttpResponse.json(bundle),
+      ),
+    )
+
+    renderProfile('/players/p-1')
+
+    // The awaiting row reads AWAITING; the live row still reads LIVE.
+    expect(await screen.findByText('AWAITING')).toBeInTheDocument()
+    expect(screen.getByText('LIVE')).toBeInTheDocument()
+    // The awaiting row must NOT be labelled LIVE.
+    expect(screen.getAllByText('LIVE')).toHaveLength(1)
   })
 })


### PR DESCRIPTION
Three contained, high-ROI bugfixes found via a code scan + open issues.

## Fixes

### #364 — Public profile labels awaiting-confirmation matches as "LIVE"
A rated match whose result has been **posted but not yet confirmed** by the opponent still sits at `status=in_progress`, identical to a genuinely-live match — so the public profile showed it flashing a green **LIVE** chip.

- **API:** `players.py` derives an `awaiting_confirmation` boolean on `PlayerMatchRow` (`in_progress AND has ≥1 signature`), mirroring the "Awaiting confirmation" bucket `matches.py:_status_label` already models — computed inline so routers don't import each other (per `api/CLAUDE.md`). Eager-loads `Match.signatures`. `schema.d.ts` regenerated.
- **Web:** `ResultChip` checks the flag *before* the LIVE branch and renders a distinct amber **AWAITING** chip (uppercase, matching the profile's sibling chips `LIVE`/`UP NEXT`/`WIN`/`LOSS`).

### Dashboard AttentionFooter — orphaned separator
The footer rendered a trailing `·` before the "View all" link. The middle-dot is now emitted only *between* summary parts (`aria-hidden`).

### Match-list PaginationFooter — out-of-range page range
A stale/deep-linked `?page=999` against a 25-row list briefly rendered "Showing 24951–25000 of 25". Now clamps the page to `[1, totalPages]` with the same `safePage` guard the player-profile footer already uses (#637).

## Testing
- API: `ruff` + `ruff format --check` clean, `mypy --strict` (77 files) clean, **486 pytest passed** (incl. new awaiting-confirmation coverage).
- Web: **995 vitest passed**, `lint` clean, `tsc -b && vite build` clean, **128 Playwright e2e passed**.
- OpenAPI: regenerated `schema.d.ts` diffs clean against committed (no drift).
- Skipped root `e2e/` (needs full compose stack; qa-review covers the integrated browser path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)