### PR TITLE
Anchor match history stats on a stable completed_at; reject non-integer best_of

### DIFF
--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -108,7 +108,10 @@ async def get_dashboard(
         participant_filter(select(Match), current_user.id)
         .where(Match.status == MatchStatus.completed)
         .options(*match_eager_options())
-        .order_by(Match.updated_at.desc())
+        # Recent-first by the stable completion time, not the mutable
+        # ``updated_at`` — editing an old completed match must not bump it back
+        # to the top of recent results.
+        .order_by(Match.completed_at.desc())
         .limit(RECENT_RESULTS_LIMIT)
     )
     # Exact attention totals, independent of the eager-load cap above so the
@@ -270,6 +273,8 @@ def _build_recent_result(
 ) -> DashboardRecentResult:
     mine = resolve_my_side(match, current_user_id)
     assert mine is not None  # query filters to participants
+    # The completed_q filters status == completed, so completed_at is set.
+    assert match.completed_at is not None
     side_wins = side_win_counts(match)
     my_games_won = side_wins.get(mine.side_number, 0)
     opp_games_won = sum(
@@ -281,7 +286,7 @@ def _build_recent_result(
         is_win=my_games_won > opp_games_won,
         my_games_won=my_games_won,
         opponent_games_won=opp_games_won,
-        completed_at=match.updated_at,
+        completed_at=match.completed_at,
         my_rating_change=my_rating_change,
     )
 
@@ -468,7 +473,8 @@ async def _current_streak(
                     Match.status == MatchStatus.completed,
                     MatchSide.won.is_not(None),
                 )
-                .order_by(Match.updated_at.desc())
+                # Most-recent-completion first; stable under later edits.
+                .order_by(Match.completed_at.desc())
                 .limit(STREAK_SCAN_LIMIT)
             )
         )

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1139,7 +1139,9 @@ def _history_base_query(
 
     Pass ``before`` to restrict to matches completed before that instant, so a
     match viewed in the past shows the form as it stood then rather than the
-    players' current form."""
+    players' current form. Ordering and the ``before`` cutoff both key off the
+    stable ``completed_at`` (not the mutable ``updated_at``) so editing an old
+    completed match can't shuffle it within — or out of — a history window."""
     query = (
         select(Match)
         .where(
@@ -1147,10 +1149,10 @@ def _history_base_query(
             Match.id != current_match_id,
         )
         .options(*_match_history_options())
-        .order_by(Match.updated_at.desc())
+        .order_by(Match.completed_at.desc())
     )
     if before is not None:
-        query = query.where(Match.updated_at < before)
+        query = query.where(Match.completed_at < before)
     return query
 
 
@@ -1247,7 +1249,7 @@ async def _load_career_before(
                 player.user_id == user_id,
                 Match.status == MatchStatus.completed,
                 Match.id != current_match_id,
-                Match.updated_at < before,
+                Match.completed_at < before,
             )
         )
     ).one()
@@ -1257,6 +1259,8 @@ async def _load_career_before(
 def _build_form_result(past_match: Match, user_id: uuid.UUID) -> MatchDetailsFormResult:
     mine = my_side(past_match, user_id)
     assert mine is not None  # participant_filter guarantees membership
+    # The history query filters status == completed, so completed_at is set.
+    assert past_match.completed_at is not None
     side_wins = side_win_counts(past_match)
     player_games = side_wins.get(mine.side_number, 0)
     opp_games = sum(wins for n, wins in side_wins.items() if n != mine.side_number)
@@ -1266,7 +1270,7 @@ def _build_form_result(past_match: Match, user_id: uuid.UUID) -> MatchDetailsFor
         player_games_won=player_games,
         opponent_games_won=opp_games,
         opponent_username=opponent_username(past_match, user_id),
-        completed_at=past_match.updated_at,
+        completed_at=past_match.completed_at,
     )
 
 
@@ -1292,6 +1296,8 @@ async def _load_head_to_head(
         past_a = my_side(past, user_a)
         past_b = my_side(past, user_b)
         assert past_a is not None and past_b is not None
+        # The history query filters status == completed, so completed_at is set.
+        assert past.completed_at is not None
         side_wins = side_win_counts(past)
         a_games = side_wins.get(past_a.side_number, 0)
         b_games = side_wins.get(past_b.side_number, 0)
@@ -1301,7 +1307,7 @@ async def _load_head_to_head(
         meetings.append(
             MatchDetailsH2HMeeting(
                 match_id=past.id,
-                completed_at=past.updated_at,
+                completed_at=past.completed_at,
                 side_1_games_won=a_games,
                 side_2_games_won=b_games,
                 winner_side_number=winner_side,
@@ -1330,7 +1336,7 @@ async def _load_head_to_head(
         .where(
             Match.status == MatchStatus.completed,
             Match.id != current_match_id,
-            Match.updated_at < match.created_at,
+            Match.completed_at < match.created_at,
             a_player.user_id == user_a,
             b_player.user_id == user_b,
             a_side.id != b_side.id,
@@ -1910,7 +1916,7 @@ async def post_match_result(
     if not awaiting_confirmation:
         # Solo / unrated path: no second sign-off needed — finalize
         # immediately, no signature row inserted.
-        match.status = MatchStatus.completed
+        match.mark_completed()
         _set_side_won(match, decided_side)
         await _apply_rating_update(db, match)
     else:
@@ -1969,7 +1975,7 @@ async def confirm_match_result(
         db, match, current_user.id, "You've already signed this match."
     )
     if _all_sides_signed(match):
-        match.status = MatchStatus.completed
+        match.mark_completed()
         _set_side_won(match, _posted_decided_side(match))
         await _apply_rating_update(db, match)
 
@@ -2010,6 +2016,9 @@ async def dispute_match_result(
     # Scoring is reopened anyway (no signatures + ``disputed`` is non-terminal),
     # and re-posting via /results flips it back to ``in_progress``.
     match.status = MatchStatus.disputed
+    # Un-completed: drop the completion stamp so a re-post stamps a fresh one
+    # and this match doesn't linger in any history window while disputed.
+    match.completed_at = None
     for side in match.sides:
         # ``side.won`` is only stamped at completion now, so it's still None
         # on an awaiting-confirmation match — nulling it here is defensive.

--- a/api/app/models/match.py
+++ b/api/app/models/match.py
@@ -47,6 +47,11 @@ class Match(Base):
             "status",
             text("updated_at DESC"),
         ),
+        Index(
+            "ix_matches_status_completed_at",
+            "status",
+            text("completed_at DESC"),
+        ),
         Index("ix_matches_league_id", "league_id"),
     )
 
@@ -84,6 +89,23 @@ class Match(Base):
         onupdate=func.now(),
         nullable=False,
     )
+    # Stamped once the match reaches ``completed`` and kept stable thereafter —
+    # editing a completed match (which bumps ``updated_at``) must not move it in
+    # or out of another match's historical window. Cleared back to NULL when a
+    # match is disputed (un-completed) and re-stamped on the next completion.
+    # NULL for any match that hasn't completed. History/form/H2H queries anchor
+    # on this, not on the mutable ``updated_at``.
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    def mark_completed(self) -> None:
+        """Flip to ``completed`` and stamp the stable completion time in one
+        step, so the "completed ⟹ ``completed_at`` is set" invariant the
+        history/form/H2H windows rely on can't be half-applied by a caller that
+        sets the status but forgets the stamp."""
+        self.status = MatchStatus.completed
+        self.completed_at = func.now()
 
     match_settings: Mapped[MatchSettings] = relationship(back_populates="matches")
     league: Mapped["League"] = relationship(back_populates="matches")

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -47,7 +47,12 @@ class MatchCreate(BaseModel):
 
     opponent_user_id: uuid.UUID | None = None
     league_id: uuid.UUID | None = None
-    best_of: int = Field(description="Total games to play; one of 1, 3, 5, 7.")
+    # ``strict`` rejects non-integer JSON (e.g. the string "5") with a 422
+    # rather than coercing it before ``_best_of_allowed`` runs. The OpenAPI
+    # contract still exposes this as a plain integer.
+    best_of: int = Field(
+        strict=True, description="Total games to play; one of 1, 3, 5, 7."
+    )
     rated: bool = True
 
     @field_validator("best_of")

--- a/api/migrations/versions/20260514_0000_0004_create_match_tables.py
+++ b/api/migrations/versions/20260514_0000_0004_create_match_tables.py
@@ -5,6 +5,7 @@ Revises: 0003
 Create Date: 2026-05-14 00:00:00.000000
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -79,9 +80,7 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             nullable=False,
         ),
-        sa.CheckConstraint(
-            "team_size IN (1, 2)", name="ck_match_settings_team_size"
-        ),
+        sa.CheckConstraint("team_size IN (1, 2)", name="ck_match_settings_team_size"),
         sa.CheckConstraint(
             "best_of >= 1 AND best_of % 2 = 1", name="ck_match_settings_best_of"
         ),
@@ -125,6 +124,15 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             nullable=False,
         ),
+        # Stable completion timestamp, stamped once the match reaches
+        # ``completed`` and left untouched when the row is later edited (which
+        # would bump ``updated_at``). NULL until/unless completed. Recent-form,
+        # career-before, and H2H history windows anchor on this.
+        sa.Column(
+            "completed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
     )
     op.create_index(
         "ix_matches_created_by_user_id_created_at",
@@ -138,12 +146,21 @@ def upgrade() -> None:
         "matches",
         ["status", sa.text("created_at DESC")],
     )
-    # Supports the dashboard's "last 5 completed" view, which orders by
-    # updated_at (no dedicated completed_at column).
+    # Supports the dashboard's open-match attention lists (in_progress /
+    # disputed), which order by updated_at (last activity). The completed-match
+    # views moved to ix_matches_status_completed_at.
     op.create_index(
         "ix_matches_status_updated_at",
         "matches",
         ["status", sa.text("updated_at DESC")],
+    )
+    # Supports the match-details history windows (recent form / career-before /
+    # H2H), which filter status == completed and order by / cut off on the
+    # stable completed_at.
+    op.create_index(
+        "ix_matches_status_completed_at",
+        "matches",
+        ["status", sa.text("completed_at DESC")],
     )
 
     op.create_table(
@@ -171,9 +188,7 @@ def upgrade() -> None:
         sa.UniqueConstraint(
             "match_id", "side_number", name="uq_match_sides_match_id_side_number"
         ),
-        sa.CheckConstraint(
-            "side_number IN (1, 2)", name="ck_match_sides_side_number"
-        ),
+        sa.CheckConstraint("side_number IN (1, 2)", name="ck_match_sides_side_number"),
         sa.CheckConstraint("score >= 0", name="ck_match_sides_score"),
     )
     op.create_index("ix_match_sides_match_id", "match_sides", ["match_id"])
@@ -213,9 +228,7 @@ def upgrade() -> None:
             "match_id", "user_id", name="uq_match_side_players_match_id_user_id"
         ),
     )
-    op.create_index(
-        "ix_match_side_players_user_id", "match_side_players", ["user_id"]
-    )
+    op.create_index("ix_match_side_players_user_id", "match_side_players", ["user_id"])
     op.create_index(
         "ix_match_side_players_match_side_id",
         "match_side_players",
@@ -293,9 +306,7 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             nullable=False,
         ),
-        sa.UniqueConstraint(
-            "match_game_id", name="uq_match_game_scores_match_game_id"
-        ),
+        sa.UniqueConstraint("match_game_id", name="uq_match_game_scores_match_game_id"),
         sa.CheckConstraint(
             "side_1_points >= 0", name="ck_match_game_scores_side_1_points"
         ),

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1,12 +1,13 @@
 import asyncio
 import uuid
 from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta
 
 import pytest
 from fastapi import HTTPException
 from httpx import AsyncClient
 from rq import Queue
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
@@ -243,6 +244,25 @@ async def test_even_best_of_is_rejected(
         json={
             "opponent_user_id": str(opponent.id),
             "best_of": 4,
+            "rated": True,
+        },
+    )
+    assert response.status_code == 422
+
+
+async def test_best_of_rejects_a_numeric_string(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """``best_of`` is a strict int: the JSON string "5" is rejected with a 422
+    rather than coerced to 5 (which would slip past ``_best_of_allowed``)."""
+    await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "string-rival")
+
+    response = await api_client.post(
+        "/v1/matches",
+        json={
+            "opponent_user_id": str(opponent.id),
+            "best_of": "5",
             "rated": True,
         },
     )
@@ -1730,6 +1750,41 @@ async def test_details_recent_form_excludes_matches_after_this_one(
     my_match_ids = {r["match_id"] for r in forms[str(me.id)]["recent_results"]}
     assert earlier["id"] in my_match_ids
     assert later["id"] not in my_match_ids
+
+
+async def test_details_recent_form_is_stable_when_a_prior_match_is_edited(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """History windows anchor on the stable ``completed_at``, not the mutable
+    ``updated_at``. Editing an old completed match *after* the current match was
+    created (which bumps ``updated_at`` past it) must not drop it out of recent
+    form — it was still completed beforehand."""
+    me = await start_session(api_client, db_session)
+    opp = await make_user(db_session, "edit-rival")
+    async with opponent_session(db_session, "edit-third-party") as (
+        other_client,
+        other,
+    ):
+        earlier = await _play_match_to_completion(
+            api_client, other_client, other.id, best_of=3, side_1_wins=True
+        )
+        current = await _create_match(api_client, opp.id, best_of=3)
+
+    # Simulate a late edit to the already-completed prior match: shove its
+    # ``updated_at`` to well after the current match's ``created_at``. Under the
+    # old (updated_at-based) cutoff this would evict it from recent form.
+    current_created_at = datetime.fromisoformat(current["created_at"])
+    await db_session.execute(
+        update(Match)
+        .where(Match.id == uuid.UUID(earlier["id"]))
+        .values(updated_at=current_created_at + timedelta(days=1))
+    )
+    await db_session.commit()
+
+    detail = (await api_client.get(f"/v1/matches/{current['id']}")).json()
+    forms = {f["user_id"]: f for f in detail["recent_form"]}
+    my_match_ids = {r["match_id"] for r in forms[str(me.id)]["recent_results"]}
+    assert earlier["id"] in my_match_ids
 
 
 async def test_details_head_to_head_counts_prior_meetings_per_side(


### PR DESCRIPTION
## What

Two backend fixes to match handling.

### 1. (Medium) Match-details history stats used the mutable `updated_at` as the completion cutoff

Recent-form, career-before, and head-to-head windows filtered prior matches on `Match.updated_at < current.created_at`. Editing an *old completed* match bumps its `updated_at`, which silently dropped it out of (or reshuffled it within) those windows even though it completed before the current match was created. The schema documents these fields as anchored to `created_at`, but `updated_at` made the historical record unstable after edits.

No existing table offered a stable completion time (signatures / rating-history are absent for solo/unrated matches; games and rating-history get rewritten on re-post/recompute), so this adds a dedicated, stable timestamp:

- New nullable `Match.completed_at` column + `ix_matches_status_completed_at` index (migration `0004` edited in place, per the pre-deploy convention).
- `Match.mark_completed()` stamps `status` + `completed_at` together so the "completed ⟹ `completed_at` set" invariant can't be half-applied; used at the two completion points; cleared to `NULL` on dispute (un-completion).
- History queries — plus the dashboard recent-completed and win/loss-streak queries — key off `completed_at` instead of `updated_at`. Open-match attention lists stay on `updated_at` (they track last activity, not completion).

### 2. (Low) `POST /v1/matches` accepted `"best_of": "5"`

`best_of` was a plain `int`, so Pydantic coerced numeric strings before the allowed-values validator ran. It's now `Field(strict=True, …)`, so non-integer JSON 422s. OpenAPI still exposes it as a plain integer (no `schema.d.ts` drift).

## Testing

- API CI gates green from `api/`: `ruff check`, `ruff format --check`, `mypy --strict` (77 files), `pytest` (**493 passed**).
- OpenAPI schema drift check: regenerated `schema.d.ts` — **no drift**.
- Added regression tests: `best_of: "5"` is rejected (422); and an old completed match whose `updated_at` is shoved past the current match's `created_at` still stays in recent form.
- Web-client / iOS / root-e2e suites not applicable (API-only diff, no schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)