### PR TITLE
Reject a merged-away opponent in create_match

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -624,7 +624,12 @@ async def create_match(
                 detail="You cannot start a match against yourself.",
             )
         opponent = (
-            await db.execute(select(User).where(User.id == payload.opponent_user_id))
+            await db.execute(
+                select(User).where(
+                    User.id == payload.opponent_user_id,
+                    User.merged_into_user_id.is_(None),
+                )
+            )
         ).scalar_one_or_none()
         if opponent is None:
             raise HTTPException(status_code=404, detail="Opponent not found.")

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -270,6 +270,29 @@ async def test_unknown_opponent_is_rejected(
     assert "opponent" in response.json()["detail"].lower()
 
 
+async def test_merged_away_opponent_is_rejected(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A tombstoned (merged-away) opponent must be treated like an unknown
+    one — a rated match must never be minted against a dead account."""
+    await start_session(api_client, db_session)
+    ghost = await make_user(db_session, "ghost")
+    survivor = await make_user(db_session, "survivor")
+    ghost.merged_into_user_id = survivor.id
+    await db_session.commit()
+
+    response = await api_client.post(
+        "/v1/matches",
+        json={
+            "opponent_user_id": str(ghost.id),
+            "best_of": 5,
+            "rated": True,
+        },
+    )
+    assert response.status_code == 404
+    assert "opponent" in response.json()["detail"].lower()
+
+
 async def test_even_best_of_is_rejected(
     api_client: AsyncClient, db_session: AsyncSession
 ):


### PR DESCRIPTION
## Summary
- `create_match` resolved the opponent with a plain `select(User).where(User.id == ...)`, missing the `merged_into_user_id.is_(None)` filter every other user lookup applies (`players.py`, `notifications/service.py`).
- A rated match could be minted against a tombstoned (merged-away) ghost account that its survivor would never see, and a fresh `UserLeagueRating` would be created on the ghost.
- Fix: filter `merged_into_user_id.is_(None)` when resolving the opponent, so a merged-away id now 404s like an unknown one.

## Test plan
- [x] Added `test_merged_away_opponent_is_rejected` — creates a ghost merged into a survivor, asserts `POST /v1/matches` 404s
- [x] `ruff check` / `ruff format --check` / `mypy` all pass
- [x] `pytest tests/test_matches.py` — 124 passed

Fixes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxSjK2qX5VZf57DaV4NKco