### PR TITLE
Fix concurrent rating-recompute race with per-league advisory lock

### DIFF
--- a/api/app/ratings/jobs.py
+++ b/api/app/ratings/jobs.py
@@ -57,6 +57,8 @@ async def _recompute_after_merge(user_id: uuid.UUID) -> None:
         )
         if not league_ids:
             return
-        for league_id in league_ids:
+        # Consistent acquisition order prevents deadlocks when two concurrent
+        # jobs for different users share overlapping league sets.
+        for league_id in sorted(league_ids):
             await recompute_league_ratings(session, league_id, {user_id})
         await session.commit()

--- a/api/app/ratings/recompute.py
+++ b/api/app/ratings/recompute.py
@@ -9,13 +9,22 @@ match, growing the affected-users set as we discover them.
 
 Idempotent: reads current state and rewrites it deterministically, so a
 retried call lands on the same result.
+
+Concurrent safety: two workers recomputing the same league would interleave
+DELETE/INSERT under READ COMMITTED and produce a corrupt final row.
+``recompute_league_ratings`` acquires a per-league ``pg_advisory_xact_lock``
+before touching any data; the lock is held for the life of the caller's
+transaction and released on commit or rollback.  The caller must not commit
+mid-loop across multiple leagues, or locks for earlier leagues are released
+before later ones are acquired (see ``app.ratings.jobs``).
 """
 
+import struct
 import uuid
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -34,6 +43,16 @@ from app.models import (
 from app.ratings.base import state_rating_value
 from app.ratings.registry import get_calculator
 from app.ratings.validation import validate_state
+
+
+def _league_lock_key(league_id: uuid.UUID) -> int:
+    """Fold the 128-bit league UUID into a signed 64-bit advisory-lock key.
+
+    XOR of the two 64-bit halves keeps the key stable and collision-free
+    enough for advisory locking (a collision only causes harmless extra
+    serialisation between two different leagues)."""
+    hi, lo = struct.unpack(">qq", league_id.bytes)
+    return int(hi) ^ int(lo)
 
 
 def _decided_sides(match: Match) -> tuple[MatchSide, MatchSide] | None:
@@ -78,6 +97,15 @@ async def recompute_league_ratings(
     calculator = get_calculator(strategy.key)
     if calculator is None:
         return
+
+    # Serialise concurrent recomputes for this league. Two workers racing on
+    # the same league would interleave DELETE/INSERT under READ COMMITTED and
+    # corrupt the final rating row. The lock is transaction-scoped and released
+    # automatically when the caller commits or rolls back.
+    await db.execute(
+        text("SELECT pg_advisory_xact_lock(:key)"),
+        {"key": _league_lock_key(league_id)},
+    )
 
     # updated_at is set when the match completes, which is the moment
     # ratings move — and what we order the replay by.

--- a/api/tests/test_rating_recompute.py
+++ b/api/tests/test_rating_recompute.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import select, text
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from app.leagues import get_default_league
 from app.models import (
@@ -22,7 +22,7 @@ from app.models import (
     RatingStrategy,
     UserLeagueRating,
 )
-from app.ratings.recompute import recompute_league_ratings
+from app.ratings.recompute import _league_lock_key, recompute_league_ratings
 from tests._helpers import make_user
 
 # ----- fixtures + helpers -------------------------------------------------
@@ -410,3 +410,36 @@ async def test_recompute_is_idempotent(
         .all()
     )
     assert len(rows) == 1
+
+
+# ----- advisory lock -------------------------------------------------------
+
+
+async def test_recompute_holds_advisory_lock_for_transaction(
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+) -> None:
+    """``recompute_league_ratings`` must hold a per-league advisory lock for
+    the duration of the caller's transaction so a concurrent worker cannot
+    interleave its own DELETE/INSERT on the same league.
+
+    Proof: call recompute in session 1 (no commit), then try to grab the same
+    lock from session 2 — ``pg_try_advisory_xact_lock`` must return ``false``."""
+    league = await get_default_league(db_session)
+
+    # Session 1 acquires the lock (no seed users → early-exit after lock,
+    # before any match data is needed).
+    await recompute_league_ratings(db_session, league.id, set())
+
+    lock_key = _league_lock_key(league.id)
+    sm = async_sessionmaker(engine, expire_on_commit=False)
+    async with sm() as session2:
+        result = await session2.execute(
+            text("SELECT pg_try_advisory_xact_lock(:key)"),
+            {"key": lock_key},
+        )
+        acquired = result.scalar_one()
+
+    assert acquired is False, (
+        "advisory lock should be held by session 1's open transaction"
+    )


### PR DESCRIPTION
Fixes #246.

## Summary

- Two RQ workers recomputing the same league interleave `DELETE`/`INSERT` under `READ COMMITTED`, corrupting the final `user_league_ratings` row. Fixed by acquiring `pg_advisory_xact_lock` keyed on `league_id` at the top of `recompute_league_ratings`, before any reads or writes. The lock is transaction-scoped and releases automatically on commit/rollback.
- Sorted `league_ids` in `_recompute_after_merge` so concurrent jobs always acquire locks in the same order, preventing deadlocks when two users share overlapping league sets.
- Added a deterministic lock-contention test: session 2's `pg_try_advisory_xact_lock` returns `false` while session 1 holds an uncommitted recompute transaction.

## Test plan

- [ ] `pytest tests/test_rating_recompute.py` — all 8 tests pass including new `test_recompute_holds_advisory_lock_for_transaction`
- [ ] Full API suite: 505/505 passed
- [ ] Web-client vitest: 1038/1038 passed, lint + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)