### PR TITLE
Make "Recent opponents" honest: drop the stranger backfill (#167)

### DIFF
--- a/api/app/players.py
+++ b/api/app/players.py
@@ -92,18 +92,19 @@ async def list_recent_opponents(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> list[PlayerRead]:
-    """Opponents to feature in the new-match picker.
+    """Opponents the caller has actually played, for the new-match picker.
 
-    Ranked by how recently the caller last played them (most recent first).
-    A player with little or no match history is backfilled with other
-    registered users, alphabetically, so the list is never short or empty.
+    Ranked by how recently the caller last played them (most recent first),
+    tie-broken alphabetically. Returns only real opponents — a caller with no
+    match history gets an empty list, so the picker never presents strangers as
+    "recent opponents" (#167).
     """
     # Join the caller's side and the opponent's side of each shared match so
     # the database returns hydrated User rows already ordered by recency —
     # one round trip, no Python re-sort.
     opp = aliased(MatchSidePlayer)
     mine = aliased(MatchSidePlayer)
-    opponents = list(
+    opponents = (
         (
             await db.execute(
                 select(User)
@@ -122,9 +123,7 @@ async def list_recent_opponents(
                 )
                 .group_by(User.id)
                 # Stable tiebreaker so ties on created_at (seed data, tests,
-                # concurrent creates) don't reorder across requests. Matches
-                # the alphabetical backfill below, so the list reads as one
-                # coherent order.
+                # concurrent creates) don't reorder across requests.
                 .order_by(func.max(Match.created_at).desc(), User.username)
                 .limit(limit)
             )
@@ -132,26 +131,6 @@ async def list_recent_opponents(
         .scalars()
         .all()
     )
-
-    if len(opponents) < limit:
-        played_ids = [user.id for user in opponents]
-        backfill = (
-            (
-                await db.execute(
-                    select(User)
-                    .where(
-                        User.id != current_user.id,
-                        User.merged_into_user_id.is_(None),
-                        User.id.notin_(played_ids),
-                    )
-                    .order_by(User.username)
-                    .limit(limit - len(opponents))
-                )
-            )
-            .scalars()
-            .all()
-        )
-        opponents.extend(backfill)
 
     league = await resolve_league(db, league_id)
     ratings = await _load_player_ratings(db, league.id, (user.id for user in opponents))

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -120,7 +120,7 @@ async def test_recent_opponents_dedupes_repeated_opponents(
     assert _usernames(response) == ["ana", "bo"]
 
 
-async def test_recent_opponents_backfills_with_other_players(
+async def test_recent_opponents_excludes_never_played_users(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     me = await start_session(api_client, db_session)
@@ -132,11 +132,11 @@ async def test_recent_opponents_backfills_with_other_players(
 
     response = await api_client.get("/v1/players/recent")
     assert response.status_code == 200
-    # The played opponent leads; never-played users backfill alphabetically.
-    assert _usernames(response) == ["rival", "amy", "zoe"]
+    # Only the actual opponent — strangers are no longer backfilled (#167).
+    assert _usernames(response) == ["rival"]
 
 
-async def test_recent_opponents_for_a_new_player_is_a_non_empty_default(
+async def test_recent_opponents_for_a_new_player_is_empty(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     await start_session(api_client, db_session)
@@ -147,8 +147,9 @@ async def test_recent_opponents_for_a_new_player_is_a_non_empty_default(
 
     response = await api_client.get("/v1/players/recent")
     assert response.status_code == 200
-    # No match history at all — fall back to the alphabetical roster.
-    assert _usernames(response) == ["alice", "bob", "charlie"]
+    # No match history at all → empty, not a roster of strangers (#167). The
+    # picker steers the new user to search/solo instead.
+    assert response.json() == []
 
 
 async def test_recent_opponents_excludes_the_current_user(
@@ -195,9 +196,12 @@ async def test_recent_opponents_is_empty_without_other_users(
 async def test_recent_opponents_respects_the_limit(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    await start_session(api_client, db_session)
-    for name in ("ana", "bo", "cy", "di"):
-        await make_user(db_session, name)
+    me = await start_session(api_client, db_session)
+    for offset, name in enumerate(("ana", "bo", "cy", "di")):
+        opponent = await make_user(db_session, name)
+        await _record_match(
+            db_session, me, opponent, created_at=BASE_TIME - timedelta(days=offset)
+        )
 
     response = await api_client.get("/v1/players/recent", params={"limit": 2})
     assert response.status_code == 200

--- a/web-client/e2e/match-creation.spec.ts
+++ b/web-client/e2e/match-creation.spec.ts
@@ -50,12 +50,15 @@ test.describe('New match — page', () => {
     }
   })
 
-  test('shows an empty state when there are no other players', async ({
+  test('shows an empty state but keeps search when the caller has no opponents yet (#167)', async ({
     page,
   }) => {
     const nm = await NewMatchPage.open(page, { players: [] })
 
     await expect(nm.emptyPlayers).toBeVisible()
+    // An empty grid no longer means an empty roster — search is the way to
+    // find a first opponent, so it stays reachable.
+    await expect(nm.searchAllButton).toBeVisible()
   })
 })
 

--- a/web-client/e2e/opponent-picker.spec.ts
+++ b/web-client/e2e/opponent-picker.spec.ts
@@ -50,13 +50,15 @@ test.describe('Opponent picker — recent opponents', () => {
     ])
   })
 
-  test('shows an empty state and hides search when nobody else exists', async ({
+  test('shows an empty state but keeps search when the caller has no opponents yet (#167)', async ({
     page,
   }) => {
     const nm = await NewMatchPage.open(page, { players: [] })
 
     await expect(nm.emptyPlayers).toBeVisible()
-    await expect(nm.searchAllButton).toBeHidden()
+    // An empty grid no longer means an empty roster — search is the way to
+    // find a first opponent, so it stays reachable.
+    await expect(nm.searchAllButton).toBeVisible()
   })
 
   test('surfaces a retry button when recent opponents fail to load', async ({

--- a/web-client/e2e/page-objects/matches/new-match.page.ts
+++ b/web-client/e2e/page-objects/matches/new-match.page.ts
@@ -62,7 +62,7 @@ export class NewMatchPage {
     this.selectedOpponentName = page.locator('.nm-selected .name')
     this.summaryTop = page.locator('.nm-summary .top')
     this.summarySub = page.locator('.nm-summary .sub')
-    this.emptyPlayers = page.getByText(/no other players yet/i)
+    this.emptyPlayers = page.getByText(/no opponents yet/i)
     this.recentSkeleton = page.getByRole('status', { name: /loading players/i })
     this.pickerError = page.locator('.nm-picker-error')
     this.pickerRetry = page.getByRole('button', { name: /try again/i })

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -91,9 +91,10 @@ export function matchScoreMutationPrefix(matchId: string) {
 }
 
 /**
- * Opponents to feature in the new-match picker, most-recently-played first
- * (backfilled with other registered players by the API). Errors are thrown so
- * the surrounding error boundary can render a retry affordance.
+ * Opponents the caller has actually played, most-recently-played first, for the
+ * new-match picker. Empty for a caller with no match history — the picker falls
+ * back to search/solo (#167). Errors are thrown so the surrounding error
+ * boundary can render a retry affordance.
  */
 export function useRecentOpponents(options: { enabled?: boolean } = {}) {
   return useQuery({

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -561,11 +561,12 @@ export interface paths {
         };
         /**
          * List Recent Opponents
-         * @description Opponents to feature in the new-match picker.
+         * @description Opponents the caller has actually played, for the new-match picker.
          *
-         *     Ranked by how recently the caller last played them (most recent first).
-         *     A player with little or no match history is backfilled with other
-         *     registered users, alphabetically, so the list is never short or empty.
+         *     Ranked by how recently the caller last played them (most recent first),
+         *     tie-broken alphabetically. Returns only real opponents — a caller with no
+         *     match history gets an empty list, so the picker never presents strangers as
+         *     "recent opponents" (#167).
          */
         get: operations["list_recent_opponents_v1_players_recent_get"];
         put?: never;

--- a/web-client/src/components/matches/opponent-picker/recent-opponents.page.tsx
+++ b/web-client/src/components/matches/opponent-picker/recent-opponents.page.tsx
@@ -15,7 +15,7 @@ const scoped = (container: Container) => ({
   queryChip(name: string | RegExp) {
     return container.queryByRole('button', { name })
   },
-  /** The "Search all players" affordance, hidden until chips exist. */
+  /** The "Search all players" affordance, available whenever loaded. */
   querySearchAll() {
     return container.queryByRole('button', { name: /search all players/i })
   },
@@ -23,12 +23,12 @@ const scoped = (container: Container) => ({
   queryLoading() {
     return container.queryByRole('status', { name: /loading players/i })
   },
-  /** The "no other players yet" empty state. */
+  /** The "no opponents yet" empty state. */
   queryEmpty() {
-    return container.queryByText(/no other players yet/i)
+    return container.queryByText(/no opponents yet/i)
   },
   findEmpty() {
-    return container.findByText(/no other players yet/i)
+    return container.findByText(/no opponents yet/i)
   },
 })
 

--- a/web-client/src/components/matches/opponent-picker/recent-opponents.test.tsx
+++ b/web-client/src/components/matches/opponent-picker/recent-opponents.test.tsx
@@ -70,11 +70,13 @@ describe('RecentOpponents', () => {
     expect(searched).toBe(true)
   })
 
-  it('shows an empty state and hides search when nobody else exists', async () => {
+  it('shows an empty state but still offers search when the caller has no history (#167)', async () => {
     recentOpponentsPage.mockRecent(() => HttpResponse.json([]))
     recentOpponentsPage.render()
 
     await recentOpponentsPage.findEmpty()
-    expect(recentOpponentsPage.querySearchAll()).not.toBeInTheDocument()
+    // Search is the way forward for a player with no opponents yet, so it must
+    // stay reachable even when the grid is empty.
+    expect(recentOpponentsPage.querySearchAll()).toBeInTheDocument()
   })
 })

--- a/web-client/src/components/matches/opponent-picker/recent-opponents.tsx
+++ b/web-client/src/components/matches/opponent-picker/recent-opponents.tsx
@@ -31,9 +31,10 @@ function RecentSkeleton() {
 }
 
 /**
- * The default opponent-picker view: a grid of recently-played opponents
- * (backfilled with other registered players by the API), plus a "Search all
- * players" affordance that hands off to the typeahead. Errors throw to the
+ * The default opponent-picker view: a grid of the caller's actual recent
+ * opponents, plus a "Search all players" affordance that hands off to the
+ * typeahead. A caller with no match history sees an empty state pointing at
+ * search rather than a roster of strangers (#167). Errors throw to the
  * surrounding `OpponentPickerBoundary`.
  */
 export const RecentOpponents = ({
@@ -53,7 +54,9 @@ export const RecentOpponents = ({
     <div>
       <div className="nm-recent-label">
         <span>Recent opponents</span>
-        {!isLoading && players.length > 0 && (
+        {/* Search is always reachable once loaded — a caller with no history
+            now sees an empty grid, and search is their way forward (#167). */}
+        {!isLoading && (
           <button
             type="button"
             className="search-btn"
@@ -67,8 +70,8 @@ export const RecentOpponents = ({
         <RecentSkeleton />
       ) : players.length === 0 ? (
         <div className="nm-no-match">
-          No other players yet. Start the match without picking one for a
-          casual solo session.
+          No opponents yet — use Search to find a player, or start the match
+          without one for a casual solo session.
         </div>
       ) : (
         <div className="nm-recent-grid">

--- a/web-client/src/routes/_app/matches/new.test.tsx
+++ b/web-client/src/routes/_app/matches/new.test.tsx
@@ -547,17 +547,18 @@ describe('NewMatchPage — recent opponents', () => {
     expect(names).toEqual(['carol.recent', 'alice.older', 'bob.oldest'])
   })
 
-  it('shows an empty state when there are no other players', async () => {
+  it('shows an empty state but keeps search when the caller has no opponents yet (#167)', async () => {
     server.use(http.get('*/v1/players/recent', () => HttpResponse.json([])))
     renderNewMatch()
 
     expect(
-      await screen.findByText(/no other players yet/i),
+      await screen.findByText(/no opponents yet/i),
     ).toBeInTheDocument()
-    // With nobody to find, the search affordance is hidden.
+    // The empty grid no longer means an empty roster — search is the way to
+    // find a first opponent, so it stays available.
     expect(
-      screen.queryByRole('button', { name: /search all players/i }),
-    ).not.toBeInTheDocument()
+      screen.getByRole('button', { name: /search all players/i }),
+    ).toBeInTheDocument()
   })
 
   it('shows a retry button when recent opponents fail to load, and recovers', async () => {


### PR DESCRIPTION
## What

`GET /v1/players/recent` (the new-match opponent picker) used to **backfill** its list with other registered users whenever the caller had little or no real match history — so a brand-new user saw four "Recent opponents" they'd never played. This drops the backfill: the endpoint now returns **only opponents the caller has actually played** (empty for a user with no history), matching the issue's recommended **Option B**.

Closes #167.

## Changes

- **API** (`api/app/players.py`): removed the stranger-backfill query from `list_recent_opponents`; ranked-by-recency real opponents only. Docstring updated (kept to the API's own contract).
- **FE** (`recent-opponents.tsx`): empty-state copy → "No opponents yet — use Search to find a player, or start the match without one for a casual solo session.", and the **Search all players** affordance now stays reachable when the grid is empty (it was hidden before — a dead end for new users).
- Updated `matches.ts` JSDoc, the regenerated `schema.d.ts`, the page object, and the vitest + Playwright tests (component, route, and both e2e empty-state specs).

## Don't break (per issue)

- Search-all-players + solo/TBD affordances unchanged.
- Dashboard "Closely matched" suggestion (#161) untouched.

## Testing

- API: `ruff` + `ruff format --check` + `mypy` (strict) + `pytest` — 506 passed.
- web-client: `vitest` (1041 passed), `lint`, `build` (tsc + vite), Playwright e2e (128 passed).
- OpenAPI schema regenerated; no drift.

## Follow-up (out of scope)

- iOS new-match empty state (`NewMatchView.swift`) still says "No other players yet" — same stale framing, now also fed by this API change. Flagged as a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)