### PR TITLE
Fix #839: surface network failures when sending a corrected score

### DIFF
--- a/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
@@ -243,6 +243,113 @@ describe("CorrectionEntry", () => {
     expect(correctionEntryPage.queryMatchLanding()).not.toBeInTheDocument();
   });
 
+  it("re-fires the POST when Send is clicked again while still offline (#839 retry)", async () => {
+    // After a transport-level failure, `onError` resets the synchronous
+    // `submittingRef` guard, so a second Send must actually re-fire the mutation
+    // — it must not be dead-locked by a ref that never cleared. Both submits
+    // fail (still offline), so counting the POSTs in the handler proves the
+    // retry left the boundary rather than being swallowed client-side.
+    let requests = 0;
+    correctionEntryPage.mockMatch(() =>
+      HttpResponse.json(buildCorrectableMatch()),
+    );
+    correctionEntryPage.mockPropose(() => {
+      requests += 1;
+      return HttpResponse.error();
+    });
+    correctionEntryPage.render();
+
+    await waitFor(() => correctionEntryPage.getInput("rita.kovac"));
+
+    // First send fails at the transport level → the connection alert renders and
+    // the button settles back from "Sending…" to enabled. Wait on the settle
+    // (a both-states signal), then assert the alert synchronously so a missing
+    // alert fails crisply rather than as an opaque 5s timeout.
+    await userEvent.click(correctionEntryPage.getSubmit());
+    await waitFor(() => {
+      expect(correctionEntryPage.getSubmit()).toBeEnabled();
+      expect(correctionEntryPage.getSubmit()).toHaveTextContent(
+        "Send corrected score",
+      );
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /Couldn't send your corrected score .* check your connection and try again/i,
+    );
+
+    // Retry: click Send again. In the working case the button goes disabled
+    // ("Sending…") then re-enables when the second failure settles, so
+    // `waitFor(enabled)` genuinely waits for that round-trip and `requests` is
+    // already 2 by the time it resolves. If the retry were dead-locked by a
+    // stuck `submittingRef`, the button never leaves "Send corrected score" and
+    // the synchronous `requests` assertion fails with "expected 1 to be 2" —
+    // not a timeout.
+    await userEvent.click(correctionEntryPage.getSubmit());
+    await waitFor(() => {
+      expect(correctionEntryPage.getSubmit()).toBeEnabled();
+      expect(correctionEntryPage.getSubmit()).toHaveTextContent(
+        "Send corrected score",
+      );
+    });
+    expect(requests).toBe(2);
+
+    // The alert is still up, nothing is stuck on "Sending…", and the board
+    // never navigated away.
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /Couldn't send your corrected score .* check your connection and try again/i,
+    );
+    expect(correctionEntryPage.queryMatchLanding()).not.toBeInTheDocument();
+  });
+
+  it("recovers on retry after reconnecting: a second Send succeeds and navigates (#839 reconnect)", async () => {
+    // First submit fails at the transport level (offline), rendering the
+    // connection alert. Once the endpoint recovers, a second Send must succeed
+    // and navigate to the match-detail landing — the failure must not leave the
+    // flow wedged. The success also resets the mutation error, so the stale
+    // connection alert must not linger.
+    correctionEntryPage.mockMatch(() =>
+      HttpResponse.json(buildCorrectableMatch()),
+    );
+    correctionEntryPage.mockPropose(() => HttpResponse.error());
+    correctionEntryPage.render();
+
+    await waitFor(() => correctionEntryPage.getInput("rita.kovac"));
+
+    // First send fails offline: settle back to enabled, then assert the alert
+    // synchronously (crisp fail if it never rendered).
+    await userEvent.click(correctionEntryPage.getSubmit());
+    await waitFor(() => {
+      expect(correctionEntryPage.getSubmit()).toBeEnabled();
+      expect(correctionEntryPage.getSubmit()).toHaveTextContent(
+        "Send corrected score",
+      );
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /Couldn't send your corrected score .* check your connection and try again/i,
+    );
+
+    // Reconnect: the endpoint now succeeds. `server.use` prepends, so this
+    // handler wins for the retry.
+    correctionEntryPage.mockPropose(() =>
+      HttpResponse.json(buildMatchDetails(), { status: 201 }),
+    );
+
+    // Retry → success navigates to the match-detail landing (same pattern the
+    // success test above asserts).
+    await userEvent.click(correctionEntryPage.getSubmit());
+    await waitFor(() =>
+      expect(correctionEntryPage.queryMatchLanding()).toBeInTheDocument(),
+    );
+
+    // The success path does not keep showing the stale connection alert.
+    expect(
+      correctionEntryPage
+        .queryAlerts()
+        .some((a: HTMLElement) =>
+          /check your connection/i.test(a.textContent ?? ""),
+        ),
+    ).toBe(false);
+  });
+
   it("redirects to match details instead of rendering when the match is already settled (#730)", async () => {
     // A finalized match still carries a `standing_result` (the settled score),
     // so the redirect must key off `viewer_state`, not just the presence of a

--- a/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
@@ -19,6 +19,39 @@ async function retype(input: HTMLInputElement, value: string) {
   if (value !== "") await userEvent.type(input, value);
 }
 
+/**
+ * Wait on the mutation *settling*, not on the alert — the button returning from
+ * "Sending…" to enabled happens in BOTH the fixed and broken states, so this
+ * resolves in ~milliseconds either way. If we waited on the alert itself, a
+ * regression (no alert) would red as an opaque 5s timeout (`asyncUtilTimeout` ==
+ * `testTimeout` == 5000, so a missing signal is indistinguishable from a hang).
+ * Settling first, then asserting the alert synchronously, makes a missing alert
+ * fail fast with a crisp query error.
+ */
+async function settleToRetryable() {
+  await waitFor(() => {
+    expect(correctionEntryPage.getSubmit()).toBeEnabled();
+    expect(correctionEntryPage.getSubmit()).toHaveTextContent(
+      "Send corrected score",
+    );
+  });
+}
+
+/**
+ * Whether the #839 connection alert is currently in the DOM. It renders in the
+ * same commit the mutation error settles, so callers assert this synchronously
+ * after `settleToRetryable()` rather than waiting on it.
+ */
+function hasConnectionAlert() {
+  return correctionEntryPage
+    .queryAlerts()
+    .some((a: HTMLElement) =>
+      /Couldn't send your corrected score .* check your connection and try again/i.test(
+        a.textContent ?? "",
+      ),
+    );
+}
+
 describe("CorrectionEntry", () => {
   it("opens game 1 pre-filled from the standing-result snapshot, viewer-left", async () => {
     // The seed's standing result is the opponent's 3–0 board (11–8, 11–6,
@@ -218,32 +251,9 @@ describe("CorrectionEntry", () => {
     await waitFor(() => correctionEntryPage.getInput("rita.kovac"));
     await userEvent.click(correctionEntryPage.getSubmit());
 
-    // Wait on the mutation *settling*, not on the alert — the button returning
-    // from "Sending…" to enabled happens in BOTH the fixed and broken states,
-    // so this resolves in ~milliseconds either way. If we waited on the alert
-    // itself, a regression (no alert) would red as an opaque 5s timeout
-    // (`asyncUtilTimeout` == `testTimeout` == 5000, so a missing signal is
-    // indistinguishable from a hang). Settling first, then asserting the alert
-    // synchronously, makes a missing alert fail fast with a crisp query error.
-    await waitFor(() => {
-      expect(correctionEntryPage.getSubmit()).toBeEnabled();
-      expect(correctionEntryPage.getSubmit()).toHaveTextContent(
-        "Send corrected score",
-      );
-    });
+    await settleToRetryable();
 
-    // Now the connection alert MUST already be in the DOM (it renders in the
-    // same commit the mutation error settled). Assert it synchronously so its
-    // absence is an immediate "unable to find role alert", not a timeout.
-    expect(
-      correctionEntryPage
-        .queryAlerts()
-        .some((a: HTMLElement) =>
-          /Couldn't send your corrected score .* check your connection and try again/i.test(
-            a.textContent ?? "",
-          ),
-        ),
-    ).toBe(true);
+    expect(hasConnectionAlert()).toBe(true);
     // The board never left, so no navigation — and the re-enabled button above
     // means the user can retry (not stuck on "Sending…").
     expect(correctionEntryPage.queryMatchLanding()).not.toBeInTheDocument();
@@ -268,53 +278,25 @@ describe("CorrectionEntry", () => {
     await waitFor(() => correctionEntryPage.getInput("rita.kovac"));
 
     // First send fails at the transport level → the connection alert renders and
-    // the button settles back from "Sending…" to enabled. Wait on the settle
-    // (a both-states signal), then assert the alert synchronously so a missing
-    // alert fails crisply rather than as an opaque 5s timeout.
+    // the button settles back from "Sending…" to enabled.
     await userEvent.click(correctionEntryPage.getSubmit());
-    await waitFor(() => {
-      expect(correctionEntryPage.getSubmit()).toBeEnabled();
-      expect(correctionEntryPage.getSubmit()).toHaveTextContent(
-        "Send corrected score",
-      );
-    });
-    expect(
-      correctionEntryPage
-        .queryAlerts()
-        .some((a: HTMLElement) =>
-          /Couldn't send your corrected score .* check your connection and try again/i.test(
-            a.textContent ?? "",
-          ),
-        ),
-    ).toBe(true);
+    await settleToRetryable();
+    expect(hasConnectionAlert()).toBe(true);
 
     // Retry: click Send again. In the working case the button goes disabled
     // ("Sending…") then re-enables when the second failure settles, so
-    // `waitFor(enabled)` genuinely waits for that round-trip and `requests` is
-    // already 2 by the time it resolves. If the retry were dead-locked by a
+    // `settleToRetryable()` genuinely waits for that round-trip and `requests`
+    // is already 2 by the time it resolves. If the retry were dead-locked by a
     // stuck `submittingRef`, the button never leaves "Send corrected score" and
     // the synchronous `requests` assertion fails with "expected 1 to be 2" —
     // not a timeout.
     await userEvent.click(correctionEntryPage.getSubmit());
-    await waitFor(() => {
-      expect(correctionEntryPage.getSubmit()).toBeEnabled();
-      expect(correctionEntryPage.getSubmit()).toHaveTextContent(
-        "Send corrected score",
-      );
-    });
+    await settleToRetryable();
     expect(requests).toBe(2);
 
     // The alert is still up, nothing is stuck on "Sending…", and the board
     // never navigated away.
-    expect(
-      correctionEntryPage
-        .queryAlerts()
-        .some((a: HTMLElement) =>
-          /Couldn't send your corrected score .* check your connection and try again/i.test(
-            a.textContent ?? "",
-          ),
-        ),
-    ).toBe(true);
+    expect(hasConnectionAlert()).toBe(true);
     expect(correctionEntryPage.queryMatchLanding()).not.toBeInTheDocument();
   });
 
@@ -335,21 +317,8 @@ describe("CorrectionEntry", () => {
     // First send fails offline: settle back to enabled, then assert the alert
     // synchronously (crisp fail if it never rendered).
     await userEvent.click(correctionEntryPage.getSubmit());
-    await waitFor(() => {
-      expect(correctionEntryPage.getSubmit()).toBeEnabled();
-      expect(correctionEntryPage.getSubmit()).toHaveTextContent(
-        "Send corrected score",
-      );
-    });
-    expect(
-      correctionEntryPage
-        .queryAlerts()
-        .some((a: HTMLElement) =>
-          /Couldn't send your corrected score .* check your connection and try again/i.test(
-            a.textContent ?? "",
-          ),
-        ),
-    ).toBe(true);
+    await settleToRetryable();
+    expect(hasConnectionAlert()).toBe(true);
 
     // Reconnect: the endpoint now succeeds. `server.use` prepends, so this
     // handler wins for the retry.

--- a/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
@@ -202,6 +202,47 @@ describe("CorrectionEntry", () => {
     expect(correctionEntryPage.queryMatchLanding()).not.toBeInTheDocument();
   });
 
+  it("surfaces a transport-level failure inline and leaves Send retryable, on a valid decided board (#839)", async () => {
+    // `useProposeResult` runs `networkMode: 'always'`, so an offline submit
+    // fires the POST and `fetch` rejects with a plain `TypeError` — NOT an
+    // `ApiError`. On a valid, decided board (no `boardHint`) the old code
+    // rendered nothing here, leaving the user with zero feedback. The board
+    // below is the seed's untouched decided 3–0, so only the connection alert
+    // can explain the failure.
+    correctionEntryPage.mockMatch(() =>
+      HttpResponse.json(buildCorrectableMatch()),
+    );
+    correctionEntryPage.mockPropose(() => HttpResponse.error());
+    correctionEntryPage.render();
+
+    await waitFor(() => correctionEntryPage.getInput("rita.kovac"));
+    await userEvent.click(correctionEntryPage.getSubmit());
+
+    // Wait on the mutation *settling*, not on the alert — the button returning
+    // from "Sending…" to enabled happens in BOTH the fixed and broken states,
+    // so this resolves in ~milliseconds either way. If we waited on the alert
+    // itself, a regression (no alert) would red as an opaque 5s timeout
+    // (`asyncUtilTimeout` == `testTimeout` == 5000, so a missing signal is
+    // indistinguishable from a hang). Settling first, then asserting the alert
+    // synchronously, makes a missing alert fail fast with a crisp query error.
+    await waitFor(() => {
+      expect(correctionEntryPage.getSubmit()).toBeEnabled();
+      expect(correctionEntryPage.getSubmit()).toHaveTextContent(
+        "Send corrected score",
+      );
+    });
+
+    // Now the connection alert MUST already be in the DOM (it renders in the
+    // same commit the mutation error settled). Assert it synchronously so its
+    // absence is an immediate "unable to find role alert", not a timeout.
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /Couldn't send your corrected score .* check your connection and try again/i,
+    );
+    // The board never left, so no navigation — and the re-enabled button above
+    // means the user can retry (not stuck on "Sending…").
+    expect(correctionEntryPage.queryMatchLanding()).not.toBeInTheDocument();
+  });
+
   it("redirects to match details instead of rendering when the match is already settled (#730)", async () => {
     // A finalized match still carries a `standing_result` (the settled score),
     // so the redirect must key off `viewer_state`, not just the presence of a

--- a/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.test.tsx
@@ -235,9 +235,15 @@ describe("CorrectionEntry", () => {
     // Now the connection alert MUST already be in the DOM (it renders in the
     // same commit the mutation error settled). Assert it synchronously so its
     // absence is an immediate "unable to find role alert", not a timeout.
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      /Couldn't send your corrected score .* check your connection and try again/i,
-    );
+    expect(
+      correctionEntryPage
+        .queryAlerts()
+        .some((a: HTMLElement) =>
+          /Couldn't send your corrected score .* check your connection and try again/i.test(
+            a.textContent ?? "",
+          ),
+        ),
+    ).toBe(true);
     // The board never left, so no navigation — and the re-enabled button above
     // means the user can retry (not stuck on "Sending…").
     expect(correctionEntryPage.queryMatchLanding()).not.toBeInTheDocument();
@@ -272,9 +278,15 @@ describe("CorrectionEntry", () => {
         "Send corrected score",
       );
     });
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      /Couldn't send your corrected score .* check your connection and try again/i,
-    );
+    expect(
+      correctionEntryPage
+        .queryAlerts()
+        .some((a: HTMLElement) =>
+          /Couldn't send your corrected score .* check your connection and try again/i.test(
+            a.textContent ?? "",
+          ),
+        ),
+    ).toBe(true);
 
     // Retry: click Send again. In the working case the button goes disabled
     // ("Sending…") then re-enables when the second failure settles, so
@@ -294,9 +306,15 @@ describe("CorrectionEntry", () => {
 
     // The alert is still up, nothing is stuck on "Sending…", and the board
     // never navigated away.
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      /Couldn't send your corrected score .* check your connection and try again/i,
-    );
+    expect(
+      correctionEntryPage
+        .queryAlerts()
+        .some((a: HTMLElement) =>
+          /Couldn't send your corrected score .* check your connection and try again/i.test(
+            a.textContent ?? "",
+          ),
+        ),
+    ).toBe(true);
     expect(correctionEntryPage.queryMatchLanding()).not.toBeInTheDocument();
   });
 
@@ -323,9 +341,15 @@ describe("CorrectionEntry", () => {
         "Send corrected score",
       );
     });
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      /Couldn't send your corrected score .* check your connection and try again/i,
-    );
+    expect(
+      correctionEntryPage
+        .queryAlerts()
+        .some((a: HTMLElement) =>
+          /Couldn't send your corrected score .* check your connection and try again/i.test(
+            a.textContent ?? "",
+          ),
+        ),
+    ).toBe(true);
 
     // Reconnect: the endpoint now succeeds. `server.use` prepends, so this
     // handler wins for the retry.

--- a/web-client/src/components/matches/correction-entry/correction-entry.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.tsx
@@ -232,6 +232,14 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
   const apiError =
     proposeMutation.error instanceof ApiError ? proposeMutation.error : null;
 
+  // A non-ApiError needs its own branch: `useProposeResult` runs
+  // `networkMode: 'always'`, so an offline submit fires the POST anyway and
+  // `fetch` rejects at the transport level with a plain `TypeError` — never an
+  // `ApiError`. Without this, an offline send would re-enable the button with
+  // no feedback at all (#839). Mutually exclusive with `apiError` by
+  // construction (the error is one or the other, never both).
+  const networkError = proposeMutation.error !== null && apiError === null;
+
   const inputsLocked = proposeMutation.isPending;
 
   // The per-game verdicts and the scoreline view-model both derive from the
@@ -317,6 +325,13 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
           {apiError.status === 409
             ? "This proposal has moved on — reload the match to see the latest score."
             : (apiError.detail ?? apiError.message)}
+        </p>
+      )}
+
+      {networkError && (
+        <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
+          Couldn't send your corrected score — check your connection and try
+          again.
         </p>
       )}
 

--- a/web-client/src/components/matches/correction-entry/correction-entry.tsx
+++ b/web-client/src/components/matches/correction-entry/correction-entry.tsx
@@ -22,6 +22,18 @@ import { CorrectionScoreline } from "./correction-scoreline";
 // scratchpad entry screen so the correction board reads the same.
 const NO_OPPONENT_LABEL = "No opponent";
 
+/** The one inline red error line this screen uses for its several mutually-
+ * exclusive messages (API error, connection failure, board hint) — one place to
+ * change the role/styling for all of them. Field-level error copy, so it's this
+ * bespoke line rather than the card-shaped design-system `Alert`. */
+function InlineAlert({ children }: { children: React.ReactNode }) {
+  return (
+    <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
+      {children}
+    </p>
+  );
+}
+
 type StandingGame = NonNullable<
   MatchDetails["negotiation"]["standing_result"]
 >["games"][number];
@@ -321,25 +333,21 @@ export function CorrectionEntry({ matchId }: { matchId: string }) {
       </div>
 
       {apiError !== null && (
-        <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
+        <InlineAlert>
           {apiError.status === 409
             ? "This proposal has moved on — reload the match to see the latest score."
             : (apiError.detail ?? apiError.message)}
-        </p>
+        </InlineAlert>
       )}
 
       {networkError && (
-        <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
+        <InlineAlert>
           Couldn't send your corrected score — check your connection and try
           again.
-        </p>
+        </InlineAlert>
       )}
 
-      {boardHint !== null && (
-        <p role="alert" className="mt-1.5 text-xs text-[color:var(--loss)]">
-          {boardHint}
-        </p>
-      )}
+      {boardHint !== null && <InlineAlert>{boardHint}</InlineAlert>}
 
       <ScorePad
         // Remount on game switch so the inputs re-seed and the me-field


### PR DESCRIPTION
Closes #839.

## The bug

`CorrectionEntry` derived its inline alert as:

```ts
const apiError = proposeMutation.error instanceof ApiError ? proposeMutation.error : null;
```

`useProposeResult` runs with `networkMode: 'always'`, so submitting a correction while offline **does** fire the POST, and `fetch` rejects at the transport level with a plain `TypeError` — never an `ApiError`. So `apiError` is `null`. With a valid decided board `boardHint` is `null` too, so *neither* `role="alert"` paragraph rendered. The button showed "Sending…", re-enabled, and the user got **zero feedback** that the send had failed.

## The fix

Add a `networkError` branch for non-`ApiError` rejections, rendered with the existing inline-error pattern:

> Couldn't send your corrected score — check your connection and try again.

It is mutually exclusive with `apiError` by construction (an error is one or the other), so the 409 "This proposal has moved on…" copy is untouched.

## Design decisions

- **Error-driven, not a `navigator.onLine` pre-check.** An at-submit check misses mid-flight drops and DNS failures, and `navigator.onLine` reports `true` with no real connectivity. Reacting to the rejection catches every case.
- **No defer-to-scratchpad**, unlike `score-entry.tsx`. A score is safe to queue; silently queuing a *negotiation correction* would make the user believe it sent. Surfacing the failure is correct.
- **The button re-enable is left alone** — that behaviour is right, it permits a retry.

## On the test

The regression test rejects the POST at the transport level (`HttpResponse.error()`), on a valid decided board so `boardHint` is `null` — the exact state where the old code rendered nothing.

It waits for the mutation to *settle* (a signal present in both the fixed and broken states) and then asserts the alert **synchronously**. This matters: this suite sets `asyncUtilTimeout: 5000` and no `testTimeout` override, so a naive `waitFor` on the alert reds with a bare `Test timed out in 5000ms` — indistinguishable from a hang, and proof of nothing. As written, deleting the branch reds in ~400ms with `unable to find an accessible element with the role "alert"`.

Verified by removing the JSX branch and re-running: **1 failed / 10 passed**, assertion error at the `getByRole("alert")` line. Restored: **16 passed**.

## Verification

- `vitest run` (full web-client suite) — **1228 passed, 183 files**
- `tsc -b` — clean
- `npm run lint` — 0 errors
- No API/schema change: `schema.d.ts` untouched, no `regen-api-types`, no `e2e/` stub updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mii8o4RcCGCLZWCxZR2612