### PR TITLE
Add/fix regression tests from the "add tests" issue backlog

### DIFF
--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -202,6 +202,81 @@ async def test_merge_tombstones_ephemeral_user_keeping_session_token(
     assert [t.context for t in leftover] == [SESSION_TOKEN_CONTEXT]
 
 
+# ----- atomicity ----------------------------------------------------------
+
+
+async def test_merge_rolls_back_on_intra_transaction_failure(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    """``merge_user`` runs inside the caller's transaction and never commits, so
+    a failure partway through must leave *nothing* applied once the caller
+    unwinds: the ephemeral user stays live (not tombstoned) and its match stays
+    owned by it. The other merge tests only assert the committed happy path —
+    this locks in the atomicity guarantee (#240). It bites against any
+    regression that slips a commit into the middle of the merge."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    opponent = await _make_ephemeral(db_session, "spinning-otter")
+    match = await _record_match(db_session, ephemeral, ephemeral, opponent)
+    # Capture ids up front: the rollback below expires every ORM instance, after
+    # which even reading `.id` would emit a lazy load outside the async loop.
+    ephemeral_id = ephemeral.id
+    verified_id = verified.id
+    opponent_id = opponent.id
+    match_id = match.id
+
+    class _MergeInterrupted(Exception):
+        pass
+
+    # Detonate at the final tombstone step — `datetime.now(UTC)` in the closing
+    # `update(User)` — *after* the match ownership has already been re-pointed
+    # earlier in the same transaction.
+    class _ExplodingDatetime:
+        @staticmethod
+        def now(tz: object = None) -> datetime:
+            raise _MergeInterrupted("merge interrupted mid-transaction")
+
+    monkeypatch.setattr("app.account_merge.datetime", _ExplodingDatetime)
+
+    with pytest.raises(_MergeInterrupted):
+        await merge_user(db_session, from_user_id=ephemeral_id, to_user_id=verified_id)
+    # The caller unwinds the failed request transaction.
+    await db_session.rollback()
+
+    # Ephemeral user is still live — not tombstoned. Select the columns directly
+    # rather than the ORM object: after the rollback the identity-map instance is
+    # expired, so attribute access would emit a lazy load outside the async loop.
+    tombstone = (
+        await db_session.execute(
+            select(User.merged_into_user_id, User.merged_at).where(
+                User.id == ephemeral_id
+            )
+        )
+    ).one()
+    assert tombstone.merged_into_user_id is None
+    assert tombstone.merged_at is None
+
+    # Match ownership and the side player are untouched.
+    creator_id = (
+        await db_session.execute(
+            select(Match.created_by_user_id).where(Match.id == match_id)
+        )
+    ).scalar_one()
+    assert creator_id == ephemeral_id
+    player_ids = set(
+        (
+            await db_session.execute(
+                select(MatchSidePlayer.user_id).where(
+                    MatchSidePlayer.match_id == match_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert player_ids == {ephemeral_id, opponent_id}
+
+
 async def test_merge_moves_league_membership_when_target_has_none(
     db_session: AsyncSession,
 ):

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1973,6 +1973,37 @@ async def test_details_recent_form_excludes_self_from_career_count(
     assert opp_form["rating_history"] == [1500.0]
 
 
+async def test_details_career_count_excludes_only_the_viewed_match(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Viewing a *completed* match counts earlier matches as priors while
+    excluding the match being viewed. The single-match sibling test above
+    passes even if the ``Match.id != current_match_id`` self-exclusion guard
+    were dropped — with two matches between the same pair, only this one bites
+    (#198): the first counts, the current is excluded."""
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "career-guard-opp") as (
+        opp_client,
+        opp,
+    ):
+        await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
+        second = await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
+
+    detail = (await api_client.get(f"/v1/matches/{second['id']}")).json()
+    forms = {f["user_id"]: f for f in detail["recent_form"]}
+    # Exactly one prior counts for each player — the first match — and the
+    # current (second) match excludes itself.
+    for f in forms.values():
+        assert f["career_matches_before"] == 1
+    # I won the first match (side 1); the opponent lost it.
+    assert forms[str(me.id)]["career_wins_before"] == 1
+    assert forms[str(opp.id)]["career_wins_before"] == 0
+
+
 async def test_list_matches_csv_export(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/api/tests/test_rating_recompute.py
+++ b/api/tests/test_rating_recompute.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from app.leagues import get_default_league
 from app.models import (
     League,
+    LeagueVisibility,
     Match,
     MatchGame,
     MatchGameScore,
@@ -443,3 +444,101 @@ async def test_recompute_holds_advisory_lock_for_transaction(
     assert acquired is False, (
         "advisory lock should be held by session 1's open transaction"
     )
+
+
+# ----- multi-league cascade -----------------------------------------------
+
+
+async def test_recompute_after_merge_rebuilds_each_league_independently(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """The merged user holds rated matches in two leagues.
+    ``_recompute_after_merge`` loops over *every* league the user has a
+    completed rated match in and rebuilds each one's timeline; the rest of the
+    suite only exercises the single-league path. Drive that loop here — calling
+    ``recompute_league_ratings`` per league exactly as the job does (the job
+    itself opens its own engine via ``get_engine()`` and so can't run against
+    the test container) — and assert no cross-league leakage (#245).
+
+    Fortymm ships a single default league today, so this is forward-looking:
+    the loop already exists and would regress silently without coverage."""
+    strategy = rating_strategies["glicko2"]
+    league_a = await get_default_league(db_session)
+    league_b = League(
+        name="Second League",
+        description="A second glicko-2 league.",
+        visibility=LeagueVisibility.public,
+        is_default=False,
+        rating_strategy_id=strategy.id,
+    )
+    db_session.add(league_b)
+    await db_session.commit()
+    await db_session.refresh(league_b)
+
+    me = await make_user(db_session, "survivor")
+    opp_a = await make_user(db_session, "rival-a")
+    opp_b = await make_user(db_session, "rival-b")
+    await _seed_rating(db_session, league_a, me.id, strategy)
+    await _seed_rating(db_session, league_a, opp_a.id, strategy)
+    await _seed_rating(db_session, league_b, me.id, strategy)
+    await _seed_rating(db_session, league_b, opp_b.id, strategy)
+
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    # I win in league A and lose in league B — asymmetric, so any cross-league
+    # bleed would visibly corrupt one league's rating.
+    match_a = await _build_completed_match(db_session, league_a, me, opp_a, base)
+    match_b = await _build_completed_match(
+        db_session, league_b, opp_b, me, base + timedelta(hours=1)
+    )
+
+    # Mirror ``_recompute_after_merge``'s per-league loop over every league the
+    # merged user has a completed rated match in.
+    for league_id in (league_a.id, league_b.id):
+        await recompute_league_ratings(db_session, league_id, {me.id})
+    await db_session.commit()
+
+    # My rating moved up in the league I won and down in the one I lost — proof
+    # each league's recompute saw only its own match.
+    rating_a = (
+        await db_session.execute(
+            select(UserLeagueRating).where(
+                UserLeagueRating.user_id == me.id,
+                UserLeagueRating.league_id == league_a.id,
+            )
+        )
+    ).scalar_one()
+    rating_b = (
+        await db_session.execute(
+            select(UserLeagueRating).where(
+                UserLeagueRating.user_id == me.id,
+                UserLeagueRating.league_id == league_b.id,
+            )
+        )
+    ).scalar_one()
+    assert rating_a.rating_value is not None and rating_a.rating_value > 1500.0
+    assert rating_b.rating_value is not None and rating_b.rating_value < 1500.0
+
+    # My history rows stay partitioned by league: each league references only
+    # its own match, never the other's.
+    history = (
+        (
+            await db_session.execute(
+                select(RatingHistory).where(RatingHistory.user_id == me.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    a_match_ids = {
+        r.match_id
+        for r in history
+        if r.league_id == league_a.id and r.match_id is not None
+    }
+    b_match_ids = {
+        r.match_id
+        for r in history
+        if r.league_id == league_b.id and r.match_id is not None
+    }
+    assert a_match_ids == {match_a.id}
+    assert b_match_ids == {match_b.id}

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -16,6 +16,7 @@ from app.sessions import (
     CSRF_HEADER_NAME,
     SESSION_COOKIE_NAME,
     SESSION_TOKEN_CONTEXT,
+    _maybe_merge_prior_session,
 )
 from tests._helpers import CSRF_EVENT_HOOKS, make_client, make_raw_client, start_session
 
@@ -523,3 +524,35 @@ async def test_session_reissues_csrf_cookie_when_dropped(raw_client: AsyncClient
     assert any(h.startswith(f"{CSRF_COOKIE_NAME}=") for h in set_cookies)
     assert not any(h.startswith(f"{SESSION_COOKIE_NAME}=") for h in set_cookies)
     assert raw_client.cookies.get(CSRF_COOKIE_NAME)
+
+
+@pytest.mark.parametrize(
+    "cookie",
+    [
+        pytest.param(None, id="absent"),
+        pytest.param("", id="empty"),
+        pytest.param("dGhpcy10b2tlbi13YXMtbmV2ZXItaXNzdWVk", id="unknown"),
+        pytest.param("!!! not base64url $$$", id="malformed"),
+    ],
+)
+async def test_maybe_merge_prior_session_no_merge_on_unresolvable_cookie(
+    db_session: AsyncSession, cookie: str | None
+):
+    """Sign-in must proceed without a merge — and crucially without raising —
+    when the browser's session cookie doesn't resolve to a live guest: absent,
+    malformed, or a token that was never issued (`_find_session_user` returns
+    None). `_maybe_merge_prior_session` is otherwise only exercised indirectly
+    via the login integration tests; lock the contract in directly so a future
+    change to `_find_session_user` can't start surfacing 500s on sign-in (#242).
+    """
+    target = User(
+        username="rita.kovac",
+        email="rita@example.com",
+        confirmed_at=datetime.now(UTC),
+    )
+    db_session.add(target)
+    await db_session.commit()
+    await db_session.refresh(target)
+
+    merged = await _maybe_merge_prior_session(db_session, cookie, target)
+    assert merged is None

--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -17,6 +17,7 @@ import {
   dashboardRating,
   dashboardRecentResult,
   dashboardResponse,
+  sessionResponse,
 } from '@/test/factories'
 import { GUEST_PERSIST_DISMISS_KEY } from './guest-persist-banner'
 import { DashboardPage } from './dashboard-page'
@@ -128,7 +129,16 @@ describe('DashboardPage', () => {
   })
 
   it('greets the signed-in user by their username', async () => {
+    // Stub the session explicitly rather than leaning on the shared mutable
+    // `mockSession` default — handlers like `PATCH /v1/me` mutate that
+    // singleton in place, so a sibling test's leak could otherwise flip the
+    // expected username under a reorder (#288).
     server.use(
+      http.get('*/v1/session', () =>
+        HttpResponse.json(
+          sessionResponse({ user: { username: 'rita.kovac' } }),
+        ),
+      ),
       http.get('*/v1/dashboard', () =>
         HttpResponse.json(dashboardResponse()),
       ),

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -163,6 +163,78 @@ function inProgressMatch(overrides: Parameters<typeof matchDetails>[0] = {}) {
   })
 }
 
+// Mirror of `participantSides` with the current user on side 2 — the opponent
+// holds side 1. Exercises the `mySideNumber === 1 ? … : …` flip for its side-2
+// branch, which every other fixture leaves untested (#210).
+function participantSidesMeSide2({
+  meWins,
+  oppWins,
+  meWon = null,
+}: {
+  meWins: number
+  oppWins: number
+  meWon?: boolean | null
+}): [MatchDetailsSide, MatchDetailsSide] {
+  return [
+    {
+      side_number: 1,
+      players: [
+        { user_id: 'u-opp', username: 'nguyen.t', is_current_user: false },
+      ],
+      games_won: oppWins,
+      won: meWon === null ? null : !meWon,
+      is_current_user_side: false,
+    },
+    {
+      side_number: 2,
+      players: [
+        { user_id: 'u-me', username: 'rita.kovac', is_current_user: true },
+      ],
+      games_won: meWins,
+      won: meWon,
+      is_current_user_side: true,
+    },
+  ]
+}
+
+// Raw game score from the side-2 perspective: `side_1_points` holds the
+// opponent's points and `side_2_points` holds mine (the inverse of `score`).
+function scoreSide2(
+  id: string,
+  myPoints: number,
+  oppPoints: number,
+): MatchDetailsScore {
+  return {
+    id,
+    side_1_points: oppPoints,
+    side_2_points: myPoints,
+    winner_side_number: myPoints > oppPoints ? 2 : 1,
+    version: 1,
+  }
+}
+
+function inProgressMatchMeSide2(
+  overrides: Parameters<typeof matchDetails>[0] = {},
+) {
+  return matchDetails({
+    id: 'm-1',
+    status: 'in_progress',
+    status_label: 'Live',
+    best_of: 5,
+    games_to_win: 3,
+    affects_rating: true,
+    sides: participantSidesMeSide2({ meWins: 1, oppWins: 1 }),
+    games: [
+      { id: 'g-1', game_number: 1, score: scoreSide2('s-1', 11, 8) },
+      { id: 'g-2', game_number: 2, score: scoreSide2('s-2', 9, 11) },
+    ],
+    current_game: { game_number: 3 },
+    can_score: true,
+    can_finalize: false,
+    ...overrides,
+  })
+}
+
 describe('ScoreEntry — create', () => {
   it('POSTs the score (fire-and-forget) and lands on the next un-scored game', async () => {
     const user = userEvent.setup()
@@ -1934,6 +2006,97 @@ describe('ScoreEntry — conflicts', () => {
       side_1_points: 12,
       side_2_points: 10,
       expected_version: 2,
+    })
+  })
+})
+
+describe('ScoreEntry — current user on side 2 (#210)', () => {
+  it('POSTs the create with my points flipped into side_2_points', async () => {
+    const user = userEvent.setup()
+    let captured: unknown = null
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(inProgressMatchMeSide2()),
+      ),
+      http.post(
+        '*/v1/matches/m-1/games/3/scores/new',
+        async ({ request }) => {
+          captured = await request.json()
+          return HttpResponse.json(
+            inProgressMatchMeSide2({
+              sides: participantSidesMeSide2({ meWins: 2, oppWins: 1 }),
+              games: [
+                { id: 'g-1', game_number: 1, score: scoreSide2('s-1', 11, 8) },
+                { id: 'g-2', game_number: 2, score: scoreSide2('s-2', 9, 11) },
+                { id: 'g-3', game_number: 3, score: scoreSide2('s-3', 11, 4) },
+              ],
+              current_game: { game_number: 4 },
+            }),
+          )
+        },
+      ),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+    await user.type(
+      screen.getByRole('textbox', { name: 'rita.kovac score' }),
+      '11',
+    )
+    await user.type(
+      screen.getByRole('textbox', { name: 'nguyen.t score' }),
+      '4',
+    )
+    await user.click(screen.getByRole('button', { name: /save game & next/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText('scoring-new m-1 4')).toBeInTheDocument(),
+    )
+    // I'm on side 2, so my 11 lands in `side_2_points` and the opponent's 4 in
+    // `side_1_points` — the inverse of the side-1 fixtures. A dropped flip would
+    // ship `{ side_1_points: 11, side_2_points: 4 }`, recording my win as a loss.
+    expect(captured).toEqual({ side_1_points: 4, side_2_points: 11 })
+  })
+
+  it('pre-populates the edit form with my side-2 score and PUTs it back flipped', async () => {
+    const user = userEvent.setup()
+    let captured: unknown = null
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(inProgressMatchMeSide2()),
+      ),
+      http.put('*/v1/matches/m-1/games/1/scores', async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json(inProgressMatchMeSide2())
+      }),
+    )
+
+    renderScoreEntry({ kind: 'edit', matchId: 'm-1', gameNumber: 1 })
+
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    // Game 1 is stored raw as side_1=8 (opp), side_2=11 (me). The form must
+    // show the user-relative values — my 11, not the raw side-1 number.
+    await waitFor(() => expect(meInput).toHaveValue('11'))
+    expect(oppInput).toHaveValue('8')
+
+    await user.clear(meInput)
+    await user.type(meInput, '12')
+    await user.clear(oppInput)
+    await user.type(oppInput, '10')
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText('scoring-new m-1 3')).toBeInTheDocument(),
+    )
+    // Flipped back on the way out: my 12 → side_2_points, opp 10 → side_1_points.
+    expect(captured).toEqual({
+      side_1_points: 10,
+      side_2_points: 12,
+      expected_version: 1,
     })
   })
 })

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -547,13 +547,22 @@ export const handlers = [
     // handlers — anything else succeeds.
     if (body.token === 'expired')
       return detail('That sign-in link is invalid or expired.', 400)
-    mockSession.data.user = {
-      ...mockSession.data.user,
-      email: mockSession.data.user.email ?? 'rita@example.com',
-      confirmed_at:
-        mockSession.data.user.confirmed_at ?? new Date().toISOString(),
-    }
-    return HttpResponse.json(mockSession)
+    // Return a *fresh* confirmed session rather than mutating the shared
+    // `mockSession` singleton in place. The old in-place write leaked
+    // `email`/`confirmed_at` into whichever test ran next in file order, so a
+    // reorder or single-test run could flake (#229).
+    return HttpResponse.json({
+      ...mockSession,
+      data: {
+        ...mockSession.data,
+        user: {
+          ...mockSession.data.user,
+          email: mockSession.data.user.email ?? 'rita@example.com',
+          confirmed_at:
+            mockSession.data.user.confirmed_at ?? new Date().toISOString(),
+        },
+      },
+    })
   }),
   // Default: not a merge, so the verify/confirm screens finalize straight away.
   // Tests that exercise the gate override this with `server.use(...)`.

--- a/web-client/src/routes/confirm-email.test.tsx
+++ b/web-client/src/routes/confirm-email.test.tsx
@@ -8,10 +8,19 @@ import {
 } from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
 import { server } from '@/mocks/server'
 import { mockSession } from '@/mocks/handlers'
 import { Route as ConfirmEmailRoute } from './confirm-email'
+
+vi.mock('sonner', async () => {
+  const actual = await vi.importActual<typeof import('sonner')>('sonner')
+  return {
+    ...actual,
+    toast: { ...actual.toast, success: vi.fn() },
+  }
+})
 
 interface TestRouterContext {
   queryClient: QueryClient
@@ -109,6 +118,31 @@ describe('/confirm-email token scrubbing (#521)', () => {
     // …with the token scrubbed.
     await waitFor(() => {
       expect(router.state.location.search).toEqual({ token: '' })
+    })
+  })
+})
+
+describe('/confirm-email merged-matches toast (#241)', () => {
+  it('uses singular copy when exactly one match is merged', async () => {
+    // Default `/v1/merge/preview` is a no-merge, so confirm-email auto-confirms;
+    // the confirm response carries the merge summary that drives the toast.
+    server.use(
+      http.post('*/v1/me/email/confirm', () =>
+        HttpResponse.json({
+          ...mockSession,
+          merged: { matches_moved: 1 },
+        }),
+      ),
+    )
+    renderAt('/confirm-email?token=good-token-with-one-merge')
+
+    // confirm-email branches on `moved === 1` for the singular copy, the same
+    // as login.verifying — lock the singular path in here too so a refactor
+    // can't regress it to "We brought your 1 matches with you." (#241).
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        'We brought your 1 match with you.',
+      )
     })
   })
 })

--- a/web-client/src/routes/login.test.tsx
+++ b/web-client/src/routes/login.test.tsx
@@ -302,8 +302,11 @@ describe('/login/verifying flow', () => {
     expect(
       await screen.findByRole('heading', { name: /welcome back/i }),
     ).toBeInTheDocument()
-    // The session query data should now reflect a confirmed account.
-    expect(mockSession.data.user.email).toBeTruthy()
+    // The consumed session (written into the query cache) reflects a confirmed
+    // account — the success receipt shows its email. Asserting on the rendered
+    // output instead of the shared `mockSession` singleton keeps this test from
+    // depending on a handler mutating module state (#229).
+    expect(await screen.findByText('rita@example.com')).toBeInTheDocument()
   })
 
   it('routes to ?error=expired when the API rejects the token', async () => {
@@ -359,6 +362,26 @@ describe('/login/verifying flow', () => {
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith(
         'We brought your 3 matches with you.',
+      )
+    })
+  })
+
+  it('uses singular copy when exactly one match is merged', async () => {
+    server.use(
+      http.post('*/v1/login/consume', () =>
+        HttpResponse.json({
+          ...mockSession,
+          merged: { matches_moved: 1 },
+        }),
+      ),
+    )
+    renderAt('/login/verifying?token=good-token-with-one-merge')
+
+    // Lock in the singular branch so a future refactor can't regress this to
+    // the ungrammatical "We brought your 1 matches with you." (#241).
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        'We brought your 1 match with you.',
       )
     })
   })


### PR DESCRIPTION
Implements eight open **test-related issues**. Each new regression test was verified to actually *bite* — I broke the guarded behavior, confirmed the test goes red, then restored.

## What's in here

| Issue | Change |
|---|---|
| #130 | Rename the stale `"navigates to the dashboard"` new-match test (it asserts the scoring page). |
| #198 | Two-match positive case for `career_matches_before` — the single-match sibling passes even with the self-exclusion dropped; this asserts a prior **is** counted (==1) while the current is excluded. |
| #210 | Side-2 create + edit coverage for `score-entry` — every fixture put the current user on side 1, leaving the `mySideNumber` flip untested. |
| #229 | Make the MSW `/v1/login/consume` handler non-mutating so it stops leaking `email`/`confirmed_at` into the next test in file order; assert on rendered output instead of the shared `mockSession` singleton. |
| #240 | `merge_user` atomicity test — force a mid-transaction failure, assert the rollback unwinds everything (ephemeral not tombstoned, match still owned). |
| #241 | Lock in the singular `"1 match"` merge-toast copy. |
| #245 | Multi-league cascade test (two glicko-2 leagues, win in one / loss in the other), asserting no cross-league leakage. Forward-looking — the loop exists but nothing drives multi-league today. |
| #288 | Stub `/v1/session` explicitly in the dashboard greeting test instead of leaning on the mutable `mockSession` default. |

**Skipped (with reasons):** #163 — the API contract is already fully covered by `test_non_participant_cannot_score`; only an optional e2e remained. #475 — a `data-testid` refactor, not "add tests."

## Testing
- API: `ruff check` / `ruff format --check` / `mypy --strict` ✓; `pytest` **514 passed**.
- Web: `vitest` **1044 passed**; `eslint` 0 errors; `tsc -b && vite build` ✓; Playwright e2e **128 passed**.
- OpenAPI schema: no drift. Root compose-stack e2e skipped (test-only + DEV-only mock change; nothing in the deployed stack changed). iOS unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)