### PR TITLE
Fix #900 + #218: label mobile player cards, unify panel chrome onto the shared Card

### DIFF
--- a/web-client/src/components/matches/match-details.test.tsx
+++ b/web-client/src/components/matches/match-details.test.tsx
@@ -445,15 +445,14 @@ describe("MatchDetails — page wiring", () => {
     });
     matchDetailsPage.mockMatch("m-form", match);
 
-    const { container } = matchDetailsPage.render("m-form");
+    matchDetailsPage.render("m-form");
 
-    // Wait for the Players snapshot card title to render. The header now
-    // carries the temporal frame so the per-field labels don't have to.
-    await waitFor(() =>
-      expect(container.querySelector(".md-card__hd h3")).toHaveTextContent(
-        "Players · going into this match",
-      ),
-    );
+    // Wait for the Players snapshot panel to render. It's a labelled landmark
+    // named by its own heading — which carries the temporal frame, so the
+    // per-field labels don't have to.
+    await screen.findByRole("region", {
+      name: "Players · going into this match",
+    });
     // Wiring only: each half's content (form rows, rating box, career strip)
     // is pinned by the players-panel query and component tests. Here we prove
     // the panel projected *this* payload — my history half and the rookie's
@@ -523,16 +522,16 @@ describe("MatchDetails — page wiring", () => {
     });
     matchDetailsPage.mockMatch("m-h2h", match);
 
-    const { container } = matchDetailsPage.render("m-h2h");
+    matchDetailsPage.render("m-h2h");
 
-    await waitFor(() => {
-      const headings = Array.from(
-        container.querySelectorAll(".md-card__hd h3"),
-      );
-      expect(headings.map((h) => h.textContent)).toContain("Head to head");
+    // The panel is a labelled landmark named by its heading; the content
+    // lookups below are scoped inside it, so they also prove the body belongs
+    // to *this* panel.
+    const h2hPanel = await screen.findByRole("region", {
+      name: "Head to head",
     });
-    const h2hCard = container.querySelector(".md-h2h")!;
-    expect(screen.getByText("3 MEETINGS")).toBeInTheDocument();
+    const h2hCard = h2hPanel.querySelector(".md-h2h")!;
+    expect(within(h2hPanel).getByText("3 MEETINGS")).toBeInTheDocument();
     // Win counts: left = me = 2, right = opp = 1.
     const counts = h2hCard.querySelectorAll(".md-h2h__count");
     expect(counts[0]).toHaveTextContent("2");
@@ -580,17 +579,12 @@ describe("MatchDetails — page wiring", () => {
     });
     matchDetailsPage.mockMatch("m-rated", match);
 
-    const { container } = matchDetailsPage.render("m-rated");
+    matchDetailsPage.render("m-rated");
 
-    await waitFor(() => {
-      const headings = Array.from(
-        container.querySelectorAll(".md-card__hd h3"),
-      );
-      expect(headings.map((h) => h.textContent)).toContain(
-        "Result · rating change",
-      );
+    const ratingsPanel = await screen.findByRole("region", {
+      name: "Result · rating change",
     });
-    const rows = container.querySelectorAll(".md-rating-row");
+    const rows = ratingsPanel.querySelectorAll(".md-rating-row");
     expect(rows).toHaveLength(2);
     const [winnerRow, loserRow] = Array.from(rows);
     expect(
@@ -615,15 +609,22 @@ describe("MatchDetails — page wiring", () => {
     });
     matchDetailsPage.mockMatch("m-unrated", match);
 
-    const { container } = matchDetailsPage.render("m-unrated");
+    matchDetailsPage.render("m-unrated");
 
-    await waitFor(() =>
-      expect(container.querySelector(".md-card__hd h3")).toBeInTheDocument(),
-    );
-    const headings = Array.from(container.querySelectorAll(".md-card__hd h3"));
-    expect(headings.map((h) => h.textContent)).not.toContain(
-      "Result · rating change",
-    );
+    // Two guards, so the absence below can't pass vacuously on a page that
+    // simply hasn't rendered yet: the always-present Match info panel proves
+    // the page rendered, and the ratings section's own busy status being gone
+    // proves *that* section settled — it resolved to nothing rather than still
+    // being in flight (a suspended Ratings renders that status as its
+    // fallback, so a mid-flight section would fail here rather than sneak a
+    // free pass through the absence assertion).
+    await screen.findByRole("region", { name: "Match info" });
+    expect(
+      screen.queryByRole("status", { name: "Loading rating change" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: "Result · rating change" }),
+    ).not.toBeInTheDocument();
   });
 
   it("hides the rating change card while the match is still live", async () => {
@@ -663,13 +664,17 @@ describe("MatchDetails — page wiring", () => {
 
     const { container } = matchDetailsPage.render("m-live-rated");
 
-    await waitFor(() =>
-      expect(container.querySelector(".md-card__hd h3")).toBeInTheDocument(),
-    );
-    const headings = Array.from(container.querySelectorAll(".md-card__hd h3"));
-    expect(headings.map((h) => h.textContent)).not.toContain(
-      "Result · rating change",
-    );
+    // Same two guards as above, same reason: the page has rendered (Match info
+    // panel) and the ratings section has settled (its busy status is gone), so
+    // the absence assertions below are about a section that *chose* to render
+    // nothing — not one that is still loading.
+    await screen.findByRole("region", { name: "Match info" });
+    expect(
+      screen.queryByRole("status", { name: "Loading rating change" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: "Result · rating change" }),
+    ).not.toBeInTheDocument();
     expect(container.querySelector(".md-rating-row")).toBeNull();
   });
 });

--- a/web-client/src/components/matches/match-details/card-meta.test.tsx
+++ b/web-client/src/components/matches/match-details/card-meta.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CardMeta } from "./card-meta";
+
+describe("CardMeta", () => {
+  // Every panel caption routes through this one component, so the panels can no
+  // longer drift apart from each other — but they can still drift *together*,
+  // away from the grey they shipped with. That is what this pins.
+  //
+  // `--fg-muted` is `--chalk-500` (#6b7283). `text-muted-foreground` is the
+  // tempting design-system token and is wrong: `.fortymm-theme` remaps it to
+  // `--chalk-300` (#a9b0c2), a visibly lighter grey. A caption that quietly
+  // switched tokens is exactly the regression #218 exists to prevent.
+  it("captions in the muted grey, not the lighter design-system token", () => {
+    render(<CardMeta>3 MEETINGS</CardMeta>);
+
+    const caption = screen.getByText("3 MEETINGS");
+    expect(caption).toHaveClass(
+      "self-center",
+      "text-[11px]",
+      "font-medium",
+      "tracking-[0.08em]",
+      "text-[color:var(--fg-muted)]",
+    );
+    expect(caption).not.toHaveClass("text-muted-foreground");
+  });
+
+  it("renders into the card header's trailing action slot", () => {
+    render(<CardMeta>SNAPSHOT · NOW</CardMeta>);
+
+    expect(screen.getByText("SNAPSHOT · NOW")).toHaveAttribute(
+      "data-slot",
+      "card-action",
+    );
+  });
+});

--- a/web-client/src/components/matches/match-details/card-meta.tsx
+++ b/web-client/src/components/matches/match-details/card-meta.tsx
@@ -1,0 +1,26 @@
+import { type ReactNode } from "react";
+
+import { CardAction } from "@/components/ui/card";
+
+/**
+ * The trailing caption in a match-details panel header — the head-to-head
+ * meeting count, the players panel's snapshot label.
+ *
+ * `text-muted-foreground` looks like the right design-system token here and is
+ * not: `.fortymm-theme` remaps it to the lighter `--chalk-300`. `--fg-muted`
+ * (`--chalk-500`) is the grey these captions have always been, back when they
+ * shared the one `.md-card__hd-meta` rule. Keep it.
+ *
+ * `self-center` centres the caption against the overline, which `CardHeader`
+ * would otherwise top-align in its `items-start` grid.
+ */
+export const CARD_META_CLASS =
+  "self-center text-[11px] font-medium tracking-[0.08em] text-[color:var(--fg-muted)]";
+
+export interface CardMetaProps {
+  children: ReactNode;
+}
+
+export const CardMeta = ({ children }: CardMetaProps) => (
+  <CardAction className={CARD_META_CLASS}>{children}</CardAction>
+);

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.page.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.page.tsx
@@ -32,9 +32,9 @@ const scoped = (container: Container) => {
         name: "Head to head",
       });
     },
-    /** The "N MEETING(S)" count in the card header. */
+    /** The "N MEETING(S)" count in the shared Card's trailing header slot. */
     getMeta() {
-      return getCard().querySelector(".md-card__hd-meta")!;
+      return getCard().querySelector('[data-slot="card-action"]')!;
     },
     /** The left side's player-name label. */
     getLeftLabel() {

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.test.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.test.tsx
@@ -11,6 +11,24 @@ describe("HeadToHeadDisplay", () => {
     expect(headToHeadDisplayPage.getTitle()).toHaveTextContent("Head to head");
   });
 
+  it("renders the panel through the shared Card, not the hand-rolled chrome", async () => {
+    headToHeadDisplayPage.render();
+
+    const card = await headToHeadDisplayPage.findCard();
+    // The landmark must survive the reskin: the shared Card renders `asChild`,
+    // so the styled card element *is* the labelled <section> — not an
+    // anonymous <div> wrapping one.
+    expect(card.tagName).toBe("SECTION");
+    expect(card).toHaveAttribute("data-slot", "card");
+    // Shared design-system chrome (hairline ring, rounded corners)…
+    expect(card).toHaveClass("bg-card", "rounded-xl", "ring-1");
+    // …and none of the bespoke `.md-card` family it replaced.
+    expect(card).not.toHaveClass("md-card");
+    expect(card.querySelector(".md-card__hd")).toBeNull();
+    expect(card.querySelector(".md-card__body")).toBeNull();
+    expect(card.querySelector(".md-card__hd-meta")).toBeNull();
+  });
+
   it("shows the side labels and win counts", async () => {
     headToHeadDisplayPage.render();
 

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.tsx
@@ -1,6 +1,12 @@
 import { useId } from "react";
 
 import { Overline } from "@/components/overline";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+} from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 import { type HeadToHeadView } from "./head-to-head-query";
@@ -22,65 +28,78 @@ export const HeadToHeadDisplay = ({ headToHead }: HeadToHeadDisplayProps) => {
   const rightPct = 100 - leftPct;
 
   return (
-    <section className="md-card" aria-labelledby={id}>
-      <div className="md-card__hd">
-        <Overline as="h3" id={id}>
-          Head to head
-        </Overline>
-        <span className="md-card__hd-meta">
-          {totalMeetings} {totalMeetings === 1 ? "MEETING" : "MEETINGS"}
-        </span>
-      </div>
-      <div className="md-card__body md-h2h">
-        <div className="md-h2h__counts">
-          <div className="md-h2h__count-label md-h2h__count-label--l">
-            {leftLabel}
-          </div>
-          <div
-            className={cn(
-              "md-h2h__count",
-              "md-h2h__count--l",
-              leftWins > rightWins && "md-h2h__count--win",
-            )}
-          >
-            {leftWins}
-          </div>
-          <span className="md-h2h__sep">—</span>
-          <div
-            className={cn(
-              "md-h2h__count",
-              "md-h2h__count--r",
-              rightWins > leftWins && "md-h2h__count--win",
-            )}
-          >
-            {rightWins}
-          </div>
-          <div className="md-h2h__count-label md-h2h__count-label--r">
-            {rightLabel}
-          </div>
-        </div>
-        {hasMeetings ? (
-          <>
-            <div className="md-h2h__bar" aria-hidden="true">
-              <div
-                style={{ width: `${leftPct}%`, background: "var(--serve-500)" }}
-              />
-              <div
-                style={{ width: `${rightPct}%`, background: "var(--ink-500)" }}
-              />
+    // `asChild` keeps the panel a labelled `<section>` landmark while the
+    // shared design-system Card supplies the chrome (ring, radius, spacing) —
+    // no bespoke `.md-card` classes, and no hard rule under the title.
+    <Card asChild>
+      <section aria-labelledby={id}>
+        <CardHeader>
+          <Overline as="h3" id={id}>
+            Head to head
+          </Overline>
+          <CardAction className="self-center text-[11px] font-medium tracking-[0.08em] text-[color:var(--fg-muted)]">
+            {totalMeetings} {totalMeetings === 1 ? "MEETING" : "MEETINGS"}
+          </CardAction>
+        </CardHeader>
+        {/* `md-h2h` is content layout (the panel's own vertical rhythm), not
+            card chrome — it stays. */}
+        <CardContent className="md-h2h">
+          <div className="md-h2h__counts">
+            <div className="md-h2h__count-label md-h2h__count-label--l">
+              {leftLabel}
             </div>
-            <div>
-              {headToHead.recentMeetings.map((meeting) => (
-                <MeetingRow key={meeting.matchId} meeting={meeting} />
-              ))}
+            <div
+              className={cn(
+                "md-h2h__count",
+                "md-h2h__count--l",
+                leftWins > rightWins && "md-h2h__count--win",
+              )}
+            >
+              {leftWins}
             </div>
-          </>
-        ) : (
-          <div className="md-h2h__empty">
-            No prior meetings — this match is the start of the rivalry.
+            <span className="md-h2h__sep">—</span>
+            <div
+              className={cn(
+                "md-h2h__count",
+                "md-h2h__count--r",
+                rightWins > leftWins && "md-h2h__count--win",
+              )}
+            >
+              {rightWins}
+            </div>
+            <div className="md-h2h__count-label md-h2h__count-label--r">
+              {rightLabel}
+            </div>
           </div>
-        )}
-      </div>
-    </section>
+          {hasMeetings ? (
+            <>
+              <div className="md-h2h__bar" aria-hidden="true">
+                <div
+                  style={{
+                    width: `${leftPct}%`,
+                    background: "var(--serve-500)",
+                  }}
+                />
+                <div
+                  style={{
+                    width: `${rightPct}%`,
+                    background: "var(--ink-500)",
+                  }}
+                />
+              </div>
+              <div>
+                {headToHead.recentMeetings.map((meeting) => (
+                  <MeetingRow key={meeting.matchId} meeting={meeting} />
+                ))}
+              </div>
+            </>
+          ) : (
+            <div className="md-h2h__empty">
+              No prior meetings — this match is the start of the rivalry.
+            </div>
+          )}
+        </CardContent>
+      </section>
+    </Card>
   );
 };

--- a/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.tsx
+++ b/web-client/src/components/matches/match-details/head-to-head/head-to-head-fetcher/head-to-head-display.tsx
@@ -1,12 +1,9 @@
 import { useId } from "react";
 
 import { Overline } from "@/components/overline";
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardHeader,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+import { CardMeta } from "../../card-meta";
 import { cn } from "@/lib/utils";
 
 import { type HeadToHeadView } from "./head-to-head-query";
@@ -37,9 +34,9 @@ export const HeadToHeadDisplay = ({ headToHead }: HeadToHeadDisplayProps) => {
           <Overline as="h3" id={id}>
             Head to head
           </Overline>
-          <CardAction className="self-center text-[11px] font-medium tracking-[0.08em] text-[color:var(--fg-muted)]">
+          <CardMeta>
             {totalMeetings} {totalMeetings === 1 ? "MEETING" : "MEETINGS"}
-          </CardAction>
+          </CardMeta>
         </CardHeader>
         {/* `md-h2h` is content layout (the panel's own vertical rhythm), not
             card chrome — it stays. */}

--- a/web-client/src/components/matches/match-details/match-info/match-info-fetcher/match-info-display.page.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-fetcher/match-info-display.page.tsx
@@ -7,6 +7,26 @@ import {
 } from "./match-info-display";
 import { buildMatchInfoDisplayProps } from "./match-info-display.factory";
 
+/**
+ * A structural fingerprint of a panel's *card chrome*: the card element itself
+ * plus its immediate slots (header, content). Deliberately blind to the bits
+ * the skeleton and the loaded panel are supposed to differ on — role,
+ * accessible name, leaf content — so it can pin the one thing they must agree
+ * on: the box the panel occupies. `MatchInfoSkeleton`'s page object reuses it,
+ * and the skeleton test compares the two fingerprints, which is what stops the
+ * skeleton and the loaded card from drifting into different-shaped boxes.
+ */
+export const cardChrome = (card: Element) => ({
+  tag: card.tagName,
+  slot: card.getAttribute("data-slot"),
+  className: card.className,
+  slots: Array.from(card.children).map((child) => ({
+    tag: child.tagName,
+    slot: child.getAttribute("data-slot"),
+    className: child.className,
+  })),
+});
+
 const scoped = (container: Container) => ({
   /** The card's `<section>` landmark, named by its visible heading. */
   getCard() {
@@ -15,9 +35,20 @@ const scoped = (container: Container) => ({
   queryCard() {
     return container.queryByRole("region", { name: "Match info" });
   },
+  /** The loaded panel's card chrome — see {@link cardChrome}. */
+  getCardChrome() {
+    return cardChrome(this.getCard());
+  },
   /** The visible card heading. */
   getTitle() {
     return container.getByRole("heading", { level: 3, name: "Match info" });
+  },
+  /** The `<dl>` holding the rows. Queried by tag: a description list has no
+   * role of its own, and its list semantics are the thing under test. */
+  getRowList() {
+    const list = this.getCard().querySelector("dl");
+    if (!list) throw new Error("No <dl> of info rows inside the card");
+    return list;
   },
   // Row lookups (`getLabel(label)` / `getValue(label)`) come from the row's
   // own page object.

--- a/web-client/src/components/matches/match-details/match-info/match-info-fetcher/match-info-display.test.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-fetcher/match-info-display.test.tsx
@@ -9,6 +9,29 @@ describe("MatchInfoDisplay", () => {
     expect(matchInfoDisplayPage.getTitle()).toBeInTheDocument();
   });
 
+  it("wears the shared design-system card, not the hand-rolled .md-card", () => {
+    matchInfoDisplayPage.render();
+
+    // `Card asChild` keeps the panel a labelled <section> landmark (asserted
+    // above) while the chrome comes from the shared Card — same as the
+    // dashboard's. The bespoke `.md-card` family is gone.
+    const card = matchInfoDisplayPage.getCard();
+    expect(card.tagName).toBe("SECTION");
+    expect(card).toHaveAttribute("data-slot", "card");
+    expect(card).toHaveClass("bg-card", "rounded-xl");
+    expect(card).not.toHaveClass("md-card");
+  });
+
+  it("keeps the rows a description list inside the card's content slot", () => {
+    matchInfoDisplayPage.render();
+
+    // The rows are <dt>/<dd> pairs; `CardContent` has no `asChild`, so the <dl>
+    // nests inside it rather than the list semantics being flattened away.
+    const list = matchInfoDisplayPage.getRowList();
+    expect(list.tagName).toBe("DL");
+    expect(list.closest('[data-slot="card-content"]')).not.toBeNull();
+  });
+
   it("renders one row per view row, in order, with its value", () => {
     matchInfoDisplayPage.render({
       info: {

--- a/web-client/src/components/matches/match-details/match-info/match-info-fetcher/match-info-display.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-fetcher/match-info-display.tsx
@@ -1,6 +1,7 @@
 import { useId } from "react";
 
 import { Overline } from "@/components/overline";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 import { InfoRow } from "./match-info-display/info-row";
 import { type MatchInfoView } from "./match-info-query";
@@ -9,21 +10,33 @@ export interface MatchInfoDisplayProps {
   info: MatchInfoView;
 }
 
+/**
+ * The match-info sidebar card. Wears the shared design-system `Card` chrome
+ * (`asChild`, so the panel stays a `<section aria-labelledby>` landmark rather
+ * than an anonymous div) instead of the bespoke `.md-card` classes. The rows
+ * live in a `<dl>` *inside* `CardContent` — `CardContent` is a plain div with
+ * no `asChild`, and the description-list semantics matter more than saving a
+ * wrapper. `MatchInfoSkeleton` mirrors this chrome; change them together.
+ */
 export const MatchInfoDisplay = ({ info }: MatchInfoDisplayProps) => {
   const id = useId();
 
   return (
-    <section className="md-card" aria-labelledby={id}>
-      <div className="md-card__hd">
-        <Overline as="h3" id={id}>
-          Match info
-        </Overline>
-      </div>
-      <dl className="md-card__body">
-        {info.rows.map((row) => (
-          <InfoRow key={row.label} row={row} />
-        ))}
-      </dl>
-    </section>
+    <Card asChild>
+      <section aria-labelledby={id}>
+        <CardHeader>
+          <Overline as="h3" id={id}>
+            Match info
+          </Overline>
+        </CardHeader>
+        <CardContent>
+          <dl>
+            {info.rows.map((row) => (
+              <InfoRow key={row.label} row={row} />
+            ))}
+          </dl>
+        </CardContent>
+      </section>
+    </Card>
   );
 };

--- a/web-client/src/components/matches/match-details/match-info/match-info-skeleton.page.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-skeleton.page.tsx
@@ -1,5 +1,6 @@
 import { render, screen, type Container } from "@/test/utilities";
 
+import { cardChrome } from "./match-info-fetcher/match-info-display.page";
 import { MatchInfoSkeleton } from "./match-info-skeleton";
 
 const scoped = (container: Container) => ({
@@ -7,10 +8,15 @@ const scoped = (container: Container) => ({
   getStatus() {
     return container.getByRole("status", { name: /loading match info/i });
   },
-  /** The card chrome the loaded card reuses (the status region is itself the
-   * `.md-card`). */
+  /** The shared design-system card the skeleton wears. Rendered with
+   * `Card asChild`, so the status `<section>` *is* the card element. */
   queryCard() {
-    return this.getStatus().closest(".md-card");
+    return this.getStatus().closest('[data-slot="card"]');
+  },
+  /** The skeleton's card chrome, in the same shape the loaded panel's page
+   * object reports — see {@link cardChrome}. */
+  getCardChrome() {
+    return cardChrome(this.getStatus());
   },
   /** The label/value rows reserved so the card keeps its height before the
    * real rows arrive. */

--- a/web-client/src/components/matches/match-details/match-info/match-info-skeleton.test.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-skeleton.test.tsx
@@ -1,3 +1,4 @@
+import { matchInfoDisplayPage } from "./match-info-fetcher/match-info-display.page";
 import { matchInfoSkeletonPage } from "./match-info-skeleton.page";
 
 describe("MatchInfoSkeleton", () => {
@@ -15,5 +16,27 @@ describe("MatchInfoSkeleton", () => {
 
     expect(matchInfoSkeletonPage.queryCard()).not.toBeNull();
     expect(matchInfoSkeletonPage.queryInfoRows().length).toBe(3);
+  });
+
+  it("wears the shared design-system card, not the hand-rolled .md-card", () => {
+    matchInfoSkeletonPage.render();
+
+    const card = matchInfoSkeletonPage.getStatus();
+    expect(card.tagName).toBe("SECTION");
+    expect(card).toHaveAttribute("data-slot", "card");
+    expect(card).not.toHaveClass("md-card");
+  });
+
+  // The half of the contract that matters: if the skeleton and the loaded panel
+  // ever wear *different* chrome (one on the shared Card, one still hand-rolled;
+  // one with a CardHeader, the other a bare div), the panel visibly resizes the
+  // moment the data lands. Comparing the two chromes fails the moment they drift.
+  it("wears the same card chrome as the loaded panel, so the panel doesn't jump on load", () => {
+    matchInfoDisplayPage.render();
+    matchInfoSkeletonPage.render();
+
+    expect(matchInfoSkeletonPage.getCardChrome()).toEqual(
+      matchInfoDisplayPage.getCardChrome(),
+    );
   });
 });

--- a/web-client/src/components/matches/match-details/match-info/match-info-skeleton.tsx
+++ b/web-client/src/components/matches/match-details/match-info/match-info-skeleton.tsx
@@ -1,34 +1,35 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
 const SK = "md-sk animate-pulse";
 
 /**
  * Loading placeholder for the {@link MatchInfo} sidebar card, shown as its
- * `<Suspense>` fallback. Reuses the real `.md-card` / `.md-info-row` structural
- * classes so the card chrome and label/value rows occupy the same boxes the
- * loaded card will — only the leaf text becomes shimmer blocks. Renders a
- * representative three rows (the loaded count varies); each row's height is
- * pinned by `.md-info-row`, not the bar inside it. This mirrors
- * `MatchInfoDisplay`'s markup by hand (Suspense unmounts the real tree during
- * load), so revisit it if that structure changes.
+ * `<Suspense>` fallback. Wears the *same* shared-`Card` chrome as
+ * `MatchInfoDisplay` — `Card asChild` around a `<section>`, a `CardHeader`, a
+ * `CardContent` — so the card box and the label/value rows occupy the boxes the
+ * loaded card will and nothing shifts when the data lands. Only the leaf text
+ * becomes shimmer blocks. Renders a representative three rows (the loaded count
+ * varies); each row's height is pinned by `.md-info-row`, not the bar inside it.
+ * This mirrors `MatchInfoDisplay`'s markup by hand (Suspense unmounts the real
+ * tree during load), so revisit it if that structure changes — the skeleton test
+ * asserts the two chromes stay identical.
  */
 export const MatchInfoSkeleton = () => {
   return (
-    <section
-      className="md-card"
-      role="status"
-      aria-busy="true"
-      aria-label="Loading match info"
-    >
-      <div className="md-card__hd" aria-hidden="true">
-        <span className={`${SK} md-sk--card-title`} />
-      </div>
-      <div className="md-card__body" aria-hidden="true">
-        {Array.from({ length: 3 }, (_, i) => (
-          <div key={i} className="md-info-row">
-            <span className={`${SK} md-sk--info-k`} />
-            <span className={`${SK} md-sk--info-v`} />
-          </div>
-        ))}
-      </div>
-    </section>
+    <Card asChild>
+      <section role="status" aria-busy="true" aria-label="Loading match info">
+        <CardHeader aria-hidden="true">
+          <span className={`${SK} md-sk--card-title`} />
+        </CardHeader>
+        <CardContent aria-hidden="true">
+          {Array.from({ length: 3 }, (_, i) => (
+            <div key={i} className="md-info-row">
+              <span className={`${SK} md-sk--info-k`} />
+              <span className={`${SK} md-sk--info-v`} />
+            </div>
+          ))}
+        </CardContent>
+      </section>
+    </Card>
   );
 };

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher/players-panel-display.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher/players-panel-display.page.tsx
@@ -20,6 +20,10 @@ const scoped = (container: Container) => ({
       name: "Players · going into this match",
     });
   },
+  /** The two-profile grid inside the card body. */
+  queryPlayersGrid() {
+    return this.getPanel().querySelector(".md-players");
+  },
   /** The visible card heading. */
   getTitle() {
     return container.getByRole("heading", {
@@ -27,9 +31,11 @@ const scoped = (container: Container) => ({
       name: "Players · going into this match",
     });
   },
-  /** The "SNAPSHOT · …" stamp in the card header. */
+  /** The "SNAPSHOT · …" stamp in the card header's trailing action slot. */
   getSnapshotLabel(text: string) {
-    return container.getByText(text, { selector: ".md-card__hd-meta" });
+    return container.getByText(text, {
+      selector: '[data-slot="card-action"]',
+    });
   },
   /**
    * One player's half of the panel, scoped by the player's name — the same

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher/players-panel-display.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher/players-panel-display.test.tsx
@@ -41,28 +41,6 @@ describe("PlayersPanelDisplay", () => {
     ).toBeInTheDocument();
   });
 
-  // The caption must wear the same treatment as the head-to-head panel's — the
-  // two cards sit side by side, and #218 is about making them look alike. Pin
-  // the tokens: `text-muted-foreground` looks like the right design-system
-  // choice but `.fortymm-theme` remaps it to a lighter grey (`--chalk-300`),
-  // which would silently restyle a caption this chrome-only change must leave
-  // untouched.
-  it("captions the header in the muted grey the head-to-head panel uses", () => {
-    playersPanelDisplayPage.render({
-      panel: buildPlayersPanelView({ snapshotLabel: "SNAPSHOT · NOW" }),
-    });
-
-    const caption = playersPanelDisplayPage.getSnapshotLabel("SNAPSHOT · NOW");
-    expect(caption).toHaveClass(
-      "self-center",
-      "text-[11px]",
-      "font-medium",
-      "tracking-[0.08em]",
-      "text-[color:var(--fg-muted)]",
-    );
-    expect(caption).not.toHaveClass("text-muted-foreground");
-  });
-
   it("renders a profile per side from the view", () => {
     // Wiring only: profile content is pinned by the query and profile tests.
     playersPanelDisplayPage.render({

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher/players-panel-display.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher/players-panel-display.test.tsx
@@ -6,14 +6,27 @@ import {
 import { playersPanelDisplayPage } from "./players-panel-display.page";
 
 describe("PlayersPanelDisplay", () => {
+  // The panel wears the shared design-system Card (#218), not a hand-rolled
+  // card class — but `asChild` must keep it a labelled `<section>` landmark.
+  // A silent degrade to an anonymous card `<div>` would fail both halves here.
   it("renders a region landmark named by the visible card heading", () => {
     playersPanelDisplayPage.render();
 
     const panel = playersPanelDisplayPage.getPanel();
-    expect(panel).toHaveClass("md-card");
+    expect(panel.tagName).toBe("SECTION");
     const id = playersPanelDisplayPage.getTitle().getAttribute("id");
     expect(id).toBeTruthy();
     expect(panel).toHaveAttribute("aria-labelledby", id);
+  });
+
+  it("takes its chrome from the shared Card, wrapping the two-profile grid", () => {
+    playersPanelDisplayPage.render();
+
+    const panel = playersPanelDisplayPage.getPanel();
+    expect(panel).toHaveAttribute("data-slot", "card");
+    expect(panel).not.toHaveClass("md-card");
+    // The grid between the two halves is content, not chrome — it survives.
+    expect(playersPanelDisplayPage.queryPlayersGrid()).not.toBeNull();
   });
 
   it("stamps the header with the view's snapshot label", () => {
@@ -26,6 +39,28 @@ describe("PlayersPanelDisplay", () => {
     expect(
       playersPanelDisplayPage.getSnapshotLabel("SNAPSHOT · 8 JUN, 12:00"),
     ).toBeInTheDocument();
+  });
+
+  // The caption must wear the same treatment as the head-to-head panel's — the
+  // two cards sit side by side, and #218 is about making them look alike. Pin
+  // the tokens: `text-muted-foreground` looks like the right design-system
+  // choice but `.fortymm-theme` remaps it to a lighter grey (`--chalk-300`),
+  // which would silently restyle a caption this chrome-only change must leave
+  // untouched.
+  it("captions the header in the muted grey the head-to-head panel uses", () => {
+    playersPanelDisplayPage.render({
+      panel: buildPlayersPanelView({ snapshotLabel: "SNAPSHOT · NOW" }),
+    });
+
+    const caption = playersPanelDisplayPage.getSnapshotLabel("SNAPSHOT · NOW");
+    expect(caption).toHaveClass(
+      "self-center",
+      "text-[11px]",
+      "font-medium",
+      "tracking-[0.08em]",
+      "text-[color:var(--fg-muted)]",
+    );
+    expect(caption).not.toHaveClass("text-muted-foreground");
   });
 
   it("renders a profile per side from the view", () => {

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher/players-panel-display.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher/players-panel-display.tsx
@@ -1,7 +1,9 @@
 import { useId } from "react";
 
 import { Overline } from "@/components/overline";
-import { Card, CardAction, CardContent, CardHeader } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+import { CardMeta } from "../../card-meta";
 
 import { NoOpponentProfile } from "./players-panel-display/no-opponent-profile";
 import { PlayerProfile } from "./players-panel-display/player-profile";
@@ -29,14 +31,7 @@ export const PlayersPanelDisplay = ({ panel }: PlayersPanelDisplayProps) => {
           <Overline as="h3" id={id}>
             Players · going into this match
           </Overline>
-          {/* Caption treatment is kept byte-identical to the head-to-head
-              panel's `CardAction` — same size, tracking, and the `--fg-muted`
-              grey both captions shipped with. `text-muted-foreground` is NOT
-              the same colour here: `.fortymm-theme` remaps it to the lighter
-              `--chalk-300`. */}
-          <CardAction className="self-center text-[11px] font-medium tracking-[0.08em] text-[color:var(--fg-muted)]">
-            {panel.snapshotLabel}
-          </CardAction>
+          <CardMeta>{panel.snapshotLabel}</CardMeta>
         </CardHeader>
         <CardContent className="md-players px-0">
           {panel.left ? (

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher/players-panel-display.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-fetcher/players-panel-display.tsx
@@ -1,6 +1,7 @@
 import { useId } from "react";
 
 import { Overline } from "@/components/overline";
+import { Card, CardAction, CardContent, CardHeader } from "@/components/ui/card";
 
 import { NoOpponentProfile } from "./players-panel-display/no-opponent-profile";
 import { PlayerProfile } from "./players-panel-display/player-profile";
@@ -10,30 +11,47 @@ export interface PlayersPanelDisplayProps {
   panel: PlayersPanelView;
 }
 
+/**
+ * The "Players · going into this match" snapshot panel. Chrome is the shared
+ * design-system `Card` (#218) — `asChild` keeps it a `<section>` labelled by
+ * its own heading rather than an anonymous `<div>`. `CardContent` drops its
+ * horizontal padding: `.md-players` is a full-bleed `1fr 1px 1fr` grid whose
+ * `.md-profile` halves supply their own padding, and its divider is meant to
+ * run edge to edge.
+ */
 export const PlayersPanelDisplay = ({ panel }: PlayersPanelDisplayProps) => {
   const id = useId();
 
   return (
-    <section className="md-card" aria-labelledby={id}>
-      <div className="md-card__hd">
-        <Overline as="h3" id={id}>
-          Players · going into this match
-        </Overline>
-        <span className="md-card__hd-meta">{panel.snapshotLabel}</span>
-      </div>
-      <div className="md-players">
-        {panel.left ? (
-          <PlayerProfile profile={panel.left} />
-        ) : (
-          <NoOpponentProfile />
-        )}
-        <div className="md-players__divider" />
-        {panel.right ? (
-          <PlayerProfile profile={panel.right} />
-        ) : (
-          <NoOpponentProfile />
-        )}
-      </div>
-    </section>
+    <Card asChild>
+      <section aria-labelledby={id}>
+        <CardHeader>
+          <Overline as="h3" id={id}>
+            Players · going into this match
+          </Overline>
+          {/* Caption treatment is kept byte-identical to the head-to-head
+              panel's `CardAction` — same size, tracking, and the `--fg-muted`
+              grey both captions shipped with. `text-muted-foreground` is NOT
+              the same colour here: `.fortymm-theme` remaps it to the lighter
+              `--chalk-300`. */}
+          <CardAction className="self-center text-[11px] font-medium tracking-[0.08em] text-[color:var(--fg-muted)]">
+            {panel.snapshotLabel}
+          </CardAction>
+        </CardHeader>
+        <CardContent className="md-players px-0">
+          {panel.left ? (
+            <PlayerProfile profile={panel.left} />
+          ) : (
+            <NoOpponentProfile />
+          )}
+          <div className="md-players__divider" />
+          {panel.right ? (
+            <PlayerProfile profile={panel.right} />
+          ) : (
+            <NoOpponentProfile />
+          )}
+        </CardContent>
+      </section>
+    </Card>
   );
 };

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-skeleton.page.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-skeleton.page.tsx
@@ -7,10 +7,10 @@ const scoped = (container: Container) => ({
   getStatus() {
     return container.getByRole("status", { name: /loading the players panel/i });
   },
-  /** The card chrome the loaded panel reuses (the status region is itself the
-   * `.md-card`). */
+  /** The shared design-system Card chrome the loaded panel also wears — the
+   * status region is itself the card (`Card asChild`). */
   queryCard() {
-    return this.getStatus().closest(".md-card");
+    return this.getStatus().closest('[data-slot="card"]');
   },
   /** The two-profile grid the loaded panel reuses; reserved so the card keeps
    * its height before the profiles arrive. */

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-skeleton.test.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-skeleton.test.tsx
@@ -9,11 +9,16 @@ describe("PlayersPanelSkeleton", () => {
   });
 
   // No-layout-shift contract: the skeleton reserves the same card + two-profile
-  // grid the loaded panel renders, so swapping them shifts nothing.
-  it("reserves the card and the two-profile grid", () => {
+  // grid the loaded panel renders, so swapping them shifts nothing. Both are on
+  // the shared design-system Card (#218) — if only one moved, the panel would
+  // visibly resize the moment the data arrived.
+  it("reserves the shared Card chrome and the two-profile grid", () => {
     playersPanelSkeletonPage.render();
 
-    expect(playersPanelSkeletonPage.queryCard()).not.toBeNull();
+    const status = playersPanelSkeletonPage.getStatus();
+    expect(status.tagName).toBe("SECTION");
+    expect(playersPanelSkeletonPage.queryCard()).toBe(status);
+    expect(status).not.toHaveClass("md-card");
     expect(playersPanelSkeletonPage.queryPlayersGrid()).not.toBeNull();
   });
 });

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-skeleton.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-skeleton.tsx
@@ -1,3 +1,5 @@
+import { Card, CardAction, CardContent, CardHeader } from "@/components/ui/card";
+
 const SK = "md-sk animate-pulse";
 
 /** One profile half — identity, rating box, recent-form list, career grid —
@@ -42,29 +44,40 @@ const ProfileSkeleton = () => (
 
 /**
  * Loading placeholder for the {@link PlayersPanel}, shown as its `<Suspense>`
- * fallback. Reuses the real `.md-card` / `.md-players` / `.md-profile`
- * structural classes so the card chrome and both profile columns occupy the
- * same boxes the loaded panel will — only the leaf text/avatars become shimmer
- * blocks. This mirrors `PlayersPanelDisplay`'s markup by hand (Suspense
- * unmounts the real tree during load), so revisit it if that structure changes.
+ * fallback. Reuses the same shared `Card` chrome (#218) and the same
+ * `.md-players` / `.md-profile` structural classes as the loaded panel, so the
+ * card and both profile columns occupy the boxes the loaded panel will — only
+ * the leaf text/avatars become shimmer blocks. The `asChild` card keeps the
+ * status region a `<section>` the same way the display stays a landmark. This
+ * mirrors `PlayersPanelDisplay`'s markup by hand (Suspense unmounts the real
+ * tree during load), so revisit it if that structure changes.
  */
 export const PlayersPanelSkeleton = () => {
   return (
-    <section
-      className="md-card"
-      role="status"
-      aria-busy="true"
-      aria-label="Loading the players panel"
-    >
-      <div className="md-card__hd" aria-hidden="true">
-        <span className={`${SK} md-sk--card-title`} />
-        <span className={`${SK} md-sk--meta`} />
-      </div>
-      <div className="md-players" aria-hidden="true">
-        <ProfileSkeleton />
-        <div className="md-players__divider" />
-        <ProfileSkeleton />
-      </div>
-    </section>
+    <Card asChild>
+      <section
+        role="status"
+        aria-busy="true"
+        aria-label="Loading the players panel"
+      >
+        <CardHeader aria-hidden="true">
+          <span className={`${SK} md-sk--card-title`} />
+          {/* `self-center` mirrors the loaded caption, which centres against
+              the overline in `CardHeader`'s `items-start` grid — so the
+              shimmer sits where the real text will. No colour class: the
+              placeholder is a shimmer block, not text. */}
+          <CardAction className="self-center">
+            <span className={`${SK} md-sk--meta`} />
+          </CardAction>
+        </CardHeader>
+        {/* Padding-free for the same reason as the loaded panel: `.md-players`
+            is a full-bleed grid and each `.md-profile` half pads itself. */}
+        <CardContent className="md-players px-0" aria-hidden="true">
+          <ProfileSkeleton />
+          <div className="md-players__divider" />
+          <ProfileSkeleton />
+        </CardContent>
+      </section>
+    </Card>
   );
 };

--- a/web-client/src/components/matches/match-details/players-panel/players-panel-skeleton.tsx
+++ b/web-client/src/components/matches/match-details/players-panel/players-panel-skeleton.tsx
@@ -1,4 +1,6 @@
-import { Card, CardAction, CardContent, CardHeader } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+import { CardMeta } from "../card-meta";
 
 const SK = "md-sk animate-pulse";
 
@@ -62,13 +64,12 @@ export const PlayersPanelSkeleton = () => {
       >
         <CardHeader aria-hidden="true">
           <span className={`${SK} md-sk--card-title`} />
-          {/* `self-center` mirrors the loaded caption, which centres against
-              the overline in `CardHeader`'s `items-start` grid — so the
-              shimmer sits where the real text will. No colour class: the
-              placeholder is a shimmer block, not text. */}
-          <CardAction className="self-center">
+          {/* Same CardMeta as the loaded caption, so the shimmer sits exactly
+              where the real text will. (Its text colour is inert here — the
+              placeholder is a shimmer block, not text.) */}
+          <CardMeta>
             <span className={`${SK} md-sk--meta`} />
-          </CardAction>
+          </CardMeta>
         </CardHeader>
         {/* Padding-free for the same reason as the loaded panel: `.md-players`
             is a full-bleed grid and each `.md-profile` half pads itself. */}

--- a/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-display.page.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-display.page.tsx
@@ -27,6 +27,28 @@ const scoped = (container: Container) => {
     getDividers() {
       return Array.from(getCard().querySelectorAll(".md-rating-divider"));
     },
+    /**
+     * The card's header slot — the shared design-system `CardHeader`. Its
+     * absence of a bottom rule is the point of the migration.
+     */
+    queryHeader() {
+      return getCard().querySelector('[data-slot="card-header"]');
+    },
+    /** The card's body slot — the shared design-system `CardContent`. */
+    queryContent() {
+      return getCard().querySelector('[data-slot="card-content"]');
+    },
+    /**
+     * Anything still wearing the hand-rolled `.md-card*` chrome the shared
+     * `Card` replaced (the container class or its header/body slots).
+     */
+    queryLegacyChrome() {
+      const card = getCard();
+      return [
+        ...(card.classList.contains("md-card") ? [card] : []),
+        ...card.querySelectorAll(".md-card, .md-card__hd, .md-card__body"),
+      ];
+    },
     // Row lookups (`getRow(username)`, `queryDelta(username)`, …) come from
     // the row's own page object.
     ...ratingRowPage.within(container),

--- a/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-display.test.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-display.test.tsx
@@ -10,6 +10,24 @@ describe("RatingsDisplay", () => {
     expect(ratingsDisplayPage.getTitle()).toHaveTextContent(
       "Result · rating change",
     );
+    // `asChild` must keep the landmark a <section>: an anonymous <div> would
+    // drop the region role the heading names.
+    expect(ratingsDisplayPage.getCard().tagName).toBe("SECTION");
+  });
+
+  it("wears the shared design-system card chrome, not the hand-rolled one", () => {
+    ratingsDisplayPage.render();
+
+    const card = ratingsDisplayPage.getCard();
+    // The shared `Card` slotted its chrome onto our <section>: hairline ring,
+    // not the `.md-card` border.
+    expect(card).toHaveAttribute("data-slot", "card");
+    expect(card).toHaveClass("bg-card", "rounded-xl", "ring-1");
+    expect(ratingsDisplayPage.queryHeader()).toBeInTheDocument();
+    expect(ratingsDisplayPage.queryContent()).toBeInTheDocument();
+    // No `.md-card` container, and no `.md-card__hd` — the rule under the
+    // title is gone with it.
+    expect(ratingsDisplayPage.queryLegacyChrome()).toEqual([]);
   });
 
   it("renders one row per side in view order", () => {

--- a/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-display.tsx
+++ b/web-client/src/components/matches/match-details/ratings/ratings-fetcher/ratings-display.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useId } from "react";
 
 import { Overline } from "@/components/overline";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 import { RatingRow } from "./ratings-display/rating-row";
 import { type RatingsView } from "./ratings-query";
@@ -13,20 +14,27 @@ export const RatingsDisplay = ({ ratings }: RatingsDisplayProps) => {
   const id = useId();
 
   return (
-    <section className="md-card" aria-labelledby={id}>
-      <div className="md-card__hd">
-        <Overline as="h3" id={id}>
-          Result · rating change
-        </Overline>
-      </div>
-      <div className="md-card__body md-rating-card__body">
-        {ratings.rows.map((row, i) => (
-          <Fragment key={row.username}>
-            {i > 0 && <hr className="md-rating-divider" />}
-            <RatingRow row={row} />
-          </Fragment>
-        ))}
-      </div>
-    </section>
+    // `asChild` keeps the panel a labelled landmark `<section>` while taking the
+    // shared design-system card chrome (hairline ring, no rule under the title)
+    // instead of the hand-rolled `.md-card` family.
+    <Card asChild>
+      <section aria-labelledby={id}>
+        <CardHeader>
+          <Overline as="h3" id={id}>
+            Result · rating change
+          </Overline>
+        </CardHeader>
+        {/* `md-rating-card__body` is content layout (the column gap between
+            players), not card chrome — it stays. */}
+        <CardContent className="md-rating-card__body">
+          {ratings.rows.map((row, i) => (
+            <Fragment key={row.username}>
+              {i > 0 && <hr className="md-rating-divider" />}
+              <RatingRow row={row} />
+            </Fragment>
+          ))}
+        </CardContent>
+      </section>
+    </Card>
   );
 };

--- a/web-client/src/components/ui/card.test.tsx
+++ b/web-client/src/components/ui/card.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@/test/utilities";
+
+import { Card, CardContent, CardTitle } from "./card";
+
+const card = () =>
+  document.querySelector('[data-slot="card"]') as HTMLElement;
+
+describe("Card", () => {
+  it("renders a plain div container by default", () => {
+    render(
+      <Card className="mt-8">
+        <CardContent>Body</CardContent>
+      </Card>,
+    );
+
+    // Guards every existing caller (dashboard, tournament, /design-system):
+    // the default rendering must stay an anonymous <div> with the card's
+    // styling, so opting in to `asChild` can't change anyone else's DOM.
+    expect(card().tagName).toBe("DIV");
+    expect(card()).toHaveAttribute("data-size", "default");
+    expect(card()).toHaveClass("bg-card", "rounded-xl", "mt-8");
+  });
+
+  it("renders as the caller's element when asChild, forwarding its classes", () => {
+    render(
+      // The <section> deliberately carries no card classes of its own — every
+      // card class on it below must have arrived via the Slot.
+      <Card asChild className="mt-8">
+        <section aria-labelledby="panel-heading">
+          <CardTitle id="panel-heading">Head to head</CardTitle>
+          <CardContent>Body</CardContent>
+        </section>
+      </Card>,
+    );
+
+    expect(card().tagName).toBe("SECTION");
+    // The card's own base classes and the caller's className both land on the
+    // child element, so it looks identical to a default card.
+    expect(card()).toHaveClass("bg-card", "rounded-xl", "mt-8");
+    expect(card()).toHaveAttribute("data-size", "default");
+    // The child's own props survive — this is the point of the opt-in: the
+    // panel stays a labelled landmark region instead of an anonymous div.
+    expect(card()).toHaveAttribute("aria-labelledby", "panel-heading");
+    expect(
+      screen.getByRole("region", { name: "Head to head" }),
+    ).toBe(card());
+  });
+});

--- a/web-client/src/components/ui/card.tsx
+++ b/web-client/src/components/ui/card.tsx
@@ -1,14 +1,24 @@
 import * as React from "react"
+import { Slot } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
 function Card({
   className,
   size = "default",
+  asChild = false,
   ...props
-}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+}: React.ComponentProps<"div"> & {
+  size?: "default" | "sm"
+  asChild?: boolean
+}) {
+  // `asChild` lets a caller render the card as their own element — e.g. a
+  // `<section aria-labelledby>` landmark — instead of an anonymous `<div>`,
+  // without losing the card's styling. Mirrors `Button`/`Badge`.
+  const Comp = asChild ? Slot.Root : "div"
+
   return (
-    <div
+    <Comp
       data-slot="card"
       data-size={size}
       className={cn(

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -3251,8 +3251,8 @@ body.dark.fortymm-theme {
   margin: 0 auto;
 }
 /* Card-section skeletons (players panel, match info) — leaf sizes only; the
-   `.md-card`/`.md-profile`/`.md-info-row` containers supply every dimension
-   that drives height, so the swap to real content doesn't shift. */
+   shared `Card` and the `.md-profile`/`.md-info-row` containers supply every
+   dimension that drives height, so the swap to real content doesn't shift. */
 .fortymm-theme .md-sk--card-title {
   width: 130px;
   height: 12px;

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -2611,12 +2611,6 @@ body.dark.fortymm-theme {
 }
 
 /* ---------- Cards ---------- */
-.fortymm-theme .md-card {
-  background: var(--bg-card);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--r-md);
-}
-
 /* Acceptance callout that leads the match-details page when a posted result
    needs the viewer's action (or is waiting on the opponent's). The active
    "awaiting your acceptance" state is a Featured card (orange ring + accent glow, the
@@ -2838,21 +2832,6 @@ body.dark.fortymm-theme {
   }
 }
 
-.fortymm-theme .md-card__hd {
-  padding: 14px 18px 10px;
-  border-bottom: 1px solid var(--ink-700);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-.fortymm-theme .md-card__body {
-  padding: 18px;
-}
-.fortymm-theme .md-card__hd-meta {
-  font: 500 11px var(--font-ui);
-  color: var(--fg-muted);
-  letter-spacing: 0.08em;
-}
 .fortymm-theme .md-rating-card__body {
   display: flex;
   flex-direction: column;

--- a/web-client/src/routes/_app/players/index.test.tsx
+++ b/web-client/src/routes/_app/players/index.test.tsx
@@ -116,6 +116,49 @@ describe('players roster rank column (#841)', () => {
     expect(unratedSeed.classList.contains('players-seed--top')).toBe(false)
   })
 
+  it('captions the stat cells with their column names, leaving name + seed bare (#900)', async () => {
+    const items = [playerRow({ id: 'p-1', username: 'ace.top', rank: 1 })]
+    server.use(
+      http.get('*/v1/session', () => HttpResponse.json(sessionResponse())),
+      http.get('*/v1/players', () =>
+        HttpResponse.json({ items, page: 1, page_size: 25, total: items.length }),
+      ),
+    )
+
+    renderRoster('/players')
+    await screen.findByText('ace.top')
+
+    // Below 640px the shared match-list stylesheet hides the thead and re-adds
+    // each column's name inside the card via `td[data-label]::before`. Zip the
+    // header cells against the row's cells so we assert the caption *equals the
+    // column it stands in for* — retyping the strings here would let a mismatched
+    // dash ("W-L" vs "W–L") pass while the mobile caption disagreed with desktop.
+    const row = screen.getByText('ace.top').closest('tr')!
+    const headers = [
+      ...row.closest('table')!.querySelectorAll('thead th'),
+    ].map((th) => th.textContent)
+    const labels = [...row.querySelectorAll('td')].map(
+      (td) => td.dataset.label ?? null,
+    )
+    expect(headers).toHaveLength(labels.length)
+
+    // Rating / W–L / Form each caption themselves with their column's own words.
+    expect(labels[2]).toBe(headers[2])
+    expect(labels[3]).toBe(headers[3])
+    expect(labels[4]).toBe(headers[4])
+    // ...and those words are non-empty, so the assertions above can't pass by
+    // both sides being blank.
+    expect(labels.slice(2).every((l) => (l?.length ?? 0) > 0)).toBe(true)
+
+    // Seed + player are the card's caption and headline — they carry no stat
+    // label (the CSS gives them their own treatment via `.id-cell` /
+    // `data-cell="players"`).
+    expect(labels[0]).toBeNull()
+    expect(labels[1]).toBeNull()
+    expect(row.querySelectorAll('td')[0].classList).toContain('id-cell')
+    expect(row.querySelectorAll('td')[1].dataset.cell).toBe('players')
+  })
+
   it('does not crash when the roster is empty', async () => {
     server.use(
       http.get('*/v1/session', () => HttpResponse.json(sessionResponse())),

--- a/web-client/src/routes/_app/players/index.tsx
+++ b/web-client/src/routes/_app/players/index.tsx
@@ -307,25 +307,32 @@ function PlayerRow({ player }: { player: PlayerSummary }) {
         }
       }}
     >
-      <td>
+      {/* Below 640px the shared match-list stylesheet hides the thead and paints
+       * each row as a card, re-adding the column name only for cells that opt in
+       * via `data-label` (#900). Without it the stat values sat there bare — a
+       * lone "1500" with nothing saying it's a rating. The label copy must match
+       * the <th> text above so the mobile caption and the desktop column agree.
+       * The name/seed cells take the same headline/caption hooks the matches row
+       * uses (`data-cell="players"` / `.id-cell`) instead of a stat label. */}
+      <td className="id-cell">
         <SeedCell rank={player.rank} />
       </td>
-      <td>
+      <td data-cell="players">
         <div className="player">
           <UserAvatar name={player.username} size={32} />
           <span className="player-name">{player.username}</span>
         </div>
       </td>
-      <td>
+      <td data-label="Rating">
         <RatingCell rating={player.rating} />
       </td>
-      <td>
+      <td data-label="W–L">
         <span className="players-record">
           {player.wins}
           <span className="players-record-loss"> – {player.losses}</span>
         </span>
       </td>
-      <td>
+      <td data-label="Form · L5">
         <FormDots form={player.form} />
       </td>
     </tr>


### PR DESCRIPTION
Two web-client issues. No API, OpenAPI, or iOS surface is touched.

## #900 — mobile player cards showed bare numbers

The players list borrows the matches list's stylesheet. Below 640px that CSS hides the table header and paints each row as a card, then re-adds the column name **only** for cells that opt in with a `data-label` attribute (`td[data-label]::before { content: attr(data-label) }`). The matches list opts in; the players list emitted bare `<td>`s — so a phone showed a naked `1500`, `0 – 1` and a row of form dots with nothing to identify them.

Label the rating, win–loss and form cells, and adopt the matches list's existing headline/caption hooks for the name and seed. **No stylesheet change** — the CSS was already there, the players table just never opted in.

## #218 — three panel treatments, one card

The four match-details panels hand-rolled their own chrome in a bespoke `.md-card` class family while the rest of the app renders through the shared design-system `Card`. Two card implementations is the bug: they drift.

Route all four (plus the two loading skeletons) through `ui/card.tsx`, then delete the dead `.md-card` rules. The visual unification falls out — the canonical Card wears a hairline **ring** rather than a heavier border, and has **no hard rule under the title**.

`Card` gains an opt-in `asChild` (Radix `Slot`, mirroring `button.tsx`) so the panels stay `<section aria-labelledby>` landmarks. Without it, four labelled regions would have silently become anonymous divs — and note `getByRole("region")` alone does *not* catch that, since the query still resolves against the inner `<section>`.

Only chrome moves. The content styles stay: the head-to-head win bar, the rules *between* rating rows, the divider between the two players, and `.md-confirm-callout` (same surface tokens, not part of the family).

### Two premises in issue #218 were stale
- The "head-to-head **v1**" with the orange status dot **does not exist in the code**. There is one head-to-head panel.
- The dashboard's `RecentResultsCard` is **not** the separator-free reference it's described as — it has both a header rule and per-row status dots. The real canonical is the shared `Card` the design-system page showcases.

## Testing

- vitest **185 files / 1281 tests** green; `tsc -b` clean; lint 0 errors; build ✓
- Playwright (web-client) **139 passed** — design-system pixel baselines did not shift
- Every change was implemented by a domain-expert agent and independently re-verified by a separate agent that re-ran the checks and mutation-tested each claim. One chore **failed** first verification (the two panels' header captions had diverged to different greys — `text-muted-foreground` is remapped by `.fortymm-theme` to a lighter chalk than `--fg-muted`) and was fixed, then re-verified in real Chromium via `getComputedStyle` against the built CSS.
- A `/simplify` pass then found that the fix's own guard was false confidence — the test pinned its *own copy* of the class literal, so the panels could still diverge with the test green. The caption now has one definition (`CardMeta`).

**#900 is not provable by any unit test.** The label is drawn by a CSS container query + `::before` content, which jsdom cannot render; the suite only proves the attributes are *emitted*. Visibility needs a browser at 375×667 — that's what the QA pass covers.

## Follow-ups deliberately not done here
- The players page impersonates the matches page in the DOM (`.match-list-page` / `table.matches`) purely to borrow its stylesheet. That coupling is the real debt behind #900; a shared responsive-table primitive belongs with the players-route strangle.
- Four competing uppercase-eyebrow implementations, and RBAC pages hand-rolling panel chrome inline.
- `dashboard/your-game-row/card.tsx` is a second thin wrapper over `ui/card.tsx` using inline-style padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbS6JXvgswK9k4j6nwrxHc