### PR TITLE
Show a resend cooldown on /login/sent instead of bouncing to /login (#616)

### DIFF
--- a/web-client/src/components/login/login-screens.tsx
+++ b/web-client/src/components/login/login-screens.tsx
@@ -13,6 +13,11 @@ import './login.css'
 // LOGIN_TOKEN_LIFETIME. The countdown owns this so routes only pass send time.
 const LOGIN_LINK_TTL_MS = 15 * 60 * 1000
 
+// Resend is throttled for a short window after each send so a rapid click
+// burst can't hammer the (per-hour rate-limited) request endpoint into a 429.
+// Anchored on `sentAt`, which re-stamps on every send.
+const RESEND_COOLDOWN_MS = 30 * 1000
+
 /* ─── Brand atoms ───────────────────────────────────────────────────── */
 
 function Display({
@@ -583,6 +588,25 @@ function BounceReceipt({ email }: { email: string }) {
   )
 }
 
+/** Seconds left on the resend cooldown for a link sent at `sentAt` (epoch-ms),
+ *  ticking down to 0. Mirrors ExpiresCountdown's derive-now-during-render
+ *  approach so a fresh send time takes effect immediately. */
+function useResendCooldown(sentAt: number) {
+  const readyAt = sentAt + RESEND_COOLDOWN_MS
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const t = Date.now()
+      setNow(t)
+      if (t >= readyAt) clearInterval(id)
+    }, 1000)
+    return () => clearInterval(id)
+  }, [readyAt])
+
+  return Math.max(0, Math.ceil((readyAt - now) / 1000))
+}
+
 /** Live countdown to a sign-in link's expiry. `sentAt` is the epoch-ms send
  *  time; this owns the link lifetime (matches the API's LOGIN_TOKEN_LIFETIME),
  *  ticks once a second, and at zero flips to a spent "Link expired" treatment
@@ -986,6 +1010,7 @@ export interface ScreenSentProps {
   onStartOver?: () => void
   resending?: boolean
   resendMessage?: string | null
+  resendError?: string | null
 }
 
 export function ScreenSent({
@@ -995,10 +1020,15 @@ export function ScreenSent({
   onStartOver,
   resending = false,
   resendMessage = null,
+  resendError = null,
 }: ScreenSentProps) {
   // Stable fallback so the countdown doesn't reset every render when no
   // send time was threaded in.
   const [fallbackSentAt] = useState(() => Date.now())
+  // Throttle Resend right after a send so rapid clicks can't bounce the user
+  // off this screen (the request endpoint is rate-limited); show the wait.
+  const cooldown = useResendCooldown(sentAt ?? fallbackSentAt)
+  const resendDisabled = resending || !onResend || cooldown > 0
   return (
     <Shell
       left={
@@ -1029,13 +1059,21 @@ export function ScreenSent({
               style={{
                 ...btnGhost,
                 flex: 1,
-                opacity: resending ? 0.7 : 1,
-                cursor: resending ? 'wait' : 'pointer',
+                opacity: resendDisabled ? 0.7 : 1,
+                cursor: resending
+                  ? 'wait'
+                  : resendDisabled
+                    ? 'not-allowed'
+                    : 'pointer',
               }}
               onClick={onResend}
-              disabled={resending || !onResend}
+              disabled={resendDisabled}
             >
-              {resending ? 'Resending…' : 'Resend'}
+              {resending
+                ? 'Resending…'
+                : cooldown > 0
+                  ? `Resend in ${cooldown}s`
+                  : 'Resend'}
             </button>
             <button
               type="button"
@@ -1054,6 +1092,16 @@ export function ScreenSent({
               style={{ marginTop: 6 }}
             >
               {resendMessage}
+            </p>
+          )}
+
+          {resendError && (
+            <p
+              className="fmm-help fmm-help--err"
+              role="alert"
+              style={{ marginTop: 6 }}
+            >
+              {resendError}
             </p>
           )}
 

--- a/web-client/src/routes/login.sent.tsx
+++ b/web-client/src/routes/login.sent.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
+import { ApiError } from '@/api/client'
 import { useRequestLogin } from '@/api/session'
 import { ScreenSent, ScreenSentBounced } from '@/components/login/login-screens'
 import { Turnstile, type TurnstileHandle } from '@/components/turnstile'
@@ -27,6 +28,7 @@ function LoginSentPage() {
   // the link without bouncing through /login to re-run the challenge.
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
   const [resendMessage, setResendMessage] = useState<string | null>(null)
+  const [resendError, setResendError] = useState<string | null>(null)
   const captchaRef = useRef<TurnstileHandle | null>(null)
   const inFlight = useRef(false)
 
@@ -41,12 +43,15 @@ function LoginSentPage() {
 
   // "Resend" re-issues the link in place: POST a new request with the held
   // captcha token, reset the expiry countdown (a new sentAt), and reset the
-  // widget so the next resend gets a fresh token. A captcha/network failure
-  // falls back to the full /login flow rather than stranding the user here.
+  // widget so the next resend gets a fresh token. The Resend control is
+  // cooldown-throttled (see ScreenSent), so a failure here means a genuine
+  // server error — surface it inline and keep the user on this screen (they
+  // still hold their original link) rather than bouncing them to /login.
   const resend = () => {
     if (inFlight.current || !email || !captchaToken) return
     inFlight.current = true
     setResendMessage(null)
+    setResendError(null)
     requestLogin.mutate(
       { email, captchaToken },
       {
@@ -58,7 +63,13 @@ function LoginSentPage() {
             search: { email, sentAt: Date.now(), error: undefined },
           })
         },
-        onError: () => startOver(),
+        onError: (err) => {
+          setResendError(
+            err instanceof ApiError && err.status === 429
+              ? "That's a lot of links — give it a minute before resending again."
+              : "Couldn't resend just now. Try again in a moment, or start over.",
+          )
+        },
         onSettled: () => {
           inFlight.current = false
           // Turnstile tokens are single-use; drop the spent one and ask the
@@ -91,6 +102,7 @@ function LoginSentPage() {
         onResend={email && captchaToken ? resend : undefined}
         resending={requestLogin.isPending}
         resendMessage={resendMessage}
+        resendError={resendError}
       />
       <Turnstile
         handleRef={(h) => {

--- a/web-client/src/routes/login.test.tsx
+++ b/web-client/src/routes/login.test.tsx
@@ -228,6 +228,54 @@ describe('/login/sent flow', () => {
     expect(await screen.findByText(/new link sent/i)).toBeInTheDocument()
   })
 
+  it('throttles Resend with a cooldown right after the link was sent, so a rapid burst stays put (#616)', async () => {
+    let requests = 0
+    server.use(
+      http.post('*/v1/login/request', async ({ request }) => {
+        requests += 1
+        const body = (await request.json()) as { email: string }
+        return HttpResponse.json({ email: body.email }, { status: 202 })
+      }),
+    )
+    // A just-sent link (sentAt ≈ now) opens the cooldown window.
+    const { router } = renderAt(
+      `/login/sent?email=rita@example.com&sentAt=${Date.now()}`,
+    )
+
+    // The button shows the cooldown countdown and is disabled.
+    const resendBtn = await screen.findByRole('button', {
+      name: /resend in \d+s/i,
+    })
+    expect(resendBtn).toBeDisabled()
+
+    // A synchronous click burst neither fires a request nor bounces to /login.
+    fireEvent.click(resendBtn)
+    fireEvent.click(resendBtn)
+    fireEvent.click(resendBtn)
+
+    expect(requests).toBe(0)
+    expect(router.state.location.pathname).toBe('/login/sent')
+  })
+
+  it('keeps the user on the sent screen and shows guidance when a resend errors (#616)', async () => {
+    server.use(
+      http.post('*/v1/login/request', () =>
+        HttpResponse.json({ detail: 'Too Many Requests' }, { status: 429 }),
+      ),
+    )
+    const user = userEvent.setup()
+    // Old sentAt → cooldown already elapsed, so Resend is enabled.
+    const { router } = renderAt('/login/sent?email=rita@example.com&sentAt=1000')
+
+    const resendBtn = await screen.findByRole('button', { name: /^resend$/i })
+    await waitFor(() => expect(resendBtn).toBeEnabled())
+    await user.click(resendBtn)
+
+    expect(await screen.findByText(/lot of links/i)).toBeInTheDocument()
+    // Did NOT bounce back to /login.
+    expect(router.state.location.pathname).toBe('/login/sent')
+  })
+
   it('"Start over" routes back to /login with the email prefilled', async () => {
     const user = userEvent.setup()
     const { router } = renderAt('/login/sent?email=rita@example.com&sentAt=1000')


### PR DESCRIPTION
## Summary
Fixes #616 — rapid **Resend** clicks on the `/login/sent` ("check your inbox") screen bounced the user back to `/login?email=…` instead of showing a cooldown.

**Root cause:** a click burst tripped the rate-limited `/v1/login/request` endpoint into a 429, and the resend handler's `onError` navigated away via `startOver()`.

## Changes
- **Visible resend cooldown** (`login-screens.tsx`): new `RESEND_COOLDOWN_MS` (30s) + a `useResendCooldown(sentAt)` hook mirroring the existing `ExpiresCountdown` tick pattern. The Resend button disables and shows `Resend in Ns`, anchored on `sentAt` (which re-stamps on every send) — so a burst can't reach the endpoint.
- **Stay on the sent screen on error** (`login.sent.tsx`): `onError` no longer calls `startOver()`. It surfaces the failure inline (via the existing `fmm-help--err` alert), with tailored copy for a 429. The user keeps their original link; the explicit **Start over** button remains for manual recovery.

## Testing
- `npm run test:run` — 1010 passed (added 2 regression tests in `login.test.tsx`: a fresh-send cooldown burst that fires zero requests and stays put, and a 429 resend that shows guidance without bouncing).
- `npm run lint` — clean; `npm run build` — ✓.
- `npm run test:e2e` — 128 passed.

No `api/**` changes → no OpenAPI regen needed. Root e2e skipped (login-UI-only, no backend change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)