### PR TITLE
Fix Unread notifications vanishing mid-read (#762)

### DIFF
--- a/web-client/src/components/notifications/notifications-page.tsx
+++ b/web-client/src/components/notifications/notifications-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import {
   useMarkAllNotificationsRead,
   useNotificationFeed,
@@ -11,6 +11,7 @@ import {
 } from './notifications-page/notifications-view'
 import { useAutoMarkRead } from './use-auto-mark-read'
 import { useFollowNotification } from './use-follow-notification'
+import { useStickyUnread } from './use-sticky-unread'
 
 /** Route container for the full notifications page — wires the feed query, the
  * filter state, and the mark-read mutations to the pure view. */
@@ -21,6 +22,26 @@ export function NotificationsPage() {
   const follow = useFollowNotification()
   const markAll = useMarkAllNotificationsRead()
   const markSeen = useAutoMarkRead()
+  const { pinned: stickyUnread, remember, forget } = useStickyUnread(
+    filter === 'unread',
+  )
+
+  // A row that scrolls into view auto-marks-read AND gets pinned, so viewing it
+  // doesn't drop it off the Unread filter mid-read (#762).
+  const handleSeen = useCallback(
+    (id: string) => {
+      remember(id)
+      markSeen(id)
+    },
+    [remember, markSeen],
+  )
+
+  // "Mark all read" is an explicit bulk dismiss — forget the snapshot so the
+  // Unread list actually empties instead of leaving the just-read rows pinned.
+  const handleMarkAllRead = useCallback(() => {
+    forget()
+    markAll.mutate()
+  }, [forget, markAll])
 
   if (feed.isPending || taxonomy.isPending) {
     return (
@@ -49,8 +70,9 @@ export function NotificationsPage() {
       filter={filter}
       onFilterChange={setFilter}
       onActivate={follow}
-      onMarkAllRead={() => markAll.mutate()}
-      onSeen={markSeen}
+      onMarkAllRead={handleMarkAllRead}
+      onSeen={handleSeen}
+      stickyUnread={stickyUnread}
     />
   )
 }

--- a/web-client/src/components/notifications/notifications-page/notifications-view.factory.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.factory.tsx
@@ -46,6 +46,7 @@ export function buildNotificationsViewProps(
     onFilterChange: () => {},
     onActivate: () => {},
     onMarkAllRead: () => {},
+    stickyUnread: new Set<string>(),
     ...overrides,
   }
 }

--- a/web-client/src/components/notifications/notifications-page/notifications-view.page.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.page.tsx
@@ -30,7 +30,14 @@ const scoped = (container: Container) => ({
 
 export const notificationsViewPage = {
   render(overrides: Partial<NotificationsViewProps> = {}) {
-    render(<NotificationsView {...buildNotificationsViewProps(overrides)} />)
+    const utils = render(<NotificationsView {...buildNotificationsViewProps(overrides)} />)
+    return {
+      ...utils,
+      /** Re-render with a fresh set of overrides (e.g. an updated feed). */
+      rerenderWith(next: Partial<NotificationsViewProps> = {}) {
+        utils.rerender(<NotificationsView {...buildNotificationsViewProps(next)} />)
+      },
+    }
   },
 
   within(container: Container = screen) {

--- a/web-client/src/components/notifications/notifications-page/notifications-view.test.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.test.tsx
@@ -29,22 +29,37 @@ describe('NotificationsView', () => {
     expect(notificationsViewPage.queryTitle('Rating +12')).not.toBeInTheDocument()
   })
 
-  it('keeps an unread row visible after it auto-marks-read (#762)', () => {
+  it('keeps a seen row visible after it auto-marks-read (#762)', () => {
     const items = buildNotificationsItems()
+    // n-1 has been seen (auto-mark-read pins it via stickyUnread).
+    const stickyUnread = new Set(['n-1'])
     const { rerenderWith } = notificationsViewPage.render({
       items,
       filter: 'unread',
+      stickyUnread,
     })
     expect(notificationsViewPage.queryTitle('Confirm your score')).toBeInTheDocument()
 
-    // The row is seen and auto-marked-read: the feed cache flips its read_at.
+    // The auto-mark-read lands: the feed cache flips the row's read_at.
     const readNow = items.map((item) =>
       item.id === 'n-1' ? { ...item, read_at: '2026-07-03T00:00:00.000Z' } : item,
     )
-    rerenderWith({ items: readNow, filter: 'unread' })
+    rerenderWith({ items: readNow, filter: 'unread', stickyUnread })
 
     // It stays on screen (just loses the unread emphasis) instead of vanishing.
     expect(notificationsViewPage.queryTitle('Confirm your score')).toBeInTheDocument()
+  })
+
+  it('drops a read row that was never pinned from the unread filter', () => {
+    const items = buildNotificationsItems().map((item) =>
+      item.id === 'n-1' ? { ...item, read_at: '2026-07-03T00:00:00.000Z' } : item,
+    )
+    // Empty snapshot: nothing was seen, so a read row (e.g. Mark all read, or a
+    // read on another tab) is not kept around.
+    notificationsViewPage.render({ items, filter: 'unread', stickyUnread: new Set() })
+    expect(
+      notificationsViewPage.queryTitle('Confirm your score'),
+    ).not.toBeInTheDocument()
   })
 
   it('filters by category', () => {

--- a/web-client/src/components/notifications/notifications-page/notifications-view.test.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.test.tsx
@@ -29,6 +29,24 @@ describe('NotificationsView', () => {
     expect(notificationsViewPage.queryTitle('Rating +12')).not.toBeInTheDocument()
   })
 
+  it('keeps an unread row visible after it auto-marks-read (#762)', () => {
+    const items = buildNotificationsItems()
+    const { rerenderWith } = notificationsViewPage.render({
+      items,
+      filter: 'unread',
+    })
+    expect(notificationsViewPage.queryTitle('Confirm your score')).toBeInTheDocument()
+
+    // The row is seen and auto-marked-read: the feed cache flips its read_at.
+    const readNow = items.map((item) =>
+      item.id === 'n-1' ? { ...item, read_at: '2026-07-03T00:00:00.000Z' } : item,
+    )
+    rerenderWith({ items: readNow, filter: 'unread' })
+
+    // It stays on screen (just loses the unread emphasis) instead of vanishing.
+    expect(notificationsViewPage.queryTitle('Confirm your score')).toBeInTheDocument()
+  })
+
   it('filters by category', () => {
     notificationsViewPage.render({ filter: 'rating_change' })
     expect(notificationsViewPage.queryTitle('Rating +12')).toBeInTheDocument()

--- a/web-client/src/components/notifications/notifications-page/notifications-view.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.tsx
@@ -6,12 +6,20 @@ import type {
 import { cn } from '@/lib/utils'
 import type { NotificationCategory } from '../notification-meta'
 import { NotificationRow } from '../notification-row'
+import { useStickyUnread } from '../use-sticky-unread'
 
 export type NotificationFilter = 'all' | 'unread' | NotificationCategory
 
-function matchesFilter(item: NotificationItem, filter: NotificationFilter) {
+function matchesFilter(
+  item: NotificationItem,
+  filter: NotificationFilter,
+  stickyUnread: ReadonlySet<string>,
+) {
   if (filter === 'all') return true
-  if (filter === 'unread') return item.read_at == null
+  // Keep rows that were unread when the filter opened even after they
+  // auto-mark-read, so viewing them doesn't make them vanish mid-read (#762).
+  if (filter === 'unread')
+    return item.read_at == null || stickyUnread.has(item.id)
   return item.category === filter
 }
 
@@ -29,7 +37,8 @@ export interface NotificationsViewProps {
 }
 
 /** The full notifications page: a Bebas header, category filter pills, and the
- * filtered list (or an empty state). Pure — data + handlers come in as props. */
+ * filtered list (or an empty state). Data + handlers come in as props; the only
+ * local state is the Unread filter's sticky snapshot (see `useStickyUnread`). */
 export function NotificationsView({
   items,
   categoryTypes,
@@ -40,7 +49,10 @@ export function NotificationsView({
   onMarkAllRead,
   onSeen,
 }: NotificationsViewProps) {
-  const shown = items.filter((item) => matchesFilter(item, filter))
+  const stickyUnread = useStickyUnread(items, filter === 'unread')
+  const shown = items.filter((item) =>
+    matchesFilter(item, filter, stickyUnread),
+  )
   const filters: { key: NotificationFilter; label: string }[] = [
     { key: 'all', label: 'All' },
     { key: 'unread', label: 'Unread' },

--- a/web-client/src/components/notifications/notifications-page/notifications-view.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.tsx
@@ -6,9 +6,10 @@ import type {
 import { cn } from '@/lib/utils'
 import type { NotificationCategory } from '../notification-meta'
 import { NotificationRow } from '../notification-row'
-import { useStickyUnread } from '../use-sticky-unread'
 
 export type NotificationFilter = 'all' | 'unread' | NotificationCategory
+
+const EMPTY_STICKY: ReadonlySet<string> = new Set()
 
 function matchesFilter(
   item: NotificationItem,
@@ -34,11 +35,13 @@ export interface NotificationsViewProps {
   onMarkAllRead: () => void
   /** Called with a row's id when it scrolls into view (auto mark-read). */
   onSeen?: (id: string) => void
+  /** Ids to keep visible on the Unread filter after they auto-mark-read, so
+   * viewing a row doesn't make it vanish mid-read (#762). See `useStickyUnread`. */
+  stickyUnread?: ReadonlySet<string>
 }
 
 /** The full notifications page: a Bebas header, category filter pills, and the
- * filtered list (or an empty state). Data + handlers come in as props; the only
- * local state is the Unread filter's sticky snapshot (see `useStickyUnread`). */
+ * filtered list (or an empty state). Pure — data + handlers come in as props. */
 export function NotificationsView({
   items,
   categoryTypes,
@@ -48,8 +51,8 @@ export function NotificationsView({
   onActivate,
   onMarkAllRead,
   onSeen,
+  stickyUnread = EMPTY_STICKY,
 }: NotificationsViewProps) {
-  const stickyUnread = useStickyUnread(items, filter === 'unread')
   const shown = items.filter((item) =>
     matchesFilter(item, filter, stickyUnread),
   )

--- a/web-client/src/components/notifications/use-sticky-unread.test.ts
+++ b/web-client/src/components/notifications/use-sticky-unread.test.ts
@@ -1,55 +1,52 @@
-import { renderHook } from '@/test/utilities'
-import { buildNotificationItem } from './notification-row.factory'
+import { act, renderHook } from '@/test/utilities'
 import { useStickyUnread } from './use-sticky-unread'
 
-const unread = (id: string) => buildNotificationItem({ id, read_at: null })
-const read = (id: string) =>
-  buildNotificationItem({ id, read_at: '2026-01-01T00:00:00.000Z' })
-
 describe('useStickyUnread', () => {
-  it('pins the currently-unread rows while active', () => {
-    const { result } = renderHook(
-      ({ items }) => useStickyUnread(items, true),
-      { initialProps: { items: [unread('n-1'), read('n-2')] } },
-    )
-    expect([...result.current]).toEqual(['n-1'])
+  it('pins ids reported via remember while active', () => {
+    const { result } = renderHook(() => useStickyUnread(true))
+    act(() => result.current.remember('n-1'))
+    expect([...result.current.pinned]).toEqual(['n-1'])
   })
 
-  it('keeps a row pinned after it flips to read', () => {
-    const { result, rerender } = renderHook(
-      ({ items }) => useStickyUnread(items, true),
-      { initialProps: { items: [unread('n-1')] } },
-    )
-    expect(result.current.has('n-1')).toBe(true)
-    // The row auto-marks-read: same id, now with a read_at.
-    rerender({ items: [read('n-1')] })
-    expect(result.current.has('n-1')).toBe(true)
+  it('keeps a pinned id even after the row it names flips to read', () => {
+    // The hook holds ids, not read state — so a row stays pinned through its
+    // optimistic read_at flip. (The view test asserts the visible effect.)
+    const { result } = renderHook(() => useStickyUnread(true))
+    act(() => result.current.remember('n-1'))
+    act(() => result.current.remember('n-1'))
+    expect([...result.current.pinned]).toEqual(['n-1'])
   })
 
-  it('accumulates rows that become unread later (e.g. a new arrival)', () => {
-    const { result, rerender } = renderHook(
-      ({ items }) => useStickyUnread(items, true),
-      { initialProps: { items: [unread('n-1')] } },
-    )
-    rerender({ items: [unread('n-1'), unread('n-2')] })
-    expect([...result.current].sort()).toEqual(['n-1', 'n-2'])
+  it('exposes no pins while inactive, even after remember', () => {
+    const { result } = renderHook(({ active }) => useStickyUnread(active), {
+      initialProps: { active: false },
+    })
+    act(() => result.current.remember('n-1'))
+    expect(result.current.pinned.size).toBe(0)
   })
 
-  it('clears the snapshot when the filter goes inactive', () => {
+  it('forgets the whole snapshot on demand (e.g. Mark all read)', () => {
+    const { result } = renderHook(() => useStickyUnread(true))
+    act(() => result.current.remember('n-1'))
+    act(() => result.current.forget())
+    expect(result.current.pinned.size).toBe(0)
+  })
+
+  it('starts fresh on re-entry: leaving and returning drops earlier pins', () => {
     const { result, rerender } = renderHook(
-      ({ active }) => useStickyUnread([unread('n-1')], active),
+      ({ active }) => useStickyUnread(active),
       { initialProps: { active: true } },
     )
-    expect(result.current.has('n-1')).toBe(true)
-    // Leaving the Unread filter forgets the pinned rows so re-entering is fresh.
-    rerender({ active: false })
-    expect(result.current.size).toBe(0)
-  })
+    act(() => result.current.remember('n-1'))
+    expect(result.current.pinned.has('n-1')).toBe(true)
 
-  it('does not pin anything while inactive', () => {
-    const { result } = renderHook(() =>
-      useStickyUnread([unread('n-1')], false),
-    )
-    expect(result.current.size).toBe(0)
+    // Leave the Unread filter...
+    rerender({ active: false })
+    expect(result.current.pinned.size).toBe(0)
+
+    // ...and come back: n-1 (read in the meantime) is no longer pinned, so it
+    // drops off instead of being resurrected.
+    rerender({ active: true })
+    expect(result.current.pinned.size).toBe(0)
   })
 })

--- a/web-client/src/components/notifications/use-sticky-unread.test.ts
+++ b/web-client/src/components/notifications/use-sticky-unread.test.ts
@@ -1,0 +1,55 @@
+import { renderHook } from '@/test/utilities'
+import { buildNotificationItem } from './notification-row.factory'
+import { useStickyUnread } from './use-sticky-unread'
+
+const unread = (id: string) => buildNotificationItem({ id, read_at: null })
+const read = (id: string) =>
+  buildNotificationItem({ id, read_at: '2026-01-01T00:00:00.000Z' })
+
+describe('useStickyUnread', () => {
+  it('pins the currently-unread rows while active', () => {
+    const { result } = renderHook(
+      ({ items }) => useStickyUnread(items, true),
+      { initialProps: { items: [unread('n-1'), read('n-2')] } },
+    )
+    expect([...result.current]).toEqual(['n-1'])
+  })
+
+  it('keeps a row pinned after it flips to read', () => {
+    const { result, rerender } = renderHook(
+      ({ items }) => useStickyUnread(items, true),
+      { initialProps: { items: [unread('n-1')] } },
+    )
+    expect(result.current.has('n-1')).toBe(true)
+    // The row auto-marks-read: same id, now with a read_at.
+    rerender({ items: [read('n-1')] })
+    expect(result.current.has('n-1')).toBe(true)
+  })
+
+  it('accumulates rows that become unread later (e.g. a new arrival)', () => {
+    const { result, rerender } = renderHook(
+      ({ items }) => useStickyUnread(items, true),
+      { initialProps: { items: [unread('n-1')] } },
+    )
+    rerender({ items: [unread('n-1'), unread('n-2')] })
+    expect([...result.current].sort()).toEqual(['n-1', 'n-2'])
+  })
+
+  it('clears the snapshot when the filter goes inactive', () => {
+    const { result, rerender } = renderHook(
+      ({ active }) => useStickyUnread([unread('n-1')], active),
+      { initialProps: { active: true } },
+    )
+    expect(result.current.has('n-1')).toBe(true)
+    // Leaving the Unread filter forgets the pinned rows so re-entering is fresh.
+    rerender({ active: false })
+    expect(result.current.size).toBe(0)
+  })
+
+  it('does not pin anything while inactive', () => {
+    const { result } = renderHook(() =>
+      useStickyUnread([unread('n-1')], false),
+    )
+    expect(result.current.size).toBe(0)
+  })
+})

--- a/web-client/src/components/notifications/use-sticky-unread.ts
+++ b/web-client/src/components/notifications/use-sticky-unread.ts
@@ -31,7 +31,7 @@ export function useStickyUnread(
   } else {
     let grown: Set<string> | null = null
     for (const item of items) {
-      if (item.read_at == null && !(grown ?? pinned).has(item.id)) {
+      if (item.read_at == null && !pinned.has(item.id)) {
         grown ??= new Set(pinned)
         grown.add(item.id)
       }

--- a/web-client/src/components/notifications/use-sticky-unread.ts
+++ b/web-client/src/components/notifications/use-sticky-unread.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import type { NotificationItem } from '@/api/notifications'
+
+/**
+ * Tracks the ids of every row that has been unread while the Unread filter is
+ * active, so the view can keep showing them after they flip to read.
+ *
+ * Rows auto-mark-read after a moment on screen (`use-auto-mark-read`), and the
+ * optimistic cache write flips their `read_at` in the very feed this page
+ * renders. A naive `read_at == null` filter would then drop each row the instant
+ * it's read, emptying the Unread list mid-read even though the user never
+ * dismissed anything (#762). Pinning the ids lets those rows stay put (they
+ * merely lose the unread emphasis) until the user leaves the filter.
+ *
+ * Leaving the Unread filter (`active` goes false) clears the snapshot, so
+ * re-entering starts fresh and rows read in the meantime drop off.
+ */
+export function useStickyUnread(
+  items: NotificationItem[],
+  active: boolean,
+): ReadonlySet<string> {
+  const [pinned, setPinned] = useState<ReadonlySet<string>>(() => new Set())
+
+  // Derive the next snapshot during render (React's recommended alternative to a
+  // setState-in-effect): grow it with any currently-unread id while the filter
+  // is active, reset it to empty the moment the filter goes inactive. Guarding
+  // the setState on an actual change keeps it from looping.
+  let next: ReadonlySet<string> = pinned
+  if (!active) {
+    if (pinned.size > 0) next = new Set()
+  } else {
+    let grown: Set<string> | null = null
+    for (const item of items) {
+      if (item.read_at == null && !(grown ?? pinned).has(item.id)) {
+        grown ??= new Set(pinned)
+        grown.add(item.id)
+      }
+    }
+    if (grown) next = grown
+  }
+  if (next !== pinned) setPinned(next)
+
+  return next
+}

--- a/web-client/src/components/notifications/use-sticky-unread.ts
+++ b/web-client/src/components/notifications/use-sticky-unread.ts
@@ -1,44 +1,60 @@
-import { useState } from 'react'
-import type { NotificationItem } from '@/api/notifications'
+import { useCallback, useState } from 'react'
+
+const EMPTY: ReadonlySet<string> = new Set()
+
+export interface StickyUnread {
+  /** Ids to keep visible on the Unread filter; empty while the filter is off. */
+  pinned: ReadonlySet<string>
+  /** Record a row the view just auto-marked-read so it stays put (#762). */
+  remember: (id: string) => void
+  /** Drop the whole snapshot — e.g. an explicit "Mark all read" should empty
+   * the list rather than leave the just-read rows pinned. */
+  forget: () => void
+}
 
 /**
- * Tracks the ids of every row that has been unread while the Unread filter is
- * active, so the view can keep showing them after they flip to read.
+ * Keeps the rows a user is *actively reading* from vanishing out from under
+ * them on the Unread filter.
  *
  * Rows auto-mark-read after a moment on screen (`use-auto-mark-read`), and the
  * optimistic cache write flips their `read_at` in the very feed this page
  * renders. A naive `read_at == null` filter would then drop each row the instant
  * it's read, emptying the Unread list mid-read even though the user never
- * dismissed anything (#762). Pinning the ids lets those rows stay put (they
- * merely lose the unread emphasis) until the user leaves the filter.
+ * dismissed anything (#762). The view reports each row it auto-marks via
+ * `remember`; those ids stay pinned (they merely lose the unread emphasis) until
+ * the filter is left or the snapshot is explicitly `forget`-ten.
  *
- * Leaving the Unread filter (`active` goes false) clears the snapshot, so
- * re-entering starts fresh and rows read in the meantime drop off.
+ * Pinning only what this view auto-read — rather than every row that happens to
+ * be unread — is deliberate: a bulk "Mark all read" (`forget`) or a row read on
+ * another tab/device is not something the user is mid-reading here, so it drops
+ * off the Unread filter as expected instead of lingering.
+ *
+ * `active` is the Unread filter being on. Entering or leaving it starts a fresh
+ * snapshot, so re-entering shows only rows read during this visit.
  */
-export function useStickyUnread(
-  items: NotificationItem[],
-  active: boolean,
-): ReadonlySet<string> {
-  const [pinned, setPinned] = useState<ReadonlySet<string>>(() => new Set())
+export function useStickyUnread(active: boolean): StickyUnread {
+  const [pinned, setPinned] = useState<ReadonlySet<string>>(EMPTY)
+  const [wasActive, setWasActive] = useState(active)
 
-  // Derive the next snapshot during render (React's recommended alternative to a
-  // setState-in-effect): grow it with any currently-unread id while the filter
-  // is active, reset it to empty the moment the filter goes inactive. Guarding
-  // the setState on an actual change keeps it from looping.
-  let next: ReadonlySet<string> = pinned
-  if (!active) {
-    if (pinned.size > 0) next = new Set()
-  } else {
-    let grown: Set<string> | null = null
-    for (const item of items) {
-      if (item.read_at == null && !pinned.has(item.id)) {
-        grown ??= new Set(pinned)
-        grown.add(item.id)
-      }
+  // Reset on any enter/leave of the filter (state-adjustment during render, the
+  // React-recommended alternative to a setState-in-effect). Use the cleared set
+  // for this render too, not just the next one.
+  let current = pinned
+  if (wasActive !== active) {
+    setWasActive(active)
+    if (pinned.size > 0) {
+      current = EMPTY
+      setPinned(EMPTY)
     }
-    if (grown) next = grown
   }
-  if (next !== pinned) setPinned(next)
 
-  return next
+  const remember = useCallback((id: string) => {
+    setPinned((prev) => (prev.has(id) ? prev : new Set(prev).add(id)))
+  }, [])
+
+  const forget = useCallback(() => {
+    setPinned((prev) => (prev.size === 0 ? prev : EMPTY))
+  }, [])
+
+  return { pinned: active ? current : EMPTY, remember, forget }
 }


### PR DESCRIPTION
## Summary

Fixes #762. On the **Unread** filter of the notifications page, rows auto-mark-read after ~800ms on screen (`use-seen-on-screen` → `use-auto-mark-read`), and `useMarkNotificationsRead.onMutate` optimistically flips `read_at` in the very feed cache the page renders. The plain `read_at == null` filter then dropped each row the instant it was read, progressively emptying the list to the "All caught up" empty state even though the user never dismissed anything.

## Fix

A new `useStickyUnread` hook pins the ids of rows **this view actually auto-marks-read** (reported via `remember`, wired through `onSeen`). `matchesFilter` keeps a row on the Unread filter if it's currently unread **or** pinned, so a row you're mid-reading stays put (it merely loses the unread emphasis) instead of vanishing.

Pinning only what the view auto-read — rather than every row that happens to be unread — is deliberate:

- An explicit **"Mark all read"** (`forget`) empties the Unread list as expected, instead of leaving the just-read rows pinned while the badge shows 0.
- A row read on **another tab/device** drops off the Unread filter on the next poll instead of lingering.

Entering or leaving the filter starts a fresh snapshot, so re-entering shows only rows read during the current visit. The snapshot is derived during render (React's recommended alternative to a `setState`-in-effect), so there's no one-render flash. The view stays pure — `stickyUnread` is a prop the container supplies.

## Changes

- `use-sticky-unread.ts` — new hook: `{ pinned, remember, forget }`, keyed on the Unread filter being active.
- `notifications-page.tsx` — container wires `remember` into `onSeen` and `forget` into "Mark all read", and passes `stickyUnread` down.
- `notifications-view.tsx` — `matchesFilter` consults the `stickyUnread` prop; view is pure again.
- `notifications-view.page.tsx` — page object gains a `rerenderWith` helper.
- Tests: `use-sticky-unread.test.ts` (pin / inactive-noop / forget / fresh-on-re-entry) and two `notifications-view` cases (a seen row survives auto-mark-read; a never-seen read row drops off).

## Testing

- `npx vitest run` — full suite green (1165 tests).
- `npm run lint`, `npm run build` (`tsc -b && vite build`) — clean.
- Local Playwright e2e — 131/133 (the 2 failures are this container's browser-build screenshot/timing mismatch, unrelated files; green in CI).
- Browser smoke against the dev server — page renders with a real session, filters and empty state work, auto-mark-read works, desktop + mobile render.
- Code review, security review, and a QA pass found no regressions. (QA noted a *pre-existing* mobile header overflow, untouched by this diff — worth a separate ticket.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsZsaPkrMWHjU4wDNrBtPw