### PR TITLE
Fix mutation-changed.ts to no-op cleanly on all-excluded diffs

### DIFF
--- a/web-client/scripts/mutation-changed.ts
+++ b/web-client/scripts/mutation-changed.ts
@@ -9,8 +9,11 @@
  * like `*.factory.{ts,tsx}` at the brace-internal comma.
  *
  * When no source file changed we exit 0 (not an error), which keeps this
- * usable as a non-blocking PR check. (A run whose changed files are all
- * excluded still starts, finds zero mutants, and exits cleanly.)
+ * usable as a non-blocking PR check. A run whose changed files are all
+ * excluded (e.g. a diff confined to `src/mocks/**`) still starts, but Stryker
+ * finds zero mutants and treats that as a `ConfigError` ("No tests were
+ * executed") rather than a clean no-op — we catch that specific message below
+ * and exit 0 too, since "nothing to mutate" isn't a mutation-testing failure.
  *
  * Run from the web-client/ directory (the npm script and CI both do).
  * Usage: node scripts/mutation-changed.ts [base-ref]   (defaults to origin/main)
@@ -47,6 +50,13 @@ console.log(changed.map((p) => `  ${p}`).join("\n"));
 try {
   await new Stryker({ mutate: [...changed, ...excludes] }).runMutationTest();
 } catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("No tests were executed")) {
+    console.log(
+      "All changed files fell under the config's exclusions — nothing to mutate.",
+    );
+    process.exit(0);
+  }
   console.error(error);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
PR #768's `web-client-mutation` CI check failed (not a required check, so it didn't block merge) on a diff confined to `src/mocks/**`. `stryker.config.mjs` deliberately excludes `src/mocks/**` from mutation, so `scripts/mutation-changed.ts` handed Stryker a `mutate` glob that matched zero files. Stryker's dry run then finds 0 mutants and throws `ConfigError: No tests were executed...` instead of the "starts, finds zero mutants, exits cleanly" behavior the script's own doc comment promised.

Reproduced locally: `npm run test:mutation:changed -- origin/main` against the #768 diff exits 1 with that exact error.

Fix: catch that specific `ConfigError` message in `mutation-changed.ts` and exit 0 — "nothing to mutate because everything changed is excluded" is a no-op, not a mutation-testing failure.

## Test plan
- [x] Reproduced the failure locally with `npm run test:mutation:changed -- origin/main` (mocks-only diff)
- [x] After the fix, same command logs the no-op message and exits 0
- [x] `mise exec -- npm run lint` (no new errors; one pre-existing unrelated warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS4vCfxXEZwxQctXz1jyGQ