### PR TITLE
workflow: freshness preflight hook + /epic gated conductor

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/install_tools.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/check-main-freshness.sh"
           }
         ]
       }

--- a/.claude/skills/epic/SKILL.md
+++ b/.claude/skills/epic/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: epic
+description: Drive a change end-to-end through the fortymm arc — /grill-with-docs → /to-chores → /do-chores → /land-the-plane — as a GATED conductor. It sequences the four phases and carries the plan→work-order→PR artifact chain, but stops for your decision at every phase boundary and never merges. Use to run a whole feature/bugfix through the arc from one entry point; use the individual skills when you only want one phase.
+disable-model-invocation: true
+argument-hint: "[the goal to drive — an issue ref, a plan/PRD path, or a one-line description]"
+---
+
+# Epic — a gated conductor for the fortymm arc
+
+Run a change through the four phases of the fortymm workflow, in order, **stopping
+at every human gate**:
+
+```
+[preflight] → /grill-with-docs → /to-chores → /do-chores → /land-the-plane
+```
+
+## This is a conductor, NOT an autopilot
+
+The gates between phases are the whole point — they are where the human catches a
+false premise, right-sizes the decomposition, and decides what ships. This skill
+**never runs a phase's decision on the user's behalf**. At each boundary it
+summarises what the phase produced, states the decision that's now the user's,
+and **waits for an explicit go-ahead** before starting the next phase. It never
+merges (that stays with the user), never skips a gate, and never retries a
+blocked phase in a loop.
+
+If you find yourself wanting to "just push through" a gate to save a round-trip:
+don't. The one time the gate cost a round-trip this arc was designed for, it
+also caught a wrong claim before it shipped.
+
+## Step 0 — Preflight (do this before grilling)
+
+The individual skills and the domain-expert agents register at **session launch**,
+so a stale checkout silently runs an old set (this is the failure the
+`check-main-freshness.sh` SessionStart hook warns about). Before starting the arc,
+confirm freshness so `/to-chores` and `/do-chores` dispatch to the current agents:
+
+1. `git fetch origin` and compare local default branch to `origin/<default>`
+   (`git rev-list --count main..origin/main`).
+2. If behind **and** `.claude/skills`/`.claude/agents` changed upstream: **stop**.
+   Tell the user to fast-forward the main checkout and **restart the session**,
+   because a mid-session pull won't re-register skills/agents. Resume `/epic`
+   after the restart.
+3. If behind only on unrelated code, note it and continue (or offer to ff first).
+4. Confirm the target of the arc (the `argument-hint`: an issue ref, a plan doc,
+   or a described goal). If it's an issue, read it now.
+
+## The arc, phase by phase
+
+Each phase is run by its own skill (invoke it via the Skill tool; if a skill's
+`disable-model-invocation` blocks that, tell the user to type the `/command` and
+continue once it returns). After each phase, **stop at the gate.**
+
+### 1. `/grill-with-docs` — sharpen the plan, capture the decisions
+
+Runs the relentless interview (`/grilling`) with `/domain-modeling`, producing an
+**agreed plan** plus any ADRs / `CONTEXT.md` entries the decisions warrant —
+written *during* the grill, not deferred.
+
+**Gate:** the plan is only "agreed" when the user says so. Do not advance to
+decomposition on your own read of the conversation. Surface the plan's crux
+decisions and confirm before continuing.
+
+### 2. `/to-chores` — shard the agreed plan into a work order
+
+Breaks the plan into `.claude/work-order.md`: tracer-bullet slices of small,
+agent-tagged chores, with `[main]` steps at every cross-layer seam (OpenAPI
+regen especially). Decompose-only.
+
+**Gate:** `/to-chores` already quizzes the user on granularity and requires
+approval before it writes the file. Relay that approval step — do not fabricate
+the plan a chore depends on; if a decision isn't captured, that's a loop back to
+`/grill-with-docs`, not an invention. **Right-size the ceremony:** a genuinely
+single-tree change is one slice / one or two chores, not a manufactured epic.
+
+### 3. `/do-chores` — drive the work order to green
+
+Dispatches each chore to its domain-expert subagent in dependency order, verifies
+with the chore's own command, ticks the checkbox, and commits **per slice**.
+Serialises across every `[main]` seam; parallelises independent trees.
+
+**Gate:** on a chore failure, `/do-chores` marks it `⚠ BLOCKED` and stops that
+slice — surface the blocker to the user and stop; don't retry-thrash. Only when
+every slice is committed do you offer to land.
+
+### 4. `/land-the-plane` — review and ship
+
+Runs `/simplify`, all applicable test suites, commits + pushes, opens the PR, then
+`/code-review`, `/security-review`, and the QA pass **that matches what changed**
+(browser for `web-client/**`, Simulator for `ios/**`, skip when neither was
+touched). Its review depth should track the change's risk, not a fixed ceremony.
+
+**Gate:** it stops at any surfaced code-review issue, security finding, or QA bug
+— raise them to the user, don't auto-fix. And it stops **before merge**: this is
+an agent-authored branch, self-merge is blocked (two-party review), so the merge
+is always the user's. `/epic` ends here — report the PR and hand off.
+
+## Invariants (hold these across every phase)
+
+- **Never merge.** The arc ends at a ready, green PR; the user merges.
+- **Never skip a gate**, even for a "small" change — right-size the *work*, not the
+  checkpoints.
+- **Carry the artifact chain**: the agreed plan (+ ADRs) → `.claude/work-order.md`
+  → the branch/PR. Each phase consumes the previous phase's artifact; don't
+  re-establish context the artifact already holds.
+- **A failure stops its phase**, surfaced to the user — not a silent workaround.
+
+## Resumability
+
+The state lives in durable artifacts, so `/epic` is resumable: a written ADR /
+agreed plan means grilling is done; a `.claude/work-order.md` with ticked boxes
+means `/do-chores` can resume from the checkboxes; an open PR means you're in
+`/land-the-plane`. On re-entry, read those artifacts to find the current phase and
+continue from its gate rather than restarting the arc.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,12 @@ gitignored `.claude/work-order.md` — a checkbox list of small, agent-tagged
 **chores** grouped under demoable **tracer-bullet** slices, with `[main]` steps at
 the cross-layer seams. `/do-chores` then drives it: dispatches each chore to its
 expert in dependency order, verifies, ticks it off, and commits per slice. Arc:
-`/grill-with-docs` → `/to-chores` → `/do-chores` → `/land-the-plane`.
+`/grill-with-docs` → `/to-chores` → `/do-chores` → `/land-the-plane`. `/epic` is
+the gated conductor for that whole arc from one entry point — it sequences the
+four phases but stops at every human gate and never merges (run the individual
+skills when you only want one phase). A `check-main-freshness.sh` SessionStart
+hook warns when the local default branch is behind origin, since a stale checkout
+silently runs an old set of skills/agents (they register at launch).
 
 ## Common commands
 

--- a/scripts/check-main-freshness.sh
+++ b/scripts/check-main-freshness.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# SessionStart freshness check.
+#
+# The tax this pays down: a session launched from a checkout whose local default
+# branch is behind origin silently runs a stale set of .claude/skills and
+# .claude/agents — they register at *launch*, so pulling mid-session doesn't help
+# (you must restart). We hit exactly this when PR #853 (the /to-chores + domain
+# -expert agents) had merged to origin/main but the local checkout was 9 commits
+# behind, so the session couldn't see the very tools it needed.
+#
+# This runs on LOCAL (unlike install_tools.sh, which skips local) because that's
+# where the staleness bites. It only ever WARNS — never blocks the session, never
+# mutates anything. stdout on a SessionStart hook is added to the model's context,
+# so Claude relays the warning in its first reply.
+#
+# Best-effort and bounded: a debounced, time-limited single-branch fetch. If the
+# network is down or slow it gives up quietly and compares against the last-known
+# remote ref.
+
+set -u
+
+cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0  # not a git repo → nothing to do
+
+# Default branch (usually main); fall back to main if origin/HEAD isn't set.
+default_branch="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+default_branch="${default_branch:-main}"
+
+local_ref="refs/heads/${default_branch}"
+remote_ref="refs/remotes/origin/${default_branch}"
+git show-ref --verify --quiet "$local_ref" || exit 0  # no local default branch to compare
+
+# Debounce: only fetch if we haven't in the last 10 minutes (SessionStart also
+# fires on every resume — don't hit the network each time).
+fetch_head="$(git rev-parse --git-path FETCH_HEAD 2>/dev/null)"
+now="$(date +%s)"
+last=0
+if [ -f "$fetch_head" ]; then
+  last="$(stat -f %m "$fetch_head" 2>/dev/null || stat -c %Y "$fetch_head" 2>/dev/null || echo 0)"
+fi
+
+if [ "$((now - last))" -gt 600 ]; then
+  # Bound the fetch so a dead network can't hang the session. There's no
+  # `timeout` binary on macOS, so cap the transport instead: ConnectTimeout for
+  # ssh remotes (this repo's), low-speed limits for http. BatchMode keeps ssh
+  # from ever blocking on a prompt. Best-effort — failure is swallowed.
+  GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh} -o ConnectTimeout=8 -o BatchMode=yes" \
+    GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME=8 \
+    git fetch --quiet origin "$default_branch" 2>/dev/null || true
+fi
+
+git show-ref --verify --quiet "$remote_ref" || exit 0  # never fetched this remote → skip
+
+behind="$(git rev-list --count "${local_ref}..${remote_ref}" 2>/dev/null || echo 0)"
+[ "${behind:-0}" -eq 0 ] && exit 0  # up to date (or ahead) → silent
+
+# The fast-forward must happen in whatever working tree has the default branch
+# checked out (a worktree on a feature branch can't ff `main`). Find it; fall
+# back to the current dir if the branch isn't checked out anywhere.
+target="$(git worktree list --porcelain 2>/dev/null \
+  | awk -v b="refs/heads/${default_branch}" '/^worktree /{p=$2} /^branch /{if ($2==b) print p}' \
+  | head -1)"
+target="${target:-$(pwd)}"
+
+# Did the launch-registered surfaces (skills/agents) change upstream? That's the
+# case worth shouting about, because a plain `git pull` won't fix this session.
+surfaces_note=""
+if ! git diff --quiet "$local_ref" "$remote_ref" -- .claude/skills .claude/agents 2>/dev/null; then
+  surfaces_note="
+   This includes .claude/skills and/or .claude/agents, which register at LAUNCH —
+   so this session may be running a stale set. A pull alone won't fix it; restart
+   the session after fast-forwarding."
+fi
+
+cat <<MSG
+[freshness] Local '${default_branch}' is ${behind} commit(s) behind origin/${default_branch}.${surfaces_note}
+   Fast-forward when convenient:
+     git -C "${target}" merge --ff-only origin/${default_branch}
+MSG
+exit 0


### PR DESCRIPTION
Two workflow-ergonomics additions, both prompted by the #835 run — where the local `main` checkout was 9 commits behind origin, so PR #853's `/to-chores` + domain-expert agents (merged upstream) weren't registered in the session and forced a mid-flow fast-forward + restart.

## 1. `scripts/check-main-freshness.sh` — SessionStart freshness warning

Runs alongside `install_tools.sh` on `SessionStart`. Warns when the local default branch is behind `origin`, and **shouts specifically** when `.claude/skills` / `.claude/agents` changed upstream — those register at **launch**, so a mid-session pull won't help (you must restart). Points the fast-forward at whatever checkout actually has `main`.

- Runs on **local** (unlike `install_tools.sh`, which skips local) — that's where the staleness bit.
- Best-effort and safe: debounced 10 min, transport-bounded (`ssh ConnectTimeout` / http low-speed, since macOS has no `timeout` binary), and it **only ever warns** — never blocks the session, never mutates anything.

## 2. `.claude/skills/epic/SKILL.md` — `/epic` gated conductor

One entry point for the whole arc: `/grill-with-docs → /to-chores → /do-chores → /land-the-plane`.

Explicitly **not an autopilot**. It sequences the four phases and carries the plan→work-order→PR artifact chain, but **stops at every human gate**, never skips a gate, and **never merges** (self-merge is blocked; the merge stays with the user). The gates are the point — during #835, one of them caught a wrong claim (the "delete-500" that was really a benign `SAWarning`) before it shipped. Includes a freshness preflight (Step 0) and resumability from the durable artifacts (ADR / `work-order.md` checkboxes / open PR).

`CLAUDE.md` notes both alongside the existing arc documentation.

## Testing

- `bash -n` clean; ran `check-main-freshness.sh` against a checkout 1 commit behind origin → correct warning, no job-control noise, points ff at the real `main` checkout; debounce verified (no refetch within 10 min); silent-and-exit-0 when up to date.
- `settings.json` validated as JSON; hook wired into the existing `SessionStart` array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)