### PR TITLE
Fix #171: polish score/match copy for best-of-1 (Single) matches

### DIFF
--- a/web-client/src/components/dashboard/first-match/first-match-card.test.tsx
+++ b/web-client/src/components/dashboard/first-match/first-match-card.test.tsx
@@ -101,6 +101,17 @@ describe('FirstMatchCard', () => {
     expect(screen.getByRole('button', { name: /start scoring/i })).toBeEnabled()
   })
 
+  it('summarises a best-of-1 pick as "Single game", not "Best of 1"', async () => {
+    renderFirstMatchCard()
+
+    await pickNguyen()
+    await userEvent.click(screen.getByRole('radio', { name: /^1/ }))
+
+    expect(screen.getByText('Single game · rated')).toBeInTheDocument()
+    expect(screen.queryByText(/Best of 1/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/first to 1/)).not.toBeInTheDocument()
+  })
+
   it('clears the opponent and resets rated on Change', async () => {
     renderFirstMatchCard()
     await pickNguyen()

--- a/web-client/src/components/dashboard/first-match/first-match-card.tsx
+++ b/web-client/src/components/dashboard/first-match/first-match-card.tsx
@@ -64,9 +64,9 @@ export const FirstMatchCard = () => {
 
   const gamesToWin = Math.ceil(bestOf / 2)
   const effectivelyRated = rated && opponent !== null
-  const summary = `Best of ${bestOf} · first to ${gamesToWin} · ${
-    effectivelyRated ? 'rated' : 'unrated'
-  }`
+  const lengthCopy =
+    bestOf === 1 ? 'Single game' : `Best of ${bestOf} · first to ${gamesToWin}`
+  const summary = `${lengthCopy} · ${effectivelyRated ? 'rated' : 'unrated'}`
 
   function handlePick(player: Parameters<typeof opponentFromPlayer>[0]) {
     setOpponent(opponentFromPlayer(player))

--- a/web-client/src/components/matches/match-details/match-info/match-info-fetcher/match-info-query.test.ts
+++ b/web-client/src/components/matches/match-details/match-info/match-info-fetcher/match-info-query.test.ts
@@ -56,6 +56,36 @@ describe("matchInfoQuery", () => {
     });
   });
 
+  it("frames a best-of-1 match as a single game", async () => {
+    matchInfoQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({ team_size: 1, best_of: 1, games_to_win: 1 }),
+      ),
+    );
+
+    const result = await renderInfo();
+
+    expect(result.current.data?.rows[0]).toEqual({
+      label: "Format",
+      value: "Singles · Single game",
+    });
+  });
+
+  it("frames a best-of-1 team match as Doubles · Single game", async () => {
+    matchInfoQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({ team_size: 2, best_of: 1, games_to_win: 1 }),
+      ),
+    );
+
+    const result = await renderInfo();
+
+    expect(result.current.data?.rows[0]).toEqual({
+      label: "Format",
+      value: "Doubles · Single game",
+    });
+  });
+
   it("passes the server's status label through untouched", async () => {
     matchInfoQueryPage.mockEndpoint(() =>
       HttpResponse.json(buildMatchDetails({ status_label: "In progress" })),

--- a/web-client/src/components/matches/match-details/match-info/match-info-fetcher/match-info-query.ts
+++ b/web-client/src/components/matches/match-details/match-info/match-info-fetcher/match-info-query.ts
@@ -17,11 +17,18 @@ export type MatchInfoView = {
 
 const selectMatchInfo = (match: MatchDetailsResult): MatchInfoView => {
   const details = match.unmigrated;
+  const teamLabel = details.team_size === 1 ? "Singles" : "Doubles";
+  // A best-of-1 match is a single game, so drop the "Best of N, first to M"
+  // race framing that only makes sense for a multi-game set.
+  const formatValue =
+    details.best_of === 1
+      ? `${teamLabel} · Single game`
+      : `${teamLabel} · Best of ${details.best_of}, first to ${details.games_to_win}`;
   return {
     rows: [
       {
         label: "Format",
-        value: `${details.team_size === 1 ? "Singles" : "Doubles"} · Best of ${details.best_of}, first to ${details.games_to_win}`,
+        value: formatValue,
       },
       { label: "Status", value: details.status_label },
       { label: "Rated", value: details.affects_rating ? "Yes" : "No" },

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display.factory.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display.factory.tsx
@@ -15,6 +15,8 @@ export function buildScoreboardView(
     // Null by default so the view renders without a router — scored grid
     // cells may carry typed <Link>s; see `gameGridPage.render`.
     gameGrid: null,
+    // Multi-game by default; a best-of-1 view sets this false to hide the grid.
+    showGameGrid: true,
     ...overrides,
   };
 }

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display.test.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display.test.tsx
@@ -92,6 +92,19 @@ describe("ScoreboardDisplay", () => {
     expect(scoreboardDisplayPage.gameGrid.queryGrid()).not.toBeInTheDocument();
   });
 
+  it("omits the game grid for a best-of-1 view even when a gameGrid is present", () => {
+    // A single-game match suppresses the grid via showGameGrid; the query still
+    // projects a (one-cell) gameGrid, so the flag is what hides it.
+    scoreboardDisplayPage.render({
+      scoreboard: buildScoreboardView({
+        showGameGrid: false,
+        gameGrid: buildGameGridView(),
+      }),
+    });
+
+    expect(scoreboardDisplayPage.gameGrid.queryGrid()).not.toBeInTheDocument();
+  });
+
   it("labels the region via useId, pointing aria-labelledby at the heading id", () => {
     scoreboardDisplayPage.render();
 

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display.tsx
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-display.tsx
@@ -19,7 +19,9 @@ export const ScoreboardDisplay = ({ scoreboard }: ScoreboardDisplayProps) => {
       <div className="md-hero__grid-bg" aria-hidden="true" />
       <Heading heading={scoreboard.heading} />
       <HeroRow heroRow={scoreboard.heroRow} />
-      {scoreboard.gameGrid && <GameGrid gameGrid={scoreboard.gameGrid} />}
+      {scoreboard.showGameGrid && scoreboard.gameGrid && (
+        <GameGrid gameGrid={scoreboard.gameGrid} />
+      )}
     </section>
   );
 };

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.test.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.test.ts
@@ -207,8 +207,8 @@ describe("scoreboardQuery", () => {
     scoreboardQueryPage.mockEndpoint(() =>
       HttpResponse.json(
         buildMatchDetails({
-          best_of: 1,
-          games_to_win: 1,
+          best_of: 3,
+          games_to_win: 2,
           data: { scoreboard: { status: "final" } },
         }),
       ),
@@ -217,7 +217,40 @@ describe("scoreboardQuery", () => {
     const { result } = scoreboardQueryPage.render();
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data?.heading.raceLabel).toBe("First to 1");
+    expect(result.current.data?.heading.raceLabel).toBe("First to 2");
+  });
+
+  it("projects a best-of-1 match as a single game: SINGLE label, no race, no grid", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({
+          best_of: 1,
+          games_to_win: 1,
+          data: { scoreboard: { status: "live" } },
+        }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heading.formatLabel).toBe("SINGLES · SINGLE");
+    expect(result.current.data?.heading.raceLabel).toBeNull();
+    // The single-game grid is suppressed via the flag the display reads.
+    expect(result.current.data?.showGameGrid).toBe(false);
+  });
+
+  it("labels a best-of-1 team match DOUBLES · SINGLE", async () => {
+    scoreboardQueryPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildMatchDetails({ team_size: 2, best_of: 1, games_to_win: 1 }),
+      ),
+    );
+
+    const { result } = scoreboardQueryPage.render();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.heading.formatLabel).toBe("DOUBLES · SINGLE");
   });
 
   it("reports no games recorded for a match that has not started", async () => {

--- a/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.ts
+++ b/web-client/src/components/matches/match-details/scoreboard/scoreboard-fetcher/scoreboard-query.ts
@@ -18,10 +18,12 @@ export type StatusChipView = {
 
 export type ScoreboardHeadingView = {
   chip: StatusChipView;
-  /** e.g. "SINGLES · BO5" */
+  /** e.g. "SINGLES · BO5"; "SINGLES · SINGLE" for a best-of-1 (single-game)
+   * match. */
   formatLabel: string;
   /** e.g. "First to 3"; null for an upcoming match, where the race to a
-   * games target hasn't started. */
+   * games target hasn't started, and for a best-of-1 match, where there is no
+   * race — a single game decides it. */
   raceLabel: string | null;
 };
 
@@ -104,6 +106,11 @@ export type ScoreboardView = {
   /** Null when there's nothing to tabulate: an upcoming match, or a match
    * without two sides. */
   gameGrid: GameGridView | null;
+  /** Whether the per-game grid should render. False for a best-of-1
+   * (single-game) match, where a one-cell grid is just noise — the hero
+   * scoreline already tells the whole story. The display reads this flag
+   * rather than re-deriving `best_of`. */
+  showGameGrid: boolean;
 };
 
 const games = (n: number) => `${n} ${n === 1 ? "game" : "games"}`;
@@ -187,11 +194,20 @@ const selectHeading = (match: MatchDetailsResult): ScoreboardHeadingView => {
   const status = match.data.scoreboard.status;
   const details = match.unmigrated;
 
+  const teamLabel = details.team_size === 1 ? "SINGLES" : "DOUBLES";
+  const isSingleGame = details.best_of === 1;
   return {
     chip: selectChip(status, details),
-    formatLabel: `${details.team_size === 1 ? "SINGLES" : "DOUBLES"} · BO${details.best_of}`,
+    // A best-of-1 is a single game — "SINGLE" instead of "BO1".
+    formatLabel: isSingleGame
+      ? `${teamLabel} · SINGLE`
+      : `${teamLabel} · BO${details.best_of}`,
+    // No race pill for an upcoming match (race not started) or a best-of-1
+    // (there is no race — one game decides it).
     raceLabel:
-      status === "scheduled" ? null : `First to ${details.games_to_win}`,
+      status === "scheduled" || isSingleGame
+        ? null
+        : `First to ${details.games_to_win}`,
   };
 };
 
@@ -301,6 +317,9 @@ const selectScoreboard = (match: MatchDetailsResult): ScoreboardView => ({
   heading: selectHeading(match),
   heroRow: selectHeroRow(match),
   gameGrid: selectGameGrid(match),
+  // A best-of-1 match plays a single game, so the per-game grid adds nothing
+  // over the hero scoreline — hide it.
+  showGameGrid: match.unmigrated.best_of !== 1,
 });
 
 export const scoreboardQuery = (matchId: string) => ({

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -954,6 +954,57 @@ describe('ScoreEntry — create', () => {
       screen.queryByText(/rejected by the server/i),
     ).not.toBeInTheDocument()
   })
+
+  it('reads as a single game for a best-of-1 match (#171)', async () => {
+    // A best-of-1 ("Single") match has no "final game" / "next game" framing:
+    // before a valid score is typed the copy speaks only of posting the one
+    // result, and there is no SCORELINE strip to switch games on. (The
+    // finalize copy — shown once a valid score is entered — is unchanged and
+    // covered elsewhere, so this asserts the pre-valid-score state only.)
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          matchDetails({
+            id: 'm-1',
+            status: 'in_progress',
+            status_label: 'Live',
+            best_of: 1,
+            games_to_win: 1,
+            affects_rating: true,
+            sides: participantSides({ meWins: 0, oppWins: 0 }),
+            games: [],
+            current_game: { game_number: 1 },
+            can_score: true,
+            can_finalize: false,
+          }),
+        ),
+      ),
+    )
+
+    const { container } = renderScoreEntry({
+      kind: 'create',
+      matchId: 'm-1',
+      gameNumber: 1,
+    })
+
+    await screen.findByRole('heading', { name: /enter game 1 score/i })
+
+    // Subtitle drops the "Final game." lead — it's the only game.
+    expect(screen.getByText('Save to post the result.')).toBeInTheDocument()
+    // The submit button posts the result rather than saving a "final game".
+    expect(
+      screen.getByRole('button', { name: /save & post/i }),
+    ).toBeInTheDocument()
+
+    // The keyboard hint says "to save", not "for next / save game".
+    const hint = container.querySelector('.hint')
+    expect(hint?.textContent).toMatch(/to save/)
+    expect(hint?.textContent).not.toMatch(/next \/ save game/)
+
+    // No SCORELINE strip: a best-of-1 has nothing to switch between.
+    expect(screen.queryByText('SCORELINE')).not.toBeInTheDocument()
+    expect(container.querySelector('.sl-label')).toBeNull()
+  })
 })
 
 describe('ScoreEntry — name layout (#566)', () => {

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -685,7 +685,9 @@ function ScoreEntryInner({
       ? 'Save updates the score for this game.'
       : gameNumber < bestOf
         ? `Save this game to continue to game ${gameNumber + 1}.`
-        : 'Final game. Save to post the result.'
+        : bestOf === 1
+          ? 'Save to post the result.'
+          : 'Final game. Save to post the result.'
   const submitLabel = wouldFinalize
     ? finalizeMutation.isPending
       ? data.affects_rating
@@ -698,7 +700,9 @@ function ScoreEntryInner({
       ? 'Save changes →'
       : gameNumber < bestOf
         ? 'Save game & next →'
-        : 'Save final game →'
+        : bestOf === 1
+          ? 'Save & post →'
+          : 'Save final game →'
 
   return (
     <>
@@ -706,8 +710,8 @@ function ScoreEntryInner({
         <div className="entry-head">
           <h2>{heading}</h2>
           <div className="hint">
-            Type <kbd>0</kbd>–<kbd>9</kbd> &nbsp;·&nbsp; <kbd>Enter</kbd> for
-            next / save game
+            Type <kbd>0</kbd>–<kbd>9</kbd> &nbsp;·&nbsp; <kbd>Enter</kbd>{' '}
+            {bestOf === 1 ? 'to save' : 'for next / save game'}
           </div>
         </div>
 
@@ -779,15 +783,17 @@ function ScoreEntryInner({
           clearDisabled={deleteMutation.isPending}
         />
 
-        <Scoreline
-          data={data}
-          activeGameNumber={gameNumber}
-          decider={decider}
-          matchId={matchId}
-          mySideNumber={mySideNumber}
-          onClearCell={onClearCell}
-          clearDisabled={inputsLocked || cellDeleteMutation.isPending}
-        />
+        {bestOf > 1 && (
+          <Scoreline
+            data={data}
+            activeGameNumber={gameNumber}
+            decider={decider}
+            matchId={matchId}
+            mySideNumber={mySideNumber}
+            onClearCell={onClearCell}
+            clearDisabled={inputsLocked || cellDeleteMutation.isPending}
+          />
+        )}
       </div>
 
       <AlertDialog


### PR DESCRIPTION
## What

Single (`best_of: 1`) matches were rendered with multi-game copy that read oddly. This polishes every affected surface for BO1 — **guarded strictly on `best_of === 1`, so BO3/BO5/BO7 output is byte-identical**.

Closes #171.

## Changes (BO1 only)

**Match details** (`/matches/$matchId`)
- Info row: `Singles · Best of 1, first to 1` → `Singles · Single game`
- Scoreboard label: `SINGLES · BO1` → `SINGLES · SINGLE`
- Hide the `First to 1` pill
- Hide the degenerate one-cell per-game grid (via a `showGameGrid` view-model flag read by the display layer)

**Scoring page** (`ScoreEntry`)
- Pre-save subtitle: `Final game. Save to post the result.` → `Save to post the result.`
- Submit button: `Save final game →` → `Save & post →`
- Keyboard hint: `… Enter for next / save game` → `… Enter to save`
- Hide the one-cell SCORELINE strip
- The finalize-copy path (once a valid score is typed) and multi-game copy are untouched.

**Dashboard "Your next match" card** (found by the completeness pass — same bug, third surface)
- Summary: `Best of 1 · first to 1 · unrated` → `Single game · unrated`

## Notes

Pure client-side copy / conditional-render — no API, BFF, or OpenAPI/schema change. The issue's original scoring-page quotes (`GAME 01 OF 01`, `RATED · BEST OF 1 · FIRST TO 1`) no longer exist in the live component; the real residuals are addressed above.

## Verify

- `web-client`: `npm run test:run` → **1262 pass**, `tsc -b` → 0, `npm run lint` clean.
- Each affected component gained a BO1 render test asserting the new user-visible strings and the absence of the pill/grid/SCORELINE; multi-game (BO5) assertions preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)