### PR TITLE
Fix #801: route the poster to match detail when a result already exists

### DIFF
--- a/web-client/src/api/client.ts
+++ b/web-client/src/api/client.ts
@@ -222,6 +222,32 @@ export function conflictDetail(
 }
 
 /**
+ * True when `error` is the propose-result NEGOTIATION conflict specifically —
+ * the server's `_negotiation_conflict`, whose 409 body is the viewer-relative
+ * negotiation OBJECT (`{ detail: { viewer_state, your_turn, standing_result … } }`).
+ * That's the "a result already exists" case: a refetch reliably surfaces the
+ * standing result, so score-entry can redirect the poster to match detail (#801).
+ *
+ * It deliberately does NOT match the other two propose 409s, whose `detail` is a
+ * plain STRING: the lock race ("A result is already being posted…") and the
+ * terminal guard ("This match is no longer open to results.") — those are
+ * transient/plain errors the caller should keep surfacing with a live retry,
+ * never a permanent redirect. Nor does it match the score-write `committed_score`
+ * conflict object (that shape has no `viewer_state`), keeping the two object-body
+ * 409s distinct.
+ */
+export function isNegotiationConflict(error: ApiError): boolean {
+  if (error.status !== 409) return false
+  const detail = (error.body as { detail?: unknown } | null | undefined)?.detail
+  return (
+    detail !== null &&
+    typeof detail === 'object' &&
+    !Array.isArray(detail) &&
+    'viewer_state' in detail
+  )
+}
+
+/**
  * Throws ApiError when the openapi-fetch result has an error or no data. Pass
  * `{ allowEmpty: true }` for endpoints that legitimately return no body (e.g.
  * 204 DELETEs).

--- a/web-client/src/api/matches.test.ts
+++ b/web-client/src/api/matches.test.ts
@@ -15,6 +15,7 @@ import {
   useCreateMatch,
   useDeleteScore,
   useMatch,
+  useProposeResult,
 } from './matches'
 
 /** A promise plus its externally-callable `resolve`. Lets a test hold a mocked
@@ -870,6 +871,106 @@ describe('useCreateMatch', () => {
     })
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['dashboard'],
+    })
+  })
+})
+
+describe('useProposeResult', () => {
+  // #801: the NEGOTIATION-conflict 409 (`_negotiation_conflict`, "a result
+  // already exists") means the opponent already posted the standing result. The
+  // mutation must refetch the observed match so score-entry's
+  // `standing_result`/`completed` early-return can route the poster to match
+  // detail — the minimal Option A that replaces the #800 reconcile interstitial
+  // ADR-0005 deleted. The server's body for THIS 409 is the viewer-relative
+  // negotiation OBJECT (has `viewer_state`); the lock-race/terminal 409s carry a
+  // plain-STRING detail and must NOT trigger the refetch (they may not have
+  // committed yet, so a refetch could strand the screen with no standing result).
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+
+  // The `_negotiation_conflict` 409 body: `detail` is the negotiation object.
+  const negotiationConflict = {
+    detail: {
+      viewer_state: 'review',
+      your_turn: true,
+      standing_result: {
+        id: 'r-opp',
+        games: [{ game_number: 1, side_1_points: 4, side_2_points: 11 }],
+        submitted_by: 'u-opp',
+        submitted_at: '2026-05-12T19:30:00Z',
+      },
+      prior_result: null,
+      diff: null,
+    },
+  }
+
+  it('refetches the observed match on a negotiation-conflict 409', async () => {
+    const matchId = 'm-801'
+    server.use(
+      http.post('*/v1/matches/:matchId/results', () =>
+        HttpResponse.json(negotiationConflict, { status: 409 }),
+      ),
+    )
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useProposeResult(matchId), { wrapper })
+    result.current.mutate({ games: [] })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: matchQueryKey(matchId),
+    })
+  })
+
+  it('does NOT refetch on a plain-string lock-race 409, so score-entry keeps it retryable', async () => {
+    const matchId = 'm-801-lock'
+    server.use(
+      http.post('*/v1/matches/:matchId/results', () =>
+        HttpResponse.json(
+          {
+            detail:
+              'A result is already being posted for this match. Refresh to see the latest.',
+          },
+          { status: 409 },
+        ),
+      ),
+    )
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useProposeResult(matchId), { wrapper })
+    result.current.mutate({ games: [] })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    // A string-bodied 409 (lock race / terminal) is NOT a negotiation conflict —
+    // no refetch, so score-entry surfaces it as a normal retryable error.
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: matchQueryKey(matchId),
+    })
+  })
+
+  it('does NOT refetch on a non-409 finalize error, so score-entry can surface it for retry', async () => {
+    const matchId = 'm-801b'
+    server.use(
+      http.post('*/v1/matches/:matchId/results', () =>
+        HttpResponse.json(
+          { detail: 'This payload was rejected by the server.' },
+          { status: 422 },
+        ),
+      ),
+    )
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useProposeResult(matchId), { wrapper })
+    result.current.mutate({ games: [] })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    // A 422 (or 500 / transport drop) stays put on the score-entry screen for
+    // the user to fix and retry — no refetch, so nothing navigates them away.
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: matchQueryKey(matchId),
     })
   })
 })

--- a/web-client/src/api/matches.ts
+++ b/web-client/src/api/matches.ts
@@ -9,6 +9,7 @@ import {
   ApiError,
   api,
   conflictDetail,
+  isNegotiationConflict,
   resolveBaseUrl,
   unwrap,
 } from './client'
@@ -700,6 +701,27 @@ export function useProposeResult(matchId: string) {
         }),
       ),
     onSuccess: (data) => applyBoardWriteCache(queryClient, matchId, data),
+    // The NEGOTIATION-conflict 409 (`_negotiation_conflict`, "a result already
+    // exists") means the opponent already posted a standing result out from under
+    // this screen. The entered score is fine; there's nothing left to propose.
+    // Refetch the observed match so score-entry's own early-return
+    // (`standing_result`/`completed`) can route the poster to match detail, where
+    // they can Accept. This is the minimal "Option A" replacing the #800 reconcile
+    // interstitial that ADR-0005 (#827) deleted — no interstitial, just re-sync +
+    // the existing redirect.
+    //
+    // Gate on `isNegotiationConflict` specifically, NOT every 409: the other two
+    // propose 409s carry a plain-STRING detail — the lock race ("a result is
+    // already being posted…") and the terminal guard ("no longer open to
+    // results") — where a concurrent post may not have committed yet, so a
+    // refetch can return a still-`in_progress` match with no `standing_result`
+    // and the redirect would never fire. Those (and a 422/500/transport drop)
+    // must stay put so score-entry surfaces them with a live retry.
+    onError: (error) => {
+      if (error instanceof ApiError && isNegotiationConflict(error)) {
+        queryClient.invalidateQueries({ queryKey: matchQueryKey(matchId) })
+      }
+    },
   })
 }
 

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -1300,7 +1300,9 @@ function renderScoringApp(
 
 // A match sitting on the deciding game: 2–0 with games 1 and 2 scored, so the
 // next entry (game 3) can finish the match.
-function decidingGameMatch() {
+function decidingGameMatch(
+  overrides: Parameters<typeof matchDetails>[0] = {},
+) {
   return inProgressMatch({
     sides: participantSides({ meWins: 2, oppWins: 0 }),
     games: [
@@ -1308,7 +1310,34 @@ function decidingGameMatch() {
       { id: 'g-2', game_number: 2, score: score('s-2', 11, 6) },
     ],
     current_game: { game_number: 3 },
+    ...overrides,
   })
+}
+
+// The propose-result NEGOTIATION-conflict 409 body: the server's
+// `_negotiation_conflict` responds with the viewer-relative negotiation OBJECT
+// as `detail` (it has `viewer_state`), NOT a plain string. `isNegotiationConflict`
+// keys on that object shape to trigger the calm redirect — the lock-race /
+// terminal 409s (plain-string detail) deliberately don't match.
+function negotiationConflictBody() {
+  return {
+    detail: {
+      viewer_state: 'review',
+      your_turn: true,
+      standing_result: {
+        id: 'r-opp',
+        games: [
+          { game_number: 1, side_1_points: 4, side_2_points: 11 },
+          { game_number: 2, side_1_points: 6, side_2_points: 11 },
+          { game_number: 3, side_1_points: 9, side_2_points: 11 },
+        ],
+        submitted_by: 'u-opp',
+        submitted_at: '2026-05-12T19:30:00Z',
+      },
+      prior_result: null,
+      diff: null,
+    },
+  }
 }
 
 // The finalized MatchDetails a successful POST /results returns: a completed
@@ -1894,7 +1923,7 @@ describe('ScoreEntry — failed saves', () => {
   // The finalize hook's contract is that its errors matter (unlike the swallowed
   // per-game saves). When the banner's online finalize fails, it surfaces the
   // server's reason instead of silently reverting.
-  it('banner surfaces a finalize error (e.g. result already posted) instead of failing silently', async () => {
+  it('a finalize 409 (result already posted) redirects calmly instead of dead-ending (#801)', async () => {
     const user = userEvent.setup()
     server.use(
       http.get('*/v1/matches/m-1', () =>
@@ -1904,10 +1933,7 @@ describe('ScoreEntry — failed saves', () => {
         HttpResponse.error(),
       ),
       http.post('*/v1/matches/m-1/results', () =>
-        HttpResponse.json(
-          { detail: 'A result has already been posted.' },
-          { status: 409 },
-        ),
+        HttpResponse.json(negotiationConflictBody(), { status: 409 }),
       ),
     )
 
@@ -1930,12 +1956,15 @@ describe('ScoreEntry — failed saves', () => {
     onlineManager.setOnline(true)
     await user.click(screen.getByRole('button', { name: /post result/i }))
 
-    // The reason surfaces inline rather than reverting silently, and the button
-    // stays usable for another attempt.
-    await screen.findByText('A result has already been posted.')
+    // A negotiation-conflict 409 means the match moved on (a result is already
+    // posted): the fix refetches the match and shows a CALM redirect notice — not
+    // the old red dead-end that re-fired the same 409 — and locks the submit so it
+    // can't re-fire while the redirect is pending (#801, replacing the pre-fix
+    // inline-error-and-retry behavior for THIS 409 shape).
+    await screen.findByText(/taking you there/i)
     expect(
       screen.getByRole('button', { name: /post result/i }),
-    ).toBeEnabled()
+    ).toBeDisabled()
   })
 
   // Regression for the fully-offline path (QA BUG 1): with NO games persisted
@@ -3130,6 +3159,168 @@ describe('ScoreEntry — finalize connection drop (#868)', () => {
     expect(resultsCalls).toBe(2)
     // No stale connection copy survives the successful resend.
     expect(hasConnectionAlert()).toBe(false)
+  })
+})
+
+describe('ScoreEntry — stale finalize hits a posted result (409 → redirect) (#801)', () => {
+  // The bug: a participant sits on a stale deciding-game screen while the
+  // opponent has already POSTed a final result. Tapping "Post result" hits the
+  // server's negotiation 409 (`_negotiation_conflict`). Pre-fix the score pad
+  // dead-ended on a red "Failed"/detail error with the button still live,
+  // re-firing the same 409. Option A (this fix, replacing the #800 interstitial
+  // ADR-0005 removed): `useProposeResult` refetches the match on a 409, and
+  // score-entry's own `standing_result`/`completed` early-return routes the
+  // poster to match detail. In the transient window before the refetch lands we
+  // show CALM redirect copy, not the red error.
+
+  // The refetched match once the opponent's standing result is visible: still
+  // in_progress (rated, awaiting the viewer's Accept), but `standing_result` is
+  // now set — which trips score-entry's early-return `<Navigate>` to detail.
+  function opponentStandingMatch() {
+    return decidingGameMatch({
+      negotiation: {
+        viewer_state: 'review',
+        your_turn: true,
+        standing_result: {
+          id: 'r-opp',
+          games: [
+            { game_number: 1, side_1_points: 4, side_2_points: 11 },
+            { game_number: 2, side_1_points: 6, side_2_points: 11 },
+            { game_number: 3, side_1_points: 9, side_2_points: 11 },
+          ],
+          submitted_by: 'u-opp',
+          submitted_at: '2026-05-12T19:30:00Z',
+        },
+        prior_result: null,
+        diff: null,
+      },
+    })
+  }
+
+  it('shows calm redirect copy — not a red error, with the submit locked — during the 409 window', async () => {
+    const user = userEvent.setup()
+    // The refetch keeps returning the same live match (standing_result null), so
+    // the early-return doesn't fire and we stay frozen in the transient window,
+    // which is exactly what we want to assert on. The actual navigation is
+    // covered by the next test.
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(decidingGameMatch())),
+      http.post('*/v1/matches/m-1/results', () =>
+        HttpResponse.json(negotiationConflictBody(), { status: 409 }),
+      ),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    await user.type(meInput, '11')
+    await user.type(oppInput, '3')
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+
+    // Calm "the app talking back" notice appears.
+    expect(await screen.findByText(/taking you there/i)).toBeInTheDocument()
+    // The old red dead-end copy is gone: the generic "Failed to post match
+    // result" error is not surfaced.
+    expect(
+      screen.queryByText(/failed to post match result/i),
+    ).not.toBeInTheDocument()
+    // The valid score stays clean — a 409 doesn't mean the entered board is bad.
+    expect(meInput).not.toHaveAttribute('aria-invalid', 'true')
+    expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
+    // The submit is locked so it can't re-fire the same conflict.
+    expect(
+      screen.getByRole('button', { name: /post result/i }),
+    ).toBeDisabled()
+  })
+
+  it('refetches on the 409 and lands on match detail once the opponent result is visible', async () => {
+    const user = userEvent.setup()
+    // Before the post the match is the stale live deciding game; once the propose
+    // POST 409s (opponent already posted), any subsequent GET — the 409-driven
+    // refetch — reports the opponent's standing result, tripping the
+    // early-return redirect. Gating on `posted` (not a raw GET counter) is robust
+    // to however many GETs the screen issues on mount.
+    let posted = false
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(
+          posted ? opponentStandingMatch() : decidingGameMatch(),
+        ),
+      ),
+      http.post('*/v1/matches/m-1/results', () => {
+        posted = true
+        return HttpResponse.json(negotiationConflictBody(), { status: 409 })
+      }),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    await user.type(meInput, '11')
+    await user.type(oppInput, '3')
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+
+    // The refetch sees the posted result and the early-return navigates to detail.
+    await waitFor(() =>
+      expect(screen.getByText('match-page m-1')).toBeInTheDocument(),
+    )
+    // Never dead-ended on the red error.
+    expect(
+      screen.queryByText(/failed to post match result/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('a plain-string lock-race 409 stays retryable (red error, live submit) — no calm redirect', async () => {
+    // The other two propose 409s carry a plain-STRING detail (lock race /
+    // terminal). `isNegotiationConflict` doesn't match them, so they must NOT
+    // enter the calm-redirect/lock path — a concurrent post might not have
+    // committed, and a refetch could leave `standing_result` null and strand the
+    // screen on "Taking you there…" forever. They fall through to the normal
+    // (red) finalize error with the submit live for another attempt, exactly as
+    // before the #801 fix.
+    const user = userEvent.setup()
+    let getCalls = 0
+    server.use(
+      http.get('*/v1/matches/m-1', () => {
+        getCalls += 1
+        return HttpResponse.json(decidingGameMatch())
+      }),
+      http.post('*/v1/matches/m-1/results', () =>
+        HttpResponse.json(
+          {
+            detail:
+              'A result is already being posted for this match. Refresh to see the latest.',
+          },
+          { status: 409 },
+        ),
+      ),
+    )
+
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    await user.type(meInput, '11')
+    await user.type(oppInput, '3')
+    // The screen's initial load GET(s); anything past this would be a refetch.
+    const getsBeforePost = getCalls
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+
+    // The plain-string detail renders as the normal (red) finalize error…
+    await screen.findByText(/already being posted for this match/i)
+    // …not the calm redirect.
+    expect(screen.queryByText(/taking you there/i)).not.toBeInTheDocument()
+    // The submit stays live for another attempt (not locked).
+    expect(
+      screen.getByRole('button', { name: /post result/i }),
+    ).toBeEnabled()
+    // And no refetch was triggered — the string 409 doesn't invalidate.
+    expect(getCalls).toBe(getsBeforePost)
   })
 })
 

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -7,7 +7,7 @@ import {
 } from '@tanstack/react-router'
 import { onlineManager, useQueryClient } from '@tanstack/react-query'
 import { Check, Loader2, TriangleAlert, X as XIcon } from 'lucide-react'
-import { ApiError } from '@/api/client'
+import { ApiError, isNegotiationConflict } from '@/api/client'
 import {
   forgetScoreSaves,
   matchDetailRoute,
@@ -375,6 +375,25 @@ function ScoreEntryInner({
   // request, so we branch on the rejection that really happened.
   const finalizeNetworkError =
     finalizeMutation.error !== null && finalizeApiError === null
+  // The NEGOTIATION-conflict 409 ("a result already exists") is not an error to
+  // fix here — the opponent already posted the standing result. `useProposeResult`
+  // refetches the match on this 409; once the fresh data lands, the
+  // `standing_result`/`completed` early-return above navigates to match detail
+  // (where the poster can Accept). Until that one-round-trip refetch resolves
+  // we're in a transient redirect window: show CALM "taking you there" copy
+  // instead of the red "Failed" error, and don't paint the valid inputs red. This
+  // is the minimal Option A that replaces the #800 reconcile interstitial ADR-0005
+  // (#827) removed.
+  //
+  // Only the negotiation-conflict 409 redirects. The other propose 409s carry a
+  // plain-STRING detail — the lock race ("a result is already being posted…") and
+  // the terminal guard ("no longer open to results") — and their concurrent post
+  // may not have committed, so a refetch could leave `standing_result` null and
+  // strand the screen on "Taking you there…" forever. Those fall through to the
+  // normal red-error path below (string detail rendered, submit live for retry),
+  // exactly as before this fix.
+  const finalizeRedirecting =
+    finalizeApiError !== null && isNegotiationConflict(finalizeApiError)
 
   // Build the hypothetical full-match games list including the current input,
   // so we can ask the scoring lib whether saving this entry would make the
@@ -437,7 +456,8 @@ function ScoreEntryInner({
   const showScoreError =
     inputsInvalid ||
     overrunError !== null ||
-    finalizeApiError !== null ||
+    // A 409 is surfaced as the calm redirect notice below, not the red error.
+    (finalizeApiError !== null && !finalizeRedirecting) ||
     finalizeNetworkError
   // The "both scores required" hint is its own, lower-severity line — shown only
   // when exactly one field is filled and there's no harder error to surface.
@@ -670,8 +690,10 @@ function ScoreEntryInner({
   }
 
   // Only finalize pending state locks inputs — per-game mutations are
-  // fire-and-forget, so we don't want to make the UI feel laggy on those.
-  const inputsLocked = finalizeMutation.isPending
+  // fire-and-forget, so we don't want to make the UI feel laggy on those. Also
+  // lock during the 409 redirect window so the still-valid submit can't re-fire
+  // the same conflict while the match refetches and the early-return navigates.
+  const inputsLocked = finalizeMutation.isPending || finalizeRedirecting
   const isEdit = mode.kind === 'edit'
 
   const heading = isEdit
@@ -728,6 +750,17 @@ function ScoreEntryInner({
             onKeepCommitted={keepCommittedScore}
             onUseMine={overwriteWithMyScore}
           />
+        )}
+
+        {finalizeRedirecting && (
+          // Calm "the app talking back" notice (design-system Alert, default
+          // variant — not the red error line) for the transient window between a
+          // propose 409 and the refetch-driven redirect to match detail.
+          <Alert className="mb-3">
+            <Loader2 className="animate-spin" aria-hidden />
+            <AlertTitle>This match already has a posted result</AlertTitle>
+            <AlertDescription>Taking you there…</AlertDescription>
+          </Alert>
         )}
 
         <ScorePad


### PR DESCRIPTION
## What

Fixes #801. A stale **"Post result"** — the opponent already posted a standing result out from under the score-entry screen — hit the server's negotiation 409 (`_negotiation_conflict`, "a result already exists") and dead-ended on a generic red *"Failed to post match result"* with the button still live, re-firing the same 409. No path forward.

## Why the issue's suggested fix doesn't apply

Issue 801 proposed reusing #800's board-conflict reconcile interstitial. **That path no longer exists** — #827 / ADR-0005 deleted it (it false-rejected legitimate out-of-order clinches and soft-locked finalize, #825). ADR-0005's recorded direction is "propose/accept is the only reconciliation," so this fix extends that rather than resurrecting the removed interstitial.

## The fix — minimal "Option A", web-client only

On the **negotiation-conflict 409**, `useProposeResult` refetches the match; the fresh `standing_result` then trips score-entry's **existing** early-return (`score-entry.tsx:209`), which navigates the poster to **match detail** where they can Accept. During the one-round-trip refetch window the pad shows a calm *"This match already has a posted result — taking you there…"* notice instead of the red error, with the submit locked so it can't re-fire.

## Scoped precisely — no wedge

Redirect fires **only** for the negotiation-conflict 409 (body is the negotiation object — `viewer_state` etc.), via a new `isNegotiationConflict` discriminator. The other two propose 409s carry a plain-**string** detail — the lock race (*"a result is already being posted…"*) and the terminal guard (*"no longer open to results"*) — where a concurrent post may not have committed yet, so a refetch could leave `standing_result` null and strand the screen on "Taking you there…" forever. Those keep their **pre-existing inline red-error-with-live-retry** behavior. (This wedge was caught in verification and closed before commit.)

## Behavior-change note

Only the **negotiation-conflict 409** ("a result already exists") is no longer inline-retryable — it now does a calm redirect + locked submit. The **lock-race and terminal 409s (string detail) remain inline-retryable exactly as before.** The 422 / overrun / transport-drop paths are unchanged.

## Scope

Web-client only — the server already 409s correctly, so **no API/schema/iOS change and no openapi regen**. Files: `src/api/client.ts` (new `isNegotiationConflict`), `src/api/matches.ts`, `src/components/matches/score-entry.tsx` + their tests.

## Tests

Full web-client suite green (**1261 passed**), `tsc -b` + `eslint` clean. New coverage: the negotiation-409 redirect (calm copy + no red "Failed" + eventual `<Navigate>` to match detail + locked submit), and the lock-race string-409 negative case (renders the string error, submit stays **enabled**, **no** refetch). Hook-level tests assert `useProposeResult` invalidates on an object-body 409 but not on a string-body 409 or a 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)