### PR TITLE
Guard CorrectionEntry submit against same-frame double-tap (#737)

### DIFF
--- a/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
@@ -1,5 +1,6 @@
 import { HttpResponse } from "msw";
 import userEvent from "@testing-library/user-event";
+import { fireEvent } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
@@ -144,6 +145,35 @@ describe("CorrectionEntry", () => {
       ),
     );
     expect(correctionEntryPage.getInput("leo.mertens")).toHaveValue("6");
+  });
+
+  it('fires a single POST /results when "Send corrected score" is double-clicked in one frame (#737)', async () => {
+    // Mirrors score-entry's #641 regression test: a fast double-tap lands a
+    // second click before React commits the button's `disabled` re-render, so
+    // only the synchronous in-flight ref (not `proposeMutation.isPending`
+    // alone) can swallow the second tap. Two *synchronous* fireEvent clicks
+    // reproduce the same-frame race (awaited user-event clicks would let the
+    // `disabled` attr alone block the second, hiding the regression).
+    let requests = 0;
+    correctionEntryPage.mockMatch(() =>
+      HttpResponse.json(buildCorrectableMatch()),
+    );
+    correctionEntryPage.mockPropose(() => {
+      requests += 1;
+      // Never resolves — keeps the propose in flight so the test can count
+      // the POSTs the double-click produced.
+      return new Promise<never>(() => {});
+    });
+    correctionEntryPage.render();
+
+    await waitFor(() => correctionEntryPage.getInput("rita.kovac"));
+
+    const submit = correctionEntryPage.getSubmit();
+    fireEvent.click(submit);
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(submit).toBeDisabled());
+    expect(requests).toBe(1);
   });
 
   it("surfaces a 409 (the proposal moved on) inline without navigating away", async () => {

--- a/web-client/src/components/matches/correction-entry/correction-entry.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.tsx
@@ -79,6 +79,12 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
   const [selectedGameNumber, setSelectedGameNumber] = useState(1);
   const meRef = useRef<HTMLInputElement>(null);
   const oppRef = useRef<HTMLInputElement>(null);
+  // Synchronous double-submit guard, mirroring score-entry's `finalizingRef`
+  // (#641): `proposeMutation.isPending` is a render snapshot that only takes
+  // effect on the next commit, so a same-frame double-tap can land a second
+  // submit before React re-renders. This ref flips synchronously inside the
+  // submit gesture, so it catches the second tap even within the same frame.
+  const submittingRef = useRef(false);
 
   if (isLoading || !data) {
     return <div aria-busy="true" data-testid="correction-entry-loading" />;
@@ -214,10 +220,17 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
   }));
 
   function onSubmit() {
-    if (!canSubmit || proposeMutation.isPending) return;
+    if (!canSubmit) return;
+    if (proposeMutation.isPending || submittingRef.current) return;
+    submittingRef.current = true;
     proposeMutation.mutate(
       { games: correctedGames, supersedes_result_id: standingId },
-      { onSuccess: () => navigate(matchDetailRoute(matchId)) },
+      {
+        onSuccess: () => navigate(matchDetailRoute(matchId)),
+        onError: () => {
+          submittingRef.current = false;
+        },
+      },
     );
   }
 


### PR DESCRIPTION
## Summary
- `CorrectionEntry.onSubmit` only guarded against a duplicate submit via `proposeMutation.isPending`, a render snapshot that flips on the next commit — a same-frame double-tap on "Send corrected score" could fire two concurrent `POST /matches/{id}/results` with the same `supersedes_result_id`. The second 409s and surfaces a spurious "This proposal has moved on" alert.
- Mirrors the synchronous `finalizingRef` guard `score-entry.tsx` already uses for the same problem (#641/#550/#538): added a `submittingRef`, checked alongside `proposeMutation.isPending`, set inside the submit gesture, and cleared in `onError` (success navigates away).

Fixes #737.

## Test plan
- [x] Added a regression test mirroring score-entry's #641 test: two synchronous `fireEvent.click` calls on "Send corrected score" produce exactly one `POST /results`.
- [x] `npm run test -- src/components/matches/correction-entry/correction-entry.test.tsx` — 7/7 passing
- [x] `npm run build` (tsc + vite build) — passes
- [x] `npm run lint` — no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VE7VbfTC8XRvBi6aZbGWNd