### PR TITLE
Fix B8: iOS Live tab badge always 0 on iOS 17

### DIFF
--- a/ios/Fortymm/MatchFlow/MatchAPI.swift
+++ b/ios/Fortymm/MatchFlow/MatchAPI.swift
@@ -35,6 +35,77 @@ enum APIMatchStatus: String, LenientRawDecodable {
     case unknown
 }
 
+/// Per-status match counts behind the filter-tab badges, framed by the closed
+/// `APIMatchStatus` domain instead of raw strings.
+///
+/// The server sends `status_counts` as an *open* map keyed by the raw status
+/// string (`{"pending": …, "in_progress": …, "completed": …, …}` — see
+/// `MatchListResponse` in the OpenAPI schema; the count feed is dense, seeding
+/// every status to 0).
+///
+/// `APIClient`'s shared decoder uses `.convertFromSnakeCase` — and whether that
+/// strategy rewrites the keys *inside* a `[String: Int]` dictionary depends on
+/// the device's Foundation: the objc-era `JSONDecoder` (iOS 17, our minimum
+/// target) converts them (`in_progress` → `inProgress`), while swift-foundation
+/// (iOS 18+) leaves them alone. The old string-keyed lookup
+/// (`statusCounts["in_progress"]`) therefore read 0 on iOS 17 — the "Live badge
+/// always 0" bug — and worked on iOS 18. We re-canonicalise decoded keys back to
+/// snake_case at the boundary (idempotent on already-snake keys, so it's correct
+/// on both), and expose only enum-keyed accessors so no caller can mis-key the
+/// map again. Modelling the open dict (rather than a fixed field set) keeps the
+/// "All" total faithful to every bucket the feed can show — including `voided` /
+/// `disputed` / any status added server-side later.
+struct StatusCounts: Decodable, Equatable {
+    /// Counts keyed by canonical (snake_case) API status string.
+    private let byStatus: [String: Int]
+
+    /// Empty counts — the initial state before the first list fetch.
+    static let empty = StatusCounts([:] as [APIMatchStatus: Int])
+
+    /// Build directly from typed statuses (seed / preview / test construction).
+    init(_ counts: [APIMatchStatus: Int]) {
+        byStatus = Dictionary(
+            counts.map { ($0.key.rawValue, $0.value) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode([String: Int].self)
+        byStatus = Dictionary(
+            raw.map { (Self.canonicalKey($0.key), $0.value) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
+    /// The count feeding a tab: a specific status's bucket, or — for the "All"
+    /// tab (`nil`) — the sum of *every* bucket the server sent, so voided /
+    /// disputed / any future status the unfiltered feed still shows are counted.
+    func count(for status: APIMatchStatus?) -> Int {
+        guard let status else { return total }
+        return byStatus[status.rawValue] ?? 0
+    }
+
+    /// Sum across every status bucket — the "All" badge.
+    var total: Int { byStatus.values.reduce(0, +) }
+
+    /// Invert `.convertFromSnakeCase` on a decoded key so it matches the
+    /// server's snake_case status string. Idempotent on already-snake keys, so
+    /// it's correct whether or not the decoder applied the strategy.
+    private static func canonicalKey(_ key: String) -> String {
+        var out = ""
+        for ch in key {
+            if ch.isUppercase {
+                out.append("_")
+                out.append(Character(ch.lowercased()))
+            } else {
+                out.append(ch)
+            }
+        }
+        return out
+    }
+}
+
 // MARK: - Shared nested types
 
 struct MatchLeagueDTO: Decodable {
@@ -226,7 +297,7 @@ struct MatchListResponseDTO: Decodable {
     /// Per-status totals for the filter tabs, keyed by the raw API status string
     /// ("pending", "in_progress", …). Honors the active `q` but not the status
     /// filter, so the counts stay stable as the user switches tabs.
-    let statusCounts: [String: Int]
+    let statusCounts: StatusCounts
 }
 
 // MARK: - Players (opponent picker)

--- a/ios/Fortymm/MatchFlow/MatchModels.swift
+++ b/ios/Fortymm/MatchFlow/MatchModels.swift
@@ -342,10 +342,11 @@ struct ResumeScoring: Identifiable {
 }
 
 /// A page of the match list plus the per-status counts that drive the filter
-/// tab badges. `statusCounts` is keyed by the raw API status string.
+/// tab badges. `statusCounts` reads its buckets by `APIMatchStatus`, not a raw
+/// string, so a tab can't mis-key the map.
 struct MatchListPage {
     let items: [FinalMatch]
-    let statusCounts: [String: Int]
+    let statusCounts: StatusCounts
 }
 
 /// Head-to-head summary from the detail BFF, framed from the current user's

--- a/ios/Fortymm/Matches/MatchesListView.swift
+++ b/ios/Fortymm/Matches/MatchesListView.swift
@@ -26,7 +26,7 @@ struct MatchesListView: View {
     @State private var resumeLoading = false
 
     @State private var matches: [FinalMatch] = []
-    @State private var statusCounts: [String: Int] = [:]
+    @State private var statusCounts: StatusCounts = .empty
     @State private var loading = true
     @State private var errorMessage: String?
     /// Coalesces overlapping fetches (tab switch racing a search) — each reload
@@ -144,8 +144,7 @@ struct MatchesListView: View {
     }
 
     private func count(for tab: StatusTab) -> Int {
-        guard let key = tab.countKey else { return statusCounts.values.reduce(0, +) }
-        return statusCounts[key] ?? 0
+        statusCounts.count(for: tab.apiStatus)
     }
 
     private var searchField: some View {
@@ -256,8 +255,8 @@ struct MatchesListView: View {
 }
 
 /// Lifecycle filter tabs, mirroring the web `/matches` status tabs. The
-/// `apiStatus` is sent as the `status` query param (nil = no filter); the
-/// `countKey` indexes the server's `status_counts` for the tab badge.
+/// `apiStatus` is sent as the `status` query param (nil = no filter) and also
+/// selects the tab's badge count from `StatusCounts` (nil = the "All" total).
 private enum StatusTab: CaseIterable, Identifiable {
     case all, live, upNext, final
 
@@ -286,11 +285,6 @@ private enum StatusTab: CaseIterable, Identifiable {
     static func tab(for status: APIMatchStatus?) -> StatusTab {
         allCases.first { $0.apiStatus == status } ?? .all
     }
-
-    /// `status_counts` key for this tab's badge — derived from `apiStatus` so the
-    /// filter value and the count lookup can't drift apart. Nil for "All", which
-    /// sums every status instead.
-    var countKey: String? { apiStatus?.rawValue }
 }
 
 private struct MatchRow: View {

--- a/ios/Fortymm/Networking/APIClient.swift
+++ b/ios/Fortymm/Networking/APIClient.swift
@@ -70,6 +70,14 @@ struct APIClient {
         self.session = session
         self.tokens = tokens
         let decoder = JSONDecoder()
+        // NB: on the objc-era Foundation (iOS 17, our minimum target)
+        // `.convertFromSnakeCase` also rewrites the keys *inside* a
+        // `[String: …]` dictionary (`in_progress` → `inProgress`);
+        // swift-foundation (iOS 18+) does not. So DTOs must not decode a raw
+        // `[String: …]` map keyed by a server string and then look it up by that
+        // string — it silently reads nil on iOS 17. Model such maps as a typed
+        // value that re-canonicalises keys at the boundary (see `StatusCounts`).
+        // Named struct fields are unaffected on either OS.
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         decoder.dateDecodingStrategy = .custom(APIClient.decodeDate)
         self.decoder = decoder


### PR DESCRIPTION
## B8 — iOS Live tab badge is always 0

### Root cause (version-dependent — this is the important nuance)
The Matches list decodes the BFF's `status_counts` map through `APIClient`'s shared `.convertFromSnakeCase` decoder, then looked it up by the raw status string: `statusCounts["in_progress"]` (`MatchesListView.swift`).

`JSONDecoder` is the **device's** Foundation, not the build toolchain's:
- **iOS 17 (objc-era Foundation — our minimum deployment target):** `.convertFromSnakeCase` *also* rewrites the keys **inside** a `[String: Int]` dictionary, so `in_progress` arrives as `inProgress`. The lookup by `"in_progress"` misses → `?? 0`. **Bug reproduces.**
- **iOS 18+ (swift-foundation):** dictionary keys are left alone, so the same lookup works. **Bug invisible** — which is also why a macOS decode probe (swift-foundation) can't see it.

Only **Live** breaks: `pending`/`completed` have no underscore to mangle.

### Fix
Replace the stringly-typed `[String: Int]` with a `StatusCounts` value that:
- **re-canonicalises decoded keys back to snake_case at the boundary** — idempotent on already-snake keys, so it's correct on *both* Foundations regardless of which one mangles;
- exposes only **enum-keyed accessors** (`count(for: APIMatchStatus?)`), so the raw string key never reaches a call site and a tab can't mis-key the map again;
- **models the server's open `status_counts` map** (not a fixed field set), keeping the "All" total faithful to every bucket the unfiltered feed shows — including `voided`/`disputed` and any status added server-side later (the `/v1/matches` browsing query applies no status exclusion).

The `apiStatus`→count coupling that previously leaked across `MatchListResponseDTO` → `MatchListPage` → view `@State` as a raw string (`StatusTab.countKey`) is deleted.

A guard comment at the shared decoder documents the footgun so the next raw-`[String:…]` decode doesn't reintroduce it.

### Verification
- **Whole-app `xcodebuild` build succeeds** (iPhone 17 sim, iOS 26.5), zero errors.
- **`swiftc` regression harness** (iOS has no XCTest target) compiled against the real `MatchAPI.swift`, feeding the **iOS-17 mangled shape** `{"inProgress": 3, "pending": 1, "completed": 5, "voided": 2}` directly: resolves **Live = 3** and **All = 11** (voided included). Also covers the un-mangled shape and `unknown → 0`.

### Scope / honest caveats
- I could not run an **iOS 17 simulator locally** (only iOS 26.5 installed), so the objc-Foundation mangle is asserted from documented behaviour + the deployment target, not an on-device repro. The fix is **correct and harmless on every supported OS** either way (real bugfix on iOS 17; clean domain-model hardening on iOS 18+).
- **Out of scope (follow-up):** migrating the hand-rolled `MatchListResponseDTO` onto the generated `Components.Schemas.MatchListResponse` (#798 types are reference-only). Noted DTO drift: the schema now carries `attention_count`/`awaiting_confirmation_count` the iOS DTO doesn't model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)