### PR TITLE
Defence-in-depth: never render a silent, empty finalize alert

### DIFF
--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.test.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.test.tsx
@@ -2,10 +2,46 @@ import { HttpResponse } from "msw";
 import userEvent from "@testing-library/user-event";
 
 import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
-import { fireEvent, waitFor } from "@/test/utilities";
+import { fireEvent, screen, waitFor } from "@/test/utilities";
 
 import { buildFinalizeCalloutView } from "./finalize-callout-active/finalize-callout-display.factory";
 import { finalizeCalloutActivePage } from "./finalize-callout-active.page";
+
+/**
+ * Wait on the mutation *settling*, not on the alert — the CTA returning from
+ * "Posting…" to enabled "Post result" happens in BOTH the fixed and broken
+ * states, so this resolves in ~milliseconds either way. React Query commits
+ * `isPending=false` and the settled `error` in the SAME state update, so the
+ * commit where the button re-enables is the same commit that renders the alert;
+ * callers can therefore assert the alert synchronously right after this.
+ *
+ * If we waited on the alert itself, a regression (no alert) would red as an
+ * opaque 5s timeout — `asyncUtilTimeout` == `testTimeout` == 5000, so a missing
+ * signal is indistinguishable from a hang. Settling first, then asserting the
+ * alert synchronously, makes a missing alert fail fast with a crisp query error.
+ */
+async function settleToRetryable() {
+  await waitFor(() => {
+    const button = finalizeCalloutActivePage.getPostButton();
+    expect(button).toBeEnabled();
+    expect(button).toHaveTextContent("Post result");
+  });
+}
+
+/**
+ * Whether the #867 connection alert is currently in the DOM. It renders in the
+ * same commit the transport-level mutation error settles, so callers assert
+ * this synchronously after `settleToRetryable()` rather than waiting on it.
+ * Scoped with `.some(...)` so a co-rendered alert can't blow up a singular
+ * `getByRole("alert")`.
+ */
+function hasConnectionAlert() {
+  return screen
+    .queryAllByRole("alert")
+    .some((a: HTMLElement) =>
+      /check your connection and try again/i.test(a.textContent ?? ""),
+    );
+}
 
 describe("FinalizeCalloutActive", () => {
   it("posts exactly the view's canonical games, unchanged", async () => {
@@ -130,5 +166,111 @@ describe("FinalizeCalloutActive", () => {
     await waitFor(() =>
       expect(finalizeCalloutActivePage.queryError()).not.toBeInTheDocument(),
     );
+  });
+
+  it("surfaces a transport-level failure as a connection alert (#867)", async () => {
+    // `useProposeResult` runs `networkMode: 'always'`, so an offline submit
+    // fires the POST anyway and `fetch` rejects with a plain `TypeError` — NOT
+    // an `ApiError`. `HttpResponse.error()` reproduces that thrown TypeError
+    // (a rejected request, not a 500 status). The old code rendered nothing in
+    // this branch, leaving the user with zero feedback (#867).
+    finalizeCalloutActivePage.mockResultsEndpoint(() => HttpResponse.error());
+    finalizeCalloutActivePage.render();
+
+    await userEvent.click(finalizeCalloutActivePage.getPostButton());
+
+    // Settle back from "Posting…" to enabled first, THEN assert the alert
+    // synchronously — a missing alert fails as an assertion error in ms, not an
+    // opaque 5s timeout.
+    await settleToRetryable();
+    expect(hasConnectionAlert()).toBe(true);
+  });
+
+  it("re-fires the POST when clicked again while still offline (#867 retry)", async () => {
+    // After a transport-level failure, `onError` resets the synchronous
+    // `inFlightRef` guard, so a second click must actually re-fire the mutation
+    // — it must not be dead-locked by a ref that never cleared. Both attempts
+    // fail (still offline), so counting the POSTs proves the retry left the
+    // boundary rather than being swallowed client-side.
+    let requests = 0;
+    finalizeCalloutActivePage.mockResultsEndpoint(() => {
+      requests += 1;
+      return HttpResponse.error();
+    });
+    finalizeCalloutActivePage.render();
+
+    // First send fails at the transport level → the connection alert renders and
+    // the button settles back from "Posting…" to enabled.
+    await userEvent.click(finalizeCalloutActivePage.getPostButton());
+    await settleToRetryable();
+    expect(requests).toBe(1);
+    expect(hasConnectionAlert()).toBe(true);
+
+    // Retry: click again. The awaited click commits the pending/disabled render,
+    // so `settleToRetryable()` genuinely waits for the second round-trip and
+    // `requests` is already 2 by the time it resolves. If the retry were
+    // dead-locked by a stuck `inFlightRef`, the button never leaves "Post result"
+    // and the synchronous `requests` assertion fails "expected 1 to be 2" — not
+    // a timeout.
+    await userEvent.click(finalizeCalloutActivePage.getPostButton());
+    await settleToRetryable();
+    expect(requests).toBe(2);
+    expect(hasConnectionAlert()).toBe(true);
+  });
+
+  it("clears the stale connection alert after a reconnecting retry succeeds (#867 reconnect)", async () => {
+    // First submit fails at the transport level (offline), rendering the
+    // connection alert. Once the endpoint recovers, a second click must succeed
+    // and the stale connection alert must not linger — the success resets the
+    // mutation error.
+    let requests = 0;
+    finalizeCalloutActivePage.mockResultsEndpoint(() => {
+      requests += 1;
+      return HttpResponse.error();
+    });
+    finalizeCalloutActivePage.render();
+
+    await userEvent.click(finalizeCalloutActivePage.getPostButton());
+    await settleToRetryable();
+    expect(hasConnectionAlert()).toBe(true);
+
+    // Reconnect: the endpoint now succeeds. `server.use` prepends, so this
+    // handler wins for the retry.
+    finalizeCalloutActivePage.mockResultsEndpoint(() => {
+      requests += 1;
+      return HttpResponse.json(buildMatchDetails(), { status: 201 });
+    });
+
+    await userEvent.click(finalizeCalloutActivePage.getPostButton());
+    await waitFor(() => expect(requests).toBe(2));
+    await settleToRetryable();
+
+    // The success path does not keep showing the stale connection alert.
+    expect(hasConnectionAlert()).toBe(false);
+  });
+
+  it("shows the server's 409 detail, not the connection copy (branches don't cross)", async () => {
+    // A 409 is an `ApiError`, not a transport TypeError, so the `apiError`
+    // branch — the server's `detail` copy — must win. The connection copy must
+    // NOT appear (guard against the two error branches crossing).
+    finalizeCalloutActivePage.mockResultsEndpoint(() =>
+      HttpResponse.json(
+        { detail: "Match already has a posted result" },
+        { status: 409 },
+      ),
+    );
+    finalizeCalloutActivePage.render();
+
+    await userEvent.click(finalizeCalloutActivePage.getPostButton());
+
+    await settleToRetryable();
+    expect(
+      screen
+        .queryAllByRole("alert")
+        .some((a: HTMLElement) =>
+          /Match already has a posted result/.test(a.textContent ?? ""),
+        ),
+    ).toBe(true);
+    expect(hasConnectionAlert()).toBe(false);
   });
 });

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.test.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.test.tsx
@@ -243,9 +243,11 @@ describe("FinalizeCalloutActive", () => {
   it("renders non-empty copy when the server rejects with a blank detail", async () => {
     // `detail: ""` is falsy, and the display gates its alert on
     // `{errorMessage && …}`. Deriving the copy with `??` would pass the empty
-    // string straight through and render NO alert — the same silent dead button
-    // #867 fixed on the transport branch, surviving on the API branch. `||`
-    // skips the blank `detail` to a guaranteed non-empty fallback.
+    // string straight through and render NO alert — a silent dead button. No
+    // results-path error emits an empty detail today, so this pins the
+    // defence-in-depth invariant (an error state always renders some copy)
+    // rather than a reachable server response; `||` skips the blank `detail` to
+    // a guaranteed non-empty fallback.
     finalizeCalloutActivePage.mockResultsEndpoint(() =>
       HttpResponse.json({ detail: "" }, { status: 409 }),
     );

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.test.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.test.tsx
@@ -2,7 +2,7 @@ import { HttpResponse } from "msw";
 import userEvent from "@testing-library/user-event";
 
 import { buildMatchDetails } from "@/mocks/factories/matches/match-details.factory";
-import { fireEvent, screen, waitFor } from "@/test/utilities";
+import { fireEvent, waitFor } from "@/test/utilities";
 
 import { buildFinalizeCalloutView } from "./finalize-callout-active/finalize-callout-display.factory";
 import { finalizeCalloutActivePage } from "./finalize-callout-active.page";
@@ -32,16 +32,13 @@ async function settleToRetryable() {
  * Whether the #867 connection alert is currently in the DOM. It renders in the
  * same commit the transport-level mutation error settles, so callers assert
  * this synchronously after `settleToRetryable()` rather than waiting on it.
- * Scoped with `.some(...)` so a co-rendered alert can't blow up a singular
- * `getByRole("alert")`.
+ * Uses the page object's plural `hasErrorMatching` (not a singular
+ * `getByRole("alert")`) so a co-rendered second alert can't blow up the query.
  */
-function hasConnectionAlert() {
-  return screen
-    .queryAllByRole("alert")
-    .some((a: HTMLElement) =>
-      /check your connection and try again/i.test(a.textContent ?? ""),
-    );
-}
+const hasConnectionAlert = () =>
+  finalizeCalloutActivePage.hasErrorMatching(
+    /check your connection and try again/i,
+  );
 
 describe("FinalizeCalloutActive", () => {
   it("posts exactly the view's canonical games, unchanged", async () => {
@@ -199,22 +196,25 @@ describe("FinalizeCalloutActive", () => {
     });
     finalizeCalloutActivePage.render();
 
-    // First send fails at the transport level → the connection alert renders and
-    // the button settles back from "Posting…" to enabled.
+    // First send fails at the transport level. Anchor the wait on the request
+    // count — the observable that actually advances — before settling: after a
+    // failure the button is already enabled reading "Post result", so a
+    // `settleToRetryable()` predicate can resolve on the pre-click render before
+    // the POST has left the boundary.
     await userEvent.click(finalizeCalloutActivePage.getPostButton());
+    await waitFor(() => expect(requests).toBe(1));
     await settleToRetryable();
-    expect(requests).toBe(1);
     expect(hasConnectionAlert()).toBe(true);
 
-    // Retry: click again. The awaited click commits the pending/disabled render,
-    // so `settleToRetryable()` genuinely waits for the second round-trip and
-    // `requests` is already 2 by the time it resolves. If the retry were
-    // dead-locked by a stuck `inFlightRef`, the button never leaves "Post result"
-    // and the synchronous `requests` assertion fails "expected 1 to be 2" — not
-    // a timeout.
+    // Retry: click again. The point being pinned is that the retry actually
+    // re-fires — `onError` reset the synchronous `inFlightRef`, so the second
+    // click leaves the boundary rather than being swallowed. We wait on the
+    // request count reaching 2 (short timeout so a stuck `inFlightRef` reds as a
+    // crisp "expected 1 to be 2" fast, never masquerading as the suite's 5s
+    // `asyncUtilTimeout`), then settle and assert the alert synchronously.
     await userEvent.click(finalizeCalloutActivePage.getPostButton());
+    await waitFor(() => expect(requests).toBe(2), { timeout: 1000 });
     await settleToRetryable();
-    expect(requests).toBe(2);
     expect(hasConnectionAlert()).toBe(true);
   });
 
@@ -230,7 +230,12 @@ describe("FinalizeCalloutActive", () => {
     });
     finalizeCalloutActivePage.render();
 
+    // Anchor on the request count first (the observable that advances), then
+    // settle and assert the alert synchronously — the same discipline the retry
+    // test uses, so an already-enabled button can't resolve `settleToRetryable`
+    // before the POST has left the boundary.
     await userEvent.click(finalizeCalloutActivePage.getPostButton());
+    await waitFor(() => expect(requests).toBe(1));
     await settleToRetryable();
     expect(hasConnectionAlert()).toBe(true);
 
@@ -265,11 +270,9 @@ describe("FinalizeCalloutActive", () => {
 
     await settleToRetryable();
     expect(
-      screen
-        .queryAllByRole("alert")
-        .some((a: HTMLElement) =>
-          /Match already has a posted result/.test(a.textContent ?? ""),
-        ),
+      finalizeCalloutActivePage.hasErrorMatching(
+        /Match already has a posted result/,
+      ),
     ).toBe(true);
     expect(hasConnectionAlert()).toBe(false);
   });

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.test.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.test.tsx
@@ -137,6 +137,27 @@ describe("FinalizeCalloutActive", () => {
     );
   });
 
+  it("renders a non-empty fallback alert when the 409 detail is empty (#867 API branch)", async () => {
+    // A 409 whose body is `{"detail": ""}`. The component must use `||` (not
+    // `??`) so the empty-string detail is skipped for a non-empty fallback: the
+    // display gates the alert on `{errorMessage && …}`, so passing `""` through
+    // would suppress the alert entirely and leave a dead button (#867). This
+    // reds fast (crisp assertion, not a 5s timeout) if `||` reverts to `??`.
+    finalizeCalloutActivePage.mockResultsEndpoint(() =>
+      HttpResponse.json({ detail: "" }, { status: 409 }),
+    );
+    finalizeCalloutActivePage.render();
+
+    await userEvent.click(finalizeCalloutActivePage.getPostButton());
+
+    // Settle back to enabled first, THEN assert synchronously — a suppressed
+    // alert fails as a crisp assertion in ms, not an opaque 5s timeout.
+    await settleToRetryable();
+    const alerts = finalizeCalloutActivePage.queryAllErrors();
+    expect(alerts).not.toHaveLength(0);
+    expect(alerts[0]).toHaveTextContent(/Couldn't post the result — try again\./);
+  });
+
   it("clears a previous failure when the post is retried", async () => {
     let attempts = 0;
     finalizeCalloutActivePage.mockResultsEndpoint(() => {

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.tsx
@@ -12,16 +12,25 @@ export interface FinalizeCalloutActiveProps {
 }
 
 /** Wires the post-result mutation onto the pure display: posting the view's
- * canonical games, surfacing pending state, and keeping API failures visible
- * inline (without throwOnError a 409 — opponent confirmed first, double-click,
- * etc. — would otherwise vanish and the button would appear inert). */
+ * canonical games, surfacing pending state, and keeping failures visible inline
+ * — both API rejections (without throwOnError a 409 — opponent confirmed first,
+ * double-click, etc. — would otherwise vanish and the button would appear
+ * inert) and transport-level ones (an offline send, #867). */
 export function FinalizeCalloutActive({
   view,
   matchId,
 }: FinalizeCalloutActiveProps) {
   const finalizeMutation = useProposeResult(matchId);
-  const error =
+  const apiError =
     finalizeMutation.error instanceof ApiError ? finalizeMutation.error : null;
+
+  // A non-ApiError needs its own branch: `useProposeResult` runs
+  // `networkMode: 'always'`, so an offline submit fires the POST anyway and
+  // `fetch` rejects at the transport level with a plain `TypeError` — never an
+  // `ApiError`. Without this, an offline send would re-enable the button with
+  // no feedback at all (#867). Mutually exclusive with `apiError` by
+  // construction (the error is one or the other, never both).
+  const networkError = finalizeMutation.error !== null && apiError === null;
   // Synchronous double-submit guard. `disabled={pending}` only takes effect on
   // the next render, so a fast double-click lands a second tap before React
   // commits the disable — firing two concurrent POST /results that pile up on
@@ -39,7 +48,13 @@ export function FinalizeCalloutActive({
   return (
     <FinalizeCalloutDisplay
       pending={finalizeMutation.isPending}
-      errorMessage={error ? (error.detail ?? error.message) : null}
+      errorMessage={
+        apiError
+          ? (apiError.detail ?? apiError.message)
+          : networkError
+            ? "Couldn't post the result — check your connection and try again."
+            : null
+      }
       onPost={() => {
         if (inFlightRef.current) return;
         inFlightRef.current = true;

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.tsx
@@ -11,6 +11,13 @@ export interface FinalizeCalloutActiveProps {
   matchId: string;
 }
 
+// Last-resort copy for an `ApiError` whose `detail` AND `message` are both
+// empty. Guarantees the invariant: whenever the mutation is in an error state,
+// some non-empty copy renders — never a dead button (#867).
+const API_FALLBACK = "Couldn't post the result — try again.";
+const CONNECTION_COPY =
+  "Couldn't post the result — check your connection and try again.";
+
 /** Wires the post-result mutation onto the pure display: posting the view's
  * canonical games, surfacing pending state, and keeping failures visible inline
  * — both API rejections (without throwOnError a 409 — opponent confirmed first,
@@ -50,9 +57,15 @@ export function FinalizeCalloutActive({
       pending={finalizeMutation.isPending}
       errorMessage={
         apiError
-          ? (apiError.detail ?? apiError.message)
+          ? // `||`, NOT `??`: an empty-string `detail` is falsy, and the display
+            // gates the alert on `{errorMessage && …}`, so a `??` fallback would
+            // pass `""` through and silently suppress the alert — the button
+            // returns to "Post result" with zero feedback, reintroducing #867 on
+            // the API branch. `||` skips over an empty `detail`/`message` to a
+            // guaranteed non-empty fallback.
+            (apiError.detail || apiError.message || API_FALLBACK)
           : networkError
-            ? "Couldn't post the result — check your connection and try again."
+            ? CONNECTION_COPY
             : null
       }
       onPost={() => {

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.tsx
@@ -13,8 +13,8 @@ export interface FinalizeCalloutActiveProps {
 
 const CONNECTION_COPY =
   "Couldn't post the result — check your connection and try again.";
-// Last-resort copy for an `ApiError` whose `detail` AND `message` are both
-// empty, so that an error state can never render a silent, dead button.
+// Last-resort copy for an `ApiError` carrying an empty `detail` AND `message`,
+// so an error state can never render as a silent, dead button.
 const API_FALLBACK = "Couldn't post the result — try again.";
 
 /** Wires the post-result mutation onto the pure display: posting the view's
@@ -39,14 +39,16 @@ export function FinalizeCalloutActive({
   // exclusive with `apiError` by construction (the error is one or the other,
   // never both).
   const networkError = finalizeMutation.error !== null && apiError === null;
-  // `||`, NOT `??`: an empty-string `detail` is falsy, and the display gates the
-  // alert on `{errorMessage && …}`. A `??` fallback passes `""` straight
-  // through, so a rejection carrying `{"detail": ""}` renders no alert at all —
-  // the button returns to "Post result" with zero feedback, which is the very
-  // dead-button bug #867 fixed one branch over. `||` skips an empty
-  // `detail`/`message` to a guaranteed non-empty fallback, establishing the
-  // invariant: whenever the mutation is in an error state, some copy is on
-  // screen.
+  // `||`, NOT `??`: the display gates the alert on `{errorMessage && …}`, so any
+  // falsy string renders nothing. `extractDetail` passes a server `detail`
+  // through verbatim, and `ApiError`'s `super(detail ?? …)` leaves `message`
+  // empty too when `detail` is `""` — so a `{"detail": ""}` rejection would
+  // reduce to `""` under `??` and re-enable the button with no feedback, the
+  // same dead-button shape #867 was about. No results-path error emits an empty
+  // detail today, so this is defence-in-depth rather than a live bug; `||` skips
+  // an empty `detail`/`message` to a guaranteed non-empty fallback and makes the
+  // invariant local — an error state always renders some copy — instead of
+  // resting on every server message staying non-empty forever.
   const errorMessage = networkError
     ? CONNECTION_COPY
     : apiError

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active/finalize-callout-display.page.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active/finalize-callout-display.page.tsx
@@ -22,6 +22,21 @@ const scoped = (container: Container) => ({
   queryError() {
     return container.queryByRole("alert");
   },
+  /**
+   * All alerts in scope. Plural (vs `queryError`'s singular) because a second
+   * co-rendered alert would make the singular `getByRole("alert")` throw; the
+   * offline-retry tests need to assert against whichever alert is present
+   * without that ambiguity blowing up.
+   */
+  queryAllErrors() {
+    return container.queryAllByRole("alert");
+  },
+  /** True iff some alert's `textContent` matches `pattern`. */
+  hasErrorMatching(pattern: RegExp) {
+    return container
+      .queryAllByRole("alert")
+      .some((a: HTMLElement) => pattern.test(a.textContent ?? ""));
+  },
 });
 
 /** Test page-object for the pure `FinalizeCalloutDisplay` — props in, DOM


### PR DESCRIPTION
> **This branch was originally the fix for #867.** [#876](https://github.com/mightymoose/fortymm/pull/876) landed that fix first (plus #868's `score-entry` case) while this was in review, and #867 is now closed. I merged `main`, took #876's transport-error branch wholesale, and reduced this PR to what survives independently.

Net diff against `main`: 2 files, +71/−2. **No live bug is claimed** — see the reachability note below.

## What this changes

`finalize-callout-active.tsx` derived its alert copy with `apiError.detail ?? apiError.message`. The display gates the alert on `{errorMessage && (<p role="alert">…)}`, so a falsy string renders nothing. Tracing the boundary, an empty string *can* reach that gate: `ApiError.detail` is `extractDetail(error)`, which returns a server `detail` verbatim, and `ApiError`'s `super(detail ?? …)` leaves `message` empty too when `detail` is `""` — so `{"detail": ""}` reduces to `""` and the button re-enables with no feedback, the same dead-button shape as #867.

This switches to `||` plus a guaranteed non-empty `API_FALLBACK`, making **"an error state always renders some copy"** a local invariant.

## Reachability — this is defence-in-depth, not a live bug

I checked whether the API can actually emit an empty `detail` on the results/finalize path. It can't, as the code stands: every raise there uses a non-empty constant (`"This match is no longer open to results."`, `"Result not found."`), and Pydantic 422s always carry a non-empty `msg`. So **the input can't occur against the current server** — this does not mean the #876 you just merged has a reachable silent-failure bug. The value of the change is that the invariant no longer rests on every server message staying non-empty forever.

If that's not worth carrying, this PR is safe to close with no loss — #867 itself is already fixed on `main`.

## Tests (both absent from `main`)

- **`renders non-empty copy when the server rejects with a blank detail`** — pins the invariant above. Asserts on the alert's `textContent`, not just presence (an alert rendering `""` would satisfy `toBeInTheDocument`). Reverting `||` → `??` reds this test alone, in ~10ms with an assertion, not the suite's 5s `asyncUtilTimeout`.
- **`re-fires the POST when clicked again while the connection is still down`** — `main` covers the transport failure and the reconnect but does not pin the `inFlightRef` reset in `onError` (the guard that lets a second click reach the network). Counts POSTs at the MSW boundary, so a dead-locked button reds with "expected 1 to be 2". This one is genuine new coverage regardless of the reachability question.

Full suite: **1244 passed** (183 files). `tsc -b` and `eslint` clean.

## Not addressed here

`networkError` being the *complement* of `ApiError` (a client `TypeError`/`ZodError` mislabelled as a connection problem) is [#877](https://github.com/mightymoose/fortymm/issues/877)'s root cause, to be fixed at the `ApiError` boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCiULc35AwKoSZjYrov1gA