### PR TITLE
Fix guest session race across concurrently opened tabs

### DIFF
--- a/e2e/tests/dashboard-session.spec.ts
+++ b/e2e/tests/dashboard-session.spec.ts
@@ -14,4 +14,28 @@ test.describe('Dashboard', () => {
         expect(session?.value).not.toBe('');
         expect(session?.httpOnly).toBe(true);
     });
+
+    test('opening several cold tabs at once mints only one guest session', async ({ context }) => {
+        // Regression for #824: each tab has its own QueryClient, so without an
+        // origin-wide singleflight every one of these would race
+        // `/v1/session` and mint its own guest, with the last `Set-Cookie`
+        // winning and the others left holding a stale identity.
+        const pages = await Promise.all([context.newPage(), context.newPage(), context.newPage()]);
+        const dashboards = await Promise.all(pages.map((page) => DashboardPage.navigateTo(page)));
+
+        for (const dashboard of dashboards) {
+            await expect(dashboard.userMenu.skeleton).not.toBeVisible();
+            await expect(dashboard.userMenu.menu).not.toContainText('Guest');
+        }
+
+        const usernames = await Promise.all(dashboards.map((dashboard) => dashboard.userMenu.menu.innerText()));
+        expect(new Set(usernames).size).toBe(1);
+
+        const cookies = await context.cookies();
+        const sessionCookies = cookies.filter((cookie) => cookie.name === 'session');
+        expect(sessionCookies).toHaveLength(1);
+        expect(sessionCookies[0]?.value).not.toBe('');
+
+        await Promise.all(pages.map((page) => page.close()));
+    });
 });

--- a/web-client/src/api/client.ts
+++ b/web-client/src/api/client.ts
@@ -82,6 +82,13 @@ function readCookie(name: string): string | null {
   return null
 }
 
+/** True once the double-submit CSRF cookie is readable — i.e. some request has
+ * already completed the session bootstrap and the browser has a cookie jar to
+ * show for it. */
+export function hasCsrfCookie(): boolean {
+  return readCookie(CSRF_COOKIE_NAME) !== null
+}
+
 api.use({
   // Double-submit CSRF: echo the server-set `csrf_token` cookie back in a
   // header on every mutating request. The backend (app/main.py:csrf_protect)

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -4,7 +4,7 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query'
-import { ApiError, api, unwrap } from './client'
+import { ApiError, api, hasCsrfCookie, unwrap } from './client'
 import { clearAppEntered } from '@/lib/landing-redirect'
 import type { components } from './schema'
 
@@ -13,11 +13,86 @@ export type SessionUser = components['schemas']['SessionUser']
 
 export const SESSION_QUERY_KEY = ['session'] as const
 
+// TanStack Query only single-flights `/v1/session` within one tab's
+// QueryClient. Several cold tabs opened at once each have their own
+// QueryClient, so each fires its own request before the browser has a
+// `session` cookie, and each mints its own guest — the last `Set-Cookie` wins
+// and the other tabs are left holding a stale identity (#824). This lock
+// widens the singleflight to the whole origin for the one race that matters:
+// the cold bootstrap. Once a `csrf_token` cookie is readable, a session
+// already exists, so later calls skip the lock entirely.
+const SESSION_LOCK_NAME = 'fortymm:session-bootstrap'
+const SESSION_LOCK_STORAGE_KEY = 'fortymm:session-bootstrap:lock'
+const SESSION_LOCK_TTL_MS = 10_000
+const SESSION_LOCK_POLL_MS = 50
+
+interface StorageLockRecord {
+  owner: string
+  expires: number
+}
+
+function readStorageLock(): StorageLockRecord | null {
+  const raw = localStorage.getItem(SESSION_LOCK_STORAGE_KEY)
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as StorageLockRecord
+  } catch {
+    return null
+  }
+}
+
+// Fallback single-flight for browsers without the Web Locks API. localStorage
+// writes aren't atomic across tabs, so this can't guarantee mutual exclusion
+// the way `navigator.locks` does — but it narrows the race window to
+// milliseconds, and the TTL means a tab that crashes mid-bootstrap can never
+// wedge the others (they just wait out the TTL and proceed).
+async function withStorageLock<T>(fn: () => Promise<T>): Promise<T> {
+  const owner = `${Date.now()}-${Math.random()}`
+  const deadline = Date.now() + SESSION_LOCK_TTL_MS
+  for (;;) {
+    const held = readStorageLock()
+    if (!held || held.expires < Date.now()) {
+      localStorage.setItem(
+        SESSION_LOCK_STORAGE_KEY,
+        JSON.stringify({ owner, expires: Date.now() + SESSION_LOCK_TTL_MS }),
+      )
+      // Yield a tick, then re-read: narrows (but can't eliminate) the window
+      // where two tabs both saw no lock and both wrote.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      if (readStorageLock()?.owner === owner) break
+    }
+    if (Date.now() > deadline) break
+    if (hasCsrfCookie()) return fn()
+    await new Promise((resolve) => setTimeout(resolve, SESSION_LOCK_POLL_MS))
+  }
+  try {
+    return await fn()
+  } finally {
+    if (readStorageLock()?.owner === owner) {
+      localStorage.removeItem(SESSION_LOCK_STORAGE_KEY)
+    }
+  }
+}
+
+/** Single-flights the `/v1/session` cold-bootstrap request across every tab
+ * on the origin, not just within one TanStack QueryClient. */
+async function withSessionBootstrapLock<T>(fn: () => Promise<T>): Promise<T> {
+  // A session already exists — no mint race to guard against.
+  if (hasCsrfCookie()) return fn()
+  if (typeof navigator !== 'undefined' && navigator.locks?.request) {
+    return navigator.locks.request(SESSION_LOCK_NAME, () => fn())
+  }
+  if (typeof localStorage === 'undefined') return fn()
+  return withStorageLock(fn)
+}
+
 export function sessionQueryOptions() {
   return queryOptions({
     queryKey: SESSION_QUERY_KEY,
-    queryFn: async (): Promise<Session> =>
-      unwrap('load session', await api.GET('/v1/session')),
+    queryFn: (): Promise<Session> =>
+      withSessionBootstrapLock(async () =>
+        unwrap('load session', await api.GET('/v1/session')),
+      ),
     staleTime: 1000 * 60 * 5,
     // Don't retry a 401 (session merged away): the 401 already cleared the
     // cookie, so a retry would silently mint a *new* guest and race the

--- a/web-client/src/routes/_app/route.tsx
+++ b/web-client/src/routes/_app/route.tsx
@@ -7,10 +7,14 @@ import { sessionQueryOptions } from '@/api/session'
 /**
  * Pathless layout for every in-app surface. Its loader establishes the session
  * once — `ensureQueryData` mints (or loads) the guest and is single-flighted by
- * TanStack Query — and the route does not render its children until that
- * resolves. So the session cookie is set before any child loader or BFF query
- * fires, which keeps the displayed identity in sync with the cookie and stops
- * concurrent cold-load requests from each minting a different guest (#487).
+ * TanStack Query within this tab — and the route does not render its children
+ * until that resolves. So the session cookie is set before any child loader or
+ * BFF query fires, which keeps the displayed identity in sync with the cookie
+ * and stops concurrent cold-load requests *within one tab* from each minting a
+ * different guest (#487). Across tabs, the `queryFn` in `sessionQueryOptions`
+ * (api/session.ts) additionally single-flights the cold bootstrap
+ * origin-wide, so several tabs opened at once still converge on one guest
+ * (#824).
  *
  * Pathless (`_app`) → adds no URL segment, so child paths (`/dashboard`,
  * `/matches`, …) are unchanged. The chrome lives here so children render only


### PR DESCRIPTION
## Summary
- Opening several first-time-guest tabs at once each fired its own `/v1/session` request before any tab had a cookie yet, since TanStack Query's single-flight only applies within one tab's `QueryClient`. Each request minted a distinct guest and the last `Set-Cookie` won, leaving the other tabs holding a stale identity until reload.
- Added an origin-wide single-flight around the cold session bootstrap: `navigator.locks.request('fortymm:session-bootstrap', ...)` when available, with a `localStorage`-based TTL fallback for browsers without Web Locks (self-expires so a crashed tab can't wedge the others).
- The lock is skipped entirely once the readable `csrf_token` cookie exists — a session already exists at that point, so there's no mint race to guard against.

## Test plan
- [x] `npx vitest run` in `web-client/` — all 1113 existing tests pass
- [x] `npx tsc -b` in `web-client/` — clean
- [x] `npm run lint` in `web-client/` — clean
- [x] Added a Playwright regression test (`e2e/tests/dashboard-session.spec.ts`) that opens 3 tabs concurrently and asserts they converge on one guest username and one `session` cookie
- [x] Verified against a real docker QA stack (real API, MSW off): reverted the fix and confirmed the new test fails (3 distinct guest usernames), then restored the fix and confirmed it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnuqVGAxjNhqd35CVbKuGi