### PR TITLE
Declare uq_match_results_supersedes_result_id on the MatchResult model

### DIFF
--- a/api/app/models/match_result.py
+++ b/api/app/models/match_result.py
@@ -2,7 +2,15 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, func, text
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    UniqueConstraint,
+    func,
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -38,6 +46,13 @@ class MatchResult(Base):
         CheckConstraint(
             "(accepted_by_user_id IS NULL) = (accepted_at IS NULL)",
             name="ck_match_results_accepted_pair",
+        ),
+        # Bounds each proposal to at most one successor so the negotiation chain
+        # stays linear: two concurrent counters to the same parent collide and
+        # one 409s on the IntegrityError. Mirrors the production migration.
+        UniqueConstraint(
+            "supersedes_result_id",
+            name="uq_match_results_supersedes_result_id",
         ),
     )
 

--- a/api/tests/test_match_result_model.py
+++ b/api/tests/test_match_result_model.py
@@ -1,0 +1,71 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.leagues import get_default_league
+from app.models import (
+    Match,
+    MatchResult,
+    MatchSettings,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    User,
+)
+
+
+async def _make_match(db: AsyncSession, creator: User) -> Match:
+    league = await get_default_league(db)
+    settings = MatchSettings(team_size=1, best_of=5, affects_rating=False)
+    match = Match(
+        match_settings=settings,
+        league=league,
+        created_by_user_id=creator.id,
+        status=MatchStatus.in_progress,
+    )
+    side = MatchSide(match=match, side_number=1)
+    side.players.append(MatchSidePlayer(match=match, user=creator))
+    db.add(match)
+    await db.commit()
+    await db.refresh(match)
+    return match
+
+
+async def test_supersedes_result_id_is_unique(db_session: AsyncSession):
+    """The metadata-built schema must encode the linear result-chain invariant:
+    a proposal can have at most one successor. Two counters pointing at the same
+    parent violate ``uq_match_results_supersedes_result_id`` and one collides —
+    the same IntegrityError the concurrent-counter code path relies on."""
+    creator = User(username="alice")
+    db_session.add(creator)
+    await db_session.commit()
+
+    match = await _make_match(db_session, creator)
+
+    base = MatchResult(
+        match_id=match.id,
+        submitted_by_user_id=creator.id,
+        games=[],
+    )
+    db_session.add(base)
+    await db_session.commit()
+    await db_session.refresh(base)
+
+    db_session.add(
+        MatchResult(
+            match_id=match.id,
+            submitted_by_user_id=creator.id,
+            games=[],
+            supersedes_result_id=base.id,
+        )
+    )
+    db_session.add(
+        MatchResult(
+            match_id=match.id,
+            submitted_by_user_id=creator.id,
+            games=[],
+            supersedes_result_id=base.id,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()


### PR DESCRIPTION
## Problem

The result-chain invariant — a `MatchResult` can have at most one successor, so the negotiation chain stays linear — is enforced in production by `uq_match_results_supersedes_result_id` (migration `20260514_0000_0004_create_match_tables.py`). The SQLAlchemy model didn't declare it, and tests build schema from `Base.metadata.create_all`, so the test schema silently lacked the constraint the concurrent-counter code path relies on.

## Change

- `api/app/models/match_result.py`: add `UniqueConstraint("supersedes_result_id", name="uq_match_results_supersedes_result_id")` to `__table_args__` (plus the `UniqueConstraint` import). Migration left unchanged — production already has it.
- `api/tests/test_match_result_model.py`: focused test proving the metadata-created schema rejects two rows sharing a non-null `supersedes_result_id` with an `IntegrityError`. Verified it fails without the constraint and passes with it.

## Checks (from `api/`)

- `ruff check app tests` — pass
- `ruff format --check app tests` — pass
- `mypy` — pass (78 files)
- `pytest tests/test_match_result_model.py` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)