### PR TITLE
Ratings: short-circuit _load_rating_changes for non-completed matches

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1181,14 +1181,17 @@ async def _notify_result_posted(
 
 
 async def _load_rating_changes(
-    db: AsyncSession, match_id: uuid.UUID
+    db: AsyncSession, match: Match
 ) -> dict[uuid.UUID, RatingChange]:
     """Returns ``user_id -> RatingChange`` for every rating row this match
-    produced. Empty for matches that didn't move ratings."""
+    produced. Empty for matches that didn't move ratings — including, always,
+    a non-completed match, since no rating rows can exist before completion."""
+    if match.status != MatchStatus.completed:
+        return {}
     rows = (
         (
             await db.execute(
-                select(RatingHistory).where(RatingHistory.match_id == match_id)
+                select(RatingHistory).where(RatingHistory.match_id == match.id)
             )
         )
         .scalars()
@@ -1441,11 +1444,7 @@ _EMPTY_EXTRAS = ViewExtras(rating_changes={}, recent_form=[], head_to_head=None)
 async def _load_view_extras(db: AsyncSession, match: Match) -> ViewExtras:
     user_ids = _singles_user_ids(match)
     return ViewExtras(
-        rating_changes=(
-            await _load_rating_changes(db, match.id)
-            if match.status == MatchStatus.completed
-            else {}
-        ),
+        rating_changes=await _load_rating_changes(db, match),
         recent_form=await _load_recent_form(db, user_ids, match),
         head_to_head=await _load_head_to_head(
             db, user_ids if len(user_ids) == 2 else [], match

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1441,7 +1441,11 @@ _EMPTY_EXTRAS = ViewExtras(rating_changes={}, recent_form=[], head_to_head=None)
 async def _load_view_extras(db: AsyncSession, match: Match) -> ViewExtras:
     user_ids = _singles_user_ids(match)
     return ViewExtras(
-        rating_changes=await _load_rating_changes(db, match.id),
+        rating_changes=(
+            await _load_rating_changes(db, match.id)
+            if match.status == MatchStatus.completed
+            else {}
+        ),
         recent_form=await _load_recent_form(db, user_ids, match),
         head_to_head=await _load_head_to_head(
             db, user_ids if len(user_ids) == 2 else [], match


### PR DESCRIPTION
## Summary

`GET /v1/matches/{id}` (and the post-score `create_game_score` / `update_game_score` / `delete_game_score` / `post_match_result` / `accept_match_result` paths) all funnel through `_load_view_extras`, which unconditionally called `_load_rating_changes` — a query against `RatingHistory` — even for in-progress or pending matches that can't have any rating history rows yet.

- `_load_view_extras` in `api/app/matches.py` now only calls `_load_rating_changes` when `match.status == MatchStatus.completed`, short-circuiting to `{}` otherwise. Since every one of the callers above funnels through this single helper, the fix covers the detail view and all post-score paths at once.

Fixes #181.

## Test plan

- [x] `ruff check app tests` / `ruff format --check app tests`
- [x] `mypy` (strict) — no issues
- [x] `pytest` — full suite passes (532 passed), including `test_matches.py`'s participant/spectator rating-change gating regression test


---
_Generated by [Claude Code](https://claude.ai/code/session_01MEMCkgQX9Jh9HXiQJmxYYQ)_