### PR TITLE
Add parse-at-boundaries rule + fetching-data skill

### DIFF
--- a/.claude/rules/parse-at-boundaries.md
+++ b/.claude/rules/parse-at-boundaries.md
@@ -1,0 +1,34 @@
+# Parse untrusted data at every boundary
+
+Any data entering the app from outside its own memory is **untrusted until parsed**. That
+includes:
+
+- network responses (from our API or any third party),
+- HTTP request/form bodies,
+- URL path params and query strings,
+- `localStorage` / `sessionStorage` and other persisted client state,
+- uploaded files,
+- environment variables and process config.
+
+## The rule
+
+**Parse the input at the boundary, then carry the parsed, typed value inward.** The interior
+of the app should only ever hold values that have already been validated at the edge.
+
+- Never cast an `unknown` / `any` (or a `JSON.parse` result) and trust it. A type annotation
+  is a compile-time claim, **not** a runtime check — the value can still be anything.
+- Turn unstructured input into a trusted typed value **once**, at the edge, and let the type
+  system guarantee everything downstream. ("Parse, don't validate.")
+- If the input doesn't match, fail loudly at the boundary — reject the request, show an
+  inline error, redirect, or throw — rather than letting a malformed value leak inward and
+  surface as a confusing failure far from its source.
+
+## The tools we use
+
+The parser is idiomatic to each surface — see the relevant `CLAUDE.md`:
+
+- **API (Python)** → **Pydantic** models validate request/response bodies. See
+  `api/CLAUDE.md` ("type the I/O boundaries so errors are caught by the type checker").
+- **iOS (Swift)** → **`Codable`** decoding against the generated `ios/Fortymm/Generated/Types.swift`.
+- **Web client (TypeScript)** → **Zod** everywhere (forms, URLs, network, storage). See the
+  `## Boundaries` and `## Forms` sections of `web-client/CLAUDE.md`.

--- a/.claude/skills/fetching-data/SKILL.md
+++ b/.claude/skills/fetching-data/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: fetching-data
+description: Fetch server data in web-client/ the fortymm way — share TanStack Query *options objects* (queryOptions factories), not custom-hook logic, following tkdodo's "Creating Query Abstractions". Use whenever you read server data with TanStack Query: adding or changing a query/mutation, a `*-query.ts` file, a `use*` data hook, a `queryOptions`/`queryKey` factory, or wiring cache invalidation. Complements the react-component skill (which owns file layout).
+---
+
+# Fetching data in web-client
+
+We follow tkdodo's [Creating Query Abstractions](https://tkdodo.eu/blog/creating-query-abstractions):
+**abstract the *configuration*, not the *hook*.** The unit we share is a
+TanStack Query **options object** produced by a `queryOptions()` factory —
+never a generic wrapper around `useQuery`.
+
+The file layout (which directory a `*-query.ts` lives in, the query → fetcher →
+display split) is owned by the **react-component** skill — read it for where
+things go. This skill is about what goes *inside* the data layer.
+
+## The one rule
+
+A query is defined by a factory that returns `queryOptions({...})`. Everything
+that needs the data spreads that object. Don't wrap `useQuery` in a bespoke hook
+that hides its options.
+
+```ts
+// src/api/matches.ts
+import { queryOptions } from "@tanstack/react-query";
+
+export function matchQueryOptions(matchId: string) {
+  return queryOptions({
+    queryKey: matchQueryKey(matchId),
+    queryFn: async (): Promise<MatchDetails> =>
+      unwrap("load match", await api.GET("/v1/matches/{match_id}", {
+        params: { path: { match_id: matchId } },
+      })),
+    retry: false,
+    throwOnError: true,
+  });
+}
+```
+
+`queryOptions()` (not a bare object literal) is what preserves type inference
+for `select`, `queryClient.getQueryData`, and suspense variants. Prefer it for
+every new base factory. (Some older factories — e.g. `matchDetailsQuery` in
+`match-details-query.ts` — still return a bare object; new code uses
+`queryOptions()`.)
+
+## Colocate four things in one file
+
+Per query, the `*-query.ts` file owns:
+
+1. **A query-key factory** — one exported function, the *only* place the key is
+   spelled. Use a structured, hierarchical key so related caches invalidate
+   together:
+   ```ts
+   export const matchDetailsQueryKey = (matchId: string) =>
+     [{ scope: "matches", version: "v1", entity: "details", matchId }] as const;
+   ```
+   (Flat tuple keys like `["players", "recent"] as const` also exist for
+   simple, param-less caches — fine, but still behind a named factory.)
+2. **The `queryFn`** — hits the API via `api.GET(...)` (openapi-fetch), then
+   **parses the payload at the boundary**. `unwrap(label, result)` turns the
+   openapi-fetch result into data-or-throw (`src/api/client.ts`); on top of that,
+   a Zod `schema.parse(...)` makes it a trusted typed value. The canonical
+   example is `matchDetailsResultFromPayload` in `match-details-query.ts`, whose
+   `queryFn` runs `matchDetailsSchema.parse(payload)` so a malformed payload fails
+   loudly instead of priming a bad cache entry — the web instance of
+   `.claude/rules/parse-at-boundaries.md`. (`api.GET` types are compile-time only,
+   off `schema.d.ts`; the parse is the runtime guarantee. Some existing queries
+   still return the unparsed typed payload — new boundary-critical ones parse.)
+3. **The `queryOptions()` factory** (above).
+4. **Derived view-model queries** via `select`, layered by *spreading the base
+   factory* — the canonical way to add a projection without re-declaring the
+   key/fn:
+   ```ts
+   export const scoreboardQuery = (matchId: string) => ({
+     ...matchDetailsQuery(matchId),
+     select: selectScoreboard,   // pure payload → View mapping, unit-tested
+   });
+   ```
+   All mapping / label / ordering logic lives in the `select`, tested as pure
+   functions (see the react-component skill's query → fetcher → display split).
+
+## Thin custom hooks are fine — thin
+
+A `use*` hook may exist as a convenience, but it must be a one-liner over the
+factory with **no extra options surface**:
+
+```ts
+export function useMatch(matchId: string) {
+  return useQuery(matchQueryOptions(matchId));
+}
+```
+
+Fetchers usually skip the hook and call `useSuspenseQuery(thingQuery(id))`
+directly. Callers that need `select`, `throwOnError`, suspense, etc. spread the
+factory and add them at the call site:
+`useQuery({ ...matchQueryOptions(id), select: (m) => m.status })`.
+
+## Mutations invalidate via the same key factory
+
+Never hand-write a key at an invalidation site — import the factory so the key
+has exactly one source of truth:
+
+```ts
+queryClient.invalidateQueries({ queryKey: matchDetailsQueryKey(matchId) });
+```
+
+## Anti-patterns (don't)
+
+- **A generic `useQuery` wrapper** that takes `options?: Partial<UseQueryOptions>`.
+  It collapses `data` to `unknown` and re-hides the whole API. Share a
+  `queryOptions` object instead.
+- **Over-parameterized hooks** that grow a new boolean/option every time a
+  caller needs a tweak. Expose the options object; let the caller compose.
+- **Inlined query keys** in components, `queryFn`s, or `invalidateQueries` —
+  always the key factory.
+- **Trusting the payload.** `api.GET` is typed off `schema.d.ts` (compile-time
+  only). Parse it with Zod in the `queryFn` before it enters the cache.
+- **Putting `select`/label/ordering logic in the component.** It belongs in the
+  query file's `select`, where it's unit-tested without a DOM.
+
+## Definition of done
+
+From `web-client/`: `npm run lint`, `npm run build` (type-checks), and
+`npm run test:run` pass. The `*-query.ts` gets a plain `.test.ts` covering its
+`select`/parsing as pure functions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,8 @@ The iOS app mirrors this with `ios/Fortymm/Generated/Types.swift`, generated fro
 
 **BFF endpoints — one per page.** Each page-level UI surface has a single backend endpoint that returns all the data it needs, pre-shaped for that page; joining, aggregation, and status-label mapping happen on the server, current-user-aware. Exception: independently-interactive widgets (typeaheads, infinite-scroll panels) keep their own endpoints. Rule of thumb: if the widget fetches in response to user input rather than on page load, it's its own endpoint.
 
+**Parse untrusted data at every boundary** — the rule and its rationale live in `.claude/rules/parse-at-boundaries.md`. The parser is idiomatic to each surface: the API validates request/response bodies with **Pydantic** (`api/CLAUDE.md` — "type the I/O boundaries"); the iOS app decodes with **`Codable`** against generated `ios/Fortymm/Generated/Types.swift`; the **web client uses Zod** everywhere (`web-client/CLAUDE.md` — `## Boundaries` and `## Forms`).
+
 Layer-specific architecture and conventions live in `api/CLAUDE.md` and `web-client/CLAUDE.md` (loaded automatically when working in those directories).
 
 ## Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ The iOS app mirrors this with `ios/Fortymm/Generated/Types.swift`, generated fro
 
 **BFF endpoints — one per page.** Each page-level UI surface has a single backend endpoint that returns all the data it needs, pre-shaped for that page; joining, aggregation, and status-label mapping happen on the server, current-user-aware. Exception: independently-interactive widgets (typeaheads, infinite-scroll panels) keep their own endpoints. Rule of thumb: if the widget fetches in response to user input rather than on page load, it's its own endpoint.
 
-**Parse untrusted data at every boundary** — the rule and its rationale live in `.claude/rules/parse-at-boundaries.md`. The parser is idiomatic to each surface: the API validates request/response bodies with **Pydantic** (`api/CLAUDE.md` — "type the I/O boundaries"); the iOS app decodes with **`Codable`** against generated `ios/Fortymm/Generated/Types.swift`; the **web client uses Zod** everywhere (`web-client/CLAUDE.md` — `## Boundaries` and `## Forms`).
+**Parse untrusted data at every boundary.** The parser is idiomatic to each surface: the API validates request/response bodies with **Pydantic** (`api/CLAUDE.md` — "type the I/O boundaries"); the iOS app decodes with **`Codable`** against generated `ios/Fortymm/Generated/Types.swift`; the **web client uses Zod** everywhere (`web-client/CLAUDE.md` — `## Boundaries` and `## Forms`).
 
 Layer-specific architecture and conventions live in `api/CLAUDE.md` and `web-client/CLAUDE.md` (loaded automatically when working in those directories).
 

--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -42,8 +42,7 @@ custom element only when nothing in the design system is a reasonable fit.
 
 ## Boundaries
 
-We **parse untrusted data at every boundary with Zod** (the repo-wide rule and its
-rationale live in `.claude/rules/parse-at-boundaries.md`). The tool per surface:
+We **parse untrusted data at every boundary with Zod.** The tool per surface:
 
 - **Forms** → React Hook Form + `zodResolver`. See `## Forms` below.
 - **URL search + path params** → a Zod schema. Prefer a route

--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -40,6 +40,23 @@ treatments via the same className/token patterns the showcase uses (e.g. the
 "Featured" highlight) rather than reinventing borders and gradients. Reach for a
 custom element only when nothing in the design system is a reasonable fit.
 
+## Boundaries
+
+We **parse untrusted data at every boundary with Zod** (the repo-wide rule and its
+rationale live in `.claude/rules/parse-at-boundaries.md`). The tool per surface:
+
+- **Forms** → React Hook Form + `zodResolver`. See `## Forms` below.
+- **URL search + path params** → a Zod schema. Prefer a route
+  `validateSearch: (s) => schema.parse(s)` over the raw
+  `(search: Record<string, unknown>) => ({ ... })` spread for new routes, so a malformed
+  URL fails at the route boundary instead of leaking `undefined`s into the page.
+- **Network responses** → Zod-parse the decoded payload at the fetch boundary before it
+  flows into the app. The generated `schema.d.ts` (see the root `CLAUDE.md` OpenAPI
+  invariant) gives the compile-time shape; Zod gives the runtime guarantee — they're
+  complementary, not redundant.
+- **`localStorage` / `sessionStorage` / any other external input** → read the value as
+  `unknown` and `.parse()` it through a Zod schema; treat a parse failure as absent.
+
 ## Forms
 
 **Every form that submits a mutation uses React Hook Form + Zod.** Drive the


### PR DESCRIPTION
Two related web-client documentation additions.

## 1. Parse-at-untrusted-boundaries rule

Documents a repo-wide invariant: **any time untrusted data crosses a boundary into the app, parse it at that boundary** — never trust a bare `unknown`/`any` cast or a type annotation as a runtime check. Boundaries: network → web, network → iOS, forms, URL path/query params, `localStorage`/`sessionStorage`, uploads, env vars.

- **`.claude/rules/parse-at-boundaries.md`** (new) — the tool-agnostic principle ("parse, don't validate"), the *why*.
- **`CLAUDE.md`** / **`web-client/CLAUDE.md`** — just specify the parser per surface: **Pydantic** (API), **`Codable`** (iOS), **Zod** (web: forms via RHF+`zodResolver`, URL params, network responses, `localStorage`). No restatement of the concept, no back-link — the rule file stands alone.

## 2. `fetching-data` skill

**`.claude/skills/fetching-data/SKILL.md`** — codifies how we read server data with TanStack Query, following tkdodo's [Creating Query Abstractions](https://tkdodo.eu/blog/creating-query-abstractions): share `queryOptions()` factories (not generic `useQuery` wrappers), colocate a query-key factory + `queryFn` + options + `select`-layered view models in one `*-query.ts`, **parse payloads with Zod in the `queryFn`** (ties to the rule above), keep `use*` hooks thin, and invalidate via the key factory. Complements the existing **react-component** skill, which owns file layout. All code examples are drawn from real code (`matchQueryOptions`, `scoreboardQuery`, `matchDetailsQueryKey`, `matchDetailsResultFromPayload`).

Docs-only — no app code changes. `AGENTS.md` (untracked Codex mirror) intentionally left unsynced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)