### PR TITLE
Fix #763: pod resource requests/limits + right-sized UAT api replicas

### DIFF
--- a/deploy/uat/templates/api.yaml
+++ b/deploy/uat/templates/api.yaml
@@ -25,6 +25,13 @@ spec:
           imagePullPolicy: {{ .Values.pullPolicy }}
           # Migrations + seeds run in the migrate Job, not here.
           command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
           envFrom:
             {{- include "fortymm-uat.appEnvFrom" . | nindent 12 }}
           ports:

--- a/deploy/uat/templates/migrate-job.yaml
+++ b/deploy/uat/templates/migrate-job.yaml
@@ -8,8 +8,19 @@ metadata:
   annotations:
     # post-* so the in-chart postgres already exists (a pre-install hook would
     # run before any non-hook resource is created, with no DB to migrate
-    # against). The Job waits for postgres, then migrates + seeds. api/worker
-    # may briefly serve before this finishes on an upgrade — acceptable for UAT.
+    # against). The Job waits for postgres, then migrates + seeds.
+    #
+    # api readiness is deliberately NOT gated on this Job (re: issue #763, "gate
+    # api readiness behind migrations"): redeploy-uat.sh runs
+    # `helm upgrade --install --wait`, and --wait blocks on the api Deployment
+    # going Ready BEFORE it fires post-install hooks. Gating readiness on
+    # migrations would deadlock — api never goes Ready, so --wait never runs this
+    # hook — and the redeploy fails at the 5m timeout. Hence post-hook + ungated.
+    #
+    # api readiness is /v1/readyz (503 on an unreachable DB, since PR #777), but
+    # it only does SELECT 1 — connectivity, not migration completion. So on a
+    # fresh install the api can briefly serve against a reachable-but-unmigrated
+    # schema during this Job's window. Knowingly accepted for single-node UAT.
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
     # Keep the last Job around so its logs are inspectable; only delete the
@@ -40,6 +51,13 @@ spec:
         - name: migrate
           image: {{ include "fortymm-uat.apiImage" . }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
           envFrom:
             {{- include "fortymm-uat.appEnvFrom" . | nindent 12 }}
           command:

--- a/deploy/uat/templates/nginx.yaml
+++ b/deploy/uat/templates/nginx.yaml
@@ -31,6 +31,13 @@ spec:
         - name: nginx
           image: {{ .Values.images.nginx }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
           ports:
             - containerPort: 80
           volumeMounts:

--- a/deploy/uat/templates/postgres.yaml
+++ b/deploy/uat/templates/postgres.yaml
@@ -39,10 +39,10 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 256Mi
+              memory: 512Mi
             limits:
               cpu: 500m
-              memory: 256Mi
+              memory: 512Mi
           env:
             - name: POSTGRES_USER
               value: {{ .Values.postgres.user | quote }}

--- a/deploy/uat/templates/postgres.yaml
+++ b/deploy/uat/templates/postgres.yaml
@@ -34,6 +34,15 @@ spec:
         - name: postgres
           image: {{ .Values.images.postgres }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          # requests==limits → Guaranteed QoS, so the kubelet/kernel evict the
+          # burstable app pods before this data tier under memory pressure (#763).
+          resources:
+            requests:
+              cpu: 500m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
           env:
             - name: POSTGRES_USER
               value: {{ .Values.postgres.user | quote }}

--- a/deploy/uat/templates/redis.yaml
+++ b/deploy/uat/templates/redis.yaml
@@ -23,10 +23,10 @@ spec:
           resources:
             requests:
               cpu: 250m
-              memory: 64Mi
+              memory: 128Mi
             limits:
               cpu: 250m
-              memory: 64Mi
+              memory: 128Mi
           ports:
             - containerPort: 6379
           readinessProbe:

--- a/deploy/uat/templates/redis.yaml
+++ b/deploy/uat/templates/redis.yaml
@@ -18,6 +18,15 @@ spec:
         - name: redis
           image: {{ .Values.images.redis }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          # requests==limits → Guaranteed QoS, so the kubelet/kernel evict the
+          # burstable app pods before this data tier under memory pressure (#763).
+          resources:
+            requests:
+              cpu: 250m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 64Mi
           ports:
             - containerPort: 6379
           readinessProbe:

--- a/deploy/uat/templates/retirement-sweep-cronjob.yaml
+++ b/deploy/uat/templates/retirement-sweep-cronjob.yaml
@@ -36,6 +36,13 @@ spec:
               image: {{ include "fortymm-uat.apiImage" . }}
               imagePullPolicy: {{ .Values.pullPolicy }}
               command: ["python", "-m", "app.retirement_sweep"]
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 1000m
+                  memory: 512Mi
               envFrom:
                 {{- include "fortymm-uat.appEnvFrom" . | nindent 16 }}
               volumeMounts:

--- a/deploy/uat/templates/tailscale.yaml
+++ b/deploy/uat/templates/tailscale.yaml
@@ -86,6 +86,13 @@ spec:
         - name: tailscale
           image: {{ .Values.tailscale.image }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
           env:
             - name: TS_KUBE_SECRET
               value: {{ .Values.tailscale.stateSecret | quote }}

--- a/deploy/uat/templates/web.yaml
+++ b/deploy/uat/templates/web.yaml
@@ -23,6 +23,13 @@ spec:
         - name: web-client
           image: {{ include "fortymm-uat.webImage" . }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
           ports:
             - containerPort: 80
           readinessProbe:

--- a/deploy/uat/templates/worker.yaml
+++ b/deploy/uat/templates/worker.yaml
@@ -19,6 +19,13 @@ spec:
           image: {{ include "fortymm-uat.apiImage" . }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           command: ["rq", "worker", "--url", "{{ .Values.config.REDIS_URL }}", {{ range $i, $q := splitList " " .Values.worker.queues }}{{ if $i }}, {{ end }}{{ $q | quote }}{{ end }}]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 2000m
+              memory: 1Gi
           envFrom:
             {{- include "fortymm-uat.appEnvFrom" . | nindent 12 }}
           volumeMounts:

--- a/deploy/uat/values.yaml
+++ b/deploy/uat/values.yaml
@@ -19,11 +19,14 @@ pullPolicy: IfNotPresent
 # Stateless request-serving tiers scale horizontally with a zero-downtime
 # RollingUpdate. maxUnavailable: 0 keeps full capacity during a rollout (new
 # pods must go Ready before old ones are torn down); maxSurge adds headroom.
+# On a single-node cluster replicas buy no real availability (one failure
+# domain) — 2 replicas + maxSurge 1 is the minimum that still rolls without
+# dropping capacity, at far less memory pressure than a larger pod count.
 api:
-  replicas: 5
+  replicas: 2
   rollingUpdate:
     maxUnavailable: 0
-    maxSurge: 2
+    maxSurge: 1
 web:
   replicas: 2
   rollingUpdate:


### PR DESCRIPTION
Fixes #763 (UAT deploy hardening). Two reliability gaps from a whole-repo review.

## Scope decision (Option A)
The issue's finding #1 headline fix — "gate api readiness behind migrations" — is a **deploy-wedging trap**: `redeploy-uat.sh` runs `helm upgrade --install --wait`, and `--wait` blocks on the api Deployment going Ready *before* it fires the `post-install` migrate hook. Gating readiness on migrations would deadlock (api never Ready → hook never runs → 5m timeout). So this PR **fixes the resources gap (#2)** and **re-documents #1** as a knowingly-accepted UAT tradeoff rather than restructuring the migration ordering. The broader prod-readiness gap is tracked separately in #881.

## Changes (all in `deploy/uat/`)
- **Resource requests/limits on every container.** postgres & redis are `requests==limits` → **Guaranteed QoS**, so the kubelet/kernel evict the burstable app tier before the data tier under memory pressure (the "protect the data tier" ask). App tier (api/worker/web/nginx/migrate/retirement-sweep/tailscale) is Burstable (small request, generous limit; worker gets a 1Gi ceiling for ortools solver spikes).
- **api replicas `5→2`, maxSurge `2→1`.** On a single-node k3d cluster, replicas buy no availability (one failure domain) — only zero-downtime rollout, which 2+1 achieves at far less memory pressure (≤3 api pods mid-rollout, not 7).
- **migrate-job comment rewritten** to name the `helm upgrade --wait` deadlock as *why* readiness isn't gated on migrations (deters a re-file of #763), and to correct the stale "always 200" framing — readiness is `/v1/readyz` since #777, but it checks DB connectivity (`SELECT 1`), not migration completion.

Worst-case summed requests during a rollout: **~1.1 GiB / 1.3 cores**, far under the node's 7.75 GiB / 24 CPU — no Pending-scheduling risk.

## Testing
Infra-only; nothing observable in the UI, so no browser/Simulator QA (per the work order's Testing notes).
- `helm lint deploy/uat` → 0 failed
- `helm template deploy/uat` → renders clean (exit 0); every container carries requests+limits; postgres/redis render QoS **Guaranteed** (verified via PyYAML parse of the rendered output).
- **Not verified here (destructive/shared, left to the operator):** an actual `redeploy-uat` + `kubectl get pod -o jsonpath='{.status.qosClass}'` reading `Guaranteed`, and a rollout with no `OOMKilled`/`Pending` pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6qT8zQ55hi5kyeqKsgZ8W
