### PR TITLE
iOS: fix match decoding against the negotiation schema; mirror the web dispute flow

### DIFF
--- a/ios/Fortymm/MatchFlow/MatchAPI.swift
+++ b/ios/Fortymm/MatchFlow/MatchAPI.swift
@@ -11,21 +11,28 @@ import Foundation
 
 // MARK: - Status
 
-/// Mirror of `app.models.match.MatchStatus`. Lenient: an unrecognised value
-/// (e.g. a status added server-side later) decodes to `.unknown` rather than
+/// A string-backed API enum that decodes leniently: an unrecognised value
+/// (e.g. a case added server-side later) decodes to `.unknown` rather than
 /// throwing, so the app keeps rendering.
-enum APIMatchStatus: String, Decodable {
+protocol LenientRawDecodable: RawRepresentable, Decodable where RawValue == String {
+    static var unknown: Self { get }
+}
+
+extension LenientRawDecodable {
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = Self(rawValue: raw) ?? .unknown
+    }
+}
+
+/// Mirror of `app.models.match.MatchStatus`.
+enum APIMatchStatus: String, LenientRawDecodable {
     case pending
     case inProgress = "in_progress"
     case completed
     case disputed
     case voided
     case unknown
-
-    init(from decoder: Decoder) throws {
-        let raw = try decoder.singleValueContainer().decode(String.self)
-        self = APIMatchStatus(rawValue: raw) ?? .unknown
-    }
 }
 
 // MARK: - Shared nested types
@@ -75,9 +82,8 @@ struct MatchGameDTO: Decodable {
 // MARK: - Result negotiation (propose/accept)
 
 /// Mirror of `app.schemas.match.ViewerState` — the viewer-relative phase of the
-/// propose/accept negotiation. Lenient like `APIMatchStatus`: an unrecognised
-/// value decodes to `.unknown` so a server-side addition doesn't brick the app.
-enum ViewerStateDTO: String, Decodable {
+/// propose/accept negotiation.
+enum ViewerStateDTO: String, LenientRawDecodable {
     /// No result posted yet — the match is still being scored.
     case live
     /// The viewer's side posted the standing result and owes nothing.
@@ -91,9 +97,25 @@ enum ViewerStateDTO: String, Decodable {
     case `final`
     case unknown
 
-    init(from decoder: Decoder) throws {
-        let raw = try decoder.singleValueContainer().decode(String.self)
-        self = ViewerStateDTO(rawValue: raw) ?? .unknown
+    /// A proposal has been posted and is still being negotiated — the states
+    /// where the board is no longer a live scratchpad but the match isn't
+    /// settled either.
+    var hasStandingProposal: Bool {
+        switch self {
+        case .awaiting, .review, .corrected: return true
+        case .live, .final, .unknown: return false
+        }
+    }
+
+    /// The viewer owes an accept-or-correct on the standing proposal: the
+    /// opponent posted it (first posting → `review`; a correction over the
+    /// viewer's own prior proposal → `corrected`). Matches the server's
+    /// `your_turn`, which is set exactly for these two states.
+    var viewerOwesResponse: Bool {
+        switch self {
+        case .review, .corrected: return true
+        case .live, .awaiting, .final, .unknown: return false
+        }
     }
 }
 
@@ -107,12 +129,14 @@ struct NegotiationGameDTO: Decodable {
 
 /// A proposed result (`NegotiationResult`) — an immutable snapshot of the board
 /// as claimed by whoever submitted it. `id` doubles as the concurrency token
-/// for `POST .../results/{id}/acceptance` and `supersedes_result_id`.
+/// for `POST .../results/{id}/acceptance` and `supersedes_result_id`. The wire
+/// shape also carries `submitted_by`/`submitted_at`; they're left undeclared
+/// (JSONDecoder ignores them) so decoding never depends on fields the app
+/// doesn't read — the failure mode that broke every match screen when
+/// `signatures` was removed server-side.
 struct NegotiationResultDTO: Decodable {
     let id: UUID
     let games: [NegotiationGameDTO]
-    let submittedBy: UUID
-    let submittedAt: Date
 }
 
 /// One changed game between the viewer's prior proposal and the standing
@@ -125,12 +149,13 @@ struct NegotiationDiffEntryDTO: Decodable {
 }
 
 /// Mirror of `MatchNegotiation` — always present on both the detail and list
-/// shapes. `diff` is only populated for the `corrected` state.
+/// shapes. `diff` is only populated for the `corrected` state. The wire shape's
+/// `your_turn` and `prior_result` are left undeclared: `your_turn` is fully
+/// implied by `viewer_state` (review/corrected), and nothing reads the prior
+/// result (the diff is server-computed).
 struct MatchNegotiationDTO: Decodable {
     let viewerState: ViewerStateDTO
-    let yourTurn: Bool
     let standingResult: NegotiationResultDTO?
-    let priorResult: NegotiationResultDTO?
     let diff: [NegotiationDiffEntryDTO]?
 }
 

--- a/ios/Fortymm/MatchFlow/MatchAPI.swift
+++ b/ios/Fortymm/MatchFlow/MatchAPI.swift
@@ -72,8 +72,66 @@ struct MatchGameDTO: Decodable {
     let score: MatchScoreDTO?
 }
 
-struct MatchSignatureDTO: Decodable {
-    let userId: UUID
+// MARK: - Result negotiation (propose/accept)
+
+/// Mirror of `app.schemas.match.ViewerState` — the viewer-relative phase of the
+/// propose/accept negotiation. Lenient like `APIMatchStatus`: an unrecognised
+/// value decodes to `.unknown` so a server-side addition doesn't brick the app.
+enum ViewerStateDTO: String, Decodable {
+    /// No result posted yet — the match is still being scored.
+    case live
+    /// The viewer's side posted the standing result and owes nothing.
+    case awaiting
+    /// The opponent posted and the viewer has no prior proposal — the viewer
+    /// should accept or suggest a correction.
+    case review
+    /// The opponent posted a correction over the viewer's own prior proposal.
+    case corrected
+    /// A result has been accepted; the match is settled.
+    case `final`
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = ViewerStateDTO(rawValue: raw) ?? .unknown
+    }
+}
+
+/// One game of a proposed result (`NegotiationGame`), on the canonical
+/// side-1/side-2 axis.
+struct NegotiationGameDTO: Decodable {
+    let gameNumber: Int
+    let side1Points: Int
+    let side2Points: Int
+}
+
+/// A proposed result (`NegotiationResult`) — an immutable snapshot of the board
+/// as claimed by whoever submitted it. `id` doubles as the concurrency token
+/// for `POST .../results/{id}/acceptance` and `supersedes_result_id`.
+struct NegotiationResultDTO: Decodable {
+    let id: UUID
+    let games: [NegotiationGameDTO]
+    let submittedBy: UUID
+    let submittedAt: Date
+}
+
+/// One changed game between the viewer's prior proposal and the standing
+/// correction (`NegotiationDiffEntry`). `old == nil` means the correction added
+/// this game.
+struct NegotiationDiffEntryDTO: Decodable {
+    let gameNumber: Int
+    let old: NegotiationGameDTO?
+    let new: NegotiationGameDTO
+}
+
+/// Mirror of `MatchNegotiation` — always present on both the detail and list
+/// shapes. `diff` is only populated for the `corrected` state.
+struct MatchNegotiationDTO: Decodable {
+    let viewerState: ViewerStateDTO
+    let yourTurn: Bool
+    let standingResult: NegotiationResultDTO?
+    let priorResult: NegotiationResultDTO?
+    let diff: [NegotiationDiffEntryDTO]?
 }
 
 struct H2HMeetingDTO: Decodable {
@@ -105,8 +163,7 @@ struct MatchDetailsDTO: Decodable {
     let games: [MatchGameDTO]
     let canScore: Bool
     let canFinalize: Bool
-    let canConfirm: Bool
-    let signatures: [MatchSignatureDTO]
+    let negotiation: MatchNegotiationDTO
     let headToHead: H2HDTO?
 }
 
@@ -130,7 +187,10 @@ struct MatchListRowDTO: Decodable {
     /// The viewer can enter scores for this (live) match — drives the row's
     /// "Score" affordance.
     let canScore: Bool
-    let canConfirm: Bool
+    /// Viewer-relative negotiation state — populated on list rows too (unlike
+    /// the old `signatures` field), so the row-level "your turn" affordances
+    /// are authoritative without a detail fetch.
+    let negotiation: MatchNegotiationDTO
 }
 
 struct MatchListResponseDTO: Decodable {
@@ -163,6 +223,11 @@ struct CreateMatchBody: Encodable {
 
 struct PostResultsBody: Encodable {
     let games: [GameWrite]
+    /// The standing result this posting supersedes (a correction/counter).
+    /// `nil` on the first proposal; otherwise must equal the current standing
+    /// result's id or the server 409s with the moved-on negotiation state.
+    /// supersedesResultId → supersedes_result_id via convertToSnakeCase.
+    var supersedesResultId: UUID? = nil
 
     struct GameWrite: Encodable {
         let gameNumber: Int

--- a/ios/Fortymm/MatchFlow/MatchDetailView.swift
+++ b/ios/Fortymm/MatchFlow/MatchDetailView.swift
@@ -50,8 +50,9 @@ struct MatchDetailView: View {
                 .padding(.bottom, 120)
             }
             // Pull-to-refresh: the one in-foreground way to pick up a cross-device
-            // change (the opponent confirmed/disputed) while staring at this screen,
-            // since there's no live poll. Mirrors the dashboard/matches-list pulls.
+            // change (the opponent accepted or corrected) while staring at this
+            // screen, since there's no live poll. Mirrors the dashboard/matches-list
+            // pulls.
             .refreshable { await refresh(force: true) }
             footer
             if actioning { FMBlockingSpinner() }
@@ -61,8 +62,8 @@ struct MatchDetailView: View {
             else { withAnimation(.spring(response: 0.42, dampingFraction: 0.5).delay(0.06)) { reveal = true } }
         }
         .task { await refresh() }
-        // Foregrounding may reveal a cross-device change (the opponent confirmed
-        // or disputed the posted result) — refetch so the status isn't stale.
+        // Foregrounding may reveal a cross-device change (the opponent accepted
+        // or corrected the posted result) — refetch so the status isn't stale.
         .refetchOnForeground { Task { await refresh(force: true) } }
         .alert(
             "Something went wrong",
@@ -505,12 +506,12 @@ struct MatchDetailView: View {
         footerButton("Back to matches", showArrow: false, action: onBack)
     }
 
-    /// Finalize footer: a decided, unsigned board. The primary action re-posts
-    /// the saved games into the sign-off flow — both the recovery path for a
-    /// match stranded *past* the decider (issue #445) and the one-tap fix for a
-    /// mistaken dispute (resubmit the scores unchanged). Because the scores are
-    /// a scratchpad until someone signs, the board is also still editable, so we
-    /// also offer "Edit scores" to correct a game before posting.
+    /// Finalize footer: a decided board with no result proposed yet. The
+    /// primary action posts the saved games as the first proposal — the
+    /// recovery path for a match stranded *past* the decider (issue #445).
+    /// Because the scores are a scratchpad until a result is proposed, the
+    /// board is also still editable, so we also offer "Edit scores" to correct
+    /// a game before posting.
     @ViewBuilder
     private var finalizeFooter: some View {
         VStack(spacing: 10) {

--- a/ios/Fortymm/MatchFlow/MatchDetailView.swift
+++ b/ios/Fortymm/MatchFlow/MatchDetailView.swift
@@ -37,6 +37,10 @@ struct MatchDetailView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     breadcrumb
                     hero
+                    if negotiationState == .corrected,
+                       let diff = match.negotiation?.diff, !diff.isEmpty {
+                        whatChangedSection(diff)
+                    }
                     if !match.games.isEmpty { gamesSection }
                     if match.rated, let delta = match.ratingDelta { ratingSection(delta) }
                     infoSection
@@ -75,11 +79,32 @@ struct MatchDetailView: View {
         .resumeScoringCover($resuming) { Task { await refresh(force: true) } }
     }
 
-    /// Sign off on (or dispute) the posted result, then refresh from the server
-    /// so the screen reflects the new status (decided → celebration; disputed →
-    /// back to live). Surfaces an alert on failure and leaves the screen as-is.
-    private func confirm() async { await act { try await service.confirmMatch($0) } }
-    private func dispute() async { await act { try await service.disputeMatch($0) } }
+    /// The viewer-relative negotiation phase (`.unknown` for seed/preview data).
+    private var negotiationState: NegotiationViewerState {
+        match.negotiation?.viewerState ?? .unknown
+    }
+
+    /// Accept the standing proposal, making the result official. The standing
+    /// result's id is the concurrency token: a 409 means the proposal moved on
+    /// (the opponent posted a correction the viewer hasn't seen) — mirror the
+    /// web's behavior by refetching and prompting a re-review rather than
+    /// silently retargeting the new result (#726).
+    private func accept() async {
+        guard !actioning,
+              let id = UUID(uuidString: match.id),
+              let resultId = match.negotiation?.standingResultId else { return }
+        actioning = true
+        defer { actioning = false }
+        do {
+            let updated = try await service.acceptResult(matchId: id, resultId: resultId)
+            withAnimation { live = updated }
+        } catch APIError.http(409, _) {
+            actionError = "This result changed — review the latest score before accepting."
+            await refresh(force: true)
+        } catch {
+            actionError = error.fmMessage
+        }
+    }
 
     /// Post the result of a match that's been scored to a decision but never
     /// posted (the `can_finalize` recovery path) — sends the already-saved games
@@ -93,18 +118,6 @@ struct MatchDetailView: View {
             let updated = try await service.postResult(
                 matchId: id, games: match.games, yourSideNumber: match.yourSideNumber
             )
-            withAnimation { live = updated }
-        } catch {
-            actionError = error.fmMessage
-        }
-    }
-
-    private func act(_ run: (UUID) async throws -> FinalMatch) async {
-        guard !actioning, let id = UUID(uuidString: match.id) else { return }
-        actioning = true
-        defer { actioning = false }
-        do {
-            let updated = try await run(id)
             withAnimation { live = updated }
         } catch {
             actionError = error.fmMessage
@@ -191,13 +204,21 @@ struct MatchDetailView: View {
             }
 
             if match.awaitingConfirmation {
-                Text(match.canConfirm
-                     ? "\(match.opponent.handle) posted this result. Confirm it to make it official, or dispute it."
-                     : "Result posted — awaiting \(match.opponent.handle)'s confirmation.")
-                    .font(FMFont.ui(12, weight: .medium))
-                    .foregroundStyle(FMColor.fg3)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: .infinity, alignment: .center)
+                VStack(spacing: 5) {
+                    Text(negotiationCopy)
+                        .font(FMFont.ui(12, weight: .medium))
+                        .foregroundStyle(FMColor.fg3)
+                    if match.canConfirm {
+                        // The stakes line, mirroring the web callout.
+                        Text(match.rated
+                             ? "Accepting finalizes this rated match and updates both ratings."
+                             : "Accepting finalizes this match. It doesn't affect ratings.")
+                            .font(FMFont.ui(11, weight: .medium))
+                            .foregroundStyle(FMColor.fgMuted)
+                    }
+                }
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity, alignment: .center)
             }
         }
         .padding(.horizontal, 18)
@@ -209,6 +230,19 @@ struct MatchDetailView: View {
         .overlay { if reveal && youWon && !reduceMotion { BurstView().allowsHitTesting(false) } }
         .padding(.horizontal, 16)
         .padding(.top, 8)
+    }
+
+    /// The one-line negotiation status under the hero score, keyed off the
+    /// viewer phase — mirrors the web's confirmation callout copy.
+    private var negotiationCopy: String {
+        switch negotiationState {
+        case .review:
+            return "\(match.opponent.handle) posted this result. Accept it to make it official, or suggest a correction."
+        case .corrected:
+            return "\(match.opponent.handle) corrected the score. Review what changed, then accept the correction or counter."
+        default:
+            return "Result posted — awaiting \(match.opponent.handle)'s acceptance."
+        }
     }
 
     /// Orange once the result is official; amber while it's still provisional.
@@ -226,6 +260,50 @@ struct MatchDetailView: View {
                 .multilineTextAlignment(.center)
         }
         .frame(width: 96)
+    }
+
+    // MARK: What changed (corrected-phase diff)
+
+    /// The server-computed per-game diff between the viewer's prior proposal
+    /// and the standing correction: old score struck through → new score, with
+    /// newly-added games flagged. Scores are canonical side-1–side-2, matching
+    /// the web's ScoreDiff.
+    private func whatChangedSection(_ diff: [ScoreDiffEntry]) -> some View {
+        Section_("What changed") {
+            VStack(spacing: 0) {
+                ForEach(Array(diff.enumerated()), id: \.element.id) { i, entry in
+                    HStack(spacing: 10) {
+                        Text("GAME \(entry.gameNumber)")
+                            .font(FMFont.ui(10, weight: .semibold))
+                            .tracking(1.2)
+                            .foregroundStyle(FMColor.fgMuted)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        if let old = entry.old {
+                            Text(old)
+                                .font(FMFont.mono(15, weight: .semibold))
+                                .strikethrough()
+                                .foregroundStyle(FMColor.loss)
+                            Image(systemName: "arrow.right")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(FMColor.fgMuted)
+                        } else {
+                            Text("NEW GAME")
+                                .font(FMFont.ui(9, weight: .semibold))
+                                .tracking(1.0)
+                                .foregroundStyle(FMColor.fgMuted)
+                        }
+                        Text(entry.new)
+                            .font(FMFont.mono(15, weight: .bold))
+                            .foregroundStyle(FMColor.serve500)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    if i < diff.count - 1 { Divider().overlay(FMColor.ink700) }
+                }
+            }
+            .background(FMColor.ink900)
+            .fmRoundedBorder(radius: FMRadius.lg, color: FMColor.borderSubtle)
+        }
     }
 
     // MARK: Games
@@ -370,7 +448,9 @@ struct MatchDetailView: View {
     private var footer: some View {
         Group {
             if match.canConfirm {
-                confirmFooter
+                acceptFooter
+            } else if negotiationState == .awaiting, let ctx = match.correctionContext {
+                awaitingFooter(ctx)
             } else if match.canFinalize {
                 finalizeFooter
             } else if let ctx = match.resumeContext {
@@ -434,16 +514,7 @@ struct MatchDetailView: View {
         VStack(spacing: 10) {
             footerButton("Post result", disabled: actioning) { Task { await finalize() } }
             if let ctx = match.resumeContext {
-                Button { resuming = ctx } label: {
-                    Text("Edit scores")
-                        .font(FMFont.ui(15, weight: .semibold))
-                        .foregroundStyle(FMColor.fg2)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 48)
-                        .fmRoundedBorder(radius: 13, color: FMColor.borderDefault)
-                }
-                .buttonStyle(.plain)
-                .disabled(actioning)
+                secondaryFooterButton("Edit scores") { resuming = ctx }
             }
         }
     }
@@ -455,23 +526,47 @@ struct MatchDetailView: View {
         footerButton(match.games.isEmpty ? "Enter scores" : "Resume scoring") { resuming = ctx }
     }
 
-    /// Sign-off footer: shown when the current user owes a confirm/dispute on a
-    /// posted result. Dispute rewinds it; confirm makes the result official.
-    private var confirmFooter: some View {
-        HStack(spacing: 10) {
-            Button { Task { await dispute() } } label: {
-                Text("Dispute")
-                    .font(FMFont.ui(15, weight: .semibold))
-                    .foregroundStyle(FMColor.loss)
-                    .padding(.horizontal, 22)
-                    .frame(height: 50)
-                    .fmRoundedBorder(radius: 13, color: FMColor.loss.opacity(0.5))
+    /// A bordered, secondary footer action (the non-primary verb in a pair).
+    private func secondaryFooterButton(
+        _ title: String, action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(FMFont.ui(15, weight: .semibold))
+                .foregroundStyle(FMColor.fg2)
+                .frame(maxWidth: .infinity)
+                .frame(height: 48)
+                .fmRoundedBorder(radius: 13, color: FMColor.borderDefault)
+        }
+        .buttonStyle(.plain)
+        .disabled(actioning)
+    }
+
+    /// Sign-off footer: the current user owes an accept-or-correct on the
+    /// standing proposal. Accept makes the result official; the secondary verb
+    /// opens the correction board — "Suggest correction" against a first
+    /// posting (`review`), "Counter" against a correction of the viewer's own
+    /// prior proposal (`corrected`). Mirrors the web's confirmation callout.
+    private var acceptFooter: some View {
+        VStack(spacing: 10) {
+            footerButton("Accept result", showArrow: false, disabled: actioning) {
+                Task { await accept() }
             }
-            .buttonStyle(.plain)
-            .disabled(actioning)
-            footerButton("Confirm result", showArrow: false, disabled: actioning) {
-                Task { await confirm() }
+            if let ctx = match.correctionContext {
+                secondaryFooterButton(
+                    negotiationState == .corrected ? "Counter" : "Suggest correction"
+                ) { resuming = ctx }
             }
+        }
+    }
+
+    /// Awaiting footer: the viewer's own side posted the standing proposal —
+    /// nothing is owed, but the viewer can still self-edit their posting (a
+    /// correction that supersedes it), mirroring the web's "Edit result".
+    private func awaitingFooter(_ ctx: ResumeScoring) -> some View {
+        VStack(spacing: 10) {
+            footerButton("Back to matches", showArrow: false, action: onBack)
+            secondaryFooterButton("Edit result") { resuming = ctx }
         }
     }
 }

--- a/ios/Fortymm/MatchFlow/MatchDetailView.swift
+++ b/ios/Fortymm/MatchFlow/MatchDetailView.swift
@@ -15,7 +15,7 @@ struct MatchDetailView: View {
     @State private var reveal = false
     @State private var live: FinalMatch?
 
-    /// A confirm/dispute request is in flight (blocks the footer + dims the UI).
+    /// An accept (or post) request is in flight (blocks the footer + dims the UI).
     @State private var actioning = false
     @State private var actionError: String?
     /// Non-nil while the resume-scoring flow is presented over this screen.
@@ -37,8 +37,9 @@ struct MatchDetailView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     breadcrumb
                     hero
-                    if negotiationState == .corrected,
-                       let diff = match.negotiation?.diff, !diff.isEmpty {
+                    // `diff` is only populated for the `corrected` phase, so
+                    // non-emptiness alone gates the section.
+                    if let diff = match.negotiation?.diff, !diff.isEmpty {
                         whatChangedSection(diff)
                     }
                     if !match.games.isEmpty { gamesSection }
@@ -80,7 +81,7 @@ struct MatchDetailView: View {
     }
 
     /// The viewer-relative negotiation phase (`.unknown` for seed/preview data).
-    private var negotiationState: NegotiationViewerState {
+    private var negotiationState: ViewerStateDTO {
         match.negotiation?.viewerState ?? .unknown
     }
 
@@ -271,7 +272,8 @@ struct MatchDetailView: View {
     private func whatChangedSection(_ diff: [ScoreDiffEntry]) -> some View {
         Section_("What changed") {
             VStack(spacing: 0) {
-                ForEach(Array(diff.enumerated()), id: \.element.id) { i, entry in
+                ForEach(diff.indices, id: \.self) { i in
+                    let entry = diff[i]
                     HStack(spacing: 10) {
                         Text("GAME \(entry.gameNumber)")
                             .font(FMFont.ui(10, weight: .semibold))
@@ -477,7 +479,7 @@ struct MatchDetailView: View {
     }
 
     /// The footer's full-width ball-gradient pill — shared by every primary
-    /// footer action (back, post, resume, confirm) so the shape/shadow live once.
+    /// footer action (back, post, resume, accept) so the shape/shadow live once.
     private func footerButton(
         _ title: String, showArrow: Bool = true, disabled: Bool = false,
         action: @escaping () -> Void

--- a/ios/Fortymm/MatchFlow/MatchFlowView.swift
+++ b/ios/Fortymm/MatchFlow/MatchFlowView.swift
@@ -75,6 +75,7 @@ struct MatchFlowView: View {
                     config: config,
                     initialGames: resume?.games ?? [],
                     onPost: post,
+                    correction: resume?.isCorrection ?? false,
                     meName: session.username,
                     // Resuming has no setup step to fall back to — exiting closes
                     // the flow (back to wherever it was launched from).
@@ -128,6 +129,9 @@ struct MatchFlowView: View {
     }
 
     /// Post the completed games for the match and show the server's result.
+    /// A correction board (resume carries `supersedesResultId`) posts as a
+    /// counter-proposal superseding the standing result; the server 409s if
+    /// that proposal has since moved on (accepted or re-corrected).
     private func post(_ games: [Game]) {
         guard let matchId, !busy else { return }
         busy = true
@@ -135,9 +139,12 @@ struct MatchFlowView: View {
             do {
                 final = try await service.postResult(
                     matchId: matchId, games: games,
-                    yourSideNumber: resume?.yourSideNumber ?? 1
+                    yourSideNumber: resume?.yourSideNumber ?? 1,
+                    supersedes: resume?.supersedesResultId
                 )
                 withAnimation { step = .detail }
+            } catch APIError.http(409, _) where resume?.isCorrection == true {
+                errorMessage = "This result changed while you were editing — reopen the match to review the latest score."
             } catch {
                 errorMessage = error.fmMessage
             }

--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -86,13 +86,6 @@ struct Game: Hashable {
 
 // MARK: - Result negotiation (view model)
 
-/// Viewer-relative phase of the propose/accept negotiation. Mirrors the web
-/// client's use of `negotiation.viewer_state`; `.unknown` covers a
-/// forward-compatible server addition (treated as "nothing actionable").
-enum NegotiationViewerState {
-    case live, awaiting, review, corrected, settled, unknown
-}
-
 /// One changed game between the viewer's prior proposal and the standing
 /// correction, pre-formatted for display. Scores are canonical side-1–side-2,
 /// matching the web's `ScoreDiff` rendering.
@@ -105,12 +98,12 @@ struct ScoreDiffEntry: Identifiable {
 }
 
 /// The negotiation state the detail/list screens act on: which phase the
-/// viewer is in, the standing proposal's id (the acceptance / supersedes
-/// token), its board (viewer-oriented, for seeding a correction), and the
-/// server-computed diff shown in the `corrected` phase.
+/// viewer is in (the lenient DTO enum, used directly like `APIMatchStatus`),
+/// the standing proposal's id (the acceptance / supersedes token), its board
+/// (viewer-oriented, for seeding a correction), and the server-computed diff
+/// shown in the `corrected` phase.
 struct MatchNegotiation {
-    let viewerState: NegotiationViewerState
-    let yourTurn: Bool
+    let viewerState: ViewerStateDTO
     let standingResultId: UUID?
     /// The standing proposal's games with `a` = you, `b` = them — the immutable
     /// snapshot a correction board is seeded from (mirroring the web's
@@ -142,18 +135,25 @@ struct FinalMatch: Identifiable {
     /// posted result is still awaiting the opponent's confirmation, so the
     /// W/L celebration and rating change are not yet real.
     var decided: Bool = true
+    /// The viewer-relative negotiation state, when the match came from the API
+    /// (nil only for seed/preview builders). Carries the acceptance token, the
+    /// standing board for corrections, and the `corrected`-phase diff — and is
+    /// the single source the derived flags below read, so they can't drift
+    /// from it.
+    var negotiation: MatchNegotiation? = nil
+
     /// True when a result has been posted but the match isn't decided yet — i.e.
     /// it's genuinely awaiting a sign-off. Distinct from `!decided`, which is
     /// also true for a freshly-created *live* match that has no posted result.
-    var awaitingConfirmation: Bool = false
+    var awaitingConfirmation: Bool {
+        inProgress && negotiation?.viewerState.hasStandingProposal == true
+    }
     /// The current user owes an accept-or-correct on the standing proposal
     /// (negotiation `review` or `corrected` — the states where the opponent
     /// posted and it's the viewer's turn).
-    var canConfirm: Bool = false
-    /// The viewer-relative negotiation state, when the match came from the API
-    /// (nil only for seed/preview builders). Carries the acceptance token, the
-    /// standing board for corrections, and the `corrected`-phase diff.
-    var negotiation: MatchNegotiation? = nil
+    var canConfirm: Bool {
+        viewerIsParticipant && negotiation?.viewerState.viewerOwesResponse == true
+    }
     /// Server head-to-head, when the detail BFF provided it.
     var h2h: MatchH2H? = nil
     // --- neutral, side-ordered view (for the matches list, which is a global
@@ -178,10 +178,9 @@ struct FinalMatch: Identifiable {
     var canScore: Bool = false
     /// The saved games already form a decided, valid match and the viewer can
     /// post the result. True for a match scored to a decision but never posted
-    /// (e.g. a web user entered the games then left, or a dispute that cleared
-    /// the signatures). `canScore` is *also* true here — the board stays
-    /// editable until signed — so the detail screen offers both "Post result"
-    /// (resubmit) and "Edit scores".
+    /// (e.g. a web user entered the games then left). `canScore` is *also*
+    /// true here — the board stays a scratchpad until a result is proposed —
+    /// so the detail screen offers both "Post result" and "Edit scores".
     var canFinalize: Bool = false
     /// The viewer's side number (1 or 2). Used to orient entered scores back to
     /// the canonical side-1/side-2 axis when resuming a match the viewer didn't
@@ -219,7 +218,7 @@ struct FinalMatch: Identifiable {
         guard viewerIsParticipant,
               let negotiation,
               let standingId = negotiation.standingResultId,
-              [.review, .corrected, .awaiting].contains(negotiation.viewerState),
+              negotiation.viewerState.hasStandingProposal,
               let uuid = UUID(uuidString: id) else { return nil }
         return ResumeScoring(
             matchId: uuid,

--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -84,6 +84,42 @@ struct Game: Hashable {
     var b: Int?
 }
 
+// MARK: - Result negotiation (view model)
+
+/// Viewer-relative phase of the propose/accept negotiation. Mirrors the web
+/// client's use of `negotiation.viewer_state`; `.unknown` covers a
+/// forward-compatible server addition (treated as "nothing actionable").
+enum NegotiationViewerState {
+    case live, awaiting, review, corrected, settled, unknown
+}
+
+/// One changed game between the viewer's prior proposal and the standing
+/// correction, pre-formatted for display. Scores are canonical side-1–side-2,
+/// matching the web's `ScoreDiff` rendering.
+struct ScoreDiffEntry: Identifiable {
+    let gameNumber: Int
+    /// "11–7" as previously proposed; nil when the correction added this game.
+    let old: String?
+    let new: String
+    var id: Int { gameNumber }
+}
+
+/// The negotiation state the detail/list screens act on: which phase the
+/// viewer is in, the standing proposal's id (the acceptance / supersedes
+/// token), its board (viewer-oriented, for seeding a correction), and the
+/// server-computed diff shown in the `corrected` phase.
+struct MatchNegotiation {
+    let viewerState: NegotiationViewerState
+    let yourTurn: Bool
+    let standingResultId: UUID?
+    /// The standing proposal's games with `a` = you, `b` = them — the immutable
+    /// snapshot a correction board is seeded from (mirroring the web's
+    /// correction entry, which seeds from `standing_result`, not the live
+    /// scratchpad).
+    let standingGames: [Game]
+    let diff: [ScoreDiffEntry]
+}
+
 /// A finished, posted match — the shape the detail screen and matches list read.
 struct FinalMatch: Identifiable {
     let id: String
@@ -110,8 +146,14 @@ struct FinalMatch: Identifiable {
     /// it's genuinely awaiting a sign-off. Distinct from `!decided`, which is
     /// also true for a freshly-created *live* match that has no posted result.
     var awaitingConfirmation: Bool = false
-    /// The current user owes a confirm/dispute on this posted result.
+    /// The current user owes an accept-or-correct on the standing proposal
+    /// (negotiation `review` or `corrected` — the states where the opponent
+    /// posted and it's the viewer's turn).
     var canConfirm: Bool = false
+    /// The viewer-relative negotiation state, when the match came from the API
+    /// (nil only for seed/preview builders). Carries the acceptance token, the
+    /// standing board for corrections, and the `corrected`-phase diff.
+    var negotiation: MatchNegotiation? = nil
     /// Server head-to-head, when the detail BFF provided it.
     var h2h: MatchH2H? = nil
     // --- neutral, side-ordered view (for the matches list, which is a global
@@ -147,10 +189,9 @@ struct FinalMatch: Identifiable {
     var yourSideNumber: Int = 1
 
     /// The viewer can resume entering / editing scores. Relies solely on the
-    /// server's `canScore`, which is false once a result is signed (awaiting
-    /// confirmation) — so this stays correct on the *list* surface too, where
-    /// `awaitingConfirmation` is only a games-won guess (the list row carries no
-    /// signatures). Single source of truth for the "Score" affordances on the
+    /// server's `canScore`, which is false once a result has been proposed (the
+    /// scratchpad closes; changes then flow through the propose/accept
+    /// negotiation). Single source of truth for the "Score" affordances on the
     /// list, detail, and dashboard.
     var canResume: Bool { canScore && inProgress }
 
@@ -167,6 +208,27 @@ struct FinalMatch: Identifiable {
             yourSideNumber: yourSideNumber
         )
     }
+
+    /// Context for the correction board — the score-entry flow seeded from the
+    /// standing proposal and posting with `supersedes_result_id`. Serves all
+    /// three correction verbs the web offers: "Suggest correction" (review),
+    /// "Counter" (corrected), and "Edit result" (a self-edit while awaiting).
+    /// Nil when there's no standing proposal to correct or the viewer isn't a
+    /// participant.
+    var correctionContext: ResumeScoring? {
+        guard viewerIsParticipant,
+              let negotiation,
+              let standingId = negotiation.standingResultId,
+              [.review, .corrected, .awaiting].contains(negotiation.viewerState),
+              let uuid = UUID(uuidString: id) else { return nil }
+        return ResumeScoring(
+            matchId: uuid,
+            config: MatchConfig(opponent: solo ? nil : opponent, bestOf: bestOf, rated: rated),
+            games: negotiation.standingGames,
+            yourSideNumber: yourSideNumber,
+            supersedesResultId: standingId
+        )
+    }
 }
 
 /// Everything the scoring flow needs to resume an existing in-progress match:
@@ -178,7 +240,14 @@ struct ResumeScoring: Identifiable {
     let config: MatchConfig
     let games: [Game]
     var yourSideNumber: Int = 1
+    /// When set, this board is a *correction*: it was seeded from the standing
+    /// proposal with this id, and posting supersedes that proposal (a counter,
+    /// or a self-edit of the viewer's own posting). Nil for plain live scoring.
+    var supersedesResultId: UUID? = nil
     var id: UUID { matchId }
+
+    /// Correction boards tweak the score-entry copy ("Send corrected score").
+    var isCorrection: Bool { supersedesResultId != nil }
 }
 
 /// A page of the match list plus the per-status counts that drive the filter

--- a/ios/Fortymm/MatchFlow/MatchService.swift
+++ b/ios/Fortymm/MatchFlow/MatchService.swift
@@ -95,16 +95,20 @@ struct MatchService {
         return Self.finalMatch(from: details)
     }
 
-    /// Fetch the match and accept its standing proposal, if the viewer owes one
-    /// (negotiation `review`/`corrected`). Used by the push-notification
-    /// "Approve" action, whose payload carries only the match id — the fetch
-    /// resolves the current standing result id (the acceptance token). Throws
-    /// if nothing is awaiting the viewer's sign-off (e.g. already accepted).
+    /// Nothing is standing to accept (the match is live or already settled) —
+    /// a client-side precondition, deliberately distinct from `APIError.http`
+    /// so it can't be mistaken for a real server 409.
+    struct NoStandingResult: Error {}
+
+    /// Fetch the match and accept its standing proposal. Used by the
+    /// push-notification "Approve" action, whose payload carries only the
+    /// match id — the fetch resolves the current standing result id (the
+    /// acceptance token). Whether the viewer is actually allowed to accept is
+    /// the server's call: an out-of-turn acceptance gets the real 409/4xx.
     func acceptStandingResult(_ matchId: UUID) async throws -> FinalMatch {
         let details: MatchDetailsDTO = try await client.get("/v1/matches/\(matchId.uuidString)")
-        guard details.negotiation.yourTurn,
-              let standing = details.negotiation.standingResult else {
-            throw APIError.http(status: 409, detail: "No result is awaiting your sign-off.")
+        guard let standing = details.negotiation.standingResult else {
+            throw NoStandingResult()
         }
         return try await acceptResult(matchId: matchId, resultId: standing.id)
     }
@@ -176,31 +180,22 @@ struct MatchService {
 
     // MARK: Negotiation DTO → view model
 
-    private static func viewerState(_ s: ViewerStateDTO) -> NegotiationViewerState {
-        switch s {
-        case .live: return .live
-        case .awaiting: return .awaiting
-        case .review: return .review
-        case .corrected: return .corrected
-        case .final: return .settled
-        case .unknown: return .unknown
-        }
+    /// Project canonical side-1/side-2 points onto the viewer-relative axis
+    /// (`a` = you, `b` = them) — the one place the orientation rule lives, used
+    /// by both the match-games and standing-result mappings.
+    private static func orientedGame(side1: Int, side2: Int, mineIsSide1: Bool) -> Game {
+        mineIsSide1 ? Game(a: side1, b: side2) : Game(a: side2, b: side1)
     }
 
-    /// Map the wire negotiation onto the view model: resolve the viewer phase,
-    /// re-orient the standing board so `a` = you, and pre-format the
-    /// `corrected`-phase diff (canonical side-1–side-2, like the web's
-    /// ScoreDiff).
+    /// Map the wire negotiation onto the view model: re-orient the standing
+    /// board so `a` = you, and pre-format the `corrected`-phase diff (canonical
+    /// side-1–side-2, like the web's ScoreDiff).
     private static func negotiation(
         _ n: MatchNegotiationDTO, mineIsSide1: Bool
     ) -> MatchNegotiation {
         let standingGames: [Game] = (n.standingResult?.games ?? [])
             .sorted { $0.gameNumber < $1.gameNumber }
-            .map { g in
-                mineIsSide1
-                    ? Game(a: g.side1Points, b: g.side2Points)
-                    : Game(a: g.side2Points, b: g.side1Points)
-            }
+            .map { orientedGame(side1: $0.side1Points, side2: $0.side2Points, mineIsSide1: mineIsSide1) }
         func fmt(_ g: NegotiationGameDTO) -> String { "\(g.side1Points)–\(g.side2Points)" }
         let diff: [ScoreDiffEntry] = (n.diff ?? []).map { entry in
             ScoreDiffEntry(
@@ -210,8 +205,7 @@ struct MatchService {
             )
         }
         return MatchNegotiation(
-            viewerState: viewerState(n.viewerState),
-            yourTurn: n.yourTurn,
+            viewerState: n.viewerState,
             standingResultId: n.standingResult?.id,
             standingGames: standingGames,
             diff: diff
@@ -277,27 +271,19 @@ struct MatchService {
             .sorted { $0.gameNumber < $1.gameNumber }
             .compactMap { g in
                 guard let s = g.score else { return nil }
-                return mineIsSide1
-                    ? Game(a: s.side1Points, b: s.side2Points)
-                    : Game(a: s.side2Points, b: s.side1Points)
+                return orientedGame(
+                    side1: s.side1Points, side2: s.side2Points, mineIsSide1: mineIsSide1
+                )
             }
 
         let decided = status == .completed
         let rated = ratedHint ?? (mine?.ratingChange != nil)
         let delta = mine?.ratingChange.map { Int($0.delta.rounded()) }
         // The negotiation block is populated on both the detail and list shapes,
-        // so "a result has been posted" is authoritative everywhere — no more
+        // so the sign-off flags (`awaitingConfirmation`, `canConfirm`) are
+        // derived from it on `FinalMatch` itself — authoritative everywhere, no
         // games-won heuristic (which mis-read a rewound board as posted).
         let negotiation = Self.negotiation(negotiationDTO, mineIsSide1: mineIsSide1)
-        let resultPosted = [.awaiting, .review, .corrected]
-            .contains(negotiation.viewerState)
-        let awaitingConfirmation = status == .inProgress && resultPosted
-        // The viewer owes an accept-or-correct: the opponent posted the standing
-        // proposal (first posting → `review`; a correction over the viewer's own
-        // prior proposal → `corrected`). Matches `your_turn`, which the server
-        // sets exactly for these two states.
-        let canConfirm = viewerIsParticipant && negotiation.yourTurn
-            && [.review, .corrected].contains(negotiation.viewerState)
 
         return FinalMatch(
             id: id.uuidString,
@@ -316,8 +302,6 @@ struct MatchService {
             context: rated ? "Rated · \(league.name)" : "Casual",
             statusLabel: statusLabel,
             decided: decided,
-            awaitingConfirmation: awaitingConfirmation,
-            canConfirm: canConfirm,
             negotiation: negotiation,
             h2h: h2h.map { mapH2H($0, mineIsSide1: mineIsSide1) },
             sideA: sidePlayer(side1),
@@ -327,10 +311,9 @@ struct MatchService {
             viewerIsParticipant: viewerIsParticipant,
             inProgress: status == .inProgress,
             // `canScore` is the server's authoritative "scores are editable"
-            // signal — true whenever no result is signed (the scratchpad is
-            // open), regardless of whether a next game remains. `canResume` is
-            // built on it, so it stays correct on the list surface where
-            // `awaitingConfirmation` is only a heuristic.
+            // signal — true whenever no result has been proposed (the
+            // scratchpad is open), regardless of whether a next game remains.
+            // `canResume` is built on it.
             canScore: canScore && viewerIsParticipant,
             canFinalize: canFinalize && viewerIsParticipant,
             yourSideNumber: mine?.sideNumber ?? 1

--- a/ios/Fortymm/MatchFlow/MatchService.swift
+++ b/ios/Fortymm/MatchFlow/MatchService.swift
@@ -48,48 +48,65 @@ struct MatchService {
         return details.id
     }
 
-    /// Post the canonical result (`POST /v1/matches/{id}/results`) and return
-    /// the resulting match. For a solo match this comes back `completed`; for a
-    /// two-player match it stays awaiting the opponent's confirmation.
+    /// Propose a result (`POST /v1/matches/{id}/results`) — the first verb of
+    /// the propose/accept negotiation — and return the resulting match. A solo
+    /// or unrated match self-accepts and comes back `completed`; a rated
+    /// two-player match leaves the proposal standing for the opponent to accept.
     /// `yourSideNumber` orients the entered scores (`a` = you, `b` = them) back
     /// to the canonical side-1/side-2 axis the API expects. A freshly created
     /// match puts the creator on side 1; resuming a match the viewer didn't
     /// create may put them on side 2, in which case the points are swapped.
-    func postResult(matchId: UUID, games: [Game], yourSideNumber: Int = 1) async throws -> FinalMatch {
+    /// `supersedes` marks this posting as a correction of the standing proposal
+    /// with that id (a counter, or a self-edit of the viewer's own posting);
+    /// the server 409s if the proposal has moved on.
+    func postResult(
+        matchId: UUID, games: [Game], yourSideNumber: Int = 1,
+        supersedes: UUID? = nil
+    ) async throws -> FinalMatch {
         let youAreSide1 = yourSideNumber != 2
-        let payload = PostResultsBody(games: games.enumerated().compactMap { i, g in
-            guard let a = g.a, let b = g.b else { return nil }
-            return PostResultsBody.GameWrite(
-                gameNumber: i + 1,
-                side1Points: youAreSide1 ? a : b,
-                side2Points: youAreSide1 ? b : a
-            )
-        })
+        let payload = PostResultsBody(
+            games: games.enumerated().compactMap { i, g in
+                guard let a = g.a, let b = g.b else { return nil }
+                return PostResultsBody.GameWrite(
+                    gameNumber: i + 1,
+                    side1Points: youAreSide1 ? a : b,
+                    side2Points: youAreSide1 ? b : a
+                )
+            },
+            supersedesResultId: supersedes
+        )
         let details: MatchDetailsDTO = try await client.post(
             "/v1/matches/\(matchId.uuidString)/results", body: payload
         )
         return Self.finalMatch(from: details)
     }
 
-    // MARK: Confirm / dispute
+    // MARK: Accept
 
-    /// Sign off on a posted result (`POST /v1/matches/{id}/confirmation`). Once
-    /// every side has signed the match comes back `completed`; until then it
-    /// stays awaiting the remaining sign-off.
-    func confirmMatch(_ id: UUID) async throws -> FinalMatch {
+    /// Accept the standing proposal (`POST /v1/matches/{id}/results/{resultId}/
+    /// acceptance`) — the second verb of the negotiation. `resultId` is the
+    /// concurrency token: it must be the current standing proposal's id, or the
+    /// server 409s (the proposal moved on — superseded or already accepted).
+    /// On success the match comes back `completed`.
+    func acceptResult(matchId: UUID, resultId: UUID) async throws -> FinalMatch {
         let details: MatchDetailsDTO = try await client.post(
-            "/v1/matches/\(id.uuidString)/confirmation"
+            "/v1/matches/\(matchId.uuidString)/results/\(resultId.uuidString)/acceptance"
         )
         return Self.finalMatch(from: details)
     }
 
-    /// Reject a posted result (`POST /v1/matches/{id}/dispute`). Clears the
-    /// signatures and rewinds the result, returning the match to `in_progress`.
-    func disputeMatch(_ id: UUID) async throws -> FinalMatch {
-        let details: MatchDetailsDTO = try await client.post(
-            "/v1/matches/\(id.uuidString)/dispute"
-        )
-        return Self.finalMatch(from: details)
+    /// Fetch the match and accept its standing proposal, if the viewer owes one
+    /// (negotiation `review`/`corrected`). Used by the push-notification
+    /// "Approve" action, whose payload carries only the match id — the fetch
+    /// resolves the current standing result id (the acceptance token). Throws
+    /// if nothing is awaiting the viewer's sign-off (e.g. already accepted).
+    func acceptStandingResult(_ matchId: UUID) async throws -> FinalMatch {
+        let details: MatchDetailsDTO = try await client.get("/v1/matches/\(matchId.uuidString)")
+        guard details.negotiation.yourTurn,
+              let standing = details.negotiation.standingResult else {
+            throw APIError.http(status: 409, detail: "No result is awaiting your sign-off.")
+        }
+        return try await acceptResult(matchId: matchId, resultId: standing.id)
     }
 
     // MARK: Read
@@ -134,14 +151,10 @@ struct MatchService {
         common(
             id: d.id, status: d.status, statusLabel: d.statusLabel,
             league: d.league, sides: d.sides, bestOf: d.bestOf,
-            createdAt: d.createdAt, canConfirm: d.canConfirm, canScore: d.canScore,
+            createdAt: d.createdAt, canScore: d.canScore,
             canFinalize: d.canFinalize,
             ratedHint: d.affectsRating, games: d.games, h2h: d.headToHead,
-            // The detail DTO carries the authoritative sign-off signal: a result
-            // is awaiting confirmation iff someone has signed. (A dispute clears
-            // signatures but keeps the game rows, so a games-won count alone
-            // would wrongly read as "result posted" afterwards.)
-            signaturesPosted: !d.signatures.isEmpty
+            negotiation: d.negotiation
         )
     }
 
@@ -149,7 +162,7 @@ struct MatchService {
         common(
             id: r.id, status: r.status, statusLabel: r.statusLabel,
             league: r.league, sides: r.sides, bestOf: r.bestOf,
-            createdAt: r.createdAt, canConfirm: r.canConfirm, canScore: r.canScore,
+            createdAt: r.createdAt, canScore: r.canScore,
             // The list row omits can_finalize; the detail refetch (on open) fills
             // in the authoritative value and surfaces the "Post result" path.
             canFinalize: false,
@@ -157,10 +170,51 @@ struct MatchService {
             // omitted on list rows), so don't infer rated from a missing delta —
             // that mislabels finalized rated matches as "Friendly" (#453).
             ratedHint: r.affectsRating, games: nil, h2h: nil,
-            // The list row omits signatures; fall back to the games-won heuristic.
-            // This row is transient anyway — the detail view refetches on open and
-            // replaces it with the signature-accurate copy.
-            signaturesPosted: nil
+            negotiation: r.negotiation
+        )
+    }
+
+    // MARK: Negotiation DTO → view model
+
+    private static func viewerState(_ s: ViewerStateDTO) -> NegotiationViewerState {
+        switch s {
+        case .live: return .live
+        case .awaiting: return .awaiting
+        case .review: return .review
+        case .corrected: return .corrected
+        case .final: return .settled
+        case .unknown: return .unknown
+        }
+    }
+
+    /// Map the wire negotiation onto the view model: resolve the viewer phase,
+    /// re-orient the standing board so `a` = you, and pre-format the
+    /// `corrected`-phase diff (canonical side-1–side-2, like the web's
+    /// ScoreDiff).
+    private static func negotiation(
+        _ n: MatchNegotiationDTO, mineIsSide1: Bool
+    ) -> MatchNegotiation {
+        let standingGames: [Game] = (n.standingResult?.games ?? [])
+            .sorted { $0.gameNumber < $1.gameNumber }
+            .map { g in
+                mineIsSide1
+                    ? Game(a: g.side1Points, b: g.side2Points)
+                    : Game(a: g.side2Points, b: g.side1Points)
+            }
+        func fmt(_ g: NegotiationGameDTO) -> String { "\(g.side1Points)–\(g.side2Points)" }
+        let diff: [ScoreDiffEntry] = (n.diff ?? []).map { entry in
+            ScoreDiffEntry(
+                gameNumber: entry.gameNumber,
+                old: entry.old.map(fmt),
+                new: fmt(entry.new)
+            )
+        }
+        return MatchNegotiation(
+            viewerState: viewerState(n.viewerState),
+            yourTurn: n.yourTurn,
+            standingResultId: n.standingResult?.id,
+            standingGames: standingGames,
+            diff: diff
         )
     }
 
@@ -170,8 +224,9 @@ struct MatchService {
     private static func common(
         id: UUID, status: APIMatchStatus, statusLabel: String,
         league: MatchLeagueDTO, sides: [MatchSideDTO], bestOf: Int,
-        createdAt: Date, canConfirm: Bool, canScore: Bool, canFinalize: Bool,
-        ratedHint: Bool?, games: [MatchGameDTO]?, h2h: H2HDTO?, signaturesPosted: Bool?
+        createdAt: Date, canScore: Bool, canFinalize: Bool,
+        ratedHint: Bool?, games: [MatchGameDTO]?, h2h: H2HDTO?,
+        negotiation negotiationDTO: MatchNegotiationDTO
     ) -> FinalMatch {
         let viewerIsParticipant = sides.contains(where: \.isCurrentUserSide)
         let mine = sides.first(where: \.isCurrentUserSide) ?? sides.first
@@ -230,10 +285,19 @@ struct MatchService {
         let decided = status == .completed
         let rated = ratedHint ?? (mine?.ratingChange != nil)
         let delta = mine?.ratingChange.map { Int($0.delta.rounded()) }
-        // Prefer the authoritative signatures signal (detail path); fall back to
-        // the games-won heuristic only when signatures aren't available (list row).
-        let resultPosted = signaturesPosted ?? ((mine?.gamesWon ?? 0) + (theirs?.gamesWon ?? 0) > 0)
+        // The negotiation block is populated on both the detail and list shapes,
+        // so "a result has been posted" is authoritative everywhere — no more
+        // games-won heuristic (which mis-read a rewound board as posted).
+        let negotiation = Self.negotiation(negotiationDTO, mineIsSide1: mineIsSide1)
+        let resultPosted = [.awaiting, .review, .corrected]
+            .contains(negotiation.viewerState)
         let awaitingConfirmation = status == .inProgress && resultPosted
+        // The viewer owes an accept-or-correct: the opponent posted the standing
+        // proposal (first posting → `review`; a correction over the viewer's own
+        // prior proposal → `corrected`). Matches `your_turn`, which the server
+        // sets exactly for these two states.
+        let canConfirm = viewerIsParticipant && negotiation.yourTurn
+            && [.review, .corrected].contains(negotiation.viewerState)
 
         return FinalMatch(
             id: id.uuidString,
@@ -254,6 +318,7 @@ struct MatchService {
             decided: decided,
             awaitingConfirmation: awaitingConfirmation,
             canConfirm: canConfirm,
+            negotiation: negotiation,
             h2h: h2h.map { mapH2H($0, mineIsSide1: mineIsSide1) },
             sideA: sidePlayer(side1),
             sideB: (side2?.players.isEmpty ?? true) ? .guest : sidePlayer(side2),

--- a/ios/Fortymm/MatchFlow/ScoreEntryView.swift
+++ b/ios/Fortymm/MatchFlow/ScoreEntryView.swift
@@ -13,6 +13,10 @@ struct ScoreEntryView: View {
     /// Hand the completed games (in order, game 1…N) up to the coordinator,
     /// which posts them to the API and renders the server's result.
     var onPost: ([Game]) -> Void
+    /// True when this board is a *correction* of a posted result (seeded from
+    /// the standing proposal; posting supersedes it). Only changes copy — the
+    /// entry/edit mechanics are identical to live scoring.
+    var correction: Bool = false
     /// The signed-in player's username, so the "you" panel labels your side with
     /// the same handle the posted result, list, and detail views show (and that
     /// the web scoreboard shows) — rather than a generic "You". Falls back to the
@@ -201,7 +205,9 @@ struct ScoreEntryView: View {
                 if editing {
                     clearButton
                 } else {
-                    Text("This finishes the match — post the result.")
+                    Text(correction
+                         ? "Sending posts the corrected score for \(opp.handle) to confirm."
+                         : "This finishes the match — post the result.")
                         .font(FMFont.ui(12, weight: .medium))
                         .foregroundStyle(FMColor.fg3)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -246,7 +252,8 @@ struct ScoreEntryView: View {
     private func postButton(expand: Bool) -> some View {
         Button(action: post) {
             HStack(spacing: 8) {
-                Text("Post result").font(FMFont.ui(16, weight: .bold))
+                Text(correction ? "Send corrected score" : "Post result")
+                    .font(FMFont.ui(16, weight: .bold))
                 if expand { Image(systemName: "arrow.right").font(.system(size: 15, weight: .bold)) }
             }
             .foregroundStyle(FMColor.fgInverse)

--- a/ios/Fortymm/Notifications/PushNotificationManager.swift
+++ b/ios/Fortymm/Notifications/PushNotificationManager.swift
@@ -10,7 +10,9 @@ enum MatchNotification {
     /// Must equal `MATCH_RESULT_CONFIRMATION_CATEGORY` in `app/notifications/apns.py`.
     static let category = "MATCH_RESULT_CONFIRMATION"
     static let approveAction = "CONFIRM_MATCH_ACTION"
-    static let disputeAction = "DISPUTE_MATCH_ACTION"
+    /// Surface verb is "Suggest correction" (the dispute verb was replaced by
+    /// the propose/accept negotiation); the wire identifier stays stable.
+    static let suggestCorrectionAction = "DISPUTE_MATCH_ACTION"
     /// Must equal the `data` key the server sends (`{"match_id": "<uuid>"}`).
     static let matchIdKey = "match_id"
 }
@@ -83,14 +85,14 @@ final class PushNotificationManager: NSObject {
             title: "Approve",
             options: []
         )
-        let dispute = UNNotificationAction(
-            identifier: MatchNotification.disputeAction,
+        let suggestCorrection = UNNotificationAction(
+            identifier: MatchNotification.suggestCorrectionAction,
             title: "Suggest correction",
             options: [.foreground]
         )
         return UNNotificationCategory(
             identifier: MatchNotification.category,
-            actions: [approve, dispute],
+            actions: [approve, suggestCorrection],
             intentIdentifiers: [],
             options: []
         )
@@ -183,9 +185,20 @@ extension PushNotificationManager: UNUserNotificationCenterDelegate {
         case MatchNotification.approveAction:
             // The push payload carries only the match id; the service fetches
             // the match to resolve the standing proposal (the acceptance
-            // token) and accepts it.
-            act(completionHandler) { try await self.matchService.acceptStandingResult(matchId) }
-        case MatchNotification.disputeAction, UNNotificationDefaultActionIdentifier:
+            // token) and accepts it. Best-effort: a failed sign-off (the
+            // proposal moved on, or was already accepted) shouldn't hang the
+            // notification — the match screen reconciles state on next open.
+            // iOS gives this background action a short window; the fetch +
+            // accept pair fits comfortably.
+            Task {
+                do {
+                    _ = try await self.matchService.acceptStandingResult(matchId)
+                } catch {
+                    print("[push] match accept failed: \(error.fmMessage)")
+                }
+                completionHandler()
+            }
+        case MatchNotification.suggestCorrectionAction, UNNotificationDefaultActionIdentifier:
             // A correction needs the full board editor — open the app on the
             // match (the action is registered `.foreground`), same as a body
             // tap.
@@ -196,25 +209,6 @@ extension PushNotificationManager: UNUserNotificationCenterDelegate {
                 completionHandler()
             }
         default:
-            completionHandler()
-        }
-    }
-
-    /// Run the accept call, then signal completion regardless of outcome.
-    /// Best-effort: a failed sign-off (e.g. the proposal moved on, or was
-    /// already accepted) shouldn't hang the notification — the match screen
-    /// reconciles state on next open. iOS gives this background action a short
-    /// window; the fetch + accept pair fits comfortably.
-    private func act(
-        _ completionHandler: @escaping () -> Void,
-        _ work: @escaping () async throws -> FinalMatch
-    ) {
-        Task {
-            do {
-                _ = try await work()
-            } catch {
-                print("[push] match action failed: \(error.fmMessage)")
-            }
             completionHandler()
         }
     }

--- a/ios/Fortymm/Notifications/PushNotificationManager.swift
+++ b/ios/Fortymm/Notifications/PushNotificationManager.swift
@@ -73,10 +73,10 @@ final class PushNotificationManager: NSObject {
         center.setNotificationCategories([Self.matchConfirmationCategory()])
     }
 
-    /// The "a result is waiting on you" category: Approve confirms the posted
-    /// result, Dispute rejects it. Both run without `.foreground` so a quick
-    /// tap acts in the background; Dispute is `.destructive` (red) since it
-    /// rewinds the opponent's posted result.
+    /// The "a result is waiting on you" category: Approve accepts the standing
+    /// proposal in the background (no `.foreground` — a quick tap acts without
+    /// opening the app). Suggesting a correction needs the full board editor,
+    /// so that action opens the app on the match instead of acting inline.
     private static func matchConfirmationCategory() -> UNNotificationCategory {
         let approve = UNNotificationAction(
             identifier: MatchNotification.approveAction,
@@ -85,8 +85,8 @@ final class PushNotificationManager: NSObject {
         )
         let dispute = UNNotificationAction(
             identifier: MatchNotification.disputeAction,
-            title: "Dispute",
-            options: [.destructive]
+            title: "Suggest correction",
+            options: [.foreground]
         )
         return UNNotificationCategory(
             identifier: MatchNotification.category,
@@ -161,9 +161,10 @@ extension PushNotificationManager: UNUserNotificationCenterDelegate {
     }
 
     /// The user acted on a notification. For a match-confirmation push:
-    /// Approve / Dispute hit the corresponding endpoint in the background;
-    /// tapping the body (the default action) routes to the match. Anything we
-    /// don't recognise — or a payload missing its `match_id` — just dismisses.
+    /// Approve accepts the standing proposal in the background; "Suggest
+    /// correction" and a body tap both open the app on the match (a correction
+    /// needs the full board editor). Anything we don't recognise — or a payload
+    /// missing its `match_id` — just dismisses.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
@@ -180,10 +181,14 @@ extension PushNotificationManager: UNUserNotificationCenterDelegate {
 
         switch response.actionIdentifier {
         case MatchNotification.approveAction:
-            act(completionHandler) { try await self.matchService.confirmMatch(matchId) }
-        case MatchNotification.disputeAction:
-            act(completionHandler) { try await self.matchService.disputeMatch(matchId) }
-        case UNNotificationDefaultActionIdentifier:
+            // The push payload carries only the match id; the service fetches
+            // the match to resolve the standing proposal (the acceptance
+            // token) and accepts it.
+            act(completionHandler) { try await self.matchService.acceptStandingResult(matchId) }
+        case MatchNotification.disputeAction, UNNotificationDefaultActionIdentifier:
+            // A correction needs the full board editor — open the app on the
+            // match (the action is registered `.foreground`), same as a body
+            // tap.
             // Body tap → open the match. Hop to the main actor: `onOpenMatch`
             // drives SwiftUI state.
             DispatchQueue.main.async {
@@ -195,11 +200,11 @@ extension PushNotificationManager: UNUserNotificationCenterDelegate {
         }
     }
 
-    /// Run a confirm/dispute call, then signal completion regardless of outcome.
-    /// Best-effort: a failed sign-off (e.g. the opponent already confirmed)
-    /// shouldn't hang the notification — the match screen reconciles state on
-    /// next open. iOS gives this background action a short window; the single
-    /// round-trip fits comfortably.
+    /// Run the accept call, then signal completion regardless of outcome.
+    /// Best-effort: a failed sign-off (e.g. the proposal moved on, or was
+    /// already accepted) shouldn't hang the notification — the match screen
+    /// reconciles state on next open. iOS gives this background action a short
+    /// window; the fetch + accept pair fits comfortably.
     private func act(
         _ completionHandler: @escaping () -> Void,
         _ work: @escaping () async throws -> FinalMatch

--- a/ios/Fortymm/Notifications/PushNotificationManager.swift
+++ b/ios/Fortymm/Notifications/PushNotificationManager.swift
@@ -3,9 +3,10 @@ import UserNotifications
 
 /// Identifiers shared with the backend push payload (`api/app/notifications`).
 /// A push whose `aps.category` is `MATCH_RESULT_CONFIRMATION` renders the
-/// Approve / Dispute buttons registered below; the `match_id` userInfo key tells
-/// the app which match the buttons (and a tap) act on. Kept in one place so the
-/// device-side registration can't drift from what the server sends.
+/// Approve / Suggest-correction buttons registered below; the `match_id`
+/// userInfo key tells the app which match the buttons (and a tap) act on. Kept
+/// in one place so the device-side registration can't drift from what the
+/// server sends.
 enum MatchNotification {
     /// Must equal `MATCH_RESULT_CONFIRMATION_CATEGORY` in `app/notifications/apns.py`.
     static let category = "MATCH_RESULT_CONFIRMATION"
@@ -23,13 +24,13 @@ enum MatchNotification {
 /// 2. receives the APNs device token (via the app delegate, see
 ///    `FortymmApp.swift`), hex-encodes it, and POSTs it to the backend so the
 ///    server can push to this device,
-/// 3. registers the "match result" notification category so a confirm/dispute
-///    push carries Approve / Dispute action buttons,
+/// 3. registers the "match result" notification category so a result-awaiting
+///    push carries Approve / Suggest-correction action buttons,
 /// 4. presents pushes as a banner even while the app is foregrounded (otherwise
 ///    a self-test looks like nothing happened),
-/// 5. handles a tapped action: Approve/Dispute call the match endpoints
-///    directly (no need to open the app); tapping the body deep-links to the
-///    match via `onOpenMatch`.
+/// 5. handles a tapped action: Approve accepts the standing proposal in the
+///    background (no need to open the app); Suggest correction and a body tap
+///    both deep-link to the match via `onOpenMatch`.
 ///
 /// A singleton because the `UIApplicationDelegate` token callbacks and the
 /// SwiftUI view that triggers registration must talk to the same instance, and

--- a/web-client/src/test/setup.ts
+++ b/web-client/src/test/setup.ts
@@ -51,5 +51,12 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => {
   server.resetHandlers()
   resetMockMatches()
+  // The session-bootstrap storage lock (api/session.ts) survives in
+  // localStorage across tests within a file. A test that tears down with a
+  // `/v1/session` request still in flight strands the lock, and the next
+  // tests' session fetches poll it until its 10s TTL lapses — flaky 5s
+  // timeouts two tests downstream. No test owns cross-test storage, so wipe
+  // it wholesale.
+  window.localStorage.clear()
 })
 afterAll(() => server.close())


### PR DESCRIPTION
## Problem

Every iOS screen touching match data (New Match, Matches list, match detail) failed with "Something went wrong — Couldn't read the server's response". `MatchDetailsDTO`/`MatchListRowDTO` still declared the required `can_confirm`/`signatures` fields that 77d5b4f (#723) removed from the API in favor of a single `negotiation` object, so `JSONDecoder` threw `keyNotFound` on every real payload. The iOS confirm/dispute service also called the removed `/confirmation` and `/dispute` endpoints.

## Fix

- **MatchAPI.swift** — DTO mirrors of `MatchNegotiation`/`NegotiationResult`/`NegotiationGame`/`NegotiationDiffEntry` with a lenient `ViewerStateDTO` (unknown-tolerant, like `APIMatchStatus`); dropped `can_confirm`/`signatures`/`MatchSignatureDTO`; `PostResultsBody` gains `supersedes_result_id`.
- **MatchService.swift** — `canConfirm` and "result posted" now derive from `negotiation` (authoritative on list rows too; the `signaturesPosted` optional + games-won heuristic are deleted). New `acceptResult` (POST `results/{id}/acceptance`) and supersedes-aware `postResult` replace the dead confirm/dispute calls.
- **MatchDetailView.swift** — mirrors the web negotiation UI:
  - `review`: "Accept result" + "Suggest correction", with the rated/unrated stakes line
  - `corrected`: "What changed" per-game diff (old struck → new, "new game" flag) + "Accept result" / "Counter"
  - `awaiting`: passive "awaiting X's acceptance" notice + "Edit result" self-correction
  - a stale accept (409: the proposal moved on) prompts a re-review and refetches instead of silently retargeting (mirrors web #726)
- **Corrections** reuse the score-entry board (`ScoreEntryView` + `MatchFlowView`), seeded from the immutable standing-result snapshot and posted with `supersedes_result_id`; correction copy swaps in ("Send corrected score").
- **Push actions** — Approve fetches the match and accepts the standing proposal (the payload only carries the match id); Dispute becomes a foreground "Suggest correction" that deep-links to the match, since a correction needs the board editor.

## Verification (iOS Simulator against live UAT)

- Matches list loads (19 matches incl. "Awaiting confirmation" rows); New match → Start → score entry → post all work (previously all decode-failed).
- Solo BO1: propose self-accepts → Final detail.
- Two-party rated BO3 (second party driven via curl): `review` state renders Accept/Suggest-correction; correction board seeds 4–11/8–11 viewer-left, flipping G2 and adding G3 posts with correct side orientation (server diff confirms); `awaiting` shows the passive notice + Edit result; opponent counter puts iOS in `corrected` with the "What changed" diff; Accept finalizes (status Final, rating −162 applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GenSpiU6Xhse7EQDnLD4Ca