### PR TITLE
Fix #810: don't force-redirect to scoring after the user left mid-create

### DIFF
--- a/web-client/src/components/matches/match-setup/use-start-match.test.tsx
+++ b/web-client/src/components/matches/match-setup/use-start-match.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { act, render, waitFor } from '@testing-library/react'
 import {
   RouterProvider,
@@ -53,10 +54,16 @@ function renderStartMatch() {
     ]),
     history: createMemoryHistory({ initialEntries: ['/'] }),
   })
+  // Mount under StrictMode so the effect double-invoke (mount→cleanup→remount)
+  // the real app (src/main.tsx) exercises is reproduced here — a cleanup-only
+  // mounted-ref would latch false and permanently suppress the redirect, and
+  // this harness is where that must be caught (#810).
   render(
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>,
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </StrictMode>,
   )
   return {
     async ready() {

--- a/web-client/src/components/matches/match-setup/use-start-match.test.tsx
+++ b/web-client/src/components/matches/match-setup/use-start-match.test.tsx
@@ -172,6 +172,71 @@ describe('useStartMatch', () => {
     expect(postCount).toBe(1)
   })
 
+  it('leaves a spent instance behind: an old in-flight create resolving after the user left does not redirect, and a freshly-mounted form still creates + redirects', async () => {
+    // One handler serves both hooks (server.use is reset per test): the FIRST
+    // create (instance 1) is held open so the user can leave mid-flight; the
+    // SECOND (instance 2, the fresh form) resolves immediately so it can prove
+    // it still redirects. Both return a fully valid MatchDetails so each passes
+    // the network Zod parse and reaches the (gated) redirect branch.
+    let postCount = 0
+    let releasePost: () => void = () => {}
+    const postReleased = new Promise<void>((resolve) => {
+      releasePost = resolve
+    })
+    server.use(
+      http.post('*/v1/matches', async () => {
+        postCount += 1
+        if (postCount === 1) await postReleased
+        const seed = newMatchSeed({ bestOf: 5, rated: false, opponent: null })
+        return HttpResponse.json(projectMatchDetails(seed), { status: 201 })
+      }),
+    )
+
+    // Instance 1: fire the create (holding its promise so we can drain the full
+    // success branch later), then navigate away — unmounting the Probe/hook —
+    // while the POST is still in flight.
+    const hook1 = renderStartMatch()
+    const { submit: submit1 } = await hook1.ready()
+    let submit1Promise: unknown
+    act(() => {
+      submit1Promise = submit1({ opponent: null, bestOf: 5, rated: false })
+    })
+    await act(async () => {
+      await hook1.router.navigate({
+        to: '/matches/$matchId',
+        params: { matchId: 'left-behind' },
+      })
+    })
+    // Pin the ordering: instance 1's request must be the held call #1 before
+    // instance 2 submits, so its own (immediate) create is call #2.
+    await waitFor(() => expect(postCount).toBe(1))
+
+    // Instance 2: an independent, freshly-mounted form. Its create resolves
+    // immediately and MUST redirect to scoring — proving the fresh instance is
+    // not latched by anything the spent instance 1 left behind.
+    const hook2 = renderStartMatch()
+    const { submit: submit2 } = await hook2.ready()
+    await act(() => submit2({ opponent: null, bestOf: 5, rated: false }))
+    expect(hook2.router.state.location.pathname).toMatch(
+      /^\/matches\/.+\/games\/1\/scores\/new$/,
+    )
+
+    // Now release instance 1's stale create and drain its success branch.
+    await act(async () => {
+      releasePost()
+      await submit1Promise
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    // Instance 1's router stayed exactly where the user left it — releasing the
+    // stale create did not yank it to the new match's scoring page. On the
+    // pre-fix hook this pathname is the scoring route, so the exact-match is the
+    // red signal (strictly stronger than "not scoring").
+    expect(hook1.router.state.location.pathname).toBe('/matches/left-behind')
+    // Both creates ran to completion — background-complete, never aborted.
+    expect(postCount).toBe(2)
+  })
+
   it('surfaces a server error through apiError', async () => {
     // A lapsed session is a `session_ended` 401 that the global middleware
     // catches and redirects to `/login` (covered in api/client.test.ts) — the

--- a/web-client/src/components/matches/match-setup/use-start-match.test.tsx
+++ b/web-client/src/components/matches/match-setup/use-start-match.test.tsx
@@ -10,6 +10,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
 
 import { server } from '@/mocks/server'
+import { newMatchSeed, projectMatchDetails } from '@/mocks/match-store'
 
 import { useStartMatch } from './use-start-match'
 import { buildOpponent } from './selected-opponent.factory'
@@ -109,6 +110,61 @@ describe('useStartMatch', () => {
       await new Promise((r) => setTimeout(r, 0))
     })
 
+    expect(postCount).toBe(1)
+  })
+
+  it('does not redirect to scoring if the user navigated away mid-create', async () => {
+    // Hold the POST open so the create is still in flight when the user leaves.
+    let postCount = 0
+    let releasePost: () => void = () => {}
+    const postReleased = new Promise<void>((resolve) => {
+      releasePost = resolve
+    })
+    server.use(
+      http.post('*/v1/matches', async () => {
+        postCount += 1
+        // Hold the create open so the component can unmount mid-flight, then
+        // return a *fully valid* MatchDetails payload (built with the same mock
+        // helpers the default handler uses) so it passes the network Zod parse
+        // and the pre-fix hook actually reaches its unconditional redirect —
+        // otherwise the create would reject and mask the bug this test guards.
+        await postReleased
+        const seed = newMatchSeed({ bestOf: 5, rated: false, opponent: null })
+        return HttpResponse.json(projectMatchDetails(seed), { status: 201 })
+      }),
+    )
+    const hook = renderStartMatch()
+    const { submit } = await hook.ready()
+
+    // Fire the create (capture its promise so we can await the full success
+    // branch, incl. the redirect the pre-fix hook would fire), then navigate
+    // away (unmounting the Probe/hook) before the create resolves.
+    let submitPromise: unknown
+    act(() => {
+      submitPromise = submit({ opponent: null, bestOf: 5, rated: false })
+    })
+    await act(async () => {
+      await hook.router.navigate({
+        to: '/matches/$matchId',
+        params: { matchId: 'somewhere-else' },
+      })
+    })
+
+    // Now let the in-flight create resolve and drain the success branch.
+    await act(async () => {
+      releasePost()
+      await submitPromise
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    // (a) No forced redirect back to scoring — the user's navigation stands.
+    expect(hook.router.state.location.pathname).not.toMatch(
+      /\/games\/1\/scores\/new$/,
+    )
+    expect(hook.router.state.location.pathname).toBe(
+      '/matches/somewhere-else',
+    )
+    // (b) The create still ran to completion (background-complete, not aborted).
     expect(postCount).toBe(1)
   })
 

--- a/web-client/src/components/matches/match-setup/use-start-match.test.tsx
+++ b/web-client/src/components/matches/match-setup/use-start-match.test.tsx
@@ -158,12 +158,9 @@ describe('useStartMatch', () => {
     })
 
     // (a) No forced redirect back to scoring — the user's navigation stands.
-    expect(hook.router.state.location.pathname).not.toMatch(
-      /\/games\/1\/scores\/new$/,
-    )
-    expect(hook.router.state.location.pathname).toBe(
-      '/matches/somewhere-else',
-    )
+    // The exact-match is strictly stronger than "not the scoring route": on the
+    // pre-fix hook this is the scoring path, so this assertion is the red signal.
+    expect(hook.router.state.location.pathname).toBe('/matches/somewhere-else')
     // (b) The create still ran to completion (background-complete, not aborted).
     expect(postCount).toBe(1)
   })

--- a/web-client/src/components/matches/match-setup/use-start-match.ts
+++ b/web-client/src/components/matches/match-setup/use-start-match.ts
@@ -73,8 +73,14 @@ export function useStartMatch(): UseStartMatchResult {
 
   // Tracks whether this hook's component is still mounted, so the async success
   // branch below can tell a still-open form from one the user has already left.
+  // Set true in the body (not just false in cleanup): under React StrictMode the
+  // effect is mount→cleanup→remount, so a cleanup-only ref would latch false on
+  // the first simulated unmount and never recover, permanently suppressing the
+  // redirect in dev. Re-asserting true on (re)mount is the canonical is-mounted
+  // pattern.
   const mountedRef = useRef(true)
   useEffect(() => {
+    mountedRef.current = true
     return () => {
       mountedRef.current = false
     }

--- a/web-client/src/components/matches/match-setup/use-start-match.ts
+++ b/web-client/src/components/matches/match-setup/use-start-match.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { z } from 'zod'
 
@@ -71,6 +71,15 @@ export function useStartMatch(): UseStartMatchResult {
   // is not a `navigate()` call, so no navigation option can reach that path.
   const submitState = useRef<'idle' | 'submitting' | 'done'>('idle')
 
+  // Tracks whether this hook's component is still mounted, so the async success
+  // branch below can tell a still-open form from one the user has already left.
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
   async function submit({ opponent, bestOf, rated }: StartMatchInput) {
     setSubmitted(true)
     const validation = matchFormSchema.safeParse({
@@ -97,12 +106,26 @@ export function useStartMatch(): UseStartMatchResult {
         best_of: bestOf,
         rated: opponent !== null && rated,
       })
+      // Latch the #81 duplicate-create guard BEFORE the mount gate so
+      // `hasSucceeded()` and the "this form is spent" contract are unchanged
+      // whether or not we still redirect.
       submitState.current = 'done'
-      // Replace, don't push: the new-match form is a one-shot step, so the
-      // history stack shouldn't keep it. Otherwise browser/mobile Back from
-      // score entry re-opens the creation form for a match that already
-      // exists, instead of returning to wherever the user came from (#441).
-      navigate({ ...nextScoringDestination(created), replace: true })
+      // Gate the redirect on the form still being mounted:
+      //   (1) A user who navigated away mid-request must not be yanked back to
+      //       the new match's scoring page against their choice to leave (#810).
+      //   (2) Background-complete, not abort: the create above already finished,
+      //       so the match lands in their list via the `['matches','list']`
+      //       invalidation — we only suppress the redirect, never cancel the POST.
+      //   (3) bfcache doesn't confound the unmount signal: a page with an
+      //       in-flight `fetch` is bfcache-ineligible, so a mid-request Back is a
+      //       real React unmount that flips `mountedRef`, not a frozen page.
+      if (mountedRef.current) {
+        // Replace, don't push: the new-match form is a one-shot step, so the
+        // history stack shouldn't keep it. Otherwise browser/mobile Back from
+        // score entry re-opens the creation form for a match that already
+        // exists, instead of returning to wherever the user came from (#441).
+        navigate({ ...nextScoringDestination(created), replace: true })
+      }
     } catch (err) {
       // Let the user try again — only a *successful* create latches the guard.
       submitState.current = 'idle'

--- a/web-client/src/routes/_app/matches/new.test.tsx
+++ b/web-client/src/routes/_app/matches/new.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   RouterProvider,
@@ -529,6 +529,62 @@ describe('NewMatchPage', () => {
     expect(
       screen.queryByRole('alertdialog', { name: /discard changes/i }),
     ).not.toBeInTheDocument()
+  })
+
+  it('does not redirect to scoring when a dirty form is discarded-and-left mid-create (#810)', async () => {
+    const user = userEvent.setup()
+    // Hold the create open so the user can leave while it is still in flight.
+    let releasePost: () => void = () => {}
+    const postReleased = new Promise<void>((resolve) => {
+      releasePost = resolve
+    })
+    server.use(
+      http.get('*/v1/players/recent', () =>
+        HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }]),
+      ),
+      http.post('*/v1/matches', async () => {
+        await postReleased
+        return HttpResponse.json(pendingMatch(), { status: 201 })
+      }),
+    )
+    const { router } = renderNewMatch()
+
+    // Dirty the form (pick an opponent), then start the match — the POST hangs.
+    await user.click(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    )
+    await user.click(screen.getByRole('button', { name: /start match/i }))
+
+    // Leave mid-create. Cancel is disabled while submitting, so drive the exact
+    // navigation Cancel fires (to /dashboard) directly. The form is still dirty
+    // and the create hasn't succeeded (`hasSucceeded()` is false mid-flight), so
+    // the blocker catches it and pops the discard dialog.
+    act(() => {
+      void router.navigate({ to: '/dashboard' })
+    })
+    await user.click(
+      await screen.findByRole('button', { name: /discard.*leave/i }),
+    )
+    await waitFor(() =>
+      expect(screen.getByText('Dashboard route')).toBeInTheDocument(),
+    )
+
+    // Let the held create resolve and settle; the pre-fix hook fires its
+    // unconditional redirect here (two macrotask ticks so the create's promise
+    // chain and any resulting navigation flush before we assert).
+    await act(async () => {
+      releasePost()
+      await new Promise((r) => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    // The user's choice to leave stands — no yank back to scoring. Assert
+    // synchronously (not via waitFor) so a pre-fix redirect surfaces as a clean
+    // "still on scoring" failure rather than an opaque timeout.
+    expect(
+      screen.queryByText('Scoring route m-test game 1'),
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('Dashboard route')).toBeInTheDocument()
   })
 
   it('shows a wait cursor on the Start match button while submitting (#77)', async () => {


### PR DESCRIPTION
## What

`useStartMatch().submit()` unconditionally called `navigate({ ...nextScoringDestination(created), replace: true })` once `POST /v1/matches` resolved — yanking the user to the new match's scoring page **even if they had already navigated away** while the create was in flight (a nav link, browser Back, or the #75 "Discard & leave" confirmation). Reported in #810.

## Fix

Gate the post-create redirect in the shared match-setup submit hook on the component still being **mounted** (a `mountedRef`), so:

- **A user who left is no longer redirected back.** Their navigation stands.
- **The create still completes in the background** — the match lands in their match list via the existing `['matches','list']` invalidation. We suppress only the redirect; the POST is never aborted (a deliberate decision — aborting can't reliably prevent server-side creation anyway).
- The `#81` duplicate-create latch (`submitState.current = 'done'`) still fires **before** the gate, so `hasSucceeded()` and the `useBlocker` contract are byte-for-byte unchanged. The error path and the global `session_ended` 401→`/login` handler are untouched.

Fixes both callers at once (`/matches/new` and the dashboard "Log your first match" hero) since they share the hook.

### StrictMode footnote (2nd commit)

The first cut of the mounted-ref was cleanup-only, which latches `false` under React StrictMode's dev mount→cleanup→remount and permanently suppressed the redirect in `npm run dev`. Caught by the e2e suite (10 new-match specs red). Fixed by re-asserting the ref true in the effect body (canonical is-mounted pattern) and wrapping the vitest harness in `<StrictMode>` so the happy-path test guards it.

## Testing

- **vitest** `1250 passed` — incl. a new regression test: hold `POST /v1/matches` open, unmount mid-create, resolve → asserts no scoring redirect **and** the create still fired (`postCount === 1`). Red on the pre-fix hook.
- **lint** 0 errors · **build/tsc** clean
- **e2e (Playwright)** `139 passed` — the suite that caught the StrictMode regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)