### PR TITLE
Fix 5 security/correctness issues (cookie Secure, token race, Redis fail-closed, entered field, PWA SW)

### DIFF
--- a/api/app/rate_limiting.py
+++ b/api/app/rate_limiting.py
@@ -93,15 +93,20 @@ class RedisRateLimiter:
             return
 
         rate_key = await self._identifier(request)
-        limiter = self._limiters.get(rate_key)
-        if limiter is None:
-            bucket = await RedisBucket.init(
-                self._rates, _redis, f"{self._bucket_key}:{rate_key}"
-            )
-            limiter = Limiter(bucket)
-            self._limiters[rate_key] = limiter
+        try:
+            limiter = self._limiters.get(rate_key)
+            if limiter is None:
+                bucket = await RedisBucket.init(
+                    self._rates, _redis, f"{self._bucket_key}:{rate_key}"
+                )
+                limiter = Limiter(bucket)
+                self._limiters[rate_key] = limiter
 
-        success = await limiter.try_acquire_async(rate_key, blocking=False)
+            success = await limiter.try_acquire_async(rate_key, blocking=False)
+        except redis_asyncio.RedisError:
+            # Redis unavailable mid-request: fall open rather than 500ing the
+            # protected route (matches the behaviour when _redis is None).
+            return
         if not success:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -175,7 +175,6 @@ class TournamentEventCreate(BaseModel):
     draw_type: DrawType
     max_players: int = Field(gt=0)
     entry_fee: float = Field(ge=0)
-    entered: int = 0
     slot: Slot
     match_settings: MatchSettings
     predicates: list[Predicate] = Field(default_factory=list)

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -967,10 +967,12 @@ async def confirm_email(
     """
     token_row = (
         await db.execute(
-            select(UserToken).where(
+            select(UserToken)
+            .where(
                 UserToken.token == _hash_token(payload.token),
                 _pending_email_token_clause(),
             )
+            .with_for_update()
         )
     ).scalar_one_or_none()
     if token_row is None:
@@ -1277,10 +1279,12 @@ async def consume_login_token(
     """
     token_row = (
         await db.execute(
-            select(UserToken).where(
+            select(UserToken)
+            .where(
                 UserToken.token == _hash_token(payload.token),
                 _login_token_clause(),
             )
+            .with_for_update()
         )
     ).scalar_one_or_none()
     if token_row is None:

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -332,7 +332,7 @@ async def create_event(
         draw_type=payload.draw_type,
         max_players=payload.max_players,
         entry_fee=payload.entry_fee,
-        entered=payload.entered,
+        entered=0,
         slot=payload.slot.model_dump(),
         match_settings=payload.match_settings.model_dump(),
         predicates=[p.model_dump() for p in payload.predicates],

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -100,7 +100,6 @@ def _event_payload(**overrides: Any) -> dict[str, Any]:
         "draw_type": "rr-then-ko",
         "max_players": 64,
         "entry_fee": 45,
-        "entered": 52,
         "slot": {"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         "match_settings": {"rated": True, "length_games": 5},
         "predicates": [{"id": "pr-1", "field": "rating", "op": "<", "value": 1500}],
@@ -319,7 +318,7 @@ async def test_create_event_round_trips_jsonb(
     assert body["max_players"] == 64
     # entry_fee is emitted as a JSON number, not a Decimal string.
     assert body["entry_fee"] == 45
-    assert body["entered"] == 52
+    assert body["entered"] == 0
     assert body["slot"] == {"date": "2026-06-13", "start": "09:00", "end": "18:00"}
     assert body["match_settings"] == {"rated": True, "length_games": 5}
     assert body["predicates"] == [

--- a/deploy/uat/values.yaml
+++ b/deploy/uat/values.yaml
@@ -19,7 +19,7 @@ pullPolicy: IfNotPresent
 config:
   DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm
   REDIS_URL: redis://redis:6379/0
-  SESSION_COOKIE_SECURE: "false"
+  SESSION_COOKIE_SECURE: "true"
 
 postgres:
   user: postgres

--- a/docker-compose.uat.yml
+++ b/docker-compose.uat.yml
@@ -61,7 +61,7 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm
       REDIS_URL: redis://redis:6379/0
-      SESSION_COOKIE_SECURE: "false"
+      SESSION_COOKIE_SECURE: "true"
     depends_on:
       postgres:
         condition: service_healthy

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -2408,11 +2408,6 @@ export interface components {
             max_players: number;
             /** Entry Fee */
             entry_fee: number;
-            /**
-             * Entered
-             * @default 0
-             */
-            entered: number;
             slot: components["schemas"]["Slot"];
             match_settings: components["schemas"]["MatchSettings"];
             /** Predicates */

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -220,13 +220,12 @@ const event: TournamentEvent = {
 }
 
 describe('eventToCreateBody', () => {
-  it('maps the event to a snake_case create body, including entered', () => {
+  it('maps the event to a snake_case create body, excluding server-managed entered', () => {
     const body = eventToCreateBody(event)
 
     expect(body.draw_type).toBe('rr-then-ko')
     expect(body.max_players).toBe(48)
     expect(body.entry_fee).toBe(30)
-    expect(body.entered).toBe(41)
     expect(body.match_settings).toEqual({ rated: true, length_games: 3 })
     expect(body.pools).toEqual([
       {
@@ -248,6 +247,9 @@ describe('eventToCreateBody', () => {
       pools: wire.pools ?? [],
       id: event.id,
       tournament_id: 't-1',
+      // `entered` is server-managed and absent from the create body; supply the
+      // read-shape value directly so the round-trip assertion holds.
+      entered: event.entered,
       created_at: '2026-06-01T00:00:00Z',
       updated_at: '2026-06-01T00:00:00Z',
     })

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -154,7 +154,7 @@ function eventToApiFields(ev: TournamentEvent) {
 
 /** Build the event *create* body (POST) from a prototype `TournamentEvent`. */
 export function eventToCreateBody(ev: TournamentEvent): TournamentEventCreate {
-  return { ...eventToApiFields(ev), entered: ev.entered }
+  return eventToApiFields(ev)
 }
 
 /** Build the event *update* body (PATCH) from a prototype `TournamentEvent`.

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -63,10 +63,14 @@ async function unregisterServiceWorkers() {
 
 async function enableMocking() {
   if (!import.meta.env.DEV) {
-    await unregisterServiceWorkers()
+    // Production never loads MSW, so there's nothing to clean up. Calling
+    // unregisterServiceWorkers() here would evict the PWA worker on every
+    // page load before React mounts, defeating the cache entirely.
     return
   }
   if (import.meta.env.VITE_ENABLE_MSW === 'false') {
+    // Dev with MSW disabled (e.g. docker compose real-API mode): clear any
+    // stale MSW worker left from a previous dev-server session.
     await unregisterServiceWorkers()
     return
   }

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -297,7 +297,7 @@ export function createEvent(
     draw_type: body.draw_type,
     max_players: body.max_players,
     entry_fee: body.entry_fee,
-    entered: body.entered ?? 0,
+    entered: 0,
     slot: body.slot,
     match_settings: body.match_settings,
     predicates: body.predicates ?? [],


### PR DESCRIPTION
## Summary

- **UAT cookies missing `Secure`**: `SESSION_COOKIE_SECURE` was `false` in both `deploy/uat/values.yaml` and `docker-compose.uat.yml`. UAT is HTTPS-fronted (Caddy/Tailscale), so session and CSRF cookies need the `Secure` flag. Dev and QA composes remain `false` (plain HTTP).

- **Token consumption race** (`confirm_email` + `consume_login_token`): both endpoints did a bare `SELECT` then `DELETE` in a later step. Two concurrent requests with the same bearer token could both authenticate. Added `SELECT ... FOR UPDATE` so the second concurrent request blocks until the first transaction commits (deleting the token), then finds nothing and returns a 400. Composes with the existing `IntegrityError` guard from #681.

- **Redis rate limiter fail-closed on live errors**: `RedisBucket.init` and `try_acquire_async` were uncaught — a Redis connection drop after startup would 500 any rate-limited route. Now catches `redis.RedisError` and falls open, matching the documented intent and the `_redis is None` startup path.

- **Tournament `entered` writable on create**: `TournamentEventCreate` exposed `entered`, letting callers set the registration count at creation time. Removed from the schema (`extra="forbid"` now rejects it); route hardcodes `0`. `schema.d.ts` regenerated; web client `eventToCreateBody`, MSW mock, and tests updated.

- **PWA service worker evicted in production**: `enableMocking()` called `unregisterServiceWorkers()` in every non-DEV build, killing the Workbox PWA worker on every page load before React mounted — the SW could never serve cached assets. The cleanup is only correct in dev when switching from MSW-enabled to real-API mode (`VITE_ENABLE_MSW=false`).

## Not in this PR (surfaced, need decisions)

- **#5 Rate limits collapse to nginx pod IP** — `request.client.host` is the nginx container IP; needs `--forwarded-allow-ips` scoped to the pod CIDR (not `*`).
- **#4 iOS APNs entitlement hardcoded to `development`** — breaks TestFlight push; needs per-build-configuration xcconfig fix.
- **#9 RBAC last-admin lockout** — `set_user_roles` has no guard preventing removal of the last holder of `authorization.manage`.
- **#2 UAT CAPTCHA key configuration** — verify `.env` has `TURNSTILE_SECRET_KEY` and `VITE_TURNSTILE_SITE_KEY` set.

## Test plan

- [x] `pytest` — 504 passed
- [x] `ruff check/format`, `mypy` — clean
- [x] `vitest` — 1038 passed
- [x] `tsc -b && vite build` — clean
- [x] web Playwright e2e — 128 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)