### PR TITLE
Fix #183: fail loud on doubles rating updates instead of silent skip

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1550,8 +1550,6 @@ async def _apply_rating_update(db: AsyncSession, match: Match) -> None:
         return
     if not match.match_settings.affects_rating:
         return
-    if match.match_settings.team_size != 1:
-        return
 
     league = match.league
     strategy = league.rating_strategy
@@ -1560,6 +1558,20 @@ async def _apply_rating_update(db: AsyncSession, match: Match) -> None:
     calculator = get_calculator(strategy.key)
     if calculator is None:
         return
+
+    # Doubles tripwire. This match would have received an automatic rating
+    # update (completed + rated + automatic strategy + calculator present) but
+    # the calculator only knows ``update_singles``. Fail loud rather than
+    # silently skip — a doubles match that completes without moving ratings is
+    # an easy bug to miss. Unreachable today (match creation hardcodes
+    # team_size=1), this trips the moment doubles support lands without a
+    # doubles-aware calculator. See https://github.com/mightymoose/fortymm/issues/183
+    if match.match_settings.team_size != 1:
+        raise NotImplementedError(
+            "Rating updates for doubles (team_size != 1) are not implemented; "
+            "add a doubles-aware calculator before enabling doubles matches "
+            "(see issue #183)."
+        )
 
     already_applied = (
         await db.execute(

--- a/api/app/ratings/base.py
+++ b/api/app/ratings/base.py
@@ -5,7 +5,9 @@ class RatingCalculator(Protocol):
     """A strategy that knows how to update player ratings after a singles match.
 
     The hook in ``app.matches`` only calls singles for v1 — doubles is unwired
-    on the match-creation side (team_size hardcoded to 1). Add a doubles method
+    on the match-creation side (team_size hardcoded to 1). A runtime guard in
+    ``_apply_rating_update`` raises ``NotImplementedError`` if a doubles match
+    ever reaches the rating hook (see issue #183); add a doubles method here
     when that opens up.
     """
 

--- a/api/tests/test_ratings.py
+++ b/api/tests/test_ratings.py
@@ -9,8 +9,14 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.matches import _apply_rating_update, _load_match
 from app.models import (
     League,
+    Match,
+    MatchSettings,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
     RatingHistory,
     RatingHistorySource,
     RatingStrategy,
@@ -113,6 +119,53 @@ def test_validate_state_rejects_extra_keys(
             {"rating": 1500.0, "rd": 350.0, "volatility": 0.06, "extra": 1},
             rating_strategies["glicko2"],
         )
+
+
+# ----- hook: doubles tripwire ----------------------------------------------
+
+
+async def test_doubles_match_rating_update_raises_not_implemented(
+    db_session: AsyncSession,
+    default_league: League,
+):
+    """A completed, rated, automatic-strategy match with ``team_size != 1``
+    must fail loud rather than silently skip its rating update — the calculator
+    only knows singles. Match creation hardcodes team_size=1 so this is
+    unreachable today; the guard trips the moment doubles support lands without
+    a doubles-aware calculator (issue #183)."""
+    winner = await make_user(db_session, "doubles-winner")
+    loser = await make_user(db_session, "doubles-loser")
+
+    settings = MatchSettings(team_size=2, best_of=1, affects_rating=True)
+    match = Match(
+        match_settings=settings,
+        league=default_league,
+        created_by_user_id=winner.id,
+        status=MatchStatus.completed,
+    )
+    side1 = MatchSide(match=match, side_number=1, won=True, score=1)
+    side1.players.append(MatchSidePlayer(match=match, user=winner))
+    side2 = MatchSide(match=match, side_number=2, won=False, score=0)
+    side2.players.append(MatchSidePlayer(match=match, user=loser))
+    db_session.add(match)
+    await db_session.commit()
+
+    loaded = await _load_match(db_session, match.id)
+    assert loaded is not None
+    with pytest.raises(NotImplementedError, match="doubles"):
+        await _apply_rating_update(db_session, loaded)
+
+    # Nothing was written — the guard fires before any history row.
+    rows = (
+        (
+            await db_session.execute(
+                select(RatingHistory).where(RatingHistory.match_id == match.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
 
 
 # ----- hook: end-to-end through the score endpoint -------------------------


### PR DESCRIPTION
## What

`_apply_rating_update` in `api/app/matches.py` early-returned for any match with `team_size != 1`, so the moment doubles support lands, two-on-two matches would **silently** never move ratings — an easy bug to miss ([#183](https://github.com/mightymoose/fortymm/issues/183)).

This replaces the silent `return` with a fail-loud `raise NotImplementedError`, honoring the issue author's stated preference for failing loud over a silent skip.

## Key decisions

- **Placement:** the guard now sits *below* the `is_automatic` / `calculator is None` gates, not above them. A doubles match on a **manual** (non-automatic) rating strategy was always a legitimate no-op — raising there would turn a valid no-op into a 500. The guard now fires only for a match that genuinely *would* have received an automatic singles update but can't because it's doubles — exactly the condition the issue describes.
- **Behavior:** both call sites (`/results` solo-finalize and `/confirmation`) run before `db.commit()`, so the raise rolls the finalize back rather than committing a rating-less completion.
- **No routing-level guard:** match creation hardcodes `team_size=1`, so there is no doubles input to reject at the route today. The rating hook is the only place that can fail loud.
- Cross-referenced the runtime guard in the `RatingCalculator` Protocol docstring (`api/app/ratings/base.py`) so it's discoverable.

Out of scope (noted in the issue): `recompute.py` excludes doubles via a SQL `team_size == 1` filter — correct batch behavior, not the silent-skip this issue targets.

## Tests

- New unit test builds a `team_size=2` completed/rated match directly (creation still hardcodes `team_size=1`) and asserts `_apply_rating_update` raises `NotImplementedError` and writes no history rows.
- Full API suite green: `ruff check`, `ruff format --check`, `mypy` (strict), `pytest` (507 passed). No OpenAPI schema drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)