### PR TITLE
Highlight the sidebar section you're actually in, and drop the selected item's left bar

### DIFF
--- a/web-client/src/components/app-shell.factory.tsx
+++ b/web-client/src/components/app-shell.factory.tsx
@@ -1,0 +1,12 @@
+import type { AppShellProps } from './app-shell'
+
+/**
+ * Props for `AppShell` — the authenticated chrome wrapped around one page's
+ * content. The shell takes nothing but its children; the interesting input is
+ * the router's pathname (see `app-shell.page.tsx`), not a prop.
+ */
+export function buildAppShellProps(
+  overrides: Partial<AppShellProps> = {},
+): AppShellProps {
+  return { children: <div>Page content</div>, ...overrides }
+}

--- a/web-client/src/components/app-shell.page.tsx
+++ b/web-client/src/components/app-shell.page.tsx
@@ -1,0 +1,130 @@
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import { AppShell, type AppShellProps } from './app-shell'
+import { buildAppShellProps } from './app-shell.factory'
+
+/**
+ * Every `<Link>` target the sidebar can render (top-level items + sub-nav
+ * children). They're registered as stub routes so the typed links resolve at
+ * render time. The *pathnames tests render at* (e.g. `/players/u_7`) do NOT
+ * need to be here: the shell reads `location.pathname` from history, which is
+ * populated whether or not a route matches.
+ */
+const NAV_LINK_PATHS = [
+  '/dashboard',
+  '/matches',
+  '/players',
+  '/tournaments',
+  '/notifications',
+  '/notifications/settings',
+  '/admin',
+  '/admin/roles',
+  '/admin/permissions',
+  '/admin/users',
+  '/admin/broadcast',
+]
+
+/** Trimmed label of a nav link (the icon `<span>` contributes no text). */
+const labelOf = (el: Element) => el.textContent?.trim() ?? ''
+
+const scoped = (container: Container) => {
+  const sidebar = (): HTMLElement =>
+    container.getByRole('complementary', { name: 'Main navigation' })
+  const labels = (selector: string) =>
+    Array.from(sidebar().querySelectorAll<HTMLAnchorElement>(selector)).map(
+      labelOf,
+    )
+
+  return {
+    /** The sidebar itself. */
+    getSidebar: sidebar,
+
+    /**
+     * Any nav link in the sidebar by its label — top-level ("Matches") or
+     * sub-nav ("Preferences"); the labels are unique across both levels.
+     */
+    getNavLink(label: string) {
+      return within(sidebar()).getByRole('link', { name: label })
+    },
+    /**
+     * Async variant, and the way every test starts: the router mounts on a
+     * tick, and permission-gated items (Tournaments, Administration and its
+     * children) only appear once `/v1/session` resolves. Await one of those
+     * before reading any active state synchronously.
+     */
+    async findNavLink(label: string) {
+      const bar = await container.findByRole('complementary', {
+        name: 'Main navigation',
+      })
+      return within(bar).findByRole('link', { name: label })
+    },
+
+    /**
+     * Labels of the top-level items carrying the full active treatment
+     * (`.app-shell__nav-link.is-active`). Empty when nothing is active.
+     */
+    getActiveNavLabels() {
+      return labels('.app-shell__nav-link.is-active')
+    },
+    /**
+     * Labels of the top-level items carrying only the icon-tint treatment
+     * (`.is-parent-active`) — an item with children never takes `is-active`.
+     */
+    getParentActiveNavLabels() {
+      return labels('.app-shell__nav-link.is-parent-active')
+    },
+    /** Labels of the active sub-nav children (`.app-shell__sub-nav-link.is-active`). */
+    getActiveSubNavLabels() {
+      return labels('.app-shell__sub-nav-link.is-active')
+    },
+  }
+}
+
+/**
+ * Test page-object for `AppShell`. `render(pathname)` mounts the shell under a
+ * memory router seeded at that pathname (the only input its nav-highlighting
+ * cares about) with every nav link target registered as a stub route. The
+ * router and the session query both resolve asynchronously, so tests start with
+ * `await appShellPage.findNavLink(...)`.
+ *
+ * Active state is asserted through the BEM classes, not `aria-current`: a
+ * TanStack `<Link>` stamps `aria-current="page"` (plus `data-status="active"`)
+ * on *every* link whose `to` is a prefix of the location — its default
+ * `activeOptions.exact` is `false` — so the parent items and the Inbox child
+ * all carry it regardless of what the shell decides. The `is-active` /
+ * `is-parent-active` classes are the shell's own contract (they drive the CSS
+ * and the e2e locators), so they're what these accessors read.
+ */
+export const appShellPage = {
+  render(pathname: string, overrides: Partial<AppShellProps> = {}) {
+    const props = buildAppShellProps(overrides)
+    const rootRoute = createRootRoute({ component: () => <AppShell {...props} /> })
+    const routes = NAV_LINK_PATHS.map((path) =>
+      createRoute({
+        getParentRoute: () => rootRoute,
+        path,
+        component: () => <div>{path}</div>,
+      }),
+    )
+    const router = createRouter({
+      routeTree: rootRoute.addChildren(routes),
+      history: createMemoryHistory({ initialEntries: [pathname] }),
+    })
+    render(<RouterProvider router={router} />)
+  },
+
+  /** Scope the accessors to a container — the whole `screen` by default. */
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/app-shell.page.tsx
+++ b/web-client/src/components/app-shell.page.tsx
@@ -5,7 +5,10 @@ import {
   createRoute,
   createRouter,
 } from '@tanstack/react-router'
+import { http, HttpResponse } from 'msw'
 
+import { mockSession } from '@/mocks/handlers'
+import { server } from '@/mocks/server'
 import { render, screen, within, type Container } from '@/test/utilities'
 
 import { AppShell, type AppShellProps } from './app-shell'
@@ -44,9 +47,6 @@ const scoped = (container: Container) => {
     )
 
   return {
-    /** The sidebar itself. */
-    getSidebar: sidebar,
-
     /**
      * Any nav link in the sidebar by its label — top-level ("Matches") or
      * sub-nav ("Preferences"); the labels are unique across both levels.
@@ -105,6 +105,11 @@ const scoped = (container: Container) => {
  */
 export const appShellPage = {
   render(pathname: string, overrides: Partial<AppShellProps> = {}) {
+    // The default handler sleeps 600ms to make the dev UI's loading states
+    // visible. The permission-gated items (Tournaments, Administration) can't
+    // render until this resolves, so tests would pay it as real wall clock.
+    server.use(http.get('*/v1/session', () => HttpResponse.json(mockSession)))
+
     const props = buildAppShellProps(overrides)
     const rootRoute = createRootRoute({ component: () => <AppShell {...props} /> })
     const routes = NAV_LINK_PATHS.map((path) =>

--- a/web-client/src/components/app-shell.test.tsx
+++ b/web-client/src/components/app-shell.test.tsx
@@ -1,0 +1,108 @@
+import { appShellPage } from './app-shell.page'
+
+/**
+ * The sidebar's active state. A top-level item owns its whole route subtree
+ * (prefix match, guarded by a trailing slash); sub-nav children stay on strict
+ * equality so only one child lights at a time.
+ *
+ * Assertions read the `is-active` / `is-parent-active` classes — see the page
+ * object for why `aria-current` (which TanStack's `<Link>` stamps on every
+ * prefix match of its own accord) can't stand in for them.
+ */
+describe('AppShell sidebar', () => {
+  it('lights Players on a player detail route beneath it', async () => {
+    appShellPage.render('/players/u_7')
+    await appShellPage.findNavLink('Players')
+
+    expect(appShellPage.getNavLink('Players')).toHaveClass('is-active')
+    expect(appShellPage.getActiveNavLabels()).toEqual(['Players'])
+  })
+
+  it.each([
+    '/matches/new',
+    '/matches/m_42',
+    '/matches/m_42/results/new',
+    '/matches/m_42/games/2/scores/new',
+    '/matches/m_42/games/2/scores/edit',
+  ])('lights Matches on %s', async (pathname) => {
+    appShellPage.render(pathname)
+    await appShellPage.findNavLink('Matches')
+
+    expect(appShellPage.getNavLink('Matches')).toHaveClass('is-active')
+    expect(appShellPage.getActiveNavLabels()).toEqual(['Matches'])
+  })
+
+  it('lights Tournaments on a tournament detail route', async () => {
+    appShellPage.render('/tournaments/t_9')
+    // Tournaments is permission-gated: it only renders once the session lands.
+    await appShellPage.findNavLink('Tournaments')
+
+    expect(appShellPage.getNavLink('Tournaments')).toHaveClass('is-active')
+    expect(appShellPage.getActiveNavLabels()).toEqual(['Tournaments'])
+  })
+
+  it.each([
+    ['/dashboard', 'Dashboard'],
+    ['/matches', 'Matches'],
+    ['/players', 'Players'],
+    ['/tournaments', 'Tournaments'],
+  ])('lights %s itself, and only it', async (pathname, label) => {
+    appShellPage.render(pathname)
+    await appShellPage.findNavLink(label)
+
+    expect(appShellPage.getNavLink(label)).toHaveClass('is-active')
+    expect(appShellPage.getActiveNavLabels()).toEqual([label])
+  })
+
+  it('does not light Players on a sibling route that merely shares its prefix', async () => {
+    appShellPage.render('/players-archive')
+    // Wait for the gated items so the whole nav is on screen before asserting
+    // nothing in it is active.
+    await appShellPage.findNavLink('Tournaments')
+
+    expect(appShellPage.getNavLink('Players')).not.toHaveClass('is-active')
+    expect(appShellPage.getActiveNavLabels()).toEqual([])
+  })
+
+  it('lights only the Inbox child on the notifications index', async () => {
+    appShellPage.render('/notifications')
+    await appShellPage.findNavLink('Inbox')
+
+    expect(appShellPage.getActiveSubNavLabels()).toEqual(['Inbox'])
+    expect(appShellPage.getActiveNavLabels()).toEqual([])
+    expect(appShellPage.getParentActiveNavLabels()).toEqual(['Notifications'])
+  })
+
+  it('lights only the Preferences child on the notification settings route, tinting Notifications without activating it', async () => {
+    appShellPage.render('/notifications/settings')
+    await appShellPage.findNavLink('Preferences')
+
+    // Strict equality for children: Inbox (/notifications) must stay dark even
+    // though the pathname sits beneath it.
+    expect(appShellPage.getActiveSubNavLabels()).toEqual(['Preferences'])
+    expect(appShellPage.getNavLink('Inbox')).not.toHaveClass('is-active')
+    // The parent keeps the icon tint only — never the full active class.
+    expect(appShellPage.getNavLink('Notifications')).toHaveClass(
+      'is-parent-active',
+    )
+    expect(appShellPage.getNavLink('Notifications')).not.toHaveClass('is-active')
+    expect(appShellPage.getParentActiveNavLabels()).toEqual(['Notifications'])
+    expect(appShellPage.getActiveNavLabels()).toEqual([])
+  })
+
+  it('lights only the Roles child on the admin roles route, tinting Administration without activating it', async () => {
+    appShellPage.render('/admin/roles')
+    await appShellPage.findNavLink('Roles')
+
+    expect(appShellPage.getActiveSubNavLabels()).toEqual(['Roles'])
+    expect(appShellPage.getNavLink('Overview')).not.toHaveClass('is-active')
+    expect(appShellPage.getNavLink('Administration')).toHaveClass(
+      'is-parent-active',
+    )
+    expect(appShellPage.getNavLink('Administration')).not.toHaveClass(
+      'is-active',
+    )
+    expect(appShellPage.getParentActiveNavLabels()).toEqual(['Administration'])
+    expect(appShellPage.getActiveNavLabels()).toEqual([])
+  })
+})

--- a/web-client/src/components/app-shell.test.tsx
+++ b/web-client/src/components/app-shell.test.tsx
@@ -105,4 +105,16 @@ describe('AppShell sidebar', () => {
     expect(appShellPage.getParentActiveNavLabels()).toEqual(['Administration'])
     expect(appShellPage.getActiveNavLabels()).toEqual([])
   })
+
+  it('still tints the parent on a route deeper than any listed child', async () => {
+    // No such route exists yet. The point is that when one is added, the
+    // section it belongs to stays lit rather than going dark — the very bug
+    // this predicate exists to prevent.
+    appShellPage.render('/admin/users/u_1')
+    await appShellPage.findNavLink('Administration')
+
+    expect(appShellPage.getParentActiveNavLabels()).toEqual(['Administration'])
+    // Deeper than "Users", so no child claims the strict-equality highlight.
+    expect(appShellPage.getActiveSubNavLabels()).toEqual([])
+  })
 })

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -188,7 +188,7 @@ function isUnder(pathname: string, to: string) {
 
 function renderNavItem(item: NavItem, pathname: string, closeOnMobile: () => void) {
   const childActive = item.children?.some((c) => pathname === c.to) ?? false
-  const isActive = isUnder(pathname, item.to) || childActive
+  const isActive = isUnder(pathname, item.to)
   return (
     <li key={item.label}>
       <Link

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -187,7 +187,10 @@ function isUnder(pathname: string, to: string) {
 }
 
 function renderNavItem(item: NavItem, pathname: string, closeOnMobile: () => void) {
-  const childActive = item.children?.some((c) => pathname === c.to) ?? false
+  // One notion of "you are in this section", used for all three decisions
+  // below. Deriving the parent tint from an exhaustive child match instead
+  // would leave a route deeper than any listed child (a future
+  // `/admin/users/:id`) expanding the sub-nav with nothing lit at all.
   const isActive = isUnder(pathname, item.to)
   return (
     <li key={item.label}>
@@ -195,8 +198,10 @@ function renderNavItem(item: NavItem, pathname: string, closeOnMobile: () => voi
         to={item.to}
         className={cn(
           'app-shell__nav-link',
+          // A parent defers the full treatment to its children and keeps only
+          // the icon tint.
           isActive && !item.children && 'is-active',
-          item.children && childActive && 'is-parent-active',
+          isActive && item.children && 'is-parent-active',
         )}
         onClick={closeOnMobile}
       >

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -172,9 +172,23 @@ function filterNavByPermissions(
     .filter((s) => s.items.length > 0)
 }
 
+/**
+ * A top-level nav item owns its whole route subtree: `/matches` stays lit on
+ * `/matches/new` and `/matches/123/games/2/scores/edit`, `/players` on
+ * `/players/abc`. The trailing slash is load-bearing — a bare `startsWith`
+ * would light Players on a sibling like `/players-archive`.
+ *
+ * Sub-nav children deliberately do NOT use this: they stay on strict equality,
+ * or `/notifications/settings` would light both Inbox (`/notifications`) and
+ * Preferences at once.
+ */
+function isUnder(pathname: string, to: string) {
+  return pathname === to || pathname.startsWith(`${to}/`)
+}
+
 function renderNavItem(item: NavItem, pathname: string, closeOnMobile: () => void) {
   const childActive = item.children?.some((c) => pathname === c.to) ?? false
-  const isActive = pathname === item.to || childActive
+  const isActive = isUnder(pathname, item.to) || childActive
   return (
     <li key={item.label}>
       <Link
@@ -212,7 +226,7 @@ function renderNavItem(item: NavItem, pathname: string, closeOnMobile: () => voi
   )
 }
 
-interface AppShellProps {
+export interface AppShellProps {
   children: ReactNode
 }
 

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -922,17 +922,6 @@ body.dark.fortymm-theme {
 .app-shell__nav-link.is-active .app-shell__nav-icon {
   color: var(--ball-400);
 }
-.app-shell__nav-link.is-active::before {
-  content: '';
-  position: absolute;
-  left: -3px;
-  top: 8px;
-  bottom: 8px;
-  width: 3px;
-  border-radius: 0 2px 2px 0;
-  background: var(--ball-500);
-  box-shadow: 0 0 8px rgba(255, 122, 26, 0.6);
-}
 
 .app-shell__nav-link.is-parent-active .app-shell__nav-icon {
   color: var(--ball-400);

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -887,7 +887,6 @@ body.dark.fortymm-theme {
   gap: 2px;
 }
 .app-shell__nav-link {
-  position: relative;
   display: flex;
   align-items: center;
   gap: 12px;


### PR DESCRIPTION
## What

Two things the sidebar got wrong:

**1. Nothing highlighted on a detail page.** The active-state predicate was strict pathname equality, so a nav item only lit up when the URL matched its target *exactly*. Every route *beneath* a section left the whole sidebar dark:

| Route | Should light | Did light |
| --- | --- | --- |
| `/players/{id}` (the reported case) | Players | — |
| `/matches/new` | Matches | — |
| `/matches/{id}` | Matches | — |
| `/matches/{id}/results/new` | Matches | — |
| `/matches/{id}/games/{n}/scores/{new,edit}` | Matches | — |
| `/tournaments/{id}` | Tournaments | — |

A top-level item now owns its whole route subtree. The trailing-slash boundary is load-bearing — a bare `startsWith` would light **Players** on a sibling like `/players-archive`, and there's a test pinning exactly that.

**2. The selected item had a left accent bar.** Removed. It was a 3px glowing `::before` pseudo-element, not a CSS border. The selected treatment is now the soft background pill plus the accent icon/label colour.

## What deliberately did *not* change

Notifications and Administration behave exactly as before. Their sub-nav children stay on **strict equality** — prefix-matching them would light both *Inbox* (`/notifications`) and *Preferences* at once on `/notifications/settings` — and the parents keep their icon-tint-only treatment rather than taking the full active pill. The sub-nav's own tick marker is untouched. Regression tests pin all of this.

`/settings` has no sidebar entry and isn't getting one.

## Why not TanStack's `activeProps`?

Considered and rejected. The router's own matcher *is* `isUnder()` byte-for-byte (prefix + segment-boundary guard, `activeOptions.exact` defaults to `false`), but the shell makes three decisions per item and only one is link-local: the parent icon-tint depends on whether a **child** is active, and the sub-nav `<ul>` is a **sibling** element `activeProps` can't reach. Adopting it for just the one decision would compute "active" two different ways in the same component.

## Notes

`app-shell` had no test at all — this adds the component quartet (15 tests). While in there, `/v1/session` is served without the mock handlers' 600ms dev-latency delay, which the permission-gated nav items were making the suite pay as wall clock (2.86s → 0.48s for this file).

## Testing

- vitest: **187 files / 1311 tests pass**
- `tsc -b` clean, eslint 0 errors, `vite build` succeeds
- web-client Playwright: **139 pass**
- Root e2e skipped — it makes zero reference to the sidebar (verified by grep); nothing outside `web-client/` changed, so no API/iOS/OpenAPI regen applies.
- Predicate proven red-then-green: under the old strict-equality predicate, exactly the 7 "route beneath a section" tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbGWuAHWUnRkr9L2k2sfet