### PR TITLE
Add session-bootstrap error boundary on _app (#292)

### DIFF
--- a/web-client/src/components/app-error.css
+++ b/web-client/src/components/app-error.css
@@ -1,0 +1,30 @@
+/* Global error boundary screen (#292). Full-screen, self-themed fallback shown
+   when a route loader/component throws without its own errorComponent — most
+   notably the `_app` session bootstrap failing. Mirrors the root loader's
+   full-bleed framing so the failed-startup state reads as part of the same
+   surface, and centers the shared `.md-error-state` block. */
+
+.app-error {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-app);
+  font-family: var(--font-ui);
+  overflow: auto;
+}
+
+.app-error__wordmark {
+  position: absolute;
+  top: 26px;
+  left: 30px;
+  opacity: 0.5;
+}
+
+/* The shared error block is left-aligned with a tall min-height for in-page
+   use; here it's centered in the viewport, so drop the min-height and let it
+   size to its content. */
+.app-error .md-error-state {
+  min-height: 0;
+}

--- a/web-client/src/components/app-error.test.tsx
+++ b/web-client/src/components/app-error.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { server } from '@/mocks/server'
+import { mockSession } from '@/mocks/handlers'
+import { sessionQueryOptions } from '@/api/session'
+import { AppError } from './app-error'
+
+// Mirror the production wiring: a layout route whose loader bootstraps the
+// session (like `_app`) with AppError as its `errorComponent`. When
+// `GET /v1/session` fails the loader rejects and the route renders AppError (#292).
+function renderApp() {
+  const queryClient = new QueryClient({
+    // The session query owns its retry predicate; zero the delay so the few
+    // retries it does run resolve instantly instead of stalling the test.
+    defaultOptions: { queries: { retryDelay: 0 } },
+  })
+  const rootRoute = createRootRoute()
+  const layoutRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    loader: () => queryClient.ensureQueryData(sessionQueryOptions()),
+    errorComponent: AppError,
+    component: () => <div>dashboard-content</div>,
+  })
+  const routeTree = rootRoute.addChildren([layoutRoute])
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('AppError (global session-bootstrap boundary)', () => {
+  it('shows the branded error screen when the session bootstrap fails', async () => {
+    server.use(
+      http.get('*/v1/session', () => new HttpResponse(null, { status: 500 })),
+    )
+
+    renderApp()
+
+    expect(
+      await screen.findByText('Something went wrong.'),
+    ).toBeInTheDocument()
+    // The failing page content never renders — no silent forever-skeleton.
+    expect(screen.queryByText('dashboard-content')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Try again' }),
+    ).toBeInTheDocument()
+  })
+
+  it('recovers to the page when retry succeeds', async () => {
+    // Flip the flag (rather than counting attempts) so the test doesn't couple
+    // to the session query's retry count: the bootstrap fails, then the retry
+    // click — after we clear the flag — lets the refetch through.
+    let failSession = true
+    server.use(
+      http.get('*/v1/session', () =>
+        failSession
+          ? new HttpResponse(null, { status: 500 })
+          : HttpResponse.json(mockSession),
+      ),
+    )
+
+    renderApp()
+    await screen.findByText('Something went wrong.')
+
+    failSession = false
+    await userEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(await screen.findByText('dashboard-content')).toBeInTheDocument()
+    expect(screen.queryByText('Something went wrong.')).not.toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/app-error.tsx
+++ b/web-client/src/components/app-error.tsx
@@ -1,0 +1,66 @@
+import { useRouter } from '@tanstack/react-router'
+
+import { Wordmark } from '@/components/wordmark'
+import './app-error.css'
+
+export interface AppErrorProps {
+  error: Error
+  reset: () => void
+}
+
+/**
+ * Error boundary for the `_app` layout route (`errorComponent`). It owns the
+ * session bootstrap (#292): if `GET /v1/session` fails after retries,
+ * `ensureQueryData` rejects the layout loader. Without a boundary that left
+ * every session-gated page (`enabled: session.isSuccess`) disabled and pending
+ * — a silent forever-skeleton with no way out. Routing the failure here gives a
+ * branded screen with a real retry.
+ *
+ * Scoped to `_app` rather than a global `defaultErrorComponent` on purpose: this
+ * replaces the whole `_app` subtree (AppShell can't render without a session)
+ * and stays *outside* any child's own React error boundary — a per-route default
+ * would land inside the admin/tournament `RbacBoundary` and shadow its handling.
+ *
+ * Full-screen and self-themed: it carries its own `dark fortymm-theme` wrapper
+ * rather than relying on an ancestor's.
+ */
+export function AppError({ reset }: AppErrorProps) {
+  const router = useRouter()
+  return (
+    <div className="app-error dark fortymm-theme">
+      <Wordmark size={20} className="app-error__wordmark" />
+      <div role="alert" className="md-error-state" data-tone="alert">
+        <div className="md-error-state__code">
+          <span className="md-error-state__dot" aria-hidden="true" />
+          Error
+        </div>
+        <h1 className="md-error-state__title">Something went wrong.</h1>
+        <p className="md-error-state__sub">
+          We couldn&rsquo;t load the page — could be us, could be the network.
+          Try again in a moment.
+        </p>
+        <div className="md-error-state__actions">
+          <button
+            type="button"
+            className="md-btn md-btn--primary"
+            onClick={() => {
+              // Reset the router's error boundary, then re-run the loaders so
+              // the session bootstrap (and any other failed loader) refetches.
+              reset()
+              void router.invalidate()
+            }}
+          >
+            Try again
+          </button>
+          <button
+            type="button"
+            className="md-btn md-btn--ghost"
+            onClick={() => window.location.reload()}
+          >
+            Reload page
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web-client/src/routes/_app/route.tsx
+++ b/web-client/src/routes/_app/route.tsx
@@ -1,5 +1,6 @@
 import { Outlet, createFileRoute } from '@tanstack/react-router'
 import { AppShell } from '@/components/app-shell'
+import { AppError } from '@/components/app-error'
 import { RootLoader } from '@/components/root-loader'
 import { sessionQueryOptions } from '@/api/session'
 
@@ -14,11 +15,21 @@ import { sessionQueryOptions } from '@/api/session'
  * Pathless (`_app`) → adds no URL segment, so child paths (`/dashboard`,
  * `/matches`, …) are unchanged. The chrome lives here so children render only
  * their page content.
+ *
+ * `errorComponent` owns the session-bootstrap failure (#292): when the loader's
+ * `ensureQueryData` rejects, every session-gated child page (`enabled:
+ * session.isSuccess`) would otherwise sit on a silent forever-skeleton. Routing
+ * it here gives a branded retry. Scoped to `_app` (not a global
+ * `defaultErrorComponent`) on purpose: this boundary sits outside AppShell, so
+ * it never lands *inside* a child's own React error boundary the way a
+ * per-route default would (e.g. the admin/tournament `RbacBoundary` that wraps
+ * its `<Outlet>` — a global default would shadow its 403/error handling).
  */
 export const Route = createFileRoute('/_app')({
   loader: ({ context }) =>
     context.queryClient.ensureQueryData(sessionQueryOptions()),
   pendingComponent: RootLoader,
+  errorComponent: AppError,
   component: AppLayout,
 })
 


### PR DESCRIPTION
## What

Fixes #292. A failed `GET /v1/session` left every session-gated page (`enabled: session.isSuccess`) staring at a **silent forever-skeleton** — the `_app` layout loader's `ensureQueryData(sessionQueryOptions())` rejected with no boundary to catch it, so child pages never mounted past their loading state, with no error and no way out.

## How

- New `AppError` component (`web-client/src/components/app-error.tsx` + `.css`): a branded, full-screen "Something went wrong" screen reusing the design system's `.md-error-state` / `.md-btn` treatment, with **Try again** (`reset()` + `router.invalidate()` re-runs the session bootstrap) and a hard **Reload page** fallback.
- Wired as the **`_app` route's `errorComponent`** (`web-client/src/routes/_app/route.tsx`).

### Why `_app` `errorComponent`, not a global `defaultErrorComponent`

I first wired this as a global `defaultErrorComponent` and it broke the admin/permissions e2e. A global default makes TanStack Router insert a per-route CatchBoundary around each child route — and because admin/tournaments wrap their `<Outlet>` in a React `RbacBoundary`, the child route's CatchBoundary renders *through* the Outlet and lands **inside** `RbacBoundary`. That shadowed the RBAC 403 / "Something went wrong loading this page" handling (the page's query error hit `AppError` before `RbacBoundary` saw it).

Scoping the boundary to `_app` puts it **outside** AppShell — and thus outside every nested `RbacBoundary` — so it only catches the session-bootstrap loader failure. Nested React error boundaries still catch their own errors. This also leaves login/landing (outside `_app`) untouched, so they don't inherit session-bootstrap copy.

### Audit of `enabled: session.isSuccess` callers

No per-page change needed: dashboard, match-list, players, and recent-opponents all live under `_app`, whose loader now routes session failure to `AppError` *before* those components mount. They only ever see `isSuccess` (load) or `isPending` (brief skeleton) — the disabled-pending limbo is structurally impossible now.

## Testing

- New `app-error.test.tsx`: a memory-router layout whose loader bootstraps the session with `AppError` as `errorComponent` — asserts the branded screen shows on failure (page content never renders) and that **retry recovers** to the page once the session succeeds.
- `npm run test:run` — 1005 passed
- `npm run lint` + `npm run build` — clean
- `npm run test:e2e` — 128 passed (incl. the previously-affected `rbac-permissions` recovery test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)