### PR TITLE
Scale UAT api/web to 5/2 pods with zero-downtime rolling updates

### DIFF
--- a/deploy/uat/templates/api.yaml
+++ b/deploy/uat/templates/api.yaml
@@ -5,7 +5,12 @@ metadata:
   labels:
     {{- include "fortymm-uat.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.api.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.api.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.api.rollingUpdate.maxSurge }}
   selector:
     matchLabels:
       {{- include "fortymm-uat.selector" (dict "component" "api") | nindent 6 }}

--- a/deploy/uat/templates/web.yaml
+++ b/deploy/uat/templates/web.yaml
@@ -5,7 +5,12 @@ metadata:
   labels:
     {{- include "fortymm-uat.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.web.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.web.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.web.rollingUpdate.maxSurge }}
   selector:
     matchLabels:
       {{- include "fortymm-uat.selector" (dict "component" "web") | nindent 6 }}

--- a/deploy/uat/values.yaml
+++ b/deploy/uat/values.yaml
@@ -15,6 +15,20 @@ images:
 
 pullPolicy: IfNotPresent
 
+# Stateless request-serving tiers scale horizontally with a zero-downtime
+# RollingUpdate. maxUnavailable: 0 keeps full capacity during a rollout (new
+# pods must go Ready before old ones are torn down); maxSurge adds headroom.
+api:
+  replicas: 5
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 2
+web:
+  replicas: 2
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
 # Non-secret runtime config (mirrors the `environment:` blocks in compose).
 config:
   DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm


### PR DESCRIPTION
Makes the UAT stack's two stateless request-serving tiers scale horizontally with a zero-downtime rolling update.

## What changed (`deploy/uat/`)
- `values.yaml` — `api.replicas: 5`, `web.replicas: 2`, plus per-tier `rollingUpdate` knobs (`maxUnavailable: 0`, `maxSurge: 2`/`1`).
- `templates/api.yaml` & `templates/web.yaml` — wired `replicas` + a `strategy: RollingUpdate` block from those values.

`maxUnavailable: 0` keeps full capacity during a rollout — new pods must pass readiness before old ones are torn down. Postgres/redis/worker/nginx are untouched (stateful/singleton by design).

Verified with `helm template` (api→5, web→2, both RollingUpdate) and `helm lint` (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)