### PR TITLE
Fix five easy backlog bugs (#732, #728, #753, #751, #77)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1178,13 +1178,14 @@ def _game_scores_text(match: Match, poster_side_number: int) -> str:
 def _result_confirmation_copy(
     match: Match, poster_id: uuid.UUID
 ) -> tuple[str, str] | None:
-    """Title + body for the "confirm or dispute the result your opponent
-    posted" push, framed for the *recipient* (the side that didn't post).
+    """Title + body for the "accept or suggest a correction to the result your
+    opponent posted" push, framed for the *recipient* (the side that didn't
+    post).
 
     The headline carries the games-won score and, where there's room, the
     body lists the individual game scores — both oriented so the poster's
     number comes first. Returns ``None`` when the match isn't a two-human
-    match (nothing to confirm)."""
+    match (nothing to accept)."""
     poster_side = my_side(match, poster_id)
     recipient_side = opponent_side(match, poster_id)
     if poster_side is None or recipient_side is None or not poster_side.players:
@@ -1205,21 +1206,21 @@ def _result_confirmation_copy(
 
     games = _game_scores_text(match, poster_side.side_number)
     body = (
-        f"{headline}. Games: {games}. Approve or dispute?"
+        f"{headline}. Games: {games}. Accept or suggest a correction?"
         if games
-        else f"{headline}. Approve or dispute?"
+        else f"{headline}. Accept or suggest a correction?"
     )
-    return "Confirm your match result", body
+    return "Review your match result", body
 
 
 async def _notify_result_posted(
     notifications: NotificationService, match: Match, poster_id: uuid.UUID
 ) -> None:
-    """Queue a confirm/dispute prompt to every player on the side that now owes
-    a sign-off. Each enqueued job persists the in-app record (the bell feed) and
+    """Queue an accept/counter prompt to every player on the side that now owes
+    a response. Each enqueued job persists the in-app record (the bell feed) and
     fans out push/email per the recipient's preferences in the worker. The APNs
-    ``category``/``data`` carry the Approve/Dispute action group and the match
-    id so a tapped push deep-links to the right match."""
+    ``category``/``data`` carry the action group and the match id so a tapped
+    push deep-links to the right match."""
     copy = _result_confirmation_copy(match, poster_id)
     recipient_side = opponent_side(match, poster_id)
     if copy is None or recipient_side is None:

--- a/api/app/notifications/apns.py
+++ b/api/app/notifications/apns.py
@@ -30,7 +30,8 @@ Environment = Literal["sandbox", "production"]
 
 # Category identifier shared with the iOS client (see
 # ``PushNotificationManager`` in the iOS app). A push carrying this category
-# renders the Approve / Dispute action buttons the app registered for it.
+# renders the Approve / Suggest correction action buttons the app registered
+# for it.
 MATCH_RESULT_CONFIRMATION_CATEGORY = "MATCH_RESULT_CONFIRMATION"
 
 _APNS_HOSTS: dict[str, str] = {

--- a/api/app/notifications/apns.py
+++ b/api/app/notifications/apns.py
@@ -187,8 +187,17 @@ class APNsClient:
         data: Mapping[str, str] | None = None,
     ) -> SendResult:
         url = f"{_APNS_HOSTS[environment]}/3/device/{token}"
+        try:
+            provider_jwt = self._provider_jwt()
+        except (jwt.PyJWTError, ValueError) as exc:
+            # A malformed/expired ``auth_key_pem`` surfaces as a bare
+            # ``ValueError`` from cryptography's PEM loader (via PyJWT's
+            # ``ECAlgorithm.prepare_key``), not a ``PyJWTError`` — catch both
+            # so a bad key can't raise out of `send` (#753).
+            log.warning("APNs provider JWT minting failed: %s", exc)
+            return SendResult(SendOutcome.FAILED, str(exc) or exc.__class__.__name__)
         headers = {
-            "authorization": f"bearer {self._provider_jwt()}",
+            "authorization": f"bearer {provider_jwt}",
             "apns-topic": self._config.bundle_id,
             "apns-push-type": "alert",
         }

--- a/api/app/rbac.py
+++ b/api/app/rbac.py
@@ -479,5 +479,15 @@ async def delete_user(
         )
     user = await _get_user_or_404(db, user_id)
     await db.delete(user)
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "This user has activity (matches, results, or tournaments) "
+                "and cannot be deleted."
+            ),
+        ) from None
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/tests/test_notifications_apns.py
+++ b/api/tests/test_notifications_apns.py
@@ -1,0 +1,24 @@
+from app.notifications.apns import APNsClient, APNsConfig, SendOutcome
+
+
+async def test_send_returns_failed_on_malformed_auth_key() -> None:
+    """A malformed/expired ``APNS_AUTH_KEY`` must not raise out of ``send`` —
+    that would abort the whole ``notify()`` call (including the email
+    enqueue) for every subsequent push in the fan-out (#753)."""
+    client = APNsClient(
+        APNsConfig(
+            key_id="key-id",
+            team_id="team-id",
+            bundle_id="com.fortymm.ios-client",
+            auth_key_pem="not a real PEM key",
+        )
+    )
+
+    result = await client.send(
+        "device-token",
+        environment="sandbox",
+        title="title",
+        body="body",
+    )
+
+    assert result.outcome is SendOutcome.FAILED

--- a/api/tests/test_rbac.py
+++ b/api/tests/test_rbac.py
@@ -1,3 +1,4 @@
+import uuid
 from collections.abc import AsyncIterator
 
 import pytest_asyncio
@@ -7,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
 from app.main import app
-from app.models import Permission, Role, RolePermission, User, UserRole
+from app.models import Permission, Role, RolePermission, Tournament, User, UserRole
 from app.rbac import _require_rbac
 from app.sessions import get_current_user
 from tests._helpers import CSRF_EVENT_HOOKS
@@ -373,6 +374,32 @@ async def test_delete_user_refuses_self(api_client: AsyncClient, admin_user: Use
     response = await api_client.delete(f"/v1/users/{admin_user.id}")
     assert response.status_code == 400
     assert "your own" in response.json()["detail"]
+
+
+async def test_delete_user_with_activity_returns_409(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A user referenced by an ON DELETE RESTRICT FK (e.g. a tournament they
+    created) can't be hard-deleted — the route must turn the IntegrityError
+    into a clean 409 instead of a raw 500 (#751)."""
+    user = (await api_client.post("/v1/users", json={"username": "doomed"})).json()
+    db_session.add(
+        Tournament(
+            name="Doomed Open",
+            address={},
+            created_by_user_id=uuid.UUID(user["id"]),
+        )
+    )
+    await db_session.commit()
+
+    response = await api_client.delete(f"/v1/users/{user['id']}")
+    assert response.status_code == 409
+    assert "activity" in response.json()["detail"]
+
+    remaining = (
+        await db_session.execute(select(User).where(User.username == "doomed"))
+    ).scalar_one_or_none()
+    assert remaining is not None
 
 
 # ----- regression: case-insensitive uniqueness ----------------------------

--- a/web-client/src/components/dashboard/first-match/first-match-card.tsx
+++ b/web-client/src/components/dashboard/first-match/first-match-card.tsx
@@ -135,6 +135,7 @@ export const FirstMatchCard = () => {
           type="button"
           className="nm-btn nm-btn-primary"
           disabled={!opponent || submitting}
+          aria-busy={submitting}
           onClick={() => submit({ opponent, bestOf, rated })}
         >
           {submitting ? 'Starting…' : 'Start scoring'}

--- a/web-client/src/components/matches/correction-entry/correction-entry.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.tsx
@@ -283,7 +283,7 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
         <div className="hint">
           Fix the game(s) that look off — switch games on the SCORELINE, add or
           remove games until the board has a winner, then send the corrected
-          score to {oppName} to confirm.
+          score to {oppName} to accept.
         </div>
       </div>
 
@@ -347,7 +347,7 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
           selectedValidation.oneSideFilled && selectedValidation.error === null
         }
         inputsLocked={inputsLocked}
-        subtitle={`Sending the corrected score posts the result for ${oppName} to confirm.`}
+        subtitle={`Sending the corrected score posts the result for ${oppName} to accept.`}
         submitLabel={
           proposeMutation.isPending ? "Sending…" : "Send corrected score"
         }

--- a/web-client/src/components/matches/match-details/confirmation-callout.page.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout.page.tsx
@@ -33,7 +33,7 @@ const scoped = (container: Container) => ({
    * so it stays unambiguous when composed alongside the other sections. */
   queryLoading() {
     return container.queryByRole("status", {
-      name: /loading the result sign-off prompt/i,
+      name: /loading the result acceptance prompt/i,
     });
   },
   /**

--- a/web-client/src/components/matches/match-details/confirmation-callout.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout.tsx
@@ -6,22 +6,22 @@ export interface ConfirmationCalloutProps {
   matchId: string;
 }
 
-/** The posted-result sign-off callout: featured Confirm/Dispute CTAs when the
- * viewer's signature is the one missing, or the passive "Awaiting <opponent>"
- * notice once they've signed. Self-fetching; renders nothing when neither
+/** The posted-result acceptance callout: featured Accept/Counter CTAs when the
+ * viewer's acceptance is the one missing, or the passive "Awaiting <opponent>"
+ * notice once they've accepted. Self-fetching; renders nothing when neither
  * state applies. */
 export function ConfirmationCallout({ matchId }: ConfirmationCalloutProps) {
   return (
-    // Renders nothing when no sign-off is in play, so a visible skeleton would
-    // flash then collapse. A visually-hidden status keeps the load announced
-    // (and tests a sync handle) while reserving no space.
+    // Renders nothing when no acceptance is in play, so a visible skeleton
+    // would flash then collapse. A visually-hidden status keeps the load
+    // announced (and tests a sync handle) while reserving no space.
     <Suspense
       fallback={
         <span
           className="sr-only"
           role="status"
           aria-busy="true"
-          aria-label="Loading the result sign-off prompt"
+          aria-label="Loading the result acceptance prompt"
         />
       }
     >

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.test.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.test.tsx
@@ -23,7 +23,7 @@ describe("ConfirmationCalloutDisplay", () => {
         confirmationCalloutDisplayPage.getCallout(),
       );
       expect(callout).toHaveTextContent(
-        "Posted result · awaiting your sign-off",
+        "Posted result · awaiting your acceptance",
       );
       expect(callout).toHaveTextContent(
         "Accept the result to finalize this match.",

--- a/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
+++ b/web-client/src/components/matches/match-details/confirmation-callout/confirmation-callout-fetcher/confirmation-callout-active/confirmation-callout-display.tsx
@@ -145,7 +145,7 @@ export function ConfirmationCalloutDisplay({
         <div className="md-confirm-callout__copy">
           <div className="md-confirm-callout__kicker">
             <span className="ball-dot" aria-hidden="true" /> Posted result ·
-            awaiting your sign-off
+            awaiting your acceptance
           </div>
           <h3 className="md-confirm-callout__headline">
             Accept the result to finalize this match.
@@ -190,7 +190,7 @@ export function ConfirmationCalloutDisplay({
         <div className="md-confirm-callout__copy">
           <div className="md-confirm-callout__kicker">
             <span className="ball-dot" aria-hidden="true" /> Corrected result ·
-            awaiting your sign-off
+            awaiting your acceptance
           </div>
           <h3 className="md-confirm-callout__headline">
             Your opponent corrected the score.

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active/finalize-callout-display.test.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active/finalize-callout-display.test.tsx
@@ -9,7 +9,7 @@ describe("FinalizeCalloutDisplay", () => {
     const callout = finalizeCalloutDisplayPage.getCallout();
     expect(callout).toHaveTextContent("Scores ready · not yet posted");
     expect(callout).toHaveTextContent(
-      "Post this result for your opponent to confirm.",
+      "Post this result for your opponent to accept.",
     );
     expect(finalizeCalloutDisplayPage.getPostButton()).toHaveTextContent(
       "Post result",

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active/finalize-callout-display.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active/finalize-callout-display.tsx
@@ -24,11 +24,11 @@ export function FinalizeCalloutDisplay({
           yet posted
         </div>
         <h3 className="md-confirm-callout__headline">
-          Post this result for your opponent to confirm.
+          Post this result for your opponent to accept.
         </h3>
         <p className="md-confirm-callout__body">
           These scores already decide the match but haven't been posted. Post
-          them as-is to send the result for sign-off, or edit any game in the
+          them as-is to send the result for acceptance, or edit any game in the
           scoreboard below first.
         </p>
         {errorMessage && (

--- a/web-client/src/components/matches/match-setup/match-setup.css
+++ b/web-client/src/components/matches/match-setup/match-setup.css
@@ -659,6 +659,12 @@
   cursor: not-allowed;
   opacity: 0.55;
 }
+/* The primary CTA disables while its own request is in flight (label swaps to
+   "Starting…"/"Posting…"/etc.) rather than because the action is blocked, so
+   it gets a "wait" cursor instead of the generic "not-allowed" (#77). */
+.nm-btn-primary:disabled {
+  cursor: wait;
+}
 .nm-btn-primary:disabled:hover {
   background: var(--ball-500);
   box-shadow: none;

--- a/web-client/src/components/matches/match-setup/match-setup.css
+++ b/web-client/src/components/matches/match-setup/match-setup.css
@@ -659,10 +659,13 @@
   cursor: not-allowed;
   opacity: 0.55;
 }
-/* The primary CTA disables while its own request is in flight (label swaps to
-   "Starting…"/"Posting…"/etc.) rather than because the action is blocked, so
-   it gets a "wait" cursor instead of the generic "not-allowed" (#77). */
-.nm-btn-primary:disabled {
+/* Some nm-btn-primary CTAs disable for two different reasons — a genuinely
+   blocked action (e.g. no opponent picked yet) or their own request being in
+   flight (label swaps to "Starting…"/"Posting…"/etc., `aria-busy` set). Only
+   the in-flight case gets a "wait" cursor instead of the generic
+   "not-allowed" (#77) — scope on `aria-busy` so a blocked-but-idle button
+   doesn't fire it too. */
+.nm-btn-primary:disabled[aria-busy='true'] {
   cursor: wait;
 }
 .nm-btn-primary:disabled:hover {

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -655,7 +655,7 @@ function ScoreEntryInner({
     : `Enter game ${gameNumber} score.`
   const subtitle = wouldFinalize
     ? data.affects_rating
-      ? 'This score finishes the match — submitting posts the result for your opponent to confirm.'
+      ? 'This score finishes the match — submitting posts the result for your opponent to accept.'
       : 'This score finishes the match — submitting will finalize the result immediately.'
     : isEdit
       ? 'Save updates the score for this game.'

--- a/web-client/src/routes/_app/matches/new.tsx
+++ b/web-client/src/routes/_app/matches/new.tsx
@@ -205,6 +205,7 @@ function SubmitRow({
           className="nm-btn nm-btn-primary"
           onClick={onSubmit}
           disabled={submitting}
+          aria-busy={submitting}
         >
           {submitting ? 'Starting…' : 'Start match'}
           {!submitting && <ArrowRight size={16} strokeWidth={2.5} />}


### PR DESCRIPTION
## Summary

Five small, low-risk fixes pulled from the open bug backlog:

- **#732** — Propose/accept UI still used "confirm / sign-off" terminology (e.g. "awaiting your sign-off", "for your opponent to confirm"). Unified all of it to accept/propose vocabulary ("awaiting your acceptance", "to accept"), matching the wording already used by the passive "awaiting" callout variant.
- **#728** — Result-notification push copy used the retired dispute-model vocabulary ("Confirm your match result… Approve or dispute?"). Rewrote `_result_confirmation_copy` in `api/app/matches.py` to "Review your match result… Accept or suggest a correction?", matching the web UI's copy. (The grammar half of this issue — "reported losing you" — turned out to already be fixed; a test at `test_matches.py:3404` documents the correct "losing to you" phrasing already in place.)
- **#753** — `APNsClient.send()` minted its provider JWT (`jwt.encode`) outside any try/except; a malformed/expired `APNS_AUTH_KEY` raised a bare `ValueError`/`PyJWTError` out of `send()`, which propagated through `notify()` and aborted the email send for the same notification. Now caught and turned into a `SendResult(FAILED, ...)`, consistent with how the existing httpx error path already behaves. Added `test_notifications_apns.py` covering the malformed-key case.
- **#751** — Admin `delete_user` did a bare `db.delete(user)` / `db.commit()` with no try/except, so deleting any user referenced by an `ON DELETE RESTRICT` FK (matches, results, tournaments, etc.) raised an uncaught `IntegrityError` → 500. Now caught and mapped to a clean 409, matching the same pattern already used elsewhere in `rbac.py`. Added a regression test.
- **#77** — The "Start match" button showed "Starting…" while pending but gave no other visual cue (no spinner, no cursor change). Per instruction, added only a `cursor: wait` style on the pending primary button — no spinner.

## Test plan

- [x] `cd api && ruff check app tests && ruff format --check app tests && mypy` — clean
- [x] `cd api && pytest` — 541 passed (local Postgres 16, no Docker available in this environment)
- [x] `cd web-client && npx tsc -b && npm run lint` — clean
- [x] `cd web-client && npm run test:run` — 1170 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019gh8R1Sv37khJEn4Ma2gKx)_