### PR TITLE
Cover the Best-of and Rated dirty paths on /matches/new (#75)

### DIFF
--- a/web-client/src/routes/_app/matches/new.test.tsx
+++ b/web-client/src/routes/_app/matches/new.test.tsx
@@ -437,6 +437,67 @@ describe('NewMatchPage', () => {
     )
   })
 
+  it('confirms on Cancel when only Best-of was changed (#75)', async () => {
+    const user = userEvent.setup()
+    server.use(http.get('*/v1/players/recent', () => HttpResponse.json([])))
+    renderNewMatch()
+
+    // No opponent — the sole dirtying edit is the match length, which isolates
+    // the `bestOf !== DEFAULT_BEST_OF` arm of `isDirty`. The default is 5
+    // ('Std'), so pick 7 ('Long').
+    await user.click(await screen.findByRole('radio', { name: /7\s*long/i }))
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+    expect(
+      await screen.findByRole('alertdialog', { name: /discard changes/i }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Dashboard route')).not.toBeInTheDocument()
+
+    await user.click(
+      await screen.findByRole('button', { name: /discard.*leave/i }),
+    )
+    await waitFor(() =>
+      expect(screen.getByText('Dashboard route')).toBeInTheDocument(),
+    )
+  })
+
+  it("confirms on Cancel after the issue's full repro: opponent + Best-of + Rated (#75)", async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/players/recent', () =>
+        HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }]),
+      ),
+    )
+    renderNewMatch()
+
+    // #75's repro dirties all three fields. There is deliberately no
+    // "Rated-only" sibling to this test: the Rated switch is
+    // `disabled={!ratable}` (RatedField) and clearing the opponent resets
+    // `rated` to false, so `rated !== DEFAULT_RATED` can never be the *only*
+    // reason `isDirty` is true. That arm of the predicate is defense-in-depth,
+    // and Rated is only reachable — hence only testable — alongside an opponent.
+    await user.click(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    )
+    await user.click(screen.getByRole('radio', { name: /7\s*long/i }))
+    await user.click(screen.getByRole('switch', { name: /rated match/i }))
+    expect(screen.getByRole('switch', { name: /rated match/i })).toBeChecked()
+
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+    expect(
+      await screen.findByRole('alertdialog', { name: /discard changes/i }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Dashboard route')).not.toBeInTheDocument()
+
+    await user.click(
+      await screen.findByRole('button', { name: /discard.*leave/i }),
+    )
+    await waitFor(() =>
+      expect(screen.getByText('Dashboard route')).toBeInTheDocument(),
+    )
+  })
+
   it('does not block the post-create redirect for a dirty (rated, opponent-picked) form', async () => {
     // Regression: the dirty-form blocker's `shouldBlockFn` must not catch the
     // in-app navigate() a successful Start match fires — the form is still


### PR DESCRIPTION
## What

Test-only. Adds the two `#75` dirty-form cases that were guarded by the code but not by a test.

The dirty-form Cancel guard on `/matches/new` shipped in #809 (`b00c1b9`). Issue #75's repro dirties the form three ways — pick an opponent, change Best-of, toggle Rated — but `new.test.tsx` only exercised the opponent path.

- **Best-of only** — isolates the `bestOf !== DEFAULT_BEST_OF` arm of `isDirty` with no opponent picked.
- **The issue's full repro** — opponent + Best-of + Rated together.

## Why there is no "Rated-only" test

`RatedField` renders the switch `disabled={!ratable}` where `ratable = opponent !== null`, and clearing the opponent resets `rated` to `false`. So `rated !== DEFAULT_RATED` can never be the *sole* reason `isDirty` is true — that arm is defense-in-depth. Rated is only reachable, and therefore only testable, alongside an opponent. A "Rated-only dirty" test would assert a state the UI cannot produce.

## Evidence the tests are load-bearing

With `shouldBlockFn` temporarily forced to `() => false`, exactly the three `#75` tests fail and the other 29 stay green. Each fails with:

```
TestingLibraryElementError: Unable to find role="alertdialog" and name `/discard changes/i`
<body><div><div>Dashboard route</div>
```

That rendered `Dashboard route` is #75's reported "Actual": the form silently destroyed, no confirmation.

## Verification

- `vitest src/routes/_app/matches/new.test.tsx` — 32 passed (was 30)
- Full suite — 183 files, 1229 passed
- `tsc -b` clean, `eslint` clean

No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014D2zuazdPWa5L21etnPjb4