### PR TITLE
Reject out-of-order "games past the decider" in scratchpad scoring

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1574,6 +1574,69 @@ async def _apply_rating_update(db: AsyncSession, match: Match) -> None:
 # ----- finalize-payload validation + apply --------------------------------
 
 
+def _first_decider(
+    games: list[MatchResultsGameWrite], target: int
+) -> tuple[int, int] | None:
+    """Walk ``games`` in game-number order tallying wins; return
+    ``(decided_side, decided_game_number)`` for the first game at which a side
+    reaches ``target`` wins, else ``None``.
+
+    Gap-tolerant: it does not care whether the numbers are contiguous — callers
+    that require ``1..N`` numbering check that separately. The single source of
+    truth for "who clinched, and when" shared by the finalize validator and the
+    scratchpad overrun guard, so the two can never drift."""
+    wins: dict[int, int] = {1: 0, 2: 0}
+    for g in sorted(games, key=lambda g: g.game_number):
+        winner = 1 if g.side_1_points > g.side_2_points else 2
+        wins[winner] += 1
+        if wins[winner] >= target:
+            return winner, g.game_number
+    return None
+
+
+def _overrun_decider(games: list[MatchResultsGameWrite], best_of: int) -> int | None:
+    """The game number at which the match was already decided when there are
+    scored games numbered *after* it ("overrun"). Returns ``None`` for empty,
+    still-undecided, or exactly-decided-at-the-last-game boards — all legal
+    scratchpad states.
+
+    Gap-tolerant on purpose: it shares the decider core with the finalize
+    validator but does **not** require ``1..N`` contiguity, so legitimate
+    out-of-order / gappy entry (e.g. scoring game 3 first) is allowed right up
+    until a side actually clinches *before* the highest-numbered scored game.
+    That is the impossible state — games can't have been played after the match
+    was already won — so the scratchpad write path rejects it."""
+    if not games:
+        return None
+    decider = _first_decider(games, _games_to_win(best_of))
+    if decider is None:
+        return None
+    _, decided_at = decider
+    if decided_at < max(g.game_number for g in games):
+        return decided_at
+    return None
+
+
+def _enforce_no_overrun(
+    games: list[MatchResultsGameWrite], best_of: int, game_number: int
+) -> None:
+    """Reject a scratchpad write (422) when the prospective board ``games`` would
+    leave the match decided before its last scored game. Shared by both
+    score-write paths so the check, status, and message can't drift; each caller
+    builds its own prospective board (the create path mutates the ORM then reads
+    it back, the update path substitutes the payload because its write is raw
+    SQL), then hands it here."""
+    decided_at = _overrun_decider(games, best_of)
+    if decided_at is not None:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"The match was already decided at game {decided_at}; "
+                f"game {game_number} can't be played."
+            ),
+        )
+
+
 def _validate_finalize_games(games: list[MatchResultsGameWrite], best_of: int) -> int:
     """Cross-game invariants for a finalize payload. Per-game point legality
     is already enforced by ``MatchResultsGameWrite``. Returns the decided side
@@ -1591,22 +1654,13 @@ def _validate_finalize_games(games: list[MatchResultsGameWrite], best_of: int) -
         raise ValueError("Games must be numbered 1..N consecutively with no gaps.")
 
     target = _games_to_win(best_of)
-    games_in_order = sorted(games, key=lambda g: g.game_number)
-    wins: dict[int, int] = {1: 0, 2: 0}
-    decided_at: int | None = None
-    decided_side: int | None = None
-    for g in games_in_order:
-        winner = 1 if g.side_1_points > g.side_2_points else 2
-        wins[winner] += 1
-        if decided_side is None and wins[winner] >= target:
-            decided_side = winner
-            decided_at = g.game_number
-
-    if decided_side is None or decided_at is None:
+    decider = _first_decider(games, target)
+    if decider is None:
         raise ValueError(
             f"No side reached {target} game wins — the match isn't decided."
         )
-    if decided_at != games_in_order[-1].game_number:
+    decided_side, decided_at = decider
+    if decided_at != max(numbers):
         raise ValueError(
             "Scored games extend past the deciding game; "
             "drop any games after the decider."
@@ -1852,6 +1906,14 @@ async def create_game_score(
         side_2_points=payload.side_2_points,
     )
 
+    # The board can't have games after the match was already decided. The ORM
+    # is mutated above, so ``_games_payload_from_match`` already reflects this
+    # write; reject before commit (request teardown rolls back the uncommitted
+    # session). Gap-tolerant — only a clinch *before* the last scored game trips.
+    _enforce_no_overrun(
+        _games_payload_from_match(match), match.match_settings.best_of, game_number
+    )
+
     try:
         await db.commit()
     except IntegrityError as exc:
@@ -1890,6 +1952,23 @@ async def update_game_score(
     game = next((g for g in match.games if g.game_number == game_number), None)
     if game is None or game.score is None:
         raise HTTPException(status_code=404, detail="Score not found.")
+
+    # Editing a game's winner can move the decider earlier, so the same
+    # "no games past the decider" guard the create path enforces applies here.
+    # The UPDATE below runs in raw SQL, so in-memory ``match.games`` still holds
+    # the OLD score — build the prospective board by substituting the payload
+    # points for this game before checking.
+    prospective = [
+        g
+        if g.game_number != game_number
+        else MatchResultsGameWrite(
+            game_number=game_number,
+            side_1_points=payload.side_1_points,
+            side_2_points=payload.side_2_points,
+        )
+        for g in _games_payload_from_match(match)
+    ]
+    _enforce_no_overrun(prospective, match.match_settings.best_of, game_number)
 
     # Optimistic concurrency: replace the points only while the committed row is
     # still at the version the caller last read. The ``WHERE version =`` clause

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -976,6 +976,152 @@ async def test_score_create_accepts_gaps(
     assert body["can_finalize"] is False
 
 
+async def _sweep_games(
+    api_client: AsyncClient, match_id: str, game_numbers: list[int]
+) -> None:
+    """Save a side-1 win (11-2) for each given game number, asserting 201."""
+    for n in game_numbers:
+        response = await api_client.post(
+            f"/v1/matches/{match_id}/games/{n}/scores/new",
+            json={"side_1_points": 11, "side_2_points": 2},
+        )
+        assert response.status_code == 201, response.json()
+
+
+async def test_score_create_422_when_board_already_decided(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # First-to-4 (best of 7): once side 1 sweeps games 1-4 the match is decided,
+    # so game 5 can never be played. The scratchpad must reject the write — even
+    # though games 1-4 alone (decider == last == 4) are a perfectly valid board.
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=7)
+
+    await _sweep_games(api_client, match["id"], [1, 2, 3, 4])
+
+    response = await api_client.post(
+        f"/v1/matches/{match['id']}/games/5/scores/new",
+        json={"side_1_points": 11, "side_2_points": 2},
+    )
+    assert response.status_code == 422
+    assert "already decided at game 4" in response.json()["detail"]
+
+
+async def test_score_create_422_on_full_sweep_out_of_order(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # The literal bug report: building a 7-0 board by entering games out of
+    # order. With games 1-4 swept, a direct write to game 7 is rejected — you
+    # can't play a game after the match was already won.
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=7)
+
+    await _sweep_games(api_client, match["id"], [1, 2, 3, 4])
+
+    response = await api_client.post(
+        f"/v1/matches/{match['id']}/games/7/scores/new",
+        json={"side_1_points": 11, "side_2_points": 2},
+    )
+    assert response.status_code == 422
+    assert "already decided at game 4" in response.json()["detail"]
+
+
+async def test_4_3_board_to_game_7_is_valid_and_finalizes(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # A best-of-7 that goes the distance: 3-3 after six games, side 1 clinches
+    # game 7. The decider is the last game, so every save lands and the full
+    # seven-game board finalizes — proving the guard doesn't kill a legitimate
+    # 4-3 result.
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=7)
+
+    # side 1 wins odd games, side 2 wins even games → 3-3 after game 6.
+    for n in range(1, 7):
+        side1, side2 = (11, 2) if n % 2 == 1 else (2, 11)
+        response = await api_client.post(
+            f"/v1/matches/{match['id']}/games/{n}/scores/new",
+            json={"side_1_points": side1, "side_2_points": side2},
+        )
+        assert response.status_code == 201, response.json()
+
+    after_g7 = await api_client.post(
+        f"/v1/matches/{match['id']}/games/7/scores/new",
+        json={"side_1_points": 11, "side_2_points": 2},
+    )
+    assert after_g7.status_code == 201
+    assert after_g7.json()["can_finalize"] is True
+
+    finalize = await api_client.post(
+        f"/v1/matches/{match['id']}/results",
+        json={
+            "games": [
+                {
+                    "game_number": n,
+                    "side_1_points": 11 if (n % 2 == 1 or n == 7) else 2,
+                    "side_2_points": 2 if (n % 2 == 1 or n == 7) else 11,
+                }
+                for n in range(1, 8)
+            ]
+        },
+    )
+    assert finalize.status_code == 201, finalize.json()
+
+
+async def test_legit_4_1_board_still_finalizes(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # A 4-1 best-of-7 (decider at game 5) — guards against over-rejecting a
+    # normal short board where the decider is the highest scored game.
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=7)
+
+    # side 2 takes game 4; side 1 wins 1,2,3,5 → clinches at game 5.
+    for n, (side1, side2) in enumerate(
+        [(11, 2), (11, 2), (11, 2), (2, 11), (11, 2)], start=1
+    ):
+        response = await api_client.post(
+            f"/v1/matches/{match['id']}/games/{n}/scores/new",
+            json={"side_1_points": side1, "side_2_points": side2},
+        )
+        assert response.status_code == 201, response.json()
+
+    body = (await api_client.get(f"/v1/matches/{match['id']}")).json()
+    assert body["can_finalize"] is True
+
+
+async def test_score_update_422_when_edit_creates_overrun(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # Editing an existing game's winner can move the decider earlier. Start from
+    # a valid board where side 2 took game 4 (so side 1 clinches at game 5);
+    # flipping game 4 to a side-1 win makes side 1 reach 4 wins at game 4 while
+    # game 5 is still scored → overrun → 422.
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=7)
+
+    for n, (side1, side2) in enumerate(
+        [(11, 2), (11, 2), (11, 2), (2, 11), (11, 2)], start=1
+    ):
+        response = await api_client.post(
+            f"/v1/matches/{match['id']}/games/{n}/scores/new",
+            json={"side_1_points": side1, "side_2_points": side2},
+        )
+        assert response.status_code == 201, response.json()
+
+    edit = await api_client.put(
+        f"/v1/matches/{match['id']}/games/4/scores",
+        json={"side_1_points": 11, "side_2_points": 2, "expected_version": 1},
+    )
+    assert edit.status_code == 422
+    assert "already decided at game 4" in edit.json()["detail"]
+
+
 async def test_score_update_overwrites_in_place(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -2101,6 +2101,132 @@ describe('ScoreEntry — current user on side 2 (#210)', () => {
   })
 })
 
+describe('ScoreEntry — games past the decider', () => {
+  // Best-of-7 swept 4-0: the match is decided at game 4, so games 5-7 can
+  // never be played. Mirrors the server's "no games past the decider" guard.
+  function decidedBoard(
+    overrides: Parameters<typeof matchDetails>[0] = {},
+  ) {
+    return inProgressMatch({
+      best_of: 7,
+      games_to_win: 4,
+      sides: participantSides({ meWins: 4, oppWins: 0 }),
+      games: [
+        { id: 'g-1', game_number: 1, score: score('s-1', 11, 2) },
+        { id: 'g-2', game_number: 2, score: score('s-2', 11, 2) },
+        { id: 'g-3', game_number: 3, score: score('s-3', 11, 2) },
+        { id: 'g-4', game_number: 4, score: score('s-4', 11, 2) },
+      ],
+      current_game: null,
+      ...overrides,
+    })
+  }
+
+  it('mutes the games after the decider in the scoreline', async () => {
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(decidedBoard())),
+    )
+    renderScoreEntry({ kind: 'edit', matchId: 'm-1', gameNumber: 1 })
+
+    // Games 5-7 render as muted, non-navigable cells…
+    expect(
+      await screen.findByLabelText('Game 5, not playable'),
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText('Game 7, not playable')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /game 5/i })).toBeNull()
+    // …while the played games stay navigable for editing.
+    expect(
+      screen.getByRole('link', { name: /game 2, saved/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('bounces a direct URL to an unscored game past the decider', async () => {
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(decidedBoard())),
+    )
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 5 })
+
+    expect(await screen.findByText('match-page m-1')).toBeInTheDocument()
+  })
+
+  it('keeps the deciding game itself editable', async () => {
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(decidedBoard())),
+    )
+    renderScoreEntry({ kind: 'edit', matchId: 'm-1', gameNumber: 4 })
+
+    expect(await screen.findByText(/edit game 4 score/i)).toBeInTheDocument()
+  })
+
+  it('blocks filling a gap that would decide the match before its last game', async () => {
+    const user = userEvent.setup()
+    let posted = false
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          inProgressMatch({
+            best_of: 7,
+            games_to_win: 4,
+            // Side 1 already clinched at game 5 with game 4 left blank — a gappy
+            // decided board. Filling game 4 with a side-1 win would move the
+            // decider to game 4 while game 5 is scored: impossible.
+            sides: participantSides({ meWins: 4, oppWins: 0 }),
+            games: [
+              { id: 'g-1', game_number: 1, score: score('s-1', 11, 2) },
+              { id: 'g-2', game_number: 2, score: score('s-2', 11, 2) },
+              { id: 'g-3', game_number: 3, score: score('s-3', 11, 2) },
+              { id: 'g-5', game_number: 5, score: score('s-5', 11, 2) },
+            ],
+            current_game: { game_number: 4 },
+          }),
+        ),
+      ),
+      http.post('*/v1/matches/m-1/games/4/scores/new', () => {
+        posted = true
+        return HttpResponse.json(inProgressMatch())
+      }),
+    )
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 4 })
+
+    await user.type(
+      await screen.findByRole('textbox', { name: 'rita.kovac score' }),
+      '11',
+    )
+    await user.type(
+      screen.getByRole('textbox', { name: 'nguyen.t score' }),
+      '2',
+    )
+
+    // The actionable message is shown and the write is never fired (the score
+    // 11-2 is legal, but it would decide the match at game 4 with game 5 scored).
+    expect(
+      screen.getByText(/already decided at game 4/i),
+    ).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /save/i }))
+    expect(posted).toBe(false)
+  })
+
+  it('keeps the next game navigable while the match is undecided', async () => {
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          inProgressMatch({
+            best_of: 5,
+            sides: participantSides({ meWins: 1, oppWins: 0 }),
+            games: [{ id: 'g-1', game_number: 1, score: score('s-1', 11, 2) }],
+            current_game: { game_number: 2 },
+          }),
+        ),
+      ),
+    )
+    renderScoreEntry({ kind: 'edit', matchId: 'm-1', gameNumber: 1 })
+
+    expect(
+      await screen.findByRole('link', { name: /game 2, not yet played/i }),
+    ).toBeInTheDocument()
+  })
+})
+
 afterEach(() => {
   // Restore connectivity so the offline test doesn't leak into others.
   onlineManager.setOnline(true)

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -36,7 +36,12 @@ import {
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { cn, initialsOf } from '@/lib/utils'
-import { isDecidedMatch } from '@/lib/scoring'
+import {
+  deciderGameNumber,
+  isDecidedMatch,
+  overrunDecider,
+  type GamePoints,
+} from '@/lib/scoring'
 import { isScoreConflict, useGameSaveState } from './score-saves'
 import { SaveBanner } from './save-banner'
 import { ScorePad } from './score-pad'
@@ -47,6 +52,19 @@ import {
 
 /** The non-null persisted score on a game. */
 type PersistedScore = NonNullable<MatchDetails['games'][number]['score']>
+
+/** The persisted games as `GamePoints` for the scoring lib — drops un-scored
+ * games and the side orientation, the shape `deciderGameNumber`/`overrunDecider`
+ * expect. */
+function scoredGamePoints(games: MatchDetails['games']): GamePoints[] {
+  return games
+    .filter((g) => g.score)
+    .map((g) => ({
+      game_number: g.game_number,
+      side_1_points: g.score!.side_1_points,
+      side_2_points: g.score!.side_2_points,
+    }))
+}
 
 // Placeholder for the opponent label on solo matches — mirrors the match
 // details hero. Distinct from `initialsOf('Opponent')` so users can tell
@@ -166,10 +184,23 @@ function ScoreEntryInner({
   if (data.status === 'completed' || data.negotiation.standing_result !== null) {
     return <Navigate {...matchDetailRoute(matchId)} />
   }
+  // The game number past which no more games can be played: once a side has
+  // clinched (gap-tolerant), the trailing games are unplayable. Drives the nav
+  // bounce below and (passed down) the scoreline cell gating, mirroring the
+  // server's "no games past the decider" guard on the score-write endpoints.
+  const scoredGames = scoredGamePoints(data.games)
+  const decider = deciderGameNumber(scoredGames, data.best_of)
+  const isScored = (n: number) =>
+    data.games.some((g) => g.game_number === n && g.score)
+
+  // Bounce out-of-range games, and any *unscored* game past the decider — those
+  // can never be played. An already-scored game at/under the decider stays
+  // editable (you can still fix the deciding game itself).
   if (
     !Number.isInteger(gameNumber) ||
     gameNumber < 1 ||
-    gameNumber > data.best_of
+    gameNumber > data.best_of ||
+    (decider !== null && gameNumber > decider && !isScored(gameNumber))
   ) {
     return <Navigate {...matchDetailRoute(matchId)} />
   }
@@ -304,13 +335,7 @@ function ScoreEntryInner({
   // match" and posts /results instead of /scores/new.
   const hypotheticalGames: MatchResultsGameWrite[] = inputsValid
     ? [
-        ...data.games
-          .filter((g) => g.game_number !== gameNumber && g.score)
-          .map((g) => ({
-            game_number: g.game_number,
-            side_1_points: g.score!.side_1_points,
-            side_2_points: g.score!.side_2_points,
-          })),
+        ...scoredGames.filter((g) => g.game_number !== gameNumber),
         mySideNumber === 1
           ? {
               game_number: gameNumber,
@@ -327,6 +352,15 @@ function ScoreEntryInner({
   const wouldFinalize =
     inputsValid && isDecidedMatch(hypotheticalGames, bestOf)
 
+  // Mirror the server's "no games past the decider" guard inline. The scoreline
+  // already mutes/bounces the games numbered after a known decider, but one path
+  // slips through: scoring a later game *clinches* the match while an earlier
+  // game is still blank, then the user goes back to fill that gap — which would
+  // leave the match decided before its last scored game (impossible). Catch it
+  // here so the user sees an actionable message and stays on the screen, instead
+  // of firing a write the server 422s and getting navigated away with no reason.
+  const overrunAt = inputsValid ? overrunDecider(hypotheticalGames, bestOf) : null
+
   // Per the fire-and-forget posture: only finalize errors are surfaced. The
   // per-game mutations (save / delete) self-heal at finalize, so their errors
   // are intentionally hidden here (surfaced in the scoreline instead). All
@@ -340,8 +374,14 @@ function ScoreEntryInner({
   // entered score is fine, so don't paint the fields red for those.
   const inputsInvalid =
     localScoreError !== null || finalizeApiError?.status === 422
-  // The message line, though, surfaces every finalize error (409/500 included).
-  const showScoreError = inputsInvalid || finalizeApiError !== null
+  // The message line, though, surfaces every finalize error (409/500 included)
+  // and the cross-game overrun block (a legal score that the board can't take).
+  const overrunError =
+    overrunAt !== null
+      ? `The match is already decided at game ${overrunAt} — clear the games after it before saving this score.`
+      : null
+  const showScoreError =
+    inputsInvalid || overrunError !== null || finalizeApiError !== null
   // The "both scores required" hint is its own, lower-severity line — shown only
   // when exactly one field is filled and there's no harder error to surface.
   const showBothRequired = oneSideFilled && !showScoreError
@@ -384,6 +424,10 @@ function ScoreEntryInner({
 
   function onSubmit() {
     if (!inputsValid) return
+    // The score is legal on its own but the board can't take it (it would leave
+    // the match decided before its last game). Block the write — the inline
+    // `overrunError` tells the user to clear the trailing games first.
+    if (overrunAt !== null) return
     // Ignore a second Save while the per-game save is still in flight (#538):
     // a double-tap would otherwise fire a duplicate create that 409s. This
     // synchronous guard is the only protection now — the mutationFn no longer
@@ -623,13 +667,13 @@ function ScoreEntryInner({
             onKeyDown: (e) => handleKey(e, 'opp'),
           }}
           gamesTally={bestOf > 1 ? `${meWins} – ${oppWins}` : null}
-          // The scratchpad surfaces both the local validation error and a
-          // finalize API rejection (409/500 too) here; `showScoreError` gates
-          // when any of them shows, with the finalize detail/message as the
-          // fallback copy when there's no local validation error.
+          // The scratchpad surfaces the local validation error, the cross-game
+          // overrun block, and a finalize API rejection (409/500 too) here;
+          // `showScoreError` gates when any of them shows, in that precedence.
           scoreError={
             showScoreError
               ? (localScoreError ??
+                overrunError ??
                 finalizeApiError?.detail ??
                 finalizeApiError?.message ??
                 null)
@@ -639,7 +683,7 @@ function ScoreEntryInner({
           inputsLocked={inputsLocked}
           subtitle={subtitle}
           submitLabel={submitLabel}
-          canSubmit={inputsValid}
+          canSubmit={inputsValid && overrunAt === null}
           onSubmit={onSubmit}
           onClear={isEdit ? onClear : undefined}
           clearDisabled={deleteMutation.isPending}
@@ -648,6 +692,7 @@ function ScoreEntryInner({
         <Scoreline
           data={data}
           activeGameNumber={gameNumber}
+          decider={decider}
           matchId={matchId}
           mySideNumber={mySideNumber}
           onClearCell={onClearCell}
@@ -813,6 +858,7 @@ function ScoreConflictNotice({
 function Scoreline({
   data,
   activeGameNumber,
+  decider,
   matchId,
   mySideNumber,
   onClearCell,
@@ -820,6 +866,13 @@ function Scoreline({
 }: {
   data: MatchDetails
   activeGameNumber: number
+  /** The gap-tolerant decider game number (computed by the parent). Once a side
+   * has clinched, the games numbered after it can never be played — those
+   * unscored trailing cells render muted and non-navigable, so the user can't
+   * enter an impossible "games past the decider" board. (An already-scored
+   * trailing cell stays navigable so a pre-existing overrun board can be
+   * cleared.) Mirrors the server guard. */
+  decider: number | null
   matchId: string
   mySideNumber: 1 | 2
   onClearCell: (gameNumber: number) => void
@@ -839,6 +892,8 @@ function Scoreline({
       >
         {Array.from({ length: data.best_of }, (_, i) => i + 1).map((n) => {
           const game = data.games.find((x) => x.game_number === n) ?? null
+          const playable =
+            decider === null || n <= decider || game?.score != null
           return (
             <ScorelineCell
               key={n}
@@ -846,6 +901,7 @@ function Scoreline({
               matchId={matchId}
               score={game?.score ?? null}
               isActive={n === activeGameNumber}
+              playable={playable}
               mySideNumber={mySideNumber}
               clearDisabled={clearDisabled}
               onClear={onClearCell}
@@ -862,6 +918,7 @@ function ScorelineCell({
   matchId,
   score,
   isActive,
+  playable,
   mySideNumber,
   clearDisabled,
   onClear,
@@ -870,6 +927,7 @@ function ScorelineCell({
   matchId: string
   score: PersistedScore | null
   isActive: boolean
+  playable: boolean
   mySideNumber: 1 | 2
   clearDisabled: boolean
   onClear: (gameNumber: number) => void
@@ -1017,6 +1075,21 @@ function ScorelineCell({
       <div
         className={cls}
         aria-label={`Game ${n}, saving, ${myPoints} to ${oppPoints}`}
+      >
+        {inner}
+      </div>
+    )
+  }
+
+  // Past the decider: the match was already won, so this game can't be played.
+  // Render muted and non-navigable (only ever reached for an unscored cell —
+  // a scored cell stays playable so a stray board can be cleared).
+  if (!playable) {
+    return (
+      <div
+        className={cn(cls, 'unplayable')}
+        aria-disabled="true"
+        aria-label={`Game ${n}, not playable`}
       >
         {inner}
       </div>

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1918,6 +1918,16 @@ body.dark.fortymm-theme {
   opacity: 0.5;
   border-style: dashed;
 }
+/* Past the decider — the match is already won, so this game can't be played.
+   Muted and non-interactive (rendered as a plain div, no hover/cursor). */
+.fortymm-theme .sl-cell.unplayable {
+  opacity: 0.3;
+  cursor: default;
+  border-style: dashed;
+}
+.fortymm-theme .sl-cell.unplayable:hover {
+  border-color: var(--ink-600);
+}
 .fortymm-theme .sl-cell .sl-n {
   font: 600 10px var(--font-mono);
   letter-spacing: 0.14em;

--- a/web-client/src/lib/scoring.test.ts
+++ b/web-client/src/lib/scoring.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  deciderGameNumber,
   firstMatchScoreError,
   illegalScoreReason,
   isDecidedMatch,
+  overrunDecider,
   type GamePoints,
 } from './scoring'
 
@@ -99,5 +101,93 @@ describe('firstMatchScoreError', () => {
         3,
       ),
     ).toMatch(/before the last game/i)
+  })
+})
+
+describe('deciderGameNumber', () => {
+  it('is null for an empty board', () => {
+    expect(deciderGameNumber([], 7)).toBeNull()
+  })
+
+  it('is null while no side has clinched', () => {
+    expect(deciderGameNumber([game(1, 11, 2), game(2, 2, 11)], 7)).toBeNull()
+  })
+
+  it('returns the clinching game for a 4-0 sweep (best of 7)', () => {
+    expect(
+      deciderGameNumber(
+        [game(1, 11, 2), game(2, 11, 2), game(3, 11, 2), game(4, 11, 2)],
+        7,
+      ),
+    ).toBe(4)
+  })
+
+  it('returns the last game for a 4-3 that goes the distance', () => {
+    const games = [
+      game(1, 11, 2),
+      game(2, 2, 11),
+      game(3, 11, 2),
+      game(4, 2, 11),
+      game(5, 11, 2),
+      game(6, 2, 11),
+      game(7, 11, 2),
+    ]
+    expect(deciderGameNumber(games, 7)).toBe(7)
+  })
+
+  it('is gap-tolerant — a single non-clinching game returns null', () => {
+    expect(deciderGameNumber([game(3, 11, 9)], 5)).toBeNull()
+  })
+
+  it('reports the early decider even when trailing games are present', () => {
+    // The overrun board: 4-0 by game 4 with games 5-7 also scored. The decider
+    // is unaffected by the (impossible) trailing games.
+    const games = [
+      game(1, 11, 2),
+      game(2, 11, 2),
+      game(3, 11, 2),
+      game(4, 11, 2),
+      game(5, 11, 2),
+    ]
+    expect(deciderGameNumber(games, 7)).toBe(4)
+  })
+})
+
+describe('overrunDecider', () => {
+  it('is null when the decider is the last scored game (4-0 in four games)', () => {
+    const games = [game(1, 11, 2), game(2, 11, 2), game(3, 11, 2), game(4, 11, 2)]
+    expect(overrunDecider(games, 7)).toBeNull()
+  })
+
+  it('reports the decider when later games are also scored (overrun)', () => {
+    const games = [
+      game(1, 11, 2),
+      game(2, 11, 2),
+      game(3, 11, 2),
+      game(4, 11, 2),
+      game(5, 11, 2),
+    ]
+    expect(overrunDecider(games, 7)).toBe(4)
+  })
+
+  it('is null for an undecided board', () => {
+    expect(overrunDecider([game(1, 11, 2), game(2, 2, 11)], 7)).toBeNull()
+  })
+
+  it('is null for an empty board', () => {
+    expect(overrunDecider([], 7)).toBeNull()
+  })
+
+  it('is null for a 4-3 that goes the distance', () => {
+    const games = [
+      game(1, 11, 2),
+      game(2, 2, 11),
+      game(3, 11, 2),
+      game(4, 2, 11),
+      game(5, 11, 2),
+      game(6, 2, 11),
+      game(7, 11, 2),
+    ]
+    expect(overrunDecider(games, 7)).toBeNull()
   })
 })

--- a/web-client/src/lib/scoring.ts
+++ b/web-client/src/lib/scoring.ts
@@ -119,6 +119,39 @@ export function isDecidedMatch(games: GamePoints[], bestOf: number): boolean {
   return matchScoreSchema(bestOf).safeParse(games).success
 }
 
+// The game number at which the match is first decided, walking scored games in
+// game-number order — gap-tolerant, so it answers "past which game can no more
+// games be played?" even for a board that still has gaps or trailing scratch
+// games. Null when no side has clinched yet. Mirrors the backend `_first_decider`
+// in api/app/matches.py.
+//
+// Distinct from `isDecidedMatch`, which additionally requires a complete,
+// contiguous, decider-at-the-last-game board (it drives the Finalize button).
+// This one drives score-entry cell gating.
+export function deciderGameNumber(
+  games: GamePoints[],
+  bestOf: number,
+): number | null {
+  return matchDecision(games, Math.ceil(bestOf / 2)).decidedAt
+}
+
+// The game number a board was decided at when later games are *also* scored
+// ("overrun") — i.e. a side clinched strictly before the highest-numbered
+// scored game, which is impossible (you can't play on after the match is won).
+// Null for empty, undecided, or exactly-decided-at-the-last-game boards. The
+// FE mirror of the backend `_overrun_decider`; drives the score-entry inline
+// block that stops the user saving such a score.
+export function overrunDecider(
+  games: GamePoints[],
+  bestOf: number,
+): number | null {
+  if (games.length === 0) return null
+  const decidedAt = deciderGameNumber(games, bestOf)
+  if (decidedAt === null) return null
+  const lastScored = Math.max(...games.map((g) => g.game_number))
+  return decidedAt < lastScored ? decidedAt : null
+}
+
 // The first cross-game completeness rule the board violates, as a human-readable
 // message — or null when the board forms a complete, decided match. The
 // validation half of `matchScoreSchema` (mirror of the boolean `isDecidedMatch`),


### PR DESCRIPTION
## Problem

In a best-of-7 "first to 4" match, entering games **out of order** (clicking scoreline cells or navigating to game numbers directly) could build an impossible board — e.g. all 7 games won 11–2 by one side, rendering as **"SETS 7–0 · Live"**. First-to-4 means games 5/6/7 are unplayable once a side wins 4.

Root cause: the per-game **scratchpad** write endpoints (`create_game_score` / `update_game_score`) only guarded `game_number ≤ best_of` — no order-aware "no games past the decider" check. The order-aware validators (`_validate_finalize_games`, `isDecidedMatch`) only ran at *propose* time, so the nonsensical board could never become a `MatchResult` but lived fine as a scratchpad. The FE compounded it: `wouldFinalize` was `null` for an out-of-order board, so "Finalize" never appeared and the user just kept saving games.

## Fix

Authoritative server guard + matching FE guidance. Gaps stay allowed (a gappy board is merely *incomplete*; the finalize validator already blocks it from becoming a result). A board is an **overrun** iff a side reaches `ceil(best_of/2)` wins *strictly before* the highest-numbered scored game.

**Backend (`api/app/matches.py`)**
- Extract `_first_decider` (shared walk-and-tally decider core); refactor `_validate_finalize_games` to use it.
- Add gap-tolerant `_overrun_decider` + `_enforce_no_overrun`, and guard both score-write paths (422 with an actionable message). `side_win_counts` left uncapped (no overrun board can be built now; capping would diverge the SETS line from the games grid).

**Frontend**
- `scoring.ts`: `deciderGameNumber` + `overrunDecider` — FE mirrors of the backend helpers, both over the existing `matchDecision` core.
- `score-entry.tsx`: scoreline mutes / makes non-navigable the games past the decider; direct navigation to them bounces to the match page; submitting a score that would overrun the board is blocked **inline** with an actionable message ("The match is already decided at game N — clear the games after it…") and never fires the doomed write.

## Discriminating cases (covered by tests)

- 4–3 over 7 games (went the distance) → **valid**, still finalizes.
- 4–0 in games 1–4 → **valid** (decider is the last game).
- Write G5 onto that 4–0 board → **422**.
- Fill a gap that clinches before a later scored game → **422** / inline FE block.

## Testing

- API: `ruff check` · `ruff format --check` · `mypy` · `pytest` (**518 passed**, incl. 5 new overrun cases).
- web-client: `npm run lint` · `npm run build` · `npm run test:run` (**1094 passed**) · `npm run test:e2e` (**128 passed**, incl. `score-entry.spec.ts`).
- OpenAPI: `mise run regen-api-types` → `schema.d.ts` unchanged (no route/response/docstring changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)