### PR TITLE
Show the player's rating across all New Match opponent-picker surfaces

### DIFF
--- a/web-client/src/components/matches/opponent-picker/recent-opponents.test.tsx
+++ b/web-client/src/components/matches/opponent-picker/recent-opponents.test.tsx
@@ -26,12 +26,23 @@ describe('RecentOpponents', () => {
     )
     recentOpponentsPage.render()
 
-    // Recent chips always read as "registered player", and the "GR" initials
-    // are not part of the accessible name.
-    const chip = await recentOpponentsPage.findChip(
-      'grace.hopper, REGISTERED PLAYER',
+    // A rated chip reads as its rating, and the "GR" initials are not part of
+    // the accessible name.
+    const chip = await recentOpponentsPage.findChip('grace.hopper, RATING 1500')
+    expect(chip).toHaveAccessibleName('grace.hopper, RATING 1500')
+  })
+
+  it('labels a rated chip by its rating, matching the search row', async () => {
+    recentOpponentsPage.mockRecent(() =>
+      HttpResponse.json([
+        buildPlayer({ id: 'pl-1', username: 'alan.turing', rating: 1662 }),
+      ]),
     )
-    expect(chip).toHaveAccessibleName('grace.hopper, REGISTERED PLAYER')
+    recentOpponentsPage.render()
+
+    expect(
+      await recentOpponentsPage.findChip('alan.turing, RATING 1662'),
+    ).toBeInTheDocument()
   })
 
   it('renders a readable fallback name for a blank username (#101)', async () => {

--- a/web-client/src/components/matches/opponent-picker/recent-opponents.tsx
+++ b/web-client/src/components/matches/opponent-picker/recent-opponents.tsx
@@ -3,8 +3,9 @@ import { useSession } from '@/api/session'
 import { UserAvatar } from '@/components/ui/user-avatar'
 
 import {
-  REGISTERED_PLAYER_LABEL,
   displayPlayerName,
+  playerAccessibleName,
+  playerRoleLabel,
 } from './player-identity'
 
 export interface RecentOpponentsProps {
@@ -81,14 +82,16 @@ export const RecentOpponents = ({
               key={p.id}
               className="nm-chip"
               // Explicit accessible name so the decorative avatar initials
-              // aren't read as part of the player's name (#99).
-              aria-label={`${displayPlayerName(p.username)}, ${REGISTERED_PLAYER_LABEL}`}
+              // aren't read as part of the player's name (#99). The role label
+              // shows the rating when known and falls back to the generic
+              // label only for unrated players, matching the search row.
+              aria-label={playerAccessibleName(p)}
               onClick={() => onPick(p)}
             >
               <UserAvatar name={p.username} size={32} decorative />
               <div className="body">
                 <div className="n">{displayPlayerName(p.username)}</div>
-                <div className="m">{REGISTERED_PLAYER_LABEL}</div>
+                <div className="m">{playerRoleLabel(p)}</div>
               </div>
             </button>
           ))}

--- a/web-client/src/routes/_app/matches/new.test.tsx
+++ b/web-client/src/routes/_app/matches/new.test.tsx
@@ -297,6 +297,46 @@ describe('NewMatchPage', () => {
     })
   })
 
+  it('shows the rating on the selected-opponent card for a rated player, matching the picker', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/players/recent', () =>
+        HttpResponse.json([
+          { id: 'pl-1', username: 'ada.lovelace', rating: 1662 },
+        ]),
+      ),
+    )
+    renderNewMatch()
+
+    // The recent chip already reads its rating; picking it must carry that
+    // rating through to the selected-opponent card rather than falling back to
+    // the generic "REGISTERED PLAYER" label.
+    await user.click(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    )
+    const selected = screen.getByRole('button', { name: /^change$/i })
+      .parentElement!
+    expect(selected).toHaveTextContent(/RATING 1662/)
+    expect(selected).not.toHaveTextContent(/REGISTERED PLAYER/)
+  })
+
+  it('falls back to the generic label on the selected card for an unrated player', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/players/recent', () =>
+        HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }]),
+      ),
+    )
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    )
+    expect(
+      screen.getByRole('button', { name: /^change$/i }).parentElement!,
+    ).toHaveTextContent(/REGISTERED PLAYER/)
+  })
+
   it('surfaces the API error detail when match creation fails', async () => {
     const user = userEvent.setup()
     server.use(

--- a/web-client/src/routes/_app/matches/new.tsx
+++ b/web-client/src/routes/_app/matches/new.tsx
@@ -11,6 +11,7 @@ import {
   type Player,
 } from '@/api/matches'
 import { OpponentPicker } from '@/components/matches/opponent-picker'
+import { playerRoleLabel } from '@/components/matches/opponent-picker/player-identity'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import { pageTitle } from '@/lib/page-title'
 import { cn } from '@/lib/utils'
@@ -30,10 +31,11 @@ export const Route = createFileRoute('/_app/matches/new')({
 interface Opponent {
   id: string
   name: string
+  rating?: number | null
 }
 
 function opponentFromPlayer(player: Player): Opponent {
-  return { id: player.id, name: player.username }
+  return { id: player.id, name: player.username, rating: player.rating }
 }
 
 /* ------------------------------------------------------------------ */
@@ -247,7 +249,9 @@ function SelectedOpponent({
       <UserAvatar name={opponent.name} size={48} />
       <div className="info">
         <div className="name">{opponent.name}</div>
-        <div className="rating">REGISTERED PLAYER</div>
+        {/* Same secondary label the picker chips and search rows use: the
+            rating when known, the generic label only for unrated players. */}
+        <div className="rating">{playerRoleLabel(opponent)}</div>
       </div>
       <button type="button" className="change" onClick={onChange}>
         Change


### PR DESCRIPTION
## Problem

In the New Match opponent picker, three surfaces showed a player's secondary label inconsistently. The **search-results row** correctly showed the rating when known (e.g. "RATING 1662"), but the **recent-opponents grid** and the **selected-opponent confirmation card** both hardcoded "REGISTERED PLAYER" — so the same player read "RATING 1662" in search yet "REGISTERED PLAYER" in the grid and after being picked.

## Fix (FE-only consistency change)

All three surfaces now use the shared `player-identity.ts` helpers (`playerAccessibleName` / `playerRoleLabel`) that the search row already used — rating when known, generic label only for unrated players.

- **Recent grid** (`recent-opponents.tsx`): `aria-label={playerAccessibleName(p)}` and `{playerRoleLabel(p)}` for the secondary line.
- **Selected card** (`new.tsx`): `opponentFromPlayer` now carries `rating` through the local `Opponent` model, and the card renders `{playerRoleLabel(opponent)}`.

The #99 accessible-name behavior (decorative avatar, name + role) is preserved. No API or iOS changes.

## Tests

- recent-opponents: updated the #99 test to expect `RATING 1500`, added a rated-branch lock test; blank-username (#101) test still documents the unrated fallback.
- new-match: added tests asserting the selected card shows `RATING 1662` for a rated opponent and `REGISTERED PLAYER` for an unrated one.

## Verification

- `npm run test:run` — 1044 passed
- `npm run lint` — clean (lone pre-existing `mockServiceWorker.js` warning)
- `npm run build` — succeeds
- `npm run test:e2e` — 128 passed
- Code review + security review — clean
- QA (Quinn, real QA stack, MSW off): all three surfaces show matching rating labels for the same player, desktop + mobile, no layout regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)