### PR TITLE
Fix three small issues: #130, #196, #237

### DIFF
--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -68,6 +68,12 @@ async def merge_user(
       * ``to_user_id`` already exists.
       * ``from_user_id != to_user_id``.
     """
+    if from_user_id == to_user_id:
+        # A self-merge would no-op every UPDATE and then the final tombstone
+        # DELETE would destroy the surviving account. Refuse loudly rather
+        # than silently lose the user.
+        raise ValueError("merge_user: from_user_id must not equal to_user_id")
+
     matches_moved = await _repoint_match_side_players(
         db, from_user_id=from_user_id, to_user_id=to_user_id
     )

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1366,8 +1366,9 @@ async def _load_pre_match_rating(
     )
     if not rows:
         return None, []
-    history = list(reversed(rows))
-    return history[-1], history
+    # ``rows`` is DESC, so ``rows[0]`` is already the most-recent value; the
+    # history list is the chronological (ASC) reversal.
+    return rows[0], list(reversed(rows))
 
 
 async def _load_career_before(

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -3,6 +3,7 @@
 import hashlib
 from datetime import UTC, datetime
 
+import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -395,9 +396,18 @@ async def test_merge_summary_zero_when_ephemeral_played_nothing(
     assert summary.matches_moved == 0
 
 
+async def test_merge_self_merge_raises(db_session: AsyncSession):
+    # A self-merge would no-op every UPDATE and then tombstone-delete the only
+    # remaining account. merge_user refuses it rather than losing the user.
+    user = await _make_verified(db_session, "self@example.com")
+    with pytest.raises(ValueError, match="must not equal"):
+        await merge_user(db_session, from_user_id=user.id, to_user_id=user.id)
+
+
 # ----- skip cases handled by the endpoint guard ---------------------------
-# (`merge_user` itself doesn't check verified-ness or same-id — those are
-# the caller's responsibility, enforced in sessions._maybe_merge_prior_session.)
+# (`merge_user` itself doesn't check verified-ness — that's the caller's
+# responsibility, enforced in sessions._maybe_merge_prior_session. Same-id is
+# guarded inside merge_user; see test_merge_self_merge_raises.)
 
 
 async def test_merge_with_user_league_rating_collision_drops_ephemeral(

--- a/web-client/src/routes/_app/matches/new.test.tsx
+++ b/web-client/src/routes/_app/matches/new.test.tsx
@@ -120,7 +120,7 @@ function DetailsProbe({ matchId }: { matchId: string }) {
 }
 
 describe('NewMatchPage', () => {
-  it('creates a match against a picked opponent and navigates to the dashboard', async () => {
+  it('creates a match against a picked opponent and navigates to the scoring page', async () => {
     const user = userEvent.setup()
     let captured: unknown = null
     server.use(


### PR DESCRIPTION
Three low-risk, fully-specified cleanup issues, one commit each.

## Changes

- **#130** — Rename the stale match-create test description. The success redirect moved from `/dashboard` to the scoring route in #125, but the `it(...)` text still said "navigates to the dashboard". Now "navigates to the scoring page". (test-only, no runtime change)
- **#196** — `_load_pre_match_rating` in `api/app/matches.py` no longer does reverse→tail→re-reverse. The query is already `DESC`, so it returns `rows[0]` for the most-recent value and `list(reversed(rows))` for the chronological history directly.
- **#237** — `merge_user` now raises `ValueError` when `from_user_id == to_user_id`. A self-merge would no-op every UPDATE and then tombstone-delete the only surviving account. The docstring already documented this as a caller invariant; now it's enforced. Added a unit test and updated the adjacent "skip cases" comment.

## Testing

- API: `ruff check` + `ruff format --check` + `mypy` (strict, 78 files) clean; **508 pytest passed** (includes the new `test_merge_self_merge_raises`).
- Web: `npm run lint` (0 errors) + `npm run build` clean; **1041 vitest passed**.
- OpenAPI schema: regenerated, **no drift**.
- e2e/iOS: N/A — no rendered-UI flow, API contract, or `ios/**` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)