### PR TITLE
Make the matches Attention tab viewer-relative (#729)

### DIFF
--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -6,13 +6,14 @@ from typing import Literal
 from fastapi import APIRouter, Depends
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import aliased, selectinload
+from sqlalchemy.orm import selectinload
 
 from app.attention import attention_priority, list_attention_kind
 from app.db import get_session
 from app.matches import (
     current_game_number,
     match_eager_options,
+    my_standing_proposal_exists,
     opponent_username,
     participant_filter,
     side_win_counts,
@@ -23,7 +24,6 @@ from app.matches import (
 from app.models import (
     League,
     Match,
-    MatchResult,
     MatchSide,
     MatchSidePlayer,
     MatchStatus,
@@ -87,24 +87,12 @@ async def get_dashboard(
     # every other in_progress match — either no result yet ("score") or a
     # standing result the *other* side proposed ("review"). The Python classifier
     # (``list_attention_kind``) refines which per row.
-    _superseding = aliased(MatchResult)
-    my_standing_proposal_exists = (
-        select(MatchResult.id)
-        .where(
-            MatchResult.match_id == Match.id,
-            MatchResult.accepted_by_user_id.is_(None),
-            MatchResult.submitted_by_user_id == current_user.id,
-            ~select(_superseding.id)
-            .where(_superseding.supersedes_result_id == MatchResult.id)
-            .exists(),
-        )
-        .exists()
-    )
+    my_standing_proposal = my_standing_proposal_exists(current_user.id)
     in_progress_q = (
         participant_filter(select(Match), current_user.id)
         .where(
             Match.status == MatchStatus.in_progress,
-            ~my_standing_proposal_exists,
+            ~my_standing_proposal,
         )
         .options(*match_eager_options())
         .order_by(Match.updated_at.asc())
@@ -136,7 +124,7 @@ async def get_dashboard(
             func.count(Match.id).filter(
                 and_(
                     Match.status == MatchStatus.in_progress,
-                    ~my_standing_proposal_exists,
+                    ~my_standing_proposal,
                 )
             ),
             func.count(Match.id).filter(
@@ -144,7 +132,7 @@ async def get_dashboard(
                     Match.status == MatchStatus.pending,
                     and_(
                         Match.status == MatchStatus.in_progress,
-                        my_standing_proposal_exists,
+                        my_standing_proposal,
                     ),
                 )
             ),

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -726,15 +726,11 @@ def _filtered_matches_query(
     return base if filter_ is None else _apply_list_filter(base, filter_)
 
 
-# Open statuses an attention row can hold — the only ones where the current
-# user can still owe (or be owed) a move. Completed/voided drop out. Used by the
-# sort-key fallback below; membership itself is the narrower *actionable* set
-# (``_actionable_attention_filter``).
-_ATTENTION_STATUSES = (
-    MatchStatus.pending,
-    MatchStatus.in_progress,
-    MatchStatus.disputed,
-)
+# Sort rank for a match that ``list_attention_kind`` can't classify — sits above
+# every real ``attention_priority`` (0–5) so a surprise row sinks to the bottom
+# rather than crashing the page. Only reachable defensively: the actionable
+# filter already excludes everything that would classify as ``None``.
+_UNCLASSIFIED_SORT_RANK = 99
 
 
 def _actionable_attention_filter[SelectT: Select[Any]](
@@ -788,7 +784,7 @@ def _attention_sort_key(
     if kind is None:
         # Defensive: an open participant match always classifies. Sink any
         # surprise to the bottom rather than crash the page.
-        return (len(_ATTENTION_STATUSES) + 99, match.updated_at)
+        return (_UNCLASSIFIED_SORT_RANK, match.updated_at)
     return (
         attention_priority(kind, match.match_settings.affects_rating),
         match.updated_at,

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -591,7 +591,15 @@ def my_standing_proposal_exists(current_user_id: uuid.UUID) -> Any:
     opponent* to accept: the current user has already signed and owes no move.
     It's the SQL twin of ``list_attention_kind``'s ``waiting_opponent`` bucket.
     Shared by the dashboard's waiting/actionable split and the matches-list
-    Attention filter so the two can never disagree about who owes a move."""
+    Attention filter so the two can never disagree about who owes a move.
+
+    Singles-only assumption: this keys on ``submitted_by_user_id ==
+    current_user``, whereas ``list_attention_kind`` treats a proposal from *any*
+    player on the viewer's side as theirs (``_submitted_on_side``). For
+    ``team_size == 1`` (the only topology today — see ``create_match``) the two
+    coincide. When doubles lands, a partner's proposal would make this ``False``
+    while the classifier says ``waiting_opponent``, so this must move to a
+    side-based match to keep the SQL and Python twins aligned."""
     superseding = aliased(MatchResult)
     return (
         select(MatchResult.id)

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -18,7 +18,7 @@ from fastapi import (
     status,
 )
 from pyrate_limiter import Duration, Rate
-from sqlalchemy import CursorResult, Select, func, select, update
+from sqlalchemy import CursorResult, Select, and_, func, or_, select, update
 from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
@@ -583,6 +583,30 @@ def _has_result_exists() -> Any:
     return select(MatchResult.id).where(MatchResult.match_id == Match.id).exists()
 
 
+def my_standing_proposal_exists(current_user_id: uuid.UUID) -> Any:
+    """``EXISTS`` correlated subquery: ``current_user`` submitted the *standing*
+    proposal on this match — the unaccepted result nothing else supersedes.
+
+    On an ``in_progress`` match that means the match is parked *waiting on the
+    opponent* to accept: the current user has already signed and owes no move.
+    It's the SQL twin of ``list_attention_kind``'s ``waiting_opponent`` bucket.
+    Shared by the dashboard's waiting/actionable split and the matches-list
+    Attention filter so the two can never disagree about who owes a move."""
+    superseding = aliased(MatchResult)
+    return (
+        select(MatchResult.id)
+        .where(
+            MatchResult.match_id == Match.id,
+            MatchResult.accepted_by_user_id.is_(None),
+            MatchResult.submitted_by_user_id == current_user_id,
+            ~select(superseding.id)
+            .where(superseding.supersedes_result_id == MatchResult.id)
+            .exists(),
+        )
+        .exists()
+    )
+
+
 def _player_username_filter[SelectT: Select[Any]](query: SelectT, q: str) -> SelectT:
     """Restrict to matches that have *any* player whose username matches ``q``.
 
@@ -702,8 +726,10 @@ def _filtered_matches_query(
     return base if filter_ is None else _apply_list_filter(base, filter_)
 
 
-# Open statuses the Attention filter ranges over — the only ones where the
-# current user can still owe (or be owed) a move. Completed/voided drop out.
+# Open statuses an attention row can hold — the only ones where the current
+# user can still owe (or be owed) a move. Completed/voided drop out. Used by the
+# sort-key fallback below; membership itself is the narrower *actionable* set
+# (``_actionable_attention_filter``).
 _ATTENTION_STATUSES = (
     MatchStatus.pending,
     MatchStatus.in_progress,
@@ -711,14 +737,41 @@ _ATTENTION_STATUSES = (
 )
 
 
+def _actionable_attention_filter[SelectT: Select[Any]](
+    query: SelectT, current_user_id: uuid.UUID
+) -> SelectT:
+    """Narrow ``query`` to the caller's matches that need *their own* action —
+    the Attention tab's membership, computed per viewer (issue #729).
+
+    Mirrors the actionable half of ``app.attention.list_attention_kind``
+    (``dispute`` / ``review`` / ``score``): a disputed match (either side may
+    re-score) or an in-progress match where the caller has *not* submitted the
+    standing proposal. This deliberately excludes the passive waiting buckets —
+    ``waiting_others`` (a pending/scheduled match) and ``waiting_opponent`` (the
+    caller's own posted result awaiting the opponent's sign-off) — so the tab
+    never flags a match the caller is merely waiting on. The poster and the
+    reviewer of the same posted result therefore see *different* Attention
+    counts, unlike before."""
+    return query.where(
+        or_(
+            Match.status == MatchStatus.disputed,
+            and_(
+                Match.status == MatchStatus.in_progress,
+                ~my_standing_proposal_exists(current_user_id),
+            ),
+        )
+    )
+
+
 def _attention_matches_query(
     q: str | None, current_user_id: uuid.UUID
 ) -> Select[tuple[Match]]:
-    """The caller's own open matches (optionally search-narrowed) — the row set
-    behind the Attention tab and its tab-badge count. Restricted to
-    participation, unlike the perspective-neutral browsing query."""
-    base = participant_filter(select(Match), current_user_id).where(
-        Match.status.in_(_ATTENTION_STATUSES)
+    """The caller's own matches that need their action (optionally
+    search-narrowed) — the row set behind the Attention tab and its tab-badge
+    count. Restricted to participation, unlike the perspective-neutral browsing
+    query, and to the *actionable* buckets, unlike a plain open-status scan."""
+    base = _actionable_attention_filter(
+        participant_filter(select(Match), current_user_id), current_user_id
     )
     if q:
         base = _player_username_filter(base, q)
@@ -814,12 +867,12 @@ async def list_matches(
     # The list is open to every signed-in user. Writes still gate on
     # `_is_participant` downstream.
     if attention:
-        # The Attention set is bounded by the caller's *open* matches — a handful
-        # even for an active player — so we load them all, rank by attention
-        # priority in Python (no SQL ordering captures the per-user bucketing),
-        # and paginate the sorted list. Its length *is* the tab-badge count, so
-        # no separate aggregate is needed on this path.
-        open_matches = (
+        # The Attention set is bounded by the caller's *actionable* open matches
+        # (issue #729) — a handful even for an active player — so we load them
+        # all, rank by attention priority in Python (no SQL ordering captures the
+        # per-user bucketing), and paginate the sorted list. Its length *is* the
+        # tab-badge count, so no separate aggregate is needed on this path.
+        actionable_matches = (
             (
                 await db.execute(
                     _attention_matches_query(q, current_user.id).options(
@@ -831,7 +884,7 @@ async def list_matches(
             .all()
         )
         ranked = sorted(
-            open_matches, key=lambda m: _attention_sort_key(m, current_user.id)
+            actionable_matches, key=lambda m: _attention_sort_key(m, current_user.id)
         )
         total = attention_count = len(ranked)
         start = (page - 1) * page_size
@@ -878,10 +931,12 @@ async def list_matches(
 async def _attention_count(
     db: AsyncSession, q: str | None, current_user_id: uuid.UUID
 ) -> int:
-    """Count of the caller's open matches under the active search — the Attention
-    tab's badge when a different tab is showing."""
-    query = participant_filter(select(func.count(Match.id)), current_user_id).where(
-        Match.status.in_(_ATTENTION_STATUSES)
+    """Count of the caller's matches that need their action under the active
+    search — the Attention tab's badge when a different tab is showing. Uses the
+    same actionable filter as the tab's row set so badge and list agree."""
+    query = _actionable_attention_filter(
+        participant_filter(select(func.count(Match.id)), current_user_id),
+        current_user_id,
     )
     if q:
         query = _player_username_filter(query, q)

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -830,10 +830,63 @@ async def test_list_row_attention_kind_reflects_who_must_act(
     listing = (await api_client.get("/v1/matches")).json()
     by_id = {row["id"]: row["attention"] for row in listing["items"]}
     # The side that proposed reads as passively waiting; the opposing side owes
-    # a review. Both still ride the attention set.
+    # a review. Both still carry their per-row attention kind on the browsing
+    # list…
     assert by_id[waiting["id"]] == "waiting_opponent"
     assert by_id[to_review["id"]] == "review"
-    assert listing["attention_count"] == 2
+    # …but only the actionable one counts toward *my* Attention badge — the
+    # match I merely posted and am waiting on is not my problem (issue #729).
+    assert listing["attention_count"] == 1
+
+
+async def test_attention_tab_is_viewer_relative_for_a_posted_result(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # The exact issue #729 scenario: on an in-progress match with a posted
+    # result, the poster is merely waiting while the opponent must review. The
+    # Attention tab (membership *and* badge) has to reflect whose turn it is,
+    # not read identically for both participants.
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        posted = await _create_match(api_client, opp.id, best_of=1)
+        await _post_bo1_result(api_client, posted["id"])
+
+        # Poster: they've signed and owe nothing — the match is neither in their
+        # Attention list nor counted in their badge.
+        poster_view = (
+            await api_client.get("/v1/matches", params={"attention": "true"})
+        ).json()
+        assert [row["id"] for row in poster_view["items"]] == []
+        assert poster_view["attention_count"] == 0
+
+        # Opponent: it's their turn to review — the match *is* their attention.
+        opp_view = (
+            await opp_client.get("/v1/matches", params={"attention": "true"})
+        ).json()
+        assert [row["id"] for row in opp_view["items"]] == [posted["id"]]
+        assert opp_view["attention_count"] == 1
+
+
+async def test_attention_tab_excludes_pending_scheduled_matches(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # A pending/scheduled match ("Up next") is nobody's turn yet — it's a
+    # ``waiting_others`` row, so it must not inflate the Attention badge (#729).
+    await start_session(api_client, db_session)
+    opp = await make_user(db_session, "rival")
+    scheduled = await _create_match(api_client, opp.id, best_of=1)
+    # Matches are created ``in_progress``; drop this one to ``pending`` to model
+    # a scheduled ("Up next") match with no scoring started.
+    await db_session.execute(
+        update(Match)
+        .where(Match.id == uuid.UUID(scheduled["id"]))
+        .values(status=MatchStatus.pending)
+    )
+    await db_session.commit()
+
+    listing = (await api_client.get("/v1/matches", params={"attention": "true"})).json()
+    assert scheduled["id"] not in {row["id"] for row in listing["items"]}
+    assert listing["attention_count"] == 0
 
 
 # ----- TT scoring rules ---------------------------------------------------

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -635,6 +635,14 @@ function listAttentionRank(seed: SeedMatch, kind: ListAttentionKind): number {
   return LIST_ATTENTION_PRIORITY[kind]
 }
 
+// The actionable buckets — the Attention tab's membership. An allow-list rather
+// than a deny-list of the passive kinds, so a future `ListAttentionKind` added
+// to the union stays out of the tab until it's explicitly opted in here (a new
+// *waiting* kind can't silently leak in). Mirrors the server's
+// `_actionable_attention_filter` (issue #729).
+const ACTIONABLE_LIST_KINDS: ReadonlySet<ListAttentionKind> =
+  new Set<ListAttentionKind>(['dispute', 'review', 'score'])
+
 /** The Attention tab's row set: the current user's *actionable* open matches,
  * ranked by urgency then oldest-first — mirrors the BFF's attention path. Only
  * the actionable buckets are members; the passive waiting rows (`waiting_opponent`
@@ -644,13 +652,9 @@ export function rankAttentionSeeds(seeds: SeedMatch[]): SeedMatch[] {
   return seeds
     .flatMap((seed) => {
       const kind = listAttentionKind(seed)
-      if (
-        kind === null ||
-        kind === 'waiting_opponent' ||
-        kind === 'waiting_others'
-      )
-        return []
-      return [{ seed, rank: listAttentionRank(seed, kind) }]
+      return kind !== null && ACTIONABLE_LIST_KINDS.has(kind)
+        ? [{ seed, rank: listAttentionRank(seed, kind) }]
+        : []
     })
     .sort(
       (a, b) =>

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -635,13 +635,22 @@ function listAttentionRank(seed: SeedMatch, kind: ListAttentionKind): number {
   return LIST_ATTENTION_PRIORITY[kind]
 }
 
-/** The Attention tab's row set: the current user's open matches, ranked by
- * urgency then oldest-first — mirrors the BFF's attention path. */
+/** The Attention tab's row set: the current user's *actionable* open matches,
+ * ranked by urgency then oldest-first — mirrors the BFF's attention path. Only
+ * the actionable buckets are members; the passive waiting rows (`waiting_opponent`
+ * — my posted result awaiting the opponent — and `waiting_others` — a pending
+ * match) are excluded so the tab is viewer-relative (issue #729). */
 export function rankAttentionSeeds(seeds: SeedMatch[]): SeedMatch[] {
   return seeds
     .flatMap((seed) => {
       const kind = listAttentionKind(seed)
-      return kind ? [{ seed, rank: listAttentionRank(seed, kind) }] : []
+      if (
+        kind === null ||
+        kind === 'waiting_opponent' ||
+        kind === 'waiting_others'
+      )
+        return []
+      return [{ seed, rank: listAttentionRank(seed, kind) }]
     })
     .sort(
       (a, b) =>


### PR DESCRIPTION
Fixes #729.

## Problem

On `/matches`, the **Attention** filter tab (and its badge) counted *all* of the caller's open matches, regardless of whose turn it was. It ranged over `pending`, `in_progress`, and `disputed` for the caller — which includes the two *passive* buckets from `list_attention_kind`:

- `waiting_opponent` — the caller posted a result and is waiting on the opponent to sign off, and
- `waiting_others` — a pending/scheduled ("Up next") match.

So on an in-progress posted match, both the poster and the opponent saw the same Attention count. The poster — who has nothing to do — got their match flagged as "needs attention" (labeled "Waiting on opponent"), and the tab therefore never read as *your* actionable queue.

The dashboard's "Needs your attention" panel already excludes those passive buckets (they feed a separate `waiting_count`), so the two surfaces that share the `app.attention` module disagreed about what "attention" means.

## Fix

- Factor the dashboard's inline "did I submit the standing proposal?" subquery into a shared `my_standing_proposal_exists()` helper in `app/matches.py`, and have the dashboard import it — so the waiting/actionable split has one definition.
- Add `_actionable_attention_filter()`, which narrows to the *actionable* half of `list_attention_kind` (`dispute` / `review` / `score`): a disputed match, or an in-progress match where the caller did **not** submit the standing proposal. It excludes `waiting_opponent` and `waiting_others`.
- The Attention tab's row set (`_attention_matches_query`) and its badge (`_attention_count`) both use it.

Result: the poster and the reviewer of the same posted result now see **different** Attention counts. Per-row attention labels ("Waiting on opponent" vs "Needs your review") on the other tabs are unchanged — only tab membership/count became viewer-relative.

The MSW mock's `rankAttentionSeeds` is updated to match so the web-client tests exercise the same behavior.

## Tests

- Updated `test_list_row_attention_kind_reflects_who_must_act` — the poster's `waiting_opponent` match no longer counts toward their Attention badge (2 → 1).
- Added `test_attention_tab_is_viewer_relative_for_a_posted_result` — poster sees an empty Attention list/count of 0; opponent sees the match with a count of 1.
- Added `test_attention_tab_excludes_pending_scheduled_matches`.
- `ruff`, `ruff format`, `mypy --strict`, and the `test_matches` + `test_dashboard` suites pass; web-client `tsc`, `eslint`, and the `matches`/`mocks` vitest suites (637 tests) pass.

No OpenAPI/route/schema changes, so `schema.d.ts` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoEsnhm8jtQA8FGTbY8UT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoEsnhm8jtQA8FGTbY8UT7)_