### PR TITLE
Fix #226: drop the dead bounce screen and the fabricated verify-error log

### DIFF
--- a/web-client/src/components/login/login-screens.test.tsx
+++ b/web-client/src/components/login/login-screens.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { act, render, screen } from '@/test/utilities'
 
-import { ScreenEmail, ScreenSent } from './login-screens'
+import { ScreenEmail, ScreenSent, ScreenVerifyNetError } from './login-screens'
 
 describe('ScreenSent expiry countdown', () => {
   beforeEach(() => {
@@ -75,5 +75,42 @@ describe('ScreenEmail over-long address (#377)', () => {
       screen.getByText("That doesn't look like a valid email."),
     ).toBeInTheDocument()
     expect(screen.getByText(/FAILED/)).toBeInTheDocument()
+  })
+})
+
+describe('ScreenVerifyNetError fabricated diagnostics (#226)', () => {
+  // This screen came in wholesale from a static design mockup, so it used to
+  // render invented diagnostics at the user: a hostname we don't own and a
+  // fake HTTP log (522s against /auth/verify endpoints that don't exist).
+  // Never show the user a detail we didn't actually observe.
+  it('renders no invented hostnames, status codes or request logs', () => {
+    const { container } = render(<ScreenVerifyNetError />)
+    const text = container.textContent ?? ''
+
+    expect(text).not.toMatch(/auth\.fortymm\.com/)
+    expect(text).not.toMatch(/522/)
+    expect(text).not.toMatch(/\/auth\/verify/)
+    expect(text).not.toMatch(/\/auth\/session/)
+    expect(text).not.toMatch(/gave up after/i)
+    expect(text).not.toMatch(/retry 2\/3/i)
+  })
+
+  it('still explains the failure and offers both recovery actions', async () => {
+    const user = userEvent.setup()
+    const onRetry = vi.fn()
+    const onSendNewLink = vi.fn()
+    render(
+      <ScreenVerifyNetError onRetry={onRetry} onSendNewLink={onSendNewLink} />,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: /couldn.t reach fortymm/i }),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /retry verification/i }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+
+    await user.click(screen.getByRole('button', { name: /send a new link/i }))
+    expect(onSendNewLink).toHaveBeenCalledTimes(1)
   })
 })

--- a/web-client/src/components/login/login-screens.tsx
+++ b/web-client/src/components/login/login-screens.tsx
@@ -350,49 +350,6 @@ function EmailReceipt({ email }: { email: string }) {
   )
 }
 
-type SolverLine = [string, string, string, string]
-
-const FAILED_VERIFY_LOG: SolverLine[] = [
-  ['200', 'POST', '/auth/verify', 'token signature ok'],
-  ['…', 'GET', '/auth/session', 'connecting…'],
-  ['522', 'GET', '/auth/session', 'origin unreachable'],
-  ['522', 'GET', '/auth/session', 'retry 2/3 · failed'],
-  ['ERR', '···', '/auth/session', 'gave up after 12s'],
-]
-
-function solverStatusColor(status: string) {
-  if (status === '200') return 'var(--serve-500)'
-  if (status === '…') return 'var(--warn)'
-  return 'var(--loss)'
-}
-
-function SolverLog({ lines }: { lines: SolverLine[] }) {
-  return (
-    <div style={logCard}>
-      {lines.map((l, i) => {
-        const statusColor = solverStatusColor(l[0])
-        const pathColor =
-          statusColor === 'var(--loss)' ? 'var(--loss)' : 'var(--ball-500)'
-        return (
-          <div
-            key={i}
-            style={{
-              display: 'grid',
-              gridTemplateColumns: '42px 56px 1fr auto',
-              gap: 10,
-            }}
-          >
-            <span style={{ color: statusColor }}>{l[0]}</span>
-            <span style={{ color: 'var(--fg-2)' }}>{l[1]}</span>
-            <span style={{ color: pathColor }}>{l[2]}</span>
-            <span style={{ color: 'var(--fg-muted)' }}>{l[3]}</span>
-          </div>
-        )
-      })}
-    </div>
-  )
-}
-
 function SuccessReceipt({
   username,
   email,
@@ -518,71 +475,6 @@ function InlineError({
         }}
       >
         {detail}
-      </div>
-    </div>
-  )
-}
-
-function BounceReceipt({ email }: { email: string }) {
-  return (
-    <div
-      style={{
-        ...receiptCard,
-        borderColor: 'rgba(255,77,109,0.35)',
-        boxShadow:
-          '0 0 0 1px rgba(255,77,109,0.18), 0 8px 24px rgba(255,77,109,0.10)',
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 14,
-          padding: '4px 0 12px',
-        }}
-      >
-        <XBadge />
-        <div>
-          <div
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 10.5,
-              fontWeight: 700,
-              color: 'var(--loss)',
-              letterSpacing: '0.18em',
-            }}
-          >
-            ● ERR_HARD_BOUNCE
-          </div>
-          <div
-            style={{
-              fontFamily: 'var(--font-ui)',
-              fontSize: 14,
-              fontWeight: 500,
-              color: 'var(--fg-1)',
-              marginTop: 4,
-            }}
-          >
-            Mailbox doesn’t exist
-          </div>
-        </div>
-      </div>
-      <div style={receiptDiv} />
-      <div style={receiptRow}>
-        <span style={receiptK}>To</span>
-        <span style={{ ...receiptV, color: 'var(--loss)' }}>{email}</span>
-      </div>
-      <div style={receiptDiv} />
-      <div style={receiptRow}>
-        <span style={receiptK}>Reason</span>
-        <span style={receiptV}>550 5.1.1 No such user</span>
-      </div>
-      <div style={receiptDiv} />
-      <div style={receiptRow}>
-        <span style={receiptK}>Server</span>
-        <span style={{ ...receiptV, color: 'var(--fg-3)' }}>
-          mx1.club37.de
-        </span>
       </div>
     </div>
   )
@@ -852,18 +744,6 @@ const receiptV: CSSProperties = {
 }
 
 const receiptDiv: CSSProperties = { height: 1, background: 'var(--ink-700)' }
-
-const logCard: CSSProperties = {
-  marginTop: 4,
-  background: 'var(--ink-950)',
-  border: '1px solid var(--ink-600)',
-  borderRadius: 'var(--r-md)',
-  padding: 14,
-  fontFamily: 'var(--font-mono)',
-  fontSize: 11.5,
-  color: 'var(--fg-3)',
-  lineHeight: 1.7,
-}
 
 /* ─── Screens ───────────────────────────────────────────────────────── */
 
@@ -1235,75 +1115,6 @@ export function ScreenEmailSendFailed({
   )
 }
 
-export interface ScreenSentBouncedProps {
-  email: string
-  onChangeEmail?: () => void
-  onRetry?: () => void
-  retrying?: boolean
-}
-
-export function ScreenSentBounced({
-  email,
-  onChangeEmail,
-  onRetry,
-  retrying = false,
-}: ScreenSentBouncedProps) {
-  return (
-    <Shell
-      left={
-        <HeroCol
-          eyebrow="● Returned to sender"
-          h1a="No mailbox"
-          h1b="at that address."
-        />
-      }
-      right={
-        <FormCol
-          stepNo="02"
-          stepLabel="Inbox · bounced"
-          title={`Couldn’t deliver to ${email}`}
-          subtitle="Their server bounced our email right back. Probably a typo. Try a different address."
-          accent="var(--loss)"
-        >
-          <BounceReceipt email={email} />
-
-          <div style={{ display: 'flex', gap: 10 }}>
-            <button
-              type="button"
-              style={{ ...btnPrimary, flex: 1 }}
-              onClick={onChangeEmail}
-              disabled={!onChangeEmail}
-            >
-              Use a different email
-            </button>
-            <button
-              type="button"
-              style={btnGhost}
-              onClick={onRetry}
-              disabled={retrying || !onRetry}
-            >
-              {retrying ? 'Retrying…' : 'Retry same address'}
-            </button>
-          </div>
-
-          <div style={fineprint}>
-            Did you mean{' '}
-            <LinkButton onClick={onChangeEmail}>tomas.fischer@club37.de</LinkButton>?
-            <br />
-            <span style={{ color: 'var(--fg-muted)' }}>
-              If your address is right, it might be on a blocklist.{' '}
-              <a href="mailto:support@fortymm.com" style={linkInline}>
-                Tell us
-              </a>
-              .
-            </span>
-          </div>
-        </FormCol>
-      }
-    />
-  )
-}
-
 export interface ScreenVerifyNetErrorProps {
   onRetry?: () => void
   onSendNewLink?: () => void
@@ -1328,17 +1139,19 @@ export function ScreenVerifyNetError({
         <FormCol
           stepNo="03"
           stepLabel="Verifying · failed"
-          title="Couldn’t reach the auth server"
-          subtitle="Couldn’t reach the server. Check your connection — your link is still good for a few more minutes."
+          title="Couldn’t reach FortyMM to verify your link"
+          subtitle="The request didn’t get through. Check your connection and give it another go."
           accent="var(--loss)"
         >
+          {/* Only what we actually know: the request didn't get through. No
+              invented hostnames, status codes, timings or request logs — and no
+              claim about the link's fate we can't stand behind, since a failed
+              request tells us nothing about what the server did (#226). */}
           <InlineError
-            code="ERR_NETWORK_UNREACHABLE"
-            title="auth.fortymm.com is unreachable"
-            detail="The server didn’t answer. Your device looks online; our edge node may be down."
+            code="ERR_NETWORK"
+            title="We couldn’t reach FortyMM"
+            detail="The verification didn’t go through. Your link should still be good — retry it, or send yourself a new one."
           />
-
-          <SolverLog lines={FAILED_VERIFY_LOG} />
 
           <div style={{ display: 'flex', gap: 10 }}>
             <button

--- a/web-client/src/routes/login.index.tsx
+++ b/web-client/src/routes/login.index.tsx
@@ -61,7 +61,7 @@ function LoginPage() {
             // Stamp the send time so /login/sent can run a real expiry
             // countdown anchored to when the link actually went out (survives
             // refresh; a fresh send via resend re-stamps it).
-            search: { email, sentAt: Date.now(), error: undefined },
+            search: { email, sentAt: Date.now() },
           })
         } catch (err) {
           if (err instanceof ApiError) {

--- a/web-client/src/routes/login.sent.tsx
+++ b/web-client/src/routes/login.sent.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
 import { ApiError } from '@/api/client'
 import { useRequestLogin } from '@/api/session'
-import { ScreenSent, ScreenSentBounced } from '@/components/login/login-screens'
+import { ScreenSent } from '@/components/login/login-screens'
 import { Turnstile, type TurnstileHandle } from '@/components/turnstile'
 import { pageTitle } from '@/lib/page-title'
 
@@ -11,8 +11,10 @@ export const Route = createFileRoute('/login/sent')({
   head: () => ({
     meta: [{ title: pageTitle('Check your inbox') }],
   }),
+  // No `error` key: this page has exactly one state. A hand-typed `?error=…`
+  // is simply never read, so it falls through to the normal "check your inbox"
+  // screen rather than a bespoke error screen (#226).
   validateSearch: (search: Record<string, unknown>) => ({
-    error: search.error === 'bounce' ? ('bounce' as const) : undefined,
     email: typeof search.email === 'string' ? search.email : '',
     sentAt: typeof search.sentAt === 'number' ? search.sentAt : undefined,
   }),
@@ -20,7 +22,7 @@ export const Route = createFileRoute('/login/sent')({
 })
 
 function LoginSentPage() {
-  const { error, email, sentAt } = Route.useSearch()
+  const { email, sentAt } = Route.useSearch()
   const navigate = useNavigate()
   const requestLogin = useRequestLogin()
   // A fresh captcha token is kept on this page (the Turnstile widget below
@@ -32,8 +34,8 @@ function LoginSentPage() {
   const captchaRef = useRef<TurnstileHandle | null>(null)
   const inFlight = useRef(false)
 
-  // "Start over" (and bounce recovery) goes back to /login with the email
-  // prefilled to re-run the whole flow from scratch.
+  // "Start over" goes back to /login with the email prefilled to re-run the
+  // whole flow from scratch.
   const startOver = () => {
     navigate({
       to: '/login',
@@ -60,7 +62,7 @@ function LoginSentPage() {
           navigate({
             to: '/login/sent',
             replace: true,
-            search: { email, sentAt: Date.now(), error: undefined },
+            search: { email, sentAt: Date.now() },
           })
         },
         onError: (err) => {
@@ -78,16 +80,6 @@ function LoginSentPage() {
           captchaRef.current?.reset()
         },
       },
-    )
-  }
-
-  if (error === 'bounce') {
-    return (
-      <ScreenSentBounced
-        email={email}
-        onChangeEmail={startOver}
-        onRetry={startOver}
-      />
     )
   }
 

--- a/web-client/src/routes/login.test.tsx
+++ b/web-client/src/routes/login.test.tsx
@@ -276,6 +276,28 @@ describe('/login/sent flow', () => {
     expect(router.state.location.pathname).toBe('/login/sent')
   })
 
+  // Regression test for #226: `?error=bounce` used to render a dead-end screen
+  // full of fabricated delivery diagnostics (a made-up SMTP reason, mail server
+  // and "did you mean" address). Nothing ever sets it, so a hand-typed URL was
+  // the only way in. The key is dropped from the search schema now — the page
+  // must fall through to the normal "check your inbox" screen, not blank out.
+  it('falls through to the normal sent screen for a hand-typed ?error=bounce', async () => {
+    const { router } = renderAt(
+      '/login/sent?error=bounce&email=rita@example.com&sentAt=1000',
+    )
+
+    // The route's search schema has no `error` key, so nothing reads one: the
+    // page renders its single, normal state instead of blanking or crashing.
+    expect(
+      await screen.findByRole('heading', { name: /link sent to rita@example.com/i }),
+    ).toBeInTheDocument()
+    expect(router.state.location.pathname).toBe('/login/sent')
+    // None of the deleted bounce screen's fabricated fixtures reach the user.
+    expect(screen.queryByText(/couldn.t deliver/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/tomas\.fischer@club37\.de/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/550 5\.1\.1/)).not.toBeInTheDocument()
+  })
+
   it('"Start over" routes back to /login with the email prefilled', async () => {
     const user = userEvent.setup()
     const { router } = renderAt('/login/sent?email=rita@example.com&sentAt=1000')


### PR DESCRIPTION
Closes #226

The login screens were imported wholesale as a static design mockup in #224; #225 wired up the ones that had a backend. Two were left rendering the mockup's invented content to real users.

## 1. `ScreenSentBounced` — deleted (the issue's own alternative)

It was unreachable: nothing in the app ever set `?error=bounce`, so it could only be hit by hand-typing the URL — at which point it showed the user a hardcoded SMTP reason (`550 5.1.1 No such user`), a hardcoded server (`mx1.club37.de`), and a hardcoded "Did you mean **tomas.fischer@club37.de**?" — a stranger's address, on a domain neither party has touched.

**Why delete rather than build the bounce-webhook path the issue sketches.** A bounce is asynchronous: `POST /v1/login/request` enqueues an RQ job and returns immediately, the worker relays via plain SMTP, and the only party who ever learns about a bounce is Postmark. For `/login/sent` to flip itself to `?error=bounce`, an **anonymous, unauthenticated** page would have to poll an endpoint that truthfully answers *"did the mail I just sent to `X` bounce?"*

That endpoint is a **mailbox-validity oracle**. Type any third-party address into the login form, wait, poll, and FortyMM tells you whether the mailbox exists — a free email verifier, paid for with FortyMM-branded spam at every address tested. Handing the client an opaque `request_id` doesn't help: the attacker is the submitter and holds the token by construction. And it directly contradicts the invariant the login flow already defends — the uniform `202` on `/v1/login/request` exists precisely so the endpoint can't be used as an oracle.

So the last mile of that pipeline is architecturally wrong, not merely expensive. The genuinely valuable half — telling a **signed-in** user that their own address is undeliverable — is safe (you can only see bounce state for an account you already control) and should be built as a separate, properly-scoped follow-up rather than reverse-engineered from a mockup. Filed as #916, which records the oracle reasoning as an explicit non-goal so nobody rebuilds the anonymous version from the mockup later.

## 2. `ScreenVerifyNetError` — fixed, not deleted (approved sibling defect)

Same fixture-leak class, and **worse, because it's reachable**: `/login/verifying?error=net` really is set on a network failure during verify. It rendered a fabricated HTTP log at the user — `POST /auth/verify`, `GET /auth/session`, `522 origin unreachable`, `retry 2/3 · failed`, `gave up after 12s`, and the hostname `auth.fortymm.com is unreachable`. None of those endpoints exist (our API serves `/v1/login/…`) and that host isn't ours.

The screen is kept, along with its real Retry / Send-a-new-link actions. Only the invented diagnostics are gone; the copy now states just what we actually know. It deliberately says the link *should* still be good rather than *is* — a failed request tells us nothing about what the server did, and asserting otherwise would be the same defect in a new coat.

## Verification

Independently reproduced by a separate verifier agent, not just self-reported:

- Full suite green: **183 files / 1272 tests passed**, `tsc -b` and `eslint` exit 0.
- Driven in a real headless browser: hand-typed `/login/sent?error=bounce` renders the normal "check your inbox" screen — no crash, no blank page, no console errors, none of the fixtures.
- `/login/verifying?error=net` renders the new copy, and **Retry was clicked live** and genuinely worked (navigated on to `/login/welcome`) — not a dead button.
- Zero fabricated strings survive in shipping source; the only remaining hits are the new tests' negative assertions.

Worth recording: TanStack Router does **not** strip unknown search keys — `error=bounce` stays in the URL. The fall-through is safe because the route's schema no longer *declares* `error`, so nothing reads it. The route comment says so, rather than the tempting-but-false "unknown keys are dropped".

## Tests

- `routes/login.test.tsx` — regression guard for #226: hand-typed `?error=bounce` renders the normal sent screen and none of the bounce fixtures.
- `login-screens.test.tsx` — `ScreenVerifyNetError` renders no invented hostname/status/log, and still offers both working recovery actions.

No API route or schema touched, so no `schema.d.ts` regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012z5s58oMcFphrLP3cc4arP

