### PR TITLE
Fix five easy backlog bugs (#813, #247, #278, #753, #811)

### DIFF
--- a/api/app/notifications/service.py
+++ b/api/app/notifications/service.py
@@ -18,6 +18,7 @@ from typing import Any, assert_never, cast
 
 from sqlalchemy import ColumnElement, CursorResult, delete, func, select, update
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import queue as queue_module
@@ -232,13 +233,30 @@ class NotificationService:
             result.in_app_created = True
 
         if NotificationChannel.PUSH in effective:
-            result.pushed = await self.send_to_user(
-                user_id,
-                title=title,
-                body=body,
-                category=push_category,
-                data=push_data,
-            )
+            # Push is best-effort and must never sink the whole notification:
+            # the in-app row above is already committed, and the email below
+            # still needs to enqueue. The APNs client already self-guards its
+            # own send (a bad auth key returns FAILED rather than raising, see
+            # apns.py), so the residual raiser on this path is a DB error from
+            # the device-token query or the gone-token prune — catch that
+            # specifically (not a bare Exception, which would also swallow the
+            # programmer errors we want to surface) so a Redis/DB flap can't
+            # drop the email (#753). Roll back so the failed push transaction
+            # doesn't taint the session for the email enqueue below.
+            try:
+                result.pushed = await self.send_to_user(
+                    user_id,
+                    title=title,
+                    body=body,
+                    category=push_category,
+                    data=push_data,
+                )
+            except SQLAlchemyError:
+                await self._db.rollback()
+                log.exception(
+                    "Push delivery failed; continuing with remaining channels",
+                    extra={"user_id": str(user_id), "category": category.value},
+                )
 
         if (
             NotificationChannel.EMAIL in effective

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
+import redis.exceptions
 from coolname import generate_slug
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
 from pyrate_limiter import Duration, Rate
@@ -764,7 +765,12 @@ def _enqueue_rating_recompute_after_merge(user_id: uuid.UUID) -> None:
     leave the DB inconsistent because the merge stands on its own. We
     log+swallow enqueue failures rather than fail the sign-in: the recompute
     is recoverable (re-run by admin tool or re-fire on next login), but a
-    failed sign-in here is user-visible breakage."""
+    failed sign-in here is user-visible breakage.
+
+    We catch only the Redis/connection failures we mean to tolerate — a
+    programmer error here (a signature mismatch in the recompute job, an
+    ImportError from a rename) should crash loudly in tests, not hide behind a
+    log line."""
     try:
         queue_module.get_ratings_queue().enqueue(
             RECOMPUTE_AFTER_MERGE_JOB,
@@ -772,7 +778,7 @@ def _enqueue_rating_recompute_after_merge(user_id: uuid.UUID) -> None:
             result_ttl=60,
             failure_ttl=86400,
         )
-    except Exception:
+    except (redis.exceptions.RedisError, ConnectionError, TimeoutError):
         log.exception(
             "Failed to enqueue rating recompute after merge",
             extra={"user_id": str(user_id)},
@@ -1150,12 +1156,6 @@ async def request_login_email(
     piece of mail either way — rather than the unknown case silently
     delivering nothing.
 
-    Accounts whose email hasn't been confirmed yet get the confirmation
-    link re-sent instead of a sign-in link. The login token would let
-    someone sign in without proving control of the inbox; the confirmation
-    link clears that hurdle and (per ``confirm_email``) rotates them into
-    a session anyway.
-
     Records the requesting browser's guest on the token so the merge it drives
     is token-bound (follows the guest cross-device), mirroring the settings
     merge flow.
@@ -1167,15 +1167,14 @@ async def request_login_email(
 
     await _verify_captcha_or_400(payload.captcha_token)
 
+    # ``users.email`` is only ever set by ``confirm_email`` (alongside
+    # ``confirmed_at``), so an address lookup can only ever match a confirmed
+    # account — there is no unconfirmed-user branch to handle here.
     user = (
         await db.execute(select(User).where(User.email == email))
     ).scalar_one_or_none()
     if user is None:
         await _send_no_account_email_or_503(email)
-        return LoginRequestAccepted(email=email)
-
-    if user.confirmed_at is None:
-        await _issue_and_send_confirmation_email(db, user, email)
         return LoginRequestAccepted(email=email)
 
     guest_id = await _requesting_guest_id(db, session_cookie, target=user)
@@ -1246,35 +1245,6 @@ async def _issue_and_send_login_email(
     )
     try:
         job = _enqueue_login_email(email, raw_token, user.username)
-    except Exception:
-        await db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Email service unavailable. Try again in a moment.",
-        ) from None
-    try:
-        await db.commit()
-    except Exception:
-        await db.rollback()
-        try:
-            job.cancel()
-        except Exception:
-            pass
-        raise
-
-
-async def _issue_and_send_confirmation_email(
-    db: AsyncSession, user: User, email: str
-) -> None:
-    """Re-issue this user's pending email-confirmation link. Preserves the
-    prior change-token's context so the audit trail still records what the
-    user was originally changing away from."""
-    prior = await _pending_change_token(db, user.id)
-    raw_token = await _issue_confirmation_token(
-        db, user, email, prior.context if prior else _email_change_context(None)
-    )
-    try:
-        job = _enqueue_confirmation_email(email, raw_token, user.username)
     except Exception:
         await db.rollback()
         raise HTTPException(

--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -155,15 +155,14 @@ async def test_request_for_unknown_email_sends_no_account_email_without_token(
     assert job.args == ("rita@example.com",)
 
 
-async def test_request_for_unconfirmed_account_resends_confirmation(
+async def test_request_for_emailed_account_always_issues_login_link(
     api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
 ):
-    """An account whose email isn't confirmed yet gets the confirmation
-    link re-sent instead of a sign-in link, so the user has a path
-    forward. Response shape stays identical for enumeration safety."""
-    user = User(username="pending", email="rita@example.com", confirmed_at=None)
-    db_session.add(user)
-    await db_session.commit()
+    """``users.email`` is only ever set by ``confirm_email`` (alongside
+    ``confirmed_at``), so an address lookup can only match a confirmed
+    account — there is no unconfirmed-resend branch. A found account always
+    gets a sign-in link, never a confirmation re-send. (#278)"""
+    await _make_confirmed_user(db_session, "rita@example.com")
 
     response = await api_client.post("/v1/login/request", json=REQUEST_BODY)
     assert response.status_code == 202
@@ -178,7 +177,8 @@ async def test_request_for_unconfirmed_account_resends_confirmation(
         .scalars()
         .all()
     )
-    assert login_tokens == []
+    assert len(login_tokens) == 1
+    assert login_tokens[0].sent_to == "rita@example.com"
 
     change_tokens = (
         (
@@ -189,11 +189,14 @@ async def test_request_for_unconfirmed_account_resends_confirmation(
         .scalars()
         .all()
     )
-    assert len(change_tokens) == 1
-    assert change_tokens[0].sent_to == "rita@example.com"
-    assert change_tokens[0].user_id == user.id
+    assert change_tokens == []
 
     assert fake_email_queue.finished_job_registry.count == 1
+    job = fake_email_queue.fetch_job(
+        fake_email_queue.finished_job_registry.get_job_ids()[0]
+    )
+    assert job is not None
+    assert job.func_name == "app.email.send_login_email"
 
 
 async def test_request_replaces_prior_login_token_for_same_user(

--- a/api/tests/test_notification_preferences.py
+++ b/api/tests/test_notification_preferences.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 
 from httpx import AsyncClient
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import (
@@ -326,6 +327,46 @@ async def test_notify_defaults_deliver_in_app_push_and_email(
     assert result.pushed == 1
     assert result.emailed is True
     assert [p.token for p in sender.sent] == [f"tok-{user.id}"]
+    stored = (
+        (
+            await db_session.execute(
+                select(Notification).where(Notification.user_id == user.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [n.title for n in stored] == ["Draw posted"]
+
+
+async def test_notify_push_failure_does_not_drop_email(db_session: AsyncSession):
+    """#753: a DB error on the push path (device-token query or gone-token
+    prune) must not sink the whole notification — the in-app row is already
+    committed and the email still has to enqueue. The push branch catches the
+    SQLAlchemyError, rolls back, and lets the remaining channels proceed."""
+
+    class DbFlappingService(NotificationService):
+        async def _tokens_for_user(self, user_id):
+            raise SQLAlchemyError("db connection lost mid-push")
+
+    user = await make_user(db_session, "push-explodes")
+    user.email = "boom@example.com"
+    user.confirmed_at = datetime.now(UTC)
+    await db_session.commit()
+    await _add_device(db_session, user.id)
+
+    service = DbFlappingService(db_session, FakeSender())
+    result = await service.notify(
+        user_id=user.id,
+        category=NotificationCategory.TOURNAMENT,
+        title="Draw posted",
+        body="R16 is live",
+    )
+
+    # Push failed silently; the durable in-app row and the email both survive.
+    assert result.pushed == 0
+    assert result.in_app_created is True
+    assert result.emailed is True
     stored = (
         (
             await db_session.execute(

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -79,12 +79,6 @@ internal protocol APIProtocol: Sendable {
     /// piece of mail either way — rather than the unknown case silently
     /// delivering nothing.
     ///
-    /// Accounts whose email hasn't been confirmed yet get the confirmation
-    /// link re-sent instead of a sign-in link. The login token would let
-    /// someone sign in without proving control of the inbox; the confirmation
-    /// link clears that hurdle and (per ``confirm_email``) rotates them into
-    /// a session anyway.
-    ///
     /// Records the requesting browser's guest on the token so the merge it drives
     /// is token-bound (follows the guest cross-device), mirroring the settings
     /// merge flow.
@@ -580,12 +574,6 @@ extension APIProtocol {
     /// indistinguishable from the outside — same status, same shape, and a
     /// piece of mail either way — rather than the unknown case silently
     /// delivering nothing.
-    ///
-    /// Accounts whose email hasn't been confirmed yet get the confirmation
-    /// link re-sent instead of a sign-in link. The login token would let
-    /// someone sign in without proving control of the inbox; the confirmation
-    /// link clears that hurdle and (per ``confirm_email``) rotates them into
-    /// a session anyway.
     ///
     /// Records the requesting browser's guest on the token so the merge it drives
     /// is token-bound (follows the guest cross-device), mirroring the settings
@@ -7446,12 +7434,6 @@ internal enum Operations {
     /// indistinguishable from the outside — same status, same shape, and a
     /// piece of mail either way — rather than the unknown case silently
     /// delivering nothing.
-    ///
-    /// Accounts whose email hasn't been confirmed yet get the confirmation
-    /// link re-sent instead of a sign-in link. The login token would let
-    /// someone sign in without proving control of the inbox; the confirmation
-    /// link clears that hurdle and (per ``confirm_email``) rotates them into
-    /// a session anyway.
     ///
     /// Records the requesting browser's guest on the token so the merge it drives
     /// is token-bound (follows the guest cross-device), mirroring the settings

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -139,12 +139,6 @@ export interface paths {
          *     piece of mail either way — rather than the unknown case silently
          *     delivering nothing.
          *
-         *     Accounts whose email hasn't been confirmed yet get the confirmation
-         *     link re-sent instead of a sign-in link. The login token would let
-         *     someone sign in without proving control of the inbox; the confirmation
-         *     link clears that hurdle and (per ``confirm_email``) rotates them into
-         *     a session anyway.
-         *
          *     Records the requesting browser's guest on the token so the merge it drives
          *     is token-bound (follows the guest cross-device), mirroring the settings
          *     merge flow.

--- a/web-client/src/components/dashboard/first-match/first-match-card.test.tsx
+++ b/web-client/src/components/dashboard/first-match/first-match-card.test.tsx
@@ -111,6 +111,48 @@ describe('FirstMatchCard', () => {
     expect(screen.getByRole('button', { name: /start scoring/i })).toBeDisabled()
   })
 
+  it('warns before discarding a picked opponent on navigation (#811)', async () => {
+    const { router } = renderFirstMatchCard()
+    await pickNguyen()
+
+    // Attempt to leave for another route while the hero holds a picked
+    // opponent — the blocker should intercept and open the confirmation.
+    act(() => {
+      void router.navigate({ to: '/settings' })
+    })
+
+    expect(
+      await screen.findByRole('alertdialog', { name: 'Discard changes?' }),
+    ).toBeInTheDocument()
+
+    // "Keep editing" stays put.
+    await userEvent.click(screen.getByRole('button', { name: 'Keep editing' }))
+    expect(router.state.location.pathname).toBe('/')
+
+    // "Discard & leave" lets the navigation through.
+    act(() => {
+      void router.navigate({ to: '/settings' })
+    })
+    await screen.findByRole('alertdialog', { name: 'Discard changes?' })
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Discard & leave' }),
+    )
+    await screen.findByText('settings route')
+    expect(router.state.location.pathname).toBe('/settings')
+  })
+
+  it('does not block navigation before an opponent is picked (#811)', async () => {
+    const { router } = renderFirstMatchCard()
+    await screen.findByRole('combobox')
+
+    act(() => {
+      void router.navigate({ to: '/settings' })
+    })
+
+    await screen.findByText('settings route')
+    expect(router.state.location.pathname).toBe('/settings')
+  })
+
   it('creates the match and navigates to scoring on submit', async () => {
     const { router } = renderFirstMatchCard()
     await pickNguyen()

--- a/web-client/src/components/dashboard/first-match/first-match-card.tsx
+++ b/web-client/src/components/dashboard/first-match/first-match-card.tsx
@@ -15,16 +15,7 @@ import { useStartMatch } from '@/components/matches/match-setup/use-start-match'
 import { Card } from '@/components/dashboard/your-game-row/card'
 import { C, MONO, UI } from '@/components/dashboard/dashboard-tokens'
 import { Overline } from '@/components/overline'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
+import { DiscardMatchSetupDialog } from '@/components/matches/match-setup/discard-match-setup-dialog'
 import '@/components/matches/match-setup/match-setup.css'
 
 /**
@@ -55,9 +46,10 @@ export const FirstMatchCard = () => {
   // `useBlocker` + `AlertDialog` treatment here (#811). `hasSucceeded()` reads
   // a ref so the post-create redirect isn't itself blocked.
   const isDirty = opponent !== null
+  const shouldBlock = () => isDirty && !hasSucceeded()
   const blocker = useBlocker({
-    shouldBlockFn: () => isDirty && !hasSucceeded(),
-    enableBeforeUnload: () => isDirty && !hasSucceeded(),
+    shouldBlockFn: shouldBlock,
+    enableBeforeUnload: shouldBlock,
     withResolver: true,
   })
 
@@ -179,36 +171,11 @@ export const FirstMatchCard = () => {
         )}
       </div>
 
-      <AlertDialog
+      <DiscardMatchSetupDialog
         open={blocker.status === 'blocked'}
-        onOpenChange={(open) => {
-          // Radix fires onOpenChange(false) on overlay click / Escape — treat
-          // that as "stay" so a stray dismiss never discards the picked
-          // opponent.
-          if (!open) blocker.reset?.()
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Discard changes?</AlertDialogTitle>
-            <AlertDialogDescription>
-              You've picked an opponent or changed the match settings. Leaving
-              now discards them.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => blocker.reset?.()}>
-              Keep editing
-            </AlertDialogCancel>
-            <AlertDialogAction
-              variant="destructive"
-              onClick={() => blocker.proceed?.()}
-            >
-              Discard &amp; leave
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onLeave={() => blocker.proceed?.()}
+        onStay={() => blocker.reset?.()}
+      />
     </Card>
   )
 }

--- a/web-client/src/components/dashboard/first-match/first-match-card.tsx
+++ b/web-client/src/components/dashboard/first-match/first-match-card.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useBlocker } from '@tanstack/react-router'
 import { ArrowRight } from 'lucide-react'
 
 import { deriveEmailStatus, useSession } from '@/api/session'
@@ -14,6 +15,16 @@ import { useStartMatch } from '@/components/matches/match-setup/use-start-match'
 import { Card } from '@/components/dashboard/your-game-row/card'
 import { C, MONO, UI } from '@/components/dashboard/dashboard-tokens'
 import { Overline } from '@/components/overline'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import '@/components/matches/match-setup/match-setup.css'
 
 /**
@@ -34,7 +45,21 @@ export const FirstMatchCard = () => {
   // this hero requires an opponent before it is even submittable, so rated
   // defaults on the moment one is picked — matching the mock.
   const [rated, setRated] = useState(true)
-  const { submit, apiError, submitting, submitted } = useStartMatch()
+  const { submit, apiError, submitting, submitted, hasSucceeded } =
+    useStartMatch()
+
+  // The only reachable dirty state is a picked opponent — best-of and rated
+  // are gated behind `opponent !== null`, so a null opponent means the hero is
+  // untouched. Leaving with an opponent picked would silently discard it, the
+  // same class of gap #75 closed on /matches/new; reuse that page's
+  // `useBlocker` + `AlertDialog` treatment here (#811). `hasSucceeded()` reads
+  // a ref so the post-create redirect isn't itself blocked.
+  const isDirty = opponent !== null
+  const blocker = useBlocker({
+    shouldBlockFn: () => isDirty && !hasSucceeded(),
+    enableBeforeUnload: () => isDirty && !hasSucceeded(),
+    withResolver: true,
+  })
 
   const me = session?.data.user ?? null
   const isGuest =
@@ -153,6 +178,37 @@ export const FirstMatchCard = () => {
           </p>
         )}
       </div>
+
+      <AlertDialog
+        open={blocker.status === 'blocked'}
+        onOpenChange={(open) => {
+          // Radix fires onOpenChange(false) on overlay click / Escape — treat
+          // that as "stay" so a stray dismiss never discards the picked
+          // opponent.
+          if (!open) blocker.reset?.()
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Discard changes?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You've picked an opponent or changed the match settings. Leaving
+              now discards them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => blocker.reset?.()}>
+              Keep editing
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => blocker.proceed?.()}
+            >
+              Discard &amp; leave
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
   )
 }

--- a/web-client/src/components/matches/match-setup/discard-match-setup-dialog.tsx
+++ b/web-client/src/components/matches/match-setup/discard-match-setup-dialog.tsx
@@ -1,0 +1,54 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+// The in-app leave confirmation shared by the two match-setup surfaces
+// (/matches/new and the dashboard FirstMatchCard). Both hold the same kind of
+// unsaved state — a picked opponent / changed format — so they share one
+// dialog rather than hand-copying it (#75, #811). Driven by the router
+// blocker's resolver: "Discard & leave" proceeds with the blocked navigation,
+// "Keep editing" cancels it; browser refresh/close is handled separately by
+// the blocker's enableBeforeUnload. Mirrors score-entry's `UnsavedScorePrompt`.
+export function DiscardMatchSetupDialog({
+  open,
+  onLeave,
+  onStay,
+}: {
+  open: boolean
+  onLeave?: () => void
+  onStay?: () => void
+}) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        // Radix fires onOpenChange(false) on overlay click / Escape — treat
+        // that as "stay" so a stray dismiss never discards the form.
+        if (!next) onStay?.()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Discard changes?</AlertDialogTitle>
+          <AlertDialogDescription>
+            You've picked an opponent or changed the match settings. Leaving now
+            discards them.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onStay}>Keep editing</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={onLeave}>
+            Discard &amp; leave
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2250,16 +2250,14 @@ body.dark.fortymm-theme {
     border-color: var(--loss);
   }
 
-  /* Single row of buttons, equal-width, full-bleed across the card. */
+  /* Subtitle stacked above a single row of equal-width, full-bleed buttons.
+     The subtitle carries the pre-submit finalize warning, so it must stay
+     visible on mobile — don't hide it (#813). */
   .fortymm-theme .single-actions {
-    flex-direction: row;
+    flex-direction: column;
     align-items: stretch;
-    flex-wrap: nowrap;
-    gap: 8px;
+    gap: 10px;
     padding: 0;
-  }
-  .fortymm-theme .result-line {
-    display: none;
   }
   .fortymm-theme .action-btns {
     width: 100%;

--- a/web-client/src/routes/_app/matches/new.tsx
+++ b/web-client/src/routes/_app/matches/new.tsx
@@ -15,17 +15,8 @@ import {
   type Opponent,
 } from '@/components/matches/match-setup/opponent'
 import { useStartMatch } from '@/components/matches/match-setup/use-start-match'
+import { DiscardMatchSetupDialog } from '@/components/matches/match-setup/discard-match-setup-dialog'
 import { UserAvatar } from '@/components/ui/user-avatar'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
 import { pageTitle } from '@/lib/page-title'
 import './new.css'
 
@@ -167,36 +158,11 @@ function MatchCard() {
         onCancel={() => navigate({ to: '/dashboard' })}
       />
 
-      <AlertDialog
+      <DiscardMatchSetupDialog
         open={blocker.status === 'blocked'}
-        onOpenChange={(open) => {
-          // Radix fires onOpenChange(false) on overlay click / Escape — treat
-          // that as "stay on the page" so a stray dismiss never discards the
-          // form.
-          if (!open) blocker.reset?.()
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Discard changes?</AlertDialogTitle>
-            <AlertDialogDescription>
-              You've picked an opponent or changed the match settings. Leaving
-              now discards them.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => blocker.reset?.()}>
-              Keep editing
-            </AlertDialogCancel>
-            <AlertDialogAction
-              variant="destructive"
-              onClick={() => blocker.proceed?.()}
-            >
-              Discard &amp; leave
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onLeave={() => blocker.proceed?.()}
+        onStay={() => blocker.reset?.()}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Five small, independent backlog fixes spanning web-client + api.

### #813 — score-entry finalize subtitle invisible on mobile
The mobile `@media (max-width: 880px)` rule `display: none`'d `.result-line`, whose only consumer is the score-pad subtitle carrying the pre-submit finalize warning ("submitting posts the result for your opponent to accept"). Stack `.single-actions` as a column on mobile so the subtitle sits above the full-width button row and stays visible. `.single-actions`/`.result-line` are score-pad-only, so nothing else is affected.

### #247 — narrow the broad catch in `_enqueue_rating_recompute_after_merge`
A bare `except Exception` hid programmer errors (signature mismatch, `ImportError`) behind a log line. Narrowed to `(redis.exceptions.RedisError, ConnectionError, TimeoutError)` — a Redis flap still keeps sign-in alive, but real bugs crash loudly in tests.

### #278 — delete the dead unconfirmed branch in `request_login_email`
After the pending-only set_email change, `users.email` is only ever written by `confirm_email` (alongside `confirmed_at`), so an address lookup can only match a **confirmed** account. The unconfirmed-resend branch and its `_issue_and_send_confirmation_email` helper were unreachable and the docstring was stale. Deleted both and retargeted the test to assert an emailed account always gets a login link. Regenerated `schema.d.ts` + `Types.swift` (the route docstring feeds the OpenAPI description).

### #753 — guard notify()'s push branch so a failure can't drop the email
`NotificationService.notify()` ran the push send before the email enqueue with no guard; a failure on the push path dropped the email and failed the RQ job **after** the in-app row was already committed. Note the issue's titular root cause (jwt.encode raising on a bad APNs key) **already landed on main** — `apns.send` now self-guards and returns `FAILED` rather than raising. This closes the residual notify()-level gap: the remaining raiser is a DB error from the device-token query / gone-token prune, so the push branch now catches `SQLAlchemyError`, rolls back, and lets email still enqueue.

### #811 — dirty-form confirmation for FirstMatchCard
The dashboard hero used the same `useStartMatch()` hook as `/matches/new` but had no navigation-discard protection (the gap #75/#809 closed on `/matches/new`). Reused the same `useBlocker` + `AlertDialog` pattern, with `hasSucceeded()` as the post-create redirect escape hatch.

## Testing
- `web-client`: full vitest suite (1188 tests) green; added dirty-form + no-block tests to `first-match-card.test.tsx`; `tsc -b` + eslint clean.
- `api`: `ruff` + `mypy --strict` clean; `test_login`, `test_notification_preferences` (added a push-DB-failure regression), `test_email`, `test_session`, `test_account_merge`, `test_notifications` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)