### PR TITLE
Fix five mobile layout issues (#740, #731, #702, #74, #263)

### DIFF
--- a/web-client/e2e/design-system-avatar.spec.ts
+++ b/web-client/e2e/design-system-avatar.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+/** #263: the Avatar showcase must demo the IMAGE variant (a real
+ * `AvatarImage`, not just initials) and label it "image · initials · stack". */
+test.describe('Design System — Avatar showcase (#263)', () => {
+    test('shows the IMAGE variant and labels it image · initials · stack', async ({
+        page,
+    }) => {
+        await page.goto('/design-system');
+
+        const avatar = page.getByRole('region', { name: 'Avatar' });
+        await expect(avatar).toBeVisible();
+
+        // Tag now advertises the IMAGE variant.
+        await expect(avatar).toContainText('image · initials · stack');
+
+        // A real avatar image renders (Radix only shows the <img> once it
+        // loads; the data-URI source loads offline).
+        const image = avatar.locator('img[data-slot="avatar-image"]');
+        await expect(image).toBeVisible();
+
+        // Stack circles keep their ring separators (the pre-existing half of
+        // #263) — every overlapped avatar carries a ring.
+        const ringed = avatar.locator('[data-slot="avatar"].ring-2');
+        expect(await ringed.count()).toBeGreaterThanOrEqual(4);
+    });
+});

--- a/web-client/e2e/matches/mobile-callout.spec.ts
+++ b/web-client/e2e/matches/mobile-callout.spec.ts
@@ -1,0 +1,218 @@
+import { test, expect, Page, Locator } from '@playwright/test';
+import { matchDetails, sessionResponse } from '../../src/test/factories';
+import type { components } from '../../src/api/schema';
+
+type MatchDetails = components['schemas']['MatchDetails'];
+type MatchNegotiation = components['schemas']['MatchNegotiation'];
+
+const CORRECTED_ID = '00000000-0000-4000-8000-0000000007a0';
+const REVIEW_ID = '00000000-0000-4000-8000-0000000007b0';
+
+const ISO = '2026-01-01T00:00:00Z';
+
+const negGame = (n: number, s1: number, s2: number) => ({
+    game_number: n,
+    side_1_points: s1,
+    side_2_points: s2,
+});
+
+/** Rated match whose opponent countered the viewer's proposal: the `corrected`
+ * callout renders the ScoreDiff (a changed game + a NEW GAME row) above the
+ * stakes line — the exact #740 repro. */
+const correctedNegotiation = (): MatchNegotiation => ({
+    viewer_state: 'corrected',
+    your_turn: true,
+    standing_result: {
+        id: '00000000-0000-4000-8000-0000000007a1',
+        games: [negGame(1, 9, 11), negGame(2, 11, 5), negGame(3, 11, 8)],
+        submitted_by: '00000000-0000-4000-8000-0000000007a2',
+        submitted_at: ISO,
+    },
+    prior_result: {
+        id: '00000000-0000-4000-8000-0000000007a3',
+        games: [negGame(1, 11, 7), negGame(2, 11, 5)],
+        submitted_by: '00000000-0000-4000-8000-0000000007a4',
+        submitted_at: ISO,
+    },
+    diff: [
+        { game_number: 1, old: negGame(1, 11, 7), new: negGame(1, 9, 11) },
+        { game_number: 3, old: null, new: negGame(3, 11, 8) },
+    ],
+});
+
+const reviewNegotiation = (): MatchNegotiation => ({
+    viewer_state: 'review',
+    your_turn: true,
+    standing_result: {
+        id: '00000000-0000-4000-8000-0000000007b1',
+        games: [negGame(1, 11, 7), negGame(2, 11, 5), negGame(3, 11, 8)],
+        submitted_by: '00000000-0000-4000-8000-0000000007b2',
+        submitted_at: ISO,
+    },
+    prior_result: null,
+    diff: null,
+});
+
+const negotiatingMatch = (
+    id: string,
+    negotiation: MatchNegotiation,
+): MatchDetails =>
+    matchDetails({
+        id,
+        status: 'in_progress',
+        status_label: 'Live',
+        affects_rating: true,
+        can_score: false,
+        current_game: null,
+        negotiation,
+    });
+
+class Harness {
+    constructor(private readonly page: Page) {}
+
+    async mock(match: MatchDetails) {
+        await this.page.route('**/api/v1/session', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify(
+                    sessionResponse({ user: { username: 'rita.kovac' } }),
+                ),
+            }),
+        );
+        await this.page.route(`**/api/v1/matches/${match.id}`, (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify(match),
+            }),
+        );
+    }
+
+    goTo(id: string) {
+        return this.page.goto(`/matches/${id}`);
+    }
+}
+
+type Box = { x: number; y: number; width: number; height: number };
+
+const boxOf = async (loc: Locator): Promise<Box> => {
+    const box = await loc.boundingBox();
+    if (!box) throw new Error('element not visible / no box');
+    return box;
+};
+
+/** Vertical overlap in px between two boxes (>0 means they collide). */
+const vOverlap = (a: Box, b: Box): number =>
+    Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y);
+
+/** Relative luminance (0=black, 1=white) of an element's computed text color.
+ * Guards #740/#731: the stakes helper text used `--muted` (a dark *surface*
+ * token, ~0.02 luminance) and read as "hidden behind" the box — legible muted
+ * text (`--muted-foreground`, a light chalk grey) sits well above 0.3. */
+const textLuminance = (loc: Locator): Promise<number> =>
+    loc.evaluate((el) => {
+        const m = getComputedStyle(el)
+            .color.match(/[\d.]+/g)!
+            .map(Number);
+        const [r, g, b] = m.map((c) => {
+            const s = c / 255;
+            return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+        });
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    });
+
+test.use({ viewport: { width: 375, height: 667 } });
+
+test.describe('Mobile sign-off callout layout (375px)', () => {
+    test('corrected: diff box, stakes line, and actions do not overlap', async ({
+        page,
+    }, testInfo) => {
+        const h = new Harness(page);
+        await h.mock(negotiatingMatch(CORRECTED_ID, correctedNegotiation()));
+        await h.goTo(CORRECTED_ID);
+
+        const callout = page.getByTestId('match-confirm-callout');
+        await expect(callout).toBeVisible();
+
+        const diff = page.getByTestId('score-diff');
+        const stakes = callout.locator('.md-confirm-callout__stakes');
+        const accept = callout.getByRole('button', { name: /Accept/ });
+        const counter = callout.getByRole('link', { name: /Counter/ });
+
+        await expect(diff).toBeVisible();
+        await expect(stakes).toBeVisible();
+
+        await page.screenshot({
+            path: testInfo.outputPath('corrected-mobile.png'),
+            fullPage: true,
+        });
+
+        const [diffBox, stakesBox, acceptBox, counterBox] = await Promise.all([
+            boxOf(diff),
+            boxOf(stakes),
+            boxOf(accept),
+            boxOf(counter),
+        ]);
+
+        // #740: the diff box must sit fully above the stakes paragraph.
+        expect(
+            vOverlap(diffBox, stakesBox),
+            'score-diff overlaps the stakes line',
+        ).toBeLessThanOrEqual(0);
+        // #731: the stakes helper text must clear the Accept/Counter row.
+        expect(
+            vOverlap(stakesBox, acceptBox),
+            'stakes line overlaps the Accept button',
+        ).toBeLessThanOrEqual(0);
+        expect(
+            vOverlap(stakesBox, counterBox),
+            'stakes line overlaps the Counter link',
+        ).toBeLessThanOrEqual(0);
+        // #740/#731: the helper text must be legible, not near-invisible.
+        expect(
+            await textLuminance(stakes),
+            'stakes helper text is too low-contrast to read',
+        ).toBeGreaterThan(0.3);
+    });
+
+    test('review: stakes line does not overlap the actions row', async ({
+        page,
+    }, testInfo) => {
+        const h = new Harness(page);
+        await h.mock(negotiatingMatch(REVIEW_ID, reviewNegotiation()));
+        await h.goTo(REVIEW_ID);
+
+        const callout = page.getByTestId('match-confirm-callout');
+        await expect(callout).toBeVisible();
+
+        const stakes = callout.locator('.md-confirm-callout__stakes');
+        const accept = callout.getByRole('button', { name: /Accept/ });
+        const correct = callout.getByRole('link', { name: /Suggest correction/ });
+
+        await expect(stakes).toBeVisible();
+        await page.screenshot({
+            path: testInfo.outputPath('review-mobile.png'),
+            fullPage: true,
+        });
+
+        const [stakesBox, acceptBox, correctBox] = await Promise.all([
+            boxOf(stakes),
+            boxOf(accept),
+            boxOf(correct),
+        ]);
+
+        expect(
+            vOverlap(stakesBox, acceptBox),
+            'stakes line overlaps the Accept button',
+        ).toBeLessThanOrEqual(0);
+        expect(
+            vOverlap(stakesBox, correctBox),
+            'stakes line overlaps the Suggest correction link',
+        ).toBeLessThanOrEqual(0);
+        expect(
+            await textLuminance(stakes),
+            'stakes helper text is too low-contrast to read',
+        ).toBeGreaterThan(0.3);
+    });
+});

--- a/web-client/e2e/matches/mobile-match-list-scroll.spec.ts
+++ b/web-client/e2e/matches/mobile-match-list-scroll.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+import {
+    matchListResponse,
+    matchListRow,
+    sessionResponse,
+} from '../../src/test/factories';
+
+const SESSION = sessionResponse({ user: { username: 'rita.kovac' } });
+
+/** Enough cards that the list is taller than a 375×667 phone viewport. */
+const ROWS = Array.from({ length: 8 }, (_, i) =>
+    matchListRow({
+        id: `m-${i}`,
+        opponent: `opponent.${i}`,
+        status: 'in_progress',
+        status_label: 'Live',
+        current_game_number: 2,
+    }),
+);
+
+async function installListMock(page: Page) {
+    await page.route('**/api/v1/**', (route: Route) => {
+        const path = new URL(route.request().url()).pathname.replace(
+            /^\/api/,
+            '',
+        );
+        if (path === '/v1/session') {
+            return route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify(SESSION),
+            });
+        }
+        if (path === '/v1/matches' && route.request().method() === 'GET') {
+            return route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify(
+                    matchListResponse({ items: ROWS, total: ROWS.length }),
+                ),
+            });
+        }
+        return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+}
+
+test.use({ viewport: { width: 375, height: 667 } });
+
+test.describe('Mobile /matches scroll (#702)', () => {
+    test('the whole page scrolls; the card list is not trapped in a short inner window', async ({
+        page,
+    }, testInfo) => {
+        await installListMock(page);
+        await page.goto('/matches');
+
+        // Cards rendered.
+        const rows = page.locator('table.matches tbody tr');
+        await expect(rows.first()).toBeVisible();
+        expect(await rows.count()).toBe(ROWS.length);
+
+        await page.screenshot({
+            path: testInfo.outputPath('matches-mobile.png'),
+            fullPage: true,
+        });
+
+        // The `.table-wrap` must NOT be the scroll container: with page-scroll
+        // it grows to its content instead of clipping the list into a ~283px
+        // window. Allow 1px for rounding.
+        const wrap = page.locator('.table-wrap');
+        const wrapClipped = await wrap.evaluate(
+            (el) => el.scrollHeight - el.clientHeight,
+        );
+        expect(
+            wrapClipped,
+            '.table-wrap still clips the card list into an inner scroll window',
+        ).toBeLessThanOrEqual(1);
+
+        // The document itself scrolls (the list is taller than the viewport).
+        const docScrollable = await page.evaluate(
+            () =>
+                document.documentElement.scrollHeight > window.innerHeight + 1,
+        );
+        expect(docScrollable, 'the page as a whole does not scroll').toBe(true);
+
+        // The sticky topbar stays pinned after scrolling to the bottom.
+        await page.evaluate(() =>
+            window.scrollTo(0, document.documentElement.scrollHeight),
+        );
+        const topbar = page.locator('.app-shell__topbar');
+        const box = await topbar.boundingBox();
+        expect(box, 'topbar has no box').not.toBeNull();
+        expect(
+            Math.abs(box!.y),
+            'topbar did not stay pinned to the viewport top',
+        ).toBeLessThanOrEqual(2);
+    });
+});

--- a/web-client/e2e/matches/mobile-summary.spec.ts
+++ b/web-client/e2e/matches/mobile-summary.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { player } from '../../src/test/factories';
+import { NewMatchPage } from '../page-objects/matches/new-match.page';
+
+test.use({ viewport: { width: 375, height: 667 } });
+
+/** A single unbreakable token wider than a 375px column — the #74 repro. */
+const LONG_OPPONENT = player({
+    username: 'maximiliana_von_habsburg_longnametest',
+});
+
+test.describe('Mobile New Match summary line (375px)', () => {
+    test('long opponent name wraps instead of clipping mid-word', async ({
+        page,
+    }, testInfo) => {
+        const nm = await NewMatchPage.open(page, { players: [LONG_OPPONENT] });
+        await nm.pickPlayer(LONG_OPPONENT.username);
+
+        await expect(nm.summaryTop).toBeVisible();
+        await expect(nm.summaryTop).toContainText(LONG_OPPONENT.username);
+
+        await page.screenshot({
+            path: testInfo.outputPath('summary-long-name-mobile.png'),
+            fullPage: true,
+        });
+
+        // The line must not overflow its column — i.e. it wrapped rather than
+        // being clipped mid-word. Allow 1px for sub-pixel rounding.
+        const overflow = await nm.summaryTop.evaluate(
+            (el) => el.scrollWidth - el.clientWidth,
+        );
+        expect(overflow, 'summary top line overflows its column').toBeLessThanOrEqual(1);
+    });
+});

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
@@ -30,7 +30,7 @@ export interface ConfirmationCalloutDisplayProps {
 /** The rated/unrated stakes line, shared by the review + corrected callouts. */
 function StakesLine({ rated }: { rated: boolean }) {
   return (
-    <p className="md-confirm-callout__stakes text-xs text-[color:var(--muted)]">
+    <p className="md-confirm-callout__stakes text-xs text-[color:var(--muted-foreground)]">
       {rated
         ? "Accepting finalizes this rated match and updates both ratings."
         : "Accepting finalizes this match. It doesn't affect ratings."}

--- a/web-client/src/components/matches/match-list/match-list.css
+++ b/web-client/src/components/matches/match-list/match-list.css
@@ -188,6 +188,26 @@
    * tell when the table is actually too narrow. */
   container-type: inline-size;
 }
+/* On a phone the page opts out of the viewport-fixed inner-scroll layout: each
+ * card is ~5× taller than a table row, so squeezing the list through the
+ * ~283px `.table-wrap` window showed only ~1 card at a time (#702). Below 640px
+ * let the whole page scroll instead — drop the fixed height + inner overflow so
+ * the card list flows into the document scroll (the app-shell topbar is
+ * `position: sticky`, so it stays pinned as the page scrolls). The card layout
+ * itself is a container query on `.table-wrap`, which keeps firing without the
+ * overflow, and the pagination footer simply flows to the end of the list.
+ * Above 640px the scrolling table (and its 640–960px horizontal scroll) is
+ * untouched. */
+@media (max-width: 640px) {
+  .match-list-page {
+    height: auto;
+    overflow: visible;
+  }
+  .match-list-page .table-wrap {
+    flex: none;
+    overflow: visible;
+  }
+}
 .match-list-page table.matches {
   width: 100%;
   border-collapse: separate;

--- a/web-client/src/routes/_app/matches/new.css
+++ b/web-client/src/routes/_app/matches/new.css
@@ -716,6 +716,10 @@
   font: 600 16px var(--font-ui);
   letter-spacing: 0.01em;
   color: var(--fg-1);
+  /* A long opponent username is a single unbreakable token that, at 375px,
+     overflowed the flex column and clipped mid-word (#74). Let it wrap at any
+     point so the summary flows onto multiple lines instead of being cut off. */
+  overflow-wrap: anywhere;
 }
 .nm-summary .read .top .opp-tbd {
   font-weight: 500;

--- a/web-client/src/routes/design-system.tsx
+++ b/web-client/src/routes/design-system.tsx
@@ -29,7 +29,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { AspectRatio } from '@/components/ui/aspect-ratio'
-import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import {
   Breadcrumb,
@@ -202,6 +202,12 @@ export const Route = createFileRoute('/design-system')({
   }),
   component: DesignSystemPage,
 })
+
+/** Inline SVG avatar for the Avatar IMAGE-variant demo (#263). A data URI keeps
+ * the showcase self-contained — no network fetch, so it renders identically
+ * offline and in the e2e run instead of falling back to initials. */
+const DEMO_AVATAR_SRC =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' fill='%233a4a6e'/%3E%3Ccircle cx='32' cy='25' r='13' fill='%23e9edf5'/%3E%3Crect x='11' y='42' width='42' height='24' rx='12' fill='%23e9edf5'/%3E%3C/svg%3E"
 
 function Section({
   id,
@@ -699,8 +705,14 @@ function DataDisplaySection() {
         </div>
       </Showcase>
 
-      <Showcase title="Avatar" tag="initials · stack">
+      <Showcase title="Avatar" tag="image · initials · stack">
         <div className="flex flex-wrap items-center gap-6">
+          <div className="flex items-center gap-3">
+            <Avatar className="size-14 text-base">
+              <AvatarImage src={DEMO_AVATAR_SRC} alt="" />
+              <AvatarFallback>IMG</AvatarFallback>
+            </Avatar>
+          </div>
           <div className="flex items-center gap-3">
             <Avatar className="size-7 text-xs">
               <AvatarFallback>TN</AvatarFallback>


### PR DESCRIPTION
Five mobile (375px) layout/legibility fixes. Each is locked by a new headless-Playwright regression spec that fails on the old code and passes on the fix.

## Fixes

**#740 + #731 — sign-off callout "Accepting finalizes…" stakes line**
Reported as the diff box "overlapping" / the helper text "clipped behind" the buttons — but reproducing the exact repro at 375px shows the bounding boxes do **not** intersect. The root cause is contrast, not geometry: the stakes line painted text in `--muted`, which resolves to `--ink-700`, a dark **surface** token (not a text token). So the copy rendered near-invisible on the dark card and QA read it as "hidden behind." Switched to `--muted-foreground` (legible chalk grey). The spec asserts both non-overlap **and** text luminance.

**#702 — mobile `/matches` card list trapped in a ~283px inner-scroll window**
Below 640px, drop the viewport-fixed height + inner overflow on `.match-list-page` / `.table-wrap` so the whole page scrolls; the app-shell topbar is `position: sticky` and stays pinned. The card layout is a container query on `.table-wrap`, so it keeps firing without the overflow.

**#74 — New Match summary line clipped a long opponent username mid-word**
Added `overflow-wrap: anywhere` to `.nm-summary .top`, matching the existing `.nm-no-match` precedent.

**#263 — `/design-system` Avatar showcase missing the IMAGE variant**
Added an `AvatarImage` example (inline-SVG data URI, renders offline) and updated the tag to "image · initials · stack". Stack ring-separators were already present.

## Verification
- `tsc -b` clean, lint clean
- vitest: 1111 passed
- e2e: 39 passed (incl. 4 new specs: `mobile-callout`, `mobile-match-list-scroll`, `mobile-summary`, `design-system-avatar`)

## Notes
- Not touched: **#218** (unify panel/card styles) is a desktop restyle epic needing design judgment, out of scope for this branch.
- Discovered sibling bug out of scope: the selected-opponent chip (`.nm-selected .name`) still clips behind "Change" at 375px — a different element from #74's summary line.

Closes #740
Closes #731
Closes #702
Closes #74
Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018je8HDLpCJbHKQfZYDJBXN