### PR TITLE
Serialize the per-game score endpoints under the match row lock (#835)

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1876,7 +1876,14 @@ async def create_game_score(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> MatchDetails:
-    match = await _load_match_for_scoring(db, match_id, current_user.id)
+    # Take the blocking match row lock so this score write serializes against a
+    # concurrent first ``post_match_result`` (which locks the same row NOWAIT).
+    # The lock is acquired *before* the eager load, so the ``_enforce_scorable``
+    # recheck below runs on the serialized (post-freeze) state — a score can no
+    # longer commit atop a result the propose already froze (#835, ADR-0009).
+    # Blocking (not NOWAIT): the common score-vs-score contention resolves via
+    # the uq_match_games / version guards and must not spuriously 409.
+    match = await _load_match_for_scoring(db, match_id, current_user.id, lock=True)
     _enforce_scorable(match)
     if game_number > match.match_settings.best_of:
         raise HTTPException(
@@ -1943,7 +1950,12 @@ async def update_game_score(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> MatchDetails:
-    match = await _load_match_for_scoring(db, match_id, current_user.id)
+    # Blocking match row lock (see ``create_game_score``): serializes this update
+    # against a concurrent first ``post_match_result`` so ``_enforce_scorable``
+    # rechecks the serialized state and the conditional UPDATE below can't race a
+    # board freeze that deletes the target score row (#835, ADR-0009). Blocking,
+    # not NOWAIT, so the common score-vs-score edit isn't spuriously 409'd.
+    match = await _load_match_for_scoring(db, match_id, current_user.id, lock=True)
     _enforce_scorable(match)
 
     game = next((g for g in match.games if g.game_number == game_number), None)
@@ -2012,7 +2024,12 @@ async def delete_game_score(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> MatchDetails:
-    match = await _load_match_for_scoring(db, match_id, current_user.id)
+    # Blocking match row lock (see ``create_game_score``): serializes this delete
+    # against a concurrent first ``post_match_result`` so ``_enforce_scorable``
+    # rechecks the serialized state, and two racing clears re-read under the lock
+    # — the loser sees the already-cleared score and 404s instead of a lying 200
+    # (#835, ADR-0009). Blocking, not NOWAIT, to match the other score paths.
+    match = await _load_match_for_scoring(db, match_id, current_user.id, lock=True)
     _enforce_scorable(match)
 
     game = next((g for g in match.games if g.game_number == game_number), None)

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1845,8 +1845,9 @@ async def _load_match_for_scoring(
     lock: bool = False,
     nowait: bool = False,
 ) -> Match:
-    # ``lock`` callers (the negotiation transitions) take the row lock *before*
-    # the eager load so the match state they read is the serialized one.
+    # ``lock`` callers (the negotiation transitions, and per ADR-0009 the score
+    # endpoints) take the row lock *before* the eager load so the match state
+    # they read is the serialized one.
     if lock:
         await _lock_match_row(db, match_id, nowait=nowait)
     match = await _load_match(db, match_id)

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -996,17 +996,22 @@ async def test_concurrent_score_create_returns_409_not_500(
     api_client: AsyncClient, db_session: AsyncSession, engine: AsyncEngine
 ):
     """Regression for #362. Two participants sitting on the same
-    game-score-entry page who submit at the same instant both lazily insert
-    the same game row (``uq_match_games_match_id_game_number``); the loser of
-    the race trips the unique constraint at commit. Before the guard that
-    surfaced as a raw 500 — it must be the same clean 409 the sequential
-    already-scored path returns.
+    game-score-entry page who submit at the same instant must both get a clean
+    409, never a raw 500.
+
+    Since ADR-0009 the score path takes the blocking match row lock, so the two
+    creates *serialize*: the loser waits, re-reads the committed game under the
+    lock, and 409s via the ``game.score is not None`` pre-check rather than the
+    ``uq_match_games_match_id_game_number`` collision at commit. (The
+    ``except IntegrityError`` handler on the create path is retained as a
+    backstop for any residual same-game insert race, but the lock means this
+    test exercises the pre-check path.)
 
     Driven on two *separate* DB sessions (real distinct Postgres connections)
-    via ``asyncio.gather`` so the constraint actually arbitrates — the shared
-    ``db_session`` override can't surface the race. An un-mapped
-    ``IntegrityError`` would escape ``run``'s ``HTTPException``-only ``except``
-    and fail the test loudly, which is exactly the 500 we're guarding against.
+    via ``asyncio.gather`` — the shared ``db_session`` override can't surface
+    the race. An un-mapped exception would escape ``run``'s
+    ``HTTPException``-only ``except`` and fail the test loudly, which is exactly
+    the 500 we're guarding against.
     """
     me = await start_session(api_client, db_session)
     async with opponent_session(db_session, "race-opp") as (_opp_client, opp):
@@ -1348,9 +1353,11 @@ async def test_update_game_score_racing_first_propose_never_500s(
             ),
         )
 
-        # Clean serialized outcome: the updater never 500s / never leaks a raw
-        # StaleDataError/InvalidRequestError; the first-propose is bounced.
-        assert updater_status in (200, 409), updater_status
+        # Clean serialized outcome: the updater holds the lock, the first-propose
+        # (NOWAIT) is bounced, and the update runs under the lock against its
+        # still-unfrozen target row (version 1) — a deterministic 200, never a
+        # raw StaleDataError/InvalidRequestError.
+        assert updater_status == 200, updater_status
         assert proposer_status == 409, proposer_status
 
 

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1055,6 +1055,71 @@ async def test_concurrent_score_create_returns_409_not_500(
             assert len(scores) == 1, scores
 
 
+def _install_scoring_load_barrier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[asyncio.Event, asyncio.Event]:
+    """Barrier on the ``_load_match_for_scoring`` seam for a deterministic
+    first-propose race. The score path (which never passes ``nowait``) parks
+    after loading until ``settled`` is set; the propose (``nowait=True``) sails
+    through. Returns ``(loaded, settled)`` — the score racer sets ``loaded`` once
+    it has loaded, the propose sets ``settled`` once it has run, pinning
+    "scorer loads → proposer settles → scorer commits"."""
+    loaded = asyncio.Event()
+    settled = asyncio.Event()
+    real_loader = matches_mod._load_match_for_scoring
+
+    async def loader_with_barrier(
+        db: AsyncSession,
+        target_id: uuid.UUID,
+        current_user_id: uuid.UUID,
+        *,
+        lock: bool = False,
+        nowait: bool = False,
+    ) -> Match:
+        result = await real_loader(
+            db, target_id, current_user_id, lock=lock, nowait=nowait
+        )
+        if not nowait:
+            loaded.set()
+            await settled.wait()
+        return result
+
+    monkeypatch.setattr(matches_mod, "_load_match_for_scoring", loader_with_barrier)
+    return loaded, settled
+
+
+async def _first_propose_after_barrier(
+    make_session: async_sessionmaker[AsyncSession],
+    loaded: asyncio.Event,
+    settled: asyncio.Event,
+    match_id: uuid.UUID,
+    user_id: uuid.UUID,
+    games: list[MatchResultsGameWrite],
+) -> int:
+    """The proposer half of a barriered first-propose race (see
+    ``_install_scoring_load_barrier``): wait for the score racer to load, then
+    post a first result directly on its own real session, signalling ``settled``
+    when done so the parked racer can resume. Returns the result status."""
+    await loaded.wait()
+    async with make_session() as session:
+        user = (
+            await session.execute(select(User).where(User.id == user_id))
+        ).scalar_one()
+        try:
+            await post_match_result(
+                match_id,
+                MatchResultsWrite(games=games),
+                user,
+                session,
+                NotificationService(session, FakeSender()),
+            )
+            return 201
+        except HTTPException as exc:
+            return exc.status_code
+        finally:
+            settled.set()
+
+
 async def test_create_game_score_racing_first_propose_never_strays(
     api_client: AsyncClient,
     db_session: AsyncSession,
@@ -1101,29 +1166,7 @@ async def test_create_game_score_racing_first_propose_never_strays(
         )
 
         make_session = async_sessionmaker(engine, expire_on_commit=False)
-        scorer_loaded = asyncio.Event()
-        propose_settled = asyncio.Event()
-        real_loader = matches_mod._load_match_for_scoring
-
-        async def loader_with_barrier(
-            db: AsyncSession,
-            target_id: uuid.UUID,
-            current_user_id: uuid.UUID,
-            *,
-            lock: bool = False,
-            nowait: bool = False,
-        ) -> Match:
-            result = await real_loader(
-                db, target_id, current_user_id, lock=lock, nowait=nowait
-            )
-            # The score path never passes ``nowait`` (propose does): park it after
-            # the load so the proposer runs to completion first.
-            if not nowait:
-                scorer_loaded.set()
-                await propose_settled.wait()
-            return result
-
-        monkeypatch.setattr(matches_mod, "_load_match_for_scoring", loader_with_barrier)
+        loaded, settled = _install_scoring_load_barrier(monkeypatch)
 
         async def scorer() -> int:
             async with make_session() as session:
@@ -1137,33 +1180,19 @@ async def test_create_game_score_racing_first_propose_never_strays(
                 except HTTPException as exc:
                     return exc.status_code
 
-        async def proposer() -> int:
-            await scorer_loaded.wait()
-            async with make_session() as session:
-                user = (
-                    await session.execute(select(User).where(User.id == me_id))
-                ).scalar_one()
-                notifications = NotificationService(session, FakeSender())
-                # Decided 3-1, clinch at game 4, games 1&2 match the scratchpad.
-                payload = MatchResultsWrite(
-                    games=[
-                        _game(1, 11, 2),
-                        _game(2, 2, 11),
-                        _game(3, 11, 2),
-                        _game(4, 11, 2),
-                    ]
-                )
-                try:
-                    await post_match_result(
-                        match_id, payload, user, session, notifications
-                    )
-                    return 201
-                except HTTPException as exc:
-                    return exc.status_code
-                finally:
-                    propose_settled.set()
-
-        scorer_status, proposer_status = await asyncio.gather(scorer(), proposer())
+        # First-propose board: decided 3-1, clinch at game 4, games 1&2 match the
+        # scratchpad.
+        scorer_status, proposer_status = await asyncio.gather(
+            scorer(),
+            _first_propose_after_barrier(
+                make_session,
+                loaded,
+                settled,
+                match_id,
+                me_id,
+                [_game(1, 11, 2), _game(2, 2, 11), _game(3, 11, 2), _game(4, 11, 2)],
+            ),
+        )
 
         # The scorer holds the lock; the concurrent first-propose (NOWAIT) bounces.
         assert scorer_status == 201, scorer_status
@@ -1291,27 +1320,7 @@ async def test_update_game_score_racing_first_propose_never_500s(
         )
 
         make_session = async_sessionmaker(engine, expire_on_commit=False)
-        updater_loaded = asyncio.Event()
-        propose_settled = asyncio.Event()
-        real_loader = matches_mod._load_match_for_scoring
-
-        async def loader_with_barrier(
-            db: AsyncSession,
-            target_id: uuid.UUID,
-            current_user_id: uuid.UUID,
-            *,
-            lock: bool = False,
-            nowait: bool = False,
-        ) -> Match:
-            result = await real_loader(
-                db, target_id, current_user_id, lock=lock, nowait=nowait
-            )
-            if not nowait:
-                updater_loaded.set()
-                await propose_settled.wait()
-            return result
-
-        monkeypatch.setattr(matches_mod, "_load_match_for_scoring", loader_with_barrier)
+        loaded, settled = _install_scoring_load_barrier(monkeypatch)
 
         async def updater() -> int:
             async with make_session() as session:
@@ -1327,32 +1336,17 @@ async def test_update_game_score_racing_first_propose_never_500s(
                 except HTTPException as exc:
                     return exc.status_code
 
-        async def proposer() -> int:
-            await updater_loaded.wait()
-            async with make_session() as session:
-                user = (
-                    await session.execute(select(User).where(User.id == me_id))
-                ).scalar_one()
-                notifications = NotificationService(session, FakeSender())
-                payload = MatchResultsWrite(
-                    games=[
-                        _game(1, 11, 9),
-                        _game(2, 2, 11),
-                        _game(3, 11, 2),
-                        _game(4, 11, 2),
-                    ]
-                )
-                try:
-                    await post_match_result(
-                        match_id, payload, user, session, notifications
-                    )
-                    return 201
-                except HTTPException as exc:
-                    return exc.status_code
-                finally:
-                    propose_settled.set()
-
-        updater_status, proposer_status = await asyncio.gather(updater(), proposer())
+        updater_status, proposer_status = await asyncio.gather(
+            updater(),
+            _first_propose_after_barrier(
+                make_session,
+                loaded,
+                settled,
+                match_id,
+                me_id,
+                [_game(1, 11, 9), _game(2, 2, 11), _game(3, 11, 2), _game(4, 11, 2)],
+            ),
+        )
 
         # Clean serialized outcome: the updater never 500s / never leaks a raw
         # StaleDataError/InvalidRequestError; the first-propose is bounced.

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -10,11 +10,14 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
+from app import matches as matches_mod
 from app.matches import (
     _compact_games,
     accept_match_result,
     create_game_score,
+    delete_game_score,
     post_match_result,
+    update_game_score,
 )
 from app.models import (
     League,
@@ -32,6 +35,7 @@ from app.models import (
 from app.notifications.apns import MATCH_RESULT_CONFIRMATION_CATEGORY
 from app.notifications.service import NotificationService
 from app.schemas.match import (
+    MatchGameScoreUpdate,
     MatchGameScoreWrite,
     MatchResultsGameWrite,
     MatchResultsWrite,
@@ -1049,6 +1053,311 @@ async def test_concurrent_score_create_returns_409_not_500(
                 .all()
             )
             assert len(scores) == 1, scores
+
+
+async def test_create_game_score_racing_first_propose_never_strays(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #835. A per-game score write must not commit *atop* a
+    result the concurrent first-propose already froze.
+
+    Before the fix the three score endpoints loaded the match *without* the row
+    lock and enforced ``_is_scorable`` on that lock-free snapshot. A scorer that
+    loaded before the freeze could commit after it — stranding a scratchpad game
+    on top of a minted result the frozen board never described.
+
+    Deterministic interleave via a barrier on the ``_load_match_for_scoring``
+    seam: the score path (no ``nowait``) parks after loading until the proposer
+    (which passes ``nowait=True``) has run to completion, pinning "scorer loads
+    → proposer settles → scorer commits".
+
+    Post-fix the scorer takes the *blocking* row lock on its load, so the
+    concurrent first-propose (which locks ``NOWAIT``) bounces with a 409, and
+    the scorer's own ``_enforce_scorable`` recheck runs under the lock on still
+    -unfrozen state: the write lands as a plain scratchpad edit (board
+    ``[1, 2, 5]``, no result) rather than a stray game atop a frozen result.
+
+    Pre-fix this is RED: both sides return ``(201, 201)`` and the committed match
+    carries a stray game 5 on top of a posted result.
+    """
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "race-opp") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=5)
+        match_id = uuid.UUID(match["id"])
+        me_id = me.id
+
+        # Seed the shared scratchpad at 1-1 (game 1 to side 1, game 2 to side 2)
+        # BEFORE installing the barrier, so both racers see the same pre-image.
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/1/scores/new",
+            json={"side_1_points": 11, "side_2_points": 2},
+        )
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/2/scores/new",
+            json={"side_1_points": 2, "side_2_points": 11},
+        )
+
+        make_session = async_sessionmaker(engine, expire_on_commit=False)
+        scorer_loaded = asyncio.Event()
+        propose_settled = asyncio.Event()
+        real_loader = matches_mod._load_match_for_scoring
+
+        async def loader_with_barrier(
+            db: AsyncSession,
+            target_id: uuid.UUID,
+            current_user_id: uuid.UUID,
+            *,
+            lock: bool = False,
+            nowait: bool = False,
+        ) -> Match:
+            result = await real_loader(
+                db, target_id, current_user_id, lock=lock, nowait=nowait
+            )
+            # The score path never passes ``nowait`` (propose does): park it after
+            # the load so the proposer runs to completion first.
+            if not nowait:
+                scorer_loaded.set()
+                await propose_settled.wait()
+            return result
+
+        monkeypatch.setattr(matches_mod, "_load_match_for_scoring", loader_with_barrier)
+
+        async def scorer() -> int:
+            async with make_session() as session:
+                user = (
+                    await session.execute(select(User).where(User.id == me_id))
+                ).scalar_one()
+                payload = MatchGameScoreWrite(side_1_points=11, side_2_points=2)
+                try:
+                    await create_game_score(match_id, payload, 5, user, session)
+                    return 201
+                except HTTPException as exc:
+                    return exc.status_code
+
+        async def proposer() -> int:
+            await scorer_loaded.wait()
+            async with make_session() as session:
+                user = (
+                    await session.execute(select(User).where(User.id == me_id))
+                ).scalar_one()
+                notifications = NotificationService(session, FakeSender())
+                # Decided 3-1, clinch at game 4, games 1&2 match the scratchpad.
+                payload = MatchResultsWrite(
+                    games=[
+                        _game(1, 11, 2),
+                        _game(2, 2, 11),
+                        _game(3, 11, 2),
+                        _game(4, 11, 2),
+                    ]
+                )
+                try:
+                    await post_match_result(
+                        match_id, payload, user, session, notifications
+                    )
+                    return 201
+                except HTTPException as exc:
+                    return exc.status_code
+                finally:
+                    propose_settled.set()
+
+        scorer_status, proposer_status = await asyncio.gather(scorer(), proposer())
+
+        # The scorer holds the lock; the concurrent first-propose (NOWAIT) bounces.
+        assert scorer_status == 201, scorer_status
+        assert proposer_status == 409, proposer_status
+
+        async with make_session() as verify:
+            final = (
+                await verify.execute(
+                    select(Match)
+                    .where(Match.id == match_id)
+                    .options(
+                        selectinload(Match.results),
+                        selectinload(Match.games),
+                    )
+                )
+            ).scalar_one()
+            # No result was minted, and the board is a still-editable scratchpad —
+            # the #835 stray-atop-a-frozen-result is unreachable.
+            assert final.results == []
+            assert sorted(g.game_number for g in final.games) == [1, 2, 5]
+
+
+async def test_delete_game_score_double_clear_never_500s(
+    api_client: AsyncClient, db_session: AsyncSession, engine: AsyncEngine
+) -> None:
+    """Audit finding #8. Two participants clearing the same game's score at once
+    must serialize to one 200 (cleared) + one 404 (already gone), never a raw
+    error or a lying double-200.
+
+    Pre-fix both loads are lock-free, so both find the score, both null it, and
+    both commit — the loser's ``delete-orphan`` DELETE matches zero rows and only
+    emits a benign ``SAWarning`` (the models carry no ``version_id_col``, so it
+    does *not* raise ``StaleDataError``). That yields ``[200, 200]`` — a lying
+    success. The blocking lock makes the loser re-read the now-empty game and
+    return a truthful 404 instead.
+    """
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "race-opp") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=5)
+        match_id = uuid.UUID(match["id"])
+        me_id = me.id
+
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/3/scores/new",
+            json={"side_1_points": 11, "side_2_points": 5},
+        )
+
+        make_session = async_sessionmaker(engine, expire_on_commit=False)
+
+        async def run() -> object:
+            async with make_session() as session:
+                user = (
+                    await session.execute(select(User).where(User.id == me_id))
+                ).scalar_one()
+                try:
+                    await delete_game_score(match_id, 3, user, session)
+                    return 200
+                except HTTPException as exc:
+                    return exc.status_code
+
+        outcomes = await asyncio.gather(run(), run())
+
+        # One truthful clear, one truthful "already gone" — never a 500, never a
+        # raw exception, never a double-200.
+        assert all(isinstance(o, int) for o in outcomes), outcomes
+        assert all(o != 500 for o in outcomes), outcomes
+        assert sorted(outcomes) == [200, 404], outcomes
+
+        async with make_session() as verify:
+            scores = (
+                (
+                    await verify.execute(
+                        select(MatchGameScore)
+                        .join(MatchGame, MatchGameScore.match_game_id == MatchGame.id)
+                        .where(MatchGame.match_id == match_id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert scores == [], scores
+
+
+async def test_update_game_score_racing_first_propose_never_500s(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A conditional update whose target score row a concurrent first-propose
+    deletes (via ``_commit_canonical_games``'s clear/reinsert) must not 500 on
+    the ``db.refresh(game.score)`` of a since-deleted row — that refresh is the
+    one genuine-500 candidate on the score path.
+
+    Same barrier technique as the #835 create test: the updater parks after its
+    lock-free load, the first-propose freezes the board (deleting the score row
+    the update targets), then the updater proceeds.
+
+    Pre-fix the update loads without the lock, so the propose freezes underneath
+    it: the conditional UPDATE matches zero rows (its target id was deleted) and
+    ``db.refresh`` is called on that deleted row — a raw
+    ``sqlalchemy.exc.InvalidRequestError`` (an uncaught 500), not an
+    ``HTTPException``, so it escapes the handler entirely.
+
+    Post-fix the updater takes the *blocking* lock first, so the first-propose
+    (NOWAIT) bounces with a 409 and the update runs under the lock against
+    still-unfrozen state — its target row still exists at version 1, so the
+    conditional UPDATE matches and it returns a clean 200. The proposer 409s.
+    """
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "race-opp") as (_opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=5)
+        match_id = uuid.UUID(match["id"])
+        me_id = me.id
+
+        # Seed games 1 & 2 so the propose board's first two games match the
+        # scratchpad; the update targets game 1 (version 1).
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/1/scores/new",
+            json={"side_1_points": 11, "side_2_points": 9},
+        )
+        await api_client.post(
+            f"/v1/matches/{match['id']}/games/2/scores/new",
+            json={"side_1_points": 2, "side_2_points": 11},
+        )
+
+        make_session = async_sessionmaker(engine, expire_on_commit=False)
+        updater_loaded = asyncio.Event()
+        propose_settled = asyncio.Event()
+        real_loader = matches_mod._load_match_for_scoring
+
+        async def loader_with_barrier(
+            db: AsyncSession,
+            target_id: uuid.UUID,
+            current_user_id: uuid.UUID,
+            *,
+            lock: bool = False,
+            nowait: bool = False,
+        ) -> Match:
+            result = await real_loader(
+                db, target_id, current_user_id, lock=lock, nowait=nowait
+            )
+            if not nowait:
+                updater_loaded.set()
+                await propose_settled.wait()
+            return result
+
+        monkeypatch.setattr(matches_mod, "_load_match_for_scoring", loader_with_barrier)
+
+        async def updater() -> int:
+            async with make_session() as session:
+                user = (
+                    await session.execute(select(User).where(User.id == me_id))
+                ).scalar_one()
+                payload = MatchGameScoreUpdate(
+                    side_1_points=8, side_2_points=11, expected_version=1
+                )
+                try:
+                    await update_game_score(match_id, payload, 1, user, session)
+                    return 200
+                except HTTPException as exc:
+                    return exc.status_code
+
+        async def proposer() -> int:
+            await updater_loaded.wait()
+            async with make_session() as session:
+                user = (
+                    await session.execute(select(User).where(User.id == me_id))
+                ).scalar_one()
+                notifications = NotificationService(session, FakeSender())
+                payload = MatchResultsWrite(
+                    games=[
+                        _game(1, 11, 9),
+                        _game(2, 2, 11),
+                        _game(3, 11, 2),
+                        _game(4, 11, 2),
+                    ]
+                )
+                try:
+                    await post_match_result(
+                        match_id, payload, user, session, notifications
+                    )
+                    return 201
+                except HTTPException as exc:
+                    return exc.status_code
+                finally:
+                    propose_settled.set()
+
+        updater_status, proposer_status = await asyncio.gather(updater(), proposer())
+
+        # Clean serialized outcome: the updater never 500s / never leaks a raw
+        # StaleDataError/InvalidRequestError; the first-propose is bounced.
+        assert updater_status in (200, 409), updater_status
+        assert proposer_status == 409, proposer_status
 
 
 async def test_score_create_422_when_game_number_exceeds_best_of(

--- a/docs/adr/0009-score-endpoints-lock-the-match-row.md
+++ b/docs/adr/0009-score-endpoints-lock-the-match-row.md
@@ -1,0 +1,54 @@
+---
+status: accepted
+---
+
+# The per-game score endpoints take the blocking match row lock
+
+The three per-game score endpoints — `create`/`update`/`delete_game_score` —
+loaded the match with `_load_match_for_scoring(...)` **without a row lock** and
+then checked `_enforce_scorable` on that lock-free in-memory state. Meanwhile the
+sign-off transitions (`post_match_result`, `/results/{id}/acceptance`) take the
+`matches` row lock via `_lock_match_row`, and a first `post_match_result` freezes
+the scratchpad and clears/reinserts `match_games` under that lock. So the
+scratchpad-scorable gate on the score path was a lock-free TOCTOU: a score write
+could evaluate "still scorable" *before* a concurrent first propose froze the
+board and then commit *after* it (#835).
+
+**We take the match row lock on the score-endpoint load path too** — the three
+endpoints now load with `lock=True`. Because `_load_match_for_scoring` acquires
+the lock *before* the eager load, the existing `_enforce_scorable` immediately
+after becomes a correct under-lock recheck: a score write now serializes against a
+concurrent first propose and either holds the lock (so the propose's `NOWAIT`
+bounces to a clean 409) or waits and re-reads the frozen board (a clean 409). No
+other logic changed.
+
+## Considered option: NOWAIT parity with `post_match_result`
+
+`post_match_result` locks `NOWAIT` so a double-tapped *finalize* 409s fast instead
+of parking a pooled connection on the lock (#641). Mirroring that on the score
+path was rejected. The common contention on the score path is **score-vs-score**
+(two participants tapping in points), which today resolves gracefully via the
+`uq_match_games` / per-game `version` guards. `NOWAIT` would make every concurrent
+score-vs-score write spuriously 409 "a result is being posted" — a regression in
+the common case to fix a rare one. The **blocking** lock serializes the two brief
+single-row score commits and, against a real propose, produces the *correct*
+frozen-board 409. Score writes have none of the long-in-flight duration that made
+`NOWAIT` matter for finalize.
+
+## Consequences
+
+- One lock closes a family of races off the same root cause: the #835 create-stray
+  (a game the frozen result never described, left unremovable because the match is
+  now frozen), and the delete/update-vs-propose races.
+- A score write can now briefly make a *concurrent* propose's `NOWAIT` trip — the
+  propose 409s "a result is already being posted" while a score write holds the
+  lock. The window is a single-row commit and the client action (refresh/retry) is
+  correct either way.
+- **Empirical correction to the audit.** The 2026-07-07 audit's finding #8 called
+  `delete_game_score` under a race an unhandled **500** (`StaleDataError`). It is
+  not: the models carry no SQLAlchemy `version_id_col`, so a stale delete-orphan
+  whose row a concurrent propose already removed only emits a benign `SAWarning`
+  and returns a lying `200` — never `StaleDataError`. The one genuine pre-fix 500
+  was on a *different* path: `update_game_score`'s `db.refresh(game.score)` of a
+  row the propose deleted raises `InvalidRequestError`. The lock closes both, and
+  the delete loser now re-reads and 404s cleanly instead of the lying 200.


### PR DESCRIPTION
## What

The three per-game score endpoints (`create`/`update`/`delete_game_score`) loaded the match **lock-free** and checked `_enforce_scorable` on that in-memory snapshot, while a first `post_match_result` freezes the scratchpad + clears/reinserts `match_games` under the `matches` row lock. A score write that loaded *before* the freeze could commit *after* it — a lock-free TOCTOU (#835).

**Fix:** take the **blocking** row lock (`_load_match_for_scoring(..., lock=True)`) on all three score endpoints' load path, mirroring the acceptance path. The lock is acquired before the eager load, so the existing `_enforce_scorable` becomes a correct under-lock recheck — no other logic changed. Blocking, not NOWAIT: the common **score-vs-score** contention resolves via the `uq_match_games`/`version` guards and must not be spuriously 409'd. Decision recorded in **ADR-0009**.

One lock closes a family of races off the same root cause:

- **#835 create-stray (CONFIRMED):** a game the frozen result never described, left unremovable because the match is now frozen.
- **audit #8 double-clear:** now a clean `200`/`404` instead of a lying double-`200` + `SAWarning`. (Empirical correction: this was **never** a `StaleDataError`/500 — the models carry no `version_id_col`.)
- **update-vs-propose:** the one *genuine* pre-fix 500 — `db.refresh(game.score)` on a row the propose deleted (`InvalidRequestError`) — now a clean `409`.

## Tests

Three deterministic-barrier regression tests (barrier on the `_load_match_for_scoring` seam), each verified RED→GREEN:
- `test_create_game_score_racing_first_propose_never_strays`
- `test_delete_game_score_double_clear_never_500s`
- `test_update_game_score_racing_first_propose_never_500s`

## Verification

- API gate (CI-equivalent): `ruff check` + `ruff format --check` + `mypy --strict` clean; `pytest` **584 passed**.
- No OpenAPI drift (function-body + comment changes only — no route/schema/docstring), so no `schema.d.ts`/`Types.swift` regen and no web/iOS follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)