### PR TITLE
Skip decided matches with a player-less side in rating recompute

### DIFF
--- a/api/app/ratings/recompute.py
+++ b/api/app/ratings/recompute.py
@@ -59,10 +59,18 @@ def _decided_sides(match: Match) -> tuple[MatchSide, MatchSide] | None:
     """Return ``(winning_side, losing_side)`` for a decided binary result, or
     ``None`` when the match has no clear winner/loser — a forfeit/void/partial
     write leaves ``MatchSide.won`` as ``None``. Such a match never produced a
-    rating delta, so the cascade skips it rather than crashing on the lookup."""
+    rating delta, so the cascade skips it rather than crashing on the lookup.
+
+    Also returns ``None`` when a decided side has no players — the solo-match
+    sentinel side, or a forfeit that stamped ``won`` on a player-less side. The
+    live rating path guards this explicitly (``app/matches.py``) and writes no
+    ``RatingHistory``, so the callers' ``players[0]`` lookups below would
+    otherwise ``IndexError`` on a match that never contributed a delta."""
     winning_side = next((s for s in match.sides if s.won is True), None)
     losing_side = next((s for s in match.sides if s.won is False), None)
     if winning_side is None or losing_side is None:
+        return None
+    if not winning_side.players or not losing_side.players:
         return None
     return winning_side, losing_side
 

--- a/api/tests/test_rating_recompute.py
+++ b/api/tests/test_rating_recompute.py
@@ -367,6 +367,65 @@ async def test_recompute_skips_matches_without_a_decided_outcome(
     assert {row.match_id for row in rows} == {decided.id}
 
 
+async def test_recompute_skips_decided_match_with_a_player_less_side(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """A completed, rated match with a decided (``won`` set) side that has no
+    players — the solo-match sentinel side, or a forfeit that stamped ``won``
+    on a player-less side — produced no rating delta (the live path guards it,
+    ``app/matches.py``). The cascade must skip it rather than ``IndexError`` on
+    ``players[0]``, which would otherwise roll back the whole league recompute."""
+    league = await get_default_league(db_session)
+    strategy = rating_strategies["glicko2"]
+    me = await make_user(db_session, "me")
+    opp = await make_user(db_session, "opp")
+    for user in (me, opp):
+        await _seed_rating(db_session, league, user.id, strategy)
+
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    # A normal decided match the cascade should still process...
+    decided = await _build_completed_match(db_session, league, me, opp, base)
+    # ...and a decided match whose losing side has no players.
+    settings = MatchSettings(team_size=1, best_of=1, affects_rating=True)
+    player_less = Match(
+        match_settings=settings,
+        league=league,
+        created_by_user_id=me.id,
+        status=MatchStatus.completed,
+    )
+    side1 = MatchSide(match=player_less, side_number=1, won=True, score=1)
+    side1.players.append(MatchSidePlayer(match=player_less, user=me))
+    # The losing side is decided (won=False) but carries no players.
+    MatchSide(match=player_less, side_number=2, won=False, score=0)
+    db_session.add(player_less)
+    await db_session.commit()
+    await db_session.refresh(player_less)
+    await db_session.execute(
+        text("UPDATE matches SET created_at = :ts, updated_at = :ts WHERE id = :id"),
+        {"ts": base + timedelta(hours=1), "id": player_less.id},
+    )
+    await db_session.commit()
+
+    # Must not raise.
+    await recompute_league_ratings(db_session, league.id, {me.id})
+    await db_session.commit()
+
+    # The decided match still produced its history; the player-less one produced none.
+    rows = (
+        (
+            await db_session.execute(
+                select(RatingHistory).where(
+                    RatingHistory.match_id.in_([decided.id, player_less.id])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {row.match_id for row in rows} == {decided.id}
+
+
 # ----- idempotency --------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Fixes #748.

`recompute_league_ratings` indexed `winning_side.players[0]` / `losing_side.players[0]` (`api/app/ratings/recompute.py`) with **no empty-players guard**, while `_decided_sides` only checked `won is True/False` — not whether each decided side actually has players.

A completed, `affects_rating=True`, `team_size==1` match with an empty decided side (the solo-match sentinel side, or a forfeit that stamped `won` on a player-less side) made `players[0]` raise `IndexError`. That exception aborted the **entire per-league recompute** and rolled back the surrounding merge-recompute transaction — one degenerate match blocked rating settlement for the whole league.

The **live** rating path already guards this explicitly (`api/app/matches.py`: `if not winning_side.players or not losing_side.players: return`) and writes no `RatingHistory` for such matches. Recompute's match query still selected them, so the two paths disagreed.

## Fix

Mirror the live guard in `_decided_sides`: return `None` when either decided side has no players, so the cascade skips the match — exactly as it already skips undecided matches. Both `players[0]` call sites already short-circuit on `decided is None`, so the single guard covers both.

## Testing

- Added `test_recompute_skips_decided_match_with_a_player_less_side`, which builds a completed rated match whose losing side is decided (`won=False`) but carries no players. Verified it raises `IndexError` on the pre-fix code and passes with the fix; the sibling decided match still produces its history rows.
- `ruff check`, `ruff format --check`, and `mypy` all clean.
- Ran the rating/match test subset (191 passed) against a local Postgres via `TEST_DATABASE_URL` (Docker unavailable in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJyX29DgxWdZ4DLQJMqxcN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJyX29DgxWdZ4DLQJMqxcN)_