### PR TITLE
Fix #277: deterministic most-recent selection in _pending_change_token

### DIFF
--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -632,12 +632,18 @@ async def _pending_change_token(
     re-deliver) — now that ``user.email`` no longer mirrors the pending
     address, the token is the only source of truth for the resend target.
     Also drives the ``pending_email`` field on the session response."""
+    # Defensive determinism: today ``_issue_confirmation_token`` deletes prior
+    # change tokens before inserting, so at most one is pending. If a future
+    # path ever leaves more than one, return the most recent. ``id`` is a random
+    # UUIDv4, not a sequence, so order by ``created_at`` (the real recency
+    # signal); ``id.desc()`` is only a stable tiebreak.
     result = await db.execute(
         select(UserToken)
         .where(
             UserToken.user_id == user_id,
             _pending_email_token_clause(),
         )
+        .order_by(UserToken.created_at.desc(), UserToken.id.desc())
         .limit(1)
     )
     return result.scalar_one_or_none()

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -1,6 +1,6 @@
 import hashlib
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytest_asyncio
@@ -137,6 +137,40 @@ async def test_set_email_is_pending_only(
 
     finished = fake_email_queue.finished_job_registry
     assert finished.count == 1
+
+
+async def test_pending_email_reflects_most_recent_token(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Defensive determinism (issue #277): ``set_email`` rotates change tokens
+    so only one is ever pending, but if more than one is present the session's
+    ``pending_email`` must reflect the *most recent* by ``created_at`` — not an
+    arbitrary row, since ``UserToken.id`` is a random UUID, not a sequence."""
+    user = await start_session(api_client, db_session)
+    older = datetime(2026, 1, 1, tzinfo=UTC)
+    db_session.add_all(
+        [
+            UserToken(
+                user_id=user.id,
+                context=EMAIL_CHANGE_CONTEXT_PREFIX,
+                token=b"older-token",
+                sent_to="older@example.com",
+                created_at=older,
+            ),
+            UserToken(
+                user_id=user.id,
+                context=EMAIL_CHANGE_CONTEXT_PREFIX,
+                token=b"newer-token",
+                sent_to="newer@example.com",
+                created_at=older + timedelta(hours=1),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    response = await api_client.get("/v1/session")
+    assert response.status_code == 200
+    assert response.json()["data"]["user"]["pending_email"] == "newer@example.com"
 
 
 async def test_set_email_requires_session(api_client: AsyncClient):


### PR DESCRIPTION
## Summary

Fixes #277 — adds defensive determinism to `_pending_change_token` in `api/app/sessions.py`.

The query selected `LIMIT 1` from `user_tokens` (filtered by `user_id` + pending-email clause) with **no `ORDER BY`**. Today this is safe because `_issue_confirmation_token` bulk-deletes prior change tokens before inserting, so at most one pending token exists. But the invariant is implicit: any future path that wrote a change token without that bulk-delete would make the result DB-order-dependent. Both `resend_email_confirmation` and the session response's `pending_email` field rely on getting the user's *most recent* change-in-flight.

## Change

Added `.order_by(UserToken.created_at.desc(), UserToken.id.desc())` before `.limit(1)`.

Note: the issue suggested `id.desc()`, but `UserToken.id` is a **random UUIDv4** (`default=uuid.uuid4`), not a sequential integer — ordering by it gives arbitrary order, not "most recent." So `created_at` (the real recency signal) is the primary key and `id.desc()` is only a stable tiebreaker.

## Tests

- New regression test `test_pending_email_reflects_most_recent_token` in `api/tests/test_email.py`: inserts two pending `change:` tokens with different `created_at`, asserts the session response's `pending_email` reflects the newer one. Verified it fails without the fix and passes with it.
- `pytest tests/test_email.py` (46 passed), `pytest tests/test_session.py` (37 passed), `ruff` clean, `mypy` clean.
- No OpenAPI/schema changes (internal helper query only).

Slack thread: https://fortymmworkspace.slack.com/archives/C0BDJ35057S/p1782254748382419?thread_ts=1782254748.382419&cid=C0BDJ35057S

---
_Generated by [Claude Code](https://claude.ai/code/session_017QMfA3LGiidg2aVkij9mYR)_