### PR TITLE
Fix score-cap drift, create-match cache invalidation, Started-column dates, and sign-in cache leak

### DIFF
--- a/web-client/src/api/matches.test.ts
+++ b/web-client/src/api/matches.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { http, HttpResponse } from 'msw'
-import { QueryClient } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
 
 import { server } from '@/mocks/server'
 import { matchDetails } from '@/test/factories'
@@ -10,6 +12,7 @@ import {
   matchQueryKey,
   matchQueryOptions,
   scoreMutationKey,
+  useCreateMatch,
 } from './matches'
 
 let queryClient: QueryClient
@@ -192,4 +195,33 @@ it('marks the match detail query stale on a rejected save (#564)', async () => {
   spy.mockRestore()
   // The error path invalidated the canonical match query key.
   expect(invalidations).toContainEqual(matchQueryKey(matchId))
+})
+
+describe('useCreateMatch', () => {
+  it('invalidates the matches-list and dashboard caches on success (#761)', async () => {
+    const created = matchDetails({ id: 'm-new' })
+    server.use(
+      http.post('*/v1/matches', () => HttpResponse.json(created, { status: 201 })),
+    )
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children)
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useCreateMatch(), { wrapper })
+    result.current.mutate({
+      opponent_user_id: 'u-op',
+      best_of: 5,
+      rated: false,
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['matches', 'list'],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['dashboard'],
+    })
+  })
 })

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -195,6 +195,8 @@ export function useCreateMatch() {
         matchDetailsQueryKey(created.id),
         matchDetailsResultFromPayload(created),
       )
+      queryClient.invalidateQueries({ queryKey: ['matches', 'list'] })
+      queryClient.invalidateQueries({ queryKey: DASHBOARD_QUERY_KEY })
     },
   })
 }

--- a/web-client/src/api/session.test.ts
+++ b/web-client/src/api/session.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+
+import { server } from '@/mocks/server'
+import {
+  SESSION_QUERY_KEY,
+  useConfirmEmail,
+  useConsumeLoginToken,
+} from './session'
+
+let queryClient: QueryClient
+
+beforeEach(() => {
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+})
+
+afterEach(() => {
+  queryClient.clear()
+  vi.restoreAllMocks()
+})
+
+function wrapperFor(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children)
+}
+
+// Regression for #754: a guest who has browsed the app (matches/dashboard
+// queries cached under the guest identity) must not keep seeing that data
+// after a magic-link/confirm-email sign-in lands them on a *different*
+// existing account (skip_merge) — the same leak `useLogout` already guards
+// against.
+describe('useConsumeLoginToken', () => {
+  it("clears the prior guest's caches before seeding the new session", async () => {
+    queryClient.setQueryData(['matches', 'list'], { stale: 'guest data' })
+    server.use(
+      http.post('*/v1/login/consume', () =>
+        HttpResponse.json({
+          data: { user: { id: 'u-2', username: 'new-user' } },
+        }),
+      ),
+    )
+
+    const { result } = renderHook(() => useConsumeLoginToken(), {
+      wrapper: wrapperFor(queryClient),
+    })
+    result.current.mutate({ token: 'tok' })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(queryClient.getQueryData(['matches', 'list'])).toBeUndefined()
+    expect(queryClient.getQueryData(SESSION_QUERY_KEY)).toMatchObject({
+      data: { user: { id: 'u-2' } },
+    })
+  })
+})
+
+describe('useConfirmEmail', () => {
+  it("clears the prior guest's caches before seeding the new session", async () => {
+    queryClient.setQueryData(['dashboard'], { stale: 'guest data' })
+    server.use(
+      http.post('*/v1/me/email/confirm', () =>
+        HttpResponse.json({
+          data: { user: { id: 'u-2', username: 'new-user' } },
+        }),
+      ),
+    )
+
+    const { result } = renderHook(() => useConfirmEmail(), {
+      wrapper: wrapperFor(queryClient),
+    })
+    result.current.mutate({ token: 'tok' })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(queryClient.getQueryData(['dashboard'])).toBeUndefined()
+    expect(queryClient.getQueryData(SESSION_QUERY_KEY)).toMatchObject({
+      data: { user: { id: 'u-2' } },
+    })
+  })
+})

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -157,7 +157,12 @@ export function useConfirmEmail() {
           body: { token, skip_merge: skipMerge },
         }),
       ),
+    // This can sign the caller into a *different* existing account
+    // (skip_merge). Drop the prior identity's cached per-user data first — the
+    // same leak useLogout guards against (#754) — then reseed the session so
+    // it doesn't need a refetch.
     onSuccess: (session) => {
+      qc.clear()
       qc.setQueryData(SESSION_QUERY_KEY, session)
     },
   })
@@ -218,7 +223,10 @@ export function useConsumeLoginToken() {
           body: { token, skip_merge: skipMerge },
         }),
       ),
+    // Same identity-leak guard as useConfirmEmail (#754): this can sign a
+    // browsing guest into a different existing account.
     onSuccess: (session) => {
+      qc.clear()
       qc.setQueryData(SESSION_QUERY_KEY, session)
     },
   })

--- a/web-client/src/components/matches/match-list/match-list-row-view.test.ts
+++ b/web-client/src/components/matches/match-list/match-list-row-view.test.ts
@@ -93,6 +93,28 @@ describe('formatCreatedAt', () => {
       created.toLocaleDateString(),
     )
   })
+
+  it('treats a zone-less UTC timestamp as UTC, like every other date helper (#760)', () => {
+    const now = new Date('2026-06-14T20:00:00Z')
+    expect(formatCreatedAt('2026-06-14T04:05:00', now)).toBe(
+      formatCreatedAt('2026-06-14T04:05:00Z', now),
+    )
+  })
+
+  it('buckets by calendar day, not a rolling 24h window (#760)', () => {
+    // Created just before midnight, viewed just after — a different calendar
+    // day only 90 minutes later, not "same day".
+    const created = new Date('2026-06-14T23:30:00')
+    const now = new Date('2026-06-15T01:00:00')
+    expect(formatCreatedAt(created.toISOString(), now)).toBe('yesterday')
+  })
+
+  it('counts calendar days elapsed, not full 24h periods (#760)', () => {
+    // ~28h apart but spans two midnights — 2 calendar days ago, not "yesterday".
+    const created = new Date('2026-06-13T23:00:00')
+    const now = new Date('2026-06-15T03:00:00')
+    expect(formatCreatedAt(created.toISOString(), now)).toBe('2d ago')
+  })
 })
 
 describe('projectMatchListRow', () => {

--- a/web-client/src/components/matches/match-list/match-list-row-view.ts
+++ b/web-client/src/components/matches/match-list/match-list-row-view.ts
@@ -1,6 +1,9 @@
+import { differenceInCalendarDays } from 'date-fns'
+
 import type { MatchListFilter, MatchListRow } from '@/api/matches'
 import type { components } from '@/api/schema'
 import { matchDetailRoute, scoringNewRoute } from '@/api/matches'
+import { parseApiDate } from '@/lib/dates'
 import { API_TO_TONE, STATUS_TONE, type StatusKey } from './match-list-status'
 import type {
   MatchListRowView,
@@ -97,8 +100,8 @@ export function shortId(id: string): string {
 /** Relative/absolute 'when' string for the Started column (was TimeCell's
  * body). Pure given a `now` it can default to new Date(). */
 export function formatCreatedAt(iso: string, now: Date = new Date()): string {
-  const created = new Date(iso)
-  const days = Math.floor((now.getTime() - created.getTime()) / 86400000)
+  const created = parseApiDate(iso)
+  const days = differenceInCalendarDays(now, created)
   if (days === 0) {
     const hh = String(created.getHours()).padStart(2, '0')
     const mm = String(created.getMinutes()).padStart(2, '0')

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -641,11 +641,11 @@ describe('ScoreEntry — create', () => {
     expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
   })
 
-  it('keeps a 3-digit entry intact instead of silently truncating to 2 digits', async () => {
-    // Regression for #442: typing "100" used to be cut to "10", then the
-    // win-by-2 check fired against a value the user never entered. The input
-    // now keeps up to 3 digits, so the score the user sees is the score the
-    // validation reasons about.
+  it('keeps a 2-digit entry intact instead of silently truncating to 1 digit', async () => {
+    // Regression for #442: typing a two-digit score used to be cut short,
+    // then the win-by-2 check fired against a value the user never entered.
+    // The input keeps the digits the user typed, so the score the user sees
+    // is the score the validation reasons about.
     const user = userEvent.setup()
     server.use(
       http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
@@ -657,20 +657,21 @@ describe('ScoreEntry — create', () => {
     })
     const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
 
-    await user.type(meInput, '100')
-    expect(meInput).toHaveValue('100')
+    await user.type(meInput, '15')
+    expect(meInput).toHaveValue('15')
 
     // The illegal-score hint references the typed value, not a mutated one:
-    // 100–97 is a deuce game that doesn't lead by exactly 2.
-    await user.type(oppInput, '97')
-    expect(oppInput).toHaveValue('97')
+    // 15–12 is a deuce game that doesn't lead by exactly 2.
+    await user.type(oppInput, '12')
+    expect(oppInput).toHaveValue('12')
     expect(screen.getByRole('alert')).toHaveTextContent(/leads by exactly 2/i)
 
-    // A 4th digit is no longer truncated to a plausible 3-digit score (#624):
+    // A 3rd digit is no longer truncated to a plausible 2-digit score (#624,
+    // #771 — the FE input caps at 99, matching the server's per-side cap):
     // the over-long value is kept verbatim and flagged as malformed instead.
     await user.clear(meInput)
-    await user.type(meInput, '1005')
-    expect(meInput).toHaveValue('1005')
+    await user.type(meInput, '100')
+    expect(meInput).toHaveValue('100')
     expect(meInput).toHaveAttribute('aria-invalid', 'true')
   })
 

--- a/web-client/src/components/matches/score-pad/validate-game-score.test.ts
+++ b/web-client/src/components/matches/score-pad/validate-game-score.test.ts
@@ -34,14 +34,20 @@ describe('validateGameScore', () => {
     const v = validateGameScore('11.5', '7')
     expect(v.meMalformed).toBe(true)
     expect(v.oppMalformed).toBe(false)
-    expect(v.error).toBe('Enter each score as a whole number from 0 to 999.')
+    expect(v.error).toBe('Enter each score as a whole number from 0 to 99.')
     expect(v.valid).toBe(false)
   })
 
   it('reports a format error for an over-long run of digits', () => {
-    const v = validateGameScore('11', '9999')
+    const v = validateGameScore('11', '999')
     expect(v.oppMalformed).toBe(true)
-    expect(v.error).toBe('Enter each score as a whole number from 0 to 999.')
+    expect(v.error).toBe('Enter each score as a whole number from 0 to 99.')
+  })
+
+  it('surfaces the illegal-score reason for a score above the 99 cap', () => {
+    const v = validateGameScore('101', '99')
+    expect(v.meMalformed).toBe(true)
+    expect(v.error).toBe('Enter each score as a whole number from 0 to 99.')
   })
 
   it('surfaces the illegal-score reason for a tie', () => {

--- a/web-client/src/components/matches/score-pad/validate-game-score.ts
+++ b/web-client/src/components/matches/score-pad/validate-game-score.ts
@@ -15,26 +15,27 @@ export interface GameScoreValidation {
   /** A hard error to surface (malformed digits, or an illegal final score), or
    * null when there's nothing to say yet. */
   error: string | null
-  /** The `me` field holds malformed text (not 1–3 digits). */
+  /** The `me` field holds malformed text (not 1–2 digits). */
   meMalformed: boolean
-  /** The `opp` field holds malformed text (not 1–3 digits). */
+  /** The `opp` field holds malformed text (not 1–2 digits). */
   oppMalformed: boolean
 }
 
 /**
  * Validate one game's two raw input strings (taken verbatim — see the #624
- * no-coercion note in the scratchpad entry). A side is well-formed only as 1–3
- * digits; both filled and well-formed are then run through the shared
- * `illegalScoreReason` table-tennis rule.
+ * no-coercion note in the scratchpad entry). A side is well-formed only as 1–2
+ * digits (server caps each side at 99, `api/app/schemas/match.py`); both
+ * filled and well-formed are then run through the shared `illegalScoreReason`
+ * table-tennis rule.
  */
 export function validateGameScore(me: string, opp: string): GameScoreValidation {
   const bothFilled = me !== '' && opp !== ''
   const oneSideFilled = (me !== '') !== (opp !== '')
-  const meMalformed = me !== '' && !/^\d{1,3}$/.test(me)
-  const oppMalformed = opp !== '' && !/^\d{1,3}$/.test(opp)
+  const meMalformed = me !== '' && !/^\d{1,2}$/.test(me)
+  const oppMalformed = opp !== '' && !/^\d{1,2}$/.test(opp)
   const formatError =
     meMalformed || oppMalformed
-      ? 'Enter each score as a whole number from 0 to 999.'
+      ? 'Enter each score as a whole number from 0 to 99.'
       : null
   const error =
     formatError ??

--- a/web-client/src/lib/scoring.test.ts
+++ b/web-client/src/lib/scoring.test.ts
@@ -82,6 +82,7 @@ describe('illegalScoreReason', () => {
     [12, 9, /both sides reach 10/i], // past 11 without a deuce
     [15, 10, /exactly 2/i], // deuce, but won by more than 2
     [13, 10, /exactly 2/i],
+    [101, 99, /at most 99/i], // above the server's per-side cap
   ])('rejects the illegal score %i–%i', (a, b, pattern) => {
     expect(illegalScoreReason(a, b)).toMatch(pattern)
   })

--- a/web-client/src/lib/scoring.ts
+++ b/web-client/src/lib/scoring.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 export function illegalScoreReason(a: number, b: number): string | null {
   const winner = Math.max(a, b)
   const loser = Math.min(a, b)
+  if (winner > 99) return 'Each side can score at most 99 points.'
   if (winner < 11) return 'The winning side must reach at least 11 points.'
   if (a === b) return 'A game cannot end in a tie.'
   if (winner === 11 && loser > 9)


### PR DESCRIPTION
## Summary
Four independent, self-contained web-client bugs from the 2026-07-01 whole-repo code-review round, fixed together since none touch the API/schema and none conflict:

- Fixes #771 — the FE score validation had no upper bound (accepted 0–999) while the server caps each side at 99, so a legal-looking `101–99` passed client validation and then 422'd on submit. `illegalScoreReason` now rejects `winner > 99`, and the raw-input regex/copy in `validate-game-score.ts` is tightened from 1–3 digits/"0 to 999" to 1–2 digits/"0 to 99".
- Fixes #761 — `useCreateMatch`'s `onSuccess` only seeded the detail cache; it now also invalidates `['matches','list']` and `DASHBOARD_QUERY_KEY` (mirroring `applyScoreMutationCache`), so a newly created match shows up in the list/dashboard immediately instead of waiting out `staleTime`.
- Fixes #760 — `formatCreatedAt` parsed the API timestamp with `new Date(iso)` directly (misparsing zone-less UTC values in the browser's local zone) and bucketed elapsed time with a rolling 24h window instead of a calendar-day diff. Now routes through the shared `parseApiDate` helper and buckets with `differenceInCalendarDays`.
- Fixes #754 — `useConsumeLoginToken` and `useConfirmEmail` only ever `setQueryData`'d the session on success, so a guest who had browsed the app and then signed into a *different* existing account (`skip_merge`) briefly saw the prior guest's cached matches/dashboard data. Both now `qc.clear()` before reseeding the session — the same guard `useLogout` already has.

## Test plan
- [x] `npm run test:run` — full suite passes (171 files / 1121 tests), including new/updated coverage for each fix
- [x] `npm run build` (tsc -b + vite build) passes
- [x] `npm run lint` — clean (one pre-existing unrelated warning in `mockServiceWorker.js`)

https://claude.ai/code/session_01RpaZFsFEuzH2RWr27Lai8h