### PR TITLE
Name the dashboard recent-results table via aria-labelledby (#127)

### DIFF
--- a/web-client/src/components/dashboard/your-game-row/recent-results-card.page.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card.page.tsx
@@ -11,6 +11,10 @@ const scoped = (container: Container) => ({
   queryTable() {
     return container.queryByRole('table')
   },
+  /** The results table resolved by its accessible name, or null if unnamed. */
+  queryTableByName(name: string | RegExp) {
+    return container.queryByRole('table', { name })
+  },
   /** The "No completed matches yet." empty state, or null when rows exist. */
   queryEmptyState() {
     return container.queryByText('No completed matches yet.')

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card.test.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card.test.tsx
@@ -10,6 +10,14 @@ describe('RecentResultsCard', () => {
     expect(recentResultsCardPage.queryTable()).toBeNull()
   })
 
+  it('names the table after its "Recent matches" label for screen readers (#127)', () => {
+    recentResultsCardPage.render()
+
+    expect(
+      recentResultsCardPage.queryTableByName('Recent matches'),
+    ).toBeInTheDocument()
+  })
+
   it('renders a row per result with the opponent and game score', () => {
     recentResultsCardPage.render()
 

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card.tsx
@@ -32,7 +32,7 @@ export const RecentResultsCard = ({ rows }: RecentResultsCardProps) => {
           borderBottom: `1px solid ${C.ink700}`,
         }}
       >
-        <Overline>Recent matches</Overline>
+        <Overline id="dashboard-recent-results-label">Recent matches</Overline>
         <div style={{ flex: 1 }} />
         <span style={{ font: `500 11px ${UI}`, color: C.chalk500 }}>
           <Mono size={11} color={C.chalk100}>
@@ -53,6 +53,7 @@ export const RecentResultsCard = ({ rows }: RecentResultsCardProps) => {
         </div>
       ) : (
         <table
+          aria-labelledby="dashboard-recent-results-label"
           style={{
             width: '100%',
             borderCollapse: 'collapse',


### PR DESCRIPTION
Fixes #127.

The recent-results `<table>` on `/dashboard` had no programmatic association with its visible "Recent matches" eyebrow, so a screen reader announced it as an unnamed table. Gave the `Overline` an `id` and referenced it from the table's `aria-labelledby`.

Added a page-object accessor (`queryTableByName`) and a test asserting the table resolves by its accessible name "Recent matches".

🤖 Generated with [Claude Code](https://claude.com/claude-code)