### PR TITLE
iOS: align new-match empty-state copy with post-#167 semantics

### DIFF
--- a/ios/Fortymm/MatchFlow/NewMatchView.swift
+++ b/ios/Fortymm/MatchFlow/NewMatchView.swift
@@ -169,7 +169,7 @@ struct NewMatchView: View {
             } else if recentFailed {
                 pickerNote("Couldn't load players. Search to find an opponent.")
             } else if recent.isEmpty {
-                pickerNote("No other players yet — start a solo match or search.")
+                pickerNote("No opponents yet — use Search to find a player, or start a solo match.")
             } else {
                 LazyVGrid(columns: [GridItem(.flexible(), spacing: 9), GridItem(.flexible(), spacing: 9)], spacing: 9) {
                     ForEach(recent) { p in


### PR DESCRIPTION
## What

Updates the iOS new-match opponent-picker empty-state copy in `NewMatchView.swift`:

- **Before:** "No other players yet — start a solo match or search."
- **After:** "No opponents yet — use Search to find a player, or start a solo match."

## Why

[#167](https://github.com/mightymoose/fortymm/pull/695) changed `GET /v1/players/recent` to stop backfilling the recent-opponents list with strangers — it now returns only opponents the caller has actually played, and an empty list for a user with no match history. So an empty grid no longer means "no other players exist"; it means the user has no recent opponents yet. The old copy was stale.

The web client was already updated to match ("No opponents yet — use Search to find a player, or start the match without one for a casual solo session."); this brings iOS into line.

This is a pure copy change. The "Search all" affordance lives outside the `recent.isEmpty` branch (`NewMatchView.swift:158`), so it stays reachable in the empty state.

> Note: scoped to iOS only and based on `main`. The api/web half ships separately via the open PR #695.

## Testing

- Clean simulator build: `rm -rf ios/build/sim && xcodebuild ... build` → **BUILD SUCCEEDED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)