### PR TITLE
Harden rating_history against concurrent double-completion (#180)

### DIFF
--- a/api/app/models/rating_history.py
+++ b/api/app/models/rating_history.py
@@ -46,6 +46,17 @@ class RatingHistory(Base):
             text("created_at DESC"),
         ),
         Index("ix_rating_history_match_id", "match_id"),
+        # Defense in depth against a concurrent double-completion writing two
+        # history rows (and double-applying the rating) for the same match.
+        # Partial on ``match_id IS NOT NULL`` so manual/import/initial rows —
+        # which legitimately share a (NULL match_id, user_id) — are unaffected.
+        Index(
+            "uq_rating_history_match_id_user_id",
+            "match_id",
+            "user_id",
+            unique=True,
+            postgresql_where=text("match_id IS NOT NULL"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/api/migrations/versions/20260516_0001_0006_create_rating_state_tables.py
+++ b/api/migrations/versions/20260516_0001_0006_create_rating_state_tables.py
@@ -142,9 +142,19 @@ def upgrade() -> None:
         ["league_id", "user_id", sa.text("created_at DESC")],
     )
     op.create_index("ix_rating_history_match_id", "rating_history", ["match_id"])
+    op.create_index(
+        "uq_rating_history_match_id_user_id",
+        "rating_history",
+        ["match_id", "user_id"],
+        unique=True,
+        postgresql_where=sa.text("match_id IS NOT NULL"),
+    )
 
 
 def downgrade() -> None:
+    op.drop_index(
+        "uq_rating_history_match_id_user_id", table_name="rating_history"
+    )
     op.drop_index("ix_rating_history_match_id", table_name="rating_history")
     op.drop_index(
         "ix_rating_history_league_id_user_id_created_at",

--- a/api/tests/test_ratings.py
+++ b/api/tests/test_ratings.py
@@ -7,6 +7,7 @@ import jsonschema
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import (
@@ -460,3 +461,74 @@ async def test_manual_history_row_with_null_match_round_trips(
     assert reloaded.source == RatingHistorySource.import_
     assert reloaded.note == "USATT 2026-04 batch"
     assert reloaded.created_by_user_id == admin.id
+
+
+async def test_rating_history_rejects_duplicate_match_user_row(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    default_league: League,
+):
+    """The partial ``UNIQUE(match_id, user_id)`` index makes a concurrent
+    double-completion fail loudly instead of writing a second history-row pair
+    (and double-applying the rating) for the same match + player."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        await _score_to_completion(api_client, opp_client, opp.id)
+
+    existing = (
+        await db_session.execute(
+            select(RatingHistory)
+            .where(RatingHistory.source == RatingHistorySource.match)
+            .limit(1)
+        )
+    ).scalar_one()
+
+    dup = RatingHistory(
+        league_id=existing.league_id,
+        user_id=existing.user_id,
+        match_id=existing.match_id,
+        rating_strategy_id=existing.rating_strategy_id,
+        rating_value=existing.rating_value,
+        rating_state=existing.rating_state,
+        previous_rating_value=existing.previous_rating_value,
+        source=RatingHistorySource.match,
+    )
+    db_session.add(dup)
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+async def test_rating_history_allows_many_null_match_rows_per_user(
+    db_session: AsyncSession,
+    default_league: League,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """The unique index is partial on ``match_id IS NOT NULL``, so a user can
+    hold multiple manual/import/initial rows (all with a NULL ``match_id``)
+    without tripping it."""
+    player = await make_user(db_session, "player")
+    for value in (1500.0, 1600.0):
+        db_session.add(
+            RatingHistory(
+                league_id=default_league.id,
+                user_id=player.id,
+                match_id=None,
+                rating_strategy_id=rating_strategies["manual"].id,
+                rating_value=value,
+                rating_state={"rating": value},
+                previous_rating_value=None,
+                source=RatingHistorySource.manual,
+            )
+        )
+    await db_session.commit()
+
+    rows = (
+        (
+            await db_session.execute(
+                select(RatingHistory).where(RatingHistory.user_id == player.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2


### PR DESCRIPTION
## What

Adds a partial `UNIQUE(match_id, user_id) WHERE match_id IS NOT NULL` index to `rating_history`, as defense-in-depth against the race described in #180.

`_apply_rating_update` short-circuits on a plain `SELECT … LIMIT 1` of existing history rows for the match. Two simultaneous score-completion requests could both pass that check and both write a history-row pair — four rows instead of two, double-applying the rating change. The new partial unique index turns the duplicate insert into a clean `IntegrityError` instead.

The index is **partial** on `match_id IS NOT NULL` so manual / import / initial rows (which legitimately carry a `NULL` match_id and can share a `(NULL, user_id)`) are unaffected.

## Changes

- `api/app/models/rating_history.py` — new `uq_rating_history_match_id_user_id` index in `__table_args__`.
- `api/migrations/versions/…0006_create_rating_state_tables.py` — matching `create_index` + downgrade drop, **edited in place** per the pre-deploy convention (revision chain frozen).
- `api/tests/test_ratings.py` — two regression tests: duplicate `(match_id, user_id)` match row raises `IntegrityError`; multiple `NULL`-match rows for one user coexist (proves the partial clause).

## Why it's safe with merge / recompute

- `merge_user` **deletes** the ephemeral user's match-sourced history rows (only re-points `created_by_user_id`), so no `(match_id, user_id)` collision.
- `recompute` does **delete-then-insert** for affected matches, so re-inserts never collide with surviving rows.

## Testing

- `ruff check` ✅, `ruff format --check` ✅, `mypy` (strict) ✅
- `pytest` — **508 passed** ✅
- Applied the migration to `head` against a real Postgres 16 — index created as `UNIQUE, btree (match_id, user_id) WHERE match_id IS NOT NULL` — then `downgrade base` reversed cleanly.
- OpenAPI schema: no drift.

Closes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)