### PR TITLE
Compact the MSW mock board before checking can_finalize (ADR 0002)

### DIFF
--- a/web-client/src/mocks/match-store.test.ts
+++ b/web-client/src/mocks/match-store.test.ts
@@ -1,0 +1,59 @@
+import {
+  newMatchSeed,
+  projectMatchDetails,
+  type SeedGame,
+} from '@/mocks/match-store'
+
+/** Builds the scratchpad games array for a seed: one entry per scored game,
+ * left as-is (gaps and all) so tests can exercise the store's own compaction. */
+function scoredGames(
+  scores: { game_number: number; side_1_points: number; side_2_points: number }[],
+): SeedGame[] {
+  return scores.map((s) => ({
+    id: `g-${s.game_number}`,
+    game_number: s.game_number,
+    score: {
+      id: `s-${s.game_number}`,
+      side_1_points: s.side_1_points,
+      side_2_points: s.side_2_points,
+    },
+  }))
+}
+
+describe('canFinalizeSeed (via projectMatchDetails)', () => {
+  it('reports finalizable for a gappy-but-decided board — an out-of-order clinch that left a hole, matching the API compaction (ADR 0002)', () => {
+    const seed = newMatchSeed({
+      bestOf: 5,
+      rated: false,
+      opponent: { id: 'u-opp', username: 'rival' },
+    })
+    // Side 1 clinches at game 5 (3rd win) while game 4 was never scored —
+    // saved board is [1,2,3,5].
+    seed.games = scoredGames([
+      { game_number: 1, side_1_points: 11, side_2_points: 7 },
+      { game_number: 2, side_1_points: 11, side_2_points: 8 },
+      { game_number: 3, side_1_points: 9, side_2_points: 11 },
+      { game_number: 5, side_1_points: 11, side_2_points: 6 },
+    ])
+
+    expect(projectMatchDetails(seed).can_finalize).toBe(true)
+  })
+
+  it('reports not finalizable for a real overrun — games scored after the decider', () => {
+    const seed = newMatchSeed({
+      bestOf: 5,
+      rated: false,
+      opponent: { id: 'u-opp', username: 'rival' },
+    })
+    // Side 1 clinches at game 3 (3rd win) but game 4 is also scored — an
+    // impossible "kept playing after winning" board.
+    seed.games = scoredGames([
+      { game_number: 1, side_1_points: 11, side_2_points: 7 },
+      { game_number: 2, side_1_points: 11, side_2_points: 8 },
+      { game_number: 3, side_1_points: 11, side_2_points: 9 },
+      { game_number: 4, side_1_points: 11, side_2_points: 6 },
+    ])
+
+    expect(projectMatchDetails(seed).can_finalize).toBe(false)
+  })
+})

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -1,4 +1,5 @@
 import type { components } from '@/api/schema'
+import { compactGames, isDecidedMatch } from '@/lib/scoring'
 
 type MatchStatus = components['schemas']['MatchStatus']
 type MatchDetails = components['schemas']['app__schemas__match__MatchDetails']
@@ -330,7 +331,10 @@ function scorableSeed(seed: SeedMatch): boolean {
 
 /** Whether the currently-saved scores form a complete, validly-ordered,
  * decided match — i.e. the FIRST ``POST /results`` would succeed against the
- * current scratchpad state. Mirrors the server's ``_can_finalize`` predicate. */
+ * current scratchpad state. Mirrors the server's ``_can_finalize`` predicate,
+ * including its compaction of a gappy-but-decided board (ADR 0002): an
+ * out-of-order clinch that left a hole (e.g. ``[1,2,3,5]``) is closed up
+ * before validating, so it reports finalizable just like the API. */
 function canFinalizeSeed(seed: SeedMatch): boolean {
   if (seed.status !== 'in_progress' && seed.status !== 'disputed') return false
   // Once any result is posted, accept/counter is the next action, not a first
@@ -344,27 +348,7 @@ function canFinalizeSeed(seed: SeedMatch): boolean {
       side_2_points: g.score!.side_2_points,
     }))
   if (scored.length === 0) return false
-  const numbers = scored.map((g) => g.game_number).sort((a, b) => a - b)
-  if (numbers[numbers.length - 1] > seed.best_of) return false
-  for (let i = 0; i < numbers.length; i += 1) {
-    if (numbers[i] !== i + 1) return false
-  }
-  const target = gamesToWin(seed.best_of)
-  const ordered = scored
-    .slice()
-    .sort((a, b) => a.game_number - b.game_number)
-  let wins1 = 0
-  let wins2 = 0
-  let decidedAt: number | null = null
-  for (const g of ordered) {
-    if (g.side_1_points > g.side_2_points) wins1 += 1
-    else if (g.side_2_points > g.side_1_points) wins2 += 1
-    if (decidedAt === null && (wins1 >= target || wins2 >= target)) {
-      decidedAt = g.game_number
-    }
-  }
-  if (decidedAt === null) return false
-  return decidedAt === ordered[ordered.length - 1].game_number
+  return isDecidedMatch(compactGames(scored), seed.best_of)
 }
 
 function projectSides(seed: SeedMatch): {


### PR DESCRIPTION
## Summary
- ADR 0002 has the API compact a gappy-but-decided scratchpad board (an out-of-order clinch that left a hole, e.g. `[1,2,3,5]`) before validating `_can_finalize` — so it reports `can_finalize: true`.
- `web-client/src/mocks/match-store.ts`'s `canFinalizeSeed` rejected non-contiguous raw game numbers *before* any compaction, so dev/MSW disagreed with production for exactly that gappy-but-decided shape.
- Rewrote `canFinalizeSeed` to reuse the existing `compactGames`/`isDecidedMatch` helpers from `web-client/src/lib/scoring.ts` (which already mirror the server's `_compact_games`/`_validate_finalize_games`), instead of duplicating the raw contiguous-numbering/decider logic inline.
- Added `web-client/src/mocks/match-store.test.ts` covering both cases: a gappy `[1,2,3,5]` decided board now reports `can_finalize: true`, and a real overrun (games scored after the decider) still reports `false`.

## Test plan
- [x] `mise exec -- npm run lint` (no new errors; one pre-existing unrelated warning)
- [x] `mise exec -- npm run test:run -- src/mocks/match-store.test.ts` (2 passed)
- [x] `npx tsc -b` (clean)
- [x] Full `npm run test:run` (170 files / 1113 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS4vCfxXEZwxQctXz1jyGQ