### PR TITLE
Fix #845: profile empty state says "no matches", not "no rated matches"

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,6 +74,44 @@ decided board, not an edit of individual game cells. The corrector may add,
 remove, or change games, so long as the outcome is again a decided board.
 _Avoid_: dispute, edit, amendment.
 
+## Match taxonomy
+
+**Rating**:
+A player's skill number in a league, moved only by **rated matches**. A player who
+has never finished a rated match has no rating ("Unrated" on their profile). Copy
+about "no rated matches yet" is correct when it is talking about *rating* — never
+when it is talking about a player's **match history**, which counts every kind of
+match.
+_Avoid_: score, rank, ELO (the number is a rating).
+
+**Rated match**:
+A match played for rating: it moves both players' **rating** when it completes.
+Always has a real opponent (you cannot play a rated match against nobody), and it
+completes only once the opposing side **accepts** the result.
+_Avoid_: ranked match, competitive match.
+
+**Unrated match**:
+A match that does not touch anyone's **rating**. May still have a named opponent
+(a friendly), or none at all (a **solo match**). Completes as soon as a result is
+recorded — there is no second party whose sign-off is worth waiting on.
+_Avoid_: casual match, friendly (a friendly is one *kind* of unrated match, not a
+synonym).
+
+**Solo match**:
+An unrated match with no opponent — the player records their own games against a
+player-less second side. Rendered as "No opponent" in a match list, and always
+unrated (a rated match needs an opponent). Its empty second side is a structural
+sentinel, not an absence to be filtered away.
+_Avoid_: practice match, single-player match, self match.
+
+**Match history**:
+Every match a player was on a side of — regardless of rating, opponent, or
+outcome — newest first. It is *not* a rated-play record: it includes unrated,
+solo, and still-in-progress matches. Contrast with **rating**, which is
+rated-only. This distinction is the whole point of issue #845: a player with an
+empty history "has no matches yet", not "no *rated* matches yet".
+_Avoid_: results, rated history, match log.
+
 ## Session and identity
 
 **Guest**:

--- a/docs/adr/0008-player-profile-matches-is-full-history.md
+++ b/docs/adr/0008-player-profile-matches-is-full-history.md
@@ -1,0 +1,32 @@
+# The player-profile Matches section is a full match history, not a rated-play record
+
+The per-player matches endpoint (`_paginated_player_matches` in `api/app/players.py`)
+filters on participation alone — every match the player is on a side of, any status,
+rated or not, opponent or solo. The profile's Matches section renders exactly that,
+including the deliberate "No opponent" row for solo matches. We treat this all-inclusive
+list as the intended contract and fixed the empty-state copy that contradicted it
+(it read "hasn't played any *rated* matches"; issue #845).
+
+The crux: a player's **rating** is rated-only, but their **match history** is
+all-inclusive. Copy and code must not conflate the two.
+
+## Considered options
+
+- **Broaden the copy to match the list (chosen).** The list's breadth is intentional —
+  the row renderer has first-class handling for solo/unrated/in-progress matches, and
+  the hero already labels a rating-less player "Unrated" separately. The stray word
+  "rated" in the empty state was the only thing out of step, so we removed it. Minimal,
+  and it keeps working behavior.
+- **Narrow the list to match the copy — filter to rated matches.** Rejected: it would
+  delete intended, tested behavior (the "No opponent" solo row, unrated friendlies,
+  in-progress matches) to satisfy one adjective, and it would make the Matches section
+  a second rated-only surface redundant with the rating hero.
+- **Add explicit sub-scopes (All / Rated tabs).** Rejected as over-engineering for a P4
+  copy bug; no product need for a rated-only filter on the profile exists today.
+
+## Consequences
+
+The next person who sees the rating-flavored hero next to an all-inclusive list should
+not "fix" the list back down to rated-only — that reconciliation was considered and
+rejected here. If a rated-only view is ever wanted, it is a new scoped surface, not a
+narrowing of Match history.

--- a/web-client/src/components/players/player-profile.tsx
+++ b/web-client/src/components/players/player-profile.tsx
@@ -300,7 +300,6 @@ function MatchesEmpty() {
       >
         No matches yet
       </div>
-      <div>This player hasn’t played any rated matches.</div>
     </div>
   )
 }


### PR DESCRIPTION
Closes #845.

## The bug
The player-profile Matches section's empty state read *"This player hasn't played any **rated** matches."* — but the per-player matches endpoint (`api/app/players.py` `_paginated_player_matches`) filters on **participation alone** and returns every match the player is on a side of: rated, unrated, solo (no opponent), and in-progress. The row renderer deliberately handles the solo "No opponent" case, so the list's breadth is the intended contract; the word "rated" was the straggler.

## The fix
Drop the contradictory subtext (`player-profile.tsx:303`). The bold **"No matches yet"** heading already states it correctly and scope-neutrally. One-line deletion; no test asserted the removed string (`$userId.test.tsx` pins only the heading), and the 3 profile-route tests still pass.

## Domain docs (grill-with-docs)
The copy leaked an *unstated contract*, so this PR also records it so the next person doesn't "fix" it the other way (re-filtering the list to rated-only):

- **`CONTEXT.md` → new "Match taxonomy" section** — `Rating`, `Rated match`, `Unrated match`, `Solo match`, `Match history`. The crux: **rating is rated-only; match history is all-inclusive.** ("No rated matches yet" copy is correct when it's about *rating*, wrong when it's about *history*.)
- **`docs/adr/0008`** — the profile Matches section is a full match history, not a rated-play record; records the two rejected alternatives (narrow the list to rated; add All/Rated tabs) and why broadening the copy won.

🤖 Generated with [Claude Code](https://claude.com/claude-code)