### PR TITLE
Roll UAT deployments atomically with unique per-build image tags

### DIFF
--- a/scripts/redeploy-uat.sh
+++ b/scripts/redeploy-uat.sh
@@ -26,8 +26,8 @@ RELEASE="fortymm-uat"
 CHART="deploy/uat"
 HOST_PORT=8084
 NODE_PORT=30084
-API_IMAGE="fortymm/api:uat"
-WEB_IMAGE="fortymm/web:uat"
+API_REPO="fortymm/api"
+WEB_REPO="fortymm/web"
 APNS_KEY="secrets/AuthKey_68VYRLMWWR.p8"
 UAT_URL="${UAT_URL:-https://uat.fortymm.com}"
 
@@ -65,6 +65,23 @@ if [ "$before" = "$after" ]; then
 else
   echo "(advanced $branch: $before -> $after)"
 fi
+
+# Tag every build with a unique id (post-merge commit + build epoch) instead of
+# a static `:uat`. The tag is the image string in the pod template, so a unique
+# tag makes `helm upgrade` see a changed template and roll both deployments
+# atomically (honoring the zero-downtime RollingUpdate). With the old mutable
+# `:uat` tag the template never changed, so a redeploy re-imported new content
+# under the same tag but never rolled — and when only one web replica later
+# restarted on its own it drifted onto the new build while its sibling stayed on
+# the old one. The two content-hashed SPA bundles then sat behind the
+# round-robin routing nginx, so ~half of loads fetched index.html from one pod
+# but got its `assets/index-*.js` chunk routed to the other → 404 → blank page.
+# The epoch suffix forces a fresh roll even on a same-commit rebuild. (Old
+# unique tags accumulate in the k3d image store; prune with `k3d image` /
+# `docker image prune` if it grows.)
+IMAGE_TAG="$(git rev-parse --short HEAD)-$(date +%s)"
+API_IMAGE="${API_REPO}:${IMAGE_TAG}"
+WEB_IMAGE="${WEB_REPO}:${IMAGE_TAG}"
 
 # --- cluster ----------------------------------------------------------------
 echo
@@ -153,12 +170,15 @@ echo
 echo "==> helm upgrade --install $RELEASE"
 helm upgrade --install "$RELEASE" "$CHART" \
   --namespace "$NAMESPACE" \
+  --set images.api.tag="$IMAGE_TAG" \
+  --set images.web.tag="$IMAGE_TAG" \
   --wait --timeout 5m
 
 # The migrate Job is a post-* Helm hook; --wait above already blocks on it.
 echo
-echo "==> Waiting for the api rollout"
+echo "==> Waiting for the api and web-client rollouts"
 kubectl rollout status deploy/api -n "$NAMESPACE" --timeout=120s
+kubectl rollout status deploy/web-client -n "$NAMESPACE" --timeout=120s
 
 echo
 echo "==> Waiting for api to report ready at $UAT_URL"


### PR DESCRIPTION
## Problem

UAT's web app serves a **blank page ~half the time** — reported as "not working in Safari," but it's browser-agnostic (Safari just happened to catch it). The entry bundle 404s: a page load fetches `index.html` from one `web-client` replica but nginx round-robins the request for that HTML's hashed `assets/index-*.js` chunk to the *other* replica, which was built separately and doesn't have that hash → 404 → blank app.

Confirmed live: the two web pods ran the same `fortymm/web:uat` tag but **different image digests** (`sha256:0657ac…` vs `sha256:28959b…`), and a `curl` loop of `/` flipped between two entry hashes, each 404ing on the other pod. Reproduced in WebKit (Safari's engine) via `playwright-cli open --browser=webkit`.

## Root cause

`redeploy-uat.sh` tagged images with a **static `:uat`**. The tag is the image string in the pod template, so `helm upgrade` saw an unchanged template and **never rolled the deployment** — a redeploy just re-imported new content under the same tag in place. When one replica later restarted on its own it picked up the new build while its sibling stayed on the old one, stranding the two replicas on mismatched content-hashed SPA bundles behind the round-robin routing nginx.

## Fix

- Tag every build `<git-short-sha>-<epoch>` and pass it to `helm` (`--set images.{api,web}.tag`). The pod template now changes each deploy, so **both `api` and `web-client` roll atomically** via the existing zero-downtime `RollingUpdate` — every replica always runs the identical build. The epoch suffix forces a roll even on a same-commit rebuild.
- Wait on the `web-client` rollout in the smoke check (previously only `api` was waited on), so a failed web roll is actually caught.

Verified with `bash -n` and `helm template` (renders `fortymm/{api,web}:<sha>-<epoch>`; pinned base images untouched).

## Notes

- **Takes effect on the next `redeploy-uat.sh` run** (from `main`/`uat-deploy`). To unblock the currently-broken UAT immediately: `kubectl rollout restart deployment/web-client -n fortymm-uat`.
- Residual: 2 replicas + rolling update still leaves a *seconds*-long window where a client that loaded `index.html` from an old pod fetches a chunk after that pod is gone. Acceptable for UAT; the airtight fix (shared asset origin / retained old hashes) is left for if this pattern reaches multi-replica prod.
- Old unique tags accumulate in the k3d image store — prune with `k3d image` / `docker image prune` if it grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)