### PR TITLE
Lock in scoring authz: logged-out → 401 test (#163)

### DIFF
--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -1722,6 +1722,30 @@ async def test_score_delete_404_when_no_saved_score(
     assert response.status_code == 404
 
 
+async def test_logged_out_cannot_score(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    # Auth is enforced before participant/existence checks: a real, valid match
+    # (seeded by a genuinely authenticated client) still 401s a cookieless caller.
+    async with make_client() as owner_client:
+        owner = await start_session(owner_client, db_session)
+        opp = await make_user(db_session, "rival")
+        del owner
+        match = await _create_match(owner_client, opp.id, best_of=5)
+
+    # ``api_client`` never called ``/v1/session``, so it carries no session cookie.
+    post = await api_client.post(
+        f"/v1/matches/{match['id']}/games/1/scores/new",
+        json={"side_1_points": 11, "side_2_points": 4},
+    )
+    assert post.status_code == 401
+    put = await api_client.put(
+        f"/v1/matches/{match['id']}/games/1/scores",
+        json={"side_1_points": 11, "side_2_points": 4, "expected_version": 1},
+    )
+    assert put.status_code == 401
+
+
 async def test_non_participant_cannot_score(
     api_client: AsyncClient, db_session: AsyncSession
 ):


### PR DESCRIPTION
## What

Adds `test_logged_out_cannot_score` to `api/tests/test_matches.py`: a session-less client POSTing and PUTting to the scoring routes gets **401**, asserted against a *real seeded match* (seeded by a separate authenticated client) so it proves auth fires **before** the participant/existence check — a valid target still 401s the anonymous caller.

Closes #163.

## Why this shape

#163 asked to "lock in: only match participants can write scores" with regression tests + an e2e. Verifying against current `main`:

- ✅ **API, authenticated outsider → 404** — already covered by the pre-existing `test_non_participant_cannot_score` (POST/PUT/DELETE/results).
- ✅ **API, unauthenticated → 401** — was the real gap. This PR adds it. The 401-vs-404 distinction is load-bearing: an authenticated non-participant gets 404 on the same real match, so a cookieless caller getting 401 proves the auth layer rejects first.

### The e2e was intentionally dropped (issue premise went stale)

#163 (filed 2026-05-16) assumed a non-participant hitting the scoring URL sees a "not found" surface. That's no longer how it works:

- `GET /v1/matches/{id}` is now **public** — returns 200 to a non-participant (`test_get_match_is_open_to_non_participants`).
- The scoring screen therefore doesn't 404; `ScoreEntry` **redirects a spectator to the read-only match detail page** (`<Navigate {...matchDetailRoute(matchId)}>`, `score-entry.tsx`).

So the FE behavior is a UX redirect, not a security surface — and it already has a web-client unit test on that same `<Navigate>` path. The write guard that actually enforces "only participants can score" lives at the API layer, which is what this PR pins down. An e2e here would assert UX, not security.

## Test

```
pytest tests/test_matches.py -k "logged_out_cannot_score or non_participant or requires_a_session" -q
6 passed, 135 deselected
```
Independently verified (implementer ≠ verifier): 401 originates in `get_current_user` (auth dep resolved before the handler body's match load); ruff + mypy clean (mypy covers `app/`).

Test-only change — no routes/schemas/docstrings touched, so no OpenAPI regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)