### PR TITLE
Surface `had_corrections` so completed matches can show "Agreed after corrections" (#719)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -385,6 +385,12 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
 
     Non-participants / anonymous callers get a neutral spectator mapping
     (``your_turn=False``, no diff/prior)."""
+    # Match-level, viewer-independent: the chain holds a correction iff more than
+    # one proposal was ever posted (a counter or self-edit superseded the first).
+    # The FE reads this on the ``final`` state to pick "Confirmed" vs "Agreed
+    # after corrections" (#719).
+    had_corrections = len(match.results) > 1
+
     accepted = accepted_result(match)
     if accepted is not None:
         return MatchNegotiation(
@@ -393,6 +399,7 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
             standing_result=_negotiation_result(accepted),
             prior_result=None,
             diff=None,
+            had_corrections=had_corrections,
         )
 
     standing = standing_result(match)
@@ -403,6 +410,7 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
             standing_result=None,
             prior_result=None,
             diff=None,
+            had_corrections=had_corrections,
         )
 
     standing_view = _negotiation_result(standing)
@@ -418,6 +426,7 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
             standing_result=standing_view,
             prior_result=None,
             diff=None,
+            had_corrections=had_corrections,
         )
 
     if _submitted_on_side(match, standing, viewer_side):
@@ -428,6 +437,7 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
             standing_result=standing_view,
             prior_result=None,
             diff=None,
+            had_corrections=had_corrections,
         )
 
     # The opponent submitted the standing result → the viewer must act. Walk the
@@ -452,6 +462,7 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
             standing_result=standing_view,
             prior_result=None,
             diff=None,
+            had_corrections=had_corrections,
         )
 
     return MatchNegotiation(
@@ -460,6 +471,7 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
         standing_result=standing_view,
         prior_result=_negotiation_result(prior),
         diff=_negotiation_diff(prior.games, standing.games),
+        had_corrections=had_corrections,
     )
 
 

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -220,6 +220,13 @@ class MatchNegotiation(BaseModel):
     standing_result: NegotiationResult | None
     prior_result: NegotiationResult | None
     diff: list[NegotiationDiffEntry] | None
+    # Match-level (NOT viewer-relative, unlike the fields above — distinct from
+    # the ``viewer_state == "corrected"`` case): true when the result chain holds
+    # more than one proposal, i.e. at least one correction was posted before the
+    # chain settled. The FE reads this on the ``final`` state to label a completed
+    # match "Confirmed" (clean first-post→accept) vs "Agreed after corrections"
+    # (a counter/self-edit preceded the agreement).
+    had_corrections: bool
 
 
 class MatchDetails(BaseModel):

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -2429,6 +2429,8 @@ async def test_accept_finalizes_and_applies_ratings_once(
         assert neg["your_turn"] is False
         assert neg["prior_result"] is None
         assert neg["diff"] is None
+        # A single posted result accepted as-is — no correction in the chain.
+        assert neg["had_corrections"] is False
         sides = sorted(body["sides"], key=lambda s: s["side_number"])
         assert [s["won"] for s in sides] == [True, False]
 
@@ -2479,6 +2481,39 @@ async def test_accept_finalizes_and_applies_ratings_once(
             .all()
         )
         assert len(rating_rows_after) == 2
+
+
+async def test_final_had_corrections_flag_tracks_chain_length(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The ``final`` negotiation block's match-level ``had_corrections`` flag is
+    true iff the agreed result was *not* the first one posted — i.e. a counter
+    (or self-edit) preceded the agreement. It drives the completed-match
+    callout's "Confirmed" vs "Agreed after corrections" copy (#719).
+
+    Two matches contrast the cases: a clean first-post→accept has
+    ``had_corrections`` false; a counter→accept has it true."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "corrected-opp") as (opp_client, opp):
+        # Clean: I post once, the opponent accepts it unchanged → not corrected.
+        clean = await _create_match(api_client, opp.id, best_of=1)
+        await _propose(api_client, clean["id"], s1=11, s2=4)
+        clean_final = await accept_standing_result(opp_client, clean["id"])
+        assert clean_final["negotiation"]["viewer_state"] == "final"
+        assert clean_final["negotiation"]["had_corrections"] is False
+
+        # Corrected: I post, the opponent counters, I accept the counter → the
+        # agreed result is the second in the chain, so the flag is true.
+        disputed = await _create_match(api_client, opp.id, best_of=1)
+        first = await _propose(api_client, disputed["id"], s1=11, s2=4)
+        first_id = first["body"]["negotiation"]["standing_result"]["id"]
+        counter = await _propose(
+            opp_client, disputed["id"], s1=4, s2=11, supersedes=first_id
+        )
+        assert counter["status"] == 201, counter
+        disputed_final = await accept_standing_result(api_client, disputed["id"])
+        assert disputed_final["negotiation"]["viewer_state"] == "final"
+        assert disputed_final["negotiation"]["had_corrections"] is True
 
 
 async def test_accept_superseded_result_id_is_409(

--- a/web-client/e2e/score-entry.spec.ts
+++ b/web-client/e2e/score-entry.spec.ts
@@ -162,6 +162,7 @@ function projectMatchDetails(seed: Seed) {
       standing_result: null,
       prior_result: null,
       diff: null,
+      had_corrections: false,
     },
   }
 }

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1578,6 +1578,8 @@ export interface components {
             prior_result: components["schemas"]["NegotiationResult"] | null;
             /** Diff */
             diff: components["schemas"]["NegotiationDiffEntry"][] | null;
+            /** Had Corrections */
+            had_corrections: boolean;
         };
         /**
          * MatchResultsGameWrite

--- a/web-client/src/components/matches/correction-entry/correction-entry.factory.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.factory.tsx
@@ -95,6 +95,7 @@ export function buildCorrectableMatch(
       standing_result: standing,
       prior_result: null,
       diff: null,
+      had_corrections: false,
     },
     ...overrides,
   });

--- a/web-client/src/components/matches/match-details/confirmation-callout.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout.test.tsx
@@ -29,6 +29,7 @@ const reviewMatch = (): MatchDetails =>
       },
       prior_result: null,
       diff: null,
+      had_corrections: false,
     },
   });
 
@@ -47,6 +48,7 @@ const finalMatch = (): MatchDetails =>
       },
       prior_result: null,
       diff: null,
+      had_corrections: false,
     },
     data: buildMatchDetailsData({
       scoreboard: buildScoreboard({ status: "final" }),

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher.test.tsx
@@ -21,6 +21,7 @@ const reviewMatch = () =>
       },
       prior_result: null,
       diff: null,
+      had_corrections: false,
     },
   });
 

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.test.ts
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.test.ts
@@ -42,6 +42,7 @@ const reviewMatch = (
       standing_result: standingResult(),
       prior_result: null,
       diff: null,
+      had_corrections: false,
       ...negotiation,
     },
     ...overrides,
@@ -146,14 +147,14 @@ describe("confirmationCalloutQuery", () => {
     });
   });
 
-  it("projects the final state as plain 'confirmed' when there was no prior proposal", async () => {
+  it("projects the final state as plain 'confirmed' when the chain wasn't corrected", async () => {
     confirmationCalloutQueryPage.mockEndpoint(() =>
       HttpResponse.json(
         reviewMatch({
           viewer_state: "final",
           your_turn: false,
           standing_result: standingResult(),
-          prior_result: null,
+          had_corrections: false,
         }),
       ),
     );
@@ -166,14 +167,17 @@ describe("confirmationCalloutQuery", () => {
     });
   });
 
-  it("projects the final state as 'after corrections' when a prior proposal preceded the agreement", async () => {
+  it("projects the final state as 'after corrections' when the chain was corrected", async () => {
     confirmationCalloutQueryPage.mockEndpoint(() =>
       HttpResponse.json(
+        // `had_corrections` is the match-level signal; the final state carries
+        // no `prior_result`, so the derivation must read `had_corrections`.
         reviewMatch({
           viewer_state: "final",
           your_turn: false,
           standing_result: standingResult(),
-          prior_result: standingResult("r-0"),
+          prior_result: null,
+          had_corrections: true,
         }),
       ),
     );

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.ts
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.ts
@@ -20,8 +20,8 @@ type NegotiationDiffEntry = components["schemas"]["NegotiationDiffEntry"];
  * - `awaiting`: the viewer's own side proposed; we wait on the opponent. A
  *   passive notice plus an "Edit result" action (a self-edit that supersedes
  *   the viewer's standing proposal).
- * - `final`: the match is settled. `afterCorrections` is true when there was
- *   back-and-forth (the viewer had a prior proposal before the agreed one). */
+ * - `final`: the match is settled. `afterCorrections` is true when the result
+ *   chain held more than one proposal (a correction preceded the agreement). */
 export type ConfirmationCalloutView =
   | { kind: "review"; resultId: string; rated: boolean }
   | {
@@ -72,11 +72,12 @@ const selectConfirmationCallout = (
     }
 
     case "final":
-      // A non-null `prior_result` means the viewer had proposed before the
-      // agreed result, i.e. the match went through at least one correction.
+      // `had_corrections` is the match-level signal that the chain held more
+      // than one proposal — a counter or self-edit landed before the agreed
+      // result. (Distinct from the viewer-relative `viewer_state === "corrected"`.)
       return {
         kind: "final",
-        afterCorrections: negotiation.prior_result !== null,
+        afterCorrections: negotiation.had_corrections,
       };
 
     default:

--- a/web-client/src/components/matches/match-details/save-your-match/save-your-match-fetcher/save-your-match-query.test.ts
+++ b/web-client/src/components/matches/match-details/save-your-match/save-your-match-fetcher/save-your-match-query.test.ts
@@ -134,6 +134,7 @@ describe("saveYourMatchQuery", () => {
             },
             prior_result: null,
             diff: null,
+            had_corrections: false,
           },
         }),
       ),

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -224,11 +224,16 @@ export const LIVE_NEGOTIATION: MatchNegotiation = {
   standing_result: null,
   prior_result: null,
   diff: null,
+  had_corrections: false,
 }
 
 /** The viewer-relative negotiation block — mirrors `_negotiation` in the API.
  * The mock current user always sits on side 1 (the viewer's side). */
 export function negotiationOf(seed: SeedMatch): MatchNegotiation {
+  // Match-level (viewer-independent): the chain holds a correction iff more than
+  // one proposal was ever posted. Mirrors `_negotiation` in the API.
+  const had_corrections = seed.results.length > 1
+
   const accepted = acceptedResult(seed)
   if (accepted !== null) {
     return {
@@ -237,6 +242,7 @@ export function negotiationOf(seed: SeedMatch): MatchNegotiation {
       standing_result: negotiationResultView(accepted),
       prior_result: null,
       diff: null,
+      had_corrections,
     }
   }
 
@@ -255,6 +261,7 @@ export function negotiationOf(seed: SeedMatch): MatchNegotiation {
       standing_result: standingView,
       prior_result: null,
       diff: null,
+      had_corrections,
     }
   }
 
@@ -281,6 +288,7 @@ export function negotiationOf(seed: SeedMatch): MatchNegotiation {
       standing_result: standingView,
       prior_result: null,
       diff: null,
+      had_corrections,
     }
   }
 
@@ -290,6 +298,7 @@ export function negotiationOf(seed: SeedMatch): MatchNegotiation {
     standing_result: standingView,
     prior_result: negotiationResultView(prior),
     diff: negotiationDiff(prior.games, standing.games),
+    had_corrections,
   }
 }
 


### PR DESCRIPTION
## What

Completes the #719 acceptance criterion ("final → confirmed vs agreed after N corrections") for the two-verb match-result negotiation (epic #721).

The FE renders a `final` match's callout as either **"Confirmed"** or **"Agreed after corrections"**, but it decided via `negotiation.prior_result !== null` — which the backend always sets to `None` on the `final` branch. So "Agreed after corrections" was **unreachable in production**; every completed match showed "Confirmed".

## How (Option B — match-level, unambiguous)

Add a match-level `MatchNegotiation.had_corrections: bool` = *the result chain holds more than one proposal* (a counter or self-edit preceded the agreed result). Computed once in `_negotiation()` as `len(match.results) > 1` and threaded through every branch.

- **Viewer-independent on purpose** — distinct from the viewer-relative `viewer_state == "corrected"` case (named `had_corrections` rather than `corrected` precisely to avoid that collision on the same schema object).
- The FE `final` derivation now reads `negotiation.had_corrections` directly. The display branch + "Agreed after corrections" copy already existed; this just makes them reachable.

### Changes
- `api`: `had_corrections` on `MatchNegotiation` + `_negotiation`; mirrored in the MSW mock store (`match-store.ts`); `schema.d.ts` regenerated.
- `test` (backend): a chain with a counter then accept → `had_corrections` true; a clean first-post→accept → false.
- `test` (FE): the `final`-case query test drives the callout off `had_corrections` (the "after corrections" case keeps `prior_result: null` to prove the derivation reads the new field).

## Testing
- API: `ruff check` ✓, `ruff format --check` ✓, `mypy` (strict, 78 files) ✓, `pytest` (514 passed) ✓
- web-client: `vitest` (1057 passed) ✓, `lint` (0 errors) ✓, `tsc -b && vite build` ✓, Playwright e2e (128 passed) ✓
- OpenAPI schema: regenerated `schema.d.ts` is idempotent vs a fresh dump (CI `openapi-schema` gate will pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)