### PR TITLE
Fix #195: kill the per-user N+1 in the match-details extras, behind a repository seam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ deploy/observability/charts/
 
 # Xcode-resolved SwiftPM pins (tooling-only, regenerated on build)
 ios/Fortymm.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+.qa-artifacts/

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -10,16 +10,15 @@ from sqlalchemy.orm import selectinload
 
 from app.attention import attention_priority, list_attention_kind
 from app.db import get_session
-from app.matches import (
+from app.match_queries import (
     _attention_matches_query,
     current_game_number,
     match_eager_options,
     my_standing_proposal_exists,
     opponent_username,
     participant_filter,
-    side_win_counts,
 )
-from app.matches import (
+from app.match_queries import (
     my_side as resolve_my_side,
 )
 from app.models import (
@@ -33,6 +32,7 @@ from app.models import (
     UserLeagueRating,
 )
 from app.ratings import RatingStrategyKey, parse_strategy_key
+from app.result_acceptance import side_win_counts
 from app.retirement import retirement_deadline
 from app.schemas.dashboard import (
     AttentionKind,

--- a/api/app/domain/match/extras.py
+++ b/api/app/domain/match/extras.py
@@ -14,16 +14,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 
-
-def rating_delta(before: float | None, after: float) -> float:
-    """The rating movement a completed match produced. A player who had no
-    rating in the league going in moved by nothing, not by their whole rating.
-
-    The single home for that rule: ``schemas.rating.RatingChange.from_history``
-    (the dashboard's path) and ``MatchDetailsRepository.rating_changes`` (the
-    match-details path) both call it, so the two surfaces cannot drift into
-    disagreeing about the same player's delta."""
-    return after - before if before is not None else 0.0
+from app.domain.rating import rating_delta
 
 
 @dataclass(frozen=True)
@@ -32,8 +23,8 @@ class RatingChange:
     for a player who had no rating in the league going in.
 
     ``delta`` is *derived*, never stored: it is by definition
-    ``rating_delta(before, after)``, so a ``RatingChange`` that disagrees with its
-    own endpoints cannot be constructed."""
+    ``app.domain.rating.rating_delta(before, after)``, so a ``RatingChange`` that
+    disagrees with its own endpoints cannot be constructed."""
 
     before: float | None
     after: float

--- a/api/app/domain/match/extras.py
+++ b/api/app/domain/match/extras.py
@@ -1,0 +1,122 @@
+"""Domain models for the match-details *view extras* — the rating changes,
+per-player recent form, and head-to-head block that hang off a match a
+participant is looking at.
+
+Like ``app.domain.match.models`` these are in-process, storage-agnostic shapes:
+no SQLAlchemy, no Pydantic. ``app.repositories.match_details_repository`` builds
+them from persisted rows and ``app.mappers.match_extras_mapper`` turns them into
+the response schemas, so the router never sees either end.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+
+def rating_delta(before: float | None, after: float) -> float:
+    """The rating movement a completed match produced. A player who had no
+    rating in the league going in moved by nothing, not by their whole rating.
+
+    The single home for that rule: ``schemas.rating.RatingChange.from_history``
+    (the dashboard's path) and ``MatchDetailsRepository.rating_changes`` (the
+    match-details path) both call it, so the two surfaces cannot drift into
+    disagreeing about the same player's delta."""
+    return after - before if before is not None else 0.0
+
+
+@dataclass(frozen=True)
+class RatingChange:
+    """A player's rating delta on the match being viewed. ``before`` is ``None``
+    for a player who had no rating in the league going in."""
+
+    before: float | None
+    after: float
+    delta: float
+
+    @classmethod
+    def of(cls, before: float | None, after: float) -> RatingChange:
+        return cls(before=before, after=after, delta=rating_delta(before, after))
+
+
+@dataclass(frozen=True)
+class FormResult:
+    """One past completed match, framed from the cited *player's* perspective
+    (not from a side number in that past match)."""
+
+    match_id: uuid.UUID
+    is_win: bool
+    player_games_won: int
+    opponent_games_won: int
+    opponent_username: str | None
+    completed_at: datetime
+
+
+@dataclass(frozen=True)
+class PreMatchRating:
+    """A player's rating in this match's league as it stood *before* this match:
+    the most recent value plus the chronological (oldest-first) trail behind it.
+    ``value`` is ``None`` — and ``history`` empty — for a player with no prior
+    rating in the league."""
+
+    value: float | None
+    history: list[float]
+
+
+@dataclass(frozen=True)
+class CareerRecord:
+    """A player's cross-league completed-match totals as of some instant."""
+
+    matches: int
+    wins: int
+
+
+@dataclass(frozen=True)
+class PlayerForm:
+    """One player's form going into this match, keyed by ``user_id`` so the
+    mapper (and the FE) can attach it to whichever side carries that user."""
+
+    user_id: uuid.UUID
+    recent_results: list[FormResult]
+    rating_before: PreMatchRating
+    career_before: CareerRecord
+
+
+@dataclass(frozen=True)
+class HeadToHeadMeeting:
+    """One past meeting between the two players in the match being viewed. Game
+    counts are aligned to *this* match's side numbers, not the side numbers of
+    the historical match."""
+
+    match_id: uuid.UUID
+    completed_at: datetime
+    side_1_games_won: int
+    side_2_games_won: int
+    winner_side_number: int | None
+    rated: bool
+
+
+@dataclass(frozen=True)
+class HeadToHead:
+    """The rivalry going into this match: totals over every prior meeting, plus
+    the most recent few of them."""
+
+    total_meetings: int
+    side_1_wins: int
+    side_2_wins: int
+    recent_meetings: list[HeadToHeadMeeting]
+
+
+@dataclass(frozen=True)
+class MatchViewExtras:
+    """The whole participant-only extras block. Non-participants (anonymous
+    holders of the share URL, signed-in spectators) get ``empty()`` — see #515."""
+
+    rating_changes: dict[uuid.UUID, RatingChange]
+    recent_form: list[PlayerForm]
+    head_to_head: HeadToHead | None
+
+    @classmethod
+    def empty(cls) -> MatchViewExtras:
+        return cls(rating_changes={}, recent_form=[], head_to_head=None)

--- a/api/app/domain/match/extras.py
+++ b/api/app/domain/match/extras.py
@@ -29,15 +29,18 @@ def rating_delta(before: float | None, after: float) -> float:
 @dataclass(frozen=True)
 class RatingChange:
     """A player's rating delta on the match being viewed. ``before`` is ``None``
-    for a player who had no rating in the league going in."""
+    for a player who had no rating in the league going in.
+
+    ``delta`` is *derived*, never stored: it is by definition
+    ``rating_delta(before, after)``, so a ``RatingChange`` that disagrees with its
+    own endpoints cannot be constructed."""
 
     before: float | None
     after: float
-    delta: float
 
-    @classmethod
-    def of(cls, before: float | None, after: float) -> RatingChange:
-        return cls(before=before, after=after, delta=rating_delta(before, after))
+    @property
+    def delta(self) -> float:
+        return rating_delta(self.before, self.after)
 
 
 @dataclass(frozen=True)
@@ -56,12 +59,18 @@ class FormResult:
 @dataclass(frozen=True)
 class PreMatchRating:
     """A player's rating in this match's league as it stood *before* this match:
-    the most recent value plus the chronological (oldest-first) trail behind it.
-    ``value`` is ``None`` — and ``history`` empty — for a player with no prior
-    rating in the league."""
+    the chronological (oldest-first) trail of every value they carried into it.
 
-    value: float | None
+    ``value`` — the rating they actually took into the match — is *derived*, never
+    stored: it is the last entry of the trail, and ``None`` exactly when the trail
+    is empty (a player with no prior rating in the league). Storing both would let
+    a value drift from the history it is supposed to end."""
+
     history: list[float]
+
+    @property
+    def value(self) -> float | None:
+        return self.history[-1] if self.history else None
 
 
 @dataclass(frozen=True)

--- a/api/app/domain/rating.py
+++ b/api/app/domain/rating.py
@@ -1,0 +1,21 @@
+"""Domain rules about *ratings*, independent of any one surface that shows them.
+
+Storage-agnostic and framework-agnostic: no SQLAlchemy, no Pydantic, no FastAPI.
+Both the rating wire schema (``app.schemas.rating``) and the match-details extras
+domain (``app.domain.match.extras``) import from here, so neither has to reach
+into the other.
+"""
+
+from __future__ import annotations
+
+
+def rating_delta(before: float | None, after: float) -> float:
+    """The rating movement a completed match produced. A player who had no
+    rating in the league going in moved by nothing, not by their whole rating.
+
+    The single home for that rule: ``schemas.rating.RatingChange.from_history``
+    (the dashboard's path) and ``domain.match.extras.RatingChange.delta`` — via
+    ``MatchDetailsRepository.rating_changes`` (the match-details path) — both call
+    it, so the two surfaces cannot drift into disagreeing about the same player's
+    delta. Never inline ``after - before`` at a call site; that is how they drift."""
+    return after - before if before is not None else 0.0

--- a/api/app/mappers/match_extras_mapper.py
+++ b/api/app/mappers/match_extras_mapper.py
@@ -11,7 +11,9 @@ builds the in-progress ``schemas.view`` replacement under the ``data`` key.)
 from __future__ import annotations
 
 import uuid
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from types import MappingProxyType
 
 from app.domain.match.extras import HeadToHead as HeadToHeadModel
 from app.domain.match.extras import MatchViewExtras
@@ -28,10 +30,18 @@ from app.schemas.rating import RatingChange
 
 @dataclass(frozen=True)
 class MatchDetailsExtras:
-    """The serialized extras, ready to drop onto ``MatchDetails``."""
+    """The serialized extras, ready to drop onto ``MatchDetails``.
 
-    rating_changes: dict[uuid.UUID, RatingChange]
-    recent_form: list[MatchDetailsPlayerForm]
+    Deeply immutable, on purpose. ``frozen=True`` only stops attributes being
+    *rebound* — it would happily hand every caller the same mutable ``dict`` /
+    ``list``. So the collections are read-only too: ``Mapping`` / ``Sequence``
+    make ``extras.rating_changes[uid] = ...`` and ``extras.recent_form.append(...)``
+    a type error, and the ``MappingProxyType`` / ``tuple`` behind them make such a
+    write a ``TypeError`` at runtime rather than a silent shared-state mutation.
+    See ``empty_extras`` for why that matters."""
+
+    rating_changes: Mapping[uuid.UUID, RatingChange]
+    recent_form: Sequence[MatchDetailsPlayerForm]
     head_to_head: MatchDetailsH2H | None
 
 
@@ -81,11 +91,13 @@ def _head_to_head(h2h: HeadToHeadModel) -> MatchDetailsH2H:
 
 def serialize_match_extras(extras: MatchViewExtras) -> MatchDetailsExtras:
     return MatchDetailsExtras(
-        rating_changes={
-            user_id: _rating_change(change)
-            for user_id, change in extras.rating_changes.items()
-        },
-        recent_form=[_player_form(form) for form in extras.recent_form],
+        rating_changes=MappingProxyType(
+            {
+                user_id: _rating_change(change)
+                for user_id, change in extras.rating_changes.items()
+            }
+        ),
+        recent_form=tuple(_player_form(form) for form in extras.recent_form),
         head_to_head=(
             _head_to_head(extras.head_to_head)
             if extras.head_to_head is not None
@@ -94,5 +106,15 @@ def serialize_match_extras(extras: MatchViewExtras) -> MatchDetailsExtras:
     )
 
 
-# The extras a non-participant sees: none of them (#515).
-EMPTY_EXTRAS = serialize_match_extras(MatchViewExtras.empty())
+def empty_extras() -> MatchDetailsExtras:
+    """The extras a non-participant sees: none of them (#515).
+
+    A *function*, not a module-level ``EMPTY_EXTRAS`` constant — do not "optimize"
+    it back into one. A shared instance is a shared object: every spectator and
+    anonymous share-URL viewer would be handed the same collections, so a single
+    stray write anywhere (``extras.rating_changes[uid] = ...``) would poison the
+    process and leak one real player's ratings/form into every later response.
+    A fresh instance per call means there is nothing shared to poison — and the
+    read-only collections on ``MatchDetailsExtras`` mean a future field added here
+    can't quietly re-arm the trap."""
+    return serialize_match_extras(MatchViewExtras.empty())

--- a/api/app/mappers/match_extras_mapper.py
+++ b/api/app/mappers/match_extras_mapper.py
@@ -1,0 +1,98 @@
+"""Serializes the domain match-details extras (``app.domain.match.extras``) into
+the *existing* ``MatchDetails`` response schemas — the ``recent_form`` and
+``head_to_head`` blocks and the per-side ``RatingChange``.
+
+This is the only place that knows both the domain shapes and the wire shapes;
+the repository yields the former and the router consumes the latter, so neither
+has to know the other exists. (Distinct from ``match_details_mapper``, which
+builds the in-progress ``schemas.view`` replacement under the ``data`` key.)
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from app.domain.match.extras import HeadToHead as HeadToHeadModel
+from app.domain.match.extras import MatchViewExtras
+from app.domain.match.extras import PlayerForm as PlayerFormModel
+from app.domain.match.extras import RatingChange as RatingChangeModel
+from app.schemas.match import (
+    MatchDetailsFormResult,
+    MatchDetailsH2H,
+    MatchDetailsH2HMeeting,
+    MatchDetailsPlayerForm,
+)
+from app.schemas.rating import RatingChange
+
+
+@dataclass(frozen=True)
+class MatchDetailsExtras:
+    """The serialized extras, ready to drop onto ``MatchDetails``."""
+
+    rating_changes: dict[uuid.UUID, RatingChange]
+    recent_form: list[MatchDetailsPlayerForm]
+    head_to_head: MatchDetailsH2H | None
+
+
+def _rating_change(change: RatingChangeModel) -> RatingChange:
+    return RatingChange(before=change.before, after=change.after, delta=change.delta)
+
+
+def _player_form(form: PlayerFormModel) -> MatchDetailsPlayerForm:
+    return MatchDetailsPlayerForm(
+        user_id=form.user_id,
+        recent_results=[
+            MatchDetailsFormResult(
+                match_id=result.match_id,
+                is_win=result.is_win,
+                player_games_won=result.player_games_won,
+                opponent_games_won=result.opponent_games_won,
+                opponent_username=result.opponent_username,
+                completed_at=result.completed_at,
+            )
+            for result in form.recent_results
+        ],
+        rating_before=form.rating_before.value,
+        rating_history=form.rating_before.history,
+        career_matches_before=form.career_before.matches,
+        career_wins_before=form.career_before.wins,
+    )
+
+
+def _head_to_head(h2h: HeadToHeadModel) -> MatchDetailsH2H:
+    return MatchDetailsH2H(
+        total_meetings=h2h.total_meetings,
+        side_1_wins=h2h.side_1_wins,
+        side_2_wins=h2h.side_2_wins,
+        recent_meetings=[
+            MatchDetailsH2HMeeting(
+                match_id=meeting.match_id,
+                completed_at=meeting.completed_at,
+                side_1_games_won=meeting.side_1_games_won,
+                side_2_games_won=meeting.side_2_games_won,
+                winner_side_number=meeting.winner_side_number,
+                rated=meeting.rated,
+            )
+            for meeting in h2h.recent_meetings
+        ],
+    )
+
+
+def serialize_match_extras(extras: MatchViewExtras) -> MatchDetailsExtras:
+    return MatchDetailsExtras(
+        rating_changes={
+            user_id: _rating_change(change)
+            for user_id, change in extras.rating_changes.items()
+        },
+        recent_form=[_player_form(form) for form in extras.recent_form],
+        head_to_head=(
+            _head_to_head(extras.head_to_head)
+            if extras.head_to_head is not None
+            else None
+        ),
+    )
+
+
+# The extras a non-participant sees: none of them (#515).
+EMPTY_EXTRAS = serialize_match_extras(MatchViewExtras.empty())

--- a/api/app/match_queries.py
+++ b/api/app/match_queries.py
@@ -1,0 +1,256 @@
+"""Shared match query builders and loaded-row readers.
+
+The neutral home for the SQLAlchemy fragments (eager-load chains, ``EXISTS``
+filters, base queries) and the small readers over an already-loaded ``Match``
+that more than one caller needs — the matches router, the dashboard BFF, and the
+match-details read path all build on these.
+
+They used to live on the ``app.matches`` router, which made every other module
+import a router's internals (against the ``api/CLAUDE.md`` rule that routers must
+not depend on each other) and made a match-details module importing them a
+circular import. Nothing here holds a FastAPI type, and nothing here reaches back
+into ``app.matches`` — so the match-details read path can import these freely.
+
+One wart, inherited rather than introduced: ``escape_like`` still comes from
+``app.players``, which does define a router. It's a pure string helper with no
+router dependency of its own and it creates no cycle for our callers, but it does
+mean this module is not yet the clean leaf it should be. Moving it to a neutral
+home would finish the job.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import aliased, selectinload
+from sqlalchemy.sql.base import ExecutableOption
+
+from app.models import (
+    Match,
+    MatchGame,
+    MatchResult,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    User,
+)
+from app.players import escape_like
+from app.result_acceptance import _games_to_win, side_win_counts
+
+# ----- eager-load chains ---------------------------------------------------
+
+
+# Shared eager-load chain. Used by every read path that returns a hierarchical
+# match — async SQLAlchemy can't lazy-load mid-request, so all collections are
+# pulled up front. The posted results (the propose/accept chain) are needed
+# wherever ``can_finalize`` / the awaiting-acceptance status label / the
+# derived ``negotiation`` block are computed.
+#
+# ``Match.league`` is eager (serializers read ``league.id``/``league.name``) but
+# its nested ``rating_strategy`` is NOT — only the score-write finalize paths
+# read it (inside ``_apply_rating_update``), and they load it explicitly via
+# ``match_rating_eager_options`` so the list / detail / dashboard reads don't pay
+# an extra ``selectinload`` on the strategy row (issue #182).
+def match_eager_options() -> tuple[ExecutableOption, ...]:
+    return (
+        selectinload(Match.match_settings),
+        selectinload(Match.league),
+        selectinload(Match.results),
+        *match_history_options(),
+    )
+
+
+def match_history_options() -> tuple[ExecutableOption, ...]:
+    """Subset of ``match_eager_options`` for paths that only need sides + scores
+    (recent form, H2H): no match_settings, no league/rating-strategy."""
+    return (
+        selectinload(Match.sides)
+        .selectinload(MatchSide.players)
+        .selectinload(MatchSidePlayer.user),
+        selectinload(Match.games).selectinload(MatchGame.score),
+    )
+
+
+def history_base_query(
+    current_match_id: uuid.UUID, before: datetime | None = None
+) -> Select[tuple[Match]]:
+    """Foundation for both recent-form and H2H lookups: completed matches
+    other than this one, eagerly loading just the sides + games subtree.
+
+    Pass ``before`` to restrict to matches completed before that instant, so a
+    match viewed in the past shows the form as it stood then rather than the
+    players' current form. Ordering and the ``before`` cutoff both key off the
+    stable ``completed_at`` (not the mutable ``updated_at``) so editing an old
+    completed match can't shuffle it within — or out of — a history window."""
+    query = (
+        select(Match)
+        .where(
+            Match.status == MatchStatus.completed,
+            Match.id != current_match_id,
+        )
+        .options(*match_history_options())
+        .order_by(Match.completed_at.desc())
+    )
+    if before is not None:
+        query = query.where(Match.completed_at < before)
+    return query
+
+
+# ----- query filters -------------------------------------------------------
+
+
+def participant_filter[SelectT: Select[Any]](
+    query: SelectT, current_user_id: uuid.UUID
+) -> SelectT:
+    me_in_match = (
+        select(MatchSidePlayer.id)
+        .where(
+            MatchSidePlayer.match_id == Match.id,
+            MatchSidePlayer.user_id == current_user_id,
+        )
+        .exists()
+    )
+    return query.where(me_in_match)
+
+
+def my_standing_proposal_exists(current_user_id: uuid.UUID) -> Any:
+    """``EXISTS`` correlated subquery: ``current_user`` submitted the *standing*
+    proposal on this match — the unaccepted result nothing else supersedes.
+
+    On an ``in_progress`` match that means the match is parked *waiting on the
+    opponent* to accept: the current user has already signed and owes no move.
+    It's the SQL twin of ``list_attention_kind``'s ``waiting_opponent`` bucket.
+    Shared by the dashboard's waiting/actionable split and the matches-list
+    Attention filter so the two can never disagree about who owes a move.
+
+    Singles-only assumption: this keys on ``submitted_by_user_id ==
+    current_user``, whereas ``list_attention_kind`` treats a proposal from *any*
+    player on the viewer's side as theirs (``_submitted_on_side``). For
+    ``team_size == 1`` (the only topology today — see ``create_match``) the two
+    coincide. When doubles lands, a partner's proposal would make this ``False``
+    while the classifier says ``waiting_opponent``, so this must move to a
+    side-based match to keep the SQL and Python twins aligned."""
+    superseding = aliased(MatchResult)
+    return (
+        select(MatchResult.id)
+        .where(
+            MatchResult.match_id == Match.id,
+            MatchResult.accepted_by_user_id.is_(None),
+            MatchResult.submitted_by_user_id == current_user_id,
+            ~select(superseding.id)
+            .where(superseding.supersedes_result_id == MatchResult.id)
+            .exists(),
+        )
+        .exists()
+    )
+
+
+def _player_username_filter[SelectT: Select[Any]](query: SelectT, q: str) -> SelectT:
+    """Restrict to matches that have *any* player whose username matches ``q``.
+
+    A row-narrowing filter preserves the ``Select``'s row shape, so it's
+    generic over whatever the caller is selecting (matches list vs. status
+    counts).
+    """
+    pattern = f"%{escape_like(q.strip())}%"
+    has_matching_player = (
+        select(MatchSidePlayer.id)
+        .join(User, User.id == MatchSidePlayer.user_id)
+        .where(
+            MatchSidePlayer.match_id == Match.id,
+            User.username.ilike(pattern, escape="\\"),
+        )
+        .exists()
+    )
+    return query.where(has_matching_player)
+
+
+def _actionable_attention_filter[SelectT: Select[Any]](
+    query: SelectT, current_user_id: uuid.UUID
+) -> SelectT:
+    """Narrow ``query`` to the caller's matches that need *their own* action —
+    the Attention tab's membership, computed per viewer (issue #729).
+
+    Mirrors the actionable half of ``app.attention.list_attention_kind``
+    (``review`` / ``score``): an in-progress match where the caller has *not*
+    submitted the standing proposal. This deliberately excludes the passive
+    waiting buckets — ``waiting_others`` (a pending/scheduled match) and
+    ``waiting_opponent`` (the caller's own posted result awaiting the opponent's
+    acceptance) — so the tab never flags a match the caller is merely waiting
+    on. The poster and the reviewer of the same posted result therefore see
+    *different* Attention counts, unlike before."""
+    return query.where(
+        Match.status == MatchStatus.in_progress,
+        ~my_standing_proposal_exists(current_user_id),
+    )
+
+
+def _attention_matches_query(
+    q: str | None, current_user_id: uuid.UUID
+) -> Select[tuple[Match]]:
+    """The caller's own matches that need their action (optionally
+    search-narrowed) — the row set behind the Attention tab and its tab-badge
+    count. Restricted to participation, unlike the perspective-neutral browsing
+    query, and to the *actionable* buckets, unlike a plain open-status scan."""
+    base = _actionable_attention_filter(
+        participant_filter(select(Match), current_user_id), current_user_id
+    )
+    if q:
+        base = _player_username_filter(base, q)
+    return base
+
+
+# ----- readers over a loaded match -----------------------------------------
+
+
+def my_side(match: Match, user_id: uuid.UUID) -> MatchSide | None:
+    return next(
+        (s for s in match.sides if any(p.user_id == user_id for p in s.players)),
+        None,
+    )
+
+
+def opponent_side(match: Match, user_id: uuid.UUID) -> MatchSide | None:
+    mine = my_side(match, user_id)
+    if mine is None:
+        return None
+    return next((s for s in match.sides if s.side_number != mine.side_number), None)
+
+
+def opponent_username(match: Match, user_id: uuid.UUID) -> str | None:
+    opp = opponent_side(match, user_id)
+    if opp is None or not opp.players:
+        return None
+    return opp.players[0].user.username
+
+
+def current_game_number(match: Match) -> int | None:
+    """The next un-scored game number for an open match. ``None`` when:
+
+    - the match is finalized / voided / pending (not in progress);
+    - any result has been posted (the board is frozen — score writes are locked
+      once a result exists);
+    - the currently-saved games already decide the match — even if some game
+      numbers in ``1..best_of`` were never played, there's no meaningful
+      "next game to play" (a bo3 won 2-0 has no game 3). Returning a
+      phantom number here would deep-link the dashboard / list / scoring
+      page to a game that doesn't exist.
+
+    Game rows are created lazily by the score-write endpoints, so the next
+    game to score may not have a ``MatchGame`` row yet — this helper exposes
+    the number rather than an object so deeplinks work either way."""
+    if match.status != MatchStatus.in_progress:
+        return None
+    if match.results:
+        return None
+    target = _games_to_win(match.match_settings.best_of)
+    wins = side_win_counts(match)
+    if any(c >= target for c in wins.values()):
+        return None
+    best_of = match.match_settings.best_of
+    scored = {g.game_number for g in match.games if g.score is not None}
+    for n in range(1, best_of + 1):
+        if n not in scored:
+            return n
+    return None

--- a/api/app/match_queries.py
+++ b/api/app/match_queries.py
@@ -8,14 +8,11 @@ match-details read path all build on these.
 They used to live on the ``app.matches`` router, which made every other module
 import a router's internals (against the ``api/CLAUDE.md`` rule that routers must
 not depend on each other) and made a match-details module importing them a
-circular import. Nothing here holds a FastAPI type, and nothing here reaches back
-into ``app.matches`` — so the match-details read path can import these freely.
-
-One wart, inherited rather than introduced: ``escape_like`` still comes from
-``app.players``, which does define a router. It's a pure string helper with no
-router dependency of its own and it creates no cycle for our callers, but it does
-mean this module is not yet the clean leaf it should be. Moving it to a neutral
-home would finish the job.
+circular import. This module is a leaf: nothing here holds a FastAPI type, and
+nothing here reaches back into a router — importing it (or the match-details read
+path built on it) does not construct a single ``APIRouter``. Keep it that way; if
+you need a helper that lives on a router, move the helper out rather than
+importing the router.
 """
 
 import uuid
@@ -35,8 +32,8 @@ from app.models import (
     MatchStatus,
     User,
 )
-from app.players import escape_like
 from app.result_acceptance import _games_to_win, side_win_counts
+from app.sql import escape_like
 
 # ----- eager-load chains ---------------------------------------------------
 

--- a/api/app/match_queries.py
+++ b/api/app/match_queries.py
@@ -204,6 +204,15 @@ def _attention_matches_query(
 # ----- readers over a loaded match -----------------------------------------
 
 
+def singles_user_ids(match: Match) -> list[uuid.UUID]:
+    """Singles player IDs, ordered by side number. Sides without exactly one
+    player are skipped — no doubles surface yet."""
+    sides_in_order = sorted(match.sides, key=lambda s: s.side_number)
+    return [
+        side.players[0].user_id for side in sides_in_order if len(side.players) == 1
+    ]
+
+
 def my_side(match: Match, user_id: uuid.UUID) -> MatchSide | None:
     return next(
         (s for s in match.sides if any(p.user_id == user_id for p in s.players)),

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -2,7 +2,6 @@ import csv
 import io
 import logging
 import uuid
-from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Annotated, Any, cast
 
@@ -20,7 +19,7 @@ from pyrate_limiter import Duration, Rate
 from sqlalchemy import CursorResult, Select, func, select, update
 from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import aliased, selectinload
+from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.base import ExecutableOption
 
 from app.attention import (
@@ -31,17 +30,21 @@ from app.db import get_session
 from app.domain.match.models import Match as MatchModel
 from app.leagues import resolve_league
 from app.mappers.match_details_mapper import serialize_match_details
+from app.mappers.match_extras_mapper import (
+    EMPTY_EXTRAS,
+    MatchDetailsExtras,
+    serialize_match_extras,
+)
 from app.match_queries import (
     _actionable_attention_filter,
     _attention_matches_query,
     _player_username_filter,
     current_game_number,
-    history_base_query,
     match_eager_options,
     my_side,
     opponent_side,
-    opponent_username,
     participant_filter,
+    singles_user_ids,
 )
 from app.models import (
     League,
@@ -53,7 +56,6 @@ from app.models import (
     MatchSide,
     MatchSidePlayer,
     MatchStatus,
-    RatingHistory,
     User,
 )
 from app.notifications.apns import MATCH_RESULT_CONFIRMATION_CATEGORY
@@ -77,12 +79,8 @@ from app.schemas.match import (
     MatchCreate,
     MatchDetails,
     MatchDetailsCurrentGame,
-    MatchDetailsFormResult,
     MatchDetailsGame,
-    MatchDetailsH2H,
-    MatchDetailsH2HMeeting,
     MatchDetailsPlayer,
-    MatchDetailsPlayerForm,
     MatchDetailsScore,
     MatchDetailsSide,
     MatchGameScoreConflict,
@@ -110,11 +108,6 @@ router = APIRouter(prefix="/v1")
 log = logging.getLogger(__name__)
 
 MAX_PAGE_SIZE = 100
-RECENT_FORM_LIMIT = 5
-H2H_MEETINGS_LIMIT = 5
-# Cap on the pre-match sparkline so the BFF stays cheap; the dashboard
-# Sparkline already pads single points to 2.
-RATING_HISTORY_LIMIT = 10
 
 
 # ----- helpers -------------------------------------------------------------
@@ -414,13 +407,32 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
     )
 
 
+async def _view_extras(match_service: MatchService, match: Match) -> MatchDetailsExtras:
+    """The participant-only extras block (rating changes, recent form,
+    head-to-head) for an already-loaded ``match``.
+
+    The router hands the service the primitives it already holds and gets back a
+    domain model; the SQL lives in ``MatchDetailsRepository`` and the wire shapes
+    are built by the extras mapper. Callers gate on participation *before* calling
+    this — a non-participant gets ``EMPTY_EXTRAS`` (see #515)."""
+    return serialize_match_extras(
+        await match_service.load_view_extras(
+            match_id=match.id,
+            league_id=match.league_id,
+            status=match.status,
+            created_at=match.created_at,
+            user_ids=singles_user_ids(match),
+        )
+    )
+
+
 def _serialize_details(
     match: Match,
     current_user_id: uuid.UUID | None,
-    extras: "ViewExtras | None" = None,
+    extras: MatchDetailsExtras | None = None,
     domain_match: MatchModel | None = None,
 ) -> MatchDetails:
-    extras = extras or _EMPTY_EXTRAS
+    extras = extras or EMPTY_EXTRAS
     # The ``data`` view is built from the domain model. The match-details
     # endpoint loads it through MatchService/MatchRepository and passes it in;
     # the other serialize call sites already hold the full ORM row, so they
@@ -926,7 +938,9 @@ async def get_match(
     is_participant = current_user is not None and _is_participant(
         match, current_user.id
     )
-    extras = await _load_view_extras(db, match) if is_participant else _EMPTY_EXTRAS
+    extras = (
+        await _view_extras(match_service, match) if is_participant else EMPTY_EXTRAS
+    )
     return _serialize_details(
         match,
         current_user.id if current_user else None,
@@ -1112,266 +1126,6 @@ async def _notify_result_posted(
                 collapse_id=f"result-confirm:{match.id}",
             )
         )
-
-
-async def _load_rating_changes(
-    db: AsyncSession, match: Match
-) -> dict[uuid.UUID, RatingChange]:
-    """Returns ``user_id -> RatingChange`` for every rating row this match
-    produced. Empty for matches that didn't move ratings — including, always,
-    a non-completed match, since no rating rows can exist before completion."""
-    if match.status != MatchStatus.completed:
-        return {}
-    rows = (
-        (
-            await db.execute(
-                select(RatingHistory).where(RatingHistory.match_id == match.id)
-            )
-        )
-        .scalars()
-        .all()
-    )
-    return {row.user_id: RatingChange.from_history(row) for row in rows}
-
-
-def _singles_user_ids(match: Match) -> list[uuid.UUID]:
-    """Singles player IDs, ordered by side number. Sides without exactly one
-    player are skipped — no doubles surface yet."""
-    sides_in_order = sorted(match.sides, key=lambda s: s.side_number)
-    return [
-        side.players[0].user_id for side in sides_in_order if len(side.players) == 1
-    ]
-
-
-async def _load_recent_form(
-    db: AsyncSession,
-    user_ids: list[uuid.UUID],
-    match: Match,
-) -> list[MatchDetailsPlayerForm]:
-    if not user_ids:
-        return []
-
-    # One round-trip for every player's career counts, rather than one per
-    # player. Users with no prior completed matches produce no GROUP BY row, so
-    # the lookup below defaults them to ``(0, 0)``.
-    career_before = await _load_career_before(db, user_ids, match.created_at)
-
-    result: list[MatchDetailsPlayerForm] = []
-    for user_id in user_ids:
-        rows = (
-            (
-                await db.execute(
-                    participant_filter(
-                        history_base_query(match.id, before=match.created_at),
-                        user_id,
-                    ).limit(RECENT_FORM_LIMIT)
-                )
-            )
-            .scalars()
-            .all()
-        )
-        rating_before, rating_history = await _load_pre_match_rating(
-            db, user_id, match.league_id, match.created_at
-        )
-        matches_before, wins_before = career_before.get(user_id, (0, 0))
-        result.append(
-            MatchDetailsPlayerForm(
-                user_id=user_id,
-                recent_results=[_build_form_result(past, user_id) for past in rows],
-                rating_before=rating_before,
-                rating_history=rating_history,
-                career_matches_before=matches_before,
-                career_wins_before=wins_before,
-            )
-        )
-    return result
-
-
-async def _load_pre_match_rating(
-    db: AsyncSession,
-    user_id: uuid.UUID,
-    league_id: uuid.UUID,
-    before: datetime,
-) -> tuple[float | None, list[float]]:
-    """Returns ``(most-recent-value, chronological-list)``. Strict ``<`` on
-    ``before`` so this match's own rating row never leaks in."""
-    rows = (
-        (
-            await db.execute(
-                select(RatingHistory.rating_value)
-                .where(
-                    RatingHistory.user_id == user_id,
-                    RatingHistory.league_id == league_id,
-                    RatingHistory.created_at < before,
-                )
-                .order_by(RatingHistory.created_at.desc())
-                .limit(RATING_HISTORY_LIMIT)
-            )
-        )
-        .scalars()
-        .all()
-    )
-    if not rows:
-        return None, []
-    # ``rows`` is DESC, so ``rows[0]`` is already the most-recent value; the
-    # history list is the chronological (ASC) reversal.
-    return rows[0], list(reversed(rows))
-
-
-async def _load_career_before(
-    db: AsyncSession,
-    user_ids: list[uuid.UUID],
-    before: datetime,
-) -> dict[uuid.UUID, tuple[int, int]]:
-    """Cross-league ``(matches, wins)`` completed strictly before ``before``
-    (the current match's ``created_at``), for every user in ``user_ids`` in a
-    single grouped query. The current match is excluded by the date filter
-    alone: a completed match's ``completed_at`` is always ``>=`` its own
-    ``created_at``, so it can never satisfy ``completed_at < created_at``. No
-    separate ``id`` guard is needed (issue #202).
-
-    A user with no prior completed matches has **no row** under ``GROUP BY`` and
-    so is simply absent from the mapping — callers must default them to
-    ``(0, 0)``."""
-    if not user_ids:
-        return {}
-    side = aliased(MatchSide)
-    player = aliased(MatchSidePlayer)
-    rows = (
-        await db.execute(
-            select(
-                player.user_id,
-                func.count(Match.id),
-                func.count(Match.id).filter(side.won.is_(True)),
-            )
-            .join(side, side.match_id == Match.id)
-            .join(player, player.match_side_id == side.id)
-            .where(
-                player.user_id.in_(user_ids),
-                Match.status == MatchStatus.completed,
-                Match.completed_at < before,
-            )
-            .group_by(player.user_id)
-        )
-    ).all()
-    return {row[0]: (int(row[1]), int(row[2])) for row in rows}
-
-
-def _build_form_result(past_match: Match, user_id: uuid.UUID) -> MatchDetailsFormResult:
-    mine = my_side(past_match, user_id)
-    assert mine is not None  # participant_filter guarantees membership
-    # The history query filters status == completed, so completed_at is set.
-    assert past_match.completed_at is not None
-    side_wins = side_win_counts(past_match)
-    player_games = side_wins.get(mine.side_number, 0)
-    opp_games = sum(wins for n, wins in side_wins.items() if n != mine.side_number)
-    return MatchDetailsFormResult(
-        match_id=past_match.id,
-        is_win=mine.won is True,
-        player_games_won=player_games,
-        opponent_games_won=opp_games,
-        opponent_username=opponent_username(past_match, user_id),
-        completed_at=past_match.completed_at,
-    )
-
-
-async def _load_head_to_head(
-    db: AsyncSession,
-    user_ids: list[uuid.UUID],
-    match: Match,
-) -> MatchDetailsH2H | None:
-    if len(user_ids) != 2:
-        return None
-    current_match_id = match.id
-    user_a, user_b = user_ids
-    rows_query = participant_filter(
-        participant_filter(
-            history_base_query(current_match_id, before=match.created_at), user_a
-        ),
-        user_b,
-    ).options(selectinload(Match.match_settings))
-    rows = (await db.execute(rows_query.limit(H2H_MEETINGS_LIMIT))).scalars().all()
-
-    meetings: list[MatchDetailsH2HMeeting] = []
-    for past in rows:
-        past_a = my_side(past, user_a)
-        past_b = my_side(past, user_b)
-        assert past_a is not None and past_b is not None
-        # The history query filters status == completed, so completed_at is set.
-        assert past.completed_at is not None
-        side_wins = side_win_counts(past)
-        a_games = side_wins.get(past_a.side_number, 0)
-        b_games = side_wins.get(past_b.side_number, 0)
-        winner_side: int | None = (
-            1 if past_a.won is True else 2 if past_b.won is True else None
-        )
-        meetings.append(
-            MatchDetailsH2HMeeting(
-                match_id=past.id,
-                completed_at=past.completed_at,
-                side_1_games_won=a_games,
-                side_2_games_won=b_games,
-                winner_side_number=winner_side,
-                rated=past.match_settings.affects_rating,
-            )
-        )
-
-    # Prior-meetings aggregates (completed before this match) so the displayed
-    # window doesn't undercount the rivalry going into this match. Driven from
-    # MatchSide.won so a future void that leaves `won` null naturally
-    # drops out of both totals.
-    a_side = aliased(MatchSide)
-    b_side = aliased(MatchSide)
-    a_player = aliased(MatchSidePlayer)
-    b_player = aliased(MatchSidePlayer)
-    counts_query = (
-        select(
-            func.count(Match.id),
-            func.count(Match.id).filter(a_side.won.is_(True)),
-            func.count(Match.id).filter(b_side.won.is_(True)),
-        )
-        .join(a_side, a_side.match_id == Match.id)
-        .join(a_player, a_player.match_side_id == a_side.id)
-        .join(b_side, b_side.match_id == Match.id)
-        .join(b_player, b_player.match_side_id == b_side.id)
-        .where(
-            Match.status == MatchStatus.completed,
-            Match.id != current_match_id,
-            Match.completed_at < match.created_at,
-            a_player.user_id == user_a,
-            b_player.user_id == user_b,
-            a_side.id != b_side.id,
-        )
-    )
-    total, a_wins, b_wins = (await db.execute(counts_query)).one()
-
-    return MatchDetailsH2H(
-        total_meetings=total,
-        side_1_wins=a_wins,
-        side_2_wins=b_wins,
-        recent_meetings=meetings,
-    )
-
-
-@dataclass
-class ViewExtras:
-    rating_changes: dict[uuid.UUID, RatingChange]
-    recent_form: list[MatchDetailsPlayerForm]
-    head_to_head: MatchDetailsH2H | None
-
-
-_EMPTY_EXTRAS = ViewExtras(rating_changes={}, recent_form=[], head_to_head=None)
-
-
-async def _load_view_extras(db: AsyncSession, match: Match) -> ViewExtras:
-    user_ids = _singles_user_ids(match)
-    return ViewExtras(
-        rating_changes=await _load_rating_changes(db, match),
-        recent_form=await _load_recent_form(db, user_ids, match),
-        head_to_head=await _load_head_to_head(
-            db, user_ids if len(user_ids) == 2 else [], match
-        ),
-    )
 
 
 # ----- finalize-payload validation + apply --------------------------------
@@ -1720,6 +1474,7 @@ async def create_game_score(
     game_number: Annotated[int, Path(ge=1, le=7)],
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
+    match_service: MatchService = Depends(get_match_service),
 ) -> MatchDetails:
     # Take the blocking match row lock so this score write serializes against a
     # concurrent first ``post_match_result`` (which locks the same row NOWAIT).
@@ -1779,7 +1534,7 @@ async def create_game_score(
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None
-    extras = await _load_view_extras(db, reloaded)
+    extras = await _view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
 
 
@@ -1794,6 +1549,7 @@ async def update_game_score(
     game_number: Annotated[int, Path(ge=1, le=7)],
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
+    match_service: MatchService = Depends(get_match_service),
 ) -> MatchDetails:
     # Blocking match row lock (see ``create_game_score``): serializes this update
     # against a concurrent first ``post_match_result`` so ``_enforce_scorable``
@@ -1855,7 +1611,7 @@ async def update_game_score(
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None
-    extras = await _load_view_extras(db, reloaded)
+    extras = await _view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
 
 
@@ -1868,6 +1624,7 @@ async def delete_game_score(
     game_number: Annotated[int, Path(ge=1, le=7)],
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
+    match_service: MatchService = Depends(get_match_service),
 ) -> MatchDetails:
     # Blocking match row lock (see ``create_game_score``): serializes this delete
     # against a concurrent first ``post_match_result`` so ``_enforce_scorable``
@@ -1890,7 +1647,7 @@ async def delete_game_score(
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None
-    extras = await _load_view_extras(db, reloaded)
+    extras = await _view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
 
 
@@ -1916,6 +1673,7 @@ async def post_match_result(
     payload: MatchResultsWrite,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
+    match_service: MatchService = Depends(get_match_service),
     notifications: NotificationService = Depends(get_notification_service),
 ) -> MatchDetails:
     """Propose a result for a match — the first verb of the propose/accept
@@ -2043,7 +1801,7 @@ async def post_match_result(
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None
-    extras = await _load_view_extras(db, reloaded)
+    extras = await _view_extras(match_service, reloaded)
     details = _serialize_details(reloaded, current_user.id, extras)
     # Record + notify the side that now owes an acceptance. Built after the
     # response and best-effort: the result is already committed, so *nothing*
@@ -2074,6 +1832,7 @@ async def accept_match_result(
     result_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
+    match_service: MatchService = Depends(get_match_service),
 ) -> MatchDetails:
     """Accept a standing proposal — the second verb of the negotiation. The
     opposing side ratifies the proposing side's board; the match completes,
@@ -2132,5 +1891,5 @@ async def accept_match_result(
 
     reloaded = await _load_match(db, match.id)
     assert reloaded is not None
-    extras = await _load_view_extras(db, reloaded)
+    extras = await _view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -31,6 +31,18 @@ from app.db import get_session
 from app.domain.match.models import Match as MatchModel
 from app.leagues import resolve_league
 from app.mappers.match_details_mapper import serialize_match_details
+from app.match_queries import (
+    _actionable_attention_filter,
+    _attention_matches_query,
+    _player_username_filter,
+    current_game_number,
+    history_base_query,
+    match_eager_options,
+    my_side,
+    opponent_side,
+    opponent_username,
+    participant_filter,
+)
 from app.models import (
     League,
     Match,
@@ -48,7 +60,6 @@ from app.notifications.apns import MATCH_RESULT_CONFIRMATION_CATEGORY
 from app.notifications.dependencies import get_notification_service
 from app.notifications.service import NotificationService
 from app.notifications.taxonomy import NotificationCategory
-from app.players import escape_like
 from app.rate_limiting import RedisRateLimiter
 from app.result_acceptance import (
     PostedGamesNotDecisiveError,
@@ -58,9 +69,7 @@ from app.result_acceptance import (
     _games_to_win,
     _set_side_won,
     accept_standing_result,
-)
-from app.result_acceptance import (
-    side_win_counts as side_win_counts,  # noqa: PLC0414  (explicit re-export: app.dashboard imports it from here)
+    side_win_counts,
 )
 from app.result_chain import accepted_result, standing_result
 from app.retirement import retirement_deadline
@@ -140,26 +149,6 @@ def _side_schema(
     )
 
 
-# Shared eager-load chain. Used by every read path that returns a hierarchical
-# match — async SQLAlchemy can't lazy-load mid-request, so all collections are
-# pulled up front. The posted results (the propose/accept chain) are needed
-# wherever ``can_finalize`` / the awaiting-acceptance status label / the
-# derived ``negotiation`` block are computed.
-#
-# ``Match.league`` is eager (serializers read ``league.id``/``league.name``) but
-# its nested ``rating_strategy`` is NOT — only the score-write finalize paths
-# read it (inside ``_apply_rating_update``), and they load it explicitly via
-# ``match_rating_eager_options`` so the list / detail / dashboard reads don't pay
-# an extra ``selectinload`` on the strategy row (issue #182).
-def match_eager_options() -> tuple[ExecutableOption, ...]:
-    return (
-        selectinload(Match.match_settings),
-        selectinload(Match.league),
-        selectinload(Match.results),
-        *_match_history_options(),
-    )
-
-
 # The finalize/score-write superset: everything a read needs, plus the league's
 # rating strategy that ``_apply_rating_update`` reads when a completing match
 # applies ratings. Under async SQLAlchemy a lazy access on the unloaded
@@ -170,17 +159,6 @@ def match_rating_eager_options() -> tuple[ExecutableOption, ...]:
     return (
         *match_eager_options(),
         selectinload(Match.league).selectinload(League.rating_strategy),
-    )
-
-
-def _match_history_options() -> tuple[ExecutableOption, ...]:
-    """Subset of ``match_eager_options`` for paths that only need sides + scores
-    (recent form, H2H): no match_settings, no league/rating-strategy."""
-    return (
-        selectinload(Match.sides)
-        .selectinload(MatchSide.players)
-        .selectinload(MatchSidePlayer.user),
-        selectinload(Match.games).selectinload(MatchGame.score),
     )
 
 
@@ -196,27 +174,6 @@ async def _load_match(
         .options(*(options if options is not None else match_eager_options()))
     )
     return result.scalar_one_or_none()
-
-
-def my_side(match: Match, user_id: uuid.UUID) -> MatchSide | None:
-    return next(
-        (s for s in match.sides if any(p.user_id == user_id for p in s.players)),
-        None,
-    )
-
-
-def opponent_side(match: Match, user_id: uuid.UUID) -> MatchSide | None:
-    mine = my_side(match, user_id)
-    if mine is None:
-        return None
-    return next((s for s in match.sides if s.side_number != mine.side_number), None)
-
-
-def opponent_username(match: Match, user_id: uuid.UUID) -> str | None:
-    opp = opponent_side(match, user_id)
-    if opp is None or not opp.players:
-        return None
-    return opp.players[0].user.username
 
 
 def _is_participant(match: Match, user_id: uuid.UUID) -> bool:
@@ -293,37 +250,6 @@ async def _committed_score(
         return None
     game = next((g for g in reloaded.games if g.game_number == game_number), None)
     return _score_view(game.score) if game and game.score else None
-
-
-def current_game_number(match: Match) -> int | None:
-    """The next un-scored game number for an open match. ``None`` when:
-
-    - the match is finalized / voided / pending (not in progress);
-    - any result has been posted (the board is frozen — score writes are locked
-      once a result exists);
-    - the currently-saved games already decide the match — even if some game
-      numbers in ``1..best_of`` were never played, there's no meaningful
-      "next game to play" (a bo3 won 2-0 has no game 3). Returning a
-      phantom number here would deep-link the dashboard / list / scoring
-      page to a game that doesn't exist.
-
-    Game rows are created lazily by the score-write endpoints, so the next
-    game to score may not have a ``MatchGame`` row yet — this helper exposes
-    the number rather than an object so deeplinks work either way."""
-    if match.status != MatchStatus.in_progress:
-        return None
-    if match.results:
-        return None
-    target = _games_to_win(match.match_settings.best_of)
-    wins = side_win_counts(match)
-    if any(c >= target for c in wins.values()):
-        return None
-    best_of = match.match_settings.best_of
-    scored = {g.game_number for g in match.games if g.score is not None}
-    for n in range(1, best_of + 1):
-        if n not in scored:
-            return n
-    return None
 
 
 def _negotiation_game(snapshot: dict[str, int]) -> NegotiationGame:
@@ -583,20 +509,6 @@ def _add_side(match: Match, side_number: int, player: User | None) -> None:
 # ----- list helpers --------------------------------------------------------
 
 
-def participant_filter[SelectT: Select[Any]](
-    query: SelectT, current_user_id: uuid.UUID
-) -> SelectT:
-    me_in_match = (
-        select(MatchSidePlayer.id)
-        .where(
-            MatchSidePlayer.match_id == Match.id,
-            MatchSidePlayer.user_id == current_user_id,
-        )
-        .exists()
-    )
-    return query.where(me_in_match)
-
-
 def _has_result_exists() -> Any:
     """``EXISTS`` correlated subquery: this match has any result row. On an
     ``in_progress`` match the presence of any result means a standing proposal
@@ -606,58 +518,6 @@ def _has_result_exists() -> Any:
     so the list filter and the status-count aggregate split the Live vs awaiting
     buckets identically (issue #381)."""
     return select(MatchResult.id).where(MatchResult.match_id == Match.id).exists()
-
-
-def my_standing_proposal_exists(current_user_id: uuid.UUID) -> Any:
-    """``EXISTS`` correlated subquery: ``current_user`` submitted the *standing*
-    proposal on this match — the unaccepted result nothing else supersedes.
-
-    On an ``in_progress`` match that means the match is parked *waiting on the
-    opponent* to accept: the current user has already signed and owes no move.
-    It's the SQL twin of ``list_attention_kind``'s ``waiting_opponent`` bucket.
-    Shared by the dashboard's waiting/actionable split and the matches-list
-    Attention filter so the two can never disagree about who owes a move.
-
-    Singles-only assumption: this keys on ``submitted_by_user_id ==
-    current_user``, whereas ``list_attention_kind`` treats a proposal from *any*
-    player on the viewer's side as theirs (``_submitted_on_side``). For
-    ``team_size == 1`` (the only topology today — see ``create_match``) the two
-    coincide. When doubles lands, a partner's proposal would make this ``False``
-    while the classifier says ``waiting_opponent``, so this must move to a
-    side-based match to keep the SQL and Python twins aligned."""
-    superseding = aliased(MatchResult)
-    return (
-        select(MatchResult.id)
-        .where(
-            MatchResult.match_id == Match.id,
-            MatchResult.accepted_by_user_id.is_(None),
-            MatchResult.submitted_by_user_id == current_user_id,
-            ~select(superseding.id)
-            .where(superseding.supersedes_result_id == MatchResult.id)
-            .exists(),
-        )
-        .exists()
-    )
-
-
-def _player_username_filter[SelectT: Select[Any]](query: SelectT, q: str) -> SelectT:
-    """Restrict to matches that have *any* player whose username matches ``q``.
-
-    A row-narrowing filter preserves the ``Select``'s row shape, so it's
-    generic over whatever the caller is selecting (matches list vs. status
-    counts).
-    """
-    pattern = f"%{escape_like(q.strip())}%"
-    has_matching_player = (
-        select(MatchSidePlayer.id)
-        .join(User, User.id == MatchSidePlayer.user_id)
-        .where(
-            MatchSidePlayer.match_id == Match.id,
-            User.username.ilike(pattern, escape="\\"),
-        )
-        .exists()
-    )
-    return query.where(has_matching_player)
 
 
 # ----- endpoints -----------------------------------------------------------
@@ -764,41 +624,6 @@ def _filtered_matches_query(
 # rather than crashing the page. Only reachable defensively: the actionable
 # filter already excludes everything that would classify as ``None``.
 _UNCLASSIFIED_SORT_RANK = 99
-
-
-def _actionable_attention_filter[SelectT: Select[Any]](
-    query: SelectT, current_user_id: uuid.UUID
-) -> SelectT:
-    """Narrow ``query`` to the caller's matches that need *their own* action —
-    the Attention tab's membership, computed per viewer (issue #729).
-
-    Mirrors the actionable half of ``app.attention.list_attention_kind``
-    (``review`` / ``score``): an in-progress match where the caller has *not*
-    submitted the standing proposal. This deliberately excludes the passive
-    waiting buckets — ``waiting_others`` (a pending/scheduled match) and
-    ``waiting_opponent`` (the caller's own posted result awaiting the opponent's
-    acceptance) — so the tab never flags a match the caller is merely waiting
-    on. The poster and the reviewer of the same posted result therefore see
-    *different* Attention counts, unlike before."""
-    return query.where(
-        Match.status == MatchStatus.in_progress,
-        ~my_standing_proposal_exists(current_user_id),
-    )
-
-
-def _attention_matches_query(
-    q: str | None, current_user_id: uuid.UUID
-) -> Select[tuple[Match]]:
-    """The caller's own matches that need their action (optionally
-    search-narrowed) — the row set behind the Attention tab and its tab-badge
-    count. Restricted to participation, unlike the perspective-neutral browsing
-    query, and to the *actionable* buckets, unlike a plain open-status scan."""
-    base = _actionable_attention_filter(
-        participant_filter(select(Match), current_user_id), current_user_id
-    )
-    if q:
-        base = _player_username_filter(base, q)
-    return base
 
 
 def _attention_sort_key(
@@ -1318,31 +1143,6 @@ def _singles_user_ids(match: Match) -> list[uuid.UUID]:
     ]
 
 
-def _history_base_query(
-    current_match_id: uuid.UUID, before: datetime | None = None
-) -> Select[tuple[Match]]:
-    """Foundation for both recent-form and H2H lookups: completed matches
-    other than this one, eagerly loading just the sides + games subtree.
-
-    Pass ``before`` to restrict to matches completed before that instant, so a
-    match viewed in the past shows the form as it stood then rather than the
-    players' current form. Ordering and the ``before`` cutoff both key off the
-    stable ``completed_at`` (not the mutable ``updated_at``) so editing an old
-    completed match can't shuffle it within — or out of — a history window."""
-    query = (
-        select(Match)
-        .where(
-            Match.status == MatchStatus.completed,
-            Match.id != current_match_id,
-        )
-        .options(*_match_history_options())
-        .order_by(Match.completed_at.desc())
-    )
-    if before is not None:
-        query = query.where(Match.completed_at < before)
-    return query
-
-
 async def _load_recent_form(
     db: AsyncSession,
     user_ids: list[uuid.UUID],
@@ -1362,7 +1162,7 @@ async def _load_recent_form(
             (
                 await db.execute(
                     participant_filter(
-                        _history_base_query(match.id, before=match.created_at),
+                        history_base_query(match.id, before=match.created_at),
                         user_id,
                     ).limit(RECENT_FORM_LIMIT)
                 )
@@ -1486,7 +1286,7 @@ async def _load_head_to_head(
     user_a, user_b = user_ids
     rows_query = participant_filter(
         participant_filter(
-            _history_base_query(current_match_id, before=match.created_at), user_a
+            history_base_query(current_match_id, before=match.created_at), user_a
         ),
         user_b,
     ).options(selectinload(Match.match_settings))

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -2,6 +2,7 @@ import csv
 import io
 import logging
 import uuid
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Annotated, Any, cast
 
@@ -31,8 +32,8 @@ from app.domain.match.models import Match as MatchModel
 from app.leagues import resolve_league
 from app.mappers.match_details_mapper import serialize_match_details
 from app.mappers.match_extras_mapper import (
-    EMPTY_EXTRAS,
     MatchDetailsExtras,
+    empty_extras,
     serialize_match_extras,
 )
 from app.match_queries import (
@@ -117,7 +118,7 @@ def _side_schema(
     side: MatchSide,
     side_wins: dict[int, int],
     current_user_id: uuid.UUID | None,
-    rating_changes: dict[uuid.UUID, RatingChange] | None = None,
+    rating_changes: Mapping[uuid.UUID, RatingChange] | None = None,
 ) -> MatchDetailsSide:
     # Singles only for v1: each side has at most one rated player.
     rating_change = (
@@ -414,7 +415,7 @@ async def _view_extras(match_service: MatchService, match: Match) -> MatchDetail
     The router hands the service the primitives it already holds and gets back a
     domain model; the SQL lives in ``MatchDetailsRepository`` and the wire shapes
     are built by the extras mapper. Callers gate on participation *before* calling
-    this — a non-participant gets ``EMPTY_EXTRAS`` (see #515)."""
+    this — a non-participant gets ``empty_extras()`` (see #515)."""
     return serialize_match_extras(
         await match_service.load_view_extras(
             match_id=match.id,
@@ -432,7 +433,7 @@ def _serialize_details(
     extras: MatchDetailsExtras | None = None,
     domain_match: MatchModel | None = None,
 ) -> MatchDetails:
-    extras = extras or EMPTY_EXTRAS
+    extras = extras or empty_extras()
     # The ``data`` view is built from the domain model. The match-details
     # endpoint loads it through MatchService/MatchRepository and passes it in;
     # the other serialize call sites already hold the full ORM row, so they
@@ -496,7 +497,9 @@ def _serialize_details(
         # it is, and (when the opponent corrected the viewer's own proposal) the
         # diff. Drives the accept CTA + the negotiation callouts (#713).
         negotiation=_negotiation(match, current_user_id),
-        recent_form=extras.recent_form,
+        # ``extras.recent_form`` is a read-only Sequence; the response model owns
+        # its own list, so copy rather than alias it.
+        recent_form=list(extras.recent_form),
         head_to_head=extras.head_to_head,
         data=serialize_match_details(domain_match),
     )
@@ -939,7 +942,7 @@ async def get_match(
         match, current_user.id
     )
     extras = (
-        await _view_extras(match_service, match) if is_participant else EMPTY_EXTRAS
+        await _view_extras(match_service, match) if is_participant else empty_extras()
     )
     return _serialize_details(
         match,

--- a/api/app/notifications/service.py
+++ b/api/app/notifications/service.py
@@ -42,7 +42,6 @@ from app.notifications.taxonomy import (
     resolve_cell_enabled,
     resolve_channel_enabled,
 )
-from app.players import escape_like
 from app.schemas.notification import (
     BroadcastRecipient,
     BroadcastRecipientList,
@@ -64,6 +63,7 @@ from app.schemas.notification import (
     TestNotificationResponse,
     UnreadCountResponse,
 )
+from app.sql import escape_like
 
 log = logging.getLogger(__name__)
 

--- a/api/app/players.py
+++ b/api/app/players.py
@@ -30,6 +30,7 @@ from app.schemas.player import (
     PlayerSummary,
 )
 from app.sessions import get_current_user
+from app.sql import escape_like
 
 router = APIRouter(prefix="/v1")
 
@@ -121,12 +122,6 @@ async def _load_player_ranks(
         )
     ).all()
     return {user_id: int(rank) for user_id, rank in rows}
-
-
-def escape_like(term: str) -> str:
-    """Escape LIKE wildcards so a query of ``%`` matches a literal percent
-    sign rather than every username."""
-    return term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 @router.get("/players/recent", response_model=list[PlayerRead])

--- a/api/app/repositories/match_details_repository.py
+++ b/api/app/repositories/match_details_repository.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import func, select
+from sqlalchemy import ARRAY, Uuid, cast, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
 
@@ -89,7 +89,7 @@ class MatchDetailsRepository:
             .all()
         )
         return {
-            row.user_id: RatingChange.of(
+            row.user_id: RatingChange(
                 before=row.previous_rating_value, after=row.rating_value
             )
             for row in rows
@@ -146,57 +146,81 @@ class MatchDetailsRepository:
         ``before``, plus the chronological trail behind it, in **one** round-trip
         rather than one query per user (issue #195).
 
-        The per-user ``ORDER BY created_at DESC LIMIT n`` collapses into a single
-        ``ROW_NUMBER() OVER (PARTITION BY user_id ...)`` window, capped in an outer
-        query (a window function can't be filtered in its own ``WHERE``). The cap
-        is therefore genuinely **per user** — a flat ``LIMIT`` over the whole
-        result set would starve the second player.
+        The cited ids are ``unnest``-ed into a driving table and each one is joined
+        to its *own* ``ORDER BY created_at DESC LIMIT n`` subquery via ``CROSS JOIN
+        LATERAL``. One statement, but the cap stays genuinely **per user** — a flat
+        ``LIMIT`` over a batched result set would starve the second player.
+
+        **Do not "simplify" this into a ``ROW_NUMBER() OVER (PARTITION BY
+        user_id)`` window.** That shape is also one statement and also caps per
+        user, but it throws away the per-user ``LIMIT`` pushdown: Postgres cannot
+        stop an index scan early across partitions (its ``Run Condition:
+        row_number() <= 10`` filters rows, it does not terminate the scan), so the
+        window reads *every* in-league rating row each cited player owns and sorts
+        the lot just to keep ten each. The cost is unbounded in career length.
+
+        ``EXPLAIN (ANALYZE, BUFFERS)``, 93k-row ``rating_history``, two players
+        holding 3000 and 300 rows:
+
+        ==================  ============  =======  ========
+        shape               rows scanned  buffers  exec
+        ==================  ============  =======  ========
+        ROW_NUMBER() window         3300      113  1.871 ms
+        CROSS JOIN LATERAL            20        8  0.030 ms
+        ==================  ============  =======  ========
+
+        The lateral is flat in career length (``rows=10 loops=2``); the window
+        grows with it. Both plans *use* the composite index
+        ``ix_rating_history_league_id_user_id_created_at`` — no index fixes the
+        window, the over-scan is inherent to its shape.
 
         Strict ``<`` on ``before`` so this match's own rating row never leaks in.
 
-        A player with no rating history in the league has **no rows** in the
-        windowed result; they are defaulted back in as an unrated player, so every
+        A player with no rating history in the league matches **no rows** in their
+        lateral; they are defaulted back in as an unrated player, so every
         requested id is always a key of the returned dict."""
         if not user_ids:
             return {}
-        ranked = (
-            select(
-                RatingHistory.user_id,
-                RatingHistory.rating_value,
-                func.row_number()
-                .over(
-                    partition_by=RatingHistory.user_id,
-                    order_by=RatingHistory.created_at.desc(),
-                )
-                .label("rn"),
-            )
+        # The driving table: the cited ids as rows. Deduped first (order-preserving)
+        # because ``unnest`` — unlike the ``IN`` list this replaced — would emit a
+        # repeated id twice and join it to its trail twice. Cast explicitly: an
+        # untyped array bind leaves ``unnest()`` polymorphic and Postgres rejects it.
+        cited_ids = list(dict.fromkeys(user_ids))
+        cited = func.unnest(cast(cited_ids, ARRAY(Uuid(as_uuid=True)))).column_valued(
+            "cited_user_id"
+        )
+        trail = (
+            select(RatingHistory.rating_value, RatingHistory.created_at)
             .where(
-                RatingHistory.user_id.in_(user_ids),
+                RatingHistory.user_id == cited,
                 RatingHistory.league_id == league_id,
                 RatingHistory.created_at < before,
             )
-            .subquery()
+            .order_by(RatingHistory.created_at.desc())
+            .limit(RATING_HISTORY_LIMIT)
+            .lateral("trail")
         )
         rows = (
             await self._db.execute(
-                select(ranked.c.user_id, ranked.c.rating_value)
-                .where(ranked.c.rn <= RATING_HISTORY_LIMIT)
-                .order_by(ranked.c.user_id, ranked.c.rn)
+                select(cited.label("user_id"), trail.c.rating_value).order_by(
+                    cited, trail.c.created_at
+                )
             )
         ).all()
 
-        # Rows arrive newest-first per user (``rn`` ascending), so the head of each
-        # trail is the most-recent value and the history is its chronological
-        # (ASC) reversal.
+        # The lateral hands back each player's newest ``RATING_HISTORY_LIMIT`` rows;
+        # the outer ``ORDER BY created_at`` re-sorts them oldest-first, so each
+        # trail *is* the chronological history and its tail is the current value
+        # (which ``PreMatchRating.value`` derives — see the dataclass).
         trails: dict[uuid.UUID, list[float]] = {}
         for row in rows:
             trails.setdefault(row[0], []).append(float(row[1]))
         rated = {
-            user_id: PreMatchRating(value=trail[0], history=list(reversed(trail)))
-            for user_id, trail in trails.items()
+            user_id: PreMatchRating(history=history)
+            for user_id, history in trails.items()
         }
         return {
-            user_id: rated.get(user_id, PreMatchRating(value=None, history=[]))
+            user_id: rated.get(user_id, PreMatchRating(history=[]))
             for user_id in user_ids
         }
 

--- a/api/app/repositories/match_details_repository.py
+++ b/api/app/repositories/match_details_repository.py
@@ -107,6 +107,11 @@ class MatchDetailsRepository:
         if not user_ids:
             return []
 
+        # Batched once for every player, ahead of the loop — one round-trip
+        # each, not one per user (issue #195).
+        careers = await self.career_before(user_ids, created_at)
+        ratings = await self.pre_match_ratings(user_ids, league_id, created_at)
+
         result: list[PlayerForm] = []
         for user_id in user_ids:
             rows = (
@@ -125,73 +130,121 @@ class MatchDetailsRepository:
                 PlayerForm(
                     user_id=user_id,
                     recent_results=[_form_result(past, user_id) for past in rows],
-                    rating_before=await self.pre_match_rating(
-                        user_id, league_id, created_at
-                    ),
-                    career_before=await self.career_before(user_id, created_at),
+                    rating_before=ratings[user_id],
+                    career_before=careers[user_id],
                 )
             )
         return result
 
-    async def pre_match_rating(
+    async def pre_match_ratings(
         self,
-        user_id: uuid.UUID,
+        user_ids: list[uuid.UUID],
         league_id: uuid.UUID,
         before: datetime,
-    ) -> PreMatchRating:
-        """The player's rating in ``league_id`` as of just before ``before``,
-        plus the chronological trail behind it. Strict ``<`` on ``before`` so
-        this match's own rating row never leaks in."""
-        rows = (
-            (
-                await self._db.execute(
-                    select(RatingHistory.rating_value)
-                    .where(
-                        RatingHistory.user_id == user_id,
-                        RatingHistory.league_id == league_id,
-                        RatingHistory.created_at < before,
-                    )
-                    .order_by(RatingHistory.created_at.desc())
-                    .limit(RATING_HISTORY_LIMIT)
+    ) -> dict[uuid.UUID, PreMatchRating]:
+        """Every cited player's rating in ``league_id`` as of just before
+        ``before``, plus the chronological trail behind it, in **one** round-trip
+        rather than one query per user (issue #195).
+
+        The per-user ``ORDER BY created_at DESC LIMIT n`` collapses into a single
+        ``ROW_NUMBER() OVER (PARTITION BY user_id ...)`` window, capped in an outer
+        query (a window function can't be filtered in its own ``WHERE``). The cap
+        is therefore genuinely **per user** — a flat ``LIMIT`` over the whole
+        result set would starve the second player.
+
+        Strict ``<`` on ``before`` so this match's own rating row never leaks in.
+
+        A player with no rating history in the league has **no rows** in the
+        windowed result; they are defaulted back in as an unrated player, so every
+        requested id is always a key of the returned dict."""
+        if not user_ids:
+            return {}
+        ranked = (
+            select(
+                RatingHistory.user_id,
+                RatingHistory.rating_value,
+                func.row_number()
+                .over(
+                    partition_by=RatingHistory.user_id,
+                    order_by=RatingHistory.created_at.desc(),
                 )
+                .label("rn"),
             )
-            .scalars()
-            .all()
+            .where(
+                RatingHistory.user_id.in_(user_ids),
+                RatingHistory.league_id == league_id,
+                RatingHistory.created_at < before,
+            )
+            .subquery()
         )
-        if not rows:
-            return PreMatchRating(value=None, history=[])
-        # ``rows`` is DESC, so ``rows[0]`` is already the most-recent value; the
-        # history list is the chronological (ASC) reversal.
-        return PreMatchRating(value=rows[0], history=list(reversed(rows)))
+        rows = (
+            await self._db.execute(
+                select(ranked.c.user_id, ranked.c.rating_value)
+                .where(ranked.c.rn <= RATING_HISTORY_LIMIT)
+                .order_by(ranked.c.user_id, ranked.c.rn)
+            )
+        ).all()
+
+        # Rows arrive newest-first per user (``rn`` ascending), so the head of each
+        # trail is the most-recent value and the history is its chronological
+        # (ASC) reversal.
+        trails: dict[uuid.UUID, list[float]] = {}
+        for row in rows:
+            trails.setdefault(row[0], []).append(float(row[1]))
+        rated = {
+            user_id: PreMatchRating(value=trail[0], history=list(reversed(trail)))
+            for user_id, trail in trails.items()
+        }
+        return {
+            user_id: rated.get(user_id, PreMatchRating(value=None, history=[]))
+            for user_id in user_ids
+        }
 
     async def career_before(
         self,
-        user_id: uuid.UUID,
+        user_ids: list[uuid.UUID],
         before: datetime,
-    ) -> CareerRecord:
-        """Cross-league ``(matches, wins)`` completed strictly before ``before``
-        (the current match's ``created_at``). The current match is excluded by the
-        date filter alone: a completed match's ``completed_at`` is always ``>=`` its
-        own ``created_at``, so it can never satisfy ``completed_at < created_at``. No
-        separate ``id`` guard is needed (issue #202)."""
+    ) -> dict[uuid.UUID, CareerRecord]:
+        """Every cited player's cross-league ``(matches, wins)`` completed strictly
+        before ``before`` (the current match's ``created_at``), in **one**
+        ``GROUP BY user_id`` round-trip rather than one query per user (issue #195).
+
+        The current match is excluded by the date filter alone: a completed match's
+        ``completed_at`` is always ``>=`` its own ``created_at``, so it can never
+        satisfy ``completed_at < created_at``. No separate ``id`` guard is needed
+        (issue #202).
+
+        A player with no prior completed matches has **no row** in the grouped
+        result; they are defaulted back in as a zero record, so every requested id
+        is always a key of the returned dict."""
+        if not user_ids:
+            return {}
         side = aliased(MatchSide)
         player = aliased(MatchSidePlayer)
-        row = (
+        rows = (
             await self._db.execute(
                 select(
+                    player.user_id,
                     func.count(Match.id),
                     func.count(Match.id).filter(side.won.is_(True)),
                 )
                 .join(side, side.match_id == Match.id)
                 .join(player, player.match_side_id == side.id)
                 .where(
-                    player.user_id == user_id,
+                    player.user_id.in_(user_ids),
                     Match.status == MatchStatus.completed,
                     Match.completed_at < before,
                 )
+                .group_by(player.user_id)
             )
-        ).one()
-        return CareerRecord(matches=int(row[0]), wins=int(row[1]))
+        ).all()
+        played = {
+            row[0]: CareerRecord(matches=int(row[1]), wins=int(row[2])) for row in rows
+        }
+        return {
+            user_id: played.get(user_id, CareerRecord(matches=0, wins=0))
+            for user_id in user_ids
+        }
 
     async def head_to_head(
         self,

--- a/api/app/repositories/match_details_repository.py
+++ b/api/app/repositories/match_details_repository.py
@@ -1,0 +1,275 @@
+"""Data access for the match-details *view extras* — rating changes, per-player
+recent form (with the pre-match rating trail and career record), and the
+head-to-head block.
+
+A plain class wired with an ``AsyncSession`` (no FastAPI imports) so it's
+constructible in the REPL, in scripts, and in tests. It takes **primitives** —
+the ids / instants / status the caller already holds from the match it loaded —
+and returns the storage-agnostic ``app.domain.match.extras`` shapes; the SQL and
+the ORM rows stop here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased, selectinload
+
+from app.domain.match.extras import (
+    CareerRecord,
+    FormResult,
+    HeadToHead,
+    HeadToHeadMeeting,
+    PlayerForm,
+    PreMatchRating,
+    RatingChange,
+)
+from app.match_queries import (
+    history_base_query,
+    my_side,
+    opponent_username,
+    participant_filter,
+)
+from app.models import (
+    Match,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    RatingHistory,
+)
+from app.result_acceptance import side_win_counts
+
+RECENT_FORM_LIMIT = 5
+H2H_MEETINGS_LIMIT = 5
+# Cap on the pre-match sparkline so the BFF stays cheap; the dashboard
+# Sparkline already pads single points to 2.
+RATING_HISTORY_LIMIT = 10
+
+
+def _form_result(past_match: Match, user_id: uuid.UUID) -> FormResult:
+    mine = my_side(past_match, user_id)
+    assert mine is not None  # participant_filter guarantees membership
+    # The history query filters status == completed, so completed_at is set.
+    assert past_match.completed_at is not None
+    side_wins = side_win_counts(past_match)
+    player_games = side_wins.get(mine.side_number, 0)
+    opp_games = sum(wins for n, wins in side_wins.items() if n != mine.side_number)
+    return FormResult(
+        match_id=past_match.id,
+        is_win=mine.won is True,
+        player_games_won=player_games,
+        opponent_games_won=opp_games,
+        opponent_username=opponent_username(past_match, user_id),
+        completed_at=past_match.completed_at,
+    )
+
+
+class MatchDetailsRepository:
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def rating_changes(
+        self, match_id: uuid.UUID, status: MatchStatus
+    ) -> dict[uuid.UUID, RatingChange]:
+        """Returns ``user_id -> RatingChange`` for every rating row this match
+        produced. Empty for matches that didn't move ratings — including, always,
+        a non-completed match, since no rating rows can exist before completion."""
+        if status != MatchStatus.completed:
+            return {}
+        rows = (
+            (
+                await self._db.execute(
+                    select(RatingHistory).where(RatingHistory.match_id == match_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return {
+            row.user_id: RatingChange.of(
+                before=row.previous_rating_value, after=row.rating_value
+            )
+            for row in rows
+        }
+
+    async def recent_form(
+        self,
+        user_ids: list[uuid.UUID],
+        match_id: uuid.UUID,
+        league_id: uuid.UUID,
+        created_at: datetime,
+    ) -> list[PlayerForm]:
+        """Each player's last few completed matches before this one, with the
+        rating + career record they carried into it."""
+        if not user_ids:
+            return []
+
+        result: list[PlayerForm] = []
+        for user_id in user_ids:
+            rows = (
+                (
+                    await self._db.execute(
+                        participant_filter(
+                            history_base_query(match_id, before=created_at),
+                            user_id,
+                        ).limit(RECENT_FORM_LIMIT)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            result.append(
+                PlayerForm(
+                    user_id=user_id,
+                    recent_results=[_form_result(past, user_id) for past in rows],
+                    rating_before=await self.pre_match_rating(
+                        user_id, league_id, created_at
+                    ),
+                    career_before=await self.career_before(user_id, created_at),
+                )
+            )
+        return result
+
+    async def pre_match_rating(
+        self,
+        user_id: uuid.UUID,
+        league_id: uuid.UUID,
+        before: datetime,
+    ) -> PreMatchRating:
+        """The player's rating in ``league_id`` as of just before ``before``,
+        plus the chronological trail behind it. Strict ``<`` on ``before`` so
+        this match's own rating row never leaks in."""
+        rows = (
+            (
+                await self._db.execute(
+                    select(RatingHistory.rating_value)
+                    .where(
+                        RatingHistory.user_id == user_id,
+                        RatingHistory.league_id == league_id,
+                        RatingHistory.created_at < before,
+                    )
+                    .order_by(RatingHistory.created_at.desc())
+                    .limit(RATING_HISTORY_LIMIT)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if not rows:
+            return PreMatchRating(value=None, history=[])
+        # ``rows`` is DESC, so ``rows[0]`` is already the most-recent value; the
+        # history list is the chronological (ASC) reversal.
+        return PreMatchRating(value=rows[0], history=list(reversed(rows)))
+
+    async def career_before(
+        self,
+        user_id: uuid.UUID,
+        before: datetime,
+    ) -> CareerRecord:
+        """Cross-league ``(matches, wins)`` completed strictly before ``before``
+        (the current match's ``created_at``). The current match is excluded by the
+        date filter alone: a completed match's ``completed_at`` is always ``>=`` its
+        own ``created_at``, so it can never satisfy ``completed_at < created_at``. No
+        separate ``id`` guard is needed (issue #202)."""
+        side = aliased(MatchSide)
+        player = aliased(MatchSidePlayer)
+        row = (
+            await self._db.execute(
+                select(
+                    func.count(Match.id),
+                    func.count(Match.id).filter(side.won.is_(True)),
+                )
+                .join(side, side.match_id == Match.id)
+                .join(player, player.match_side_id == side.id)
+                .where(
+                    player.user_id == user_id,
+                    Match.status == MatchStatus.completed,
+                    Match.completed_at < before,
+                )
+            )
+        ).one()
+        return CareerRecord(matches=int(row[0]), wins=int(row[1]))
+
+    async def head_to_head(
+        self,
+        user_ids: list[uuid.UUID],
+        match_id: uuid.UUID,
+        created_at: datetime,
+    ) -> HeadToHead | None:
+        """The rivalry between this match's two singles players as it stood
+        going into it. ``None`` unless there are exactly two players."""
+        if len(user_ids) != 2:
+            return None
+        user_a, user_b = user_ids
+        rows_query = participant_filter(
+            participant_filter(history_base_query(match_id, before=created_at), user_a),
+            user_b,
+        ).options(selectinload(Match.match_settings))
+        rows = (
+            (await self._db.execute(rows_query.limit(H2H_MEETINGS_LIMIT)))
+            .scalars()
+            .all()
+        )
+
+        meetings: list[HeadToHeadMeeting] = []
+        for past in rows:
+            past_a = my_side(past, user_a)
+            past_b = my_side(past, user_b)
+            assert past_a is not None and past_b is not None
+            # The history query filters status == completed, so completed_at is set.
+            assert past.completed_at is not None
+            side_wins = side_win_counts(past)
+            a_games = side_wins.get(past_a.side_number, 0)
+            b_games = side_wins.get(past_b.side_number, 0)
+            winner_side: int | None = (
+                1 if past_a.won is True else 2 if past_b.won is True else None
+            )
+            meetings.append(
+                HeadToHeadMeeting(
+                    match_id=past.id,
+                    completed_at=past.completed_at,
+                    side_1_games_won=a_games,
+                    side_2_games_won=b_games,
+                    winner_side_number=winner_side,
+                    rated=past.match_settings.affects_rating,
+                )
+            )
+
+        # Prior-meetings aggregates (completed before this match) so the displayed
+        # window doesn't undercount the rivalry going into this match. Driven from
+        # MatchSide.won so a future void that leaves `won` null naturally
+        # drops out of both totals.
+        a_side = aliased(MatchSide)
+        b_side = aliased(MatchSide)
+        a_player = aliased(MatchSidePlayer)
+        b_player = aliased(MatchSidePlayer)
+        counts_query = (
+            select(
+                func.count(Match.id),
+                func.count(Match.id).filter(a_side.won.is_(True)),
+                func.count(Match.id).filter(b_side.won.is_(True)),
+            )
+            .join(a_side, a_side.match_id == Match.id)
+            .join(a_player, a_player.match_side_id == a_side.id)
+            .join(b_side, b_side.match_id == Match.id)
+            .join(b_player, b_player.match_side_id == b_side.id)
+            .where(
+                Match.status == MatchStatus.completed,
+                Match.id != match_id,
+                Match.completed_at < created_at,
+                a_player.user_id == user_a,
+                b_player.user_id == user_b,
+                a_side.id != b_side.id,
+            )
+        )
+        total, a_wins, b_wins = (await self._db.execute(counts_query)).one()
+
+        return HeadToHead(
+            total_meetings=total,
+            side_1_wins=a_wins,
+            side_2_wins=b_wins,
+            recent_meetings=meetings,
+        )

--- a/api/app/schemas/rating.py
+++ b/api/app/schemas/rating.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-from app.domain.match.extras import rating_delta
+from app.domain.rating import rating_delta
 
 if TYPE_CHECKING:
     from app.models.rating_history import RatingHistory

--- a/api/app/schemas/rating.py
+++ b/api/app/schemas/rating.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
+from app.domain.match.extras import rating_delta
+
 if TYPE_CHECKING:
     from app.models.rating_history import RatingHistory
 
@@ -18,5 +20,8 @@ class RatingChange(BaseModel):
     @classmethod
     def from_history(cls, row: RatingHistory) -> RatingChange:
         prev = row.previous_rating_value
-        delta = row.rating_value - prev if prev is not None else 0.0
-        return cls(before=prev, after=row.rating_value, delta=delta)
+        return cls(
+            before=prev,
+            after=row.rating_value,
+            delta=rating_delta(prev, row.rating_value),
+        )

--- a/api/app/services/dependencies.py
+++ b/api/app/services/dependencies.py
@@ -10,9 +10,10 @@ from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
+from app.repositories.match_details_repository import MatchDetailsRepository
 from app.repositories.match_repository import MatchRepository
 from app.services.match_service import MatchService
 
 
 def get_match_service(db: AsyncSession = Depends(get_session)) -> MatchService:
-    return MatchService(MatchRepository(db))
+    return MatchService(MatchRepository(db), MatchDetailsRepository(db))

--- a/api/app/services/match_service.py
+++ b/api/app/services/match_service.py
@@ -5,16 +5,49 @@ it a repository directly. A thin provider wires it for request handling."""
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 
+from app.domain.match.extras import MatchViewExtras
 from app.domain.match.models import Match
+from app.models.match import MatchStatus
+from app.repositories.match_details_repository import MatchDetailsRepository
 from app.repositories.match_repository import MatchRepository
 
 
 class MatchService:
-    def __init__(self, matches: MatchRepository) -> None:
+    def __init__(
+        self, matches: MatchRepository, details: MatchDetailsRepository
+    ) -> None:
         self._matches = matches
+        self._details = details
 
     async def get_match(self, match_id: uuid.UUID) -> Match | None:
         """Load the domain match for ``match_id`` via the repository, or
         ``None`` when no match exists (the caller maps that to a 404)."""
         return await self._matches.get(match_id)
+
+    async def load_view_extras(
+        self,
+        *,
+        match_id: uuid.UUID,
+        league_id: uuid.UUID,
+        status: MatchStatus,
+        created_at: datetime,
+        user_ids: list[uuid.UUID],
+    ) -> MatchViewExtras:
+        """The participant-only extras block for a match the caller has already
+        loaded: rating changes, each player's recent form, and the head-to-head.
+
+        Takes primitives rather than a loaded row so the repository stays free of
+        the ORM hierarchy. Callers that must *not* show the extras (anonymous or
+        spectator viewers — see #515) pass none of this and use
+        ``MatchViewExtras.empty()`` instead."""
+        return MatchViewExtras(
+            rating_changes=await self._details.rating_changes(match_id, status),
+            recent_form=await self._details.recent_form(
+                user_ids, match_id, league_id, created_at
+            ),
+            head_to_head=await self._details.head_to_head(
+                user_ids, match_id, created_at
+            ),
+        )

--- a/api/app/sql.py
+++ b/api/app/sql.py
@@ -1,0 +1,14 @@
+"""Pure SQL text helpers, shared by every module that builds a query.
+
+Deliberately framework-free — no FastAPI, no routers, not even a session — so the
+bottom of the query stack (``app.match_queries``, the repositories) can import it
+without transitively constructing a router and its route table.
+"""
+
+from __future__ import annotations
+
+
+def escape_like(term: str) -> str:
+    """Escape LIKE wildcards so a query of ``%`` matches a literal percent
+    sign rather than every username."""
+    return term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -10,8 +10,8 @@ from dataclasses import dataclass
 
 from httpx import ASGITransport, AsyncClient, Request
 from rq import Queue
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import event, select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from app.main import app as fastapi_app
 from app.models import User
@@ -156,6 +156,44 @@ async def opponent_session(
         yield client, user
     finally:
         await client.aclose()
+
+
+@asynccontextmanager
+async def counted_statements(
+    engine: AsyncEngine,
+) -> AsyncIterator[tuple[AsyncSession, list[str]]]:
+    """Yields ``(session, statements)``: a session whose every emitted SQL
+    statement is appended to the list, for the N+1 tripwires that pin how many
+    round-trips a loader costs.
+
+    Example::
+
+        async with counted_statements(engine) as (session, statements):
+            await MatchDetailsRepository(session).career_before(ids, now)
+        assert len(statements) == 1, statements
+
+    **Why a fresh session, not the ``db_session`` fixture.** The counter must see
+    only the statements the code under test emits: a fresh
+    ``async_sessionmaker`` session keeps the setup's already-committed INSERTs out
+    of the count, and starts with an empty identity map so the shared session's
+    cached rows / pending flushes can't mask a query the loader really would have
+    issued against a cold session (which is what a real request gets).
+
+    **Why the batching callers cite three ids.** A reintroduced per-user loop
+    emits one statement per user, so three ids fail loudly against a pin of one —
+    where a two-id list could still be read off as a coincidence.
+    """
+    statements: list[str] = []
+
+    def before(conn: object, cursor: object, statement: str, *args: object) -> None:
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", before)
+    try:
+        async with async_sessionmaker(engine)() as session:
+            yield session, statements
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", before)
 
 
 # ----- push notifications ---------------------------------------------------

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi import HTTPException
 from httpx import AsyncClient
 from rq import Queue
-from sqlalchemy import event, select, update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.base import ExecutableOption
@@ -44,32 +44,23 @@ from app.repositories.match_details_repository import (
     RATING_HISTORY_LIMIT,
     MatchDetailsRepository,
 )
-from app.repositories.match_repository import MatchRepository
 from app.schemas.match import (
     MatchGameScoreUpdate,
     MatchGameScoreWrite,
     MatchResultsGameWrite,
     MatchResultsWrite,
 )
-from app.services.match_service import MatchService
+from app.services.dependencies import get_match_service
 from tests._helpers import (
     FakeSender,
     accept_standing_result,
+    counted_statements,
     enqueued_notification_jobs,
     make_client,
     make_user,
     opponent_session,
     start_session,
 )
-
-
-def _match_service(session: AsyncSession) -> MatchService:
-    """The wiring ``get_match_service`` would do for a request. The concurrency
-    tests below drive the score-write handlers as plain functions on their own
-    real sessions (bypassing FastAPI's DI), so they construct the service the
-    handlers now depend on themselves."""
-    return MatchService(MatchRepository(session), MatchDetailsRepository(session))
-
 
 # ----- decided-board compaction (#742) ------------------------------------
 
@@ -1054,7 +1045,7 @@ async def test_concurrent_score_create_returns_409_not_500(
                 )
                 try:
                     await create_game_score(
-                        match_id, payload, 1, user, session, _match_service(session)
+                        match_id, payload, 1, user, session, get_match_service(session)
                     )
                     return "ok"
                 except HTTPException as exc:
@@ -1145,7 +1136,7 @@ async def _first_propose_after_barrier(
                 MatchResultsWrite(games=games),
                 user,
                 session,
-                _match_service(session),
+                get_match_service(session),
                 NotificationService(session, FakeSender()),
             )
             return 201
@@ -1211,7 +1202,7 @@ async def test_create_game_score_racing_first_propose_never_strays(
                 payload = MatchGameScoreWrite(side_1_points=11, side_2_points=2)
                 try:
                     await create_game_score(
-                        match_id, payload, 5, user, session, _match_service(session)
+                        match_id, payload, 5, user, session, get_match_service(session)
                     )
                     return 201
                 except HTTPException as exc:
@@ -1286,7 +1277,7 @@ async def test_delete_game_score_double_clear_never_500s(
                 ).scalar_one()
                 try:
                     await delete_game_score(
-                        match_id, 3, user, session, _match_service(session)
+                        match_id, 3, user, session, get_match_service(session)
                     )
                     return 200
                 except HTTPException as exc:
@@ -1371,7 +1362,7 @@ async def test_update_game_score_racing_first_propose_never_500s(
                 )
                 try:
                     await update_game_score(
-                        match_id, payload, 1, user, session, _match_service(session)
+                        match_id, payload, 1, user, session, get_match_service(session)
                     )
                     return 200
                 except HTTPException as exc:
@@ -2467,7 +2458,7 @@ async def test_concurrent_propose_counters_nowait_409(
                         payload,
                         poster,
                         session,
-                        _match_service(session),
+                        get_match_service(session),
                         notifications,
                     )
                     return "ok"
@@ -2534,7 +2525,7 @@ async def test_concurrent_results_posts_do_not_pile_up(
                         payload,
                         poster,
                         session,
-                        _match_service(session),
+                        get_match_service(session),
                         notifications,
                     )
                     return "ok"
@@ -3329,28 +3320,14 @@ async def test_career_before_batches_every_user_into_one_statement(
 ):
     """The career record for N players costs one SQL statement, not N (#195).
 
-    Three ids on purpose: a reintroduced per-user loop emits three statements and
-    fails loudly here, where a two-id list could still be read as a coincidence.
-    The counter runs on its own fresh ``async_sessionmaker`` session so the setup
-    INSERTs (already committed on ``db_session``) can't inflate the count, and so
-    the shared session's identity map / pending flushes can't mask a query.
+    Counted on a fresh session, over three ids — see ``counted_statements``.
     """
     user_ids = [(await make_user(db_session, f"career-batch-{n}")).id for n in range(3)]
 
-    statements: list[str] = []
-
-    def before(conn: object, cursor: object, statement: str, *args: object) -> None:
-        statements.append(statement)
-
-    fresh_session = async_sessionmaker(engine)
-    event.listen(engine.sync_engine, "before_cursor_execute", before)
-    try:
-        async with fresh_session() as session:
-            careers = await MatchDetailsRepository(session).career_before(
-                user_ids, datetime.now(UTC)
-            )
-    finally:
-        event.remove(engine.sync_engine, "before_cursor_execute", before)
+    async with counted_statements(engine) as (session, statements):
+        careers = await MatchDetailsRepository(session).career_before(
+            user_ids, datetime.now(UTC)
+        )
 
     assert len(statements) == 1, statements
     assert list(careers) == user_ids
@@ -3382,28 +3359,6 @@ async def test_career_before_defaults_a_zero_history_player_to_zero(
     assert careers[opp.id] == CareerRecord(matches=1, wins=0)
 
 
-def _standalone_rating_row(
-    league: League,
-    user: User,
-    strategy: RatingStrategy,
-    value: float,
-    created_at: datetime,
-) -> RatingHistory:
-    """A match-less rating row at a chosen instant. ``match_id`` stays ``None`` so
-    the partial unique index on ``(match_id, user_id)`` doesn't cap a player at one
-    row — these tests need a player to carry more than the sparkline limit."""
-    return RatingHistory(
-        league_id=league.id,
-        user_id=user.id,
-        match_id=None,
-        rating_strategy_id=strategy.id,
-        rating_value=value,
-        rating_state={"rating": value, "rd": 350.0, "volatility": 0.06},
-        source=RatingHistorySource.manual,
-        created_at=created_at,
-    )
-
-
 async def test_pre_match_ratings_batches_every_user_into_one_statement(
     db_session: AsyncSession,
     engine: AsyncEngine,
@@ -3413,40 +3368,28 @@ async def test_pre_match_ratings_batches_every_user_into_one_statement(
     """The pre-match rating + sparkline for N players costs one SQL statement,
     not N (#195).
 
-    Three ids on purpose: a reintroduced per-user loop emits three statements and
-    fails loudly here, where a two-id list could still be read as a coincidence.
-    The counter runs on its own fresh ``async_sessionmaker`` session so the setup
-    INSERTs (already committed on ``db_session``) can't inflate the count, and so
-    the shared session's identity map / pending flushes can't mask a query.
+    Counted on a fresh session, over three ids — see ``counted_statements``.
     """
     users = [await make_user(db_session, f"rating-batch-{n}") for n in range(3)]
     user_ids = [user.id for user in users]
     for n, user in enumerate(users):
         db_session.add(
-            _standalone_rating_row(
+            _match_history_row(
                 default_league,
                 user,
+                None,
                 rating_strategies["glicko2"],
+                RatingHistorySource.manual,
                 value=1500.0 + n,
                 created_at=datetime(2026, 5, 1, tzinfo=UTC),
             )
         )
     await db_session.commit()
 
-    statements: list[str] = []
-
-    def before(conn: object, cursor: object, statement: str, *args: object) -> None:
-        statements.append(statement)
-
-    fresh_session = async_sessionmaker(engine)
-    event.listen(engine.sync_engine, "before_cursor_execute", before)
-    try:
-        async with fresh_session() as session:
-            ratings = await MatchDetailsRepository(session).pre_match_ratings(
-                user_ids, default_league.id, datetime.now(UTC)
-            )
-    finally:
-        event.remove(engine.sync_engine, "before_cursor_execute", before)
+    async with counted_statements(engine) as (session, statements):
+        ratings = await MatchDetailsRepository(session).pre_match_ratings(
+            user_ids, default_league.id, datetime.now(UTC)
+        )
 
     assert len(statements) == 1, statements
     assert list(ratings) == user_ids
@@ -3458,9 +3401,9 @@ async def test_pre_match_ratings_defaults_a_never_rated_player_to_null(
     db_session: AsyncSession,
     default_league: League,
 ):
-    """A player with no rating history has *no rows* in the batched window
-    result. They must be defaulted back in as an unrated player — a present key
-    holding ``value=None, history=[]``, not a dropped key (which would silently
+    """A player with no rating history matches *no rows* in their lateral. They
+    must be defaulted back in as an unrated player — a present key holding an
+    empty trail (and so a ``None`` value), not a dropped key (which would silently
     strip them from recent_form) and not a ``KeyError``."""
     me = await start_session(api_client, db_session)
     newcomer = await make_user(db_session, "rating-null-newcomer")
@@ -3473,9 +3416,10 @@ async def test_pre_match_ratings_defaults_a_never_rated_player_to_null(
 
     # Present, not missing — the whole trap of batching this loader.
     assert newcomer.id in ratings
-    assert ratings[newcomer.id] == PreMatchRating(value=None, history=[])
+    assert ratings[newcomer.id] == PreMatchRating(history=[])
+    assert ratings[newcomer.id].value is None
     # And the player who *does* have history keeps their league-join seed.
-    assert ratings[me.id] == PreMatchRating(value=1500.0, history=[1500.0])
+    assert ratings[me.id] == PreMatchRating(history=[1500.0])
 
 
 async def test_pre_match_ratings_caps_the_sparkline_per_user(
@@ -3490,28 +3434,26 @@ async def test_pre_match_ratings_caps_the_sparkline_per_user(
     a = await make_user(db_session, "rating-cap-a")
     b = await make_user(db_session, "rating-cap-b")
     base = datetime(2026, 5, 1, tzinfo=UTC)
+    manual = RatingHistorySource.manual
     for n in range(RATING_HISTORY_LIMIT + 2):
         at = base + timedelta(minutes=n)
-        db_session.add(
-            _standalone_rating_row(default_league, a, strategy, 1000.0 + n, at)
-        )
-        db_session.add(
-            _standalone_rating_row(default_league, b, strategy, 2000.0 + n, at)
-        )
+        for user, value in ((a, 1000.0 + n), (b, 2000.0 + n)):
+            db_session.add(
+                _match_history_row(
+                    default_league, user, None, strategy, manual, value, at
+                )
+            )
     await db_session.commit()
 
     ratings = await MatchDetailsRepository(db_session).pre_match_ratings(
         [a.id, b.id], default_league.id, base + timedelta(days=1)
     )
 
-    # Twelve rows each, ten kept each: the newest ten, oldest-first, with
-    # ``value`` the most recent of them.
-    assert ratings[a.id] == PreMatchRating(
-        value=1011.0, history=[1000.0 + n for n in range(2, 12)]
-    )
-    assert ratings[b.id] == PreMatchRating(
-        value=2011.0, history=[2000.0 + n for n in range(2, 12)]
-    )
+    # Twelve rows each, ten kept each: the newest ten, oldest-first, so the
+    # derived ``value`` is the most recent of them.
+    assert ratings[a.id] == PreMatchRating(history=[1000.0 + n for n in range(2, 12)])
+    assert ratings[b.id] == PreMatchRating(history=[2000.0 + n for n in range(2, 12)])
+    assert (ratings[a.id].value, ratings[b.id].value) == (1011.0, 2011.0)
 
 
 async def test_pre_match_ratings_ignores_other_leagues(
@@ -3539,13 +3481,20 @@ async def test_pre_match_ratings_ignores_other_leagues(
     await db_session.commit()
 
     player = await make_user(db_session, "cross-league-player")
+    manual = RatingHistorySource.manual
     base = datetime(2026, 5, 1, tzinfo=UTC)
     db_session.add(
-        _standalone_rating_row(default_league, player, strategy, 1500.0, base)
+        _match_history_row(default_league, player, None, strategy, manual, 1500.0, base)
     )
     db_session.add(
-        _standalone_rating_row(
-            other_league, player, strategy, 1900.0, base + timedelta(minutes=1)
+        _match_history_row(
+            other_league,
+            player,
+            None,
+            strategy,
+            manual,
+            1900.0,
+            base + timedelta(minutes=1),
         )
     )
     await db_session.commit()
@@ -3555,7 +3504,7 @@ async def test_pre_match_ratings_ignores_other_leagues(
     )
 
     # Only the default league's row exists as far as this match is concerned.
-    assert ratings[player.id] == PreMatchRating(value=1500.0, history=[1500.0])
+    assert ratings[player.id] == PreMatchRating(history=[1500.0])
 
 
 async def test_pre_match_ratings_excludes_a_row_stamped_at_the_cutoff(
@@ -3574,16 +3523,25 @@ async def test_pre_match_ratings_excludes_a_row_stamped_at_the_cutoff(
     """
     strategy = rating_strategies["glicko2"]
     player = await make_user(db_session, "cutoff-player")
+    manual = RatingHistorySource.manual
     # One shared literal for the cutoff and the row stamped on it: two calls to
     # now() would differ by microseconds and the boundary would never be tested.
     cutoff = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
     db_session.add(
-        _standalone_rating_row(
-            default_league, player, strategy, 1500.0, cutoff - timedelta(minutes=1)
+        _match_history_row(
+            default_league,
+            player,
+            None,
+            strategy,
+            manual,
+            1500.0,
+            cutoff - timedelta(minutes=1),
         )
     )
     db_session.add(
-        _standalone_rating_row(default_league, player, strategy, 1650.0, cutoff)
+        _match_history_row(
+            default_league, player, None, strategy, manual, 1650.0, cutoff
+        )
     )
     await db_session.commit()
 
@@ -3592,34 +3550,44 @@ async def test_pre_match_ratings_excludes_a_row_stamped_at_the_cutoff(
     )
 
     # The row *at* the cutoff is excluded; only the strictly-earlier one survives.
-    assert ratings[player.id] == PreMatchRating(value=1500.0, history=[1500.0])
+    assert ratings[player.id] == PreMatchRating(history=[1500.0])
 
 
-# The whole view-extras block for a completed singles match, pinned. The terms:
+# The whole view-extras block for a completed singles match whose two players have
+# met before, pinned. The prior history is load-bearing: with none, every history
+# window comes back empty and the ``selectinload`` chains hung off the form-rows /
+# H2H-rows queries emit *nothing* — the count would collapse to 7 and could not
+# notice an eager-load fan-out regression at all. The terms:
 #
-#   1  rating_changes    — the match's own rating rows
-#   1  career_before     — batched: one GROUP BY user_id covering both users
-#   1  pre_match_ratings — batched: one ROW_NUMBER() window covering both users
-#   2  recent_form       — the form-rows query, once per user (see below)
-#   1  head_to_head      — the prior-meetings rows
-#   1  head_to_head      — the prior-meetings counts aggregate
-#   = 7
+#    1  rating_changes    — the match's own rating rows (no eager loads)
+#    1  career_before     — batched: one GROUP BY user_id covering both users
+#    1  pre_match_ratings — batched: one CROSS JOIN LATERAL covering both users
+#    6  recent_form, player 1 — the form-rows query + its 5-query selectinload
+#                               fan-out (sides, players, user, games, score)
+#    6  recent_form, player 2 — same again: the form-rows query is the one term
+#                               that scales with player count (ADR 0015)
+#    7  head_to_head      — the prior-meetings rows + a 6-query fan-out (the same
+#                           five, plus match_settings for the ``rated`` flag)
+#    1  head_to_head      — the prior-meetings counts aggregate
+#   = 23
 #
-# The form-rows query is the one term that intentionally scales with player count
-# (ADR 0015: batching it is 2 queries → 2 queries at N=2, so it stays per-user).
-# Everything else is constant. The fixture is a single completed match with no
-# prior history for either player, so the history windows come back empty and the
-# ``selectinload`` chains on the form-rows / H2H-rows queries emit nothing — the
-# count stays a measure of *round-trips through the extras loaders*, not of the
-# eager-load options hung off them.
-EXPECTED_VIEW_EXTRAS_STATEMENTS = 7
+# The dominant term is the ``6 × N`` per-user recent-form block: the fan-out, not
+# the round-trip, is what this costs. Collapsing it is issue #920 — not fixed here,
+# so this pin is what today's shape *is*, not what it should be.
+#
+# The count is independent of how deep the history runs — ``selectinload`` batches
+# one query per relationship level whatever the row count — which is what the two
+# ``priors`` cases below prove; both measure 23.
+EXPECTED_VIEW_EXTRAS_STATEMENTS = 23
 
 
+@pytest.mark.parametrize("priors", [2, 4])
 async def test_view_extras_issues_a_pinned_number_of_statements(
-    api_client: AsyncClient, db_session: AsyncSession, engine: AsyncEngine
+    api_client: AsyncClient, db_session: AsyncSession, engine: AsyncEngine, priors: int
 ):
-    """Loading the extras for a completed singles match costs a pinned, constant
-    number of SQL statements (#195).
+    """Loading the extras for a completed singles match costs a pinned number of
+    SQL statements (#195) — one that does not grow with how much history the two
+    players have (hence the two ``priors`` cases).
 
     This is the tripwire the per-loader batching tests can't be. They prove each
     *loader* emits one statement per call — but they'd still pass if someone moved
@@ -3631,11 +3599,17 @@ async def test_view_extras_issues_a_pinned_number_of_statements(
     Counting is scoped to ``load_view_extras`` rather than the HTTP request on
     purpose: an endpoint-level count would also sweep up session / auth /
     rate-limit statements and go red for reasons that have nothing to do with the
-    N+1. The counter runs on a fresh ``async_sessionmaker`` session so the setup's
-    committed writes and the shared session's identity map can't skew the count.
+    N+1. It runs on a fresh session — see ``counted_statements``.
     """
     me = await start_session(api_client, db_session)
     async with opponent_session(db_session, "roundtrip-opp") as (opp_client, opp):
+        # Prior meetings, so both players carry recent form and a head-to-head
+        # into the match under test and every eager-load chain has rows to fan
+        # out over.
+        for n in range(priors):
+            await _play_match_to_completion(
+                api_client, opp_client, opp.id, best_of=3, side_1_wins=n % 2 == 0
+            )
         finished = await _play_match_to_completion(
             api_client, opp_client, opp.id, best_of=3, side_1_wins=True
         )
@@ -3645,24 +3619,14 @@ async def test_view_extras_issues_a_pinned_number_of_statements(
         )
     ).scalar_one()
 
-    statements: list[str] = []
-
-    def before(conn: object, cursor: object, statement: str, *args: object) -> None:
-        statements.append(statement)
-
-    fresh_session = async_sessionmaker(engine)
-    event.listen(engine.sync_engine, "before_cursor_execute", before)
-    try:
-        async with fresh_session() as session:
-            extras = await _match_service(session).load_view_extras(
-                match_id=match.id,
-                league_id=match.league_id,
-                status=match.status,
-                created_at=match.created_at,
-                user_ids=[me.id, opp.id],
-            )
-    finally:
-        event.remove(engine.sync_engine, "before_cursor_execute", before)
+    async with counted_statements(engine) as (session, statements):
+        extras = await get_match_service(session).load_view_extras(
+            match_id=match.id,
+            league_id=match.league_id,
+            status=match.status,
+            created_at=match.created_at,
+            user_ids=[me.id, opp.id],
+        )
 
     for n, statement in enumerate(statements, start=1):
         print(f"[{n}] {' '.join(statement.split())}")
@@ -3670,8 +3634,10 @@ async def test_view_extras_issues_a_pinned_number_of_statements(
     assert len(statements) == EXPECTED_VIEW_EXTRAS_STATEMENTS, statements
     # And the block it counted is the real one, fully populated.
     assert {form.user_id for form in extras.recent_form} == {me.id, opp.id}
+    assert all(form.recent_results for form in extras.recent_form)
     assert set(extras.rating_changes) == {me.id, opp.id}
     assert extras.head_to_head is not None
+    assert extras.head_to_head.total_meetings == priors
 
 
 async def test_list_matches_csv_export(
@@ -4172,7 +4138,11 @@ async def test_concurrent_accept_and_counter_serialize(
                 ).scalar_one()
                 try:
                     await accept_match_result(
-                        match_id, standing_id, actor, session, _match_service(session)
+                        match_id,
+                        standing_id,
+                        actor,
+                        session,
+                        get_match_service(session),
                     )
                     return "ok-accept"
                 except HTTPException as exc:
@@ -4198,7 +4168,7 @@ async def test_concurrent_accept_and_counter_serialize(
                         payload,
                         actor,
                         session,
-                        _match_service(session),
+                        get_match_service(session),
                         notifications,
                     )
                     return "ok-counter"
@@ -4478,16 +4448,31 @@ def _match_history_row(
     match: Match | None,
     strategy: RatingStrategy,
     source: RatingHistorySource,
+    value: float = 1500.0,
+    created_at: datetime | None = None,
 ) -> RatingHistory:
-    return RatingHistory(
+    """One ``rating_history`` row.
+
+    ``match=None`` writes a match-less row (an ``initial`` seed, or a ``manual``
+    adjustment). The partial unique index on ``(match_id, user_id)`` only covers
+    ``match_id IS NOT NULL``, so those rows don't cap a player at one — which is
+    how the sparkline tests give a player more history than the trail limit.
+
+    ``created_at`` defaults to the column's ``now()`` server default; pass it to
+    place the row at a chosen instant (never as ``None``, which would insert a
+    NULL over that default)."""
+    row = RatingHistory(
         league_id=league.id,
         user_id=user.id,
         match_id=match.id if match is not None else None,
         rating_strategy_id=strategy.id,
-        rating_value=1500.0,
-        rating_state={"rating": 1500.0, "rd": 350.0, "volatility": 0.06},
+        rating_value=value,
+        rating_state={"rating": value, "rd": 350.0, "volatility": 0.06},
         source=source,
     )
+    if created_at is not None:
+        row.created_at = created_at
+    return row
 
 
 async def test_void_sets_status_and_deletes_all_rating_history(

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -39,12 +39,15 @@ from app.models import (
 )
 from app.notifications.apns import MATCH_RESULT_CONFIRMATION_CATEGORY
 from app.notifications.service import NotificationService
+from app.repositories.match_details_repository import MatchDetailsRepository
+from app.repositories.match_repository import MatchRepository
 from app.schemas.match import (
     MatchGameScoreUpdate,
     MatchGameScoreWrite,
     MatchResultsGameWrite,
     MatchResultsWrite,
 )
+from app.services.match_service import MatchService
 from tests._helpers import (
     FakeSender,
     accept_standing_result,
@@ -54,6 +57,15 @@ from tests._helpers import (
     opponent_session,
     start_session,
 )
+
+
+def _match_service(session: AsyncSession) -> MatchService:
+    """The wiring ``get_match_service`` would do for a request. The concurrency
+    tests below drive the score-write handlers as plain functions on their own
+    real sessions (bypassing FastAPI's DI), so they construct the service the
+    handlers now depend on themselves."""
+    return MatchService(MatchRepository(session), MatchDetailsRepository(session))
+
 
 # ----- decided-board compaction (#742) ------------------------------------
 
@@ -1037,7 +1049,9 @@ async def test_concurrent_score_create_returns_409_not_500(
                     side_1_points=side_1, side_2_points=side_2
                 )
                 try:
-                    await create_game_score(match_id, payload, 1, user, session)
+                    await create_game_score(
+                        match_id, payload, 1, user, session, _match_service(session)
+                    )
                     return "ok"
                 except HTTPException as exc:
                     return exc.status_code
@@ -1127,6 +1141,7 @@ async def _first_propose_after_barrier(
                 MatchResultsWrite(games=games),
                 user,
                 session,
+                _match_service(session),
                 NotificationService(session, FakeSender()),
             )
             return 201
@@ -1191,7 +1206,9 @@ async def test_create_game_score_racing_first_propose_never_strays(
                 ).scalar_one()
                 payload = MatchGameScoreWrite(side_1_points=11, side_2_points=2)
                 try:
-                    await create_game_score(match_id, payload, 5, user, session)
+                    await create_game_score(
+                        match_id, payload, 5, user, session, _match_service(session)
+                    )
                     return 201
                 except HTTPException as exc:
                     return exc.status_code
@@ -1264,7 +1281,9 @@ async def test_delete_game_score_double_clear_never_500s(
                     await session.execute(select(User).where(User.id == me_id))
                 ).scalar_one()
                 try:
-                    await delete_game_score(match_id, 3, user, session)
+                    await delete_game_score(
+                        match_id, 3, user, session, _match_service(session)
+                    )
                     return 200
                 except HTTPException as exc:
                     return exc.status_code
@@ -1347,7 +1366,9 @@ async def test_update_game_score_racing_first_propose_never_500s(
                     side_1_points=8, side_2_points=11, expected_version=1
                 )
                 try:
-                    await update_game_score(match_id, payload, 1, user, session)
+                    await update_game_score(
+                        match_id, payload, 1, user, session, _match_service(session)
+                    )
                     return 200
                 except HTTPException as exc:
                     return exc.status_code
@@ -2438,7 +2459,12 @@ async def test_concurrent_propose_counters_nowait_409(
                 )
                 try:
                     await post_match_result(
-                        match_id, payload, poster, session, notifications
+                        match_id,
+                        payload,
+                        poster,
+                        session,
+                        _match_service(session),
+                        notifications,
                     )
                     return "ok"
                 except HTTPException as exc:
@@ -2500,7 +2526,12 @@ async def test_concurrent_results_posts_do_not_pile_up(
                 notifications = NotificationService(session, FakeSender())
                 try:
                     await post_match_result(
-                        match_id, payload, poster, session, notifications
+                        match_id,
+                        payload,
+                        poster,
+                        session,
+                        _match_service(session),
+                        notifications,
                     )
                     return "ok"
                 except HTTPException as exc:
@@ -3786,7 +3817,9 @@ async def test_concurrent_accept_and_counter_serialize(
                     await session.execute(select(User).where(User.id == me_id))
                 ).scalar_one()
                 try:
-                    await accept_match_result(match_id, standing_id, actor, session)
+                    await accept_match_result(
+                        match_id, standing_id, actor, session, _match_service(session)
+                    )
                     return "ok-accept"
                 except HTTPException as exc:
                     return exc.status_code
@@ -3807,7 +3840,12 @@ async def test_concurrent_accept_and_counter_serialize(
                 )
                 try:
                     await post_match_result(
-                        match_id, payload, actor, session, notifications
+                        match_id,
+                        payload,
+                        actor,
+                        session,
+                        _match_service(session),
+                        notifications,
                     )
                     return "ok-counter"
                 except HTTPException as exc:

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -6,12 +6,13 @@ import pytest
 from fastapi import HTTPException
 from httpx import AsyncClient
 from rq import Queue
-from sqlalchemy import select, update
+from sqlalchemy import event, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.base import ExecutableOption
 
 from app import matches as matches_mod
+from app.domain.match.extras import CareerRecord, PreMatchRating
 from app.match_voiding import void_match
 from app.matches import (
     _compact_games,
@@ -39,7 +40,10 @@ from app.models import (
 )
 from app.notifications.apns import MATCH_RESULT_CONFIRMATION_CATEGORY
 from app.notifications.service import NotificationService
-from app.repositories.match_details_repository import MatchDetailsRepository
+from app.repositories.match_details_repository import (
+    RATING_HISTORY_LIMIT,
+    MatchDetailsRepository,
+)
 from app.repositories.match_repository import MatchRepository
 from app.schemas.match import (
     MatchGameScoreUpdate,
@@ -3318,6 +3322,356 @@ async def test_details_career_counts_are_per_player(
     assert forms[str(me.id)]["career_wins_before"] == 2
     assert forms[str(opp.id)]["career_matches_before"] == 1
     assert forms[str(opp.id)]["career_wins_before"] == 0
+
+
+async def test_career_before_batches_every_user_into_one_statement(
+    db_session: AsyncSession, engine: AsyncEngine
+):
+    """The career record for N players costs one SQL statement, not N (#195).
+
+    Three ids on purpose: a reintroduced per-user loop emits three statements and
+    fails loudly here, where a two-id list could still be read as a coincidence.
+    The counter runs on its own fresh ``async_sessionmaker`` session so the setup
+    INSERTs (already committed on ``db_session``) can't inflate the count, and so
+    the shared session's identity map / pending flushes can't mask a query.
+    """
+    user_ids = [(await make_user(db_session, f"career-batch-{n}")).id for n in range(3)]
+
+    statements: list[str] = []
+
+    def before(conn: object, cursor: object, statement: str, *args: object) -> None:
+        statements.append(statement)
+
+    fresh_session = async_sessionmaker(engine)
+    event.listen(engine.sync_engine, "before_cursor_execute", before)
+    try:
+        async with fresh_session() as session:
+            careers = await MatchDetailsRepository(session).career_before(
+                user_ids, datetime.now(UTC)
+            )
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", before)
+
+    assert len(statements) == 1, statements
+    assert list(careers) == user_ids
+
+
+async def test_career_before_defaults_a_zero_history_player_to_zero(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A player with no completed matches has *no row* in the batched
+    ``GROUP BY user_id`` result. They must be defaulted back in as a 0/0 record —
+    not dropped from the dict (which would silently strip them from recent_form)
+    and not a ``KeyError``."""
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "career-zero-opp") as (opp_client, opp):
+        await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
+    newcomer = await make_user(db_session, "career-zero-newcomer")
+
+    careers = await MatchDetailsRepository(db_session).career_before(
+        [me.id, opp.id, newcomer.id], datetime.now(UTC) + timedelta(days=1)
+    )
+
+    # Present, not missing — the whole trap of batching this loader.
+    assert newcomer.id in careers
+    assert careers[newcomer.id] == CareerRecord(matches=0, wins=0)
+    # And the players who *do* have history keep their real numbers.
+    assert careers[me.id] == CareerRecord(matches=1, wins=1)
+    assert careers[opp.id] == CareerRecord(matches=1, wins=0)
+
+
+def _standalone_rating_row(
+    league: League,
+    user: User,
+    strategy: RatingStrategy,
+    value: float,
+    created_at: datetime,
+) -> RatingHistory:
+    """A match-less rating row at a chosen instant. ``match_id`` stays ``None`` so
+    the partial unique index on ``(match_id, user_id)`` doesn't cap a player at one
+    row — these tests need a player to carry more than the sparkline limit."""
+    return RatingHistory(
+        league_id=league.id,
+        user_id=user.id,
+        match_id=None,
+        rating_strategy_id=strategy.id,
+        rating_value=value,
+        rating_state={"rating": value, "rd": 350.0, "volatility": 0.06},
+        source=RatingHistorySource.manual,
+        created_at=created_at,
+    )
+
+
+async def test_pre_match_ratings_batches_every_user_into_one_statement(
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    default_league: League,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """The pre-match rating + sparkline for N players costs one SQL statement,
+    not N (#195).
+
+    Three ids on purpose: a reintroduced per-user loop emits three statements and
+    fails loudly here, where a two-id list could still be read as a coincidence.
+    The counter runs on its own fresh ``async_sessionmaker`` session so the setup
+    INSERTs (already committed on ``db_session``) can't inflate the count, and so
+    the shared session's identity map / pending flushes can't mask a query.
+    """
+    users = [await make_user(db_session, f"rating-batch-{n}") for n in range(3)]
+    user_ids = [user.id for user in users]
+    for n, user in enumerate(users):
+        db_session.add(
+            _standalone_rating_row(
+                default_league,
+                user,
+                rating_strategies["glicko2"],
+                value=1500.0 + n,
+                created_at=datetime(2026, 5, 1, tzinfo=UTC),
+            )
+        )
+    await db_session.commit()
+
+    statements: list[str] = []
+
+    def before(conn: object, cursor: object, statement: str, *args: object) -> None:
+        statements.append(statement)
+
+    fresh_session = async_sessionmaker(engine)
+    event.listen(engine.sync_engine, "before_cursor_execute", before)
+    try:
+        async with fresh_session() as session:
+            ratings = await MatchDetailsRepository(session).pre_match_ratings(
+                user_ids, default_league.id, datetime.now(UTC)
+            )
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", before)
+
+    assert len(statements) == 1, statements
+    assert list(ratings) == user_ids
+    assert [ratings[user_id].value for user_id in user_ids] == [1500.0, 1501.0, 1502.0]
+
+
+async def test_pre_match_ratings_defaults_a_never_rated_player_to_null(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    default_league: League,
+):
+    """A player with no rating history has *no rows* in the batched window
+    result. They must be defaulted back in as an unrated player — a present key
+    holding ``value=None, history=[]``, not a dropped key (which would silently
+    strip them from recent_form) and not a ``KeyError``."""
+    me = await start_session(api_client, db_session)
+    newcomer = await make_user(db_session, "rating-null-newcomer")
+
+    ratings = await MatchDetailsRepository(db_session).pre_match_ratings(
+        [me.id, newcomer.id],
+        default_league.id,
+        datetime.now(UTC) + timedelta(days=1),
+    )
+
+    # Present, not missing — the whole trap of batching this loader.
+    assert newcomer.id in ratings
+    assert ratings[newcomer.id] == PreMatchRating(value=None, history=[])
+    # And the player who *does* have history keeps their league-join seed.
+    assert ratings[me.id] == PreMatchRating(value=1500.0, history=[1500.0])
+
+
+async def test_pre_match_ratings_caps_the_sparkline_per_user(
+    db_session: AsyncSession,
+    default_league: League,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """The 10-row cap is per *player*, not a flat cap on the batched result set:
+    a naive ``LIMIT 10`` over the whole window would hand all ten rows to the
+    first player and starve the second."""
+    strategy = rating_strategies["glicko2"]
+    a = await make_user(db_session, "rating-cap-a")
+    b = await make_user(db_session, "rating-cap-b")
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    for n in range(RATING_HISTORY_LIMIT + 2):
+        at = base + timedelta(minutes=n)
+        db_session.add(
+            _standalone_rating_row(default_league, a, strategy, 1000.0 + n, at)
+        )
+        db_session.add(
+            _standalone_rating_row(default_league, b, strategy, 2000.0 + n, at)
+        )
+    await db_session.commit()
+
+    ratings = await MatchDetailsRepository(db_session).pre_match_ratings(
+        [a.id, b.id], default_league.id, base + timedelta(days=1)
+    )
+
+    # Twelve rows each, ten kept each: the newest ten, oldest-first, with
+    # ``value`` the most recent of them.
+    assert ratings[a.id] == PreMatchRating(
+        value=1011.0, history=[1000.0 + n for n in range(2, 12)]
+    )
+    assert ratings[b.id] == PreMatchRating(
+        value=2011.0, history=[2000.0 + n for n in range(2, 12)]
+    )
+
+
+async def test_pre_match_ratings_ignores_other_leagues(
+    db_session: AsyncSession,
+    default_league: League,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """The sparkline is scoped to *this match's* league. A player rated in a
+    second league must not have that league's ratings bleed into the trail shown
+    on a match played in the default league.
+
+    The other-league row is deliberately the player's *newest*, so dropping the
+    ``RatingHistory.league_id == league_id`` filter doesn't merely lengthen the
+    history — it also hijacks ``value`` — and this test goes red on both counts.
+    """
+    strategy = rating_strategies["glicko2"]
+    other_league = League(
+        name="Other League",
+        description="A league this match is not played in.",
+        visibility=LeagueVisibility.public,
+        is_default=False,
+        rating_strategy_id=strategy.id,
+    )
+    db_session.add(other_league)
+    await db_session.commit()
+
+    player = await make_user(db_session, "cross-league-player")
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    db_session.add(
+        _standalone_rating_row(default_league, player, strategy, 1500.0, base)
+    )
+    db_session.add(
+        _standalone_rating_row(
+            other_league, player, strategy, 1900.0, base + timedelta(minutes=1)
+        )
+    )
+    await db_session.commit()
+
+    ratings = await MatchDetailsRepository(db_session).pre_match_ratings(
+        [player.id], default_league.id, base + timedelta(days=1)
+    )
+
+    # Only the default league's row exists as far as this match is concerned.
+    assert ratings[player.id] == PreMatchRating(value=1500.0, history=[1500.0])
+
+
+async def test_pre_match_ratings_excludes_a_row_stamped_at_the_cutoff(
+    db_session: AsyncSession,
+    default_league: League,
+    rating_strategies: dict[str, RatingStrategy],
+):
+    """``before`` is an exclusive bound: a rating row stamped at *exactly* the
+    cutoff instant is not part of the "before" trail.
+
+    That strictness is what keeps a match's own rating row out of its own
+    pre-match sparkline — the trail must show what the player carried *into* the
+    match, never what the match itself did to them. Relaxing ``created_at <
+    before`` to ``<=`` lets the cutoff row in as the newest entry, hijacking both
+    ``value`` and ``history``, and fails this test.
+    """
+    strategy = rating_strategies["glicko2"]
+    player = await make_user(db_session, "cutoff-player")
+    # One shared literal for the cutoff and the row stamped on it: two calls to
+    # now() would differ by microseconds and the boundary would never be tested.
+    cutoff = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    db_session.add(
+        _standalone_rating_row(
+            default_league, player, strategy, 1500.0, cutoff - timedelta(minutes=1)
+        )
+    )
+    db_session.add(
+        _standalone_rating_row(default_league, player, strategy, 1650.0, cutoff)
+    )
+    await db_session.commit()
+
+    ratings = await MatchDetailsRepository(db_session).pre_match_ratings(
+        [player.id], default_league.id, cutoff
+    )
+
+    # The row *at* the cutoff is excluded; only the strictly-earlier one survives.
+    assert ratings[player.id] == PreMatchRating(value=1500.0, history=[1500.0])
+
+
+# The whole view-extras block for a completed singles match, pinned. The terms:
+#
+#   1  rating_changes    — the match's own rating rows
+#   1  career_before     — batched: one GROUP BY user_id covering both users
+#   1  pre_match_ratings — batched: one ROW_NUMBER() window covering both users
+#   2  recent_form       — the form-rows query, once per user (see below)
+#   1  head_to_head      — the prior-meetings rows
+#   1  head_to_head      — the prior-meetings counts aggregate
+#   = 7
+#
+# The form-rows query is the one term that intentionally scales with player count
+# (ADR 0015: batching it is 2 queries → 2 queries at N=2, so it stays per-user).
+# Everything else is constant. The fixture is a single completed match with no
+# prior history for either player, so the history windows come back empty and the
+# ``selectinload`` chains on the form-rows / H2H-rows queries emit nothing — the
+# count stays a measure of *round-trips through the extras loaders*, not of the
+# eager-load options hung off them.
+EXPECTED_VIEW_EXTRAS_STATEMENTS = 7
+
+
+async def test_view_extras_issues_a_pinned_number_of_statements(
+    api_client: AsyncClient, db_session: AsyncSession, engine: AsyncEngine
+):
+    """Loading the extras for a completed singles match costs a pinned, constant
+    number of SQL statements (#195).
+
+    This is the tripwire the per-loader batching tests can't be. They prove each
+    *loader* emits one statement per call — but they'd still pass if someone moved
+    ``career_before`` or ``pre_match_ratings`` back *inside* ``recent_form``'s
+    per-user loop: the loader would keep emitting exactly one statement, just N
+    times over. Only a total count around the whole block catches that, and this
+    test is written so that regression fails it — the count rises above the pin.
+
+    Counting is scoped to ``load_view_extras`` rather than the HTTP request on
+    purpose: an endpoint-level count would also sweep up session / auth /
+    rate-limit statements and go red for reasons that have nothing to do with the
+    N+1. The counter runs on a fresh ``async_sessionmaker`` session so the setup's
+    committed writes and the shared session's identity map can't skew the count.
+    """
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "roundtrip-opp") as (opp_client, opp):
+        finished = await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
+    match = (
+        await db_session.execute(
+            select(Match).where(Match.id == uuid.UUID(finished["id"]))
+        )
+    ).scalar_one()
+
+    statements: list[str] = []
+
+    def before(conn: object, cursor: object, statement: str, *args: object) -> None:
+        statements.append(statement)
+
+    fresh_session = async_sessionmaker(engine)
+    event.listen(engine.sync_engine, "before_cursor_execute", before)
+    try:
+        async with fresh_session() as session:
+            extras = await _match_service(session).load_view_extras(
+                match_id=match.id,
+                league_id=match.league_id,
+                status=match.status,
+                created_at=match.created_at,
+                user_ids=[me.id, opp.id],
+            )
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", before)
+
+    for n, statement in enumerate(statements, start=1):
+        print(f"[{n}] {' '.join(statement.split())}")
+
+    assert len(statements) == EXPECTED_VIEW_EXTRAS_STATEMENTS, statements
+    # And the block it counted is the real one, fully populated.
+    assert {form.user_id for form in extras.recent_form} == {me.id, opp.id}
+    assert set(extras.rating_changes) == {me.id, opp.id}
+    assert extras.head_to_head is not None
 
 
 async def test_list_matches_csv_export(

--- a/docs/adr/0015-match-details-extras-load-through-a-repository.md
+++ b/docs/adr/0015-match-details-extras-load-through-a-repository.md
@@ -1,0 +1,97 @@
+# 15. Match-details extras load through a repository, and batch their per-user aggregates
+
+Date: 2026-07-11
+
+## Status
+
+Accepted
+
+## Context
+
+`GET /v1/matches/{id}` — and the five score-write endpoints, which all return the
+same `MatchDetails` payload — build a "view extras" block: rating changes, each
+player's recent form (with their pre-match rating sparkline and career record),
+and the head-to-head record.
+
+Two problems had accumulated in `api/app/matches.py`:
+
+1. **An N+1 in `_load_recent_form`** (issue #195). It looped over the match's
+   users and issued three sequential `await db.execute(...)` calls *per user* —
+   the recent-form rows, `_load_pre_match_rating`, and `_load_career_before`.
+   For a singles match (N=2) that is 6 round-trips for this panel alone.
+
+2. **The router was the de-facto shared query module.** ~270 lines of raw
+   SQLAlchemy lived in a 2,324-line router, and `app/dashboard.py` imported
+   seven helpers directly out of it — squarely against the `api/CLAUDE.md` rule
+   that routers must not import each other's internals and that a handler should
+   "call a service/query function, not contain raw SQLAlchemy queries".
+
+## Decision
+
+**Batch the per-user aggregates; do not parallelise with `asyncio.gather`.**
+
+`_load_career_before` becomes a single `GROUP BY user_id` query and
+`_load_pre_match_rating` a single `ROW_NUMBER() OVER (PARTITION BY user_id ORDER
+BY created_at DESC)` window query, each covering every user in one round-trip.
+The recent-form *rows* query stays inside the per-user loop.
+
+**Move the extras behind the repository → domain → mapper seam** that
+`MatchRepository` / `app/domain/match/models.py` / `app/mappers/` already
+establish, rather than leaving raw SQL in the router. The shared helpers
+(`participant_filter`, `my_side`, `opponent_username`, …) move out of the router
+so nothing imports it any more.
+
+**The response contract is frozen.** The extras keep serialising into the
+existing `MatchDetails` Pydantic schemas; `openapi.json`, `schema.d.ts`, and
+`Types.swift` are unchanged. This is an internal re-layering plus a query fix.
+
+## Consequences
+
+### Why not `asyncio.gather` over short-lived sessions
+
+The issue floated a session-factory + `gather` approach. We rejected it:
+
+- **It does not fix the stated problem.** It still issues 6 round-trips; it only
+  overlaps them. The complaint in #195 is the round-trip *count*.
+- **It multiplies pooled connections on the hottest endpoint.**
+  `app/db.py` builds the engine with `create_async_engine(url, pool_pre_ping=True)`
+  and no `pool_size`/`max_overflow`, so it runs on SQLAlchemy's defaults —
+  **5 + 10 overflow = 15 connections per process**. `gather`-ing three loaders on
+  their own sessions makes one in-flight request hold its own pooled connection
+  *plus three more*. That is the pool-exhaustion failure mode of issue #641.
+- **It is only accidentally safe.** It reads committed data today purely because
+  all five score-write callers happen to `await db.commit()` *before* calling
+  `_load_view_extras`. It becomes a silent footgun the moment anyone calls the
+  extras mid-transaction — and there are six call sites.
+
+Batching adds zero connections and is correct on any session in any transaction
+state.
+
+### Why the recent-form rows query stays per-user
+
+Batching it (a window function for the top-N match ids, then one hydrating
+`SELECT ... WHERE id IN (...)`) would take **2 queries to 2 queries** at N=2 — it
+buys literally nothing. It only pays off for doubles, which cannot occur:
+`result_acceptance.py` raises on `team_size != 1` (issue #183) and
+`_singles_user_ids` skips any side without exactly one player. So the honest win
+here is **6 round-trips → 4**, not 6 → 2.
+
+### What "fixed" means, given we cannot measure it
+
+There is no perf harness, and testcontainer Postgres makes any latency number
+noise. So the acceptance criterion is deterministic, not temporal: **each batched
+loader issues exactly one SQL statement regardless of how many user ids it is
+given** (asserted with a 3-element list, so a reintroduced per-user loop fails
+loudly), plus a blunt total-round-trip tripwire around the extras block. We are
+explicitly *not* claiming a latency improvement.
+
+### Accepted costs
+
+- Batching turns "this user has no history" from a `(0, 0)` / `(None, [])` return
+  into a **missing key** in the result dict. Both batched loaders must default
+  explicitly; this is the specific regression the refactor risks, and it is
+  covered by tests for a zero-history player.
+- The write paths still recompute the extras on every score save even though all
+  of them except `rating_changes` are strictly-pre-match history and cannot have
+  changed. That is a real and larger inefficiency, tracked separately as
+  **issue #911** — it is not fixed here.

--- a/docs/adr/0015-match-details-extras-load-through-a-repository.md
+++ b/docs/adr/0015-match-details-extras-load-through-a-repository.md
@@ -67,14 +67,41 @@ The issue floated a session-factory + `gather` approach. We rejected it:
 Batching adds zero connections and is correct on any session in any transaction
 state.
 
-### Why the recent-form rows query stays per-user
+### Why the recent-form rows query stays per-user — and why that reasoning was wrong
 
-Batching it (a window function for the top-N match ids, then one hydrating
-`SELECT ... WHERE id IN (...)`) would take **2 queries to 2 queries** at N=2 — it
-buys literally nothing. It only pays off for doubles, which cannot occur:
-`result_acceptance.py` raises on `team_size != 1` (issue #183) and
-`_singles_user_ids` skips any side without exactly one player. So the honest win
-here is **6 round-trips → 4**, not 6 → 2.
+The original argument was: batching it (a window function for the top-N match ids,
+then one hydrating `SELECT ... WHERE id IN (...)`) takes **2 queries to 2 queries**
+at N=2, so it buys nothing; it would only pay off for doubles, which cannot occur
+(`result_acceptance.py` raises on `team_size != 1`, issue #183).
+
+**That arithmetic was wrong, and it was never measured.** The recent-form rows
+query is `history_base_query(...)`, which attaches `match_history_options()` — a
+`selectinload` chain (`sides → players → user`, `games → score`). So each per-user
+execute fans out into **6 round-trips, not 1**. Counted against a completed singles
+match *with prior history* (an empty-history fixture hides this, because the eager
+chains have no rows to fan out over), the whole extras block is:
+
+```
+ 1  rating_changes
+ 1  career_before        (batched here)
+ 1  pre_match_ratings    (batched here)
+ 6  player 1 recent-form rows + its selectinload fan-out
+ 6  player 2 recent-form rows + its selectinload fan-out
+ 7  head-to-head rows + its fan-out
+ 1  head-to-head counts
+---
+23  total
+```
+
+So the per-user term is `6 × N`, and batching it is worth roughly **12 → 6** —
+about three times what this ADR's decision actually saved. It is the *dominant*
+term, and it was YAGNI'd on an unchecked number.
+
+We are still not doing it here (this change is already three slices deep, and the
+right response to having been wrong about a query's cost is a measured follow-up,
+not a same-day scope expansion). It is filed as **issue #920** with the breakdown
+above. What this ADR actually delivers is **25 → 23** statements, plus two loaders
+that are now O(1) in player count instead of O(N), plus the guard.
 
 ### What "fixed" means, given we cannot measure it
 
@@ -84,6 +111,29 @@ loader issues exactly one SQL statement regardless of how many user ids it is
 given** (asserted with a 3-element list, so a reintroduced per-user loop fails
 loudly), plus a blunt total-round-trip tripwire around the extras block. We are
 explicitly *not* claiming a latency improvement.
+
+The tripwire is pinned against a fixture that **has prior history**. This matters:
+an empty-history fixture makes the `selectinload` chains emit nothing, so it counts
+7 statements where a real match costs 23 — it would flatter the change and, worse,
+would not notice an eager-load fan-out regression at all. Pin the realistic case.
+
+### A batched query is not automatically a cheaper query
+
+Batching `pre_match_ratings` with `ROW_NUMBER() OVER (PARTITION BY user_id ...)`
+collapsed N round-trips into one — and silently **threw away the per-user `LIMIT`
+pushdown**. Postgres cannot stop an index scan early across window partitions (the
+`Run Condition: row_number() <= 10` doesn't terminate it), so the query read every
+one of a player's in-league rating rows and sorted them just to return 10. Measured
+on a 120k-row `rating_history`: 600 rows scanned / 614 buffers, versus 20 rows / 26
+buffers for the per-user query it replaced — and **unbounded in career length** (a
+player with 3000 rating rows sorted 3300). No index fixes it; the over-scan is
+inherent to the shape.
+
+The loader therefore uses a `LATERAL` join with the `LIMIT` *inside* — one round-trip
+**and** the pushdown. `career_before` has no such hazard precisely because it has no
+per-user `LIMIT` to lose: it aggregates the whole career either way, so its `GROUP BY`
+scans exactly what the per-user queries scanned, minus the round-trips. The rule:
+**`LIMIT` present → a window batch can regress; no `LIMIT` → the `GROUP BY` is free.**
 
 ### Accepted costs
 


### PR DESCRIPTION
Closes #195.

## What this does

`_load_recent_form` looped over the match's players and issued three sequential DB queries **per player**. This batches the two aggregate loaders, and moves the whole view-extras block out of the router and behind the repository → domain → mapper seam the codebase already establishes.

Three commits, each independently reviewable:

1. **Move the shared match-query helpers out of the router.** `app/dashboard.py` was importing seven helpers straight out of the `matches` *router*, against `api/CLAUDE.md`'s "don't import another router's internals". More urgently it was a hard blocker: a match-details module needs four of those same helpers, so importing them from the router while the router imports it back is a **circular import**. Function bodies were moved verbatim (verified by AST-comparing every one against the base).
2. **Load the extras through `MatchDetailsRepository`** → storage-agnostic domain dataclasses → mapper → the *existing* response schemas, reached via the `MatchService` `Depends` the details endpoint already used.
3. **Batch the per-user aggregates, and guard the N+1 from coming back.**

## The honest numbers

The issue frames this as "6 round-trips". While building the tripwire I measured the extras block properly and **the issue's premise — and my own ADR's — were both wrong**:

| | statements |
|---|---|
| `rating_changes` | 1 |
| `career_before` — now one `GROUP BY user_id` | 1 |
| `pre_match_ratings` — now one `CROSS JOIN LATERAL` | 1 |
| **recent-form rows, per player (×2)** | **12** |
| head-to-head rows + fan-out | 7 |
| head-to-head counts | 1 |
| **total (2-player match, with history)** | **23** |

The recent-form rows query attaches `selectinload` chains, so **each per-user load fans out into 6 statements, not 1**. I had YAGNI'd batching it on the claim that it was "2 queries → 2 queries, buys nothing" — that was never checked. It's worth **12 → 6**, roughly three times what this PR actually saves. Filed as **#920** with the breakdown; ADR 0015 is corrected rather than quietly left wrong.

**So what this PR really delivers: 25 → 23 statements, two loaders that are now O(1) in player count instead of O(N), a genuine scan-cost fix, and a guard.** No latency claim — there's no perf harness and testcontainer Postgres makes any millisecond figure noise.

## A batched query is not automatically a cheaper query

The first cut of the sparkline used `ROW_NUMBER() OVER (PARTITION BY user_id …)`. It collapsed N round-trips into one **and silently threw away the per-user `LIMIT` pushdown** — PG16's run condition filters but doesn't terminate the scan, so it read a player's *entire* rating history to return 10 rows. Measured at 15k rating rows: **15,300 rows scanned, 6.55 ms**. Rewritten as a `CROSS JOIN LATERAL` with the `LIMIT` inside: still one statement, but **20 rows, 0.08 ms — flat in career length**.

`career_before` has no such hazard precisely because it has no per-user `LIMIT` to lose. The rule, now in the ADR: **`LIMIT` present → a window batch can regress; no `LIMIT` → the `GROUP BY` is free.**

## How the N+1 is guarded

- Each batched loader asserts **exactly one SQL statement for a three-element user-id list** (a reintroduced per-user loop emits three).
- A **tripwire** pins the whole extras block at **23** statements, parametrized over 2 and 4 prior matches to prove the count doesn't drift with history volume. This catches what the per-loader tests structurally **cannot**: moving a batched loader back *inside* the loop still emits one statement per call — just N times. Only the total sees it. (The tripwire was originally pinned at 7 against a no-history fixture, where the eager-load chains emit nothing and hide 16 statements. Patching the fixture to 0/2/4 priors yields 7/23/23 — that gap is why it's now pinned on the realistic case.)
- The specific way batching breaks — a `GROUP BY` returns **no row** for a player with no history, so they `KeyError` or vanish from the panel — is covered for both loaders.
- The sparkline is now proven league-scoped and proven to exclude a row stamped *at* the cutoff (the strict `<` is what keeps a match's own rating row out of its own pre-match trail). **Both mutations previously survived the entire suite.**

## Contract frozen

No route, response-model, or docstring changes. `openapi.json`, `schema.d.ts` and `Types.swift` all regenerate **byte-identical** — so there is no web or iOS work in this change, and that frozen contract is itself the proof the re-layering broke nothing.

## Testing

- API: ruff + `ruff format --check` + `mypy --strict` + **630 passed**
- Web client: **1282 vitest passed**, lint clean, `tsc -b && vite build` clean
- Root e2e (composed docker stack, real API): **6 passed**
- OpenAPI drift check: clean

## Follow-ups filed

- **#920** — the recent-form rows query costs 6 round-trips per player (the dominant term; 12 → 6 available)
- **#921** — two batched career queries that disagree on what counts as a match, so the players list and the match page can report different records
- **#922** — the recent-result reader is duplicated and the copies have **already drifted** on how a win is derived
- **#923** — thin domain `Match` forces a double-load on the details GET
- **#911** — the five score-write paths recompute pre-match history that cannot have changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mt9ti6QwmUpdXAKZbwMgC