### PR TITLE
Guard the dashboard greeting on session.isError (#287)

### DIFF
--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -140,6 +140,24 @@ describe('DashboardPage', () => {
     ).toBeInTheDocument()
   })
 
+  it('falls back to a bare "Hi" when the session fails to load (#287)', async () => {
+    // A 401 (session merged away) errors immediately — the session query skips
+    // its retry on 401 — so the page settles into its error state.
+    server.use(
+      http.get('*/v1/session', () => new HttpResponse(null, { status: 401 })),
+    )
+    renderDashboard()
+
+    // No username is available on a session error, so the greeting renders
+    // without one rather than reading a stale value.
+    expect(
+      await screen.findByRole('heading', { name: /^Hi\.?$/ }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: /Hi, @/ }),
+    ).not.toBeInTheDocument()
+  })
+
   it('hides the attention panel and shows the empty recent-results card when nothing is pending', async () => {
     server.use(
       http.get('*/v1/dashboard', () =>

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -20,7 +20,11 @@ export function DashboardPage() {
   const dashboard = useDashboard({ enabled: session.isSuccess })
   const isLoading = dashboard.isPending
   const data = dashboard.data
-  const user = session.data?.data.user
+  // Explicitly drop the user on a session error so the greeting falls back to a
+  // bare "Hi" rather than reading a stale value — mirrors UserMenu's
+  // `!isError && data ? … : 'Guest'` pattern (#287).
+  const user =
+    !session.isError && session.data ? session.data.data.user : undefined
   const username = user?.username
   const greeting = username ? `Hi, @${username}` : 'Hi'
   // Guest with at least one completed match — "you have things to lose now".


### PR DESCRIPTION
## What

Fixes #287. The dashboard greeting derived its user with optional chaining alone (`session.data?.data.user`), so on a session error it *implicitly* fell back to a bare "Hi". This makes the error handling explicit, mirroring `UserMenu`'s canonical pattern (`!isError && data ? data.data.user : 'Guest'`):

```tsx
const user = !session.isError && session.data ? session.data.data.user : undefined
```

On an errored session the user is deterministically dropped (so a stale cached value can't leak through), and the greeting renders "Hi".

## Test

Adds a regression test: a 401 `/v1/session` response (the session-merged case, which the query skips retry on → immediate error state) renders the heading "Hi" and never "Hi, @username".

## Verification
- `vitest` — 1008/1008 pass
- `eslint` — clean
- `tsc -b && vite build` — clean
- web-client Playwright e2e — 128 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)