### PR TITLE
Guard first-post "Post result" against silently overwriting a committed game (D1)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -76,6 +76,7 @@ from app.schemas.match import (
     MatchListResponse,
     MatchListRow,
     MatchNegotiation,
+    MatchResultBoardConflict,
     MatchResultsGameWrite,
     MatchResultsWrite,
     NegotiationDiffEntry,
@@ -2169,10 +2170,48 @@ def _negotiation_conflict(match: Match, current_user_id: uuid.UUID) -> HTTPExcep
     )
 
 
+def _scratchpad_divergence(
+    match: Match, proposed_games: list[MatchResultsGameWrite]
+) -> list[int]:
+    """Game numbers where a first-post proposal disagrees with the committed
+    scratchpad — the board-level analogue of the per-game ``version`` guard.
+
+    "Post result" assembles its board client-side from a possibly-stale view;
+    if a concurrent participant committed a game this client never saw, the
+    proposal would silently overwrite it (issue D1). For every committed
+    scratchpad game that *has a score*, require the proposal to carry the same
+    number with identical points. A committed game the proposal **changes or
+    drops** diverges. *Additions* — a proposal game with no committed score yet
+    (an empty ``MatchGame`` cell, or a game the scratchpad never held) — are
+    fine: filling in the final games is the whole point of posting.
+
+    Compare the **raw** (pre-compaction) proposal: the client numbers its games
+    the way the scratchpad does, so the numbers line up before compaction
+    renumbers them. Only meaningful for a first post — once a result stands the
+    scratchpad is frozen. (A game the opponent *deleted* pre-post has no
+    committed score to compare, so a stale board resurrecting it reads as an
+    addition; that edge is out of scope, see
+    ``docs/adr/0003-first-post-propose-guards-scratchpad-divergence.md``.)"""
+    proposed_by_number = {g.game_number: g for g in proposed_games}
+    diverging: list[int] = []
+    for game in match.games:
+        if game.score is None:
+            continue
+        proposed = proposed_by_number.get(game.game_number)
+        if (
+            proposed is None
+            or proposed.side_1_points != game.score.side_1_points
+            or proposed.side_2_points != game.score.side_2_points
+        ):
+            diverging.append(game.game_number)
+    return diverging
+
+
 @router.post(
     "/matches/{match_id}/results",
     response_model=MatchDetails,
     status_code=status.HTTP_201_CREATED,
+    responses={409: {"model": MatchResultBoardConflict}},
 )
 async def post_match_result(
     match_id: uuid.UUID,
@@ -2227,6 +2266,11 @@ async def post_match_result(
     # supersedes an existing result — would 409 before it could supersede.
     # Propose has its OWN gates below (first-post vs counter) instead.
 
+    # The board as the client sent it, before compaction renumbers the games —
+    # the scratchpad-divergence check below compares against this, since the
+    # client numbers its games the way the committed scratchpad does.
+    raw_games = payload.games
+
     # Compact once, upstream of every consumer below (_validate_finalize_games,
     # _commit_canonical_games, and the immutable _result_games_snapshot), so the
     # minted board is contiguous (see `_compact_games`). Covers both the first
@@ -2247,6 +2291,34 @@ async def post_match_result(
         # first-post (or any existing chain) loses here with the current state.
         if match.results:
             raise _negotiation_conflict(match, current_user.id)
+        # No result yet, so the scratchpad is still the shared, editable board.
+        # Reject a proposal that would silently overwrite a game another
+        # participant committed to it that this (stale) client never saw — the
+        # board-level version guard (issue D1). Gated *behind* the results check
+        # so it only ever fires pre-result: once a result stands the negotiation
+        # conflict above owns the moved-on state, and we never undo a result.
+        diverging = _scratchpad_divergence(match, raw_games)
+        if diverging:
+            extras = await _load_view_extras(db, match)
+            log.info(
+                "Rejected a stale first-post proposal diverging from the "
+                "committed scratchpad",
+                extra={
+                    "match_id": str(match.id),
+                    "diverging_games": diverging,
+                },
+            )
+            raise HTTPException(
+                status_code=409,
+                detail=MatchResultBoardConflict(
+                    message=(
+                        "The score changed while you were entering it — a "
+                        "game was saved by someone else. Review the board "
+                        "before posting."
+                    ),
+                    committed_match=_serialize_details(match, current_user.id, extras),
+                ).model_dump(mode="json"),
+            )
     else:
         # Counter: must target the live standing proposal. If it was already
         # accepted or superseded by a concurrent counter, the id won't match —

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -414,3 +414,23 @@ class MatchResultsWrite(BaseModel):
     # posting; otherwise must equal the current standing result's id (the
     # handler 409s on a stale or mismatched value).
     supersedes_result_id: uuid.UUID | None = None
+
+
+class MatchResultBoardConflict(BaseModel):
+    """409 body for a first-post proposal whose board disagrees with a game
+    already committed to the shared scratchpad — the board-level analogue of
+    ``MatchGameScoreConflict``'s per-game version guard (issue D1 / #747-B2).
+
+    A pre-result "Post result" assembles its board client-side; if a concurrent
+    participant committed a game this client never saw, the payload would
+    silently overwrite it. The handler rejects that and returns the true board
+    in ``committed_match`` (the same ``MatchDetails`` shape the success path
+    returns) so the client re-syncs from the body — without a refetch — and the
+    poster re-decides against reality instead of clobbering a committed game.
+
+    ``committed_match`` is the discriminator the client keys on to tell this
+    apart from the per-game ``committed_score`` conflict, the negotiation
+    conflict, and a plain-string 409 (a locked match)."""
+
+    message: str
+    committed_match: MatchDetails

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1468,11 +1468,15 @@ async def test_propose_commits_canon_and_leaves_result_standing(
     async with opponent_session(db_session, "rival") as (opp_client, opp):
         match = await _create_match(api_client, opp.id, best_of=3)
 
-        # Pre-propose, the FE has scratched in a totally different game 1 score.
-        # The /results payload is canon — it should win.
+        # Pre-propose, the FE has scratched game 1 into the shared scratchpad;
+        # the /results payload posts the *same* board (agreeing with the
+        # committed game and adding game 2). Propose obliterates the scratchpad
+        # and reinserts from the payload. (A payload that *disagreed* with a
+        # committed game would be rejected — see
+        # ``test_propose_first_post_409s_on_scratchpad_divergence``.)
         await api_client.post(
             f"/v1/matches/{match['id']}/games/1/scores/new",
-            json={"side_1_points": 5, "side_2_points": 11},
+            json={"side_1_points": 11, "side_2_points": 4},
         )
 
         response = await api_client.post(
@@ -1556,6 +1560,133 @@ async def test_propose_first_post_requires_no_existing_result(
             detail["standing_result"]["id"]
             == first.json()["negotiation"]["standing_result"]["id"]
         )
+
+
+async def test_propose_first_post_409s_on_scratchpad_divergence(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The D1 guard: a first proposal whose board disagrees with a game a
+    concurrent participant committed to the shared scratchpad is rejected 409
+    (``MatchResultBoardConflict``) rather than silently overwriting it. The body
+    carries the true committed match so the client re-syncs from it.
+
+    Repro: the creator (side 1) commits games 1-2 in their own favor (2-0), the
+    opponent (side 2) commits game 3 in *theirs* (real board 2-1), then the
+    creator — stale, still seeing game 3 unplayed — posts a 3-0 board that
+    overwrites game 3. The committed game 3 must win."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "stale-poster-rival") as (
+        opp_client,
+        opp,
+    ):
+        match = await _create_match(api_client, opp.id, best_of=5)
+        # Creator commits games 1 + 2 (their wins).
+        for n in (1, 2):
+            await api_client.post(
+                f"/v1/matches/{match['id']}/games/{n}/scores/new",
+                json={"side_1_points": 11, "side_2_points": 3},
+            )
+        # Opponent commits game 3 in their own favor — the game the stale poster
+        # never saw.
+        opp_g3 = await opp_client.post(
+            f"/v1/matches/{match['id']}/games/3/scores/new",
+            json={"side_1_points": 3, "side_2_points": 11},
+        )
+        assert opp_g3.status_code == 201
+
+        # Stale poster posts a 3-0 sweep, overwriting the opponent's game 3.
+        response = await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 3},
+                    {"game_number": 2, "side_1_points": 11, "side_2_points": 3},
+                    {"game_number": 3, "side_1_points": 11, "side_2_points": 0},
+                ]
+            },
+        )
+        assert response.status_code == 409
+        detail = response.json()["detail"]
+        # Board conflict, not the negotiation conflict: it carries the whole
+        # committed match so the client re-syncs without a refetch.
+        assert "committed_match" in detail
+        committed = detail["committed_match"]
+        g3 = next(g for g in committed["games"] if g["game_number"] == 3)
+        assert g3["score"]["side_1_points"] == 3
+        assert g3["score"]["side_2_points"] == 11
+        # No result was minted, and the opponent's committed game 3 survives.
+        results = (await db_session.execute(select(MatchResult))).scalars().all()
+        assert results == []
+        g3_rows = (
+            (
+                await db_session.execute(
+                    select(MatchGameScore)
+                    .join(MatchGame)
+                    .where(MatchGame.game_number == 3)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(g3_rows) == 1
+        assert (g3_rows[0].side_1_points, g3_rows[0].side_2_points) == (3, 11)
+
+
+async def test_propose_first_post_allows_games_absent_from_scratchpad(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The guard rejects only *disagreement* with a committed game — it allows
+    *additions*. A first proposal may carry games the scratchpad never held (the
+    poster typed the deciding games without saving them per-game), as long as
+    every committed-scored game appears unchanged."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "additions-rival") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        # Only game 1 is committed to the scratchpad.
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/1/scores/new",
+            json={"side_1_points": 11, "side_2_points": 4},
+        )
+        # The proposal keeps game 1 unchanged and *adds* game 2 (never scratched).
+        response = await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 4},
+                    {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
+                ]
+            },
+        )
+        assert response.status_code == 201
+
+
+async def test_propose_first_post_ignores_blank_committed_cell(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A committed ``MatchGame`` whose score was cleared (a blank cell, score
+    ``None``) is not a divergence target — filling it in is a legit addition, so
+    the proposal posts."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "blank-cell-rival") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        # Scratch game 1, then clear it — the MatchGame row lingers with no score.
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/1/scores/new",
+            json={"side_1_points": 11, "side_2_points": 4},
+        )
+        await api_client.delete(f"/v1/matches/{match['id']}/games/1/scores")
+        # The proposal fills game 1 (blank) with a *different* score — allowed,
+        # because there is no committed score to disagree with.
+        response = await api_client.post(
+            f"/v1/matches/{match['id']}/results",
+            json={
+                "games": [
+                    {"game_number": 1, "side_1_points": 11, "side_2_points": 9},
+                    {"game_number": 2, "side_1_points": 11, "side_2_points": 7},
+                ]
+            },
+        )
+        assert response.status_code == 201
 
 
 async def test_propose_undecided_board_is_422(

--- a/docs/adr/0003-first-post-propose-guards-scratchpad-divergence.md
+++ b/docs/adr/0003-first-post-propose-guards-scratchpad-divergence.md
@@ -1,0 +1,91 @@
+# A first-post proposal is rejected when it disagrees with the committed scratchpad
+
+Before any result exists, the working board is a **shared scratchpad**
+(`match_games` + `match_game_scores`) that either participant edits one game at a
+time via `PUT .../games/{n}/scores`, guarded by an optimistic-concurrency
+`version` token: a write whose expected version is stale 409s rather than
+overwriting a concurrent participant's save.
+
+"Post result" (the first-post `POST /matches/{id}/results`) bypassed that guard.
+It assembles a board **client-side** and the server's `_commit_canonical_games`
+**clears + reinserts** `match_games` from the payload with no comparison against
+what's committed (the `MatchResultsWrite` contract is literally "the list is
+canon… no merge"). So a poster with a stale view — who never saw a game the
+opponent committed to the scratchpad — silently overwrote it by posting.
+
+We close the gap with the board-level analogue of the per-game version guard:
+**on a first proposal, every committed scratchpad game that has a score must
+appear in the proposed board with identical points, or the propose is rejected
+409** (`_scratchpad_divergence` / `MatchResultBoardConflict`). *Additions* — a
+proposed game with no committed score (an empty cell, or a game the scratchpad
+never held) — are allowed; filling in the deciding games is the whole point of
+posting. The 409 carries the **whole committed match** so the client re-syncs
+from the body (no refetch) and re-decides against reality. The check is gated
+**behind** the existing "a result already exists" gate, so it only ever fires
+pre-result: once a result stands, the negotiation conflict owns the moved-on
+state and nothing is undone. This is the UI-reachable face of the "post overwrites
+a committed game" hazard (issue D1 / #747-B2).
+
+## Rejected alternative: a per-game version token on the propose payload
+
+The faithful mirror of the per-game guard would be to carry an
+`expected_version` per game in `MatchResultsWrite` and reject on a stale version.
+Rejected:
+
+- It forces a request-schema change across **three CI-gated codegen boundaries**
+  (`openapi.json` → `web-client` `schema.d.ts` → iOS `Types.swift`), for a guard
+  that only needs to answer "does this board still agree with what's saved?"
+- It **collides with compaction.** A decided board is compacted (empty slots
+  dropped, games renumbered `1..N`) before it's minted; versions keyed to the
+  original game numbers would need a preserved mapping through the renumber.
+- The only thing a version token catches that value-comparison doesn't is
+  **same-value churn** (save 11-4, someone re-saves 11-4) — which by definition
+  loses no data and needs no conflict.
+
+Value-comparison is complete for the actual defect (a *different* committed score
+being overwritten) and touches no schema.
+
+## Rejected alternative: let "Post result" force-overwrite
+
+Keeping the "list is canon, no merge" behavior and simply surfacing a warning was
+rejected: silent overwrite of a committed game **is** the bug. Pre-result, the
+only sanctioned way to change a committed game is the version-guarded per-game
+`PUT`, which makes the poster consciously reconcile against the opponent's value.
+"Post result" means *mint the agreed scratchpad*, never *overwrite-and-mint*.
+(Full-board re-score is the **correction** surface — ADR 0001 — which exists only
+*after* a result stands and the scratchpad is frozen.)
+
+## Consequence for the front end
+
+The reconcile is server-authoritative and lands the poster on the *true* board.
+`useProposeResult`'s `onError` re-syncs the caches from `committed_match`, and the
+score-entry screen replaces the score pad with a **blocking interstitial** ("the
+score changed — a game was saved by someone else") whose single action resumes
+scoring at the next still-unplayed game (or the match page when the committed
+board is already fully scored). It never presents the opponent's committed game as
+the poster's editable draft.
+
+## Known non-goal: delete-divergence
+
+A game the opponent *deletes* from the scratchpad pre-post has no committed score
+to compare against, so a stale board that resurrects it reads as an addition and
+posts. This is out of scope: it's rare (`delete_game_score` has no version guard
+either), and the resurrected board is still a decided board the poster is claiming
+happened. Revisit if pre-result deletes become a real conflict source.
+
+## Compaction caveat
+
+The client compacts the board before sending, so for an **out-of-order clinch**
+(a gappy board, e.g. game 5 scored with game 4 blank) the server compares
+renumbered payload games against the gappy committed numbers and may **falsely**
+flag divergence. That failure is conservative — a false *reject*, never a silent
+overwrite — and the poster simply re-syncs and re-decides. Contiguous boards (the
+overwhelming common case, including every D1 repro) compact to themselves, so the
+numbers line up and the check is exact.
+
+## Bug context
+
+Fixes D1 (reproduced on matches `13df574e` / `3da4be11`): a rated best-of-5 where
+the poster saved games 1–2, the opponent committed game 3 in their own favor
+(real board 2-1), and the poster's stale one-tap "Post result" proposed 3-0,
+silently replacing the opponent's game 3 with no conflict on either side.

--- a/docs/adr/0003-first-post-propose-guards-scratchpad-divergence.md
+++ b/docs/adr/0003-first-post-propose-guards-scratchpad-divergence.md
@@ -62,8 +62,11 @@ The reconcile is server-authoritative and lands the poster on the *true* board.
 score-entry screen replaces the score pad with a **blocking interstitial** ("the
 score changed — a game was saved by someone else") whose single action resumes
 scoring at the next still-unplayed game (or the match page when the committed
-board is already fully scored). It never presents the opponent's committed game as
-the poster's editable draft.
+board is already *decided* — keyed on the decider, not on the first empty slot, so
+a board clinched before its last game doesn't point "Resume" at an unplayable
+game). The interstitial is computed ahead of the screen's participant/decided/
+out-of-range nav bounces so a decided committed board can't preempt it. It never
+presents the opponent's committed game as the poster's editable draft.
 
 ## Known non-goal: delete-divergence
 

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -3134,6 +3134,44 @@ internal enum Components {
                 case diff
             }
         }
+        /// 409 body for a first-post proposal whose board disagrees with a game
+        /// already committed to the shared scratchpad — the board-level analogue of
+        /// ``MatchGameScoreConflict``'s per-game version guard (issue D1 / #747-B2).
+        ///
+        /// A pre-result "Post result" assembles its board client-side; if a concurrent
+        /// participant committed a game this client never saw, the payload would
+        /// silently overwrite it. The handler rejects that and returns the true board
+        /// in ``committed_match`` (the same ``MatchDetails`` shape the success path
+        /// returns) so the client re-syncs from the body — without a refetch — and the
+        /// poster re-decides against reality instead of clobbering a committed game.
+        ///
+        /// ``committed_match`` is the discriminator the client keys on to tell this
+        /// apart from the per-game ``committed_score`` conflict, the negotiation
+        /// conflict, and a plain-string 409 (a locked match).
+        ///
+        /// - Remark: Generated from `#/components/schemas/MatchResultBoardConflict`.
+        internal struct MatchResultBoardConflict: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/MatchResultBoardConflict/message`.
+            internal var message: Swift.String
+            /// - Remark: Generated from `#/components/schemas/MatchResultBoardConflict/committed_match`.
+            internal var committedMatch: Components.Schemas.AppSchemasMatchMatchDetails
+            /// Creates a new `MatchResultBoardConflict`.
+            ///
+            /// - Parameters:
+            ///   - message:
+            ///   - committedMatch:
+            internal init(
+                message: Swift.String,
+                committedMatch: Components.Schemas.AppSchemasMatchMatchDetails
+            ) {
+                self.message = message
+                self.committedMatch = committedMatch
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case message
+                case committedMatch = "committed_match"
+            }
+        }
         /// One game inside a finalize-the-match payload. Per-game point legality
         /// is checked here; cross-game checks (contiguous numbering, decided result,
         /// no scores past the decider) live in the handler against the full list.
@@ -12085,6 +12123,57 @@ internal enum Operations {
                     default:
                         try throwUnexpectedResponseStatus(
                             expectedStatus: "created",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct Conflict: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/matches/{match_id}/results/POST/responses/409/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/matches/{match_id}/results/POST/responses/409/content/application\/json`.
+                    case json(Components.Schemas.MatchResultBoardConflict)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.MatchResultBoardConflict {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.PostMatchResultV1MatchesMatchIdResultsPost.Output.Conflict.Body
+                /// Creates a new `Conflict`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.PostMatchResultV1MatchesMatchIdResultsPost.Output.Conflict.Body) {
+                    self.body = body
+                }
+            }
+            /// Conflict
+            ///
+            /// - Remark: Generated from `#/paths//v1/matches/{match_id}/results/post(post_match_result_v1_matches__match_id__results_post)/responses/409`.
+            ///
+            /// HTTP response code: `409 conflict`.
+            case conflict(Operations.PostMatchResultV1MatchesMatchIdResultsPost.Output.Conflict)
+            /// The associated value of the enum case if `self` is `.conflict`.
+            ///
+            /// - Throws: An error if `self` is not `.conflict`.
+            /// - SeeAlso: `.conflict`.
+            internal var conflict: Operations.PostMatchResultV1MatchesMatchIdResultsPost.Output.Conflict {
+                get throws {
+                    switch self {
+                    case let .conflict(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "conflict",
                             response: self
                         )
                     }

--- a/web-client/src/api/client.ts
+++ b/web-client/src/api/client.ts
@@ -209,6 +209,34 @@ export function conflictDetail(
 }
 
 /**
+ * The structured conflict detail when `error` is a first-post propose 409 whose
+ * body carries `{ detail: { message, committed_match } }` — the board-level
+ * concurrency conflict (issue D1): the proposed board disagreed with a game a
+ * concurrent participant committed to the shared scratchpad, so the server
+ * rejected it and returned the true committed match to re-sync from. Keyed on
+ * `committed_match`, which distinguishes it from the per-game `committed_score`
+ * conflict, the negotiation conflict, and a plain-string 409 (a locked match).
+ * Returns `null` for anything else. `committed_match` is left `unknown` here in
+ * the same loose style as `conflictDetail`; the caller narrows it to
+ * `MatchDetails`.
+ */
+export function boardConflictDetail(
+  error: ApiError,
+): { message?: string; committed_match: unknown } | null {
+  if (error.status !== 409) return null
+  const detail = (error.body as { detail?: unknown } | null | undefined)?.detail
+  if (
+    detail &&
+    typeof detail === 'object' &&
+    !Array.isArray(detail) &&
+    'committed_match' in detail
+  ) {
+    return detail as { message?: string; committed_match: unknown }
+  }
+  return null
+}
+
+/**
  * Throws ApiError when the openapi-fetch result has an error or no data. Pass
  * `{ allowEmpty: true }` for endpoints that legitimately return no body (e.g.
  * 204 DELETEs).

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -5,7 +5,14 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query'
-import { ApiError, api, conflictDetail, resolveBaseUrl, unwrap } from './client'
+import {
+  ApiError,
+  api,
+  boardConflictDetail,
+  conflictDetail,
+  resolveBaseUrl,
+  unwrap,
+} from './client'
 import { DASHBOARD_QUERY_KEY } from './dashboard'
 import {
   matchDetailsQueryKey,
@@ -602,6 +609,19 @@ export function useProposeResult(matchId: string) {
         }),
       ),
     onSuccess: (data) => applyScoreMutationCache(queryClient, matchId, data),
+    onError: (error) => {
+      // Board-level conflict (issue D1): the proposed board disagreed with a
+      // game a concurrent participant committed to the shared scratchpad. The
+      // 409 carries the true committed match, so re-sync the caches straight
+      // from it (games + scoreboard + list) — no refetch. The entry screen
+      // reads the same `boardConflictDetail` off the mutation error to render
+      // the blocking "the score changed" interstitial against this fresh board.
+      if (!(error instanceof ApiError)) return
+      const committed = boardConflictDetail(error)?.committed_match as
+        | MatchDetails
+        | undefined
+      if (committed) applyScoreMutationCache(queryClient, matchId, committed)
+    },
   })
 }
 

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1580,6 +1580,28 @@ export interface components {
             diff: components["schemas"]["NegotiationDiffEntry"][] | null;
         };
         /**
+         * MatchResultBoardConflict
+         * @description 409 body for a first-post proposal whose board disagrees with a game
+         *     already committed to the shared scratchpad — the board-level analogue of
+         *     ``MatchGameScoreConflict``'s per-game version guard (issue D1 / #747-B2).
+         *
+         *     A pre-result "Post result" assembles its board client-side; if a concurrent
+         *     participant committed a game this client never saw, the payload would
+         *     silently overwrite it. The handler rejects that and returns the true board
+         *     in ``committed_match`` (the same ``MatchDetails`` shape the success path
+         *     returns) so the client re-syncs from the body — without a refetch — and the
+         *     poster re-decides against reality instead of clobbering a committed game.
+         *
+         *     ``committed_match`` is the discriminator the client keys on to tell this
+         *     apart from the per-game ``committed_score`` conflict, the negotiation
+         *     conflict, and a plain-string 409 (a locked match).
+         */
+        MatchResultBoardConflict: {
+            /** Message */
+            message: string;
+            committed_match: components["schemas"]["app__schemas__match__MatchDetails"];
+        };
+        /**
          * MatchResultsGameWrite
          * @description One game inside a finalize-the-match payload. Per-game point legality
          *     is checked here; cross-game checks (contiguous numbering, decided result,
@@ -3736,6 +3758,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["app__schemas__match__MatchDetails"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchResultBoardConflict"];
                 };
             };
             /** @description Validation Error */

--- a/web-client/src/components/matches/save-banner.test.tsx
+++ b/web-client/src/components/matches/save-banner.test.tsx
@@ -16,7 +16,7 @@ import { http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 import { server } from '@/mocks/server'
 import { matchDetails } from '@/test/factories'
-import { fireScoreSave } from '@/api/matches'
+import { fireScoreSave, useProposeResult } from '@/api/matches'
 import { SaveBanner } from './save-banner'
 
 // Bo5, 1-1 on the board, game 3 next — a single game-3 failure can't decide the
@@ -73,6 +73,7 @@ function renderBanner() {
     path: '/',
     component: function Harness() {
       const qc = useQueryClient()
+      const proposeMutation = useProposeResult('m-1')
       return (
         <>
           <button
@@ -86,7 +87,11 @@ function renderBanner() {
           >
             fail game 3
           </button>
-          <SaveBanner matchId="m-1" activeGameNumber={4} />
+          <SaveBanner
+            matchId="m-1"
+            activeGameNumber={4}
+            proposeMutation={proposeMutation}
+          />
         </>
       )
     },

--- a/web-client/src/components/matches/save-banner.tsx
+++ b/web-client/src/components/matches/save-banner.tsx
@@ -29,6 +29,12 @@ export interface SaveBannerProps {
    * finishes the match: we stay on it, the banner surfaces (informational
    * only), and the main "Post result" button owns finalizing. */
   activeGameNumber: number
+  /** The entry screen's own propose mutation, shared so a "Post result" fired
+   * from this banner and one fired from the main button are the *same* request.
+   * That way a board-level conflict (issue D1) surfaces once — on the entry
+   * screen's blocking interstitial — instead of only inside this banner, and
+   * the banner is hidden while that interstitial owns the reconcile. */
+  proposeMutation: ReturnType<typeof useProposeResult>
 }
 
 /**
@@ -57,11 +63,14 @@ export function SaveBanner(props: SaveBannerProps) {
   )
 }
 
-function FailedSaveBanner({ matchId, activeGameNumber }: SaveBannerProps) {
+function FailedSaveBanner({
+  matchId,
+  activeGameNumber,
+  proposeMutation: finalizeMutation,
+}: SaveBannerProps) {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const { data } = useMatch(matchId)
-  const finalizeMutation = useProposeResult(matchId)
   // Conflicts are handled by ConflictReviewBanner — exclude them here so the
   // retry/finalize path never re-fires a stale write over the committed score.
   const allFailed = useFailedGameSaves(matchId).filter((entry) => !entry.conflict)

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -526,6 +526,83 @@ describe('ScoreEntry — create', () => {
     expect(await screen.findByText('scoring-new m-1 4')).toBeInTheDocument()
   })
 
+  it('blocks with a "View match →" interstitial when the concurrent scratchpad already decided the match', async () => {
+    // Stale poster: their view is 2-0 on game 3, so a win reads as a 3-0 sweep.
+    // But while they were away the opponent committed games 3, 4 and 5 in their
+    // own favor — the true board is 2-3 and the match is *already decided* (for
+    // the opponent), no result posted yet. The interstitial must recognise the
+    // decided board and offer "View match →" rather than pointing "Resume" at an
+    // unplayable game.
+    const user = userEvent.setup()
+    const committedMatch = matchDetails({
+      id: 'm-1',
+      status: 'in_progress',
+      status_label: 'Live',
+      best_of: 5,
+      games_to_win: 3,
+      affects_rating: true,
+      sides: participantSides({ meWins: 2, oppWins: 3 }),
+      games: [
+        { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
+        { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
+        { id: 'g-3', game_number: 3, score: score('s-3', 3, 11) },
+        { id: 'g-4', game_number: 4, score: score('s-4', 5, 11) },
+        { id: 'g-5', game_number: 5, score: score('s-5', 7, 11) },
+      ],
+      current_game: null,
+      can_score: false,
+      can_finalize: false,
+    })
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          inProgressMatch({
+            sides: participantSides({ meWins: 2, oppWins: 0 }),
+            games: [
+              { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
+              { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
+            ],
+            current_game: { game_number: 3 },
+          }),
+        ),
+      ),
+      http.post('*/v1/matches/m-1/results', () =>
+        HttpResponse.json(
+          {
+            detail: {
+              message: 'The score changed while you were entering it.',
+              committed_match: committedMatch,
+            },
+          },
+          { status: 409 },
+        ),
+      ),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    await user.type(meInput, '11')
+    await user.type(oppInput, '0')
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+
+    // The interstitial renders (not preempted by the decided-board nav bounce)
+    // and reads the true board as decided, so the CTA is "View match →".
+    expect(
+      await screen.findByText(/the score changed while you were entering it/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('textbox', { name: 'rita.kovac score' }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /resume scoring/i }),
+    ).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /view match/i }))
+    expect(await screen.findByText('match-page m-1')).toBeInTheDocument()
+  })
+
   it('finalizes an out-of-order clinch (game 4 blank) and posts the compacted board (#742)', async () => {
     // The repro: Bo7, games 1-3 to side 1, then the user jumps to game 5 (game 4
     // still blank) and scores the clinching 4th win there. That leaves a gappy

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -603,6 +603,72 @@ describe('ScoreEntry — create', () => {
     expect(await screen.findByText('match-page m-1')).toBeInTheDocument()
   })
 
+  it('shows the board-conflict interstitial from the edit route too (not bounced to scoring-new)', async () => {
+    // Edit-mode variant of D1: the poster is on the *edit* sheet for a game they
+    // already scored, and posts. The concurrent participant both cleared that
+    // game and changed another, so the re-synced committed board leaves this
+    // route's game unscored — which would otherwise trip the "edit mode + no
+    // saved score → scoring-new" bounce and preempt the interstitial. The
+    // conflict must win: the interstitial renders in place.
+    const user = userEvent.setup()
+    const committedMatch = matchDetails({
+      id: 'm-1',
+      status: 'in_progress',
+      status_label: 'Live',
+      best_of: 5,
+      games_to_win: 3,
+      affects_rating: true,
+      sides: participantSides({ meWins: 1, oppWins: 1 }),
+      games: [
+        { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
+        // Opponent changed game 2 to their favor and cleared game 3.
+        { id: 'g-2', game_number: 2, score: score('s-2', 3, 11) },
+      ],
+      current_game: { game_number: 3 },
+      can_score: true,
+      can_finalize: false,
+    })
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          inProgressMatch({
+            sides: participantSides({ meWins: 3, oppWins: 0 }),
+            games: [
+              { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
+              { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
+              // The poster's stale view has game 3 scored — hence the edit route.
+              { id: 'g-3', game_number: 3, score: score('s-3', 11, 0) },
+            ],
+            current_game: null,
+          }),
+        ),
+      ),
+      http.post('*/v1/matches/m-1/results', () =>
+        HttpResponse.json(
+          {
+            detail: {
+              message: 'The score changed while you were entering it.',
+              committed_match: committedMatch,
+            },
+          },
+          { status: 409 },
+        ),
+      ),
+    )
+
+    renderScoreEntry({ kind: 'edit', matchId: 'm-1', gameNumber: 3 })
+    await user.click(await screen.findByRole('button', { name: /post result/i }))
+
+    expect(
+      await screen.findByText(/the score changed while you were entering it/i),
+    ).toBeInTheDocument()
+    // Not bounced to the scoring-new stub despite edit-mode + now-unscored game.
+    expect(screen.queryByText('scoring-new m-1 3')).not.toBeInTheDocument()
+    // Resume lands on the true next game (3).
+    await user.click(screen.getByRole('button', { name: /resume scoring/i }))
+    expect(await screen.findByText('scoring-new m-1 3')).toBeInTheDocument()
+  })
+
   it('finalizes an out-of-order clinch (game 4 blank) and posts the compacted board (#742)', async () => {
     // The repro: Bo7, games 1-3 to side 1, then the user jumps to game 5 (game 4
     // still blank) and scores the clinching 4th win there. That leaves a gappy

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -449,6 +449,83 @@ describe('ScoreEntry — create', () => {
     })
   })
 
+  it('blocks with a "the score changed" interstitial when the first-post loses to a concurrent scratchpad save (D1)', async () => {
+    // The poster is stale: their view is 2-0 with game 3 unplayed, so typing a
+    // win reads as a 3-0 sweep. But the opponent has committed game 3 in *their*
+    // favor (real board 2-1). Posting the sweep 409s with the committed match;
+    // the entry screen must replace the score pad with a blocking notice instead
+    // of silently overwriting the opponent's game 3.
+    const user = userEvent.setup()
+    const committedMatch = matchDetails({
+      id: 'm-1',
+      status: 'in_progress',
+      status_label: 'Live',
+      best_of: 5,
+      games_to_win: 3,
+      affects_rating: true,
+      sides: participantSides({ meWins: 2, oppWins: 1 }),
+      games: [
+        { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
+        { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
+        // Opponent's committed game 3 — 3-11 in their favor.
+        { id: 'g-3', game_number: 3, score: score('s-3', 3, 11) },
+      ],
+      current_game: { game_number: 4 },
+      can_score: true,
+      can_finalize: false,
+    })
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          inProgressMatch({
+            sides: participantSides({ meWins: 2, oppWins: 0 }),
+            games: [
+              { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
+              { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
+            ],
+            current_game: { game_number: 3 },
+          }),
+        ),
+      ),
+      http.post('*/v1/matches/m-1/results', () =>
+        HttpResponse.json(
+          {
+            detail: {
+              message: 'The score changed while you were entering it.',
+              committed_match: committedMatch,
+            },
+          },
+          { status: 409 },
+        ),
+      ),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    await user.type(meInput, '11')
+    await user.type(oppInput, '0')
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+
+    // The blocking interstitial replaces the score pad, names the game the
+    // opponent committed, and shows the true (2-1) board isn't over.
+    expect(
+      await screen.findByText(/the score changed while you were entering it/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Game 3:/)).toBeInTheDocument()
+    expect(screen.getByText(/2–1 and isn't over/i)).toBeInTheDocument()
+    // The editable field is gone — no path to re-overwrite the committed game.
+    expect(
+      screen.queryByRole('textbox', { name: 'rita.kovac score' }),
+    ).not.toBeInTheDocument()
+
+    // "Resume scoring →" takes the poster to the next unplayed game (4).
+    await user.click(screen.getByRole('button', { name: /resume scoring/i }))
+    expect(await screen.findByText('scoring-new m-1 4')).toBeInTheDocument()
+  })
+
   it('finalizes an out-of-order clinch (game 4 blank) and posts the compacted board (#742)', async () => {
     // The repro: Bo7, games 1-3 to side 1, then the user jumps to game 5 (game 4
     // still blank) and scores the clinching 4th win there. That leaves a gappy

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -7,7 +7,7 @@ import {
 } from '@tanstack/react-router'
 import { onlineManager, useQueryClient } from '@tanstack/react-query'
 import { Check, Loader2, TriangleAlert, X as XIcon } from 'lucide-react'
-import { ApiError } from '@/api/client'
+import { ApiError, boardConflictDetail } from '@/api/client'
 import {
   forgetScoreSaves,
   matchDetailRoute,
@@ -209,13 +209,34 @@ function ScoreEntryInner({
   const game = data.games.find((g) => g.game_number === gameNumber) ?? null
   const persistedScore = game?.score ?? null
 
+  // A first-post that lost to a concurrent scratchpad save (issue D1): the
+  // proposed board disagreed with a game someone else committed. The 409 carries
+  // the true committed match; `useProposeResult`'s onError already re-synced the
+  // caches from it, so `data` now reflects reality. We block the score pad below
+  // and show a "the score changed" interstitial instead of silently overwriting.
+  // Computed here (before the create→edit redirect) because the re-sync gives the
+  // active game a committed score, which would otherwise bounce the poster to the
+  // edit page — presenting the opponent's committed game as their editable draft,
+  // the exact thing the interstitial exists to avoid.
+  const finalizeApiError =
+    finalizeMutation.error instanceof ApiError ? finalizeMutation.error : null
+  const boardConflict = finalizeApiError
+    ? boardConflictDetail(finalizeApiError)
+    : null
+
   // Mode/URL/state alignment: in create mode but a score exists → swap to
   // the edit URL so Save doesn't try to POST .../scores/new and 409. The
   // inverse — edit mode but no saved score — swaps to the create URL.
   // Skipped while this page's own save is settling: the success cache
   // write makes the score "exist" a beat before onSettled navigates to the
-  // next game, and this redirect must not outrun that navigation.
-  if (mode.kind === 'create' && persistedScore && !saveMutation.isSuccess) {
+  // next game, and this redirect must not outrun that navigation. Also skipped
+  // during a board conflict — the interstitial owns the reconcile in place.
+  if (
+    mode.kind === 'create' &&
+    persistedScore &&
+    !saveMutation.isSuccess &&
+    !boardConflict
+  ) {
     return <Navigate {...scoringEditRoute(matchId, gameNumber)} replace />
   }
   if (mode.kind === 'edit' && !persistedScore) {
@@ -374,8 +395,35 @@ function ScoreEntryInner({
   // finalize errors surface, not just 422 validation drift — for a deciding
   // game this button is the sole finalize path (the banner is informational),
   // so a 409 "already posted" / 500 must be visible here rather than swallowed.
-  const finalizeApiError =
-    finalizeMutation.error instanceof ApiError ? finalizeMutation.error : null
+  const committedMatch = boardConflict?.committed_match as
+    | MatchDetails
+    | undefined
+  // The games the poster's proposal changed or dropped vs. what's committed —
+  // named in the interstitial so the poster sees exactly what moved.
+  const attemptedByNumber = new Map(
+    (finalizeMutation.variables?.games ?? []).map((g) => [g.game_number, g]),
+  )
+  const divergingGames = (committedMatch?.games ?? []).filter((g) => {
+    if (!g.score) return false
+    const attempted = attemptedByNumber.get(g.game_number)
+    return (
+      !attempted ||
+      attempted.side_1_points !== g.score.side_1_points ||
+      attempted.side_2_points !== g.score.side_2_points
+    )
+  })
+  // Where "Resume" sends them: the first still-unplayed game on the true board,
+  // or the match page when the committed board is already fully scored.
+  const committedForResume = committedMatch ?? data
+  const nextUnplayedGame = (() => {
+    const scored = new Set(
+      committedForResume.games.filter((g) => g.score).map((g) => g.game_number),
+    )
+    for (let n = 1; n <= committedForResume.best_of; n += 1) {
+      if (!scored.has(n)) return n
+    }
+    return null
+  })()
   // The score *inputs* are only invalid for genuine validation problems (local
   // illegal score, or a 422 drift the server rejected) — a 409/500 means the
   // entered score is fine, so don't paint the fields red for those.
@@ -638,9 +686,15 @@ function ScoreEntryInner({
           </div>
         </div>
 
-        <SaveBanner matchId={matchId} activeGameNumber={gameNumber} />
+        {!boardConflict && (
+          <SaveBanner
+            matchId={matchId}
+            activeGameNumber={gameNumber}
+            proposeMutation={finalizeMutation}
+          />
+        )}
 
-        {conflict && (
+        {conflict && !boardConflict && (
           <ScoreConflictNotice
             meName={meName}
             oppName={oppName}
@@ -653,48 +707,78 @@ function ScoreEntryInner({
           />
         )}
 
-        <ScorePad
-          me={{
-            name: meName,
-            initials: meInitials,
-            value: me,
-            inputRef: meRef,
-            autoFocus: true,
-            invalid: meInvalid,
-            onChange: onMeChange,
-            onKeyDown: (e) => handleKey(e, 'me'),
-          }}
-          opp={{
-            name: oppName,
-            initials: oppHasPlayer ? initialsOf(oppName) : null,
-            value: opp,
-            inputRef: oppRef,
-            invalid: oppInvalid,
-            onChange: onOppChange,
-            onKeyDown: (e) => handleKey(e, 'opp'),
-          }}
-          gamesTally={bestOf > 1 ? `${meWins} – ${oppWins}` : null}
-          // The scratchpad surfaces the local validation error, the cross-game
-          // overrun block, and a finalize API rejection (409/500 too) here;
-          // `showScoreError` gates when any of them shows, in that precedence.
-          scoreError={
-            showScoreError
-              ? (localScoreError ??
-                overrunError ??
-                finalizeApiError?.detail ??
-                finalizeApiError?.message ??
-                null)
-              : null
-          }
-          showBothRequired={showBothRequired}
-          inputsLocked={inputsLocked}
-          subtitle={subtitle}
-          submitLabel={submitLabel}
-          canSubmit={inputsValid && overrunAt === null}
-          onSubmit={onSubmit}
-          onClear={isEdit ? onClear : undefined}
-          clearDisabled={deleteMutation.isPending}
-        />
+        {boardConflict ? (
+          // The board changed under the poster (issue D1). Replace the score pad
+          // with a blocking notice — no editable field, since the game they were
+          // about to overwrite is now committed and read-only in the scoreline
+          // below — and send them to the *true* state on click.
+          <BoardChangedInterstitial
+            meName={meName}
+            oppName={oppName}
+            mySideNumber={mySideNumber}
+            divergingGames={divergingGames}
+            meWins={meWins}
+            oppWins={oppWins}
+            decided={nextUnplayedGame === null}
+            resumeLabel={
+              nextUnplayedGame === null ? 'View match →' : 'Resume scoring →'
+            }
+            onResume={() => {
+              // Clear the propose error before leaving so it doesn't re-render
+              // the interstitial over the next game's screen (the component
+              // stays mounted across the game-number param change).
+              finalizeMutation.reset()
+              navigate(
+                nextUnplayedGame === null
+                  ? matchDetailRoute(matchId)
+                  : scoringNewRoute(matchId, nextUnplayedGame),
+              )
+            }}
+          />
+        ) : (
+          <ScorePad
+            me={{
+              name: meName,
+              initials: meInitials,
+              value: me,
+              inputRef: meRef,
+              autoFocus: true,
+              invalid: meInvalid,
+              onChange: onMeChange,
+              onKeyDown: (e) => handleKey(e, 'me'),
+            }}
+            opp={{
+              name: oppName,
+              initials: oppHasPlayer ? initialsOf(oppName) : null,
+              value: opp,
+              inputRef: oppRef,
+              invalid: oppInvalid,
+              onChange: onOppChange,
+              onKeyDown: (e) => handleKey(e, 'opp'),
+            }}
+            gamesTally={bestOf > 1 ? `${meWins} – ${oppWins}` : null}
+            // The scratchpad surfaces the local validation error, the cross-game
+            // overrun block, and a finalize API rejection (409/500 too) here;
+            // `showScoreError` gates when any of them shows, in that precedence.
+            scoreError={
+              showScoreError
+                ? (localScoreError ??
+                  overrunError ??
+                  finalizeApiError?.detail ??
+                  finalizeApiError?.message ??
+                  null)
+                : null
+            }
+            showBothRequired={showBothRequired}
+            inputsLocked={inputsLocked}
+            subtitle={subtitle}
+            submitLabel={submitLabel}
+            canSubmit={inputsValid && overrunAt === null}
+            onSubmit={onSubmit}
+            onClear={isEdit ? onClear : undefined}
+            clearDisabled={deleteMutation.isPending}
+          />
+        )}
 
         <Scoreline
           data={data}
@@ -791,6 +875,86 @@ function UnsavedScorePrompt({
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+  )
+}
+
+// Surfaced when a first-post "Post result" lost to a concurrent scratchpad save
+// (issue D1): the board the poster tried to post disagreed with a game someone
+// else committed, so the server rejected it and re-synced the true board. This
+// *replaces* the score pad — a blocking notice, not an editable field, because
+// the game they were about to overwrite is now committed and read-only. The one
+// action re-decides against reality: resume scoring the still-live board (or view
+// the match when it's already fully scored). A design-system Alert, loss-tinted.
+function BoardChangedInterstitial({
+  meName,
+  oppName,
+  mySideNumber,
+  divergingGames,
+  meWins,
+  oppWins,
+  decided,
+  resumeLabel,
+  onResume,
+}: {
+  meName: string
+  oppName: string
+  mySideNumber: 1 | 2
+  divergingGames: MatchDetails['games']
+  meWins: number
+  oppWins: number
+  decided: boolean
+  resumeLabel: string
+  onResume: () => void
+}) {
+  return (
+    <Alert
+      role="alert"
+      variant="destructive"
+      className="save-banner mb-4 border-[color:var(--loss)]/45 bg-[color:var(--loss)]/10"
+    >
+      <TriangleAlert aria-hidden />
+      <AlertTitle>The score changed while you were entering it.</AlertTitle>
+      <AlertDescription className="text-[color:var(--fg-3)]">
+        <span>
+          {divergingGames.length > 0 ? (
+            <>
+              A game was saved by someone else:{' '}
+              {divergingGames.map((g, i) => {
+                const me =
+                  mySideNumber === 1 ? g.score!.side_1_points : g.score!.side_2_points
+                const opp =
+                  mySideNumber === 1 ? g.score!.side_2_points : g.score!.side_1_points
+                return (
+                  <span key={g.game_number}>
+                    {i > 0 ? ', ' : ''}
+                    <strong className="text-[color:var(--fg-1)]">
+                      Game {g.game_number}: {meName} {me}–{opp} {oppName}
+                    </strong>
+                  </span>
+                )
+              })}
+              .{' '}
+            </>
+          ) : (
+            <>The board was updated by someone else. </>
+          )}
+          {decided
+            ? 'The match is decided on the current board — review it before posting again.'
+            : `The match is ${meWins}–${oppWins} and isn't over yet.`}
+        </span>
+        <span className="mt-3 flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="border-[color:var(--loss)]/50 text-[color:var(--loss)] hover:bg-[color:var(--loss)]/10 hover:text-[color:var(--loss)]"
+            onClick={onResume}
+          >
+            {resumeLabel}
+          </Button>
+        </span>
+      </AlertDescription>
+    </Alert>
   )
 }
 

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -170,6 +170,22 @@ function ScoreEntryInner({
     )
   }
 
+  // A first-post that lost to a concurrent scratchpad save (issue D1): the
+  // proposed board disagreed with a game someone else committed. The 409 carries
+  // the true committed match; `useProposeResult`'s onError already re-synced the
+  // caches from it, so `data` now reflects reality. We block the score pad below
+  // and show a "the score changed" interstitial instead of silently overwriting.
+  // Computed up here — ahead of every early `<Navigate>` return — because the
+  // re-synced committed board can be decided or leave this route's game past the
+  // decider, either of which would otherwise bounce the poster away (to match
+  // detail, or the edit page) before the interstitial ever renders, dropping the
+  // "score changed" explanation the conflict exists to deliver.
+  const finalizeApiError =
+    finalizeMutation.error instanceof ApiError ? finalizeMutation.error : null
+  const boardConflict = finalizeApiError
+    ? boardConflictDetail(finalizeApiError)
+    : null
+
   // The scoring screen is participant-only; spectators bounce back to the
   // read-only details page. The opponent side is always present — a real
   // player, or the player-less placeholder for solo matches.
@@ -182,7 +198,10 @@ function ScoreEntryInner({
   // Once a match is finalized every write path 409s — there's nothing to do
   // here. Same goes once a result is posted — scores are frozen the instant the
   // first proposal lands; accepting it lives on the match-details page.
-  if (data.status === 'completed' || data.negotiation.standing_result !== null) {
+  if (
+    !boardConflict &&
+    (data.status === 'completed' || data.negotiation.standing_result !== null)
+  ) {
     return <Navigate {...matchDetailRoute(matchId)} />
   }
   // The game number past which no more games can be played: once a side has
@@ -198,31 +217,17 @@ function ScoreEntryInner({
   // can never be played. An already-scored game at/under the decider stays
   // editable (you can still fix the deciding game itself).
   if (
-    !Number.isInteger(gameNumber) ||
-    gameNumber < 1 ||
-    gameNumber > data.best_of ||
-    (decider !== null && gameNumber > decider && !isScored(gameNumber))
+    !boardConflict &&
+    (!Number.isInteger(gameNumber) ||
+      gameNumber < 1 ||
+      gameNumber > data.best_of ||
+      (decider !== null && gameNumber > decider && !isScored(gameNumber)))
   ) {
     return <Navigate {...matchDetailRoute(matchId)} />
   }
 
   const game = data.games.find((g) => g.game_number === gameNumber) ?? null
   const persistedScore = game?.score ?? null
-
-  // A first-post that lost to a concurrent scratchpad save (issue D1): the
-  // proposed board disagreed with a game someone else committed. The 409 carries
-  // the true committed match; `useProposeResult`'s onError already re-synced the
-  // caches from it, so `data` now reflects reality. We block the score pad below
-  // and show a "the score changed" interstitial instead of silently overwriting.
-  // Computed here (before the create→edit redirect) because the re-sync gives the
-  // active game a committed score, which would otherwise bounce the poster to the
-  // edit page — presenting the opponent's committed game as their editable draft,
-  // the exact thing the interstitial exists to avoid.
-  const finalizeApiError =
-    finalizeMutation.error instanceof ApiError ? finalizeMutation.error : null
-  const boardConflict = finalizeApiError
-    ? boardConflictDetail(finalizeApiError)
-    : null
 
   // Mode/URL/state alignment: in create mode but a score exists → swap to
   // the edit URL so Save doesn't try to POST .../scores/new and 409. The
@@ -413,9 +418,16 @@ function ScoreEntryInner({
     )
   })
   // Where "Resume" sends them: the first still-unplayed game on the true board,
-  // or the match page when the committed board is already fully scored.
+  // or the match page when the committed board leaves nothing left to play. A
+  // board decided *before* its last slot (a 3-0 sweep with games 4-5 blank) has
+  // unscored slots that can never be played — so gate on the decider, not on the
+  // first empty slot, or "Resume" would point at an unplayable game.
   const committedForResume = committedMatch ?? data
   const nextUnplayedGame = (() => {
+    const resumeScored = scoredGamePoints(committedForResume.games)
+    if (deciderGameNumber(resumeScored, committedForResume.best_of) !== null) {
+      return null
+    }
     const scored = new Set(
       committedForResume.games.filter((g) => g.score).map((g) => g.game_number),
     )

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -11,6 +11,7 @@ import { ApiError, boardConflictDetail } from '@/api/client'
 import {
   forgetScoreSaves,
   matchDetailRoute,
+  nextScoringDestination,
   recordedGameNumbers,
   scoringEditRoute,
   scoringNewRoute,
@@ -244,7 +245,7 @@ function ScoreEntryInner({
   ) {
     return <Navigate {...scoringEditRoute(matchId, gameNumber)} replace />
   }
-  if (mode.kind === 'edit' && !persistedScore) {
+  if (mode.kind === 'edit' && !persistedScore && !boardConflict) {
     return <Navigate {...scoringNewRoute(matchId, gameNumber)} replace />
   }
 
@@ -404,38 +405,26 @@ function ScoreEntryInner({
     | MatchDetails
     | undefined
   // The games the poster's proposal changed or dropped vs. what's committed —
-  // named in the interstitial so the poster sees exactly what moved.
+  // named in the interstitial so the poster sees exactly what moved. Only the
+  // rare conflict path consumes this, so skip the work when there's no conflict.
   const attemptedByNumber = new Map(
     (finalizeMutation.variables?.games ?? []).map((g) => [g.game_number, g]),
   )
-  const divergingGames = (committedMatch?.games ?? []).filter((g) => {
-    if (!g.score) return false
-    const attempted = attemptedByNumber.get(g.game_number)
-    return (
-      !attempted ||
-      attempted.side_1_points !== g.score.side_1_points ||
-      attempted.side_2_points !== g.score.side_2_points
-    )
-  })
-  // Where "Resume" sends them: the first still-unplayed game on the true board,
-  // or the match page when the committed board leaves nothing left to play. A
-  // board decided *before* its last slot (a 3-0 sweep with games 4-5 blank) has
-  // unscored slots that can never be played — so gate on the decider, not on the
-  // first empty slot, or "Resume" would point at an unplayable game.
-  const committedForResume = committedMatch ?? data
-  const nextUnplayedGame = (() => {
-    const resumeScored = scoredGamePoints(committedForResume.games)
-    if (deciderGameNumber(resumeScored, committedForResume.best_of) !== null) {
-      return null
-    }
-    const scored = new Set(
-      committedForResume.games.filter((g) => g.score).map((g) => g.game_number),
-    )
-    for (let n = 1; n <= committedForResume.best_of; n += 1) {
-      if (!scored.has(n)) return n
-    }
-    return null
-  })()
+  const divergingGames = committedMatch
+    ? committedMatch.games.filter((g) => {
+        if (!g.score) return false
+        const attempted = attemptedByNumber.get(g.game_number)
+        return (
+          !attempted ||
+          attempted.side_1_points !== g.score.side_1_points ||
+          attempted.side_2_points !== g.score.side_2_points
+        )
+      })
+    : []
+  // Where "Resume" sends them on the true board: the server already computes the
+  // next playable game as `current_game` (null once the board is decided, even
+  // when it clinched before its last slot — a 3-0 sweep has no game 4 to resume),
+  // so reuse it rather than re-deriving the decider here.
   // The score *inputs* are only invalid for genuine validation problems (local
   // illegal score, or a 422 drift the server rejected) — a 409/500 means the
   // entered score is fine, so don't paint the fields red for those.
@@ -731,20 +720,13 @@ function ScoreEntryInner({
             divergingGames={divergingGames}
             meWins={meWins}
             oppWins={oppWins}
-            decided={nextUnplayedGame === null}
-            resumeLabel={
-              nextUnplayedGame === null ? 'View match →' : 'Resume scoring →'
-            }
+            decided={committedMatch?.current_game == null}
             onResume={() => {
               // Clear the propose error before leaving so it doesn't re-render
               // the interstitial over the next game's screen (the component
               // stays mounted across the game-number param change).
               finalizeMutation.reset()
-              navigate(
-                nextUnplayedGame === null
-                  ? matchDetailRoute(matchId)
-                  : scoringNewRoute(matchId, nextUnplayedGame),
-              )
+              navigate(nextScoringDestination(committedMatch ?? data))
             }}
           />
         ) : (
@@ -905,7 +887,6 @@ function BoardChangedInterstitial({
   meWins,
   oppWins,
   decided,
-  resumeLabel,
   onResume,
 }: {
   meName: string
@@ -915,9 +896,9 @@ function BoardChangedInterstitial({
   meWins: number
   oppWins: number
   decided: boolean
-  resumeLabel: string
   onResume: () => void
 }) {
+  const resumeLabel = decided ? 'View match →' : 'Resume scoring →'
   return (
     <Alert
       role="alert"

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -833,7 +833,23 @@ export const handlers = [
         body.games,
         body.supersedes_result_id ?? null,
       )
-      if (error) return detail(error.message, error.status)
+      if (error) {
+        // A board-level conflict (issue D1) carries the whole committed match so
+        // the client re-syncs from the body — mirror the server's
+        // `MatchResultBoardConflict` shape rather than the plain-string 409.
+        if (error.boardConflict) {
+          return HttpResponse.json(
+            {
+              detail: {
+                message: error.message,
+                committed_match: projectMatchDetails(seed),
+              },
+            },
+            { status: 409 },
+          )
+        }
+        return detail(error.message, error.status)
+      }
       return HttpResponse.json(projectMatchDetails(seed), { status: 201 })
     },
   ),

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -1192,7 +1192,7 @@ export function proposeSeed(
   seed: SeedMatch,
   games: SeedResultGame[],
   supersedesResultId: string | null,
-): { status: number; message: string } | null {
+): { status: number; message: string; boardConflict?: boolean } | null {
   // Strict decided-board precondition (422), before the negotiation gates.
   const validationError = validateProposedGames(seed, games)
   if (validationError) return { status: 422, message: validationError }
@@ -1203,6 +1203,30 @@ export function proposeSeed(
       return {
         status: 409,
         message: 'This match already has a posted result.',
+      }
+    }
+    // Board-level scratchpad guard (issue D1): reject a proposal that would
+    // overwrite a game another participant committed to the shared scratchpad
+    // that this client never saw. Every committed-scored game must appear
+    // unchanged; additions (games with no committed score) are fine. Mirrors the
+    // server's ``_scratchpad_divergence``. Runs before syncScratchpadGames so the
+    // committed board the handler returns still reflects what's saved.
+    const diverges = seed.games.some((g) => {
+      if (!g.score) return false
+      const proposed = games.find((pg) => pg.game_number === g.game_number)
+      return (
+        !proposed ||
+        proposed.side_1_points !== g.score.side_1_points ||
+        proposed.side_2_points !== g.score.side_2_points
+      )
+    })
+    if (diverges) {
+      return {
+        status: 409,
+        boardConflict: true,
+        message:
+          'The score changed while you were entering it — a game was ' +
+          'saved by someone else. Review the board before posting.',
       }
     }
   } else {


### PR DESCRIPTION
## The bug (D1 / #747-B2)

Rated BO5, both players on the match. The poster saves G1 and G2 to the shared **scratchpad** and sits on the G3 sheet (tally 2-0). The opponent saves G3 *in their own favor* (real board 2-1). The poster's browser never learns of it — a concurrent participant's scratchpad save only becomes visible when this client attempts its own write and gets a 409. The poster's stale sheet still shows G3 unplayed; typing a win reads as a 3-0 sweep, the button offers **"Post result"**, and clicking it silently proposed 3-0 — **replacing the opponent's committed G3**, no conflict warning on either side.

**Root cause — a concurrency asymmetry.** The pre-result scratchpad is edited one game at a time via `PUT .../games/{n}/scores`, guarded by an optimistic-concurrency `version` token. But "Post result" (`POST /matches/{id}/results`) bypassed that path: it assembled a board client-side and `_commit_canonical_games` cleared + reinserted `match_games` from the payload with **no comparison** against what was committed. A stale client-assembled board won over a committed game.

## The fix (server-authoritative)

Give the first-post propose the board-level analogue of the per-game version guard, under the same `FOR UPDATE NOWAIT` lock: **every committed scratchpad game that has a score must appear in the proposed board with identical points, or the propose is rejected 409** (`_scratchpad_divergence` / `MatchResultBoardConflict`). *Additions* — a proposed game with no committed score — are allowed. The 409 carries the **whole committed match** so the client re-syncs from the body (no refetch) and re-decides against reality. The check is gated **behind** the existing "a result already exists" gate, so it only ever fires pre-result and never undoes a posted result.

## Reconcile UX

`useProposeResult`'s `onError` re-syncs the caches from `committed_match`, and the score-entry screen replaces the score pad with a **blocking interstitial** ("the score changed — a game was saved by someone else"). Its single CTA resumes scoring at the next still-unplayed game, or "View match →" when the committed board is already decided. It never presents the opponent's committed game as the poster's editable draft.

## Notes

- ADR `docs/adr/0003-first-post-propose-guards-scratchpad-divergence.md` records why value-compare-and-reject was chosen over a per-game `expected_version` token (three CI-gated codegen boundaries + collides with compaction's renumbering) and over a force-overwrite affordance (silent data loss *is* the bug). Delete-divergence is a documented non-goal.
- `schema.d.ts` and `ios/Fortymm/Generated/Types.swift` regenerated for the new 409 model.

## Verification

- **API**: full suite green — 538 pytest, ruff/format/mypy clean. Tests cover the D1 repro (409 with `committed_match` showing the opponent's G3, no result minted, G3 survives), additions-only → 201, blank committed cell → 201, result-already-exists → still the negotiation conflict (gate ordering), edit-mode + decided-board interstitial branches, solo/unrated unaffected.
- **web-client**: 1168 vitest pass, eslint clean, `tsc -b` + `vite build` green; `score-entry.spec` Playwright (133) green. Interstitial tests cover undecided (→ "Resume scoring →"), decided-for-opponent (→ "View match →"), and the edit-route conflict.
- **Codegen**: `schema.d.ts` and iOS `Types.swift` regenerated — zero drift vs the live openapi; iOS app **BUILD SUCCEEDED**.
- **Runtime-verified on the assembled QA stack** (real nginx+api+worker+postgres, MSW off): drove the exact D1 sequence over HTTP with two accounts — creator commits G1/G2, opponent commits G3 (3-11), creator posts a stale 3-0 sweep → **409** `MatchResultBoardConflict` carrying the true board; G3 stayed 3-11 and no result was minted.
- **Remaining for the reviewer**: a two-*browser* visual pass (the interstitial render + re-sync + "Resume scoring" nav in a live UI) — the server/data half is runtime-confirmed above; the pixel-level UI pass is the one piece a background job can't drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)