### PR TITLE
Fix #289: render usernames bare, drop the leading @

### DIFF
--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -22,6 +22,10 @@ compose stack the web origin is also where nginx proxies the API.
 - Path alias: `@/*` → `src/*` (see `vite.config.ts`, `components.json`).
 - shadcn components go under `src/components/ui` (configured in
   `components.json`).
+- **Render usernames bare — no leading `@`.** Display a username as
+  `{username}`, never `@{username}`. This holds everywhere: the dashboard
+  greeting, the login confirmation/success screens, the merge gate, the user
+  menu, match details, and the topbar pill. (#289)
 
 ## Design system
 

--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -136,7 +136,7 @@ describe('DashboardPage', () => {
     renderDashboard()
 
     expect(
-      await screen.findByRole('heading', { name: /Hi, @rita\.kovac/ }),
+      await screen.findByRole('heading', { name: /Hi, rita\.kovac/ }),
     ).toBeInTheDocument()
   })
 
@@ -154,7 +154,7 @@ describe('DashboardPage', () => {
       await screen.findByRole('heading', { name: /^Hi\.?$/ }),
     ).toBeInTheDocument()
     expect(
-      screen.queryByRole('heading', { name: /Hi, @/ }),
+      screen.queryByRole('heading', { name: /Hi, \S/ }),
     ).not.toBeInTheDocument()
   })
 
@@ -319,7 +319,7 @@ describe('DashboardPage · guest persistence banner', () => {
 
     // Wait until something else from the dashboard has rendered, then
     // confirm the banner is absent.
-    await screen.findByRole('heading', { name: /Hi, @rita\.kovac/ })
+    await screen.findByRole('heading', { name: /Hi, rita\.kovac/ })
     expect(
       screen.queryByTestId('dashboard-guest-persist-banner'),
     ).not.toBeInTheDocument()
@@ -335,7 +335,7 @@ describe('DashboardPage · guest persistence banner', () => {
     )
     renderDashboard()
 
-    await screen.findByRole('heading', { name: /Hi, @rita\.kovac/ })
+    await screen.findByRole('heading', { name: /Hi, rita\.kovac/ })
     expect(
       screen.queryByTestId('dashboard-guest-persist-banner'),
     ).not.toBeInTheDocument()
@@ -364,7 +364,7 @@ describe('DashboardPage · guest persistence banner', () => {
     // Re-mount within the same "session" — the banner should remain hidden.
     unmount()
     renderDashboard()
-    await screen.findByRole('heading', { name: /Hi, @rita\.kovac/ })
+    await screen.findByRole('heading', { name: /Hi, rita\.kovac/ })
     expect(
       screen.queryByTestId('dashboard-guest-persist-banner'),
     ).not.toBeInTheDocument()

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -26,7 +26,7 @@ export function DashboardPage() {
   const user =
     !session.isError && session.data ? session.data.data.user : undefined
   const username = user?.username
-  const greeting = username ? `Hi, @${username}` : 'Hi'
+  const greeting = username ? `Hi, ${username}` : 'Hi'
   // Guest with at least one completed match — "you have things to lose now".
   // Zero-match guests and verified/pending-verification users never see this.
   const isGuest =

--- a/web-client/src/components/dashboard/page-title.factory.tsx
+++ b/web-client/src/components/dashboard/page-title.factory.tsx
@@ -8,5 +8,5 @@ import type { PageTitleProps } from './page-title'
 export function buildPageTitleProps(
   overrides: Partial<PageTitleProps> = {},
 ): PageTitleProps {
-  return { greeting: 'Hi, @rita.kovac', compact: false, ...overrides }
+  return { greeting: 'Hi, rita.kovac', compact: false, ...overrides }
 }

--- a/web-client/src/components/dashboard/page-title.test.tsx
+++ b/web-client/src/components/dashboard/page-title.test.tsx
@@ -2,9 +2,9 @@ import { pageTitlePage } from './page-title.page'
 
 describe('PageTitle', () => {
   it('greets the user in the heading', async () => {
-    pageTitlePage.render({ greeting: 'Hi, @rita.kovac' })
+    pageTitlePage.render({ greeting: 'Hi, rita.kovac' })
 
-    expect(await pageTitlePage.findHeading(/Hi, @rita\.kovac/)).toBeInTheDocument()
+    expect(await pageTitlePage.findHeading(/Hi, rita\.kovac/)).toBeInTheDocument()
   })
 
   it('renders the subtitle when one is given', async () => {
@@ -22,16 +22,16 @@ describe('PageTitle', () => {
   })
 
   it('renders a placeholder bar instead of the greeting while loading', async () => {
-    pageTitlePage.render({ greeting: 'Hi, @rita.kovac', loading: true })
+    pageTitlePage.render({ greeting: 'Hi, rita.kovac', loading: true })
 
     expect(await pageTitlePage.findHeading(/loading greeting/i)).toBeInTheDocument()
     expect(pageTitlePage.querySubtitle(/rita\.kovac/)).toBeNull()
   })
 
   it('shows the greeting and no placeholder once loaded', async () => {
-    pageTitlePage.render({ greeting: 'Hi, @rita.kovac', loading: false })
+    pageTitlePage.render({ greeting: 'Hi, rita.kovac', loading: false })
 
-    await pageTitlePage.findHeading(/Hi, @rita\.kovac/)
+    await pageTitlePage.findHeading(/Hi, rita\.kovac/)
     expect(pageTitlePage.queryGreetingSkeleton()).toBeNull()
   })
 

--- a/web-client/src/components/login/login-screens.tsx
+++ b/web-client/src/components/login/login-screens.tsx
@@ -438,7 +438,7 @@ function SuccessReceipt({
               marginTop: 4,
             }}
           >
-            @{username}
+            {username}
           </div>
         </div>
       </div>
@@ -1138,7 +1138,7 @@ export function ScreenSuccess({
         <HeroCol
           eyebrow="● You’re in"
           h1a="Welcome back"
-          h1b={username ? `@${username}.` : '.'}
+          h1b={username ? `${username}.` : '.'}
         />
       }
       right={

--- a/web-client/src/components/login/merge-gate.tsx
+++ b/web-client/src/components/login/merge-gate.tsx
@@ -22,7 +22,7 @@ export function MergeGate({
   onNotNow,
 }: MergeGateProps) {
   const matchLabel = matchesCount === 1 ? '1 match' : `${matchesCount} matches`
-  const from = guestUsername ? `@${guestUsername}` : 'your guest session'
+  const from = guestUsername || 'your guest session'
   return (
     <div
       style={{
@@ -42,7 +42,7 @@ export function MergeGate({
         Bring your matches over?
       </h1>
       <p style={{ color: 'var(--fg-2)' }}>
-        You're signing in as <strong>@{ownerUsername}</strong>. We can bring the{' '}
+        You're signing in as <strong>{ownerUsername}</strong>. We can bring the{' '}
         <strong>{matchLabel}</strong> you played in {from} into this account.
       </p>
       <div


### PR DESCRIPTION
## What

Resolves #289 — picks a single username-rendering convention (**bare, no leading `@`**) and aligns the UI.

The app was split: the dashboard greeting and the login confirmation / success / merge-gate screens prefixed usernames with `@`, while the rest of the UI (user menu, match details, topbar pill) rendered them bare. This standardizes on **bare usernames** everywhere.

## Changes

- `dashboard-page.tsx` — greeting `Hi, @{username}` → `Hi, {username}`
- `login-screens.tsx` — confirmation receipt and success-screen hero drop the `@`
- `merge-gate.tsx` — "signing in as" owner + "played in" guest username drop the `@` (and the now-redundant ternary collapses to `||`)
- Tests + factory updated to match (`page-title`, `dashboard-page`); the negative assertion `/Hi, @/` becomes `/Hi, \S/` so it still catches an unexpected username greeting
- **Documented the convention** in `web-client/CLAUDE.md` so it's a deliberate choice, not drift

## Testing

- vitest: 1041 passed
- eslint: clean (the one warning is pre-existing in generated `mockServiceWorker.js`)
- `tsc -b && vite build`: clean
- web-client Playwright e2e: 128 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)