### PR TITLE
Fix new-match summary dot spacing (#367) + dashboard greeting flash (#286)

### DIFF
--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -58,7 +58,11 @@ export function DashboardPage() {
           rating={data.rating ? Math.round(data.rating.current) : null}
         />
       )}
-      <PageTitle greeting={greeting} compact={compact} />
+      <PageTitle
+        greeting={greeting}
+        compact={compact}
+        loading={session.isLoading}
+      />
       {isLoading ? (
         <AttentionPanelSkeleton />
       ) : (

--- a/web-client/src/components/dashboard/page-title.page.tsx
+++ b/web-client/src/components/dashboard/page-title.page.tsx
@@ -16,6 +16,12 @@ const scoped = (container: Container) => ({
   getHeading(name: string | RegExp) {
     return container.getByRole('heading', { name })
   },
+  /** The greeting placeholder bar shown while the session is in flight, or
+   * null once it has resolved. The heading keeps its `role` and gains an
+   * `aria-busy`/`aria-label` while loading (mirroring `UserMenu`). */
+  queryGreetingSkeleton() {
+    return container.queryByRole('heading', { name: /loading greeting/i })
+  },
   /** The optional subtitle line, or null when none was supplied. */
   querySubtitle(text: string | RegExp) {
     return container.queryByText(text)

--- a/web-client/src/components/dashboard/page-title.test.tsx
+++ b/web-client/src/components/dashboard/page-title.test.tsx
@@ -21,6 +21,20 @@ describe('PageTitle', () => {
     expect(pageTitlePage.querySubtitle('Two matches to score')).toBeNull()
   })
 
+  it('renders a placeholder bar instead of the greeting while loading', async () => {
+    pageTitlePage.render({ greeting: 'Hi, @rita.kovac', loading: true })
+
+    expect(await pageTitlePage.findHeading(/loading greeting/i)).toBeInTheDocument()
+    expect(pageTitlePage.querySubtitle(/rita\.kovac/)).toBeNull()
+  })
+
+  it('shows the greeting and no placeholder once loaded', async () => {
+    pageTitlePage.render({ greeting: 'Hi, @rita.kovac', loading: false })
+
+    await pageTitlePage.findHeading(/Hi, @rita\.kovac/)
+    expect(pageTitlePage.queryGreetingSkeleton()).toBeNull()
+  })
+
   it('links the "Log a match" action to /matches/new', async () => {
     pageTitlePage.render()
 

--- a/web-client/src/components/dashboard/page-title.tsx
+++ b/web-client/src/components/dashboard/page-title.tsx
@@ -3,6 +3,7 @@ import { Plus } from 'lucide-react'
 import { Overline } from '@/components/overline'
 import { fmtLongDate } from '@/lib/dates'
 import { C, UI } from '@/components/dashboard/dashboard-tokens'
+import { Shimmer } from '@/components/dashboard/shimmer'
 
 import { Button } from './page-title/button'
 
@@ -10,9 +11,17 @@ export interface PageTitleProps {
   greeting: string
   subtitle?: string
   compact: boolean
+  /** While the session is in flight the greeting name is unknown; render a
+   * placeholder bar in the heading instead of flashing a bare "Hi" (#286). */
+  loading?: boolean
 }
 
-export const PageTitle = ({ greeting, subtitle, compact }: PageTitleProps) => {
+export const PageTitle = ({
+  greeting,
+  subtitle,
+  compact,
+  loading = false,
+}: PageTitleProps) => {
   return (
     <div
       style={{
@@ -28,6 +37,8 @@ export const PageTitle = ({ greeting, subtitle, compact }: PageTitleProps) => {
           Dashboard · {fmtLongDate()}
         </Overline>
         <h1
+          aria-busy={loading || undefined}
+          aria-label={loading ? 'Loading greeting' : undefined}
           style={{
             margin: 0,
             font: `700 ${compact ? 26 : 32}px ${UI}`,
@@ -36,8 +47,19 @@ export const PageTitle = ({ greeting, subtitle, compact }: PageTitleProps) => {
             lineHeight: 1.05,
           }}
         >
-          {greeting}
-          <span style={{ color: C.ball500 }}>.</span>
+          {loading ? (
+            <Shimmer
+              width={compact ? 150 : 200}
+              height={compact ? 26 : 32}
+              radius={8}
+              style={{ display: 'inline-block', verticalAlign: 'middle' }}
+            />
+          ) : (
+            <>
+              {greeting}
+              <span style={{ color: C.ball500 }}>.</span>
+            </>
+          )}
         </h1>
         {subtitle && (
           <div style={{ marginTop: 6, font: `400 14px ${UI}`, color: C.chalk300 }}>

--- a/web-client/src/routes/_app/matches/new.css
+++ b/web-client/src/routes/_app/matches/new.css
@@ -735,7 +735,6 @@
   color: var(--fg-3);
 }
 .nm-summary .read .sub .dot {
-  margin: 0 10px;
   color: var(--ink-500);
 }
 .nm-summary .read .nm-error {

--- a/web-client/src/routes/_app/matches/new.tsx
+++ b/web-client/src/routes/_app/matches/new.tsx
@@ -377,14 +377,14 @@ function SubmitRow({
           )}
         </div>
         <div className="sub">
-          {lengthCopy}
-          <span className="dot">·</span>
+          {lengthCopy}{' '}
+          <span className="dot">·</span>{' '}
           {effectivelyRated ? (
             <span className="rated">Rated</span>
           ) : (
             <span className="unrated">Unrated</span>
-          )}
-          <span className="dot">·</span>
+          )}{' '}
+          <span className="dot">·</span>{' '}
           games to 11, win by 2
         </div>
         {error && (


### PR DESCRIPTION
Fixes #367 and #286 — two small web-client UI fixes.

## #367 — New-match summary missing spaces around middle dots
The summary footer separated segments with `.dot` spans whose spacing came **only** from a CSS `margin: 0 10px`. JSX strips the inter-element newline whitespace, so the actual DOM text content was `Best of 5 · first to 3·Rated·games to 11, win by 2` — wrong for copy/paste and screen readers, and what the bug screenshot showed.

- `new.tsx`: add literal `{' '}` separators around the dot spans.
- `new.css`: drop the now-redundant `margin: 0 10px` so every separator is a single uniform space, matching the leading literal ` · `.

Result: `Best of 5 · first to 3 · Rated · games to 11, win by 2`.

## #286 — Dashboard greeting flashes "Hi" before the session resolves
`PageTitle` renders above the dashboard's loading gate, so the greeting flashed a bare **"Hi"** while `useSession()` was in flight, then snapped to **"Hi, @username"**.

- `page-title.tsx`: add a `loading` prop that renders the dashboard `Shimmer` placeholder in the `<h1>` (with `aria-busy`/`aria-label`, mirroring `UserMenu`) until the session resolves.
- `dashboard-page.tsx`: pass `loading={session.isLoading}`.

**No layout shift:** the `<h1>`'s `line-height: 1.05` fixes its box height in both states (shimmer height matches font size), and the "Log a match" button is held at the right edge by a flex spacer — so the greeting growing from skeleton to `Hi, @username.` never moves anything.

## Testing
- vitest: 991 passed (incl. 2 new PageTitle loading-state tests)
- eslint: 0 errors
- `tsc -b && vite build`: clean
- web-client Playwright e2e: 128 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)