### PR TITLE
Validate match-completeness live on the correction form (#734)

### DIFF
--- a/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
@@ -69,6 +69,35 @@ describe("CorrectionEntry", () => {
     );
   });
 
+  it("warns inline and disables submit when a correction leaves the match undecided (#734)", async () => {
+    correctionEntryPage.mockMatch(() =>
+      HttpResponse.json(buildCorrectableMatch()),
+    );
+    correctionEntryPage.render();
+
+    // Seed is a decided 3–0 (best-of-5). Flip game 3 so the viewer loses it:
+    // the board becomes 2–1, and no side has reached 3 wins — undecided.
+    const me3 = await waitFor(() =>
+      correctionEntryPage.getInput(3, "rita.kovac"),
+    );
+    await userEvent.clear(me3);
+    await userEvent.type(me3, "9");
+    const opp3 = correctionEntryPage.getInput(3, "leo.mertens");
+    await userEvent.clear(opp3);
+    await userEvent.type(opp3, "11");
+
+    await waitFor(() =>
+      expect(
+        correctionEntryPage
+          .queryAlerts()
+          .some((a: HTMLElement) =>
+            /no side has won 3 games/i.test(a.textContent ?? ""),
+          ),
+      ).toBe(true),
+    );
+    expect(correctionEntryPage.getSubmit()).toBeDisabled();
+  });
+
   it("surfaces a 409 (the proposal moved on) inline without navigating away", async () => {
     correctionEntryPage.mockMatch(() =>
       HttpResponse.json(buildCorrectableMatch()),

--- a/web-client/src/components/matches/correction-entry/correction-entry.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.tsx
@@ -9,6 +9,7 @@ import {
   type MatchResultsGameWrite,
 } from "@/api/matches";
 import { initialsOf } from "@/lib/utils";
+import { firstMatchScoreError } from "@/lib/scoring";
 import { ScorePad } from "../score-pad";
 import {
   isAcceptableScoreInput,
@@ -99,6 +100,34 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
   const validations = current.map((d) => validateGameScore(d.me, d.opp));
   const allValid = validations.every((v) => v.valid);
 
+  // The orientation-restored board — kept as the single source for both the
+  // completeness check and the submit payload, so what we validate is exactly
+  // what we post.
+  const correctedGames: MatchResultsGameWrite[] = current.map((d) =>
+    mySideNumber === 1
+      ? {
+          game_number: d.gameNumber,
+          side_1_points: Number(d.me),
+          side_2_points: Number(d.opp),
+        }
+      : {
+          game_number: d.gameNumber,
+          side_1_points: Number(d.opp),
+          side_2_points: Number(d.me),
+        },
+  );
+
+  // Once every game is individually legal, validate the board as a *whole* the
+  // same way the score-entry page does live and the server does on submit: a
+  // correction that leaves the match undecided (e.g. a BO5 board edited to 2–1)
+  // must warn inline and block submit, not only fail on the server (#734). The
+  // numbers aren't trustworthy until per-game valid (`Number('')` is 0), so we
+  // only parse the board once `allValid`.
+  const boardError = allValid
+    ? firstMatchScoreError(correctedGames, data.best_of)
+    : null;
+  const canSubmit = allValid && boardError === null;
+
   // A 409 means the standing result moved on (someone else proposed/accepted
   // since this screen loaded); a 422 means the board itself was rejected. Both
   // surface inline; everything else falls back to the API message.
@@ -108,22 +137,9 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
   const inputsLocked = proposeMutation.isPending;
 
   function onSubmit() {
-    if (!allValid || proposeMutation.isPending) return;
-    const games: MatchResultsGameWrite[] = current.map((d) =>
-      mySideNumber === 1
-        ? {
-            game_number: d.gameNumber,
-            side_1_points: Number(d.me),
-            side_2_points: Number(d.opp),
-          }
-        : {
-            game_number: d.gameNumber,
-            side_1_points: Number(d.opp),
-            side_2_points: Number(d.me),
-          },
-    );
+    if (!canSubmit || proposeMutation.isPending) return;
     proposeMutation.mutate(
-      { games, supersedes_result_id: standingId },
+      { games: correctedGames, supersedes_result_id: standingId },
       { onSuccess: () => navigate(matchDetailRoute(matchId)) },
     );
   }
@@ -194,6 +210,12 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
         );
       })}
 
+      {boardError !== null && (
+        <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
+          {boardError}
+        </p>
+      )}
+
       <div className="single-actions">
         <div className="result-line subtle">
           {data.affects_rating
@@ -204,7 +226,7 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
           <button
             type="button"
             className="btn primary"
-            disabled={!allValid || inputsLocked}
+            disabled={!canSubmit || inputsLocked}
             onClick={onSubmit}
           >
             {proposeMutation.isPending ? "Sending…" : "Send corrected score"}

--- a/web-client/src/components/matches/save-banner.tsx
+++ b/web-client/src/components/matches/save-banner.tsx
@@ -10,7 +10,7 @@ import {
   useProposeResult,
   useMatch,
 } from '@/api/matches'
-import { decidedSide, type GamePoints } from '@/lib/scoring'
+import { isDecidedMatch, type GamePoints } from '@/lib/scoring'
 import { cn } from '@/lib/utils'
 import {
   Alert,
@@ -107,7 +107,7 @@ function FailedSaveBanner({ matchId, activeGameNumber }: SaveBannerProps) {
     (a, b) => a.game_number - b.game_number,
   )
   const wouldFinalize =
-    data != null && decidedSide(mergedGames, data.best_of) !== null
+    data != null && isDecidedMatch(mergedGames, data.best_of)
 
   // Normally the active game is omitted — its pre-filled inputs are the retry
   // surface, so the banner needn't also shout about it. The exception is when

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -36,7 +36,7 @@ import {
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { cn, initialsOf } from '@/lib/utils'
-import { decidedSide } from '@/lib/scoring'
+import { isDecidedMatch } from '@/lib/scoring'
 import { isScoreConflict, useGameSaveState } from './score-saves'
 import { SaveBanner } from './save-banner'
 import { ScorePad } from './score-pad'
@@ -325,7 +325,7 @@ function ScoreEntryInner({
       ]
     : []
   const wouldFinalize =
-    inputsValid && decidedSide(hypotheticalGames, bestOf) !== null
+    inputsValid && isDecidedMatch(hypotheticalGames, bestOf)
 
   // Per the fire-and-forget posture: only finalize errors are surfaced. The
   // per-game mutations (save / delete) self-heal at finalize, so their errors

--- a/web-client/src/lib/scoring.test.ts
+++ b/web-client/src/lib/scoring.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { illegalScoreReason } from './scoring'
+import {
+  firstMatchScoreError,
+  illegalScoreReason,
+  isDecidedMatch,
+  type GamePoints,
+} from './scoring'
+
+const game = (
+  game_number: number,
+  side_1_points: number,
+  side_2_points: number,
+): GamePoints => ({ game_number, side_1_points, side_2_points })
 
 describe('illegalScoreReason', () => {
   it.each([
@@ -26,5 +37,67 @@ describe('illegalScoreReason', () => {
     [13, 10, /exactly 2/i],
   ])('rejects the illegal score %i–%i', (a, b, pattern) => {
     expect(illegalScoreReason(a, b)).toMatch(pattern)
+  })
+})
+
+describe('isDecidedMatch', () => {
+  it('accepts a complete, decided board (3–0 in a BO5)', () => {
+    expect(
+      isDecidedMatch([game(1, 11, 8), game(2, 11, 6), game(3, 11, 9)], 5),
+    ).toBe(true)
+  })
+
+  it('rejects an empty board (save banner before any game is saved)', () => {
+    expect(isDecidedMatch([], 5)).toBe(false)
+  })
+
+  it('rejects a single non-contiguous game (score-entry mid-entry)', () => {
+    // score-entry asks "would saving game 3 finish the match?" before games 1–2
+    // exist — a lone game 3 is not a decided board.
+    expect(isDecidedMatch([game(3, 11, 8)], 5)).toBe(false)
+  })
+
+  it('rejects an undecided board (no side reached the target)', () => {
+    expect(isDecidedMatch([game(1, 11, 8), game(2, 8, 11)], 3)).toBe(false)
+  })
+
+  it('rejects scored games past the decider', () => {
+    // Decided at game 2 (side 1 wins twice), game 3 trails the decider.
+    expect(
+      isDecidedMatch([game(1, 11, 8), game(2, 11, 6), game(3, 8, 11)], 3),
+    ).toBe(false)
+  })
+
+  it('rejects a game numbered past best_of', () => {
+    expect(
+      isDecidedMatch([game(1, 11, 8), game(2, 11, 6), game(3, 11, 9)], 1),
+    ).toBe(false)
+  })
+
+  it('rejects an illegal game score', () => {
+    expect(isDecidedMatch([game(1, 11, 8), game(2, 5, 3)], 3)).toBe(false)
+  })
+})
+
+describe('firstMatchScoreError', () => {
+  it('returns null for a complete, decided board', () => {
+    expect(
+      firstMatchScoreError([game(1, 11, 8), game(2, 11, 6), game(3, 11, 9)], 5),
+    ).toBeNull()
+  })
+
+  it('explains an undecided board', () => {
+    expect(firstMatchScoreError([game(1, 11, 8), game(2, 8, 11)], 5)).toMatch(
+      /no side has won 3 games/i,
+    )
+  })
+
+  it('explains a decider that lands before the last game', () => {
+    expect(
+      firstMatchScoreError(
+        [game(1, 11, 8), game(2, 11, 6), game(3, 8, 11)],
+        3,
+      ),
+    ).toMatch(/before the last game/i)
   })
 })

--- a/web-client/src/lib/scoring.ts
+++ b/web-client/src/lib/scoring.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod'
+
 // Mirrors the server-side table-tennis rule in api/app/schemas/match.py
 // (MatchGameScoreWrite._table_tennis_rules) so the client doesn't submit a
 // final score the server will reject with a 422. Returns the reason a score is
@@ -18,38 +20,39 @@ export function illegalScoreReason(a: number, b: number): string | null {
   return null
 }
 
-export type GamePoints = {
-  game_number: number
-  side_1_points: number
-  side_2_points: number
+// A single legal, completed game score. The `illegalScoreReason` refinement is
+// the same per-game table-tennis rule `validateGameScore` applies live to the
+// raw inputs — shared here so the composed match schema (below) is built from
+// already-legal games. Its message is unreachable in practice (every caller
+// pre-gates per-game legality before parsing the match), so a static message
+// is fine.
+const gameScoreSchema = z
+  .object({
+    game_number: z.number(),
+    side_1_points: z.number(),
+    side_2_points: z.number(),
+  })
+  .refine(
+    (g) => illegalScoreReason(g.side_1_points, g.side_2_points) === null,
+    { message: 'Each game must be a legal, completed score.' },
+  )
+
+export type GamePoints = z.infer<typeof gameScoreSchema>
+
+interface MatchDecision {
+  ordered: GamePoints[]
+  decidedBy: 1 | 2 | null
+  decidedAt: number | null
 }
 
-// Mirrors the server-side finalize-payload cross-game validator in
-// api/app/matches.py (_validate_finalize_games). Returns the decided side
-// number (1 or 2) when the given games form a complete, validly-ordered,
-// decided match for the given best_of — and null otherwise. Used by the
-// scoring page to decide whether the submit button should save-this-game or
-// finalize-the-match.
-export function decidedSide(
-  games: GamePoints[],
-  bestOf: number,
-): 1 | 2 | null {
-  if (games.length === 0) return null
-
-  const numbers = games.map((g) => g.game_number).sort((a, b) => a - b)
-  // No duplicates / gaps / numbers past best_of.
-  if (numbers[numbers.length - 1] > bestOf) return null
-  for (let i = 0; i < numbers.length; i += 1) {
-    if (numbers[i] !== i + 1) return null
-  }
-
-  const target = Math.ceil(bestOf / 2)
+// Walk the games in order and find who (if anyone) first reached `target` game
+// wins, and on which game. Pure helper shared by the match-schema refinements.
+function matchDecision(games: GamePoints[], target: number): MatchDecision {
   const ordered = [...games].sort((a, b) => a.game_number - b.game_number)
   const wins: Record<1 | 2, number> = { 1: 0, 2: 0 }
-  let decidedAt: number | null = null
   let decidedBy: 1 | 2 | null = null
+  let decidedAt: number | null = null
   for (const g of ordered) {
-    if (illegalScoreReason(g.side_1_points, g.side_2_points)) return null
     const winner: 1 | 2 = g.side_1_points > g.side_2_points ? 1 : 2
     wins[winner] += 1
     if (decidedBy === null && wins[winner] >= target) {
@@ -57,8 +60,74 @@ export function decidedSide(
       decidedAt = g.game_number
     }
   }
-  if (decidedBy === null) return null
-  // No scored games past the decider.
-  if (decidedAt !== ordered[ordered.length - 1].game_number) return null
-  return decidedBy
+  return { ordered, decidedBy, decidedAt }
+}
+
+/**
+ * The schema for a complete, decided match board — a `z.array` of legal games
+ * composed with the cross-game completeness rules in
+ * api/app/matches.py (`_validate_finalize_games`): numbered 1..N with no
+ * gaps/dupes, no game past `best_of`, some side reaches `ceil(best_of/2)` wins,
+ * and the decider is the last game (nothing scored past it).
+ *
+ * One schema, two uses: as a *predicate* (`isDecidedMatch`) the score-entry
+ * page and save banner ask "would saving this game finish the match?" to route
+ * finalize-vs-save; as straight *validation* (`firstMatchScoreError`) the
+ * correction surface surfaces the first failing message inline (#734). Factory
+ * because the rules depend on `bestOf`.
+ */
+function matchScoreSchema(bestOf: number) {
+  const target = Math.ceil(bestOf / 2)
+  return z
+    .array(gameScoreSchema)
+    .refine((games) => games.length > 0, {
+      message: 'Enter at least one game to finish the match.',
+    })
+    .refine((games) => games.every((g) => g.game_number <= bestOf), {
+      message: `A best-of-${bestOf} match has at most ${bestOf} games.`,
+    })
+    .refine(
+      (games) => {
+        const numbers = games.map((g) => g.game_number).sort((a, b) => a - b)
+        return numbers.every((n, i) => n === i + 1)
+      },
+      { message: 'Games must be numbered 1…N with no gaps or duplicates.' },
+    )
+    .refine((games) => matchDecision(games, target).decidedBy !== null, {
+      message: `No side has won ${target} games yet — adjust the scores so the match has a winner.`,
+    })
+    .refine(
+      (games) => {
+        const d = matchDecision(games, target)
+        return (
+          d.decidedBy === null ||
+          d.decidedAt === d.ordered[d.ordered.length - 1]?.game_number
+        )
+      },
+      {
+        message: `One side reaches ${target} game wins before the last game — adjust the scores so the deciding game is the last one.`,
+      },
+    )
+}
+
+// Whether the given games form a complete, validly-ordered, decided match for
+// `best_of` — the boolean predicate over `matchScoreSchema`. Replaces the old
+// `decidedSide` (no client consumer needed the winning side number, only
+// decided-or-not). Returns false for an empty, non-contiguous, illegal, or
+// undecided board — matching every null branch of the prior implementation.
+export function isDecidedMatch(games: GamePoints[], bestOf: number): boolean {
+  return matchScoreSchema(bestOf).safeParse(games).success
+}
+
+// The first cross-game completeness rule the board violates, as a human-readable
+// message — or null when the board forms a complete, decided match. The
+// validation half of `matchScoreSchema` (mirror of the boolean `isDecidedMatch`),
+// shown inline by the correction surface (#734). Callers pre-gate per-game
+// legality, so the surfaced message is always a board-level one.
+export function firstMatchScoreError(
+  games: GamePoints[],
+  bestOf: number,
+): string | null {
+  const result = matchScoreSchema(bestOf).safeParse(games)
+  return result.success ? null : (result.error.issues[0]?.message ?? null)
 }


### PR DESCRIPTION
## What

Fixes #734. The match-result **correction form** validated match-completeness only on submit — unlike the live-validating score-entry page. Entering a correction that left the match undecided (e.g. a BO5 board edited to 2–1) kept **Send corrected score** enabled and only failed on the server (*"No side reached N game wins…"*).

## How

Lifted the cross-game completeness rule into a **composed zod schema** in `web-client/src/lib/scoring.ts` (`gameScoreSchema` → `matchScoreSchema(bestOf)`), mirroring the server's `_validate_finalize_games` in `api/app/matches.py`. The same schema is consumed two ways:

- **`isDecidedMatch(games, bestOf)`** — boolean predicate that *replaces* `decidedSide`; drives the score-entry page + save banner's finalize-vs-save routing. (No client consumer needed `decidedSide`'s winning-side number, only decided-or-not.)
- **`firstMatchScoreError(games, bestOf)`** — first failing rule as a human-readable message; the correction form shows it inline (red `role="alert"`) and disables submit until the board is decided.

The correction form now builds `correctedGames` once and uses it for both validation and the submit payload (*"validate exactly what we post"*).

## Testing

- `scoring.test.ts`: `isDecidedMatch` covers all six false-branches of the old `decidedSide` (empty, non-contiguous, undecided, trailing-past-decider, `>best_of`, illegal game) + `firstMatchScoreError` messages.
- `correction-entry.test.tsx`: editing game 3 to a loss (board → 2–1) shows the inline warning and disables submit.
- Full web-client suite **1074 passed**; lint ✓; build (`tsc -b && vite build`) ✓; web-client Playwright e2e **128 passed**.
- API / iOS / OpenAPI-schema gates n/a (those trees untouched). Root `e2e/` has no specs on this surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)