### PR TITLE
Fix confirm_email: burn pending token on address-race rollback (#275)

### DIFF
--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -1018,6 +1018,11 @@ async def confirm_email(
     # address first) can surface anywhere in this block — not just at
     # commit. Return the opaque "invalid or expired" so we don't leak
     # who owns the address.
+    #
+    # Capture the token PK before entering the try block so we can
+    # issue a targeted DELETE in the except path without touching the
+    # expired ORM object after rollback.
+    token_id = token_row.id
     raw_session = secrets.token_urlsafe(32)
     try:
         user.email = token_row.sent_to
@@ -1034,6 +1039,11 @@ async def confirm_email(
         await db.commit()
     except IntegrityError:
         await db.rollback()
+        # Burn the pending-change token so the user isn't trapped in a
+        # resend loop: without this, the rollback restores the token and
+        # every subsequent resend+click hits the same IntegrityError.
+        await db.execute(delete(UserToken).where(UserToken.id == token_id))
+        await db.commit()
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="That confirmation link is invalid or expired.",

--- a/api/tests/test_email.py
+++ b/api/tests/test_email.py
@@ -710,6 +710,17 @@ async def test_confirm_email_handles_address_race(
     # Caller's row is untouched — the rollback preserved their prior state.
     assert me.email is None
     assert me.confirmed_at is None
+    # The pending-change token must be burned so the user isn't trapped in a
+    # resend loop where every click hits the same IntegrityError.
+    remaining = (
+        await db_session.execute(
+            select(UserToken).where(
+                UserToken.user_id == me.id,
+                _pending_email_token_clause(),
+            )
+        )
+    ).scalar_one_or_none()
+    assert remaining is None
 
 
 async def test_confirm_email_does_not_require_session(api_client: AsyncClient):


### PR DESCRIPTION
## Summary

- In `confirm_email`, when the email-mutation transaction rolls back due to a unique-constraint race (another user confirmed the same address first), the `db.delete(token_row)` inside the `try` block was also rolled back — leaving the pending-change token intact.
- Every subsequent resend+click would hit the same `IntegrityError`, trapping the user in an infinite loop with no way out except submitting a different address.
- Fix: capture `token_id = token_row.id` before the `try` block, then issue a targeted `DELETE … WHERE id = token_id` + commit in the `except IntegrityError` handler. The user still gets the generic "invalid or expired" error (no address leakage).
- Adds the missing assertion to `test_confirm_email_handles_address_race` (verified it fails against unfixed code and passes after the fix).

## Test plan

- [x] `ruff check` / `ruff format --check` / `mypy` — all clean
- [x] `pytest` — 504/504 passed (including the updated race test)
- [x] New assertion confirmed red → green (ran against unfixed code first)

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)