### PR TITLE
Fix #499: color H2H meeting rows by winner, not viewer

### DIFF
--- a/web-client/src/components/matches/match-details.test.tsx
+++ b/web-client/src/components/matches/match-details.test.tsx
@@ -537,11 +537,15 @@ describe("MatchDetails — page wiring", () => {
     const counts = h2hCard.querySelectorAll(".md-h2h__count");
     expect(counts[0]).toHaveTextContent("2");
     expect(counts[1]).toHaveTextContent("1");
-    // Three rows, newest first; the loss row gets the L marker.
+    // Three rows, newest first; the loss row tints the opponent's (right)
+    // score, the win row tints mine (left).
     const rows = h2hCard.querySelectorAll(".md-h2h__row");
     expect(rows).toHaveLength(3);
-    expect(rows[0].querySelector(".md-h2h__result--l")).not.toBeNull();
-    expect(rows[1].querySelector(".md-h2h__result--w")).not.toBeNull();
+    const scoreSides = (row: Element) =>
+      row.querySelectorAll(".md-h2h__score-side");
+    expect(scoreSides(rows[0])[1]).toHaveClass("md-h2h__score-side--win");
+    expect(scoreSides(rows[0])[0]).not.toHaveClass("md-h2h__score-side--win");
+    expect(scoreSides(rows[1])[0]).toHaveClass("md-h2h__score-side--win");
   });
 
   it("shows the rating change card when ratings moved", async () => {

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.test.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.test.tsx
@@ -68,11 +68,11 @@ describe("HeadToHeadDisplay", () => {
     expect(headToHeadDisplayPage.queryEmpty()).not.toBeInTheDocument();
     expect(headToHeadDisplayPage.getRows()).toHaveLength(2);
     // Wiring only: row content is pinned by the meeting-row tests.
-    expect(headToHeadDisplayPage.meeting(0).getResult()).toHaveTextContent(
-      /^L$/,
+    expect(headToHeadDisplayPage.meeting(0).getLeftScore()).not.toHaveClass(
+      "md-h2h__score-side--win",
     );
-    expect(headToHeadDisplayPage.meeting(1).getResult()).toHaveTextContent(
-      /^W$/,
+    expect(headToHeadDisplayPage.meeting(1).getLeftScore()).toHaveClass(
+      "md-h2h__score-side--win",
     );
   });
 

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.page.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.page.tsx
@@ -44,7 +44,12 @@ const scoped = (container: Container) => {
     },
     /** The "Rated" marker, or `null` for an unrated meeting. */
     getRatedTag() {
-      return getRow().querySelector(".md-h2h__tag");
+      return getRow().querySelector(".md-h2h__tag:not(.md-h2h__tag--neutral)");
+    },
+    /** The "No result" marker, or `null` when the meeting has a decided
+     * winner. */
+    getNoResultTag() {
+      return getRow().querySelector(".md-h2h__tag--neutral");
     },
   };
 };

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.page.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.page.tsx
@@ -28,14 +28,19 @@ const scoped = (container: Container) => {
     getDate() {
       return getRow().querySelector(".md-h2h__date")!;
     },
-    /** The "left–right" games-won score; its `--win` modifier marks a left
-     * win. */
+    /** The "left–right" games-won score container. */
     getScore() {
       return getRow().querySelector(".md-h2h__score")!;
     },
-    /** The W/L marker; its `--w`/`--l` modifier carries the win/loss tone. */
-    getResult() {
-      return getRow().querySelector(".md-h2h__result")!;
+    /** The left side's games-won count; carries the `--win` modifier when the
+     * left side won that meeting. */
+    getLeftScore() {
+      return getRow().querySelectorAll(".md-h2h__score-side")[0]!;
+    },
+    /** The right side's games-won count; carries the `--win` modifier when
+     * the right side won that meeting. */
+    getRightScore() {
+      return getRow().querySelectorAll(".md-h2h__score-side")[1]!;
     },
     /** The "Rated" marker, or `null` for an unrated meeting. */
     getRatedTag() {

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.test.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.test.tsx
@@ -45,42 +45,43 @@ describe("MeetingRow", () => {
     expect(meetingRowPage.getRatedTag()).toBeNull();
   });
 
-  it("marks a left win with the win-toned score and a W result", async () => {
+  it("tints the left side's score when the left side won", async () => {
     meetingRowPage.render({
       meeting: buildHeadToHeadMeetingView({ leftWon: true }),
     });
 
     await meetingRowPage.findRow();
-    expect(meetingRowPage.getScore()).toHaveClass("md-h2h__score--win");
-    const result = meetingRowPage.getResult();
-    expect(result).toHaveTextContent(/^W$/);
-    expect(result).toHaveClass("md-h2h__result--w");
-    expect(result).not.toHaveClass("md-h2h__result--l");
+    expect(meetingRowPage.getLeftScore()).toHaveClass("md-h2h__score-side--win");
+    expect(meetingRowPage.getRightScore()).not.toHaveClass(
+      "md-h2h__score-side--win",
+    );
   });
 
-  it("marks a left loss without the win tone and an L result", async () => {
+  it("tints the right side's score when the right side won", async () => {
     meetingRowPage.render({
       meeting: buildHeadToHeadMeetingView({ leftWon: false }),
     });
 
     await meetingRowPage.findRow();
-    expect(meetingRowPage.getScore()).not.toHaveClass("md-h2h__score--win");
-    const result = meetingRowPage.getResult();
-    expect(result).toHaveTextContent(/^L$/);
-    expect(result).toHaveClass("md-h2h__result--l");
-    expect(result).not.toHaveClass("md-h2h__result--w");
+    expect(meetingRowPage.getRightScore()).toHaveClass(
+      "md-h2h__score-side--win",
+    );
+    expect(meetingRowPage.getLeftScore()).not.toHaveClass(
+      "md-h2h__score-side--win",
+    );
   });
 
-  it("shows a neutral dash with no outcome class when winner is unknown", async () => {
+  it("tints neither side when no winner was recorded", async () => {
     meetingRowPage.render({
       meeting: buildHeadToHeadMeetingView({ leftWon: null }),
     });
 
     await meetingRowPage.findRow();
-    expect(meetingRowPage.getScore()).not.toHaveClass("md-h2h__score--win");
-    const result = meetingRowPage.getResult();
-    expect(result).toHaveTextContent(/^–$/);
-    expect(result).not.toHaveClass("md-h2h__result--w");
-    expect(result).not.toHaveClass("md-h2h__result--l");
+    expect(meetingRowPage.getLeftScore()).not.toHaveClass(
+      "md-h2h__score-side--win",
+    );
+    expect(meetingRowPage.getRightScore()).not.toHaveClass(
+      "md-h2h__score-side--win",
+    );
   });
 });

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.test.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.test.tsx
@@ -71,7 +71,7 @@ describe("MeetingRow", () => {
     );
   });
 
-  it("tints neither side when no winner was recorded", async () => {
+  it("tints neither side and shows a No result tag when no winner was recorded", async () => {
     meetingRowPage.render({
       meeting: buildHeadToHeadMeetingView({ leftWon: null }),
     });
@@ -83,5 +83,15 @@ describe("MeetingRow", () => {
     expect(meetingRowPage.getRightScore()).not.toHaveClass(
       "md-h2h__score-side--win",
     );
+    expect(meetingRowPage.getNoResultTag()).toHaveTextContent(/^No result$/);
+  });
+
+  it("omits the No result tag for a decided meeting", async () => {
+    meetingRowPage.render({
+      meeting: buildHeadToHeadMeetingView({ leftWon: true }),
+    });
+
+    await meetingRowPage.findRow();
+    expect(meetingRowPage.getNoResultTag()).toBeNull();
   });
 });

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.tsx
@@ -9,6 +9,10 @@ export interface MeetingRowProps {
   meeting: HeadToHeadMeetingView;
 }
 
+/** A bare "W"/"L" reads as a personal result ("you won"), which has no
+ * referent for a spectator watching two other players' history (#499) — so
+ * the outcome is conveyed by tinting whichever side's game count actually
+ * won, the same way the scoreboard's hero row and game grid do. */
 export const MeetingRow = ({ meeting }: MeetingRowProps) => (
   <Link
     {...matchDetailRoute(meeting.matchId)}
@@ -20,19 +24,24 @@ export const MeetingRow = ({ meeting }: MeetingRowProps) => (
       <span className="md-h2h__label">Match</span>
       {meeting.rated && <span className="md-h2h__tag">Rated</span>}
     </span>
-    <span
-      className={cn("md-h2h__score", meeting.leftWon === true && "md-h2h__score--win")}
-    >
-      {meeting.leftGamesWon}–{meeting.rightGamesWon}
-    </span>
-    <span
-      className={cn(
-        "md-h2h__result",
-        meeting.leftWon === true && "md-h2h__result--w",
-        meeting.leftWon === false && "md-h2h__result--l",
-      )}
-    >
-      {meeting.leftWon === true ? "W" : meeting.leftWon === false ? "L" : "–"}
+    <span className="md-h2h__score">
+      <span
+        className={cn(
+          "md-h2h__score-side",
+          meeting.leftWon === true && "md-h2h__score-side--win",
+        )}
+      >
+        {meeting.leftGamesWon}
+      </span>
+      <span className="md-h2h__score-sep">–</span>
+      <span
+        className={cn(
+          "md-h2h__score-side",
+          meeting.leftWon === false && "md-h2h__score-side--win",
+        )}
+      >
+        {meeting.rightGamesWon}
+      </span>
     </span>
   </Link>
 );

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display/meeting-row.tsx
@@ -23,6 +23,9 @@ export const MeetingRow = ({ meeting }: MeetingRowProps) => (
     <span className="md-h2h__meta">
       <span className="md-h2h__label">Match</span>
       {meeting.rated && <span className="md-h2h__tag">Rated</span>}
+      {meeting.leftWon === null && (
+        <span className="md-h2h__tag md-h2h__tag--neutral">No result</span>
+      )}
     </span>
     <span className="md-h2h__score">
       <span

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -3670,7 +3670,7 @@ body.dark.fortymm-theme {
 }
 .fortymm-theme .md-h2h__row {
   display: grid;
-  grid-template-columns: 70px 1fr auto auto;
+  grid-template-columns: 70px 1fr auto;
   align-items: center;
   gap: 10px;
   padding: 10px 8px;
@@ -3724,24 +3724,18 @@ body.dark.fortymm-theme {
   color: var(--ball-500);
 }
 .fortymm-theme .md-h2h__score {
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
   font: 700 13px var(--font-mono);
   color: var(--fg-1);
   font-variant-numeric: tabular-nums;
 }
-.fortymm-theme .md-h2h__score--win {
+.fortymm-theme .md-h2h__score-side--win {
   color: var(--serve-500);
 }
-.fortymm-theme .md-h2h__result {
-  font: 600 10px var(--font-mono);
-  letter-spacing: 0.14em;
-  min-width: 18px;
-  text-align: right;
-}
-.fortymm-theme .md-h2h__result--w {
-  color: var(--serve-500);
-}
-.fortymm-theme .md-h2h__result--l {
-  color: var(--loss);
+.fortymm-theme .md-h2h__score-sep {
+  color: var(--fg-3);
 }
 .fortymm-theme .md-h2h__empty {
   font: 400 13px var(--font-ui);

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -3719,6 +3719,10 @@ body.dark.fortymm-theme {
   text-transform: uppercase;
   color: var(--serve-500);
 }
+.fortymm-theme .md-h2h__tag--neutral {
+  border-color: var(--border-subtle);
+  color: var(--fg-3);
+}
 .fortymm-theme .md-h2h__label--tonight {
   font-weight: 600;
   color: var(--ball-500);


### PR DESCRIPTION
## Summary

Fixes #499.

The head-to-head card's per-meeting "W"/"L" badge was relative to whichever side the perspective-ordering anchor put on the left — the viewer's own side when they're a match participant, otherwise an arbitrary side 1. That reads as a personal result ("you won"/"you lost"), which has no obvious referent for a spectator (a third user or an anonymous viewer) looking at two other players' rivalry — exactly the ambiguity the issue called out.

Picked the issue's third option ("color the score by winner instead"): drop the ambiguous letter badge and tint whichever side's game count actually won that meeting, the same way the scoreboard's hero row (`hero-score.tsx`) and game grid already color per side rather than per viewer.

- `meeting-row.tsx`: replaced the combined score + W/L letter with two independently-tinted score spans (`md-h2h__score-side--win` on whichever side won).
- `index.css`: reworked `.md-h2h__score*` rules for the per-side layout; dropped the now-unused `.md-h2h__result*` rules and the row's fourth grid column.
- Updated the component test, the scoped page object (`getLeftScore`/`getRightScore` replace `getResult`), the display wiring test, and the `match-details.test.tsx` integration test to match.

## Test plan

- [x] `npx vitest run` — full web-client suite (180 files / 1170 tests) passes
- [x] `npm run lint` — clean (pre-existing unrelated warning in `mockServiceWorker.js`)
- [x] `npm run build` — typechecks and builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012dN3V4PcZY4stuFuHL48gy)_