### PR TITLE
Backend bug fixes (ghost opponents, recompute crash, confirm-token expiry) + iOS scoring username (#451)

### DIFF
--- a/api/app/players.py
+++ b/api/app/players.py
@@ -115,7 +115,10 @@ async def list_recent_opponents(
                         mine.user_id == current_user.id,
                     ),
                 )
-                .where(User.id != current_user.id)
+                .where(
+                    User.id != current_user.id,
+                    User.merged_into_user_id.is_(None),
+                )
                 .group_by(User.id)
                 # Stable tiebreaker so ties on created_at (seed data, tests,
                 # concurrent creates) don't reorder across requests. Matches

--- a/api/app/ratings/recompute.py
+++ b/api/app/ratings/recompute.py
@@ -36,6 +36,18 @@ from app.ratings.registry import get_calculator
 from app.ratings.validation import validate_state
 
 
+def _decided_sides(match: Match) -> tuple[MatchSide, MatchSide] | None:
+    """Return ``(winning_side, losing_side)`` for a decided binary result, or
+    ``None`` when the match has no clear winner/loser — a forfeit/void/partial
+    write leaves ``MatchSide.won`` as ``None``. Such a match never produced a
+    rating delta, so the cascade skips it rather than crashing on the lookup."""
+    winning_side = next((s for s in match.sides if s.won is True), None)
+    losing_side = next((s for s in match.sides if s.won is False), None)
+    if winning_side is None or losing_side is None:
+        return None
+    return winning_side, losing_side
+
+
 async def recompute_league_ratings(
     db: AsyncSession,
     league_id: uuid.UUID,
@@ -111,8 +123,10 @@ async def recompute_league_ratings(
     affected_users: set[uuid.UUID] = set(seed_user_ids)
     affected_matches: list[Match] = []
     for match in matches:
-        winning_side = next(s for s in match.sides if s.won is True)
-        losing_side = next(s for s in match.sides if s.won is False)
+        decided = _decided_sides(match)
+        if decided is None:
+            continue
+        winning_side, losing_side = decided
         participants = {
             winning_side.players[0].user_id,
             losing_side.players[0].user_id,
@@ -170,8 +184,10 @@ async def recompute_league_ratings(
             ulr.rating_value = value
 
     for match in affected_matches:
-        winning_side = next(s for s in match.sides if s.won is True)
-        losing_side = next(s for s in match.sides if s.won is False)
+        decided = _decided_sides(match)
+        if decided is None:
+            continue
+        winning_side, losing_side = decided
         winner_id = winning_side.players[0].user_id
         loser_id = losing_side.players[0].user_id
         if winner_id not in states_by_user or loser_id not in states_by_user:

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -117,12 +117,9 @@ def _target_id_from_merge_context(context: str) -> uuid.UUID | None:
 
 
 def _token_expired(token_row: UserToken, lifetime: timedelta) -> bool:
-    """True once ``token_row`` is older than ``lifetime``. Normalizes a
-    possibly-naïve ``created_at`` to UTC so the comparison is timezone-safe."""
-    issued_at = token_row.created_at
-    if issued_at.tzinfo is None:
-        issued_at = issued_at.replace(tzinfo=UTC)
-    return datetime.now(UTC) - issued_at > lifetime
+    """True once ``token_row`` is older than ``lifetime``. ``created_at`` is a
+    ``DateTime(timezone=True)`` column, so it is always timezone-aware here."""
+    return datetime.now(UTC) - token_row.created_at > lifetime
 
 
 def _pending_email_token_clause() -> ColumnElement[bool]:

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -86,6 +86,10 @@ EMAIL_CHANGE_CONTEXT_PREFIX = "change:"
 EMAIL_MERGE_CONTEXT_PREFIX = "merge:"
 LOGIN_TOKEN_CONTEXT = "login"
 LOGIN_TOKEN_LIFETIME = timedelta(minutes=15)
+# Email-change and account-merge confirmation links are mailed (so they tolerate
+# slower inbox round-trips than an in-app sign-in) but still expire, so a leaked
+# or forwarded link can't be redeemed indefinitely.
+EMAIL_CONFIRM_TOKEN_LIFETIME = timedelta(hours=24)
 SESSION_LIFETIME = timedelta(days=30)
 EMAIL_TAKEN_DETAIL = "That email is already in use."
 
@@ -110,6 +114,15 @@ def _target_id_from_merge_context(context: str) -> uuid.UUID | None:
         return uuid.UUID(context.removeprefix(EMAIL_MERGE_CONTEXT_PREFIX))
     except ValueError:
         return None
+
+
+def _token_expired(token_row: UserToken, lifetime: timedelta) -> bool:
+    """True once ``token_row`` is older than ``lifetime``. Normalizes a
+    possibly-naïve ``created_at`` to UTC so the comparison is timezone-safe."""
+    issued_at = token_row.created_at
+    if issued_at.tzinfo is None:
+        issued_at = issued_at.replace(tzinfo=UTC)
+    return datetime.now(UTC) - issued_at > lifetime
 
 
 def _pending_email_token_clause() -> ColumnElement[bool]:
@@ -968,6 +981,13 @@ async def confirm_email(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="That confirmation link is invalid or expired.",
         )
+    if _token_expired(token_row, EMAIL_CONFIRM_TOKEN_LIFETIME):
+        await db.delete(token_row)
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That confirmation link is invalid or expired.",
+        )
     if token_row.context.startswith(EMAIL_MERGE_CONTEXT_PREFIX):
         return await _confirm_account_merge(
             db, response, token_row, skip_merge=payload.skip_merge
@@ -1272,10 +1292,7 @@ async def consume_login_token(
             detail="That sign-in link is invalid or expired.",
         )
 
-    issued_at = token_row.created_at
-    if issued_at.tzinfo is None:
-        issued_at = issued_at.replace(tzinfo=UTC)
-    if datetime.now(UTC) - issued_at > LOGIN_TOKEN_LIFETIME:
+    if _token_expired(token_row, LOGIN_TOKEN_LIFETIME):
         await db.delete(token_row)
         await db.commit()
         raise HTTPException(

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -574,6 +574,48 @@ async def test_confirm_email_rejects_unknown_token(
     assert response.status_code == 400
 
 
+async def test_confirm_email_rejects_an_expired_token(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+):
+    """An email-change link past its lifetime is rejected and burned, so a
+    leaked or forwarded link can't be redeemed indefinitely."""
+    user = await start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(api_client, db_session, fake_email_queue)
+
+    # Age the token past its 24h lifetime.
+    token_row = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+            )
+        )
+    ).scalar_one()
+    token_row.created_at = datetime.now(UTC) - timedelta(hours=25)
+    await db_session.commit()
+
+    response = await api_client.post("/v1/me/email/confirm", json={"token": raw_token})
+    assert response.status_code == 400
+
+    # The address change did not take effect...
+    await db_session.refresh(user)
+    assert user.email != "rita@example.com"
+    assert user.confirmed_at is None
+
+    # ...and the stale token is burned.
+    remaining = (
+        (
+            await db_session.execute(
+                select(UserToken).where(
+                    UserToken.context.startswith(EMAIL_CHANGE_CONTEXT_PREFIX)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []
+
+
 async def test_confirm_email_works_from_a_different_browser(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -160,6 +160,25 @@ async def test_recent_opponents_excludes_the_current_user(
     assert me.username not in _usernames(response)
 
 
+async def test_recent_opponents_excludes_merged_ghost_opponents(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    me = await start_session(api_client, db_session)
+    ghost = await make_user(db_session, "ghost")
+    survivor = await make_user(db_session, "survivor")
+    await _record_match(db_session, me, ghost, created_at=BASE_TIME)
+
+    # ``ghost`` was folded into another account: a tombstone, not a real user.
+    ghost.merged_into_user_id = survivor.id
+    await db_session.commit()
+
+    response = await api_client.get("/v1/players/recent")
+    assert response.status_code == 200
+    # The tombstoned opponent must not surface as a selectable player, even
+    # though it leads the recency ordering.
+    assert "ghost" not in _usernames(response)
+
+
 async def test_recent_opponents_is_empty_without_other_users(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/api/tests/test_rating_recompute.py
+++ b/api/tests/test_rating_recompute.py
@@ -305,6 +305,67 @@ async def test_recompute_restores_user_to_last_pre_window_rating(
     assert opp_row.previous_rating_value == 1550.0
 
 
+# ----- non-binary outcomes ------------------------------------------------
+
+
+async def test_recompute_skips_matches_without_a_decided_outcome(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """A completed-but-undecided match (e.g. a void/forfeit that leaves
+    ``MatchSide.won`` as ``None``) has no rating delta to rebuild. The cascade
+    must skip it rather than crash on the ``next(...)`` winner lookup, which
+    would otherwise roll back every league in the same recompute run."""
+    league = await get_default_league(db_session)
+    strategy = rating_strategies["glicko2"]
+    me = await make_user(db_session, "me")
+    opp = await make_user(db_session, "opp")
+    for user in (me, opp):
+        await _seed_rating(db_session, league, user.id, strategy)
+
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    # A normal decided match the cascade should still process...
+    decided = await _build_completed_match(db_session, league, me, opp, base)
+    # ...and an undecided one sharing both players: no winner/loser flag.
+    settings = MatchSettings(team_size=1, best_of=1, affects_rating=True)
+    undecided = Match(
+        match_settings=settings,
+        league=league,
+        created_by_user_id=me.id,
+        status=MatchStatus.completed,
+    )
+    side1 = MatchSide(match=undecided, side_number=1, won=None, score=0)
+    side1.players.append(MatchSidePlayer(match=undecided, user=me))
+    side2 = MatchSide(match=undecided, side_number=2, won=None, score=0)
+    side2.players.append(MatchSidePlayer(match=undecided, user=opp))
+    db_session.add(undecided)
+    await db_session.commit()
+    await db_session.refresh(undecided)
+    await db_session.execute(
+        text("UPDATE matches SET created_at = :ts, updated_at = :ts WHERE id = :id"),
+        {"ts": base + timedelta(hours=1), "id": undecided.id},
+    )
+    await db_session.commit()
+
+    # Must not raise.
+    await recompute_league_ratings(db_session, league.id, {me.id})
+    await db_session.commit()
+
+    # The decided match still produced its history; the undecided one produced none.
+    rows = (
+        (
+            await db_session.execute(
+                select(RatingHistory).where(
+                    RatingHistory.match_id.in_([decided.id, undecided.id])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {row.match_id for row in rows} == {decided.id}
+
+
 # ----- idempotency --------------------------------------------------------
 
 


### PR DESCRIPTION
Bundles a set of backend bug fixes with an iOS UI consistency fix.

## Backend (already on the branch)
- **Ghost opponents** — exclude merged-away users (`merged_into_user_id IS NULL`) from recent-opponents.
- **Recompute crash** — guard undecided matches in rating recompute via a `_decided_sides` helper instead of an unguarded `next(...)`.
- **Confirm-token expiry** — confirm-email tokens now expire, sharing one `_token_expired` check with login tokens.
- Tests added: `test_email.py`, `test_players.py`, `test_rating_recompute.py`.

## iOS — `#451` scoring-screen username
Match detail showed the local player's real username while the score-entry scoreboard hardcoded **"You"** (the `MatchSeed.me` placeholder), so the same person read as two identities across screens. The web scoreboard is the source of truth and shows the username (falling back to "You" only for a playerless side).

- Thread `SessionStore.username` into `ScoreEntryView` via a new optional `meName` param (`MatchFlowView` reads it from the environment).
- Build the "you" panel from the real handle; keep `MatchSeed.me` as the pre-session fallback.

Closes #451.

## Testing
- API: `ruff check` ✓, `ruff format --check` ✓, `mypy` (strict) ✓, `pytest` — **491 passed** ✓
- iOS: clean simulator build — **BUILD SUCCEEDED** ✓
- OpenAPI schema: regenerated, **no drift** ✓
- Web suites / root e2e: not run (web-client unchanged; backend changes covered by new pytest tests, iOS change is a UI label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)