### PR TITLE
Fix #841: roster Seed shows true rating rank, not the page-row index

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -103,6 +103,21 @@ is to drop the stale identity and send the holder to sign in, never to quietly
 mint a fresh guest in their place.
 _Avoid_: logged out, expired, unauthenticated.
 
+## Players roster
+
+**Rank**:
+A player's position on a league's rating ladder — rank 1 is the highest-rated
+player in the league. It is a *global* fact about the player within a league:
+the same no matter how the roster is searched, sorted into pages, or otherwise
+windowed. Computed by standard competition ranking — your rank is one more than
+the number of players *strictly* above you by rating, so equal-rated players
+share a rank and the next rank skips (…, 7, 7, 9, …). A player with **no rating**
+(never finished a rated match) has **no rank** at all — not a large number at the
+bottom of the list.
+_Avoid_: seed, top seed, position, row number (the roster's leftmost column may
+be *styled* with tournament "seed" flavor, but the underlying concept is a
+rating rank, never the player's index on the current page).
+
 ## Dashboard
 
 **First-match**:

--- a/api/app/players.py
+++ b/api/app/players.py
@@ -78,6 +78,51 @@ async def _load_player_ratings(
     return {user_id: rating for user_id, rating in rows}
 
 
+async def _load_player_ranks(
+    db: AsyncSession, league_id: uuid.UUID, user_ids: Iterable[uuid.UUID]
+) -> dict[uuid.UUID, int]:
+    """One round trip: returns ``user_id -> rank`` for the requested users.
+
+    ``rank`` is a player's GLOBAL position on the league's rating ladder by
+    STANDARD COMPETITION RANKING — ``rank = 1 + (# of players rated strictly
+    higher)``, so equal ratings share a rank and the next rank skips
+    (…, 7, 7, 9, …), exactly what SQL ``RANK()`` computes.
+
+    The window is evaluated over the ENTIRE non-merged, rated league population
+    and only THEN filtered to ``user_ids`` — never over ``user_ids`` alone — so
+    a player's rank is a global fact, invariant under the roster's search or
+    pagination (the #841 regression). Tombstoned (merged-away) users are
+    excluded from the population so a ghost never inflates a real rank.
+
+    Users with no rating in the league are absent from the result (so
+    ``.get()`` yields ``None``): no rating, no rank.
+    """
+    ids = list(user_ids)
+    if not ids:
+        return {}
+    ranked = (
+        select(
+            UserLeagueRating.user_id.label("user_id"),
+            func.rank()
+            .over(order_by=UserLeagueRating.rating_value.desc())
+            .label("rank"),
+        )
+        .join(User, User.id == UserLeagueRating.user_id)
+        .where(
+            UserLeagueRating.league_id == league_id,
+            User.merged_into_user_id.is_(None),
+            UserLeagueRating.rating_value.is_not(None),
+        )
+    ).subquery()
+
+    rows = (
+        await db.execute(
+            select(ranked.c.user_id, ranked.c.rank).where(ranked.c.user_id.in_(ids))
+        )
+    ).all()
+    return {user_id: int(rank) for user_id, rank in rows}
+
+
 def escape_like(term: str) -> str:
     """Escape LIKE wildcards so a query of ``%`` matches a literal percent
     sign rather than every username."""
@@ -273,14 +318,15 @@ async def _summarize_players(
     db: AsyncSession, users: list[User], league_id: uuid.UUID
 ) -> list[PlayerSummary]:
     """Hydrate a list of ``User``s into the ``PlayerSummary`` shape the
-    `/players` list + profile-page hero render. Three round trips total
-    (ratings, W-L, form) regardless of page size."""
+    `/players` list + profile-page hero render. Four round trips total
+    (ratings, W-L, form, ranks) regardless of page size."""
     if not users:
         return []
     user_ids = [user.id for user in users]
     ratings = await _load_player_ratings(db, league_id, user_ids)
     wl = await _load_wl_counts(db, user_ids)
     form = await _load_form(db, user_ids)
+    ranks = await _load_player_ranks(db, league_id, user_ids)
     return [
         PlayerSummary(
             id=user.id,
@@ -289,6 +335,7 @@ async def _summarize_players(
             wins=wl.get(user.id, (0, 0))[0],
             losses=wl.get(user.id, (0, 0))[1],
             form=form.get(user.id, ""),
+            rank=ranks.get(user.id),
         )
         for user in users
     ]

--- a/api/app/schemas/player.py
+++ b/api/app/schemas/player.py
@@ -38,6 +38,12 @@ class PlayerSummary(BaseModel):
     # Newest-first 0..5 character string of `W`/`L`. Empty when the player
     # has no completed matches yet.
     form: str = ""
+    # Global position on the league's rating ladder (rank 1 = highest-rated),
+    # by standard competition ranking — a *global* fact, invariant under the
+    # roster's search/pagination. `None` for a player with no rating (never
+    # finished a rated match): no rating, no rank. See CONTEXT.md ("Rank") and
+    # docs/adr/0008. Never the player's row index on the current page (#841).
+    rank: int | None = None
 
 
 class PlayerListResponse(BaseModel):

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -398,6 +398,138 @@ async def _record_match_with_winner(
     return match
 
 
+async def _rate(
+    db_session: AsyncSession, user: User, rating_value: float | None
+) -> None:
+    """Attach a default-league ``UserLeagueRating`` to ``user``. A ``None``
+    ``rating_value`` models a player who has a rating row but has never
+    finished a rated match (unranked)."""
+    league = await get_default_league(db_session)
+    db_session.add(
+        UserLeagueRating(
+            league_id=league.id,
+            user_id=user.id,
+            rating_value=rating_value,
+        )
+    )
+    await db_session.commit()
+
+
+def _rank_for(items: list[dict], username: str):
+    for player in items:
+        if player["username"] == username:
+            return player["rank"]
+    raise KeyError(username)
+
+
+async def test_list_players_rank_is_none_for_unrated_player(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A player with no rating (never finished a rated match) has no rank —
+    no rating, no ladder position."""
+    await start_session(api_client, db_session)
+    rated = await make_user(db_session, "rank.rated")
+    unrated = await make_user(db_session, "rank.unrated")
+    await _rate(db_session, rated, 1600.0)
+    # `unrated` gets no rating row at all → absent from the rank population.
+    assert unrated is not None
+
+    response = await api_client.get("/v1/players", params={"q": "rank."})
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert _rank_for(items, "rank.rated") == 1
+    assert _rank_for(items, "rank.unrated") is None
+
+
+async def test_list_players_rank_ties_share_and_next_rank_skips(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Standard competition ranking: two players tied on rating share a rank
+    and the next-lower player's rank SKIPS the shared slot (…, 1, 1, 3)."""
+    await start_session(api_client, db_session)
+    top_a = await make_user(db_session, "tie.aaa")
+    top_b = await make_user(db_session, "tie.bbb")
+    lower = await make_user(db_session, "tie.ccc")
+    await _rate(db_session, top_a, 1800.0)
+    await _rate(db_session, top_b, 1800.0)
+    await _rate(db_session, lower, 1500.0)
+
+    response = await api_client.get("/v1/players", params={"q": "tie."})
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert _rank_for(items, "tie.aaa") == 1
+    assert _rank_for(items, "tie.bbb") == 1
+    # The tie consumes ranks 1 and 2, so the next player is rank 3, not 2.
+    assert _rank_for(items, "tie.ccc") == 3
+
+
+async def test_list_players_rank_is_global_across_filter_and_pagination(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The #841 regression guard: a player's rank is a GLOBAL ladder fact,
+    identical whether the row is fetched unfiltered, under a ``q`` search that
+    hides higher-rated players, or on page 2 — never the row's index on the
+    current page."""
+    await start_session(api_client, db_session)
+    # A descending ladder; ``mid`` sits at global rank 3.
+    top = await make_user(db_session, "glob.top")
+    second = await make_user(db_session, "glob.second")
+    mid = await make_user(db_session, "glob.mid")
+    fourth = await make_user(db_session, "glob.fourth")
+    fifth = await make_user(db_session, "glob.fifth")
+    await _rate(db_session, top, 2000.0)
+    await _rate(db_session, second, 1900.0)
+    await _rate(db_session, mid, 1800.0)
+    await _rate(db_session, fourth, 1700.0)
+    await _rate(db_session, fifth, 1600.0)
+
+    # Unfiltered: mid is globally rank 3.
+    unfiltered = await api_client.get("/v1/players", params={"page_size": 100})
+    assert unfiltered.status_code == 200
+    assert _rank_for(unfiltered.json()["items"], "glob.mid") == 3
+
+    # Under a search filter that excludes the two higher-rated players, mid
+    # would be row 1 of the results — its rank must still be 3.
+    filtered = await api_client.get("/v1/players", params={"q": "glob.mid"})
+    assert _rank_for(filtered.json()["items"], "glob.mid") == 3
+
+    # On page 2 (page_size 1, ordered by rating desc), mid is the only row —
+    # its rank must be 3, not the page-relative index 1.
+    page3 = await api_client.get(
+        "/v1/players", params={"q": "glob.", "page": 3, "page_size": 1}
+    )
+    page3_items = page3.json()["items"]
+    assert len(page3_items) == 1
+    assert page3_items[0]["username"] == "glob.mid"
+    assert page3_items[0]["rank"] == 3
+
+
+async def test_list_players_rank_ignores_merged_ghost(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A tombstoned (merged-away) high-rated user must NOT be part of the rank
+    population — otherwise it would push every real player one rank down."""
+    await start_session(api_client, db_session)
+    ghost = await make_user(db_session, "ghost.top")
+    survivor = await make_user(db_session, "ghost.survivor")
+    real_top = await make_user(db_session, "real.top")
+    real_second = await make_user(db_session, "real.second")
+    # The ghost outrates everyone, but it's a tombstone.
+    await _rate(db_session, ghost, 3000.0)
+    await _rate(db_session, real_top, 2000.0)
+    await _rate(db_session, real_second, 1500.0)
+
+    ghost.merged_into_user_id = survivor.id
+    await db_session.commit()
+
+    response = await api_client.get("/v1/players", params={"page_size": 100})
+    assert response.status_code == 200
+    items = response.json()["items"]
+    # The ghost is excluded, so the real top is rank 1 (not 2).
+    assert _rank_for(items, "real.top") == 1
+    assert _rank_for(items, "real.second") == 2
+
+
 async def test_list_players_requires_a_session(api_client: AsyncClient):
     async with make_client() as client:
         response = await client.get("/v1/players")

--- a/docs/adr/0008-roster-rank-is-a-global-rating-fact.md
+++ b/docs/adr/0008-roster-rank-is-a-global-rating-fact.md
@@ -1,0 +1,67 @@
+# Roster rank is a global rating fact, not a page index
+
+The `/players` roster shows a **Seed** column with the top four styled gold
+(`players-seed--top`, the `--ball-500` top-seed accent). The number was computed
+purely on the client as `startIndex + i + 1` — the row's position on the current
+page. The server keeps a rating-descending sort, so on the *unfiltered first
+page* that index coincidentally equals rating rank, and the column looked right.
+
+The coincidence is the whole bug (finding #841). The moment the roster is
+searched or paged, page-index numbering renumbers the visible rows `1..N` and
+gilds the first four — so typing "zoe" (true rating rank ~250) paints her as
+**Seed #1** with the top-seed accent, and row 1 of page 2 always shows "#1". The
+column made a semantic promise — "these are the strongest players" — that a page
+index cannot keep.
+
+We decided the roster's leftmost number is a **Rank**: a player's global
+position on the league's rating ladder, computed server-side and carried per-row
+on `PlayerSummary` as `rank: int | None`. Rank is a *global* fact within a
+league — invariant under search, pagination, and any other windowing of the
+roster.
+
+- **Computation: standard competition ranking.** `rank = 1 + the number of
+  non-merged, rated players in the league with strictly greater rating`. Equal
+  ratings share a rank and the next rank skips (…, 7, 7, 9, …). Strictly-greater
+  gives shared ranks and null-for-unrated for free.
+- **Unrated players have no rank.** A player who has never finished a rated
+  match has a `NULL` league rating and therefore `rank = None`, rendered as an
+  em-dash — never a number at the bottom of the list. Numbering them would
+  recreate the same lie ("#251" reads as "251st best," but they are *unranked*).
+- **The population excludes tombstones.** The count is taken over the same
+  non-merged (`merged_into_user_id IS NULL`) population the roster itself lists,
+  so a high-rated merged-away ghost cannot inflate everyone's rank.
+- **The UI is unchanged in look.** The column header stays "Seed" and the gold
+  top-four accent stays — only the underlying number becomes honest. The accent
+  now keys off `rank != null && rank <= 4` (a naïve `rank <= 4` would gild every
+  unrated player, since `null <= 4` is `true` in JS). A rating tie into the top
+  four may correctly gild a fifth player.
+
+## Considered options
+
+- **Client-side page index (status quo).** Free, no schema change, no extra
+  query — but it is only correct on the unfiltered first page and actively
+  misleads under every search and on every later page. Rejected: it is the bug.
+- **Drop the Seed framing whenever it can't be trusted** (blank the column under
+  a filter or beyond page 1). Cheap and honest, but throws away a genuinely
+  useful signal — a searching user most wants to know "how good is this player,"
+  and rank answers exactly that. Rejected in favour of showing the true rank.
+- **Global server-side rating rank on `PlayerSummary` (chosen).** Costs one
+  extra indexed count-query per hydrate and a regeneration of the cross-platform
+  generated types (`web-client/src/api/schema.d.ts`,
+  `ios/Fortymm/Generated/Types.swift`). We accept that cost to make the column
+  tell the truth everywhere. `rank: int | None` makes "unrated has no rank"
+  unrepresentable-as-a-number at the type boundary.
+
+## Consequences
+
+- Rank rides on the shared `PlayerSummary`, so the profile-page hero receives it
+  too. This change does **not** display it there — a scoped follow-up can, with
+  its own placement/design pass.
+- iOS has no roster surface (it uses `/v1/players/recent` and
+  `/v1/players/search`), so the only iOS impact is the regenerated types-only
+  drift guard; there is no functional iOS change.
+- The next contributor who sees a whole-population count where `startIndex + i +
+  1` "would do" should read this ADR before "simplifying" it: the cheap version
+  is a lie under search and pagination.
+</content>
+</invoke>

--- a/docs/adr/0008-roster-rank-is-a-global-rating-fact.md
+++ b/docs/adr/0008-roster-rank-is-a-global-rating-fact.md
@@ -63,5 +63,3 @@ roster.
 - The next contributor who sees a whole-population count where `startIndex + i +
   1` "would do" should read this ADR before "simplifying" it: the cheap version
   is a lie under search and pagination.
-</content>
-</invoke>

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -4152,6 +4152,8 @@ internal enum Components {
             internal var losses: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/PlayerDetail/form`.
             internal var form: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/PlayerDetail/rank`.
+            internal var rank: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/PlayerDetail/matches`.
             internal var matches: Components.Schemas.PlayerMatchListResponse
             /// Creates a new `PlayerDetail`.
@@ -4163,6 +4165,7 @@ internal enum Components {
             ///   - wins:
             ///   - losses:
             ///   - form:
+            ///   - rank:
             ///   - matches:
             internal init(
                 id: Swift.String,
@@ -4171,6 +4174,7 @@ internal enum Components {
                 wins: Swift.Int? = nil,
                 losses: Swift.Int? = nil,
                 form: Swift.String? = nil,
+                rank: Swift.Int? = nil,
                 matches: Components.Schemas.PlayerMatchListResponse
             ) {
                 self.id = id
@@ -4179,6 +4183,7 @@ internal enum Components {
                 self.wins = wins
                 self.losses = losses
                 self.form = form
+                self.rank = rank
                 self.matches = matches
             }
             internal enum CodingKeys: String, CodingKey {
@@ -4188,6 +4193,7 @@ internal enum Components {
                 case wins
                 case losses
                 case form
+                case rank
                 case matches
             }
         }
@@ -4436,6 +4442,8 @@ internal enum Components {
             internal var losses: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/PlayerSummary/form`.
             internal var form: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/PlayerSummary/rank`.
+            internal var rank: Swift.Int?
             /// Creates a new `PlayerSummary`.
             ///
             /// - Parameters:
@@ -4445,13 +4453,15 @@ internal enum Components {
             ///   - wins:
             ///   - losses:
             ///   - form:
+            ///   - rank:
             internal init(
                 id: Swift.String,
                 username: Swift.String,
                 rating: Swift.Double? = nil,
                 wins: Swift.Int? = nil,
                 losses: Swift.Int? = nil,
-                form: Swift.String? = nil
+                form: Swift.String? = nil,
+                rank: Swift.Int? = nil
             ) {
                 self.id = id
                 self.username = username
@@ -4459,6 +4469,7 @@ internal enum Components {
                 self.wins = wins
                 self.losses = losses
                 self.form = form
+                self.rank = rank
             }
             internal enum CodingKeys: String, CodingKey {
                 case id
@@ -4467,6 +4478,7 @@ internal enum Components {
                 case wins
                 case losses
                 case form
+                case rank
             }
         }
         /// A slice of tables reserved for a window of time within an event.

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -2001,6 +2001,8 @@ export interface components {
              * @default
              */
             form: string;
+            /** Rank */
+            rank?: number | null;
             matches: components["schemas"]["PlayerMatchListResponse"];
         };
         /**
@@ -2136,6 +2138,8 @@ export interface components {
              * @default
              */
             form: string;
+            /** Rank */
+            rank?: number | null;
         };
         /**
          * Pool

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -130,12 +130,35 @@ function djb2(s: string): number {
   return Math.abs(h)
 }
 
+/** Global rating rank (1 = highest) keyed by player id, derived from the whole
+ * mock roster. Rated players are sorted by rating descending and numbered
+ * 1-based; an unrated player (null rating, e.g. `park.j`) maps to `null`. This
+ * mirrors the real `rank` field the API projects, so the roster renders true
+ * ranks instead of page-index numbering (#841). Memoized — the roster is
+ * static. */
+let rankByIdCache: Map<string, number | null> | null = null
+function rosterRankById(): Map<string, number | null> {
+  if (rankByIdCache) return rankByIdCache
+  const roster = mockPlayerRoster()
+  const map = new Map<string, number | null>()
+  roster
+    .filter((p) => (p.rating ?? null) !== null)
+    .sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0))
+    .forEach((p, i) => map.set(p.id, i + 1))
+  for (const p of roster) {
+    if (!map.has(p.id)) map.set(p.id, null)
+  }
+  rankByIdCache = map
+  return map
+}
+
 function summarizePlayer(p: {
   id: string
   username: string
   rating?: number | null
 }): PlayerSummary {
   const rating = p.rating ?? null
+  const rank = rosterRankById().get(p.id) ?? null
   // The current user gets real W-L derived from `mockMatches` so the
   // self-profile feels live. Everyone else gets deterministic synthesis
   // seeded by username — stable across reloads.
@@ -171,6 +194,7 @@ function summarizePlayer(p: {
       id: p.id,
       username: p.username,
       rating,
+      rank,
       wins,
       losses,
       form: recent.join(''),
@@ -186,6 +210,7 @@ function summarizePlayer(p: {
     id: p.id,
     username: p.username,
     rating,
+    rank,
     wins,
     losses,
     form,

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -140,11 +140,20 @@ let rankByIdCache: Map<string, number> | null = null
 function rosterRankById(): Map<string, number> {
   if (rankByIdCache) return rankByIdCache
   const map = new Map<string, number>()
+  // Standard competition ranking, mirroring the API's SQL `RANK()`: equal
+  // ratings share a rank and the next rank skips (…, 7, 7, 9, …). Unrated
+  // players are simply absent — callers read `.get(id) ?? null`.
+  let prevRating: number | null = null
+  let prevRank = 0
   mockPlayerRoster()
     .filter((p) => p.rating != null)
     .sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0))
-    .forEach((p, i) => map.set(p.id, i + 1))
-  // Unrated players are simply absent — callers read `.get(id) ?? null`.
+    .forEach((p, i) => {
+      const rank = p.rating === prevRating ? prevRank : i + 1
+      map.set(p.id, rank)
+      prevRating = p.rating ?? null
+      prevRank = rank
+    })
   rankByIdCache = map
   return map
 }

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -136,18 +136,15 @@ function djb2(s: string): number {
  * mirrors the real `rank` field the API projects, so the roster renders true
  * ranks instead of page-index numbering (#841). Memoized — the roster is
  * static. */
-let rankByIdCache: Map<string, number | null> | null = null
-function rosterRankById(): Map<string, number | null> {
+let rankByIdCache: Map<string, number> | null = null
+function rosterRankById(): Map<string, number> {
   if (rankByIdCache) return rankByIdCache
-  const roster = mockPlayerRoster()
-  const map = new Map<string, number | null>()
-  roster
-    .filter((p) => (p.rating ?? null) !== null)
+  const map = new Map<string, number>()
+  mockPlayerRoster()
+    .filter((p) => p.rating != null)
     .sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0))
     .forEach((p, i) => map.set(p.id, i + 1))
-  for (const p of roster) {
-    if (!map.has(p.id)) map.set(p.id, null)
-  }
+  // Unrated players are simply absent — callers read `.get(id) ?? null`.
   rankByIdCache = map
   return map
 }

--- a/web-client/src/routes/_app/players/index.test.tsx
+++ b/web-client/src/routes/_app/players/index.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { server } from '@/mocks/server'
+import { sessionResponse } from '@/test/factories'
+import { Route } from './index'
+
+const PlayersRoute = Route.options.component!
+
+/** A PlayerSummary row — only the fields the roster table reads. `rank` is the
+ * player's true global rating rank (1 = highest); `null` means unrated. */
+function playerRow(
+  overrides: {
+    id: string
+    username: string
+    rank: number | null
+    rating?: number | null
+  },
+) {
+  return {
+    rating: 1500,
+    wins: 10,
+    losses: 5,
+    form: 'WWLWL',
+    ...overrides,
+  }
+}
+
+function renderRoster(initialEntry: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute()
+  const rosterRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/players/',
+    component: PlayersRoute,
+    validateSearch: Route.options.validateSearch,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([rosterRoute]),
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+/** Find the row whose player-name cell reads `username`, then return its
+ * rank/seed span so the assertions don't collide with the em-dashes the
+ * rating/form cells also render for unrated/empty players. */
+function seedSpanFor(username: string): HTMLElement {
+  const row = screen.getByText(username).closest('tr')
+  if (!row) throw new Error(`no row for ${username}`)
+  const span = within(row).getByText((_, el) =>
+    el?.classList.contains('players-seed') ?? false,
+  )
+  return span
+}
+
+describe('players roster rank column (#841)', () => {
+  it('renders true global ranks, gilds the top 4, and shows an em-dash for unrated', async () => {
+    const items = [
+      playerRow({ id: 'p-1', username: 'ace.top', rank: 1 }),
+      playerRow({ id: 'p-2', username: 'mid.player', rank: 7 }),
+      playerRow({
+        id: 'p-3',
+        username: 'unrated.rookie',
+        rank: null,
+        rating: null,
+      }),
+    ]
+    server.use(
+      http.get('*/v1/session', () => HttpResponse.json(sessionResponse())),
+      http.get('*/v1/players', () =>
+        HttpResponse.json({
+          items,
+          page: 1,
+          page_size: 25,
+          total: items.length,
+        }),
+      ),
+    )
+
+    renderRoster('/players')
+
+    // Rows render once the list resolves.
+    await screen.findByText('ace.top')
+
+    // Ranked rows show `#N`.
+    const topSeed = seedSpanFor('ace.top')
+    expect(topSeed.textContent).toBe('#1')
+    const midSeed = seedSpanFor('mid.player')
+    expect(midSeed.textContent).toBe('#7')
+
+    // A top-4 rank IS gilded gold.
+    expect(topSeed.classList.contains('players-seed--top')).toBe(true)
+    // A rank outside the top 4 is NOT gilded.
+    expect(midSeed.classList.contains('players-seed--top')).toBe(false)
+
+    // The unrated row shows the em-dash and is NOT gilded — the null guard
+    // matters because `null <= 4` is truthy in JS.
+    const unratedSeed = seedSpanFor('unrated.rookie')
+    expect(unratedSeed.textContent).toBe('—')
+    expect(unratedSeed.classList.contains('players-seed--top')).toBe(false)
+  })
+
+  it('does not crash when the roster is empty', async () => {
+    server.use(
+      http.get('*/v1/session', () => HttpResponse.json(sessionResponse())),
+      http.get('*/v1/players', () =>
+        HttpResponse.json({ items: [], page: 1, page_size: 25, total: 0 }),
+      ),
+    )
+
+    renderRoster('/players')
+
+    await waitFor(() =>
+      expect(screen.getByText(/no players match/i)).toBeInTheDocument(),
+    )
+  })
+})

--- a/web-client/src/routes/_app/players/index.tsx
+++ b/web-client/src/routes/_app/players/index.tsx
@@ -291,10 +291,6 @@ function SkeletonRows() {
 
 function PlayerRow({ player }: { player: PlayerSummary }) {
   const navigate = useNavigate()
-  // `rank` is the player's true global rating rank (1 = highest); `null` means
-  // unrated. Guard the null explicitly — in JS `null <= 4` is `true`, so a bare
-  // `rank <= 4` would gild every unrated player gold (#841).
-  const rank = player.rank ?? null
   const open = () =>
     navigate({ to: '/players/$userId', params: { userId: player.id } })
   return (
@@ -312,14 +308,7 @@ function PlayerRow({ player }: { player: PlayerSummary }) {
       }}
     >
       <td>
-        <span
-          className={
-            'players-seed' +
-            (rank != null && rank <= 4 ? ' players-seed--top' : '')
-          }
-        >
-          {rank != null ? `#${rank}` : '—'}
-        </span>
+        <SeedCell rank={player.rank} />
       </td>
       <td>
         <div className="player">
@@ -340,6 +329,25 @@ function PlayerRow({ player }: { player: PlayerSummary }) {
         <FormDots form={player.form} />
       </td>
     </tr>
+  )
+}
+
+function SeedCell({ rank }: { rank: number | null | undefined }) {
+  // `rank` is the player's true global rating rank (1 = highest); `null` /
+  // undefined means unrated — render a dim em-dash, like the rating/form cells,
+  // rather than a number. Guard the null explicitly: in JS `null <= 4` is
+  // `true`, so a bare `rank <= 4` would gild every unrated player gold (#841).
+  if (rank === null || rank === undefined) {
+    return (
+      <span className="players-seed" style={{ color: 'var(--fg-3)' }}>
+        —
+      </span>
+    )
+  }
+  return (
+    <span className={'players-seed' + (rank <= 4 ? ' players-seed--top' : '')}>
+      #{rank}
+    </span>
   )
 }
 

--- a/web-client/src/routes/_app/players/index.tsx
+++ b/web-client/src/routes/_app/players/index.tsx
@@ -142,10 +142,9 @@ function PlayersPage() {
   }, [isLoading, isFetching, page, totalPages, setPage])
 
   // The redirect runs in an effect, so an out-of-range page paints for one
-  // frame first. Clamp the page the footer + seed numbering render with so the
-  // range math never shows start > end during that frame.
+  // frame first. Clamp the page the footer renders with so the range math
+  // never shows start > end during that frame.
   const displayPage = Math.min(page, totalPages)
-  const startIndex = (displayPage - 1) * PAGE_SIZE
 
   return (
     <div className="match-list-page">
@@ -155,7 +154,6 @@ function PlayersPage() {
         <PlayerTable
           rows={items}
           isLoading={isLoading}
-          startIndex={startIndex}
           onClear={onClear}
         />
       </div>
@@ -221,12 +219,10 @@ function FilterRow({
 function PlayerTable({
   rows,
   isLoading,
-  startIndex,
   onClear,
 }: {
   rows: PlayerSummary[]
   isLoading: boolean
-  startIndex: number
   onClear: () => void
 }) {
   if (isLoading && rows.length === 0) {
@@ -260,8 +256,8 @@ function PlayerTable({
         </tr>
       </thead>
       <tbody>
-        {rows.map((p, i) => (
-          <PlayerRow key={p.id} player={p} seed={startIndex + i + 1} />
+        {rows.map((p) => (
+          <PlayerRow key={p.id} player={p} />
         ))}
       </tbody>
     </table>
@@ -293,8 +289,12 @@ function SkeletonRows() {
   )
 }
 
-function PlayerRow({ player, seed }: { player: PlayerSummary; seed: number }) {
+function PlayerRow({ player }: { player: PlayerSummary }) {
   const navigate = useNavigate()
+  // `rank` is the player's true global rating rank (1 = highest); `null` means
+  // unrated. Guard the null explicitly — in JS `null <= 4` is `true`, so a bare
+  // `rank <= 4` would gild every unrated player gold (#841).
+  const rank = player.rank ?? null
   const open = () =>
     navigate({ to: '/players/$userId', params: { userId: player.id } })
   return (
@@ -314,10 +314,11 @@ function PlayerRow({ player, seed }: { player: PlayerSummary; seed: number }) {
       <td>
         <span
           className={
-            'players-seed' + (seed <= 4 ? ' players-seed--top' : '')
+            'players-seed' +
+            (rank != null && rank <= 4 ? ' players-seed--top' : '')
           }
         >
-          #{seed}
+          {rank != null ? `#${rank}` : '—'}
         </span>
       </td>
       <td>


### PR DESCRIPTION
## Problem (#841)

The `/players` roster "Seed" was computed on the client as `startIndex + i + 1` — a page-relative row index dressed up as a rating rank. The server keeps a rating-desc sort, so on the *unfiltered first page* the index coincidentally equals rank. But any search or page > 1 renumbers the visible rows `1..N` and gilds the first four gold — so searching "zoe" (true rank ~250) painted her as **Seed #1** with the top-seed accent.

## Fix

The roster number is now a **true global rating rank**, computed server-side and carried per-row on `PlayerSummary` (`rank: int | None`). It's invariant under search and pagination — a global fact, not a page index.

- **Rank = standard competition ranking**: `1 + count of non-merged, rated players in the league with strictly greater rating`. Ties share a rank, the next rank skips. Computed over the *whole* league population (excludes tombstoned/merged users so a high-rated ghost can't inflate ranks).
- **Unrated players have no rank** — rendered as an em-dash `—`, never a number.
- **UI look unchanged**: the column header stays "Seed" and the gold top-4 accent stays — only the number becomes honest. The accent is guarded `rank != null && rank <= 4` (the `null <= 4 === true` JS footgun would otherwise gild every unrated player).
- Profile hero carries `rank` silently (no display this PR — a scoped follow-up can add it).
- **iOS**: no roster surface, so only the regenerated types-only drift guard (`Types.swift`) changes — no functional iOS change.

## Design docs

This was designed in a grilling session first; the decision + domain term are recorded:
- `CONTEXT.md` — new **Rank** glossary term
- `docs/adr/0008-roster-rank-is-a-global-rating-fact.md`

## Commits (atomic)

1. Add `rank` to `PlayerSummary` + regenerate `schema.d.ts` & `Types.swift`
2. Compute global rank server-side (`_load_player_ranks`) + pytest (ties, unrated, filter/page #841 guard, tombstone exclusion)
3. Carry `rank` in the MSW player factory
4. Roster reads `player.rank` (not the page index), drops dead `startIndex`, + route vitest

## Verification

- API: `ruff` / `mypy` clean; `pytest` green (38 in test_players.py, incl. 4 new)
- web-client: `lint` clean; `test:run` 1196 pass; `build` ok; `test:e2e` 133 pass

Fixes #841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeHbFJLvz6B1txgyURQgpL