### PR TITLE
Add /v1/readyz so the UAT probe and smoke check catch broken deploys

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -134,8 +134,9 @@ async def readyz(response: Response) -> ReadyzResponse:
     gating readiness on it would pull the API pod out of rotation for every
     endpoint whenever just the worker restarts.
     """
-    redis_health = _check_redis()
-    database_health = await _check_database()
+    redis_health, database_health = await asyncio.gather(
+        asyncio.to_thread(_check_redis), _check_database()
+    )
     if not redis_health.healthy or not database_health.healthy:
         response.status_code = 503
     return ReadyzResponse(redis=redis_health, database=database_health)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -110,6 +110,11 @@ class HealthResponse(BaseModel):
     solver: ComponentHealth
 
 
+class ReadyzResponse(BaseModel):
+    redis: ComponentHealth
+    database: ComponentHealth
+
+
 @app.get("/v1/health")
 async def health() -> HealthResponse:
     return HealthResponse(
@@ -117,6 +122,23 @@ async def health() -> HealthResponse:
         database=await _check_database(),
         solver=await asyncio.to_thread(_check_solver_sync),
     )
+
+
+@app.get("/v1/readyz", include_in_schema=False)
+async def readyz(response: Response) -> ReadyzResponse:
+    """Machine-readable readiness gate for the k8s probe and deploy smoke
+    check. Unlike ``/v1/health`` (a diagnostic dashboard endpoint that always
+    returns 200), this returns 503 when a component the request path
+    actually depends on — redis, the database — is unhealthy. The solver is
+    deliberately excluded: it's an async RQ worker off the request path, and
+    gating readiness on it would pull the API pod out of rotation for every
+    endpoint whenever just the worker restarts.
+    """
+    redis_health = _check_redis()
+    database_health = await _check_database()
+    if not redis_health.healthy or not database_health.healthy:
+        response.status_code = 503
+    return ReadyzResponse(redis=redis_health, database=database_health)
 
 
 def _check_redis() -> ComponentHealth:

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -1,5 +1,7 @@
+import pytest
 from fastapi.testclient import TestClient
 
+from app import db as db_module
 from app import main as main_module
 from app import queue as queue_module
 from app.main import ComponentHealth, app
@@ -7,12 +9,39 @@ from app.main import ComponentHealth, app
 client = TestClient(app)
 
 
-def test_health_reports_all_components_healthy(monkeypatch):
+@pytest.fixture
+def healthy_database(monkeypatch):
+    """Stub `_check_database` to report healthy without touching a real DB."""
+
     async def fake_db_check():
-        return ComponentHealth(healthy=True, latency_ms=2.3)
+        return ComponentHealth(healthy=True, latency_ms=1.0)
 
     monkeypatch.setattr(main_module, "_check_database", fake_db_check)
 
+
+@pytest.fixture
+def broken_database(monkeypatch):
+    """Make `_check_database` report unhealthy via a `get_engine` that raises."""
+
+    class BrokenEngine:
+        def connect(self):
+            raise RuntimeError("postgres unreachable")
+
+    monkeypatch.setattr(db_module, "get_engine", BrokenEngine)
+
+
+@pytest.fixture
+def broken_redis(monkeypatch):
+    """Make `_check_redis` (and the solver check, which shares the queue
+    connection) report unhealthy via a `get_queue` that raises."""
+
+    def boom():
+        raise RuntimeError("redis unreachable")
+
+    monkeypatch.setattr(queue_module, "get_queue", boom)
+
+
+def test_health_reports_all_components_healthy(healthy_database):
     response = client.get("/v1/health")
     assert response.status_code == 200
     body = response.json()
@@ -25,17 +54,9 @@ def test_health_reports_all_components_healthy(monkeypatch):
     assert response.headers["content-type"] == "application/json"
 
 
-def test_health_reports_redis_and_solver_unhealthy_when_queue_unavailable(monkeypatch):
-    async def fake_db_check():
-        return ComponentHealth(healthy=True, latency_ms=1.0)
-
-    monkeypatch.setattr(main_module, "_check_database", fake_db_check)
-
-    def boom():
-        raise RuntimeError("redis unreachable")
-
-    monkeypatch.setattr(queue_module, "get_queue", boom)
-
+def test_health_reports_redis_and_solver_unhealthy_when_queue_unavailable(
+    healthy_database, broken_redis
+):
     response = client.get("/v1/health")
     assert response.status_code == 200
     body = response.json()
@@ -47,15 +68,10 @@ def test_health_reports_redis_and_solver_unhealthy_when_queue_unavailable(monkey
     assert body["database"]["healthy"] is True
 
 
-def test_health_awaits_solver_check_via_to_thread(monkeypatch):
+def test_health_awaits_solver_check_via_to_thread(healthy_database, monkeypatch):
     """The solver probe is blocking (RQ polling with time.sleep), so `health()`
     must hand it to `asyncio.to_thread` rather than calling it inline."""
     import asyncio
-
-    async def fake_db_check():
-        return ComponentHealth(healthy=True, latency_ms=1.0)
-
-    monkeypatch.setattr(main_module, "_check_database", fake_db_check)
 
     def fake_solver_check():
         return ComponentHealth(healthy=True, latency_ms=5.0)
@@ -79,15 +95,7 @@ def test_health_awaits_solver_check_via_to_thread(monkeypatch):
     assert to_thread_calls == [fake_solver_check]
 
 
-def test_health_reports_database_unhealthy_when_engine_broken(monkeypatch):
-    class BrokenEngine:
-        def connect(self):
-            raise RuntimeError("postgres unreachable")
-
-    from app import db as db_module
-
-    monkeypatch.setattr(db_module, "get_engine", BrokenEngine)
-
+def test_health_reports_database_unhealthy_when_engine_broken(broken_database):
     response = client.get("/v1/health")
     assert response.status_code == 200
     body = response.json()
@@ -96,12 +104,7 @@ def test_health_reports_database_unhealthy_when_engine_broken(monkeypatch):
     assert "postgres unreachable" in body["database"]["error"]
 
 
-def test_readyz_returns_200_when_redis_and_database_healthy(monkeypatch):
-    async def fake_db_check():
-        return ComponentHealth(healthy=True, latency_ms=1.0)
-
-    monkeypatch.setattr(main_module, "_check_database", fake_db_check)
-
+def test_readyz_returns_200_when_redis_and_database_healthy(healthy_database):
     response = client.get("/v1/readyz")
     assert response.status_code == 200
     body = response.json()
@@ -111,15 +114,7 @@ def test_readyz_returns_200_when_redis_and_database_healthy(monkeypatch):
     assert body["database"]["healthy"] is True
 
 
-def test_readyz_returns_503_when_database_unhealthy(monkeypatch):
-    class BrokenEngine:
-        def connect(self):
-            raise RuntimeError("postgres unreachable")
-
-    from app import db as db_module
-
-    monkeypatch.setattr(db_module, "get_engine", BrokenEngine)
-
+def test_readyz_returns_503_when_database_unhealthy(broken_database):
     response = client.get("/v1/readyz")
     assert response.status_code == 503
     body = response.json()
@@ -128,17 +123,7 @@ def test_readyz_returns_503_when_database_unhealthy(monkeypatch):
     assert "postgres unreachable" in body["database"]["error"]
 
 
-def test_readyz_returns_503_when_redis_unhealthy(monkeypatch):
-    async def fake_db_check():
-        return ComponentHealth(healthy=True, latency_ms=1.0)
-
-    monkeypatch.setattr(main_module, "_check_database", fake_db_check)
-
-    def boom():
-        raise RuntimeError("redis unreachable")
-
-    monkeypatch.setattr(queue_module, "get_queue", boom)
-
+def test_readyz_returns_503_when_redis_unhealthy(healthy_database, broken_redis):
     response = client.get("/v1/readyz")
     assert response.status_code == 503
     body = response.json()
@@ -146,14 +131,9 @@ def test_readyz_returns_503_when_redis_unhealthy(monkeypatch):
     assert body["redis"]["healthy"] is False
 
 
-def test_readyz_does_not_check_solver(monkeypatch):
+def test_readyz_does_not_check_solver(healthy_database, monkeypatch):
     """A down solver worker must not fail readiness — it's an async RQ worker
     off the request path, not something the API needs to serve traffic."""
-
-    async def fake_db_check():
-        return ComponentHealth(healthy=True, latency_ms=1.0)
-
-    monkeypatch.setattr(main_module, "_check_database", fake_db_check)
 
     def fail_if_called():
         raise AssertionError("readyz must not invoke the solver check")

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -94,3 +94,71 @@ def test_health_reports_database_unhealthy_when_engine_broken(monkeypatch):
 
     assert body["database"]["healthy"] is False
     assert "postgres unreachable" in body["database"]["error"]
+
+
+def test_readyz_returns_200_when_redis_and_database_healthy(monkeypatch):
+    async def fake_db_check():
+        return ComponentHealth(healthy=True, latency_ms=1.0)
+
+    monkeypatch.setattr(main_module, "_check_database", fake_db_check)
+
+    response = client.get("/v1/readyz")
+    assert response.status_code == 200
+    body = response.json()
+
+    assert set(body.keys()) == {"redis", "database"}
+    assert body["redis"]["healthy"] is True
+    assert body["database"]["healthy"] is True
+
+
+def test_readyz_returns_503_when_database_unhealthy(monkeypatch):
+    class BrokenEngine:
+        def connect(self):
+            raise RuntimeError("postgres unreachable")
+
+    from app import db as db_module
+
+    monkeypatch.setattr(db_module, "get_engine", BrokenEngine)
+
+    response = client.get("/v1/readyz")
+    assert response.status_code == 503
+    body = response.json()
+
+    assert body["database"]["healthy"] is False
+    assert "postgres unreachable" in body["database"]["error"]
+
+
+def test_readyz_returns_503_when_redis_unhealthy(monkeypatch):
+    async def fake_db_check():
+        return ComponentHealth(healthy=True, latency_ms=1.0)
+
+    monkeypatch.setattr(main_module, "_check_database", fake_db_check)
+
+    def boom():
+        raise RuntimeError("redis unreachable")
+
+    monkeypatch.setattr(queue_module, "get_queue", boom)
+
+    response = client.get("/v1/readyz")
+    assert response.status_code == 503
+    body = response.json()
+
+    assert body["redis"]["healthy"] is False
+
+
+def test_readyz_does_not_check_solver(monkeypatch):
+    """A down solver worker must not fail readiness — it's an async RQ worker
+    off the request path, not something the API needs to serve traffic."""
+
+    async def fake_db_check():
+        return ComponentHealth(healthy=True, latency_ms=1.0)
+
+    monkeypatch.setattr(main_module, "_check_database", fake_db_check)
+
+    def fail_if_called():
+        raise AssertionError("readyz must not invoke the solver check")
+
+    monkeypatch.setattr(main_module, "_check_solver_sync", fail_if_called)
+
+    response = client.get("/v1/readyz")
+    assert response.status_code == 200

--- a/deploy/uat/templates/api.yaml
+++ b/deploy/uat/templates/api.yaml
@@ -34,13 +34,15 @@ spec:
               mountPath: {{ .Values.apnsKeyPath }}
               subPath: {{ .Values.apnsKeyFile }}
               readOnly: true
-          # /v1/health depends on the DB being migrated and the worker reachable
-          # via redis, so it can be red for a while on first boot — keep the
-          # readiness window generous. Liveness is a plain TCP check so a not-yet
-          # -migrated DB doesn't trigger a restart loop.
+          # /v1/readyz depends on the DB being migrated and redis being
+          # reachable, so it can be red for a while on first boot — keep the
+          # readiness window generous. It returns a non-2xx status when
+          # unhealthy (unlike /v1/health, a diagnostic endpoint that always
+          # returns 200), so this actually gates traffic. Liveness is a plain
+          # TCP check so a not-yet-migrated DB doesn't trigger a restart loop.
           readinessProbe:
             httpGet:
-              path: /v1/health
+              path: /v1/readyz
               port: 8000
             initialDelaySeconds: 10
             periodSeconds: 5

--- a/scripts/redeploy-uat.sh
+++ b/scripts/redeploy-uat.sh
@@ -161,11 +161,11 @@ echo "==> Waiting for the api rollout"
 kubectl rollout status deploy/api -n "$NAMESPACE" --timeout=120s
 
 echo
-echo "==> Waiting for api to report healthy at $UAT_URL"
+echo "==> Waiting for api to report ready at $UAT_URL"
 deadline=$(( $(date +%s) + 90 ))
-until curl -fsS --max-time 3 "$UAT_URL/api/v1/health" >/dev/null 2>&1; do
+until curl -fsS --max-time 3 "$UAT_URL/api/v1/readyz" >/dev/null 2>&1; do
   if [ "$(date +%s)" -ge "$deadline" ]; then
-    echo "ERROR: $UAT_URL/api/v1/health did not respond within 90s" >&2
+    echo "ERROR: $UAT_URL/api/v1/readyz did not respond within 90s" >&2
     echo "--- recent api logs ---" >&2
     kubectl logs -n "$NAMESPACE" deploy/api --tail=40 >&2 || true
     exit 1
@@ -218,6 +218,9 @@ echo
 echo "==> Pod status"
 kubectl get pods -n "$NAMESPACE"
 
+echo
+echo "==> Readiness"
+curl -fsS "$UAT_URL/api/v1/readyz"
 echo
 echo "==> Health"
 curl -fsS "$UAT_URL/api/v1/health"


### PR DESCRIPTION
## Summary
- `GET /v1/health` always returns 200 even when a component is unhealthy (`healthy=false` only shows up in the body), so the k8s readiness probe (`deploy/uat/templates/api.yaml`) and `redeploy-uat.sh`'s smoke check never catch a broken deploy.
- Added `GET /v1/readyz` — a machine-readable readiness gate that returns 503 when redis or the database is unhealthy. `/v1/health` is left untouched as a diagnostic endpoint (still always 200, full body) since `admin-overview` relies on that shape via `unwrap`, which would otherwise throw on a non-2xx.
- The solver is deliberately excluded from `/readyz`: it's an async RQ worker off the request path, and its check can block up to 10s while the probe/smoke-check timeout is 3s.
- Repointed the k8s `readinessProbe` and the redeploy smoke check (the actual bug — `curl -fsS` was exiting 0 on a broken deploy) at `/v1/readyz`. Left `e2e/global-setup.ts` and `qa-up.sh` on `/v1/health`, since they intentionally wait for the solver worker too.
- `/readyz` is `include_in_schema=False` (no TS client consumer), so `openapi.json`/`schema.d.ts` are unaffected.

## Test plan
- [x] `pytest tests/test_health.py` — 8 passed, including new `/readyz` cases (200 healthy, 503 on DB down, 503 on redis down, solver never checked)
- [x] `pytest` (full api suite) — 531 passed
- [x] `ruff check`, `ruff format --check`, `mypy` — all clean
- [x] Confirmed `/v1/readyz` is absent from `app.openapi()['paths']`, `/v1/health` unaffected

Fixes #758

https://claude.ai/code/session_01LmfA8kZdbEh8u8r9gPK4Fk