### PR TITLE
Fix mobile matches list: stack rows into cards at ≤640px (#157)

### DIFF
--- a/web-client/src/components/matches/match-list/match-list-table/match-list-row.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table/match-list-row.tsx
@@ -81,7 +81,7 @@ export const MatchListRow = ({ row, navigate }: MatchListRowProps) => {
       }}
     >
       <td className="id-cell">{row.shortLabel}</td>
-      <td>
+      <td data-cell="players">
         <div className="players-cell">
           <PlayerChip chip={row.side1} />
           <span className="players-vs">vs</span>

--- a/web-client/src/components/matches/match-list/match-list-table/match-list-row.tsx
+++ b/web-client/src/components/matches/match-list/match-list-table/match-list-row.tsx
@@ -88,16 +88,16 @@ export const MatchListRow = ({ row, navigate }: MatchListRowProps) => {
           <PlayerChip chip={row.side2} />
         </div>
       </td>
-      <td>
+      <td data-label="Score">
         <ScoreCell score={row.score} />
       </td>
-      <td>
+      <td data-label="Status">
         <StatusBadge status={row.status} />
       </td>
-      <td>
+      <td data-label="Started">
         <TimeCell time={row.time} />
       </td>
-      <td onClick={(e) => e.stopPropagation()}>
+      <td className="action-cell" onClick={(e) => e.stopPropagation()}>
         {row.action !== null ? (
           <Button
             asChild

--- a/web-client/src/components/matches/match-list/match-list.css
+++ b/web-client/src/components/matches/match-list/match-list.css
@@ -550,3 +550,85 @@
   font-size: 12px;
   color: var(--fg-3);
 }
+
+/* On a phone the six-column table forces awkward horizontal scrolling: a row's
+ * score, status, and action sit off-screen with no scroll cue, so a user can't
+ * tell a match is live or take any action (#157). Below 640px collapse the
+ * table into one stacked card per row, each field labeled from its column
+ * header (via `data-label`). This overrides the ≤960px `max-content` scroll
+ * width above, so cards never reintroduce horizontal scroll. The 640–960px
+ * band (tablets / narrow desktop) keeps the scrolling table. */
+@container (max-width: 640px) {
+  .match-list-page table.matches,
+  .match-list-page table.matches tbody {
+    display: block;
+    min-width: 0;
+  }
+  /* Column headers live inside each card now (see td::before). */
+  .match-list-page table.matches thead {
+    display: none;
+  }
+  .match-list-page table.matches tbody tr {
+    display: block;
+    margin: 12px;
+    padding: 14px 16px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 12px;
+    background: var(--bg-card);
+  }
+  .match-list-page table.matches tbody tr:hover {
+    background: var(--bg-card);
+  }
+  /* The live rail moves from the first cell's inset shadow to the card edge. */
+  .match-list-page table.matches tbody tr.is-live {
+    border-left: 2px solid var(--serve-500);
+  }
+  .match-list-page table.matches tbody tr.is-live td:first-child {
+    box-shadow: none;
+  }
+  .match-list-page table.matches tbody td {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 6px 0;
+    border-bottom: none;
+    white-space: normal;
+  }
+  /* Labeled cells (Score / Status / Started) get the column name as a leading
+   * caption, matching the thead styling. */
+  .match-list-page table.matches tbody td[data-label]::before {
+    content: attr(data-label);
+    flex: none;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  /* Match id: a quiet caption at the top of the card, no value column. */
+  .match-list-page table.matches tbody td.id-cell {
+    padding-top: 0;
+    justify-content: flex-start;
+  }
+  /* Players: the card's headline — full width, left-aligned, no scrunching. */
+  .match-list-page table.matches tbody td:nth-child(2) {
+    padding-top: 2px;
+    padding-bottom: 10px;
+  }
+  .match-list-page table.matches tbody td:nth-child(2) .players-cell {
+    gap: 8px;
+  }
+  /* The action button is the card's primary CTA — give it the full width. */
+  .match-list-page table.matches tbody td.action-cell {
+    padding-top: 12px;
+  }
+  /* A passive row (no CTA) leaves an empty action cell — collapse it so the
+   * card doesn't carry dead trailing space. */
+  .match-list-page table.matches tbody td.action-cell:empty {
+    display: none;
+  }
+  .match-list-page table.matches tbody td.action-cell > * {
+    width: 100%;
+  }
+}

--- a/web-client/src/components/matches/match-list/match-list.css
+++ b/web-client/src/components/matches/match-list/match-list.css
@@ -559,10 +559,14 @@
  * width above, so cards never reintroduce horizontal scroll. The 640–960px
  * band (tablets / narrow desktop) keeps the scrolling table. */
 @container (max-width: 640px) {
-  .match-list-page table.matches,
-  .match-list-page table.matches tbody {
+  /* `min-width: 0` lets the table (a flex item in `.table-wrap`) shrink below
+   * its content width, undoing the ≤960px `max-content` scroll rule. */
+  .match-list-page table.matches {
     display: block;
     min-width: 0;
+  }
+  .match-list-page table.matches tbody {
+    display: block;
   }
   /* Column headers live inside each card now (see td::before). */
   .match-list-page table.matches thead {
@@ -612,11 +616,11 @@
     justify-content: flex-start;
   }
   /* Players: the card's headline — full width, left-aligned, no scrunching. */
-  .match-list-page table.matches tbody td:nth-child(2) {
+  .match-list-page table.matches tbody td[data-cell='players'] {
     padding-top: 2px;
     padding-bottom: 10px;
   }
-  .match-list-page table.matches tbody td:nth-child(2) .players-cell {
+  .match-list-page table.matches tbody td[data-cell='players'] .players-cell {
     gap: 8px;
   }
   /* The action button is the card's primary CTA — give it the full width. */

--- a/web-client/src/components/matches/match-list/match-list.css
+++ b/web-client/src/components/matches/match-list/match-list.css
@@ -480,6 +480,10 @@
   padding: 18px 16px;
 }
 .match-list-page .skeleton-line {
+  /* Fill the cell in both layouts: a block child stretches to the cell width
+   * on desktop, but the ≤640px card rule makes the cell a flex container, where
+   * this empty div would otherwise collapse to zero width (no shimmer bar). */
+  width: 100%;
   height: 14px;
   border-radius: 4px;
   background: linear-gradient(
@@ -559,8 +563,9 @@
  * width above, so cards never reintroduce horizontal scroll. The 640–960px
  * band (tablets / narrow desktop) keeps the scrolling table. */
 @container (max-width: 640px) {
-  /* `min-width: 0` lets the table (a flex item in `.table-wrap`) shrink below
-   * its content width, undoing the ≤960px `max-content` scroll rule. */
+  /* `min-width: 0` cancels the ≤960px `min-width: max-content` scroll rule
+   * (same specificity, later source order wins) so the block-laid-out table
+   * shrinks to the wrap instead of overflowing it. */
   .match-list-page table.matches {
     display: block;
     min-width: 0;


### PR DESCRIPTION
Closes #157.

## Problem
At 375px the `/matches` table showed only **Match #** and **Opponent**; **Score, Status, Started, and the row action** were clipped/scrolled off-screen. #658 made every column *reachable* via horizontal scroll, but a wide data table scrolling sideways on a phone (with no scroll cue) is a poor affordance — a user still can't see at a glance whether a match is live or take a row action.

## Fix
Below **640px**, collapse the table into one **stacked card per row** (the issue's stated first preference). Implemented as a CSS-only transform on the existing `container-type: inline-size` table wrap — no JS/card component, the presentational row cells are reused as-is:

- Column headers become per-field captions via `data-label` (`Score` / `Status` / `Started`).
- The live rail moves from the first cell's inset shadow to the card's **left border**.
- The row action becomes a **full-width CTA**; passive rows collapse their empty action cell.
- The override block sits at the end of the stylesheet so it wins the specificity tie against the base `tbody td` rule (and resets the `≤960px` `max-content` scroll width, so cards never reintroduce horizontal scroll).
- The **640–960px** band (tablets / narrow-desktop after the sidebar collapses) keeps the existing scrolling table; desktop is unchanged.

## Verification
Rendered at **375px** in a headless Chromium against the dev server:
- All fields visible, `table-wrap` `scrollWidth === clientWidth` (no horizontal overflow).
- Actionable rows show a full-width "Enter score" button; FINAL/SCHEDULED rows show no button.
- Live row shows the green left-border rail.
- Desktop (1280px) full table unchanged.

`tsc -b`, `lint`, `vite build`, and the full vitest suite (1041 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)