### PR TITLE
Fix /matches header overlap + missing CTA on mobile (#156)

### DIFF
--- a/web-client/src/components/matches/match-list/match-list.css
+++ b/web-client/src/components/matches/match-list/match-list.css
@@ -51,6 +51,37 @@
   animation: ball-pulse 1.4s ease-in-out infinite;
 }
 
+/* On a phone the single-line action bar can't fit title + crumb + LIVE pill +
+ * both buttons, so they overlap and the "+ New match" CTA falls off the edge
+ * entirely (#156). Let the bar wrap: title + LIVE pill share the first row, the
+ * two CTAs drop to a full-width second row as comfortable touch targets. The
+ * decorative crumb has no room and the section is already titled "Matches", so
+ * drop it rather than truncate it mid-word. Desktop (one line) is untouched. */
+@media (max-width: 640px) {
+  .match-list-page .action-bar {
+    height: auto;
+    min-height: 56px;
+    flex-wrap: wrap;
+    padding: 12px 16px;
+    gap: 10px 12px;
+  }
+  .match-list-page .action-bar-crumb {
+    display: none;
+  }
+  .match-list-page .action-bar-title {
+    margin-right: auto;
+  }
+  /* Force the CTAs onto their own row below the title/pill. */
+  .match-list-page .action-bar .filter-spacer {
+    flex-basis: 100%;
+    height: 0;
+  }
+  /* Export + New match split the second row so the primary CTA stays reachable. */
+  .match-list-page .action-bar > a {
+    flex: 1 1 0;
+  }
+}
+
 /* ============ Filter row ============ */
 .match-list-page .filter-row {
   padding: 16px 24px;


### PR DESCRIPTION
## Summary

Fixes #156. At narrow widths (≤375px) the `/matches` page header was a single-line, fixed-height flex row that couldn't fit the title, subtitle, LIVE pill, and both buttons — they overlapped and the **"+ New match"** CTA fell off the edge entirely, leaving no way to start a match from mobile.

This adds a `≤640px` breakpoint (the same one the sibling filter-row already uses) that lets `.action-bar` wrap:
- Title + LIVE pill share the first row.
- The decorative crumb ("Across tournaments, club nights, ladder & casual") is dropped on phones — it's redundant with the "Matches" title and previously truncated mid-word.
- Export CSV + New match split a full-width second row as comfortable touch targets, keeping the primary CTA reachable.

Desktop (single line) is untouched.

## Before / After (375×667)

Before: title overlaps the truncated subtitle, "1 LIVE" chip overlaps, Export CSV wedged in, **"+ New match" missing**.
After: title + LIVE on row one, Export CSV + New match on a full-width row two.

## Testing

- `npm run test:run` — 989 unit tests pass (incl. the 4 `action-bar` tests)
- `npm run lint` — clean
- `npm run build` (tsc -b + vite build) — passes
- `npm run test:e2e` — 128 Playwright tests pass
- Manually verified at 375px in the browser (MSW dev): bug reproduced, then fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)