### PR TITLE
Fix new-match Cancel dirty-form loss, toast double-fire, stale session cache (#75, #77, #233, #239)

### DIFF
--- a/web-client/src/api/session.test.ts
+++ b/web-client/src/api/session.test.ts
@@ -57,6 +57,37 @@ describe('useConsumeLoginToken', () => {
       data: { user: { id: 'u-2' } },
     })
   })
+
+  // #239: `merged` is a one-time mutation result, never returned by
+  // `GET /v1/session` — caching it verbatim would let a later
+  // `useSession().data.merged` read see a stale truthy value for the whole
+  // 5min staleTime window.
+  it('strips `merged` before seeding the session cache', async () => {
+    server.use(
+      http.post('*/v1/login/consume', () =>
+        HttpResponse.json({
+          data: { user: { id: 'u-2', username: 'new-user' } },
+          merged: { matches_moved: 3 },
+        }),
+      ),
+    )
+
+    const { result } = renderHook(() => useConsumeLoginToken(), {
+      wrapper: wrapperFor(queryClient),
+    })
+    result.current.mutate({ token: 'tok' })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // The mutation result itself still carries `merged` (callers read it off
+    // the mutate callback to drive the toast) — only the cached copy is
+    // stripped.
+    expect(result.current.data?.merged).toEqual({ matches_moved: 3 })
+    expect(
+      queryClient.getQueryData<{ merged: unknown }>(SESSION_QUERY_KEY)
+        ?.merged,
+    ).toBeNull()
+  })
 })
 
 describe('useConfirmEmail', () => {
@@ -81,5 +112,30 @@ describe('useConfirmEmail', () => {
     expect(queryClient.getQueryData(SESSION_QUERY_KEY)).toMatchObject({
       data: { user: { id: 'u-2' } },
     })
+  })
+
+  // #239: same stale-cache guard as useConsumeLoginToken.
+  it('strips `merged` before seeding the session cache', async () => {
+    server.use(
+      http.post('*/v1/me/email/confirm', () =>
+        HttpResponse.json({
+          data: { user: { id: 'u-2', username: 'new-user' } },
+          merged: { matches_moved: 2 },
+        }),
+      ),
+    )
+
+    const { result } = renderHook(() => useConfirmEmail(), {
+      wrapper: wrapperFor(queryClient),
+    })
+    result.current.mutate({ token: 'tok' })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.merged).toEqual({ matches_moved: 2 })
+    expect(
+      queryClient.getQueryData<{ merged: unknown }>(SESSION_QUERY_KEY)
+        ?.merged,
+    ).toBeNull()
   })
 })

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -238,7 +238,11 @@ export function useConfirmEmail() {
     // it doesn't need a refetch.
     onSuccess: (session) => {
       qc.clear()
-      qc.setQueryData(SESSION_QUERY_KEY, session)
+      // `merged` is a one-time mutation result, not a field `GET /v1/session`
+      // ever returns — cache it verbatim and a stale truthy value would sit
+      // under SESSION_QUERY_KEY for the 5min staleTime, ready to mislead any
+      // future `useSession().data.merged` reader (#239).
+      qc.setQueryData(SESSION_QUERY_KEY, { ...session, merged: null })
     },
   })
 }
@@ -302,7 +306,9 @@ export function useConsumeLoginToken() {
     // browsing guest into a different existing account.
     onSuccess: (session) => {
       qc.clear()
-      qc.setQueryData(SESSION_QUERY_KEY, session)
+      // Strip the one-time `merged` result before caching (#239) — see the
+      // matching comment on useConfirmEmail.
+      qc.setQueryData(SESSION_QUERY_KEY, { ...session, merged: null })
     },
   })
 }

--- a/web-client/src/components/matches/match-setup/match-setup.css
+++ b/web-client/src/components/matches/match-setup/match-setup.css
@@ -659,6 +659,13 @@
   cursor: not-allowed;
   opacity: 0.55;
 }
+/* The primary submit button disables while its "Starting…" request is in
+   flight, not because the action is forbidden — `wait` distinguishes that
+   pending state from the `not-allowed` cursor other disabled controls use
+   (#77). */
+.nm-btn-primary:disabled {
+  cursor: wait;
+}
 .nm-btn-primary:disabled:hover {
   background: var(--ball-500);
   box-shadow: none;

--- a/web-client/src/components/matches/match-setup/use-start-match.ts
+++ b/web-client/src/components/matches/match-setup/use-start-match.ts
@@ -85,7 +85,15 @@ export function useStartMatch(): UseStartMatchResult {
       // history stack shouldn't keep it. Otherwise browser/mobile Back from
       // score entry re-opens the creation form for a match that already
       // exists, instead of returning to wherever the user came from (#441).
-      navigate({ ...nextScoringDestination(created), replace: true })
+      // `ignoreBlocker` skips the form's own dirty-navigation guard (#75) —
+      // a successful create isn't a discard, and gating the guard on mutation
+      // state instead would race this redirect against the still-dirty form
+      // fields re-rendering.
+      navigate({
+        ...nextScoringDestination(created),
+        replace: true,
+        ignoreBlocker: true,
+      })
     } catch (err) {
       // Let the user try again — only a *successful* create latches the guard.
       submitState.current = 'idle'

--- a/web-client/src/routes/_app/matches/new.test.tsx
+++ b/web-client/src/routes/_app/matches/new.test.tsx
@@ -387,6 +387,56 @@ describe('NewMatchPage', () => {
     expect(posts).toBe(1)
   })
 
+  it('navigates away immediately on Cancel when the form is untouched', async () => {
+    const user = userEvent.setup()
+    server.use(http.get('*/v1/players/recent', () => HttpResponse.json([])))
+    renderNewMatch()
+
+    await user.click(
+      await screen.findByRole('button', { name: /^cancel$/i }),
+    )
+    await waitFor(() =>
+      expect(screen.getByText('Dashboard route')).toBeInTheDocument(),
+    )
+  })
+
+  it('confirms before discarding a dirty form on Cancel (#75)', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/players/recent', () =>
+        HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }]),
+      ),
+    )
+    renderNewMatch()
+
+    // Dirty the form by picking an opponent.
+    await user.click(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    )
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+    // Still on the form — a confirmation dialog blocks the navigation.
+    const dialog = await screen.findByRole('alertdialog')
+    expect(dialog).toHaveTextContent(/discard changes/i)
+    expect(screen.queryByText('Dashboard route')).not.toBeInTheDocument()
+
+    // "Keep editing" dismisses the dialog without navigating.
+    await user.click(screen.getByRole('button', { name: /keep editing/i }))
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /ada\.lovelace|^change$/i }),
+    ).toBeInTheDocument()
+
+    // Cancel again and confirm the discard.
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+    await user.click(
+      await screen.findByRole('button', { name: /discard changes/i }),
+    )
+    await waitFor(() =>
+      expect(screen.getByText('Dashboard route')).toBeInTheDocument(),
+    )
+  })
+
   it('surfaces a timeout error and re-enables the button when the create aborts (#76)', async () => {
     const user = userEvent.setup()
     server.use(http.get('*/v1/players/recent', () => HttpResponse.json([])))

--- a/web-client/src/routes/_app/matches/new.tsx
+++ b/web-client/src/routes/_app/matches/new.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useBlocker, useNavigate } from '@tanstack/react-router'
 import { ArrowRight } from 'lucide-react'
 
 import {
@@ -69,10 +69,18 @@ function MatchCard() {
   // the no-opponent match is unrated by definition.
   const [rated, setRated] = useState(false)
   const { submit, apiError, submitting, submitted } = useStartMatch()
-  // Guards Cancel against silently discarding an in-progress setup (#75) — any
-  // deviation from the form's defaults counts as dirty.
-  const dirty = opponent !== null || bestOf !== 5 || rated !== false
-  const [confirmDiscard, setConfirmDiscard] = useState(false)
+  // Guards any in-app navigation away from an in-progress setup — Cancel,
+  // browser Back, a sidebar link — not just the Cancel button (#75). Any
+  // deviation from the form's defaults counts as dirty. Mirrors the
+  // useBlocker pattern already established on /settings (#440); the
+  // post-submit redirect to scoring bypasses it via `ignoreBlocker`
+  // (use-start-match.ts) rather than racing this flag back to false.
+  const dirty = opponent !== null || bestOf !== 5 || rated
+  const blocker = useBlocker({
+    shouldBlockFn: () => dirty,
+    enableBeforeUnload: () => dirty,
+    withResolver: true,
+  })
 
   const me = session?.data.user ?? null
   // The hint nudges guests toward claiming an account so their rated history
@@ -142,12 +150,17 @@ function MatchCard() {
         error={submitted ? apiError : null}
         submitting={submitting}
         onSubmit={() => submit({ opponent, bestOf, rated })}
-        onCancel={() =>
-          dirty ? setConfirmDiscard(true) : navigate({ to: '/dashboard' })
-        }
+        onCancel={() => navigate({ to: '/dashboard' })}
       />
 
-      <AlertDialog open={confirmDiscard} onOpenChange={setConfirmDiscard}>
+      <AlertDialog
+        open={blocker.status === 'blocked'}
+        onOpenChange={(open) => {
+          // Radix fires onOpenChange(false) on overlay click / Escape — treat
+          // that as "stay on the page" so a stray dismiss never discards edits.
+          if (!open) blocker.reset?.()
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Discard changes?</AlertDialogTitle>
@@ -157,10 +170,12 @@ function MatchCard() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Keep editing</AlertDialogCancel>
+            <AlertDialogCancel onClick={() => blocker.reset?.()}>
+              Keep editing
+            </AlertDialogCancel>
             <AlertDialogAction
               variant="destructive"
-              onClick={() => navigate({ to: '/dashboard' })}
+              onClick={() => blocker.proceed?.()}
             >
               Discard changes
             </AlertDialogAction>

--- a/web-client/src/routes/_app/matches/new.tsx
+++ b/web-client/src/routes/_app/matches/new.tsx
@@ -2,6 +2,16 @@ import { useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { ArrowRight } from 'lucide-react'
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { deriveEmailStatus, useSession } from '@/api/session'
 import { OpponentPicker } from '@/components/matches/opponent-picker'
 import {
@@ -59,6 +69,10 @@ function MatchCard() {
   // the no-opponent match is unrated by definition.
   const [rated, setRated] = useState(false)
   const { submit, apiError, submitting, submitted } = useStartMatch()
+  // Guards Cancel against silently discarding an in-progress setup (#75) — any
+  // deviation from the form's defaults counts as dirty.
+  const dirty = opponent !== null || bestOf !== 5 || rated !== false
+  const [confirmDiscard, setConfirmDiscard] = useState(false)
 
   const me = session?.data.user ?? null
   // The hint nudges guests toward claiming an account so their rated history
@@ -128,8 +142,31 @@ function MatchCard() {
         error={submitted ? apiError : null}
         submitting={submitting}
         onSubmit={() => submit({ opponent, bestOf, rated })}
-        onCancel={() => navigate({ to: '/dashboard' })}
+        onCancel={() =>
+          dirty ? setConfirmDiscard(true) : navigate({ to: '/dashboard' })
+        }
       />
+
+      <AlertDialog open={confirmDiscard} onOpenChange={setConfirmDiscard}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Discard changes?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You've picked an opponent or changed the match settings. Leaving
+              now discards them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep editing</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => navigate({ to: '/dashboard' })}
+            >
+              Discard changes
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/web-client/src/routes/confirm-email.tsx
+++ b/web-client/src/routes/confirm-email.tsx
@@ -3,7 +3,7 @@ import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
 import { ApiError } from '@/api/client'
-import { useConfirmEmail, useMergePreview } from '@/api/session'
+import { type Session, useConfirmEmail, useMergePreview } from '@/api/session'
 import { btnPrimary } from '@/components/login/styles'
 import {
   LinkCheckPage,
@@ -43,13 +43,27 @@ const CONFIRM_COPY: Partial<
   },
 }
 
+// Passed as a mutation `onSuccess`, so it fires exactly once per successful
+// confirm — unlike a useEffect keyed on confirm.isSuccess/confirm.data, which
+// React StrictMode's double-invoke could fire twice (#233). Mirrors
+// login.verifying.tsx's identical toast.
+function showMergeToast(session: Session) {
+  const moved = session.merged?.matches_moved ?? 0
+  if (moved > 0) {
+    toast.success(
+      moved === 1
+        ? 'We brought your 1 match with you.'
+        : `We brought your ${moved} matches with you.`,
+    )
+  }
+}
+
 function ConfirmEmailPage() {
   const { token } = Route.useSearch()
   const navigate = useNavigate()
   const preview = useMergePreview()
   const confirm = useConfirmEmail()
   const fired = useRef(false)
-  const toastFired = useRef(false)
 
   // Preview the link first. A merge that would carry matches over waits for the
   // user at the gate; everything else (plain confirm, empty guest, or a preview
@@ -60,25 +74,12 @@ function ConfirmEmailPage() {
     preview.mutate(token, {
       onSuccess: (p) => {
         if (!(p.is_merge && p.guest_matches_count > 0)) {
-          confirm.mutate({ token })
+          confirm.mutate({ token }, { onSuccess: showMergeToast })
         }
       },
-      onError: () => confirm.mutate({ token }),
+      onError: () => confirm.mutate({ token }, { onSuccess: showMergeToast }),
     })
   }, [token, preview, confirm])
-
-  useEffect(() => {
-    if (!confirm.isSuccess || toastFired.current) return
-    toastFired.current = true
-    const moved = confirm.data?.merged?.matches_moved ?? 0
-    if (moved > 0) {
-      toast.success(
-        moved === 1
-          ? 'We brought your 1 match with you.'
-          : `We brought your ${moved} matches with you.`,
-      )
-    }
-  }, [confirm.isSuccess, confirm.data])
 
   // The token is a single-use bearer credential. Once the confirm settles,
   // drop it from the URL so it doesn't linger in the address bar / history /
@@ -124,8 +125,15 @@ function ConfirmEmailPage() {
         guestUsername={p.guest_username ?? null}
         matchesCount={p.guest_matches_count}
         busy={confirm.isPending}
-        onBringThemOver={() => confirm.mutate({ token })}
-        onNotNow={() => confirm.mutate({ token, skipMerge: true })}
+        onBringThemOver={() =>
+          confirm.mutate({ token }, { onSuccess: showMergeToast })
+        }
+        onNotNow={() =>
+          confirm.mutate(
+            { token, skipMerge: true },
+            { onSuccess: showMergeToast },
+          )
+        }
       />
     )
   }

--- a/web-client/src/routes/confirm-email.tsx
+++ b/web-client/src/routes/confirm-email.tsx
@@ -49,6 +49,7 @@ function ConfirmEmailPage() {
   const preview = useMergePreview()
   const confirm = useConfirmEmail()
   const fired = useRef(false)
+  const toastFired = useRef(false)
 
   // Preview the link first. A merge that would carry matches over waits for the
   // user at the gate; everything else (plain confirm, empty guest, or a preview
@@ -67,7 +68,8 @@ function ConfirmEmailPage() {
   }, [token, preview, confirm])
 
   useEffect(() => {
-    if (!confirm.isSuccess) return
+    if (!confirm.isSuccess || toastFired.current) return
+    toastFired.current = true
     const moved = confirm.data?.merged?.matches_moved ?? 0
     if (moved > 0) {
       toast.success(


### PR DESCRIPTION
## Summary

Fixes four small, old bugs picked from the open issue backlog:

- **#75** — Clicking **Cancel** on `/matches/new` discarded a dirty form (picked opponent, changed Best-of/Rated) with no confirmation. It now shows a "Discard changes?" `AlertDialog` (matching the pattern already used on `/settings`, #440) before navigating away; an untouched form still cancels immediately.
- **#77** — The **Start match** button now shows `cursor: wait` while its create request is pending, instead of the generic `cursor: not-allowed` every other disabled control uses — distinguishing "processing" from "forbidden". No spinner added, per request.
- **#233** — `confirm-email.tsx`'s "We brought your N matches with you" toast fired from a `useEffect` with no once-guard, so React StrictMode's double-invoke could fire it twice. Added a `toastFired` ref guard, mirroring the existing `fired` ref pattern already in the same file (and in `login.verifying.tsx`).
- **#239** — `useConfirmEmail` / `useConsumeLoginToken` cached the mutation's one-time `merged` field verbatim under `SESSION_QUERY_KEY` (5 min staleTime), which could mislead a future `useSession().data.merged` reader with a stale truthy value. Both now strip `merged` (set to `null`) before caching; the raw mutation result (read by the toast logic) is untouched.

**#76** (client-side timeout on a hung `POST /matches`) was picked as a fifth candidate but turned out to already be fixed and tested in `api/matches.ts` (`CREATE_MATCH_TIMEOUT_MS` / `AbortSignal.timeout`) — no code change needed; flagging so the issue can be closed.

---

## ⚠️ Closed as superseded (2026-07-05)

This branch (`claude/easy-github-issues-ihhzs4`) was cut from an older `main` (base `f9ee970`) and has since been **fully overtaken** by other PRs that landed the same fixes. On current `main`, every fix in this PR already exists:

| Issue | This PR's fix | Already on `main` |
|---|---|---|
| #75 Cancel dirty-form dialog | `useBlocker` + discard `AlertDialog` | ✅ `routes/_app/matches/new.tsx` (`useBlocker` + `DiscardMatchSetupDialog`), via #809 / #826 |
| #77 cursor `wait` on Start-match | `cursor: wait` in `match-setup.css` | ✅ `match-setup.css` in-flight rule, via #826 |
| #233 toast double-fire guard | `toastFired` ref | ✅ `confirm-email.tsx` `fired` ref (main also refactored to a shared `showMergeToast`) |
| #239 strip `merged` from session cache | set `merged: null` before caching | ✅ `api/session.ts` (`{ ...session, merged: null }`) |

Because `main` already carries all four fixes — in some cases in a more refined form — merging this PR would only re-resolve a 6-file conflict to re-apply present behavior, with a real risk of regressing the refined versions. Closing as **superseded** rather than merging. The underlying issues (#75/#77/#233/#239, and #76) are resolved on `main`; they can be closed on their own merits.
