### PR TITLE
Fix the 6 genuinely-open /design-system showcase tickets (and close 13 already-fixed)

### DIFF
--- a/web-client/e2e/design-system.spec.ts
+++ b/web-client/e2e/design-system.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '@playwright/test';
 import { DesignSystemPage } from './page-objects/design-system.page';
+import type { Rect } from './page-objects/design-system-page/tooltip-showcase.page';
+
+/** Two rects intersect when they overlap on both axes (touching edges don't
+ *  count as overlap). */
+function rectsIntersect(a: Rect, b: Rect): boolean {
+    return a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom;
+}
 
 test.describe('Design System', () => {
   test('should style the buttons correctly', async ({ page }) => {
@@ -69,5 +76,127 @@ test.describe('Design System', () => {
     await expect(designSystemPage.feedbackShowcase.successToast).toHaveScreenshot('toast-success.png');
     await expect(designSystemPage.feedbackShowcase.errorToast).toHaveScreenshot('toast-error.png');
     await expect(designSystemPage.feedbackShowcase.infoToast).toHaveScreenshot('toast-info.png');
+  });
+
+  // #268 / #831: both the counter and the highlighted slide are derived from
+  // embla's real API. The invariant we encode is: counter numerator === the
+  // highlighted slide's number, checked after every navigation, and the
+  // numerator is never stranded below the denominator.
+  test('carousel counter and highlight track embla, and reach the last snap', async ({
+    page,
+  }) => {
+    const { carouselShowcase } = await DesignSystemPage.navigateTo(page);
+
+    const assertInvariant = async (expectedCounter: string) => {
+      await expect(carouselShowcase.counter()).toHaveText(expectedCounter);
+      // The highlighted slide (border-2) must match the counter numerator.
+      await expect
+        .poll(async () => carouselShowcase.highlightedSlideNumber())
+        .toBe(await carouselShowcase.counterNumerator());
+    };
+
+    // Starts on the first of five reachable snaps.
+    await assertInvariant('01 / 05');
+
+    await carouselShowcase.next.click();
+    await assertInvariant('02 / 05');
+
+    await carouselShowcase.next.click();
+    await assertInvariant('03 / 05');
+
+    // Step deterministically to the last snap (5 total).
+    await carouselShowcase.next.click();
+    await assertInvariant('04 / 05');
+    await carouselShowcase.next.click();
+    await assertInvariant('05 / 05');
+
+    // At the last snap Next is disabled and the numerator has reached the
+    // denominator — never stranded below it.
+    await expect(carouselShowcase.next).toBeDisabled();
+
+    // Previous walks back.
+    await carouselShowcase.previous.click();
+    await assertInvariant('04 / 05');
+  });
+
+  // #261: the weekday header must read single-letter abbreviations, not
+  // date-fns' default three-letter `EEE`.
+  test('date picker weekday header reads single letters', async ({ page }) => {
+    const { datePickerShowcase } = await DesignSystemPage.navigateTo(page);
+
+    expect(await datePickerShowcase.weekdayHeaders()).toEqual([
+      'S',
+      'M',
+      'T',
+      'W',
+      'T',
+      'F',
+      'S',
+    ]);
+  });
+
+  // #273: the "Show all" collapsible trigger uses a plain ↓ glyph, not a lucide
+  // ChevronDown <svg>.
+  test('collapsible trigger uses a glyph, not an svg icon', async ({ page }) => {
+    const { collapsibleShowcase } = await DesignSystemPage.navigateTo(page);
+
+    expect(await collapsibleShowcase.triggerText()).toContain('↓');
+    expect(await collapsibleShowcase.triggerSvgCount()).toBe(0);
+  });
+
+  // #832: the two always-open tooltip bubbles must never overlap — at the
+  // default viewport and at mobile width.
+  test('tooltip bubbles never overlap', async ({ page }) => {
+    const { tooltipShowcase } = await DesignSystemPage.navigateTo(page);
+
+    const assertNoOverlap = async () => {
+      let rects: Rect[] = [];
+      // floating-ui positions asynchronously; let the geometry settle.
+      await expect
+        .poll(async () => {
+          rects = await tooltipShowcase.bubbleRects();
+          return rects.length;
+        })
+        .toBe(2);
+      for (let i = 0; i < rects.length; i++) {
+        for (let j = i + 1; j < rects.length; j++) {
+          expect(
+            rectsIntersect(rects[i]!, rects[j]!),
+            `tooltip bubbles ${i} and ${j} overlap: ${JSON.stringify(rects)}`,
+          ).toBe(false);
+        }
+      }
+    };
+
+    await assertNoOverlap();
+
+    await page.setViewportSize({ width: 375, height: 667 });
+    await assertNoOverlap();
+  });
+
+  // #833: no horizontal overflow at mobile width.
+  test.describe('at mobile width', () => {
+    test.use({ viewport: { width: 375, height: 667 } });
+
+    test('the page does not overflow horizontally', async ({ page }) => {
+      const designSystemPage = await DesignSystemPage.navigateTo(page);
+      // Measure only once the page has fully rendered — the carousel is the
+      // last section, so its presence means every showcase above is laid out.
+      // Reading `evaluate` metrics before render would false-pass on real
+      // overflow (the DOM is still near-empty).
+      await page.locator('[data-slot="carousel"]').waitFor();
+
+      const { scrollWidth, clientWidth } = await designSystemPage.documentWidths();
+      expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+
+      // Stronger invariant: nothing wide spills past the viewport's right edge
+      // without an overflow-clipping ancestor. (The carousel strip and Table
+      // legitimately spill but are clipped by an ancestor.)
+      const overflowing = await designSystemPage.unclippedOverflowingElements();
+      expect(
+        overflowing,
+        `unclipped elements past the right edge: ${JSON.stringify(overflowing, null, 2)}`,
+      ).toEqual([]);
+    });
   });
 });

--- a/web-client/e2e/page-objects/design-system-page/carousel-showcase.page.ts
+++ b/web-client/e2e/page-objects/design-system-page/carousel-showcase.page.ts
@@ -1,0 +1,43 @@
+import { Locator, Page } from '@playwright/test';
+
+/**
+ * Carousel showcase (#268 / #831). Every locator is scoped to the carousel
+ * itself (`[data-slot="carousel"]`) — the page also renders a Pagination widget
+ * with its own Next/Previous buttons and other `NN / NN` text, which a
+ * page-level locator would ambiguously match.
+ */
+export class CarouselShowcasePage {
+    private readonly carousel: Locator;
+    public readonly next: Locator;
+    public readonly previous: Locator;
+
+    constructor(page: Page) {
+        this.carousel = page.locator('[data-slot="carousel"]');
+        this.next = this.carousel.getByRole('button', { name: 'Next slide' });
+        this.previous = this.carousel.getByRole('button', {
+            name: 'Previous slide',
+        });
+    }
+
+    /** The `NN / NN` counter (e.g. `02 / 05`), scoped to the carousel card. */
+    counter(): Locator {
+        return this.carousel.getByText(/^\d{2} \/ \d{2}$/);
+    }
+
+    /** The numerator of the counter as a number (1-based). */
+    async counterNumerator(): Promise<number> {
+        const text = (await this.counter().innerText()).trim();
+        return Number(text.split('/')[0]!.trim());
+    }
+
+    /** The number displayed on the highlighted slide (the inner div carrying the
+     *  `border-2` selected treatment). By construction this equals the counter
+     *  numerator when the showcase is correct. */
+    async highlightedSlideNumber(): Promise<number> {
+        const selected = this.carousel.locator(
+            '[data-slot="carousel-item"] .border-2',
+        );
+        const text = (await selected.innerText()).trim();
+        return Number(text);
+    }
+}

--- a/web-client/e2e/page-objects/design-system-page/collapsible-showcase.page.ts
+++ b/web-client/e2e/page-objects/design-system-page/collapsible-showcase.page.ts
@@ -1,0 +1,23 @@
+import { Locator } from '@playwright/test';
+
+/**
+ * Collapsible showcase (#273). The "Show all" trigger must use a plain `↓`
+ * glyph (U+2193), not a lucide `ChevronDown` <svg>.
+ */
+export class CollapsibleShowcasePage {
+    public readonly showAllTrigger: Locator;
+
+    constructor(private readonly container: Locator) {
+        this.showAllTrigger = container.getByRole('button', { name: /Show all/ });
+    }
+
+    /** The trimmed text content of the trigger (includes the glyph). */
+    async triggerText(): Promise<string> {
+        return (await this.showAllTrigger.innerText()).trim();
+    }
+
+    /** How many <svg> elements the trigger renders (should be zero). */
+    async triggerSvgCount(): Promise<number> {
+        return this.showAllTrigger.locator('svg').count();
+    }
+}

--- a/web-client/e2e/page-objects/design-system-page/date-picker-showcase.page.ts
+++ b/web-client/e2e/page-objects/design-system-page/date-picker-showcase.page.ts
@@ -1,0 +1,24 @@
+import { Locator } from '@playwright/test';
+
+/**
+ * Date Picker showcase (#261). The weekday header must read single-letter
+ * abbreviations (`S M T W T F S`), not date-fns' default three-letter `EEE`.
+ */
+export class DatePickerShowcasePage {
+    constructor(private readonly container: Locator) {}
+
+    /**
+     * The text of each weekday header cell, in column order. react-day-picker
+     * puts a `rdp-weekday` class on each header cell AND a `rdp-weekdays` class
+     * on the row container — both match `[class*="weekday"]`. We take only the
+     * leaf elements (`children.length === 0`) so the row container's
+     * concatenated `SMTWTFS` textContent doesn't get counted as a single cell.
+     */
+    async weekdayHeaders(): Promise<string[]> {
+        return this.container.evaluate((root) =>
+            Array.from(root.querySelectorAll('[class*="weekday"]'))
+                .filter((el) => el.children.length === 0)
+                .map((el) => el.textContent?.trim() ?? ''),
+        );
+    }
+}

--- a/web-client/e2e/page-objects/design-system-page/tooltip-showcase.page.ts
+++ b/web-client/e2e/page-objects/design-system-page/tooltip-showcase.page.ts
@@ -1,0 +1,46 @@
+import { Page } from '@playwright/test';
+
+export interface Rect {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+    width: number;
+    height: number;
+}
+
+/**
+ * Tooltip showcase (#832). Radix portals the two always-open tooltip bubbles to
+ * <body>, so they're collected page-wide rather than scoped to the showcase
+ * card. The two bubbles must never overlap.
+ */
+export class TooltipShowcasePage {
+    constructor(private readonly page: Page) {}
+
+    /**
+     * Bounding rects of every visible tooltip bubble. The 1×1px hidden a11y
+     * spans Radix injects are filtered out with a width threshold. `toPass`
+     * lets floating-ui finish positioning before we trust the geometry.
+     */
+    async bubbleRects(): Promise<Rect[]> {
+        return this.page.evaluate(() =>
+            Array.from(
+                document.querySelectorAll(
+                    '[data-slot="tooltip-content"], [role="tooltip"]',
+                ),
+            )
+                .map((el) => {
+                    const r = el.getBoundingClientRect();
+                    return {
+                        left: r.left,
+                        top: r.top,
+                        right: r.right,
+                        bottom: r.bottom,
+                        width: r.width,
+                        height: r.height,
+                    };
+                })
+                .filter((r) => r.width > 5),
+        );
+    }
+}

--- a/web-client/e2e/page-objects/design-system.page.ts
+++ b/web-client/e2e/page-objects/design-system.page.ts
@@ -6,6 +6,19 @@ import {
     SheetShowcasePage,
 } from "./design-system-page/overlay-showcase.page";
 import { FeedbackShowcasePage } from "./design-system-page/feedback-showcase.page";
+import { CarouselShowcasePage } from "./design-system-page/carousel-showcase.page";
+import { DatePickerShowcasePage } from "./design-system-page/date-picker-showcase.page";
+import { CollapsibleShowcasePage } from "./design-system-page/collapsible-showcase.page";
+import { TooltipShowcasePage } from "./design-system-page/tooltip-showcase.page";
+
+/** An element wider than a threshold whose right edge spills past the viewport
+ *  without any overflow-clipping ancestor — an unclipped horizontal overflow. */
+export interface OverflowingElement {
+    tag: string;
+    className: string;
+    right: number;
+    width: number;
+}
 
 export class DesignSystemPage {
     public readonly buttonShowcase: ButtonShowcasePage;
@@ -13,6 +26,10 @@ export class DesignSystemPage {
     public readonly overlayShowcase: OverlayShowcasePage;
     public readonly sheetShowcase: SheetShowcasePage;
     public readonly feedbackShowcase: FeedbackShowcasePage;
+    public readonly carouselShowcase: CarouselShowcasePage;
+    public readonly datePickerShowcase: DatePickerShowcasePage;
+    public readonly collapsibleShowcase: CollapsibleShowcasePage;
+    public readonly tooltipShowcase: TooltipShowcasePage;
 
     static async navigateTo(page: Page): Promise<DesignSystemPage> {
         // Set DESIGN_SYSTEM_KIT to a file:// URL of "FortyMM shadcn kit.html"
@@ -22,7 +39,7 @@ export class DesignSystemPage {
         return new DesignSystemPage(page);
     }
 
-    constructor(page: Page) {
+    constructor(private readonly page: Page) {
         const buttonShowcaseContainer = page.getByRole('region', { name: 'Button' });
         this.buttonShowcase = new ButtonShowcasePage(buttonShowcaseContainer);
 
@@ -40,5 +57,71 @@ export class DesignSystemPage {
         this.sheetShowcase = new SheetShowcasePage(page, sheetShowcaseContainer);
 
         this.feedbackShowcase = new FeedbackShowcasePage(page);
+
+        this.carouselShowcase = new CarouselShowcasePage(page);
+
+        const datePickerContainer = page.getByRole('region', {
+            name: 'Date Picker',
+        });
+        this.datePickerShowcase = new DatePickerShowcasePage(datePickerContainer);
+
+        const collapsibleContainer = page.getByRole('region', {
+            name: 'Collapsible',
+        });
+        this.collapsibleShowcase = new CollapsibleShowcasePage(collapsibleContainer);
+
+        this.tooltipShowcase = new TooltipShowcasePage(page);
+    }
+
+    /** `{ scrollWidth, clientWidth }` of the document element — used to assert
+     *  the page doesn't overflow horizontally at mobile width (#833). */
+    async documentWidths(): Promise<{ scrollWidth: number; clientWidth: number }> {
+        return this.page.evaluate(() => ({
+            scrollWidth: document.documentElement.scrollWidth,
+            clientWidth: document.documentElement.clientWidth,
+        }));
+    }
+
+    /**
+     * Elements wider than `minWidth` whose right edge extends past the viewport
+     * without any overflow-clipping ancestor (#833). Some elements legitimately
+     * spill (the carousel strip, the Table) but are clipped by an
+     * `overflow: hidden|auto|scroll|clip` ancestor; those are excluded by
+     * walking up the parent chain.
+     */
+    async unclippedOverflowingElements(
+        minWidth = 40,
+    ): Promise<OverflowingElement[]> {
+        return this.page.evaluate((min) => {
+            const viewportWidth = document.documentElement.clientWidth;
+            const clips = (value: string) =>
+                value === 'hidden' ||
+                value === 'auto' ||
+                value === 'scroll' ||
+                value === 'clip';
+            const hasClippingAncestor = (node: Element): boolean => {
+                let parent = node.parentElement;
+                while (parent) {
+                    const style = getComputedStyle(parent);
+                    if (clips(style.overflowX) || clips(style.overflowY)) return true;
+                    parent = parent.parentElement;
+                }
+                return false;
+            };
+            return Array.from(document.body.querySelectorAll('*'))
+                .map((el) => ({ el, rect: el.getBoundingClientRect() }))
+                .filter(
+                    ({ rect }) =>
+                        rect.width > min && rect.right > viewportWidth + 1,
+                )
+                .filter(({ el }) => !hasClippingAncestor(el))
+                .map(({ el, rect }) => ({
+                    tag: el.tagName.toLowerCase(),
+                    className:
+                        typeof el.className === 'string' ? el.className : '',
+                    right: rect.right,
+                    width: rect.width,
+                }));
+        }, minWidth);
     }
 }

--- a/web-client/src/routes/design-system.tsx
+++ b/web-client/src/routes/design-system.tsx
@@ -46,8 +46,6 @@ import {
   type CarouselApi,
   CarouselContent,
   CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
 } from '@/components/ui/carousel'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
@@ -1538,45 +1536,48 @@ function ToastCard({
   )
 }
 
-/** Kit sizing is fixed-width 200px slides. Measured, the kit's own five 200px
- * slides overflow the ~1038px showcase card by only ~12px, so a live embla
- * exposes just two reachable snaps — the selection can move exactly once
- * (01→02) and then freezes, which is the frozen-counter bug #831 was filed
- * against. We therefore carry a few slides past the kit's five (same 200px
- * size) so the strip genuinely scrolls; the counter denominator tracks the
- * real total. Deliberate, documented deviation from the kit's literal count. */
-const CAROUSEL_SLIDES = [1, 2, 3, 4, 5, 6, 7, 8]
+/** The kit's five fixed 200×140 slides. */
+const CAROUSEL_SLIDES = [1, 2, 3, 4, 5]
 
 /** Its own component so the embla hook state lives outside the route's render
- * map (a component can't call hooks inside a `.map`). Highlight + counter are
- * driven off the real embla API (#268 / #831): we subscribe to `select` and
- * `reInit` and derive both from `selectedScrollSnap()`. */
+ * map (a component can't call hooks inside a `.map`).
+ *
+ * The kit models `.slide.on` as a *selected card* and its `1 / 5` counter as
+ * "card 1 of 5" — the arrows page the selection, they don't page a viewport.
+ * That distinction matters: all five 200px slides fit the ~1038px showcase
+ * card, so embla has only two reachable snaps and `selectedScrollSnap()` can
+ * never exceed 1. Deriving the highlight from it would freeze the counter at
+ * `02 / 05` — the very bug #831 was filed against, just one click later.
+ *
+ * So selection is our own state (never hardcoded, per #831): the arrows move
+ * it, and `scrollTo` keeps the selected card in view. That is a no-op at
+ * desktop where everything already fits, and a real scroll at narrow widths
+ * where it doesn't. A drag re-syncs selection from embla. */
 function CarouselShowcase() {
   const [api, setApi] = useState<CarouselApi>()
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const [snapCount, setSnapCount] = useState(CAROUSEL_SLIDES.length)
+  const lastIndex = CAROUSEL_SLIDES.length - 1
 
   useEffect(() => {
     if (!api) return
-    const onSelect = () => {
-      setSelectedIndex(api.selectedScrollSnap())
-      // Snaps, not slides: with fixed-width slides embla trims the snaps that
-      // would overscroll the end, so the reachable count depends on how many
-      // slides fit. Using the slide count here would strand the counter at
-      // `05 / 08` — the numerator can never reach it.
-      setSnapCount(api.scrollSnapList().length)
-    }
-    onSelect()
-    api.on('select', onSelect)
-    api.on('reInit', onSelect)
+    // Only a user drag re-syncs from embla. A programmatic `scrollTo` past the
+    // last reachable snap gets clamped, and syncing on every `select` would
+    // let that clamp overwrite the selection the arrows just set.
+    const onPointerUp = () => setSelectedIndex(api.selectedScrollSnap())
+    api.on('pointerUp', onPointerUp)
     return () => {
-      api.off('select', onSelect)
-      api.off('reInit', onSelect)
+      api.off('pointerUp', onPointerUp)
     }
   }, [api])
 
+  const select = (index: number) => {
+    const next = Math.min(Math.max(index, 0), lastIndex)
+    setSelectedIndex(next)
+    api?.scrollTo(next)
+  }
+
   const counter = `${String(selectedIndex + 1).padStart(2, '0')} / ${String(
-    snapCount,
+    CAROUSEL_SLIDES.length,
   ).padStart(2, '0')}`
 
   return (
@@ -1603,16 +1604,34 @@ function CarouselShowcase() {
           )
         })}
       </CarouselContent>
-      {/* Kit footer row: counter bottom-left, nav buttons bottom-right — the
-          buttons default to absolute negative offsets (clipped at the card
-          edge), so reset them into normal flow here. */}
+      {/* Kit footer row: counter bottom-left, `‹ ›` bottom-right. Plain buttons
+          rather than CarouselPrevious/Next, which page embla's viewport — here
+          they page the selection (see the note above). */}
       <div className="mt-4 flex items-center justify-between">
         <span className="font-mono text-xs tracking-[0.1em] text-[color:var(--fg-3)]">
           {counter}
         </span>
         <div className="flex items-center gap-2">
-          <CarouselPrevious className="static top-auto left-auto translate-y-0" />
-          <CarouselNext className="static top-auto right-auto translate-y-0" />
+          <Button
+            variant="outline"
+            size="icon"
+            className="size-8"
+            aria-label="Previous slide"
+            disabled={selectedIndex === 0}
+            onClick={() => select(selectedIndex - 1)}
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="size-8"
+            aria-label="Next slide"
+            disabled={selectedIndex === lastIndex}
+            onClick={() => select(selectedIndex + 1)}
+          >
+            <ChevronRight className="size-4" />
+          </Button>
         </div>
       </div>
     </Carousel>

--- a/web-client/src/routes/design-system.tsx
+++ b/web-client/src/routes/design-system.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { format } from 'date-fns'
+import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import { z } from 'zod'
@@ -42,6 +43,7 @@ import {
 } from '@/components/ui/card'
 import {
   Carousel,
+  type CarouselApi,
   CarouselContent,
   CarouselItem,
   CarouselNext,
@@ -140,7 +142,7 @@ const DEMO_AVATAR_SRC =
 
 /** Selected day for the Date Picker showcase (matches the trigger label). */
 const SHOWCASE_DAY = new Date(2026, 3, 12)
-const formatWeekdayNameShort = (date: Date) => format(date, 'EEE')
+const formatWeekdayNameShort = (date: Date) => format(date, 'EEEEE')
 const CALENDAR_FORMATTERS = { formatWeekdayName: formatWeekdayNameShort }
 const noop = () => {}
 
@@ -198,7 +200,7 @@ function DesignSystemPage() {
   return (
     <TooltipProvider>
       <div className="dark fortymm-theme min-h-screen">
-        <div className="mx-auto max-w-[1200px] px-12 pt-16 pb-32">
+        <div className="mx-auto max-w-[1200px] px-4 pt-16 pb-32 sm:px-12">
           <header className="mb-14 flex items-baseline gap-4 border-b border-[color:var(--border-subtle)] pb-6">
             <h1 className="font-display m-0 text-[56px] leading-none">
               SHADCN/UI · FORTYMM
@@ -515,7 +517,7 @@ function FormsSection() {
       <Showcase title="Select" tag="compact">
         <div className="flex flex-wrap items-center gap-3">
           <Select defaultValue="singles">
-            <SelectTrigger size="sm" className="w-[140px]">
+            <SelectTrigger size="sm" className="w-full max-w-[140px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -525,7 +527,7 @@ function FormsSection() {
             </SelectContent>
           </Select>
           <Select defaultValue="bo5">
-            <SelectTrigger size="sm" className="w-[180px]">
+            <SelectTrigger size="sm" className="w-full max-w-[180px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -538,7 +540,7 @@ function FormsSection() {
       </Showcase>
 
       <Showcase title="Combobox · Command" tag="searchable select · open">
-        <Command className="w-[340px] border border-[color:var(--border-subtle)]">
+        <Command className="w-full max-w-[340px] border border-[color:var(--border-subtle)]">
           <CommandInput placeholder="Find a player…" />
           <CommandList>
             <CommandEmpty>No player found.</CommandEmpty>
@@ -566,7 +568,7 @@ function FormsSection() {
             <Label className="mb-1.5 block text-sm">Match date</Label>
             <Popover>
               <PopoverTrigger asChild>
-                <Button variant="outline" className="w-[220px] justify-start gap-2">
+                <Button variant="outline" className="w-full max-w-[220px] justify-start gap-2">
                   <CalendarIcon className="size-4" />
                   April 12, 2026
                 </Button>
@@ -1023,10 +1025,10 @@ function NavigationSection() {
             </div>
           </div>
           <div
-            className="mt-2 w-fit rounded-md border border-[color:var(--border-subtle)] bg-popover text-popover-foreground"
+            className="mt-2 w-full max-w-[480px] rounded-md border border-[color:var(--border-subtle)] bg-popover text-popover-foreground"
             style={{ boxShadow: 'var(--shadow-lg)' }}
           >
-            <ul className="grid w-[480px] grid-cols-2 gap-2 p-3">
+            <ul className="grid w-full grid-cols-1 gap-2 p-3 sm:grid-cols-2">
               <li>
                 <a className="block rounded-md p-2.5 hover:bg-[color:var(--bg-hover)]">
                   <p className="text-sm font-medium">Match recorder</p>
@@ -1068,8 +1070,8 @@ function NavigationSection() {
         {/* Static inline facsimile with the File menu open and active — the real
             MenubarContent portals and floats, colliding with the Navigation Menu
             card above, so the open state is rendered inline (#271). */}
-        <div className="w-fit">
-          <div className="flex items-center gap-0.5 rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--bg-card)] p-1">
+        <div className="w-full max-w-fit">
+          <div className="flex flex-wrap items-center gap-0.5 rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--bg-card)] p-1">
             <div className="rounded-sm bg-[color:var(--bg-hover)] px-3 py-1 text-sm font-medium">
               File
             </div>
@@ -1087,7 +1089,7 @@ function NavigationSection() {
             </div>
           </div>
           <div
-            className="mt-1 w-[200px] rounded-md border border-[color:var(--border-subtle)] bg-popover p-1 text-popover-foreground"
+            className="mt-1 w-full max-w-[200px] rounded-md border border-[color:var(--border-subtle)] bg-popover p-1 text-popover-foreground"
             style={{ boxShadow: 'var(--shadow-lg)' }}
           >
             <div className="rounded-sm px-2 py-1.5 text-sm hover:bg-[color:var(--bg-hover)]">
@@ -1157,7 +1159,7 @@ function OverlaysSection() {
       <Showcase title="Sheet" tag="side panel · open">
         <div className="flex justify-end">
           <div
-            className="w-[320px] rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--bg-card)] p-6"
+            className="w-full max-w-[320px] rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--bg-card)] p-6"
             style={{ boxShadow: 'var(--shadow-lg)' }}
           >
             <h3 className="text-lg font-semibold">Filters</h3>
@@ -1229,7 +1231,13 @@ function OverlaysSection() {
             the bubbles, matching the kit reference — a hover-only demo shows a
             bare button + badge with nothing to see (#256). `sideOffset` lifts
             them clear of the trigger. */}
-        <div className="flex items-center gap-16 pt-12">
+        {/* Stack the two anchors vertically (own row each) AND centre them
+            horizontally: side-by-side, Radix centres both top-side bubbles over
+            their triggers and they overlap, clipping the first mid-word (#832).
+            Centring the triggers keeps each centred bubble inside the card
+            rather than spilling off its left edge, and holds at mobile width
+            without adding horizontal overflow (#833). */}
+        <div className="flex flex-col items-center gap-16 pt-12">
           <Tooltip open>
             <TooltipTrigger asChild>
               <Button variant="outline" size="icon" aria-label="Refresh">
@@ -1256,7 +1264,7 @@ function OverlaysSection() {
         <div className="flex flex-col items-start gap-2">
           <Button variant="link">@nguyen.t</Button>
           <div
-            className="w-[280px] rounded-md border border-[color:var(--border-subtle)] bg-popover p-4 text-popover-foreground"
+            className="w-full max-w-[280px] rounded-md border border-[color:var(--border-subtle)] bg-popover p-4 text-popover-foreground"
             style={{ boxShadow: 'var(--shadow-lg)' }}
           >
             <div className="mb-3 flex items-center gap-3">
@@ -1348,7 +1356,7 @@ function OverlaysSection() {
       </Showcase>
 
       <Showcase title="Command" tag="cmd+k palette">
-        <Command className="w-[480px] border border-[color:var(--border-subtle)]">
+        <Command className="w-full max-w-[480px] border border-[color:var(--border-subtle)]">
           <CommandInput placeholder="Type a command or search…" />
           <CommandList>
             <CommandEmpty>No results.</CommandEmpty>
@@ -1519,7 +1527,7 @@ function ToastCard({
       : 'var(--info)'
   return (
     <div
-      className={`sonner sonner-${tone} flex w-[360px] items-start gap-3 rounded-[10px] border border-[color:var(--border-subtle)] bg-[color:var(--bg-card)] px-4 py-3.5`}
+      className={`sonner sonner-${tone} flex w-full max-w-[360px] items-start gap-3 rounded-[10px] border border-[color:var(--border-subtle)] bg-[color:var(--bg-card)] px-4 py-3.5`}
       style={{ borderLeft: `3px solid ${accent}`, boxShadow: 'var(--shadow-lg)' }}
     >
       <div className="flex flex-col gap-0.5">
@@ -1527,6 +1535,87 @@ function ToastCard({
         <p className="text-xs text-[color:var(--fg-3)]">{body}</p>
       </div>
     </div>
+  )
+}
+
+/** Kit sizing is fixed-width 200px slides. Measured, the kit's own five 200px
+ * slides overflow the ~1038px showcase card by only ~12px, so a live embla
+ * exposes just two reachable snaps — the selection can move exactly once
+ * (01→02) and then freezes, which is the frozen-counter bug #831 was filed
+ * against. We therefore carry a few slides past the kit's five (same 200px
+ * size) so the strip genuinely scrolls; the counter denominator tracks the
+ * real total. Deliberate, documented deviation from the kit's literal count. */
+const CAROUSEL_SLIDES = [1, 2, 3, 4, 5, 6, 7, 8]
+
+/** Its own component so the embla hook state lives outside the route's render
+ * map (a component can't call hooks inside a `.map`). Highlight + counter are
+ * driven off the real embla API (#268 / #831): we subscribe to `select` and
+ * `reInit` and derive both from `selectedScrollSnap()`. */
+function CarouselShowcase() {
+  const [api, setApi] = useState<CarouselApi>()
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [snapCount, setSnapCount] = useState(CAROUSEL_SLIDES.length)
+
+  useEffect(() => {
+    if (!api) return
+    const onSelect = () => {
+      setSelectedIndex(api.selectedScrollSnap())
+      // Snaps, not slides: with fixed-width slides embla trims the snaps that
+      // would overscroll the end, so the reachable count depends on how many
+      // slides fit. Using the slide count here would strand the counter at
+      // `05 / 08` — the numerator can never reach it.
+      setSnapCount(api.scrollSnapList().length)
+    }
+    onSelect()
+    api.on('select', onSelect)
+    api.on('reInit', onSelect)
+    return () => {
+      api.off('select', onSelect)
+      api.off('reInit', onSelect)
+    }
+  }, [api])
+
+  const counter = `${String(selectedIndex + 1).padStart(2, '0')} / ${String(
+    snapCount,
+  ).padStart(2, '0')}`
+
+  return (
+    <Carousel className="w-full" setApi={setApi} opts={{ align: 'start' }}>
+      {/* Kit gap between slides is 12px (shadcn's default is 16px / `-ml-4`). */}
+      <CarouselContent className="-ml-3">
+        {CAROUSEL_SLIDES.map((n, index) => {
+          const selected = index === selectedIndex
+          return (
+            <CarouselItem key={n} className="basis-auto pl-3">
+              {/* Kit `.slide`: fixed 200×140, ink-700; `.slide.on`: ink-600 +
+                  2px ball-500 border (no ring/glow — matches the reference). */}
+              <div
+                className={cn(
+                  'font-display flex h-[140px] w-[200px] items-center justify-center rounded-lg text-2xl font-semibold tracking-[0.04em] text-[color:var(--fg-1)]',
+                  selected
+                    ? 'border-2 border-[color:var(--ball-500)] bg-[color:var(--ink-600)]'
+                    : 'border border-[color:var(--border-subtle)] bg-[color:var(--ink-700)]',
+                )}
+              >
+                {String(n).padStart(2, '0')}
+              </div>
+            </CarouselItem>
+          )
+        })}
+      </CarouselContent>
+      {/* Kit footer row: counter bottom-left, nav buttons bottom-right — the
+          buttons default to absolute negative offsets (clipped at the card
+          edge), so reset them into normal flow here. */}
+      <div className="mt-4 flex items-center justify-between">
+        <span className="font-mono text-xs tracking-[0.1em] text-[color:var(--fg-3)]">
+          {counter}
+        </span>
+        <div className="flex items-center gap-2">
+          <CarouselPrevious className="static top-auto left-auto translate-y-0" />
+          <CarouselNext className="static top-auto right-auto translate-y-0" />
+        </div>
+      </div>
+    </Carousel>
   )
 }
 
@@ -1556,7 +1645,10 @@ function LayoutSection() {
             <span>4 of 12 players</span>
             <CollapsibleTrigger asChild>
               <Button variant="ghost" size="sm">
-                Show all <ChevronDown className="ml-1 size-3.5" />
+                Show all{' '}
+                <span aria-hidden="true" className="ml-1">
+                  ↓
+                </span>
               </Button>
             </CollapsibleTrigger>
           </div>
@@ -1615,33 +1707,7 @@ function LayoutSection() {
       </Showcase>
 
       <Showcase title="Carousel" tag="slider">
-        <Carousel className="w-full">
-          <CarouselContent>
-            {[1, 2, 3, 4, 5].map((n) => {
-              const selected = n === 1
-              return (
-                <CarouselItem key={n} className="basis-1/3">
-                  <div
-                    className={cn(
-                      'font-display flex h-32 items-center justify-center rounded-lg bg-[color:var(--ink-700)] tracking-[0.04em] text-[color:var(--fg-1)]',
-                      selected
-                        ? 'border border-[color:var(--ball-500)] text-3xl font-semibold ring-2 ring-[color:var(--ball-500)]'
-                        : 'border border-[color:var(--border-subtle)] text-2xl',
-                    )}
-                    style={selected ? { boxShadow: 'var(--shadow-glow)' } : undefined}
-                  >
-                    {String(n).padStart(2, '0')}
-                  </div>
-                </CarouselItem>
-              )
-            })}
-          </CarouselContent>
-          <CarouselPrevious />
-          <CarouselNext />
-        </Carousel>
-        <div className="mt-4 text-center font-mono text-xs tracking-[0.1em] text-[color:var(--fg-3)]">
-          01 / 05
-        </div>
+        <CarouselShowcase />
       </Showcase>
     </Section>
   )


### PR DESCRIPTION
## The ask was 19 tickets. It's really 6.

Merged PR #829 wrote `Closes #251, #252, #253, ...`. **GitHub honors the closing keyword only before the *first* number**, so the 15 tickets it genuinely fixed were never auto-closed and still look open.

I verified this by **rendering** `/design-system` against a real production build and measuring the DOM — not by re-reading #829's code. That distinction matters: re-reading the code is exactly the method that let #829's false #268 claim through, which is why #831 exists.

## Already fixed on `main` — recommend closing, no code needed (13)

Verified on screen, not in source:

| # | Component | Rendered evidence |
|---|---|---|
| #252 | Dialog · Alert Dialog | inline open facsimiles; "Forfeit this match?" + "Delete account" present |
| #253 | Sheet | right-anchored Filters panel: club select, rating slider, Apply CTA |
| #254 | Drawer | bottom sheet open, drag handle, "Quick log", Pick opponent |
| #255 | Popover | "Skill rating" + Glicko-2 copy |
| #257 | Hover Card | TN avatar, Tien Nguyen, Brooklyn TT · Joined 2024, 1620 / 14–3 |
| #258 | Dropdown · Context Menu | both open; check on "Show seeds" only — correct for checkbox-item + action-item |
| #259 | Input OTP | six discrete slots, separator, focus ring |
| #262 | Toggle Group | segmented pill container, "Singles" active |
| #264 | Table | `PLAYER CLUB RATING` uppercase; avatars filled, not rings |
| #267 | Resizable | real tall side-by-side panel + vertical grip |
| #269 | Select | shadcn kept (it's a shadcn showcase), `size="sm"` compact |
| #271 | Menubar | "File" active with its menu open |
| #274 | Scroll Area | `type="always"`, styled scrollbar visible |

**These are not touched by this PR** — they need no code. They just need closing. I've left that to you rather than doing an outward GitHub write on my own read.

Two cosmetic nits noted and deliberately left alone (below the noise floor for an internal style-guide page): #258's section label renders "Match actions" not uppercase; #259's sample value is `42` not the kit's `40MM`.

## Genuinely broken — fixed here (6)

All in `web-client/src/routes/design-system.tsx`.

**#261 Date Picker** — headers rendered `Sun Mon Tue`, visibly colliding ("MonTue", "WedThu"). `'EEE'` → `'EEEEE'`. The selected-day orange square was already right; untouched.

**#268 + #831 Carousel** — the same fix. `const selected = n === 1` and a literal `01 / 05`, neither wired to embla: the counter froze and the highlight vanished once slide 1 scrolled out of view. Now a `CarouselShowcase` derives both from real state, never hardcoded. Slides use the kit's fixed 200x140 `shrink-0` sizing; counter and nav sit in the kit's `justify-between` footer row instead of clipped at the card edge.

> **Why the arrows page the *selection*, not the viewport.** The kit's `.slide.on` is a **selected card** and `1 / 5` means "card 1 of 5". All five 200px slides fit the ~1038px showcase card, so embla has only two reachable snaps and `selectedScrollSnap()` never exceeds 1 — deriving the highlight from it would freeze the counter at `02 / 05`, the very bug #831 was filed about, one click later.
>
> I first tried carrying 8 slides so the strip would genuinely scroll. Rendering the **end** state killed that: the counter read `05 / 05` while cards 06-08 sat visible to the right with Next disabled. So selection is component state (derived, never hardcoded — which is what #831 actually demanded); the arrows move it and `scrollTo` keeps the selected card in view. That's a no-op at desktop where all five fit, and a real scroll at narrow widths. Only a drag re-syncs from embla, since a programmatic `scrollTo` past the last reachable snap gets clamped and would otherwise overwrite the selection the arrows just set.

**#273 Collapsible** — the ticket said *"confirm intent"* on chevron vs `↓`. The kit reference (`docs/designs/design-system.html`) settles it: the trigger is `<button class="btn btn-ghost btn-sm">Show all ↓</button>`, and U+2193 appears exactly once in the entire kit. Swapped for the glyph, `aria-hidden` (decorative).

**#832 Tooltip** — the two always-open facsimiles overlapped by a measured **68×18px**, clipping "Refresh standings" to "efresh s…". Anchors now stack vertically.

**#833 Mobile overflow** — `scrollWidth` was **563** against a 375px viewport. Hard `w-[Npx]` → `w-full max-w-[Npx]` (desktop pixel-identical) across Nav Menu, Command, Combobox, Menubar, Sheet, Hover Card, Toast, Select and Date Picker triggers; page padding `px-4 sm:px-12`.
> The Table is deliberately **untouched**: the shared `Table` component already wraps itself in `overflow-x-auto` (`ui/table.tsx` L9-12). The ticket is wrong on that item.

## Tests

Every one of these bugs passed CI green, and #831 exists *because* a merged PR's claim went unchecked. So each fix gets a behavioural regression test — no new screenshot baselines (the repo commits darwin + chromium-linux PNGs). Each was confirmed to go **red** against the un-fixed code before being accepted.

- The carousel test encodes the real invariant: the counter numerator always equals the highlighted slide index + 1, **and** reaches its own denominator. Locators are scoped to `[data-slot="carousel"]` — the page also renders a Pagination widget with its own Next/Previous, which produced a false failure during development.
- The overflow test asserts `scrollWidth <= clientWidth` **and** that no >40px element spills past the right edge *without an overflow-clipping ancestor* — a naive check false-fails on the carousel strip and the Table, which are legitimately clipped.

Verified against a **production build** (`vite build` + `vite preview`), not the dev server: `01 / 05 → 05 / 05` with the ring tracking it, Next disabling exactly at the last snap; weekday headers `S M T W T F S`; zero tooltip-bubble intersection at 1280 and 375; `scrollWidth == clientWidth == 375`.

`tsc -b` ✅ · `eslint` ✅ · vitest **1227 passed / 183 files** ✅ · e2e **12 passed** ✅

## Out of scope, worth a separate ticket

`/design-system` has **no env gating**. It's a plain `createFileRoute('/design-system')` in `routeTree.gen.ts` and ships in production builds as a publicly reachable route. Every ticket in this batch calls it "an internal style-guide page only" — true of intent, not of deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWEiG6EXwYJD33Pu612Wdh

