### PR TITLE
Lock the signup honeypot out of the accessibility tree (#886)

### DIFF
--- a/web-client/src/components/login/login-screens.test.tsx
+++ b/web-client/src/components/login/login-screens.test.tsx
@@ -78,6 +78,24 @@ describe('ScreenEmail over-long address (#377)', () => {
   })
 })
 
+describe('ScreenEmail honeypot', () => {
+  it('keeps the honeypot in the DOM but out of the accessibility tree', () => {
+    render(<ScreenEmail onSubmit={vi.fn()} />)
+
+    // The trap is still wired: bots parse the DOM, so the field must be there.
+    expect(screen.getByTestId('login-honeypot')).toBeInTheDocument()
+
+    // ...but a human never perceives it. `*ByRole` skips `aria-hidden`
+    // subtrees, which is the same lens a screen reader uses.
+    expect(
+      screen.queryByRole('textbox', { name: /leave this empty/i }),
+    ).toBeNull()
+    expect(screen.getAllByRole('textbox')).toEqual([
+      screen.getByLabelText('Email address'),
+    ])
+  })
+})
+
 describe('ScreenVerifyNetError fabricated diagnostics (#226)', () => {
   // This screen came in wholesale from a static design mockup, so it used to
   // render invented diagnostics at the user: a hostname we don't own and a

--- a/web-client/src/lib/form-helpers.ts
+++ b/web-client/src/lib/form-helpers.ts
@@ -1,8 +1,12 @@
 import type { CSSProperties } from 'react'
 
-// Off-screen but still focusable so AT users hear "Leave this empty" — bots
-// pattern-match every visible field, then fill blanks anyway. Honeypots work
-// by being targeted by automation, not by being invisible to humans.
+// Positions the bot-trap field off-screen. Call sites must also wrap it in
+// `aria-hidden="true"` with `tabIndex={-1}`, so it stays out of view, out of
+// the tab order and out of the accessibility tree — a human (sighted or on a
+// screen reader) can never reach it, so anything typed into it is a bot. It
+// must stay in the DOM and parseable, though: never `display: none` or the
+// `hidden` attribute, because bots fill every field they can parse and that's
+// the whole trap.
 export const HONEYPOT_STYLE: CSSProperties = {
   position: 'absolute',
   left: '-9999px',

--- a/web-client/src/routes/_app/settings.test.tsx
+++ b/web-client/src/routes/_app/settings.test.tsx
@@ -157,6 +157,26 @@ describe('SettingsPage email section', () => {
     )
   })
 
+  it('keeps the honeypot in the DOM but out of the accessibility tree', async () => {
+    await renderSettings()
+
+    const section = (await screen.findByLabelText(/^email$/i)).closest(
+      'section',
+    ) as HTMLElement
+
+    // The trap is still wired: bots parse the DOM, so the field must be there.
+    expect(within(section).getByTestId('email-honeypot')).toBeInTheDocument()
+
+    // ...but a human never perceives it. `*ByRole` skips `aria-hidden`
+    // subtrees, which is the same lens a screen reader uses.
+    expect(
+      within(section).queryByRole('textbox', { name: /leave this empty/i }),
+    ).toBeNull()
+    expect(within(section).getAllByRole('textbox')).toEqual([
+      within(section).getByLabelText(/^email$/i),
+    ])
+  })
+
   it('focuses the email input when a guest is deep-linked via #sec-email', async () => {
     await renderSettings('/settings#sec-email')
     const emailInput = await screen.findByLabelText(/^email$/i)


### PR DESCRIPTION
## What #886 reported

The account-claim honeypot ("Leave this empty") was said to be exposed to assistive tech on `/settings#sec-email`.

## What I found: it isn't — #886 is a false positive

Both honeypots (settings + login) have carried `aria-hidden="true"` + `tabIndex={-1}` since #598 (2026-06-17), and they work:

- A live Chrome probe against the running app as a guest: Playwright's `ariaSnapshot` (which respects `aria-hidden`) has **no** "Leave this empty", and the only textboxes exposed are `Username` and `Email`. The honeypot is absent from the CDP tree even as an ignored node.
- **UAT is not stale** — I pulled the deployed `settings-CXTTBzTa.js` chunk off uat.fortymm.com and it does contain `"aria-hidden":"true"` on the honeypot wrapper.
- Both QA screenshots show nothing visible on the page.

QA's tool was almost certainly dumping the *full* CDP accessibility tree, which includes `ignored: true` nodes. An ignored input has no computed label — so it renders in such a dump as exactly the reported symptom: "Leave this empty" plus an unlabeled textbox.

## What this PR actually fixes

The real defect is the comment above `HONEYPOT_STYLE`, which asserted the **opposite** of what the code does:

> `// Off-screen but still focusable so AT users hear "Leave this empty"`

That contradiction is what invited this ticket, and it invites a future dev to "resolve" it by deleting the `aria-hidden` that is doing the actual work. So:

1. **Correct the comment** to state the durable constraint: offscreen, call sites wrap in `aria-hidden="true"` + `tabIndex={-1}`, and it must stay in the DOM (never `display:none`/`hidden`) because bots fill every field they can parse — that's the trap.
2. **Add regression tests** on both honeypots proving both halves at once: the field is still in the DOM (`getByTestId`) *and* out of the accessibility tree (`queryByRole('textbox', { name: /leave this empty/i })` is null — RTL's `*ByRole` skips `aria-hidden` subtrees, the same lens a screen reader uses). Each also asserts the form exposes exactly one accessible textbox, so no extra unnamed input can creep in.

No production behavior changes. The hiding mechanism is untouched.

## Verification

- Touched tests: `Test Files 2 passed (2)` / `Tests 27 passed (27)`.
- Full web-client suite: `186 files / 1296 tests passed`. Build + lint clean.
- **Red-then-green:** temporarily removing `aria-hidden="true"` from the settings wrapper flips *only* the `queryByRole` assertion red (the honeypot input surfaces as a named textbox) while `getByTestId` stays green — so the test discriminates rather than tautologically passing. Probe reverted.

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164WqjTrMENNdwTBRvFFLpY