### PR TITLE
Rich FE for the two-verb negotiation: correction flow + per-state callouts (#717–#720)

### DIFF
--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -649,6 +649,16 @@ export function scoringEditRoute(matchId: string, gameNumber: number) {
   }
 }
 
+/** The "Suggest a correction" proposal-authoring route (#718). Reached from the
+ * match-detail callouts: a self-edit while awaiting, "Suggest correction" on
+ * review, or "Counter" on a standing correction. */
+export function correctionRoute(matchId: string) {
+  return {
+    to: '/matches/$matchId/correct' as const,
+    params: { matchId },
+  }
+}
+
 /** Where to land after writing a per-game score — the next un-scored slot, or
  * the match detail page when there's no next game (match finalized, or every
  * game has a saved score). */

--- a/web-client/src/components/matches/correction-entry/correction-entry.factory.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.factory.tsx
@@ -1,0 +1,101 @@
+import type { components } from "@/api/schema";
+
+import {
+  buildMatchDetails,
+  buildMatchDetailsSide,
+  buildMatchDetailsPlayer,
+  type MatchDetails,
+} from "@/mocks/factories/matches/match-details.factory";
+
+type NegotiationGame = components["schemas"]["NegotiationGame"];
+type NegotiationResult = components["schemas"]["NegotiationResult"];
+
+export const STANDING_RESULT_ID = "11110000-0000-4000-8000-000000000000";
+
+/** One game inside a standing-result snapshot. */
+export function buildStandingGame(
+  overrides: Partial<NegotiationGame> = {},
+): NegotiationGame {
+  return {
+    game_number: 1,
+    side_1_points: 11,
+    side_2_points: 8,
+    ...overrides,
+  };
+}
+
+/**
+ * A standing result the viewer can correct — the opponent's 3–0 proposal
+ * (best-of-5), submitted by the opponent. Games are the immutable snapshot the
+ * correction screen pre-fills from.
+ */
+export function buildStandingResult(
+  overrides: Partial<NegotiationResult> = {},
+): NegotiationResult {
+  return {
+    id: STANDING_RESULT_ID,
+    games: [
+      buildStandingGame({
+        game_number: 1,
+        side_1_points: 11,
+        side_2_points: 8,
+      }),
+      buildStandingGame({
+        game_number: 2,
+        side_1_points: 11,
+        side_2_points: 6,
+      }),
+      buildStandingGame({
+        game_number: 3,
+        side_1_points: 11,
+        side_2_points: 9,
+      }),
+    ],
+    submitted_by: "leo.mertens",
+    submitted_at: "2026-06-08T13:00:00Z",
+    ...overrides,
+  };
+}
+
+/**
+ * A `MatchDetails` in the `review` state: the viewer (side 1, `rita.kovac`)
+ * faces the opponent's standing proposal and can suggest a correction. Pass
+ * `standing` to reshape the proposed board.
+ */
+export function buildCorrectableMatch(
+  overrides: Partial<MatchDetails> = {},
+): MatchDetails {
+  const standing = buildStandingResult();
+  return buildMatchDetails({
+    id: "m-correct-1",
+    status: "in_progress",
+    status_label: "Live",
+    best_of: 5,
+    games_to_win: 3,
+    affects_rating: true,
+    sides: [
+      buildMatchDetailsSide({ side_number: 1, games_won: 0 }),
+      buildMatchDetailsSide({
+        side_number: 2,
+        players: [
+          buildMatchDetailsPlayer({
+            user_id: "u-opponent",
+            username: "leo.mertens",
+            is_current_user: false,
+          }),
+        ],
+        games_won: 3,
+        is_current_user_side: false,
+      }),
+    ],
+    current_game: null,
+    negotiation: {
+      viewer_state: "review",
+      your_turn: true,
+      standing_result: standing,
+      prior_result: null,
+      diff: null,
+    },
+    ...overrides,
+  });
+}

--- a/web-client/src/components/matches/correction-entry/correction-entry.page.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.page.tsx
@@ -1,0 +1,100 @@
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+
+import {
+  mockMatchDetailsEndpoint,
+  type MatchDetailsResolver,
+} from "@/mocks/endpoints/matches/match-details.endpoint";
+import {
+  mockMatchResultsEndpoint,
+  type MatchResultsResolver,
+} from "@/mocks/endpoints/matches/match-results.endpoint";
+import { server } from "@/mocks/server";
+import { render, screen, within, type Container } from "@/test/utilities";
+
+import { CorrectionEntry } from "./correction-entry";
+
+const DEFAULT_MATCH_ID = "m-correct-1";
+
+const scoped = (container: Container) => ({
+  /** The busy placeholder shown while the match query is pending. */
+  queryLoading() {
+    return container.queryByTestId("correction-entry-loading");
+  },
+  /** A side's numeric input within game `gameNumber`, by the participant's name
+   * (the field label is `"<name> score"`). Games stack in document order, so we
+   * scope to the matching `Game N` section. */
+  getInput(gameNumber: number, name: string) {
+    const heading = container.getByRole("heading", {
+      name: `Game ${gameNumber}`,
+    });
+    const section = heading.closest("section") as HTMLElement;
+    return within(section).getByLabelText(`${name} score`) as HTMLInputElement;
+  },
+  /** The single shared "Send corrected score" submit (or its pending label). */
+  getSubmit() {
+    return container.getByRole("button", {
+      name: /send corrected score|sending/i,
+    });
+  },
+  /** Any visible `role="alert"` line (per-game score error or the API error). */
+  queryAlerts() {
+    return container.queryAllByRole("alert");
+  },
+  /** The match-details landing the route navigates to on a successful send. */
+  queryMatchLanding() {
+    return container.queryByTestId("match-landing");
+  },
+});
+
+/**
+ * Test page-object for `CorrectionEntry`. The component reads the match via
+ * `useMatch` (regular query, `throwOnError`) and writes via `useProposeResult`,
+ * and it calls `useNavigate` on success — so it mounts under a memory router
+ * with a `/matches/$matchId` landing route, the same shape the real file route
+ * uses. Stubs `GET /v1/matches/:matchId` (the pre-fill source) and
+ * `POST /v1/matches/:matchId/results` (the propose target).
+ */
+export const correctionEntryPage = {
+  /** Stub the match-details GET that seeds the inputs. */
+  mockMatch(resolver: MatchDetailsResolver) {
+    mockMatchDetailsEndpoint(server, resolver);
+  },
+
+  /** Stub the propose POST the submit fires. */
+  mockPropose(resolver: MatchResultsResolver) {
+    mockMatchResultsEndpoint(server, resolver);
+  },
+
+  render(matchId: string = DEFAULT_MATCH_ID) {
+    const rootRoute = createRootRoute();
+    const correctRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/matches/$matchId/correct",
+      component: () => <CorrectionEntry matchId={matchId} />,
+    });
+    const matchRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/matches/$matchId",
+      component: () => <div data-testid="match-landing">match-landing</div>,
+    });
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([correctRoute, matchRoute]),
+      history: createMemoryHistory({
+        initialEntries: [`/matches/${matchId}/correct`],
+      }),
+    });
+    render(<RouterProvider router={router} />);
+  },
+
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
@@ -1,0 +1,97 @@
+import { HttpResponse } from "msw";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
+import { waitFor } from "@/test/utilities";
+
+import {
+  STANDING_RESULT_ID,
+  buildCorrectableMatch,
+} from "./correction-entry.factory";
+import { correctionEntryPage } from "./correction-entry.page";
+
+describe("CorrectionEntry", () => {
+  it("pre-fills the inputs from the standing-result snapshot (not the scratchpad)", async () => {
+    // The seed's standing result is the opponent's 3–0 board (11–8, 11–6,
+    // 11–9). The viewer is side 1 (rita.kovac), so the left field reads
+    // side_1_points and the right reads side_2_points.
+    correctionEntryPage.mockMatch(() =>
+      HttpResponse.json(buildCorrectableMatch()),
+    );
+    correctionEntryPage.render();
+
+    await waitFor(() =>
+      expect(correctionEntryPage.getInput(1, "rita.kovac")).toHaveValue("11"),
+    );
+    expect(correctionEntryPage.getInput(1, "leo.mertens")).toHaveValue("8");
+    expect(correctionEntryPage.getInput(2, "leo.mertens")).toHaveValue("6");
+    expect(correctionEntryPage.getInput(3, "leo.mertens")).toHaveValue("9");
+  });
+
+  it("posts the corrected board with supersedes_result_id and navigates home on success", async () => {
+    let postedBody: unknown = null;
+    correctionEntryPage.mockMatch(() =>
+      HttpResponse.json(buildCorrectableMatch()),
+    );
+    correctionEntryPage.mockPropose(async ({ request }) => {
+      postedBody = await request.json();
+      return HttpResponse.json(buildMatchDetails(), { status: 201 });
+    });
+    correctionEntryPage.render();
+
+    // Correct game 3: the viewer says they actually won it 11–9 (flip the
+    // opponent's 11–9). Edit the viewer's side from a blank.
+    const me3 = await waitFor(() =>
+      correctionEntryPage.getInput(3, "rita.kovac"),
+    );
+    await userEvent.clear(me3);
+    await userEvent.type(me3, "11");
+    const opp3 = correctionEntryPage.getInput(3, "leo.mertens");
+    await userEvent.clear(opp3);
+    await userEvent.type(opp3, "9");
+
+    await userEvent.click(correctionEntryPage.getSubmit());
+
+    await waitFor(() =>
+      expect(postedBody).toEqual({
+        supersedes_result_id: STANDING_RESULT_ID,
+        games: [
+          { game_number: 1, side_1_points: 11, side_2_points: 8 },
+          { game_number: 2, side_1_points: 11, side_2_points: 6 },
+          { game_number: 3, side_1_points: 11, side_2_points: 9 },
+        ],
+      }),
+    );
+    // On success the route navigates back to the match-details landing.
+    await waitFor(() =>
+      expect(correctionEntryPage.queryMatchLanding()).toBeInTheDocument(),
+    );
+  });
+
+  it("surfaces a 409 (the proposal moved on) inline without navigating away", async () => {
+    correctionEntryPage.mockMatch(() =>
+      HttpResponse.json(buildCorrectableMatch()),
+    );
+    correctionEntryPage.mockPropose(() =>
+      HttpResponse.json(
+        { detail: "The standing result has moved on." },
+        { status: 409 },
+      ),
+    );
+    correctionEntryPage.render();
+
+    await waitFor(() => correctionEntryPage.getInput(1, "rita.kovac"));
+    await userEvent.click(correctionEntryPage.getSubmit());
+
+    await waitFor(() =>
+      expect(
+        correctionEntryPage
+          .queryAlerts()
+          .some((a: HTMLElement) => /moved on/i.test(a.textContent ?? "")),
+      ).toBe(true),
+    );
+    // Still on the correction screen — no navigation on a rejected propose.
+    expect(correctionEntryPage.queryMatchLanding()).not.toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/correction-entry/correction-entry.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.tsx
@@ -1,0 +1,208 @@
+import { useState } from "react";
+import { Navigate, useNavigate } from "@tanstack/react-router";
+import { ApiError } from "@/api/client";
+import {
+  matchDetailRoute,
+  useMatch,
+  useProposeResult,
+  type MatchDetails,
+  type MatchResultsGameWrite,
+} from "@/api/matches";
+import { initialsOf } from "@/lib/utils";
+import { ScorePad } from "../score-pad";
+import {
+  isAcceptableScoreInput,
+  validateGameScore,
+} from "../score-pad/validate-game-score";
+
+// Placeholder identity for a player-less (solo) opponent side, mirroring the
+// scratchpad entry screen so the correction board reads the same.
+const NO_OPPONENT_LABEL = "No opponent";
+
+type StandingGame = NonNullable<
+  MatchDetails["negotiation"]["standing_result"]
+>["games"][number];
+
+/** One game's two raw input strings, keyed by `game_number`. The viewer always
+ * reads the left field as *their* side, regardless of side number. */
+interface GameDraft {
+  gameNumber: number;
+  me: string;
+  opp: string;
+}
+
+/**
+ * Seed the editable drafts from the immutable standing-result snapshot (NOT the
+ * live scratchpad). The viewer's side reads left; the orientation is restored on
+ * submit from `mySideNumber`.
+ */
+function seedDrafts(games: StandingGame[], mySideNumber: 1 | 2): GameDraft[] {
+  return [...games]
+    .sort((a, b) => a.game_number - b.game_number)
+    .map((g) => ({
+      gameNumber: g.game_number,
+      me: String(mySideNumber === 1 ? g.side_1_points : g.side_2_points),
+      opp: String(mySideNumber === 1 ? g.side_2_points : g.side_1_points),
+    }));
+}
+
+/**
+ * "Suggest a correction" screen. Pre-fills the score inputs from
+ * `negotiation.standing_result.games` (the immutable proposal snapshot) and, on
+ * submit, posts a counter-proposal that supersedes that standing result. A 409
+ * (the proposal moved on) is surfaced inline; success navigates back to the
+ * match-details page.
+ */
+export function CorrectionEntry({ matchId }: { matchId: string }) {
+  const navigate = useNavigate();
+  const { data, isLoading } = useMatch(matchId);
+  const proposeMutation = useProposeResult(matchId);
+
+  // `null` means "not seeded yet" — seeded once `data` arrives (below), so we
+  // avoid a state-syncing effect on first render.
+  const [drafts, setDrafts] = useState<GameDraft[] | null>(null);
+
+  if (isLoading || !data) {
+    return <div aria-busy="true" data-testid="correction-entry-loading" />;
+  }
+
+  const standing = data.negotiation.standing_result;
+  const mySide = data.sides.find((s) => s.is_current_user_side) ?? null;
+  const oppSide = data.sides.find((s) => !s.is_current_user_side) ?? null;
+
+  // The correction flow only applies to participants with a standing result to
+  // correct. Spectators, or a match with no proposal in play, bounce back.
+  if (!standing || !mySide || !oppSide) {
+    return <Navigate {...matchDetailRoute(matchId)} />;
+  }
+
+  // Captured here (rather than read inside `onSubmit`) so the standing-result
+  // narrowing from the guard above survives into the submit closure.
+  const standingId = standing.id;
+  const mySideNumber: 1 | 2 = mySide.side_number === 2 ? 2 : 1;
+  const meName = mySide.players[0]?.username ?? "You";
+  const meInitials = initialsOf(meName);
+  const oppUsername = oppSide.players[0]?.username ?? null;
+  const oppName = oppUsername ?? NO_OPPONENT_LABEL;
+  const oppHasPlayer = oppUsername !== null;
+
+  const current = drafts ?? seedDrafts(standing.games, mySideNumber);
+
+  const setGame = (gameNumber: number, next: Partial<GameDraft>) => {
+    setDrafts(
+      current.map((d) => (d.gameNumber === gameNumber ? { ...d, ...next } : d)),
+    );
+    if (proposeMutation.error) proposeMutation.reset();
+  };
+
+  // Per-game validation verdicts, indexed alongside `current`.
+  const validations = current.map((d) => validateGameScore(d.me, d.opp));
+  const allValid = validations.every((v) => v.valid);
+
+  // A 409 means the standing result moved on (someone else proposed/accepted
+  // since this screen loaded); a 422 means the board itself was rejected. Both
+  // surface inline; everything else falls back to the API message.
+  const apiError =
+    proposeMutation.error instanceof ApiError ? proposeMutation.error : null;
+
+  const inputsLocked = proposeMutation.isPending;
+
+  function onSubmit() {
+    if (!allValid || proposeMutation.isPending) return;
+    const games: MatchResultsGameWrite[] = current.map((d) =>
+      mySideNumber === 1
+        ? {
+            game_number: d.gameNumber,
+            side_1_points: Number(d.me),
+            side_2_points: Number(d.opp),
+          }
+        : {
+            game_number: d.gameNumber,
+            side_1_points: Number(d.opp),
+            side_2_points: Number(d.me),
+          },
+    );
+    proposeMutation.mutate(
+      { games, supersedes_result_id: standingId },
+      { onSuccess: () => navigate(matchDetailRoute(matchId)) },
+    );
+  }
+
+  return (
+    <div className="entry-wrap">
+      <div className="entry-head">
+        <h2>Suggest a correction.</h2>
+        <div className="hint">
+          Adjust the game(s) that look off, then send the corrected score to{" "}
+          {oppName} to confirm.
+        </div>
+      </div>
+
+      {apiError !== null && (
+        <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
+          {apiError.status === 409
+            ? "This proposal has moved on — reload the match to see the latest score."
+            : (apiError.detail ?? apiError.message)}
+        </p>
+      )}
+
+      {current.map((d, i) => {
+        const v = validations[i];
+        return (
+          <section key={d.gameNumber} className="correction-game">
+            <h3 className="text-sm font-medium text-[color:var(--muted)]">
+              Game {d.gameNumber}
+            </h3>
+            <ScorePad
+              me={{
+                name: meName,
+                initials: meInitials,
+                value: d.me,
+                invalid: v.meMalformed || (!v.valid && v.error !== null),
+                onChange: (value) => {
+                  if (!isAcceptableScoreInput(value)) return;
+                  setGame(d.gameNumber, { me: value });
+                },
+              }}
+              opp={{
+                name: oppName,
+                initials: oppHasPlayer ? initialsOf(oppName) : null,
+                value: d.opp,
+                invalid: v.oppMalformed || (!v.valid && v.error !== null),
+                onChange: (value) => {
+                  if (!isAcceptableScoreInput(value)) return;
+                  setGame(d.gameNumber, { opp: value });
+                },
+              }}
+              gamesTally={null}
+              scoreError={v.error}
+              showBothRequired={v.oneSideFilled && v.error === null}
+              inputsLocked={inputsLocked}
+              // The per-game pads are inputs-only (hideActions); a single shared
+              // action row below the whole board owns the one submit.
+              hideActions
+            />
+          </section>
+        );
+      })}
+
+      <div className="single-actions">
+        <div className="result-line subtle">
+          {data.affects_rating
+            ? "Sending the corrected score posts it for your opponent to confirm."
+            : "Sending the corrected score finalizes the match immediately."}
+        </div>
+        <div className="action-btns">
+          <button
+            type="button"
+            className="btn primary"
+            disabled={!allValid || inputsLocked}
+            onClick={onSubmit}
+          >
+            {proposeMutation.isPending ? "Sending…" : "Send corrected score"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-client/src/components/matches/correction-entry/correction-entry.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.tsx
@@ -158,7 +158,13 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
                 name: meName,
                 initials: meInitials,
                 value: d.me,
-                invalid: v.meMalformed || (!v.valid && v.error !== null),
+                // Red-flag this field when its own value is malformed, or when a
+                // pair-level rule violation (tie/deuce) makes neither side
+                // individually malformed — but NOT when only the *other* side is
+                // malformed (its error shouldn't bleed onto this clean input).
+                invalid:
+                  v.meMalformed ||
+                  (v.error !== null && !v.meMalformed && !v.oppMalformed),
                 onChange: (value) => {
                   if (!isAcceptableScoreInput(value)) return;
                   setGame(d.gameNumber, { me: value });
@@ -168,7 +174,9 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
                 name: oppName,
                 initials: oppHasPlayer ? initialsOf(oppName) : null,
                 value: d.opp,
-                invalid: v.oppMalformed || (!v.valid && v.error !== null),
+                invalid:
+                  v.oppMalformed ||
+                  (v.error !== null && !v.meMalformed && !v.oppMalformed),
                 onChange: (value) => {
                   if (!isAcceptableScoreInput(value)) return;
                   setGame(d.gameNumber, { opp: value });

--- a/web-client/src/components/matches/match-details.page.tsx
+++ b/web-client/src/components/matches/match-details.page.tsx
@@ -69,6 +69,13 @@ export const matchDetailsPage = {
       path: "/matches/$matchId",
       component: () => <div>match-page</div>,
     });
+    // The correction-route target for the confirmation callout's
+    // "Suggest correction" / "Counter" / "Edit result" links.
+    const correctRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/matches/$matchId/correct",
+      component: () => <div>correction-route</div>,
+    });
     const router = createRouter({
       routeTree: rootRoute.addChildren([
         detailsRoute,
@@ -76,6 +83,7 @@ export const matchDetailsPage = {
         scoringEdit,
         matchesList,
         matchPage,
+        correctRoute,
       ]),
       history: createMemoryHistory({ initialEntries: ["/details"] }),
     });

--- a/web-client/src/components/matches/match-details/confirmation-callout.page.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout.page.tsx
@@ -1,4 +1,11 @@
 import { ErrorBoundary } from "react-error-boundary";
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
 
 import {
   mockMatchAcceptanceEndpoint,
@@ -72,15 +79,34 @@ export const confirmationCalloutPage = {
       ...overrides,
     };
 
-    render(
+    // The display renders correction `<Link>`s, so mount the wrapper under a
+    // memory router that registers the correction route.
+    const tree = (
       <ErrorBoundary
         fallbackRender={() => (
           <div role="alert">Couldn’t load the confirmation callout</div>
         )}
       >
         <ConfirmationCallout {...props} />
-      </ErrorBoundary>,
+      </ErrorBoundary>
     );
+    const rootRoute = createRootRoute();
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/",
+      component: () => tree,
+    });
+    const correctRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/matches/$matchId/correct",
+      component: () => <div>correction-route</div>,
+    });
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, correctRoute]),
+      history: createMemoryHistory({ initialEntries: ["/"] }),
+    });
+
+    render(<RouterProvider router={router} />);
   },
 
   /**

--- a/web-client/src/components/matches/match-details/confirmation-callout.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout.test.tsx
@@ -9,12 +9,12 @@ import {
   buildMatchDetailsData,
   buildScoreboard,
 } from "@/mocks/factories/matches/scoreboard.factory";
-import { waitFor, waitForElementToBeRemoved } from "@/test/utilities";
+import { waitFor } from "@/test/utilities";
 
 import { confirmationCalloutPage } from "./confirmation-callout.page";
 
 /** A live match with a standing proposal the opponent posted — the viewer must
- * act, so the callout renders its actionable (Accept) variant. */
+ * act, so the callout renders its review (Accept) variant. */
 const reviewMatch = (): MatchDetails =>
   buildMatchDetails({
     status: "in_progress",
@@ -36,28 +36,41 @@ const finalMatch = (): MatchDetails =>
   buildMatchDetails({
     status: "completed",
     status_label: "Final",
+    negotiation: {
+      viewer_state: "final",
+      your_turn: false,
+      standing_result: {
+        id: "r-1",
+        games: [{ game_number: 1, side_1_points: 11, side_2_points: 7 }],
+        submitted_by: "u-opponent",
+        submitted_at: "2026-06-10T12:00:00Z",
+      },
+      prior_result: null,
+      diff: null,
+    },
     data: buildMatchDetailsData({
       scoreboard: buildScoreboard({ status: "final" }),
     }),
   });
 
 describe("ConfirmationCallout", () => {
-  it("shows its Suspense fallback, then the callout when it's the viewer's turn", async () => {
+  it("resolves to the callout when it's the viewer's turn", async () => {
     confirmationCalloutPage.mockEndpoint(() =>
       HttpResponse.json(reviewMatch()),
     );
 
     confirmationCalloutPage.render();
 
-    expect(confirmationCalloutPage.queryLoading()).toBeInTheDocument();
-    await waitForElementToBeRemoved(confirmationCalloutPage.queryLoading());
     // Wiring only: callout content is pinned by the display tests.
-    expect(confirmationCalloutPage.getCallout()).toBeInTheDocument();
+    await waitFor(() =>
+      expect(confirmationCalloutPage.getCallout()).toBeInTheDocument(),
+    );
+    expect(confirmationCalloutPage.getAcceptButton()).toBeInTheDocument();
   });
 
-  it("gives way once the viewer accepts and the match finalizes", async () => {
-    // Accepting flips the refetched payload to final — neither callout state
-    // applies any more, so the section must disappear in place.
+  it("settles into the confirmed notice once the viewer accepts and the match finalizes", async () => {
+    // Accepting flips the refetched payload to final — the callout transitions
+    // from the Accept CTA to a quiet "Confirmed" notice (no action to press).
     let accepted = false;
     confirmationCalloutPage.mockEndpoint(() =>
       HttpResponse.json(accepted ? finalMatch() : reviewMatch()),
@@ -69,12 +82,15 @@ describe("ConfirmationCallout", () => {
 
     confirmationCalloutPage.render();
 
-    await waitForElementToBeRemoved(confirmationCalloutPage.queryLoading());
+    await waitFor(() => confirmationCalloutPage.getAcceptButton());
     await userEvent.click(confirmationCalloutPage.getAcceptButton());
 
     await waitFor(() =>
-      expect(confirmationCalloutPage.queryCallout()).not.toBeInTheDocument(),
+      expect(
+        confirmationCalloutPage.queryAcceptButton(),
+      ).not.toBeInTheDocument(),
     );
+    expect(confirmationCalloutPage.getCallout()).toHaveTextContent("Confirmed");
   });
 
   it("propagates a query failure to the ancestor error boundary", async () => {
@@ -84,7 +100,10 @@ describe("ConfirmationCallout", () => {
 
     confirmationCalloutPage.render();
 
-    await waitForElementToBeRemoved(confirmationCalloutPage.queryLoading());
-    expect(confirmationCalloutPage.queryBoundaryError()).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        confirmationCalloutPage.queryBoundaryError(),
+      ).toBeInTheDocument(),
+    );
   });
 });

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher.page.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher.page.tsx
@@ -1,5 +1,12 @@
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
 
 import {
   mockMatchDetailsEndpoint,
@@ -55,7 +62,9 @@ export const confirmationCalloutFetcherPage = {
       ...overrides,
     };
 
-    render(
+    // The display renders correction `<Link>`s, so mount the whole fetcher tree
+    // under a memory router that registers the correction route.
+    const tree = (
       <ErrorBoundary
         fallbackRender={() => (
           <div role="alert">Couldn’t load the confirmation callout</div>
@@ -68,8 +77,25 @@ export const confirmationCalloutFetcherPage = {
         >
           <ConfirmationCalloutFetcher {...props} />
         </Suspense>
-      </ErrorBoundary>,
+      </ErrorBoundary>
     );
+    const rootRoute = createRootRoute();
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/",
+      component: () => tree,
+    });
+    const correctRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/matches/$matchId/correct",
+      component: () => <div>correction-route</div>,
+    });
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, correctRoute]),
+      history: createMemoryHistory({ initialEntries: ["/"] }),
+    });
+
+    render(<RouterProvider router={router} />);
   },
 
   /**

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher.test.tsx
@@ -1,12 +1,12 @@
 import { HttpResponse } from "msw";
 
 import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
-import { waitForElementToBeRemoved } from "@/test/utilities";
+import { waitFor } from "@/test/utilities";
 
 import { confirmationCalloutFetcherPage } from "./confirmation-callout-fetcher.page";
 
 /** A live match with a standing proposal the opponent posted — the viewer must
- * act, so the callout renders its actionable variant. */
+ * act, so the callout renders its review variant. */
 const reviewMatch = () =>
   buildMatchDetails({
     status: "in_progress",
@@ -25,24 +25,17 @@ const reviewMatch = () =>
   });
 
 describe("ConfirmationCalloutFetcher", () => {
-  it("suspends until the query resolves, then hands the view to the display", async () => {
+  it("resolves the query, then hands the view to the display", async () => {
     confirmationCalloutFetcherPage.mockEndpoint(() =>
       HttpResponse.json(reviewMatch()),
     );
 
     confirmationCalloutFetcherPage.render();
 
-    // Pending: only the Suspense fallback, no callout yet.
-    expect(confirmationCalloutFetcherPage.queryLoading()).toBeInTheDocument();
-    expect(
-      confirmationCalloutFetcherPage.queryCallout(),
-    ).not.toBeInTheDocument();
-
-    await waitForElementToBeRemoved(
-      confirmationCalloutFetcherPage.queryLoading(),
-    );
     // Wiring only: callout content is pinned by the query and display tests.
-    expect(confirmationCalloutFetcherPage.getCallout()).toBeInTheDocument();
+    await waitFor(() =>
+      expect(confirmationCalloutFetcherPage.getCallout()).toBeInTheDocument(),
+    );
   });
 
   it("renders nothing when the projection is null (no sign-off in play)", async () => {
@@ -52,8 +45,11 @@ describe("ConfirmationCalloutFetcher", () => {
 
     confirmationCalloutFetcherPage.render();
 
-    await waitForElementToBeRemoved(
-      confirmationCalloutFetcherPage.queryLoading(),
+    // The loading fallback clears and no callout ever appears.
+    await waitFor(() =>
+      expect(
+        confirmationCalloutFetcherPage.queryLoading(),
+      ).not.toBeInTheDocument(),
     );
     expect(
       confirmationCalloutFetcherPage.queryCallout(),
@@ -67,9 +63,8 @@ describe("ConfirmationCalloutFetcher", () => {
 
     confirmationCalloutFetcherPage.render();
 
-    await waitForElementToBeRemoved(
-      confirmationCalloutFetcherPage.queryLoading(),
+    await waitFor(() =>
+      expect(confirmationCalloutFetcherPage.queryError()).toBeInTheDocument(),
     );
-    expect(confirmationCalloutFetcherPage.queryError()).toBeInTheDocument();
   });
 });

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.page.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.page.tsx
@@ -1,4 +1,12 @@
 import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+
+import {
   mockMatchAcceptanceEndpoint,
   type MatchAcceptanceResolver,
 } from "@/mocks/endpoints/matches/match-acceptance.endpoint";
@@ -11,8 +19,8 @@ import {
 } from "./confirmation-callout-active";
 import { confirmationCalloutDisplayPage } from "./confirmation-callout-active/confirmation-callout-display.page";
 import {
-  buildActionableConfirmationView,
   buildAwaitingConfirmationView,
+  buildReviewConfirmationView,
 } from "./confirmation-callout-active/confirmation-callout-display.factory";
 
 const DEFAULT_MATCH_ID = "m-1";
@@ -24,7 +32,9 @@ const scoped = (container: Container) => ({
 
 /**
  * Test page-object for `ConfirmationCalloutActive` — the layer that owns the
- * accept mutation. Tests stub
+ * accept mutation. The display below it renders correction `<Link>`s, so the
+ * component mounts under a minimal memory router that registers the correction
+ * route. Tests stub
  * `POST /v1/matches/:matchId/results/:resultId/acceptance` and drive the CTA;
  * no GET stub is needed because the mutation's cache invalidation only
  * refetches *mounted* queries, and this harness mounts none.
@@ -40,11 +50,26 @@ export const confirmationCalloutActivePage = {
 
   render(overrides: Partial<ConfirmationCalloutActiveProps> = {}) {
     const props: ConfirmationCalloutActiveProps = {
-      view: buildActionableConfirmationView(),
+      view: buildReviewConfirmationView(),
       matchId: DEFAULT_MATCH_ID,
       ...overrides,
     };
-    render(<ConfirmationCalloutActive {...props} />);
+    const rootRoute = createRootRoute();
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/",
+      component: () => <ConfirmationCalloutActive {...props} />,
+    });
+    const correctRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/matches/$matchId/correct",
+      component: () => <div>correction-route</div>,
+    });
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, correctRoute]),
+      history: createMemoryHistory({ initialEntries: ["/"] }),
+    });
+    render(<RouterProvider router={router} />);
   },
 
   /**

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.test.tsx
@@ -18,7 +18,9 @@ describe("ConfirmationCalloutActive", () => {
     });
     confirmationCalloutActivePage.render();
 
-    const button = confirmationCalloutActivePage.getAcceptButton();
+    const button = await waitFor(() =>
+      confirmationCalloutActivePage.getAcceptButton(),
+    );
     fireEvent.click(button);
     fireEvent.click(button);
 
@@ -38,7 +40,9 @@ describe("ConfirmationCalloutActive", () => {
     });
     confirmationCalloutActivePage.render();
 
-    const button = confirmationCalloutActivePage.getAcceptButton();
+    const button = await waitFor(() =>
+      confirmationCalloutActivePage.getAcceptButton(),
+    );
     await userEvent.click(button);
     await waitFor(() => expect(acceptHits).toBe(1));
     await userEvent.click(button);
@@ -52,6 +56,7 @@ describe("ConfirmationCalloutActive", () => {
     );
     confirmationCalloutActivePage.render();
 
+    await waitFor(() => confirmationCalloutActivePage.getAcceptButton());
     await userEvent.click(confirmationCalloutActivePage.getAcceptButton());
 
     await waitFor(() =>
@@ -70,6 +75,7 @@ describe("ConfirmationCalloutActive", () => {
     );
     confirmationCalloutActivePage.render();
 
+    await waitFor(() => confirmationCalloutActivePage.getAcceptButton());
     await userEvent.click(confirmationCalloutActivePage.getAcceptButton());
 
     await waitFor(() =>

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.tsx
@@ -11,10 +11,18 @@ export interface ConfirmationCalloutActiveProps {
   matchId: string;
 }
 
+/** True for the viewer-must-act states that carry an acceptance token. */
+function hasResultId(
+  view: ConfirmationCalloutView,
+): view is Extract<ConfirmationCalloutView, { resultId: string }> {
+  return view.kind === "review" || view.kind === "corrected";
+}
+
 /** Wires the accept mutation onto the pure display. The standing result's id is
  * the concurrency token `POST .../acceptance` takes; API failures stay visible
  * inline (without throwOnError a 409 — the proposal moved on, double-click,
- * etc. — would otherwise vanish and the button would appear inert). */
+ * etc. — would otherwise vanish and the button would appear inert). The passive
+ * (`awaiting`/`final`) variants press nothing, so the mutation simply sits idle. */
 export function ConfirmationCalloutActive({
   view,
   matchId,
@@ -32,10 +40,11 @@ export function ConfirmationCalloutActive({
   return (
     <ConfirmationCalloutDisplay
       view={view}
+      matchId={matchId}
       acceptPending={acceptMutation.isPending}
       errorMessage={error ? (error.detail ?? error.message) : null}
       onAccept={() => {
-        if (view.kind !== "actionable") return;
+        if (!hasResultId(view)) return;
         if (inFlightRef.current) return;
         inFlightRef.current = true;
         acceptMutation.reset();

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.factory.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.factory.tsx
@@ -1,17 +1,58 @@
+import type { components } from "@/api/schema";
+
 import type { ConfirmationCalloutDisplayProps } from "./confirmation-callout-display";
 import type { ConfirmationCalloutView } from "../confirmation-callout-query";
 
-/** The featured variant: the opponent's standing proposal awaits the viewer's
- * acceptance. Carries the standing result's id (the acceptance token). */
-export function buildActionableConfirmationView(
-  overrides: Partial<Extract<ConfirmationCalloutView, { kind: "actionable" }>> = {},
+type NegotiationDiffEntry = components["schemas"]["NegotiationDiffEntry"];
+
+/** The review variant: the opponent posted the first result; the viewer can
+ * Accept or suggest a correction. Carries the standing result's acceptance
+ * token + the rated stakes. */
+export function buildReviewConfirmationView(
+  overrides: Partial<Extract<ConfirmationCalloutView, { kind: "review" }>> = {},
 ): ConfirmationCalloutView {
-  return { kind: "actionable", resultId: "r-1", ...overrides };
+  return { kind: "review", resultId: "r-1", rated: true, ...overrides };
 }
 
-/** The passive variant: the viewer has posted, leo.mertens hasn't accepted. */
+/** A two-game diff (one changed game + one newly-added game), mirroring the
+ * server-computed `negotiation.diff` shape. */
+export function buildCorrectionDiff(): NegotiationDiffEntry[] {
+  return [
+    {
+      game_number: 1,
+      old: { game_number: 1, side_1_points: 11, side_2_points: 7 },
+      new: { game_number: 1, side_1_points: 11, side_2_points: 9 },
+    },
+    {
+      game_number: 2,
+      old: null,
+      new: { game_number: 2, side_1_points: 11, side_2_points: 5 },
+    },
+  ];
+}
+
+/** The corrected variant: the opponent countered the viewer's prior proposal;
+ * the callout shows the diff + Accept/Counter. */
+export function buildCorrectedConfirmationView(
+  overrides: Partial<
+    Extract<ConfirmationCalloutView, { kind: "corrected" }>
+  > = {},
+): ConfirmationCalloutView {
+  return {
+    kind: "corrected",
+    resultId: "r-2",
+    rated: true,
+    diff: buildCorrectionDiff(),
+    ...overrides,
+  };
+}
+
+/** The passive awaiting variant: the viewer has posted, leo.mertens hasn't
+ * accepted. */
 export function buildAwaitingConfirmationView(
-  overrides: Partial<Extract<ConfirmationCalloutView, { kind: "awaiting" }>> = {},
+  overrides: Partial<
+    Extract<ConfirmationCalloutView, { kind: "awaiting" }>
+  > = {},
 ): ConfirmationCalloutView {
   return {
     kind: "awaiting",
@@ -20,13 +61,22 @@ export function buildAwaitingConfirmationView(
   };
 }
 
-/** Props for `ConfirmationCalloutDisplay` — the actionable variant, idle
- * (nothing pending, no error). */
+/** The final variant: the match is settled. Defaults to a plain "confirmed"
+ * (no back-and-forth). */
+export function buildFinalConfirmationView(
+  overrides: Partial<Extract<ConfirmationCalloutView, { kind: "final" }>> = {},
+): ConfirmationCalloutView {
+  return { kind: "final", afterCorrections: false, ...overrides };
+}
+
+/** Props for `ConfirmationCalloutDisplay` — the review variant, idle (nothing
+ * pending, no error). */
 export function buildConfirmationCalloutDisplayProps(
   overrides: Partial<ConfirmationCalloutDisplayProps> = {},
 ): ConfirmationCalloutDisplayProps {
   return {
-    view: buildActionableConfirmationView(),
+    view: buildReviewConfirmationView(),
+    matchId: "m-1",
     acceptPending: false,
     errorMessage: null,
     onAccept: () => {},

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.page.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.page.tsx
@@ -1,3 +1,11 @@
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+
 import { render, screen, type Container } from "@/test/utilities";
 
 import {
@@ -7,7 +15,7 @@ import {
 import { buildConfirmationCalloutDisplayProps } from "./confirmation-callout-display.factory";
 
 const scoped = (container: Container) => ({
-  /** The callout `<section>` (either variant); absent when the view projected
+  /** The callout `<section>` (any variant); absent when the view projected
    * to null upstream. */
   queryCallout() {
     return container.queryByTestId("match-confirm-callout");
@@ -15,13 +23,29 @@ const scoped = (container: Container) => ({
   getCallout() {
     return container.getByTestId("match-confirm-callout");
   },
-  /** The featured variant's primary CTA — "Accept result" idle, "Accepting…"
-   * in flight. Absent on the passive variant. */
+  /** The featured variants' primary CTA — "Accept result" idle, "Accepting…"
+   * in flight. Absent on the passive variants. */
   getAcceptButton() {
     return container.getByRole("button", { name: /accept/i });
   },
   queryAcceptButton() {
     return container.queryByRole("button", { name: /accept/i });
+  },
+  /** The "Suggest correction" link on the review variant. */
+  querySuggestCorrectionLink() {
+    return container.queryByTestId("match-confirm-callout-correct");
+  },
+  /** The "Counter" link on the corrected variant. */
+  queryCounterLink() {
+    return container.queryByTestId("match-confirm-callout-counter");
+  },
+  /** The "Edit result" link on the awaiting variant. */
+  queryEditLink() {
+    return container.queryByTestId("match-confirm-callout-edit");
+  },
+  /** The correction diff block, present only on the corrected variant. */
+  queryDiff() {
+    return container.queryByTestId("score-diff");
   },
   /** The inline API-failure line beneath the body copy; null when clean. */
   queryError() {
@@ -29,13 +53,32 @@ const scoped = (container: Container) => ({
   },
 });
 
-/** Test page-object for the pure `ConfirmationCalloutDisplay` — props in,
- * DOM out, no MSW. Embedding page objects (active/fetcher/wrapper) spread
- * `within` to expose the same callout queries as their own. */
+/** Test page-object for the pure `ConfirmationCalloutDisplay`. The callout's
+ * correction affordances are typed `<Link>`s, so `render` mounts it under a
+ * minimal router that registers the correction route they target. The router
+ * resolves asynchronously, so tests that read a link start with a `findBy*`
+ * (e.g. `await page.getCallout()` via `waitFor`). */
 export const confirmationCalloutDisplayPage = {
   render(overrides: Partial<ConfirmationCalloutDisplayProps> = {}) {
     const props = buildConfirmationCalloutDisplayProps(overrides);
-    render(<ConfirmationCalloutDisplay {...props} />);
+    const rootRoute = createRootRoute();
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/",
+      component: () => <ConfirmationCalloutDisplay {...props} />,
+    });
+    // The correction route the "Suggest correction" / "Counter" / "Edit result"
+    // links navigate to — registered so the typed <Link>s resolve at render.
+    const correctRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/matches/$matchId/correct",
+      component: () => <div>correction-route</div>,
+    });
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, correctRoute]),
+      history: createMemoryHistory({ initialEntries: ["/"] }),
+    });
+    render(<RouterProvider router={router} />);
   },
 
   /**

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.test.tsx
@@ -1,14 +1,28 @@
 import userEvent from "@testing-library/user-event";
 
-import { buildAwaitingConfirmationView } from "./confirmation-callout-display.factory";
+import { correctionRoute } from "@/api/matches";
+import { waitFor } from "@/test/utilities";
+
+import {
+  buildAwaitingConfirmationView,
+  buildCorrectedConfirmationView,
+  buildFinalConfirmationView,
+} from "./confirmation-callout-display.factory";
 import { confirmationCalloutDisplayPage } from "./confirmation-callout-display.page";
 
+// The callout mounts behind a memory router (the correction links are typed
+// `<Link>`s), so the section resolves a tick after render.
+const correctHref = (matchId: string) =>
+  `/matches/${correctionRoute(matchId).params.matchId}/correct`;
+
 describe("ConfirmationCalloutDisplay", () => {
-  describe("actionable variant", () => {
-    it("invites the viewer to accept the posted result", () => {
+  describe("review variant", () => {
+    it("invites the viewer to accept or suggest a correction, with the rated stakes", async () => {
       confirmationCalloutDisplayPage.render();
 
-      const callout = confirmationCalloutDisplayPage.getCallout();
+      const callout = await waitFor(() =>
+        confirmationCalloutDisplayPage.getCallout(),
+      );
       expect(callout).toHaveTextContent(
         "Posted result · awaiting your sign-off",
       );
@@ -19,54 +33,128 @@ describe("ConfirmationCalloutDisplay", () => {
         confirmationCalloutDisplayPage.getAcceptButton(),
       ).toHaveTextContent("Accept result");
       expect(confirmationCalloutDisplayPage.getAcceptButton()).toBeEnabled();
+      // The rated stakes line is shown.
+      expect(callout).toHaveTextContent(/rated match/i);
+      // "Suggest correction" links into the correction route.
+      expect(
+        confirmationCalloutDisplayPage.querySuggestCorrectionLink(),
+      ).toHaveAttribute("href", correctHref("m-1"));
       expect(
         confirmationCalloutDisplayPage.queryError(),
       ).not.toBeInTheDocument();
+    });
+
+    it("shows the unrated stakes when the match doesn't affect ratings", async () => {
+      confirmationCalloutDisplayPage.render({
+        view: { kind: "review", resultId: "r-1", rated: false },
+      });
+
+      const callout = await waitFor(() =>
+        confirmationCalloutDisplayPage.getCallout(),
+      );
+      expect(callout).toHaveTextContent(/doesn't affect ratings/i);
     });
 
     it("fires onAccept from the primary CTA", async () => {
       const onAccept = vi.fn();
       confirmationCalloutDisplayPage.render({ onAccept });
 
+      await waitFor(() => confirmationCalloutDisplayPage.getCallout());
       await userEvent.click(confirmationCalloutDisplayPage.getAcceptButton());
 
       expect(onAccept).toHaveBeenCalledTimes(1);
     });
 
-    it("disables the CTA and shows the in-flight label while accepting", () => {
+    it("disables the CTA and shows the in-flight label while accepting", async () => {
       confirmationCalloutDisplayPage.render({ acceptPending: true });
 
+      await waitFor(() => confirmationCalloutDisplayPage.getCallout());
       expect(
         confirmationCalloutDisplayPage.getAcceptButton(),
       ).toHaveTextContent("Accepting…");
       expect(confirmationCalloutDisplayPage.getAcceptButton()).toBeDisabled();
     });
 
-    it("surfaces an API failure inline so the button doesn't appear inert", () => {
+    it("surfaces an API failure inline so the button doesn't appear inert", async () => {
       confirmationCalloutDisplayPage.render({
         errorMessage: "Match already finalized",
       });
 
+      await waitFor(() => confirmationCalloutDisplayPage.getCallout());
       expect(confirmationCalloutDisplayPage.queryError()).toHaveTextContent(
         "Match already finalized",
       );
     });
   });
 
-  describe("awaiting variant", () => {
-    it("names the opponent being waited on, with no CTA to press", () => {
+  describe("corrected variant", () => {
+    it("renders the diff and Accept / Counter affordances", async () => {
       confirmationCalloutDisplayPage.render({
-        view: buildAwaitingConfirmationView({
-          pendingSignerName: "nguyen.t",
-        }),
+        view: buildCorrectedConfirmationView(),
       });
 
-      const callout = confirmationCalloutDisplayPage.getCallout();
+      const callout = await waitFor(() =>
+        confirmationCalloutDisplayPage.getCallout(),
+      );
+      expect(callout).toHaveTextContent("Your opponent corrected the score.");
+      // The #720 ScoreDiff is embedded, showing both diff rows.
+      const diff = confirmationCalloutDisplayPage.queryDiff();
+      expect(diff).toBeInTheDocument();
+      expect(diff).toHaveTextContent("11–7");
+      expect(diff).toHaveTextContent("11–9");
+      // Accept stays, plus a "Counter" link into the correction route.
+      expect(confirmationCalloutDisplayPage.getAcceptButton()).toBeEnabled();
+      expect(
+        confirmationCalloutDisplayPage.queryCounterLink(),
+      ).toHaveAttribute("href", correctHref("m-1"));
+    });
+  });
+
+  describe("awaiting variant", () => {
+    it("names the opponent and offers an Edit result self-edit, no Accept", async () => {
+      confirmationCalloutDisplayPage.render({
+        view: buildAwaitingConfirmationView({ pendingSignerName: "nguyen.t" }),
+      });
+
+      const callout = await waitFor(() =>
+        confirmationCalloutDisplayPage.getCallout(),
+      );
       expect(callout).toHaveTextContent("Posted · awaiting acceptance");
       expect(callout).toHaveTextContent("Waiting on nguyen.t to accept");
       expect(
         confirmationCalloutDisplayPage.queryAcceptButton(),
       ).not.toBeInTheDocument();
+      expect(
+        confirmationCalloutDisplayPage.queryEditLink(),
+      ).toHaveAttribute("href", correctHref("m-1"));
+    });
+  });
+
+  describe("final variant", () => {
+    it("reads 'Confirmed' when there was no back-and-forth", async () => {
+      confirmationCalloutDisplayPage.render({
+        view: buildFinalConfirmationView({ afterCorrections: false }),
+      });
+
+      const callout = await waitFor(() =>
+        confirmationCalloutDisplayPage.getCallout(),
+      );
+      expect(callout).toHaveTextContent("Confirmed");
+      expect(callout).not.toHaveTextContent("after corrections");
+      expect(
+        confirmationCalloutDisplayPage.queryAcceptButton(),
+      ).not.toBeInTheDocument();
+    });
+
+    it("reads 'Agreed after corrections' when a prior proposal preceded the agreement", async () => {
+      confirmationCalloutDisplayPage.render({
+        view: buildFinalConfirmationView({ afterCorrections: true }),
+      });
+
+      const callout = await waitFor(() =>
+        confirmationCalloutDisplayPage.getCallout(),
+      );
+      expect(callout).toHaveTextContent("Agreed after corrections");
     });
   });
 });

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
@@ -1,9 +1,15 @@
+import { Link } from "@tanstack/react-router";
+
+import { correctionRoute } from "@/api/matches";
 import { Overline } from "@/components/overline";
 
+import { ScoreDiff } from "../../../score-diff/score-diff";
 import type { ConfirmationCalloutView } from "../confirmation-callout-query";
 
 export interface ConfirmationCalloutDisplayProps {
   view: ConfirmationCalloutView;
+  /** The match id, used to build the correction-route links. */
+  matchId: string;
   /** True while the accept request is in flight — swaps the Accept label to
    * "Accepting…" and disables the CTA. */
   acceptPending: boolean;
@@ -13,13 +19,54 @@ export interface ConfirmationCalloutDisplayProps {
   onAccept: () => void;
 }
 
+/** The rated/unrated stakes line, shared by the review + corrected callouts. */
+function StakesLine({ rated }: { rated: boolean }) {
+  return (
+    <p className="md-confirm-callout__stakes text-xs text-[color:var(--muted)]">
+      {rated
+        ? "Accepting finalizes this rated match and updates both ratings."
+        : "Accepting finalizes this match. It doesn't affect ratings."}
+    </p>
+  );
+}
+
+function AcceptButton({
+  acceptPending,
+  onAccept,
+}: {
+  acceptPending: boolean;
+  onAccept: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="md-btn md-btn--primary"
+      disabled={acceptPending}
+      onClick={onAccept}
+    >
+      {acceptPending ? "Accepting…" : "Accept result"}
+    </button>
+  );
+}
+
+function ErrorLine({ message }: { message: string | null }) {
+  if (!message) return null;
+  return (
+    <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
+      {message}
+    </p>
+  );
+}
+
 export function ConfirmationCalloutDisplay({
   view,
+  matchId,
   acceptPending,
   errorMessage,
   onAccept,
 }: ConfirmationCalloutDisplayProps) {
-  if (view.kind === "actionable") {
+  // The opponent posted the first result — accept it or suggest a correction.
+  if (view.kind === "review") {
     return (
       <section
         className="md-confirm-callout md-confirm-callout--featured"
@@ -35,28 +82,86 @@ export function ConfirmationCalloutDisplay({
           </h3>
           <p className="md-confirm-callout__body">
             Your opponent has posted the result below. Accept it to finalize the
-            match.
+            match, or suggest a correction if the score looks off.
           </p>
-          {errorMessage && (
-            <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
-              {errorMessage}
-            </p>
-          )}
+          <StakesLine rated={view.rated} />
+          <ErrorLine message={errorMessage} />
         </div>
         <div className="md-confirm-callout__actions">
-          <button
-            type="button"
-            className="md-btn md-btn--primary"
-            disabled={acceptPending}
-            onClick={onAccept}
+          <AcceptButton acceptPending={acceptPending} onAccept={onAccept} />
+          <Link
+            {...correctionRoute(matchId)}
+            className="md-btn md-btn--ghost"
+            data-testid="match-confirm-callout-correct"
           >
-            {acceptPending ? "Accepting…" : "Accept result"}
-          </button>
+            Suggest correction
+          </Link>
         </div>
       </section>
     );
   }
 
+  // The opponent countered the viewer's own prior proposal — show the diff and
+  // let the viewer accept the correction or counter back.
+  if (view.kind === "corrected") {
+    return (
+      <section
+        className="md-confirm-callout md-confirm-callout--featured"
+        data-testid="match-confirm-callout"
+      >
+        <div className="md-confirm-callout__copy">
+          <div className="md-confirm-callout__kicker">
+            <span className="ball-dot" aria-hidden="true" /> Corrected result ·
+            awaiting your sign-off
+          </div>
+          <h3 className="md-confirm-callout__headline">
+            Your opponent corrected the score.
+          </h3>
+          <p className="md-confirm-callout__body">
+            Review what changed, then accept the corrected result or counter
+            with your own.
+          </p>
+          {view.diff.length > 0 && <ScoreDiff diff={view.diff} />}
+          <StakesLine rated={view.rated} />
+          <ErrorLine message={errorMessage} />
+        </div>
+        <div className="md-confirm-callout__actions">
+          <AcceptButton acceptPending={acceptPending} onAccept={onAccept} />
+          <Link
+            {...correctionRoute(matchId)}
+            className="md-btn md-btn--ghost"
+            data-testid="match-confirm-callout-counter"
+          >
+            Counter
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  // The match is settled — a quiet confirmation, no action to press.
+  if (view.kind === "final") {
+    return (
+      <section
+        className="md-confirm-callout md-confirm-callout--passive"
+        data-testid="match-confirm-callout"
+      >
+        <div className="md-confirm-callout__copy">
+          <Overline as="h3">
+            {view.afterCorrections ? "Agreed after corrections" : "Confirmed"}
+          </Overline>
+          <p className="md-confirm-callout__body">
+            {view.afterCorrections
+              ? "Both sides agreed on the final score after corrections. This match is settled."
+              : "Both sides confirmed this result. This match is settled."}
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  // `awaiting`: the viewer posted; we wait on the opponent. Passive notice with
+  // an "Edit result" self-edit that supersedes the viewer's standing proposal.
   return (
     <section
       className="md-confirm-callout md-confirm-callout--passive"
@@ -69,11 +174,16 @@ export function ConfirmationCalloutDisplay({
           <strong>{view.pendingSignerName}</strong> to accept before the match
           is finalized.
         </p>
-        {errorMessage && (
-          <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
-            {errorMessage}
-          </p>
-        )}
+        <ErrorLine message={errorMessage} />
+      </div>
+      <div className="md-confirm-callout__actions">
+        <Link
+          {...correctionRoute(matchId)}
+          className="md-btn md-btn--ghost"
+          data-testid="match-confirm-callout-edit"
+        >
+          Edit result
+        </Link>
       </div>
     </section>
   );

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.test.ts
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.test.ts
@@ -12,6 +12,7 @@ import { confirmationCalloutQueryPage } from "./confirmation-callout-query.page"
 
 type MatchNegotiation = components["schemas"]["MatchNegotiation"];
 type NegotiationResult = components["schemas"]["NegotiationResult"];
+type NegotiationDiffEntry = components["schemas"]["NegotiationDiffEntry"];
 
 const standingResult = (id = "r-1"): NegotiationResult => ({
   id,
@@ -20,9 +21,18 @@ const standingResult = (id = "r-1"): NegotiationResult => ({
   submitted_at: "2026-06-10T12:00:00Z",
 });
 
+const diffEntry: NegotiationDiffEntry = {
+  game_number: 1,
+  old: { game_number: 1, side_1_points: 11, side_2_points: 7 },
+  new: { game_number: 1, side_1_points: 11, side_2_points: 9 },
+};
+
 /** A live match with a standing proposal the opponent posted — the viewer must
  * act (negotiation `review`). */
-const reviewMatch = (negotiation: Partial<MatchNegotiation> = {}): MatchDetails =>
+const reviewMatch = (
+  negotiation: Partial<MatchNegotiation> = {},
+  overrides: Partial<MatchDetails> = {},
+): MatchDetails =>
   buildMatchDetails({
     status: "in_progress",
     status_label: "Awaiting confirmation",
@@ -34,6 +44,7 @@ const reviewMatch = (negotiation: Partial<MatchNegotiation> = {}): MatchDetails 
       diff: null,
       ...negotiation,
     },
+    ...overrides,
   });
 
 const renderView = async () => {
@@ -49,14 +60,71 @@ describe("confirmationCalloutQuery", () => {
     ]);
   });
 
-  it("projects the actionable state with the standing result id when it's the viewer's turn", async () => {
+  it("projects the review state with the standing result id + rated stakes", async () => {
     confirmationCalloutQueryPage.mockEndpoint(() =>
       HttpResponse.json(reviewMatch()),
     );
 
     const result = await renderView();
 
-    expect(result.current.data).toEqual({ kind: "actionable", resultId: "r-1" });
+    expect(result.current.data).toEqual({
+      kind: "review",
+      resultId: "r-1",
+      rated: true,
+    });
+  });
+
+  it("carries the unrated stakes through from affects_rating", async () => {
+    confirmationCalloutQueryPage.mockEndpoint(() =>
+      HttpResponse.json(reviewMatch({}, { affects_rating: false })),
+    );
+
+    const result = await renderView();
+
+    expect(result.current.data).toEqual({
+      kind: "review",
+      resultId: "r-1",
+      rated: false,
+    });
+  });
+
+  it("projects the corrected state with the standing id and the server diff", async () => {
+    confirmationCalloutQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        reviewMatch({
+          viewer_state: "corrected",
+          standing_result: standingResult("r-2"),
+          prior_result: standingResult("r-0"),
+          diff: [diffEntry],
+        }),
+      ),
+    );
+
+    const result = await renderView();
+
+    expect(result.current.data).toEqual({
+      kind: "corrected",
+      resultId: "r-2",
+      rated: true,
+      diff: [diffEntry],
+    });
+  });
+
+  it("defaults a corrected state's diff to an empty array when the server sends null", async () => {
+    confirmationCalloutQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        reviewMatch({
+          viewer_state: "corrected",
+          standing_result: standingResult("r-2"),
+          prior_result: standingResult("r-0"),
+          diff: null,
+        }),
+      ),
+    );
+
+    const result = await renderView();
+
+    expect(result.current.data).toMatchObject({ kind: "corrected", diff: [] });
   });
 
   it("projects the awaiting state, naming the opponent, when the viewer's own side proposed", async () => {
@@ -78,23 +146,47 @@ describe("confirmationCalloutQuery", () => {
     });
   });
 
-  it("projects null once the match is final", async () => {
+  it("projects the final state as plain 'confirmed' when there was no prior proposal", async () => {
     confirmationCalloutQueryPage.mockEndpoint(() =>
       HttpResponse.json(
         reviewMatch({
           viewer_state: "final",
           your_turn: false,
           standing_result: standingResult(),
+          prior_result: null,
         }),
       ),
     );
 
     const result = await renderView();
 
-    expect(result.current.data).toBeNull();
+    expect(result.current.data).toEqual({
+      kind: "final",
+      afterCorrections: false,
+    });
   });
 
-  it("projects null when there is no standing result (live)", async () => {
+  it("projects the final state as 'after corrections' when a prior proposal preceded the agreement", async () => {
+    confirmationCalloutQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        reviewMatch({
+          viewer_state: "final",
+          your_turn: false,
+          standing_result: standingResult(),
+          prior_result: standingResult("r-0"),
+        }),
+      ),
+    );
+
+    const result = await renderView();
+
+    expect(result.current.data).toEqual({
+      kind: "final",
+      afterCorrections: true,
+    });
+  });
+
+  it("projects null when there is no proposal in play (live)", async () => {
     confirmationCalloutQueryPage.mockEndpoint(() =>
       HttpResponse.json(
         reviewMatch({

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.ts
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.ts
@@ -1,45 +1,88 @@
+import type { components } from "@/api/schema";
+
 import {
   matchDetailsQuery,
   type MatchDetailsResult,
 } from "../../match-details-query";
 
-/** The accept state behind the confirmation callout. Null from the query means
- * nothing renders.
+type NegotiationDiffEntry = components["schemas"]["NegotiationDiffEntry"];
+
+/** The result-negotiation state behind the match-detail callout, keyed off
+ * `negotiation.viewer_state`. Null from the query means there's nothing to show
+ * for this viewer (a live match with no proposal in play).
  *
- * - `actionable`: the viewer must act on the opponent's standing proposal
- *   (negotiation states `review`/`corrected`) — surfaces the Accept CTA. Carries
- *   the standing result's id, the concurrency token `POST .../acceptance` needs.
- * - `awaiting`: the viewer's own side proposed and we're waiting on the other
- *   side to accept (negotiation state `awaiting`) — a passive notice. */
+ * - `review`: the opponent posted the first result; the viewer must Accept or
+ *   open the correction route ("Suggest correction"). Carries the standing
+ *   result id (the acceptance token) and the rated stakes.
+ * - `corrected`: the opponent countered the viewer's own prior proposal; the
+ *   viewer must Accept the correction or counter back. Adds the server-computed
+ *   `diff` so the callout can highlight what changed.
+ * - `awaiting`: the viewer's own side proposed; we wait on the opponent. A
+ *   passive notice plus an "Edit result" action (a self-edit that supersedes
+ *   the viewer's standing proposal).
+ * - `final`: the match is settled. `afterCorrections` is true when there was
+ *   back-and-forth (the viewer had a prior proposal before the agreed one). */
 export type ConfirmationCalloutView =
-  | { kind: "actionable"; resultId: string }
+  | { kind: "review"; resultId: string; rated: boolean }
+  | {
+      kind: "corrected";
+      resultId: string;
+      rated: boolean;
+      diff: NegotiationDiffEntry[];
+    }
   | {
       kind: "awaiting";
       /** Opponent we're waiting on, for the passive label. */
       pendingSignerName: string;
-    };
+    }
+  | { kind: "final"; afterCorrections: boolean };
 
 const selectConfirmationCallout = (
   match: MatchDetailsResult,
 ): ConfirmationCalloutView | null => {
   const { negotiation } = match.unmigrated;
+  const rated = match.unmigrated.affects_rating;
 
-  // The viewer must act on the opponent's standing proposal.
-  if (negotiation.your_turn && negotiation.standing_result) {
-    return { kind: "actionable", resultId: negotiation.standing_result.id };
+  switch (negotiation.viewer_state) {
+    case "review": {
+      // The opponent posted the first result; the viewer must act.
+      if (!negotiation.standing_result) return null;
+      return { kind: "review", resultId: negotiation.standing_result.id, rated };
+    }
+
+    case "corrected": {
+      // The opponent countered the viewer's own prior proposal; show the diff.
+      if (!negotiation.standing_result) return null;
+      return {
+        kind: "corrected",
+        resultId: negotiation.standing_result.id,
+        rated,
+        diff: negotiation.diff ?? [],
+      };
+    }
+
+    case "awaiting": {
+      // The viewer's own side proposed; surface a passive "awaiting" notice.
+      const otherSide = match.unmigrated.sides.find(
+        (s) => !s.is_current_user_side,
+      );
+      const pendingSignerName =
+        otherSide?.players[0]?.username ?? "your opponent";
+      return { kind: "awaiting", pendingSignerName };
+    }
+
+    case "final":
+      // A non-null `prior_result` means the viewer had proposed before the
+      // agreed result, i.e. the match went through at least one correction.
+      return {
+        kind: "final",
+        afterCorrections: negotiation.prior_result !== null,
+      };
+
+    default:
+      // `live` — no proposal in play, nothing to render.
+      return null;
   }
-
-  // The viewer's own side proposed; surface a passive "awaiting" notice.
-  if (negotiation.viewer_state === "awaiting") {
-    const otherSide = match.unmigrated.sides.find(
-      (s) => !s.is_current_user_side,
-    );
-    const pendingSignerName =
-      otherSide?.players[0]?.username ?? "your opponent";
-    return { kind: "awaiting", pendingSignerName };
-  }
-
-  return null;
 };
 
 export const confirmationCalloutQuery = (matchId: string) => ({

--- a/web-client/src/components/matches/match-details/score-diff/score-diff.factory.tsx
+++ b/web-client/src/components/matches/match-details/score-diff/score-diff.factory.tsx
@@ -1,0 +1,47 @@
+import type { components } from "@/api/schema";
+import type { ScoreDiffProps } from "./score-diff";
+
+type NegotiationGame = components["schemas"]["NegotiationGame"];
+type NegotiationDiffEntry = components["schemas"]["NegotiationDiffEntry"];
+
+/** One game's points in a result snapshot. */
+export function buildNegotiationGame(
+  overrides: Partial<NegotiationGame> = {},
+): NegotiationGame {
+  return {
+    game_number: 1,
+    side_1_points: 11,
+    side_2_points: 9,
+    ...overrides,
+  };
+}
+
+/**
+ * One diff entry. By default a *changed* game (both `old` and `new` present);
+ * pass `old: null` to model a newly-added game.
+ */
+export function buildNegotiationDiffEntry(
+  overrides: Partial<NegotiationDiffEntry> = {},
+): NegotiationDiffEntry {
+  const gameNumber = overrides.new?.game_number ?? overrides.game_number ?? 1;
+  return {
+    game_number: gameNumber,
+    old: buildNegotiationGame({ game_number: gameNumber }),
+    new: buildNegotiationGame({
+      game_number: gameNumber,
+      side_1_points: 11,
+      side_2_points: 7,
+    }),
+    ...overrides,
+  };
+}
+
+/** Props for `ScoreDiff` — a single changed game by default. */
+export function buildScoreDiffProps(
+  overrides: Partial<ScoreDiffProps> = {},
+): ScoreDiffProps {
+  return {
+    diff: [buildNegotiationDiffEntry()],
+    ...overrides,
+  };
+}

--- a/web-client/src/components/matches/match-details/score-diff/score-diff.page.tsx
+++ b/web-client/src/components/matches/match-details/score-diff/score-diff.page.tsx
@@ -1,0 +1,56 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import { ScoreDiff, type ScoreDiffProps } from "./score-diff";
+import { buildScoreDiffProps } from "./score-diff.factory";
+
+const scoped = (container: Container) => ({
+  /** The diff block itself; always present (even for an empty diff). */
+  queryDiff() {
+    return container.queryByTestId("score-diff");
+  },
+  getDiff() {
+    return container.getByTestId("score-diff");
+  },
+  /** The row for game `n`; absent when that game is unchanged (not in diff). */
+  queryEntry(gameNumber: number) {
+    return container.queryByTestId(`score-diff-entry-${gameNumber}`);
+  },
+  getEntry(gameNumber: number) {
+    return container.getByTestId(`score-diff-entry-${gameNumber}`);
+  },
+  /** The struck-through old score for game `n`; absent when the game is new. */
+  queryOld(gameNumber: number) {
+    return container.queryByTestId(`score-diff-old-${gameNumber}`);
+  },
+  /** The emphasized new score for game `n`. */
+  getNew(gameNumber: number) {
+    return container.getByTestId(`score-diff-new-${gameNumber}`);
+  },
+  /** The "new game" tag rendered only for added games (`old === null`). */
+  queryAddedTag(gameNumber: number) {
+    return container.queryByTestId(`score-diff-added-${gameNumber}`);
+  },
+});
+
+/**
+ * Test page-object for `ScoreDiff` — the per-game correction diff rendered from
+ * `negotiation.diff`. Purely presentational, so `render` mounts the component
+ * directly with no router or providers.
+ */
+export const scoreDiffPage = {
+  render(overrides: Partial<ScoreDiffProps> = {}) {
+    const props = buildScoreDiffProps(overrides);
+    render(<ScoreDiff {...props} />);
+  },
+
+  /**
+   * Scope the diff accessors to a container — the whole `screen` (default) or a
+   * `within(node)` subtree. Page objects that embed the diff (the corrected
+   * callout, #719) call this to expose the same queries as their own.
+   */
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/match-details/score-diff/score-diff.test.tsx
+++ b/web-client/src/components/matches/match-details/score-diff/score-diff.test.tsx
@@ -1,0 +1,106 @@
+import {
+  buildNegotiationDiffEntry,
+  buildNegotiationGame,
+} from "./score-diff.factory";
+import { scoreDiffPage } from "./score-diff.page";
+
+describe("ScoreDiff", () => {
+  it("renders a row per diff entry, keyed by game number", () => {
+    scoreDiffPage.render({
+      diff: [
+        buildNegotiationDiffEntry({ game_number: 2 }),
+        buildNegotiationDiffEntry({ game_number: 4 }),
+      ],
+    });
+
+    expect(scoreDiffPage.getEntry(2)).toBeInTheDocument();
+    expect(scoreDiffPage.getEntry(4)).toBeInTheDocument();
+  });
+
+  it("strikes through the old score and emphasizes the new for a changed game", () => {
+    scoreDiffPage.render({
+      diff: [
+        buildNegotiationDiffEntry({
+          game_number: 1,
+          old: buildNegotiationGame({
+            game_number: 1,
+            side_1_points: 11,
+            side_2_points: 9,
+          }),
+          new: buildNegotiationGame({
+            game_number: 1,
+            side_1_points: 9,
+            side_2_points: 11,
+          }),
+        }),
+      ],
+    });
+
+    const old = scoreDiffPage.queryOld(1);
+    expect(old).toHaveTextContent("11–9");
+    expect(old).toHaveClass("line-through");
+    expect(scoreDiffPage.getNew(1)).toHaveTextContent("9–11");
+    // A changed game carries no "new game" tag.
+    expect(scoreDiffPage.queryAddedTag(1)).not.toBeInTheDocument();
+  });
+
+  it("renders an added game (old === null) without a strikethrough", () => {
+    scoreDiffPage.render({
+      diff: [
+        buildNegotiationDiffEntry({
+          game_number: 5,
+          old: null,
+          new: buildNegotiationGame({
+            game_number: 5,
+            side_1_points: 11,
+            side_2_points: 8,
+          }),
+        }),
+      ],
+    });
+
+    // No old/struck-through score for an added game.
+    expect(scoreDiffPage.queryOld(5)).not.toBeInTheDocument();
+    expect(scoreDiffPage.getNew(5)).toHaveTextContent("11–8");
+    expect(scoreDiffPage.queryAddedTag(5)).toBeInTheDocument();
+  });
+
+  it("renders a multi-game diff mixing a changed game and an added game", () => {
+    scoreDiffPage.render({
+      diff: [
+        buildNegotiationDiffEntry({
+          game_number: 2,
+          old: buildNegotiationGame({
+            game_number: 2,
+            side_1_points: 8,
+            side_2_points: 11,
+          }),
+          new: buildNegotiationGame({
+            game_number: 2,
+            side_1_points: 11,
+            side_2_points: 8,
+          }),
+        }),
+        buildNegotiationDiffEntry({
+          game_number: 3,
+          old: null,
+          new: buildNegotiationGame({
+            game_number: 3,
+            side_1_points: 11,
+            side_2_points: 6,
+          }),
+        }),
+      ],
+    });
+
+    // Changed game 2: old struck through, new emphasized, no added tag.
+    expect(scoreDiffPage.queryOld(2)).toHaveTextContent("8–11");
+    expect(scoreDiffPage.getNew(2)).toHaveTextContent("11–8");
+    expect(scoreDiffPage.queryAddedTag(2)).not.toBeInTheDocument();
+
+    // Added game 3: no old score, new emphasized, carries the added tag.
+    expect(scoreDiffPage.queryOld(3)).not.toBeInTheDocument();
+    expect(scoreDiffPage.getNew(3)).toHaveTextContent("11–6");
+    expect(scoreDiffPage.queryAddedTag(3)).toBeInTheDocument();
+  });
+});

--- a/web-client/src/components/matches/match-details/score-diff/score-diff.tsx
+++ b/web-client/src/components/matches/match-details/score-diff/score-diff.tsx
@@ -1,0 +1,80 @@
+import { cn } from "@/lib/utils";
+import { Alert, AlertTitle } from "@/components/ui/alert";
+import type { components } from "@/api/schema";
+
+type NegotiationDiffEntry = components["schemas"]["NegotiationDiffEntry"];
+
+export interface ScoreDiffProps {
+  /**
+   * The server-computed per-game diff (`negotiation.diff`). Each entry is a
+   * game that changed between the viewer's prior proposal and the standing
+   * correction; unchanged games are simply absent. We render the shape as-is —
+   * no client-side diffing.
+   */
+  diff: NegotiationDiffEntry[];
+}
+
+/** Render a single game's points as "S1–S2". */
+function formatGame(game: { side_1_points: number; side_2_points: number }) {
+  return `${game.side_1_points}–${game.side_2_points}`;
+}
+
+/**
+ * Presentational correction diff. For each entry it shows "Game N" with the
+ * old score struck through and the new score emphasized. When `old` is null the
+ * game was newly added by the correction, so it renders without a strikethrough.
+ */
+export const ScoreDiff = ({ diff }: ScoreDiffProps) => {
+  return (
+    <Alert data-testid="score-diff">
+      <AlertTitle>What changed</AlertTitle>
+      <ul className="mt-1 grid gap-1.5">
+        {diff.map((entry) => {
+          const isAdded = entry.old === null;
+          return (
+            <li
+              key={entry.game_number}
+              data-testid={`score-diff-entry-${entry.game_number}`}
+              className="flex items-baseline gap-2 text-sm"
+            >
+              <span className="w-14 shrink-0 font-medium tabular-nums text-muted-foreground">
+                Game {entry.game_number}
+              </span>
+              {entry.old !== null && (
+                <span
+                  data-testid={`score-diff-old-${entry.game_number}`}
+                  className="font-mono line-through text-[color:var(--loss)]"
+                >
+                  {formatGame(entry.old)}
+                </span>
+              )}
+              <span
+                aria-hidden
+                className={cn(
+                  "text-muted-foreground",
+                  entry.old === null && "sr-only",
+                )}
+              >
+                {"→"}
+              </span>
+              <span
+                data-testid={`score-diff-new-${entry.game_number}`}
+                className="font-mono font-semibold text-[color:var(--win)]"
+              >
+                {formatGame(entry.new)}
+                {isAdded && (
+                  <span
+                    data-testid={`score-diff-added-${entry.game_number}`}
+                    className="ml-2 text-xs font-normal uppercase tracking-wide text-muted-foreground"
+                  >
+                    new game
+                  </span>
+                )}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </Alert>
+  );
+};

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -6,13 +6,7 @@ import {
   useNavigate,
 } from '@tanstack/react-router'
 import { onlineManager, useQueryClient } from '@tanstack/react-query'
-import {
-  Check,
-  Loader2,
-  TriangleAlert,
-  User as UserIcon,
-  X as XIcon,
-} from 'lucide-react'
+import { Check, Loader2, TriangleAlert, X as XIcon } from 'lucide-react'
 import { ApiError } from '@/api/client'
 import {
   forgetScoreSaves,
@@ -42,9 +36,14 @@ import {
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { cn, initialsOf } from '@/lib/utils'
-import { decidedSide, illegalScoreReason } from '@/lib/scoring'
+import { decidedSide } from '@/lib/scoring'
 import { isScoreConflict, useGameSaveState } from './score-saves'
 import { SaveBanner } from './save-banner'
+import { ScorePad } from './score-pad'
+import {
+  isAcceptableScoreInput,
+  validateGameScore,
+} from './score-pad/validate-game-score'
 
 /** The non-null persisted score on a game. */
 type PersistedScore = NonNullable<MatchDetails['games'][number]['score']>
@@ -271,48 +270,33 @@ function ScoreEntryInner({
   const computeDirty = (nextMe: string, nextOpp: string) =>
     digitsOnly(nextMe) !== baselineMe || digitsOnly(nextOpp) !== baselineOpp
 
-  // Take the typed value verbatim — no stripping, no truncating. We only block
-  // characters that can't begin a score (letters, sign) so non-numeric input
-  // stays rejected as before; digits and a "." are kept. Earlier we stripped
-  // non-digits and capped at 3, but that quietly turned "11.5" into "115" and
-  // "999999" into "999" — plausible-looking scores the user never typed (#624).
-  // Keeping the raw text lets a malformed entry stay visible and get flagged
-  // inline (see `formatError`) instead of masquerading as a real score.
-  const isAcceptable = (value: string) => !/[^\d.]/.test(value)
+  // Take the typed value verbatim — no stripping, no truncating (#624); the
+  // shared `isAcceptableScoreInput` only blocks characters that can't begin a
+  // score (letters, sign). Keeping the raw text lets a malformed entry stay
+  // visible and get flagged inline instead of masquerading as a real score.
   const onMeChange = (value: string) => {
-    if (!isAcceptable(value)) return
+    if (!isAcceptableScoreInput(value)) return
     setMeTyped(value)
     setIsDirty(computeDirty(value, opp))
     if (finalizeMutation.error) finalizeMutation.reset()
   }
   const onOppChange = (value: string) => {
-    if (!isAcceptable(value)) return
+    if (!isAcceptableScoreInput(value)) return
     setOppTyped(value)
     setIsDirty(computeDirty(me, value))
     if (finalizeMutation.error) finalizeMutation.reset()
   }
 
-  const bothFilled = me !== '' && opp !== ''
-  // Exactly one side filled: the Save button is disabled, so without a word
-  // it's a dead end with no explanation (#387). Tell the user both scores are
-  // required and flag the still-empty field. Only after the user has started
-  // typing — a wholly-empty pair is the untouched initial state, not an error.
-  const oneSideFilled = (me !== '') !== (opp !== '')
-  // A filled side is well-formed only as 1–3 digits. Since the inputs are no
-  // longer coerced (#624), a decimal ("11.5") or an over-long run ("999999")
-  // reaches here verbatim — caught as a format error rather than silently
-  // becoming "115"/"999". Flagged on its own, before the both-filled scoring
-  // check, so it surfaces the moment the bad side is typed.
-  const meMalformed = me !== '' && !/^\d{1,3}$/.test(me)
-  const oppMalformed = opp !== '' && !/^\d{1,3}$/.test(opp)
-  const formatError =
-    meMalformed || oppMalformed
-      ? 'Enter each score as a whole number from 0 to 999.'
-      : null
-  const localScoreError =
-    formatError ??
-    (bothFilled ? illegalScoreReason(Number(me), Number(opp)) : null)
-  const inputsValid = bothFilled && localScoreError === null
+  // The shared single-game verdict: 1–3-digit well-formedness, the "exactly one
+  // side filled" hint (#387), and the `illegalScoreReason` table-tennis rule.
+  // Now shared with the propose-a-result correction surface via `score-pad`.
+  const validation = validateGameScore(me, opp)
+  const oneSideFilled = validation.oneSideFilled
+  const meMalformed = validation.meMalformed
+  const oppMalformed = validation.oppMalformed
+  const formatError = meMalformed || oppMalformed ? validation.error : null
+  const localScoreError = validation.error
+  const inputsValid = validation.valid
 
   // Build the hypothetical full-match games list including the current input,
   // so we can ask the scoring lib whether saving this entry would make the
@@ -618,86 +602,48 @@ function ScoreEntryInner({
           />
         )}
 
-        <div className="single-entry">
-          <ScoreSide
-            side="me"
-            name={meName}
-            initials={meInitials}
-            value={me}
-            inputRef={meRef}
-            autoFocus
-            disabled={inputsLocked}
-            invalid={meInvalid}
-            onChange={onMeChange}
-            onKeyDown={(e) => handleKey(e, 'me')}
-          />
-
-          <div className="se-mid">
-            <div className="se-vs">VS</div>
-            {/* Single-game matches: the games tally is always 0–0 until the one
-                game finalizes, so it's noise — drop it (#bridge-cse). */}
-            {bestOf > 1 && (
-              <div className="se-games">
-                {meWins} – {oppWins}
-              </div>
-            )}
-          </div>
-
-          <ScoreSide
-            side="opp"
-            name={oppName}
-            initials={oppHasPlayer ? initialsOf(oppName) : null}
-            value={opp}
-            inputRef={oppRef}
-            disabled={inputsLocked}
-            invalid={oppInvalid}
-            onChange={onOppChange}
-            onKeyDown={(e) => handleKey(e, 'opp')}
-          />
-        </div>
-
-        {showScoreError && (
-          <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
-            {localScoreError ??
-              finalizeApiError?.detail ??
-              finalizeApiError?.message}
-          </p>
-        )}
-        {showBothRequired && (
-          <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
-            Enter both scores to save this game.
-          </p>
-        )}
-
-        <div className="single-actions">
-          <div className="result-line subtle">{subtitle}</div>
-          <div className="action-btns">
-            {isEdit && (
-              <button
-                type="button"
-                className="btn ghost"
-                onClick={onClear}
-                disabled={inputsLocked || deleteMutation.isPending}
-              >
-                Clear
-              </button>
-            )}
-            <button
-              type="button"
-              className="btn primary"
-              disabled={!inputsValid || inputsLocked}
-              // Don't let tapping Save blur the active input: on mobile that
-              // dismisses the soft keyboard before the synchronous navigation
-              // can hand focus to the next game's input, closing the keyboard
-              // between games (#567). Preventing the mousedown default keeps
-              // focus on the input through the tap; the click still fires.
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={onSubmit}
-            >
-              {submitLabel}
-            </button>
-          </div>
-        </div>
+        <ScorePad
+          me={{
+            name: meName,
+            initials: meInitials,
+            value: me,
+            inputRef: meRef,
+            autoFocus: true,
+            invalid: meInvalid,
+            onChange: onMeChange,
+            onKeyDown: (e) => handleKey(e, 'me'),
+          }}
+          opp={{
+            name: oppName,
+            initials: oppHasPlayer ? initialsOf(oppName) : null,
+            value: opp,
+            inputRef: oppRef,
+            invalid: oppInvalid,
+            onChange: onOppChange,
+            onKeyDown: (e) => handleKey(e, 'opp'),
+          }}
+          gamesTally={bestOf > 1 ? `${meWins} – ${oppWins}` : null}
+          // The scratchpad surfaces both the local validation error and a
+          // finalize API rejection (409/500 too) here; `showScoreError` gates
+          // when any of them shows, with the finalize detail/message as the
+          // fallback copy when there's no local validation error.
+          scoreError={
+            showScoreError
+              ? (localScoreError ??
+                finalizeApiError?.detail ??
+                finalizeApiError?.message ??
+                null)
+              : null
+          }
+          showBothRequired={showBothRequired}
+          inputsLocked={inputsLocked}
+          subtitle={subtitle}
+          submitLabel={submitLabel}
+          canSubmit={inputsValid}
+          onSubmit={onSubmit}
+          onClear={isEdit ? onClear : undefined}
+          clearDisabled={deleteMutation.isPending}
+        />
 
         <Scoreline
           data={data}
@@ -861,69 +807,6 @@ function ScoreConflictNotice({
         </span>
       </AlertDescription>
     </Alert>
-  )
-}
-
-function ScoreSide({
-  side,
-  name,
-  initials,
-  value,
-  inputRef,
-  autoFocus,
-  disabled,
-  invalid,
-  onChange,
-  onKeyDown,
-}: {
-  side: 'me' | 'opp'
-  name: string
-  // `null` means there's no player on this side — render the ghost avatar
-  // (dashed circle + person icon) instead of a contrived monogram.
-  initials: string | null
-  value: string
-  inputRef: React.RefObject<HTMLInputElement | null>
-  autoFocus?: boolean
-  disabled: boolean
-  invalid: boolean
-  onChange: (value: string) => void
-  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void
-}) {
-  const noPlayer = initials === null
-  const avatar = (
-    <div className="av" aria-hidden={noPlayer || undefined}>
-      {noPlayer ? <UserIcon size={20} strokeWidth={1.75} /> : initials}
-    </div>
-  )
-  const identity = (
-    <div className="id">
-      <div className="nm">{name}</div>
-    </div>
-  )
-
-  return (
-    <div className={cn('se-side', side, noPlayer && 'no-opponent')}>
-      <div className={cn('se-head', side === 'opp' && 'right')}>
-        {side === 'opp' && identity}
-        {avatar}
-        {side === 'me' && identity}
-      </div>
-      <input
-        ref={inputRef}
-        className="big-input"
-        type="text"
-        inputMode="numeric"
-        aria-label={`${name} score`}
-        aria-invalid={invalid || undefined}
-        placeholder="0"
-        value={value}
-        autoFocus={autoFocus}
-        disabled={disabled}
-        onFocus={(e) => e.target.select()}
-        onChange={(e) => onChange(e.target.value)}
-        onKeyDown={onKeyDown}
-      />
-    </div>
   )
 }
 

--- a/web-client/src/components/matches/score-pad.factory.tsx
+++ b/web-client/src/components/matches/score-pad.factory.tsx
@@ -1,0 +1,52 @@
+import type { ScorePadProps, ScorePadSideModel } from './score-pad'
+
+/** A viewer-side model: `rita.kovac`, empty input, valid. */
+export function buildScorePadMe(
+  overrides: Partial<ScorePadSideModel> = {},
+): ScorePadSideModel {
+  return {
+    name: 'rita.kovac',
+    initials: 'RK',
+    value: '',
+    invalid: false,
+    onChange: () => {},
+    ...overrides,
+  }
+}
+
+/** An opponent-side model: `nguyen.t`, empty input, valid. */
+export function buildScorePadOpp(
+  overrides: Partial<ScorePadSideModel> = {},
+): ScorePadSideModel {
+  return {
+    name: 'nguyen.t',
+    initials: 'NT',
+    value: '',
+    invalid: false,
+    onChange: () => {},
+    ...overrides,
+  }
+}
+
+/**
+ * Props for `ScorePad` — a best-of-5 game one in, viewer's row first, nothing
+ * typed yet, ready to save (submit disabled until both sides are filled). The
+ * games tally and copy mirror the scratchpad save surface.
+ */
+export function buildScorePadProps(
+  overrides: Partial<ScorePadProps> = {},
+): ScorePadProps {
+  return {
+    me: buildScorePadMe(),
+    opp: buildScorePadOpp(),
+    gamesTally: '0 – 0',
+    scoreError: null,
+    showBothRequired: false,
+    inputsLocked: false,
+    subtitle: 'Save this game to continue to game 2.',
+    submitLabel: 'Save game & next →',
+    canSubmit: false,
+    onSubmit: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/matches/score-pad.page.tsx
+++ b/web-client/src/components/matches/score-pad.page.tsx
@@ -1,0 +1,45 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { ScorePad, type ScorePadProps } from './score-pad'
+import { buildScorePadProps } from './score-pad.factory'
+
+const scoped = (container: Container) => ({
+  /** A side's numeric input, by the participant's name (the field's
+   * accessible label is `"<name> score"`). */
+  getInput(name: string) {
+    return container.getByLabelText(`${name} score`) as HTMLInputElement
+  },
+  /** The primary submit button, by its current label. */
+  getSubmit(label: string) {
+    return container.getByRole('button', { name: label })
+  },
+  /** The secondary "Clear" action — only present when `onClear` is supplied. */
+  queryClear() {
+    return container.queryByRole('button', { name: 'Clear' })
+  },
+  /** The games tally under the VS divider, or null when hidden. */
+  queryGamesTally() {
+    return container.queryByText('VS')?.parentElement?.querySelector('.se-games')
+  },
+  /** Every visible `role="alert"` line (score error + both-required hint). */
+  queryAlerts() {
+    return container.queryAllByRole('alert')
+  },
+})
+
+/**
+ * Test page-object for `ScorePad` — the shared two-side score-input form. Pure
+ * presentational, so `render` mounts it directly (no router/suspense harness).
+ */
+export const scorePadPage = {
+  render(overrides: Partial<ScorePadProps> = {}) {
+    const props = buildScorePadProps(overrides)
+    render(<ScorePad {...props} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/matches/score-pad.test.tsx
+++ b/web-client/src/components/matches/score-pad.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  buildScorePadMe,
+  buildScorePadOpp,
+} from './score-pad.factory'
+import { scorePadPage } from './score-pad.page'
+
+describe('ScorePad', () => {
+  it('renders both sides labelled by participant name', () => {
+    scorePadPage.render({
+      me: buildScorePadMe({ name: 'rita.kovac', value: '11' }),
+      opp: buildScorePadOpp({ name: 'nguyen.t', value: '7' }),
+    })
+
+    expect(scorePadPage.getInput('rita.kovac')).toHaveValue('11')
+    expect(scorePadPage.getInput('nguyen.t')).toHaveValue('7')
+  })
+
+  it('reports each keystroke to the side onChange', () => {
+    const onChange = vi.fn()
+    scorePadPage.render({ me: buildScorePadMe({ onChange }) })
+
+    fireEvent.change(scorePadPage.getInput('rita.kovac'), {
+      target: { value: '9' },
+    })
+
+    expect(onChange).toHaveBeenCalledWith('9')
+  })
+
+  it('flags an invalid side with aria-invalid', () => {
+    scorePadPage.render({
+      me: buildScorePadMe({ value: '11.5', invalid: true }),
+    })
+
+    expect(scorePadPage.getInput('rita.kovac')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    )
+  })
+
+  it('shows the score error line when given one', () => {
+    scorePadPage.render({ scoreError: 'A game cannot end in a tie.' })
+
+    const alerts = scorePadPage.queryAlerts()
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toHaveTextContent('A game cannot end in a tie.')
+  })
+
+  it('shows the both-required hint on its own line', () => {
+    scorePadPage.render({ showBothRequired: true })
+
+    const alerts = scorePadPage.queryAlerts()
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toHaveTextContent('Enter both scores to save this game.')
+  })
+
+  it('hides the games tally when null (single-game matches)', () => {
+    scorePadPage.render({ gamesTally: null })
+
+    expect(scorePadPage.queryGamesTally()).toBeNull()
+  })
+
+  it('renders the games tally when provided', () => {
+    scorePadPage.render({ gamesTally: '2 – 1' })
+
+    expect(scorePadPage.queryGamesTally()).toHaveTextContent('2 – 1')
+  })
+
+  it('fires onSubmit from the primary button', () => {
+    const onSubmit = vi.fn()
+    scorePadPage.render({
+      submitLabel: 'Save game & next →',
+      canSubmit: true,
+      onSubmit,
+    })
+
+    fireEvent.click(scorePadPage.getSubmit('Save game & next →'))
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables submit when it cannot submit', () => {
+    scorePadPage.render({ submitLabel: 'Save', canSubmit: false })
+
+    expect(scorePadPage.getSubmit('Save')).toBeDisabled()
+  })
+
+  it('locks the inputs and submit while a submit is in flight', () => {
+    scorePadPage.render({
+      submitLabel: 'Posting result…',
+      canSubmit: true,
+      inputsLocked: true,
+    })
+
+    expect(scorePadPage.getInput('rita.kovac')).toBeDisabled()
+    expect(scorePadPage.getSubmit('Posting result…')).toBeDisabled()
+  })
+
+  it('omits the Clear action unless onClear is supplied', () => {
+    scorePadPage.render({ onClear: undefined })
+
+    expect(scorePadPage.queryClear()).toBeNull()
+  })
+
+  it('fires onClear from the Clear action when supplied', () => {
+    const onClear = vi.fn()
+    scorePadPage.render({ onClear })
+
+    const clear = scorePadPage.queryClear()
+    expect(clear).not.toBeNull()
+    fireEvent.click(clear as HTMLElement)
+
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web-client/src/components/matches/score-pad.tsx
+++ b/web-client/src/components/matches/score-pad.tsx
@@ -1,0 +1,156 @@
+import { ScorePadSide } from "./score-pad/score-pad-side";
+
+export interface ScorePadSideModel {
+  /** The participant's display name (bare username, no leading `@`). */
+  name: string;
+  /** Monogram initials, or `null` for a player-less side (ghost avatar). */
+  initials: string | null;
+  /** The current input value (raw text, taken verbatim). */
+  value: string;
+  /** Red-flag this field. */
+  invalid: boolean;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+  autoFocus?: boolean;
+  onChange: (value: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+}
+
+export interface ScorePadProps {
+  /** The viewer's side (rendered left). */
+  me: ScorePadSideModel;
+  /** The opponent side (rendered right). */
+  opp: ScorePadSideModel;
+  /** The games-won tally shown under the VS divider (e.g. `"1 – 0"`), or null
+   * to hide it (single-game matches, where it's always 0–0 and just noise). */
+  gamesTally: string | null;
+  /** A hard error to surface beneath the inputs (illegal/malformed score, or a
+   * server rejection), or null. */
+  scoreError: string | null;
+  /** Show the lower-severity "enter both scores" hint (exactly one side filled
+   * and no harder error to surface). */
+  showBothRequired: boolean;
+  /** Disable the inputs and actions while a submit is in flight. */
+  inputsLocked: boolean;
+  /** Hide the subtitle + submit/clear action row entirely, rendering just the
+   * two-side inputs + inline errors. The multi-game correction board uses this
+   * to stack several input-only pads under one shared submit. Defaults to
+   * showing the action row, so the scratchpad surface is unchanged. */
+  hideActions?: boolean;
+  // ----- action-row props: only read when `hideActions` is false, so the
+  // input-only callers (the correction board) omit them entirely. -----
+  /** The supporting copy under the action row. */
+  subtitle?: string;
+  /** The primary submit button label. */
+  submitLabel?: string;
+  /** Whether the primary submit is enabled. */
+  canSubmit?: boolean;
+  onSubmit?: () => void;
+  /** Optional secondary "Clear" action (the scratchpad edit surface). */
+  onClear?: () => void;
+  clearDisabled?: boolean;
+}
+
+/**
+ * The shared two-side score-input form: the `me`/`opp` numeric fields, the VS /
+ * games divider, the inline error lines, and the submit/clear action row.
+ * Presentational and submit-target-agnostic — the parent owns the input state
+ * and validation (`validateGameScore`) and supplies the submit callback, so the
+ * scratchpad per-game save and the propose-a-result correction flow can share
+ * one input UI with different targets and copy.
+ */
+export const ScorePad = ({
+  me,
+  opp,
+  gamesTally,
+  scoreError,
+  showBothRequired,
+  inputsLocked,
+  subtitle,
+  submitLabel,
+  canSubmit,
+  onSubmit,
+  onClear,
+  clearDisabled,
+  hideActions = false,
+}: ScorePadProps) => {
+  return (
+    <>
+      <div className="single-entry">
+        <ScorePadSide
+          side="me"
+          name={me.name}
+          initials={me.initials}
+          value={me.value}
+          inputRef={me.inputRef}
+          autoFocus={me.autoFocus}
+          disabled={inputsLocked}
+          invalid={me.invalid}
+          onChange={me.onChange}
+          onKeyDown={me.onKeyDown}
+        />
+
+        <div className="se-mid">
+          <div className="se-vs">VS</div>
+          {/* Single-game matches: the games tally is always 0–0 until the one
+              game finalizes, so it's noise — drop it (#bridge-cse). */}
+          {gamesTally !== null && <div className="se-games">{gamesTally}</div>}
+        </div>
+
+        <ScorePadSide
+          side="opp"
+          name={opp.name}
+          initials={opp.initials}
+          value={opp.value}
+          inputRef={opp.inputRef}
+          disabled={inputsLocked}
+          invalid={opp.invalid}
+          onChange={opp.onChange}
+          onKeyDown={opp.onKeyDown}
+        />
+      </div>
+
+      {scoreError !== null && (
+        <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
+          {scoreError}
+        </p>
+      )}
+      {showBothRequired && (
+        <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
+          Enter both scores to save this game.
+        </p>
+      )}
+
+      {!hideActions && (
+        <div className="single-actions">
+          <div className="result-line subtle">{subtitle}</div>
+          <div className="action-btns">
+            {onClear && (
+              <button
+                type="button"
+                className="btn ghost"
+                onClick={onClear}
+                disabled={inputsLocked || clearDisabled}
+              >
+                Clear
+              </button>
+            )}
+            <button
+              type="button"
+              className="btn primary"
+              disabled={!canSubmit || inputsLocked}
+              // Don't let tapping Save blur the active input: on mobile that
+              // dismisses the soft keyboard before the synchronous navigation
+              // can hand focus to the next game's input, closing the keyboard
+              // between games (#567). Preventing the mousedown default keeps
+              // focus on the input through the tap; the click still fires.
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={onSubmit}
+            >
+              {submitLabel}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/web-client/src/components/matches/score-pad/score-pad-side.factory.tsx
+++ b/web-client/src/components/matches/score-pad/score-pad-side.factory.tsx
@@ -1,0 +1,18 @@
+import type { ScorePadSideProps } from './score-pad-side'
+
+/**
+ * Props for `ScorePadSide` — the viewer's own side (`'me'`), `rita.kovac`, an
+ * empty input, valid and enabled.
+ */
+export function buildScorePadSideProps(
+  overrides: Partial<ScorePadSideProps> = {},
+): ScorePadSideProps {
+  return {
+    side: 'me',
+    name: 'rita.kovac',
+    initials: 'RK',
+    value: '',
+    onChange: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/matches/score-pad/score-pad-side.page.tsx
+++ b/web-client/src/components/matches/score-pad/score-pad-side.page.tsx
@@ -1,0 +1,32 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { ScorePadSide, type ScorePadSideProps } from './score-pad-side'
+import { buildScorePadSideProps } from './score-pad-side.factory'
+
+const scoped = (container: Container) => ({
+  /** The numeric input, by its accessible label (`"<name> score"`). */
+  getInput(name: string) {
+    return container.getByLabelText(`${name} score`) as HTMLInputElement
+  },
+  /** This side's display name. */
+  getName(name: string) {
+    return container.getByText(name)
+  },
+})
+
+/**
+ * Test page-object for `ScorePadSide` — one participant's score input. Pure
+ * presentational; `render` mounts it directly.
+ */
+export const scorePadSidePage = {
+  render(overrides: Partial<ScorePadSideProps> = {}) {
+    const props = buildScorePadSideProps(overrides)
+    render(<ScorePadSide {...props} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/matches/score-pad/score-pad-side.test.tsx
+++ b/web-client/src/components/matches/score-pad/score-pad-side.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { scorePadSidePage } from './score-pad-side.page'
+
+describe('ScorePadSide', () => {
+  it('labels the input by the participant name and shows the value', () => {
+    scorePadSidePage.render({ name: 'rita.kovac', value: '11' })
+
+    expect(scorePadSidePage.getInput('rita.kovac')).toHaveValue('11')
+    expect(scorePadSidePage.getName('rita.kovac')).toBeInTheDocument()
+  })
+
+  it('reports typed input through onChange', () => {
+    const onChange = vi.fn()
+    scorePadSidePage.render({ onChange })
+
+    fireEvent.change(scorePadSidePage.getInput('rita.kovac'), {
+      target: { value: '7' },
+    })
+
+    expect(onChange).toHaveBeenCalledWith('7')
+  })
+
+  it('sets aria-invalid when invalid', () => {
+    scorePadSidePage.render({ invalid: true })
+
+    expect(scorePadSidePage.getInput('rita.kovac')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    )
+  })
+
+  it('does not set aria-invalid when valid', () => {
+    scorePadSidePage.render({ invalid: false })
+
+    expect(scorePadSidePage.getInput('rita.kovac')).not.toHaveAttribute(
+      'aria-invalid',
+    )
+  })
+
+  it('disables the input when disabled', () => {
+    scorePadSidePage.render({ disabled: true })
+
+    expect(scorePadSidePage.getInput('rita.kovac')).toBeDisabled()
+  })
+})

--- a/web-client/src/components/matches/score-pad/score-pad-side.tsx
+++ b/web-client/src/components/matches/score-pad/score-pad-side.tsx
@@ -1,0 +1,74 @@
+import { User as UserIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface ScorePadSideProps {
+  side: 'me' | 'opp'
+  name: string
+  /** `null` means there's no player on this side — render the ghost avatar
+   * (dashed circle + person icon) instead of a contrived monogram. */
+  initials: string | null
+  value: string
+  inputRef?: React.RefObject<HTMLInputElement | null>
+  autoFocus?: boolean
+  disabled?: boolean
+  invalid?: boolean
+  onChange: (value: string) => void
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
+}
+
+/**
+ * One participant's score input — the avatar/identity header plus the big
+ * numeric field. Side `'me'` puts the avatar on the left of its name, `'opp'`
+ * mirrors it. Presentational: the parent owns the value, validity, and key
+ * handling; this renders them. Extracted from the scratchpad score-entry so the
+ * scratchpad save and the propose-a-result surfaces share the same input.
+ */
+export const ScorePadSide = ({
+  side,
+  name,
+  initials,
+  value,
+  inputRef,
+  autoFocus,
+  disabled,
+  invalid,
+  onChange,
+  onKeyDown,
+}: ScorePadSideProps) => {
+  const noPlayer = initials === null
+  const avatar = (
+    <div className="av" aria-hidden={noPlayer || undefined}>
+      {noPlayer ? <UserIcon size={20} strokeWidth={1.75} /> : initials}
+    </div>
+  )
+  const identity = (
+    <div className="id">
+      <div className="nm">{name}</div>
+    </div>
+  )
+
+  return (
+    <div className={cn('se-side', side, noPlayer && 'no-opponent')}>
+      <div className={cn('se-head', side === 'opp' && 'right')}>
+        {side === 'opp' && identity}
+        {avatar}
+        {side === 'me' && identity}
+      </div>
+      <input
+        ref={inputRef}
+        className="big-input"
+        type="text"
+        inputMode="numeric"
+        aria-label={`${name} score`}
+        aria-invalid={invalid || undefined}
+        placeholder="0"
+        value={value}
+        autoFocus={autoFocus}
+        disabled={disabled}
+        onFocus={(e) => e.target.select()}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+      />
+    </div>
+  )
+}

--- a/web-client/src/components/matches/score-pad/validate-game-score.test.ts
+++ b/web-client/src/components/matches/score-pad/validate-game-score.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isAcceptableScoreInput,
+  validateGameScore,
+} from './validate-game-score'
+
+describe('validateGameScore', () => {
+  it('accepts a legal decided final score', () => {
+    expect(validateGameScore('11', '7')).toEqual({
+      valid: true,
+      oneSideFilled: false,
+      error: null,
+      meMalformed: false,
+      oppMalformed: false,
+    })
+  })
+
+  it('does not flag a wholly-empty pair (the untouched initial state)', () => {
+    const v = validateGameScore('', '')
+    expect(v.valid).toBe(false)
+    expect(v.oneSideFilled).toBe(false)
+    expect(v.error).toBeNull()
+  })
+
+  it('flags exactly one side filled as oneSideFilled with no hard error', () => {
+    const v = validateGameScore('11', '')
+    expect(v.oneSideFilled).toBe(true)
+    expect(v.error).toBeNull()
+    expect(v.valid).toBe(false)
+  })
+
+  it('reports a format error and the malformed side for a decimal entry', () => {
+    const v = validateGameScore('11.5', '7')
+    expect(v.meMalformed).toBe(true)
+    expect(v.oppMalformed).toBe(false)
+    expect(v.error).toBe('Enter each score as a whole number from 0 to 999.')
+    expect(v.valid).toBe(false)
+  })
+
+  it('reports a format error for an over-long run of digits', () => {
+    const v = validateGameScore('11', '9999')
+    expect(v.oppMalformed).toBe(true)
+    expect(v.error).toBe('Enter each score as a whole number from 0 to 999.')
+  })
+
+  it('surfaces the illegal-score reason for a tie', () => {
+    const v = validateGameScore('11', '11')
+    expect(v.meMalformed).toBe(false)
+    expect(v.oppMalformed).toBe(false)
+    expect(v.error).toBe('A game cannot end in a tie.')
+    expect(v.valid).toBe(false)
+  })
+
+  it('surfaces the illegal-score reason for a sub-11 winner', () => {
+    const v = validateGameScore('9', '7')
+    expect(v.error).toBe('The winning side must reach at least 11 points.')
+  })
+})
+
+describe('isAcceptableScoreInput', () => {
+  it('keeps digits and a decimal point', () => {
+    expect(isAcceptableScoreInput('11')).toBe(true)
+    expect(isAcceptableScoreInput('11.')).toBe(true)
+    expect(isAcceptableScoreInput('')).toBe(true)
+  })
+
+  it('rejects letters and signs', () => {
+    expect(isAcceptableScoreInput('1a')).toBe(false)
+    expect(isAcceptableScoreInput('-1')).toBe(false)
+  })
+})

--- a/web-client/src/components/matches/score-pad/validate-game-score.ts
+++ b/web-client/src/components/matches/score-pad/validate-game-score.ts
@@ -1,0 +1,59 @@
+import { illegalScoreReason } from '@/lib/scoring'
+
+/**
+ * The validation verdict for one game's two raw score-input strings, shared by
+ * every surface that edits a single game's score (the scratchpad save and the
+ * propose-a-result correction flow). Mirrors `validate_game_score` server-side
+ * and the inline messaging the scratchpad entry has always shown.
+ */
+export interface GameScoreValidation {
+  /** Both sides parse to a legal, decided final score — safe to submit. */
+  valid: boolean
+  /** Exactly one side is filled: the other is required before submitting. The
+   * untouched (wholly empty) pair is not flagged — that's the initial state. */
+  oneSideFilled: boolean
+  /** A hard error to surface (malformed digits, or an illegal final score), or
+   * null when there's nothing to say yet. */
+  error: string | null
+  /** The `me` field holds malformed text (not 1–3 digits). */
+  meMalformed: boolean
+  /** The `opp` field holds malformed text (not 1–3 digits). */
+  oppMalformed: boolean
+}
+
+/**
+ * Validate one game's two raw input strings (taken verbatim — see the #624
+ * no-coercion note in the scratchpad entry). A side is well-formed only as 1–3
+ * digits; both filled and well-formed are then run through the shared
+ * `illegalScoreReason` table-tennis rule.
+ */
+export function validateGameScore(me: string, opp: string): GameScoreValidation {
+  const bothFilled = me !== '' && opp !== ''
+  const oneSideFilled = (me !== '') !== (opp !== '')
+  const meMalformed = me !== '' && !/^\d{1,3}$/.test(me)
+  const oppMalformed = opp !== '' && !/^\d{1,3}$/.test(opp)
+  const formatError =
+    meMalformed || oppMalformed
+      ? 'Enter each score as a whole number from 0 to 999.'
+      : null
+  const error =
+    formatError ??
+    (bothFilled ? illegalScoreReason(Number(me), Number(opp)) : null)
+  return {
+    valid: bothFilled && error === null,
+    oneSideFilled,
+    error,
+    meMalformed,
+    oppMalformed,
+  }
+}
+
+/**
+ * Whether a typed string is acceptable to keep in a score field. We only block
+ * characters that can't begin a score (letters, sign); digits and a `.` are
+ * kept verbatim so a malformed entry stays visible and gets flagged inline
+ * rather than masquerading as a real score (#624).
+ */
+export function isAcceptableScoreInput(value: string): boolean {
+  return !/[^\d.]/.test(value)
+}

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -37,6 +37,7 @@ import { Route as AppAdminRolesRouteImport } from './routes/_app/admin.roles'
 import { Route as AppAdminPermissionsRouteImport } from './routes/_app/admin.permissions'
 import { Route as AppAdminBroadcastRouteImport } from './routes/_app/admin.broadcast'
 import { Route as AppMatchesMatchIdIndexRouteImport } from './routes/_app/matches.$matchId.index'
+import { Route as AppMatchesMatchIdCorrectRouteImport } from './routes/_app/matches.$matchId.correct'
 import { Route as AppMatchesMatchIdGamesGameNumberScoresNewRouteImport } from './routes/_app/matches.$matchId.games.$gameNumber.scores.new'
 import { Route as AppMatchesMatchIdGamesGameNumberScoresEditRouteImport } from './routes/_app/matches.$matchId.games.$gameNumber.scores.edit'
 
@@ -181,6 +182,12 @@ const AppMatchesMatchIdIndexRoute = AppMatchesMatchIdIndexRouteImport.update({
   path: '/matches/$matchId/',
   getParentRoute: () => AppRouteRoute,
 } as any)
+const AppMatchesMatchIdCorrectRoute =
+  AppMatchesMatchIdCorrectRouteImport.update({
+    id: '/matches/$matchId/correct',
+    path: '/matches/$matchId/correct',
+    getParentRoute: () => AppRouteRoute,
+  } as any)
 const AppMatchesMatchIdGamesGameNumberScoresNewRoute =
   AppMatchesMatchIdGamesGameNumberScoresNewRouteImport.update({
     id: '/matches/$matchId/games/$gameNumber/scores/new',
@@ -221,6 +228,7 @@ export interface FileRoutesByFullPath {
   '/notifications/': typeof AppNotificationsIndexRoute
   '/players/': typeof AppPlayersIndexRoute
   '/tournaments/': typeof AppTournamentsIndexRoute
+  '/matches/$matchId/correct': typeof AppMatchesMatchIdCorrectRoute
   '/matches/$matchId/': typeof AppMatchesMatchIdIndexRoute
   '/matches/$matchId/games/$gameNumber/scores/edit': typeof AppMatchesMatchIdGamesGameNumberScoresEditRoute
   '/matches/$matchId/games/$gameNumber/scores/new': typeof AppMatchesMatchIdGamesGameNumberScoresNewRoute
@@ -249,6 +257,7 @@ export interface FileRoutesByTo {
   '/notifications': typeof AppNotificationsIndexRoute
   '/players': typeof AppPlayersIndexRoute
   '/tournaments': typeof AppTournamentsIndexRoute
+  '/matches/$matchId/correct': typeof AppMatchesMatchIdCorrectRoute
   '/matches/$matchId': typeof AppMatchesMatchIdIndexRoute
   '/matches/$matchId/games/$gameNumber/scores/edit': typeof AppMatchesMatchIdGamesGameNumberScoresEditRoute
   '/matches/$matchId/games/$gameNumber/scores/new': typeof AppMatchesMatchIdGamesGameNumberScoresNewRoute
@@ -282,6 +291,7 @@ export interface FileRoutesById {
   '/_app/notifications/': typeof AppNotificationsIndexRoute
   '/_app/players/': typeof AppPlayersIndexRoute
   '/_app/tournaments/': typeof AppTournamentsIndexRoute
+  '/_app/matches/$matchId/correct': typeof AppMatchesMatchIdCorrectRoute
   '/_app/matches/$matchId/': typeof AppMatchesMatchIdIndexRoute
   '/_app/matches/$matchId/games/$gameNumber/scores/edit': typeof AppMatchesMatchIdGamesGameNumberScoresEditRoute
   '/_app/matches/$matchId/games/$gameNumber/scores/new': typeof AppMatchesMatchIdGamesGameNumberScoresNewRoute
@@ -315,6 +325,7 @@ export interface FileRouteTypes {
     | '/notifications/'
     | '/players/'
     | '/tournaments/'
+    | '/matches/$matchId/correct'
     | '/matches/$matchId/'
     | '/matches/$matchId/games/$gameNumber/scores/edit'
     | '/matches/$matchId/games/$gameNumber/scores/new'
@@ -343,6 +354,7 @@ export interface FileRouteTypes {
     | '/notifications'
     | '/players'
     | '/tournaments'
+    | '/matches/$matchId/correct'
     | '/matches/$matchId'
     | '/matches/$matchId/games/$gameNumber/scores/edit'
     | '/matches/$matchId/games/$gameNumber/scores/new'
@@ -375,6 +387,7 @@ export interface FileRouteTypes {
     | '/_app/notifications/'
     | '/_app/players/'
     | '/_app/tournaments/'
+    | '/_app/matches/$matchId/correct'
     | '/_app/matches/$matchId/'
     | '/_app/matches/$matchId/games/$gameNumber/scores/edit'
     | '/_app/matches/$matchId/games/$gameNumber/scores/new'
@@ -590,6 +603,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppMatchesMatchIdIndexRouteImport
       parentRoute: typeof AppRouteRoute
     }
+    '/_app/matches/$matchId/correct': {
+      id: '/_app/matches/$matchId/correct'
+      path: '/matches/$matchId/correct'
+      fullPath: '/matches/$matchId/correct'
+      preLoaderRoute: typeof AppMatchesMatchIdCorrectRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
     '/_app/matches/$matchId/games/$gameNumber/scores/new': {
       id: '/_app/matches/$matchId/games/$gameNumber/scores/new'
       path: '/matches/$matchId/games/$gameNumber/scores/new'
@@ -664,6 +684,7 @@ interface AppRouteRouteChildren {
   AppPlayersUserIdRoute: typeof AppPlayersUserIdRoute
   AppMatchesIndexRoute: typeof AppMatchesIndexRoute
   AppPlayersIndexRoute: typeof AppPlayersIndexRoute
+  AppMatchesMatchIdCorrectRoute: typeof AppMatchesMatchIdCorrectRoute
   AppMatchesMatchIdIndexRoute: typeof AppMatchesMatchIdIndexRoute
   AppMatchesMatchIdGamesGameNumberScoresEditRoute: typeof AppMatchesMatchIdGamesGameNumberScoresEditRoute
   AppMatchesMatchIdGamesGameNumberScoresNewRoute: typeof AppMatchesMatchIdGamesGameNumberScoresNewRoute
@@ -679,6 +700,7 @@ const AppRouteRouteChildren: AppRouteRouteChildren = {
   AppPlayersUserIdRoute: AppPlayersUserIdRoute,
   AppMatchesIndexRoute: AppMatchesIndexRoute,
   AppPlayersIndexRoute: AppPlayersIndexRoute,
+  AppMatchesMatchIdCorrectRoute: AppMatchesMatchIdCorrectRoute,
   AppMatchesMatchIdIndexRoute: AppMatchesMatchIdIndexRoute,
   AppMatchesMatchIdGamesGameNumberScoresEditRoute:
     AppMatchesMatchIdGamesGameNumberScoresEditRoute,

--- a/web-client/src/routes/_app/matches.$matchId.correct.tsx
+++ b/web-client/src/routes/_app/matches.$matchId.correct.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { CorrectionEntry } from "@/components/matches/correction-entry/correction-entry";
+import { MatchDetailsError } from "@/components/matches/match-details";
+import { ApiError } from "@/api/client";
+import { pageTitle } from "@/lib/page-title";
+import { isMatchId } from "@/lib/match-id";
+
+export const Route = createFileRoute("/_app/matches/$matchId/correct")({
+  head: () => ({
+    meta: [{ title: pageTitle("Suggest a correction") }],
+  }),
+  component: CorrectionRoute,
+  // `CorrectionEntry` fetches the match with `throwOnError`, so a 404 (no such
+  // match) or 422 (malformed id) throws during render. Reuse the match-details
+  // fallback so it maps to the same friendly "We couldn't find that match."
+  // dead end instead of TanStack's generic crash page (#385).
+  errorComponent: MatchDetailsError,
+});
+
+function CorrectionRoute() {
+  const { matchId } = Route.useParams();
+  if (!isMatchId(matchId)) {
+    // Reject a malformed id without hitting the API — same friendly not-found
+    // UI, no 422 and no console-noise `ApiError` (#385).
+    return (
+      <MatchDetailsError
+        error={new ApiError(404, null, `load match ${matchId}`)}
+        reset={() => {}}
+      />
+    );
+  }
+  return <CorrectionEntry matchId={matchId} />;
+}


### PR DESCRIPTION
## What

The user-facing negotiation UX on top of Unit 2's working min-FE — the **correction flow** and richer match-detail callouts. Closes **#717, #720, #718, #719** of epic #721.

- **#717 — Shared score-entry:** extracted the two-side score-input form into a submit-target-agnostic **`ScorePad`** quartet (`+ ScorePadSide + validate-game-score`), reused by the scratchpad save and the new correction flow. The scratchpad UX/DOM is byte-identical — the optimistic-concurrency save path and `score-entry.spec.ts` are unchanged.
- **#720 — Correction diff:** a presentational **`ScoreDiff`** quartet rendering the server-computed `negotiation.diff` (old struck-through → new emphasized; added games tagged). No client-side diffing — consumes the server shape as-is.
- **#718 — Correction route `matches.$matchId.correct`:** a "Suggest a correction" screen that pre-fills from `negotiation.standing_result.games` (the immutable snapshot, **not** the live scratchpad), reuses `ScorePad`, and proposes a counter via `useProposeResult({ games, supersedes_result_id: standing_result.id })`, returning to the match on success (409 surfaced inline).
- **#719 — Per-state callouts:** the match-detail callout is driven off `negotiation.viewer_state` — `review` → Accept + Suggest correction (+ stakes); `corrected` → the diff + Accept / Counter; `awaiting` → passive "waiting on opponent"; `final` → confirmed vs "agreed after corrections". List badges from `your_turn`/`viewer_state`.

Each component follows the react-component quartet convention (component + page object + factory + vitest). Built against the design-system components (no mockup was available headless — see note below).

## Testing

- `web-client` **lint** (0 errors) + **build** (`tsc -b && vite build`) + **vitest 1057 passed (167 files)** + **Playwright e2e 128 passed**.
- A `/simplify` pass ran (made `ScorePad`'s action-row props optional so the input-only correction board needn't pass dead values).
- Backend untouched (no `api/**` change; no schema drift).

## Note

The "Score Flow Redesign" mockup needs interactive Claude Design auth not available in this environment, so the correction/callout screens are styled with the existing design-system components rather than matched pixel-for-pixel. Send the mockup via "Send to Claude Code" to refine visuals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)