### PR TITLE
Fix #868, #867: surface transport-level failures when posting a result

### DIFF
--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.test.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.test.tsx
@@ -7,6 +7,35 @@ import { fireEvent, waitFor } from "@/test/utilities";
 import { buildFinalizeCalloutView } from "./finalize-callout-active/finalize-callout-display.factory";
 import { finalizeCalloutActivePage } from "./finalize-callout-active.page";
 
+/**
+ * Wait on the mutation *settling* (button back from "Posting…" to an enabled
+ * "Post result"), not on the alert — the button re-enables in BOTH the fixed
+ * and broken states, so this resolves in ~milliseconds either way. If we waited
+ * on the alert itself, a regression (no alert) would red as an opaque 5s timeout
+ * (`asyncUtilTimeout` == `testTimeout` == 5000, so a missing signal is
+ * indistinguishable from a hang). Settling first, then asserting the alert
+ * synchronously, makes a missing alert fail fast with a crisp query error.
+ */
+async function settleToRetryable() {
+  await waitFor(() => {
+    const button = finalizeCalloutActivePage.getPostButton();
+    expect(button).toBeEnabled();
+    expect(button).toHaveTextContent("Post result");
+  });
+}
+
+/**
+ * Whether the #867 connection alert is currently in the DOM. It renders in the
+ * same commit the mutation error settles, so callers assert this synchronously
+ * after `settleToRetryable()` rather than waiting on it.
+ */
+function hasConnectionAlert() {
+  const alert = finalizeCalloutActivePage.queryError();
+  return /Couldn't post this result .* check your connection and try again/i.test(
+    alert?.textContent ?? "",
+  );
+}
+
 describe("FinalizeCalloutActive", () => {
   it("posts exactly the view's canonical games, unchanged", async () => {
     let postedBody: unknown = null;
@@ -130,5 +159,24 @@ describe("FinalizeCalloutActive", () => {
     await waitFor(() =>
       expect(finalizeCalloutActivePage.queryError()).not.toBeInTheDocument(),
     );
+  });
+
+  it("surfaces a transport-level failure inline and leaves Post retryable (#867)", async () => {
+    // `useProposeResult` runs `networkMode: 'always'`, so an offline (or
+    // mid-flight-dropped) submit fires the POST and `fetch` rejects with a plain
+    // `TypeError` — NOT an `ApiError`. The old code only handled `ApiError`, so
+    // this rejection rendered nothing here and re-enabled the button silently,
+    // with no other affordance to explain the dead button. `HttpResponse.error()`
+    // rejects at the transport level (no status code), reproducing that drop.
+    finalizeCalloutActivePage.mockResultsEndpoint(() => HttpResponse.error());
+    finalizeCalloutActivePage.render();
+
+    await userEvent.click(finalizeCalloutActivePage.getPostButton());
+
+    await settleToRetryable();
+
+    // Assert the alert synchronously (crisp fail if it never rendered) rather
+    // than via a `waitFor` that would red as an opaque 5s timeout on regression.
+    expect(hasConnectionAlert()).toBe(true);
   });
 });

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.test.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.test.tsx
@@ -31,7 +31,7 @@ async function settleToRetryable() {
  */
 function hasConnectionAlert() {
   const alert = finalizeCalloutActivePage.queryError();
-  return /Couldn't post this result .* check your connection and try again/i.test(
+  return /Couldn't post the result .* check your connection and try again/i.test(
     alert?.textContent ?? "",
   );
 }
@@ -178,5 +178,34 @@ describe("FinalizeCalloutActive", () => {
     // Assert the alert synchronously (crisp fail if it never rendered) rather
     // than via a `waitFor` that would red as an opaque 5s timeout on regression.
     expect(hasConnectionAlert()).toBe(true);
+  });
+
+  it("recovers on retry after a transport drop: a second Post succeeds and clears the connection alert (#867 reconnect)", async () => {
+    // The first Post drops at the transport level (connection alert shows). Once
+    // the connection recovers, a second Post must succeed — `onPost` calls
+    // `finalizeMutation.reset()` before firing, and the success clears the
+    // mutation error, so the stale connection alert must not linger. This is the
+    // reconnect-recovery coverage the transport-error path lacked (#865 added the
+    // same shape for correction-entry).
+    let attempts = 0;
+    finalizeCalloutActivePage.mockResultsEndpoint(() => {
+      attempts += 1;
+      return attempts === 1
+        ? HttpResponse.error()
+        : HttpResponse.json(buildMatchDetails(), { status: 201 });
+    });
+    finalizeCalloutActivePage.render();
+
+    // First Post drops mid-flight → connection alert.
+    await userEvent.click(finalizeCalloutActivePage.getPostButton());
+    await settleToRetryable();
+    expect(hasConnectionAlert()).toBe(true);
+
+    // Retry now succeeds: both attempts fired and the stale alert is gone.
+    await userEvent.click(finalizeCalloutActivePage.getPostButton());
+    await waitFor(() => expect(attempts).toBe(2));
+    await waitFor(() =>
+      expect(finalizeCalloutActivePage.queryError()).not.toBeInTheDocument(),
+    );
   });
 });

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.tsx
@@ -20,8 +20,24 @@ export function FinalizeCalloutActive({
   matchId,
 }: FinalizeCalloutActiveProps) {
   const finalizeMutation = useProposeResult(matchId);
-  const error =
+  // A 409 (opponent confirmed first, double-click, etc.) or any other server
+  // rejection arrives as an `ApiError` carrying the server's `detail` copy.
+  const apiError =
     finalizeMutation.error instanceof ApiError ? finalizeMutation.error : null;
+  // A non-ApiError needs its own branch: `useProposeResult` runs
+  // `networkMode: 'always'`, so an offline (or mid-flight-dropped) submit fires
+  // the POST anyway and `fetch` rejects at the transport level with a plain
+  // `TypeError` — never an `ApiError`. Without this, a dropped send would just
+  // re-enable the button with no feedback at all, and there's no other
+  // affordance on this callout to explain the dead button (#867). Mutually
+  // exclusive with `apiError` by construction (the error is one or the other,
+  // never both).
+  const networkError = finalizeMutation.error !== null && apiError === null;
+  const errorMessage = networkError
+    ? "Couldn't post this result — check your connection and try again."
+    : apiError
+      ? (apiError.detail ?? apiError.message)
+      : null;
   // Synchronous double-submit guard. `disabled={pending}` only takes effect on
   // the next render, so a fast double-click lands a second tap before React
   // commits the disable — firing two concurrent POST /results that pile up on
@@ -39,7 +55,7 @@ export function FinalizeCalloutActive({
   return (
     <FinalizeCalloutDisplay
       pending={finalizeMutation.isPending}
-      errorMessage={error ? (error.detail ?? error.message) : null}
+      errorMessage={errorMessage}
       onPost={() => {
         if (inFlightRef.current) return;
         inFlightRef.current = true;

--- a/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.tsx
+++ b/web-client/src/components/matches/match-details/finalize-callout/finalize-callout-fetcher/finalize-callout-active.tsx
@@ -34,7 +34,7 @@ export function FinalizeCalloutActive({
   // never both).
   const networkError = finalizeMutation.error !== null && apiError === null;
   const errorMessage = networkError
-    ? "Couldn't post this result — check your connection and try again."
+    ? "Couldn't post the result — check your connection and try again."
     : apiError
       ? (apiError.detail ?? apiError.message)
       : null;

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -2833,6 +2833,156 @@ describe('ScoreEntry — games past the decider', () => {
   })
 })
 
+describe('ScoreEntry — finalize connection drop (#868)', () => {
+  // The at-submit offline guard (`wouldFinalize && onlineManager.isOnline()`)
+  // only diverts a drop we ALREADY know about to the scratchpad. When we're
+  // online at submit the guard passes and the POST /results fires — but
+  // `useProposeResult` runs `networkMode: 'always'`, so a connection that dies
+  // mid-flight rejects at the transport level with a plain `TypeError`, never an
+  // `ApiError`. Pre-fix that produced NO error at all (the button just settled),
+  // and — since there were no failed scratch saves — the SaveBanner didn't help
+  // either. These tests leave `onlineManager` online (the default) so the guard
+  // passes and the finalize path genuinely fires.
+
+  // Wait on the finalize mutation *settling* — the button returning from
+  // "Posting result…" to enabled "Post result" happens in BOTH the fixed and
+  // broken states, so this resolves in ~ms either way. Asserting the alert
+  // synchronously afterwards makes a missing alert fail with a crisp query error
+  // instead of an opaque 5s `waitFor` timeout (asyncUtilTimeout == testTimeout).
+  async function settleToPostable() {
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /post result/i }),
+      ).toBeEnabled(),
+    )
+  }
+
+  function hasConnectionAlert() {
+    return screen
+      .queryAllByRole('alert')
+      .some((a) =>
+        /Couldn't post the result .* check your connection and try again/i.test(
+          a.textContent ?? '',
+        ),
+      )
+  }
+
+  it('surfaces connection copy when the finalize POST drops mid-flight while online', async () => {
+    // Online at submit (default) so the divert guard PASSES and the POST /results
+    // actually fires — the crux of the repro. The POST then rejects at the
+    // transport level (no status code), the way a mid-flight connection drop does.
+    const user = userEvent.setup()
+    let resultsCalls = 0
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(decidingGameMatch())),
+      http.post('*/v1/matches/m-1/results', () => {
+        resultsCalls += 1
+        return HttpResponse.error()
+      }),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    await user.type(meInput, '11')
+    await user.type(oppInput, '3')
+
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+    await settleToPostable()
+
+    // The POST really left the boundary (the finalize path fired, not the
+    // scratchpad divert), and the connection copy explains the otherwise-silent
+    // drop.
+    expect(resultsCalls).toBe(1)
+    expect(hasConnectionAlert()).toBe(true)
+    // Still on the deciding game — the drop didn't navigate anywhere.
+    expect(
+      screen.getByRole('heading', { name: /enter game 3 score/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('does NOT mark the valid score inputs invalid on a transport drop', async () => {
+    // The entered score is perfectly legal; a transport drop means the POST never
+    // reached the server, so painting the fields red would be wrong. Pins the
+    // `inputsInvalid` exclusion (same reason 409/500 are excluded).
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(decidingGameMatch())),
+      http.post('*/v1/matches/m-1/results', () => HttpResponse.error()),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    await user.type(meInput, '11')
+    await user.type(oppInput, '3')
+
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+    await settleToPostable()
+
+    expect(hasConnectionAlert()).toBe(true)
+    // The valid score stays clean — no red fields for a transport failure.
+    expect(meInput).not.toHaveAttribute('aria-invalid', 'true')
+    expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('still reds the inputs on a 422 and shows a 409 detail — the ApiError branches do not regress', async () => {
+    // Guard against the new transport branch swallowing the ApiError branches: a
+    // 422 (validation drift) must still red the fields, and a 409 must still show
+    // the server's detail copy (and, like a transport drop, must NOT red the
+    // fields — the entered score is fine).
+    const user = userEvent.setup()
+    let status = 422
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(decidingGameMatch())),
+      http.post('*/v1/matches/m-1/results', () =>
+        status === 422
+          ? HttpResponse.json(
+              { detail: 'This payload was rejected by the server.' },
+              { status: 422 },
+            )
+          : HttpResponse.json(
+              { detail: 'This match already has a posted result.' },
+              { status: 409 },
+            ),
+      ),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    await user.type(meInput, '11')
+    await user.type(oppInput, '3')
+
+    // 422: the server rejected the board — the fields go red and the message shows.
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+    const alert422 = await screen.findByRole('alert')
+    expect(alert422).toHaveTextContent(/rejected by the server/i)
+    expect(meInput).toHaveAttribute('aria-invalid', 'true')
+    expect(oppInput).toHaveAttribute('aria-invalid', 'true')
+
+    // Re-type to clear the error (which resets the mutation), swing the endpoint
+    // to a 409, and re-submit the same valid board.
+    status = 409
+    await user.clear(oppInput)
+    await user.type(oppInput, '3')
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+
+    expect(
+      await screen.findByText(/already has a posted result/i),
+    ).toBeInTheDocument()
+    // A 409 means the entered score is fine — fields NOT red (like a transport drop).
+    expect(meInput).not.toHaveAttribute('aria-invalid', 'true')
+    expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
+  })
+})
+
 afterEach(() => {
   // Restore connectivity so the offline test doesn't leak into others.
   onlineManager.setOnline(true)

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -2981,6 +2981,116 @@ describe('ScoreEntry — finalize connection drop (#868)', () => {
     expect(meInput).not.toHaveAttribute('aria-invalid', 'true')
     expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
   })
+
+  it('clears the stale finalize connection copy when a re-tap while offline diverts to a scratch save (#868)', async () => {
+    // A finalize drops mid-flight while online → the connection copy shows. The
+    // user then goes genuinely offline and taps "Post result" again: now the
+    // at-submit guard (`wouldFinalize && onlineManager.isOnline()`) FAILS, so
+    // control falls through to the scratchpad divert — the scratch save fires
+    // (fails offline) and the SaveBanner surfaces. Without resetting the
+    // abandoned finalize error in that branch, the stale connection line lingers
+    // underneath, describing a request that is no longer in flight.
+    const user = userEvent.setup()
+    let scoreCalls = 0
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(decidingGameMatch())),
+      // Online finalize: rejects at the transport level (mid-flight drop).
+      http.post('*/v1/matches/m-1/results', () => HttpResponse.error()),
+      // The offline scratch-save divert targets this per-game endpoint.
+      http.post('*/v1/matches/m-1/games/3/scores/new', () => {
+        scoreCalls += 1
+        return HttpResponse.error()
+      }),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    await user.type(meInput, '11')
+    await user.type(oppInput, '3')
+
+    // Online at submit → the finalize POST fires and drops mid-flight.
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+    await settleToPostable()
+    expect(hasConnectionAlert()).toBe(true)
+
+    // Now genuinely offline: the re-tap diverts to the scratchpad instead of
+    // re-firing finalize (the guard fails), and the divert resets the finalize
+    // error it's abandoning.
+    onlineManager.setOnline(false)
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+
+    // The divert ran (the scratch save left the boundary) — this is the
+    // load-bearing "we fell through to the scratchpad" pin.
+    await waitFor(() => expect(scoreCalls).toBe(1))
+    // The scratch save's SaveBanner surfaced in place of the finalize attempt.
+    expect(
+      await screen.findByText(/these scores finish the match/i),
+    ).toBeInTheDocument()
+    // …and the stale finalize connection copy is gone (reset in the divert).
+    expect(hasConnectionAlert()).toBe(false)
+  })
+
+  it('recovers on retry after a transport drop: a second Post succeeds and navigates, no stale copy (#868 reconnect)', async () => {
+    // First finalize POST drops at the transport level (connection copy shows).
+    // Once the connection recovers, a second Post must succeed and navigate to
+    // the match-detail landing — the drop must not leave the flow wedged, and the
+    // success (which resets the mutation error) must not leave the stale
+    // connection copy lingering. Mirrors correction-entry's #839 reconnect test.
+    const user = userEvent.setup()
+    let resultsCalls = 0
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(decidingGameMatch())),
+      http.post('*/v1/matches/m-1/results', () => {
+        resultsCalls += 1
+        return resultsCalls === 1
+          ? HttpResponse.error()
+          : HttpResponse.json(
+              matchDetails({
+                id: 'm-1',
+                status: 'completed',
+                status_label: 'Final',
+                best_of: 5,
+                games_to_win: 3,
+                sides: participantSides({ meWins: 3, oppWins: 0, meWon: true }),
+                games: [
+                  { id: 'g-1', game_number: 1, score: score('s-1', 11, 4) },
+                  { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
+                  { id: 'g-3', game_number: 3, score: score('s-3', 11, 3) },
+                ],
+                current_game: null,
+                can_score: false,
+                can_finalize: false,
+              }),
+              { status: 201 },
+            )
+      }),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    await user.type(meInput, '11')
+    await user.type(oppInput, '3')
+
+    // First Post drops mid-flight → connection copy, still on the deciding game.
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+    await settleToPostable()
+    expect(hasConnectionAlert()).toBe(true)
+
+    // Retry: the connection recovered, so the second Post succeeds and navigates.
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+    await waitFor(() =>
+      expect(screen.getByText('match-page m-1')).toBeInTheDocument(),
+    )
+    expect(resultsCalls).toBe(2)
+    // No stale connection copy survives the successful resend.
+    expect(hasConnectionAlert()).toBe(false)
+  })
 })
 
 afterEach(() => {

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -352,6 +352,19 @@ function ScoreEntryInner({
   const inputsValid = validation.valid
   const finalizeApiError =
     finalizeMutation.error instanceof ApiError ? finalizeMutation.error : null
+  // A finalize error that ISN'T an `ApiError` is a transport-level drop:
+  // `useProposeResult` runs `networkMode: 'always'`, so a finalize whose
+  // connection dies mid-flight still fires the POST and `fetch` rejects with a
+  // plain `TypeError` — never an `ApiError` (#868). The at-submit offline guard
+  // below (`wouldFinalize && onlineManager.isOnline()`) diverts a *known*-offline
+  // deciding game to the scratchpad, but it can't catch a connection that dies
+  // AFTER it passes — that rejection lands here. Mutually exclusive with
+  // `finalizeApiError` by construction (the error is one or the other, never
+  // both). Mirrors correction-entry's `networkError` (#839): error-driven, not a
+  // `navigator.onLine` pre-check, on purpose — the pre-check races the actual
+  // request, so we branch on the rejection that really happened.
+  const finalizeNetworkError =
+    finalizeMutation.error !== null && finalizeApiError === null
 
   // Build the hypothetical full-match games list including the current input,
   // so we can ask the scoring lib whether saving this entry would make the
@@ -398,17 +411,24 @@ function ScoreEntryInner({
   // so a 409 "already posted" / 500 must be visible here rather than swallowed.
   // The score *inputs* are only invalid for genuine validation problems (local
   // illegal score, or a 422 drift the server rejected) — a 409/500 means the
-  // entered score is fine, so don't paint the fields red for those.
+  // entered score is fine, so don't paint the fields red for those. A
+  // transport-level drop (`finalizeNetworkError`) is the same story: the entered
+  // score is perfectly valid, the POST just never reached the server, so the
+  // fields stay clean and only the message line explains the failure (#868).
   const inputsInvalid =
     localScoreError !== null || finalizeApiError?.status === 422
-  // The message line, though, surfaces every finalize error (409/500 included)
-  // and the cross-game overrun block (a legal score that the board can't take).
+  // The message line, though, surfaces every finalize error (409/500 included),
+  // a transport-level drop, and the cross-game overrun block (a legal score that
+  // the board can't take).
   const overrunError =
     overrunAt !== null
       ? `The match is already decided at game ${overrunAt} — clear the games after it before saving this score.`
       : null
   const showScoreError =
-    inputsInvalid || overrunError !== null || finalizeApiError !== null
+    inputsInvalid ||
+    overrunError !== null ||
+    finalizeApiError !== null ||
+    finalizeNetworkError
   // The "both scores required" hint is its own, lower-severity line — shown only
   // when exactly one field is filled and there's no harder error to surface.
   const showBothRequired = oneSideFilled && !showScoreError
@@ -703,15 +723,21 @@ function ScoreEntryInner({
           }}
           gamesTally={bestOf > 1 ? `${meWins} – ${oppWins}` : null}
           // The scratchpad surfaces the local validation error, the cross-game
-          // overrun block, and a finalize API rejection (409/500 too) here;
-          // `showScoreError` gates when any of them shows, in that precedence.
+          // overrun block, a finalize API rejection (409/500 too), and — last in
+          // precedence — a transport-level drop's connection copy here;
+          // `showScoreError` gates when any of them shows, in that order. The
+          // connection copy is last because an `ApiError` (a real server verdict)
+          // is always the more specific thing to say; a bare transport failure is
+          // the fallback when the POST never reached the server at all (#868).
           scoreError={
             showScoreError
               ? (localScoreError ??
                 overrunError ??
                 finalizeApiError?.detail ??
                 finalizeApiError?.message ??
-                null)
+                (finalizeNetworkError
+                  ? "Couldn't post the result — check your connection and try again."
+                  : null))
               : null
           }
           showBothRequired={showBothRequired}

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -519,6 +519,12 @@ function ScoreEntryInner({
     // finish the match." / "Post result"), which posts the canonical result once
     // back online.
     if (wouldFinalize) {
+      // We're abandoning the finalize attempt in favour of a scratch save, so any
+      // finalize error still on screen (e.g. a prior mid-flight transport drop's
+      // connection copy, #868) is stale by definition — nothing in this branch
+      // re-runs the finalize mutation to clear it, so reset it here before the
+      // scratch save's SaveBanner takes over.
+      finalizeMutation.reset()
       saveMutation.mutate(args)
       return
     }


### PR DESCRIPTION
Closes #868
Closes #867

## The bug

`useProposeResult` runs `networkMode: 'always'` (`api/matches.ts:670`), so a finalize submit fires the POST even when the connection is dead, and `fetch` rejects at the **transport level** with a plain `TypeError` — never an `ApiError`. Two components gated their inline alert on `error instanceof ApiError`, so that rejection rendered nothing at all: the button flashed, settled, and the user had no idea whether the result posted.

- **#868 `score-entry.tsx`** — the narrower window. It *does* have an at-submit offline guard (`wouldFinalize && onlineManager.isOnline()`) that diverts a known-offline deciding game to the scratchpad. But a connection that dies *after* the guard passes still fires the POST.
- **#867 `finalize-callout-active.tsx`** — no guard, and no other affordance on the callout that could explain the dead button.

## The fix

Apply the `networkError` pattern established by #839 (#865) in `correction-entry.tsx`.

In `score-entry`, `finalizeNetworkError` feeds `showScoreError` and — **last in precedence** — the `scoreError` chain, since an `ApiError` is a real server verdict and stays the more specific thing to say. It deliberately does **not** feed `inputsInvalid`: a dropped connection means the entered score was fine, so the fields must not turn red, for exactly the reason 409/500 already don't. The `onlineManager` scratchpad divert is untouched — deferring a *known*-offline deciding game is the right UX; this only covers the drop that happens after the guard passes.

A follow-up commit also fixes a wart the first one introduced: after a mid-flight drop, a retry made while now genuinely offline falls through to the scratchpad branch, which **succeeds** — but nothing there re-runs the finalize mutation, so the stale connection copy lingered under a SaveBanner announcing a successful save. That branch now resets the mutation it is abandoning.

## Why not the "generalize across four call sites" refactor the issues ask for

Both issues propose extracting a shared `describeMutationError` / `<MutationErrorAlert>` because the `instanceof ApiError` gate appears in four components. **That premise is stale:**

- `correction-entry.tsx` — already fixed in #865.
- `save-banner.tsx` — already gates on `finalizeMutation.isError` with a "Couldn't post the result — try again." fallback, and doesn't even render in the #868 repro (no failed scratch saves).

Only two of the four were broken. Churning two carefully-commented components that landed hours ago, for zero behavioural gain on either bug, isn't worth the regression risk.

## Raised, not fixed here

**The real root cause is at the API boundary, and it deserves its own PR.** `ApiError`'s docstring (`api/client.ts:180`) claims *"For network/decode failures with no response, status is 0."* That branch is **unreachable**: `openapi-fetch` doesn't catch a `fetch()` rejection, so `await api.POST(...)` rejects before `unwrap` ever runs. Verified empirically against the real client + MSW:

| Response | What escapes `api.POST(...)` |
| --- | --- |
| `HttpResponse.error()` (transport drop) | `TypeError`, `isApiError=false` |
| `200`, `Content-Type: application/json`, HTML body | `SyntaxError`, `isApiError=false` |

So every consumer must infer "connection dropped" **by elimination** (`error !== null && apiError === null`) — now in three components and growing. That's exactly the anti-pattern `.claude/rules/parse-at-boundaries.md` exists to prevent ("parse at the boundary… fail loudly at the boundary"). It's also imprecise: as the table shows, a `SyntaxError` takes the same branch (usually a truncated-body artifact of a real drop, so the copy is accidentally right — but it wouldn't be for a proxy serving an HTML page with a 200).

Fixing it means catching the rejection in `client.ts` and rethrowing the boundary's own type, collapsing all three inferences into one `status === 0` check. **Blast radius: every query and mutation in the app.** Too wide for a two-component bug fix — worth its own ticket.

*(A first-draft review finding claimed a throwing per-call `onSuccess` — score-entry's `navigate` — could also trip the misattribution. That is **false**, and I checked rather than shipped it: `mutationObserver.js:87` fires per-call callbacks outside `Mutation.execute`'s try/catch, so they can't set `error`. Only the hook-level `onSuccess` at `mutation.js:123` runs inside it.)*

## Tests

Both regression tests reject the POST at the **transport level** (`HttpResponse.error()`), not with a status code — a 500 would arrive as an `ApiError` and pass with the bug present. Each asserts **synchronously after the mutation settles** rather than via a bare `waitFor`, because `asyncUtilTimeout` equals the default `testTimeout` in this suite and a hanging `waitFor` would red opaquely at 5s.

Guards confirmed to bite, by independent verifier agents that deleted each branch:

| Branch removed | Result |
| --- | --- |
| `networkError` (#867) | reds in **87ms**, `expected false to be true` on `hasConnectionAlert()` |
| `finalizeNetworkError` (#868) | reds in **196ms** / **65ms**, same crisp assertion |
| `finalizeMutation.reset()` in the divert | reds in **192ms**, `expected true to be false` |

The score-entry test asserts `resultsCalls === 1`, pinning that it exercises the finalize path and not the scratchpad divert.

`183 files, 1242 tests passed` · `tsc -b` clean · `vite build` clean · `eslint` 0 errors.

## Acceptance ledger

| # | Scenario | How it was confirmed |
| --- | --- | --- |
| 1 | Mid-flight drop on finalize shows connection copy | `score-entry.test.tsx` — *"surfaces connection copy when the finalize POST drops mid-flight while online"* (asserts `resultsCalls === 1`) |
| 2 | …and the valid score inputs stay clean | `score-entry.test.tsx` — *"does NOT mark the valid score inputs invalid on a transport drop"* |
| 3 | Offline finalize on match details shows an error | `finalize-callout-active.test.tsx` — *"surfaces a transport-level failure inline and leaves Post retryable (#867)"* |
| 4 | Retry after reconnect succeeds, no stale error | both files — the `#868 reconnect` and `#867 reconnect` tests |
| 5 | **Regression:** offline-*at-submit* still scratchpads | pre-existing `score-entry.test.tsx:1693` — *"offline: the deciding game stores as a scratchpad save instead of posting the result"*, still green |
| 6 | **Regression:** 409 copy unchanged, 422 still reds fields | `score-entry.test.tsx` — *"still reds the inputs on a 422 and shows a 409 detail"* |

**No browser QA pass was run, deliberately.** Every scenario above is a transport-level failure mode that a browser pass can only approximate (devtools offline-throttling races the request) and that the MSW transport-rejection tests reproduce deterministically. A hollow click-through would add ceremony, not evidence. Security review: no findings — the diff renders a static string literal and calls a client-side cache `reset()`; no new attack surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm9DXqbQGGMZdLWArrXZke