### PR TITLE
Fix result-confirmation notifications using retired dispute-model vocabulary

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1176,11 +1176,17 @@ def _game_scores_text(match: Match, poster_side_number: int) -> str:
 
 
 def _result_confirmation_copy(
-    match: Match, poster_id: uuid.UUID
+    match: Match, poster_id: uuid.UUID, *, is_counter: bool
 ) -> tuple[str, str] | None:
     """Title + body for the "accept or suggest a correction to the result your
     opponent posted" push, framed for the *recipient* (the side that didn't
     post).
+
+    ``is_counter`` picks the closing prompt to match the actual button pair
+    the recipient will see: a first-post callout offers Accept / Suggest
+    correction (``confirmation-callout-display.tsx``'s ``"review"`` case),
+    while a counter offers Accept / Counter (its ``"corrected"`` case) — the
+    same verbs the iOS push actions use (#728).
 
     The headline carries the games-won score and, where there's room, the
     body lists the individual game scores — both oriented so the poster's
@@ -1204,24 +1210,26 @@ def _result_confirmation_copy(
         phrase, hi, lo = "losing to you", recipient_games, poster_games
     headline = f"{poster_name} reported {phrase} {hi}{_SCORE_DASH}{lo}"
 
+    prompt = "Accept or counter?" if is_counter else "Accept or suggest a correction?"
     games = _game_scores_text(match, poster_side.side_number)
-    body = (
-        f"{headline}. Games: {games}. Accept or suggest a correction?"
-        if games
-        else f"{headline}. Accept or suggest a correction?"
-    )
+    body = f"{headline}. Games: {games}. {prompt}" if games else f"{headline}. {prompt}"
     return "Review your match result", body
 
 
 async def _notify_result_posted(
-    notifications: NotificationService, match: Match, poster_id: uuid.UUID
+    notifications: NotificationService,
+    match: Match,
+    poster_id: uuid.UUID,
+    *,
+    is_counter: bool,
 ) -> None:
-    """Queue an accept/counter prompt to every player on the side that now owes
-    a response. Each enqueued job persists the in-app record (the bell feed) and
-    fans out push/email per the recipient's preferences in the worker. The APNs
-    ``category``/``data`` carry the action group and the match id so a tapped
-    push deep-links to the right match."""
-    copy = _result_confirmation_copy(match, poster_id)
+    """Queue an accept/counter (or accept/suggest-correction) prompt to every
+    player on the side that now owes a response. Each enqueued job persists
+    the in-app record (the bell feed) and fans out push/email per the
+    recipient's preferences in the worker. The APNs ``category``/``data``
+    carry the action group and the match id so a tapped push deep-links to
+    the right match."""
+    copy = _result_confirmation_copy(match, poster_id, is_counter=is_counter)
     recipient_side = opponent_side(match, poster_id)
     if copy is None or recipient_side is None:
         return
@@ -2385,7 +2393,12 @@ async def post_match_result(
     # clean even when the failure was the in-app persist commit.
     if awaiting_confirmation:
         try:
-            await _notify_result_posted(notifications, reloaded, current_user.id)
+            await _notify_result_posted(
+                notifications,
+                reloaded,
+                current_user.id,
+                is_counter=payload.supersedes_result_id is not None,
+            )
         except Exception:
             await db.rollback()
             log.exception(

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1183,10 +1183,14 @@ def _result_confirmation_copy(
     post).
 
     ``is_counter`` picks the closing prompt to match the actual button pair
-    the recipient will see: a first-post callout offers Accept / Suggest
-    correction (``confirmation-callout-display.tsx``'s ``"review"`` case),
-    while a counter offers Accept / Counter (its ``"corrected"`` case) — the
-    same verbs the iOS push actions use (#728).
+    the recipient's in-app callout renders: a first-post shows Accept /
+    Suggest correction (``confirmation-callout-display.tsx``'s ``"review"``
+    case), while a counter shows Accept / Counter (its ``"corrected"`` case,
+    #728). The native iOS push notification itself only ever offers a single,
+    static Approve/Suggest-correction action pair (``PushNotificationManager
+    .swift``) — it doesn't yet grow a counter-specific action — so this body
+    text is the only place a tapped-through counter reads "Counter" until the
+    push actions themselves are split the same way.
 
     The headline carries the games-won score and, where there's room, the
     body lists the individual game scores — both oriented so the poster's
@@ -1217,11 +1221,7 @@ def _result_confirmation_copy(
 
 
 async def _notify_result_posted(
-    notifications: NotificationService,
-    match: Match,
-    poster_id: uuid.UUID,
-    *,
-    is_counter: bool,
+    notifications: NotificationService, match: Match, poster_id: uuid.UUID
 ) -> None:
     """Queue an accept/counter (or accept/suggest-correction) prompt to every
     player on the side that now owes a response. Each enqueued job persists
@@ -1229,9 +1229,23 @@ async def _notify_result_posted(
     recipient's preferences in the worker. The APNs ``category``/``data``
     carry the action group and the match id so a tapped push deep-links to
     the right match."""
-    copy = _result_confirmation_copy(match, poster_id, is_counter=is_counter)
     recipient_side = opponent_side(match, poster_id)
-    if copy is None or recipient_side is None:
+    if recipient_side is None or not recipient_side.players:
+        return
+    # Derive counter-vs-first-post from the same viewer-relative negotiation
+    # state the BFF/UI use (``_negotiation``'s ``"corrected"`` vs ``"review"``),
+    # rather than the raw ``supersedes_result_id is not None`` check — that
+    # naive check is wrong on a self-edit (poster corrects their own standing
+    # proposal before the recipient ever answers): it supersedes a result, but
+    # the recipient still lands on the first-post "review" view, not
+    # "corrected", so they must get the Accept/Suggest-correction prompt, not
+    # Accept/Counter.
+    is_counter = (
+        _negotiation(match, recipient_side.players[0].user_id).viewer_state
+        == "corrected"
+    )
+    copy = _result_confirmation_copy(match, poster_id, is_counter=is_counter)
+    if copy is None:
         return
     title, body = copy
     for player in recipient_side.players:
@@ -2393,12 +2407,7 @@ async def post_match_result(
     # clean even when the failure was the in-app persist commit.
     if awaiting_confirmation:
         try:
-            await _notify_result_posted(
-                notifications,
-                reloaded,
-                current_user.id,
-                is_counter=payload.supersedes_result_id is not None,
-            )
+            await _notify_result_posted(notifications, reloaded, current_user.id)
         except Exception:
             await db.rollback()
             log.exception(

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -3392,7 +3392,7 @@ async def test_posting_result_enqueues_confirmation_for_opponent(
     # A first post's recipient sees Accept/Suggest-correction buttons (not
     # Accept/Counter — that pair is reserved for the corrected-result case).
     assert job.title == "Review your match result"
-    assert "Accept it, or suggest a correction?" in job.body
+    assert "Accept or suggest a correction?" in job.body
     assert "dispute" not in job.body.lower()
     # Recipient-framed games-won (poster won 2–1) and the per-game scores.
     assert "poster reported beating you 2–1" in job.body
@@ -3462,6 +3462,41 @@ async def test_posting_counter_enqueues_confirmation_with_counter_prompt(
     counter_job = jobs[1]
     assert "Accept or counter?" in counter_job.body
     assert "suggest a correction" not in counter_job.body.lower()
+
+
+async def test_posting_self_edit_enqueues_first_post_prompt_not_counter(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    fake_notifications_queue: Queue,
+):
+    """A proposer correcting their own still-standing proposal (before the
+    opponent ever answers) sets ``supersedes_result_id``, but the opponent's
+    view stays the first-post ``review`` state (mirrors
+    ``test_propose_self_edit_chain_supersedes_own_proposal``) — so the
+    re-sent notification must keep the Accept/Suggest-correction prompt, not
+    switch to "Accept or counter?" just because a result was superseded."""
+    me = await start_session(api_client, db_session)
+    me.username = "proposer"
+    await db_session.commit()
+
+    async with opponent_session(db_session, "rival") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=1)
+        first = await _propose(api_client, match["id"], s1=11, s2=4)
+        assert first["status"] == 201
+        first_id = first["body"]["negotiation"]["standing_result"]["id"]
+
+        # Same proposer corrects their own board before the opponent responds.
+        second = await _propose(
+            api_client, match["id"], s1=11, s2=9, supersedes=first_id
+        )
+        assert second["status"] == 201, second
+
+    jobs = enqueued_notification_jobs(fake_notifications_queue)
+    # Both the first post and the self-edit notify the opponent (never me).
+    assert [job.user_id for job in jobs] == [opp.id, opp.id]
+    self_edit_job = jobs[1]
+    assert "Accept or suggest a correction?" in self_edit_job.body
+    assert "Accept or counter?" not in self_edit_job.body
 
 
 async def test_solo_result_enqueues_no_confirmation(

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -3389,8 +3389,10 @@ async def test_posting_result_enqueues_confirmation_for_opponent(
     assert job.push_category == MATCH_RESULT_CONFIRMATION_CATEGORY
     assert job.push_data == {"match_id": match["id"]}
     # Propose/accept vocabulary, not the retired confirm/dispute model (#728).
+    # A first post's recipient sees Accept/Suggest-correction buttons (not
+    # Accept/Counter — that pair is reserved for the corrected-result case).
     assert job.title == "Review your match result"
-    assert "Accept or counter?" in job.body
+    assert "Accept it, or suggest a correction?" in job.body
     assert "dispute" not in job.body.lower()
     # Recipient-framed games-won (poster won 2–1) and the per-game scores.
     assert "poster reported beating you 2–1" in job.body
@@ -3428,6 +3430,38 @@ async def test_posting_losing_result_enqueues_confirmation_for_opponent(
     job = jobs[0]
     # Recipient-framed games-won (poster lost 0–2), phrased grammatically.
     assert "poster reported losing to you 2–0" in job.body
+
+
+async def test_posting_counter_enqueues_confirmation_with_counter_prompt(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    fake_notifications_queue: Queue,
+):
+    """Countering a standing result (``supersedes_result_id`` set) prompts the
+    recipient with "Accept or counter?" — the Accept/Counter button pair the
+    corrected-result callout actually renders — not the first-post's
+    Accept/Suggest-correction prompt (#728)."""
+    me = await start_session(api_client, db_session)
+    me.username = "proposer"
+    await db_session.commit()
+
+    async with opponent_session(db_session, "counterer") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=1)
+        first = await _propose(api_client, match["id"], s1=11, s2=4)
+        assert first["status"] == 201
+        first_id = first["body"]["negotiation"]["standing_result"]["id"]
+
+        counter = await _propose(
+            opp_client, match["id"], s1=4, s2=11, supersedes=first_id
+        )
+        assert counter["status"] == 201, counter
+
+    jobs = enqueued_notification_jobs(fake_notifications_queue)
+    # The first post notifies the opponent; the counter notifies me back.
+    assert [job.user_id for job in jobs] == [opp.id, me.id]
+    counter_job = jobs[1]
+    assert "Accept or counter?" in counter_job.body
+    assert "suggest a correction" not in counter_job.body.lower()
 
 
 async def test_solo_result_enqueues_no_confirmation(

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -3359,10 +3359,10 @@ async def test_posting_result_enqueues_confirmation_for_opponent(
     db_session: AsyncSession,
     fake_notifications_queue: Queue,
 ):
-    """Posting a result on a two-human match enqueues one confirm/dispute
+    """Posting a result on a two-human match enqueues one accept/counter
     delivery for the opponent — filed under the result-confirmation category,
-    deep-linked to the match, carrying the Approve/Dispute push category + match
-    id, with recipient-framed copy. The poster gets nothing."""
+    deep-linked to the match, carrying the result-confirmation push category +
+    match id, with recipient-framed copy. The poster gets nothing."""
     me = await start_session(api_client, db_session)
     me.username = "poster"
     await db_session.commit()
@@ -3388,6 +3388,10 @@ async def test_posting_result_enqueues_confirmation_for_opponent(
     assert job.link == f"/matches/{match['id']}"
     assert job.push_category == MATCH_RESULT_CONFIRMATION_CATEGORY
     assert job.push_data == {"match_id": match["id"]}
+    # Propose/accept vocabulary, not the retired confirm/dispute model (#728).
+    assert job.title == "Review your match result"
+    assert "Accept or counter?" in job.body
+    assert "dispute" not in job.body.lower()
     # Recipient-framed games-won (poster won 2–1) and the per-game scores.
     assert "poster reported beating you 2–1" in job.body
     assert "11–7" in job.body


### PR DESCRIPTION
## Summary

Closes #728.

The result-confirmation push/in-app notification (sent to the side that owes a sign-off after an opponent posts a result) used the retired **confirm/dispute** vocabulary from before the two-verb **propose/accept** negotiation model shipped.

**Note:** while this branch was in flight, PR #807 independently fixed the same issue's basic vocabulary directly on `main` (title → "Review your match result", body → "Accept or suggest a correction?" universally). This PR rebases on top of that and adds the piece #807 didn't cover: **the notification now distinguishes a first-post from a genuine counter**, since the recipient's actual in-app callout renders a different button pair for each:

- First-post (recipient never proposed): body ends "**Accept or suggest a correction?**" — matches the Accept/Suggest-correction buttons.
- Counter (recipient's own prior proposal is being superseded): body ends "**Accept or counter?**" — matches the Accept/Counter buttons.

Getting that distinction right required deriving it from the same viewer-relative negotiation state (`_negotiation`'s `"corrected"` vs `"review"`) the BFF already uses — a naive `supersedes_result_id is not None` check is wrong on a **self-edit** (a proposer correcting their own still-unanswered proposal also sets `supersedes_result_id`, but the recipient, who never proposed anything, still sees the first-post view). This was caught by an adversarial code-review pass (8 independent finders converged on it) and is covered by a new regression test.

## Test plan

- [x] `test_posting_result_enqueues_confirmation_for_opponent` — first-post copy + no "dispute" anywhere.
- [x] `test_posting_counter_enqueues_confirmation_with_counter_prompt` (new) — genuine counter gets "Accept or counter?".
- [x] `test_posting_self_edit_enqueues_first_post_prompt_not_counter` (new) — self-edit still gets the first-post prompt, not "Accept or counter?".
- [x] `pytest` — full API suite passes (543 passed).
- [x] `ruff check` / `ruff format --check` — clean.
- [x] `mypy` (strict) — clean.
- [x] Adversarial code review (8 parallel finders + verification) — found and fixed the self-edit bug above.
- [x] Security review — no findings.
- [x] Manual QA against a real running stack (real Postgres/Redis/API/worker, web client with MSW disabled) driving two guest accounts through first-post, counter, and self-edit flows — bell/in-app notification copy verified correct in all three cases; no "dispute" wording found anywhere in the app.

No API schema/route changes, so no OpenAPI regeneration needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7j6DbotjdH94mn1zE94Ej)_