### PR TITLE
Fix four small issues: rating-delta a11y, dead login links, breadcrumb separator, EMPTY_FORM sentinel

### DIFF
--- a/web-client/src/components/dashboard/your-game-row/mono.tsx
+++ b/web-client/src/components/dashboard/your-game-row/mono.tsx
@@ -8,6 +8,9 @@ export interface MonoProps {
   weight?: number
   color?: string
   style?: CSSProperties
+  /** Optional spoken label — e.g. spelling out a "+8"/"Δ" delta chip so a
+   * screen reader doesn't voice the glyph as literal punctuation. */
+  ariaLabel?: string
 }
 
 /** Tabular-nums monospace text — ratings, scores, and deltas across the
@@ -18,9 +21,11 @@ export const Mono = ({
   weight = 500,
   color = C.chalk50,
   style,
+  ariaLabel,
 }: MonoProps) => {
   return (
     <span
+      aria-label={ariaLabel}
       style={{
         font: `${weight} ${size}px ${MONO}`,
         fontVariantNumeric: 'tabular-nums',

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card.tsx
@@ -2,7 +2,7 @@ import type { DashboardRecentResult } from '@/api/dashboard'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import { Overline } from '@/components/overline'
 import { fmtDateShort } from '@/lib/dates'
-import { formatRatingDelta } from '@/lib/rating'
+import { formatRatingDelta, formatRatingDeltaAria } from '@/lib/rating'
 import { C, UI } from '@/components/dashboard/dashboard-tokens'
 
 import { Card } from './card'
@@ -76,7 +76,10 @@ export const RecentResultsCard = ({ rows }: RecentResultsCardProps) => {
               <th style={{ textAlign: 'right', padding: '10px 8px 8px', fontWeight: 600 }}>
                 Score
               </th>
-              <th style={{ textAlign: 'right', padding: '10px 8px 8px', fontWeight: 600 }}>
+              <th
+                aria-label="Rating change"
+                style={{ textAlign: 'right', padding: '10px 8px 8px', fontWeight: 600 }}
+              >
                 Δ
               </th>
               <th style={{ textAlign: 'right', padding: '10px 18px 8px', fontWeight: 600 }}>
@@ -128,6 +131,7 @@ export const RecentResultsCard = ({ rows }: RecentResultsCardProps) => {
                       <Mono
                         size={12}
                         weight={500}
+                        ariaLabel={formatRatingDeltaAria(r.my_rating_change.delta)}
                         color={
                           r.my_rating_change.delta >= 0
                             ? C.serve500

--- a/web-client/src/components/login/login-screens.tsx
+++ b/web-client/src/components/login/login-screens.tsx
@@ -991,8 +991,12 @@ export function ScreenEmail({
             <br />
             <span style={{ color: 'var(--fg-muted)' }}>
               By signing in you agree to play fair. That’s it.{' '}
-              <LinkButton>House rules</LinkButton> ·{' '}
-              <LinkButton>Privacy</LinkButton>
+              {/* House rules / Privacy pages don't exist yet — render as plain
+                  text (not focusable LinkButtons) so we don't advertise
+                  interactive controls that fire nothing. Convert back to
+                  <a href="…"> once the pages land (#227). */}
+              <span style={linkInline}>House rules</span> ·{' '}
+              <span style={linkInline}>Privacy</span>
             </span>
           </div>
         </FormCol>

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher/players-panel-query.ts
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher/players-panel-query.ts
@@ -87,10 +87,15 @@ type MatchDetailsPlayerForm = NonNullable<
 >[number];
 type MatchDetailsFormResult = MatchDetailsPlayerForm["recent_results"][number];
 
+// The projection only ever reads a form's *facts*, never its `user_id` (that's
+// only used up front to match a form to its side). Dropping the id here lets
+// the no-history fallback be a real empty struct rather than carrying an
+// empty-string sentinel that could compare-equal to a real "" id elsewhere.
+type PlayerFormFacts = Omit<MatchDetailsPlayerForm, "user_id">;
+
 // A player the API returned no form entry for has no history at all — the
 // projection below then lands on the empty/Unrated/em-dash branches.
-const EMPTY_FORM: MatchDetailsPlayerForm = {
-  user_id: "",
+const EMPTY_FORM: PlayerFormFacts = {
   recent_results: [],
   rating_before: null,
   rating_history: [],
@@ -98,7 +103,7 @@ const EMPTY_FORM: MatchDetailsPlayerForm = {
   career_wins_before: 0,
 };
 
-const careerWinRate = (form: MatchDetailsPlayerForm): number | null =>
+const careerWinRate = (form: PlayerFormFacts): number | null =>
   form.career_matches_before > 0
     ? Math.round((form.career_wins_before / form.career_matches_before) * 100)
     : null;
@@ -112,7 +117,7 @@ const selectFormRow = (result: MatchDetailsFormResult): FormRowView => ({
 });
 
 const selectRecentForm = (
-  form: MatchDetailsPlayerForm,
+  form: PlayerFormFacts,
   isCurrentUser: boolean,
 ): RecentFormView => {
   const results = form.recent_results;

--- a/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-display/rating-row.factory.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-display/rating-row.factory.tsx
@@ -9,6 +9,7 @@ export function buildRatingRowChangeView(
     from: 1612,
     to: 1624,
     deltaLabel: "+12",
+    deltaAriaLabel: "Gained 12 rating",
     deltaUp: true,
     sparkline: [1580, 1601, 1612, 1624],
     ...overrides,

--- a/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-display/rating-row.test.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-display/rating-row.test.tsx
@@ -55,6 +55,22 @@ describe("RatingRow", () => {
     expect(delta).not.toHaveClass("md-delta-down");
   });
 
+  it("labels the delta chip for screen readers so the sign isn't voiced as punctuation", () => {
+    ratingRowPage.render({
+      row: buildRatingRowView({
+        change: buildRatingRowChangeView({
+          deltaLabel: "+12",
+          deltaAriaLabel: "Gained 12 rating",
+        }),
+      }),
+    });
+
+    expect(ratingRowPage.queryDelta("rita.kovac")).toHaveAttribute(
+      "aria-label",
+      "Gained 12 rating",
+    );
+  });
+
   it("tones a negative delta down", () => {
     ratingRowPage.render({
       row: buildRatingRowView({

--- a/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-display/rating-row.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-display/rating-row.tsx
@@ -43,6 +43,7 @@ export const RatingRow = ({ row }: RatingRowProps) => (
           />
         )}
         <span
+          aria-label={row.change.deltaAriaLabel}
           className={cn(
             "md-rating-row__delta-num",
             row.change.deltaUp ? "md-delta-up" : "md-delta-down",

--- a/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-query.test.ts
+++ b/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-query.test.ts
@@ -88,6 +88,7 @@ describe("ratingsQuery", () => {
             from: 1612,
             to: 1624,
             deltaLabel: "+12",
+            deltaAriaLabel: "Gained 12 rating",
             deltaUp: true,
             // History anchored before the match, post-match value appended.
             sparkline: [1580, 1601, 1612, 1624.4],
@@ -101,6 +102,7 @@ describe("ratingsQuery", () => {
             from: 1540,
             to: 1528,
             deltaLabel: "-12",
+            deltaAriaLabel: "Lost 12 rating",
             deltaUp: false,
             // No history — the line is anchored at the pre-match rating.
             sparkline: [1540, 1527.6],
@@ -188,6 +190,7 @@ describe("ratingsQuery", () => {
       from: null,
       to: 1500,
       deltaLabel: "0",
+      deltaAriaLabel: "No rating change",
       deltaUp: true,
       sparkline: null,
     });

--- a/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-query.ts
+++ b/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-query.ts
@@ -1,4 +1,4 @@
-import { formatRatingDelta } from "@/lib/rating";
+import { formatRatingDelta, formatRatingDeltaAria } from "@/lib/rating";
 import { initialsOf } from "@/lib/utils";
 
 import {
@@ -16,6 +16,9 @@ export type RatingRowChangeView = {
   to: number;
   /** Signed, rounded delta, e.g. "+12" / "-8". */
   deltaLabel: string;
+  /** Spoken form of `deltaLabel` for the delta chip's `aria-label`, e.g.
+   * "Gained 12 rating" — so a reader doesn't voice the "+" as punctuation. */
+  deltaAriaLabel: string;
   /** True for a non-negative delta — picks the delta figure's up/down tone. */
   deltaUp: boolean;
   /** Series for the trend sparkline: the pre-match rating history with the
@@ -61,6 +64,7 @@ const selectChange = (
     from: change.before === null ? null : Math.round(change.before),
     to: Math.round(change.after),
     deltaLabel: formatRatingDelta(change.delta),
+    deltaAriaLabel: formatRatingDeltaAria(change.delta),
     deltaUp: change.delta >= 0,
     sparkline: series.length >= 2 ? series : null,
   };

--- a/web-client/src/components/ui/breadcrumb.tsx
+++ b/web-client/src/components/ui/breadcrumb.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Slot } from "radix-ui"
 
 import { cn } from "@/lib/utils"
-import { ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
+import { MoreHorizontalIcon } from "lucide-react"
 
 function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
   return (
@@ -82,9 +82,8 @@ function BreadcrumbSeparator({
       className={cn("[&>svg]:size-3.5", className)}
       {...props}
     >
-      {children ?? (
-        <ChevronRightIcon />
-      )}
+      {/* Kit reference separates crumbs with a forward slash, not a chevron. */}
+      {children ?? <span>/</span>}
     </li>
   )
 }

--- a/web-client/src/lib/rating.test.ts
+++ b/web-client/src/lib/rating.test.ts
@@ -1,0 +1,29 @@
+import { formatRatingDelta, formatRatingDeltaAria } from './rating'
+
+describe('formatRatingDelta', () => {
+  it('signs and rounds a gain', () => {
+    expect(formatRatingDelta(12.4)).toBe('+12')
+  })
+
+  it('rounds a loss without an extra sign', () => {
+    expect(formatRatingDelta(-12.4)).toBe('-12')
+  })
+
+  it('renders a zero move without a sign', () => {
+    expect(formatRatingDelta(0)).toBe('0')
+  })
+})
+
+describe('formatRatingDeltaAria', () => {
+  it('spells out a gain', () => {
+    expect(formatRatingDeltaAria(8.2)).toBe('Gained 8 rating')
+  })
+
+  it('spells out a loss as a positive magnitude', () => {
+    expect(formatRatingDeltaAria(-12.4)).toBe('Lost 12 rating')
+  })
+
+  it('reads a zero move as no change', () => {
+    expect(formatRatingDeltaAria(0.2)).toBe('No rating change')
+  })
+})

--- a/web-client/src/lib/rating.ts
+++ b/web-client/src/lib/rating.ts
@@ -3,3 +3,14 @@ export function formatRatingDelta(delta: number): string {
   const sign = rounded > 0 ? '+' : ''
   return `${sign}${rounded}`
 }
+
+/** Screen-reader label for a rating delta, e.g. "Gained 8 rating" /
+ * "Lost 12 rating" / "No rating change". The visible chip renders the terse
+ * signed figure (`formatRatingDelta`); this spells it out so a reader doesn't
+ * announce the "+"/"Δ" glyph as literal punctuation. */
+export function formatRatingDeltaAria(delta: number): string {
+  const rounded = Math.round(delta)
+  if (rounded === 0) return 'No rating change'
+  const verb = rounded > 0 ? 'Gained' : 'Lost'
+  return `${verb} ${Math.abs(rounded)} rating`
+}


### PR DESCRIPTION
Batch of four self-contained fixes for easy open issues.

## Changes

- **#186 — rating-delta chip has no aria-label.** The `+8` / `Δ` delta chips on match details and the dashboard recent-results table announced their sign/glyph as literal punctuation. New `formatRatingDeltaAria` helper (`"Gained 8 rating"` / `"Lost 12 rating"` / `"No rating change"`) is applied as `aria-label` on both delta chips, plus `aria-label="Rating change"` on the compact `Δ` column header. `Mono` gains an `ariaLabel` prop to carry it.
- **#227 — dead "House rules"/"Privacy" links on login.** These pages don't exist yet, so the `LinkButton`s rendered as keyboard-focusable controls that fired nothing. Swapped to non-interactive `<span style={linkInline}>` (same visual) with a comment to convert back to `<a href>` once the pages land.
- **#266 — breadcrumb separator mismatch.** The design-system breadcrumb defaulted to a chevron; the FortyMM kit uses a forward slash. Changed the default separator slot to `/` and dropped the now-unused `ChevronRightIcon` import.
- **#197 — EMPTY_FORM `''` user_id sentinel.** The players-panel projection never reads a form's `user_id`, so the no-history fallback carried `user_id: ''` purely to satisfy the type — a footgun that could compare-equal to a real `''` id. The fact-consuming helpers are now typed against `Omit<…, "user_id">`, so the fallback is a real empty struct with no sentinel id.

## Testing

- `npm run test:run` — 1103/1104 (the single failure is a pre-existing flaky scoring-route test unrelated to this branch; passes in isolation).
- `npm run lint` — clean (only the pre-existing generated `mockServiceWorker.js` warning).
- `npm run build` (`tsc -b && vite build`) — clean.
- `npm run test:e2e` — 128/128.

Added unit tests for the new `formatRatingDeltaAria` helper and a component test asserting the delta chip's `aria-label`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)