### PR TITLE
Remove the "Play" heading from the sidenav

### DIFF
--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -46,7 +46,6 @@ type NavSection = {
 
 const NAV_SECTIONS: NavSection[] = [
   {
-    label: 'Play',
     items: [
       {
         label: 'Dashboard',


### PR DESCRIPTION
## What

Removes the **Play** section heading from the sidebar navigation. The first
nav section now renders without a label — matching the unlabeled Administration
section directly below it. The nav items underneath (Dashboard, Matches,
Players, Tournaments, Notifications) are unchanged.

Single-line change: drop `label: 'Play'` from `NAV_SECTIONS[0]` in
`web-client/src/components/app-shell.tsx`. The render path already guards on
`section.label` (`{section.label ? <div className="app-shell__nav-label">… : null}`),
so no rendering changes were needed.

## Testing

- `npm run test:run` — 1041 passed
- `npm run lint` — 0 errors
- `npm run build` (tsc -b && vite build) — clean
- `npm run test:e2e` — 128 passed (incl. `nav-gating.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)