### PR TITLE
Fix #869, #870: guard double-clear DELETE and cold-cache clobber

### DIFF
--- a/web-client/src/api/matches.test.ts
+++ b/web-client/src/api/matches.test.ts
@@ -276,7 +276,17 @@ it('does not drop a concurrently-saved game when an older save response settles 
     ),
   )
 
-  // Both fire against the empty cache, so each takes the POST (create) path.
+  // Warm the cache with an observer-free empty snapshot. The scoring screen
+  // always has a mounted `useMatch`, so the match cache is warm during play;
+  // since #870 a cold cache is left unseeded (the wholesale `return data` seed
+  // that would clobber a concurrent game is gone), so this composition test must
+  // seed a present `prev` to exercise the narrow-upsert path it's about. It
+  // stays observer-free so no refetch fires — the refetch-heal path is covered
+  // separately (#843 refetch race).
+  queryClient.setQueryData(matchQueryKey(matchId), matchDetails({ id: matchId, games: [] }))
+
+  // Both fire against the (empty-`games`) cache; the row is absent so each takes
+  // the POST (create) path.
   const p1 = fireScoreSave(queryClient, matchId, 1, {
     side_1_points: 11,
     side_2_points: 5,
@@ -355,6 +365,12 @@ it('does not drop a concurrently-saved game when a delete response settles last 
     createElement(QueryClientProvider, { client: queryClient }, children)
   const { result } = renderHook(() => useDeleteScore(matchId, 1), { wrapper })
 
+  // Warm the cache (empty `games`) so both per-game writes take the
+  // upsert-on-present path — since #870 a cold cache is left unseeded, so this
+  // composition test seeds a present `prev` (matching the always-warm scoring
+  // screen). Observer-free: no refetch fires here.
+  queryClient.setQueryData(matchQueryKey(matchId), matchDetails({ id: matchId, games: [] }))
+
   const savePromise = fireScoreSave(queryClient, matchId, 2, {
     side_1_points: 5,
     side_2_points: 11,
@@ -371,6 +387,117 @@ it('does not drop a concurrently-saved game when a delete response settles last 
   const g2 = cached?.games.find((g) => g.game_number === 2)
   expect(g2).toBeDefined()
   expect(g2?.score?.side_2_points).toBe(11)
+})
+
+/**
+ * Regression for #870: the match query has the default 5-minute `gcTime` and is
+ * dropped once it has no observer. If it's been garbage-collected and a per-game
+ * save then settles, the write must NOT wholesale-seed the cold cache from its
+ * own whole-match snapshot — that snapshot is built from the DB at *this* save's
+ * commit time and can omit a concurrent cross-game save's row, reintroducing the
+ * #843 clobber through a GC'd cache. The cold-cache branch leaves the entry
+ * unseeded (a valid `MatchDetails` can't be reconstructed from a lone game row);
+ * `invalidateMatchViews` runs after, and once an observer remounts its refetch
+ * repopulates from a fresh GET. With no observer here, `invalidateQueries`
+ * (default `refetchType: 'active'`) fires nothing, so the entry stays undefined.
+ */
+it('does not wholesale-seed a garbage-collected match cache from a stale save snapshot (#870)', async () => {
+  const matchId = 'm-870'
+
+  const game1: Game = {
+    id: 'g-1',
+    game_number: 1,
+    score: {
+      id: 's-1',
+      side_1_points: 11,
+      side_2_points: 5,
+      winner_side_number: 1,
+      version: 1,
+    },
+  }
+  // This save's whole-match snapshot — as if built before a concurrent game 2
+  // save committed, so it omits game 2. Seeding it wholesale would drop game 2.
+  const saveResponse: MatchDetails = matchDetails({ id: matchId, games: [game1] })
+
+  server.use(
+    http.post('*/v1/matches/:matchId/games/:gameNumber/scores/new', () =>
+      HttpResponse.json(saveResponse),
+    ),
+  )
+
+  // Cold cache: no `matchQueryKey` entry (GC'd), and no observer — exactly the
+  // #870 scenario. `getQueryData` is undefined before the save.
+  expect(queryClient.getQueryData(matchQueryKey(matchId))).toBeUndefined()
+
+  await fireScoreSave(queryClient, matchId, 1, {
+    side_1_points: 11,
+    side_2_points: 5,
+  })
+
+  // The stale whole-match snapshot was NOT installed — the cold cache stays
+  // unseeded rather than clobbering with a snapshot that could omit a concurrent
+  // game. It self-heals from a fresh GET once an observer remounts.
+  expect(queryClient.getQueryData(matchQueryKey(matchId))).toBeUndefined()
+})
+
+/**
+ * The complement of the #870 cold-cache case: when the match cache *is* present,
+ * a per-game save still upserts just its own game row (composing with concurrent
+ * cross-game writes) rather than replacing the whole snapshot. This is the path
+ * the fix leaves untouched.
+ */
+it('upserts only the written game into a present match cache (#870 warm path)', async () => {
+  const matchId = 'm-870-warm'
+
+  const game1Present: Game = {
+    id: 'g-1',
+    game_number: 1,
+    score: {
+      id: 's-1',
+      side_1_points: 11,
+      side_2_points: 8,
+      winner_side_number: 1,
+      version: 1,
+    },
+  }
+  const game2Existing: Game = {
+    id: 'g-2',
+    game_number: 2,
+    score: {
+      id: 's-2',
+      side_1_points: 4,
+      side_2_points: 11,
+      winner_side_number: 2,
+      version: 1,
+    },
+  }
+  // Warm cache already holds game 2 (e.g. a concurrent save landed it).
+  queryClient.setQueryData(
+    matchQueryKey(matchId),
+    matchDetails({ id: matchId, games: [game2Existing] }),
+  )
+
+  // Game 1's save response is a stale whole-match snapshot that omits game 2.
+  const saveResponse: MatchDetails = matchDetails({
+    id: matchId,
+    games: [game1Present],
+  })
+  server.use(
+    http.post('*/v1/matches/:matchId/games/:gameNumber/scores/new', () =>
+      HttpResponse.json(saveResponse),
+    ),
+  )
+
+  await fireScoreSave(queryClient, matchId, 1, {
+    side_1_points: 11,
+    side_2_points: 8,
+  })
+
+  // Only game 1 was upserted; game 2 survived (the write did not wholesale
+  // replace with the snapshot that omits it).
+  const cached = queryClient.getQueryData<MatchDetails>(matchQueryKey(matchId))
+  expect(cached?.games.find((g) => g.game_number === 1)?.score?.side_1_points).toBe(11)
+  expect(cached?.games.find((g) => g.game_number === 2)?.score?.side_2_points).toBe(11)
 })
 
 /**

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -375,7 +375,15 @@ function applyGameWriteCache(
 ) {
   const written = data.games.find((g) => g.game_number === gameNumber)
   queryClient.setQueryData<MatchDetails>(matchQueryKey(matchId), (prev) => {
-    if (!prev) return data
+    // Cold cache (garbage-collected after `gcTime`, no observer): do NOT seed
+    // from `data`. `data` is this one save's whole-match snapshot, built from
+    // the DB at its own commit time, so it can omit a concurrent cross-game
+    // save's row — wholesale-seeding it would clobber that game exactly like
+    // #843 (here through a GC'd cache, #870). Leave the entry unseeded and let
+    // the `invalidateMatchViews` refetch below repopulate it from a fresh GET.
+    // Seeding narrowly from `written` alone isn't viable — a valid
+    // `MatchDetails` needs side/status fields a single game row doesn't carry.
+    if (!prev) return prev
     // No row for this game in the response (shouldn't happen) — leave the cache
     // as-is rather than guessing.
     if (!written) return prev

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   RouterProvider,
@@ -1089,6 +1089,46 @@ describe('ScoreEntry — edit', () => {
       expect(screen.getByText('scoring-new m-1 1')).toBeInTheDocument(),
     )
     expect(deleted).toBe(true)
+  })
+
+  it('fires a single DELETE when the clear confirm is double-clicked in one frame (#869)', async () => {
+    // The confirm dialog's `open` is driven by `pendingClear !== null` — a
+    // render snapshot — so the confirm button stays mounted until React
+    // re-renders. Two clicks delivered synchronously in one frame both close
+    // over the same captured target and both reach `.mutate`, firing two
+    // DELETEs. The synchronous `clearingRef` must swallow the second.
+    //
+    // Both raw `.click()`s run inside ONE `act` (no flush between them) to
+    // reproduce the same-frame race — `fireEvent`/awaited `user.click` each
+    // flush their own `act`, which would unmount the button after the first
+    // click and hide the regression.
+    const user = userEvent.setup()
+    let deletes = 0
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      http.delete('*/v1/matches/m-1/games/1/scores', () => {
+        deletes += 1
+        return HttpResponse.json(inProgressMatch())
+      }),
+    )
+
+    renderScoreEntry({ kind: 'edit', matchId: 'm-1', gameNumber: 1 })
+
+    await screen.findByRole('textbox', { name: 'rita.kovac score' })
+    await user.click(screen.getByRole('button', { name: /^clear$/i }))
+
+    const dialog = await screen.findByRole('alertdialog')
+    const confirm = within(dialog).getByRole('button', { name: /clear game/i })
+    act(() => {
+      confirm.click()
+      confirm.click()
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText('scoring-new m-1 1')).toBeInTheDocument(),
+    )
+    // Exactly one DELETE — the second same-frame click was swallowed.
+    expect(deletes).toBe(1)
   })
 
   it('cancelling the clear confirmation keeps the saved score (#387)', async () => {

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -160,6 +160,16 @@ function ScoreEntryInner({
   // success — clearing on settle would reopen it a beat before the navigation
   // lands, leaving a window for a duplicate. Error clears it so a retry works.
   const finalizingRef = useRef(false)
+  // Synchronous clear-in-flight guard (#869). The confirm dialog's `open` is
+  // driven by `pendingClear !== null` — a render snapshot — so the confirm
+  // button stays mounted and clickable until React re-renders. Two clicks
+  // delivered synchronously in one frame both close over the same captured
+  // `target`, both clear `pendingClear`, and both reach `.mutate` before the
+  // re-render — firing two DELETE .../scores requests. Like `finalizingRef`,
+  // this ref flips inside the click gesture, so the second tap is rejected
+  // regardless of render timing. Reset in each mutation's `onSettled` so a
+  // later clear of a *different* game works normally.
+  const clearingRef = useRef(false)
   const { status, proceed, reset } = useBlocker({
     // Blocks browser refresh/close (beforeunload) only while genuinely dirty.
     enableBeforeUnload: () => isDirty,
@@ -564,6 +574,11 @@ function ScoreEntryInner({
     const target = pendingClear
     setPendingClear(null)
     if (target === null) return
+    // Reject a second synchronous confirm click while a clear is already in
+    // flight (#869) — the ref is set right before each `.mutate` below and
+    // cleared in that mutation's `onSettled`, so a legitimate later clear of a
+    // different game still fires normally.
+    if (clearingRef.current) return
     if (target === 'active') {
       if (mode.kind !== 'edit') return
       // Clearing is an explicit discard — drop any failed-save leftovers too,
@@ -572,13 +587,16 @@ function ScoreEntryInner({
       // `ignoreBlocker: true` to keep the unsaved-input blocker out of it
       // (ADR 0014, #818).
       forgetScoreSaves(queryClient, matchId, gameNumber)
+      clearingRef.current = true
       deleteMutation.mutate(undefined, {
         // After clearing, land back on this game's create route so the user
         // can re-enter — same page, just with empty inputs and create-mode
         // semantics. The remount's autoFocus puts focus on the me-input,
         // which is the first empty input.
-        onSettled: () =>
-          navigate({ ...scoringNewRoute(matchId, gameNumber), ignoreBlocker: true }),
+        onSettled: () => {
+          clearingRef.current = false
+          navigate({ ...scoringNewRoute(matchId, gameNumber), ignoreBlocker: true })
+        },
       })
       return
     }
@@ -586,7 +604,12 @@ function ScoreEntryInner({
     // strip. We refocus the first empty input on the current page so the user
     // can keep typing (deferred to the dialog's close-focus hook).
     forgetScoreSaves(queryClient, matchId, target)
-    cellDeleteMutation.mutate(target)
+    clearingRef.current = true
+    cellDeleteMutation.mutate(target, {
+      onSettled: () => {
+        clearingRef.current = false
+      },
+    })
     refocusAfterCloseRef.current = true
   }
 


### PR DESCRIPTION
Two contained web-client bug fixes, both residuals of the #843/#864 score-entry + match-cache work. No cross-layer seams, no OpenAPI/type regen, no API change. `#871` (P4, wasted-work-not-incorrectness) was closed as won't-fix during the grill.

## #869 — one "Clear game" confirm can fire two DELETEs
`web-client/src/components/matches/score-entry.tsx`. The confirm dialog's `open` is `pendingClear !== null`, so the button stays mounted and clickable until React re-renders; two `click`s delivered in one JS frame both close over the same captured target, both pass the null guard, and both `.mutate` → two `DELETE .../games/{n}/scores` (`[404, 200]`).

**Fix:** a synchronous `clearingRef` (useRef) guard at the top of `performClear`, set before each `.mutate` and reset in both mutations' `onSettled`. Deliberately **not** `isPending`/`disabled` — those are async React state with the same stale-render weakness as the current `setPendingClear(null)`, so they don't close the reproduced same-frame path; only a ref engages synchronously. Covers both affordances (active `deleteMutation` + per-cell `cellDeleteMutation`), which share `performClear`.

## #870 — a GC'd match cache lets a stale save clobber a concurrent game
`web-client/src/api/matches.ts`, `applyGameWriteCache`. When the match query has been garbage-collected (`prev === undefined`) and a per-game save settles, it wholesale-seeded the cache from its own possibly-stale whole-match snapshot, which can omit a concurrent cross-game save's row (the #843 clobber, reachable via a cold cache).

**Fix:** don't wholesale-seed on an empty cache (`if (!prev) return prev`); leave it unseeded and let the existing unconditional `invalidateMatchViews` refetch populate it. Upsert-on-present path and the legitimate whole-board `applyBoardWriteCache` seed are unchanged.

## Verification
- Both fixes carry **red-green regression tests**, independently re-verified by a separate agent (each restored the pre-fix source and confirmed the test reds for the predicted reason, then restored the fix).
- Full web-client suite **1249 passed**, `tsc -b` clean, lint 0 errors.
- Pure client-side (React ref + React Query cache) — no API/schema/BFF change, so no `schema.d.ts` regen and no `web-client/e2e/` stub updates.

Closes #869. Closes #870.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsabcotSst2QxwC1Eo2BHs