### PR TITLE
Fix: corrections that remove a game are invisible in the "What changed" diff

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -339,33 +339,39 @@ def _negotiation_diff(
     standing_games: list[dict[str, int]],
 ) -> list[NegotiationDiffEntry]:
     """Viewer-relative diff between the viewer's own last proposal (baseline)
-    and the standing proposal. Emits an entry only for games whose points
-    differ (or that the baseline lacks → ``old=None``), ordered by game number.
-    Computed purely from the two snapshots; the chain walk to pick the baseline
-    is what collapses the opponent's intermediate self-edits."""
-    by_number = {g["game_number"]: g for g in baseline_games}
+    and the standing proposal. Emits one entry per game that differs, ordered by
+    game number over the union of both boards. A correction may add, remove, or
+    change games (a decided board can shorten or lengthen — CONTEXT.md
+    "Correction", ADR-0001), so an entry is one of:
+
+    - **added** — the standing board has a game the baseline lacked (``old=None``);
+    - **removed** — the baseline had a game the standing board dropped (``new=None``);
+    - **changed** — both present, points differ.
+
+    Unchanged games are skipped. Computed purely from the two snapshots; the
+    chain walk to pick the baseline is what collapses the opponent's intermediate
+    self-edits."""
+    baseline_by_number = {g["game_number"]: g for g in baseline_games}
+    standing_by_number = {g["game_number"]: g for g in standing_games}
     entries: list[NegotiationDiffEntry] = []
-    for game in sorted(standing_games, key=lambda g: g["game_number"]):
-        old = by_number.get(game["game_number"])
-        if old is None:
-            entries.append(
-                NegotiationDiffEntry(
-                    game_number=game["game_number"],
-                    old=None,
-                    new=_negotiation_game(game),
-                )
-            )
-        elif (
-            old["side_1_points"] != game["side_1_points"]
-            or old["side_2_points"] != game["side_2_points"]
+    for number in sorted(baseline_by_number.keys() | standing_by_number.keys()):
+        old = baseline_by_number.get(number)
+        new = standing_by_number.get(number)
+        if (
+            old is not None
+            and new is not None
+            and old["side_1_points"] == new["side_1_points"]
+            and old["side_2_points"] == new["side_2_points"]
         ):
-            entries.append(
-                NegotiationDiffEntry(
-                    game_number=game["game_number"],
-                    old=_negotiation_game(old),
-                    new=_negotiation_game(game),
-                )
+            continue  # unchanged — omit
+        # ``old``/``new`` null encode removed/added; both-present is a change.
+        entries.append(
+            NegotiationDiffEntry(
+                game_number=number,
+                old=_negotiation_game(old) if old is not None else None,
+                new=_negotiation_game(new) if new is not None else None,
             )
+        )
     return entries
 
 

--- a/api/app/schemas/match.py
+++ b/api/app/schemas/match.py
@@ -193,12 +193,24 @@ class NegotiationResult(BaseModel):
 
 class NegotiationDiffEntry(BaseModel):
     """One game's difference between the prior and standing result, so the FE
-    can highlight what changed in a correction."""
+    can highlight what changed in a correction. A correction may add, remove, or
+    change games (CONTEXT.md "Correction", ADR-0001), so an entry is one of:
+
+    - **added** — ``old`` is ``None`` (the standing board gained this game);
+    - **removed** — ``new`` is ``None`` (the standing board dropped this game);
+    - **changed** — both present, points differ.
+
+    At least one of ``old``/``new`` is always present."""
 
     game_number: int
-    # ``None`` if the game didn't exist in the baseline (prior) result.
     old: NegotiationGame | None
-    new: NegotiationGame
+    new: NegotiationGame | None
+
+    @model_validator(mode="after")
+    def _at_least_one_side(self) -> "NegotiationDiffEntry":
+        if self.old is None and self.new is None:
+            raise ValueError("a diff entry must have at least one of old/new")
+        return self
 
 
 # The viewer-relative phase of the result negotiation. ``live`` = no result

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1848,6 +1848,78 @@ async def test_propose_counter_chain_across_sides(
         assert len(results) == 3
 
 
+async def _propose_board(
+    client: AsyncClient,
+    match_id: str,
+    games: list[tuple[int, int]],
+    *,
+    supersedes: str | None = None,
+) -> dict:
+    """Propose a multi-game board (list of ``(side_1, side_2)`` per game).
+    Returns the response body wrapper (``status`` + ``body``)."""
+    body: dict[str, object] = {
+        "games": [
+            {"game_number": i, "side_1_points": s1, "side_2_points": s2}
+            for i, (s1, s2) in enumerate(games, start=1)
+        ]
+    }
+    if supersedes is not None:
+        body["supersedes_result_id"] = supersedes
+    response = await client.post(f"/v1/matches/{match_id}/results", json=body)
+    return {"status": response.status_code, "body": response.json()}
+
+
+async def test_negotiation_diff_shows_removed_game_when_board_shortens(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Regression: a correction that DROPS a game must surface in the diff.
+
+    Per CONTEXT.md "Correction" / ADR-0001 a correction may add, remove, or
+    change games. I propose a 3–1 board (four games); the opponent counters with
+    a 3–0 board (three games), which flips game 3's winner (so the board clinches
+    a game earlier) and drops game 4 entirely. From my view the diff must report
+    BOTH the game-3 change AND the game-4 removal (``new`` null), ordered by
+    game number — otherwise the accept decision is made on an understated diff."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "shorten-rival") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=5)
+        # My board: S1 wins g1,g2,g4; S2 wins g3 → 3–1, decided at game 4.
+        mine = await _propose_board(
+            api_client,
+            match["id"],
+            [(11, 4), (11, 4), (4, 11), (11, 4)],
+        )
+        assert mine["status"] == 201, mine
+        mine_id = mine["body"]["negotiation"]["standing_result"]["id"]
+
+        # Opponent counters: S1 sweeps g1–g3 → 3–0, decided at game 3, game 4 gone.
+        counter = await _propose_board(
+            opp_client,
+            match["id"],
+            [(11, 4), (11, 4), (11, 4)],
+            supersedes=mine_id,
+        )
+        assert counter["status"] == 201, counter
+
+        my_neg = (await api_client.get(f"/v1/matches/{match['id']}")).json()[
+            "negotiation"
+        ]
+        assert my_neg["viewer_state"] == "corrected"
+        # Game 1/2 unchanged → skipped. Game 3 changed, game 4 removed, in order.
+        assert my_neg["diff"] == [
+            {
+                "game_number": 3,
+                "old": {"game_number": 3, "side_1_points": 4, "side_2_points": 11},
+                "new": {"game_number": 3, "side_1_points": 11, "side_2_points": 4},
+            },
+            {
+                "game_number": 4,
+                "old": {"game_number": 4, "side_1_points": 11, "side_2_points": 4},
+                "new": None,
+            },
+        ]
+
+
 # ----- negotiation BFF oracle (SPEC §4 worked cases) ----------------------
 #
 # Each case below pins the EXPECTED viewer_state + diff from the SPEC, computed

--- a/docs/designs/match-result-model.md
+++ b/docs/designs/match-result-model.md
@@ -265,7 +265,7 @@ negotiation: {
     { id: uuid, games: [...], submitted_at: datetime } | null,
   diff:                               // server-computed, viewer-relative; null when there's nothing to compare
     { game_number: int, old: { side_1_points, side_2_points } | null,
-      new: { side_1_points, side_2_points } }[] | null
+      new: { side_1_points, side_2_points } | null }[] | null
 }
 ```
 
@@ -287,8 +287,17 @@ negotiation: {
 recent proposal in the chain made by the viewer's own side** — *not* the row
 immediately superseded. Walk the chain back from `standing_result` to the
 newest row whose `submitted_by` is on the viewer's side; that's `prior_result`.
-The diff is `prior_result.games` → `standing_result.games`, emitting only
-changed game numbers with old→new points. This **collapses the opponent's
+The diff is `prior_result.games` → `standing_result.games`, emitting one entry
+per game that differs, ordered by `game_number` over the **union** of both
+boards. Because a correction may add, remove, or change games (a decided board
+can shorten or lengthen — CONTEXT.md "Correction", ADR-0001), each entry is one
+of three kinds:
+
+- **added** — `old` is `null` (the standing board gained this game);
+- **removed** — `new` is `null` (the standing board dropped this game);
+- **changed** — both present, points differ.
+
+Never both `null`; unchanged games are omitted. This **collapses the opponent's
 intermediate self-edits**: the viewer sees "what changed since I last spoke",
 not the opponent's churn. `diff` is `null` when `prior_result` is `null`
 (the viewer has nothing of their own to compare — e.g. `review`).
@@ -307,6 +316,10 @@ Worked cases (chain written oldest→newest; `A`/`B` = who proposed):
 - **opponent flip-flop then the viewer reads** — `[R1·A, R2·B, R3·B]`. Viewer
   **A**: `corrected`, `prior_result = R1`, `diff = R1→R3` — collapses B's R2/R3
   self-edits to a single "since you proposed R1" diff.
+- **shortening counter** — A proposes a 3–1 board (four games); B counters with a
+  3–0 board (three games). Viewer **A**: `corrected`, `prior_result = R1`, and the
+  diff carries a **changed** entry for the flipped game plus a **removed** entry
+  (`new` null) for the dropped game 4 — the board shortening is not silent.
 - **final** — standing row accepted. `viewer_state = final` for both;
   `standing_result` is the accepted row; the FE shows "confirmed" or "agreed
   after N corrections" (N = chain length − 1).

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -3410,7 +3410,14 @@ internal enum Components {
             }
         }
         /// One game's difference between the prior and standing result, so the FE
-        /// can highlight what changed in a correction.
+        /// can highlight what changed in a correction. A correction may add, remove, or
+        /// change games (CONTEXT.md "Correction", ADR-0001), so an entry is one of:
+        ///
+        /// - **added** — ``old`` is ``None`` (the standing board gained this game);
+        /// - **removed** — ``new`` is ``None`` (the standing board dropped this game);
+        /// - **changed** — both present, points differ.
+        ///
+        /// At least one of ``old``/``new`` is always present.
         ///
         /// - Remark: Generated from `#/components/schemas/NegotiationDiffEntry`.
         internal struct NegotiationDiffEntry: Codable, Hashable, Sendable {
@@ -3437,7 +3444,25 @@ internal enum Components {
             /// - Remark: Generated from `#/components/schemas/NegotiationDiffEntry/old`.
             internal var old: Components.Schemas.NegotiationDiffEntry.OldPayload?
             /// - Remark: Generated from `#/components/schemas/NegotiationDiffEntry/new`.
-            internal var new: Components.Schemas.NegotiationGame
+            internal struct NewPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/NegotiationDiffEntry/new/value1`.
+                internal var value1: Components.Schemas.NegotiationGame
+                /// Creates a new `NewPayload`.
+                ///
+                /// - Parameters:
+                ///   - value1:
+                internal init(value1: Components.Schemas.NegotiationGame) {
+                    self.value1 = value1
+                }
+                internal init(from decoder: any Swift.Decoder) throws {
+                    self.value1 = try .init(from: decoder)
+                }
+                internal func encode(to encoder: any Swift.Encoder) throws {
+                    try self.value1.encode(to: encoder)
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/NegotiationDiffEntry/new`.
+            internal var new: Components.Schemas.NegotiationDiffEntry.NewPayload?
             /// Creates a new `NegotiationDiffEntry`.
             ///
             /// - Parameters:
@@ -3447,7 +3472,7 @@ internal enum Components {
             internal init(
                 gameNumber: Swift.Int,
                 old: Components.Schemas.NegotiationDiffEntry.OldPayload? = nil,
-                new: Components.Schemas.NegotiationGame
+                new: Components.Schemas.NegotiationDiffEntry.NewPayload? = nil
             ) {
                 self.gameNumber = gameNumber
                 self.old = old

--- a/ios/Fortymm/MatchFlow/MatchAPI.swift
+++ b/ios/Fortymm/MatchFlow/MatchAPI.swift
@@ -139,13 +139,14 @@ struct NegotiationResultDTO: Decodable {
     let games: [NegotiationGameDTO]
 }
 
-/// One changed game between the viewer's prior proposal and the standing
-/// correction (`NegotiationDiffEntry`). `old == nil` means the correction added
-/// this game.
+/// One game the standing correction added, removed, or changed relative to the
+/// viewer's prior proposal (`NegotiationDiffEntry`). A correction may add,
+/// remove, or change games: `old == nil` means the game was added; `new == nil`
+/// means it was removed. At least one is always present.
 struct NegotiationDiffEntryDTO: Decodable {
     let gameNumber: Int
     let old: NegotiationGameDTO?
-    let new: NegotiationGameDTO
+    let new: NegotiationGameDTO?
 }
 
 /// Mirror of `MatchNegotiation` — always present on both the detail and list

--- a/ios/Fortymm/MatchFlow/MatchDetailView.swift
+++ b/ios/Fortymm/MatchFlow/MatchDetailView.swift
@@ -256,10 +256,12 @@ struct MatchDetailView: View {
 
     // MARK: What changed (corrected-phase diff)
 
-    /// The server-computed per-game diff between the viewer's prior proposal
-    /// and the standing correction: old score struck through → new score, with
-    /// newly-added games flagged. Scores are canonical side-1–side-2, matching
-    /// the web's ScoreDiff.
+    /// The server-computed per-game diff between the viewer's prior proposal and
+    /// the standing correction. A correction may add, remove, or change games:
+    /// a changed game shows old struck through → new; an added game is flagged
+    /// "NEW GAME"; a removed game (`new == nil`) shows its old score struck
+    /// through and is flagged "REMOVED GAME". Scores are canonical
+    /// side-1–side-2, matching the web's ScoreDiff.
     private func whatChangedSection(_ diff: [ScoreDiffEntry]) -> some View {
         Section_("What changed") {
             VStack(spacing: 0) {
@@ -276,18 +278,27 @@ struct MatchDetailView: View {
                                 .font(FMFont.mono(15, weight: .semibold))
                                 .strikethrough()
                                 .foregroundStyle(FMColor.loss)
-                            Image(systemName: "arrow.right")
-                                .font(.system(size: 11, weight: .semibold))
-                                .foregroundStyle(FMColor.fgMuted)
+                        }
+                        if let new = entry.new {
+                            if entry.old != nil {
+                                Image(systemName: "arrow.right")
+                                    .font(.system(size: 11, weight: .semibold))
+                                    .foregroundStyle(FMColor.fgMuted)
+                            } else {
+                                Text("NEW GAME")
+                                    .font(FMFont.ui(9, weight: .semibold))
+                                    .tracking(1.0)
+                                    .foregroundStyle(FMColor.fgMuted)
+                            }
+                            Text(new)
+                                .font(FMFont.mono(15, weight: .bold))
+                                .foregroundStyle(FMColor.serve500)
                         } else {
-                            Text("NEW GAME")
+                            Text("REMOVED GAME")
                                 .font(FMFont.ui(9, weight: .semibold))
                                 .tracking(1.0)
                                 .foregroundStyle(FMColor.fgMuted)
                         }
-                        Text(entry.new)
-                            .font(FMFont.mono(15, weight: .bold))
-                            .foregroundStyle(FMColor.serve500)
                     }
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)

--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -86,14 +86,15 @@ struct Game: Hashable {
 
 // MARK: - Result negotiation (view model)
 
-/// One changed game between the viewer's prior proposal and the standing
-/// correction, pre-formatted for display. Scores are canonical side-1–side-2,
-/// matching the web's `ScoreDiff` rendering.
+/// One game the standing correction added, removed, or changed relative to the
+/// viewer's prior proposal, pre-formatted for display. Scores are canonical
+/// side-1–side-2, matching the web's `ScoreDiff` rendering.
 struct ScoreDiffEntry: Identifiable {
     let gameNumber: Int
     /// "11–7" as previously proposed; nil when the correction added this game.
     let old: String?
-    let new: String
+    /// "11–7" as now proposed; nil when the correction removed this game.
+    let new: String?
     var id: Int { gameNumber }
 }
 

--- a/ios/Fortymm/MatchFlow/MatchService.swift
+++ b/ios/Fortymm/MatchFlow/MatchService.swift
@@ -201,7 +201,7 @@ struct MatchService {
             ScoreDiffEntry(
                 gameNumber: entry.gameNumber,
                 old: entry.old.map(fmt),
-                new: fmt(entry.new)
+                new: entry.new.map(fmt)
             )
         }
         return MatchNegotiation(

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1686,13 +1686,20 @@ export interface components {
         /**
          * NegotiationDiffEntry
          * @description One game's difference between the prior and standing result, so the FE
-         *     can highlight what changed in a correction.
+         *     can highlight what changed in a correction. A correction may add, remove, or
+         *     change games (CONTEXT.md "Correction", ADR-0001), so an entry is one of:
+         *
+         *     - **added** — ``old`` is ``None`` (the standing board gained this game);
+         *     - **removed** — ``new`` is ``None`` (the standing board dropped this game);
+         *     - **changed** — both present, points differ.
+         *
+         *     At least one of ``old``/``new`` is always present.
          */
         NegotiationDiffEntry: {
             /** Game Number */
             game_number: number;
             old: components["schemas"]["NegotiationGame"] | null;
-            new: components["schemas"]["NegotiationGame"];
+            new: components["schemas"]["NegotiationGame"] | null;
         };
         /**
          * NegotiationGame

--- a/web-client/src/components/matches/match-details/score-diff/score-diff.factory.tsx
+++ b/web-client/src/components/matches/match-details/score-diff/score-diff.factory.tsx
@@ -18,7 +18,8 @@ export function buildNegotiationGame(
 
 /**
  * One diff entry. By default a *changed* game (both `old` and `new` present);
- * pass `old: null` to model a newly-added game.
+ * pass `old: null` to model a newly-added game, or `new: null` (with a
+ * `game_number`) to model a removed game.
  */
 export function buildNegotiationDiffEntry(
   overrides: Partial<NegotiationDiffEntry> = {},

--- a/web-client/src/components/matches/match-details/score-diff/score-diff.page.tsx
+++ b/web-client/src/components/matches/match-details/score-diff/score-diff.page.tsx
@@ -26,9 +26,17 @@ const scoped = (container: Container) => ({
   getNew(gameNumber: number) {
     return container.getByTestId(`score-diff-new-${gameNumber}`);
   },
+  /** The emphasized new score for game `n`; absent when the game was removed. */
+  queryNew(gameNumber: number) {
+    return container.queryByTestId(`score-diff-new-${gameNumber}`);
+  },
   /** The "new game" tag rendered only for added games (`old === null`). */
   queryAddedTag(gameNumber: number) {
     return container.queryByTestId(`score-diff-added-${gameNumber}`);
+  },
+  /** The "removed game" tag rendered only for removed games (`new === null`). */
+  queryRemovedTag(gameNumber: number) {
+    return container.queryByTestId(`score-diff-removed-${gameNumber}`);
   },
 });
 

--- a/web-client/src/components/matches/match-details/score-diff/score-diff.test.tsx
+++ b/web-client/src/components/matches/match-details/score-diff/score-diff.test.tsx
@@ -65,6 +65,67 @@ describe("ScoreDiff", () => {
     expect(scoreDiffPage.queryAddedTag(5)).toBeInTheDocument();
   });
 
+  it("renders a removed game (new === null) as struck-through old with a removed tag", () => {
+    scoreDiffPage.render({
+      diff: [
+        buildNegotiationDiffEntry({
+          game_number: 4,
+          old: buildNegotiationGame({
+            game_number: 4,
+            side_1_points: 11,
+            side_2_points: 4,
+          }),
+          new: null,
+        }),
+      ],
+    });
+
+    // The dropped game shows its old score struck through and a "removed" tag,
+    // with no new score.
+    const old = scoreDiffPage.queryOld(4);
+    expect(old).toHaveTextContent("11–4");
+    expect(old).toHaveClass("line-through");
+    expect(scoreDiffPage.queryNew(4)).not.toBeInTheDocument();
+    expect(scoreDiffPage.queryRemovedTag(4)).toBeInTheDocument();
+  });
+
+  it("renders a shortening correction: a changed game plus a removed tail game", () => {
+    // Mirrors the API oracle (3–1 → 3–0): game 3 flips, game 4 is dropped.
+    scoreDiffPage.render({
+      diff: [
+        buildNegotiationDiffEntry({
+          game_number: 3,
+          old: buildNegotiationGame({
+            game_number: 3,
+            side_1_points: 4,
+            side_2_points: 11,
+          }),
+          new: buildNegotiationGame({
+            game_number: 3,
+            side_1_points: 11,
+            side_2_points: 4,
+          }),
+        }),
+        buildNegotiationDiffEntry({
+          game_number: 4,
+          old: buildNegotiationGame({
+            game_number: 4,
+            side_1_points: 11,
+            side_2_points: 4,
+          }),
+          new: null,
+        }),
+      ],
+    });
+
+    // The board shortening is visible: game 4's removal is not silently dropped.
+    expect(scoreDiffPage.getNew(3)).toHaveTextContent("11–4");
+    expect(scoreDiffPage.queryRemovedTag(3)).not.toBeInTheDocument();
+    expect(scoreDiffPage.queryNew(4)).not.toBeInTheDocument();
+    expect(scoreDiffPage.queryRemovedTag(4)).toBeInTheDocument();
+    expect(scoreDiffPage.queryOld(4)).toHaveTextContent("11–4");
+  });
+
   it("renders a multi-game diff mixing a changed game and an added game", () => {
     scoreDiffPage.render({
       diff: [

--- a/web-client/src/components/matches/match-details/score-diff/score-diff.tsx
+++ b/web-client/src/components/matches/match-details/score-diff/score-diff.tsx
@@ -7,9 +7,9 @@ type NegotiationDiffEntry = components["schemas"]["NegotiationDiffEntry"];
 export interface ScoreDiffProps {
   /**
    * The server-computed per-game diff (`negotiation.diff`). Each entry is a
-   * game that changed between the viewer's prior proposal and the standing
-   * correction; unchanged games are simply absent. We render the shape as-is —
-   * no client-side diffing.
+   * game the correction added, removed, or changed relative to the viewer's
+   * prior proposal; unchanged games are simply absent. We render the shape
+   * as-is — no client-side diffing.
    */
   diff: NegotiationDiffEntry[];
 }
@@ -20,9 +20,11 @@ function formatGame(game: { side_1_points: number; side_2_points: number }) {
 }
 
 /**
- * Presentational correction diff. For each entry it shows "Game N" with the
- * old score struck through and the new score emphasized. When `old` is null the
- * game was newly added by the correction, so it renders without a strikethrough.
+ * Presentational correction diff. For each entry it shows "Game N" with the old
+ * score struck through and the new score emphasized. A correction may add,
+ * remove, or change games (CONTEXT.md "Correction"): when `old` is null the
+ * game was newly added (no strikethrough); when `new` is null the game was
+ * removed (struck-through old, a "removed game" badge, no new score).
  */
 export const ScoreDiff = ({ diff }: ScoreDiffProps) => {
   return (
@@ -31,6 +33,7 @@ export const ScoreDiff = ({ diff }: ScoreDiffProps) => {
       <ul className="mt-1 grid gap-1.5">
         {diff.map((entry) => {
           const isAdded = entry.old === null;
+          const isRemoved = entry.new === null;
           return (
             <li
               key={entry.game_number}
@@ -52,25 +55,34 @@ export const ScoreDiff = ({ diff }: ScoreDiffProps) => {
                 aria-hidden
                 className={cn(
                   "text-muted-foreground",
-                  entry.old === null && "sr-only",
+                  (isAdded || isRemoved) && "sr-only",
                 )}
               >
                 {"→"}
               </span>
-              <span
-                data-testid={`score-diff-new-${entry.game_number}`}
-                className="font-mono font-semibold text-[color:var(--win)]"
-              >
-                {formatGame(entry.new)}
-                {isAdded && (
-                  <span
-                    data-testid={`score-diff-added-${entry.game_number}`}
-                    className="ml-2 text-xs font-normal uppercase tracking-wide text-muted-foreground"
-                  >
-                    new game
-                  </span>
-                )}
-              </span>
+              {entry.new !== null ? (
+                <span
+                  data-testid={`score-diff-new-${entry.game_number}`}
+                  className="font-mono font-semibold text-[color:var(--win)]"
+                >
+                  {formatGame(entry.new)}
+                  {isAdded && (
+                    <span
+                      data-testid={`score-diff-added-${entry.game_number}`}
+                      className="ml-2 text-xs font-normal uppercase tracking-wide text-muted-foreground"
+                    >
+                      new game
+                    </span>
+                  )}
+                </span>
+              ) : (
+                <span
+                  data-testid={`score-diff-removed-${entry.game_number}`}
+                  className="text-xs font-normal uppercase tracking-wide text-muted-foreground"
+                >
+                  removed game
+                </span>
+              )}
             </li>
           );
         })}


### PR DESCRIPTION
## Problem

A match-result **correction** may add, remove, or change games (CONTEXT.md → *Correction*, ADR-0001), but a **removal was unrepresentable end-to-end**:

- `_negotiation_diff` (`api/app/matches.py`) built a lookup from the baseline then iterated **only the standing board**, so a game present in the viewer's prior proposal but dropped by the counter was never emitted.
- `NegotiationDiffEntry.new` was non-nullable, so even a found removal couldn't be put on the wire.

A shortening counter (e.g. `3–1` → `3–0`) therefore **understated the "What changed" diff** — the accepter decided on incomplete information, never seeing that a game they'd claimed was dropped.

The domain model already promised removal; only the implementation and wire shape lagged. This closes that gap.

## Fix

- **API** — `_negotiation_diff` walks the **union** of both boards' game numbers, emitting `added` (`old` null), `removed` (`new` null), and `changed` entries in game-number order. `NegotiationDiffEntry.new` is now nullable, guarded by an "at least one of `old`/`new` present" `model_validator`.
- **Web** — `ScoreDiff` renders a removed game as a struck-through old score + a "removed game" badge, symmetric to the existing added-game row.
- **iOS** — `whatChangedSection` gains a "REMOVED GAME" branch; the DTO/view-model `new` fields become optional.
- **Types + docs** — regenerated `schema.d.ts` and `Types.swift`; amended spec §7 to document the three entry kinds and the nullable-pair encoding (no new ADR — subordinate to ADR-0001; no glossary change — CONTEXT.md was already correct).

## Testing

- **API:** ruff / ruff format / mypy clean; `pytest` **544 passed**, including a new oracle `test_negotiation_diff_shows_removed_game_when_board_shortens` (3–1 → 3–0 yields a changed entry for the flipped game + a removed entry for the dropped tail game).
- **Web:** vitest **1180 passed** (2 new removed-game tests in `score-diff.test.tsx`); lint 0 errors; `tsc -b && vite build` ✓; Playwright e2e **133 passed**.
- **OpenAPI drift:** regenerating `schema.d.ts` + `Types.swift` produces only the intended nullable-`new` change.
- **iOS:** clean simulator build — **BUILD SUCCEEDED**.
- Root e2e skipped (no stack up; change covered by the suites above and no root spec exercises this path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeEBVzfc9spieKWwFbm4Pn