### PR TITLE
Fix D4: session sign-out elsewhere silently drops score & mints a guest

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,6 +47,35 @@ decided board, not an edit of individual game cells. The corrector may add,
 remove, or change games, so long as the outcome is again a decided board.
 _Avoid_: dispute, edit, amendment.
 
+## Session and identity
+
+**Guest**:
+An ephemeral, email-less account minted automatically on first contact so
+anyone can start playing without signing up. Identified only by the browser's
+session cookie; disposable, and folded into a claimed account when the holder
+later signs in (a merge).
+_Avoid_: anonymous user, ephemeral user (use "guest" in product language).
+
+**Claimed account**:
+A user who has attached a confirmed email, giving them a durable identity that
+outlives any one browser session and can be signed back into on another device.
+The opposite pole from a guest.
+_Avoid_: registered user, real account.
+
+**Sign out**:
+Discarding the session cookie for the current browser origin, abandoning the
+current identity. The cookie is shared across every tab on the origin, so
+signing out in one tab ends the session for all of them — not just the tab that
+did it.
+_Avoid_: log out (button copy may say "Log out"; the act is "sign out").
+
+**Session-ended**:
+The state a tab lands in when its session cookie no longer resolves to a usable
+user — the holder signed out elsewhere, or was merged away. The app's response
+is to drop the stale identity and send the holder to sign in, never to quietly
+mint a fresh guest in their place.
+_Avoid_: logged out, expired, unauthenticated.
+
 ## Dashboard
 
 **First-match**:

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -601,8 +601,9 @@ async def get_current_user(
 
     Resolves the cookie directly (rather than via ``get_optional_user``) so it
     can tell a *tombstoned* guest — whose cookie still resolves — apart from no
-    session at all, and raise the structured ``session_merged`` 401 that sends
-    the holder to sign in instead of letting them act as a merged-away ghost.
+    session at all, raising the structured ``session_merged`` 401 for the former
+    and ``session_ended`` for the latter. Both send the holder to sign in
+    (instead of acting as a merged-away ghost, or silently minting a new guest).
     """
     user = await _find_session_user(db, session_cookie) if session_cookie else None
     if user is not None and user.merged_into_user_id is not None:

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -73,6 +73,12 @@ SESSION_TOKEN_CONTEXT = "session"
 # apart from an ordinary auth failure and redirect to login (with the owner's
 # email prefilled) instead of looping.
 SESSION_MERGED_CODE = "session_merged"
+# Stable `code` on the 401 we raise when a session cookie no longer resolves to a
+# usable user — the holder signed out (the cookie is shared across the origin, so
+# a sign-out in one tab ends every tab's session) or the session expired. Lets a
+# client tell "your session ended, sign in" apart from any other 401 and route to
+# login instead of silently minting a fresh guest in the signed-out user's place.
+SESSION_ENDED_CODE = "session_ended"
 # Email-change confirmation tokens carry the *prior* address in their context
 # (e.g. "change:old@example.com", or "change:" on first-ever set). This gives
 # us an audit trail of what each token was changing away from. Look up
@@ -356,6 +362,23 @@ def _clear_cookie_header() -> dict[str, str]:
     return {"set-cookie": "; ".join(attrs)}
 
 
+def _session_ended_exception() -> HTTPException:
+    """Build the 401 for a request whose session cookie no longer resolves to a
+    usable user — a signed-out or expired session. Carries the stable
+    ``SESSION_ENDED_CODE`` so clients redirect to login rather than treating it
+    as an ordinary auth failure (or silently minting a fresh guest), and clears
+    any lingering dead cookie so the login screen can start a clean guest. There
+    is no email to prefill — the holder isn't a known account here."""
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail={
+            "code": SESSION_ENDED_CODE,
+            "message": "You've been signed out. Sign in to continue.",
+        },
+        headers=_clear_cookie_header(),
+    )
+
+
 async def _merged_session_exception(db: AsyncSession, user: User) -> HTTPException:
     """Build the 401 for a cookie that resolves to a tombstoned (merged-away)
     guest. Carries the stable ``SESSION_MERGED_CODE`` so clients redirect to
@@ -585,10 +608,7 @@ async def get_current_user(
     if user is not None and user.merged_into_user_id is not None:
         raise await _merged_session_exception(db, user)
     if user is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="authentication required",
-        )
+        raise _session_ended_exception()
     return user
 
 

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -345,11 +345,13 @@ async def _find_session_user(db: AsyncSession, raw_token: str) -> User | None:
 
 
 def _clear_cookie_header() -> dict[str, str]:
-    """A ``Set-Cookie`` that clears the session cookie, for attaching to the 401
-    we raise when a cookie resolves to a tombstoned guest. The cookie is
-    HttpOnly, so only the server can drop it — clearing it lets the holder start
-    a fresh guest from the login screen. Mirror ``_clear_session_cookie``'s
-    attributes so the browser actually matches and drops it."""
+    """A ``Set-Cookie`` that clears the session cookie, for attaching to a 401
+    that ends a session no longer good for auth — a cookie resolving to a
+    tombstoned (merged-away) guest, or one that no longer resolves at all
+    (signed out / expired). The cookie is HttpOnly, so only the server can drop
+    it — clearing it lets the holder start a fresh guest from the login screen.
+    Mirror ``_clear_session_cookie``'s attributes so the browser actually
+    matches and drops it."""
     attrs = [
         f"{SESSION_COOKIE_NAME}=",
         "Path=/",

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -421,6 +421,23 @@ async def test_authed_endpoint_with_merged_cookie_401s(
     # test_creates_new_session_when_cookie_invalid — only tombstones 401.)
 
 
+async def test_authed_endpoint_without_session_401s_session_ended(
+    api_client: AsyncClient,
+):
+    """An authed request whose session cookie no longer resolves to a user — the
+    holder signed out (the origin-shared cookie was dropped) or the session
+    expired — returns the structured `session_ended` 401 so the client redirects
+    to sign-in instead of silently minting a fresh guest in their place. Unlike
+    the merged case there is no owner email to prefill, and the dead cookie is
+    cleared so login can start a clean guest."""
+    response = await api_client.patch("/v1/me", json={"username": "nobody"})
+    assert response.status_code == 401
+    detail = response.json()["detail"]
+    assert detail["code"] == "session_ended"
+    assert "email" not in detail
+    assert "max-age=0" in response.headers.get("set-cookie", "").lower()
+
+
 # ----- CSRF double-submit guard ---------------------------------------------
 
 

--- a/docs/adr/0004-session-invalid-401-carries-a-code.md
+++ b/docs/adr/0004-session-invalid-401-carries-a-code.md
@@ -1,0 +1,62 @@
+# A session-invalid 401 carries a structured code that ends the session
+
+When the session cookie no longer resolves to a usable user, `get_current_user`
+raises a `401` carrying a **structured `session_ended` code** (mirroring the
+existing `session_merged` code for a tombstoned/merged cookie). The web client
+matches on that **code**, not the bare `401` status: on either code it treats the
+tab as **session-ended** — drops the cached `['session']` identity and redirects
+to `/login`, clearing the dead cookie — and never lets the next bootstrap quietly
+mint a fresh guest in the signed-out user's place.
+
+Keying off an explicit code — rather than "any plain 401" — kills a
+false-positive class **by construction**: only a genuinely invalid session
+carries the code, so no future 401 added elsewhere (a bad token, a failed
+captcha, a permission check) can ever trip the global sign-out. Today those
+already return `400`/`409`, so a bare-status rule would be safe *now*; the code
+makes it safe *permanently* and is symmetric with the pattern already in place.
+The `session_ended` code lives on the single dependency every authenticated
+endpoint funnels through (`sessions.py` `get_current_user`), so one server site
+covers every write. (The 401 `detail` is an `HTTPException` payload, not part of
+any `response_model`, so it does not appear in `openapi.json` — no generated-type
+drift, same as `session_merged`.)
+
+## Bug context
+
+Fixes D4. A claimed user with an unsaved game score in tab 1 signs out from
+tab 2. Tab 1 still shows the stale identity. Clicking "Save game & next" fires
+the score write **fire-and-forget and navigates synchronously in the same
+gesture** (deliberate, to keep the mobile keyboard open — #567), so the
+cookieless write's 401 lands *after* navigation and was previously swallowed:
+the deciding game vanished with no error, and a later reload minted a brand-new
+guest. Routing the `session_ended` 401 through the existing session-ended
+handler turns that silent data loss into an honest "you've been signed out —
+sign back in."
+
+## Considered options
+
+- **Structured `session_ended` code, client matches on the code (chosen).** One
+  server site, symmetric with `session_merged`, robust against any future 401 by
+  construction. Catches the save mutation *and* the destination page's query at
+  the shared HTTP boundary, and pre-empts the reload-guest by moving the user to
+  `/login` before they'd reload into a fresh guest. Keeps the #567 optimistic
+  navigate intact.
+
+- **Client matches on the bare plain-401 status (rejected).** Client-only and
+  safe today (the only two 401 sites in the API are both session-invalid), but
+  fragile: the day anyone adds a third 401, the global sign-out misfires
+  mid-flow (e.g. nuking a guest session during a merge). The one-line server
+  code removes that latent trap.
+
+- **Await-then-navigate on the score write (rejected).** Surfacing the failure
+  inline would mean the save awaits its response before navigating, regressing
+  the #567 keyboard behavior on every save, not just the rare signed-out one.
+
+- **A durable "this browser held a claimed account" marker (rejected).** Would
+  additionally kill the silently-minted guest on a *passive reload* (where no
+  request 401s, so the reactive handler can't fire). Rejected as fragile: the
+  marker's clearing rule trades a redirect-loop risk against a silent-guest
+  window, and the passive-reload case is cosmetic — the participant guard
+  (`score-entry.tsx`) already bounces the fresh guest off the scoring surface to
+  read-only match details, so no score can be entered on a match the caller is
+  not a participant in and no data is lost. We accept a guest being minted on
+  passive reload; we do not accept silent score loss or acting on a dead session.

--- a/web-client/src/api/client.test.ts
+++ b/web-client/src/api/client.test.ts
@@ -7,7 +7,7 @@ import {
   ApiError,
   api,
   extractDetail,
-  isSessionMergedError,
+  isSessionEndedError,
   setSessionEndedHandler,
 } from './client'
 
@@ -54,6 +54,24 @@ it('fires the session-ended handler on a session_merged 401', async () => {
   })
 })
 
+it('fires the session-ended handler on a session_ended 401 (no email)', async () => {
+  await resetLatch()
+  const handler = vi.fn()
+  setSessionEndedHandler(handler)
+
+  merged401({
+    code: 'session_ended',
+    message: "You've been signed out. Sign in to continue.",
+  })
+  await api.GET('/v1/session')
+
+  expect(handler).toHaveBeenCalledTimes(1)
+  expect(handler).toHaveBeenCalledWith({
+    message: "You've been signed out. Sign in to continue.",
+    email: undefined,
+  })
+})
+
 it('ignores an ordinary (non-structured) 401', async () => {
   await resetLatch()
   const handler = vi.fn()
@@ -83,15 +101,20 @@ it('latches so a burst of 401s redirects only once', async () => {
   expect(handler).toHaveBeenCalledTimes(1)
 })
 
-it('isSessionMergedError recognizes only the structured session_merged 401', () => {
+it('isSessionEndedError recognizes both structured session-ended 401 codes', () => {
   const merged = new ApiError(401, 'gone', 'load session', {
     detail: { code: 'session_merged', message: 'gone' },
   })
-  expect(isSessionMergedError(merged)).toBe(true)
+  expect(isSessionEndedError(merged)).toBe(true)
 
-  // A bare 401 (no structured code) is not the merge case.
+  const ended = new ApiError(401, 'gone', 'save score', {
+    detail: { code: 'session_ended', message: 'signed out' },
+  })
+  expect(isSessionEndedError(ended)).toBe(true)
+
+  // A bare 401 (no structured code) is an ordinary auth failure.
   expect(
-    isSessionMergedError(
+    isSessionEndedError(
       new ApiError(401, 'unauthorized', 'load session', {
         detail: 'authentication required',
       }),
@@ -99,16 +122,16 @@ it('isSessionMergedError recognizes only the structured session_merged 401', () 
   ).toBe(false)
   // A different code, or a non-401, or a non-ApiError, all fall through.
   expect(
-    isSessionMergedError(
+    isSessionEndedError(
       new ApiError(401, null, 'x', { detail: { code: 'unauthenticated' } }),
     ),
   ).toBe(false)
   expect(
-    isSessionMergedError(
-      new ApiError(403, null, 'x', { detail: { code: 'session_merged' } }),
+    isSessionEndedError(
+      new ApiError(403, null, 'x', { detail: { code: 'session_ended' } }),
     ),
   ).toBe(false)
-  expect(isSessionMergedError(new Error('boom'))).toBe(false)
+  expect(isSessionEndedError(new Error('boom'))).toBe(false)
 })
 
 it('echoes the csrf cookie in the X-CSRF-Token header on a mutation', async () => {

--- a/web-client/src/api/client.ts
+++ b/web-client/src/api/client.ts
@@ -16,8 +16,9 @@ export const api = createClient<paths>({
 })
 
 /**
- * Info carried by the `session_merged` 401: the backend's human message and the
- * owning account's email (to prefill on the login screen).
+ * Info carried by a session-ended 401 (`session_merged` or `session_ended`): the
+ * backend's human message, and — only for the merged case — the owning account's
+ * email to prefill on the login screen.
  */
 export interface SessionEndedInfo {
   message: string
@@ -28,10 +29,11 @@ let sessionEndedHandler: ((info: SessionEndedInfo) => void) | null = null
 let sessionEndedFiring = false
 
 /**
- * Register the global "your session was merged away" handler (set once at app
- * bootstrap). It fires from the response middleware below for *any* request, so
- * a guest whose account was merged on another device is sent to sign in no
- * matter which call surfaces it — not just the session bootstrap.
+ * Register the global "your session ended" handler (set once at app bootstrap).
+ * It fires from the response middleware below for *any* request, so a holder
+ * whose session went away — merged on another device, or signed out / expired —
+ * is sent to sign in no matter which call surfaces it, not just the session
+ * bootstrap.
  */
 export function setSessionEndedHandler(
   fn: ((info: SessionEndedInfo) => void) | null,
@@ -47,6 +49,16 @@ export function setSessionEndedHandler(
 // the bare status.
 const SESSION_ENDED_CODES = new Set(['session_merged', 'session_ended'])
 
+/** True when a 401's `detail` payload carries one of the session-ended codes.
+ * Both the response-middleware reader and the `ApiError` classifier narrow the
+ * same `unknown` body (from a live `Response` vs. a stored `ApiError`), so the
+ * check lives here once. */
+function hasSessionEndedCode(detail: unknown): boolean {
+  if (!detail || typeof detail !== 'object') return false
+  const code = (detail as { code?: unknown }).code
+  return typeof code === 'string' && SESSION_ENDED_CODES.has(code)
+}
+
 async function readSessionEnded(
   response: Response,
 ): Promise<SessionEndedInfo | null> {
@@ -55,12 +67,7 @@ async function readSessionEnded(
       detail?: { code?: unknown; message?: unknown; email?: unknown }
     }
     const detail = body?.detail
-    if (
-      detail &&
-      typeof detail === 'object' &&
-      typeof detail.code === 'string' &&
-      SESSION_ENDED_CODES.has(detail.code)
-    ) {
+    if (detail && hasSessionEndedCode(detail)) {
       return {
         message:
           typeof detail.message === 'string'
@@ -141,9 +148,7 @@ api.use({
 export function isSessionEndedError(error: unknown): boolean {
   if (!(error instanceof ApiError) || error.status !== 401) return false
   const detail = (error.body as { detail?: unknown } | null | undefined)?.detail
-  if (!detail || typeof detail !== 'object') return false
-  const code = (detail as { code?: unknown }).code
-  return typeof code === 'string' && SESSION_ENDED_CODES.has(code)
+  return hasSessionEndedCode(detail)
 }
 
 export function extractDetail(value: unknown): string | null {

--- a/web-client/src/api/client.ts
+++ b/web-client/src/api/client.ts
@@ -39,7 +39,15 @@ export function setSessionEndedHandler(
   sessionEndedHandler = fn
 }
 
-async function readSessionMerged(
+// The structured 401 `code`s that mean "this tab's session is gone — sign in":
+// a guest merged away on another device (`session_merged`, carries the owner's
+// email to prefill), or a signed-out/expired session (`session_ended`, no
+// email). Any other 401 — a bare string, a different code — is an ordinary auth
+// failure and must NOT trip the global sign-out, so we match on the code, never
+// the bare status.
+const SESSION_ENDED_CODES = new Set(['session_merged', 'session_ended'])
+
+async function readSessionEnded(
   response: Response,
 ): Promise<SessionEndedInfo | null> {
   try {
@@ -50,7 +58,8 @@ async function readSessionMerged(
     if (
       detail &&
       typeof detail === 'object' &&
-      detail.code === 'session_merged'
+      typeof detail.code === 'string' &&
+      SESSION_ENDED_CODES.has(detail.code)
     ) {
       return {
         message:
@@ -109,7 +118,7 @@ api.use({
     if (response.ok) {
       sessionEndedFiring = false
     } else if (response.status === 401 && !sessionEndedFiring) {
-      const info = await readSessionMerged(response)
+      const info = await readSessionEnded(response)
       if (info) {
         // Latch so a burst of in-flight 401s triggers a single redirect.
         sessionEndedFiring = true
@@ -121,21 +130,20 @@ api.use({
 })
 
 /**
- * True when `error` is the structured `session_merged` 401 — the user's guest
- * account was merged away on another device. The global response middleware
- * (`setSessionEndedHandler`) already handles this by redirecting to `/login`, so
+ * True when `error` is a structured session-ended 401 — the guest was merged
+ * away on another device (`session_merged`), or the session was signed out /
+ * expired (`session_ended`). The global response middleware
+ * (`setSessionEndedHandler`) already handles both by redirecting to `/login`, so
  * UI error boundaries should defer to that redirect rather than show a generic
- * "something went wrong" screen (#672). A *bare* 401 (no `session_merged` code)
- * is not this case and should still surface normally.
+ * "something went wrong" screen (#672). A *bare* 401 (no session-ended code) is
+ * an ordinary auth failure and should still surface normally.
  */
-export function isSessionMergedError(error: unknown): boolean {
+export function isSessionEndedError(error: unknown): boolean {
   if (!(error instanceof ApiError) || error.status !== 401) return false
   const detail = (error.body as { detail?: unknown } | null | undefined)?.detail
-  return (
-    !!detail &&
-    typeof detail === 'object' &&
-    (detail as { code?: unknown }).code === 'session_merged'
-  )
+  if (!detail || typeof detail !== 'object') return false
+  const code = (detail as { code?: unknown }).code
+  return typeof code === 'string' && SESSION_ENDED_CODES.has(code)
 }
 
 export function extractDetail(value: unknown): string | null {

--- a/web-client/src/components/app-error.tsx
+++ b/web-client/src/components/app-error.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from '@tanstack/react-router'
 
-import { isSessionMergedError } from '@/api/client'
+import { isSessionEndedError } from '@/api/client'
 import { Wordmark } from '@/components/wordmark'
 import './app-error.css'
 
@@ -27,13 +27,13 @@ export interface AppErrorProps {
  */
 export function AppError({ error, reset }: AppErrorProps) {
   const router = useRouter()
-  // The `session_merged` 401 (guest account merged away on another device) is
-  // already handled by the global session-ended middleware, which clears the
-  // session and redirects to `/login`. Defer to that redirect instead of
-  // flashing the generic error + a "Try again" that would just re-fire the
-  // merged-away session (#672). Render nothing while the redirect lands — a
-  // bare 401 (no `session_merged` code) still falls through to the screen below.
-  if (isSessionMergedError(error)) return null
+  // A session-ended 401 (guest merged away on another device, or a signed-out /
+  // expired session) is already handled by the global session-ended middleware,
+  // which clears the session and redirects to `/login`. Defer to that redirect
+  // instead of flashing the generic error + a "Try again" that would just
+  // re-fire the dead session (#672). Render nothing while the redirect lands — a
+  // bare 401 (no session-ended code) still falls through to the screen below.
+  if (isSessionEndedError(error)) return null
   return (
     <div className="app-error dark fortymm-theme">
       <Wordmark size={20} className="app-error__wordmark" />

--- a/web-client/src/components/dashboard/first-match/first-match-card.test.tsx
+++ b/web-client/src/components/dashboard/first-match/first-match-card.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
-import { act, fireEvent, screen, within } from '@testing-library/react'
+import { act, fireEvent, screen } from '@testing-library/react'
 
 import { render } from '@/test/utilities'
 import { server } from '@/mocks/server'
@@ -164,12 +164,15 @@ describe('FirstMatchCard', () => {
     expect(postCount).toBe(1)
   })
 
-  it('offers a sign-in recovery on a 401', async () => {
+  it('surfaces a server error in an alert', async () => {
+    // A lapsed session is a `session_ended` 401 that the global middleware
+    // catches and redirects to `/login` (covered in api/client.test.ts); any
+    // other failure surfaces inline here.
     server.use(
       http.post('*/v1/matches', () =>
         HttpResponse.json(
-          { detail: 'Your session has expired.' },
-          { status: 401 },
+          { detail: 'Could not start the match right now.' },
+          { status: 500 },
         ),
       ),
     )
@@ -181,9 +184,6 @@ describe('FirstMatchCard', () => {
     )
 
     const alert = await screen.findByRole('alert')
-    expect(alert).toHaveTextContent('Your session has expired.')
-    expect(
-      within(alert).getByRole('button', { name: /sign in again/i }),
-    ).toBeInTheDocument()
+    expect(alert).toHaveTextContent('Could not start the match right now.')
   })
 })

--- a/web-client/src/components/dashboard/first-match/first-match-card.tsx
+++ b/web-client/src/components/dashboard/first-match/first-match-card.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useNavigate } from '@tanstack/react-router'
 import { ArrowRight } from 'lucide-react'
 
 import { deriveEmailStatus, useSession } from '@/api/session'
@@ -28,7 +27,6 @@ import '@/components/matches/match-setup/match-setup.css'
  * pattern at the page level).
  */
 export const FirstMatchCard = () => {
-  const navigate = useNavigate()
   const { data: session } = useSession()
   const [opponent, setOpponent] = useState<Opponent | null>(null)
   const [bestOf, setBestOf] = useState(5)
@@ -36,8 +34,7 @@ export const FirstMatchCard = () => {
   // this hero requires an opponent before it is even submittable, so rated
   // defaults on the moment one is picked — matching the mock.
   const [rated, setRated] = useState(true)
-  const { submit, apiError, sessionExpired, submitting, submitted } =
-    useStartMatch()
+  const { submit, apiError, submitting, submitted } = useStartMatch()
 
   const me = session?.data.user ?? null
   const isGuest =
@@ -129,28 +126,11 @@ export const FirstMatchCard = () => {
             {summary}
           </div>
         )}
-        {error &&
-          (sessionExpired ? (
-            <div className="nm-recovery" role="alert">
-              <p className="nm-error">{error}</p>
-              <button
-                type="button"
-                className="nm-btn nm-btn-primary nm-recovery-btn"
-                onClick={() =>
-                  navigate({
-                    to: '/login',
-                    search: { email: undefined, error: undefined },
-                  })
-                }
-              >
-                Sign in again
-              </button>
-            </div>
-          ) : (
-            <p className="nm-error" role="alert">
-              {error}
-            </p>
-          ))}
+        {error && (
+          <p className="nm-error" role="alert">
+            {error}
+          </p>
+        )}
         <button
           type="button"
           className="nm-btn nm-btn-primary"

--- a/web-client/src/components/matches/match-setup/match-setup.css
+++ b/web-client/src/components/matches/match-setup/match-setup.css
@@ -612,20 +612,6 @@
   line-height: 1.4;
   color: var(--loss, #ef4444);
 }
-.nm-recovery {
-  margin-top: 8px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 8px;
-}
-.nm-recovery .nm-error {
-  margin-top: 0;
-}
-.nm-recovery-btn {
-  height: 40px;
-  padding: 0 16px;
-}
 
 /* --- Buttons --- */
 .nm-btn {

--- a/web-client/src/components/matches/match-setup/use-start-match.test.tsx
+++ b/web-client/src/components/matches/match-setup/use-start-match.test.tsx
@@ -112,12 +112,16 @@ describe('useStartMatch', () => {
     expect(postCount).toBe(1)
   })
 
-  it('surfaces a 401 as a session-expired recovery, not a bare error', async () => {
+  it('surfaces a server error through apiError', async () => {
+    // A lapsed session is a `session_ended` 401 that the global middleware
+    // catches and redirects to `/login` (covered in api/client.test.ts) — the
+    // hook has no session-specific branch of its own; every other failure just
+    // surfaces inline.
     server.use(
       http.post('*/v1/matches', () =>
         HttpResponse.json(
-          { detail: 'Your session has expired.' },
-          { status: 401 },
+          { detail: 'Could not start the match right now.' },
+          { status: 500 },
         ),
       ),
     )
@@ -129,7 +133,6 @@ describe('useStartMatch', () => {
     )
 
     const result = await hook.ready()
-    expect(result.sessionExpired).toBe(true)
-    expect(result.apiError).toBe('Your session has expired.')
+    expect(result.apiError).toBe('Could not start the match right now.')
   })
 })

--- a/web-client/src/components/matches/match-setup/use-start-match.ts
+++ b/web-client/src/components/matches/match-setup/use-start-match.ts
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { z } from 'zod'
 
-import { ApiError, isSessionEndedError } from '@/api/client'
+import { ApiError } from '@/api/client'
 import { nextScoringDestination, useCreateMatch } from '@/api/matches'
 
 import type { Opponent } from './opponent'
@@ -31,7 +31,6 @@ export interface StartMatchInput {
 export interface UseStartMatchResult {
   submit: (input: StartMatchInput) => void
   apiError: string | null
-  sessionExpired: boolean
   submitting: boolean
   submitted: boolean
 }
@@ -48,7 +47,6 @@ export function useStartMatch(): UseStartMatchResult {
   const createMatch = useCreateMatch()
 
   const [apiError, setApiError] = useState<string | null>(null)
-  const [sessionExpired, setSessionExpired] = useState(false)
   const [submitted, setSubmitted] = useState(false)
   // Synchronous submit guard. `'submitting'` blocks the double-click race before
   // `isPending` flips on a batched re-render; `'done'` latches after a match is
@@ -75,7 +73,6 @@ export function useStartMatch(): UseStartMatchResult {
     if (submitState.current !== 'idle') return
     submitState.current = 'submitting'
     setApiError(null)
-    setSessionExpired(false)
 
     try {
       const created = await createMatch.mutateAsync({
@@ -92,19 +89,12 @@ export function useStartMatch(): UseStartMatchResult {
     } catch (err) {
       // Let the user try again — only a *successful* create latches the guard.
       submitState.current = 'idle'
-      // A bare, code-less 401 (the session lapsed mid-form) renders an unstyled
-      // "Not authenticated" with no way forward; offer a sign-in path instead
-      // (#70). A session-ended 401 (signed-out / merged) is handled globally by
-      // a redirect to `/login`, so skip it here and let that redirect win.
-      if (
-        err instanceof ApiError &&
-        err.status === 401 &&
-        !isSessionEndedError(err)
-      ) {
-        setSessionExpired(true)
-        setApiError(err.detail ?? 'Your session has expired.')
-        return
-      }
+      // A lapsed session on create surfaces as a `session_ended` 401, which the
+      // global response middleware (`setSessionEndedHandler`) already catches and
+      // redirects to `/login` — no local "sign in again" recovery needed here
+      // (this supersedes the inline CTA #70 added, back when the same case was a
+      // bare, code-less 401 the global handler ignored). Any other failure shows
+      // inline.
       setApiError(
         err instanceof ApiError
           ? (err.detail ?? err.message)
@@ -116,7 +106,6 @@ export function useStartMatch(): UseStartMatchResult {
   return {
     submit,
     apiError,
-    sessionExpired,
     submitting: createMatch.isPending,
     submitted,
   }

--- a/web-client/src/components/matches/match-setup/use-start-match.ts
+++ b/web-client/src/components/matches/match-setup/use-start-match.ts
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { z } from 'zod'
 
-import { ApiError, isSessionMergedError } from '@/api/client'
+import { ApiError, isSessionEndedError } from '@/api/client'
 import { nextScoringDestination, useCreateMatch } from '@/api/matches'
 
 import type { Opponent } from './opponent'
@@ -92,13 +92,14 @@ export function useStartMatch(): UseStartMatchResult {
     } catch (err) {
       // Let the user try again — only a *successful* create latches the guard.
       submitState.current = 'idle'
-      // A bare 401 (the session lapsed mid-form) renders an unstyled "Not
-      // authenticated" with no way forward; offer a sign-in path instead (#70).
-      // The `session_merged` 401 is handled globally by a redirect, so skip it.
+      // A bare, code-less 401 (the session lapsed mid-form) renders an unstyled
+      // "Not authenticated" with no way forward; offer a sign-in path instead
+      // (#70). A session-ended 401 (signed-out / merged) is handled globally by
+      // a redirect to `/login`, so skip it here and let that redirect win.
       if (
         err instanceof ApiError &&
         err.status === 401 &&
-        !isSessionMergedError(err)
+        !isSessionEndedError(err)
       ) {
         setSessionExpired(true)
         setApiError(err.detail ?? 'Your session has expired.')

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -8,7 +8,6 @@ import './index.css'
 import { Toaster } from '@/components/ui/sonner'
 import { NotFoundPage } from '@/components/not-found-page'
 import { setSessionEndedHandler } from '@/api/client'
-import { SESSION_QUERY_KEY } from '@/api/session'
 import { clearAppEntered } from '@/lib/landing-redirect'
 import { initFaro } from '@/observability/faro'
 import { routeTree } from './routeTree.gen'
@@ -47,9 +46,15 @@ declare module '@tanstack/react-router' {
 // and route to sign-in (email prefilled when the server knows it; the
 // signed-out case has none). Never let the next bootstrap silently mint a fresh
 // guest in the signed-out user's place.
+//
+// `clear()`, not `removeQueries(['session'])`: this is an identity-loss event,
+// so drop ALL cached per-user data (dashboard, matches, players, ...) the same
+// way `useLogout`/`useConsumeLoginToken` do — otherwise the departed user's BFF
+// responses leak into the next ephemeral session if the browser re-enters the
+// app as a fresh guest before those queries go stale (#754).
 setSessionEndedHandler(({ message, email }) => {
   clearAppEntered()
-  queryClient.removeQueries({ queryKey: SESSION_QUERY_KEY })
+  queryClient.clear()
   toast.message(message)
   void router.navigate({ to: '/login', search: { email, error: undefined } })
 })

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -42,8 +42,11 @@ declare module '@tanstack/react-router' {
   }
 }
 
-// When any request reports the session was merged away on another device, drop
-// the stale session, flash the reason, and route to sign-in (email prefilled).
+// When any request reports the session has ended — merged away on another
+// device, or signed out / expired — drop the stale session, flash the reason,
+// and route to sign-in (email prefilled when the server knows it; the
+// signed-out case has none). Never let the next bootstrap silently mint a fresh
+// guest in the signed-out user's place.
 setSessionEndedHandler(({ message, email }) => {
   clearAppEntered()
   queryClient.removeQueries({ queryKey: SESSION_QUERY_KEY })

--- a/web-client/src/routes/_app/matches/new.test.tsx
+++ b/web-client/src/routes/_app/matches/new.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   RouterProvider,
@@ -356,29 +356,6 @@ describe('NewMatchPage', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
       /opponent not found/i,
-    )
-  })
-
-  it('offers a "Sign in again" path instead of a dead error string on a 401 (#70)', async () => {
-    const user = userEvent.setup()
-    server.use(
-      http.get('*/v1/players/recent', () => HttpResponse.json([])),
-      http.post('*/v1/matches', () =>
-        HttpResponse.json({ detail: 'Not authenticated' }, { status: 401 }),
-      ),
-    )
-    renderNewMatch()
-
-    await user.click(
-      await screen.findByRole('button', { name: /start match/i }),
-    )
-
-    // The bare 401 surfaces with a recovery CTA, not just an unstyled string.
-    const alert = await screen.findByRole('alert')
-    expect(alert).toHaveTextContent(/not authenticated/i)
-    await user.click(within(alert).getByRole('button', { name: /sign in again/i }))
-    await waitFor(() =>
-      expect(screen.getByText('Login route')).toBeInTheDocument(),
     )
   })
 

--- a/web-client/src/routes/_app/matches/new.tsx
+++ b/web-client/src/routes/_app/matches/new.tsx
@@ -58,8 +58,7 @@ function MatchCard() {
   // Default off so submitting without picking an opponent "just works" —
   // the no-opponent match is unrated by definition.
   const [rated, setRated] = useState(false)
-  const { submit, apiError, sessionExpired, submitting, submitted } =
-    useStartMatch()
+  const { submit, apiError, submitting, submitted } = useStartMatch()
 
   const me = session?.data.user ?? null
   // The hint nudges guests toward claiming an account so their rated history
@@ -127,12 +126,8 @@ function MatchCard() {
         bestOf={bestOf}
         rated={rated}
         error={submitted ? apiError : null}
-        sessionExpired={sessionExpired}
         submitting={submitting}
         onSubmit={() => submit({ opponent, bestOf, rated })}
-        onSignIn={() =>
-          navigate({ to: '/login', search: { email: undefined, error: undefined } })
-        }
         onCancel={() => navigate({ to: '/dashboard' })}
       />
     </div>
@@ -148,20 +143,16 @@ function SubmitRow({
   bestOf,
   rated,
   error,
-  sessionExpired,
   submitting,
   onSubmit,
-  onSignIn,
   onCancel,
 }: {
   opponent: Opponent | null
   bestOf: number
   rated: boolean
   error: string | null
-  sessionExpired: boolean
   submitting: boolean
   onSubmit: () => void
-  onSignIn: () => void
   onCancel: () => void
 }) {
   const effectivelyRated = rated && opponent !== null
@@ -194,23 +185,11 @@ function SubmitRow({
           <span className="dot">·</span>{' '}
           games to 11, win by 2
         </div>
-        {error &&
-          (sessionExpired ? (
-            <div className="nm-recovery" role="alert">
-              <p className="nm-error">{error}</p>
-              <button
-                type="button"
-                className="nm-btn nm-btn-primary nm-recovery-btn"
-                onClick={onSignIn}
-              >
-                Sign in again
-              </button>
-            </div>
-          ) : (
-            <p className="nm-error" role="alert">
-              {error}
-            </p>
-          ))}
+        {error && (
+          <p className="nm-error" role="alert">
+            {error}
+          </p>
+        )}
       </div>
       <div className="actions">
         <button


### PR DESCRIPTION
## Problem (D4)

A signed-in (claimed) user types a G2 score in tab 1 without saving, signs out from `/settings` in tab 2, then clicks **Save game & next** in tab 1 → navigates to match details with **no error**, the score is not saved, and the header still claims the old identity. Reloading tab 1 **silently mints a brand-new guest**. In a real play-test this eats a deciding game and strands the player on a ghost account. (Verified on match 81372961.)

### Two independent defects

1. **The score write is fire-and-forget and swallows auth failures.** `onSubmit` calls `mutate()` then `navigate()` synchronously in the same gesture (deliberate — keeps the mobile keyboard open, #567). The sign-out cleared the origin-shared session cookie, so the write returns a plain `401`, but only the structured `session_merged` 401 triggered the global session-ended handler — a plain `authentication required` 401 triggered nothing, and navigation had already happened.
2. **A cold reload can't tell "signed out" from "first visit."** The cookie is simply gone, so the `_app` loader's `GET /v1/session` mints a fresh guest — indistinguishable from a genuine new visitor.

## Fix

Give `get_current_user`'s 401 a **structured `session_ended` code** (symmetric with `session_merged`), clearing the dead cookie, and have the client's global session-ended middleware match on the **code**, not the bare status. A score write against a dead session now drops the stale identity and redirects to `/login` instead of silently losing the score or minting a guest.

Matching on an explicit code (rather than "any 401") keeps other 401s from ever tripping the global sign-out — none exist in the API today (every token/captcha error is 400/409), but this is robust against future ones by construction.

**Passive-reload path is already covered** by the existing participant guard in `score-entry.tsx`, which bounces a non-participant (the fresh guest) off the scoring surface to read-only match details — so no score can be entered on a match you're not in. We accept that a guest is still minted on a bare reload (eliminating it needs a fragile durable marker); we do not accept silent score loss or acting on a dead session. See [`docs/adr/0004`](../blob/worktree-fix-d4-session-signout-score-loss/docs/adr/0004-session-invalid-401-carries-a-code.md).

## Changes

- **api** — `get_current_user` raises a structured `session_ended` 401 (new `SESSION_ENDED_CODE`, mirrors `_merged_session_exception`, clears the cookie). One site; every authed endpoint funnels through it.
- **web-client** — `readSessionMerged` → `readSessionEnded` and `isSessionMergedError` → `isSessionEndedError`, both recognizing `session_merged` **and** `session_ended`. Middleware, latch, and `setSessionEndedHandler` reused unchanged.
- **docs** — `CONTEXT.md` *Session and identity* glossary; ADR 0004.

## Verification

- api: `test_session` (41, incl. new `session_ended` test), `test_matches` + `test_rbac_authz` (171) pass; `ruff` + `mypy` clean.
- web-client: full vitest **1166 passed**; `tsc` + `eslint` clean.
- No OpenAPI drift (`schema.d.ts` unchanged — the 401 detail isn't a `response_model`).
- **Not yet exercised end-to-end on the QA stack** (real API, two tabs) — recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)