### PR TITLE
Stop /v1/health from blocking the event loop on the solver probe

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import secrets
@@ -114,7 +115,7 @@ async def health() -> HealthResponse:
     return HealthResponse(
         redis=_check_redis(),
         database=await _check_database(),
-        solver=_check_solver(),
+        solver=await asyncio.to_thread(_check_solver_sync),
     )
 
 
@@ -140,7 +141,9 @@ async def _check_database() -> ComponentHealth:
     return ComponentHealth(healthy=True, latency_ms=_elapsed_ms(started))
 
 
-def _check_solver() -> ComponentHealth:
+def _check_solver_sync() -> ComponentHealth:
+    """Blocking solver probe — polls RQ with ``time.sleep``, so callers must
+    run it off the event loop (e.g. ``await asyncio.to_thread(...)``)."""
     started = time.monotonic()
     try:
         job = queue.get_queue().enqueue("app.solver.solve_hello_world", job_timeout=10)

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -47,6 +47,38 @@ def test_health_reports_redis_and_solver_unhealthy_when_queue_unavailable(monkey
     assert body["database"]["healthy"] is True
 
 
+def test_health_awaits_solver_check_via_to_thread(monkeypatch):
+    """The solver probe is blocking (RQ polling with time.sleep), so `health()`
+    must hand it to `asyncio.to_thread` rather than calling it inline."""
+    import asyncio
+
+    async def fake_db_check():
+        return ComponentHealth(healthy=True, latency_ms=1.0)
+
+    monkeypatch.setattr(main_module, "_check_database", fake_db_check)
+
+    def fake_solver_check():
+        return ComponentHealth(healthy=True, latency_ms=5.0)
+
+    monkeypatch.setattr(main_module, "_check_solver_sync", fake_solver_check)
+
+    to_thread_calls = []
+    real_to_thread = asyncio.to_thread
+
+    async def spying_to_thread(func, /, *args, **kwargs):
+        to_thread_calls.append(func)
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(main_module.asyncio, "to_thread", spying_to_thread)
+
+    response = client.get("/v1/health")
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["solver"] == {"healthy": True, "latency_ms": 5.0, "error": None}
+    assert to_thread_calls == [fake_solver_check]
+
+
 def test_health_reports_database_unhealthy_when_engine_broken(monkeypatch):
     class BrokenEngine:
         def connect(self):


### PR DESCRIPTION
## Summary
- `_check_solver` polled RQ with `time.sleep(0.1)` for up to `SOLVER_HEALTH_TIMEOUT` (10s) seconds, called inline from the async `health()` route — parking the FastAPI event loop for that long whenever the solver worker is missing or slow.
- Renamed it to `_check_solver_sync` and call it from `health()` via `await asyncio.to_thread(_check_solver_sync)`, moving the blocking poll off the event loop. Response shape (`HealthResponse`/`ComponentHealth`) is unchanged.
- Left `_check_redis`/`_check_database` as-is — the redis ping is a single fast call, not a polling loop, and `_check_database` is already async.

## Test plan
- [x] `ruff check app tests`
- [x] `mypy`
- [x] `pytest tests/test_health.py` (4 passed) — added `test_health_awaits_solver_check_via_to_thread`, which spies on `asyncio.to_thread` to confirm `health()` hands `_check_solver_sync` to it rather than calling it inline
- [x] Full `pytest` suite (527 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS4vCfxXEZwxQctXz1jyGQ