### PR TITLE
Make H2H meeting rows clickable + rated-aware; fix Sheet width override (#498, #500, #623)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1284,7 +1284,7 @@ async def _load_head_to_head(
             _history_base_query(current_match_id, before=match.created_at), user_a
         ),
         user_b,
-    )
+    ).options(selectinload(Match.match_settings))
     rows = (await db.execute(rows_query.limit(H2H_MEETINGS_LIMIT))).scalars().all()
 
     meetings: list[MatchDetailsH2HMeeting] = []
@@ -1305,6 +1305,7 @@ async def _load_head_to_head(
                 side_1_games_won=a_games,
                 side_2_games_won=b_games,
                 winner_side_number=winner_side,
+                rated=past.match_settings.affects_rating,
             )
         )
 

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -152,6 +152,7 @@ class MatchDetailsH2HMeeting(BaseModel):
     side_1_games_won: int
     side_2_games_won: int
     winner_side_number: int | None
+    rated: bool
 
 
 class MatchDetailsH2H(BaseModel):

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1757,6 +1757,39 @@ async def test_details_head_to_head_counts_prior_meetings_per_side(
     assert h2h["side_2_wins"] == 1
     # Most-recent meeting is the one I just lost.
     assert h2h["recent_meetings"][0]["winner_side_number"] == 2
+    # Every meeting here went through the rated sign-off flow.
+    assert all(m["rated"] for m in h2h["recent_meetings"])
+
+
+async def test_details_head_to_head_flags_rated_vs_unrated_meetings(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Each meeting row carries whether it moved ratings, so the card can mark
+    rated meetings apart from casual ones (#500)."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "h2h-mixed-rival") as (
+        rival_client,
+        rival,
+    ):
+        # A rated prior meeting (full sign-off) ...
+        await _play_match_to_completion(
+            api_client, rival_client, rival.id, best_of=3, side_1_wins=True
+        )
+        # ... and an unrated one, which finalizes straight from /results.
+        unrated = await api_client.post(
+            "/v1/matches",
+            json={"opponent_user_id": str(rival.id), "best_of": 3, "rated": False},
+        )
+        assert unrated.status_code == 201
+        unrated_id = unrated.json()["id"]
+        await _post_results(api_client, unrated_id)
+
+        current = await _create_match(api_client, rival.id, best_of=5)
+
+    h2h = (await api_client.get(f"/v1/matches/{current['id']}")).json()["head_to_head"]
+    rated_by_match = {m["match_id"]: m["rated"] for m in h2h["recent_meetings"]}
+    assert rated_by_match[unrated_id] is False
+    assert any(rated_by_match.values())
 
 
 async def test_details_head_to_head_excludes_meetings_after_this_match(

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1386,6 +1386,8 @@ export interface components {
             side_2_games_won: number;
             /** Winner Side Number */
             winner_side_number: number | null;
+            /** Rated */
+            rated: boolean;
         };
         /** MatchDetailsPlayer */
         MatchDetailsPlayer: {

--- a/web-client/src/components/matches/match-details.test.tsx
+++ b/web-client/src/components/matches/match-details.test.tsx
@@ -489,6 +489,7 @@ describe("MatchDetails — page wiring", () => {
             side_1_games_won: 1,
             side_2_games_won: 3,
             winner_side_number: 2,
+            rated: true,
           },
           {
             match_id: "m-h2h-2",
@@ -496,6 +497,7 @@ describe("MatchDetails — page wiring", () => {
             side_1_games_won: 3,
             side_2_games_won: 0,
             winner_side_number: 1,
+            rated: true,
           },
           {
             match_id: "m-h2h-1",
@@ -503,6 +505,7 @@ describe("MatchDetails — page wiring", () => {
             side_1_games_won: 3,
             side_2_games_won: 2,
             winner_side_number: 1,
+            rated: false,
           },
         ],
       },

--- a/web-client/src/components/matches/match-details/head-to-head.page.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head.page.tsx
@@ -5,7 +5,8 @@ import {
   type MatchDetailsResolver,
 } from "@/mocks/endpoints/matches/match-details.endpoint";
 import { server } from "@/mocks/server";
-import { render, screen, type Container } from "@/test/utilities";
+import { renderUnderMatchRoute } from "@/test/match-route";
+import { screen, type Container } from "@/test/utilities";
 
 import { HeadToHead, type HeadToHeadProps } from "./head-to-head";
 import { headToHeadDisplayPage } from "./head-to-head/head-to-head-fetcher/head-to-head-display.page";
@@ -19,6 +20,13 @@ const scoped = (container: Container) => ({
    * unambiguous when composed alongside the other sections' status regions. */
   queryLoading() {
     return container.queryByRole("status", {
+      name: /loading head-to-head record/i,
+    });
+  },
+  /** Async variant — the tree mounts under a router that resolves a tick after
+   * render, so the fallback appears asynchronously. */
+  findLoading() {
+    return container.findByRole("status", {
       name: /loading head-to-head record/i,
     });
   },
@@ -61,7 +69,7 @@ export const headToHeadPage = {
       ...overrides,
     };
 
-    render(
+    renderUnderMatchRoute(
       <ErrorBoundary
         fallbackRender={() => (
           <div role="alert">Couldn’t load the head-to-head record</div>

--- a/web-client/src/components/matches/match-details/head-to-head.test.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head.test.tsx
@@ -18,11 +18,12 @@ describe("HeadToHead", () => {
 
     headToHeadPage.render();
 
-    // Pending: only HeadToHead's real Suspense fallback, no card yet.
-    expect(headToHeadPage.queryLoading()).toBeInTheDocument();
+    // Pending: only HeadToHead's real Suspense fallback, no card yet. The row
+    // mounts under a router, so the fallback appears a tick after render.
+    expect(await headToHeadPage.findLoading()).toBeInTheDocument();
     expect(headToHeadPage.queryError()).not.toBeInTheDocument();
 
-    await waitForElementToBeRemoved(headToHeadPage.queryLoading());
+    await waitForElementToBeRemoved(() => headToHeadPage.queryLoading());
     expect(headToHeadPage.getCard()).toBeInTheDocument();
   });
 
@@ -35,7 +36,8 @@ describe("HeadToHead", () => {
 
     headToHeadPage.render({ matchId: "m-42" });
 
-    await waitForElementToBeRemoved(headToHeadPage.queryLoading());
+    await headToHeadPage.findLoading();
+    await waitForElementToBeRemoved(() => headToHeadPage.queryLoading());
     expect(requestedMatchId).toBe("m-42");
   });
 
@@ -44,7 +46,8 @@ describe("HeadToHead", () => {
 
     headToHeadPage.render();
 
-    await waitForElementToBeRemoved(headToHeadPage.queryLoading());
+    await headToHeadPage.findLoading();
+    await waitForElementToBeRemoved(() => headToHeadPage.queryLoading());
     // Wiring only: card content is pinned by the query and display tests.
     expect(headToHeadPage.getLeftCount()).toHaveTextContent(/^2$/);
   });
@@ -56,7 +59,8 @@ describe("HeadToHead", () => {
 
     headToHeadPage.render();
 
-    await waitForElementToBeRemoved(headToHeadPage.queryLoading());
+    await headToHeadPage.findLoading();
+    await waitForElementToBeRemoved(() => headToHeadPage.queryLoading());
     expect(headToHeadPage.queryCard()).not.toBeInTheDocument();
     expect(headToHeadPage.queryError()).not.toBeInTheDocument();
   });
@@ -66,7 +70,8 @@ describe("HeadToHead", () => {
 
     headToHeadPage.render();
 
-    await waitForElementToBeRemoved(headToHeadPage.queryLoading());
+    await headToHeadPage.findLoading();
+    await waitForElementToBeRemoved(() => headToHeadPage.queryLoading());
     expect(headToHeadPage.queryError()).toBeInTheDocument();
   });
 });

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher.page.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher.page.tsx
@@ -6,7 +6,8 @@ import {
   type MatchDetailsResolver,
 } from "@/mocks/endpoints/matches/match-details.endpoint";
 import { server } from "@/mocks/server";
-import { render, screen, type Container } from "@/test/utilities";
+import { renderUnderMatchRoute } from "@/test/match-route";
+import { screen, type Container } from "@/test/utilities";
 
 import { headToHeadDisplayPage } from "./head-to-head-fetcher/head-to-head-display.page";
 import {
@@ -20,6 +21,11 @@ const scoped = (container: Container) => ({
   /** The Suspense fallback shown while the match-details query is pending. */
   queryLoading() {
     return container.queryByTestId("head-to-head-loading");
+  },
+  /** Async variant — the tree mounts under a router that resolves a tick after
+   * render, so the fallback appears asynchronously. */
+  findLoading() {
+    return container.findByTestId("head-to-head-loading");
   },
   /** The error-boundary fallback shown when the query rejects. */
   queryError() {
@@ -53,7 +59,7 @@ export const headToHeadFetcherPage = {
       ...overrides,
     };
 
-    render(
+    renderUnderMatchRoute(
       <ErrorBoundary
         fallbackRender={() => (
           <div role="alert">Couldn’t load the head-to-head record</div>

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher.test.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher.test.tsx
@@ -20,10 +20,11 @@ describe("HeadToHeadFetcher", () => {
 
     headToHeadFetcherPage.render();
 
-    expect(headToHeadFetcherPage.queryLoading()).toBeInTheDocument();
+    // The row mounts under a router, so the fallback appears a tick after render.
+    expect(await headToHeadFetcherPage.findLoading()).toBeInTheDocument();
     expect(headToHeadFetcherPage.queryCard()).not.toBeInTheDocument();
 
-    await waitForElementToBeRemoved(headToHeadFetcherPage.queryLoading());
+    await waitForElementToBeRemoved(() => headToHeadFetcherPage.queryLoading());
     expect(headToHeadFetcherPage.getCard()).toBeInTheDocument();
     // The default record's counts, projected through the query.
     expect(headToHeadFetcherPage.getLeftCount()).toHaveTextContent(/^2$/);
@@ -37,7 +38,8 @@ describe("HeadToHeadFetcher", () => {
 
     headToHeadFetcherPage.render();
 
-    await waitForElementToBeRemoved(headToHeadFetcherPage.queryLoading());
+    await headToHeadFetcherPage.findLoading();
+    await waitForElementToBeRemoved(() => headToHeadFetcherPage.queryLoading());
     expect(headToHeadFetcherPage.queryCard()).not.toBeInTheDocument();
     expect(headToHeadFetcherPage.queryError()).not.toBeInTheDocument();
   });
@@ -49,7 +51,8 @@ describe("HeadToHeadFetcher", () => {
 
     headToHeadFetcherPage.render();
 
-    await waitForElementToBeRemoved(headToHeadFetcherPage.queryLoading());
+    await headToHeadFetcherPage.findLoading();
+    await waitForElementToBeRemoved(() => headToHeadFetcherPage.queryLoading());
     expect(headToHeadFetcherPage.queryError()).toBeInTheDocument();
     expect(headToHeadFetcherPage.queryCard()).not.toBeInTheDocument();
   });

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.page.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.page.tsx
@@ -1,4 +1,5 @@
-import { render, screen, within, type Container } from "@/test/utilities";
+import { renderUnderMatchRoute } from "@/test/match-route";
+import { screen, within, type Container } from "@/test/utilities";
 
 import {
   HeadToHeadDisplay,
@@ -16,6 +17,11 @@ const scoped = (container: Container) => {
   return {
     /** The card's `<section>` landmark, named by its visible heading. */
     getCard,
+    /** Async variant — the card mounts under a router that resolves the rows'
+     * typed links asynchronously, so first reads should await this. */
+    findCard() {
+      return container.findByRole("region", { name: "Head to head" });
+    },
     queryCard() {
       return container.queryByRole("region", { name: "Head to head" });
     },
@@ -72,7 +78,7 @@ const scoped = (container: Container) => {
 export const headToHeadDisplayPage = {
   render(overrides: Partial<HeadToHeadDisplayProps> = {}) {
     const props = buildHeadToHeadDisplayProps(overrides);
-    render(<HeadToHeadDisplay {...props} />);
+    renderUnderMatchRoute(<HeadToHeadDisplay {...props} />);
   },
 
   /**

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.test.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.test.tsx
@@ -3,16 +3,18 @@ import { headToHeadDisplayPage } from "./head-to-head-display.page";
 import { buildHeadToHeadMeetingView } from "./head-to-head-display/meeting-row.factory";
 
 describe("HeadToHeadDisplay", () => {
-  it("renders the card as a region named by its heading", () => {
+  it("renders the card as a region named by its heading", async () => {
     headToHeadDisplayPage.render();
 
+    await headToHeadDisplayPage.findCard();
     expect(headToHeadDisplayPage.getCard()).toBeInTheDocument();
     expect(headToHeadDisplayPage.getTitle()).toHaveTextContent("Head to head");
   });
 
-  it("shows the side labels and win counts", () => {
+  it("shows the side labels and win counts", async () => {
     headToHeadDisplayPage.render();
 
+    await headToHeadDisplayPage.findCard();
     expect(headToHeadDisplayPage.getLeftLabel()).toHaveTextContent(
       "rita.kovac",
     );
@@ -23,9 +25,10 @@ describe("HeadToHeadDisplay", () => {
     expect(headToHeadDisplayPage.getRightCount()).toHaveTextContent(/^1$/);
   });
 
-  it("tones the leading side's count as the winner", () => {
+  it("tones the leading side's count as the winner", async () => {
     headToHeadDisplayPage.render();
 
+    await headToHeadDisplayPage.findCard();
     expect(headToHeadDisplayPage.getLeftCount()).toHaveClass(
       "md-h2h__count--win",
     );
@@ -34,21 +37,23 @@ describe("HeadToHeadDisplay", () => {
     );
   });
 
-  it("pluralizes the meeting count for several meetings", () => {
+  it("pluralizes the meeting count for several meetings", async () => {
     headToHeadDisplayPage.render();
 
+    await headToHeadDisplayPage.findCard();
     expect(headToHeadDisplayPage.getMeta()).toHaveTextContent("3 MEETINGS");
   });
 
-  it("singularizes the meeting count for a single meeting", () => {
+  it("singularizes the meeting count for a single meeting", async () => {
     headToHeadDisplayPage.render({
       headToHead: buildHeadToHeadView({ totalMeetings: 1 }),
     });
 
+    await headToHeadDisplayPage.findCard();
     expect(headToHeadDisplayPage.getMeta()).toHaveTextContent("1 MEETING");
   });
 
-  it("renders one row per recent meeting, with the bar, when there are meetings", () => {
+  it("renders one row per recent meeting, with the bar, when there are meetings", async () => {
     headToHeadDisplayPage.render({
       headToHead: buildHeadToHeadView({
         recentMeetings: [
@@ -58,6 +63,7 @@ describe("HeadToHeadDisplay", () => {
       }),
     });
 
+    await headToHeadDisplayPage.findCard();
     expect(headToHeadDisplayPage.queryBar()).toBeInTheDocument();
     expect(headToHeadDisplayPage.queryEmpty()).not.toBeInTheDocument();
     expect(headToHeadDisplayPage.getRows()).toHaveLength(2);
@@ -70,7 +76,7 @@ describe("HeadToHeadDisplay", () => {
     );
   });
 
-  it("shows the start-of-rivalry empty state with no bar or rows", () => {
+  it("shows the start-of-rivalry empty state with no bar or rows", async () => {
     headToHeadDisplayPage.render({
       headToHead: buildHeadToHeadView({
         totalMeetings: 0,
@@ -80,6 +86,7 @@ describe("HeadToHeadDisplay", () => {
       }),
     });
 
+    await headToHeadDisplayPage.findCard();
     expect(headToHeadDisplayPage.queryEmpty()).toHaveTextContent(
       /start of the rivalry/,
     );

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.factory.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.factory.tsx
@@ -8,6 +8,7 @@ export function buildHeadToHeadMeetingView(
   return {
     matchId: "m-h2h-1",
     dateLabel: "May 8",
+    rated: true,
     leftGamesWon: 3,
     rightGamesWon: 2,
     leftWon: true,

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.page.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.page.tsx
@@ -1,4 +1,5 @@
-import { render, screen, type Container } from "@/test/utilities";
+import { renderUnderMatchRoute } from "@/test/match-route";
+import { screen, type Container } from "@/test/utilities";
 
 import { MeetingRow, type MeetingRowProps } from "./meeting-row";
 import { buildMeetingRowProps } from "./meeting-row.factory";
@@ -8,12 +9,21 @@ const scoped = (container: Container) => {
     container
       .getByText("Match", { selector: ".md-h2h__label" })
       .closest(".md-h2h__row") as HTMLElement;
+  const findRow = async () => {
+    const label = await container.findByText("Match", {
+      selector: ".md-h2h__label",
+    });
+    return label.closest(".md-h2h__row") as HTMLElement;
+  };
 
   return {
-    /** The meeting's row element. A scoped container holds a single row, so
-     * there's no per-row discriminator — the embedding page object scopes to
-     * one row before reaching for these. */
+    /** The meeting's row element — a typed `<Link>` to the match. A scoped
+     * container holds a single row, so there's no per-row discriminator; the
+     * embedding page object scopes to one row before reaching for these. */
     getRow,
+    /** Async variant — the row mounts under a router that resolves the typed
+     * link asynchronously, so first reads should await this. */
+    findRow,
     /** The pre-formatted meeting date. */
     getDate() {
       return getRow().querySelector(".md-h2h__date")!;
@@ -27,19 +37,26 @@ const scoped = (container: Container) => {
     getResult() {
       return getRow().querySelector(".md-h2h__result")!;
     },
+    /** The "Rated" marker, or `null` for an unrated meeting. */
+    getRatedTag() {
+      return getRow().querySelector(".md-h2h__tag");
+    },
   };
 };
 
 /**
  * Test page-object for `MeetingRow` — one prior meeting's line in the
- * head-to-head card. A scoped container holds exactly one row, so accessors
- * take no discriminator; the head-to-head display scopes to a single row
- * element before spreading these.
+ * head-to-head card. The row is a typed `<Link>`, so `render` mounts it under
+ * a minimal router that registers the match-detail route the row targets; the
+ * router resolves asynchronously, so first reads should `await findRow()`. A
+ * scoped container holds exactly one row, so accessors take no discriminator;
+ * the head-to-head display scopes to a single row element before spreading
+ * these.
  */
 export const meetingRowPage = {
   render(overrides: Partial<MeetingRowProps> = {}) {
     const props = buildMeetingRowProps(overrides);
-    render(<MeetingRow {...props} />);
+    renderUnderMatchRoute(<MeetingRow {...props} />);
   },
 
   /**

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.test.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.test.tsx
@@ -2,7 +2,7 @@ import { buildHeadToHeadMeetingView } from "./meeting-row.factory";
 import { meetingRowPage } from "./meeting-row.page";
 
 describe("MeetingRow", () => {
-  it("shows the meeting date and the left–right games-won score", () => {
+  it("shows the meeting date and the left–right games-won score", async () => {
     meetingRowPage.render({
       meeting: buildHeadToHeadMeetingView({
         dateLabel: "Apr 12",
@@ -11,15 +11,46 @@ describe("MeetingRow", () => {
       }),
     });
 
+    await meetingRowPage.findRow();
     expect(meetingRowPage.getDate()).toHaveTextContent(/^Apr 12$/);
     expect(meetingRowPage.getScore()).toHaveTextContent("3–1");
   });
 
-  it("marks a left win with the win-toned score and a W result", () => {
+  it("links the row to the meeting's match-detail page", async () => {
+    meetingRowPage.render({
+      meeting: buildHeadToHeadMeetingView({ matchId: "m-42", dateLabel: "Apr 12" }),
+    });
+
+    const row = await meetingRowPage.findRow();
+    expect(row.tagName).toBe("A");
+    expect(row).toHaveAttribute("href", "/matches/m-42");
+    expect(row).toHaveAttribute("aria-label", "Open match from Apr 12");
+  });
+
+  it("marks a rated meeting with the Rated tag and omits it when unrated", async () => {
+    meetingRowPage.render({
+      meeting: buildHeadToHeadMeetingView({ rated: true }),
+    });
+
+    await meetingRowPage.findRow();
+    expect(meetingRowPage.getRatedTag()).toHaveTextContent(/^Rated$/);
+  });
+
+  it("omits the Rated tag for an unrated meeting", async () => {
+    meetingRowPage.render({
+      meeting: buildHeadToHeadMeetingView({ rated: false }),
+    });
+
+    await meetingRowPage.findRow();
+    expect(meetingRowPage.getRatedTag()).toBeNull();
+  });
+
+  it("marks a left win with the win-toned score and a W result", async () => {
     meetingRowPage.render({
       meeting: buildHeadToHeadMeetingView({ leftWon: true }),
     });
 
+    await meetingRowPage.findRow();
     expect(meetingRowPage.getScore()).toHaveClass("md-h2h__score--win");
     const result = meetingRowPage.getResult();
     expect(result).toHaveTextContent(/^W$/);
@@ -27,11 +58,12 @@ describe("MeetingRow", () => {
     expect(result).not.toHaveClass("md-h2h__result--l");
   });
 
-  it("marks a left loss without the win tone and an L result", () => {
+  it("marks a left loss without the win tone and an L result", async () => {
     meetingRowPage.render({
       meeting: buildHeadToHeadMeetingView({ leftWon: false }),
     });
 
+    await meetingRowPage.findRow();
     expect(meetingRowPage.getScore()).not.toHaveClass("md-h2h__score--win");
     const result = meetingRowPage.getResult();
     expect(result).toHaveTextContent(/^L$/);
@@ -39,11 +71,12 @@ describe("MeetingRow", () => {
     expect(result).not.toHaveClass("md-h2h__result--w");
   });
 
-  it("shows a neutral dash with no outcome class when winner is unknown", () => {
+  it("shows a neutral dash with no outcome class when winner is unknown", async () => {
     meetingRowPage.render({
       meeting: buildHeadToHeadMeetingView({ leftWon: null }),
     });
 
+    await meetingRowPage.findRow();
     expect(meetingRowPage.getScore()).not.toHaveClass("md-h2h__score--win");
     const result = meetingRowPage.getResult();
     expect(result).toHaveTextContent(/^–$/);

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.tsx
@@ -1,3 +1,6 @@
+import { Link } from "@tanstack/react-router";
+
+import { matchDetailRoute } from "@/api/matches";
 import { cn } from "@/lib/utils";
 
 import { type HeadToHeadMeetingView } from "../head-to-head-query";
@@ -7,9 +10,16 @@ export interface MeetingRowProps {
 }
 
 export const MeetingRow = ({ meeting }: MeetingRowProps) => (
-  <div className="md-h2h__row">
+  <Link
+    {...matchDetailRoute(meeting.matchId)}
+    className="md-h2h__row"
+    aria-label={`Open match from ${meeting.dateLabel}`}
+  >
     <span className="md-h2h__date">{meeting.dateLabel}</span>
-    <span className="md-h2h__label">Match</span>
+    <span className="md-h2h__meta">
+      <span className="md-h2h__label">Match</span>
+      {meeting.rated && <span className="md-h2h__tag">Rated</span>}
+    </span>
     <span
       className={cn("md-h2h__score", meeting.leftWon === true && "md-h2h__score--win")}
     >
@@ -24,5 +34,5 @@ export const MeetingRow = ({ meeting }: MeetingRowProps) => (
     >
       {meeting.leftWon === true ? "W" : meeting.leftWon === false ? "L" : "–"}
     </span>
-  </div>
+  </Link>
 );

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-query.test.ts
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-query.test.ts
@@ -47,12 +47,40 @@ describe("headToHeadQuery", () => {
         {
           matchId: "m-h2h-1",
           dateLabel: fmtDateShort("2026-05-08T18:00:00Z"),
+          rated: true,
           leftGamesWon: 3,
           rightGamesWon: 2,
           leftWon: true,
         },
       ],
     });
+  });
+
+  it("carries each meeting's rated flag through to the view", async () => {
+    headToHeadQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        matchWithH2H({
+          head_to_head: buildMatchDetailsH2H({
+            recent_meetings: [
+              buildMatchDetailsH2HMeeting({ match_id: "m-rated", rated: true }),
+              buildMatchDetailsH2HMeeting({
+                match_id: "m-casual",
+                rated: false,
+              }),
+            ],
+          }),
+        }),
+      ),
+    );
+
+    const result = await renderH2H();
+
+    expect(
+      result.current.data?.recentMeetings.map((m) => [m.matchId, m.rated]),
+    ).toEqual([
+      ["m-rated", true],
+      ["m-casual", false],
+    ]);
   });
 
   it("swaps counts, scores and the win flag when the viewer is on side 2", async () => {

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-query.ts
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-query.ts
@@ -10,10 +10,12 @@ import { orderedSides, type MatchDetailsSide } from "../../ordered-sides";
  * Game counts and the win flag are aligned to the card's left/right anchor so
  * the component does no per-row re-mapping. */
 export type HeadToHeadMeetingView = {
-  /** The past match's id — a stable React key; not currently linked. */
+  /** The past match's id — a stable React key and the link target for the row. */
   matchId: string;
   /** Pre-formatted meeting date, e.g. "May 8". */
   dateLabel: string;
+  /** True when the meeting moved ratings; drives the "Rated" row marker. */
+  rated: boolean;
   /** Games won by the left (perspective-first) side in that meeting. */
   leftGamesWon: number;
   /** Games won by the right side in that meeting. */
@@ -80,6 +82,7 @@ const selectHeadToHead = (match: MatchDetailsResult): HeadToHeadView | null => {
     recentMeetings: raw.recent_meetings.map((m) => ({
       matchId: m.match_id,
       dateLabel: fmtDateShort(m.completed_at),
+      rated: m.rated,
       leftGamesWon: swap ? m.side_2_games_won : m.side_1_games_won,
       rightGamesWon: swap ? m.side_1_games_won : m.side_2_games_won,
       leftWon:

--- a/web-client/src/components/rbac/users-page.tsx
+++ b/web-client/src/components/rbac/users-page.tsx
@@ -319,7 +319,7 @@ function UserDrawer({
 }) {
   return (
     <Sheet open={!!user} onOpenChange={(o) => !o && onClose()}>
-      <SheetContent side="right" className="!w-[560px] !max-w-full !sm:max-w-full p-0">
+      <SheetContent side="right" className="w-[560px] max-w-full p-0">
         {user && (
           <UserDrawerBody
             key={user.id}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -70,7 +70,7 @@ export const EventEditor = ({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="right"
-        className="!w-full gap-0 p-0 sm:!w-[820px] sm:!max-w-[820px]"
+        className="w-full gap-0 p-0 sm:w-[820px] sm:max-w-[820px]"
       >
         <SheetHeader className="border-b border-[color:var(--border-subtle)]">
           <SheetDescription className="text-[11px] font-semibold tracking-[0.14em] uppercase">

--- a/web-client/src/components/ui/sheet.test.tsx
+++ b/web-client/src/components/ui/sheet.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@/test/utilities";
+
+import { Sheet, SheetContent, SheetTitle } from "./sheet";
+
+const content = () =>
+  document.querySelector('[data-slot="sheet-content"]') as HTMLElement;
+
+describe("SheetContent", () => {
+  it("applies the side's default width when no override is given", () => {
+    render(
+      <Sheet open>
+        <SheetContent>
+          <SheetTitle>Panel</SheetTitle>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expect(content()).toHaveClass("w-[320px]");
+  });
+
+  it("lets a consumer override the width without !important (#623)", () => {
+    render(
+      <Sheet open>
+        <SheetContent className="w-[560px]">
+          <SheetTitle>Panel</SheetTitle>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    // tailwind-merge drops the base width in favour of the consumer's, so no
+    // `!important` specificity hack is needed.
+    expect(content()).toHaveClass("w-[560px]");
+    expect(content()).not.toHaveClass("w-[320px]");
+  });
+})

--- a/web-client/src/components/ui/sheet.tsx
+++ b/web-client/src/components/ui/sheet.tsx
@@ -1,9 +1,32 @@
 import * as React from "react"
 import { Dialog as SheetPrimitive } from "radix-ui"
+import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { XIcon } from "lucide-react"
+
+// Each side's classes are plain (unmodified) utilities so a consumer's width
+// override merges cleanly via tailwind-merge — no `!important` needed (#623).
+// The data-attribute approach buried width behind `data-[side=right]:w-[320px]`,
+// which tailwind-merge can't dedupe against a bare `w-[560px]`, forcing callers
+// to reach for `!important`.
+const sheetVariants = cva(
+  "fixed z-50 flex flex-col bg-popover bg-clip-padding p-6 text-sm text-popover-foreground shadow-[0_12px_32px_rgba(0,0,0,0.55)] transition duration-200 ease-in-out data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 h-auto border-b data-open:slide-in-from-top-10 data-closed:slide-out-to-top-10",
+        bottom:
+          "inset-x-0 bottom-0 h-auto border-t data-open:slide-in-from-bottom-10 data-closed:slide-out-to-bottom-10",
+        left: "inset-y-0 left-0 h-full w-[320px] border-r data-open:slide-in-from-left-10 data-closed:slide-out-to-left-10",
+        right:
+          "inset-y-0 right-0 h-full w-[320px] border-l data-open:slide-in-from-right-10 data-closed:slide-out-to-right-10",
+      },
+    },
+    defaultVariants: { side: "right" },
+  }
+)
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />
@@ -49,20 +72,17 @@ function SheetContent({
   side = "right",
   showCloseButton = true,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Content> & {
-  side?: "top" | "right" | "bottom" | "left"
-  showCloseButton?: boolean
-}) {
+}: React.ComponentProps<typeof SheetPrimitive.Content> &
+  VariantProps<typeof sheetVariants> & {
+    showCloseButton?: boolean
+  }) {
   return (
     <SheetPortal>
       <SheetOverlay />
       <SheetPrimitive.Content
         data-slot="sheet-content"
         data-side={side}
-        className={cn(
-          "fixed z-50 flex flex-col bg-popover bg-clip-padding p-6 text-sm text-popover-foreground shadow-[0_12px_32px_rgba(0,0,0,0.55)] transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-[320px] data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-[320px] data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
-          className
-        )}
+        className={cn(sheetVariants({ side }), className)}
         {...props}
       >
         {children}

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -3642,16 +3642,34 @@ body.dark.fortymm-theme {
   grid-template-columns: 70px 1fr auto auto;
   align-items: center;
   gap: 10px;
-  padding: 10px 0;
+  padding: 10px 8px;
+  margin: 0 -8px;
+  border-radius: var(--radius-sm);
   border-bottom: 1px solid var(--border-subtle);
+  color: inherit;
+  text-decoration: none;
+  transition: background var(--dur-fast) var(--ease-out);
 }
 .fortymm-theme .md-h2h__row:last-child {
   border-bottom: 0;
+}
+.fortymm-theme .md-h2h__row:hover {
+  background: var(--bg-hover);
+}
+.fortymm-theme .md-h2h__row:focus-visible {
+  outline: 2px solid var(--serve-500);
+  outline-offset: -2px;
 }
 .fortymm-theme .md-h2h__date {
   font: 500 11px var(--font-mono);
   color: var(--fg-3);
   letter-spacing: 0.06em;
+}
+.fortymm-theme .md-h2h__meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
 }
 .fortymm-theme .md-h2h__label {
   font: 500 12px var(--font-ui);
@@ -3659,6 +3677,16 @@ body.dark.fortymm-theme {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.fortymm-theme .md-h2h__tag {
+  flex: none;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--serve-500);
+  font: 600 9px var(--font-mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--serve-500);
 }
 .fortymm-theme .md-h2h__label--tonight {
   font-weight: 600;

--- a/web-client/src/mocks/factories/matches/match-details.factory.ts
+++ b/web-client/src/mocks/factories/matches/match-details.factory.ts
@@ -119,6 +119,7 @@ export function buildMatchDetailsH2HMeeting(
     side_1_games_won: 3,
     side_2_games_won: 2,
     winner_side_number: 1,
+    rated: true,
     ...overrides,
   }
 }

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -440,6 +440,7 @@ function projectHeadToHead(
       side_1_games_won: side1,
       side_2_games_won: side2,
       winner_side_number: winner,
+      rated: m.affects_rating,
     })
   }
   return {

--- a/web-client/src/test/match-route.tsx
+++ b/web-client/src/test/match-route.tsx
@@ -1,0 +1,36 @@
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+import type { ReactNode } from "react";
+
+import { render } from "@/test/utilities";
+
+/**
+ * Render `ui` under a minimal memory router that registers the
+ * `/matches/$matchId` route. Components that contain a typed `<Link>` to a
+ * match (e.g. a head-to-head meeting row) need the route present so the link
+ * resolves at render time. The router loads asynchronously, so first reads
+ * should await an async finder.
+ */
+export function renderUnderMatchRoute(ui: ReactNode) {
+  const rootRoute = createRootRoute();
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: () => <>{ui}</>,
+  });
+  const matchDetail = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/matches/$matchId",
+    component: () => <div>match-detail</div>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, matchDetail]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+  return render(<RouterProvider router={router} />);
+}


### PR DESCRIPTION
Fixes #498, #500, #623.

## What & why

### #498 — H2H meeting rows are now clickable
Each meeting row in the head-to-head card was a plain element with no way to revisit a prior meeting. Rows are now a typed `<Link>` to `/matches/$matchId` (`matchDetailRoute`), with hover/focus affordances and an `aria-label`.

### #500 — Rated vs unrated meetings are now distinguished
Every row read as a homogeneous "Match". Added a server-derived `rated` boolean to `MatchDetailsH2HMeeting` (from `match_settings.affects_rating`, the same source of truth used for the current match's `affects_rating`), eager-loaded `match_settings` only on the H2H query, and rendered a "Rated" pill on rated rows.

### #623 — Sheet width overridable without `!important`
`SheetContent` baked width into `data-[side=right]:w-[320px]`, which tailwind-merge can't dedupe against a bare `w-[560px]` — so callers reached for `!important`. Converted to a `cva` with per-side variants (matching `button.tsx` et al.), so width is a plain utility a consumer can override. Removed the `!important` hacks from the two callers (`users-page.tsx`, `event-editor.tsx`).

## Notable
- Because the rows became `<Link>`s, added `src/test/match-route.tsx` (`renderUnderMatchRoute`) to mount link-bearing components under a minimal router, and updated the H2H page-objects/tests to await the async router resolution.
- Regenerated `schema.d.ts` for the new `rated` field; updated the MSW `match-store` + factories.

## Testing
- API: `ruff` + `ruff format --check` + `mypy --strict` clean; `pytest` **487 passed** (incl. new rated-vs-unrated H2H coverage).
- Web: `tsc -b && vite build` clean; `eslint` clean; `vitest` **1003 passed**; Playwright web-client e2e **128 passed**.
- New focused tests: clickable-row link, Rated tag, query rated-mapping, Sheet width-override regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)