### PR TITLE
Harden /matches/new submit flow (#70, #76, #81)

### DIFF
--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -139,14 +139,50 @@ export function usePlayerSearch(term: string) {
 }
 
 /**
+ * Abort a match-create POST that hasn't resolved within this window. Without it
+ * a server that accepts the connection but never responds leaves the form's
+ * "Starting…" button stuck forever with no way back (#76). Generous enough that
+ * a slow-but-healthy create still completes.
+ */
+const CREATE_MATCH_TIMEOUT_MS = 15_000
+
+/**
  * Creates a match. Callers await `mutateAsync` so they can surface the API's
  * 4xx `detail` inline on the form — no global error toast is attached here.
  */
 export function useCreateMatch() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: async (input: MatchCreate): Promise<MatchDetails> =>
-      unwrap('create match', await api.POST('/v1/matches', { body: input })),
+    mutationFn: async (input: MatchCreate): Promise<MatchDetails> => {
+      try {
+        return unwrap(
+          'create match',
+          await api.POST('/v1/matches', {
+            body: input,
+            signal: AbortSignal.timeout(CREATE_MATCH_TIMEOUT_MS),
+          }),
+        )
+      } catch (err) {
+        // A timed-out request aborts the underlying fetch, which *throws* a
+        // DOMException rather than surfacing as an openapi-fetch error result.
+        // Translate it into the ApiError the form already renders inline, so the
+        // user gets "try again" and a re-enabled button instead of a dead spinner.
+        // The abort surfaces as `TimeoutError` (the platform) or `AbortError`
+        // (some fetch layers) — this signal only ever aborts on the timeout, so
+        // either name means the same thing here.
+        if (
+          err instanceof DOMException &&
+          (err.name === 'TimeoutError' || err.name === 'AbortError')
+        ) {
+          throw new ApiError(
+            0,
+            'Request timed out — please try again.',
+            'create match',
+          )
+        }
+        throw err
+      }
+    },
     // The create response already *is* the match-details payload, so seed the
     // details query cache from it. The match-details page then renders from this
     // warm entry — whether reached by an immediate redirect or later from the

--- a/web-client/src/routes/_app/matches/new.css
+++ b/web-client/src/routes/_app/matches/new.css
@@ -743,6 +743,20 @@
   line-height: 1.4;
   color: var(--loss, #ef4444);
 }
+.nm-summary .read .nm-recovery {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+.nm-summary .read .nm-recovery .nm-error {
+  margin-top: 0;
+}
+.nm-recovery-btn {
+  height: 40px;
+  padding: 0 16px;
+}
 .nm-summary .actions {
   display: flex;
   flex-shrink: 0;

--- a/web-client/src/routes/_app/matches/new.test.tsx
+++ b/web-client/src/routes/_app/matches/new.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   RouterProvider,
@@ -14,10 +14,11 @@ import {
 } from '@tanstack/react-query'
 import { Suspense } from 'react'
 import { delay, http, HttpResponse } from 'msw'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { server } from '@/mocks/server'
 import { matchDetails, sessionResponse } from '@/test/factories'
 import { matchDetailsQuery } from '@/components/matches/match-details/match-details-query'
+import { api } from '@/api/client'
 import { Route } from './new'
 
 // The page component isn't exported (route files should only export `Route`,
@@ -78,6 +79,11 @@ function renderNewMatch() {
       )
     },
   })
+  const loginRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/login',
+    component: () => <div>Login route</div>,
+  })
   const router = createRouter({
     routeTree: rootRoute.addChildren([
       newMatchRoute,
@@ -85,6 +91,7 @@ function renderNewMatch() {
       settingsRoute,
       scoringRoute,
       detailsRoute,
+      loginRoute,
     ]),
     history: createMemoryHistory({
       // Seed a prior entry (the dashboard) so a Back from score entry has
@@ -310,6 +317,84 @@ describe('NewMatchPage', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent(
       /opponent not found/i,
     )
+  })
+
+  it('offers a "Sign in again" path instead of a dead error string on a 401 (#70)', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/players/recent', () => HttpResponse.json([])),
+      http.post('*/v1/matches', () =>
+        HttpResponse.json({ detail: 'Not authenticated' }, { status: 401 }),
+      ),
+    )
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /start match/i }),
+    )
+
+    // The bare 401 surfaces with a recovery CTA, not just an unstyled string.
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/not authenticated/i)
+    await user.click(within(alert).getByRole('button', { name: /sign in again/i }))
+    await waitFor(() =>
+      expect(screen.getByText('Login route')).toBeInTheDocument(),
+    )
+  })
+
+  it('does not fire a duplicate create on a second click while one is in flight (#81)', async () => {
+    const user = userEvent.setup()
+    let posts = 0
+    server.use(
+      http.get('*/v1/players/recent', () => HttpResponse.json([])),
+      http.post('*/v1/matches', async () => {
+        posts += 1
+        await delay(20)
+        return HttpResponse.json(pendingMatch(), { status: 201 })
+      }),
+    )
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /start match/i }),
+    )
+    // The button is now in its disabled "Starting…" state; a second click must
+    // not start a second match.
+    await user.click(screen.getByRole('button', { name: /starting/i }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Scoring route m-test game 1'),
+      ).toBeInTheDocument(),
+    )
+    expect(posts).toBe(1)
+  })
+
+  it('surfaces a timeout error and re-enables the button when the create aborts (#76)', async () => {
+    const user = userEvent.setup()
+    server.use(http.get('*/v1/players/recent', () => HttpResponse.json([])))
+    // A hung POST is aborted by the hook's `AbortSignal.timeout`, which rejects
+    // the fetch with a `TimeoutError` DOMException rather than an HTTP error
+    // result. Stand in for that rejection directly — deterministic, no waiting
+    // out the real 15s timeout — and assert the hook translates it into the
+    // inline "timed out" message with the button no longer stuck on "Starting…".
+    const post = vi
+      .spyOn(api, 'POST')
+      .mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError'))
+    try {
+      renderNewMatch()
+
+      await user.click(
+        await screen.findByRole('button', { name: /start match/i }),
+      )
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(/timed out/i)
+      expect(
+        screen.getByRole('button', { name: /start match/i }),
+      ).toBeEnabled()
+    } finally {
+      post.mockRestore()
+    }
   })
 })
 

--- a/web-client/src/routes/_app/matches/new.tsx
+++ b/web-client/src/routes/_app/matches/new.tsx
@@ -3,7 +3,7 @@ import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
 import { ArrowRight } from 'lucide-react'
 import { z } from 'zod'
 
-import { ApiError } from '@/api/client'
+import { ApiError, isSessionMergedError } from '@/api/client'
 import { deriveEmailStatus, useSession } from '@/api/session'
 import {
   nextScoringDestination,
@@ -89,7 +89,13 @@ function MatchCard() {
   // the no-opponent match is unrated by definition.
   const [rated, setRated] = useState(false)
   const [apiError, setApiError] = useState<string | null>(null)
+  const [sessionExpired, setSessionExpired] = useState(false)
   const [submitted, setSubmitted] = useState(false)
+  // Synchronous submit guard. `'submitting'` blocks the double-click race before
+  // `isPending` flips on a batched re-render; `'done'` latches after a match is
+  // created so the same mounted form (e.g. restored from the bfcache on Back)
+  // can't fire a duplicate create (#81). A failed attempt resets to `'idle'`.
+  const submitState = useRef<'idle' | 'submitting' | 'done'>('idle')
 
   const me = session?.data.user ?? null
   // The hint nudges guests toward claiming an account so their rated history
@@ -116,7 +122,13 @@ function MatchCard() {
   async function handleSubmit() {
     setSubmitted(true)
     if (validationError) return
+    // Refuse a second create from this form: a rapid double-click (before
+    // `isPending` disables the button) or a re-submit after we already started
+    // a match would otherwise create a duplicate (#81).
+    if (submitState.current !== 'idle') return
+    submitState.current = 'submitting'
     setApiError(null)
+    setSessionExpired(false)
 
     try {
       const created = await createMatch.mutateAsync({
@@ -124,12 +136,27 @@ function MatchCard() {
         best_of: bestOf,
         rated: opponent !== null && rated,
       })
+      submitState.current = 'done'
       // Replace, don't push: the new-match form is a one-shot step, so the
       // history stack shouldn't keep it. Otherwise browser/mobile Back from
       // score entry re-opens the creation form for a match that already
       // exists, instead of returning to wherever the user came from (#441).
       navigate({ ...nextScoringDestination(created), replace: true })
     } catch (err) {
+      // Let the user try again — only a *successful* create latches the guard.
+      submitState.current = 'idle'
+      // A bare 401 (the session lapsed mid-form) renders an unstyled "Not
+      // authenticated" with no way forward; offer a sign-in path instead (#70).
+      // The `session_merged` 401 is handled globally by a redirect, so skip it.
+      if (
+        err instanceof ApiError &&
+        err.status === 401 &&
+        !isSessionMergedError(err)
+      ) {
+        setSessionExpired(true)
+        setApiError(err.detail ?? 'Your session has expired.')
+        return
+      }
       setApiError(
         err instanceof ApiError
           ? (err.detail ?? err.message)
@@ -192,8 +219,12 @@ function MatchCard() {
         bestOf={bestOf}
         rated={rated}
         error={error}
+        sessionExpired={sessionExpired}
         submitting={createMatch.isPending}
         onSubmit={handleSubmit}
+        onSignIn={() =>
+          navigate({ to: '/login', search: { email: undefined, error: undefined } })
+        }
         onCancel={() => navigate({ to: '/dashboard' })}
       />
     </div>
@@ -384,16 +415,20 @@ function SubmitRow({
   bestOf,
   rated,
   error,
+  sessionExpired,
   submitting,
   onSubmit,
+  onSignIn,
   onCancel,
 }: {
   opponent: Opponent | null
   bestOf: number
   rated: boolean
   error: string | null
+  sessionExpired: boolean
   submitting: boolean
   onSubmit: () => void
+  onSignIn: () => void
   onCancel: () => void
 }) {
   const effectivelyRated = rated && opponent !== null
@@ -426,11 +461,23 @@ function SubmitRow({
           <span className="dot">·</span>{' '}
           games to 11, win by 2
         </div>
-        {error && (
-          <p className="nm-error" role="alert">
-            {error}
-          </p>
-        )}
+        {error &&
+          (sessionExpired ? (
+            <div className="nm-recovery" role="alert">
+              <p className="nm-error">{error}</p>
+              <button
+                type="button"
+                className="nm-btn nm-btn-primary nm-recovery-btn"
+                onClick={onSignIn}
+              >
+                Sign in again
+              </button>
+            </div>
+          ) : (
+            <p className="nm-error" role="alert">
+              {error}
+            </p>
+          ))}
       </div>
       <div className="actions">
         <button


### PR DESCRIPTION
Three contained fixes to the match-creation submit flow on `/matches/new`. All live in the same form/submit path, so they ship together.

> **Note on branch name:** `fix/scoring-and-ui-polish` is stale — its scoring/settings work (#151, #162, #166) already landed on `main` via another PR and dropped out cleanly on rebase. This PR contains **only** the match-create trio below.

## #76 — Hung POST leaves "Starting…" forever
`useCreateMatch` now attaches `AbortSignal.timeout(15s)` to `POST /v1/matches`. An abort throws a `DOMException` (not an openapi-fetch error result), so the hook catches it and translates it into an `ApiError("Request timed out — please try again.")` — which the form already renders inline, re-enabling the button instead of stranding it on "Starting…".

## #70 — Bare 401 renders an unstyled "Not authenticated" with no recovery
The submit catch now special-cases a non-`session_merged` 401: it sets `sessionExpired` and `SubmitRow` renders a styled recovery block with a **"Sign in again"** button → `/login`. The `session_merged` 401 is still left to the existing global redirect. Opponent selection is preserved.

## #81 — Browser Back / double-click allows a duplicate match
Added a synchronous `submitState` ref (`idle → submitting → done`). It blocks the double-click race *before* `isPending` disables the button, and `'done'` latches after a successful create so a re-submit (e.g. bfcache-restored form) can't create a duplicate. A failed attempt resets to `idle` so retry still works. (The Back-to-form path was already closed by the existing `replace: true` from #441.)

## Tests
`web-client/src/routes/_app/matches/new.test.tsx` — added 3 tests: 401 → "Sign in again" navigates to `/login`; two rapid clicks → exactly one POST; aborted create → inline "timed out" + button re-enabled.

- vitest: 1041/1041 ✓
- lint + `tsc -b` + vite build ✓
- web-client Playwright e2e: 128/128 ✓ (incl. `match-creation.spec.ts`)

## Deliberate non-goals (follow-ups, not bandaids)
The `/simplify` altitude pass flagged two cross-cutting generalizations intentionally left out of this scoped fix:
- A **global request-timeout middleware** in `client.ts` (would affect every request — broad blast radius; per-mutation is correct for #76).
- A **global bare-401 → re-auth handler** (a real future improvement, but a cross-cutting middleware/UX change beyond a match-create fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)