### PR TITLE
Add disputer acknowledgement + submitter withdraw path (#359, #361)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -469,6 +469,12 @@ def _serialize_details(
         can_confirm=(
             current_user_id is not None and _can_confirm(match, current_user_id)
         ),
+        # True iff the current user posted the pending result and can retract it
+        # (the submitter's escape hatch — they can't confirm/dispute their own
+        # result). Drives the "Withdraw result" CTA.
+        can_withdraw=(
+            current_user_id is not None and _can_withdraw(match, current_user_id)
+        ),
         signatures=_signature_views(match),
         disputed_by_user_id=disputer_of(match),
         recent_form=extras.recent_form,
@@ -1107,6 +1113,48 @@ def _can_confirm(match: Match, user_id: uuid.UUID | None) -> bool:
     return True
 
 
+def _enforce_withdrawable(match: Match, user_id: uuid.UUID) -> MatchResult:
+    """Preconditions for ``POST /withdrawal`` — the submitter retracting their
+    own still-pending result. Caller is already known to be a participant
+    (``_load_match_for_scoring`` handles the 404). Returns the pending result so
+    the handler doesn't re-load it. Symmetric to ``_enforce_confirmable`` but
+    for the *opposite* party: confirm/dispute are for the side that owes a
+    sign-off, withdrawal is for the side that posted."""
+    if match.status != MatchStatus.in_progress:
+        raise HTTPException(
+            status_code=409,
+            detail="This match is no longer awaiting confirmation.",
+        )
+    result = pending_result(match)
+    if result is None:
+        raise HTTPException(
+            status_code=409,
+            detail="No posted result to withdraw. Post the result first.",
+        )
+    if result.submitted_by_user_id != user_id:
+        raise HTTPException(
+            status_code=409,
+            detail="Only the player who posted this result can withdraw it.",
+        )
+    return result
+
+
+def _can_withdraw(match: Match, user_id: uuid.UUID | None) -> bool:
+    """Mirrors ``_enforce_withdrawable`` as a boolean for the BFF surface.
+    True iff a ``POST /withdrawal`` from ``user_id`` would currently succeed
+    (ignoring transport-layer auth)."""
+    if user_id is None:
+        return False
+    if match.status != MatchStatus.in_progress:
+        return False
+    if not _is_participant(match, user_id):
+        return False
+    result = pending_result(match)
+    if result is None:
+        return False
+    return result.submitted_by_user_id == user_id
+
+
 # ----- result-confirmation push -------------------------------------------
 
 # En-dash between scores reads better than a hyphen in notification copy.
@@ -1723,6 +1771,18 @@ def _set_side_won(match: Match, decided_side: int) -> None:
         side.won = side.side_number == decided_side
 
 
+def _reset_sides_for_reopen(match: Match) -> None:
+    """Rewind the denormalized side outcome when a posted result is sent back to
+    a re-scorable board (a /dispute or /withdrawal). ``side.won`` is only stamped
+    at completion now, so it's still None on an awaiting-confirmation match —
+    nulling it is defensive. ``side.score`` is the games-won mirror — zero it so a
+    direct DB reader doesn't see won=None with score>0 (the games still imply
+    2-1 etc., but the BFF derives that from MatchGame, not from side.score)."""
+    for side in match.sides:
+        side.won = None
+        side.score = 0
+
+
 def _requires_confirmation(match: Match) -> bool:
     """Only rated matches go through the sign-off round-trip. Confirmation
     exists to protect ratings from one-sided claims; an unrated match has no
@@ -2166,15 +2226,51 @@ async def dispute_match_result(
     # Un-completed: drop the completion stamp so a re-post stamps a fresh one
     # and this match doesn't linger in any history window while disputed.
     match.completed_at = None
-    for side in match.sides:
-        # ``side.won`` is only stamped at completion now, so it's still None
-        # on an awaiting-confirmation match — nulling it here is defensive.
-        # ``side.score`` is the denormalized games-won mirror — zero it so a
-        # direct DB reader doesn't see won=None with score>0 (the games still
-        # imply 2-1 etc., but the BFF derives that from MatchGame, not from
-        # side.score).
-        side.won = None
-        side.score = 0
+    _reset_sides_for_reopen(match)
+
+    await db.commit()
+
+    reloaded = await _load_match(db, match.id)
+    assert reloaded is not None
+    extras = await _load_view_extras(db, reloaded)
+    return _serialize_details(reloaded, current_user.id, extras)
+
+
+@router.post(
+    "/matches/{match_id}/withdrawal",
+    response_model=MatchDetails,
+    # 200 (not 201): like /dispute, withdrawal is terminal for the pending
+    # result rather than creating a confirmable resource — it rewinds the match
+    # to a live, re-scorable board.
+    status_code=status.HTTP_200_OK,
+)
+async def withdraw_match_result(
+    match_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_session),
+) -> MatchDetails:
+    """Retract a result the caller posted that's still awaiting the other
+    side's sign-off — the submitter's escape hatch for a typo they spotted
+    after posting (they can't confirm or dispute their own result).
+
+    The pending result is marked ``superseded`` (it stays as history — its
+    ``games`` snapshot preserves the retracted board) and the match returns to a
+    plain ``in_progress`` / ``Live`` state with no pending result. The working
+    ``match_games`` stay in place, so scoring reopens (see ``_enforce_scorable``)
+    and the submitter can correct the wrong game and re-post via ``/results``.
+    Distinct from ``disputed``: nobody rejected the result, so the match reads
+    as ordinary Live rather than surfacing a disputer."""
+    match = await _load_match_for_scoring(db, match_id, current_user.id, lock=True)
+    result = _enforce_withdrawable(match, current_user.id)
+
+    # ``superseded`` (the reserved "a pending result was retracted/replaced"
+    # outcome) keeps the row as history while contributing no signatures and no
+    # disputer to the BFF — so the match reads as a clean reopened board.
+    result.outcome = ResultOutcome.superseded
+    # Already ``in_progress`` (a pending result implies it), but set explicitly
+    # to mirror /dispute and stay correct if the lifecycle ever changes.
+    match.status = MatchStatus.in_progress
+    _reset_sides_for_reopen(match)
 
     await db.commit()
 

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1771,13 +1771,21 @@ def _set_side_won(match: Match, decided_side: int) -> None:
         side.won = side.side_number == decided_side
 
 
-def _reset_sides_for_reopen(match: Match) -> None:
-    """Rewind the denormalized side outcome when a posted result is sent back to
-    a re-scorable board (a /dispute or /withdrawal). ``side.won`` is only stamped
-    at completion now, so it's still None on an awaiting-confirmation match —
-    nulling it is defensive. ``side.score`` is the games-won mirror — zero it so a
-    direct DB reader doesn't see won=None with score>0 (the games still imply
-    2-1 etc., but the BFF derives that from MatchGame, not from side.score)."""
+def _reopen_match(match: Match) -> None:
+    """Rewind a match's completion state when a posted result is sent back to a
+    re-scorable board (a /dispute or /withdrawal), so both reopen paths stay
+    symmetric on the completion invariants history windows depend on (#312).
+
+    ``completed_at`` is dropped so a reopened match never lingers in a history
+    window carrying a stale completion stamp (today it's already None on an
+    awaiting-confirmation match — the rated post path never stamps it — so this
+    is defensive, but it keeps the two reopen paths from diverging on a
+    load-bearing invariant). ``side.won`` is likewise only stamped at completion,
+    so nulling it is defensive too; ``side.score`` is the games-won mirror —
+    zero it so a direct DB reader doesn't see won=None with score>0 (the games
+    still imply 2-1 etc., but the BFF derives that from MatchGame, not
+    side.score)."""
+    match.completed_at = None
     for side in match.sides:
         side.won = None
         side.score = 0
@@ -2223,10 +2231,10 @@ async def dispute_match_result(
     # Scoring is reopened anyway (no pending result + ``disputed`` is
     # non-terminal), and re-posting via /results flips it back to ``in_progress``.
     match.status = MatchStatus.disputed
-    # Un-completed: drop the completion stamp so a re-post stamps a fresh one
-    # and this match doesn't linger in any history window while disputed.
-    match.completed_at = None
-    _reset_sides_for_reopen(match)
+    # Drop the completion stamp + rewind the side outcome so a re-post stamps a
+    # fresh one and this match doesn't linger in any history window while
+    # disputed (see ``_reopen_match``).
+    _reopen_match(match)
 
     await db.commit()
 
@@ -2270,7 +2278,7 @@ async def withdraw_match_result(
     # Already ``in_progress`` (a pending result implies it), but set explicitly
     # to mirror /dispute and stay correct if the lifecycle ever changes.
     match.status = MatchStatus.in_progress
-    _reset_sides_for_reopen(match)
+    _reopen_match(match)
 
     await db.commit()
 

--- a/api/app/models/match_result.py
+++ b/api/app/models/match_result.py
@@ -23,10 +23,11 @@ class ResultOutcome(enum.Enum):
     match is ``completed``.
     ``disputed`` — a participant rejected it; the match reopens for re-scoring
     and this row stays as the immutable record of what was rejected.
-    ``superseded`` — a still-``pending`` result was replaced by a re-post before
-    anyone acted on it. Unused by the current flow (a re-post only happens after
-    a terminal dispute) but reserved so re-posting over a pending result has a
-    home.
+    ``superseded`` — a still-``pending`` result was retracted before anyone
+    acted on it: the submitter withdrew it (``POST /withdrawal``), reopening the
+    match to a plain ``in_progress`` board. Like ``disputed`` it stays as history
+    and contributes no signatures, but carries no disputer — so the reopened
+    match reads as ordinary Live rather than surfacing a dispute.
     """
 
     pending = "pending"

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -208,6 +208,13 @@ class MatchDetails(BaseModel):
     # predicate gates both /confirmation and /dispute; the FE picks which
     # CTA to show. False for anonymous / non-participants.
     can_confirm: bool
+    # True when the current user is the *submitter* of a result that is still
+    # awaiting the other side's sign-off — i.e. they posted it and nobody has
+    # confirmed or disputed yet. They can't confirm or dispute their own result,
+    # so this gates a "Withdraw result" CTA that retracts the posting and
+    # reopens the match for re-scoring. False for anonymous / non-participants
+    # and for the side that owes the sign-off (they get ``can_confirm`` instead).
+    can_withdraw: bool
     # Always present (possibly empty). Default-factoried fields become
     # ``optional`` in the generated TS types; declared as required keeps the
     # FE from defending against ``undefined`` at every read.

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -2147,6 +2147,124 @@ async def test_dispute_records_disputer_and_repost_clears_it(
         assert re_post["disputed_by_user_id"] is None
 
 
+async def test_can_withdraw_flag_is_submitter_only(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """After a result is posted, the submitter (who can't confirm/dispute their
+    own result) gets ``can_withdraw=True`` and ``can_confirm=False``; the side
+    that owes a sign-off gets the mirror image."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "withdraw-flag-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        posted = await _post_results(api_client, match["id"])
+        # Submitter: can withdraw, can't confirm.
+        assert posted["can_withdraw"] is True
+        assert posted["can_confirm"] is False
+
+        # Opponent: can confirm/dispute, can't withdraw someone else's post.
+        opp_view = (await opp_client.get(f"/v1/matches/{match['id']}")).json()
+        assert opp_view["can_withdraw"] is False
+        assert opp_view["can_confirm"] is True
+
+
+async def test_withdraw_supersedes_result_and_reopens_match(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """``POST /withdrawal`` lets the submitter retract their own pending result:
+    it's marked ``superseded`` (no signatures, no disputer surfaced), the match
+    returns to a plain ``Live`` state (not ``disputed``), and scoring reopens so
+    the submitter can correct the wrong game and re-post."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "withdraw-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+        withdraw = await api_client.post(f"/v1/matches/{match['id']}/withdrawal")
+        assert withdraw.status_code == 200
+        body = withdraw.json()
+        # Plain Live — not Disputed: nobody rejected the result.
+        assert body["status"] == "in_progress"
+        assert body["status_label"] == "Live"
+        assert body["signatures"] == []
+        assert body["disputed_by_user_id"] is None
+        sides = sorted(body["sides"], key=lambda s: s["side_number"])
+        assert [s["won"] for s in sides] == [None, None]
+        # Working games preserved, board still decided → re-scorable + re-postable.
+        assert [s["games_won"] for s in sides] == [2, 0]
+        assert body["can_score"] is True
+        assert body["can_finalize"] is True
+        # Nothing pending now, so the submitter can't withdraw again.
+        assert body["can_withdraw"] is False
+
+        # The submitter can edit the contested game and re-post into sign-off.
+        put = await api_client.put(
+            f"/v1/matches/{match['id']}/games/2/scores",
+            json={"side_1_points": 11, "side_2_points": 9, "expected_version": 1},
+        )
+        assert put.status_code == 200
+        re_post = await _post_results(api_client, match["id"])
+        assert re_post["status_label"] == "Awaiting confirmation"
+
+
+async def test_opponent_cannot_withdraw_submitters_result(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Withdrawal is the *submitter's* escape hatch. The side that owes a
+    sign-off must confirm or dispute instead — withdrawing isn't theirs."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "withdraw-opp2") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+        resp = await opp_client.post(f"/v1/matches/{match['id']}/withdrawal")
+        assert resp.status_code == 409
+        assert "posted this result" in resp.json()["detail"]
+
+
+async def test_withdraw_409_when_no_result_posted(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "withdraw-early-opp") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        resp = await api_client.post(f"/v1/matches/{match['id']}/withdrawal")
+        assert resp.status_code == 409
+        assert "No posted result" in resp.json()["detail"]
+
+
+async def test_non_participant_cannot_withdraw(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A non-participant gets 404, mirroring the other write paths — no way to
+    learn the match exists."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "withdraw-np-opp") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+        async with make_client() as bystander_client:
+            await start_session(bystander_client, db_session)
+            resp = await bystander_client.post(f"/v1/matches/{match['id']}/withdrawal")
+            assert resp.status_code == 404
+
+
+async def test_withdraw_409_after_finalized(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Once both sides have signed and the match is completed there's no pending
+    result to withdraw — ``_enforce_withdrawable`` catches it on the status
+    gate."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "withdraw-final-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+        confirm = await opp_client.post(f"/v1/matches/{match['id']}/confirmation")
+        assert confirm.status_code == 201
+
+        resp = await api_client.post(f"/v1/matches/{match['id']}/withdrawal")
+        assert resp.status_code == 409
+        assert "no longer awaiting confirmation" in resp.json()["detail"]
+
+
 async def test_results_on_solo_finalizes_with_no_signature_row(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -602,6 +602,28 @@ export function useDisputeMatch(matchId: string) {
   })
 }
 
+/**
+ * Withdraws a result the caller posted while it's still awaiting the other
+ * side's sign-off — the submitter's escape hatch for a typo they spotted after
+ * posting (they can't confirm or dispute their own result). Marks the pending
+ * result `superseded` and reopens the match to a plain `Live` state so the
+ * submitter can correct the wrong game and re-post. The BFF's `can_withdraw`
+ * flag is the source of truth for whether the CTA is shown.
+ */
+export function useWithdrawMatch(matchId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (): Promise<MatchDetails> =>
+      unwrap(
+        'withdraw match result',
+        await api.POST('/v1/matches/{match_id}/withdrawal', {
+          params: { path: { match_id: matchId } },
+        }),
+      ),
+    onSuccess: (data) => applyScoreMutationCache(queryClient, matchId, data),
+  })
+}
+
 // `as const` on `to` preserves the literal so TanStack Router's typed
 // navigation can validate it against the route tree.
 

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -522,6 +522,36 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/matches/{match_id}/withdrawal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Withdraw Match Result
+         * @description Retract a result the caller posted that's still awaiting the other
+         *     side's sign-off — the submitter's escape hatch for a typo they spotted
+         *     after posting (they can't confirm or dispute their own result).
+         *
+         *     The pending result is marked ``superseded`` (it stays as history — its
+         *     ``games`` snapshot preserves the retracted board) and the match returns to a
+         *     plain ``in_progress`` / ``Live`` state with no pending result. The working
+         *     ``match_games`` stay in place, so scoring reopens (see ``_enforce_scorable``)
+         *     and the submitter can correct the wrong game and re-post via ``/results``.
+         *     Distinct from ``disputed``: nobody rejected the result, so the match reads
+         *     as ordinary Live rather than surfacing a disputer.
+         */
+        post: operations["withdraw_match_result_v1_matches__match_id__withdrawal_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/players/recent": {
         parameters: {
             query?: never;
@@ -2596,6 +2626,8 @@ export interface components {
             can_finalize: boolean;
             /** Can Confirm */
             can_confirm: boolean;
+            /** Can Withdraw */
+            can_withdraw: boolean;
             /** Signatures */
             signatures: components["schemas"]["MatchSignatureView"][];
             /** Disputed By User Id */
@@ -3760,6 +3792,39 @@ export interface operations {
         };
     };
     dispute_match_result_v1_matches__match_id__dispute_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                match_id: string;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["app__schemas__match__MatchDetails"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    withdraw_match_result_v1_matches__match_id__withdrawal_post: {
         parameters: {
             query?: never;
             header?: never;

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.page.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.page.tsx
@@ -6,6 +6,10 @@ import {
   mockMatchDisputeEndpoint,
   type MatchDisputeResolver,
 } from "@/mocks/endpoints/matches/match-dispute.endpoint";
+import {
+  mockMatchWithdrawalEndpoint,
+  type MatchWithdrawalResolver,
+} from "@/mocks/endpoints/matches/match-withdrawal.endpoint";
 import { server } from "@/mocks/server";
 import { render, screen, type Container } from "@/test/utilities";
 
@@ -14,7 +18,10 @@ import {
   type ConfirmationCalloutActiveProps,
 } from "./confirmation-callout-active";
 import { confirmationCalloutDisplayPage } from "./confirmation-callout-active/confirmation-callout-display.page";
-import { buildActionableConfirmationView } from "./confirmation-callout-active/confirmation-callout-display.factory";
+import {
+  buildActionableConfirmationView,
+  buildAwaitingConfirmationView,
+} from "./confirmation-callout-active/confirmation-callout-display.factory";
 
 const DEFAULT_MATCH_ID = "m-1";
 
@@ -40,6 +47,14 @@ export const confirmationCalloutActivePage = {
   mockDisputeEndpoint(resolver: MatchDisputeResolver) {
     mockMatchDisputeEndpoint(server, resolver);
   },
+
+  /** Stub `POST /v1/matches/:matchId/withdrawal`. */
+  mockWithdrawalEndpoint(resolver: MatchWithdrawalResolver) {
+    mockMatchWithdrawalEndpoint(server, resolver);
+  },
+
+  /** The submitter's passive awaiting view, where the Withdraw CTA lives. */
+  awaitingView: buildAwaitingConfirmationView,
 
   render(overrides: Partial<ConfirmationCalloutActiveProps> = {}) {
     const props: ConfirmationCalloutActiveProps = {

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.test.tsx
@@ -1,12 +1,19 @@
 import { HttpResponse } from "msw";
 import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
 
 import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
 import { fireEvent, waitFor } from "@/test/utilities";
 
 import { confirmationCalloutActivePage } from "./confirmation-callout-active.page";
 
+vi.mock("sonner", async () => {
+  const actual = await vi.importActual<typeof import("sonner")>("sonner");
+  return { ...actual, toast: { ...actual.toast, success: vi.fn() } };
+});
+
 describe("ConfirmationCalloutActive", () => {
+  beforeEach(() => vi.mocked(toast.success).mockClear());
   it("fires a single /confirmation when Confirm is double-clicked in one frame", async () => {
     // Two synchronous clicks before React commits the `disabled` re-render —
     // the double-tap that fired a duplicate POST /confirmation whose loser
@@ -165,5 +172,84 @@ describe("ConfirmationCalloutActive", () => {
         confirmationCalloutActivePage.queryError(),
       ).not.toBeInTheDocument(),
     );
+  });
+
+  it("acknowledges a successful dispute with a toast (#359)", async () => {
+    // Dispute unmounts this callout, so without an explicit acknowledgement the
+    // disputer gets no signal their click did anything. The copy stays neutral
+    // about who re-scores — after a dispute either player can correct the games.
+    confirmationCalloutActivePage.mockDisputeEndpoint(() =>
+      HttpResponse.json(buildMatchDetails()),
+    );
+    confirmationCalloutActivePage.render();
+
+    await userEvent.click(confirmationCalloutActivePage.getDisputeButton());
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith(
+        "Dispute sent.",
+        expect.objectContaining({
+          description: expect.stringContaining("back in progress"),
+        }),
+      ),
+    );
+  });
+
+  it("posts to /withdrawal once and acknowledges with a toast (#361)", async () => {
+    let withdrawHits = 0;
+    confirmationCalloutActivePage.mockWithdrawalEndpoint(() => {
+      withdrawHits += 1;
+      return HttpResponse.json(buildMatchDetails());
+    });
+    confirmationCalloutActivePage.render({
+      view: confirmationCalloutActivePage.awaitingView({ canWithdraw: true }),
+    });
+
+    await userEvent.click(confirmationCalloutActivePage.getWithdrawButton());
+
+    await waitFor(() => expect(withdrawHits).toBe(1));
+    expect(toast.success).toHaveBeenCalledWith(
+      "Result withdrawn.",
+      expect.objectContaining({ description: expect.any(String) }),
+    );
+  });
+
+  it("fires a single /withdrawal when Withdraw is double-clicked in one frame", async () => {
+    let withdrawHits = 0;
+    confirmationCalloutActivePage.mockWithdrawalEndpoint(() => {
+      withdrawHits += 1;
+      return new Promise<never>(() => {});
+    });
+    confirmationCalloutActivePage.render({
+      view: confirmationCalloutActivePage.awaitingView({ canWithdraw: true }),
+    });
+
+    const button = confirmationCalloutActivePage.getWithdrawButton();
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => expect(button).toBeDisabled());
+    expect(withdrawHits).toBe(1);
+  });
+
+  it("surfaces a withdrawal failure inline without acknowledging it", async () => {
+    confirmationCalloutActivePage.mockWithdrawalEndpoint(() =>
+      HttpResponse.json(
+        { detail: "This match is no longer awaiting confirmation." },
+        { status: 409 },
+      ),
+    );
+    confirmationCalloutActivePage.render({
+      view: confirmationCalloutActivePage.awaitingView({ canWithdraw: true }),
+    });
+
+    await userEvent.click(confirmationCalloutActivePage.getWithdrawButton());
+
+    await waitFor(() =>
+      expect(confirmationCalloutActivePage.queryError()).toHaveTextContent(
+        "This match is no longer awaiting confirmation.",
+      ),
+    );
+    expect(toast.success).not.toHaveBeenCalled();
   });
 });

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.tsx
@@ -1,6 +1,11 @@
 import { useRef } from "react";
+import { toast } from "sonner";
 
-import { useConfirmMatch, useDisputeMatch } from "@/api/matches";
+import {
+  useConfirmMatch,
+  useDisputeMatch,
+  useWithdrawMatch,
+} from "@/api/matches";
 import { ApiError } from "@/api/client";
 
 import { ConfirmationCalloutDisplay } from "./confirmation-callout-active/confirmation-callout-display";
@@ -11,43 +16,51 @@ export interface ConfirmationCalloutActiveProps {
   matchId: string;
 }
 
-/** Wires the confirm/dispute mutations onto the pure display. Each CTA resets
- * the *other* mutation first so a stale failure doesn't linger once the user
- * changes course, and API failures stay visible inline (without throwOnError a
- * 409 — opponent confirmed/disputed first, double-click, etc. — would
- * otherwise vanish and the buttons would appear inert). */
+/** Wires the confirm/dispute/withdraw mutations onto the pure display. Each CTA
+ * resets the *other* mutations first so a stale failure doesn't linger once the
+ * user changes course, and API failures stay visible inline (without
+ * throwOnError a 409 — opponent confirmed/disputed first, double-click, etc. —
+ * would otherwise vanish and the buttons would appear inert).
+ *
+ * Dispute and withdraw both fire a success toast: each transitions the match
+ * (back to in-progress) and unmounts this callout, so without the toast the
+ * acting user gets no acknowledgement that their click did anything (#359 for
+ * dispute, #361 for withdraw). */
 export function ConfirmationCalloutActive({
   view,
   matchId,
 }: ConfirmationCalloutActiveProps) {
   const confirmMutation = useConfirmMatch(matchId);
   const disputeMutation = useDisputeMatch(matchId);
+  const withdrawMutation = useWithdrawMatch(matchId);
   const error =
     (confirmMutation.error instanceof ApiError
       ? confirmMutation.error
       : null) ??
-    (disputeMutation.error instanceof ApiError ? disputeMutation.error : null);
-  // Synchronous double-submit guard shared by both CTAs. `disabled={pending}`
-  // only takes effect on the next render, so a fast double-click — on either
+    (disputeMutation.error instanceof ApiError ? disputeMutation.error : null) ??
+    (withdrawMutation.error instanceof ApiError ? withdrawMutation.error : null);
+  // Synchronous double-submit guard shared by every CTA. `disabled={pending}`
+  // only takes effect on the next render, so a fast double-click — on any
   // button — lands a second tap before React commits the disable and fires a
   // duplicate POST that 409s (the loser of the row-lock race). One ref covers
-  // both: confirm and dispute are mutually exclusive, and the display already
-  // disables both while either is pending, so the first action wins.
+  // all: the CTAs are mutually exclusive, and the display already disables them
+  // while any is pending, so the first action wins.
   //
   // The ref is cleared only on *error*, never on success. A successful
-  // confirm/dispute transitions the match (completed, or back to in_progress)
-  // so this whole callout unmounts — clearing on settle instead would reopen
-  // the guard the instant the request resolves, a beat *before* that unmount
-  // re-renders the button away, leaving a window where a rapid second click
-  // still fires a duplicate 409 (#641 follow-up QA). Clearing on error keeps
-  // the guard shut through that window while still letting the user change
-  // course after a *failed* attempt (e.g. confirm after a rejected dispute).
+  // confirm/dispute/withdraw transitions the match (completed, or back to
+  // in_progress) so this whole callout unmounts — clearing on settle instead
+  // would reopen the guard the instant the request resolves, a beat *before*
+  // that unmount re-renders the button away, leaving a window where a rapid
+  // second click still fires a duplicate 409 (#641 follow-up QA). Clearing on
+  // error keeps the guard shut through that window while still letting the user
+  // change course after a *failed* attempt.
   const inFlightRef = useRef(false);
   return (
     <ConfirmationCalloutDisplay
       view={view}
       confirmPending={confirmMutation.isPending}
       disputePending={disputeMutation.isPending}
+      withdrawPending={withdrawMutation.isPending}
       errorMessage={error ? (error.detail ?? error.message) : null}
       onConfirm={() => {
         if (inFlightRef.current) return;
@@ -64,6 +77,27 @@ export function ConfirmationCalloutActive({
         inFlightRef.current = true;
         confirmMutation.reset();
         disputeMutation.mutate(undefined, {
+          onSuccess: () => {
+            toast.success("Dispute sent.", {
+              description:
+                "The match is back in progress so the scores can be corrected and posted again for sign-off.",
+            });
+          },
+          onError: () => {
+            inFlightRef.current = false;
+          },
+        });
+      }}
+      onWithdraw={() => {
+        if (inFlightRef.current) return;
+        inFlightRef.current = true;
+        withdrawMutation.mutate(undefined, {
+          onSuccess: () => {
+            toast.success("Result withdrawn.", {
+              description:
+                "The match is back in progress so the scores can be corrected and posted again.",
+            });
+          },
           onError: () => {
             inFlightRef.current = false;
           },

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.tsx
@@ -91,6 +91,8 @@ export function ConfirmationCalloutActive({
       onWithdraw={() => {
         if (inFlightRef.current) return;
         inFlightRef.current = true;
+        confirmMutation.reset();
+        disputeMutation.reset();
         withdrawMutation.mutate(undefined, {
           onSuccess: () => {
             toast.success("Result withdrawn.", {

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.factory.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.factory.tsx
@@ -8,11 +8,17 @@ export function buildActionableConfirmationView(
   return { kind: "actionable", ...overrides };
 }
 
-/** The passive variant: the viewer has signed, leo.mertens hasn't. */
+/** The passive variant: the viewer has posted, leo.mertens hasn't signed.
+ * Defaults to the submitter's own view (``canWithdraw`` true). */
 export function buildAwaitingConfirmationView(
   overrides: Partial<Extract<ConfirmationCalloutView, { kind: "awaiting" }>> = {},
 ): ConfirmationCalloutView {
-  return { kind: "awaiting", pendingSignerName: "leo.mertens", ...overrides };
+  return {
+    kind: "awaiting",
+    pendingSignerName: "leo.mertens",
+    canWithdraw: true,
+    ...overrides,
+  };
 }
 
 /** Props for `ConfirmationCalloutDisplay` — the actionable variant, idle
@@ -24,9 +30,11 @@ export function buildConfirmationCalloutDisplayProps(
     view: buildActionableConfirmationView(),
     confirmPending: false,
     disputePending: false,
+    withdrawPending: false,
     errorMessage: null,
     onConfirm: () => {},
     onDispute: () => {},
+    onWithdraw: () => {},
     ...overrides,
   };
 }

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.page.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.page.tsx
@@ -31,6 +31,14 @@ const scoped = (container: Container) => ({
   queryDisputeButton() {
     return container.queryByRole("button", { name: /disput/i });
   },
+  /** The passive variant's "Withdraw result" CTA — "Withdrawing…" in flight.
+   * Only present on the submitter's own awaiting view (`canWithdraw`). */
+  getWithdrawButton() {
+    return container.getByRole("button", { name: /withdraw/i });
+  },
+  queryWithdrawButton() {
+    return container.queryByRole("button", { name: /withdraw/i });
+  },
   /** The inline API-failure line beneath the body copy; null when clean. */
   queryError() {
     return container.queryByRole("alert");

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.test.tsx
@@ -103,5 +103,55 @@ describe("ConfirmationCalloutDisplay", () => {
         confirmationCalloutDisplayPage.queryDisputeButton(),
       ).not.toBeInTheDocument();
     });
+
+    it("offers a Withdraw CTA to the submitter (#361)", () => {
+      confirmationCalloutDisplayPage.render({
+        view: buildAwaitingConfirmationView({ canWithdraw: true }),
+      });
+
+      expect(confirmationCalloutDisplayPage.getCallout()).toHaveTextContent(
+        "Withdraw it to re-score and post again",
+      );
+      expect(
+        confirmationCalloutDisplayPage.getWithdrawButton(),
+      ).toHaveTextContent("Withdraw result");
+      expect(confirmationCalloutDisplayPage.getWithdrawButton()).toBeEnabled();
+    });
+
+    it("hides the Withdraw CTA when the viewer can't withdraw", () => {
+      confirmationCalloutDisplayPage.render({
+        view: buildAwaitingConfirmationView({ canWithdraw: false }),
+      });
+
+      expect(
+        confirmationCalloutDisplayPage.queryWithdrawButton(),
+      ).not.toBeInTheDocument();
+    });
+
+    it("fires onWithdraw from the Withdraw CTA", async () => {
+      const onWithdraw = vi.fn();
+      confirmationCalloutDisplayPage.render({
+        view: buildAwaitingConfirmationView({ canWithdraw: true }),
+        onWithdraw,
+      });
+
+      await userEvent.click(confirmationCalloutDisplayPage.getWithdrawButton());
+
+      expect(onWithdraw).toHaveBeenCalledTimes(1);
+    });
+
+    it("disables the Withdraw CTA and shows the in-flight label while withdrawing", () => {
+      confirmationCalloutDisplayPage.render({
+        view: buildAwaitingConfirmationView({ canWithdraw: true }),
+        withdrawPending: true,
+      });
+
+      expect(
+        confirmationCalloutDisplayPage.getWithdrawButton(),
+      ).toHaveTextContent("Withdrawing…");
+      expect(
+        confirmationCalloutDisplayPage.getWithdrawButton(),
+      ).toBeDisabled();
+    });
   });
 });

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
@@ -10,20 +10,26 @@ export interface ConfirmationCalloutDisplayProps {
   /** True while the dispute request is in flight — swaps the Dispute label
    * to "Disputing…" and disables both CTAs. */
   disputePending: boolean;
+  /** True while the withdraw request is in flight — swaps the Withdraw label
+   * to "Withdrawing…" and disables the CTA. */
+  withdrawPending: boolean;
   /** Inline API failure to surface beneath the body copy; null when the last
    * attempt succeeded or none has been made. */
   errorMessage: string | null;
   onConfirm: () => void;
   onDispute: () => void;
+  onWithdraw: () => void;
 }
 
 export function ConfirmationCalloutDisplay({
   view,
   confirmPending,
   disputePending,
+  withdrawPending,
   errorMessage,
   onConfirm,
   onDispute,
+  onWithdraw,
 }: ConfirmationCalloutDisplayProps) {
   if (view.kind === "actionable") {
     const pending = confirmPending || disputePending;
@@ -81,11 +87,34 @@ export function ConfirmationCalloutDisplay({
       <div className="md-confirm-callout__copy">
         <Overline as="h3">Posted · awaiting confirmation</Overline>
         <p className="md-confirm-callout__body">
-          You've signed off on this result. Waiting on{" "}
+          You've posted this result. Waiting on{" "}
           <strong>{view.pendingSignerName}</strong> to confirm or dispute
           before the match is finalized.
+          {view.canWithdraw && (
+            <>
+              {" "}
+              Spotted a mistake? Withdraw it to re-score and post again.
+            </>
+          )}
         </p>
+        {errorMessage && (
+          <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
+            {errorMessage}
+          </p>
+        )}
       </div>
+      {view.canWithdraw && (
+        <div className="md-confirm-callout__actions">
+          <button
+            type="button"
+            className="md-btn md-btn--ghost"
+            disabled={withdrawPending}
+            onClick={onWithdraw}
+          >
+            {withdrawPending ? "Withdrawing…" : "Withdraw result"}
+          </button>
+        </div>
+      )}
     </section>
   );
 }

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.test.ts
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.test.ts
@@ -31,6 +31,8 @@ const awaitingMatch = (overrides: Partial<MatchDetails> = {}): MatchDetails =>
     status: "in_progress",
     status_label: "Awaiting confirmation",
     can_confirm: false,
+    // The viewer posted this result, so they may retract it.
+    can_withdraw: true,
     signatures: [viewerSignature],
     data: buildMatchDetailsData({
       scoreboard: buildScoreboard({ status: "live" }),
@@ -73,6 +75,7 @@ describe("confirmationCalloutQuery", () => {
     expect(result.current.data).toEqual({
       kind: "awaiting",
       pendingSignerName: "leo.mertens",
+      canWithdraw: true,
     });
   });
 
@@ -88,6 +91,21 @@ describe("confirmationCalloutQuery", () => {
     expect(result.current.data).toEqual({
       kind: "awaiting",
       pendingSignerName: "your opponent",
+      canWithdraw: true,
+    });
+  });
+
+  it("passes the backend's can_withdraw through to the awaiting view", async () => {
+    confirmationCalloutQueryPage.mockEndpoint(() =>
+      HttpResponse.json(awaitingMatch({ can_withdraw: false })),
+    );
+
+    const result = await renderView();
+
+    expect(result.current.data).toEqual({
+      kind: "awaiting",
+      pendingSignerName: "leo.mertens",
+      canWithdraw: false,
     });
   });
 

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.ts
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.ts
@@ -18,6 +18,10 @@ export type ConfirmationCalloutView =
       /** The user whose signature we're waiting on, for the passive label —
        * "your opponent" when the unsigned player can't be resolved by name. */
       pendingSignerName: string;
+      /** True when the viewer posted this pending result and may retract it —
+       * drives the "Withdraw result" CTA on the passive notice (the submitter's
+       * escape hatch; they can't confirm/dispute their own result). */
+      canWithdraw: boolean;
     };
 
 const selectConfirmationCallout = (
@@ -59,6 +63,7 @@ const selectConfirmationCallout = (
   return {
     kind: "awaiting",
     pendingSignerName: missing?.username ?? "your opponent",
+    canWithdraw: details.can_withdraw,
   };
 };
 

--- a/web-client/src/mocks/endpoints/matches/match-withdrawal.endpoint.ts
+++ b/web-client/src/mocks/endpoints/matches/match-withdrawal.endpoint.ts
@@ -1,0 +1,19 @@
+import { type HttpResponseResolver, http } from "msw";
+import type { components } from "@/api/schema";
+import type { server } from "../../server";
+import type { worker } from "../../browser";
+import type { ErrorBody } from "../error-body";
+
+type Backend = typeof server | typeof worker;
+type MatchDetails = components["schemas"]["app__schemas__match__MatchDetails"];
+
+export type MatchWithdrawalResolver = HttpResponseResolver<
+  { matchId: string },
+  never,
+  MatchDetails | ErrorBody
+>;
+
+export const mockMatchWithdrawalEndpoint = (
+  backend: Backend,
+  resolver: MatchWithdrawalResolver,
+) => backend.use(http.post("*/v1/matches/:matchId/withdrawal", resolver));

--- a/web-client/src/mocks/factories/matches/match-details.factory.ts
+++ b/web-client/src/mocks/factories/matches/match-details.factory.ts
@@ -182,6 +182,7 @@ export function buildMatchDetails(
     can_score: false,
     can_finalize: false,
     can_confirm: false,
+    can_withdraw: false,
     signatures: [],
     disputed_by_user_id: null,
     recent_form: [],

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -4,6 +4,7 @@ import { healthCheck, player, sessionResponse } from '@/test/factories'
 import {
   confirmSeed,
   disputeSeed,
+  withdrawSeed,
   finalizeSeed,
   findMatch,
   MOCK_CURRENT_USER,
@@ -847,6 +848,18 @@ export const handlers = [
       const seed = findMatch(String(params.matchId))
       if (!seed) return detail('Match not found.', 404)
       const message = disputeSeed(seed, MOCK_CURRENT_USER.id)
+      if (message) return detail(message, 409)
+      return HttpResponse.json(projectMatchDetails(seed))
+    },
+  ),
+
+  http.post(
+    '*/v1/matches/:matchId/withdrawal',
+    async ({ params }) => {
+      await delay(250)
+      const seed = findMatch(String(params.matchId))
+      if (!seed) return detail('Match not found.', 404)
+      const message = withdrawSeed(seed, MOCK_CURRENT_USER.id)
       if (message) return detail(message, 409)
       return HttpResponse.json(projectMatchDetails(seed))
     },

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -284,6 +284,16 @@ function canConfirmSeed(seed: SeedMatch): boolean {
   return !seed.signatures.some((sig) => sig.user_id === MOCK_CURRENT_USER.id)
 }
 
+/** Mirrors the API's ``_can_withdraw`` predicate: the current user posted the
+ * pending result (in the mock, having a signature on an awaiting-confirmation
+ * match means they posted it) and may retract it before the other side acts. */
+function canWithdrawSeed(seed: SeedMatch): boolean {
+  if (seed.status !== 'in_progress') return false
+  if (seed.signatures.length === 0) return false
+  if (seed.opponent === null) return false
+  return seed.signatures.some((sig) => sig.user_id === MOCK_CURRENT_USER.id)
+}
+
 export function projectMatchDetails(seed: SeedMatch): MatchDetails {
   const { mySide, opponentSide } = projectSides(seed)
 
@@ -323,6 +333,7 @@ export function projectMatchDetails(seed: SeedMatch): MatchDetails {
     can_score: scorableSeed(seed),
     can_finalize: canFinalizeSeed(seed),
     can_confirm: canConfirmSeed(seed),
+    can_withdraw: canWithdrawSeed(seed),
     signatures: seedSignatureViews(seed),
     disputed_by_user_id: seed.disputed_by_user_id,
     recent_form: projectRecentForm(seed, priors),
@@ -1051,6 +1062,32 @@ export function disputeSeed(seed: SeedMatch, userId: string): string | null {
   seed.signatures = []
   seed.status = 'disputed'
   seed.disputed_by_user_id = userId
+  return null
+}
+
+/** POST /v1/matches/{id}/withdrawal: the submitter retracts their own pending
+ * result. Clears every signature and keeps the match ``in_progress`` (a plain
+ * Live board — not ``disputed``, since nobody rejected it), so the submitter
+ * can re-score and re-post. Returns null on success, or a 409-suitable detail
+ * string. Mirrors the API's ``_enforce_withdrawable``. */
+export function withdrawSeed(seed: SeedMatch, userId: string): string | null {
+  if (seed.opponent === null) {
+    return "This match has no opponent and can't be signed."
+  }
+  if (seed.status !== 'in_progress') {
+    return 'This match is no longer awaiting confirmation.'
+  }
+  if (seed.signatures.length === 0) {
+    return 'No posted result to withdraw. Post the result first.'
+  }
+  // In the mock, the only way the current user holds a signature on an
+  // awaiting-confirmation match is by having posted it — so a signature is the
+  // proxy for "you are the submitter".
+  if (!seed.signatures.some((sig) => sig.user_id === userId)) {
+    return 'Only the player who posted this result can withdraw it.'
+  }
+  seed.signatures = []
+  seed.status = 'in_progress'
   return null
 }
 

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -207,6 +207,7 @@ export function matchDetails(
     can_score: true,
     can_finalize: false,
     can_confirm: false,
+    can_withdraw: false,
     signatures: [],
     disputed_by_user_id: null,
     recent_form: [mySide, opponentSide]


### PR DESCRIPTION
## Summary

Closes two gaps in the rated-match sign-off flow found in a QA pass. (The other two issues in that cluster — #360 and #366 — were verified already-fixed and are not touched here.)

- **#359 — disputer gets no acknowledgement.** Clicking **Dispute** used to just make the buttons vanish. Now a success toast confirms it: *"Dispute sent. The match is back in progress so the scores can be corrected and posted again for sign-off."* (Copy stays neutral about who re-scores — after a dispute either player can correct the games.)

- **#361 — submitter has no edit/withdraw path during *Awaiting confirmation*.** The submitter can't confirm or dispute their own result, so a typo spotted right after posting left them stuck. Adds a submitter-only **Withdraw result** action (Option A from the issue): `POST /v1/matches/{id}/withdrawal` marks the pending result `superseded` (a reserved outcome that fits this case exactly) and reopens the match to a plain **Live** board — *no DB migration*. A server-derived `can_withdraw` BFF flag drives the CTA.

Both reopen paths (`/dispute`, `/withdrawal`) now share a `_reset_sides_for_reopen` helper.

## Testing

- API: `ruff` + `ruff format --check` + `mypy --strict` clean; `pytest` **504 passed** (6 new withdrawal endpoint tests).
- Web: `vitest` **1036 passed** (new callout/withdraw/toast coverage); `lint` + `tsc -b && vite build` clean; Playwright **128 passed**.
- Root e2e (full compose stack): **4 passed**.
- OpenAPI `schema.d.ts` regenerated — no drift.
- Verified end-to-end through the browser on the prod-like QA stack (real API, MSW off): dispute toast fires; submitter sees + uses **Withdraw result**, match returns to Live, scoring re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)