### PR TITLE
Fix public profile labeling awaiting-confirmation matches as LIVE (#364)

### DIFF
--- a/api/app/domain/match/labels.py
+++ b/api/app/domain/match/labels.py
@@ -1,0 +1,28 @@
+"""Status-label mapping for a match — the single place that turns a match's
+lifecycle position into the user-facing label. Lives in the domain layer so
+both the matches list and the player-profile routers can derive the same
+label without importing each other's internals."""
+
+from app.models.match import Match, MatchStatus
+
+
+def status_label(match: Match) -> str:
+    """User-facing label for a match's lifecycle position. An ``in_progress``
+    match with at least one signature has a posted result waiting on the
+    other side — surface that distinctly so the FE doesn't need to know
+    about ``signatures`` to render it. (Requires ``match.signatures`` to be
+    loaded.)"""
+    if match.status == MatchStatus.in_progress and match.signatures:
+        return "Awaiting confirmation"
+    # Exhaustive — adding an enum member is a type error until handled.
+    match match.status:
+        case MatchStatus.pending:
+            return "Scheduled"
+        case MatchStatus.in_progress:
+            return "Live"
+        case MatchStatus.completed:
+            return "Final"
+        case MatchStatus.disputed:
+            return "Disputed"
+        case MatchStatus.voided:
+            return "Voided"

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -29,6 +29,7 @@ from app.attention import (
     list_attention_kind,
 )
 from app.db import get_session
+from app.domain.match.labels import status_label as _status_label
 from app.domain.match.models import Match as MatchModel
 from app.leagues import resolve_league
 from app.mappers.match_details_mapper import serialize_match_details
@@ -197,27 +198,6 @@ def _all_sides_signed(match: Match) -> bool:
     flip in ``POST /confirmation``."""
     signers = {sig.user_id for sig in match.signatures}
     return all(any(p.user_id in signers for p in side.players) for side in match.sides)
-
-
-def _status_label(match: Match) -> str:
-    """User-facing label for a match's lifecycle position. An ``in_progress``
-    match with at least one signature has a posted result waiting on the
-    other side — surface that distinctly so the FE doesn't need to know
-    about ``signatures`` to render it."""
-    if match.status == MatchStatus.in_progress and match.signatures:
-        return "Awaiting confirmation"
-    # Exhaustive — adding an enum member is a type error until handled.
-    match match.status:
-        case MatchStatus.pending:
-            return "Scheduled"
-        case MatchStatus.in_progress:
-            return "Live"
-        case MatchStatus.completed:
-            return "Final"
-        case MatchStatus.disputed:
-            return "Disputed"
-        case MatchStatus.voided:
-            return "Voided"
 
 
 def _games_to_win(best_of: int) -> int:

--- a/api/app/players.py
+++ b/api/app/players.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import aliased, selectinload
 from sqlalchemy.sql.base import ExecutableOption
 
 from app.db import get_session
+from app.domain.match.labels import status_label
 from app.leagues import resolve_league
 from app.models import (
     Match,
@@ -419,14 +420,17 @@ async def get_player(
 
 
 def _player_matches_eager() -> tuple[ExecutableOption, ...]:
-    """Eager-load sides + side players + per-game scores. Matches the
-    structure matches.py uses for its detail view but skips match_settings
-    + league/rating_strategy since the per-player row doesn't render those."""
+    """Eager-load sides + side players + per-game scores + signatures. Matches
+    the structure matches.py uses for its detail view but skips match_settings
+    + league/rating_strategy since the per-player row doesn't render those.
+    Signatures are needed so the row's ``status_label`` can split the derived
+    ``Awaiting confirmation`` bucket out of ``Live`` (issue #364)."""
     return (
         selectinload(Match.sides)
         .selectinload(MatchSide.players)
         .selectinload(MatchSidePlayer.user),
         selectinload(Match.games).selectinload(MatchGame.score),
+        selectinload(Match.signatures),
     )
 
 
@@ -490,6 +494,7 @@ def _serialize_player_match(match: Match, player_id: uuid.UUID) -> PlayerMatchRo
     return PlayerMatchRow(
         id=match.id,
         status=match.status,
+        status_label=status_label(match),
         created_at=match.created_at,
         opponent=opponent,
         sets=sets,

--- a/api/app/schemas/player.py
+++ b/api/app/schemas/player.py
@@ -71,6 +71,11 @@ class PlayerMatchRow(BaseModel):
 
     id: uuid.UUID
     status: MatchStatus
+    # User-facing lifecycle label (shared `_status_label` mapping). Carries the
+    # derived "Awaiting confirmation" bucket that `status` alone can't express
+    # (an in_progress match with a posted result waiting on the other side), so
+    # the public profile doesn't mislabel awaiting rows as "LIVE" (issue #364).
+    status_label: str
     created_at: datetime
     opponent: PlayerMatchOpponent
     # Newest-first list of per-game scores. Empty when no games have been

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -9,6 +9,7 @@ from app.models import (
     MatchSettings,
     MatchSide,
     MatchSidePlayer,
+    MatchSignature,
     MatchStatus,
     User,
     UserLeagueRating,
@@ -339,12 +340,17 @@ async def _record_match_with_winner(
     *,
     created_at: datetime,
     status: MatchStatus = MatchStatus.completed,
+    signed_by: User | None = None,
 ) -> Match:
     """Persist a singles match with explicit winner/loser so W-L and form
     assertions are deterministic. Same shape as `_record_match` but flips
     `MatchSide.won` on the right side. ``won`` is stamped only for completed
     matches, mirroring the API: since #485 it's written at the moment a match
-    becomes final, never while one is still in progress."""
+    becomes final, never while one is still in progress.
+
+    ``signed_by`` attaches a single ``MatchSignature`` — an ``in_progress``
+    match with one models the "posted result awaiting the other side's
+    confirmation" state."""
     settings = MatchSettings(team_size=1, best_of=5, affects_rating=False)
     league = await get_default_league(db_session)
     match = Match(
@@ -360,6 +366,8 @@ async def _record_match_with_winner(
     side1.players.append(MatchSidePlayer(match=match, user=winner))
     side2 = MatchSide(match=match, side_number=2, won=False if completed else None)
     side2.players.append(MatchSidePlayer(match=match, user=loser))
+    if signed_by is not None:
+        match.signatures.append(MatchSignature(match=match, user=signed_by))
     db_session.add(match)
     await db_session.commit()
     return match
@@ -570,6 +578,37 @@ async def test_list_player_matches_result_hidden_while_awaiting_confirmation(
     assert body["total"] == 1
     row = body["items"][0]
     assert row["status"] == "in_progress"
+    assert row["result"] is None
+    # No signature yet → genuinely live, not awaiting confirmation.
+    assert row["status_label"] == "Live"
+
+
+async def test_list_player_matches_labels_awaiting_confirmation_distinctly(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """An in_progress match with a posted result (one signature) is awaiting
+    the other side's confirmation. The public profile must surface that as
+    ``Awaiting confirmation`` rather than mislabeling it ``Live`` (issue #364)
+    — the status enum alone can't express the derived bucket, so the row
+    carries the shared ``status_label``."""
+    await start_session(api_client, db_session)
+    target = await make_user(db_session, "awaiting2.target")
+    rival = await make_user(db_session, "awaiting2.rival")
+    await _record_match_with_winner(
+        db_session,
+        target,
+        rival,
+        created_at=BASE_TIME,
+        status=MatchStatus.in_progress,
+        signed_by=target,
+    )
+
+    response = await api_client.get(f"/v1/players/{target.id}/matches")
+    assert response.status_code == 200
+    row = response.json()["items"][0]
+    assert row["status"] == "in_progress"
+    assert row["status_label"] == "Awaiting confirmation"
+    # Still no official outcome while unconfirmed.
     assert row["result"] is None
 
 

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1992,6 +1992,8 @@ export interface components {
              */
             id: string;
             status: components["schemas"]["MatchStatus"];
+            /** Status Label */
+            status_label: string;
             /**
              * Created At
              * Format: date-time

--- a/web-client/src/components/players/player-profile.tsx
+++ b/web-client/src/components/players/player-profile.tsx
@@ -400,22 +400,44 @@ function MatchRowComponent({
         )}
       </td>
       <td>
-        <ResultChip status={m.status} won={won} lost={lost} />
+        <ResultChip
+          status={m.status}
+          statusLabel={m.status_label}
+          won={won}
+          lost={lost}
+        />
       </td>
     </tr>
   )
 }
 
+// Mirrors the server's `_status_label` (api/app/domain/match/labels.py): an
+// in_progress match with a posted result waiting on the other side. The status
+// enum alone can't distinguish it from a genuinely live match, so we key off
+// the server-derived label (issue #364).
+const AWAITING_CONFIRMATION_LABEL = 'Awaiting confirmation'
+
 function ResultChip({
   status,
+  statusLabel,
   won,
   lost,
 }: {
   status: PlayerMatchRow['status']
+  statusLabel: PlayerMatchRow['status_label']
   won: boolean
   lost: boolean
 }) {
   if (status === 'in_progress') {
+    if (statusLabel === AWAITING_CONFIRMATION_LABEL) {
+      // A posted-but-unconfirmed result — distinct from genuinely live, so an
+      // anonymous viewer can tell the result isn't final/ratified yet.
+      return (
+        <span className="player-profile__result-chip player-profile__result-chip--pending">
+          AWAITING
+        </span>
+      )
+    }
     return (
       <span className="player-profile__result-chip player-profile__result-chip--live">
         LIVE

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -17,6 +17,7 @@ import {
   projectRating,
   projectRecentResult,
   rankAttentionSeeds,
+  seedStatusLabel,
   statusCountsOf,
   validateScore,
   type SeedMatch,
@@ -290,6 +291,7 @@ function projectPlayerMatches(player: {
       return {
         id: m.id,
         status: m.status,
+        status_label: seedStatusLabel(m),
         created_at: m.created_at,
         opponent: { id: opponentId, username: opponentUsername },
         sets,

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -240,7 +240,7 @@ function projectSides(seed: SeedMatch): {
   return { mySide, opponentSide }
 }
 
-function seedStatusLabel(seed: SeedMatch): string {
+export function seedStatusLabel(seed: SeedMatch): string {
   if (seed.status === 'in_progress' && seed.signatures.length > 0) {
     return 'Awaiting confirmation'
   }

--- a/web-client/src/routes/_app/players/$userId.test.tsx
+++ b/web-client/src/routes/_app/players/$userId.test.tsx
@@ -26,6 +26,7 @@ function matchRows(count: number, page: number, pageSize: number) {
       sets: [{ mine: 11, theirs: 7 }],
       result: 'W' as const,
       status: 'completed' as const,
+      status_label: 'Final' as const,
       created_at: '2026-06-01T12:00:00Z',
     }))
 }
@@ -165,5 +166,60 @@ describe('player profile match-history pagination', () => {
     })
     expect(await screen.findByText('opp.25')).toBeInTheDocument()
     expect(screen.queryByText(/no matches yet/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('player profile result chip (#364)', () => {
+  it('labels an awaiting-confirmation match AWAITING, not LIVE', async () => {
+    // An in_progress match with a posted result waiting on the other side.
+    // The server distinguishes it via `status_label`; the chip must not show
+    // it as plain LIVE (indistinguishable from a genuinely live match).
+    const awaitingRow = {
+      id: 'm-awaiting',
+      opponent: { id: 'opp-1', username: 'pending.pat' },
+      sets: [{ mine: 11, theirs: 7 }],
+      result: null,
+      status: 'in_progress' as const,
+      status_label: 'Awaiting confirmation' as const,
+      created_at: '2026-06-01T12:00:00Z',
+    }
+    // A genuinely live match (no posted result) stays LIVE.
+    const liveRow = {
+      id: 'm-live',
+      opponent: { id: 'opp-2', username: 'live.lee' },
+      sets: [],
+      result: null,
+      status: 'in_progress' as const,
+      status_label: 'Live' as const,
+      created_at: '2026-06-02T12:00:00Z',
+    }
+    const matches = {
+      items: [liveRow, awaitingRow],
+      page: 1,
+      page_size: 25,
+      total: 2,
+    }
+    server.use(
+      http.get('*/v1/session', () => HttpResponse.json(sessionResponse())),
+      http.get('*/v1/players/:playerId', () =>
+        HttpResponse.json({
+          id: 'p-1',
+          username: 'rallymaster',
+          rating: 1234,
+          wins: 0,
+          losses: 0,
+          matches,
+        }),
+      ),
+      http.get('*/v1/players/:playerId/matches', () =>
+        HttpResponse.json(matches),
+      ),
+    )
+
+    renderProfile('/players/p-1')
+
+    expect(await screen.findByText('AWAITING')).toBeInTheDocument()
+    // The live row still reads LIVE — the awaiting row didn't swallow it.
+    expect(screen.getByText('LIVE')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Fixes #364. On the public player profile (`/p/players/{username}`), matches in **Awaiting confirmation** were labeled **`LIVE`** in the status column — indistinguishable from genuinely in-progress matches. Anonymous viewers couldn't tell a posted-but-unconfirmed (disputable) result from a live one. The authed `/matches` list already distinguishes them via a server-computed `status_label`; only the public profile mis-mapped.

## Root cause

`GET /v1/players/{id}/matches` returned the raw `MatchStatus` enum on each row, and the FE `ResultChip` mapped any `in_progress` row to `LIVE`. The "awaiting confirmation" state is a *derived* bucket (an `in_progress` match carrying ≥1 signature) that the enum alone can't express.

## Changes

- **Shared mapping:** extracted the canonical `_status_label` out of the `matches` router into a new shared `api/app/domain/match/labels.py`, so the `players` router reuses it without importing another router's internals (per `api/CLAUDE.md`).
- **API:** `players.py` now eager-loads `Match.signatures` and ships `status_label` on each `PlayerMatchRow`; added the field to the schema. Regenerated `schema.d.ts` (single-field addition).
- **Web:** `ResultChip` keys off `status_label` — renders **AWAITING** for an awaiting-confirmation row, leaves genuinely-live rows as **LIVE**. MSW mocks mirror the server label via the now-exported `seedStatusLabel`.

## Testing

- **API:** `ruff` ✓ · `ruff format` ✓ · `mypy --strict` ✓ · `pytest` **486 passed** ✓ (new test asserts the Live vs Awaiting-confirmation split on profile rows)
- **Web:** `vitest` **990 passed** ✓ · `eslint` ✓ · `tsc -b && vite build` ✓ (new test pins AWAITING-vs-LIVE chip behavior)
- **OpenAPI schema drift:** none ✓
- e2e suites: no spec covers the player-profile result chip; behavior is covered by the API integration + FE component tests and the QA browser pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)