### PR TITLE
Ratings + account-merge cleanup: strategy-key enum, strategy snapshot, per-league commit, merge roles, eager-load trim

### DIFF
--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -6,9 +6,10 @@ the browser arrived with a different ephemeral session than the target account.
 The ephemeral row is kept (``merged_into_user_id`` set) rather than dropped so
 its session token still resolves and the auth layer can tell the holder their
 session was merged instead of silently minting a fresh guest. Because we no
-longer rely on ``ON DELETE CASCADE``, the ephemeral user's owned rows
-(roles, leftover league rows, rating history, non-session tokens) are cleaned up
-explicitly here.
+longer rely on ``ON DELETE CASCADE``, the ephemeral user's owned rows are handled
+explicitly here: grants worth keeping (roles) are re-pointed onto the survivor,
+and the rest (leftover league rows, rating history, non-session tokens) are
+cleaned up.
 
 Leaves the verified user's ``user_league_ratings`` and ``rating_history``
 stale relative to the freshly-moved matches — the caller enqueues the
@@ -279,10 +280,35 @@ async def merge_user(
         )
         for match in collided_matches:
             await void_match(db, match)
+    # Carry the guest's granted roles onto the survivor rather than dropping
+    # them: a role a moderator handed the ephemeral session (or that the guest
+    # earned) is a real grant we must not silently lose when the guest signs in.
+    # ``user_roles`` PKs on (user_id, role_id), so re-point only the roles the
+    # survivor doesn't already hold — a role BOTH users have would collide on
+    # that key. The leftover (already-held) ephemeral rows are dropped by the
+    # tombstone cleanup below.
+    await db.execute(
+        text(
+            """
+            UPDATE user_roles AS ur
+            SET user_id = :to_id
+            WHERE ur.user_id = :from_id
+              AND NOT EXISTS (
+                SELECT 1 FROM user_roles other
+                WHERE other.user_id = :to_id
+                  AND other.role_id = ur.role_id
+              )
+            """
+        ),
+        {"from_id": from_user_id, "to_id": to_user_id},
+    )
+
     # We tombstone rather than DELETE the user, so the rows that used to ride
     # ``ON DELETE CASCADE`` must be dropped explicitly. Order doesn't matter —
     # none of these reference each other. Keep the guest's *session* tokens so
-    # its cookie still resolves to this (now-tombstoned) row.
+    # its cookie still resolves to this (now-tombstoned) row. The role re-point
+    # above already moved every grant the survivor lacked; this clears any that
+    # stayed behind as duplicates so the tombstone ends with no roles.
     await db.execute(delete(UserRole).where(UserRole.user_id == from_user_id))
     await db.execute(delete(DeviceToken).where(DeviceToken.user_id == from_user_id))
     # A guest's in-app notifications and preference overrides are throwaway —

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -32,6 +32,7 @@ from app.models import (
     User,
     UserLeagueRating,
 )
+from app.ratings import RatingStrategyKey
 from app.retirement import retirement_deadline
 from app.schemas.dashboard import (
     AttentionKind,
@@ -488,7 +489,7 @@ def _strategy_stats(
     Keeps the API contract generic — the frontend renders whatever labels
     come back without needing to know which fields a given strategy carries.
     """
-    if strategy_key == "glicko2":
+    if strategy_key == RatingStrategyKey.glicko2:
         rd = _as_float(state.get("rd"))
         volatility = _as_float(state.get("volatility"))
         return [

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -32,7 +32,7 @@ from app.models import (
     User,
     UserLeagueRating,
 )
-from app.ratings import RatingStrategyKey
+from app.ratings import RatingStrategyKey, parse_strategy_key
 from app.retirement import retirement_deadline
 from app.schemas.dashboard import (
     AttentionKind,
@@ -488,8 +488,12 @@ def _strategy_stats(
 
     Keeps the API contract generic — the frontend renders whatever labels
     come back without needing to know which fields a given strategy carries.
+
+    ``strategy_key`` arrives as a raw ``str`` off ``RatingStrategy.key``, so it
+    is parsed to the closed enum at this boundary — an unrecognised key parses
+    to ``None`` and yields no tiles, rather than silently missing an ``==``.
     """
-    if strategy_key == RatingStrategyKey.glicko2:
+    if parse_strategy_key(strategy_key) is RatingStrategyKey.glicko2:
         rd = _as_float(state.get("rd"))
         volatility = _as_float(state.get("volatility"))
         return [

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -145,12 +145,31 @@ def _side_schema(
 # pulled up front. The posted results (the propose/accept chain) are needed
 # wherever ``can_finalize`` / the awaiting-acceptance status label / the
 # derived ``negotiation`` block are computed.
+#
+# ``Match.league`` is eager (serializers read ``league.id``/``league.name``) but
+# its nested ``rating_strategy`` is NOT — only the score-write finalize paths
+# read it (inside ``_apply_rating_update``), and they load it explicitly via
+# ``match_rating_eager_options`` so the list / detail / dashboard reads don't pay
+# an extra ``selectinload`` on the strategy row (issue #182).
 def match_eager_options() -> tuple[ExecutableOption, ...]:
     return (
         selectinload(Match.match_settings),
-        selectinload(Match.league).selectinload(League.rating_strategy),
+        selectinload(Match.league),
         selectinload(Match.results),
         *_match_history_options(),
+    )
+
+
+# The finalize/score-write superset: everything a read needs, plus the league's
+# rating strategy that ``_apply_rating_update`` reads when a completing match
+# applies ratings. Under async SQLAlchemy a lazy access on the unloaded
+# ``league.rating_strategy`` would raise ``MissingGreenlet`` mid-request, so the
+# two paths that finalize a match must load it up front rather than rely on the
+# shared read chain.
+def match_rating_eager_options() -> tuple[ExecutableOption, ...]:
+    return (
+        *match_eager_options(),
+        selectinload(Match.league).selectinload(League.rating_strategy),
     )
 
 
@@ -165,9 +184,16 @@ def _match_history_options() -> tuple[ExecutableOption, ...]:
     )
 
 
-async def _load_match(db: AsyncSession, match_id: uuid.UUID) -> Match | None:
+async def _load_match(
+    db: AsyncSession,
+    match_id: uuid.UUID,
+    *,
+    options: tuple[ExecutableOption, ...] | None = None,
+) -> Match | None:
     result = await db.execute(
-        select(Match).where(Match.id == match_id).options(*match_eager_options())
+        select(Match)
+        .where(Match.id == match_id)
+        .options(*(options if options is not None else match_eager_options()))
     )
     return result.scalar_one_or_none()
 
@@ -1844,13 +1870,19 @@ async def _load_match_for_scoring(
     *,
     lock: bool = False,
     nowait: bool = False,
+    options: tuple[ExecutableOption, ...] | None = None,
 ) -> Match:
     # ``lock`` callers (the negotiation transitions, and per ADR-0009 the score
     # endpoints) take the row lock *before* the eager load so the match state
     # they read is the serialized one.
+    #
+    # The finalize paths (``post_match_result`` self-accept, ``accept_match_result``)
+    # pass ``options=match_rating_eager_options()`` so ``_apply_rating_update`` can
+    # read ``league.rating_strategy`` without a mid-request lazy load; the scratchpad
+    # score endpoints never finalize, so they take the default read chain.
     if lock:
         await _lock_match_row(db, match_id, nowait=nowait)
-    match = await _load_match(db, match_id)
+    match = await _load_match(db, match_id, options=options)
     if match is None or not _is_participant(match, current_user_id):
         raise HTTPException(status_code=404, detail="Match not found.")
     return match
@@ -2091,7 +2123,12 @@ async def post_match_result(
     ``POST /results/{result_id}/acceptance``."""
     try:
         match = await _load_match_for_scoring(
-            db, match_id, current_user.id, lock=True, nowait=True
+            db,
+            match_id,
+            current_user.id,
+            lock=True,
+            nowait=True,
+            options=match_rating_eager_options(),
         )
     except MatchLockUnavailable as exc:
         # A concurrent propose is mid-flight (a double-tapped submit). Bail out
@@ -2236,7 +2273,13 @@ async def accept_match_result(
     negotiation state (or a 404 if no result with that id exists on the match).
     The proposing side already consented by proposing, so only a participant on
     the *opposing* side may accept."""
-    match = await _load_match_for_scoring(db, match_id, current_user.id, lock=True)
+    match = await _load_match_for_scoring(
+        db,
+        match_id,
+        current_user.id,
+        lock=True,
+        options=match_rating_eager_options(),
+    )
 
     # The path ``result_id`` must exist on this match at all (404); the live
     # standing-proposal check (409 with the moved-on state) is owned by

--- a/api/app/models/user_league_rating.py
+++ b/api/app/models/user_league_rating.py
@@ -45,6 +45,11 @@ class UserLeagueRating(Base):
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
     )
+    rating_strategy_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("rating_strategies.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
     rating_value: Mapped[float | None] = mapped_column(Float, nullable=True)
     rating_state: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
@@ -59,6 +64,7 @@ class UserLeagueRating(Base):
 
     league: Mapped["League"] = relationship()
     user: Mapped["User"] = relationship()
+    rating_strategy: Mapped["RatingStrategy"] = relationship()
 
     @classmethod
     def seed_for_strategy(
@@ -70,6 +76,7 @@ class UserLeagueRating(Base):
         return cls(
             league_id=league_id,
             user_id=user_id,
+            rating_strategy_id=strategy.id,
             rating_value=strategy.initial_rating_value,
             rating_state=(
                 dict(strategy.initial_state)

--- a/api/app/ratings/__init__.py
+++ b/api/app/ratings/__init__.py
@@ -1,10 +1,11 @@
 from app.ratings.base import RatingCalculator, RatingStrategyKey, state_rating_value
 from app.ratings.registry import STRATEGIES, get_calculator, parse_strategy_key
-from app.ratings.validation import validate_state
+from app.ratings.validation import RatingStrategyMismatchError, validate_state
 
 __all__ = [
     "RatingCalculator",
     "RatingStrategyKey",
+    "RatingStrategyMismatchError",
     "STRATEGIES",
     "get_calculator",
     "parse_strategy_key",

--- a/api/app/ratings/__init__.py
+++ b/api/app/ratings/__init__.py
@@ -1,11 +1,13 @@
-from app.ratings.base import RatingCalculator, state_rating_value
-from app.ratings.registry import STRATEGIES, get_calculator
+from app.ratings.base import RatingCalculator, RatingStrategyKey, state_rating_value
+from app.ratings.registry import STRATEGIES, get_calculator, parse_strategy_key
 from app.ratings.validation import validate_state
 
 __all__ = [
     "RatingCalculator",
+    "RatingStrategyKey",
     "STRATEGIES",
     "get_calculator",
+    "parse_strategy_key",
     "state_rating_value",
     "validate_state",
 ]

--- a/api/app/ratings/base.py
+++ b/api/app/ratings/base.py
@@ -1,4 +1,23 @@
+import enum
 from typing import Any, Protocol
+
+
+class RatingStrategyKey(enum.StrEnum):
+    """The closed set of rating-strategy keys the codebase knows by name.
+
+    One definition shared by every in-code site that names a strategy — the
+    registry, the league seeder, and the dashboard's stats branch — so a typo
+    in any one is a type error, not a silent no-op. Members are ``str`` (via
+    ``StrEnum``), so equality and dict lookup against the plain ``str`` stored
+    in ``RatingStrategy.key`` keep working.
+
+    ``manual`` is a real seeded strategy row but intentionally has no registry
+    entry: callers short-circuit on ``strategy.is_automatic`` before ever
+    reaching ``get_calculator``, so it never needs a calculator.
+    """
+
+    glicko2 = "glicko2"
+    manual = "manual"
 
 
 class RatingCalculator(Protocol):
@@ -11,7 +30,7 @@ class RatingCalculator(Protocol):
     when that opens up.
     """
 
-    key: str
+    key: RatingStrategyKey
 
     def update_singles(
         self,

--- a/api/app/ratings/glicko2.py
+++ b/api/app/ratings/glicko2.py
@@ -7,6 +7,8 @@ mapping that produces an update on every result.
 import math
 from typing import Any
 
+from app.ratings.base import RatingStrategyKey
+
 TAU = 0.5  # system constant, dampens volatility changes
 SCALE = 173.7178  # Glicko-2 conversion factor
 EPSILON = 1e-6
@@ -81,7 +83,7 @@ def _update_one(
 
 
 class Glicko2Calculator:
-    key = "glicko2"
+    key: RatingStrategyKey = RatingStrategyKey.glicko2
 
     def update_singles(
         self,

--- a/api/app/ratings/jobs.py
+++ b/api/app/ratings/jobs.py
@@ -33,6 +33,25 @@ def recompute_after_merge(user_id: str) -> None:
 
 
 async def _recompute_after_merge(user_id: uuid.UUID) -> None:
+    """Re-run and commit each affected league's rating cascade independently.
+
+    Every query in ``recompute_league_ratings`` is scoped to a single
+    ``league_id``, so leagues are independent — one league's recompute neither
+    reads nor writes another's state. We therefore commit after each league
+    rather than once at the end: partial progress survives, so a persistent
+    error in one league no longer discards the leagues already settled before it
+    (issue #248).
+
+    Failure policy: if a league's recompute raises, the leagues committed before
+    it stay committed and the exception propagates. RQ then marks the job failed
+    and a retry replays every league — harmless for the already-settled ones
+    because the recompute is idempotent (it rewrites state deterministically), so
+    only the previously-failing league has real work left to do. Letting it
+    propagate (rather than log-and-continue) keeps RQ's failed-job registry
+    meaningful. The failing league's own uncommitted work is rolled back when the
+    ``async with`` session context exits on the propagating exception, so the
+    session is never reused after a partial statement.
+    """
     sessionmaker = async_sessionmaker(get_engine(), expire_on_commit=False)
     async with sessionmaker() as session:
         # Discover leagues by rating row, not by "has a completed rated match".
@@ -56,8 +75,11 @@ async def _recompute_after_merge(user_id: uuid.UUID) -> None:
         )
         if not league_ids:
             return
-        # Consistent acquisition order prevents deadlocks when two concurrent
-        # jobs for different users share overlapping league sets.
+        # Commit per league so partial progress survives a mid-loop failure.
+        # A stable acquisition order is belt-and-braces now: with a per-league
+        # commit the job holds exactly one transaction-scoped advisory lock at a
+        # time, so cross-job deadlock is impossible rather than merely
+        # ordered-away. Kept for a deterministic, easy-to-reason-about order.
         for league_id in sorted(league_ids):
             await recompute_league_ratings(session, league_id, {user_id})
-        await session.commit()
+            await session.commit()

--- a/api/app/ratings/recompute.py
+++ b/api/app/ratings/recompute.py
@@ -386,9 +386,15 @@ async def _reset_users_to_initial_state(
 
     The non-match rows — ``initial`` (written by ``seed_user_league_rating``
     when the user joined), ``manual``, ``import`` — are the empty timeline
-    itself and stay untouched; no new event is appended. The
-    ``UserLeagueRating`` row is reset in place, never deleted: every member
-    keeps exactly one from seeding.
+    itself and stay untouched; no new event is appended. These rows can be
+    strategy-*stale* — this function re-stamps the ``UserLeagueRating`` snapshot
+    to the current ``strategy`` but leaves the history rows carrying whatever
+    ``rating_strategy_id`` they were written under. That is safe: ``_seed_states``
+    filters a seed to ``rating_strategy_id == strategy.id`` (issue #184), so a
+    row written under a superseded strategy is simply never selectable as a seed
+    under a different one — it stays as an audit-trail record and cannot be
+    replayed through the wrong calculator. The ``UserLeagueRating`` row is reset
+    in place, never deleted: every member keeps exactly one from seeding.
 
     Runs inside the caller's transaction — does not commit.
     """
@@ -465,6 +471,20 @@ async def _seed_states(
     the same instant — a seeding event precedes play at that instant — instead of
     poisoning the row comparison to NULL.
 
+    A seed row must also have been written under the league's CURRENT strategy
+    (issue #184): the subquery filters ``rating_strategy_id == strategy.id``.
+    ``rating_history`` snapshots that column per row, and a row from a superseded
+    strategy holds ``rating_state`` in that strategy's shape — the current
+    calculator/JSON Schema would misread it (a ``KeyError`` from the replay, or
+    silent corruption if the two shapes' keys overlap). Rows from a superseded
+    strategy are therefore ignored; a user whose only history rows were written
+    under a different strategy has no qualifying seed and falls through to the
+    ``initial_state`` fallback — under the new strategy their timeline correctly
+    starts at the new strategy's initial state. This is a no-op for today's data
+    (every history row in a league shares that league's strategy, there being no
+    strategy-mutation flow), and guards the same future #184 guards on the
+    ``user_league_ratings`` snapshot.
+
     A per-user VALUES join keeps this to one round trip — N affected users
     would otherwise be N queries."""
     if not cutoffs:
@@ -502,6 +522,15 @@ async def _seed_states(
         )
         .where(
             RatingHistory.league_id == league_id,
+            # Only a row written under the CURRENT strategy is a valid seed
+            # (issue #184). ``rating_history`` snapshots ``rating_strategy_id``
+            # per row; a row from a superseded strategy holds ``rating_state`` in
+            # that strategy's shape, which the current calculator would misread
+            # (KeyError, or silent corruption on overlapping keys). Filtering it
+            # out drops the user through to the ``initial_state`` fallback below —
+            # the correct semantics: under the new strategy their timeline starts
+            # at the new strategy's initial state.
+            RatingHistory.rating_strategy_id == strategy.id,
             tuple_(RatingHistory.created_at, match_sort_key)
             < tuple_(
                 cutoff_values.c.cutoff_completed_at,

--- a/api/app/ratings/recompute.py
+++ b/api/app/ratings/recompute.py
@@ -53,7 +53,7 @@ from app.models import (
 )
 from app.ratings.base import state_rating_value
 from app.ratings.registry import get_calculator, parse_strategy_key
-from app.ratings.validation import validate_state
+from app.ratings.validation import RatingStrategyMismatchError, validate_state
 
 # Sentinel ordering key for a NULL ``match_id``. Non-match history rows
 # (``initial`` / ``manual`` / ``import``) carry ``match_id IS NULL``, and a NULL
@@ -273,12 +273,31 @@ async def recompute_league_ratings(
             ulr = UserLeagueRating(
                 league_id=league_id,
                 user_id=user_id,
+                rating_strategy_id=strategy.id,
                 rating_state=state,
                 rating_value=value,
             )
             db.add(ulr)
             rating_by_user[user_id] = ulr
         else:
+            # Snapshot guard (issue #184). ``ulr`` pre-existed this recompute and
+            # holds ``rating_state`` in the shape of the strategy it was
+            # snapshotted under. If the league has since switched strategies,
+            # overwriting it from a replay run under the new strategy would leave
+            # the row's snapshot lying about its state — refuse loudly instead.
+            # Reached only for an ``is_automatic`` league (guarded above), so it
+            # fires on automatic->automatic switches; a switch to manual
+            # early-returns and those rows freeze at their last automatic value
+            # (accepted; #184). Freshly-created rows take the ``ulr is None``
+            # branch above and are stamped with the current ``strategy.id``, so
+            # the guard is scoped to existing rows only.
+            if ulr.rating_strategy_id != strategy.id:
+                raise RatingStrategyMismatchError(
+                    league_id=league_id,
+                    user_id=user_id,
+                    row_strategy_id=ulr.rating_strategy_id,
+                    league_strategy_id=strategy.id,
+                )
             ulr.rating_state = state
             ulr.rating_value = value
 
@@ -387,6 +406,14 @@ async def _reset_users_to_initial_state(
     for ulr in ratings:
         ulr.rating_state = dict(initial_state) if initial_state is not None else None
         ulr.rating_value = strategy.initial_rating_value
+        # Re-stamp the strategy snapshot (issue #184). This function is the ONE
+        # write that legitimately re-stamps ``rating_strategy_id``: it overwrites
+        # ``rating_state`` wholesale from the *current* strategy's
+        # ``initial_state`` and never reads the old state, so a stale snapshot is
+        # safe here — this is the reset/heal path. Every other write instead
+        # *refuses* on a snapshot mismatch (``RatingStrategyMismatchError``);
+        # here we heal it by aligning the snapshot to the state we just wrote.
+        ulr.rating_strategy_id = strategy.id
 
     await db.flush()
 

--- a/api/app/ratings/recompute.py
+++ b/api/app/ratings/recompute.py
@@ -14,9 +14,22 @@ Concurrent safety: two workers recomputing the same league would interleave
 DELETE/INSERT under READ COMMITTED and produce a corrupt final row.
 ``recompute_league_ratings`` acquires a per-league ``pg_advisory_xact_lock``
 before touching any data; the lock is held for the life of the caller's
-transaction and released on commit or rollback.  The caller must not commit
-mid-loop across multiple leagues, or locks for earlier leagues are released
-before later ones are acquired (see ``app.ratings.jobs``).
+transaction and released on commit or rollback.
+
+Leagues are independent, and a caller processing several of them commits after
+each one. Every query here is scoped to a single ``league_id`` — the match
+lookups, the ``rating_history`` delete, the ``user_league_ratings`` select,
+``_seed_states``, and ``_reset_users_to_initial_state`` all filter (or stamp) on
+it — so no league's recompute reads or writes another league's state. A caller
+that loops over multiple leagues therefore commits per league (see
+``app.ratings.jobs``): each league's advisory lock is held for exactly its own
+transaction, and a failure in one league leaves the leagues already committed
+before it intact. Releasing an earlier league's lock before acquiring a later
+one is harmless because there is no cross-league invariant for it to protect;
+holding at most one lock at a time also makes cross-job deadlock impossible
+rather than merely ordered-away. The only thing a per-league commit gives up is a
+single cross-league point-in-time snapshot, and no reader consumes ratings across
+leagues atomically (every read is league-scoped), so nothing depends on it.
 """
 
 import struct

--- a/api/app/ratings/recompute.py
+++ b/api/app/ratings/recompute.py
@@ -52,7 +52,7 @@ from app.models import (
     UserLeagueRating,
 )
 from app.ratings.base import state_rating_value
-from app.ratings.registry import get_calculator
+from app.ratings.registry import get_calculator, parse_strategy_key
 from app.ratings.validation import validate_state
 
 # Sentinel ordering key for a NULL ``match_id``. Non-match history rows
@@ -129,7 +129,10 @@ async def recompute_league_ratings(
     strategy = league.rating_strategy
     if not strategy.is_automatic:
         return
-    calculator = get_calculator(strategy.key)
+    strategy_key = parse_strategy_key(strategy.key)
+    if strategy_key is None:
+        return
+    calculator = get_calculator(strategy_key)
     if calculator is None:
         return
 

--- a/api/app/ratings/registry.py
+++ b/api/app/ratings/registry.py
@@ -1,10 +1,29 @@
-from app.ratings.base import RatingCalculator
+from app.ratings.base import RatingCalculator, RatingStrategyKey
 from app.ratings.glicko2 import CALCULATOR as GLICKO2_CALCULATOR
 
-STRATEGIES: dict[str, RatingCalculator] = {
+# Only automatic strategies register a calculator. ``manual`` is a valid
+# ``RatingStrategyKey`` but has no entry here — callers guard on
+# ``strategy.is_automatic`` before reaching ``get_calculator``, so it never
+# needs one.
+STRATEGIES: dict[RatingStrategyKey, RatingCalculator] = {
     GLICKO2_CALCULATOR.key: GLICKO2_CALCULATOR,
 }
 
 
-def get_calculator(key: str) -> RatingCalculator | None:
+def parse_strategy_key(key: str) -> RatingStrategyKey | None:
+    """Parse a raw ``str`` (e.g. ``RatingStrategy.key`` off the DB) into a
+    known ``RatingStrategyKey``, or ``None`` if it names no member.
+
+    This is the boundary between untrusted stringly-typed data and the closed
+    enum the rest of the ratings code uses. An unrecognised key must not crash
+    a match view — it returns ``None`` and the caller treats it as "no
+    strategy" (no rating update), exactly as an unregistered key does today.
+    """
+    try:
+        return RatingStrategyKey(key)
+    except ValueError:
+        return None
+
+
+def get_calculator(key: RatingStrategyKey) -> RatingCalculator | None:
     return STRATEGIES.get(key)

--- a/api/app/ratings/validation.py
+++ b/api/app/ratings/validation.py
@@ -1,8 +1,48 @@
+import uuid
 from typing import Any
 
 import jsonschema
 
 from app.models import RatingStrategy
+
+
+class RatingStrategyMismatchError(Exception):
+    """Raised when an *existing* ``user_league_ratings`` row is about to be used
+    for a rating write but the strategy snapshotted on the row
+    (``rating_strategy_id``) is no longer the strategy its league runs.
+
+    Its ``rating_state`` is still shaped for the *old* strategy, so
+    reinterpreting it under the *new* strategy's calculator / JSON Schema would
+    silently corrupt the rating (issue #184). The write refuses loudly instead.
+
+    The remedy is to **migrate or reset** the row (re-stamp its snapshot and
+    overwrite ``rating_state`` from the new strategy's ``initial_state`` — see
+    ``app.ratings.recompute._reset_users_to_initial_state``), **not** to retry:
+    the same stale snapshot will fail the same way every time.
+    """
+
+    def __init__(
+        self,
+        *,
+        league_id: uuid.UUID,
+        user_id: uuid.UUID,
+        row_strategy_id: uuid.UUID,
+        league_strategy_id: uuid.UUID,
+    ) -> None:
+        self.league_id = league_id
+        self.user_id = user_id
+        self.row_strategy_id = row_strategy_id
+        self.league_strategy_id = league_strategy_id
+        super().__init__(
+            f"user_league_ratings row for user {user_id} in league {league_id} "
+            f"was snapshotted under rating strategy {row_strategy_id}, but the "
+            f"league now runs strategy {league_strategy_id}. The row's "
+            f"rating_state is still in the old strategy's shape and must not be "
+            f"reinterpreted under the new strategy. Migrate or reset the row "
+            f"(re-stamp the snapshot and overwrite rating_state from the new "
+            f"strategy's initial_state) before it can take a rating update; "
+            f"retrying this write will not help."
+        )
 
 
 def validate_state(state: dict[str, Any], strategy: RatingStrategy) -> None:

--- a/api/app/result_acceptance.py
+++ b/api/app/result_acceptance.py
@@ -41,6 +41,7 @@ from app.models import (
     UserLeagueRating,
 )
 from app.ratings import (
+    RatingStrategyMismatchError,
     get_calculator,
     parse_strategy_key,
     state_rating_value,
@@ -119,6 +120,24 @@ async def _get_or_create_user_league_rating(
         )
     ).scalar_one_or_none()
     if existing is not None:
+        # Snapshot guard (issue #184). A row that pre-existed this call holds
+        # ``rating_state`` in the shape of the strategy it was snapshotted under.
+        # If the league has since switched strategies, that state must not be
+        # reinterpreted under the new one — refuse loudly rather than corrupt it.
+        # The caller (``_apply_rating_update``) only reaches here for an
+        # ``is_automatic`` league, so this fires on automatic->automatic switches;
+        # a switch to a manual strategy early-returns before the rating hook and
+        # its rows simply freeze at their last automatic value (accepted; #184).
+        # A freshly-seeded row (the branch below) can't mismatch — it's stamped
+        # with the current ``strategy.id`` — so the guard is scoped to existing
+        # rows only.
+        if existing.rating_strategy_id != strategy.id:
+            raise RatingStrategyMismatchError(
+                league_id=league_id,
+                user_id=user_id,
+                row_strategy_id=existing.rating_strategy_id,
+                league_strategy_id=strategy.id,
+            )
         return existing
     rating = UserLeagueRating.seed_for_strategy(league_id, user_id, strategy)
     db.add(rating)

--- a/api/app/result_acceptance.py
+++ b/api/app/result_acceptance.py
@@ -40,7 +40,12 @@ from app.models import (
     RatingStrategy,
     UserLeagueRating,
 )
-from app.ratings import get_calculator, state_rating_value, validate_state
+from app.ratings import (
+    get_calculator,
+    parse_strategy_key,
+    state_rating_value,
+    validate_state,
+)
 from app.result_chain import standing_result
 
 
@@ -138,7 +143,10 @@ async def _apply_rating_update(db: AsyncSession, match: Match) -> None:
     strategy = league.rating_strategy
     if not strategy.is_automatic:
         return
-    calculator = get_calculator(strategy.key)
+    strategy_key = parse_strategy_key(strategy.key)
+    if strategy_key is None:
+        return
+    calculator = get_calculator(strategy_key)
     if calculator is None:
         return
 

--- a/api/app/result_acceptance.py
+++ b/api/app/result_acceptance.py
@@ -26,7 +26,9 @@ can't live on the router the worker would otherwise have to import. The
 
 import math
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,6 +36,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models import (
     Match,
     MatchGameScore,
+    MatchSidePlayer,
     MatchStatus,
     RatingHistory,
     RatingHistorySource,
@@ -41,6 +44,7 @@ from app.models import (
     UserLeagueRating,
 )
 from app.ratings import (
+    RatingCalculator,
     RatingStrategyMismatchError,
     get_calculator,
     parse_strategy_key,
@@ -145,6 +149,98 @@ async def _get_or_create_user_league_rating(
     return rating
 
 
+def _resolve_completion_sides(
+    match: Match,
+) -> tuple[MatchSidePlayer, MatchSidePlayer] | None:
+    """Return ``(winner_player, loser_player)`` for a decided binary singles
+    result, or ``None`` when there is no clear winner/loser or a decided side
+    has no players.
+
+    Mirrors ``_decided_sides`` in ``app.ratings.recompute``: a
+    forfeit/void/partial write leaves ``MatchSide.won`` as ``None`` and never
+    produced a rating delta, so we skip rather than crash on the lookup. A
+    decided side with no players — the solo-match sentinel side, or a forfeit
+    that stamped ``won`` on a player-less side — would otherwise ``IndexError``
+    on the ``players[0]`` lookup below, so it also resolves to ``None``."""
+    winning_side = next((s for s in match.sides if s.won is True), None)
+    losing_side = next((s for s in match.sides if s.won is False), None)
+    if winning_side is None or losing_side is None:
+        return None
+    if not winning_side.players or not losing_side.players:
+        return None
+    return winning_side.players[0], losing_side.players[0]
+
+
+def _calculator_for(match: Match) -> RatingCalculator | None:
+    """The automatic-rating gate: the calculator for ``match``'s league
+    strategy, or ``None`` when the league runs a non-automatic strategy (a
+    ``manual`` league freezes its rating rows and never reaches a calculator)
+    or its key has no registered calculator. Callers short-circuit on ``None``
+    before doing any rating work — in particular before the doubles tripwire,
+    so that only a match that would otherwise be rated can trip it."""
+    strategy = match.league.rating_strategy
+    if not strategy.is_automatic:
+        return None
+    strategy_key = parse_strategy_key(strategy.key)
+    if strategy_key is None:
+        return None
+    return get_calculator(strategy_key)
+
+
+@dataclass(frozen=True)
+class _SideRatingUpdate:
+    """One side's computed singles move: the ``user_league_ratings`` row to bump
+    and the values to write into it and record in ``rating_history``."""
+
+    rating: UserLeagueRating
+    user_id: uuid.UUID
+    new_state: dict[str, Any]
+    new_value: float
+    previous_value: float | None
+
+
+def _write_match_rating_history(
+    db: AsyncSession,
+    *,
+    league_id: uuid.UUID,
+    match_id: uuid.UUID,
+    strategy: RatingStrategy,
+    winner: _SideRatingUpdate,
+    loser: _SideRatingUpdate,
+) -> None:
+    """Persist the computed singles update: bump each side's
+    ``user_league_ratings`` row to its new state/value, then append the two
+    ``rating_history`` rows (winner then loser) recording the move."""
+    for update in (winner, loser):
+        update.rating.rating_state = update.new_state
+        update.rating.rating_value = update.new_value
+
+    db.add(
+        RatingHistory(
+            league_id=league_id,
+            user_id=winner.user_id,
+            match_id=match_id,
+            rating_strategy_id=strategy.id,
+            rating_value=winner.new_value,
+            rating_state=winner.new_state,
+            previous_rating_value=winner.previous_value,
+            source=RatingHistorySource.match,
+        )
+    )
+    db.add(
+        RatingHistory(
+            league_id=league_id,
+            user_id=loser.user_id,
+            match_id=match_id,
+            rating_strategy_id=strategy.id,
+            rating_value=loser.new_value,
+            rating_state=loser.new_state,
+            previous_rating_value=loser.previous_value,
+            source=RatingHistorySource.match,
+        )
+    )
+
+
 async def _apply_rating_update(db: AsyncSession, match: Match) -> None:
     """When ``match`` has just transitioned to completed and its league runs an
     automatic rating strategy, compute the singles update and persist a
@@ -158,14 +254,7 @@ async def _apply_rating_update(db: AsyncSession, match: Match) -> None:
     if not match.match_settings.affects_rating:
         return
 
-    league = match.league
-    strategy = league.rating_strategy
-    if not strategy.is_automatic:
-        return
-    strategy_key = parse_strategy_key(strategy.key)
-    if strategy_key is None:
-        return
-    calculator = get_calculator(strategy_key)
+    calculator = _calculator_for(match)
     if calculator is None:
         return
 
@@ -191,15 +280,13 @@ async def _apply_rating_update(db: AsyncSession, match: Match) -> None:
     if already_applied is not None:
         return
 
-    winning_side = next((s for s in match.sides if s.won is True), None)
-    losing_side = next((s for s in match.sides if s.won is False), None)
-    if winning_side is None or losing_side is None:
+    sides = _resolve_completion_sides(match)
+    if sides is None:
         return
-    if not winning_side.players or not losing_side.players:
-        return
+    winner_player, loser_player = sides
 
-    winner_player = winning_side.players[0]
-    loser_player = losing_side.players[0]
+    league = match.league
+    strategy = league.rating_strategy
 
     winner_rating = await _get_or_create_user_league_rating(
         db, league.id, winner_player.user_id, strategy
@@ -219,37 +306,25 @@ async def _apply_rating_update(db: AsyncSession, match: Match) -> None:
     validate_state(new_winner_state, strategy)
     validate_state(new_loser_state, strategy)
 
-    new_winner_value = state_rating_value(new_winner_state)
-    new_loser_value = state_rating_value(new_loser_state)
-
-    winner_rating.rating_state = new_winner_state
-    winner_rating.rating_value = new_winner_value
-    loser_rating.rating_state = new_loser_state
-    loser_rating.rating_value = new_loser_value
-
-    db.add(
-        RatingHistory(
-            league_id=league.id,
+    _write_match_rating_history(
+        db,
+        league_id=league.id,
+        match_id=match.id,
+        strategy=strategy,
+        winner=_SideRatingUpdate(
+            rating=winner_rating,
             user_id=winner_player.user_id,
-            match_id=match.id,
-            rating_strategy_id=strategy.id,
-            rating_value=new_winner_value,
-            rating_state=new_winner_state,
-            previous_rating_value=prev_winner_value,
-            source=RatingHistorySource.match,
-        )
-    )
-    db.add(
-        RatingHistory(
-            league_id=league.id,
+            new_state=new_winner_state,
+            new_value=state_rating_value(new_winner_state),
+            previous_value=prev_winner_value,
+        ),
+        loser=_SideRatingUpdate(
+            rating=loser_rating,
             user_id=loser_player.user_id,
-            match_id=match.id,
-            rating_strategy_id=strategy.id,
-            rating_value=new_loser_value,
-            rating_state=new_loser_state,
-            previous_rating_value=prev_loser_value,
-            source=RatingHistorySource.match,
-        )
+            new_state=new_loser_state,
+            new_value=state_rating_value(new_loser_state),
+            previous_value=prev_loser_value,
+        ),
     )
 
 

--- a/api/app/retirement_jobs.py
+++ b/api/app/retirement_jobs.py
@@ -98,10 +98,17 @@ class RetirementOutcome(enum.Enum):
 
 
 def _eager_options() -> tuple[ExecutableOption, ...]:
-    """Reproduce the router's ``match_eager_options`` chain. Async SQLAlchemy
-    can't lazy-load mid-transaction, so every collection ``accept_standing_result``
-    and the owing-side resolution touch — match_settings, league→rating_strategy,
-    results, sides→players, games→score — is pulled up front."""
+    """The eager-load chain for the auto-acceptance path. Async SQLAlchemy can't
+    lazy-load mid-transaction, so every collection ``accept_standing_result`` and
+    the owing-side resolution touch — match_settings, league→rating_strategy,
+    results, sides→players, games→score — is pulled up front.
+
+    Note the ``league→rating_strategy`` leg: this carries its own strategy load
+    because the router's shared ``match_eager_options`` no longer does (issue
+    #182 — the read paths dropped it, and the router's finalize handlers load it
+    explicitly via ``match_rating_eager_options``). ``_apply_rating_update`` reads
+    ``league.rating_strategy``, so this worker path must load it itself or a lazy
+    access here would raise ``MissingGreenlet``."""
     return (
         selectinload(Match.match_settings),
         selectinload(Match.league).selectinload(League.rating_strategy),

--- a/api/migrations/versions/20260516_0001_0006_create_rating_state_tables.py
+++ b/api/migrations/versions/20260516_0001_0006_create_rating_state_tables.py
@@ -54,6 +54,12 @@ def upgrade() -> None:
             sa.ForeignKey("users.id", ondelete="CASCADE"),
             nullable=False,
         ),
+        sa.Column(
+            "rating_strategy_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("rating_strategies.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
         sa.Column("rating_value", sa.Float(), nullable=True),
         sa.Column(
             "rating_state",

--- a/api/scripts/seed_leagues.py
+++ b/api/scripts/seed_leagues.py
@@ -14,12 +14,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from app.db import get_engine
 from app.leagues import get_default_league
 from app.models import League, LeagueVisibility, RatingStrategy
-
+from app.ratings import RatingStrategyKey
 
 DEFAULT_LEAGUE_NAME = "FortyMM"
 DEFAULT_LEAGUE_DESCRIPTION = "The headline FortyMM league."
 DEFAULT_LEAGUE_VISIBILITY = LeagueVisibility.public
-DEFAULT_LEAGUE_RATING_STRATEGY_KEY = "glicko2"
+DEFAULT_LEAGUE_RATING_STRATEGY_KEY = RatingStrategyKey.glicko2
 
 
 async def upsert_default_league(db: AsyncSession) -> str:

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -25,10 +25,12 @@ from app.models import (
     MatchStatus,
     RatingHistory,
     RatingHistorySource,
+    Role,
     Tournament,
     TournamentEvent,
     User,
     UserLeagueRating,
+    UserRole,
     UserToken,
 )
 from app.sessions import SESSION_TOKEN_CONTEXT
@@ -474,6 +476,97 @@ async def test_merge_repoints_match_result_submitted_by(db_session: AsyncSession
 
     await db_session.refresh(result)
     assert result.submitted_by_user_id == verified.id
+
+
+# ----- roles --------------------------------------------------------------
+
+
+async def test_merge_carries_role_the_survivor_lacks(db_session: AsyncSession):
+    """A role granted to the ephemeral session must ride onto the survivor —
+    dropping it would silently revoke a grant the moment the guest signs in.
+    ``user_roles`` PKs on (user_id, role_id) with no ON DELETE CASCADE firing on
+    a tombstone, so the merge re-points the grant explicitly."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+
+    role = Role(name="tournament-director")
+    db_session.add(role)
+    await db_session.commit()
+    db_session.add(UserRole(user_id=ephemeral.id, role_id=role.id))
+    await db_session.commit()
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    survivor_role_ids = (
+        (
+            await db_session.execute(
+                select(UserRole.role_id).where(UserRole.user_id == verified.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert survivor_role_ids == [role.id]
+
+    # The tombstoned ephemeral user ends with no roles.
+    ephemeral_role_ids = (
+        (
+            await db_session.execute(
+                select(UserRole.role_id).where(UserRole.user_id == ephemeral.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert ephemeral_role_ids == []
+
+
+async def test_merge_role_held_by_both_does_not_collide(db_session: AsyncSession):
+    """When both users already hold the same role, the (user_id, role_id) PK
+    would collide on a naïve re-point. The NOT EXISTS guard skips it; the merge
+    does not raise and the survivor keeps the role exactly once, while the
+    ephemeral duplicate is cleared by the tombstone cleanup."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+
+    role = Role(name="tournament-director")
+    db_session.add(role)
+    await db_session.commit()
+    db_session.add_all(
+        [
+            UserRole(user_id=ephemeral.id, role_id=role.id),
+            UserRole(user_id=verified.id, role_id=role.id),
+        ]
+    )
+    await db_session.commit()
+
+    # Must not raise on the composite PK.
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    survivor_role_ids = (
+        (
+            await db_session.execute(
+                select(UserRole.role_id).where(UserRole.user_id == verified.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    # Held exactly once — no duplicate row.
+    assert survivor_role_ids == [role.id]
+
+    ephemeral_role_ids = (
+        (
+            await db_session.execute(
+                select(UserRole.role_id).where(UserRole.user_id == ephemeral.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert ephemeral_role_ids == []
 
 
 # ----- counts -------------------------------------------------------------

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -5,7 +5,7 @@ from httpx import AsyncClient
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dashboard import _league_percentile
+from app.dashboard import _league_percentile, _strategy_stats
 from app.models import (
     League,
     LeagueMembership,
@@ -36,6 +36,24 @@ async def _create_match(client: AsyncClient, opponent_id, best_of: int = 5) -> d
     )
     assert response.status_code == 201
     return response.json()
+
+
+def test_strategy_stats_glicko2_returns_rd_and_volatility_tiles():
+    # ``strategy_key`` arrives as a raw ``str`` off ``RatingStrategy.key`` and is
+    # parsed to the closed enum at the boundary — a recognised ``glicko2`` key
+    # yields the RD + Volatility tiles.
+    stats = _strategy_stats("glicko2", {"rd": 200.0, "volatility": 0.06})
+    assert [(s.label, s.value) for s in stats] == [
+        ("RD", "200"),
+        ("Volatility", "0.060"),
+    ]
+
+
+def test_strategy_stats_unknown_key_returns_no_tiles():
+    # An unrecognised key parses to ``None`` at the boundary and yields no
+    # strategy tiles, rather than silently missing an ``==`` comparison.
+    assert _strategy_stats("elo", {"rd": 200.0, "volatility": 0.06}) == []
+    assert _strategy_stats("", {}) == []
 
 
 async def test_dashboard_requires_a_session(api_client: AsyncClient):

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -489,6 +489,7 @@ async def _seed_rated_peers(db_session: AsyncSession) -> League:
             UserLeagueRating(
                 league_id=default_league.id,
                 user_id=peer.id,
+                rating_strategy_id=default_league.rating_strategy_id,
                 rating_value=value,
                 rating_state={"rating": value, "rd": 200.0, "volatility": 0.06},
             )

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -9,6 +9,7 @@ from rq import Queue
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
+from sqlalchemy.sql.base import ExecutableOption
 
 from app import matches as matches_mod
 from app.match_voiding import void_match
@@ -1084,9 +1085,15 @@ def _install_scoring_load_barrier(
         *,
         lock: bool = False,
         nowait: bool = False,
+        options: tuple[ExecutableOption, ...] | None = None,
     ) -> Match:
         result = await real_loader(
-            db, target_id, current_user_id, lock=lock, nowait=nowait
+            db,
+            target_id,
+            current_user_id,
+            lock=lock,
+            nowait=nowait,
+            options=options,
         )
         if not nowait:
             loaded.set()

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -337,6 +337,7 @@ async def test_search_includes_rating_for_default_league(
         UserLeagueRating(
             league_id=league.id,
             user_id=rival.id,
+            rating_strategy_id=league.rating_strategy_id,
             rating_value=1750.0,
             rating_state={"rating": 1750.0, "rd": 200.0, "volatility": 0.06},
         )
@@ -409,6 +410,7 @@ async def _rate(
         UserLeagueRating(
             league_id=league.id,
             user_id=user.id,
+            rating_strategy_id=league.rating_strategy_id,
             rating_value=rating_value,
         )
     )
@@ -593,11 +595,13 @@ async def test_list_players_sorts_by_rating_descending_with_nulls_last(
             UserLeagueRating(
                 league_id=league.id,
                 user_id=high.id,
+                rating_strategy_id=league.rating_strategy_id,
                 rating_value=2000.0,
             ),
             UserLeagueRating(
                 league_id=league.id,
                 user_id=low.id,
+                rating_strategy_id=league.rating_strategy_id,
                 rating_value=1500.0,
             ),
         ]

--- a/api/tests/test_rating_recompute.py
+++ b/api/tests/test_rating_recompute.py
@@ -25,9 +25,14 @@ from app.models import (
     User,
     UserLeagueRating,
 )
+from app.ratings import RatingStrategyMismatchError
 from app.ratings import jobs as ratings_jobs
 from app.ratings.base import state_rating_value
-from app.ratings.recompute import _league_lock_key, recompute_league_ratings
+from app.ratings.recompute import (
+    _league_lock_key,
+    _reset_users_to_initial_state,
+    recompute_league_ratings,
+)
 from app.ratings.registry import get_calculator
 from tests._helpers import make_user
 
@@ -1297,6 +1302,7 @@ async def _seed_manual_hand_set_rating(
         UserLeagueRating(
             league_id=league.id,
             user_id=me.id,
+            rating_strategy_id=strategy.id,
             rating_value=_MANUAL_RATING,
             rating_state=dict(_MANUAL_STATE),
         )
@@ -1429,3 +1435,136 @@ async def test_recompute_after_merge_manual_strategy_empty_timeline_preserved(
     assert rating.rating_value is not None
     assert rating.rating_value == _MANUAL_RATING
     assert rating.rating_state == _MANUAL_STATE
+
+
+# ----- strategy-snapshot mismatch guard (issue #184) ----------------------
+
+
+async def _make_second_automatic_strategy(db: AsyncSession) -> RatingStrategy:
+    """A second ``is_automatic`` strategy with its OWN state shape, distinct from
+    the seeded glicko2. Only glicko2 has a registered calculator, so this strategy
+    is never the league's *live* calculator — it stands in as the *old* strategy a
+    ``user_league_ratings`` row was snapshotted under, whose ``rating_state`` is in
+    a shape the current (glicko2) strategy would misread. That an automatic->
+    automatic difference (not a manual one) is what trips the guard is the point:
+    a manual switch would freeze the row before the rating hook (see #184)."""
+    strategy = RatingStrategy(
+        key="glicko2_experimental",
+        name="Experimental (test only)",
+        description="Second automatic strategy with an incompatible state shape.",
+        state_schema={
+            "type": "object",
+            "required": ["score"],
+            "properties": {"score": {"type": "number"}},
+            "additionalProperties": False,
+        },
+        initial_state={"score": 1000.0},
+        initial_rating_value=1000.0,
+        is_automatic=True,
+    )
+    db.add(strategy)
+    await db.commit()
+    await db.refresh(strategy)
+    return strategy
+
+
+async def test_recompute_refuses_row_snapshotted_under_a_different_strategy(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """A rating row snapshotted under a *different* automatic strategy than its
+    league now runs must make the next recompute raise
+    ``RatingStrategyMismatchError`` — never silently overwrite the row and leave
+    its snapshot lying (issue #184).
+
+    The league runs glicko2 (the one strategy with a calculator); the rows carry
+    a snapshot of a second automatic strategy whose ``rating_state`` shape glicko2
+    cannot interpret. The guard fires before the overwrite."""
+    league = await get_default_league(db_session)
+    glicko2 = rating_strategies["glicko2"]
+    other = await _make_second_automatic_strategy(db_session)
+    assert league.rating_strategy_id == glicko2.id
+
+    winner = await make_user(db_session, "mismatch-w")
+    loser = await make_user(db_session, "mismatch-l")
+    # Snapshot both rows under the OTHER strategy — as if the league switched
+    # from it to glicko2 after these rows were written.
+    await _seed_rating(db_session, league, winner.id, other)
+    await _seed_rating(db_session, league, loser.id, other)
+    await _build_completed_match(
+        db_session, league, winner, loser, datetime(2026, 5, 1, tzinfo=UTC)
+    )
+
+    with pytest.raises(RatingStrategyMismatchError) as exc_info:
+        await recompute_league_ratings(db_session, league.id, {winner.id})
+
+    err = exc_info.value
+    assert err.league_id == league.id
+    assert err.user_id in {winner.id, loser.id}
+    assert err.row_strategy_id == other.id
+    assert err.league_strategy_id == glicko2.id
+
+
+async def test_recompute_freshly_seeded_row_does_not_raise(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """A row this recompute *creates* is stamped with the league's current
+    strategy, so it can never mismatch — the guard must not fire on it (#184,
+    subtlety a). Neither player has a pre-existing rating row here."""
+    league = await get_default_league(db_session)
+    glicko2 = rating_strategies["glicko2"]
+    # Prove there's a second automatic strategy around; it just isn't snapshotted
+    # on any row, so nothing mismatches.
+    await _make_second_automatic_strategy(db_session)
+
+    winner = await make_user(db_session, "fresh-w")
+    loser = await make_user(db_session, "fresh-l")
+    await _build_completed_match(
+        db_session, league, winner, loser, datetime(2026, 5, 1, tzinfo=UTC)
+    )
+
+    await recompute_league_ratings(db_session, league.id, {winner.id})
+    await db_session.commit()
+
+    ratings = (
+        (
+            await db_session.execute(
+                select(UserLeagueRating).where(
+                    UserLeagueRating.user_id.in_([winner.id, loser.id])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(ratings) == 2
+    assert {r.rating_strategy_id for r in ratings} == {glicko2.id}
+
+
+async def test_reset_to_initial_state_heals_and_restamps_a_mismatched_row(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """``_reset_users_to_initial_state`` is the one write that legitimately heals
+    a mismatched row (#184, DECISION 4): it overwrites ``rating_state`` from the
+    current strategy's ``initial_state`` AND re-stamps ``rating_strategy_id`` to
+    the current strategy — never raising."""
+    league = await get_default_league(db_session)
+    glicko2 = rating_strategies["glicko2"]
+    other = await _make_second_automatic_strategy(db_session)
+
+    me = await make_user(db_session, "reset-me")
+    await _seed_rating(db_session, league, me.id, other)
+
+    await _reset_users_to_initial_state(db_session, league.id, {me.id}, glicko2)
+    await db_session.commit()
+
+    rating = (
+        await db_session.execute(
+            select(UserLeagueRating).where(UserLeagueRating.user_id == me.id)
+        )
+    ).scalar_one()
+    assert rating.rating_strategy_id == glicko2.id
+    assert rating.rating_state == glicko2.initial_state
+    assert rating.rating_value == glicko2.initial_rating_value

--- a/api/tests/test_rating_recompute.py
+++ b/api/tests/test_rating_recompute.py
@@ -1705,3 +1705,175 @@ async def test_reset_to_initial_state_heals_and_restamps_a_mismatched_row(
     assert rating.rating_strategy_id == glicko2.id
     assert rating.rating_state == glicko2.initial_state
     assert rating.rating_value == glicko2.initial_rating_value
+
+
+async def test_recompute_ignores_seed_row_written_under_a_superseded_strategy(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """A ``rating_history`` seed row written under a *superseded* strategy must
+    NOT be selected as the replay's starting state (issue #184, the seed side of
+    the same guard).
+
+    The hole this closes: a league switches from automatic strategy A to
+    automatic strategy B. ``_reset_users_to_initial_state`` heals the user's
+    ``user_league_ratings`` row (re-stamps it to B, overwrites the state), so the
+    #184 snapshot guard on THAT row will not fire. But the user's older history
+    rows, written under A, survive with A-shaped ``rating_state``. Without a
+    strategy filter on the seed query, ``_seed_states`` would select that
+    A-shaped row and feed it to B's calculator — a ``KeyError`` here (A's
+    ``{"score": ...}`` shape has no ``"rating"`` key), or silent corruption if
+    the shapes' keys overlapped.
+
+    Setup mirrors that post-switch state:
+      * league runs glicko2 (B, the one strategy with a calculator);
+      * ``me``'s ``user_league_ratings`` row is already stamped B with B-shaped
+        state (what the heal leaves behind), so the row-snapshot guard is quiet;
+      * ``me``'s only pre-match history is an ``initial`` row stamped A with
+        A-shaped ``{"score": 1000.0}`` state, dated before the match;
+      * a completed rated singles match ``me`` beats ``opp`` triggers a recompute.
+
+    The replay must seed ``me`` from B's ``initial_state``, not the stale A-shaped
+    row: no ``KeyError``, and ``me``'s produced state is B-shaped. Pre-fix the
+    A-shaped row is selected and the recompute raises ``KeyError``."""
+    league = await get_default_league(db_session)
+    glicko2 = rating_strategies["glicko2"]
+    other = await _make_second_automatic_strategy(db_session)
+    assert league.rating_strategy_id == glicko2.id
+    initial_value = glicko2.initial_rating_value
+
+    me = await make_user(db_session, "superseded-me")
+    opp = await make_user(db_session, "superseded-opp")
+    # Both live rating rows are already stamped under the CURRENT strategy (B) —
+    # ``me``'s is exactly the row ``_reset_users_to_initial_state`` heals to after
+    # a switch, so the #184 row-snapshot guard stays quiet and the seed side is
+    # what's under test.
+    await _seed_rating(db_session, league, me.id, glicko2)
+    await _seed_rating(db_session, league, opp.id, glicko2)
+
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    # ``me``'s only pre-match history: an ``initial`` row written under the OLD
+    # strategy A, holding A-shaped state glicko2 cannot read. Dated before the
+    # match so it precedes ``me``'s cutoff and WOULD qualify as a seed but for the
+    # strategy filter.
+    stale_state = {"score": 1000.0}
+    assert "rating" not in stale_state  # glicko2 would KeyError on this shape.
+    db_session.add(
+        RatingHistory(
+            league_id=league.id,
+            user_id=me.id,
+            match_id=None,
+            rating_strategy_id=other.id,
+            rating_value=1000.0,
+            rating_state=dict(stale_state),
+            previous_rating_value=None,
+            source=RatingHistorySource.initial,
+            created_at=base - timedelta(days=1),
+        )
+    )
+    await db_session.commit()
+
+    match = await _build_completed_match(db_session, league, me, opp, base)
+
+    # Must not raise KeyError: the A-shaped row is filtered out, ``me`` seeds from
+    # glicko2's initial state.
+    await recompute_league_ratings(db_session, league.id, {me.id})
+    await db_session.commit()
+
+    me_match_row = (
+        await db_session.execute(
+            select(RatingHistory).where(
+                RatingHistory.match_id == match.id,
+                RatingHistory.user_id == me.id,
+            )
+        )
+    ).scalar_one()
+    # The replay seeded ``me`` from B's initial (1500), NOT the stale A row (1000).
+    assert me_match_row.previous_rating_value == initial_value
+    # ``me``'s produced state is B-shaped (glicko2 keys), never A-shaped.
+    assert set(me_match_row.rating_state) == {"rating", "rd", "volatility"}
+    assert "score" not in me_match_row.rating_state
+    assert me_match_row.rating_strategy_id == glicko2.id
+
+    # ``me`` won, so the healed live row moved above the glicko2 initial and stays
+    # stamped under the current strategy.
+    me_rating = (
+        await db_session.execute(
+            select(UserLeagueRating).where(UserLeagueRating.user_id == me.id)
+        )
+    ).scalar_one()
+    assert me_rating.rating_strategy_id == glicko2.id
+    assert me_rating.rating_value is not None and me_rating.rating_value > initial_value
+
+    # The superseded-strategy row is left in place untouched — an audit record,
+    # simply never selectable as a seed under a different strategy.
+    stale_row = (
+        await db_session.execute(
+            select(RatingHistory).where(
+                RatingHistory.user_id == me.id,
+                RatingHistory.source == RatingHistorySource.initial,
+            )
+        )
+    ).scalar_one()
+    assert stale_row.rating_strategy_id == other.id
+    assert stale_row.rating_state == stale_state
+
+
+async def test_recompute_seeds_from_same_strategy_history_row(
+    db_session: AsyncSession,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """Regression net for the seed strategy filter: the ORDINARY same-strategy
+    case must still seed from history. A user with a pre-window history row
+    written under the league's CURRENT strategy seeds from that row, not from the
+    strategy initial — the filter added for #184 must not break normal seeding.
+
+    ``opp`` carries a pre-window glicko2 row at 1550 (distinct from the 1500
+    initial so the seed source is observable), then ``me`` beats ``opp`` in the
+    window. The recompute must seed ``opp`` from 1550."""
+    league = await get_default_league(db_session)
+    strategy = rating_strategies["glicko2"]
+    me = await make_user(db_session, "same-me")
+    opp = await make_user(db_session, "same-opp")
+    later_opp = await make_user(db_session, "same-later-opp")
+    for user in (me, opp, later_opp):
+        await _seed_rating(db_session, league, user.id, strategy)
+
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    pre_match = await _build_completed_match(
+        db_session, league, opp, later_opp, base - timedelta(days=30)
+    )
+    db_session.add(
+        RatingHistory(
+            league_id=league.id,
+            user_id=opp.id,
+            match_id=pre_match.id,
+            rating_strategy_id=strategy.id,
+            rating_value=1550.0,
+            rating_state={"rating": 1550.0, "rd": 300.0, "volatility": 0.06},
+            source=RatingHistorySource.match,
+            previous_rating_value=1500.0,
+        )
+    )
+    await db_session.commit()
+    await db_session.execute(
+        text("UPDATE rating_history SET created_at = :ts WHERE match_id = :id"),
+        {"ts": base - timedelta(days=30), "id": pre_match.id},
+    )
+    await db_session.commit()
+
+    in_window = await _build_completed_match(db_session, league, me, opp, base)
+
+    await recompute_league_ratings(db_session, league.id, {me.id})
+    await db_session.commit()
+
+    opp_row = (
+        await db_session.execute(
+            select(RatingHistory).where(
+                RatingHistory.match_id == in_window.id,
+                RatingHistory.user_id == opp.id,
+            )
+        )
+    ).scalar_one()
+    # Seeded from the same-strategy history row (1550), not the strategy initial.
+    assert opp_row.previous_rating_value == 1550.0

--- a/api/tests/test_rating_recompute.py
+++ b/api/tests/test_rating_recompute.py
@@ -1081,6 +1081,143 @@ async def test_recompute_after_merge_rebuilds_each_league_independently(
     assert b_match_ids == {match_b.id}
 
 
+# ----- per-league commit in the after-merge job (issue #248) --------------
+
+
+async def _two_league_setup(
+    db_session: AsyncSession,
+    strategy: RatingStrategy,
+) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID]:
+    """Stand up a user with a rated singles win in each of two leagues, plus a
+    rating row in both (so ``_recompute_after_merge``'s league discovery reaches
+    each). Returns plain ids — ``(user_id, first_processed_id,
+    second_processed_id)`` — sorted the way the job walks ``sorted(league_ids)``,
+    so the caller knows which league the loop reaches first. Ids (not ORM
+    objects) so a later ``expire_all`` can't trigger a sync lazy-load."""
+    league_a = await get_default_league(db_session)
+    league_b = League(
+        name="Second League",
+        description="A second glicko-2 league.",
+        visibility=LeagueVisibility.public,
+        is_default=False,
+        rating_strategy_id=strategy.id,
+    )
+    db_session.add(league_b)
+    await db_session.commit()
+    await db_session.refresh(league_b)
+
+    me = await make_user(db_session, "merged-multi")
+    opp_a = await make_user(db_session, "rival-a")
+    opp_b = await make_user(db_session, "rival-b")
+    await _seed_rating(db_session, league_a, me.id, strategy)
+    await _seed_rating(db_session, league_a, opp_a.id, strategy)
+    await _seed_rating(db_session, league_b, me.id, strategy)
+    await _seed_rating(db_session, league_b, opp_b.id, strategy)
+
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    # A win in each league, so a committed recompute moves the rating above the
+    # 1500 initial and a rolled-back one leaves it exactly at the seeded initial.
+    await _build_completed_match(db_session, league_a, me, opp_a, base)
+    await _build_completed_match(db_session, league_b, me, opp_b, base)
+
+    # The job processes leagues in ``sorted(league_ids)`` order.
+    first_id, second_id = sorted((league_a.id, league_b.id))
+    return me.id, first_id, second_id
+
+
+async def _rating_value(
+    db_session: AsyncSession, user_id: uuid.UUID, league_id: uuid.UUID
+) -> float | None:
+    row = (
+        await db_session.execute(
+            select(UserLeagueRating).where(
+                UserLeagueRating.user_id == user_id,
+                UserLeagueRating.league_id == league_id,
+            )
+        )
+    ).scalar_one()
+    return row.rating_value
+
+
+async def test_recompute_after_merge_commits_each_league_before_the_next(
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """Issue #248: the after-merge job commits each league independently, so a
+    league that raises mid-loop does NOT take its already-processed predecessors
+    down with it.
+
+    The user has a rated win in two leagues. We wrap ``recompute_league_ratings``
+    so the SECOND call (the second league in ``sorted`` order) runs its real
+    recompute and then raises — the failure lands after the work but before the
+    job's per-league commit. The job must propagate the error, yet the FIRST
+    league's recompute must already be committed while the second is rolled back.
+
+    Pre-chore (a single commit after the whole loop) this fails: the raise
+    unwinds the ``async with`` and rolls back BOTH leagues, so the first league's
+    rating is left at the seeded initial too."""
+    strategy = rating_strategies["glicko2"]
+    me_id, first_id, second_id = await _two_league_setup(db_session, strategy)
+
+    real_recompute = ratings_jobs.recompute_league_ratings
+    calls = {"n": 0}
+
+    async def flaky(
+        session: AsyncSession,
+        league_id: uuid.UUID,
+        seed_user_ids: set[uuid.UUID],
+    ) -> None:
+        calls["n"] += 1
+        # Do the real work in the session, then blow up on the 2nd league only —
+        # after its writes are flushed but before the job commits them.
+        await real_recompute(session, league_id, seed_user_ids)
+        if calls["n"] == 2:
+            raise RuntimeError("boom recomputing the second league")
+
+    monkeypatch.setattr(ratings_jobs, "recompute_league_ratings", flaky)
+    # Point the job's own engine (opened via ``get_engine()``) at the test
+    # container so its committed work is visible to ``db_session``.
+    monkeypatch.setattr(ratings_jobs, "get_engine", lambda: engine)
+
+    with pytest.raises(RuntimeError, match="second league"):
+        await ratings_jobs._recompute_after_merge(me_id)
+
+    assert calls["n"] == 2
+
+    # Fresh read: the first league committed (rating moved above initial); the
+    # second rolled back with the raising transaction (still at the seeded 1500).
+    db_session.expire_all()
+    first_value = await _rating_value(db_session, me_id, first_id)
+    second_value = await _rating_value(db_session, me_id, second_id)
+    assert first_value is not None and first_value > 1500.0
+    assert second_value == 1500.0
+
+
+async def test_recompute_after_merge_settles_every_league_on_the_happy_path(
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """When nothing raises, the per-league-commit job still settles every league:
+    the real ``_recompute_after_merge`` over two leagues commits both. Guards the
+    per-league commit boundary against a regression that drops later leaders."""
+    strategy = rating_strategies["glicko2"]
+    me_id, first_id, second_id = await _two_league_setup(db_session, strategy)
+
+    monkeypatch.setattr(ratings_jobs, "get_engine", lambda: engine)
+    await ratings_jobs._recompute_after_merge(me_id)
+
+    db_session.expire_all()
+    first_value = await _rating_value(db_session, me_id, first_id)
+    second_value = await _rating_value(db_session, me_id, second_id)
+    # A win in each league → both ratings moved above the initial and persisted.
+    assert first_value is not None and first_value > 1500.0
+    assert second_value is not None and second_value > 1500.0
+
+
 # ----- empty-timeline reset (ADR-0013) ------------------------------------
 
 # A rating clearly distinct from the strategy initial (1500), so a reset to the

--- a/api/tests/test_ratings.py
+++ b/api/tests/test_ratings.py
@@ -21,10 +21,12 @@ from app.models import (
     RatingHistory,
     RatingHistorySource,
     RatingStrategy,
+    User,
     UserLeagueRating,
 )
 from app.ratings import (
     STRATEGIES,
+    RatingStrategyMismatchError,
     get_calculator,
     state_rating_value,
     validate_state,
@@ -172,6 +174,156 @@ async def test_doubles_match_rating_update_raises_not_implemented(
         .all()
     )
     assert rows == []
+
+
+# ----- hook: strategy-snapshot mismatch guard (issue #184) -----------------
+
+
+async def _make_second_automatic_strategy(db_session: AsyncSession) -> RatingStrategy:
+    """A second ``is_automatic`` strategy with its own incompatible state shape.
+    Only glicko2 has a registered calculator, so this stands in as the *old*
+    strategy a ``user_league_ratings`` row was snapshotted under; the league still
+    runs glicko2 (the live calculator), whose schema the old state would violate.
+    The guard fires on this automatic->automatic difference (see #184)."""
+    strategy = RatingStrategy(
+        key="glicko2_experimental",
+        name="Experimental (test only)",
+        description="Second automatic strategy with an incompatible state shape.",
+        state_schema={
+            "type": "object",
+            "required": ["score"],
+            "properties": {"score": {"type": "number"}},
+            "additionalProperties": False,
+        },
+        initial_state={"score": 1000.0},
+        initial_rating_value=1000.0,
+        is_automatic=True,
+    )
+    db_session.add(strategy)
+    await db_session.commit()
+    await db_session.refresh(strategy)
+    return strategy
+
+
+async def _build_completed_singles_match(
+    db_session: AsyncSession,
+    league: League,
+    winner: User,
+    loser: User,
+) -> Match:
+    settings = MatchSettings(team_size=1, best_of=1, affects_rating=True)
+    match = Match(
+        match_settings=settings,
+        league=league,
+        created_by_user_id=winner.id,
+        status=MatchStatus.completed,
+    )
+    side1 = MatchSide(match=match, side_number=1, won=True, score=1)
+    side1.players.append(MatchSidePlayer(match=match, user=winner))
+    side2 = MatchSide(match=match, side_number=2, won=False, score=0)
+    side2.players.append(MatchSidePlayer(match=match, user=loser))
+    db_session.add(match)
+    await db_session.commit()
+    return match
+
+
+async def test_rating_hook_refuses_row_snapshotted_under_a_different_strategy(
+    db_session: AsyncSession,
+    default_league: League,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """When a player's rating row was snapshotted under a *different* automatic
+    strategy than the league now runs, the live rating hook must raise
+    ``RatingStrategyMismatchError`` — not a jsonschema ``ValidationError``, and
+    not a silent write reinterpreting the old state under the new schema (#184)."""
+    glicko2 = rating_strategies["glicko2"]
+    other = await _make_second_automatic_strategy(db_session)
+    assert default_league.rating_strategy_id == glicko2.id
+
+    winner = await make_user(db_session, "hook-mismatch-w")
+    loser = await make_user(db_session, "hook-mismatch-l")
+    # Snapshot both rows under the OTHER strategy — a league that switched away
+    # from it to glicko2 after these rows were written.
+    for user in (winner, loser):
+        db_session.add(
+            UserLeagueRating.seed_for_strategy(default_league.id, user.id, other)
+        )
+    await db_session.commit()
+
+    match = await _build_completed_singles_match(
+        db_session, default_league, winner, loser
+    )
+    loaded = await _load_match(db_session, match.id)
+    assert loaded is not None
+
+    with pytest.raises(RatingStrategyMismatchError) as exc_info:
+        await _apply_rating_update(db_session, loaded)
+
+    err = exc_info.value
+    assert err.league_id == default_league.id
+    assert err.user_id in {winner.id, loser.id}
+    assert err.row_strategy_id == other.id
+    assert err.league_strategy_id == glicko2.id
+
+    # Nothing was written — the guard fires before any history row.
+    rows = (
+        (
+            await db_session.execute(
+                select(RatingHistory).where(RatingHistory.match_id == match.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+async def test_rating_hook_freshly_seeded_row_does_not_raise(
+    db_session: AsyncSession,
+    default_league: League,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """A row this hook *creates* is stamped with the league's current strategy,
+    so it can never mismatch — the guard must not fire on it (#184, subtlety a).
+    Neither player has a pre-existing rating row here, so both are freshly seeded
+    under glicko2 and the update applies normally."""
+    glicko2 = rating_strategies["glicko2"]
+    await _make_second_automatic_strategy(db_session)
+
+    winner = await make_user(db_session, "hook-fresh-w")
+    loser = await make_user(db_session, "hook-fresh-l")
+    match = await _build_completed_singles_match(
+        db_session, default_league, winner, loser
+    )
+    loaded = await _load_match(db_session, match.id)
+    assert loaded is not None
+
+    await _apply_rating_update(db_session, loaded)
+    await db_session.commit()
+
+    ratings = (
+        (
+            await db_session.execute(
+                select(UserLeagueRating).where(
+                    UserLeagueRating.user_id.in_([winner.id, loser.id])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(ratings) == 2
+    assert {r.rating_strategy_id for r in ratings} == {glicko2.id}
+    rows = (
+        (
+            await db_session.execute(
+                select(RatingHistory).where(RatingHistory.match_id == match.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
 
 
 # ----- hook: end-to-end through the score endpoint -------------------------

--- a/api/tests/test_ratings.py
+++ b/api/tests/test_ratings.py
@@ -6,11 +6,16 @@ import uuid
 import jsonschema
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import event, select
+from sqlalchemy.exc import IntegrityError, MissingGreenlet
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
-from app.matches import _apply_rating_update, _load_match
+from app.matches import (
+    _apply_rating_update,
+    _load_match,
+    match_eager_options,
+    match_rating_eager_options,
+)
 from app.models import (
     League,
     Match,
@@ -704,6 +709,71 @@ async def test_rating_history_rejects_duplicate_match_user_row(
     db_session.add(dup)
     with pytest.raises(IntegrityError):
         await db_session.flush()
+
+
+async def test_match_rating_eager_options_loads_the_strategy_write_paths_need(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    default_league: League,
+    engine: AsyncEngine,
+):
+    """Guards the explicit ``League.rating_strategy`` load on the score-write
+    finalize paths (issue #182). The shared ``match_eager_options()`` read chain
+    deliberately does NOT eager-load the strategy — only ``_apply_rating_update``
+    reads it — so the two finalize handlers load it via
+    ``match_rating_eager_options()``. Under async SQLAlchemy a lazy access on the
+    unloaded ``league.rating_strategy`` raises ``MissingGreenlet`` at runtime, a
+    production 500 that mypy and a naive test can't catch.
+
+    THIS TEST OPENS ITS OWN FRESH ``async_sessionmaker(engine)`` SESSION ON
+    PURPOSE. The ``api_client`` shares the per-test ``db_session`` (whose
+    ``expire_on_commit=False`` keeps loaded relationships resident), so match
+    creation's ``resolve_league`` already populates ``league.rating_strategy`` in
+    that session's identity map — masking the bug entirely. A real HTTP request
+    gets a fresh session with an empty identity map, which is what this fresh
+    sessionmaker reproduces. Without it, dropping the load from
+    ``match_rating_eager_options()`` would leave every test green while score
+    submission 500s in production."""
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        body = await _score_to_completion(api_client, opp_client, opp.id)
+    match_id = uuid.UUID(body["id"])
+
+    fresh_session = async_sessionmaker(engine)  # default: empty identity map
+
+    # (i) The shared read chain must NOT emit a rating_strategies SELECT; the
+    # write chain must emit exactly one.
+    async def strategy_selects(options: object) -> int:
+        seen: list[str] = []
+
+        def before(conn: object, cursor: object, statement: str, *args: object) -> None:
+            if "rating_strategies" in statement:
+                seen.append(statement)
+
+        event.listen(engine.sync_engine, "before_cursor_execute", before)
+        try:
+            async with fresh_session() as s:
+                await _load_match(s, match_id, options=options)  # type: ignore[arg-type]
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", before)
+        return len(seen)
+
+    assert await strategy_selects(match_eager_options()) == 0
+    assert await strategy_selects(match_rating_eager_options()) == 1
+
+    # (ii) The read chain leaves the strategy unloaded → lazy access blows up.
+    async with fresh_session() as s:
+        read_only = await _load_match(s, match_id, options=match_eager_options())
+        assert read_only is not None
+        with pytest.raises(MissingGreenlet):
+            _ = read_only.league.rating_strategy.is_automatic
+
+    # (ii) The write chain has it loaded → _apply_rating_update runs clean.
+    async with fresh_session() as s:
+        ready = await _load_match(s, match_id, options=match_rating_eager_options())
+        assert ready is not None
+        assert ready.league.rating_strategy.is_automatic is True
+        await _apply_rating_update(s, ready)  # idempotent no-op; touches strategy
 
 
 async def test_rating_history_allows_many_null_match_rows_per_user(


### PR DESCRIPTION
Works through eight backend housekeeping tickets. All changes are `api/`-only; the generated OpenAPI document is byte-identical to `main`'s (44 routes, `diff` clean), so `schema.d.ts` and `Types.swift` cannot drift.

Closes #179
Closes #182
Closes #184
Closes #185
Closes #238
Closes #248

## Two tickets were already fixed — they need closing by hand, not code

Both were fixed as collateral in earlier PRs that used `Closes #a, #b, ...`, which closes only the *first* issue. I verified each against `main` @ `f0a3b8b` and left them open because closing issues wasn't authorized for this run:

- **#235** (`matches_moved` under-reports) — fixed by `b00c1b9` ("…merge count (#809)"). `matches_moved += dropped_side_players.rowcount` is present, and it's proven on the exact collision branch the issue describes: `test_merge_self_play_drops_orphaned_match_side` asserts `matches_moved == 1` for the unrated ephemeral-vs-verified same-match case, with a sibling test asserting `== 0` for the rated (voided) case.
- **#242** (test `_maybe_merge_prior_session` edge cases) — fixed by `e122486` ("…add tests issue backlog (#704)"). `test_maybe_merge_prior_session_no_merge_on_unresolvable_cookie` is parametrized over absent/empty/unknown/malformed cookies. The issue's third bullet ("user deleted between issuance and consume") is covered *by equivalence*: a hard-deleted user's session token goes with it via `ON DELETE CASCADE`, so `_find_session_user` returns `None` on the same branch as the `unknown` param.

## What changed

**#179 — a strategy-key typo is now a type error.** `RatingStrategyKey(StrEnum)` is the single definition; the Glicko-2 calculator, the registry, the league seeder, and the dashboard's RD/Volatility branch (a fifth site the issue missed) all route through it. `parse_strategy_key` is the DB→enum boundary, returning `None` for an unrecognised value so behaviour is unchanged (no calculator ⇒ no rating update, no crash). `manual` is in the enum but deliberately absent from the registry — both write paths gate on `is_automatic` first.

**#184 — a rating row snapshots the strategy that wrote it.** `rating_history` already did; the current-rating row was the gap. Adds `rating_strategy_id` NOT NULL FK (ON DELETE RESTRICT) to `user_league_ratings`. **Migration 0006 is edited in place** per the repo's pre-deploy convention; existing rows are dropped, not backfilled — **any preview stack must come up with a fresh volume (`down -v`)**. On a mismatch the write *refuses*, raising `RatingStrategyMismatchError`, rather than resetting to `initial_state` (a reset would silently zero a rating). Two deliberate exceptions: a row created in the same call can't mismatch, and `_reset_users_to_initial_state` heals + re-stamps, because it overwrites state wholesale and never reads the old state.

**#248 — a failing league no longer rolls back the leagues that settled.** The recompute module's docstring *forbade* this change ("the caller must not commit mid-loop across multiple leagues"). That warning doesn't hold up: every statement in `recompute_league_ratings`, `_seed_states`, and `_reset_users_to_initial_state` is `league_id`-scoped, so no league reads another's state. Releasing an earlier advisory lock before acquiring the next is harmless, and holding exactly one `pg_advisory_xact_lock` at a time makes deadlock *impossible* rather than merely ordered-away. Docstring rewritten to state the new contract.

**#238 — a merged guest keeps their roles.** The issue says roles are cascade-dropped; since the guest row is now tombstoned rather than deleted, they were being *explicitly* deleted. Re-pointed with the same `NOT EXISTS` idiom the neighbouring re-points use, guarded on the composite `(user_id, role_id)` PK.

**#185 / #182 — the rating hook, and what every match read pays for.** `_apply_rating_update` (which lives in `result_acceptance.py`, not `matches.py` as #185 claims) splits into three named helpers, behaviour-preserving. Then `selectinload(League.rating_strategy)` comes out of the shared `match_eager_options()`, so `/v1/matches`, `/v1/matches/{id}` and `/v1/dashboard` stop fetching a strategy row they never read; the two finalize handlers load it explicitly via `match_rating_eager_options()`.

### The eager-load trap, and why a green suite hid it

`_apply_rating_update` reads `match.league.rating_strategy`. Under async SQLAlchemy a lazy access on an unloaded relationship raises `MissingGreenlet` — a production 500. **The existing rating test passes even with the explicit load removed**, because `api_client` shares the per-test `db_session` (`expire_on_commit=False`) and `resolve_league` has already warmed the identity map. So this adds `test_match_rating_eager_options_loads_the_strategy_write_paths_need`, which opens its own session (empty identity map, like a real request) and asserts the read chain emits zero `rating_strategies` selects and raises `MissingGreenlet` on access, while the rating chain emits exactly one and runs clean.

## Verification

`614 passed`, `mypy` clean (83 files), `ruff` clean. Each of the seven code chores was implemented by a domain-expert subagent and then independently re-verified by a separate agent that re-ran the tests, reproduced the red, and adversarially checked the claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01472H1itvGhChRZagFPJMMY