### PR TITLE
Reword stale 'port stays faithful' comment in score-entry CSS (#211)

### DIFF
--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1596,8 +1596,8 @@ body.dark.fortymm-theme {
    ========================================================================= */
 /* ---------- Entry layout ---------- */
 .fortymm-theme .entry-wrap {
-  /* Motion/shadow tokens the design defines at :root — kept local so the
-     port stays faithful without expanding the shared token set. */
+  /* Motion/shadow tokens used by this section — kept scoped to avoid
+     leaking score-entry-only values into the shared token set. */
   --dur-fast: 120ms;
   --dur-base: 200ms;
   --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);


### PR DESCRIPTION
Fixes #211.

The `.entry-wrap` rule in `web-client/src/index.css` carried a comment justifying its local CSS-variable scope by citing a design-handoff fidelity constraint ("port stays faithful") that no longer exists — PR #209 removed the LiveScreen-style fixed-position wrapper the comment was written for. The token-locality choice itself still makes sense; only the framing was misleading. Reworded to drop the "port" framing.

Pure comment change, no behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)