### PR TITLE
Fix #840: one lock-aware save path so the cursor never lands on a locked slot

### DIFF
--- a/ios/Fortymm/MatchFlow/ScoreEntryView.swift
+++ b/ios/Fortymm/MatchFlow/ScoreEntryView.swift
@@ -311,11 +311,11 @@ struct ScoreEntryView: View {
         } else if editing {
             HStack(spacing: 10) {
                 clearButton
-                PrimaryAction(title: "Save changes", filled: currentValid, enabled: currentValid, action: saveEdit)
+                PrimaryAction(title: "Save changes", filled: currentValid, enabled: currentValid, action: saveActiveGame)
             }
         } else {
             // Neutral "save & next" — raised dark surface, not the hero gradient.
-            Button(action: saveNext) {
+            Button(action: saveActiveGame) {
                 HStack(spacing: 8) {
                     Text("Save game & next").font(FMFont.ui(16, weight: .bold))
                     Image(systemName: "arrow.right").font(.system(size: 16, weight: .bold))
@@ -434,12 +434,21 @@ struct ScoreEntryView: View {
         DispatchQueue.main.async { focus = .you }
     }
 
-    private func saveNext() {
+    /// Commit the active slot — the single save path shared by both action-row
+    /// buttons ("Save game & next" in live entry, "Save changes" in edit mode).
+    /// It's lock-aware: `nextIncompleteIndex()` skips slots locked past the
+    /// decider, so a save never lands the entry cursor on a locked slot (ADR-0006,
+    /// issue #840). When the board is fully scored/decided it stays put — the
+    /// action row then offers Post rather than advancing into a locked slot.
+    /// Keeping edit and live entry on ONE path is deliberate: their old divergence
+    /// (an edit-only `active = games.count - 1` fallback that ignored the lock) is
+    /// exactly what dropped the cursor onto a locked overrun slot.
+    private func saveActiveGame() {
         guard currentValid else { return }
         // The slot just saved — captured before we advance `active` off it.
         let saved = active
-        // Advance to the next still-incomplete game (wrapping); stay put if the
-        // match is fully scored.
+        // Advance to the next still-incomplete game (wrapping), skipping slots
+        // locked past the decider; stay put if the match is fully scored.
         if let next = nextIncompleteIndex() { active = next }
         editing = false
         // Fire the optimistic scratchpad write for the game we just left; the
@@ -545,21 +554,6 @@ struct ScoreEntryView: View {
         }
         clearLocally(i)
         clearing = nil
-    }
-
-    private func saveEdit() {
-        guard currentValid else { return }
-        // The slot just edited — captured before we move `active` off it.
-        let saved = active
-        editing = false
-        // Return to the first still-incomplete game, else stay on the last.
-        if let firstIncomplete = games.indices.first(where: { $0 != active && !MatchRules.gameComplete(games[$0].points) }) {
-            active = firstIncomplete
-        } else {
-            active = games.count - 1
-        }
-        // Persist the edit to the shared scratchpad (fire-and-forget).
-        fireWrite(for: saved)
     }
 
     // MARK: Per-game scratchpad writes (fire-and-forget)


### PR DESCRIPTION
Fixes #840.

## Problem
iOS score entry had **two divergent "commit the current game" actions**. The edit-mode **"Save changes"** button ran `saveEdit()`, whose next-slot search omitted the `!lockedForEntry` filter and fell back to `active = games.count - 1`. After editing an earlier game into an **overrun** (a completed game past the decider — e.g. Bo5 decided at G4, edit G2 so you clinch at G3, leaving G4 a past-decider overrun and G5 empty+locked), that fallback dropped the entry cursor onto the empty **locked** past-decider slot and raised the keyboard on it — a game the overrun lock exists to prevent. This violates **ADR-0006** ("the entry cursor should never land on a locked slot"). The server's `_enforce_no_overrun` still 422'd the actual write, so the harm was a confusing dead-end, not a bad record.

## Fix
Collapse both action-row buttons onto **one shared `saveActiveGame()`** (the former `saveNext`), which advances via the lock-aware `nextIncompleteIndex()` and **stays put when the board is decided** — the row then offers **Post** instead of advancing into a locked slot. `saveEdit` is deleted. Keeping edit and live entry on one path removes the divergence that let the bug exist; the two paths can no longer drift.

Net **+14/−20** in one file, `ios/Fortymm/MatchFlow/ScoreEntryView.swift`. No API/schema/other-layer surface touched — no OpenAPI/type regen needed.

## Verification
- **Clean-from-scratch** `xcodebuild` simulator build → `** BUILD SUCCEEDED **` (`rm -rf ios/build/sim` first, so not a stale dylib).
- **Executable `swiftc` harness** (iOS has no XCTest target) reproducing the real advance decision over the `#840` repro + regressions: the *old* `saveEdit` advance lands on locked index 4 (the bug); the *new* path stays on the legal slot. Normal-edit and fully-decided cases land on the correct enterable/complete slot; the ADR-0006 invariant `!lockedForEntry(active)` holds in every case.

## Testing notes (iOS Simulator — must-cover)
- **Happy path (the fix):** Bo5 decided at G4 (3–1). Edit G2 so you clinch at G3 (G4 becomes an overrun). Tap "Save changes" → keyboard does **not** raise on the empty locked final slot; "Post result" is present.
- **Regression — normal edit:** part-scored board, edit an earlier game without changing its winner → cursor returns to the first empty game with its keyboard, as before.
- **Regression — edit the deciding game / "Save game & next":** still land on a complete, unlocked slot with Post; live entry advances game-to-game unchanged (both buttons now share that path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)