### PR TITLE
Fix D5 (iOS overrun truncation) + D7 (Approve push binds sight-unseen)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,6 +41,14 @@ table-tennis score, ending the instant one side clinches the majority (no games
 recorded after the decider). Every result must describe a decided board.
 _Avoid_: finished score, final board.
 
+**Overrun**:
+A board with a game scored *past* the decider — some side clinched the majority,
+yet a later game is also recorded. Not a decided board, and never healed into
+one: every surface refuses it (the score-entry page blocks the save, the propose
+endpoint 422s) and the fix is to clear the games after the decider, not to drop
+them silently. Distinct from an empty *gap*, which compaction closes harmlessly.
+_Avoid_: extra games, overflow, trailing games.
+
 **Result**:
 A claim about how a match ended — a decided board that one participant puts
 forward for the other to agree to. Frozen when proposed; never edited in place.

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1233,8 +1233,11 @@ async def _notify_result_posted(
     player on the side that now owes a response. Each enqueued job persists
     the in-app record (the bell feed) and fans out push/email per the
     recipient's preferences in the worker. The APNs ``category``/``data``
-    carry the action group and the match id so a tapped push deep-links to
-    the right match."""
+    carry the action group, the match id (so a tapped push deep-links to the
+    right match), and the standing result id (so a tapped Approve binds to the
+    exact result the push described, not whatever is standing at tap time — see
+    docs/adr/0007), plus a per-match ``collapse_id`` so a superseding push
+    replaces the stale one on the lock screen."""
     recipient_side = opponent_side(match, poster_id)
     if recipient_side is None or not recipient_side.players:
         return

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1254,6 +1254,10 @@ async def _notify_result_posted(
     if copy is None:
         return
     title, body = copy
+    result = standing_result(match)
+    push_data = {"match_id": str(match.id)}
+    if result is not None:
+        push_data["result_id"] = str(result.id)
     for player in recipient_side.players:
         notifications.enqueue_notification(
             NotificationJob(
@@ -1264,7 +1268,8 @@ async def _notify_result_posted(
                 link=f"/matches/{match.id}",
                 action_label="Review",
                 push_category=MATCH_RESULT_CONFIRMATION_CATEGORY,
-                push_data={"match_id": str(match.id)},
+                push_data=push_data,
+                collapse_id=f"result-confirm:{match.id}",
             )
         )
 

--- a/api/app/notifications/apns.py
+++ b/api/app/notifications/apns.py
@@ -82,6 +82,7 @@ class PushSender(Protocol):
         body: str,
         category: str | None = None,
         data: Mapping[str, str] | None = None,
+        collapse_id: str | None = None,
     ) -> SendResult: ...
 
 
@@ -100,6 +101,7 @@ class NoopSender:
         body: str,
         category: str | None = None,
         data: Mapping[str, str] | None = None,
+        collapse_id: str | None = None,
     ) -> SendResult:
         return SendResult(SendOutcome.FAILED, "push not configured")
 
@@ -186,6 +188,7 @@ class APNsClient:
         body: str,
         category: str | None = None,
         data: Mapping[str, str] | None = None,
+        collapse_id: str | None = None,
     ) -> SendResult:
         url = f"{_APNS_HOSTS[environment]}/3/device/{token}"
         try:
@@ -202,6 +205,8 @@ class APNsClient:
             "apns-topic": self._config.bundle_id,
             "apns-push-type": "alert",
         }
+        if collapse_id is not None:
+            headers["apns-collapse-id"] = collapse_id
         # ``object`` (not ``Any``) so the heterogeneous JSON payload still
         # type-checks under mypy --strict without loosening the interior.
         aps: dict[str, object] = {

--- a/api/app/notifications/jobs.py
+++ b/api/app/notifications/jobs.py
@@ -41,4 +41,5 @@ async def _deliver(job: NotificationJob) -> None:
             delta=job.delta,
             push_category=job.push_category,
             push_data=job.push_data,
+            collapse_id=job.collapse_id,
         )

--- a/api/app/notifications/service.py
+++ b/api/app/notifications/service.py
@@ -166,6 +166,7 @@ class NotificationService:
         body: str,
         category: str | None = None,
         data: Mapping[str, str] | None = None,
+        collapse_id: str | None = None,
     ) -> int:
         """Best-effort push to every device a user has registered. Returns the
         number APNs accepted and prunes any gone tokens as a side effect.
@@ -181,7 +182,12 @@ class NotificationService:
             return 0
         tokens = await self._tokens_for_user(user_id)
         sent, _ = await self._fan_out(
-            tokens, title=title, body=body, category=category, data=data
+            tokens,
+            title=title,
+            body=body,
+            category=category,
+            data=data,
+            collapse_id=collapse_id,
         )
         return sent
 
@@ -199,6 +205,7 @@ class NotificationService:
         delta: str | None = None,
         push_category: str | None = None,
         push_data: Mapping[str, str] | None = None,
+        collapse_id: str | None = None,
     ) -> NotifyResult:
         """Deliver one notification to one user across every channel the user's
         preferences allow for the notification's category.
@@ -250,6 +257,7 @@ class NotificationService:
                     body=body,
                     category=push_category,
                     data=push_data,
+                    collapse_id=collapse_id,
                 )
             except SQLAlchemyError:
                 await self._db.rollback()
@@ -836,6 +844,7 @@ class NotificationService:
         body: str,
         category: str | None = None,
         data: Mapping[str, str] | None = None,
+        collapse_id: str | None = None,
     ) -> tuple[int, int]:
         """Send one push per token, returning ``(sent, pruned)``. Tokens APNs
         reports as gone are deleted in a single statement."""
@@ -852,6 +861,7 @@ class NotificationService:
                 body=body,
                 category=category,
                 data=data,
+                collapse_id=collapse_id,
             )
             if result.outcome is SendOutcome.SUCCESS:
                 sent += 1

--- a/api/app/schemas/notification.py
+++ b/api/app/schemas/notification.py
@@ -272,6 +272,7 @@ class NotificationJob(BaseModel):
     delta: str | None = None
     push_category: str | None = None
     push_data: dict[str, str] | None = None
+    collapse_id: str | None = None
 
 
 class BroadcastRecipient(BaseModel):

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -171,6 +171,7 @@ class SentPush:
     body: str
     category: str | None
     data: Mapping[str, str] | None
+    collapse_id: str | None = None
 
 
 class FakeSender:
@@ -197,8 +198,11 @@ class FakeSender:
         body: str,
         category: str | None = None,
         data: Mapping[str, str] | None = None,
+        collapse_id: str | None = None,
     ) -> SendResult:
-        self.sent.append(SentPush(token, environment, title, body, category, data))
+        self.sent.append(
+            SentPush(token, environment, title, body, category, data, collapse_id)
+        )
         return SendResult(self._outcomes.get(token, SendOutcome.SUCCESS))
 
 

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -3452,6 +3452,7 @@ async def test_posting_result_enqueues_confirmation_for_opponent(
             },
         )
         assert response.status_code == 201
+        standing_result_id = response.json()["negotiation"]["standing_result"]["id"]
 
     jobs = enqueued_notification_jobs(fake_notifications_queue)
     assert [job.user_id for job in jobs] == [opp.id]
@@ -3459,7 +3460,14 @@ async def test_posting_result_enqueues_confirmation_for_opponent(
     assert job.category.value == "result_confirm"
     assert job.link == f"/matches/{match['id']}"
     assert job.push_category == MATCH_RESULT_CONFIRMATION_CATEGORY
-    assert job.push_data == {"match_id": match["id"]}
+    # The push carries the specific result it's about (so the client can route
+    # to it) and a per-match collapse id (so a superseding confirmation replaces
+    # the stale banner rather than stacking).
+    assert job.push_data == {
+        "match_id": match["id"],
+        "result_id": standing_result_id,
+    }
+    assert job.collapse_id == f"result-confirm:{match['id']}"
     # Propose/accept vocabulary, not the retired confirm/dispute model (#728).
     # A first post's recipient sees Accept/Suggest-correction buttons (not
     # Accept/Counter — that pair is reserved for the corrected-result case).

--- a/docs/adr/0006-ios-rejects-overruns-instead-of-truncating.md
+++ b/docs/adr/0006-ios-rejects-overruns-instead-of-truncating.md
@@ -1,0 +1,62 @@
+# iOS rejects an overrun board, it does not silently truncate it
+
+Web and the API treat a game scored *past* the clinch — an **overrun** — as
+illegal input: the score-entry page blocks the save (`overrunDecider` disables
+Post with "the match is already decided at game N — clear the games after it"),
+and `POST /results` 422s a board that extends past the deciding game. Compaction
+only ever closes *empty* gaps; it never drops a genuinely-scored overrun game
+(ADR 0002). iOS was the odd one out: `ScoreEntryView` let the user keep tapping
+chips past the clinch, counted them into the VS tally (`setsWon` over every
+slot), and on Post silently *truncated* the board to the games through the
+decider (`gamesThroughDecider`). It **laundered** the exact illegal input 0002
+is careful to keep rejecting — a 4–0/5–0/3–1 board posted as 3–0 with no warning
+(finding D5).
+
+We decided iOS must reach the same contract: an overrun is refused, not healed.
+Concretely, mirroring web's `scoring.ts`:
+
+- **The VS tally counts only through the decider.** `setsWon` stops at the
+  clinch, so the displayed score is the decided score, not an inflated count of
+  post-decider slots.
+- **Forward-gating.** Once a side clinches, no next chip appears — the shared
+  scratchpad can't accept a forward overrun game (and, post-D6, can't *write*
+  one to the server board).
+- **Overrun detection for the retroactive case.** Editing an earlier game to
+  clinch sooner orphans later slots — an overrun forward-gating can't prevent
+  (the iOS board is a dense positional slot array, so an overrun is a completed
+  slot at an index *past* the decider). iOS gains mirrors of web's
+  `deciderGameNumber` + `overrunDecider`. **The Post-disable falls out of the
+  strict decided-board check** — an overrun board fails it (the decider isn't the
+  last scored slot), exactly as web keeps `overrunDecider` *separate* from its
+  disable. `overrunDecider` exists only to *select the inline message* ("the
+  match is decided at game N — clear the games after it"), so the user knows
+  what to fix; they clear the orphaned slots via the existing D6 confirm-clear
+  (`deleteGameScore`). This is parity with the API's 422 — iOS refuses to mint an
+  overrun rather than truncating it.
+- **`gamesThroughDecider` truncation is removed** (both callers: the
+  Post-appears gate and `post()`). A postable board is now exactly a clean
+  decided board — the iOS mirror of `isDecidedMatch`: a gap already yielded `nil`
+  under the old helper too, so no gappy-decided board regresses (iOS never
+  posted one; it has no compaction, unlike web). Anything not cleanly decided is
+  blocked upstream, so there is nothing left to truncate.
+
+## Considered options
+
+- **Block at entry (chosen).** Make the overrun *unrepresentable* on iOS —
+  forward-gate new entry and detect+block the retroactive overrun — so the
+  contract holds by construction, matching what a web user experiences.
+- **Allow entry, reject at Post with a message.** Keep letting the user type
+  past the decider but replace the silent truncation with a hard block + inline
+  error. More faithful than truncation, but leaves a foot-gun on screen and
+  writes overrun games to the shared scratchpad only to reject them later.
+- **Keep truncation but warn.** Rejected — it still heals illegal input, which
+  *is* the contract violation; a warning does not make laundering correct.
+
+## Consequence
+
+The cross-platform contract is uniform: a victor plus scored games past the
+decider is an error on every surface, surfaced to the user to fix, never
+silently rewritten. iOS carries its own `deciderGameNumber`/`overrunDecider`
+mirrors alongside the existing `setsWon`, and the truncating
+`gamesThroughDecider` is replaced by a strict decided-board predicate (the
+`isDecidedMatch` mirror). Fixes D5.

--- a/docs/adr/0007-approve-push-binds-to-the-result-it-showed.md
+++ b/docs/adr/0007-approve-push-binds-to-the-result-it-showed.md
@@ -1,0 +1,59 @@
+# The Approve push binds to the result it showed, not to current standing
+
+The result-confirmation push renders an **Approve** action on the lock screen so
+a recipient can accept their opponent's reported score in one tap. The push body
+carries the specific score ("Alice reported beating you 3–0. Games: 11-4, 11-6,
+11-8. Accept or suggest a correction?"), so the tap is informed consent — *for
+that result*. But the handler carried only `match_id` and, on tap,
+**re-resolved the current standing result** and accepted whatever that was
+(`acceptStandingResult(matchId)` → GET the match → accept `standingResult.id`).
+A stale lock-screen notification describing R1 could therefore bind the user to a
+later self-edited R2 they never saw — silently defeating the `result_id`
+concurrency token the accept endpoint (`POST /.../results/{result_id}/acceptance`,
+spec §6) exists to enforce (finding D7).
+
+We decided to keep the one-tap background Approve — the body is already fully
+informative and it is the whole point of the APNs action — but make it bind to
+the result the notification was *about*, with defense in depth:
+
+1. **`apns-collapse-id = f"result-confirm:{match_id}"`.** A superseding
+   proposal's push *replaces* the stale one on the lock screen (works even when
+   the app isn't running), so a stale Approve mostly never survives to be
+   tapped. Also gives one live result-confirmation notification per match
+   instead of a stack. The id is **scoped to the push type**, not a bare
+   `match_id`, so a future non-result push for the same match can never collapse
+   over (or be clobbered by) a pending Approve — only result-confirmation pushes
+   for a match collapse together.
+2. **`result_id` in `push_data`, used as the token.** The Approve action passes
+   *that* id to `acceptResult(matchId, resultId)` — no re-fetch of current
+   standing. The user accepts exactly the score the notification showed; a
+   superseded id 409s at the endpoint instead of binding to a different result.
+3. **409 → local follow-up notification.** If the tapped result was superseded
+   in the collapse window, iOS catches the 409, does not accept, and posts a
+   local notification ("this result changed — open the match to review"), or
+   deep-links to the match when the app is foreground. Honest feedback, no
+   silent outcome.
+
+## Considered options
+
+- **Keep one-tap, make it token-safe (chosen).** The notification is already
+  informative and the token makes staleness a 409; three layers make the stale
+  tap rare, correct when it happens, and never silent.
+- **Downgrade Approve to "open the match".** Foreground-only; always open to
+  current standing and accept there. Safest, but discards the lock-screen
+  one-tap the feature exists to provide, to solve a problem the token already
+  solves.
+- **Silent no-op on 409.** Rejected — trades D7's silent-wrong-accept for a
+  silent-nothing; the user assumes their tap worked.
+
+## Consequence
+
+The push payload gains `result_id`; the APNs sender gains an optional
+`collapse_id` parameter (the `apns-collapse-id` header) threaded from the
+notification job — added to the `PushSender` Protocol and every implementation
+(`NoopSender`, `APNsClient`, the test helper) so `mypy --strict` stays green.
+iOS's
+`acceptStandingResult(matchId)` re-fetch path is replaced by
+`acceptResult(matchId, resultId)` driven off the payload token. Accepting from a
+notification is now bound to the score the user was shown, on every surface.
+Fixes D7.

--- a/ios/Fortymm/MatchFlow/MatchAPI.swift
+++ b/ios/Fortymm/MatchFlow/MatchAPI.swift
@@ -67,10 +67,9 @@ struct MatchScoreDTO: Decodable {
     let side1Points: Int
     let side2Points: Int
     let winnerSideNumber: Int
-    // Optimistic-concurrency token from the API. iOS scores a match locally and
-    // commits the whole result via POST /results (which 409s the second poster),
-    // so it never issues the per-game conditional write that consumes this — the
-    // field is decoded only to keep the model in sync with the API schema.
+    // Optimistic-concurrency token from the API, decoded and used as the
+    // expected-version token for per-game score writes (createGameScore /
+    // updateGameScore in MatchService.swift).
     let version: Int
 }
 

--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -412,7 +412,13 @@ enum MatchRules {
         return a > b ? .you : .opponent
     }
 
-    static func setsWon(_ games: [Game]) -> SetScore {
+    /// Games-won tally, stopping at the decider: once a side reaches
+    /// `gamesToWin(bestOf:)` the count freezes, so the score reported is the
+    /// *decided* score and never an inflated post-decider count (a board that
+    /// clinched 3–0 then had a stray 4th completed game still reports 3–0).
+    /// Gap-tolerant like the web `matchDecision` (incomplete slots are skipped).
+    static func setsWon(_ games: [Game], bestOf: Int) -> SetScore {
+        let need = gamesToWin(bestOf: bestOf)
         var a = 0, b = 0
         for g in games {
             switch gameWinner(g) {
@@ -420,31 +426,69 @@ enum MatchRules {
             case .opponent: b += 1
             case .none: break
             }
+            if a >= need || b >= need { break }
         }
         return SetScore(a: a, b: b)
     }
 
     static func matchDecided(_ games: [Game], bestOf: Int) -> Bool {
-        let sw = setsWon(games)
+        let sw = setsWon(games, bestOf: bestOf)
         let need = gamesToWin(bestOf: bestOf)
         return sw.a >= need || sw.b >= need
     }
 
-    /// The canonical postable games: the gap-free run of completed games from
-    /// game 1 up to *and including* the game that decides the match, dropping
-    /// anything entered past the decider. Returns nil when the games entered so
-    /// far don't yet form a complete, decided match — in which case Post must
-    /// not be offered.
+    /// The 1-based game number at which some side first reaches
+    /// `gamesToWin(bestOf:)`, walking completed slots in index order. Gap-tolerant:
+    /// incomplete slots are skipped while counting wins (index + 1 is the game
+    /// number). nil when no side has clinched yet. Mirrors the web
+    /// `deciderGameNumber` / `matchDecision.decidedAt` in
+    /// web-client/src/lib/scoring.ts.
+    static func deciderGameNumber(_ games: [Game], bestOf: Int) -> Int? {
+        let need = gamesToWin(bestOf: bestOf)
+        var a = 0, b = 0
+        for (i, g) in games.enumerated() {
+            switch gameWinner(g) {
+            case .you: a += 1
+            case .opponent: b += 1
+            case .none: continue
+            }
+            if a >= need || b >= need { return i + 1 }
+        }
+        return nil
+    }
+
+    /// The decider game number *only* when a completed slot exists strictly past
+    /// the decider (an "overrun" — some side clinched before the last completed
+    /// game). nil for empty, undecided, or cleanly-decided-at-the-last-completed
+    /// boards. Mirrors the web `overrunDecider` in web-client/src/lib/scoring.ts
+    /// (`decidedAt < lastCompletedGameNumber ? decidedAt : nil`).
+    static func overrunDecider(_ games: [Game], bestOf: Int) -> Int? {
+        guard let decidedAt = deciderGameNumber(games, bestOf: bestOf) else { return nil }
+        // Highest 1-based game number among completed slots.
+        var lastCompleted = 0
+        for (i, g) in games.enumerated() where gameWinner(g) != nil {
+            lastCompleted = i + 1
+        }
+        return decidedAt < lastCompleted ? decidedAt : nil
+    }
+
+    /// The canonical postable games — the completed prefix from game 1 up to *and
+    /// including* the decider — returned **only** when the board is a clean decided
+    /// match. Returns nil otherwise; Post must not be offered.
     ///
     /// Assumes `games` is the dense, position-indexed slot array the score-entry
-    /// screen builds (index i ⇒ game i+1, length == bestOf). Contiguity, the
-    /// no-duplicate-game-numbers rule, and the bestOf bound that the server's
-    /// finalize validator (api/app/matches.py) and the web client's `decidedSide`
-    /// (web-client/src/lib/scoring.ts) check explicitly are guaranteed here by
-    /// that array shape rather than re-validated: a gap (incomplete slot) before
-    /// the decider yields nil, and games past the decider are truncated rather
-    /// than rejected (the client simply never posts them).
-    static func gamesThroughDecider(_ games: [Game], bestOf: Int) -> [Game]? {
+    /// screen builds (index i ⇒ game i+1, length == bestOf). Strict, at parity with
+    /// the web client's `isDecidedMatch` (web-client/src/lib/scoring.ts) and the
+    /// server's finalize validator (api/app/matches.py):
+    ///
+    /// - a gap (incomplete slot) *before* the decider ⇒ nil, and
+    /// - an **overrun** — any completed slot strictly *past* the decider ⇒ nil.
+    ///
+    /// Overruns are **refused (nil), not truncated**: a board scored past the
+    /// decider is rejected outright rather than silently trimmed to the decider.
+    static func decidedGames(_ games: [Game], bestOf: Int) -> [Game]? {
+        // A completed slot past the decider is an overrun ⇒ refuse (don't truncate).
+        if overrunDecider(games, bestOf: bestOf) != nil { return nil }
         let need = gamesToWin(bestOf: bestOf)
         var a = 0, b = 0
         for (i, g) in games.enumerated() {

--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -431,12 +431,6 @@ enum MatchRules {
         return SetScore(a: a, b: b)
     }
 
-    static func matchDecided(_ games: [Game], bestOf: Int) -> Bool {
-        let sw = setsWon(games, bestOf: bestOf)
-        let need = gamesToWin(bestOf: bestOf)
-        return sw.a >= need || sw.b >= need
-    }
-
     /// The 1-based game number at which some side first reaches
     /// `gamesToWin(bestOf:)`, walking completed slots in index order. Gap-tolerant:
     /// incomplete slots are skipped while counting wins (index + 1 is the game
@@ -487,20 +481,14 @@ enum MatchRules {
     /// Overruns are **refused (nil), not truncated**: a board scored past the
     /// decider is rejected outright rather than silently trimmed to the decider.
     static func decidedGames(_ games: [Game], bestOf: Int) -> [Game]? {
-        // A completed slot past the decider is an overrun ⇒ refuse (don't truncate).
-        if overrunDecider(games, bestOf: bestOf) != nil { return nil }
-        let need = gamesToWin(bestOf: bestOf)
-        var a = 0, b = 0
-        for (i, g) in games.enumerated() {
-            // A gap (incomplete game) before the match is decided ⇒ not postable.
-            guard let winner = gameWinner(g) else { return nil }
-            switch winner {
-            case .you: a += 1
-            case .opponent: b += 1
-            }
-            if a >= need || b >= need { return Array(games.prefix(i + 1)) }
-        }
-        return nil
+        // Refuse an overrun (a completed slot past the decider) — don't truncate —
+        // and require a clinch. `deciderGameNumber` is gap-tolerant, so also reject
+        // a gap (an incomplete slot) inside the prefix through the decider.
+        guard overrunDecider(games, bestOf: bestOf) == nil,
+              let decidedAt = deciderGameNumber(games, bestOf: bestOf)
+        else { return nil }
+        let prefix = Array(games.prefix(decidedAt))
+        return prefix.allSatisfy { gameWinner($0) != nil } ? prefix : nil
     }
 
     /// Elo delta, K = 26. Caller passes `won`; returns the signed change.

--- a/ios/Fortymm/MatchFlow/MatchService.swift
+++ b/ios/Fortymm/MatchFlow/MatchService.swift
@@ -175,24 +175,6 @@ struct MatchService {
         return Self.finalMatch(from: details)
     }
 
-    /// Nothing is standing to accept (the match is live or already settled) —
-    /// a client-side precondition, deliberately distinct from `APIError.http`
-    /// so it can't be mistaken for a real server 409.
-    struct NoStandingResult: Error {}
-
-    /// Fetch the match and accept its standing proposal. Used by the
-    /// push-notification "Approve" action, whose payload carries only the
-    /// match id — the fetch resolves the current standing result id (the
-    /// acceptance token). Whether the viewer is actually allowed to accept is
-    /// the server's call: an out-of-turn acceptance gets the real 409/4xx.
-    func acceptStandingResult(_ matchId: UUID) async throws -> FinalMatch {
-        let details: MatchDetailsDTO = try await client.get("/v1/matches/\(matchId.uuidString)")
-        guard let standing = details.negotiation.standingResult else {
-            throw NoStandingResult()
-        }
-        return try await acceptResult(matchId: matchId, resultId: standing.id)
-    }
-
     // MARK: Read
 
     /// Full detail for one match (`GET /v1/matches/{id}`).

--- a/ios/Fortymm/MatchFlow/ScoreEntryView.swift
+++ b/ios/Fortymm/MatchFlow/ScoreEntryView.swift
@@ -74,15 +74,16 @@ struct ScoreEntryView: View {
     private var current: Game { games.indices.contains(active) ? games[active].points : Game() }
     private var currentValid: Bool { MatchRules.gameComplete(current) }
 
-    /// Tally shown in the VS column. `setsWon` already ignores incomplete games,
-    /// so counting over all slots (including the one being entered) is correct.
-    private var setsDisplay: SetScore { MatchRules.setsWon(games.map(\.points)) }
+    /// Tally shown in the VS column. `setsWon` ignores incomplete games *and* now
+    /// caps the count at the decider, so a board scored past the clinch still shows
+    /// the decided score (e.g. 3–0), never a phantom tally from overrun games.
+    private var setsDisplay: SetScore { MatchRules.setsWon(games.map(\.points), bestOf: config.bestOf) }
     /// True when the games entered so far form a complete, decided match — i.e.
     /// there's a valid result to Post. Uses the same canonical rule as `post()`
     /// so the Post button never appears for games the server would reject, and
     /// never goes dead when it does appear.
     private var deciding: Bool {
-        MatchRules.gamesThroughDecider(games.map(\.points), bestOf: config.bestOf) != nil
+        MatchRules.decidedGames(games.map(\.points), bestOf: config.bestOf) != nil
     }
 
     var body: some View {
@@ -92,6 +93,7 @@ struct ScoreEntryView: View {
             scoreError
             Spacer().frame(height: 12)
             scoreline
+            overrunHint
             actionRow
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
@@ -182,6 +184,27 @@ struct ScoreEntryView: View {
         }
     }
 
+    // MARK: Overrun hint
+
+    /// Inline, purely-informational callout shown when the board has a completed
+    /// game *past* the decider (an overrun). Post is already unavailable — the
+    /// single source of truth for postability is `decidedGames`/`deciding`, which
+    /// returns nil for an overrun, so this is NOT a second disable gate. It only
+    /// tells the user which trailing games to clear (tap a chip → Clear, reusing
+    /// the existing confirm-clear → delete flow) so the decided board can be posted.
+    @ViewBuilder
+    private var overrunHint: some View {
+        if let decidedAt = MatchRules.overrunDecider(games.map(\.points), bestOf: config.bestOf) {
+            Text("The match is decided at game \(decidedAt) — clear the games after it before posting.")
+                .font(FMFont.ui(12, weight: .medium))
+                .foregroundStyle(FMColor.warn)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 24)
+                .padding(.top, 10)
+        }
+    }
+
     // MARK: Header
 
     private var header: some View {
@@ -251,7 +274,7 @@ struct ScoreEntryView: View {
                 ForEach(0..<config.bestOf, id: \.self) { i in
                     let g = games.indices.contains(i) ? games[i].points : Game()
                     let s = games.indices.contains(i) ? games[i].sync : .localOnly
-                    GameChip(index: i, game: g, sync: s, active: i == active) {
+                    GameChip(index: i, game: g, sync: s, active: i == active, locked: lockedForEntry(i)) {
                         if i != active { selectGame(i) }
                     }
                 }
@@ -424,10 +447,24 @@ struct ScoreEntryView: View {
         fireWrite(for: saved)
     }
 
+    /// True for an *empty* slot strictly past the decider once a side has clinched:
+    /// scoring it would overrun a decided match, so it can't be entered. Already-
+    /// scored slots stay tappable (so an overrun game can be selected and cleared),
+    /// and the decider game and everything before it stay editable (so the user can
+    /// still fix an earlier game). `deciderGameNumber` is 1-based, so game numbers
+    /// strictly past it are exactly the indices `>= decider`.
+    private func lockedForEntry(_ i: Int) -> Bool {
+        guard games.indices.contains(i),
+              let decider = MatchRules.deciderGameNumber(games.map(\.points), bestOf: config.bestOf)
+        else { return false }
+        return i >= decider && !MatchRules.gameComplete(games[i].points)
+    }
+
     /// Jump to any game's slot. Re-entering an already-complete game opens edit
-    /// mode (Clear / Save changes); an empty slot is plain entry.
+    /// mode (Clear / Save changes); an empty slot is plain entry. An empty slot
+    /// past the decider is locked (see `lockedForEntry`) and ignored.
     private func selectGame(_ i: Int) {
-        guard games.indices.contains(i) else { return }
+        guard games.indices.contains(i), !lockedForEntry(i) else { return }
         active = i
         editing = MatchRules.gameComplete(games[i].points)
         // A conflicted slot demands an explicit keep-mine / use-theirs decision —
@@ -435,12 +472,15 @@ struct ScoreEntryView: View {
         if case .conflict = games[i].sync { resolving = i }
     }
 
-    /// First incomplete slot searching forward from `active` and wrapping.
+    /// First incomplete slot searching forward from `active` and wrapping. Slots
+    /// locked past the decider are skipped, so saving the clinching game never
+    /// advances the user into a game they can't enter (the match is decided —
+    /// `deciding` now offers Post instead).
     private func nextIncompleteIndex() -> Int? {
         guard !games.isEmpty else { return nil }
         return (1...games.count)
             .map { (active + $0) % games.count }
-            .first { !MatchRules.gameComplete(games[$0].points) }
+            .first { !MatchRules.gameComplete(games[$0].points) && !lockedForEntry($0) }
     }
 
     /// Clear the active game. Sync-state-aware: a game that has (or may be about to
@@ -708,12 +748,13 @@ struct ScoreEntryView: View {
     }
 
     private func post() {
-        // The completed games in play order, game 1 up to and including the
-        // decider — anything entered past the decider is dropped, matching the
-        // server's finalize rules. The coordinator posts these to
-        // `POST /v1/matches/{id}/results`; the server computes sets won, the
-        // winner, and any rating change — so we don't here.
-        guard let finalGames = MatchRules.gamesThroughDecider(games.map(\.points), bestOf: config.bestOf) else { return }
+        // The clean decided board: the completed games in play order, game 1 up to
+        // and including the decider. `decidedGames` returns nil for an overrun (a
+        // completed slot past the decider) — so an overrun board is *refused* here,
+        // not silently truncated, matching the server's finalize rules and the web
+        // client. The coordinator posts these to `POST /v1/matches/{id}/results`;
+        // the server computes sets won, the winner, and any rating change — not us.
+        guard let finalGames = MatchRules.decidedGames(games.map(\.points), bestOf: config.bestOf) else { return }
         focus = nil
         onPost(finalGames)
     }
@@ -777,6 +818,10 @@ private struct GameChip: View {
     /// per-cell status dot.
     let sync: SyncState
     let active: Bool
+    /// True for an empty slot past the decider: the match is already decided, so
+    /// entering it would overrun. Rendered dimmer and made untappable — but only
+    /// empty slots are locked, so an overrun game stays selectable to be cleared.
+    let locked: Bool
     let onTap: () -> Void
 
     private var done: Bool { MatchRules.gameComplete(game) }
@@ -814,7 +859,7 @@ private struct GameChip: View {
             .fmRoundedBorder(radius: FMRadius.md,
                              color: active ? FMColor.ball500 : (done ? FMColor.borderDefault : FMColor.borderSubtle),
                              lineWidth: 1.5)
-            .opacity(!done && !active ? 0.5 : 1)
+            .opacity(locked ? 0.32 : (!done && !active ? 0.5 : 1))
             // Sync status rides in the top-trailing corner as an overlay so it
             // never widens the chip — a full best-of-7 row still shares the width
             // evenly. `.localOnly` shows nothing (looks like today's board).
@@ -824,9 +869,9 @@ private struct GameChip: View {
             }
         }
         .buttonStyle(.plain)
-        // Any game can be selected and edited in any order; only the slot that's
-        // already active is inert.
-        .disabled(active)
+        // Any scored game can be selected and edited in any order; the slot that's
+        // already active is inert, as is an empty slot locked past the decider.
+        .disabled(active || locked)
     }
 
     /// Tiny, unobtrusive glyph reflecting the slot's scratchpad sync: a spinner

--- a/ios/Fortymm/Notifications/PushNotificationManager.swift
+++ b/ios/Fortymm/Notifications/PushNotificationManager.swift
@@ -216,7 +216,7 @@ extension PushNotificationManager: UNUserNotificationCenterDelegate {
                     _ = try await self.matchService.acceptResult(
                         matchId: matchId, resultId: resultId
                     )
-                } catch let APIError.http(status, _) where status == 409 {
+                } catch APIError.http(409, _) {
                     // The tapped result was superseded (a correction landed, or
                     // it was already accepted) — do NOT accept whatever replaced
                     // it. Nudge the user to review the current score instead of

--- a/ios/Fortymm/Notifications/PushNotificationManager.swift
+++ b/ios/Fortymm/Notifications/PushNotificationManager.swift
@@ -4,9 +4,11 @@ import UserNotifications
 /// Identifiers shared with the backend push payload (`api/app/notifications`).
 /// A push whose `aps.category` is `MATCH_RESULT_CONFIRMATION` renders the
 /// Approve / Suggest-correction buttons registered below; the `match_id`
-/// userInfo key tells the app which match the buttons (and a tap) act on. Kept
-/// in one place so the device-side registration can't drift from what the
-/// server sends.
+/// userInfo key tells the app which match the buttons (and a tap) act on, and
+/// `result_id` pins Approve to the specific standing result the notification
+/// was about (so a stale push can't sign the user onto a later one). Kept in
+/// one place so the device-side registration can't drift from what the server
+/// sends.
 enum MatchNotification {
     /// Must equal `MATCH_RESULT_CONFIRMATION_CATEGORY` in `app/notifications/apns.py`.
     static let category = "MATCH_RESULT_CONFIRMATION"
@@ -16,6 +18,10 @@ enum MatchNotification {
     static let suggestCorrectionAction = "DISPUTE_MATCH_ACTION"
     /// Must equal the `data` key the server sends (`{"match_id": "<uuid>"}`).
     static let matchIdKey = "match_id"
+    /// Must equal the `data` key the server sends (`{"result_id": "<uuid>"}`) —
+    /// the standing result this push is about, used as the acceptance token so
+    /// Approve binds to that exact result rather than whatever is standing now.
+    static let resultIdKey = "result_id"
 }
 
 /// Owns the device side of remote (APNs) push notifications:
@@ -28,9 +34,10 @@ enum MatchNotification {
 ///    push carries Approve / Suggest-correction action buttons,
 /// 4. presents pushes as a banner even while the app is foregrounded (otherwise
 ///    a self-test looks like nothing happened),
-/// 5. handles a tapped action: Approve accepts the standing proposal in the
-///    background (no need to open the app); Suggest correction and a body tap
-///    both deep-link to the match via `onOpenMatch`.
+/// 5. handles a tapped action: Approve accepts the exact result the push
+///    carried (its `result_id` token) in the background (no need to open the
+///    app), 409ing gracefully if that result was superseded; Suggest
+///    correction and a body tap both deep-link to the match via `onOpenMatch`.
 ///
 /// A singleton because the `UIApplicationDelegate` token callbacks and the
 /// SwiftUI view that triggers registration must talk to the same instance, and
@@ -76,10 +83,11 @@ final class PushNotificationManager: NSObject {
         center.setNotificationCategories([Self.matchConfirmationCategory()])
     }
 
-    /// The "a result is waiting on you" category: Approve accepts the standing
-    /// proposal in the background (no `.foreground` — a quick tap acts without
-    /// opening the app). Suggesting a correction needs the full board editor,
-    /// so that action opens the app on the match instead of acting inline.
+    /// The "a result is waiting on you" category: Approve accepts the exact
+    /// result the push named in the background (no `.foreground` — a quick tap
+    /// acts without opening the app). Suggesting a correction needs the full
+    /// board editor, so that action opens the app on the match instead of
+    /// acting inline.
     private static func matchConfirmationCategory() -> UNNotificationCategory {
         let approve = UNNotificationAction(
             identifier: MatchNotification.approveAction,
@@ -164,10 +172,10 @@ extension PushNotificationManager: UNUserNotificationCenterDelegate {
     }
 
     /// The user acted on a notification. For a match-confirmation push:
-    /// Approve accepts the standing proposal in the background; "Suggest
-    /// correction" and a body tap both open the app on the match (a correction
-    /// needs the full board editor). Anything we don't recognise — or a payload
-    /// missing its `match_id` — just dismisses.
+    /// Approve accepts the exact result the push carried (its `result_id`) in
+    /// the background; "Suggest correction" and a body tap both open the app on
+    /// the match (a correction needs the full board editor). Anything we don't
+    /// recognise — or a payload missing its `match_id` — just dismisses.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
@@ -184,17 +192,39 @@ extension PushNotificationManager: UNUserNotificationCenterDelegate {
 
         switch response.actionIdentifier {
         case MatchNotification.approveAction:
-            // The push payload carries only the match id; the service fetches
-            // the match to resolve the standing proposal (the acceptance
-            // token) and accepts it. Best-effort: a failed sign-off (the
-            // proposal moved on, or was already accepted) shouldn't hang the
-            // notification — the match screen reconciles state on next open.
-            // iOS gives this background action a short window; the fetch +
-            // accept pair fits comfortably.
+            // Bind the acceptance to the *specific* result this push named
+            // (`result_id`, the acceptance token) rather than re-resolving
+            // whatever is standing now — otherwise a stale notification about
+            // result R1 could silently sign the user onto a later R2 they never
+            // saw. iOS gives this background action a short window; a single
+            // accept POST fits comfortably.
+            guard
+                let rawResult = userInfo[MatchNotification.resultIdKey] as? String,
+                let resultId = UUID(uuidString: rawResult)
+            else {
+                // Older/malformed push with no result token: don't blind-accept
+                // the current standing result — open the match so the user
+                // reviews and confirms the score themselves.
+                DispatchQueue.main.async {
+                    self.openMatch(matchId)
+                    completionHandler()
+                }
+                return
+            }
             Task {
                 do {
-                    _ = try await self.matchService.acceptStandingResult(matchId)
+                    _ = try await self.matchService.acceptResult(
+                        matchId: matchId, resultId: resultId
+                    )
+                } catch let APIError.http(status, _) where status == 409 {
+                    // The tapped result was superseded (a correction landed, or
+                    // it was already accepted) — do NOT accept whatever replaced
+                    // it. Nudge the user to review the current score instead of
+                    // binding them to a result they never saw.
+                    await self.handleSupersededApproval(matchId: matchId)
                 } catch {
+                    // Any other failure is best-effort: the match screen
+                    // reconciles state on next open.
                     print("[push] match accept failed: \(error.fmMessage)")
                 }
                 completionHandler()
@@ -221,6 +251,33 @@ extension PushNotificationManager: UNUserNotificationCenterDelegate {
             onOpenMatch(matchId)
         } else {
             pendingMatchOpen = matchId
+        }
+    }
+
+    /// The Approve action's result was superseded before the tap landed (409).
+    /// If the app is foregrounded, deep-link to the match so the user sees the
+    /// current score right away; otherwise post a plain local notification
+    /// (no Approve button — it carries only `match_id`, so tapping its body
+    /// opens the match) nudging them to review before signing off.
+    @MainActor
+    private func handleSupersededApproval(matchId: UUID) async {
+        if UIApplication.shared.applicationState == .active {
+            openMatch(matchId)
+            return
+        }
+        let content = UNMutableNotificationContent()
+        content.title = "Result changed"
+        content.body = "This result changed since we notified you — open the match to review the current score."
+        content.userInfo = [MatchNotification.matchIdKey: matchId.uuidString]
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+        do {
+            try await UNUserNotificationCenter.current().add(request)
+        } catch {
+            print("[push] superseded-approval nudge failed: \(error.localizedDescription)")
         }
     }
 }


### PR DESCRIPTION
Fixes two iOS/API bugs from the match-result-negotiation review. **D6 and D8 were already fixed on `main`** (D6 by the write-path-parity commit #828; D8 across API + web + iOS), so this PR addresses the two findings that were still present, plus a stale-comment cleanup.

## D5 — iOS silently truncated an overrun board instead of rejecting it
Web and the API treat a game scored *past* the decider (an **overrun**) as illegal input — web blocks the save, the propose endpoint 422s, and compaction never launders a real overrun (ADR 0002). iOS was the odd one out: it counted post-decider games into the VS tally, let chips stay tappable past the clinch, and on Post silently *truncated* via `gamesThroughDecider` (a 4-0/5-0/3-1 board posted as 3-0 with no warning). iOS now reaches parity — see **`docs/adr/0006`**:
- `MatchRules` gains `deciderGameNumber` + `overrunDecider` mirrors of web `scoring.ts`; `setsWon` caps the tally at the decider; the truncating `gamesThroughDecider` becomes strict `decidedGames` (overrun → `nil`, **refused not truncated**).
- `ScoreEntryView` forward-gates chips past the clinch, `post()` refuses an overrun board, and an informational hint names the games to clear (reusing the existing D6 confirm-clear). The Post-disable falls out of the strict decided-check — no redundant second gate.

## D7 — background "Approve" push accepted a proposal sight-unseen
The Approve action carried only `match_id` and re-resolved the *current* standing result at tap time, so a stale notification about R1 could bind the user to a later self-edited R2 they never saw — defeating the `result_id` concurrency token. Now the push binds to the result it showed — see **`docs/adr/0007`**, defense in depth:
1. **`apns-collapse-id = "result-confirm:{match_id}"`** — a superseding push replaces the stale one on the lock screen (scoped to the push type so it can't clobber other pushes).
2. **`result_id` in `push_data`** — Approve accepts *that* id via `acceptResult(matchId:resultId:)`; the dead `acceptStandingResult` re-fetch is removed.
3. **409 → local follow-up notification** ("this result changed — open to review"), or a foreground deep-link.

`collapse_id` is threaded atomically through `NotificationJob → jobs → service → PushSender` and all sender impls.

## Also
- New **"Overrun"** glossary term in `CONTEXT.md`.
- **D6:** deleted a stale `MatchAPI.swift` comment claiming iOS scores locally (false since #828).

## Verification
- **API:** `ruff` + `mypy` (Success, 78 files) + `pytest tests/test_matches.py` green (**132 passed**); the opponent-notification test now asserts `push_data["result_id"]` + `collapse_id`.
- **iOS:** simulator build **succeeds**; D5 helpers verified via a standalone `swiftc` harness (**17 assertions pass**).
- No OpenAPI drift (the notification schema is queue-internal; no route model changed).

## Known follow-up
The iOS app has **no test target** (one app target, no XCTest ever). The D5 helper unit tests are therefore verified via the swiftc harness but not committed as in-repo tests. Standing up the first iOS test target (framework + scheme + CI) is a separate infra decision, deferred out of this bug-fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5WC2Pif1Pjust7ZjXupiQ