### PR TITLE
Guard consume_login_token against IntegrityError race (#276)

### DIFF
--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -1324,16 +1324,29 @@ async def consume_login_token(
     # token didn't record one (bare ``login``). ``skip_merge`` lets the owner
     # sign in without bringing the guest's matches over (the gate's "not now").
     recorded_guest_id = _guest_id_from_login_context(token_row.context)
-    # Single-use: delete the link the moment we accept it.
-    await db.delete(token_row)
-    if payload.skip_merge:
-        merged = None
-    elif recorded_guest_id is not None:
-        guest = await db.get(User, recorded_guest_id)
-        merged = await _merge_guest_into(db, guest=guest, target=user)
-    else:
-        merged = await _maybe_merge_prior_session(db, session_cookie, user)
-    return await _sign_in_after_merge(db, response, user, merged)
+    # The merge helpers run a query that autoflushes the staged rows before the
+    # explicit commit, so the users.email unique-constraint race (the merge
+    # re-points rows onto an address another account already confirmed) can
+    # surface anywhere in this block — not just at commit. Roll back and return
+    # the opaque "invalid or expired" so we don't leak who owns the address.
+    # Mirrors the guard on ``confirm_email``.
+    try:
+        # Single-use: delete the link the moment we accept it.
+        await db.delete(token_row)
+        if payload.skip_merge:
+            merged = None
+        elif recorded_guest_id is not None:
+            guest = await db.get(User, recorded_guest_id)
+            merged = await _merge_guest_into(db, guest=guest, target=user)
+        else:
+            merged = await _maybe_merge_prior_session(db, session_cookie, user)
+        return await _sign_in_after_merge(db, response, user, merged)
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="That sign-in link is invalid or expired.",
+        ) from None
 
 
 @router.post(

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -5,8 +5,10 @@ from datetime import UTC, datetime, timedelta
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app import sessions
 from app.db import get_session
 from app.leagues import get_default_league
 from app.main import app
@@ -542,6 +544,30 @@ async def test_consume_merges_ephemeral_matches_into_verified_account(
     ).scalar_one_or_none()
     assert tombstoned is not None
     assert tombstoned.merged_into_user_id == rita.id
+
+
+async def test_consume_returns_400_when_merge_raises_integrity_error(
+    api_client: AsyncClient, db_session: AsyncSession, monkeypatch
+):
+    """If the email/merge race surfaces an IntegrityError mid-block (the merge
+    autoflushes the staged rows before commit), the endpoint must convert it
+    into the opaque 400 rather than letting a 500 leak out — mirroring the
+    guard on confirm_email."""
+    rita = await _make_confirmed_user(db_session, "rita@example.com")
+    raw = "raw-login-token-race"
+    await _issue_login_token(db_session, rita, raw)
+
+    # Arrive with an ephemeral guest so the merge path runs.
+    await start_session(api_client, db_session)
+
+    async def _boom(*args: object, **kwargs: object) -> None:
+        raise IntegrityError("merge", {}, Exception("duplicate key"))
+
+    monkeypatch.setattr(sessions, "_maybe_merge_prior_session", _boom)
+
+    response = await api_client.post("/v1/login/consume", json={"token": raw})
+    assert response.status_code == 400
+    assert response.json()["detail"] == "That sign-in link is invalid or expired."
 
 
 async def test_consume_omits_merge_when_no_prior_session(


### PR DESCRIPTION
Fixes #276.

## Problem

`consume_login_token` (the magic-link sign-in endpoint) calls `_maybe_merge_prior_session` / `_merge_guest_into`, which issue a query that triggers SQLAlchemy autoflush of the staged rows **before** the explicit commit. So the `users.email` unique-constraint race (the merge re-pointing rows onto an address another account already confirmed) can surface anywhere in the block — not just at `commit()` — and bubbled out as an unhandled `IntegrityError` → 500.

The parallel `confirm_email` endpoint got exactly this guard in #250; `consume_login_token` was never given the same treatment. Pre-existing, not a regression.

## Fix

Wrap the token-delete → merge → sign-in/commit block in `try/except IntegrityError`, rolling back and returning the opaque 400 `"That sign-in link is invalid or expired."` — mirroring `confirm_email` and keeping the response enumeration-safe (matches the endpoint's other 400 detail strings).

## Test

`test_consume_returns_400_when_merge_raises_integrity_error` — monkeypatches `_maybe_merge_prior_session` to raise `IntegrityError` on the merge path and asserts a clean 400 with the generic detail rather than a 500.

## Testing

- `ruff check` / `ruff format --check` ✓
- `mypy` (strict) ✓
- `pytest` — 498 passed ✓
- OpenAPI schema regen — no drift (no route/schema surface change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)