### PR TITLE
workflow: align /epic with the verifier rule; pin the scope-check base SHA

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -14,6 +14,8 @@ A fix from you would hide the very failure the driver needs to see.
 
 - The chore's **what to build**, **Scope**, **Verify** command, **Proves** claim, and
   **Demo** (how to observe the behavior end-to-end).
+- The **base SHA** the slice builds on — the ref for your scope check. If the
+  dispatch omits it, ask for it in your report rather than guessing a ref.
 - The implementing agent's summary, which is a **claim, not evidence**. Treat every
   sentence in it as something to check, especially "verified", "all green", and any
   fail-before/pass-after story.
@@ -45,7 +47,8 @@ A fix from you would hide the very failure the driver needs to see.
    test suite for it.
 
 4. **Check the `Scope`.** Did the chore touch trees or files it promised not to?
-   `git status --porcelain` and `git diff --stat` against the slice's base.
+   `git status --porcelain` and `git diff --stat <base SHA>` — the base SHA from
+   your dispatch, never a ref you inferred.
 
 ## Report
 

--- a/.claude/skills/do-chores/SKILL.md
+++ b/.claude/skills/do-chores/SKILL.md
@@ -45,7 +45,10 @@ Repeat until every chore is ticked or every remaining chore is blocked:
    grade it. You are the second-worst: you watched it happen and you want it to
    pass. So dispatch the **`verifier`** subagent (Agent tool, `subagent_type:
    "verifier"`) with the chore's *what to build*, `Scope`, `Verify`, `Proves`, and
-   `Demo`, plus the implementer's summary marked explicitly as an unverified claim.
+   `Demo`, plus the implementer's summary marked explicitly as an unverified claim,
+   plus the **base SHA** for the scope check — the commit the slice builds on
+   (`git rev-parse HEAD` before the slice's first chore; record it when you start
+   the slice). Without it the verifier has no defined ref to diff against.
 
    The verifier has **no edit tools**. It re-runs `Verify`, adversarially checks the
    `Proves` claim (did the new test actually get collected? was the command already

--- a/.claude/skills/epic/SKILL.md
+++ b/.claude/skills/epic/SKILL.md
@@ -78,11 +78,12 @@ single-tree change is one slice / one or two chores, not a manufactured epic.
 
 ### 3. `/do-chores` — drive the work order to green
 
-Dispatches each chore to its domain-expert subagent in dependency order, **re-runs
-the chore's `Verify` command itself** (a subagent's "all green" is a claim, not
-evidence), checks the result against the chore's `Proves` line, ticks the checkbox,
-and commits **per slice**. Serialises across every `[main]` seam; parallelises
-independent trees.
+Dispatches each chore to its domain-expert subagent in dependency order, then
+**dispatches a fresh `verifier` agent** for every chore (an implementer's "all
+green" is a claim, not evidence, and neither the implementer nor the driver
+grades it) — the verifier re-runs `Verify`, adversarially checks `Proves`, and
+runs the `Demo`. On PASS it ticks the checkbox, and commits **per slice**.
+Serialises across every `[main]` seam; parallelises independent trees.
 
 **Gate:** on a chore failure, `/do-chores` marks it `⚠ BLOCKED` and stops that
 slice — surface the blocker to the user and stop; don't retry-thrash. Only when


### PR DESCRIPTION
Two doc-consistency fixes to the chore-verification workflow that shipped in #857:

- **`/epic` phase-3 summary contradicted `/do-chores`**: it still said the driver "re-runs the chore's `Verify` command itself", while `/do-chores` step 3 requires dispatching an independent `verifier` agent and forbids the driver from self-grading. The conductor doc now describes the same protocol as the skill it sequences.
- **The verifier's scope check had no defined base ref**: it diffed "against the slice's base" with nothing pinning down that ref across multi-commit slices. `/do-chores` now records `git rev-parse HEAD` at slice start and passes that base SHA in the verifier dispatch; the verifier diffs against exactly that SHA and reports (rather than guesses) if it's missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw9WwcoS6hCeKZdtcF2XfC