### PR TITLE
Make the match-length radiogroup keyboard-operable (#64)

### DIFF
--- a/web-client/src/routes/_app/matches/new.test.tsx
+++ b/web-client/src/routes/_app/matches/new.test.tsx
@@ -313,6 +313,76 @@ describe('NewMatchPage', () => {
   })
 })
 
+describe('NewMatchPage — match-length keyboard (#64)', () => {
+  // The match-length radiogroup must be operable from the keyboard per
+  // WCAG 2.1.1: it is a single Tab stop (roving tabindex) and arrows/Home/End
+  // move *and* select between options.
+  function recentEmpty() {
+    return http.get('*/v1/players/recent', () => HttpResponse.json([]))
+  }
+
+  function lengthRadios() {
+    return screen
+      .getByRole('radiogroup', { name: /match length/i })
+      .querySelectorAll<HTMLButtonElement>('[role="radio"]')
+  }
+
+  it('exposes the group as a single Tab stop via roving tabindex', async () => {
+    server.use(recentEmpty())
+    renderNewMatch()
+    await screen.findByRole('radiogroup', { name: /match length/i })
+
+    const radios = lengthRadios()
+    // Default is Best of 5 ("Std"), the third option — only it is tabbable.
+    expect(Array.from(radios).map((r) => r.tabIndex)).toEqual([-1, -1, 0, -1])
+  })
+
+  it('moves and selects with ArrowRight/ArrowLeft, wrapping at the ends', async () => {
+    const user = userEvent.setup()
+    server.use(recentEmpty())
+    renderNewMatch()
+    await screen.findByRole('radiogroup', { name: /match length/i })
+
+    const [single, , std, long] = Array.from(lengthRadios())
+    std.focus()
+    expect(std).toHaveFocus()
+
+    await user.keyboard('{ArrowRight}')
+    expect(long).toHaveAttribute('aria-checked', 'true')
+    expect(long).toHaveFocus()
+
+    // Wrap forward off the last option back to the first.
+    await user.keyboard('{ArrowRight}')
+    expect(single).toHaveAttribute('aria-checked', 'true')
+    expect(single).toHaveFocus()
+
+    // Wrap backward off the first option to the last.
+    await user.keyboard('{ArrowLeft}')
+    expect(long).toHaveAttribute('aria-checked', 'true')
+    expect(long).toHaveFocus()
+  })
+
+  it('jumps to the ends with Home and End', async () => {
+    const user = userEvent.setup()
+    server.use(recentEmpty())
+    renderNewMatch()
+    await screen.findByRole('radiogroup', { name: /match length/i })
+
+    const radios = Array.from(lengthRadios())
+    const first = radios[0]
+    const last = radios[radios.length - 1]
+    radios[2].focus()
+
+    await user.keyboard('{Home}')
+    expect(first).toHaveAttribute('aria-checked', 'true')
+    expect(first).toHaveFocus()
+
+    await user.keyboard('{End}')
+    expect(last).toHaveAttribute('aria-checked', 'true')
+    expect(last).toHaveFocus()
+  })
+})
+
 describe('NewMatchPage — recent opponents', () => {
   it('shows a skeleton while recent opponents load, then the chips', async () => {
     server.use(

--- a/web-client/src/routes/_app/matches/new.tsx
+++ b/web-client/src/routes/_app/matches/new.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
 import { ArrowRight } from 'lucide-react'
 import { z } from 'zod'
@@ -243,18 +243,57 @@ function BestOfField({
   bestOf: number
   setBestOf: (n: number) => void
 }) {
+  // A radiogroup is a single tab stop with roving focus (WAI-ARIA): arrows move
+  // between options (and select as they go), Home/End jump to the ends. The
+  // buttons handle Space/Enter natively. Refs let an arrow press move focus to
+  // the newly-selected option, not just change the value (#64).
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([])
+
+  function handleKeyDown(event: React.KeyboardEvent, index: number) {
+    const last = BEST_OF_OPTIONS.length - 1
+    let next: number
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        next = index === last ? 0 : index + 1
+        break
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        next = index === 0 ? last : index - 1
+        break
+      case 'Home':
+        next = 0
+        break
+      case 'End':
+        next = last
+        break
+      default:
+        return
+    }
+    event.preventDefault()
+    setBestOf(BEST_OF_OPTIONS[next].n)
+    optionRefs.current[next]?.focus()
+  }
+
   return (
     <div>
       <div className="nm-field-label">Match length</div>
       <div className="nm-bestof" role="radiogroup" aria-label="Match length">
-        {BEST_OF_OPTIONS.map((o) => (
+        {BEST_OF_OPTIONS.map((o, i) => (
           <button
             type="button"
             key={o.n}
+            ref={(el) => {
+              optionRefs.current[i] = el
+            }}
             className={cn('nm-bestof-opt', bestOf === o.n && 'active')}
             role="radio"
             aria-checked={bestOf === o.n}
+            // Roving tabindex: only the checked option is in the tab order, so
+            // the group is one Tab stop and arrows drive the rest.
+            tabIndex={bestOf === o.n ? 0 : -1}
             onClick={() => setBestOf(o.n)}
+            onKeyDown={(e) => handleKeyDown(e, i)}
           >
             <span className="big">{o.n}</span>
             <span className="sub">{o.label}</span>


### PR DESCRIPTION
## What

The `/matches/new` **Match length** control (1/Single, 3/Short, 5/Std, 7/Long) renders a `role="radiogroup"` of `role="radio"` buttons but only supported native Space/Enter activation — **arrow keys did nothing** and each option was its own Tab stop. That fails [WCAG 2.1.1 (Keyboard)](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html): a radiogroup should be a single Tab stop with roving focus driven by the arrow keys.

## Change

- **Roving tabindex** — only the checked option has `tabIndex={0}`; the rest are `-1`, so the group is one Tab stop.
- **`onKeyDown`** — ArrowLeft/Right/Up/Down move *and* select (wrapping at the ends), Home/End jump to first/last, and focus follows the selection. Space/Enter keep working natively.

## Verification

- New vitest cases (`new.test.tsx`) drive the group with `userEvent` keyboard input: roving tabindex, arrow wraparound, Home/End. All 22 tests in the file pass; `tsc -b` + eslint clean.
- Verified live on a prod-like QA stack (real API, MSW off): focusing "Std" and pressing ArrowRight/Left/Home/End moves selection and focus as expected, with wraparound.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)