### PR TITLE
Defer AppError to the /login redirect on a session_merged 401 (#672)

### DIFF
--- a/web-client/src/api/client.test.ts
+++ b/web-client/src/api/client.test.ts
@@ -3,7 +3,7 @@ import { http, HttpResponse } from 'msw'
 
 import { server } from '@/mocks/server'
 import { sessionResponse } from '@/test/factories'
-import { api, setSessionEndedHandler } from './client'
+import { ApiError, api, isSessionMergedError, setSessionEndedHandler } from './client'
 
 afterEach(() => {
   setSessionEndedHandler(null)
@@ -75,6 +75,34 @@ it('latches so a burst of 401s redirects only once', async () => {
   await api.GET('/v1/session')
 
   expect(handler).toHaveBeenCalledTimes(1)
+})
+
+it('isSessionMergedError recognizes only the structured session_merged 401', () => {
+  const merged = new ApiError(401, 'gone', 'load session', {
+    detail: { code: 'session_merged', message: 'gone' },
+  })
+  expect(isSessionMergedError(merged)).toBe(true)
+
+  // A bare 401 (no structured code) is not the merge case.
+  expect(
+    isSessionMergedError(
+      new ApiError(401, 'unauthorized', 'load session', {
+        detail: 'authentication required',
+      }),
+    ),
+  ).toBe(false)
+  // A different code, or a non-401, or a non-ApiError, all fall through.
+  expect(
+    isSessionMergedError(
+      new ApiError(401, null, 'x', { detail: { code: 'unauthenticated' } }),
+    ),
+  ).toBe(false)
+  expect(
+    isSessionMergedError(
+      new ApiError(403, null, 'x', { detail: { code: 'session_merged' } }),
+    ),
+  ).toBe(false)
+  expect(isSessionMergedError(new Error('boom'))).toBe(false)
 })
 
 it('echoes the csrf cookie in the X-CSRF-Token header on a mutation', async () => {

--- a/web-client/src/api/client.ts
+++ b/web-client/src/api/client.ts
@@ -113,6 +113,24 @@ api.use({
   },
 })
 
+/**
+ * True when `error` is the structured `session_merged` 401 — the user's guest
+ * account was merged away on another device. The global response middleware
+ * (`setSessionEndedHandler`) already handles this by redirecting to `/login`, so
+ * UI error boundaries should defer to that redirect rather than show a generic
+ * "something went wrong" screen (#672). A *bare* 401 (no `session_merged` code)
+ * is not this case and should still surface normally.
+ */
+export function isSessionMergedError(error: unknown): boolean {
+  if (!(error instanceof ApiError) || error.status !== 401) return false
+  const detail = (error.body as { detail?: unknown } | null | undefined)?.detail
+  return (
+    !!detail &&
+    typeof detail === 'object' &&
+    (detail as { code?: unknown }).code === 'session_merged'
+  )
+}
+
 export function extractDetail(value: unknown): string | null {
   if (!value || typeof value !== 'object') return null
   const detail = (value as { detail?: unknown }).detail

--- a/web-client/src/components/app-error.test.tsx
+++ b/web-client/src/components/app-error.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   RouterProvider,
@@ -61,6 +61,34 @@ describe('AppError (global session-bootstrap boundary)', () => {
     expect(
       screen.getByRole('button', { name: 'Try again' }),
     ).toBeInTheDocument()
+  })
+
+  it('renders nothing on a session_merged 401, deferring to the /login redirect', async () => {
+    // The global session-ended middleware owns this case (clear + redirect);
+    // AppError must not flash its generic "Something went wrong" screen (#672).
+    server.use(
+      http.get(
+        '*/v1/session',
+        () =>
+          HttpResponse.json(
+            { detail: { code: 'session_merged', message: 'Merged away.' } },
+            { status: 401 },
+          ),
+      ),
+    )
+
+    const { container } = renderApp()
+
+    // The boundary still catches the rejected loader (no dashboard content),
+    // but renders null instead of the generic error screen.
+    await waitFor(() =>
+      expect(screen.queryByText('dashboard-content')).not.toBeInTheDocument(),
+    )
+    expect(screen.queryByText('Something went wrong.')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Try again' }),
+    ).not.toBeInTheDocument()
+    expect(container).toBeEmptyDOMElement()
   })
 
   it('recovers to the page when retry succeeds', async () => {

--- a/web-client/src/components/app-error.tsx
+++ b/web-client/src/components/app-error.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from '@tanstack/react-router'
 
+import { isSessionMergedError } from '@/api/client'
 import { Wordmark } from '@/components/wordmark'
 import './app-error.css'
 
@@ -24,8 +25,15 @@ export interface AppErrorProps {
  * Full-screen and self-themed: it carries its own `dark fortymm-theme` wrapper
  * rather than relying on an ancestor's.
  */
-export function AppError({ reset }: AppErrorProps) {
+export function AppError({ error, reset }: AppErrorProps) {
   const router = useRouter()
+  // The `session_merged` 401 (guest account merged away on another device) is
+  // already handled by the global session-ended middleware, which clears the
+  // session and redirects to `/login`. Defer to that redirect instead of
+  // flashing the generic error + a "Try again" that would just re-fire the
+  // merged-away session (#672). Render nothing while the redirect lands — a
+  // bare 401 (no `session_merged` code) still falls through to the screen below.
+  if (isSessionMergedError(error)) return null
   return (
     <div className="app-error dark fortymm-theme">
       <Wordmark size={20} className="app-error__wordmark" />


### PR DESCRIPTION
Fixes #672.

## Problem

`AppError` is the `_app` route's `errorComponent`. When `GET /v1/session` returns the structured **`session_merged` 401** (the user's guest account was merged away on another device), two things race:

1. The session query deliberately doesn't retry a 401, so the `_app` loader rejects → `AppError` renders.
2. The global response middleware fires `setSessionEndedHandler` (clears the session, toasts, `navigate({ to: '/login' })`).

These aren't ordered, so the user can briefly see `AppError`'s generic "Something went wrong / Try again" copy — and that "Try again" would just re-fire the merged-away session — before the redirect lands.

## Fix

- Add `isSessionMergedError(error)` to `web-client/src/api/client.ts`: true only for an `ApiError` 401 whose body carries `detail.code === 'session_merged'`. A **bare** 401 (no structured code) returns false and still shows the retry screen.
- `AppError` early-returns `null` for that case, deferring entirely to the existing session-ended redirect. Mirrors `MatchDetailsError`'s status-aware branching, using the already-passed (previously unused) `error` prop.

It's a minor, self-correcting flash on a rare cross-device merge race — not a regression (per #672, before the #292 boundary a bootstrap failure showed nothing).

## Testing

- `client.test.ts`: unit-tests `isSessionMergedError` across the merge case, bare 401, wrong code, non-401, and non-`ApiError`.
- `app-error.test.tsx`: integration test that a `session_merged` 401 bootstrap renders nothing (no dashboard, no error screen, no "Try again").
- `npm run test:run` (1007 passed), `npm run lint`, `npm run build`, `npm run test:e2e` (128 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)