### PR TITLE
Read opponent-less match rows as '(no opponent)' for screen readers (#175)

### DIFF
--- a/web-client/src/components/matches/match-list/match-list-row-view.test.ts
+++ b/web-client/src/components/matches/match-list/match-list-row-view.test.ts
@@ -187,6 +187,23 @@ describe('projectMatchListRow', () => {
     expect(projectMatchListRow(row).ariaLabel).toBe('Open match: alpha vs beta')
   })
 
+  it('reads an opponent-less row as "{s1} (no opponent)" (#175)', () => {
+    const s1 = side(['alpha'], { side_number: 1 })
+    const row = matchListRow({ sides: [s1] })
+    expect(projectMatchListRow(row).ariaLabel).toBe(
+      'Open match: alpha (no opponent)',
+    )
+  })
+
+  it('treats a player-less sentinel side 2 as no opponent (#175)', () => {
+    const s1 = side(['alpha'], { side_number: 1 })
+    const s2 = side([], { side_number: 2 })
+    const row = matchListRow({ sides: [s1, s2] })
+    expect(projectMatchListRow(row).ariaLabel).toBe(
+      'Open match: alpha (no opponent)',
+    )
+  })
+
   it('builds the short label as "M-" + shortId', () => {
     const row = matchListRow({ id: 'match-abc123' })
     expect(projectMatchListRow(row).shortLabel).toBe('M-ABC123')

--- a/web-client/src/components/matches/match-list/match-list-row-view.ts
+++ b/web-client/src/components/matches/match-list/match-list-row-view.ts
@@ -171,7 +171,12 @@ export function projectMatchListRow(
     id: row.id,
     detailRoute: matchDetailRoute(row.id),
     shortLabel: `M-${shortId(row.id)}`,
-    ariaLabel: `Open match: ${sideLabel(side1)} vs ${sideLabel(side2)}`,
+    // A null or player-less sentinel side 2 both render as "No opponent"; read
+    // that to the screen reader as a clause rather than an awkward "vs No
+    // opponent" (#175).
+    ariaLabel: side2?.players.length
+      ? `Open match: ${sideLabel(side1)} vs ${sideLabel(side2)}`
+      : `Open match: ${sideLabel(side1)} (no opponent)`,
     isLive,
     side1: projectPlayerChip(side1),
     side2: projectPlayerChip(side2),


### PR DESCRIPTION
Fixes #175.

A single-side match (e.g. a solo seed) built the `/matches` row aria-label as `Open match: rita.kovac vs No opponent`, which reads awkwardly aloud. The label is now special-cased on the missing-opponent path to read `Open match: rita.kovac (no opponent)`.

The condition checks `side2?.players.length` rather than `side2 != null` because solo matches carry a **player-less sentinel side 2** (not a null side), and `sideLabel` renders both as "No opponent" — so both must take the friendlier clause.

Added two view-model tests covering the null-side and player-less-sentinel cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)