### PR TITLE
Compact the decided board at propose to heal out-of-order clinches (#742)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1647,8 +1647,13 @@ def _compact_games(
     Renumbers by the *rank of each distinct* ``game_number`` (not by list
     position), so a genuine duplicate game_number is preserved as a duplicate
     (two games at original ``1`` both map to new ``1``) and the strict
-    ``_validate_finalize_games`` duplicate check downstream still rejects it —
-    compaction closes gaps, it doesn't launder malformed input.
+    ``_validate_finalize_games`` duplicate check downstream still rejects it.
+    (Renumbering *does* absorb an out-of-``best_of``-range game_number — e.g.
+    ``[1,2,5]`` on best-of-3 → ``[1,2,3]`` — but the real scratchpad never
+    produces one: the score endpoints reject ``game_number > best_of`` before a
+    score is ever saved, and a finalize payload's out-of-range numbers only
+    reach here via a hand-crafted API call, where relabeling three legal scored
+    games into a legal 3-game board is harmless.)
 
     Provably outcome-invariant: an empty (unscored) slot contributes 0 wins to
     either side, so dropping it and relabeling can never change the winner or
@@ -1708,21 +1713,21 @@ def _games_payload_from_match(match: Match) -> list[MatchResultsGameWrite]:
     """Recast currently-saved scores as a finalize payload, so ``_can_finalize``
     can reuse ``_validate_finalize_games`` instead of duplicating its rules.
 
-    Compacted so a gappy-but-decided saved board (an out-of-order clinch that
-    left a hole) reports ``can_finalize = true`` — the SaveBanner then offers
-    "Post result" and the user self-heals with one tap (also heals already-
-    stuck matches with no migration)."""
-    return _compact_games(
-        [
-            MatchResultsGameWrite(
-                game_number=g.game_number,
-                side_1_points=g.score.side_1_points,
-                side_2_points=g.score.side_2_points,
-            )
-            for g in match.games
-            if g.score is not None
-        ]
-    )
+    Returns the board **raw** (scored games at their real ``game_number``, gaps
+    and all). The two scratchpad overrun guards depend on this: ``create_game_score``
+    reports the tapped game in its 422 detail, and ``update_game_score`` substitutes
+    the edited game by matching the raw ``game_number`` — both would break on a
+    renumbered board. Compaction is applied by ``_can_finalize`` alone, at its own
+    call site, since only the finalize predicate wants a canonical board."""
+    return [
+        MatchResultsGameWrite(
+            game_number=g.game_number,
+            side_1_points=g.score.side_1_points,
+            side_2_points=g.score.side_2_points,
+        )
+        for g in match.games
+        if g.score is not None
+    ]
 
 
 def _can_finalize(match: Match) -> bool:
@@ -1732,14 +1737,21 @@ def _can_finalize(match: Match) -> bool:
 
     Returns False once any result exists — the FE drives this flag only for the
     FIRST proposal; subsequent counters/acceptances flow through the negotiation
-    surface, not /results-as-finalize."""
+    surface, not /results-as-finalize.
+
+    Compacts the saved board before validating, mirroring the write path: a
+    gappy-but-decided board (an out-of-order clinch that left a hole) reports
+    ``can_finalize = true`` so the finalize-callout / SaveBanner offers "Post
+    result" and the user self-heals with one tap — this also heals already-stuck
+    matches with no migration."""
     if match.status not in (MatchStatus.in_progress, MatchStatus.disputed):
         return False
     if match.results:
         return False
     try:
         _validate_finalize_games(
-            _games_payload_from_match(match), match.match_settings.best_of
+            _compact_games(_games_payload_from_match(match)),
+            match.match_settings.best_of,
         )
     except ValueError:
         return False

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1637,6 +1637,42 @@ def _enforce_no_overrun(
         )
 
 
+def _compact_games(
+    games: list[MatchResultsGameWrite],
+) -> list[MatchResultsGameWrite]:
+    """Normalize a (possibly gappy) scratchpad board into a canonical one:
+    close empty slots so the surviving scored games are numbered ``1..N`` with
+    no holes. Pure — returns fresh models, doesn't mutate input.
+
+    Renumbers by the *rank of each distinct* ``game_number`` (not by list
+    position), so a genuine duplicate game_number is preserved as a duplicate
+    (two games at original ``1`` both map to new ``1``) and the strict
+    ``_validate_finalize_games`` duplicate check downstream still rejects it —
+    compaction closes gaps, it doesn't launder malformed input.
+
+    Provably outcome-invariant: an empty (unscored) slot contributes 0 wins to
+    either side, so dropping it and relabeling can never change the winner or
+    the game score — only the cosmetic slot numbers. It heals the out-of-order
+    clinch (score game 5 while game 4 is blank → ``[1,2,3,5]`` compacts to
+    ``[1,2,3,4]`` and finalizes) without touching a real overrun (a fully-scored
+    ``[1,2,3,4,5]`` compacts to itself and stays rejected).
+    See ``docs/adr/0002-decided-board-is-compacted-at-propose.md``."""
+    rank = {
+        original: compacted
+        for compacted, original in enumerate(
+            sorted({g.game_number for g in games}), start=1
+        )
+    }
+    return [
+        MatchResultsGameWrite(
+            game_number=rank[g.game_number],
+            side_1_points=g.side_1_points,
+            side_2_points=g.side_2_points,
+        )
+        for g in sorted(games, key=lambda g: g.game_number)
+    ]
+
+
 def _validate_finalize_games(games: list[MatchResultsGameWrite], best_of: int) -> int:
     """Cross-game invariants for a finalize payload. Per-game point legality
     is already enforced by ``MatchResultsGameWrite``. Returns the decided side
@@ -1670,16 +1706,23 @@ def _validate_finalize_games(games: list[MatchResultsGameWrite], best_of: int) -
 
 def _games_payload_from_match(match: Match) -> list[MatchResultsGameWrite]:
     """Recast currently-saved scores as a finalize payload, so ``_can_finalize``
-    can reuse ``_validate_finalize_games`` instead of duplicating its rules."""
-    return [
-        MatchResultsGameWrite(
-            game_number=g.game_number,
-            side_1_points=g.score.side_1_points,
-            side_2_points=g.score.side_2_points,
-        )
-        for g in match.games
-        if g.score is not None
-    ]
+    can reuse ``_validate_finalize_games`` instead of duplicating its rules.
+
+    Compacted so a gappy-but-decided saved board (an out-of-order clinch that
+    left a hole) reports ``can_finalize = true`` — the SaveBanner then offers
+    "Post result" and the user self-heals with one tap (also heals already-
+    stuck matches with no migration)."""
+    return _compact_games(
+        [
+            MatchResultsGameWrite(
+                game_number=g.game_number,
+                side_1_points=g.score.side_1_points,
+                side_2_points=g.score.side_2_points,
+            )
+            for g in match.games
+            if g.score is not None
+        ]
+    )
 
 
 def _can_finalize(match: Match) -> bool:
@@ -2104,6 +2147,12 @@ async def post_match_result(
     # false the instant any result exists (#715), so a counter — which by design
     # supersedes an existing result — would 409 before it could supersede.
     # Propose has its OWN gates below (first-post vs counter) instead.
+
+    # Compact once, upstream of every consumer below (_validate_finalize_games,
+    # _commit_canonical_games, and the immutable _result_games_snapshot), so the
+    # minted board is contiguous (see `_compact_games`). Covers both the first
+    # proposal and the counter — they share this endpoint.
+    payload = payload.model_copy(update={"games": _compact_games(payload.games)})
 
     # Decided-board hard gate — the strict precondition: an undecided board can't
     # be a result.

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
 from app.matches import (
+    _compact_games,
     accept_match_result,
     create_game_score,
     post_match_result,
@@ -43,6 +44,41 @@ from tests._helpers import (
     opponent_session,
     start_session,
 )
+
+# ----- decided-board compaction (#742) ------------------------------------
+
+
+def _game(n: int, s1: int = 11, s2: int = 2) -> MatchResultsGameWrite:
+    return MatchResultsGameWrite(game_number=n, side_1_points=s1, side_2_points=s2)
+
+
+def test_compact_games_closes_a_gap():
+    # The #742 out-of-order clinch: game 4 blank, deciding win scored on game 5.
+    compacted = _compact_games([_game(1), _game(2), _game(3), _game(5)])
+    assert [g.game_number for g in compacted] == [1, 2, 3, 4]
+
+
+def test_compact_games_is_identity_on_a_contiguous_board():
+    compacted = _compact_games([_game(1), _game(2), _game(3)])
+    assert [g.game_number for g in compacted] == [1, 2, 3]
+
+
+def test_compact_games_leaves_an_overrun_untouched():
+    # A fully-scored board with no holes has nothing to compact — a real overrun
+    # ([1..5] where the match was already won at game 4) stays [1..5] so the
+    # strict validator still rejects it.
+    compacted = _compact_games([_game(n) for n in range(1, 6)])
+    assert [g.game_number for g in compacted] == [1, 2, 3, 4, 5]
+
+
+def test_compact_games_preserves_duplicates_and_scores():
+    # Compaction ranks by distinct game number, so a duplicate stays a duplicate
+    # (the strict validator still catches it) and each game keeps its own score.
+    compacted = _compact_games([_game(3, 11, 7), _game(1, 11, 4), _game(1, 5, 11)])
+    assert [g.game_number for g in compacted] == [1, 1, 2]
+    # Sorted-stable: game 1's two scores keep their order; game 3 → game 2.
+    assert (compacted[2].side_1_points, compacted[2].side_2_points) == (11, 7)
+
 
 # ----- create -------------------------------------------------------------
 
@@ -1888,14 +1924,10 @@ async def test_score_endpoints_409_once_match_is_completed(
 @pytest.mark.parametrize(
     "games,reason_contains",
     [
-        # Gap — games 1 and 3 with no game 2.
-        (
-            [
-                {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
-                {"game_number": 3, "side_1_points": 11, "side_2_points": 7},
-            ],
-            "consecutively",
-        ),
+        # NB: a *gap* is no longer a 422 — a gappy but decided board (e.g. games
+        # 1 and 3, side 1 winning both) is compacted to a contiguous board and
+        # finalizes. See ``test_finalize_compacts_gappy_decided_board``. Only a
+        # real overrun (games genuinely scored past the clinch, below) still 422s.
         # Duplicate game numbers.
         (
             [
@@ -2005,6 +2037,71 @@ async def test_can_finalize_flag_tracks_saved_scores(
         )
     ).json()
     assert edited["can_finalize"] is False
+
+
+async def test_finalize_compacts_gappy_decided_board(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """#742: an out-of-order clinch posts a gappy-but-decided board (games 1 and
+    3, side 1 winning both, no game 2). It used to 422 ("consecutively"); now it
+    is *compacted* to a contiguous ``[1, 2]`` board and finalizes 2-0. The
+    committed games and the immutable result snapshot are both contiguous."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "rival") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+
+        response = await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                    {"game_number": 3, "side_1_points": 11, "side_2_points": 7},
+                ]
+            },
+        )
+        assert response.status_code == 201, response.json()
+        body = response.json()
+
+        # The gap is closed: the stored board is contiguous 1..2, not 1,3.
+        games = sorted(body["games"], key=lambda g: g["game_number"])
+        assert [g["game_number"] for g in games] == [1, 2]
+        # Renumbering preserves each game's score — game 3's 11-7 becomes game 2.
+        assert games[1]["score"]["side_1_points"] == 11
+        assert games[1]["score"]["side_2_points"] == 7
+        # Side 1 swept both games → 2-0.
+        sides = sorted(body["sides"], key=lambda s: s["side_number"])
+        assert [s["games_won"] for s in sides] == [2, 0]
+
+        # The immutable result snapshot is contiguous too.
+        results = (await db_session.execute(select(MatchResult))).scalars().all()
+        assert len(results) == 1
+        assert [g["game_number"] for g in results[0].games] == [1, 2]
+
+        # No orphan scratchpad rows survive under the old game numbers.
+        game_rows = (await db_session.execute(select(MatchGame))).scalars().all()
+        assert sorted(g.game_number for g in game_rows) == [1, 2]
+
+
+async def test_can_finalize_true_for_gappy_decided_saved_board(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """#742 self-heal: a saved scratchpad where the deciding game landed out of
+    order (games 1-3 then game 5, leaving game 4 blank) is decided once
+    compacted, so ``can_finalize`` reports true — the SaveBanner then offers
+    "Post result" and the user recovers from the previously-stuck state."""
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=7)
+
+    # Side 1 wins games 1-3, then clinches the 4th win on game 5 (game 4 blank).
+    await _sweep_games(api_client, match["id"], [1, 2, 3])
+    after_g5 = await api_client.post(
+        f"/v1/matches/{match['id']}/games/5/scores/new",
+        json={"side_1_points": 11, "side_2_points": 2},
+    )
+    assert after_g5.status_code == 201, after_g5.json()
+    # The gappy board [1,2,3,5] compacts to [1,2,3,4] — decided, so finalizable.
+    assert after_g5.json()["can_finalize"] is True
 
 
 # ----- league binding -----------------------------------------------------

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1158,6 +1158,41 @@ async def test_score_update_422_when_edit_creates_overrun(
     assert "already decided at game 4" in edit.json()["detail"]
 
 
+async def test_score_update_422_on_overrun_when_board_has_a_gap(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # The overrun guard must operate on the RAW (gappy) board, not a compacted
+    # one — otherwise the edited game's raw ``game_number`` no longer aligns with
+    # the renumbered slots and the substitution lands on the wrong game, silently
+    # bypassing the guard. Board: side 1 takes games 1-3, side 2 takes games 5-6,
+    # game 4 left blank (a legal, undecided gappy scratchpad). Flipping game 5 to
+    # a side-1 win clinches side 1 at game 5 while game 6 is still scored →
+    # overrun → 422.
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    match = await _create_match(api_client, opp.id, best_of=7)
+
+    for n, (side1, side2) in [
+        (1, (11, 2)),
+        (2, (11, 2)),
+        (3, (11, 2)),
+        (5, (2, 11)),
+        (6, (2, 11)),
+    ]:
+        response = await api_client.post(
+            f"/v1/matches/{match['id']}/games/{n}/scores/new",
+            json={"side_1_points": side1, "side_2_points": side2},
+        )
+        assert response.status_code == 201, response.json()
+
+    edit = await api_client.put(
+        f"/v1/matches/{match['id']}/games/5/scores",
+        json={"side_1_points": 11, "side_2_points": 2, "expected_version": 1},
+    )
+    assert edit.status_code == 422, edit.json()
+    assert "already decided at game 5" in edit.json()["detail"]
+
+
 async def test_score_update_overwrites_in_place(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/docs/adr/0002-decided-board-is-compacted-at-propose.md
+++ b/docs/adr/0002-decided-board-is-compacted-at-propose.md
@@ -1,0 +1,67 @@
+# A decided board is compacted at propose, not gap-locked at entry
+
+When a side has clinched (some side reached `ceil(best_of/2)` game wins), the
+board it is minted from is first **compacted**: the scored games are sorted and
+renumbered `1..N` with any empty slots dropped. The scratchpad stays permissive
+— every blank game cell is tappable while no side has clinched — so a user can
+score out of order (jump to game 5 with game 4 still blank) and clinch there;
+compaction turns the resulting gappy board `[1,2,3,5]` into the canonical
+`[1,2,3,4]` that gets validated, committed, and frozen into the immutable result
+snapshot.
+
+This is provably safe: an empty slot contributes 0 wins to either side, so
+compaction can never change the winner or the game score — only cosmetic slot
+numbers. It also auto-corrects the originating mis-tap (the stray "game 5"
+becomes game 4, exactly what in-order entry produces), so finalize is silent: no
+note, no confirm, nothing to consent to.
+
+Compaction closes only *empty* holes. A real **overrun** — a game genuinely
+scored *past* the clinch, e.g. a fully-scored `[1,2,3,4,5]` where side 1 already
+won at game 4 — has no empty slot to drop, so it compacts to itself and stays
+**rejected** by the unchanged strict validator (`_validate_finalize_games` /
+`matchScoreSchema`): "scored games extend past the deciding game." One operation
+thus handles both cases correctly — heal the gap, keep blocking the overrun.
+
+We keep the validators strict and apply compaction *upstream* at the callers,
+rather than loosening the validators to tolerate gaps. Two crisp concepts stay
+separate: a *canonical decided board* (strict — is this a clean `1..N` board
+with the decider last?) versus *normalizing a gappy scratchpad into one*
+(compaction). The correction surface (ADR 0001) keeps the strict checker
+untouched — a gap there is a clear disabled-Send, not a dead-end.
+
+Compaction is applied in both server spots — the write path (`post_match_result`
+compacts `payload.games` upstream of validation, commit, and the snapshot) and
+`_can_finalize` (via `_games_payload_from_match`). The latter is what
+**incidentally heals already-stuck matches**: once `_can_finalize` compacts, any
+gappy-but-decided saved board reports `can_finalize = true`, so the SaveBanner
+offers "Post result" and the user self-heals with one tap — no migration, no
+heal-banner. The front-end mirrors both (`compactGames` in `scoring.ts`, applied
+in `score-entry.tsx`'s `wouldFinalize`/finalize payload and in the SaveBanner's
+merged board) so the optimistic board matches what the server mints.
+
+## Rejected alternative: frontier-lock the scoreline (block the gap at entry)
+
+We considered making the scoreline refuse the out-of-order tap in the first
+place — locking every game cell past the lowest unscored "frontier" so a user
+could never score game 5 while game 4 is blank. Rejected in favor of
+**allow-and-heal**:
+
+- The jump-ahead is harmless once compaction exists — the clinch finalizes
+  immediately and self-heals, so there is nothing to prevent.
+- Frontier-locking is a larger, more intrusive diff on the entry UX (new gating
+  state, new muted/blocked affordances) for a case the mint path already
+  neutralizes.
+- It would not heal the matches *already* stuck from the pre-fix behavior;
+  `_can_finalize` compaction does, with no migration.
+
+Allow-and-heal shrinks the change to `compactGames` + the `wouldFinalize`
+predicate + the server seam + these docs, and leaves the scoreline gating alone.
+
+## Bug context
+
+Fixes #742: an out-of-order clinch produced a gappy decided board that read
+"4–0" but could not finalize (a decided board was additionally required to be
+contiguous `1..N`), while #741 correctly refused every score in the empty gap
+game — a dead-end stuck at "4–0 · Live." Compaction closes the gap between *"has
+a victor"* and *"is a mintable canonical board"*, restoring the stated §1
+invariant that a match can never get stuck.

--- a/docs/designs/match-result-model.md
+++ b/docs/designs/match-result-model.md
@@ -31,10 +31,16 @@ Collapse it to the conversation and the machinery disappears:
   different result instead of accepting. There is nothing to "dispute" and
   nothing to "reopen", because a still-negotiating match was never closed.
 - **A match can never get stuck**, so there is no *withdraw* or *void*. A result
-  is only ever minted from a **decided board** (a board with a victor). Before
-  that, the match is a live scratchpad that either participant can edit; there
-  is simply no result to be stuck on. After the first proposal the negotiation
-  is always advanceable by *someone* (accept, or counter), so it can't deadlock.
+  is only ever minted from a **decided board** — a board with a victor, which is
+  always **normalizable to a canonical, mintable board** by dropping any empty
+  slots and renumbering the scored games `1..N` (*compaction*; see
+  `docs/adr/0002-decided-board-is-compacted-at-propose.md`). The invariant is
+  **a victor ⟹ a normalizable canonical board ⟹ a mintable result**: the moment
+  some side has clinched, a legal result exists to post, so the scratchpad can
+  never present a victor with no way forward. Before a victor, the match is a
+  live scratchpad that either participant can edit; there is simply no result to
+  be stuck on. After the first proposal the negotiation is always advanceable by
+  *someone* (accept, or counter), so it can't deadlock.
 
 The model that falls out is **one table and two verbs**. The supersede chain is
 the entire history; consent is two columns.

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-query.test.ts
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-query.test.ts
@@ -68,6 +68,42 @@ describe("finalizeCalloutQuery", () => {
     });
   });
 
+  it("compacts a gappy-but-decided saved board into a contiguous payload (#742 self-heal)", async () => {
+    // An already-stuck match: side 1 clinched the 4th win on game 5 with game 4
+    // left blank → saved board [1,2,3,5]. The server's `_can_finalize` now
+    // compacts, so `can_finalize` is true; this recovery surface must post the
+    // compacted [1,2,3,4], not the gappy board.
+    finalizeCalloutQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          can_finalize: true,
+          games: [1, 2, 3, 5].map((n) =>
+            buildMatchDetailsGame({
+              id: `g${n}`,
+              game_number: n,
+              score: buildMatchDetailsScore({
+                id: `s${n}`,
+                side_1_points: 11,
+                side_2_points: n,
+              }),
+            }),
+          ),
+        }),
+      ),
+    );
+
+    const result = await renderView();
+
+    expect(result.current.data).toEqual({
+      games: [
+        { game_number: 1, side_1_points: 11, side_2_points: 1 },
+        { game_number: 2, side_1_points: 11, side_2_points: 2 },
+        { game_number: 3, side_1_points: 11, side_2_points: 3 },
+        { game_number: 4, side_1_points: 11, side_2_points: 5 },
+      ],
+    });
+  });
+
   it("projects null when the board isn't finalizable, even with saved scores", async () => {
     finalizeCalloutQueryPage.mockEndpoint(() =>
       HttpResponse.json(finalizableMatch({ can_finalize: false })),

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-query.ts
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-query.ts
@@ -1,5 +1,6 @@
 import type { components } from "@/api/schema";
 
+import { compactGames } from "@/lib/scoring";
 import {
   matchDetailsQuery,
   type MatchDetailsResult,
@@ -28,14 +29,19 @@ const selectFinalizeCallout = (
   // sign-off flow.
   if (!details.can_finalize) return null;
   return {
-    games: details.games
-      .filter((g) => g.score)
-      .sort((a, b) => a.game_number - b.game_number)
-      .map((g) => ({
-        game_number: g.game_number,
-        side_1_points: g.score!.side_1_points,
-        side_2_points: g.score!.side_2_points,
-      })),
+    // The recovery surface for an already-stuck gappy-decided match: the
+    // server's `_can_finalize` now compacts, so `can_finalize` is true here;
+    // post the compacted board to match what the server mints (see
+    // `compactGames`). #742
+    games: compactGames(
+      details.games
+        .filter((g) => g.score)
+        .map((g) => ({
+          game_number: g.game_number,
+          side_1_points: g.score!.side_1_points,
+          side_2_points: g.score!.side_2_points,
+        })),
+    ),
   };
 };
 

--- a/web-client/src/components/matches/save-banner.tsx
+++ b/web-client/src/components/matches/save-banner.tsx
@@ -10,7 +10,7 @@ import {
   useProposeResult,
   useMatch,
 } from '@/api/matches'
-import { isDecidedMatch, type GamePoints } from '@/lib/scoring'
+import { compactGames, isDecidedMatch, type GamePoints } from '@/lib/scoring'
 import { cn } from '@/lib/utils'
 import {
   Alert,
@@ -103,9 +103,9 @@ function FailedSaveBanner({ matchId, activeGameNumber }: SaveBannerProps) {
       side_2_points: entry.variables.side_2_points,
     })
   }
-  const mergedGames = [...mergedByNumber.values()].sort(
-    (a, b) => a.game_number - b.game_number,
-  )
+  // Compact so a gappy offline clinch posts a contiguous board (see
+  // `compactGames`). `compactGames` sorts internally, so no pre-sort here.
+  const mergedGames = compactGames([...mergedByNumber.values()])
   const wouldFinalize =
     data != null && isDecidedMatch(mergedGames, data.best_of)
 

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -449,6 +449,85 @@ describe('ScoreEntry — create', () => {
     })
   })
 
+  it('finalizes an out-of-order clinch (game 4 blank) and posts the compacted board (#742)', async () => {
+    // The repro: Bo7, games 1-3 to side 1, then the user jumps to game 5 (game 4
+    // still blank) and scores the clinching 4th win there. That leaves a gappy
+    // decided board [1,2,3,5]. Pre-fix the button stayed "save & next" and the
+    // save funnelled into the empty game 4 (dead-end). Now the board compacts to
+    // [1,2,3,4]: the button flips to "Post result" and posts the contiguous board.
+    const user = userEvent.setup()
+    let finalizedBody: unknown = null
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          inProgressMatch({
+            best_of: 7,
+            games_to_win: 4,
+            sides: participantSides({ meWins: 3, oppWins: 0 }),
+            games: [
+              { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
+              { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
+              { id: 'g-3', game_number: 3, score: score('s-3', 11, 5) },
+            ],
+            current_game: { game_number: 4 },
+          }),
+        ),
+      ),
+      http.post('*/v1/matches/m-1/results', async ({ request }) => {
+        finalizedBody = await request.json()
+        return HttpResponse.json(
+          matchDetails({
+            id: 'm-1',
+            status: 'completed',
+            status_label: 'Final',
+            best_of: 7,
+            games_to_win: 4,
+            sides: participantSides({ meWins: 4, oppWins: 0, meWon: true }),
+            games: [
+              { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
+              { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
+              { id: 'g-3', game_number: 3, score: score('s-3', 11, 5) },
+              { id: 'g-4', game_number: 4, score: score('s-4', 11, 3) },
+            ],
+            current_game: null,
+            can_score: false,
+            can_finalize: false,
+          }),
+          { status: 201 },
+        )
+      }),
+    )
+
+    // Land on game 5 — the out-of-order slot the scoreline let the user tap.
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 5 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+
+    await user.type(meInput, '11')
+    await user.type(oppInput, '3')
+
+    // The clinch is recognised through compaction, so the button offers to post
+    // the result rather than funnelling into the empty game 4.
+    const postBtn = screen.getByRole('button', { name: /post result/i })
+    expect(postBtn).toBeInTheDocument()
+    await user.click(postBtn)
+
+    await waitFor(() =>
+      expect(screen.getByText('match-page m-1')).toBeInTheDocument(),
+    )
+    // The posted board is contiguous: the stray "game 5" was renumbered to 4.
+    expect(finalizedBody).toEqual({
+      games: [
+        { game_number: 1, side_1_points: 11, side_2_points: 4 },
+        { game_number: 2, side_1_points: 11, side_2_points: 6 },
+        { game_number: 3, side_1_points: 11, side_2_points: 5 },
+        { game_number: 4, side_1_points: 11, side_2_points: 3 },
+      ],
+    })
+  })
+
   it('fires a single POST /results when "Post result" is double-clicked in one frame (#641)', async () => {
     // A fast double-tap lands a second click before React commits the button's
     // `disabled` re-render. That fired two concurrent POST /results that piled

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -37,6 +37,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { cn, initialsOf } from '@/lib/utils'
 import {
+  compactGames,
   deciderGameNumber,
   isDecidedMatch,
   overrunDecider,
@@ -349,8 +350,14 @@ function ScoreEntryInner({
             },
       ]
     : []
-  const wouldFinalize =
-    inputsValid && isDecidedMatch(hypotheticalGames, bestOf)
+  // The canonical board this entry would post — an out-of-order clinch's gap
+  // closed (see `compactGames`), so the predicate and the posted payload below
+  // are always the same board and can't diverge.
+  const compactedGames = compactGames(hypotheticalGames)
+  // Compact before asking "is this a decided board?" so an out-of-order clinch
+  // takes the finalize branch instead of funnelling into the empty gap game (the
+  // #742 dead-end). A real overrun compacts to itself and stays non-final.
+  const wouldFinalize = inputsValid && isDecidedMatch(compactedGames, bestOf)
 
   // Mirror the server's "no games past the decider" guard inline. The scoreline
   // already mutes/bounces the games numbered after a known decider, but one path
@@ -454,7 +461,7 @@ function ScoreEntryInner({
     if (wouldFinalize && onlineManager.isOnline()) {
       finalizingRef.current = true
       finalizeMutation.mutate(
-        { games: hypotheticalGames },
+        { games: compactedGames },
         {
           onSuccess: () => navigate(matchDetailRoute(matchId)),
           onError: () => {

--- a/web-client/src/lib/scoring.test.ts
+++ b/web-client/src/lib/scoring.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  compactGames,
   deciderGameNumber,
   firstMatchScoreError,
   illegalScoreReason,
@@ -13,6 +14,50 @@ const game = (
   side_1_points: number,
   side_2_points: number,
 ): GamePoints => ({ game_number, side_1_points, side_2_points })
+
+describe('compactGames', () => {
+  it('closes a gap left by an out-of-order clinch', () => {
+    // #742: games 1-3 scored, deciding win on game 5, game 4 blank.
+    const compacted = compactGames([
+      game(1, 11, 2),
+      game(2, 11, 2),
+      game(3, 11, 2),
+      game(5, 11, 2),
+    ])
+    expect(compacted.map((g) => g.game_number)).toEqual([1, 2, 3, 4])
+  })
+
+  it('is identity on an already-contiguous board', () => {
+    const compacted = compactGames([game(1, 11, 2), game(2, 11, 2)])
+    expect(compacted.map((g) => g.game_number)).toEqual([1, 2])
+  })
+
+  it('leaves a fully-scored overrun untouched', () => {
+    const games = [
+      game(1, 11, 2),
+      game(2, 11, 2),
+      game(3, 11, 2),
+      game(4, 11, 2),
+      game(5, 11, 2),
+    ]
+    expect(compactGames(games).map((g) => g.game_number)).toEqual([
+      1, 2, 3, 4, 5,
+    ])
+  })
+
+  it('renumbers a gappy decided board into a finalize-able one', () => {
+    // The predicate score-entry uses: gappy [1,2,3,5] is not decided raw…
+    const gappy = [game(1, 11, 2), game(2, 11, 2), game(3, 11, 2), game(5, 11, 2)]
+    expect(isDecidedMatch(gappy, 7)).toBe(false)
+    // …but its compaction is.
+    expect(isDecidedMatch(compactGames(gappy), 7)).toBe(true)
+  })
+
+  it('preserves each game score under renumbering', () => {
+    const compacted = compactGames([game(3, 11, 7), game(1, 11, 4)])
+    expect(compacted).toEqual([game(1, 11, 4), game(2, 11, 7)])
+  })
+})
 
 describe('illegalScoreReason', () => {
   it.each([

--- a/web-client/src/lib/scoring.ts
+++ b/web-client/src/lib/scoring.ts
@@ -110,6 +110,30 @@ function matchScoreSchema(bestOf: number) {
     )
 }
 
+// Normalize a (possibly gappy) scratchpad board into a canonical one: sort by
+// game number and renumber the survivors 1..N with no holes. The FE mirror of
+// the backend `_compact_games` in api/app/matches.py.
+//
+// Outcome-invariant: an empty slot is 0 wins for either side, so dropping it and
+// renumbering can never change the winner or game score — only cosmetic slot
+// numbers. Heals the out-of-order clinch (`[1,2,3,5]` → `[1,2,3,4]`, which then
+// `isDecidedMatch`) without touching a real overrun (a fully-scored
+// `[1,2,3,4,5]` compacts to itself and stays rejected).
+export function compactGames(games: GamePoints[]): GamePoints[] {
+  // Renumber by the *rank of each distinct* game number (not list position), so
+  // a genuine duplicate game_number stays a duplicate — compaction closes gaps,
+  // it doesn't launder malformed input (matches `_compact_games`).
+  const rank = new Map<number, number>()
+  for (const n of [...new Set(games.map((g) => g.game_number))].sort(
+    (a, b) => a - b,
+  )) {
+    rank.set(n, rank.size + 1)
+  }
+  return [...games]
+    .sort((a, b) => a.game_number - b.game_number)
+    .map((g) => ({ ...g, game_number: rank.get(g.game_number)! }))
+}
+
 // Whether the given games form a complete, validly-ordered, decided match for
 // `best_of` — the boolean predicate over `matchScoreSchema`. Replaces the old
 // `decidedSide` (no client consumer needed the winning side number, only


### PR DESCRIPTION
## Problem

The scratchpad scorer makes every blank game cell tappable while no side has clinched, so a user can score out of order — e.g. games 1–3, then the clinching 4th win on game 5 with game 4 still blank. That produces a **gappy decided board** `[1,2,3,5]`: it has a victor (4–0) but isn't contiguous, so it failed the "decided board is numbered `1..N`" check and could not be minted. The match read "4–0" yet auto-advance funnelled into the empty game 4, which #741 rightly refuses — a **dead-end stuck at "4–0 · Live."** (Confirmed on solo Best-of-7 and rated two-player Best-of-3.)

This is a stated-invariant violation: `docs/designs/match-result-model.md` §1 promises a match can never get stuck because "a result is only ever minted from a decided board (a board with a victor)." The gappy board *has* a victor but the implementation additionally demanded contiguity.

## Fix — decided-board compaction

When a side has clinched, **compact** the board before minting it: drop empty slots and renumber the survivors `1..N`. This is provably outcome-invariant (an empty slot is 0 wins for both sides), so it only heals the gap and auto-corrects the mis-tap (stray "game 5" becomes game 4). A real **overrun** — a game genuinely scored past the clinch, `[1,2,3,4,5]` fully scored — has no empty slot to drop, compacts to itself, and stays rejected. One operation handles both.

Validators stay **strict**; compaction is applied **upstream at the callers** (new `docs/adr/0002`). New invariant, made explicit: *a victor ⟹ a normalizable canonical board ⟹ a mintable result.*

### Server (`api/app/matches.py`)
- New pure `_compact_games` — ranks by *distinct* game number, so genuine duplicates survive and `_validate_finalize_games` still 422s them.
- `post_match_result` compacts `payload.games` once, upstream of validation, commit, and the immutable result snapshot (covers first proposal + counter — same endpoint).
- `_games_payload_from_match` compacts too, so `_can_finalize` reports `true` for a gappy-decided saved board — **self-heals already-stuck matches** via the finalize-callout's "Post result" (no migration, no heal-banner).

### Frontend
- `compactGames` in `scoring.ts` mirrors the server, applied in score-entry's finalize predicate + payload (removes the funnel), the save-banner's merged board, and the finalize-callout recovery surface.
- `overrunDecider` deliberately still runs on the *raw* board (a real overrun must stay visible); verified mutually exclusive with the new finalize path.

### Docs
- New `docs/adr/0002-decided-board-is-compacted-at-propose.md` (with the rejected frontier-lock alternative).
- Sharpened the "never stuck" invariant in `match-result-model.md` §1.

## Testing
- **API:** `ruff check` · `ruff format --check` · `mypy` · `pytest` **523 passed** — incl. `_compact_games` unit tests, gappy-payload → 200 with contiguous stored board + snapshot, `can_finalize` true for a gappy saved board, and the flipped old gappy-422 case.
- **Web:** `test:run` **1104 passed**, `lint` clean, `build` (tsc) ✓, Playwright e2e **128 passed** — incl. new `compactGames` unit tests, a score-entry funnel-fix test (out-of-order clinch fires finalize and posts `[1,2,3,4]`), and a finalize-callout self-heal test.
- **OpenAPI schema:** regenerated — **no drift** (only body comments changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)