### PR TITLE
iOS: show the signed-in player's username on the scoring screen (#451)

### DIFF
--- a/ios/Fortymm/MatchFlow/MatchFlowView.swift
+++ b/ios/Fortymm/MatchFlow/MatchFlowView.swift
@@ -16,6 +16,11 @@ struct MatchFlowView: View {
     /// Close the flow. `toMatches` = land on the Matches tab (vs. just dismiss).
     var onClose: (_ toMatches: Bool) -> Void
 
+    /// Loaded session, so the scoring scoreboard can label your side with your
+    /// real username instead of a generic "You" (issue #451). Propagated into the
+    /// full-screen cover from `RootView`, which injects it.
+    @EnvironmentObject private var session: SessionStore
+
     init(
         service: MatchService = .shared,
         resume: ResumeScoring? = nil,
@@ -70,6 +75,7 @@ struct MatchFlowView: View {
                     config: config,
                     initialGames: resume?.games ?? [],
                     onPost: post,
+                    meName: session.username,
                     // Resuming has no setup step to fall back to — exiting closes
                     // the flow (back to wherever it was launched from).
                     onExit: {

--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -309,11 +309,11 @@ enum MatchRules {
 // MARK: - Seed data
 
 enum MatchSeed {
-    /// Stand-in for the signed-in player, used only on the live score-entry
-    /// scoreboard (the "you" panel) while a game is in progress. The session
-    /// doesn't surface the user's id/handle app-wide, so the entry screen
-    /// labels your side generically; the *posted* result and every list/detail
-    /// view render the real username from the API response.
+    /// Generic stand-in for the signed-in player on the live score-entry
+    /// scoreboard (the "you" panel), used only as a fallback before the session
+    /// has surfaced a username. Once it has, `ScoreEntryView.meName` carries the
+    /// real handle so the entry screen matches the posted result and every
+    /// list/detail view (and the web scoreboard) instead of labelling you "You".
     static let me = MatchPlayer(handle: "You", initials: "YOU",
                                 avatarColor: .slate, rating: 1500, you: true)
 }

--- a/ios/Fortymm/MatchFlow/ScoreEntryView.swift
+++ b/ios/Fortymm/MatchFlow/ScoreEntryView.swift
@@ -13,6 +13,11 @@ struct ScoreEntryView: View {
     /// Hand the completed games (in order, game 1…N) up to the coordinator,
     /// which posts them to the API and renders the server's result.
     var onPost: ([Game]) -> Void
+    /// The signed-in player's username, so the "you" panel labels your side with
+    /// the same handle the posted result, list, and detail views show (and that
+    /// the web scoreboard shows) — rather than a generic "You". Falls back to the
+    /// `MatchSeed.me` placeholder when the session hasn't surfaced a username yet.
+    var meName: String? = nil
     var onExit: () -> Void
 
     // One slot per game in the match; any slot can be entered or edited in any
@@ -29,7 +34,10 @@ struct ScoreEntryView: View {
     @State private var rawOpp = ""
     @FocusState private var focus: MatchSide?
 
-    private var you: MatchPlayer { MatchSeed.me }
+    private var you: MatchPlayer {
+        guard let name = meName, !name.isEmpty else { return MatchSeed.me }
+        return MatchPlayer(handle: name, initials: name.fmInitials, you: true)
+    }
     private var opp: MatchPlayer { config.opponent ?? .guest }
 
     private var current: Game { games.indices.contains(active) ? games[active] : Game() }


### PR DESCRIPTION
## Problem
Match detail (`MatchDetailView`) renders the local player's real username, while the score-entry scoreboard hardcoded **"You"** via the `MatchSeed.me` placeholder — so the same person reads as two different identities across screens (issue #451).

The web scoreboard is the cross-platform source of truth and shows the username (`score-entry.tsx`: `meName = mySide.players[0]?.username ?? 'You'`), falling back to "You" only for a playerless side. So the iOS detail screen was already correct; the scoring screen was the outlier.

## Fix
- Add an optional `meName: String?` param to `ScoreEntryView`; build the "you" panel from the real handle (deriving initials via the existing `String.fmInitials`, keeping `you: true` for the orange avatar). Falls back to `MatchSeed.me` when no username is loaded.
- `MatchFlowView` reads `SessionStore.username` from the environment (propagated into the full-screen cover from `RootView`) and passes it down.
- Refresh the now-stale `MatchSeed.me` doc comment (it claimed the session never surfaces the username — `SessionStore.username` now does).

Closes #451.

## Testing
- iOS: clean simulator build from the worktree — **BUILD SUCCEEDED**.
- No previews/tests needed updating (the new param is defaulted; `MatchFlowView` has no preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)