### PR TITLE
Fix root e2e flake: gate global setup on solver.healthy (#351)

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -13,18 +13,24 @@ const BASE_URL = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${NGINX_PORT}`
 // service has none, so the container is considered ready as soon as the
 // process starts — well before Vite's first compile finishes. Without this
 // probe the first test request races Vite's JIT transforms and times out.
-async function waitForReady(url: string, timeoutMs: number) {
+async function waitForReady(
+  url: string,
+  timeoutMs: number,
+  options: { sleepMs?: number; check?: (res: Response) => Promise<boolean> } = {},
+) {
+  const { sleepMs = 1000, check } = options
   const deadline = Date.now() + timeoutMs
   let lastError: unknown
   while (Date.now() < deadline) {
     try {
       const response = await fetch(url, { redirect: 'manual' })
-      if (response.status < 500) return
+      const ok = check ? await check(response) : response.status < 500
+      if (ok) return
       lastError = new Error(`status ${response.status}`)
     } catch (error) {
       lastError = error
     }
-    await sleep(1000)
+    await sleep(sleepMs)
   }
   throw new Error(`Timed out waiting for ${url} to respond: ${String(lastError)}`)
 }
@@ -54,5 +60,19 @@ export default async function globalSetup() {
   // resolvable/accepting through the proxy). The app fires `GET /v1/session`
   // immediately on load and hangs its session loader if that races the 502
   // window, so also gate on the API *through nginx* before running tests.
-  await waitForReady(`${BASE_URL}/api/v1/health`, 120_000)
+  //
+  // A second race: the RQ worker may not have subscribed to the `solver` queue
+  // yet when /v1/health first responds. The health endpoint enqueues a CP-SAT
+  // probe job — if no worker is listening, it waits 10 s and returns
+  // solver.healthy: false. The admin-system-health test hits that state and
+  // locks to it (staleTime: 0, retry: false, no refetchInterval). Poll until
+  // solver.healthy is true so all workers are definitely up before tests run.
+  await waitForReady(`${BASE_URL}/api/v1/health`, 120_000, {
+    sleepMs: 2000,
+    check: async (res) => {
+      if (!res.ok) return false
+      const body = await res.json() as { solver?: { healthy?: boolean } }
+      return body.solver?.healthy === true
+    },
+  })
 }


### PR DESCRIPTION
## Summary

- Fixes intermittent `admin-system-health` test failure where the RQ worker hadn't yet subscribed to the `solver` queue when global setup finished — the test's first `/v1/health` call returned `solver.healthy: false` and locked to it (no `refetchInterval`, `retry: false`)
- Global setup now polls `/api/v1/health` until `solver.healthy: true` before handing off to tests, closing the race window
- Refactored `waitForReady` with an optional `check` predicate so the solver-health poll reuses the same retry loop (no duplicate boilerplate)

## Test plan

- [x] ruff lint + format — clean
- [x] mypy — 78 files, no issues
- [x] pytest — 504 passed
- [x] vitest — 1038 passed
- [x] web-client lint + build — clean
- [x] web-client e2e — 128 passed
- [x] root e2e (against QA stack) — 4/4 passed, including `admin-system-health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)