### PR TITLE
Pin the match-result Accept to the reviewed result; reload on a stale 409 (#726)

### DIFF
--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.test.tsx
@@ -67,11 +67,10 @@ describe("ConfirmationCalloutActive", () => {
     );
   });
 
-  it("surfaces the API error detail inline when the acceptance is rejected", async () => {
-    // e.g. a 409 race: the proposal moved on, or a double click — without
-    // inline surfacing the button would appear inert.
+  it("surfaces a non-conflict API error inline so the button doesn't appear inert", async () => {
+    // A 500 (or any non-409): without inline surfacing the button looks inert.
     confirmationCalloutActivePage.mockAcceptanceEndpoint(() =>
-      HttpResponse.json({ detail: "Match already finalized" }, { status: 409 }),
+      HttpResponse.json({ detail: "Something went wrong" }, { status: 500 }),
     );
     confirmationCalloutActivePage.render();
 
@@ -80,8 +79,39 @@ describe("ConfirmationCalloutActive", () => {
 
     await waitFor(() =>
       expect(confirmationCalloutActivePage.queryError()).toHaveTextContent(
-        "Match already finalized",
+        "Something went wrong",
       ),
+    );
+  });
+
+  it("turns a 409 into a reload-to-re-review prompt, not a silent retarget (#726)", async () => {
+    // The standing result moved on between render and click. Accepting the
+    // stale token 409s; rather than show the raw detail (or worse, retarget the
+    // live result), swap Accept for a reload prompt so finalizing stays a
+    // conscious act on a seen score.
+    confirmationCalloutActivePage.mockAcceptanceEndpoint(() =>
+      HttpResponse.json({ detail: "Result superseded" }, { status: 409 }),
+    );
+    confirmationCalloutActivePage.render();
+
+    await waitFor(() => confirmationCalloutActivePage.getAcceptButton());
+    await userEvent.click(confirmationCalloutActivePage.getAcceptButton());
+
+    await waitFor(() =>
+      expect(confirmationCalloutActivePage.queryError()).toHaveTextContent(
+        /this result changed — reload/i,
+      ),
+    );
+    // The stale-result Accept is gone; the reload CTA stands in its place.
+    expect(
+      confirmationCalloutActivePage.queryAcceptButton(),
+    ).not.toBeInTheDocument();
+    expect(
+      confirmationCalloutActivePage.queryReloadButton(),
+    ).toBeInTheDocument();
+    // The raw server detail is not shown — the dedicated reload copy replaces it.
+    expect(confirmationCalloutActivePage.queryError()).not.toHaveTextContent(
+      "Result superseded",
     );
   });
 });

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.tsx
@@ -1,8 +1,10 @@
 import { useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { useAcceptResult } from "@/api/matches";
 import { ApiError } from "@/api/client";
 
+import { matchDetailsQueryKey } from "../../match-details-query";
 import { ConfirmationCalloutDisplay } from "./confirmation-callout-active/confirmation-callout-display";
 import type { ConfirmationCalloutView } from "./confirmation-callout-query";
 
@@ -27,9 +29,15 @@ export function ConfirmationCalloutActive({
   view,
   matchId,
 }: ConfirmationCalloutActiveProps) {
+  const queryClient = useQueryClient();
   const acceptMutation = useAcceptResult(matchId);
   const error =
     acceptMutation.error instanceof ApiError ? acceptMutation.error : null;
+  // A 409 means the standing result moved on between render and click — the
+  // opponent posted a correction the viewer never re-reviewed (#726). Don't
+  // silently retarget the live result; surface the correction-path "reload to
+  // re-review" prompt so accepting stays a conscious act on a seen score.
+  const staleConflict = error?.status === 409;
   // Synchronous double-submit guard. `disabled={pending}` only takes effect on
   // the next render, so a fast double-click lands a second tap before React
   // commits the disable and fires a duplicate POST that 409s. Cleared on
@@ -42,7 +50,19 @@ export function ConfirmationCalloutActive({
       view={view}
       matchId={matchId}
       acceptPending={acceptMutation.isPending}
-      errorMessage={error ? (error.detail ?? error.message) : null}
+      staleConflict={staleConflict}
+      // A 409 has dedicated reload copy + button; only surface other failures
+      // as the raw inline message.
+      errorMessage={
+        error && !staleConflict ? (error.detail ?? error.message) : null
+      }
+      onReload={() => {
+        acceptMutation.reset();
+        inFlightRef.current = false;
+        void queryClient.invalidateQueries({
+          queryKey: matchDetailsQueryKey(matchId),
+        });
+      }}
       onAccept={() => {
         if (!hasResultId(view)) return;
         if (inFlightRef.current) return;

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.factory.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.factory.tsx
@@ -78,8 +78,10 @@ export function buildConfirmationCalloutDisplayProps(
     view: buildReviewConfirmationView(),
     matchId: "m-1",
     acceptPending: false,
+    staleConflict: false,
     errorMessage: null,
     onAccept: () => {},
+    onReload: () => {},
     ...overrides,
   };
 }

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.page.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.page.tsx
@@ -31,6 +31,13 @@ const scoped = (container: Container) => ({
   queryAcceptButton() {
     return container.queryByRole("button", { name: /accept/i });
   },
+  /** The "Reload" CTA that replaces Accept after a stale-result 409 (#726). */
+  getReloadButton() {
+    return container.getByRole("button", { name: /reload/i });
+  },
+  queryReloadButton() {
+    return container.queryByRole("button", { name: /reload/i });
+  },
   /** The "Suggest correction" link on the review variant. */
   querySuggestCorrectionLink() {
     return container.queryByTestId("match-confirm-callout-correct");

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.test.tsx
@@ -85,6 +85,36 @@ describe("ConfirmationCalloutDisplay", () => {
         "Match already finalized",
       );
     });
+
+    it("swaps Accept for a reload prompt when the result moved on (#726)", async () => {
+      const onReload = vi.fn();
+      confirmationCalloutDisplayPage.render({ staleConflict: true, onReload });
+
+      await waitFor(() => confirmationCalloutDisplayPage.getCallout());
+      // The stale-result Accept is gone — finalizing an unseen result is the bug.
+      expect(
+        confirmationCalloutDisplayPage.queryAcceptButton(),
+      ).not.toBeInTheDocument();
+      expect(confirmationCalloutDisplayPage.queryError()).toHaveTextContent(
+        /this result changed — reload/i,
+      );
+      await userEvent.click(confirmationCalloutDisplayPage.getReloadButton());
+      expect(onReload).toHaveBeenCalledTimes(1);
+    });
+
+    it("hides the raw error message once a 409 is treated as a stale conflict", async () => {
+      // The active wrapper nulls `errorMessage` on a 409, but assert the display
+      // prefers the reload copy even if both were somehow set.
+      confirmationCalloutDisplayPage.render({
+        staleConflict: true,
+        errorMessage: "Conflict",
+      });
+
+      await waitFor(() => confirmationCalloutDisplayPage.getCallout());
+      expect(confirmationCalloutDisplayPage.queryError()).not.toHaveTextContent(
+        "Conflict",
+      );
+    });
   });
 
   describe("corrected variant", () => {
@@ -104,9 +134,34 @@ describe("ConfirmationCalloutDisplay", () => {
       expect(diff).toHaveTextContent("11–9");
       // Accept stays, plus a "Counter" link into the correction route.
       expect(confirmationCalloutDisplayPage.getAcceptButton()).toBeEnabled();
+      expect(confirmationCalloutDisplayPage.queryCounterLink()).toHaveAttribute(
+        "href",
+        correctHref("m-1"),
+      );
+    });
+
+    it("swaps Accept for a reload prompt on a stale conflict, keeping Counter (#726)", async () => {
+      confirmationCalloutDisplayPage.render({
+        view: buildCorrectedConfirmationView(),
+        staleConflict: true,
+      });
+
+      const callout = await waitFor(() =>
+        confirmationCalloutDisplayPage.getCallout(),
+      );
+      expect(
+        confirmationCalloutDisplayPage.queryAcceptButton(),
+      ).not.toBeInTheDocument();
+      expect(
+        confirmationCalloutDisplayPage.queryReloadButton(),
+      ).toBeInTheDocument();
+      // (The diff itself is a shadcn Alert, so assert the copy via the callout
+      // text rather than a role=alert query that would match both.)
+      expect(callout).toHaveTextContent(/this result changed — reload/i);
+      // Countering is still available — the diff just needs a fresh baseline.
       expect(
         confirmationCalloutDisplayPage.queryCounterLink(),
-      ).toHaveAttribute("href", correctHref("m-1"));
+      ).toBeInTheDocument();
     });
   });
 
@@ -124,9 +179,10 @@ describe("ConfirmationCalloutDisplay", () => {
       expect(
         confirmationCalloutDisplayPage.queryAcceptButton(),
       ).not.toBeInTheDocument();
-      expect(
-        confirmationCalloutDisplayPage.queryEditLink(),
-      ).toHaveAttribute("href", correctHref("m-1"));
+      expect(confirmationCalloutDisplayPage.queryEditLink()).toHaveAttribute(
+        "href",
+        correctHref("m-1"),
+      );
     });
   });
 

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
@@ -13,10 +13,18 @@ export interface ConfirmationCalloutDisplayProps {
   /** True while the accept request is in flight — swaps the Accept label to
    * "Accepting…" and disables the CTA. */
   acceptPending: boolean;
+  /** True when the last accept 409'd because the standing result moved on. The
+   * actionable callouts then swap Accept for a "reload to re-review" prompt so
+   * the viewer can't blindly finalize a correction they never saw (#726). */
+  staleConflict: boolean;
   /** Inline API failure to surface beneath the body copy; null when the last
-   * attempt succeeded or none has been made. */
+   * attempt succeeded, none has been made, or it was a `staleConflict` (which
+   * has its own dedicated copy + reload button). */
   errorMessage: string | null;
   onAccept: () => void;
+  /** Refetch the match so the viewer sees (and can re-review) the latest
+   * standing result. Wired to the `staleConflict` reload button. */
+  onReload: () => void;
 }
 
 /** The rated/unrated stakes line, shared by the review + corrected callouts. */
@@ -58,12 +66,74 @@ function ErrorLine({ message }: { message: string | null }) {
   );
 }
 
+/** Shown when an accept 409'd: the standing result moved on, so we prompt a
+ * re-review instead of silently retargeting the live result (#726). Mirrors the
+ * correction-entry "this proposal has moved on" copy. */
+function StaleConflictNotice() {
+  return (
+    <p
+      role="alert"
+      className="md-confirm-callout__stakes mt-1.5 text-xs text-[color:var(--warn)]"
+    >
+      This result changed — reload to review the latest score before accepting.
+    </p>
+  );
+}
+
+function ReloadButton({ onReload }: { onReload: () => void }) {
+  return (
+    <button type="button" className="md-btn md-btn--primary" onClick={onReload}>
+      Reload
+    </button>
+  );
+}
+
+/** The copy beneath the body of an actionable callout: the stale-result reload
+ * notice when the standing result moved on, otherwise the stakes line plus any
+ * inline API error. Shared verbatim by the review + corrected variants. */
+function CalloutBody({
+  staleConflict,
+  rated,
+  errorMessage,
+}: {
+  staleConflict: boolean;
+  rated: boolean;
+  errorMessage: string | null;
+}) {
+  if (staleConflict) return <StaleConflictNotice />;
+  return (
+    <>
+      <StakesLine rated={rated} />
+      <ErrorLine message={errorMessage} />
+    </>
+  );
+}
+
+/** The primary CTA of an actionable callout: Reload after a stale-result 409,
+ * otherwise Accept. Shared verbatim by the review + corrected variants. */
+function PrimaryAction({
+  staleConflict,
+  acceptPending,
+  onAccept,
+  onReload,
+}: {
+  staleConflict: boolean;
+  acceptPending: boolean;
+  onAccept: () => void;
+  onReload: () => void;
+}) {
+  if (staleConflict) return <ReloadButton onReload={onReload} />;
+  return <AcceptButton acceptPending={acceptPending} onAccept={onAccept} />;
+}
+
 export function ConfirmationCalloutDisplay({
   view,
   matchId,
   acceptPending,
+  staleConflict,
   errorMessage,
   onAccept,
+  onReload,
 }: ConfirmationCalloutDisplayProps) {
   // The opponent posted the first result — accept it or suggest a correction.
   if (view.kind === "review") {
@@ -84,11 +154,19 @@ export function ConfirmationCalloutDisplay({
             Your opponent has posted the result below. Accept it to finalize the
             match, or suggest a correction if the score looks off.
           </p>
-          <StakesLine rated={view.rated} />
-          <ErrorLine message={errorMessage} />
+          <CalloutBody
+            staleConflict={staleConflict}
+            rated={view.rated}
+            errorMessage={errorMessage}
+          />
         </div>
         <div className="md-confirm-callout__actions">
-          <AcceptButton acceptPending={acceptPending} onAccept={onAccept} />
+          <PrimaryAction
+            staleConflict={staleConflict}
+            acceptPending={acceptPending}
+            onAccept={onAccept}
+            onReload={onReload}
+          />
           <Link
             {...correctionRoute(matchId)}
             className="md-btn md-btn--ghost"
@@ -122,11 +200,19 @@ export function ConfirmationCalloutDisplay({
             with your own.
           </p>
           {view.diff.length > 0 && <ScoreDiff diff={view.diff} />}
-          <StakesLine rated={view.rated} />
-          <ErrorLine message={errorMessage} />
+          <CalloutBody
+            staleConflict={staleConflict}
+            rated={view.rated}
+            errorMessage={errorMessage}
+          />
         </div>
         <div className="md-confirm-callout__actions">
-          <AcceptButton acceptPending={acceptPending} onAccept={onAccept} />
+          <PrimaryAction
+            staleConflict={staleConflict}
+            acceptPending={acceptPending}
+            onAccept={onAccept}
+            onReload={onReload}
+          />
           <Link
             {...correctionRoute(matchId)}
             className="md-btn md-btn--ghost"

--- a/web-client/src/components/matches/match-details/match-details-query.test.ts
+++ b/web-client/src/components/matches/match-details/match-details-query.test.ts
@@ -2,6 +2,7 @@ import { HttpResponse } from "msw";
 
 import { ApiError } from "@/api/client";
 import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
+import { LIVE_NEGOTIATION } from "@/mocks/match-store";
 import { waitFor } from "@/test/utilities";
 
 import type { Query } from "@tanstack/react-query";
@@ -16,9 +17,12 @@ import { matchDetailsQueryPage } from "./match-details-query.page";
 
 const queryWithStatusLabel = (
   status_label: string,
+  overrides: Parameters<typeof buildMatchDetails>[0] = {},
 ): Pick<Query<MatchDetailsResult>, "state"> => ({
   state: {
-    data: matchDetailsResultFromPayload(buildMatchDetails({ status_label })),
+    data: matchDetailsResultFromPayload(
+      buildMatchDetails({ status_label, ...overrides }),
+    ),
   } as Query<MatchDetailsResult>["state"],
 });
 
@@ -49,6 +53,40 @@ describe("matchDetailsQuery", () => {
       ).toBe(false);
     },
   );
+
+  it("does not poll while it's the viewer's turn to act, so a correction can't swap the result out from under them (#726)", () => {
+    // A standing result is still in play (label "Awaiting confirmation"), but
+    // `your_turn` means the viewer is reviewing it. Polling here would silently
+    // replace the reviewed result with a freshly-posted correction, and the
+    // still-rendered Accept would finalize a result the viewer never saw.
+    expect(
+      refetchWhileAwaitingConfirmation(
+        queryWithStatusLabel("Awaiting confirmation", {
+          negotiation: {
+            ...LIVE_NEGOTIATION,
+            viewer_state: "review",
+            your_turn: true,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps polling for a spectator on an awaiting match (your_turn=false)", () => {
+    // Spectators share this query for the scoreboard and get `your_turn=false`,
+    // so suppressing the viewer's poll must not freeze theirs.
+    expect(
+      refetchWhileAwaitingConfirmation(
+        queryWithStatusLabel("Awaiting confirmation", {
+          negotiation: {
+            ...LIVE_NEGOTIATION,
+            viewer_state: "review",
+            your_turn: false,
+          },
+        }),
+      ),
+    ).toBeGreaterThan(0);
+  });
 
   it("does not poll before any data has loaded", () => {
     expect(

--- a/web-client/src/components/matches/match-details/match-details-query.ts
+++ b/web-client/src/components/matches/match-details/match-details-query.ts
@@ -49,7 +49,9 @@ export function matchDetailsResultFromPayload(payload: MatchDetails) {
 }
 
 /** The resolved shape `matchDetailsQuery`'s `queryFn` returns. */
-export type MatchDetailsResult = ReturnType<typeof matchDetailsResultFromPayload>;
+export type MatchDetailsResult = ReturnType<
+  typeof matchDetailsResultFromPayload
+>;
 
 /** The server's lifecycle label for a posted-but-unconfirmed result (mirrors
  * `_status_label` in api/app/matches.py). While a match sits here it is waiting
@@ -69,12 +71,22 @@ const AWAITING_CONFIRMATION_POLL_MS = 5_000;
  * the global client disables `refetchOnWindowFocus` with a 30s `staleTime`, so
  * without this the page is stuck on "Awaiting confirmation" until a manual
  * reload (#493). Returning `false` outside that state means a settled match
- * isn't polled, so the open page goes quiet again once it resolves. */
+ * isn't polled, so the open page goes quiet again once it resolves.
+ *
+ * Exception: never poll while it's the viewer's *own* turn to act
+ * (`negotiation.your_turn` — the `review`/`corrected` states). A silent poll
+ * there swaps the standing result out from under the reviewer, so their
+ * still-rendered Accept finalizes a correction they never re-reviewed (#726).
+ * Freezing the rendered result means accepting a now-superseded one 409s, and
+ * the callout surfaces that as a "reload to re-review" prompt. Spectators and
+ * the waiting proposer have `your_turn=false`, so they keep polling. */
 export function refetchWhileAwaitingConfirmation(
   query: Pick<Query<MatchDetailsResult>, "state">,
 ): number | false {
-  const label = query.state.data?.unmigrated.status_label;
-  return label === AWAITING_CONFIRMATION ? AWAITING_CONFIRMATION_POLL_MS : false;
+  const data = query.state.data?.unmigrated;
+  if (data?.status_label !== AWAITING_CONFIRMATION) return false;
+  if (data.negotiation.your_turn) return false;
+  return AWAITING_CONFIRMATION_POLL_MS;
 }
 
 export const matchDetailsQuery = (matchId: string) => ({


### PR DESCRIPTION
Fixes #726.

## Problem
On a rated match, the reviewing opponent's match-detail page polls every 5s (`refetchWhileAwaitingConfirmation` — its `status_label` is "Awaiting confirmation"). When the proposer posts a correction **B** after the opponent's screen has rendered result **A**, that poll silently swaps the standing `result_id` A→B. The still-displayed **Accept** then finalizes **B** — a result the opponent never re-reviewed. (Server data was never at risk: a stale `result_id` already 409s; this was purely a front-end consent gap.)

## Fix
Two layers:

1. **Stop the silent swap** (`match-details-query.ts`): suppress the poll while `negotiation.your_turn` is true (the `review`/`corrected` states). Gated on `your_turn`, not `viewer_state`, so spectators (`your_turn=false`) and the waiting proposer keep polling — #493 preserved. The rendered result now freezes at what the viewer is reviewing.
2. **Consent gate on the race** (`confirmation-callout-active.tsx` + `-display.tsx`): a frozen result means accepting a now-superseded one 409s. On a 409, swap the Accept button for a "This result changed — reload to review the latest score before accepting" prompt + a **Reload** button that refetches the match — mirroring the correction-entry path — instead of surfacing the raw server detail.

Also factored the shared stale/normal copy + primary-action into `CalloutBody`/`PrimaryAction` helpers (the review and corrected variants were byte-identical).

## Why the poll was the real culprit
The Accept call was *already* pinned to the rendered `result_id`. The QA report's "finalizes B" happens because the 5s poll advances that rendered id A→B before the click, so there's no stale token to 409 on. Suppressing the poll is what makes the 409 net able to fire.

Verified the poll was the **only** background refetch vector during an idle review wait: `refetchOnWindowFocus` is off globally, no broad `scope:"matches"` partial invalidation exists, and `applyScoreMutationCache` only invalidates on the viewer's own mutations.

## Testing
- web-client unit (vitest): **1057 passed** — added predicate coverage (suppresses on `your_turn`, keeps polling for spectators) and component coverage (both review/corrected swap to the reload prompt; 409→reload in the active wrapper; raw error hidden on conflict).
- web-client lint: clean · build (`tsc -b && vite build`): success
- web-client e2e (Playwright): **128 passed**
- No `api/`, `ios/`, or `schema.d.ts` changes (uses the existing `your_turn` field), so no schema-regen / iOS gates apply. Root e2e skipped — FE-only change, no API-contract impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)