### PR TITLE
Fix #874 and #863: two web-client layout bugs

### DIFF
--- a/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.page.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.page.tsx
@@ -23,16 +23,12 @@ const scoped = (container: Container) => ({
   getRows() {
     return container.queryAllByTestId('dashboard-recent-results-skeleton-row')
   },
-  /** Each row's collapsing opponent cell (`maxWidth:0; width:100%`). */
+  /** Each row's collapsing opponent cell (`maxWidth:0; width:100%`) — the test
+   * reads the win/loss dot placeholder from within each of these. */
   getOpponentCells() {
     return container.queryAllByTestId('dashboard-recent-results-skeleton-opponent')
   },
-  /** Each row's win/loss dot placeholder — the marker the old flex skeleton
-   * omitted, causing the avatar-shift the rebuild fixes. */
-  getDots() {
-    return container.queryAllByTestId('dashboard-recent-results-skeleton-dot')
-  },
-  // Count the shimmer bars so a dropped header cell or row column is caught.
+  // Expose the shimmer-bar queries so owners (YourGameRow) can read them.
   ...shimmerPage.within(container),
 })
 

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.page.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.page.tsx
@@ -12,6 +12,26 @@ const scoped = (container: Container) => ({
   queryStatus() {
     return container.queryByRole('status', { name: /loading recent matches/i })
   },
+  /** The skeleton's `<table>` — it mirrors the loaded card's table so column
+   * widths derive from the same layout. Queried by test id because the
+   * decorative inner tree is `aria-hidden`, so `getByRole('table')` can't
+   * reach it. */
+  getTable() {
+    return container.getByTestId('dashboard-recent-results-skeleton')
+  },
+  /** Every placeholder `<tbody>` row (excludes the header row). */
+  getRows() {
+    return container.queryAllByTestId('dashboard-recent-results-skeleton-row')
+  },
+  /** Each row's collapsing opponent cell (`maxWidth:0; width:100%`). */
+  getOpponentCells() {
+    return container.queryAllByTestId('dashboard-recent-results-skeleton-opponent')
+  },
+  /** Each row's win/loss dot placeholder — the marker the old flex skeleton
+   * omitted, causing the avatar-shift the rebuild fixes. */
+  getDots() {
+    return container.queryAllByTestId('dashboard-recent-results-skeleton-dot')
+  },
   // Count the shimmer bars so a dropped header cell or row column is caught.
   ...shimmerPage.within(container),
 })

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.test.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.test.tsx
@@ -1,9 +1,7 @@
 import { within } from '@/test/utilities'
 
+import { ROWS } from './recent-results-card-skeleton'
 import { recentResultsCardSkeletonPage } from './recent-results-card-skeleton.page'
-
-// Keep in sync with the ROWS constant in the component.
-const ROWS = 3
 
 describe('RecentResultsCardSkeleton', () => {
   it('announces the load through a busy status region', () => {
@@ -46,10 +44,9 @@ describe('RecentResultsCardSkeleton', () => {
     for (const cell of cells) {
       expect(cell.tagName).toBe('TD')
       expect(cell).toHaveStyle({ maxWidth: '0px', width: '100%' })
-      // The win/loss dot placeholder the loaded row renders.
+      // The win/loss dot placeholder the loaded row renders. `getByTestId`
+      // (singular) also fails if a row somehow renders more than one dot.
       expect(within(cell).getByTestId('dashboard-recent-results-skeleton-dot')).toBeInTheDocument()
     }
-
-    expect(recentResultsCardSkeletonPage.getDots()).toHaveLength(ROWS)
   })
 })

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.test.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.test.tsx
@@ -1,4 +1,9 @@
+import { within } from '@/test/utilities'
+
 import { recentResultsCardSkeletonPage } from './recent-results-card-skeleton.page'
+
+// Keep in sync with the ROWS constant in the component.
+const ROWS = 3
 
 describe('RecentResultsCardSkeleton', () => {
   it('announces the load through a busy status region', () => {
@@ -10,11 +15,41 @@ describe('RecentResultsCardSkeleton', () => {
     )
   })
 
-  // No-layout-shift contract: a two-bar header + three rows of four columns
-  // plus a leading status dot (5 bars each) = 17 reserved bars.
-  it('reserves the header and three four-column result rows', () => {
+  // The rebuild mirrors the loaded card's real <table> instead of a hand-copied
+  // flex approximation, so column widths derive from the shared layout (#863).
+  // The old flex-only skeleton had no table/thead at all — these fail on it.
+  it('mirrors the loaded card with a real table and shimmered header band', () => {
     recentResultsCardSkeletonPage.render()
 
-    expect(recentResultsCardSkeletonPage.getAllShimmers()).toHaveLength(17)
+    const table = recentResultsCardSkeletonPage.getTable()
+    expect(table.tagName).toBe('TABLE')
+    expect(table.querySelector('thead')).not.toBeNull()
+  })
+
+  it('renders one placeholder row per reserved result', () => {
+    recentResultsCardSkeletonPage.render()
+
+    expect(recentResultsCardSkeletonPage.getRows()).toHaveLength(ROWS)
+  })
+
+  // The name shimmer now lives inside the collapsing cell (maxWidth:0;
+  // width:100%) so its width is derived from the table, not a hand-set
+  // maxWidth. And each row carries the win/loss dot the loaded row renders,
+  // which the old skeleton dropped (the ~16px avatar shift). The old flex
+  // skeleton had neither a collapsing cell nor a dot, so both fail on it.
+  it('gives each row a collapsing opponent cell containing a dot placeholder', () => {
+    recentResultsCardSkeletonPage.render()
+
+    const cells = recentResultsCardSkeletonPage.getOpponentCells()
+    expect(cells).toHaveLength(ROWS)
+
+    for (const cell of cells) {
+      expect(cell.tagName).toBe('TD')
+      expect(cell).toHaveStyle({ maxWidth: '0px', width: '100%' })
+      // The win/loss dot placeholder the loaded row renders.
+      expect(within(cell).getByTestId('dashboard-recent-results-skeleton-dot')).toBeInTheDocument()
+    }
+
+    expect(recentResultsCardSkeletonPage.getDots()).toHaveLength(ROWS)
   })
 })

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.tsx
@@ -5,8 +5,14 @@ import { Card } from './card'
 
 // Three placeholder result rows — a representative slice of the last-N table.
 // Row count only affects this card's height; nothing below it depends on the
-// exact number, so a small fixed count keeps the reserved box stable.
-const ROWS = 3
+// exact number, so a small fixed count keeps the reserved box stable. Exported
+// so the test asserts the same count instead of duplicating the literal.
+export const ROWS = 3
+
+// The header and trailing (score/Δ/when) cells drop their shimmer in as an
+// inline-block so it respects the cell's text-align; the opponent-cell
+// shimmers are flex children and set their own display, so they don't use this.
+const cellBar = { display: 'inline-block' } as const
 
 /**
  * Loading placeholder for the {@link RecentResultsCard}, shown by `YourGameRow`
@@ -47,16 +53,16 @@ export const RecentResultsCardSkeleton = () => (
         <thead>
           <tr>
             <th style={{ textAlign: 'left', padding: '10px 18px 8px' }}>
-              <Shimmer width={62} height={8} style={{ display: 'inline-block' }} />
+              <Shimmer width={62} height={8} style={cellBar} />
             </th>
             <th style={{ textAlign: 'right', padding: '10px 8px 8px' }}>
-              <Shimmer width={34} height={8} style={{ display: 'inline-block' }} />
+              <Shimmer width={34} height={8} style={cellBar} />
             </th>
             <th style={{ textAlign: 'right', padding: '10px 8px 8px' }}>
-              <Shimmer width={10} height={8} style={{ display: 'inline-block' }} />
+              <Shimmer width={10} height={8} style={cellBar} />
             </th>
             <th style={{ textAlign: 'right', padding: '10px 18px 8px' }}>
-              <Shimmer width={30} height={8} style={{ display: 'inline-block' }} />
+              <Shimmer width={30} height={8} style={cellBar} />
             </th>
           </tr>
         </thead>
@@ -87,13 +93,13 @@ export const RecentResultsCardSkeleton = () => (
                 </div>
               </td>
               <td style={{ padding: '11px 8px', textAlign: 'right' }}>
-                <Shimmer width={36} height={13} style={{ display: 'inline-block' }} />
+                <Shimmer width={36} height={13} style={cellBar} />
               </td>
               <td style={{ padding: '11px 8px', textAlign: 'right' }}>
-                <Shimmer width={28} height={12} style={{ display: 'inline-block' }} />
+                <Shimmer width={28} height={12} style={cellBar} />
               </td>
               <td style={{ padding: '11px 18px', textAlign: 'right' }}>
-                <Shimmer width={44} height={11} style={{ display: 'inline-block' }} />
+                <Shimmer width={44} height={11} style={cellBar} />
               </td>
             </tr>
           ))}

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card-skeleton.tsx
@@ -10,11 +10,13 @@ const ROWS = 3
 
 /**
  * Loading placeholder for the {@link RecentResultsCard}, shown by `YourGameRow`
- * while the dashboard query resolves. Reuses the real card's `Card` chrome,
- * header strip, and four-column row layout (opponent · score · Δ · when) so the
- * card occupies the same box the loaded table will — only the leaf text/avatars
- * become shimmer bars. Mirrors `RecentResultsCard`'s markup by hand (the real
- * tree isn't mounted during load), so revisit it if that structure changes.
+ * while the dashboard query resolves. Reuses the real card's `Card` chrome and
+ * header strip, then renders the SAME `<table>` structure the loaded card does
+ * (a shimmered `<thead>` band + N `<tbody>` rows) so every column width is
+ * *derived* from the shared table layout rather than eyeballed. In particular
+ * the opponent cell keeps the loaded card's `maxWidth:0; width:100%` collapse
+ * and its inner `dot → avatar → name` flex, so the name bar doesn't snap width
+ * the moment real rows mount (#863).
  */
 export const RecentResultsCardSkeleton = () => (
   <Card
@@ -38,25 +40,65 @@ export const RecentResultsCardSkeleton = () => (
         <div style={{ flex: 1 }} />
         <Shimmer width={70} height={11} />
       </div>
-      {Array.from({ length: ROWS }, (_, i) => (
-        <div
-          key={i}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-            minWidth: 0,
-            padding: '11px 18px',
-            borderTop: i === 0 ? 'none' : `1px solid ${C.ink700}`,
-          }}
-        >
-          <Shimmer width={24} height={24} radius={12} />
-          <Shimmer height={14} style={{ flex: 1, minWidth: 0, maxWidth: 140 }} />
-          <Shimmer width={36} height={13} />
-          <Shimmer width={28} height={12} />
-          <Shimmer width={44} height={11} />
-        </div>
-      ))}
+      <table
+        data-testid="dashboard-recent-results-skeleton"
+        style={{ width: '100%', borderCollapse: 'collapse' }}
+      >
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left', padding: '10px 18px 8px' }}>
+              <Shimmer width={62} height={8} style={{ display: 'inline-block' }} />
+            </th>
+            <th style={{ textAlign: 'right', padding: '10px 8px 8px' }}>
+              <Shimmer width={34} height={8} style={{ display: 'inline-block' }} />
+            </th>
+            <th style={{ textAlign: 'right', padding: '10px 8px 8px' }}>
+              <Shimmer width={10} height={8} style={{ display: 'inline-block' }} />
+            </th>
+            <th style={{ textAlign: 'right', padding: '10px 18px 8px' }}>
+              <Shimmer width={30} height={8} style={{ display: 'inline-block' }} />
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: ROWS }, (_, i) => (
+            <tr
+              key={i}
+              data-testid="dashboard-recent-results-skeleton-row"
+              style={{ borderTop: i === 0 ? 'none' : `1px solid ${C.ink700}` }}
+            >
+              {/* Mirror the loaded card's collapsing opponent cell:
+                  maxWidth:0 + width:100% forces the column to the table width
+                  so the name shimmer's width is *derived* here rather than
+                  hand-set — the fix for the name bar snapping on load (#863). */}
+              <td
+                data-testid="dashboard-recent-results-skeleton-opponent"
+                style={{ padding: '11px 18px', maxWidth: 0, width: '100%' }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
+                  <span
+                    data-testid="dashboard-recent-results-skeleton-dot"
+                    style={{ display: 'flex', flexShrink: 0 }}
+                  >
+                    <Shimmer width={6} height={6} radius={3} />
+                  </span>
+                  <Shimmer width={24} height={24} radius={12} style={{ flexShrink: 0 }} />
+                  <Shimmer height={14} style={{ flex: 1, minWidth: 0 }} />
+                </div>
+              </td>
+              <td style={{ padding: '11px 8px', textAlign: 'right' }}>
+                <Shimmer width={36} height={13} style={{ display: 'inline-block' }} />
+              </td>
+              <td style={{ padding: '11px 8px', textAlign: 'right' }}>
+                <Shimmer width={28} height={12} style={{ display: 'inline-block' }} />
+              </td>
+              <td style={{ padding: '11px 18px', textAlign: 'right' }}>
+                <Shimmer width={44} height={11} style={{ display: 'inline-block' }} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   </Card>
 )

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1638,8 +1638,7 @@ body.dark.fortymm-theme {
   text-transform: uppercase;
   color: var(--fg-1);
   margin: 0;
-  flex: 1;
-  min-width: 0;
+  flex: 0 0 auto;
 }
 .fortymm-theme .entry-head .hint {
   font: 500 12px/1.5 var(--font-mono);
@@ -1647,6 +1646,8 @@ body.dark.fortymm-theme {
   color: var(--fg-3);
   text-align: right;
   text-transform: uppercase;
+  flex: 1 1 0;
+  min-width: 0;
 }
 .fortymm-theme .entry-head .hint kbd {
   display: inline-block;


### PR DESCRIPTION
Two independent, verified `web-client`-only layout fixes. Each issue was reproduced against source before any change (see the grill/plan in the work order).

## #874 — correction-screen heading collapses to 0px (desktop, P3)
On the match **correction** screen at desktop widths, the `<h2>` heading collapsed to ~0px and the instruction paragraph rendered through it. The shared `.entry-head` flex row gave the `<h2>` `flex:1; min-width:0` (flex-basis 0) beside a `.hint` with a content-sized auto basis; the correction screen's long instruction sentence claimed the whole row, pinning the heading at basis-0.

**Fix:** swap the flex roles — size the heading to its (short, fixed) content (`h2 { flex:0 0 auto }`) and let the hint take the remaining track and wrap (`.hint { flex:1 1 0; min-width:0 }`). The score-entry screen shares this rule; its terse right-aligned keyboard legend is visually unchanged, and the mobile override still hides the hint.

## #863 — Recent-matches skeleton name bar snaps on load (P4)
The dashboard "Recent matches" loading skeleton hand-copied the card as a flex row with a `maxWidth:140` name shimmer, while the loaded opponent column collapses to the table width (`maxWidth:0; width:100%`) since #844 — so the name bar snapped ~53px narrower on load, and the skeleton's missing win/loss dot shifted the avatar ~16px.

**Fix:** rebuild the skeleton to render the **same `<table>`** the loaded card does (shimmered `<thead>` band + `<tbody>` rows, each with a dot placeholder and the collapsing opponent cell), so column widths are *derived* from the shared layout instead of eyeballed. The skeleton is the only consumer of that hand-copied markup, so this retires the drift class. Its test was rewritten to assert the table structure (and fails against the old flex skeleton — verified by execution).

## Testing
- `web-client` vitest: **1251 passed**; lint: 0 errors; build (tsc -b + vite build): green; web-client Playwright e2e: **139 passed**.
- Each fix independently verified by a separate `verifier` agent (Verify re-run, `Proves` checked adversarially, scope contained). #863's test discrimination was proven by restoring the old component → 3 structural tests went red.
- Skipped as untouched: API, iOS, OpenAPI schema regen, root e2e.
- **Visual acceptance is browser-only** (jsdom can't measure layout) — pending the QA pass: #874 at desktop 1280×800, #863 at mobile 375×667.

Fixes #874
Fixes #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)