### PR TITLE
Rework "Suggest a correction" into a single-game board re-score (#718)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,48 @@
+# fortymm
+
+Table-tennis match tracking and rating. This glossary captures the project's
+ubiquitous language. It is a glossary only — not a spec — and is kept free of
+implementation detail.
+
+## Match result negotiation
+
+**Match**:
+A contest between two sides, played as a best-of-`N` set of games. A side wins by
+taking a majority of the games.
+
+**Scratchpad**:
+The live, shared score board for a match before any result is claimed. Either
+participant may edit it, one game at a time. It freezes the moment the first
+result is proposed.
+_Avoid_: draft, working board.
+
+**Decided board**:
+A complete, legal set of games — contiguous from game one, every game a legal
+table-tennis score, ending the instant one side clinches the majority (no games
+recorded after the decider). Every result must describe a decided board.
+_Avoid_: finished score, final board.
+
+**Result**:
+A claim about how a match ended — a decided board that one participant puts
+forward for the other to agree to. Frozen when proposed; never edited in place.
+
+**Standing result**:
+The current result on the table — the one a participant can accept or counter.
+There is at most one per match at any time.
+_Avoid_: latest result, current proposal.
+
+**Propose**:
+To put a result forward. Covers the first claim, revising one's own claim, and
+countering the other side's claim — all the same act. A propose that revises an
+existing standing result is a correction.
+
+**Accept**:
+The opposing side agreeing to the standing result. Accepting is the only consent
+the other side gives; it completes the match. There is no separate "confirm".
+_Avoid_: confirm, sign off.
+
+**Correction**:
+A proposed result that supersedes the standing one — a full re-score of the
+decided board, not an edit of individual game cells. The corrector may add,
+remove, or change games, so long as the outcome is again a decided board.
+_Avoid_: dispute, edit, amendment.

--- a/docs/adr/0001-correction-is-a-full-board-rescore.md
+++ b/docs/adr/0001-correction-is-a-full-board-rescore.md
@@ -1,0 +1,20 @@
+# A correction is a full board re-score, not a per-cell edit
+
+When a participant corrects a standing result, the correction surface lets them
+re-score the **whole decided board** — adding, removing, and changing games up to
+`best_of` — seeded from the standing result. The only constraint is that what they
+send is again a *decided board* (enforced client-side by `decidedSide` and
+server-side by the propose endpoint's 422 gate).
+
+We rejected the simpler "edit the existing game scores only" model because a
+correction frequently changes the *number* of games: if a game was recorded with
+the wrong winner (e.g. a 3–0 that was really 2–1), flipping it leaves the board
+undecided, and without the ability to add the deciding game(s) the match would be
+**stuck** with no legal result reachable. Allowing add/remove is the only model
+that lets every real correction reach a decided result.
+
+Consequence: the correction page mirrors the score-entry page's board editor
+(all `best_of` slots, add via empty slot, clear via ✕, running games tally) rather
+than a fixed list of pre-filled inputs — but it backs the edits with a local,
+unsaved buffer and submits the whole board as a single `propose`, because the
+scratchpad is frozen once a result stands.

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -651,10 +651,11 @@ export function scoringEditRoute(matchId: string, gameNumber: number) {
 
 /** The "Suggest a correction" proposal-authoring route (#718). Reached from the
  * match-detail callouts: a self-edit while awaiting, "Suggest correction" on
- * review, or "Counter" on a standing correction. */
-export function correctionRoute(matchId: string) {
+ * review, or "Counter" on a standing correction. The page is a full board
+ * re-score that posts a new (counter-)result, hence `/results/new`. */
+export function newResultRoute(matchId: string) {
   return {
-    to: '/matches/$matchId/correct' as const,
+    to: '/matches/$matchId/results/new' as const,
     params: { matchId },
   }
 }

--- a/web-client/src/components/matches/correction-entry/correction-entry.page.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.page.tsx
@@ -15,7 +15,8 @@ import {
   type MatchResultsResolver,
 } from "@/mocks/endpoints/matches/match-results.endpoint";
 import { server } from "@/mocks/server";
-import { render, screen, within, type Container } from "@/test/utilities";
+import userEvent from "@testing-library/user-event";
+import { render, screen, type Container } from "@/test/utilities";
 
 import { CorrectionEntry } from "./correction-entry";
 
@@ -26,23 +27,48 @@ const scoped = (container: Container) => ({
   queryLoading() {
     return container.queryByTestId("correction-entry-loading");
   },
-  /** A side's numeric input within game `gameNumber`, by the participant's name
-   * (the field label is `"<name> score"`). Games stack in document order, so we
-   * scope to the matching `Game N` section. */
-  getInput(gameNumber: number, name: string) {
-    const heading = container.getByRole("heading", {
-      name: `Game ${gameNumber}`,
-    });
-    const section = heading.closest("section") as HTMLElement;
-    return within(section).getByLabelText(`${name} score`) as HTMLInputElement;
+  /** A side's numeric input in the single open pad, by the participant's name
+   * (the field label is `"<name> score"`). The board shows one game at a time,
+   * switched via the scoreline, so there's never more than one such field. */
+  getInput(name: string) {
+    return container.getByLabelText(`${name} score`) as HTMLInputElement;
   },
-  /** The single shared "Send corrected score" submit (or its pending label). */
+  /** The single "Send corrected score" submit (or its pending label). */
   getSubmit() {
     return container.getByRole("button", {
       name: /send corrected score|sending/i,
     });
   },
-  /** Any visible `role="alert"` line (per-game score error or the API error). */
+  /** The in-pad "Clear" action that empties the open game. */
+  getClear() {
+    return container.getByRole("button", { name: "Clear" });
+  },
+  /** A scoreline cell — clicking it opens that game in the pad. */
+  getCell(gameNumber: number) {
+    return container.getByRole("button", {
+      name: new RegExp(`^go to game ${gameNumber}\\b`, "i"),
+    });
+  },
+  /** The active (open) scoreline cell. */
+  getActiveCell() {
+    return container.getByRole("button", { current: "step" });
+  },
+  /** A scoreline cell's hover-✕ clear (absent on empty slots). */
+  getCellClear(gameNumber: number) {
+    return container.getByRole("button", { name: `Clear game ${gameNumber}` });
+  },
+  /** A scoreline cell's hover-✕ clear, or null when the slot is empty. */
+  queryCellClear(gameNumber: number) {
+    return container.queryByRole("button", {
+      name: `Clear game ${gameNumber}`,
+    });
+  },
+  /** Open a game in the pad via its scoreline cell. */
+  async selectGame(gameNumber: number) {
+    await userEvent.click(this.getCell(gameNumber));
+  },
+  /** Any visible `role="alert"` line (per-game score error, board hint, or the
+   * API error). */
   queryAlerts() {
     return container.queryAllByRole("alert");
   },
@@ -75,7 +101,7 @@ export const correctionEntryPage = {
     const rootRoute = createRootRoute();
     const correctRoute = createRoute({
       getParentRoute: () => rootRoute,
-      path: "/matches/$matchId/correct",
+      path: "/matches/$matchId/results/new",
       component: () => <CorrectionEntry matchId={matchId} />,
     });
     const matchRoute = createRoute({
@@ -86,7 +112,7 @@ export const correctionEntryPage = {
     const router = createRouter({
       routeTree: rootRoute.addChildren([correctRoute, matchRoute]),
       history: createMemoryHistory({
-        initialEntries: [`/matches/${matchId}/correct`],
+        initialEntries: [`/matches/${matchId}/results/new`],
       }),
     });
     render(<RouterProvider router={router} />);

--- a/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
@@ -11,8 +11,14 @@ import {
 } from "./correction-entry.factory";
 import { correctionEntryPage } from "./correction-entry.page";
 
+/** Re-type a side's score in the open pad. */
+async function retype(input: HTMLInputElement, value: string) {
+  await userEvent.clear(input);
+  if (value !== "") await userEvent.type(input, value);
+}
+
 describe("CorrectionEntry", () => {
-  it("pre-fills the inputs from the standing-result snapshot (not the scratchpad)", async () => {
+  it("opens game 1 pre-filled from the standing-result snapshot, viewer-left", async () => {
     // The seed's standing result is the opponent's 3–0 board (11–8, 11–6,
     // 11–9). The viewer is side 1 (rita.kovac), so the left field reads
     // side_1_points and the right reads side_2_points.
@@ -22,11 +28,15 @@ describe("CorrectionEntry", () => {
     correctionEntryPage.render();
 
     await waitFor(() =>
-      expect(correctionEntryPage.getInput(1, "rita.kovac")).toHaveValue("11"),
+      expect(correctionEntryPage.getInput("rita.kovac")).toHaveValue("11"),
     );
-    expect(correctionEntryPage.getInput(1, "leo.mertens")).toHaveValue("8");
-    expect(correctionEntryPage.getInput(2, "leo.mertens")).toHaveValue("6");
-    expect(correctionEntryPage.getInput(3, "leo.mertens")).toHaveValue("9");
+    expect(correctionEntryPage.getInput("leo.mertens")).toHaveValue("8");
+
+    // Switch games via the scoreline — the pad re-seeds for the chosen game.
+    await correctionEntryPage.selectGame(2);
+    expect(correctionEntryPage.getInput("leo.mertens")).toHaveValue("6");
+    await correctionEntryPage.selectGame(3);
+    expect(correctionEntryPage.getInput("leo.mertens")).toHaveValue("9");
   });
 
   it("posts the corrected board with supersedes_result_id and navigates home on success", async () => {
@@ -40,16 +50,10 @@ describe("CorrectionEntry", () => {
     });
     correctionEntryPage.render();
 
-    // Correct game 3: the viewer says they actually won it 11–9 (flip the
-    // opponent's 11–9). Edit the viewer's side from a blank.
-    const me3 = await waitFor(() =>
-      correctionEntryPage.getInput(3, "rita.kovac"),
-    );
-    await userEvent.clear(me3);
-    await userEvent.type(me3, "11");
-    const opp3 = correctionEntryPage.getInput(3, "leo.mertens");
-    await userEvent.clear(opp3);
-    await userEvent.type(opp3, "9");
+    // Correct game 1: the opponent scored it 11–8; the viewer says 11–7. The
+    // board stays a decided 3–0, so Send is enabled.
+    const opp1 = await waitFor(() => correctionEntryPage.getInput("leo.mertens"));
+    await retype(opp1, "7");
 
     await userEvent.click(correctionEntryPage.getSubmit());
 
@@ -57,45 +61,89 @@ describe("CorrectionEntry", () => {
       expect(postedBody).toEqual({
         supersedes_result_id: STANDING_RESULT_ID,
         games: [
-          { game_number: 1, side_1_points: 11, side_2_points: 8 },
+          { game_number: 1, side_1_points: 11, side_2_points: 7 },
           { game_number: 2, side_1_points: 11, side_2_points: 6 },
           { game_number: 3, side_1_points: 11, side_2_points: 9 },
         ],
       }),
     );
-    // On success the route navigates back to the match-details landing.
     await waitFor(() =>
       expect(correctionEntryPage.queryMatchLanding()).toBeInTheDocument(),
     );
   });
 
-  it("warns inline and disables submit when a correction leaves the match undecided (#734)", async () => {
+  it("blocks submit when flipping a winner leaves the match undecided, then re-enables once a game is added (#734)", async () => {
     correctionEntryPage.mockMatch(() =>
       HttpResponse.json(buildCorrectableMatch()),
     );
     correctionEntryPage.render();
+    await waitFor(() => correctionEntryPage.getInput("rita.kovac"));
 
-    // Seed is a decided 3–0 (best-of-5). Flip game 3 so the viewer loses it:
-    // the board becomes 2–1, and no side has reached 3 wins — undecided.
-    const me3 = await waitFor(() =>
-      correctionEntryPage.getInput(3, "rita.kovac"),
-    );
-    await userEvent.clear(me3);
-    await userEvent.type(me3, "9");
-    const opp3 = correctionEntryPage.getInput(3, "leo.mertens");
-    await userEvent.clear(opp3);
-    await userEvent.type(opp3, "11");
+    // Flip game 3 so the viewer loses it 9–11: the board drops to 2–1, no side
+    // has 3 wins — undecided.
+    await correctionEntryPage.selectGame(3);
+    await retype(correctionEntryPage.getInput("rita.kovac"), "9");
+    await retype(correctionEntryPage.getInput("leo.mertens"), "11");
 
     await waitFor(() =>
       expect(
         correctionEntryPage
           .queryAlerts()
           .some((a: HTMLElement) =>
-            /no side has won 3 games/i.test(a.textContent ?? ""),
+            /isn't a finished match yet/i.test(a.textContent ?? ""),
           ),
       ).toBe(true),
     );
     expect(correctionEntryPage.getSubmit()).toBeDisabled();
+
+    // Add game 4 as a viewer win (11–7): the board becomes 3–1, decided — Send
+    // lights back up.
+    await correctionEntryPage.selectGame(4);
+    await retype(correctionEntryPage.getInput("rita.kovac"), "11");
+    await retype(correctionEntryPage.getInput("leo.mertens"), "7");
+
+    await waitFor(() =>
+      expect(correctionEntryPage.getSubmit()).toBeEnabled(),
+    );
+  });
+
+  it("clears a game from the scoreline ✕ and from the in-pad Clear button", async () => {
+    correctionEntryPage.mockMatch(() =>
+      HttpResponse.json(buildCorrectableMatch()),
+    );
+    correctionEntryPage.render();
+
+    await waitFor(() => correctionEntryPage.getInput("rita.kovac"));
+
+    // Scoreline ✕ on game 3 empties it (board → 2–0, undecided).
+    await userEvent.click(correctionEntryPage.getCellClear(3));
+    expect(correctionEntryPage.getCell(3)).toHaveTextContent("—");
+    // Its ✕ is gone now that the slot is empty.
+    expect(correctionEntryPage.queryCellClear(3)).toBeNull();
+
+    // In-pad Clear empties the open game (game 1).
+    await userEvent.click(correctionEntryPage.getClear());
+    expect(correctionEntryPage.getInput("rita.kovac")).toHaveValue("");
+    expect(correctionEntryPage.getCell(1)).toHaveTextContent("—");
+  });
+
+  it("advances to the next game when Enter is pressed on the opponent field", async () => {
+    correctionEntryPage.mockMatch(() =>
+      HttpResponse.json(buildCorrectableMatch()),
+    );
+    correctionEntryPage.render();
+
+    const opp1 = await waitFor(() => correctionEntryPage.getInput("leo.mertens"));
+    opp1.focus();
+    await userEvent.keyboard("{Enter}");
+
+    // Game 2 is now the open, active cell — the pad shows its 11–6 score.
+    await waitFor(() =>
+      expect(correctionEntryPage.getActiveCell()).toBe(
+        correctionEntryPage.getCell(2),
+      ),
+    );
+    expect(correctionEntryPage.getInput("leo.mertens")).toHaveValue("6");
   });
 
   it("surfaces a 409 (the proposal moved on) inline without navigating away", async () => {
@@ -110,7 +158,7 @@ describe("CorrectionEntry", () => {
     );
     correctionEntryPage.render();
 
-    await waitFor(() => correctionEntryPage.getInput(1, "rita.kovac"));
+    await waitFor(() => correctionEntryPage.getInput("rita.kovac"));
     await userEvent.click(correctionEntryPage.getSubmit());
 
     await waitFor(() =>
@@ -120,7 +168,6 @@ describe("CorrectionEntry", () => {
           .some((a: HTMLElement) => /moved on/i.test(a.textContent ?? "")),
       ).toBe(true),
     );
-    // Still on the correction screen — no navigation on a rejected propose.
     expect(correctionEntryPage.queryMatchLanding()).not.toBeInTheDocument();
   });
 });

--- a/web-client/src/components/matches/correction-entry/correction-entry.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Navigate, useNavigate } from "@tanstack/react-router";
 import { ApiError } from "@/api/client";
 import {
@@ -15,6 +15,7 @@ import {
   isAcceptableScoreInput,
   validateGameScore,
 } from "../score-pad/validate-game-score";
+import { CorrectionScoreline } from "./correction-scoreline";
 
 // Placeholder identity for a player-less (solo) opponent side, mirroring the
 // scratchpad entry screen so the correction board reads the same.
@@ -33,26 +34,39 @@ interface GameDraft {
 }
 
 /**
- * Seed the editable drafts from the immutable standing-result snapshot (NOT the
- * live scratchpad). The viewer's side reads left; the orientation is restored on
- * submit from `mySideNumber`.
+ * Seed one editable draft per `best_of` slot from the immutable standing-result
+ * snapshot (NOT the live scratchpad): played games pre-fill, the remaining
+ * slots start empty so the corrector can add games to reach a decided board
+ * (a 3–0 flipped to 2–1 needs a game 4/5 to finish). The viewer's side reads
+ * left; the orientation is restored on submit from `mySideNumber`.
  */
-function seedDrafts(games: StandingGame[], mySideNumber: 1 | 2): GameDraft[] {
-  return [...games]
-    .sort((a, b) => a.game_number - b.game_number)
-    .map((g) => ({
-      gameNumber: g.game_number,
+function seedDrafts(
+  games: StandingGame[],
+  mySideNumber: 1 | 2,
+  bestOf: number,
+): GameDraft[] {
+  const byNumber = new Map(games.map((g) => [g.game_number, g]));
+  return Array.from({ length: bestOf }, (_, i) => {
+    const gameNumber = i + 1;
+    const g = byNumber.get(gameNumber);
+    if (!g) return { gameNumber, me: "", opp: "" };
+    return {
+      gameNumber,
       me: String(mySideNumber === 1 ? g.side_1_points : g.side_2_points),
       opp: String(mySideNumber === 1 ? g.side_2_points : g.side_1_points),
-    }));
+    };
+  });
 }
 
 /**
- * "Suggest a correction" screen. Pre-fills the score inputs from
- * `negotiation.standing_result.games` (the immutable proposal snapshot) and, on
- * submit, posts a counter-proposal that supersedes that standing result. A 409
- * (the proposal moved on) is surfaced inline; success navigates back to the
- * match-details page.
+ * "Suggest a correction" screen — a full board re-score, seeded from the
+ * standing result. Unlike a per-game scratchpad edit, correcting a winner can
+ * leave the match undecided (3–0 → 2–1), so the corrector edits one game at a
+ * time in a single `ScorePad` and navigates the board via the SCORELINE strip,
+ * adding/removing games until the buffered board is a decided match. On submit
+ * it posts a counter-proposal that supersedes the standing result; a 409 (the
+ * proposal moved on) or 422 (board rejected) surfaces inline, success navigates
+ * back to the match-details page.
  */
 export function CorrectionEntry({ matchId }: { matchId: string }) {
   const navigate = useNavigate();
@@ -62,6 +76,9 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
   // `null` means "not seeded yet" — seeded once `data` arrives (below), so we
   // avoid a state-syncing effect on first render.
   const [drafts, setDrafts] = useState<GameDraft[] | null>(null);
+  const [selectedGameNumber, setSelectedGameNumber] = useState(1);
+  const meRef = useRef<HTMLInputElement>(null);
+  const oppRef = useRef<HTMLInputElement>(null);
 
   if (isLoading || !data) {
     return <div aria-busy="true" data-testid="correction-entry-loading" />;
@@ -80,6 +97,8 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
   // Captured here (rather than read inside `onSubmit`) so the standing-result
   // narrowing from the guard above survives into the submit closure.
   const standingId = standing.id;
+  const bestOf = data.best_of;
+  const gamesToWin = data.games_to_win;
   const mySideNumber: 1 | 2 = mySide.side_number === 2 ? 2 : 1;
   const meName = mySide.players[0]?.username ?? "You";
   const meInitials = initialsOf(meName);
@@ -87,7 +106,9 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
   const oppName = oppUsername ?? NO_OPPONENT_LABEL;
   const oppHasPlayer = oppUsername !== null;
 
-  const current = drafts ?? seedDrafts(standing.games, mySideNumber);
+  const current = drafts ?? seedDrafts(standing.games, mySideNumber, bestOf);
+  const selected =
+    current.find((d) => d.gameNumber === selectedGameNumber) ?? current[0];
 
   const setGame = (gameNumber: number, next: Partial<GameDraft>) => {
     setDrafts(
@@ -96,37 +117,77 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
     if (proposeMutation.error) proposeMutation.reset();
   };
 
-  // Per-game validation verdicts, indexed alongside `current`.
-  const validations = current.map((d) => validateGameScore(d.me, d.opp));
-  const allValid = validations.every((v) => v.valid);
-
-  // The orientation-restored board — kept as the single source for both the
-  // completeness check and the submit payload, so what we validate is exactly
-  // what we post.
-  const correctedGames: MatchResultsGameWrite[] = current.map((d) =>
-    mySideNumber === 1
-      ? {
-          game_number: d.gameNumber,
-          side_1_points: Number(d.me),
-          side_2_points: Number(d.opp),
-        }
-      : {
-          game_number: d.gameNumber,
-          side_1_points: Number(d.opp),
-          side_2_points: Number(d.me),
-        },
+  // Per-game verdicts across the whole buffer: a game with any input must be a
+  // legal, completed score for the board to be submittable; wholly-empty slots
+  // are just "not played yet".
+  const draftStates = current.map((d) => ({
+    draft: d,
+    validation: validateGameScore(d.me, d.opp),
+    hasInput: d.me !== "" || d.opp !== "",
+  }));
+  const allEnteredValid = draftStates.every(
+    (s) => !s.hasInput || s.validation.valid,
   );
+  const validDrafts = draftStates
+    .filter((s) => s.validation.valid)
+    .map((s) => s.draft);
 
-  // Once every game is individually legal, validate the board as a *whole* the
-  // same way the score-entry page does live and the server does on submit: a
-  // correction that leaves the match undecided (e.g. a BO5 board edited to 2–1)
-  // must warn inline and block submit, not only fail on the server (#734). The
-  // numbers aren't trustworthy until per-game valid (`Number('')` is 0), so we
-  // only parse the board once `allValid`.
-  const boardError = allValid
-    ? firstMatchScoreError(correctedGames, data.best_of)
+  // The orientation-restored board — the single source for both the
+  // completeness check and the submit payload, so what we validate is exactly
+  // what we post. Only legal, completed games make the board; ordered by game
+  // number so the contiguity/decider rules read it correctly.
+  const correctedGames: MatchResultsGameWrite[] = validDrafts
+    .map((d) =>
+      mySideNumber === 1
+        ? {
+            game_number: d.gameNumber,
+            side_1_points: Number(d.me),
+            side_2_points: Number(d.opp),
+          }
+        : {
+            game_number: d.gameNumber,
+            side_1_points: Number(d.opp),
+            side_2_points: Number(d.me),
+          },
+    )
+    .sort((a, b) => a.game_number - b.game_number);
+
+  // Validate the board as a *whole* the same way the score-entry page does live
+  // and the server does on submit: a correction that leaves the match undecided
+  // (a BO5 board edited to 2–1) must block submit, not only fail on the server
+  // (#734). Only meaningful once every entered game is individually legal.
+  const boardError = allEnteredValid
+    ? firstMatchScoreError(correctedGames, bestOf)
     : null;
-  const canSubmit = allValid && boardError === null;
+  const canSubmit = allEnteredValid && boardError === null;
+
+  // The running games tally (viewer-left), shown under the VS divider on
+  // multi-game matches so the corrector can see how close the board is to
+  // decided.
+  const myWins = validDrafts.filter((d) => Number(d.me) > Number(d.opp)).length;
+  const oppWins = validDrafts.filter(
+    (d) => Number(d.opp) > Number(d.me),
+  ).length;
+  const gamesTally = bestOf > 1 ? `${myWins} – ${oppWins}` : null;
+
+  // The board-level hint that explains a disabled Send. Three cases: an entered
+  // game is incomplete/illegal (a half-filled non-selected game leaves Send
+  // dead with nothing on the open pad to explain it); the board is a clean but
+  // undecided prefix (just needs more games — the friendly add-games copy); or
+  // a structural error (gap, too many games, a game after the decider) for
+  // which the lib's message is the clearest thing to say.
+  const contiguous = correctedGames.every((g, i) => g.game_number === i + 1);
+  const someoneWon = myWins >= gamesToWin || oppWins >= gamesToWin;
+  let boardHint: string | null = null;
+  if (!allEnteredValid) {
+    boardHint =
+      "Finish entering each game — one or more games have only one score or an illegal score.";
+  } else if (boardError !== null) {
+    boardHint =
+      contiguous && !someoneWon
+        ? "This isn't a finished match yet — add the remaining game(s) until someone wins."
+        : boardError;
+  }
 
   // A 409 means the standing result moved on (someone else proposed/accepted
   // since this screen loaded); a 422 means the board itself was rejected. Both
@@ -136,6 +197,22 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
 
   const inputsLocked = proposeMutation.isPending;
 
+  // The per-game verdicts and the scoreline view-model both derive from the
+  // single `draftStates` pass above, so the validation is computed once per
+  // game and the two derivations can't drift.
+  const selectedValidation = (
+    draftStates.find((s) => s.draft.gameNumber === selected.gameNumber) ??
+    draftStates[0]
+  ).validation;
+
+  const scorelineCells = draftStates.map(({ draft: d, validation: v, hasInput }) => ({
+    gameNumber: d.gameNumber,
+    myPoints: d.me === "" ? null : d.me,
+    oppPoints: d.opp === "" ? null : d.opp,
+    myWin: v.valid ? Number(d.me) > Number(d.opp) : null,
+    invalid: hasInput && !v.valid,
+  }));
+
   function onSubmit() {
     if (!canSubmit || proposeMutation.isPending) return;
     proposeMutation.mutate(
@@ -144,13 +221,50 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
     );
   }
 
+  function onClearSelected() {
+    setGame(selectedGameNumber, { me: "", opp: "" });
+    // Same page (no remount), so re-grab the me-input for the next entry.
+    meRef.current?.focus();
+  }
+
+  function handleKey(
+    e: React.KeyboardEvent<HTMLInputElement>,
+    side: "me" | "opp",
+  ) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (side === "me" && selected.me !== "") {
+        oppRef.current?.focus();
+        oppRef.current?.select();
+      } else if (side === "opp") {
+        // Enter on the opponent field advances to the next game (the pad
+        // remounts on the new game number and auto-focuses its me-input); on
+        // the last slot it submits the board instead of dead-ending.
+        if (selectedGameNumber < bestOf) {
+          setSelectedGameNumber(selectedGameNumber + 1);
+        } else {
+          onSubmit();
+        }
+      }
+    } else if (e.key === "ArrowRight" && side === "me") {
+      e.preventDefault();
+      oppRef.current?.focus();
+      oppRef.current?.select();
+    } else if (e.key === "ArrowLeft" && side === "opp") {
+      e.preventDefault();
+      meRef.current?.focus();
+      meRef.current?.select();
+    }
+  }
+
   return (
     <div className="entry-wrap">
       <div className="entry-head">
         <h2>Suggest a correction.</h2>
         <div className="hint">
-          Adjust the game(s) that look off, then send the corrected score to{" "}
-          {oppName} to confirm.
+          Fix the game(s) that look off — switch games on the SCORELINE, add or
+          remove games until the board has a winner, then send the corrected
+          score to {oppName} to confirm.
         </div>
       </div>
 
@@ -162,77 +276,74 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
         </p>
       )}
 
-      {current.map((d, i) => {
-        const v = validations[i];
-        return (
-          <section key={d.gameNumber} className="correction-game">
-            <h3 className="text-sm font-medium text-[color:var(--muted)]">
-              Game {d.gameNumber}
-            </h3>
-            <ScorePad
-              me={{
-                name: meName,
-                initials: meInitials,
-                value: d.me,
-                // Red-flag this field when its own value is malformed, or when a
-                // pair-level rule violation (tie/deuce) makes neither side
-                // individually malformed — but NOT when only the *other* side is
-                // malformed (its error shouldn't bleed onto this clean input).
-                invalid:
-                  v.meMalformed ||
-                  (v.error !== null && !v.meMalformed && !v.oppMalformed),
-                onChange: (value) => {
-                  if (!isAcceptableScoreInput(value)) return;
-                  setGame(d.gameNumber, { me: value });
-                },
-              }}
-              opp={{
-                name: oppName,
-                initials: oppHasPlayer ? initialsOf(oppName) : null,
-                value: d.opp,
-                invalid:
-                  v.oppMalformed ||
-                  (v.error !== null && !v.meMalformed && !v.oppMalformed),
-                onChange: (value) => {
-                  if (!isAcceptableScoreInput(value)) return;
-                  setGame(d.gameNumber, { opp: value });
-                },
-              }}
-              gamesTally={null}
-              scoreError={v.error}
-              showBothRequired={v.oneSideFilled && v.error === null}
-              inputsLocked={inputsLocked}
-              // The per-game pads are inputs-only (hideActions); a single shared
-              // action row below the whole board owns the one submit.
-              hideActions
-            />
-          </section>
-        );
-      })}
-
-      {boardError !== null && (
+      {boardHint !== null && (
         <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
-          {boardError}
+          {boardHint}
         </p>
       )}
 
-      <div className="single-actions">
-        <div className="result-line subtle">
-          {data.affects_rating
-            ? "Sending the corrected score posts it for your opponent to confirm."
-            : "Sending the corrected score finalizes the match immediately."}
-        </div>
-        <div className="action-btns">
-          <button
-            type="button"
-            className="btn primary"
-            disabled={!canSubmit || inputsLocked}
-            onClick={onSubmit}
-          >
-            {proposeMutation.isPending ? "Sending…" : "Send corrected score"}
-          </button>
-        </div>
-      </div>
+      <ScorePad
+        // Remount on game switch so the inputs re-seed and the me-field
+        // auto-focuses for the newly-opened game.
+        key={selected.gameNumber}
+        me={{
+          name: meName,
+          initials: meInitials,
+          value: selected.me,
+          inputRef: meRef,
+          autoFocus: true,
+          // Red-flag this field when its own value is malformed, or when a
+          // pair-level rule violation (tie/deuce) makes neither side
+          // individually malformed — but NOT when only the *other* side is.
+          invalid:
+            selectedValidation.meMalformed ||
+            (selectedValidation.error !== null &&
+              !selectedValidation.meMalformed &&
+              !selectedValidation.oppMalformed),
+          onChange: (value) => {
+            if (!isAcceptableScoreInput(value)) return;
+            setGame(selected.gameNumber, { me: value });
+          },
+          onKeyDown: (e) => handleKey(e, "me"),
+        }}
+        opp={{
+          name: oppName,
+          initials: oppHasPlayer ? initialsOf(oppName) : null,
+          value: selected.opp,
+          inputRef: oppRef,
+          invalid:
+            selectedValidation.oppMalformed ||
+            (selectedValidation.error !== null &&
+              !selectedValidation.meMalformed &&
+              !selectedValidation.oppMalformed),
+          onChange: (value) => {
+            if (!isAcceptableScoreInput(value)) return;
+            setGame(selected.gameNumber, { opp: value });
+          },
+          onKeyDown: (e) => handleKey(e, "opp"),
+        }}
+        gamesTally={gamesTally}
+        scoreError={selectedValidation.error}
+        showBothRequired={
+          selectedValidation.oneSideFilled && selectedValidation.error === null
+        }
+        inputsLocked={inputsLocked}
+        subtitle={`Sending the corrected score posts the result for ${oppName} to confirm.`}
+        submitLabel={
+          proposeMutation.isPending ? "Sending…" : "Send corrected score"
+        }
+        canSubmit={canSubmit}
+        onSubmit={onSubmit}
+        onClear={onClearSelected}
+        clearDisabled={selected.me === "" && selected.opp === ""}
+      />
+
+      <CorrectionScoreline
+        cells={scorelineCells}
+        activeGameNumber={selected.gameNumber}
+        onSelect={setSelectedGameNumber}
+        onClear={(n) => setGame(n, { me: "", opp: "" })}
+      />
     </div>
   );
 }

--- a/web-client/src/components/matches/correction-entry/correction-scoreline.factory.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-scoreline.factory.tsx
@@ -1,0 +1,51 @@
+import type {
+  CorrectionScorelineCell,
+  CorrectionScorelineProps,
+} from "./correction-scoreline";
+
+/** One scoreline cell — a viewer-won game `11–8` by default. */
+export function buildCorrectionScorelineCell(
+  overrides: Partial<CorrectionScorelineCell> = {},
+): CorrectionScorelineCell {
+  return {
+    gameNumber: 1,
+    myPoints: "11",
+    oppPoints: "8",
+    myWin: true,
+    invalid: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Props for `CorrectionScoreline` — a best-of-5 strip seeded from a decided
+ * 3–0 board (games 1–3 filled, 4–5 empty), game 1 open. Mirrors the
+ * correction surface's standing-result pre-fill.
+ */
+export function buildCorrectionScorelineProps(
+  overrides: Partial<CorrectionScorelineProps> = {},
+): CorrectionScorelineProps {
+  return {
+    cells: [
+      buildCorrectionScorelineCell({ gameNumber: 1, myPoints: "11", oppPoints: "8" }),
+      buildCorrectionScorelineCell({ gameNumber: 2, myPoints: "11", oppPoints: "6" }),
+      buildCorrectionScorelineCell({ gameNumber: 3, myPoints: "11", oppPoints: "9" }),
+      buildCorrectionScorelineCell({
+        gameNumber: 4,
+        myPoints: null,
+        oppPoints: null,
+        myWin: null,
+      }),
+      buildCorrectionScorelineCell({
+        gameNumber: 5,
+        myPoints: null,
+        oppPoints: null,
+        myWin: null,
+      }),
+    ],
+    activeGameNumber: 1,
+    onSelect: () => {},
+    onClear: () => {},
+    ...overrides,
+  };
+}

--- a/web-client/src/components/matches/correction-entry/correction-scoreline.page.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-scoreline.page.tsx
@@ -1,0 +1,47 @@
+import { render, screen, type Container } from "@/test/utilities";
+
+import {
+  CorrectionScoreline,
+  type CorrectionScorelineProps,
+} from "./correction-scoreline";
+import { buildCorrectionScorelineProps } from "./correction-scoreline.factory";
+
+const scoped = (container: Container) => ({
+  /** A game's cell, by its accessible label (`"Go to game N, …"`). */
+  getCell(gameNumber: number) {
+    return container.getByRole("button", {
+      name: new RegExp(`^go to game ${gameNumber}\\b`, "i"),
+    });
+  },
+  /** The active cell (the open game) — there's exactly one. */
+  getActiveCell() {
+    return container.getByRole("button", { current: "step" });
+  },
+  /** A game's hover-✕ clear button. */
+  getClear(gameNumber: number) {
+    return container.getByRole("button", { name: `Clear game ${gameNumber}` });
+  },
+  /** Whether a game's clear ✕ is present (absent on empty slots). */
+  queryClear(gameNumber: number) {
+    return container.queryByRole("button", {
+      name: `Clear game ${gameNumber}`,
+    });
+  },
+});
+
+/**
+ * Test page-object for `CorrectionScoreline` — the presentational nav strip.
+ * Pure, so `render` mounts it directly (no router/suspense harness).
+ */
+export const correctionScorelinePage = {
+  render(overrides: Partial<CorrectionScorelineProps> = {}) {
+    const props = buildCorrectionScorelineProps(overrides);
+    render(<CorrectionScoreline {...props} />);
+  },
+
+  within(container: Container = screen) {
+    return scoped(container);
+  },
+
+  ...scoped(screen),
+};

--- a/web-client/src/components/matches/correction-entry/correction-scoreline.test.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-scoreline.test.tsx
@@ -1,0 +1,71 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { correctionScorelinePage } from "./correction-scoreline.page";
+
+describe("CorrectionScoreline", () => {
+  it("marks the open game as the active (aria-current) cell", () => {
+    correctionScorelinePage.render({ activeGameNumber: 2 });
+
+    expect(correctionScorelinePage.getActiveCell()).toBe(
+      correctionScorelinePage.getCell(2),
+    );
+  });
+
+  it("selects a game on click", async () => {
+    const onSelect = vi.fn();
+    correctionScorelinePage.render({ onSelect });
+
+    await userEvent.click(correctionScorelinePage.getCell(3));
+
+    expect(onSelect).toHaveBeenCalledWith(3);
+  });
+
+  it("renders an empty slot as a dash with no clear affordance", () => {
+    correctionScorelinePage.render();
+
+    // Games 4–5 are empty in the default seed.
+    expect(correctionScorelinePage.getCell(4)).toHaveTextContent("—");
+    expect(correctionScorelinePage.queryClear(4)).not.toBeInTheDocument();
+    // A filled game offers the hover-✕ clear.
+    expect(correctionScorelinePage.queryClear(1)).toBeInTheDocument();
+  });
+
+  it("clears a filled game without selecting it", async () => {
+    const onSelect = vi.fn();
+    const onClear = vi.fn();
+    correctionScorelinePage.render({ onSelect, onClear });
+
+    await userEvent.click(correctionScorelinePage.getClear(2));
+
+    expect(onClear).toHaveBeenCalledWith(2);
+    // The ✕ stops propagation, so the cell's select doesn't also fire.
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("flags a non-active half-entered / illegal game so a disabled Send has a visible cause", () => {
+    correctionScorelinePage.render({
+      // The flagged game isn't the open one (the open game shows its own error
+      // in the pad); a *non-active* invalid cell wears the failed treatment.
+      activeGameNumber: 2,
+      cells: [
+        {
+          gameNumber: 1,
+          myPoints: "11",
+          oppPoints: null,
+          myWin: null,
+          invalid: true,
+        },
+        {
+          gameNumber: 2,
+          myPoints: null,
+          oppPoints: null,
+          myWin: null,
+          invalid: false,
+        },
+      ],
+    });
+
+    expect(correctionScorelinePage.getCell(1)).toHaveClass("failed");
+  });
+});

--- a/web-client/src/components/matches/correction-entry/correction-scoreline.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-scoreline.tsx
@@ -1,0 +1,145 @@
+import { TriangleAlert, X as XIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+/** One cell of the correction scoreline strip — a single game's buffered score
+ * in viewer orientation (my points left). Points are the raw input strings (or
+ * null when that slot is empty), so a half-entered game still shows what's
+ * typed. */
+export interface CorrectionScorelineCell {
+  gameNumber: number;
+  myPoints: string | null;
+  oppPoints: string | null;
+  /** true = the viewer won this game, false = the opponent won, null = no
+   * highlight (empty or not yet a legal, complete score). */
+  myWin: boolean | null;
+  /** Has input but isn't a legal, completed game (only one side filled, or an
+   * illegal final score) — flagged so a disabled Send has a visible cause. */
+  invalid: boolean;
+}
+
+export interface CorrectionScorelineProps {
+  /** One entry per `best_of` slot, in game order; its length drives the strip
+   * width (`--sl-cell-count`). */
+  cells: CorrectionScorelineCell[];
+  /** The game currently open in the pad above — rendered as the active cell. */
+  activeGameNumber: number;
+  /** Jump the pad to a game. */
+  onSelect: (gameNumber: number) => void;
+  /** Empty a game's buffered score (no confirmation — the buffer is local and
+   * the standing result is untouched until Send). */
+  onClear: (gameNumber: number) => void;
+}
+
+/**
+ * The navigation strip below the correction pad — reproduces the scoring
+ * page's SCORELINE look (the global `.scoreline`/`.sl-cells`/`.sl-cell` CSS)
+ * but is purely presentational and buffer-backed: cells `onSelect` to switch
+ * the open game (no route change) and the hover-✕ clears the buffered score
+ * (no API, no dialog). Distinct from `score-entry`'s scratchpad-coupled
+ * `Scoreline`, which navigates via `<Link>` and reads the save-mutation cache.
+ */
+export function CorrectionScoreline({
+  cells,
+  activeGameNumber,
+  onSelect,
+  onClear,
+}: CorrectionScorelineProps) {
+  return (
+    <div className="scoreline">
+      <div className="sl-label">SCORELINE</div>
+      <div
+        className="sl-cells"
+        style={{ "--sl-cell-count": cells.length } as React.CSSProperties}
+      >
+        {cells.map((cell) => (
+          <CorrectionScorelineCellView
+            key={cell.gameNumber}
+            cell={cell}
+            isActive={cell.gameNumber === activeGameNumber}
+            onSelect={onSelect}
+            onClear={onClear}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CorrectionScorelineCellView({
+  cell,
+  isActive,
+  onSelect,
+  onClear,
+}: {
+  cell: CorrectionScorelineCell;
+  isActive: boolean;
+  onSelect: (gameNumber: number) => void;
+  onClear: (gameNumber: number) => void;
+}) {
+  const isEmpty = cell.myPoints === null && cell.oppPoints === null;
+  const cls = cn(
+    "sl-cell",
+    isActive
+      ? "active"
+      : cell.invalid
+        ? "failed"
+        : isEmpty
+          ? "pending"
+          : "done",
+  );
+  const ariaLabel = isEmpty
+    ? `Go to game ${cell.gameNumber}, not yet entered`
+    : `Go to game ${cell.gameNumber}, ${cell.myPoints ?? "—"} to ${cell.oppPoints ?? "—"}`;
+
+  return (
+    // A clickable cell (not a button) so the hover-✕ can nest a real <button>
+    // without an invalid button-in-button — `aria-current="step"` marks the
+    // open game for assistive tech.
+    <div
+      role="button"
+      tabIndex={0}
+      className={cls}
+      aria-current={isActive ? "step" : undefined}
+      aria-label={ariaLabel}
+      onClick={() => onSelect(cell.gameNumber)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect(cell.gameNumber);
+        }
+      }}
+    >
+      {cell.invalid && (
+        <span className="sl-badge" aria-hidden>
+          <TriangleAlert size={13} strokeWidth={2.25} />
+        </span>
+      )}
+      <div className="sl-n">G{cell.gameNumber}</div>
+      <div className="sl-scores">
+        <span className={cn("s", cell.myWin === true && "w")}>
+          {cell.myPoints ?? "—"}
+        </span>
+        <span className="dash">–</span>
+        <span className={cn("s", cell.myWin === false && "w")}>
+          {cell.oppPoints ?? "—"}
+        </span>
+      </div>
+      {!isEmpty && (
+        <button
+          type="button"
+          className="sl-clear"
+          aria-label={`Clear game ${cell.gameNumber}`}
+          title={`Clear game ${cell.gameNumber}`}
+          onClick={(e) => {
+            // Don't let the clear bubble up to the cell's select handler.
+            e.stopPropagation();
+            onClear(cell.gameNumber);
+          }}
+        >
+          <XIcon size={14} strokeWidth={2.5} aria-hidden />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web-client/src/components/matches/match-details.page.tsx
+++ b/web-client/src/components/matches/match-details.page.tsx
@@ -73,7 +73,7 @@ export const matchDetailsPage = {
     // "Suggest correction" / "Counter" / "Edit result" links.
     const correctRoute = createRoute({
       getParentRoute: () => rootRoute,
-      path: "/matches/$matchId/correct",
+      path: "/matches/$matchId/results/new",
       component: () => <div>correction-route</div>,
     });
     const router = createRouter({

--- a/web-client/src/components/matches/match-details/confirmation-callout.page.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout.page.tsx
@@ -98,7 +98,7 @@ export const confirmationCalloutPage = {
     });
     const correctRoute = createRoute({
       getParentRoute: () => rootRoute,
-      path: "/matches/$matchId/correct",
+      path: "/matches/$matchId/results/new",
       component: () => <div>correction-route</div>,
     });
     const router = createRouter({

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher.page.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher.page.tsx
@@ -87,7 +87,7 @@ export const confirmationCalloutFetcherPage = {
     });
     const correctRoute = createRoute({
       getParentRoute: () => rootRoute,
-      path: "/matches/$matchId/correct",
+      path: "/matches/$matchId/results/new",
       component: () => <div>correction-route</div>,
     });
     const router = createRouter({

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.page.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active.page.tsx
@@ -62,7 +62,7 @@ export const confirmationCalloutActivePage = {
     });
     const correctRoute = createRoute({
       getParentRoute: () => rootRoute,
-      path: "/matches/$matchId/correct",
+      path: "/matches/$matchId/results/new",
       component: () => <div>correction-route</div>,
     });
     const router = createRouter({

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.page.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.page.tsx
@@ -78,7 +78,7 @@ export const confirmationCalloutDisplayPage = {
     // links navigate to — registered so the typed <Link>s resolve at render.
     const correctRoute = createRoute({
       getParentRoute: () => rootRoute,
-      path: "/matches/$matchId/correct",
+      path: "/matches/$matchId/results/new",
       component: () => <div>correction-route</div>,
     });
     const router = createRouter({

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
-import { correctionRoute } from "@/api/matches";
+import { newResultRoute } from "@/api/matches";
 import { waitFor } from "@/test/utilities";
 
 import {
@@ -13,7 +13,7 @@ import { confirmationCalloutDisplayPage } from "./confirmation-callout-display.p
 // The callout mounts behind a memory router (the correction links are typed
 // `<Link>`s), so the section resolves a tick after render.
 const correctHref = (matchId: string) =>
-  `/matches/${correctionRoute(matchId).params.matchId}/correct`;
+  `/matches/${newResultRoute(matchId).params.matchId}/results/new`;
 
 describe("ConfirmationCalloutDisplay", () => {
   describe("review variant", () => {

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
 
-import { correctionRoute } from "@/api/matches";
+import { newResultRoute } from "@/api/matches";
 import { Overline } from "@/components/overline";
 
 import { ScoreDiff } from "../../../score-diff/score-diff";
@@ -168,7 +168,7 @@ export function ConfirmationCalloutDisplay({
             onReload={onReload}
           />
           <Link
-            {...correctionRoute(matchId)}
+            {...newResultRoute(matchId)}
             className="md-btn md-btn--ghost"
             data-testid="match-confirm-callout-correct"
           >
@@ -214,7 +214,7 @@ export function ConfirmationCalloutDisplay({
             onReload={onReload}
           />
           <Link
-            {...correctionRoute(matchId)}
+            {...newResultRoute(matchId)}
             className="md-btn md-btn--ghost"
             data-testid="match-confirm-callout-counter"
           >
@@ -264,7 +264,7 @@ export function ConfirmationCalloutDisplay({
       </div>
       <div className="md-confirm-callout__actions">
         <Link
-          {...correctionRoute(matchId)}
+          {...newResultRoute(matchId)}
           className="md-btn md-btn--ghost"
           data-testid="match-confirm-callout-edit"
         >

--- a/web-client/src/components/matches/score-pad.tsx
+++ b/web-client/src/components/matches/score-pad.tsx
@@ -31,20 +31,14 @@ export interface ScorePadProps {
   showBothRequired: boolean;
   /** Disable the inputs and actions while a submit is in flight. */
   inputsLocked: boolean;
-  /** Hide the subtitle + submit/clear action row entirely, rendering just the
-   * two-side inputs + inline errors. The multi-game correction board uses this
-   * to stack several input-only pads under one shared submit. Defaults to
-   * showing the action row, so the scratchpad surface is unchanged. */
-  hideActions?: boolean;
-  // ----- action-row props: only read when `hideActions` is false, so the
-  // input-only callers (the correction board) omit them entirely. -----
+  // ----- action-row props -----
   /** The supporting copy under the action row. */
-  subtitle?: string;
+  subtitle: string;
   /** The primary submit button label. */
-  submitLabel?: string;
+  submitLabel: string;
   /** Whether the primary submit is enabled. */
-  canSubmit?: boolean;
-  onSubmit?: () => void;
+  canSubmit: boolean;
+  onSubmit: () => void;
   /** Optional secondary "Clear" action (the scratchpad edit surface). */
   onClear?: () => void;
   clearDisabled?: boolean;
@@ -71,7 +65,6 @@ export const ScorePad = ({
   onSubmit,
   onClear,
   clearDisabled,
-  hideActions = false,
 }: ScorePadProps) => {
   return (
     <>
@@ -120,37 +113,35 @@ export const ScorePad = ({
         </p>
       )}
 
-      {!hideActions && (
-        <div className="single-actions">
-          <div className="result-line subtle">{subtitle}</div>
-          <div className="action-btns">
-            {onClear && (
-              <button
-                type="button"
-                className="btn ghost"
-                onClick={onClear}
-                disabled={inputsLocked || clearDisabled}
-              >
-                Clear
-              </button>
-            )}
+      <div className="single-actions">
+        <div className="result-line subtle">{subtitle}</div>
+        <div className="action-btns">
+          {onClear && (
             <button
               type="button"
-              className="btn primary"
-              disabled={!canSubmit || inputsLocked}
-              // Don't let tapping Save blur the active input: on mobile that
-              // dismisses the soft keyboard before the synchronous navigation
-              // can hand focus to the next game's input, closing the keyboard
-              // between games (#567). Preventing the mousedown default keeps
-              // focus on the input through the tap; the click still fires.
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={onSubmit}
+              className="btn ghost"
+              onClick={onClear}
+              disabled={inputsLocked || clearDisabled}
             >
-              {submitLabel}
+              Clear
             </button>
-          </div>
+          )}
+          <button
+            type="button"
+            className="btn primary"
+            disabled={!canSubmit || inputsLocked}
+            // Don't let tapping Save blur the active input: on mobile that
+            // dismisses the soft keyboard before the synchronous navigation
+            // can hand focus to the next game's input, closing the keyboard
+            // between games (#567). Preventing the mousedown default keeps
+            // focus on the input through the tap; the click still fires.
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={onSubmit}
+          >
+            {submitLabel}
+          </button>
         </div>
-      )}
+      </div>
     </>
   );
 };

--- a/web-client/src/components/matches/score-pad.tsx
+++ b/web-client/src/components/matches/score-pad.tsx
@@ -120,6 +120,12 @@ export const ScorePad = ({
             <button
               type="button"
               className="btn ghost"
+              // Same #567 guard as the submit button: a Clear that refocuses an
+              // input (the correction board's onClearSelected) would otherwise
+              // blur on mousedown and flash the mobile soft keyboard before the
+              // click's focus() lands. Preventing the mousedown default keeps
+              // focus through the tap; the click still fires.
+              onMouseDown={(e) => e.preventDefault()}
               onClick={onClear}
               disabled={inputsLocked || clearDisabled}
             >

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -37,7 +37,7 @@ import { Route as AppAdminRolesRouteImport } from './routes/_app/admin.roles'
 import { Route as AppAdminPermissionsRouteImport } from './routes/_app/admin.permissions'
 import { Route as AppAdminBroadcastRouteImport } from './routes/_app/admin.broadcast'
 import { Route as AppMatchesMatchIdIndexRouteImport } from './routes/_app/matches.$matchId.index'
-import { Route as AppMatchesMatchIdCorrectRouteImport } from './routes/_app/matches.$matchId.correct'
+import { Route as AppMatchesMatchIdResultsNewRouteImport } from './routes/_app/matches.$matchId.results.new'
 import { Route as AppMatchesMatchIdGamesGameNumberScoresNewRouteImport } from './routes/_app/matches.$matchId.games.$gameNumber.scores.new'
 import { Route as AppMatchesMatchIdGamesGameNumberScoresEditRouteImport } from './routes/_app/matches.$matchId.games.$gameNumber.scores.edit'
 
@@ -182,10 +182,10 @@ const AppMatchesMatchIdIndexRoute = AppMatchesMatchIdIndexRouteImport.update({
   path: '/matches/$matchId/',
   getParentRoute: () => AppRouteRoute,
 } as any)
-const AppMatchesMatchIdCorrectRoute =
-  AppMatchesMatchIdCorrectRouteImport.update({
-    id: '/matches/$matchId/correct',
-    path: '/matches/$matchId/correct',
+const AppMatchesMatchIdResultsNewRoute =
+  AppMatchesMatchIdResultsNewRouteImport.update({
+    id: '/matches/$matchId/results/new',
+    path: '/matches/$matchId/results/new',
     getParentRoute: () => AppRouteRoute,
   } as any)
 const AppMatchesMatchIdGamesGameNumberScoresNewRoute =
@@ -228,8 +228,8 @@ export interface FileRoutesByFullPath {
   '/notifications/': typeof AppNotificationsIndexRoute
   '/players/': typeof AppPlayersIndexRoute
   '/tournaments/': typeof AppTournamentsIndexRoute
-  '/matches/$matchId/correct': typeof AppMatchesMatchIdCorrectRoute
   '/matches/$matchId/': typeof AppMatchesMatchIdIndexRoute
+  '/matches/$matchId/results/new': typeof AppMatchesMatchIdResultsNewRoute
   '/matches/$matchId/games/$gameNumber/scores/edit': typeof AppMatchesMatchIdGamesGameNumberScoresEditRoute
   '/matches/$matchId/games/$gameNumber/scores/new': typeof AppMatchesMatchIdGamesGameNumberScoresNewRoute
 }
@@ -257,8 +257,8 @@ export interface FileRoutesByTo {
   '/notifications': typeof AppNotificationsIndexRoute
   '/players': typeof AppPlayersIndexRoute
   '/tournaments': typeof AppTournamentsIndexRoute
-  '/matches/$matchId/correct': typeof AppMatchesMatchIdCorrectRoute
   '/matches/$matchId': typeof AppMatchesMatchIdIndexRoute
+  '/matches/$matchId/results/new': typeof AppMatchesMatchIdResultsNewRoute
   '/matches/$matchId/games/$gameNumber/scores/edit': typeof AppMatchesMatchIdGamesGameNumberScoresEditRoute
   '/matches/$matchId/games/$gameNumber/scores/new': typeof AppMatchesMatchIdGamesGameNumberScoresNewRoute
 }
@@ -291,8 +291,8 @@ export interface FileRoutesById {
   '/_app/notifications/': typeof AppNotificationsIndexRoute
   '/_app/players/': typeof AppPlayersIndexRoute
   '/_app/tournaments/': typeof AppTournamentsIndexRoute
-  '/_app/matches/$matchId/correct': typeof AppMatchesMatchIdCorrectRoute
   '/_app/matches/$matchId/': typeof AppMatchesMatchIdIndexRoute
+  '/_app/matches/$matchId/results/new': typeof AppMatchesMatchIdResultsNewRoute
   '/_app/matches/$matchId/games/$gameNumber/scores/edit': typeof AppMatchesMatchIdGamesGameNumberScoresEditRoute
   '/_app/matches/$matchId/games/$gameNumber/scores/new': typeof AppMatchesMatchIdGamesGameNumberScoresNewRoute
 }
@@ -325,8 +325,8 @@ export interface FileRouteTypes {
     | '/notifications/'
     | '/players/'
     | '/tournaments/'
-    | '/matches/$matchId/correct'
     | '/matches/$matchId/'
+    | '/matches/$matchId/results/new'
     | '/matches/$matchId/games/$gameNumber/scores/edit'
     | '/matches/$matchId/games/$gameNumber/scores/new'
   fileRoutesByTo: FileRoutesByTo
@@ -354,8 +354,8 @@ export interface FileRouteTypes {
     | '/notifications'
     | '/players'
     | '/tournaments'
-    | '/matches/$matchId/correct'
     | '/matches/$matchId'
+    | '/matches/$matchId/results/new'
     | '/matches/$matchId/games/$gameNumber/scores/edit'
     | '/matches/$matchId/games/$gameNumber/scores/new'
   id:
@@ -387,8 +387,8 @@ export interface FileRouteTypes {
     | '/_app/notifications/'
     | '/_app/players/'
     | '/_app/tournaments/'
-    | '/_app/matches/$matchId/correct'
     | '/_app/matches/$matchId/'
+    | '/_app/matches/$matchId/results/new'
     | '/_app/matches/$matchId/games/$gameNumber/scores/edit'
     | '/_app/matches/$matchId/games/$gameNumber/scores/new'
   fileRoutesById: FileRoutesById
@@ -603,11 +603,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppMatchesMatchIdIndexRouteImport
       parentRoute: typeof AppRouteRoute
     }
-    '/_app/matches/$matchId/correct': {
-      id: '/_app/matches/$matchId/correct'
-      path: '/matches/$matchId/correct'
-      fullPath: '/matches/$matchId/correct'
-      preLoaderRoute: typeof AppMatchesMatchIdCorrectRouteImport
+    '/_app/matches/$matchId/results/new': {
+      id: '/_app/matches/$matchId/results/new'
+      path: '/matches/$matchId/results/new'
+      fullPath: '/matches/$matchId/results/new'
+      preLoaderRoute: typeof AppMatchesMatchIdResultsNewRouteImport
       parentRoute: typeof AppRouteRoute
     }
     '/_app/matches/$matchId/games/$gameNumber/scores/new': {
@@ -684,8 +684,8 @@ interface AppRouteRouteChildren {
   AppPlayersUserIdRoute: typeof AppPlayersUserIdRoute
   AppMatchesIndexRoute: typeof AppMatchesIndexRoute
   AppPlayersIndexRoute: typeof AppPlayersIndexRoute
-  AppMatchesMatchIdCorrectRoute: typeof AppMatchesMatchIdCorrectRoute
   AppMatchesMatchIdIndexRoute: typeof AppMatchesMatchIdIndexRoute
+  AppMatchesMatchIdResultsNewRoute: typeof AppMatchesMatchIdResultsNewRoute
   AppMatchesMatchIdGamesGameNumberScoresEditRoute: typeof AppMatchesMatchIdGamesGameNumberScoresEditRoute
   AppMatchesMatchIdGamesGameNumberScoresNewRoute: typeof AppMatchesMatchIdGamesGameNumberScoresNewRoute
 }
@@ -700,8 +700,8 @@ const AppRouteRouteChildren: AppRouteRouteChildren = {
   AppPlayersUserIdRoute: AppPlayersUserIdRoute,
   AppMatchesIndexRoute: AppMatchesIndexRoute,
   AppPlayersIndexRoute: AppPlayersIndexRoute,
-  AppMatchesMatchIdCorrectRoute: AppMatchesMatchIdCorrectRoute,
   AppMatchesMatchIdIndexRoute: AppMatchesMatchIdIndexRoute,
+  AppMatchesMatchIdResultsNewRoute: AppMatchesMatchIdResultsNewRoute,
   AppMatchesMatchIdGamesGameNumberScoresEditRoute:
     AppMatchesMatchIdGamesGameNumberScoresEditRoute,
   AppMatchesMatchIdGamesGameNumberScoresNewRoute:

--- a/web-client/src/routes/_app/matches.$matchId.results.new.tsx
+++ b/web-client/src/routes/_app/matches.$matchId.results.new.tsx
@@ -5,7 +5,7 @@ import { ApiError } from "@/api/client";
 import { pageTitle } from "@/lib/page-title";
 import { isMatchId } from "@/lib/match-id";
 
-export const Route = createFileRoute("/_app/matches/$matchId/correct")({
+export const Route = createFileRoute("/_app/matches/$matchId/results/new")({
   head: () => ({
     meta: [{ title: pageTitle("Suggest a correction") }],
   }),


### PR DESCRIPTION
## What

Reworks the **Suggest a correction** page from a stack of one `ScorePad` per game (under a single submit) into a **single-game board re-score** that mirrors the score-entry UX: one game at a time in a single `ScorePad`, navigated via a **SCORELINE** strip.

A correction edits an *already-decided* board, and flipping a game's winner can leave the match undecided (3–0 → 2–1) — so the corrector needs to add/remove games to reach a legal result. The page is now a full board re-score, seeded from the standing result, gated on producing a **decided board**.

## Changes

- **`CorrectionEntry`** — seeds a `best_of`-length draft buffer from `negotiation.standing_result.games` (viewer-left); renders one `ScorePad` with the full action row, keyed to `selectedGameNumber`, with a running games tally, Enter-advances-to-next-game (last slot submits), per-game + board-level validation. Submit posts the whole board with `supersedes_result_id`; 409/422 surface inline. Removes the dead `affects_rating` unrated branch.
- **`CorrectionScoreline`** (new colocated quartet) — presentational nav strip: clickable cells switch the open game (local state, no route change), hover-✕ clears a buffered score (no dialog), with active/empty/invalid/win states. Reproduces the global `.scoreline` CSS without touching score-entry's mutation-cache-coupled strip.
- **Board hint** — friendly "add the remaining game(s)" copy for the clean-undecided case; `firstMatchScoreError` for structural errors; a hint + flagged cell when a *non-selected* game is incomplete, so a disabled Send always has a visible cause.
- **Route rename** `/matches/$matchId/correct` → `/matches/$matchId/results/new` (`correctionRoute` → `newResultRoute`) across the route file, `matches.ts`, the confirmation-callout links, and the test page-objects.
- **`ScorePad` tightened** — drops the now-unused `hideActions` prop (its only caller is gone) and makes the always-passed action-row props required (from the `/simplify` pass).
- **Docs** — `CONTEXT.md` glossary + ADR 0001 documenting the full-rescore decision.

## Testing

- `npm run build` (tsc + vite) — green
- `npm run lint` — clean
- `npm run test:run` — **1081 passed** (incl. rewritten `correction-entry` + new `correction-scoreline` quartets)
- `npm run test:e2e` (web-client Playwright) — **128 passed**
- Not applicable / skipped: API Python gates, iOS build, root e2e, OpenAPI regen (no `api/**`, `ios/**`, or `schema.d.ts` changes — only a hand-written FE route helper)

⚠️ Manual browser verification of the live rendering (single ScorePad + SCORELINE layout, Send grey-out → add game → light-up → land on match details) is still pending — covered by the QA step of land-the-plane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)