### PR TITLE
Fix #844: truncate long opponent names in the dashboard recent-results card

### DIFF
--- a/web-client/e2e/dashboard-recent-results.spec.ts
+++ b/web-client/e2e/dashboard-recent-results.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * Regression guard for GitHub issue #844: on a narrow (mobile) viewport the
+ * "Recent matches" card clipped its trailing Score / Δ / When columns off the
+ * right edge of the card because the auto-layout table let a long opponent
+ * username claim min-content width and shove those columns past the card.
+ *
+ * This is a *layout overflow* bug, so it can only be proven in a real browser:
+ * jsdom does no layout, and a vitest assertion that the name span carries
+ * `text-overflow: ellipsis` passes against the broken code (the ellipsis never
+ * engages until the cell is forced to collapse). The only valid proof is
+ * measuring `getBoundingClientRect()` here.
+ *
+ * The suite runs with MSW OFF (see `playwright.config.ts` webServer env
+ * `VITE_ENABLE_MSW: 'false'`), so the API is stubbed via `page.route`.
+ */
+import { expect, test, type Page, type Route } from '@playwright/test'
+import { sessionResponse } from '../src/test/factories'
+
+const SESSION = sessionResponse({ user: { username: 'rita.kovac' } })
+
+// A deliberately long (38-char) opponent name — this is the value that used to
+// blow the trailing columns off the card. Kept as a constant so the truncation
+// and `title`-attribute assertions can compare against the exact string.
+const LONG_OPPONENT = 'bartholomew.vandersteen.mcallister.iii'
+
+const DASHBOARD = {
+  attention: [],
+  attention_total_count: 0,
+  waiting_count: 0,
+  rating: null,
+  completed_match_count: 2,
+  recent_results: [
+    {
+      match_id: '11111111-1111-4111-8111-111111111111',
+      opponent_username: LONG_OPPONENT,
+      is_win: true,
+      my_games_won: 3,
+      opponent_games_won: 1,
+      completed_at: '2026-05-12T09:00:00Z',
+      my_rating_change: { before: 1500, after: 1512, delta: 12 },
+    },
+    {
+      match_id: '22222222-2222-4222-8222-222222222222',
+      opponent_username: 'kim.j',
+      is_win: false,
+      my_games_won: 1,
+      opponent_games_won: 3,
+      completed_at: '2026-05-10T09:00:00Z',
+      my_rating_change: { before: 1512, after: 1504, delta: -8 },
+    },
+  ],
+}
+
+async function installDashboardMock(page: Page) {
+  await page.route('**/api/v1/**', (route: Route) => {
+    const path = new URL(route.request().url()).pathname.replace(/^\/api/, '')
+    if (path === '/v1/session') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SESSION),
+      })
+    }
+    if (path === '/v1/dashboard') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(DASHBOARD),
+      })
+    }
+    // Anything else the AppShell/dashboard happens to fetch on load.
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '[]',
+    })
+  })
+}
+
+test.describe('Dashboard recent-results card (#844)', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('trailing columns stay within the card at 375px', async ({ page }) => {
+    await installDashboardMock(page)
+    await page.goto('/dashboard')
+    await page.locator('[data-testid="dashboard-recent-results"]').waitFor()
+
+    const m = await page.evaluate(async (longName: string) => {
+      // Text metrics are what we assert on — wait for the web font so the
+      // measured widths reflect the rendered glyphs, not a fallback face.
+      await document.fonts.ready
+
+      const label = document.querySelector('[data-testid="dashboard-recent-results"]')
+      const card = label?.closest('[data-slot="card"]') as HTMLElement | null
+      if (!card) throw new Error('recent-results card not found')
+      const cardRect = card.getBoundingClientRect()
+
+      const rows = Array.from(card.querySelectorAll('tbody > tr'))
+      // Every cell of every row (the short-named row is a regression guard: a
+      // table shares one column grid, so the long-name overflow clipped it too).
+      const cellOverflows: number[] = []
+      for (const row of rows) {
+        for (const td of Array.from(row.querySelectorAll('td'))) {
+          cellOverflows.push(td.getBoundingClientRect().right - cardRect.right)
+        }
+      }
+
+      const nameSpan = card.querySelector(
+        'tbody > tr:first-child td:first-child span[title]',
+      ) as HTMLElement | null
+      if (!nameSpan) throw new Error('opponent name span not found')
+
+      // The short-named (second) row's trailing cells: Score / Δ / When.
+      const shortRow = rows[1]
+      const shortCells = Array.from(shortRow.querySelectorAll('td'))
+      const shortRowText = shortCells.map((c) => (c.textContent ?? '').trim())
+
+      return {
+        maxCellOverflow: Math.max(...cellOverflows),
+        nameScrollWidth: nameSpan.scrollWidth,
+        nameClientWidth: nameSpan.clientWidth,
+        nameTitle: nameSpan.getAttribute('title'),
+        scoreText: shortRowText[1],
+        deltaText: shortRowText[2],
+        whenText: shortRowText[3],
+        longName,
+      }
+    }, LONG_OPPONENT)
+
+    // 1. No cell of any row spills past the right edge of the card. This is the
+    //    core #844 probe: the card is pinned to the column width (`minWidth: 0`),
+    //    so a broken table overflows *past* the card rather than widening it.
+    expect(
+      m.maxCellOverflow,
+      `worst cell right-edge px past card right-edge (rows: ${DASHBOARD.recent_results.length})`,
+    ).toBeLessThanOrEqual(1)
+
+    // 2. The long name is genuinely clipped (ellipsis engaged), not merely
+    //    styled to clip.
+    expect(
+      m.nameScrollWidth,
+      'long opponent name span.scrollWidth must exceed clientWidth (truncated)',
+    ).toBeGreaterThan(m.nameClientWidth)
+
+    // 3. The full name is preserved for hover/accessibility via `title`.
+    expect(m.nameTitle, 'name span title = full opponent username').toBe(
+      LONG_OPPONENT,
+    )
+
+    // 4. The short-named row's Score / Δ / When are actually rendered and
+    //    non-empty — a clipped row would drop them off-card.
+    expect(m.scoreText, 'short row score cell').toBe('1-3')
+    expect(m.deltaText, 'short row rating-delta cell').toBe('-8')
+    expect(m.whenText, 'short row when cell').not.toBe('')
+  })
+})

--- a/web-client/e2e/dashboard-recent-results.spec.ts
+++ b/web-client/e2e/dashboard-recent-results.spec.ts
@@ -14,6 +14,7 @@
  * `VITE_ENABLE_MSW: 'false'`), so the API is stubbed via `page.route`.
  */
 import { expect, test, type Page, type Route } from '@playwright/test'
+import type { components } from '../src/api/schema'
 import { sessionResponse } from '../src/test/factories'
 
 const SESSION = sessionResponse({ user: { username: 'rita.kovac' } })
@@ -23,6 +24,10 @@ const SESSION = sessionResponse({ user: { username: 'rita.kovac' } })
 // and `title`-attribute assertions can compare against the exact string.
 const LONG_OPPONENT = 'bartholomew.vandersteen.mcallister.iii'
 
+// `satisfies` (not `:`) so tsc fails if the OpenAPI schema drifts away from
+// this stub. The e2e suite runs MSW-off, so nothing else would catch it — see
+// web-client/CLAUDE.md on page.route stubs going green in vitest and breaking
+// here.
 const DASHBOARD = {
   attention: [],
   attention_total_count: 0,
@@ -49,7 +54,7 @@ const DASHBOARD = {
       my_rating_change: { before: 1512, after: 1504, delta: -8 },
     },
   ],
-}
+} satisfies components['schemas']['DashboardResponse']
 
 async function installDashboardMock(page: Page) {
   await page.route('**/api/v1/**', (route: Route) => {
@@ -85,7 +90,7 @@ test.describe('Dashboard recent-results card (#844)', () => {
     await page.goto('/dashboard')
     await page.locator('[data-testid="dashboard-recent-results"]').waitFor()
 
-    const m = await page.evaluate(async (longName: string) => {
+    const m = await page.evaluate(async () => {
       // Text metrics are what we assert on — wait for the web font so the
       // measured widths reflect the rendered glyphs, not a fallback face.
       await document.fonts.ready
@@ -116,6 +121,7 @@ test.describe('Dashboard recent-results card (#844)', () => {
       const shortRowText = shortCells.map((c) => (c.textContent ?? '').trim())
 
       return {
+        rowCount: rows.length,
         maxCellOverflow: Math.max(...cellOverflows),
         nameScrollWidth: nameSpan.scrollWidth,
         nameClientWidth: nameSpan.clientWidth,
@@ -123,9 +129,14 @@ test.describe('Dashboard recent-results card (#844)', () => {
         scoreText: shortRowText[1],
         deltaText: shortRowText[2],
         whenText: shortRowText[3],
-        longName,
       }
-    }, LONG_OPPONENT)
+    })
+
+    // 0. Both rows rendered. Guards the next assertion against passing
+    //    vacuously: `Math.max(...[])` is `-Infinity`, which would satisfy it.
+    expect(m.rowCount, 'recent-results rows rendered').toBe(
+      DASHBOARD.recent_results.length,
+    )
 
     // 1. No cell of any row spills past the right edge of the card. This is the
     //    core #844 probe: the card is pinned to the column width (`minWidth: 0`),
@@ -147,8 +158,10 @@ test.describe('Dashboard recent-results card (#844)', () => {
       LONG_OPPONENT,
     )
 
-    // 4. The short-named row's Score / Δ / When are actually rendered and
-    //    non-empty — a clipped row would drop them off-card.
+    // 4. The short-named row rendered with real content. These are render
+    //    smoke-checks, NOT clipping checks — `overflow: hidden` only hides
+    //    pixels, so a fully-clipped cell still reports its textContent.
+    //    Assertion 1 is the only thing that proves the columns are on-card.
     expect(m.scoreText, 'short row score cell').toBe('1-3')
     expect(m.deltaText, 'short row rating-delta cell').toBe('-8')
     expect(m.whenText, 'short row when cell').not.toBe('')

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.tsx
@@ -45,12 +45,13 @@ export const RecentResultsCardSkeleton = () => (
             display: 'flex',
             alignItems: 'center',
             gap: 10,
+            minWidth: 0,
             padding: '11px 18px',
             borderTop: i === 0 ? 'none' : `1px solid ${C.ink700}`,
           }}
         >
           <Shimmer width={24} height={24} radius={12} />
-          <Shimmer height={14} style={{ flex: 1, maxWidth: 140 }} />
+          <Shimmer height={14} style={{ flex: 1, minWidth: 0, maxWidth: 140 }} />
           <Shimmer width={36} height={13} />
           <Shimmer width={28} height={12} />
           <Shimmer width={44} height={11} />

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card.tsx
@@ -97,24 +97,34 @@ export const RecentResultsCard = ({ rows }: RecentResultsCardProps) => {
                   key={r.match_id}
                   style={{ borderTop: i === 0 ? 'none' : `1px solid ${C.ink700}` }}
                 >
-                  <td style={{ padding: '11px 18px' }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  {/* maxWidth:0 + width:100% is what actually caps this cell:
+                      in an auto-layout table the opponent column otherwise
+                      claims min-content width and pushes the trailing columns
+                      past the card, so text-overflow:ellipsis never engages
+                      until the cell is forced to collapse to the table width. */}
+                  <td style={{ padding: '11px 18px', maxWidth: 0, width: '100%' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
                       <span
                         style={{
                           width: 6,
                           height: 6,
                           borderRadius: '50%',
+                          flexShrink: 0,
                           background: r.is_win ? C.serve500 : C.loss,
                           boxShadow: `0 0 6px ${r.is_win ? 'rgba(0,226,154,0.5)' : 'rgba(255,77,109,0.5)'}`,
                         }}
                       />
                       <UserAvatar name={opponent} size={24} />
                       <span
+                        title={opponentLabel}
                         style={{
                           color: opponent ? C.chalk50 : C.chalk500,
                           fontStyle: opponent ? 'normal' : 'italic',
                           fontWeight: 500,
                           whiteSpace: 'nowrap',
+                          minWidth: 0,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
                         }}
                       >
                         {opponentLabel}

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card.tsx
@@ -115,8 +115,11 @@ export const RecentResultsCard = ({ rows }: RecentResultsCardProps) => {
                         }}
                       />
                       <UserAvatar name={opponent} size={24} />
+                      {/* Only a real username needs the tooltip: the
+                          `No opponent` placeholder would just echo its own
+                          visible text on hover. */}
                       <span
-                        title={opponentLabel}
+                        title={opponent ?? undefined}
                         style={{
                           color: opponent ? C.chalk50 : C.chalk500,
                           fontStyle: opponent ? 'normal' : 'italic',


### PR DESCRIPTION
Closes #844.

## The bug, as measured

At 375×667 with a long opponent username, the dashboard "Recent matches" card renders a **489px** table inside a **343px** card. The card is `overflow:hidden` with no scroll, so the trailing columns are simply gone:

| cell | px past the card's right edge |
| --- | --- |
| Score | +39 (all but invisible) |
| Δ (rating change) | +76 — **entirely** outside |
| When | +146 — **entirely** outside |

Two things the issue got wrong, both found by actually reproducing it in a browser:

1. **It isn't confined to the long-named row.** An HTML table shares one column grid, so a single long name widens the Opponent column for *every* row — the short-named `kim.j` row loses its Score/Δ/When too. The whole card's data columns disappear.

2. **Both fixes the issue proposed don't work.**
   - *Truncate the name (`max-width` + `text-overflow: ellipsis`)*: the ellipsis **never engages**, even with `min-width: 0` on the flex chain. In an auto-layout table the cell still claims min-content width.
   - *Wrap in `overflow-x: auto` like `/matches`*: the table stays 489px and the columns remain off-card, merely scrollable-to. That makes them *recoverable*, not *visible* — and the harm is "the viewer cannot see their own score." (The cited #702 precedent also **drops** horizontal scroll below 640px in favour of a card layout, so it isn't the template it looks like.)

## The fix

`max-width: 0; width: 100%` on the opponent `<td>` is the load-bearing part — it forces the cell to collapse to the table width, which is what finally lets `text-overflow: ellipsis` engage. Plus `min-width: 0` down the flex chain, `flexShrink: 0` on the dot/avatar so truncation eats the name rather than the glyphs, and `title={opponentLabel}` so the full username stays reachable.

The skeleton hand-copies this markup, so it gets the mirrored sizing to keep the skeleton→loaded swap from reflowing columns.

## Proof

`web-client/e2e/dashboard-recent-results.spec.ts` measures `getBoundingClientRect()` per cell against the card's rect at 375px.

**This has to be a browser test.** jsdom does no layout: a vitest assertion that the span carries `text-overflow: ellipsis` passes against the *broken* code. Verified by demo — remove `maxWidth: 0` and the spec goes red at `145.8px` past the card edge; restore it and it passes.

Verified independently at 375px / 320px / 1280px, with dotted and unbroken 40-char names, header row included: no cell overflows, no page h-scroll.

## Known cosmetic limit

At 320px the name column collapses to ~41px (~4 chars + ellipsis). Nothing clips and the scores are readable; the name is just short. Acceptable for the narrowest supported width.

## Test plan

- `vitest` — 1227 passed
- `tsc -b --noEmit` — clean
- Playwright (web-client) — 133 passed, including the new spec
- No API/schema/BFF change; no OpenAPI regen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mii8o4RcCGCLZWCxZR2612