### PR TITLE
Fix #195: batch career-before counts into one grouped query

### DIFF
--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -1351,6 +1351,11 @@ async def _load_recent_form(
     if not user_ids:
         return []
 
+    # One round-trip for every player's career counts, rather than one per
+    # player. Users with no prior completed matches produce no GROUP BY row, so
+    # the lookup below defaults them to ``(0, 0)``.
+    career_before = await _load_career_before(db, user_ids, match.created_at)
+
     result: list[MatchDetailsPlayerForm] = []
     for user_id in user_ids:
         rows = (
@@ -1368,9 +1373,7 @@ async def _load_recent_form(
         rating_before, rating_history = await _load_pre_match_rating(
             db, user_id, match.league_id, match.created_at
         )
-        matches_before, wins_before = await _load_career_before(
-            db, user_id, match.created_at
-        )
+        matches_before, wins_before = career_before.get(user_id, (0, 0))
         result.append(
             MatchDetailsPlayerForm(
                 user_id=user_id,
@@ -1417,32 +1420,41 @@ async def _load_pre_match_rating(
 
 async def _load_career_before(
     db: AsyncSession,
-    user_id: uuid.UUID,
+    user_ids: list[uuid.UUID],
     before: datetime,
-) -> tuple[int, int]:
+) -> dict[uuid.UUID, tuple[int, int]]:
     """Cross-league ``(matches, wins)`` completed strictly before ``before``
-    (the current match's ``created_at``). The current match is excluded by the
-    date filter alone: a completed match's ``completed_at`` is always ``>=`` its
-    own ``created_at``, so it can never satisfy ``completed_at < created_at``. No
-    separate ``id`` guard is needed (issue #202)."""
+    (the current match's ``created_at``), for every user in ``user_ids`` in a
+    single grouped query. The current match is excluded by the date filter
+    alone: a completed match's ``completed_at`` is always ``>=`` its own
+    ``created_at``, so it can never satisfy ``completed_at < created_at``. No
+    separate ``id`` guard is needed (issue #202).
+
+    A user with no prior completed matches has **no row** under ``GROUP BY`` and
+    so is simply absent from the mapping — callers must default them to
+    ``(0, 0)``."""
+    if not user_ids:
+        return {}
     side = aliased(MatchSide)
     player = aliased(MatchSidePlayer)
-    row = (
+    rows = (
         await db.execute(
             select(
+                player.user_id,
                 func.count(Match.id),
                 func.count(Match.id).filter(side.won.is_(True)),
             )
             .join(side, side.match_id == Match.id)
             .join(player, player.match_side_id == side.id)
             .where(
-                player.user_id == user_id,
+                player.user_id.in_(user_ids),
                 Match.status == MatchStatus.completed,
                 Match.completed_at < before,
             )
+            .group_by(player.user_id)
         )
-    ).one()
-    return int(row[0]), int(row[1])
+    ).all()
+    return {row[0]: (int(row[1]), int(row[2])) for row in rows}
 
 
 def _build_form_result(past_match: Match, user_id: uuid.UUID) -> MatchDetailsFormResult:

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -3258,6 +3258,37 @@ async def test_details_career_count_excludes_only_the_viewed_match(
     assert forms[str(opp.id)]["career_wins_before"] == 0
 
 
+async def test_details_career_counts_are_per_player(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The batched career-count query must key each player's totals to that
+    player: two participants with *different non-zero* histories (2 prior
+    matches vs 1) must not collapse onto a single shared count."""
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "per-player-opp") as (opp_client, opp):
+        # The opponent's only prior — a loss to me.
+        await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
+    async with opponent_session(db_session, "per-player-third") as (
+        third_client,
+        third,
+    ):
+        # A second prior for me only, against someone else.
+        await _play_match_to_completion(
+            api_client, third_client, third.id, best_of=3, side_1_wins=True
+        )
+
+    current = await _create_match(api_client, opp.id, best_of=3)
+    detail = (await api_client.get(f"/v1/matches/{current['id']}")).json()
+
+    forms = {f["user_id"]: f for f in detail["recent_form"]}
+    assert forms[str(me.id)]["career_matches_before"] == 2
+    assert forms[str(me.id)]["career_wins_before"] == 2
+    assert forms[str(opp.id)]["career_matches_before"] == 1
+    assert forms[str(opp.id)]["career_wins_before"] == 0
+
+
 async def test_list_matches_csv_export(
     api_client: AsyncClient, db_session: AsyncSession
 ):


### PR DESCRIPTION
Closes #195 — "path 1" only, per the issue's own cheapest-first ordering.

## What

`_load_recent_form` loops over `user_ids` and issues three sequential queries per player. One of those three — `_load_career_before` — is a plain aggregate that can be answered for every player in one shot: filter `player.user_id.in_(user_ids)` and `GROUP BY player.user_id`. The call moves out of the loop, so career counts now cost **one round-trip regardless of player count** (singles 2 → 1, doubles 4 → 1).

The `WHERE` predicates are untouched (cross-league, `status == completed`, strict `completed_at < before`), and the issue-#202 reasoning about why no separate `id` guard is needed still holds verbatim.

## The one subtlety

A user with **no prior completed matches produces no `GROUP BY` row**, so they're simply absent from the mapping. The caller defaults them to `(0, 0)`. A brand-new player is the common case, and dropping them from `recent_form` (or raising a `KeyError`) would be the obvious way to get this wrong.

## Deliberately not done

- **Rating-history sparkline stays per-user.** Batching it needs a window function for the per-user `ORDER BY` + `LIMIT`; the issue flags this as the harder half and it's out of scope.
- **No `asyncio.gather`, no session factory.** Sequential awaits per `AsyncSession` remains the convention.
- **No schema change**, so no `regen-api-types` / `regen-ios-api-types`.

## Verification

- `pytest` — 622 passed. `mypy` clean (83 files), `ruff` clean.
- Existing `test_details_recent_form_includes_pre_match_rating_and_career` already pairs a 2-win player with a zero-history opponent in one match, so it would fail if a zero-match user were dropped or not defaulted. Added `test_details_career_counts_are_per_player` (2/2 vs 1/0 in one match) so a bug that shares one count across everyone, or mis-keys a group, is caught.
- **Measured the actual round-trip claim** rather than eyeballing it: a temporary harness counting calls to `_load_career_before` through a real match-details request asserts exactly **one** call carrying **both** players. It passes on this branch and goes red on the pre-fix code (`TypeError: 'UUID' object is not iterable` — the old code passed one scalar `user_id` per loop iteration). Harness deleted before commit; it was proof, not a test worth keeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BEb223mLN7rdBnxGM8G7W