### PR TITLE
Fix #747-F2: finalize drops a failed scratch save (2-1 posts as 2-0)

### DIFF
--- a/docs/adr/0004-finalize-surfaces-reconstruct-the-full-board.md
+++ b/docs/adr/0004-finalize-surfaces-reconstruct-the-full-board.md
@@ -52,24 +52,97 @@ source it *should* have folded in.
   Fixed by including the active game's persisted score in the merged board
   (source 3 for the active game was being dropped).
 
-- **#747 F2** — `score-entry` ignores **failed scratch saves** on non-active
-  games (it builds its board from persisted + live input only). A failed
-  non-active game therefore compacts out (ADR 0002), so "Post result" records
-  e.g. a 2–1 board as 2–0 — it **erases a game**. Data corruption, the opposite
-  symptom, in the opposite file. Fix pending: `score-entry` must fold source 2
-  (failed scratch saves) into its board the way `save-banner` already does.
+- **#747 F2** — `score-entry` ignored **failed scratch saves** on non-active
+  games (it built its board from persisted + live input only). A failed
+  non-active game therefore compacted out (ADR 0002), so "Post result" recorded
+  e.g. a 2–1 board as 2–0 — it **erased a game**. Data corruption, the opposite
+  symptom, in the opposite file. Fixed by routing `score-entry`'s board through
+  the shared `reconstructBoard` helper below, which folds in source 2.
 
-Same contract violated from both ends. #755's half is fixed here; #747 F2's half
-is tracked on that issue. Once both land, both surfaces reconstruct a board that
-covers all three sources and can never hide a real finalize nor mint a board
-missing a played game.
+Same contract was violated from both ends. Both halves are now fixed: both
+surfaces reconstruct a board that covers all three sources and can never hide a
+real finalize nor mint a board missing a played game.
 
-## Rejected (for now): one shared reconstruction helper
+## Why F2 could only be fixed client-side (two boundaries, not one)
 
-The obvious end-state is a single `reconstructDecidedBoard()` both surfaces
-call, instead of two hand-rolled merges that drift. Deferred because the active
-game's live input lives only in `score-entry`'s RHF state and would have to be
-threaded into a shared helper (the banner has no access to it), making the
-shared-helper change materially larger than the two targeted source fixes. Both
-issues are fixed by adding the missing source to each existing merge; the
-unification can follow once both sides read the same three sources.
+F2 looks like a sibling of the first-post board-conflict guard (ADR 0003 / issue
+#747-B2), and both are about *not posting a board that isn't the true board* —
+but they are **complementary guards at two different boundaries**, not one fix:
+
+- **B2 is server-side.** On first propose the server value-compares the proposed
+  board against the games another participant **committed** to the scratchpad and
+  409s on divergence (`_scratchpad_divergence`, `matches.py`). It works precisely
+  because the diverging game *reached the server*.
+- **F2 can never be caught server-side.** The dropped game is a *failed* scratch
+  save — it **never reached the server**, so there is nothing for the propose
+  endpoint to compare against or "keep." The endpoint faithfully validates and
+  mints exactly the board it is handed (`_validate_finalize_games` +
+  `_commit_canonical_games`, "the list is canon, no merge"); a board missing G2
+  is a clean, decided board it cannot object to. The failed G2 exists **only** in
+  the client's mutation cache, so the reconstruction has to happen in the client
+  before the payload is sent.
+
+So "propose validates the whole match" does not rescue F2: the client must
+assemble the true board from all local sources (this ADR), *and* the server
+rejects committed-divergence (ADR 0003). Different files, different failure
+modes, both required.
+
+## Adopted: one shared `reconstructBoard` helper
+
+Both surfaces now call a single `reconstructBoard` helper
+(`web-client/src/components/matches/reconstruct-board.ts`) instead of
+hand-rolling two merges that drift — that drift was the shared root cause of
+*both* #755 and #747 F2. The module lives beside its two callers (not in the
+framework-pure `@/lib/scoring`) because it is app-aware, and it owns **both**
+app-shape → board mappings so neither caller hand-rolls either one:
+
+- `scoredGamePoints(games)` — the persisted `data.games` → `GamePoints[]`
+  mapping, exported and called by both surfaces (and by `score-entry` for its
+  `decider`), so the persisted mapping has one source.
+- the `FailedGameSave.variables` → `GamePoints` mapping, inside
+  `reconstructBoard`.
+
+Shape:
+
+```ts
+reconstructBoard({
+  persisted,                 // GamePoints[] (via scoredGamePoints)
+  failedSaves,               // FailedGameSave[]; caller passes conflicts already excluded
+  activeInput?,              // GamePoints; score-entry only, only when inputsValid
+}): GamePoints[]             // raw merged board — the CALLER compacts
+```
+
+Design points that fell out of the interview:
+
+- **Overlay order `persisted → failed → activeInput`.** The last write wins per
+  game number, so `activeInput` (passed only by `score-entry`) naturally beats a
+  same-game failed scratch, giving exactly the source precedence `live > failed >
+  persisted`. Callers therefore need not pre-filter the active game out of
+  `failedSaves`.
+- **Callers exclude conflicts**, not the helper. A conflicted failed save's
+  committed value is already in `persisted`; folding the *rejected* scratch would
+  re-introduce the data-loss overwrite the version guard prevents. `save-banner`
+  already filters `!entry.conflict` at the call site — `score-entry` does the
+  same. The helper stays a pure board-merge with no conflict opinion.
+- **The helper returns the raw merged board; the caller compacts.**
+  `score-entry` needs the un-compacted board for `overrunDecider` (which reports
+  the true game number), and both callers already own their `compactGames` call.
+
+The earlier objection — "the active game's live input lives only in
+`score-entry`'s RHF state" — is answered by making `activeInput` an *optional
+parameter*: `score-entry` passes it, `save-banner` passes none (it defers the
+active game's live value to `score-entry`'s button via `decidedHere`, unchanged).
+
+## Known limitation: the scoreline `decider` stays persisted-only
+
+The fix reconstructs only the **finalize board** (`hypotheticalGames` →
+`wouldFinalize`/`overrunDecider`/posted payload). `score-entry`'s other
+persisted-only read — `decider` (lines ~212–213), which gates scoreline cell
+muting and the out-of-range nav bounce — is deliberately **left unchanged**. So a
+failed save that would itself clinch the match (e.g. G1 persisted, G2 *failed*,
+both wins in a best-of-3) does not mute the trailing cells. This is not a
+corruption path: the **save-banner** reads persisted ⊕ failed, sees the decided
+board, and surfaces "These scores finish the match — Post result." Folding failed
+(unsaved, possibly mid-retry) scratch data into `decider` would change muting
+behavior with its own edge cases, beyond F2's blast radius; scoped out, revisit
+if it becomes a real confusion.

--- a/web-client/src/components/matches/reconstruct-board.test.ts
+++ b/web-client/src/components/matches/reconstruct-board.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { GamePoints } from '@/lib/scoring'
+import { reconstructBoard } from './reconstruct-board'
+import type { FailedGameSave } from './score-saves'
+
+function persisted(
+  gameNumber: number,
+  side_1_points: number,
+  side_2_points: number,
+): GamePoints {
+  return { game_number: gameNumber, side_1_points, side_2_points }
+}
+
+function failed(
+  gameNumber: number,
+  side_1_points: number,
+  side_2_points: number,
+  conflict = false,
+): FailedGameSave {
+  return {
+    gameNumber,
+    variables: { side_1_points, side_2_points },
+    conflict,
+    submittedAt: gameNumber,
+  }
+}
+
+const byNumber = (games: GamePoints[]) =>
+  new Map(games.map((g) => [g.game_number, g]))
+
+describe('reconstructBoard', () => {
+  it('returns the persisted games when nothing else is present', () => {
+    const board = reconstructBoard({
+      persisted: [persisted(1, 11, 5), persisted(2, 8, 11)],
+      failedSaves: [],
+    })
+    expect(byNumber(board).get(1)).toEqual(persisted(1, 11, 5))
+    expect(byNumber(board).get(2)).toEqual(persisted(2, 8, 11))
+  })
+
+  it('folds in a failed scratch save that was never persisted (the #747-F2 hole)', () => {
+    // G1 persisted (win side 1), G2 FAILED (win side 2), no persisted G2.
+    // Without folding the failed save, G2 vanishes and the board reads 1-0.
+    const board = reconstructBoard({
+      persisted: [persisted(1, 11, 5)],
+      failedSaves: [failed(2, 7, 11)],
+    })
+    expect(byNumber(board).get(2)).toEqual(persisted(2, 7, 11))
+    expect(board).toHaveLength(2)
+  })
+
+  it('lets a failed scratch save override a stale persisted score for the same game', () => {
+    // Failed save is newer than the persisted score — precedence failed > persisted.
+    const board = reconstructBoard({
+      persisted: [persisted(1, 11, 5)],
+      failedSaves: [failed(1, 11, 9)],
+    })
+    expect(byNumber(board).get(1)).toEqual(persisted(1, 11, 9))
+    expect(board).toHaveLength(1)
+  })
+
+  it('lets the active live input win over both a failed save and the persisted score', () => {
+    // Precedence live > failed > persisted, all on the same game — the last
+    // overlay (activeInput) wins. Callers need not strip the active game from
+    // failedSaves because of this.
+    const board = reconstructBoard({
+      persisted: [persisted(1, 11, 5)],
+      failedSaves: [failed(1, 11, 9)],
+      activeInput: persisted(1, 12, 10),
+    })
+    expect(byNumber(board).get(1)).toEqual(persisted(1, 12, 10))
+    expect(board).toHaveLength(1)
+  })
+
+  it('adds the active input as a new game when it has no prior score', () => {
+    const board = reconstructBoard({
+      persisted: [persisted(1, 11, 5)],
+      failedSaves: [failed(2, 7, 11)],
+      activeInput: persisted(3, 11, 9),
+    })
+    expect(board).toHaveLength(3)
+    expect(byNumber(board).get(3)).toEqual(persisted(3, 11, 9))
+  })
+})

--- a/web-client/src/components/matches/reconstruct-board.ts
+++ b/web-client/src/components/matches/reconstruct-board.ts
@@ -1,0 +1,71 @@
+import type { GamePoints } from '@/lib/scoring'
+import type { MatchDetails } from '@/api/matches'
+import type { FailedGameSave } from './score-saves'
+
+/** The persisted per-game scores as `GamePoints` — drops un-scored games and
+ * the side orientation, the shape the scoring lib
+ * (`deciderGameNumber`/`overrunDecider`/`reconstructBoard`) expects. The single
+ * source of the persisted → board mapping, shared by both finalize surfaces so
+ * the two can't drift (ADR 0004). */
+export function scoredGamePoints(games: MatchDetails['games']): GamePoints[] {
+  return games
+    .filter((g) => g.score)
+    .map((g) => ({
+      game_number: g.game_number,
+      side_1_points: g.score!.side_1_points,
+      side_2_points: g.score!.side_2_points,
+    }))
+}
+
+/**
+ * Reconstruct the candidate decided board from every source a game's newest
+ * score can live in, so a finalize surface can never mint a board missing a
+ * played game (ADR 0004). The three sources, lowest precedence first:
+ *
+ * 1. `persisted` — the committed per-game scores (map via `scoredGamePoints`).
+ * 2. `failedSaves` — per-game scratch saves that never reached the server, held
+ *    in the shared mutation cache (`useFailedGameSaves`). Newer than the
+ *    persisted score for the same game.
+ * 3. `activeInput` — the active game's live typed input. Newest of all; only
+ *    `score-entry` can pass it (the banner may be on another game's screen).
+ *
+ * They are overlaid in that order, so per game number the precedence is
+ * `live input > failed scratch > persisted` — a later source wins. That is why
+ * a caller need NOT pre-filter the active game out of `failedSaves`: an
+ * `activeInput` for the same game overwrites it here.
+ *
+ * Two deliberate non-responsibilities, both owned by the caller:
+ *
+ * - **Conflicts are excluded by the caller**, not here. A conflicted failed
+ *   save's committed value is already in `persisted`; folding the *rejected*
+ *   scratch back in would re-introduce the last-write-wins overwrite the version
+ *   guard prevents. Callers pass `useFailedGameSaves(...).filter(!conflict)`.
+ * - **The board is returned raw, not compacted.** `score-entry` needs the
+ *   un-compacted board for `overrunDecider` (which reports the true game
+ *   number), and both callers already own their `compactGames` call.
+ */
+export function reconstructBoard({
+  persisted,
+  failedSaves,
+  activeInput,
+}: {
+  persisted: GamePoints[]
+  failedSaves: FailedGameSave[]
+  activeInput?: GamePoints | null
+}): GamePoints[] {
+  const byNumber = new Map<number, GamePoints>()
+  for (const game of persisted) {
+    byNumber.set(game.game_number, game)
+  }
+  for (const entry of failedSaves) {
+    byNumber.set(entry.gameNumber, {
+      game_number: entry.gameNumber,
+      side_1_points: entry.variables.side_1_points,
+      side_2_points: entry.variables.side_2_points,
+    })
+  }
+  if (activeInput) {
+    byNumber.set(activeInput.game_number, activeInput)
+  }
+  return [...byNumber.values()]
+}

--- a/web-client/src/components/matches/save-banner.tsx
+++ b/web-client/src/components/matches/save-banner.tsx
@@ -10,7 +10,7 @@ import {
   useProposeResult,
   useMatch,
 } from '@/api/matches'
-import { compactGames, isDecidedMatch, type GamePoints } from '@/lib/scoring'
+import { compactGames, isDecidedMatch } from '@/lib/scoring'
 import { cn } from '@/lib/utils'
 import {
   Alert,
@@ -19,6 +19,7 @@ import {
   AlertTitle,
 } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
+import { reconstructBoard, scoredGamePoints } from './reconstruct-board'
 import { useFailedGameSaves } from './score-saves'
 
 export interface SaveBannerProps {
@@ -98,25 +99,19 @@ function FailedSaveBanner({
   // when it has one, still wins below: the failed-saves loop overrides the same
   // game number, and that scratch — not the persisted score — is what the cell
   // shows and what finishes the match (we don't advance once it's over).
-  const mergedByNumber = new Map<number, GamePoints>()
-  for (const game of data?.games ?? []) {
-    if (!game.score) continue
-    mergedByNumber.set(game.game_number, {
-      game_number: game.game_number,
-      side_1_points: game.score.side_1_points,
-      side_2_points: game.score.side_2_points,
-    })
-  }
-  for (const entry of allFailed) {
-    mergedByNumber.set(entry.gameNumber, {
-      game_number: entry.gameNumber,
-      side_1_points: entry.variables.side_1_points,
-      side_2_points: entry.variables.side_2_points,
-    })
-  }
+  // The shared board reconstruction (ADR 0004): persisted ⊕ failed scratch.
+  // The banner reads no live input — it may be on another game's screen — so it
+  // passes no `activeInput`, deferring the active game's live value to
+  // `score-entry`'s button via `decidedHere` below. `allFailed` already excludes
+  // conflicts (see above), as the helper requires.
   // Compact so a gappy offline clinch posts a contiguous board (see
   // `compactGames`). `compactGames` sorts internally, so no pre-sort here.
-  const mergedGames = compactGames([...mergedByNumber.values()])
+  const mergedGames = compactGames(
+    reconstructBoard({
+      persisted: scoredGamePoints(data?.games ?? []),
+      failedSaves: allFailed,
+    }),
+  )
   const wouldFinalize =
     data != null && isDecidedMatch(mergedGames, data.best_of)
 

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -12,12 +12,14 @@ import {
   QueryClient,
   QueryClientProvider,
   onlineManager,
+  useQueryClient,
 } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
 import { afterEach, describe, expect, it } from 'vitest'
 import { server } from '@/mocks/server'
 import { matchDetails } from '@/test/factories'
 import type { components } from '@/api/schema'
+import { fireScoreSave } from '@/api/matches'
 import { ScoreEntry } from './score-entry'
 
 type MatchDetailsSide = components['schemas']['MatchDetailsSide']
@@ -134,6 +136,80 @@ function renderScoreEntry(spec: RouteSpec, options: { path?: string } = {}) {
       matchPage,
     ]),
     history: createMemoryHistory({ initialEntries: [options.path ?? '/entry'] }),
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+// Like `renderScoreEntry`, but also mounts a sibling button that imperatively
+// fails `failGameNumber`'s scratch save via `fireScoreSave` — the same call the
+// real fire-and-forget save makes — so a failed save for a NON-active game lands
+// in the shared mutation cache without unmounting the entry screen. Used to
+// reproduce #747-F2: the finalize board must fold that failed game in.
+function renderEntryWithFailedSibling({
+  gameNumber,
+  failGameNumber,
+}: {
+  gameNumber: number
+  failGameNumber: number
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute()
+  const entryRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/entry',
+    component: function Entry() {
+      const qc = useQueryClient()
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() =>
+              fireScoreSave(qc, 'm-1', failGameNumber, {
+                side_1_points: 9,
+                side_2_points: 11,
+              })
+            }
+          >
+            fail game {failGameNumber}
+          </button>
+          <ScoreEntry
+            matchId="m-1"
+            gameNumber={gameNumber}
+            mode={{ kind: 'create' }}
+          />
+        </>
+      )
+    },
+  })
+  const matchPage = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches/$matchId',
+    component: () => <div>match-page m-1</div>,
+  })
+  const scoringNew = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches/$matchId/games/$gameNumber/scores/new',
+    component: () => <div>scoring-new</div>,
+  })
+  const scoringEdit = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/matches/$matchId/games/$gameNumber/scores/edit',
+    component: () => <div>scoring-edit</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([
+      entryRoute,
+      matchPage,
+      scoringNew,
+      scoringEdit,
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/entry'] }),
   })
   return render(
     <QueryClientProvider client={queryClient}>
@@ -445,6 +521,91 @@ describe('ScoreEntry — create', () => {
         { game_number: 1, side_1_points: 11, side_2_points: 4 },
         { game_number: 2, side_1_points: 11, side_2_points: 6 },
         { game_number: 3, side_1_points: 11, side_2_points: 3 },
+      ],
+    })
+  })
+
+  it('folds a FAILED scratch save on a non-active game into the posted board (#747-F2)', async () => {
+    // Bo3. G1 persisted (I won 11-8). G2's save FAILED (I lost 9-11) and lives
+    // only in the mutation cache — never persisted. I'm now on G3 and win it
+    // 11-7, so the true board is 2-1 for me. The finalize board must fold in the
+    // failed G2: post 2-1, not the 2-0 that dropping G2 would compact into
+    // (which would erase my opponent's game).
+    const user = userEvent.setup()
+    let finalizedBody: unknown = null
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          matchDetails({
+            id: 'm-1',
+            status: 'in_progress',
+            status_label: 'Live',
+            best_of: 3,
+            games_to_win: 2,
+            affects_rating: true,
+            sides: participantSides({ meWins: 1, oppWins: 0 }),
+            games: [{ id: 'g-1', game_number: 1, score: score('s-1', 11, 8) }],
+            current_game: { game_number: 2 },
+            can_score: true,
+            can_finalize: false,
+          }),
+        ),
+      ),
+      // G2's scratch save fails (500) — it never persists, so it only ever
+      // exists as a failed mutation in the cache.
+      http.post('*/v1/matches/m-1/games/2/scores/new', () =>
+        HttpResponse.json({ detail: 'boom' }, { status: 500 }),
+      ),
+      http.post('*/v1/matches/m-1/results', async ({ request }) => {
+        finalizedBody = await request.json()
+        return HttpResponse.json(
+          matchDetails({
+            id: 'm-1',
+            status: 'completed',
+            status_label: 'Final',
+            best_of: 3,
+            games_to_win: 2,
+            sides: participantSides({ meWins: 2, oppWins: 1, meWon: true }),
+            games: [
+              { id: 'g-1', game_number: 1, score: score('s-1', 11, 8) },
+              { id: 'g-2', game_number: 2, score: score('s-2', 9, 11) },
+              { id: 'g-3', game_number: 3, score: score('s-3', 11, 7) },
+            ],
+            current_game: null,
+            can_score: false,
+            can_finalize: false,
+          }),
+          { status: 201 },
+        )
+      }),
+    )
+
+    renderEntryWithFailedSibling({ gameNumber: 3, failGameNumber: 2 })
+
+    // Seed the failed G2 save into the shared mutation cache.
+    await user.click(await screen.findByRole('button', { name: 'fail game 2' }))
+    // The "Not saved" cell confirms the failure landed before we finalize.
+    await screen.findByText('Not saved')
+
+    const meInput = screen.getByRole('textbox', { name: 'rita.kovac score' })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    await user.type(meInput, '11')
+    await user.type(oppInput, '7')
+
+    // G3 clinches a 2-1 board (G1 me, G2 opp, G3 me), so the button finalizes.
+    const postBtn = await screen.findByRole('button', { name: /post result/i })
+    await user.click(postBtn)
+
+    await waitFor(() =>
+      expect(screen.getByText('match-page m-1')).toBeInTheDocument(),
+    )
+    // The failed G2 (9-11, my loss) is present — the board is 2-1, not the 2-0
+    // that omitting G2 would have compacted and posted.
+    expect(finalizedBody).toEqual({
+      games: [
+        { game_number: 1, side_1_points: 11, side_2_points: 8 },
+        { game_number: 2, side_1_points: 9, side_2_points: 11 },
+        { game_number: 3, side_1_points: 11, side_2_points: 7 },
       ],
     })
   })
@@ -1900,10 +2061,12 @@ describe('ScoreEntry — failed saves', () => {
   // Regression for the fully-offline path (QA BUG 1): with NO games persisted
   // server-side, entering game after game offline must keep advancing — the
   // next-game prediction has to count the failed scratch saves, not just
-  // `data.games`, or it bounces back to game 1 and the decided-match banner
-  // never appears. Bo3: two offline wins decide the match; we must land on
-  // game 3 with the finalize banner, then post the result online.
-  it('offline end-to-end: enter every game offline, advance correctly, then post the decided result', async () => {
+  // `data.games`, or it bounces back to game 1. Bo3 split G1 win / G2 loss so
+  // the board is still 1-1 after two offline games (no early clinch): we must
+  // advance G1→G2→G3 counting both failed saves. G3's win then finalizes the
+  // true 2-1 board — which, per #747-F2, must carry the FAILED game 2 that
+  // score-entry's board now folds in (dropping it would post a wrong 2-0).
+  it('offline: advance through every game counting failed saves, then finalize the true 2-1 board', async () => {
     const user = userEvent.setup()
     let resultsBody: unknown = null
     server.use(
@@ -1931,7 +2094,7 @@ describe('ScoreEntry — failed saves', () => {
             status_label: 'Final',
             best_of: 3,
             games_to_win: 2,
-            sides: participantSides({ meWins: 2, oppWins: 0, meWon: true }),
+            sides: participantSides({ meWins: 2, oppWins: 1, meWon: true }),
             current_game: null,
             can_score: false,
             can_finalize: false,
@@ -1945,7 +2108,7 @@ describe('ScoreEntry — failed saves', () => {
     await screen.findByRole('heading', { name: /enter game 1 score/i })
     onlineManager.setOnline(false)
 
-    // Game 1 offline → fails, advances to game 2.
+    // Game 1 offline (my win) → fails, advances to game 2.
     await user.type(
       screen.getByRole('textbox', { name: 'rita.kovac score' }),
       '11',
@@ -1954,36 +2117,43 @@ describe('ScoreEntry — failed saves', () => {
     await user.click(screen.getByRole('button', { name: /save game & next/i }))
     await screen.findByRole('heading', { name: /enter game 2 score/i })
 
-    // Game 2 offline → fails, and must advance to game 3 (NOT bounce back to
-    // game 1, which is the bug this guards).
+    // Game 2 offline (my loss) → still 1-1, undecided, so it must advance to
+    // game 3 (NOT bounce back to game 1 — the prediction has to count both
+    // failed scratch saves, which is the bug this guards).
+    await user.type(screen.getByRole('textbox', { name: 'rita.kovac score' }), '9')
+    await user.type(
+      screen.getByRole('textbox', { name: 'nguyen.t score' }),
+      '11',
+    )
+    await user.click(screen.getByRole('button', { name: /save game & next/i }))
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+
+    // Both offline games sit in the strip.
+    expect(
+      screen.getByRole('link', { name: /game 1 didn't save, 11 to 9/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /game 2 didn't save, 9 to 11/i }),
+    ).toBeInTheDocument()
+
+    // Back online, enter the deciding game 3. Its win clinches a 2-1 board — and
+    // the finalize board must fold in the FAILED game 2 (#747-F2), posting 2-1
+    // rather than dropping G2 and compacting to a wrong 2-0.
+    onlineManager.setOnline(true)
     await user.type(
       screen.getByRole('textbox', { name: 'rita.kovac score' }),
       '11',
     )
     await user.type(screen.getByRole('textbox', { name: 'nguyen.t score' }), '7')
-    await user.click(screen.getByRole('button', { name: /save game & next/i }))
-    await screen.findByRole('heading', { name: /enter game 3 score/i })
-
-    // Both offline games sit in the strip, and since they decide the Bo3 the
-    // banner offers to post the result.
-    expect(
-      screen.getByRole('link', { name: /game 1 didn't save, 11 to 9/i }),
-    ).toBeInTheDocument()
-    const banner = await screen.findByRole('alert')
-    expect(banner).toHaveTextContent('These scores finish the match.')
-
-    // Back online, post the result — both games are carried.
-    onlineManager.setOnline(true)
-    await user.click(
-      within(banner).getByRole('button', { name: /post result/i }),
-    )
+    await user.click(screen.getByRole('button', { name: /post result/i }))
     await waitFor(() =>
       expect(screen.getByText('match-page')).toBeInTheDocument(),
     )
     expect(resultsBody).toEqual({
       games: [
         { game_number: 1, side_1_points: 11, side_2_points: 9 },
-        { game_number: 2, side_1_points: 11, side_2_points: 7 },
+        { game_number: 2, side_1_points: 9, side_2_points: 11 },
+        { game_number: 3, side_1_points: 11, side_2_points: 7 },
       ],
     })
   })

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -42,10 +42,14 @@ import {
   deciderGameNumber,
   isDecidedMatch,
   overrunDecider,
-  type GamePoints,
 } from '@/lib/scoring'
 import { useNavigationOverrideRef } from '@/lib/use-navigation-override-ref'
-import { isScoreConflict, useGameSaveState } from './score-saves'
+import { reconstructBoard, scoredGamePoints } from './reconstruct-board'
+import {
+  isScoreConflict,
+  useFailedGameSaves,
+  useGameSaveState,
+} from './score-saves'
 import { SaveBanner } from './save-banner'
 import { ScorePad } from './score-pad'
 import {
@@ -55,19 +59,6 @@ import {
 
 /** The non-null persisted score on a game. */
 type PersistedScore = NonNullable<MatchDetails['games'][number]['score']>
-
-/** The persisted games as `GamePoints` for the scoring lib — drops un-scored
- * games and the side orientation, the shape `deciderGameNumber`/`overrunDecider`
- * expect. */
-function scoredGamePoints(games: MatchDetails['games']): GamePoints[] {
-  return games
-    .filter((g) => g.score)
-    .map((g) => ({
-      game_number: g.game_number,
-      side_1_points: g.score!.side_1_points,
-      side_2_points: g.score!.side_2_points,
-    }))
-}
 
 // Placeholder for the opponent label on solo matches — mirrors the match
 // details hero. Distinct from `initialsOf('Opponent')` so users can tell
@@ -117,6 +108,12 @@ function ScoreEntryInner({
   // used only to pre-fill the inputs after a failed save (the scoreline cells
   // and banner each read their own state).
   const ownSave = useGameSaveState(matchId, gameNumber)
+  // Every match game whose latest scratch save failed — needed so the finalize
+  // board folds in a game that failed on a *different* screen (issue #747-F2;
+  // ADR 0004). Conflicts are excluded below before the fold: their committed
+  // value is already persisted, and re-adding the rejected scratch would
+  // silently overwrite it.
+  const failedSaves = useFailedGameSaves(matchId)
 
   // `null` means "user hasn't typed anything yet" — we fall through to the
   // persisted score in edit mode. Avoids a state-syncing effect when `data`
@@ -361,21 +358,20 @@ function ScoreEntryInner({
   // so we can ask the scoring lib whether saving this entry would make the
   // match finalize-able. If so, the single submit button swaps to "Finalize
   // match" and posts /results instead of /scores/new.
+  //
+  // Reconstructed from all three sources (ADR 0004) via the shared helper the
+  // banner also uses: persisted ⊕ failed scratch ⊕ this game's live input. The
+  // failed-scratch fold is the #747-F2 fix — without it a game that failed to
+  // save on a different screen compacts out and a 2–1 board posts as 2–0.
+  // Conflicts are excluded (their committed value is already in `scoredGames`);
+  // the live input is layered last, so it wins for the active game even over its
+  // own failed scratch.
   const hypotheticalGames: MatchResultsGameWrite[] = inputsValid
-    ? [
-        ...scoredGames.filter((g) => g.game_number !== gameNumber),
-        mySideNumber === 1
-          ? {
-              game_number: gameNumber,
-              side_1_points: Number(me),
-              side_2_points: Number(opp),
-            }
-          : {
-              game_number: gameNumber,
-              side_1_points: Number(opp),
-              side_2_points: Number(me),
-            },
-      ]
+    ? reconstructBoard({
+        persisted: scoredGames,
+        failedSaves: failedSaves.filter((entry) => !entry.conflict),
+        activeInput: { game_number: gameNumber, ...toBody() },
+      })
     : []
   // The canonical board this entry would post — an out-of-order clinch's gap
   // closed (see `compactGames`), so the predicate and the posted payload below


### PR DESCRIPTION
## What & why

Fixes **#747-F2**: on the score-entry sheet, finalizing a match **dropped a game that had failed to save**, so a real **2–1 board posted as 2–0** — silently erasing a played game.

`score-entry` built its finalize board from **persisted scores + the active game's live input only**. A game that failed to save (e.g. G2, my loss) lives *only* in the client mutation cache — never persisted. It fell out of the board, `compactGames` renumbered the gap away, and the server accepted a clean, decided 2–0. The server can't catch this: a failed save never reached it, and propose mints exactly the board it's handed. (ADR 0003 / #747-B2 guards the *committed*-divergence case server-side; this one is inherently client-side — two complementary guards at two boundaries.)

### Repro (Bo3, you = poster)
1. G1: you win 11–8 → saves.
2. G2: you lose 9–11 → **force the save to fail** (drop network at submit). Fire-and-forget has already advanced you to G3; G2 shows "Not saved". Board is really 1–1.
3. Restore network. G3: you win 11–7 → true board **2–1**.
4. Tap **Post result** (not the banner's Retry) → **posts 2–0**, erasing G2.

## The fix

Extract a shared **`reconstructBoard()`** helper — ADR 0004's deferred end-state — that **both** `score-entry` and `save-banner` call to merge all three sources with precedence **live > failed > persisted**. This kills the two hand-rolled merges whose drift caused *both* #755 and #747-F2. The persisted→`GamePoints` mapping (`scoredGamePoints`) is shared too, so neither surface hand-rolls it.

- **Conflicts stay caller-excluded** — a conflicted save's committed value is already persisted; re-adding the rejected scratch would re-introduce the very overwrite the version guard prevents.
- **Scope: finalize board only.** The scoreline `decider` stays persisted-only (documented known limitation in ADR 0004).

### One intentional behavior change (please read before flagging the test edit)
`wouldFinalize` (the decision) and `compactedGames` (the posted payload) **must be the same board** — ADR 0002's invariant. Once the payload folds in failed saves, the decision must too. A consequence: score-entry now recognizes a clinch **one game earlier** when a prior failed save + the active input decide the match. This is *forced*, not incidental — the narrower "decide on one board, post another" alternative is exactly the divergence ADR 0002 forbids. One offline-flow test encoded the old blindness and was rewritten (split G1 win / G2 loss so it still guards the no-bounce-to-game-1 prediction); its decided-banner path stays covered in `save-banner.test.tsx`.

## Testing
- New `reconstruct-board.test.ts` (precedence, failed-save fold, active-input override).
- New `score-entry.test.tsx` regression: G2 failed on a non-active screen, G3 clinches → posts **2–1**, not 2–0.
- Full web-client suite **1184 pass**, tsc + build clean, lint clean, web-client Playwright e2e **133 pass**.
- Ran `/simplify` (shared `scoredGamePoints`, reused `toBody()`, flattened `activeInput`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193EVFniqEoe6n43NepyUzb
