### PR TITLE
Fix first-match hero: autofocus search, unclip dropdown

### DIFF
--- a/web-client/src/components/dashboard/first-match/first-match-card.tsx
+++ b/web-client/src/components/dashboard/first-match/first-match-card.tsx
@@ -62,7 +62,7 @@ export const FirstMatchCard = () => {
   const error = submitted ? apiError : null
 
   return (
-    <Card style={{ minWidth: 0 }}>
+    <Card style={{ minWidth: 0, overflow: 'visible' }}>
       <Overline style={{ color: C.ball400 }}>Your next match</Overline>
       <h2
         style={{

--- a/web-client/src/components/matches/opponent-picker.test.tsx
+++ b/web-client/src/components/matches/opponent-picker.test.tsx
@@ -99,11 +99,14 @@ describe('OpponentPicker', () => {
     expect(opponentPickerPage.getCombobox()).not.toHaveFocus()
   })
 
-  it('opens straight into search when defaultToSearch is set', async () => {
+  it('opens straight into search when defaultToSearch is set, focused', async () => {
     opponentPickerPage.mockSearch(() => HttpResponse.json([]))
     opponentPickerPage.render({ defaultToSearch: true })
 
     expect(opponentPickerPage.queryCombobox()).toBeInTheDocument()
+    // The dashboard hero opens into search — the input should be focused on
+    // mount so the user can type without a click.
+    expect(opponentPickerPage.getCombobox()).toHaveFocus()
   })
 
   it('surfaces a failed recent-opponents load in the error boundary (#96)', async () => {

--- a/web-client/src/components/matches/opponent-picker.tsx
+++ b/web-client/src/components/matches/opponent-picker.tsx
@@ -25,6 +25,10 @@ export interface OpponentPickerProps {
  * children — preserves the typed query and the search view instead of dropping
  * back to the recent grid (#96). The `focusOnMountRef` ref likewise survives a
  * reset remount, so error recovery doesn't yank focus back to the input (#131).
+ *
+ * The ref starts `true` on the `defaultToSearch` entry (the dashboard hero opens
+ * straight into search), so the input is focused on first mount without a click;
+ * on the recent-grid entry it's flipped `true` by `onSearchAll` instead.
  */
 export const OpponentPicker = ({
   onPick,
@@ -32,7 +36,7 @@ export const OpponentPicker = ({
 }: OpponentPickerProps) => {
   const [showSearch, setShowSearch] = useState(defaultToSearch)
   const [query, setQuery] = useState('')
-  const focusOnMountRef = useRef(false)
+  const focusOnMountRef = useRef(defaultToSearch)
 
   return (
     <OpponentPickerBoundary>


### PR DESCRIPTION
## What

Two UX bugs in the zero-match dashboard's **"Log your first match" hero** (`FirstMatchDashboard` → `FirstMatchCard`, which mounts `<OpponentPicker defaultToSearch>`):

1. **Search input wasn't focused on landing.** The user had to click the field before typing, even though searching is the hero's whole purpose.
2. **Results dropdown was clipped at the card edge.** Once results exceeded the space left inside the card, the dropdown got cut off.

## Fixes

- **Autofocus** — `OpponentTypeahead` focuses imperatively via `focusOnMountRef` (deliberately not `autoFocus`, per #131). That ref was only ever set `true` by `RecentOpponents`' "search all" handler, never on the `defaultToSearch` path. Now seeded from `defaultToSearch` so the existing focus effect fires on mount. The #131 error-boundary guard is unaffected (ref clears to `false` after first focus).
- **Dropdown clipping** — the dropdown is a non-portaled absolutely-positioned div (`z-index` can't beat an overflow clip). Its nearest clipping ancestor is the shadcn base `Card`'s `overflow-hidden`. Added `overflow: visible` to just the hero `Card` instance (inline style beats the utility class); every other `Card` consumer keeps `overflow-hidden`.

## Testing

- Extended the existing `defaultToSearch` spec in `opponent-picker.test.tsx` to assert the combobox is focused on mount (fails without the fix).
- `npm run lint`, `npm run build` (tsc), and `npm run test -- opponent` (44 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RumQEmjoYv9WQdHVdM4Her