### PR TITLE
Cover the 409 score-conflict flow end-to-end (#873)

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -76,7 +76,9 @@ Chrome); `trace: 'on-first-retry'`. In CI: `retries: 2`, `forbidOnly: true`,
 
 Specs live in `tests/*.spec.ts`; page objects in `page-objects/`
 (`*.page.ts`, nested per-page helpers under `page-objects/<page>-page/`, e.g.
-`page-objects/dashboard-page/user-menu.page.ts`). Keep to the patterns already here:
+`page-objects/dashboard-page/user-menu.page.ts`); non-page-object test infra
+(e.g. API-seed helpers that provision state over the real API, no `Page`) in
+`support/*.ts` (e.g. `support/match-api.ts`). Keep to the patterns already here:
 
 - **Page Object Model.** One class per surface exposing named `Locator`s (see
   `landing.page.ts`; `dashboard.page.ts` shows the child-composition variant,

--- a/e2e/page-objects/score-entry.page.ts
+++ b/e2e/page-objects/score-entry.page.ts
@@ -1,0 +1,69 @@
+import { Locator, Page } from '@playwright/test'
+
+/**
+ * The per-game score-entry surface (`/matches/$id/games/$n/scores/edit`) —
+ * scoped to what the 409-conflict spec drives: the two numeric score inputs
+ * (labelled `"<username> score"`), the primary Save button, and the
+ * `ScoreConflictNotice` an out-from-under-you save raises.
+ *
+ * Raw selectors stay here; the spec reads intent-named locators.
+ */
+export class ScoreEntryPage {
+  constructor(private readonly page: Page) {}
+
+  /** Open a game's *edit* screen (an existing score), returning the instance. */
+  static async navigateToEdit(
+    page: Page,
+    matchId: string,
+    gameNumber: number,
+  ): Promise<ScoreEntryPage> {
+    await page.goto(`/matches/${matchId}/games/${gameNumber}/scores/edit`)
+    return new ScoreEntryPage(page)
+  }
+
+  /** A participant's numeric score input, by their username (its accessible
+   * label is `"<username> score"`, see `score-pad-side.tsx`). */
+  scoreInput(username: string): Locator {
+    return this.page.getByLabel(`${username} score`)
+  }
+
+  /** The primary submit button on the edit screen ("Save changes →"). */
+  get saveButton(): Locator {
+    return this.page.getByRole('button', { name: 'Save changes →' })
+  }
+
+  /** The in-page conflict notice raised when this game's save 409'd because a
+   * concurrent participant already committed a different score. Only rendered
+   * on the conflicted game's own edit screen. */
+  get conflictNotice(): Locator {
+    return this.page.getByRole('alert').filter({
+      hasText: 'This game was saved by someone else.',
+    })
+  }
+
+  /** The list-level conflict-review banner that surfaces on the *next* game
+   * after a fire-and-forget save 409'd in the background — it routes back to
+   * the conflicted game rather than showing the notice inline. */
+  conflictReviewBanner(gameNumber: number): Locator {
+    return this.page.getByRole('alert').filter({
+      hasText: `Game ${gameNumber} was saved by someone else.`,
+    })
+  }
+
+  /** "Review game N" — hops back to that game's edit screen (where the in-page
+   * conflict notice lives). */
+  reviewGameButton(gameNumber: number): Locator {
+    return this.page.getByRole('button', { name: `Review game ${gameNumber}` })
+  }
+
+  /** "Replace with my score" — re-fires the save against the now-fresh version,
+   * deliberately overwriting the committed score. */
+  get replaceButton(): Locator {
+    return this.page.getByRole('button', { name: 'Replace with my score' })
+  }
+
+  /** "Keep saved score" — discards the rejected entry, clearing the notice. */
+  get keepSavedButton(): Locator {
+    return this.page.getByRole('button', { name: 'Keep saved score' })
+  }
+}

--- a/e2e/page-objects/score-entry.page.ts
+++ b/e2e/page-objects/score-entry.page.ts
@@ -27,9 +27,10 @@ export class ScoreEntryPage {
     return this.page.getByLabel(`${username} score`)
   }
 
-  /** The primary submit button on the edit screen ("Save changes →"). */
+  /** The primary submit button on the edit screen ("Save changes →"). Matched
+   * loosely so a cosmetic tweak to the arrow doesn't red the test. */
   get saveButton(): Locator {
-    return this.page.getByRole('button', { name: 'Save changes →' })
+    return this.page.getByRole('button', { name: /Save changes/ })
   }
 
   /** The in-page conflict notice raised when this game's save 409'd because a
@@ -60,10 +61,5 @@ export class ScoreEntryPage {
    * deliberately overwriting the committed score. */
   get replaceButton(): Locator {
     return this.page.getByRole('button', { name: 'Replace with my score' })
-  }
-
-  /** "Keep saved score" — discards the rejected entry, clearing the notice. */
-  get keepSavedButton(): Locator {
-    return this.page.getByRole('button', { name: 'Keep saved score' })
   }
 }

--- a/e2e/support/match-api.ts
+++ b/e2e/support/match-api.ts
@@ -36,16 +36,26 @@ async function csrfToken(ctx: APIRequestContext): Promise<string> {
   return cookie.value
 }
 
-/** Mint a fresh ephemeral guest: `GET /v1/session` creates a User + issues the
- * session and csrf cookies into a brand-new request context. */
-export async function mintGuest(baseURL: string): Promise<Guest> {
-  const ctx = await request.newContext({ baseURL })
+/** Build a Guest from an already-authenticated request context: reads its
+ * username (`GET /v1/session`) and the CSRF token it was issued. Shared by
+ * `mintGuest` (a fresh context) and specs that adopt the browser's own
+ * `page.request` context, so page navigations run as that guest. */
+export async function guestFromContext(ctx: APIRequestContext): Promise<Guest> {
   const res = await ctx.get(`${API}/session`)
   if (!res.ok()) {
     throw new Error(`session mint failed: ${res.status()} ${await res.text()}`)
   }
-  const body = (await res.json()) as { data: { user: { username: string } } }
-  return { ctx, username: body.data.user.username, csrf: await csrfToken(ctx) }
+  return {
+    ctx,
+    username: usernameFrom(await res.json()),
+    csrf: await csrfToken(ctx),
+  }
+}
+
+/** Mint a fresh ephemeral guest: `GET /v1/session` creates a User + issues the
+ * session and csrf cookies into a brand-new request context. */
+export async function mintGuest(baseURL: string): Promise<Guest> {
+  return guestFromContext(await request.newContext({ baseURL }))
 }
 
 /** Resolve a user's id via the opponent typeahead. Ephemeral guests are
@@ -131,6 +141,11 @@ export async function editGameScore(
       },
     },
   )
+}
+
+function usernameFrom(sessionJson: unknown): string {
+  return (sessionJson as { data: { user: { username: string } } }).data.user
+    .username
 }
 
 function versionOf(details: unknown, gameNumber: number): number {

--- a/e2e/support/match-api.ts
+++ b/e2e/support/match-api.ts
@@ -1,0 +1,145 @@
+import { APIRequestContext, APIResponse, request } from '@playwright/test'
+
+// Composed-stack API helpers for provisioning a *two-party* match directly
+// against the real API (through nginx at `/api`), bypassing the UI. The
+// 409 score-conflict flow (issue #873) is structurally unreachable on a solo
+// match — a version conflict needs two distinct participants writing the same
+// game — so a spec that drives it has to mint two real players and a shared
+// match. Doing that over the API keeps the browser side focused on the one
+// surface under test (the conflict notice + "Replace with my score"), with a
+// single deterministic browser context.
+//
+// Mutations ride the double-submit CSRF defense (`app/main.py`): once a
+// `session` cookie is present, any unsafe method must echo the non-HttpOnly
+// `csrf_token` cookie back in the `x-csrf-token` header. Each guest carries the
+// token it was issued so its writes are accepted.
+
+const API = '/api/v1'
+const CSRF_COOKIE = 'csrf_token'
+const CSRF_HEADER = 'x-csrf-token'
+
+/** A provisioned guest: its own cookie jar (session + csrf) plus the identity
+ * fields a spec needs to wire up and assert against a match. */
+export interface Guest {
+  /** Request context holding this guest's `session`/`csrf_token` cookies. */
+  readonly ctx: APIRequestContext
+  /** The auto-assigned display username (also this guest's search key). */
+  readonly username: string
+  /** The CSRF token to echo in the header on this guest's writes. */
+  readonly csrf: string
+}
+
+async function csrfToken(ctx: APIRequestContext): Promise<string> {
+  const { cookies } = await ctx.storageState()
+  const cookie = cookies.find((c) => c.name === CSRF_COOKIE)
+  if (!cookie) throw new Error('no csrf_token cookie issued for this session')
+  return cookie.value
+}
+
+/** Mint a fresh ephemeral guest: `GET /v1/session` creates a User + issues the
+ * session and csrf cookies into a brand-new request context. */
+export async function mintGuest(baseURL: string): Promise<Guest> {
+  const ctx = await request.newContext({ baseURL })
+  const res = await ctx.get(`${API}/session`)
+  if (!res.ok()) {
+    throw new Error(`session mint failed: ${res.status()} ${await res.text()}`)
+  }
+  const body = (await res.json()) as { data: { user: { username: string } } }
+  return { ctx, username: body.data.user.username, csrf: await csrfToken(ctx) }
+}
+
+/** Resolve a user's id via the opponent typeahead. Ephemeral guests are
+ * searchable (only tombstoned/merged users are excluded), so this is how one
+ * guest names another as an opponent without any claim/sign-in step. */
+export async function findUserId(
+  searcher: Guest,
+  username: string,
+): Promise<string> {
+  const res = await searcher.ctx.get(`${API}/players/search`, {
+    params: { q: username },
+  })
+  const players = (await res.json()) as ReadonlyArray<{
+    id: string
+    username: string
+  }>
+  const match = players.find((p) => p.username === username)
+  if (!match) throw new Error(`player "${username}" not found in search`)
+  return match.id
+}
+
+/** Create an unrated two-party match with `creator` on side 1 and `opponentId`
+ * on side 2. Unrated keeps the guests out of the rating system; the conflict
+ * path is independent of rating. Returns the new match id. */
+export async function createMatch(
+  creator: Guest,
+  opponentId: string,
+  bestOf: number,
+): Promise<string> {
+  const res = await creator.ctx.post(`${API}/matches`, {
+    headers: { [CSRF_HEADER]: creator.csrf },
+    data: { opponent_user_id: opponentId, best_of: bestOf, rated: false },
+  })
+  if (res.status() !== 201) {
+    throw new Error(`create match failed: ${res.status()} ${await res.text()}`)
+  }
+  return ((await res.json()) as { id: string }).id
+}
+
+/** First write of a game's score (`POST .../scores/new`) — needs no version
+ * token (the unique constraint asserts no prior score). Returns the committed
+ * version so a later conditional edit can target it. */
+export async function createGameScore(
+  writer: Guest,
+  matchId: string,
+  gameNumber: number,
+  side1: number,
+  side2: number,
+): Promise<number> {
+  const res = await writer.ctx.post(
+    `${API}/matches/${matchId}/games/${gameNumber}/scores/new`,
+    {
+      headers: { [CSRF_HEADER]: writer.csrf },
+      data: { side_1_points: side1, side_2_points: side2 },
+    },
+  )
+  if (res.status() !== 201) {
+    throw new Error(`create score failed: ${res.status()} ${await res.text()}`)
+  }
+  return versionOf(await res.json(), gameNumber)
+}
+
+/** Conditional edit of a game's score (`PUT .../scores`). The write applies
+ * only if the committed row is still at `expectedVersion`; otherwise the server
+ * returns 409 carrying the committed score. Returns the raw response so the
+ * caller can assert on its status. */
+export async function editGameScore(
+  writer: Guest,
+  matchId: string,
+  gameNumber: number,
+  side1: number,
+  side2: number,
+  expectedVersion: number,
+): Promise<APIResponse> {
+  return writer.ctx.put(
+    `${API}/matches/${matchId}/games/${gameNumber}/scores`,
+    {
+      headers: { [CSRF_HEADER]: writer.csrf },
+      data: {
+        side_1_points: side1,
+        side_2_points: side2,
+        expected_version: expectedVersion,
+      },
+    },
+  )
+}
+
+function versionOf(details: unknown, gameNumber: number): number {
+  const games = (details as { games?: ReadonlyArray<Record<string, unknown>> })
+    .games
+  const game = games?.find((g) => g.game_number === gameNumber)
+  const score = game?.score as { version?: number } | undefined
+  if (score?.version == null) {
+    throw new Error(`no committed score/version for game ${gameNumber}`)
+  }
+  return score.version
+}

--- a/e2e/support/match-api.ts
+++ b/e2e/support/match-api.ts
@@ -68,6 +68,9 @@ export async function findUserId(
   const res = await searcher.ctx.get(`${API}/players/search`, {
     params: { q: username },
   })
+  if (!res.ok()) {
+    throw new Error(`player search failed: ${res.status()} ${await res.text()}`)
+  }
   const players = (await res.json()) as ReadonlyArray<{
     id: string
     username: string

--- a/e2e/tests/score-conflict.spec.ts
+++ b/e2e/tests/score-conflict.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test'
+
+import { ScoreEntryPage } from '../page-objects/score-entry.page'
+import {
+  createGameScore,
+  createMatch,
+  editGameScore,
+  findUserId,
+  mintGuest,
+  type Guest,
+} from '../support/match-api'
+
+/**
+ * End-to-end coverage for the 409 score-conflict flow (issue #873).
+ *
+ * This path is structurally unreachable on a *solo* match: producing a version
+ * conflict requires a second participant committing the same game while the
+ * first is still editing. Every prior browser QA pass over scoring used a solo
+ * match, so the conflict notice + "Replace with my score" have never been
+ * exercised end-to-end. This spec provisions a real two-party match over the
+ * API and drives the loser's side through the browser.
+ *
+ * The ordering is load-bearing. A's page must load the score at version 1
+ * *before* B commits version 2 — otherwise A mounts already holding the fresh
+ * version and its save never conflicts. The score-detail query has no polling
+ * and no window-focus refetch fires in a single focused page, so once A has
+ * loaded v1 it holds that stale version until it submits (proven deterministic
+ * across repeated local runs against the real stack).
+ */
+test.describe('Score entry — 409 conflict flow', () => {
+  test('the loser sees the committed score and "Replace with my score" then succeeds first try', async ({
+    page,
+    context,
+    baseURL,
+  }) => {
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    // Guest A is the browser's own session, so the page navigates authenticated
+    // as A. `page.request` shares this context's cookie jar.
+    const aSession = await page.request.get('/api/v1/session')
+    expect(aSession.ok()).toBeTruthy()
+    const aUsername = (
+      (await aSession.json()) as { data: { user: { username: string } } }
+    ).data.user.username
+    const aCsrf = (await context.cookies()).find(
+      (c) => c.name === 'csrf_token',
+    )?.value
+    expect(aCsrf, 'A must be issued a csrf_token').toBeTruthy()
+    const a: Guest = { ctx: page.request, username: aUsername, csrf: aCsrf! }
+
+    // Guest B is a wholly separate session (its own cookie jar) — the concurrent
+    // participant who writes the same game out from under A.
+    const b = await mintGuest(baseURL!)
+
+    // A starts a best-of-3 (so game 1 is not the decider — saving it continues
+    // to game 2 rather than firing the finalize flow, keeping this focused on
+    // the conflict surface) match against B, and commits game 1 at version 1.
+    const opponentId = await findUserId(a, b.username)
+    const matchId = await createMatch(a, opponentId, 3)
+    const v1 = await createGameScore(a, matchId, 1, 11, 5)
+    expect(v1).toBe(1)
+
+    // A opens game 1's edit screen and loads the committed score at v1 — its
+    // own 11 must be showing before B writes, or there is no stale version to
+    // conflict on.
+    const scorePage = await ScoreEntryPage.navigateToEdit(page, matchId, 1)
+    await expect(scorePage.scoreInput(a.username)).toHaveValue('11')
+    await expect(scorePage.scoreInput(b.username)).toHaveValue('5')
+
+    // B now commits a different score (B wins 5–11), bumping the game to v2.
+    const bEdit = await editGameScore(b, matchId, 1, 5, 11, v1)
+    expect(bEdit.status()).toBe(200)
+
+    // A, still holding v1, edits to 11–9 and saves. The per-game save is
+    // fire-and-forget: it advances to the next game synchronously while the PUT
+    // settles in the background, where the conditional write loses the version
+    // race → 409. That surfaces as the conflict-review banner on game 2, which
+    // routes back to game 1 rather than showing the notice inline.
+    await scorePage.scoreInput(b.username).fill('9')
+    await scorePage.saveButton.click()
+
+    await expect(scorePage.conflictReviewBanner(1)).toBeVisible()
+    await scorePage.reviewGameButton(1).click()
+
+    // Back on game 1's edit screen, the in-page conflict notice renders B's
+    // committed score (B's win as A sees it, A on side 1 → "A 5 – 11 B") against
+    // A's rejected entry — proving the notice shows the *server's* value, not
+    // A's stale one.
+    await expect(scorePage.conflictNotice).toBeVisible()
+    await expect(scorePage.conflictNotice).toContainText(`${a.username} 5`)
+    await expect(scorePage.conflictNotice).toContainText('Your entry was 11')
+
+    // "Replace with my score" re-fires the save against the now-fresh v2. It
+    // must succeed on the first try — a 200, not a second 409 — which is the
+    // half the unit tests never covered.
+    const replacePut = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/matches/${matchId}/games/1/scores`) &&
+        r.request().method() === 'PUT',
+    )
+    await scorePage.replaceButton.click()
+    expect((await replacePut).status()).toBe(200)
+
+    // The conflict is resolved: the notice clears and A's score now stands.
+    await expect(scorePage.conflictNotice).toBeHidden()
+    await expect(scorePage.scoreInput(a.username)).toHaveValue('11')
+    await expect(scorePage.scoreInput(b.username)).toHaveValue('9')
+
+    await b.ctx.dispose()
+  })
+})

--- a/e2e/tests/score-conflict.spec.ts
+++ b/e2e/tests/score-conflict.spec.ts
@@ -6,8 +6,8 @@ import {
   createMatch,
   editGameScore,
   findUserId,
+  guestFromContext,
   mintGuest,
-  type Guest,
 } from '../support/match-api'
 
 /**
@@ -30,23 +30,13 @@ import {
 test.describe('Score entry — 409 conflict flow', () => {
   test('the loser sees the committed score and "Replace with my score" then succeeds first try', async ({
     page,
-    context,
     baseURL,
   }) => {
     expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
 
-    // Guest A is the browser's own session, so the page navigates authenticated
-    // as A. `page.request` shares this context's cookie jar.
-    const aSession = await page.request.get('/api/v1/session')
-    expect(aSession.ok()).toBeTruthy()
-    const aUsername = (
-      (await aSession.json()) as { data: { user: { username: string } } }
-    ).data.user.username
-    const aCsrf = (await context.cookies()).find(
-      (c) => c.name === 'csrf_token',
-    )?.value
-    expect(aCsrf, 'A must be issued a csrf_token').toBeTruthy()
-    const a: Guest = { ctx: page.request, username: aUsername, csrf: aCsrf! }
+    // Guest A is the browser's own session (`page.request` shares the page
+    // context's cookie jar), so page navigations run authenticated as A.
+    const a = await guestFromContext(page.request)
 
     // Guest B is a wholly separate session (its own cookie jar) — the concurrent
     // participant who writes the same game out from under A.


### PR DESCRIPTION
## What

Adds root composed-stack e2e coverage for the **409 score-conflict flow** — the one acceptance note from PR #864 (#843) that could never be confirmed, because it's structurally unreachable on a solo match. Closes #873.

The untested surface: an edit loses the optimistic-concurrency race → the conflict notice shows the **committed** score → **"Replace with my score"** then succeeds *first try* on the fresh version. A version conflict needs a *second party* writing the same game, so every prior (solo-match) browser QA pass skipped it.

## How

`e2e/tests/score-conflict.spec.ts` provisions a real two-party match over the API (through nginx) and drives the losing side through one browser:

1. Two ephemeral **guests** are minted (`GET /v1/session`). Guests are searchable as opponents and need no claim/sign-in; writes carry the CSRF double-submit token.
2. Guest **A** creates an unrated best-of-3 vs **B**, commits game 1 at **v1**, and opens game 1's edit screen — loading v1 **before** B writes.
3. Guest **B** commits a different score out-of-band → **v2**.
4. A's stale save 409s in the background (per-game saves are fire-and-forget → advance to game 2), surfacing the **"Review game 1"** banner. Clicking it returns to game 1, where the in-page notice shows B's committed score against A's rejected entry.
5. **"Replace with my score"** re-fires against v2 → asserts a **200, not a second 409** (the half unit tests never covered), and the notice clears.

New: `e2e/page-objects/score-entry.page.ts` (POM) and `e2e/support/match-api.ts` (API-seed helpers).

## Notes for review

- **No app code changes — test-only.**
- **Deviation from the issue's recipe:** it suggested two claimed accounts via **Mailpit magic links**, but the dev/e2e stack has **no Mailpit** (that's the QA stack). API-seeding two guests is faster, needs no new infra, and the 409 is still genuinely server-generated, so root `e2e/` remains the right home.
- **Determinism:** the ordering (A holds v1 before B writes) is load-bearing; `matchQueryOptions` has no polling and no focus-refetch fires in a single focused page, so the stale window is stable. Verified **green across repeated local runs** against a real stack (server mechanics proven 3×; full browser spec 3×).
- **New `e2e/support/` dir** for API-seed helpers (not a page object) — flagging the placement choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DB8C4ik4XecmBQqQyLjZ62