### PR TITLE
Parse the localStorage session lock at the boundary (Zod)

### DIFF
--- a/web-client/src/api/session.test.ts
+++ b/web-client/src/api/session.test.ts
@@ -7,6 +7,7 @@ import { createElement, type ReactNode } from 'react'
 import { server } from '@/mocks/server'
 import {
   SESSION_QUERY_KEY,
+  readStorageLock,
   useConfirmEmail,
   useConsumeLoginToken,
 } from './session'
@@ -131,5 +132,47 @@ describe('useConfirmEmail', () => {
       (queryClient.getQueryData(SESSION_QUERY_KEY) as { merged: unknown })
         .merged,
     ).toBeNull()
+  })
+})
+
+// The cross-tab bootstrap lock lives in localStorage — untrusted persisted
+// state. `readStorageLock` must parse it at the boundary so a malformed or
+// hand-edited record reads as "no lock" instead of casting garbage inward
+// (`.claude/rules/parse-at-boundaries.md`).
+describe('readStorageLock', () => {
+  const LOCK_KEY = 'fortymm:session-bootstrap:lock'
+
+  afterEach(() => {
+    localStorage.removeItem(LOCK_KEY)
+  })
+
+  it('returns null when no lock is stored', () => {
+    expect(readStorageLock()).toBeNull()
+  })
+
+  it('parses a well-formed record', () => {
+    localStorage.setItem(
+      LOCK_KEY,
+      JSON.stringify({ owner: 'tab-1', expires: 123 }),
+    )
+    expect(readStorageLock()).toEqual({ owner: 'tab-1', expires: 123 })
+  })
+
+  it('rejects non-JSON as null', () => {
+    localStorage.setItem(LOCK_KEY, 'not json{')
+    expect(readStorageLock()).toBeNull()
+  })
+
+  it('rejects a wrong-shaped record (expires as string) as null', () => {
+    localStorage.setItem(
+      LOCK_KEY,
+      JSON.stringify({ owner: 'tab-1', expires: '123' }),
+    )
+    expect(readStorageLock()).toBeNull()
+  })
+
+  it('rejects a record missing fields as null', () => {
+    localStorage.setItem(LOCK_KEY, JSON.stringify({ owner: 'tab-1' }))
+    expect(readStorageLock()).toBeNull()
   })
 })

--- a/web-client/src/api/session.ts
+++ b/web-client/src/api/session.ts
@@ -5,6 +5,7 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query'
+import { z } from 'zod'
 import { ApiError, api, hasCsrfCookie, unwrap } from './client'
 import { clearAppEntered } from '@/lib/landing-redirect'
 import type { components } from './schema'
@@ -27,16 +28,23 @@ const SESSION_LOCK_STORAGE_KEY = 'fortymm:session-bootstrap:lock'
 const SESSION_LOCK_TTL_MS = 10_000
 const SESSION_LOCK_POLL_MS = 50
 
-interface StorageLockRecord {
-  owner: string
-  expires: number
-}
+// The lock record is persisted client state (localStorage), so it's untrusted
+// on read — a different app version, a manual edit, or a truncated write could
+// leave anything there. Parse it at the boundary instead of casting the
+// `JSON.parse` result (see `.claude/rules/parse-at-boundaries.md`); a shape
+// mismatch is treated as "no lock", exactly like a parse/JSON error.
+const storageLockSchema = z.object({
+  owner: z.string(),
+  expires: z.number(),
+})
+type StorageLockRecord = z.infer<typeof storageLockSchema>
 
-function readStorageLock(): StorageLockRecord | null {
+export function readStorageLock(): StorageLockRecord | null {
   const raw = localStorage.getItem(SESSION_LOCK_STORAGE_KEY)
   if (!raw) return null
   try {
-    return JSON.parse(raw) as StorageLockRecord
+    const parsed = storageLockSchema.safeParse(JSON.parse(raw))
+    return parsed.success ? parsed.data : null
   } catch {
     return null
   }


### PR DESCRIPTION
## What

Audit of the web-client against the new `.claude/rules/parse-at-boundaries.md` rule, plus the one fix it turned up.

`readStorageLock` (`web-client/src/api/session.ts`) read the cross-tab session-bootstrap lock from `localStorage` and **cast** the `JSON.parse` result to `StorageLockRecord`. That's the exact anti-pattern the rule calls out — a compile-time cast is not a runtime check. A malformed or hand-edited record (e.g. `expires` stored as a string) sailed through the `try/catch` and then `held.expires < Date.now()` misbehaved.

Now it parses through a Zod schema + `safeParse`; a shape mismatch reads as "no lock", identical to the existing JSON-error path. The type is derived from the schema (one source of truth). `readStorageLock` is exported and covered with boundary tests (non-JSON, wrong-shaped, missing-field → all `null`).

## Audit findings (the rest — no change made, by design)

The rule/skill explicitly grandfather existing code ("*new* boundary-critical ones parse", "for *new* routes"), so this is deliberately **not** a sweeping retrofit:

- **API (Python):** clean. No raw `request.json()`/`request.form()` bypassing Pydantic; env reads are minimal.
- **`validateSearch` routes** (`index`, `login.index`, `login.sent`, `login.verifying`, `confirm-email`): use the hand-rolled `(search: Record<string, unknown>) => …` spread rather than `zodValidator`, but each already validates defensively (typeof narrowing, literal narrowing, intentional `?token=a&token=b` array-dedup). **Compliant in spirit; not bugs.** Converting to Zod is a consistency nicety that risks regressing the array-dedup edge — left alone.
- **Unparsed `queryFn`s** (8 of 9 `*-query.ts` return the typed-but-unparsed payload): grandfathered. The only boundary-critical one is `/v1/session` (`sessionQueryOptions`) — a reasonable future candidate, but parsing it means hand-maintaining a Zod mirror of the generated `SessionResponse`, a real design decision rather than an obvious fix.

## Test plan

- `npm run test:run` (session.test.ts): 9 passed (4 existing + 5 new boundary cases)
- `eslint` on changed files: clean
- `tsc -b`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)