### PR TITLE
Fix #872: fail loudly when a save response omits the written game row

### DIFF
--- a/web-client/src/api/matches.test.ts
+++ b/web-client/src/api/matches.test.ts
@@ -501,6 +501,59 @@ it('upserts only the written game into a present match cache (#870 warm path)', 
 })
 
 /**
+ * Regression for #872: `applyGameWriteCache` folds a save's response into the
+ * cache by upserting the row for the game it just wrote. That row is present
+ * today by an API-side invariant nothing on the client enforces (a save always
+ * returns the game's row; DELETE nulls the score but keeps the row). If the
+ * response ever omits that row the upsert silently no-ops and the UI shows the
+ * pre-write value until the refetch heals it, with nothing to point at. Make
+ * the boundary violation loud: `console.error` at its source. We still leave
+ * the cache untouched (no throw) so a live scoring screen survives the glitch.
+ */
+it('logs loudly and leaves the cache untouched when the save response omits the written game (#872)', async () => {
+  const matchId = 'm-872'
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  const game1Present: Game = {
+    id: 'g-1',
+    game_number: 1,
+    score: {
+      id: 's-1',
+      side_1_points: 11,
+      side_2_points: 8,
+      winner_side_number: 1,
+      version: 1,
+    },
+  }
+  // Warm cache holds game 1's pre-write value.
+  queryClient.setQueryData(
+    matchQueryKey(matchId),
+    matchDetails({ id: matchId, games: [game1Present] }),
+  )
+
+  // Boundary violation: the save's response omits the row for game 1 entirely.
+  // Game 1 already has a cached score, so this save takes the edit (PUT) path.
+  const saveResponse: MatchDetails = matchDetails({ id: matchId, games: [] })
+  server.use(
+    http.put('*/v1/matches/:matchId/games/:gameNumber/scores', () =>
+      HttpResponse.json(saveResponse),
+    ),
+  )
+
+  await fireScoreSave(queryClient, matchId, 1, {
+    side_1_points: 11,
+    side_2_points: 8,
+  })
+
+  // Loud: the invariant violation surfaced at its source.
+  expect(consoleError).toHaveBeenCalledTimes(1)
+  expect(consoleError.mock.calls[0][0]).toContain('applyGameWriteCache')
+  // Safe: the cache was left as-is (not clobbered), so the refetch can heal it.
+  const cached = queryClient.getQueryData<MatchDetails>(matchQueryKey(matchId))
+  expect(cached?.games.find((g) => g.game_number === 1)?.score?.side_1_points).toBe(11)
+})
+
+/**
  * Evidence for #843's *accepted residual* (work-order chore C3, option B).
  *
  * The C2 fix's success path fires `invalidateQueries(matchQueryKey)`, which — when

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -374,6 +374,21 @@ function applyGameWriteCache(
   gameNumber: number,
 ) {
   const written = data.games.find((g) => g.game_number === gameNumber)
+  if (!written) {
+    // Boundary invariant: a save's response always carries a row for the game
+    // it just wrote — a real save creates/returns the `MatchGame`, and DELETE
+    // nulls the score but keeps the row (api/app/matches.py). If that ever
+    // stops holding, the upsert below silently no-ops and the UI shows a stale
+    // value until the `invalidateMatchViews` refetch resolves, with nothing to
+    // point at. Fail loudly at the boundary instead (.claude/rules/parse-at-
+    // boundaries.md) so the violation surfaces at its source. We don't throw:
+    // this is a success-path cache tap and a throw would eject the user from a
+    // live scoring screen over a non-fatal glitch the refetch already heals.
+    console.error(
+      `applyGameWriteCache: save response for match ${matchId} is missing game ${gameNumber}; ` +
+        `cache left stale until refetch (API game-row invariant violated)`,
+    )
+  }
   queryClient.setQueryData<MatchDetails>(matchQueryKey(matchId), (prev) => {
     // Cold cache (garbage-collected after `gcTime`, no observer): do NOT seed
     // from `data`. `data` is this one save's whole-match snapshot, built from
@@ -384,8 +399,8 @@ function applyGameWriteCache(
     // Seeding narrowly from `written` alone isn't viable — a valid
     // `MatchDetails` needs side/status fields a single game row doesn't carry.
     if (!prev) return prev
-    // No row for this game in the response (shouldn't happen) — leave the cache
-    // as-is rather than guessing.
+    // No row for this game in the response (shouldn't happen — logged loudly
+    // above) — leave the cache as-is rather than guessing; the refetch heals it.
     if (!written) return prev
     return withGameUpserted(prev, written)
   })


### PR DESCRIPTION
## What

`applyGameWriteCache` (web-client/src/api/matches.ts) upserts a per-game save's returned row into the match cache. That row is present today only by an API-side invariant nothing on the client enforces (a save always returns the game's row; `DELETE .../scores` nulls the score but keeps the `MatchGame` row). If the response ever omits it, the upsert **silently no-ops** — the UI shows the pre-write value until the refetch resolves, with no error anywhere.

## Fix

Make the boundary violation **loud** — `console.error` at its source (per `.claude/rules/parse-at-boundaries.md`, "fail loudly at the boundary"). Deliberately **no throw**: this is a success-path cache tap, and a throw would eject the user from a live scoring screen over a non-fatal glitch the `invalidateMatchViews` refetch already heals. The cache is still left untouched (not clobbered) so the refetch wins.

Adds a regression test that goes red without the fix: it asserts the loud log fires and the cached game survives.

## Verification

- `tsc -b` clean
- `eslint` clean on touched files
- `matches.test.ts`: verified red→green (0 calls without the fix, 1 with)
- Full web-client vitest: 1253 passed

Closes #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)