### PR TITLE
iOS: New Match cancel returns to originating tab, not Matches (#420)

### DIFF
--- a/ios/Fortymm/MatchFlow/MatchFlowView.swift
+++ b/ios/Fortymm/MatchFlow/MatchFlowView.swift
@@ -60,7 +60,9 @@ struct MatchFlowView: View {
                 NewMatchView(
                     opponent: $opponent, bestOf: $bestOf, rated: $rated,
                     onStart: start,
-                    onCancel: { onClose(true) }
+                    // Cancel just dismisses the cover, leaving `selection` on the
+                    // tab the flow was launched from (e.g. Home) — not Matches.
+                    onCancel: { onClose(false) }
                 )
                 .transition(.opacity)
             case .score:


### PR DESCRIPTION
## Summary
Fixes #420. On iOS, cancelling the **New match** flow always routed to the **Matches** tab regardless of which tab launched it (e.g. Home).

The setup screen's cancel called `onClose(true)`, and `MainTabView` switches `selection` to `.matches` whenever `toMatches == true`. A plain cancel/close should not switch tabs. Changed the setup `onCancel` to `onClose(false)` so cancel just dismisses the full-screen cover and leaves the user on the originating tab.

The post-match detail's `onBack: { onClose(true) }` (landing on Matches after logging a match) is intentional and left unchanged.

## Testing
- `xcodebuild` clean simulator build (`rm -rf ios/build/sim` + Debug/iphonesimulator) → **BUILD SUCCEEDED**. The iOS app ships no XCTest target, so the compile is the gate.
- No `api/**` or `web-client/**` changes, so those suites don't apply to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)