### PR TITLE
Fix #79: 503 + Retry-After on DB pool exhaustion (transient 500s on burst creates)

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import text
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
 from app import db, queue
 from app.dashboard import router as dashboard_router
@@ -65,6 +66,30 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 
 
 app = FastAPI(title="FortyMM API", lifespan=lifespan)
+
+# When the async DB connection pool saturates under a burst, SQLAlchemy raises
+# ``sqlalchemy.exc.TimeoutError`` ("QueuePool limit ... connection timed out")
+# out of the request. Unhandled, Starlette turns that into an opaque 500 with no
+# retry hint (issue #79). Convert it to a 503 + ``Retry-After`` so the pressure
+# is transient-and-retryable to the caller. The catch is deliberately narrow —
+# only the pool-timeout class — so genuine query errors still surface as 500s.
+POOL_TIMEOUT_RETRY_AFTER_SECONDS = 1
+
+
+@app.exception_handler(SQLAlchemyTimeoutError)
+async def db_pool_timeout_handler(
+    request: Request, exc: SQLAlchemyTimeoutError
+) -> JSONResponse:
+    log.warning(
+        "DB pool exhausted; returning 503 for %s %s",
+        request.method,
+        request.url.path,
+    )
+    return JSONResponse(
+        status_code=503,
+        content={"detail": "The server is briefly overloaded. Please retry."},
+        headers={"Retry-After": str(POOL_TIMEOUT_RETRY_AFTER_SECONDS)},
+    )
 
 
 @app.middleware("http")

--- a/api/tests/test_issue_79_concurrent_creates.py
+++ b/api/tests/test_issue_79_concurrent_creates.py
@@ -1,0 +1,98 @@
+"""Repro for issue #79: transient 500s on POST /v1/matches under a burst of
+rated creates from the same user.
+
+Unlike the shared ``api_client`` fixture (which pins every request to one
+``db_session``), this exercises the *production* session lifecycle — each
+concurrent request gets its own session from a real sessionmaker bound to the
+testcontainers engine, so the real connection pool and real per-request
+transactions are in play. That is the only setup in which a per-user
+concurrency bug can surface.
+"""
+
+import asyncio
+import collections
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from app.db import get_session
+from app.main import app as fastapi_app
+from app.models import Match
+from tests._helpers import CSRF_EVENT_HOOKS, make_user
+
+
+@pytest.mark.parametrize("burst", [20])
+async def test_concurrent_rated_creates_do_not_500(
+    engine: AsyncEngine,
+    db_session: AsyncSession,
+    default_league,
+    burst: int,
+) -> None:
+    real_sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def _real_session():
+        async with real_sessionmaker() as session:
+            yield session
+
+    fastapi_app.dependency_overrides[get_session] = _real_session
+    try:
+        opponent = await make_user(db_session, "rival-79")
+
+        client = AsyncClient(
+            transport=ASGITransport(app=fastapi_app, raise_app_exceptions=True),
+            base_url="https://testserver",
+            event_hooks=CSRF_EVENT_HOOKS,
+        )
+        boot = await client.get("/v1/session")
+        assert boot.status_code == 200
+
+        async def create():
+            return await client.post(
+                "/v1/matches",
+                json={
+                    "opponent_user_id": str(opponent.id),
+                    "best_of": 5,
+                    "rated": True,
+                },
+            )
+
+        results = await asyncio.gather(
+            *[create() for _ in range(burst)], return_exceptions=True
+        )
+        await client.aclose()
+
+        statuses: collections.Counter = collections.Counter()
+        first_failure = None
+        for r in results:
+            if isinstance(r, BaseException):
+                statuses["EXC:" + type(r).__name__] += 1
+                if first_failure is None:
+                    first_failure = repr(r)
+            else:
+                statuses[r.status_code] += 1
+                if r.status_code >= 400 and first_failure is None:
+                    first_failure = f"{r.status_code}: {r.text[:500]}"
+
+        print(f"\n[issue-79] burst={burst} status distribution: {dict(statuses)}")
+        if first_failure:
+            print(f"[issue-79] first failure: {first_failure}")
+
+        async with real_sessionmaker() as s:
+            count = (
+                await s.execute(select(func.count()).select_from(Match))
+            ).scalar_one()
+        print(f"[issue-79] matches actually created: {count}")
+
+        non_201 = {k: v for k, v in statuses.items() if k != 201}
+        assert not non_201, f"expected all 201, got failures: {non_201}"
+    finally:
+        fastapi_app.dependency_overrides.clear()
+        # Clean up the rows this test committed through its own sessions
+        # (they bypass the db_session fixture's truncate).
+        async with engine.begin() as conn:
+            from app.db import Base
+
+            for table in reversed(Base.metadata.sorted_tables):
+                await conn.execute(table.delete())

--- a/api/tests/test_issue_79_saturated_pool.py
+++ b/api/tests/test_issue_79_saturated_pool.py
@@ -1,0 +1,95 @@
+"""Regression for issue #79: a *saturated* connection pool must degrade to a
+503 + ``Retry-After``, never an opaque 500.
+
+The issue-79 concurrent-creates repro shows the create path itself is correct
+under burst (no code defect). The failure mode was resource exhaustion: under
+real load the shared async pool saturates and a waiter raises
+``sqlalchemy.exc.TimeoutError``, which — unhandled — Starlette turns into a 500
+with no retry hint. ``app.main.db_pool_timeout_handler`` now catches that class
+and returns a 503 with a ``Retry-After`` header. This test forces the condition
+with a deliberately tiny pool + a held connection and asserts the graceful shape.
+"""
+
+import asyncio
+
+from httpx import ASGITransport, AsyncClient, Response
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.db import get_session
+from app.main import app as fastapi_app
+from tests._helpers import CSRF_EVENT_HOOKS, make_user
+
+
+async def test_saturated_pool_returns_503_with_retry_after(
+    postgres_url: str,
+    engine: AsyncEngine,
+    db_session: AsyncSession,
+    default_league,
+) -> None:
+    # Tiny pool: 1 connection, no overflow, 1s wait before giving up.
+    tiny = create_async_engine(
+        postgres_url, pool_size=1, max_overflow=0, pool_timeout=1
+    )
+    tiny_sessionmaker = async_sessionmaker(tiny, expire_on_commit=False)
+
+    async def _real_session():
+        async with tiny_sessionmaker() as session:
+            yield session
+
+    fastapi_app.dependency_overrides[get_session] = _real_session
+    try:
+        opponent = await make_user(db_session, "rival-79-probe")
+
+        # Bootstrap needs the pool too; do it before we hog the connection.
+        client = AsyncClient(
+            transport=ASGITransport(app=fastapi_app, raise_app_exceptions=True),
+            base_url="https://testserver",
+            event_hooks=CSRF_EVENT_HOOKS,
+        )
+        boot = await client.get("/v1/session")
+        assert boot.status_code == 200
+
+        # Hog the single connection so concurrent creates must wait -> time out.
+        held = await tiny.connect()
+        await held.exec_driver_sql("SELECT 1")
+
+        async def create() -> Response:
+            return await client.post(
+                "/v1/matches",
+                json={
+                    "opponent_user_id": str(opponent.id),
+                    "best_of": 5,
+                    "rated": True,
+                },
+            )
+
+        results = await asyncio.gather(*[create() for _ in range(5)])
+        await held.close()
+        await client.aclose()
+
+        # The single connection is held across the whole gather (closed only
+        # after), so every create must wait on the pool and hit the timeout.
+        # The handler is registered, so each resolves to a real 503 response
+        # (with Retry-After) rather than raising a TimeoutError or returning an
+        # opaque 500.
+        assert all(r.status_code == 503 for r in results), (
+            "expected every request to 503 under a saturated pool, got "
+            f"{[r.status_code for r in results]}"
+        )
+        for r in results:
+            assert "retry-after" in r.headers, (
+                "503 from pool exhaustion must carry a Retry-After header"
+            )
+    finally:
+        await tiny.dispose()
+        fastapi_app.dependency_overrides.clear()
+        from app.db import Base
+
+        async with engine.begin() as conn:
+            for table in reversed(Base.metadata.sorted_tables):
+                await conn.execute(table.delete())


### PR DESCRIPTION
## What

Closes #79.

Under a burst of rated match creates, `POST /api/v1/matches` intermittently returned **500s that then recovered**. This makes that failure mode graceful.

## Diagnosis

Diagnosis-first, because the root cause was unknown:

- **The create path is correct.** 20 concurrent rated creates from one user all return 201 — `create_match` writes only the new match's own rows (no rating write, no contended unique constraint; rating seeding happens at session bootstrap, not create). No code defect reproduces.
- **The 500s are DB connection-pool exhaustion.** When the async pool saturates, SQLAlchemy raises `sqlalchemy.exc.TimeoutError` ("QueuePool limit … connection timed out"), which propagated unhandled → Starlette emitted an **opaque 500 with no `Retry-After`**. While the burst holds the pool, waiters 500; when it drains, it recovers — exactly the reported "silent 500s then recovers" signature.

## Fix

A **global** exception handler for `sqlalchemy.exc.TimeoutError` returns **503 Service Unavailable** with a `Retry-After` header and a `{"detail": …}` body — a clear, retryable signal instead of an opaque 500. Benefits every endpoint, not just match creation.

The catch is **deliberately narrow** — only the pool-acquisition timeout class. `OperationalError` / `IntegrityError` / other query errors are *not* subclasses of `sqlalchemy.exc.TimeoutError`, so genuine errors still surface as 500s rather than being masked as 503s.

Decisions (agreed at plan gate): build now; **503** (semantically correct for overload) rather than the 429 the ticket literally suggested; **API-only** (no web-client retry this pass).

## Tests

- `test_issue_79_concurrent_creates.py` — 20 concurrent rated creates via **per-request real sessions** (production session lifecycle, not the shared `db_session` override) → all 201.
- `test_issue_79_saturated_pool.py` — a deliberately saturated 1-connection pool → 503 + `Retry-After` (fail-before confirmed: without the handler, the same scenario raises raw `TimeoutError`).

Full api suite: 621 passed. `mypy` / `ruff check` / `ruff format --check` clean.

## Not included / notes

- **No OpenAPI change** — an exception handler touches no route/schema/docstring, so no `regen-api-types` / `regen-ios-api-types` owed and the drift guard stays green.
- **Not browser-observable** — pool exhaustion can't be triggered through the web client on demand, so no browser QA pass; the saturated-pool test is the acceptance evidence.
- Whether a *single* user's ~5 creates saturate the default 15-connection prod pool wasn't independently observed (forced saturation used a 1-connection pool); the mechanism is certain and the graceful-degradation hardening is correct regardless of the exact trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)