### PR TITLE
Drop the settled-match "Confirmed" callout banner

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -385,12 +385,6 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
 
     Non-participants / anonymous callers get a neutral spectator mapping
     (``your_turn=False``, no diff/prior)."""
-    # Match-level, viewer-independent: the chain holds a correction iff more than
-    # one proposal was ever posted (a counter or self-edit superseded the first).
-    # The FE reads this on the ``final`` state to pick "Confirmed" vs "Agreed
-    # after corrections" (#719).
-    had_corrections = len(match.results) > 1
-
     accepted = accepted_result(match)
     if accepted is not None:
         return MatchNegotiation(
@@ -399,7 +393,6 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
             standing_result=_negotiation_result(accepted),
             prior_result=None,
             diff=None,
-            had_corrections=had_corrections,
         )
 
     standing = standing_result(match)
@@ -410,7 +403,6 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
             standing_result=None,
             prior_result=None,
             diff=None,
-            had_corrections=had_corrections,
         )
 
     standing_view = _negotiation_result(standing)
@@ -426,7 +418,6 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
             standing_result=standing_view,
             prior_result=None,
             diff=None,
-            had_corrections=had_corrections,
         )
 
     if _submitted_on_side(match, standing, viewer_side):
@@ -437,7 +428,6 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
             standing_result=standing_view,
             prior_result=None,
             diff=None,
-            had_corrections=had_corrections,
         )
 
     # The opponent submitted the standing result → the viewer must act. Walk the
@@ -462,7 +452,6 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
             standing_result=standing_view,
             prior_result=None,
             diff=None,
-            had_corrections=had_corrections,
         )
 
     return MatchNegotiation(
@@ -471,7 +460,6 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
         standing_result=standing_view,
         prior_result=_negotiation_result(prior),
         diff=_negotiation_diff(prior.games, standing.games),
-        had_corrections=had_corrections,
     )
 
 

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -220,13 +220,6 @@ class MatchNegotiation(BaseModel):
     standing_result: NegotiationResult | None
     prior_result: NegotiationResult | None
     diff: list[NegotiationDiffEntry] | None
-    # Match-level (NOT viewer-relative, unlike the fields above — distinct from
-    # the ``viewer_state == "corrected"`` case): true when the result chain holds
-    # more than one proposal, i.e. at least one correction was posted before the
-    # chain settled. The FE reads this on the ``final`` state to label a completed
-    # match "Confirmed" (clean first-post→accept) vs "Agreed after corrections"
-    # (a counter/self-edit preceded the agreement).
-    had_corrections: bool
 
 
 class MatchDetails(BaseModel):

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -2429,8 +2429,6 @@ async def test_accept_finalizes_and_applies_ratings_once(
         assert neg["your_turn"] is False
         assert neg["prior_result"] is None
         assert neg["diff"] is None
-        # A single posted result accepted as-is — no correction in the chain.
-        assert neg["had_corrections"] is False
         sides = sorted(body["sides"], key=lambda s: s["side_number"])
         assert [s["won"] for s in sides] == [True, False]
 
@@ -2481,39 +2479,6 @@ async def test_accept_finalizes_and_applies_ratings_once(
             .all()
         )
         assert len(rating_rows_after) == 2
-
-
-async def test_final_had_corrections_flag_tracks_chain_length(
-    api_client: AsyncClient, db_session: AsyncSession
-):
-    """The ``final`` negotiation block's match-level ``had_corrections`` flag is
-    true iff the agreed result was *not* the first one posted — i.e. a counter
-    (or self-edit) preceded the agreement. It drives the completed-match
-    callout's "Confirmed" vs "Agreed after corrections" copy (#719).
-
-    Two matches contrast the cases: a clean first-post→accept has
-    ``had_corrections`` false; a counter→accept has it true."""
-    await start_session(api_client, db_session)
-    async with opponent_session(db_session, "corrected-opp") as (opp_client, opp):
-        # Clean: I post once, the opponent accepts it unchanged → not corrected.
-        clean = await _create_match(api_client, opp.id, best_of=1)
-        await _propose(api_client, clean["id"], s1=11, s2=4)
-        clean_final = await accept_standing_result(opp_client, clean["id"])
-        assert clean_final["negotiation"]["viewer_state"] == "final"
-        assert clean_final["negotiation"]["had_corrections"] is False
-
-        # Corrected: I post, the opponent counters, I accept the counter → the
-        # agreed result is the second in the chain, so the flag is true.
-        disputed = await _create_match(api_client, opp.id, best_of=1)
-        first = await _propose(api_client, disputed["id"], s1=11, s2=4)
-        first_id = first["body"]["negotiation"]["standing_result"]["id"]
-        counter = await _propose(
-            opp_client, disputed["id"], s1=4, s2=11, supersedes=first_id
-        )
-        assert counter["status"] == 201, counter
-        disputed_final = await accept_standing_result(api_client, disputed["id"])
-        assert disputed_final["negotiation"]["viewer_state"] == "final"
-        assert disputed_final["negotiation"]["had_corrections"] is True
 
 
 async def test_accept_superseded_result_id_is_409(

--- a/web-client/e2e/score-entry.spec.ts
+++ b/web-client/e2e/score-entry.spec.ts
@@ -162,7 +162,6 @@ function projectMatchDetails(seed: Seed) {
       standing_result: null,
       prior_result: null,
       diff: null,
-      had_corrections: false,
     },
   }
 }

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1578,8 +1578,6 @@ export interface components {
             prior_result: components["schemas"]["NegotiationResult"] | null;
             /** Diff */
             diff: components["schemas"]["NegotiationDiffEntry"][] | null;
-            /** Had Corrections */
-            had_corrections: boolean;
         };
         /**
          * MatchResultsGameWrite

--- a/web-client/src/components/matches/correction-entry/correction-entry.factory.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.factory.tsx
@@ -95,7 +95,6 @@ export function buildCorrectableMatch(
       standing_result: standing,
       prior_result: null,
       diff: null,
-      had_corrections: false,
     },
     ...overrides,
   });

--- a/web-client/src/components/matches/match-details/confirmation-callout.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout.test.tsx
@@ -29,7 +29,6 @@ const reviewMatch = (): MatchDetails =>
       },
       prior_result: null,
       diff: null,
-      had_corrections: false,
     },
   });
 
@@ -48,7 +47,6 @@ const finalMatch = (): MatchDetails =>
       },
       prior_result: null,
       diff: null,
-      had_corrections: false,
     },
     data: buildMatchDetailsData({
       scoreboard: buildScoreboard({ status: "final" }),

--- a/web-client/src/components/matches/match-details/confirmation-callout.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout.test.tsx
@@ -70,9 +70,9 @@ describe("ConfirmationCallout", () => {
     expect(confirmationCalloutPage.getAcceptButton()).toBeInTheDocument();
   });
 
-  it("settles into the confirmed notice once the viewer accepts and the match finalizes", async () => {
-    // Accepting flips the refetched payload to final — the callout transitions
-    // from the Accept CTA to a quiet "Confirmed" notice (no action to press).
+  it("disappears once the viewer accepts and the match finalizes", async () => {
+    // Accepting flips the refetched payload to final — a settled match projects
+    // to null, so the callout unmounts entirely (no quiet confirmation notice).
     let accepted = false;
     confirmationCalloutPage.mockEndpoint(() =>
       HttpResponse.json(accepted ? finalMatch() : reviewMatch()),
@@ -88,11 +88,8 @@ describe("ConfirmationCallout", () => {
     await userEvent.click(confirmationCalloutPage.getAcceptButton());
 
     await waitFor(() =>
-      expect(
-        confirmationCalloutPage.queryAcceptButton(),
-      ).not.toBeInTheDocument(),
+      expect(confirmationCalloutPage.queryCallout()).not.toBeInTheDocument(),
     );
-    expect(confirmationCalloutPage.getCallout()).toHaveTextContent("Confirmed");
   });
 
   it("propagates a query failure to the ancestor error boundary", async () => {

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher.test.tsx
@@ -21,7 +21,6 @@ const reviewMatch = () =>
       },
       prior_result: null,
       diff: null,
-      had_corrections: false,
     },
   });
 

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.tsx
@@ -24,7 +24,7 @@ function hasResultId(
  * the concurrency token `POST .../acceptance` takes; API failures stay visible
  * inline (without throwOnError a 409 — the proposal moved on, double-click,
  * etc. — would otherwise vanish and the button would appear inert). The passive
- * (`awaiting`/`final`) variants press nothing, so the mutation simply sits idle. */
+ * `awaiting` variant presses nothing, so the mutation simply sits idle. */
 export function ConfirmationCalloutActive({
   view,
   matchId,

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.factory.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.factory.tsx
@@ -61,14 +61,6 @@ export function buildAwaitingConfirmationView(
   };
 }
 
-/** The final variant: the match is settled. Defaults to a plain "confirmed"
- * (no back-and-forth). */
-export function buildFinalConfirmationView(
-  overrides: Partial<Extract<ConfirmationCalloutView, { kind: "final" }>> = {},
-): ConfirmationCalloutView {
-  return { kind: "final", afterCorrections: false, ...overrides };
-}
-
 /** Props for `ConfirmationCalloutDisplay` — the review variant, idle (nothing
  * pending, no error). */
 export function buildConfirmationCalloutDisplayProps(

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.test.tsx
@@ -6,7 +6,6 @@ import { waitFor } from "@/test/utilities";
 import {
   buildAwaitingConfirmationView,
   buildCorrectedConfirmationView,
-  buildFinalConfirmationView,
 } from "./confirmation-callout-display.factory";
 import { confirmationCalloutDisplayPage } from "./confirmation-callout-display.page";
 
@@ -183,34 +182,6 @@ describe("ConfirmationCalloutDisplay", () => {
         "href",
         correctHref("m-1"),
       );
-    });
-  });
-
-  describe("final variant", () => {
-    it("reads 'Confirmed' when there was no back-and-forth", async () => {
-      confirmationCalloutDisplayPage.render({
-        view: buildFinalConfirmationView({ afterCorrections: false }),
-      });
-
-      const callout = await waitFor(() =>
-        confirmationCalloutDisplayPage.getCallout(),
-      );
-      expect(callout).toHaveTextContent("Confirmed");
-      expect(callout).not.toHaveTextContent("after corrections");
-      expect(
-        confirmationCalloutDisplayPage.queryAcceptButton(),
-      ).not.toBeInTheDocument();
-    });
-
-    it("reads 'Agreed after corrections' when a prior proposal preceded the agreement", async () => {
-      confirmationCalloutDisplayPage.render({
-        view: buildFinalConfirmationView({ afterCorrections: true }),
-      });
-
-      const callout = await waitFor(() =>
-        confirmationCalloutDisplayPage.getCallout(),
-      );
-      expect(callout).toHaveTextContent("Agreed after corrections");
     });
   });
 });

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
@@ -225,27 +225,6 @@ export function ConfirmationCalloutDisplay({
     );
   }
 
-  // The match is settled — a quiet confirmation, no action to press.
-  if (view.kind === "final") {
-    return (
-      <section
-        className="md-confirm-callout md-confirm-callout--passive"
-        data-testid="match-confirm-callout"
-      >
-        <div className="md-confirm-callout__copy">
-          <Overline as="h3">
-            {view.afterCorrections ? "Agreed after corrections" : "Confirmed"}
-          </Overline>
-          <p className="md-confirm-callout__body">
-            {view.afterCorrections
-              ? "Both sides agreed on the final score after corrections. This match is settled."
-              : "Both sides confirmed this result. This match is settled."}
-          </p>
-        </div>
-      </section>
-    );
-  }
-
   // `awaiting`: the viewer posted; we wait on the opponent. Passive notice with
   // an "Edit result" self-edit that supersedes the viewer's standing proposal.
   return (

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.test.ts
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.test.ts
@@ -147,47 +147,20 @@ describe("confirmationCalloutQuery", () => {
     });
   });
 
-  it("projects the final state as plain 'confirmed' when the chain wasn't corrected", async () => {
+  it("projects null once the match is settled (final) — the callout is gone", async () => {
     confirmationCalloutQueryPage.mockEndpoint(() =>
       HttpResponse.json(
         reviewMatch({
           viewer_state: "final",
           your_turn: false,
-          standing_result: standingResult(),
-          had_corrections: false,
+          standing_result: null,
         }),
       ),
     );
 
     const result = await renderView();
 
-    expect(result.current.data).toEqual({
-      kind: "final",
-      afterCorrections: false,
-    });
-  });
-
-  it("projects the final state as 'after corrections' when the chain was corrected", async () => {
-    confirmationCalloutQueryPage.mockEndpoint(() =>
-      HttpResponse.json(
-        // `had_corrections` is the match-level signal; the final state carries
-        // no `prior_result`, so the derivation must read `had_corrections`.
-        reviewMatch({
-          viewer_state: "final",
-          your_turn: false,
-          standing_result: standingResult(),
-          prior_result: null,
-          had_corrections: true,
-        }),
-      ),
-    );
-
-    const result = await renderView();
-
-    expect(result.current.data).toEqual({
-      kind: "final",
-      afterCorrections: true,
-    });
+    expect(result.current.data).toBeNull();
   });
 
   it("projects null when there is no proposal in play (live)", async () => {

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.test.ts
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.test.ts
@@ -42,7 +42,6 @@ const reviewMatch = (
       standing_result: standingResult(),
       prior_result: null,
       diff: null,
-      had_corrections: false,
       ...negotiation,
     },
     ...overrides,

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.ts
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.ts
@@ -9,7 +9,8 @@ type NegotiationDiffEntry = components["schemas"]["NegotiationDiffEntry"];
 
 /** The result-negotiation state behind the match-detail callout, keyed off
  * `negotiation.viewer_state`. Null from the query means there's nothing to show
- * for this viewer (a live match with no proposal in play).
+ * for this viewer — a live match with no proposal in play, or a settled match
+ * (see the note below the per-state list).
  *
  * - `review`: the opponent posted the first result; the viewer must Accept or
  *   open the correction route ("Suggest correction"). Carries the standing

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.ts
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-query.ts
@@ -20,8 +20,9 @@ type NegotiationDiffEntry = components["schemas"]["NegotiationDiffEntry"];
  * - `awaiting`: the viewer's own side proposed; we wait on the opponent. A
  *   passive notice plus an "Edit result" action (a self-edit that supersedes
  *   the viewer's standing proposal).
- * - `final`: the match is settled. `afterCorrections` is true when the result
- *   chain held more than one proposal (a correction preceded the agreement). */
+ *
+ * A settled match (`final`) projects to null — once the negotiation is over the
+ * callout has nothing left to say, so it doesn't render. */
 export type ConfirmationCalloutView =
   | { kind: "review"; resultId: string; rated: boolean }
   | {
@@ -34,8 +35,7 @@ export type ConfirmationCalloutView =
       kind: "awaiting";
       /** Opponent we're waiting on, for the passive label. */
       pendingSignerName: string;
-    }
-  | { kind: "final"; afterCorrections: boolean };
+    };
 
 const selectConfirmationCallout = (
   match: MatchDetailsResult,
@@ -71,17 +71,9 @@ const selectConfirmationCallout = (
       return { kind: "awaiting", pendingSignerName };
     }
 
-    case "final":
-      // `had_corrections` is the match-level signal that the chain held more
-      // than one proposal — a counter or self-edit landed before the agreed
-      // result. (Distinct from the viewer-relative `viewer_state === "corrected"`.)
-      return {
-        kind: "final",
-        afterCorrections: negotiation.had_corrections,
-      };
-
     default:
-      // `live` — no proposal in play, nothing to render.
+      // `live` (no proposal in play) or `final` (the match is settled) — there's
+      // no sign-off to surface, so nothing renders.
       return null;
   }
 };

--- a/web-client/src/components/matches/match-details/save-your-match/save-your-match-fetcher/save-your-match-query.test.ts
+++ b/web-client/src/components/matches/match-details/save-your-match/save-your-match-fetcher/save-your-match-query.test.ts
@@ -134,7 +134,6 @@ describe("saveYourMatchQuery", () => {
             },
             prior_result: null,
             diff: null,
-            had_corrections: false,
           },
         }),
       ),

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -224,16 +224,11 @@ export const LIVE_NEGOTIATION: MatchNegotiation = {
   standing_result: null,
   prior_result: null,
   diff: null,
-  had_corrections: false,
 }
 
 /** The viewer-relative negotiation block — mirrors `_negotiation` in the API.
  * The mock current user always sits on side 1 (the viewer's side). */
 export function negotiationOf(seed: SeedMatch): MatchNegotiation {
-  // Match-level (viewer-independent): the chain holds a correction iff more than
-  // one proposal was ever posted. Mirrors `_negotiation` in the API.
-  const had_corrections = seed.results.length > 1
-
   const accepted = acceptedResult(seed)
   if (accepted !== null) {
     return {
@@ -242,7 +237,6 @@ export function negotiationOf(seed: SeedMatch): MatchNegotiation {
       standing_result: negotiationResultView(accepted),
       prior_result: null,
       diff: null,
-      had_corrections,
     }
   }
 
@@ -261,7 +255,6 @@ export function negotiationOf(seed: SeedMatch): MatchNegotiation {
       standing_result: standingView,
       prior_result: null,
       diff: null,
-      had_corrections,
     }
   }
 
@@ -288,7 +281,6 @@ export function negotiationOf(seed: SeedMatch): MatchNegotiation {
       standing_result: standingView,
       prior_result: null,
       diff: null,
-      had_corrections,
     }
   }
 
@@ -298,7 +290,6 @@ export function negotiationOf(seed: SeedMatch): MatchNegotiation {
     standing_result: standingView,
     prior_result: negotiationResultView(prior),
     diff: negotiationDiff(prior.games, standing.games),
-    had_corrections,
   }
 }
 


### PR DESCRIPTION
## What

A settled match showed a passive **"Confirmed — Both sides confirmed this result. This match is settled."** callout (or its **"Agreed after corrections"** variant) at the top of the match-details page. This removes it, and prunes the now-dead data that fed it.

A `final` negotiation now projects to `null`, so the confirmation callout unmounts once a match settles — matching how a `live` match already renders nothing in that slot.

## How

**FE callout removal**
- Drop the `final` member from `ConfirmationCalloutView`.
- Fold the `viewer_state === "final"` switch arm into the existing `default: return null` branch (alongside `live`).
- Remove the now-dead `final` display branch and the `buildFinalConfirmationView` test factory.

**Prune the orphaned `had_corrections` signal**
Removing the callout removed the only consumer of `MatchNegotiation.had_corrections` (the `final` view read it to choose "Confirmed" vs "Agreed after corrections"). With nothing left reading it, remove it end to end:
- **api:** drop the schema field + its computation/threading in `_negotiation`; delete the backend test that asserted the flag tracks chain length and the stale assertion in the accept test.
- **web-client:** drop it from the MSW match-store mock + every test/factory fixture that hand-set it; regenerate `schema.d.ts`.

No behavior change — the field had no remaining reader.

## Testing

- api: `ruff check` / `ruff format --check` clean, `mypy` (strict) clean, `pytest` — 513 passed
- web-client: `npm run test:run` — 1060 passed; `lint` clean; `build` (tsc + vite) clean; `npm run test:e2e` — 128 passed
- `schema.d.ts` regenerated via `mise run regen-api-types` (only `had_corrections` dropped)
- `/simplify` — 4-agent pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)