### PR TITLE
Read-only is a view, not a disabled form: non-owners no longer get an editor for tournament events (ADR 0015)

### DIFF
--- a/docs/adr/0015-read-only-is-a-view-not-a-disabled-form.md
+++ b/docs/adr/0015-read-only-is-a-view-not-a-disabled-form.md
@@ -1,0 +1,136 @@
+# 15. Read-only is a view, not a disabled form
+
+Date: 2026-07-11
+
+## Status
+
+Accepted
+
+## Context
+
+Several tournament surfaces are editable by the tournament's creator and merely
+viewable by everyone else. Ownership is server-computed — `can_edit` on the
+tournament payload (`api/app/tournaments.py`, `t.created_by_user_id ==
+current_user_id`) — and every mutating endpoint independently enforces it with a
+403 (`_require_owner`). The server has never been at risk here. The question is
+only what a **non-owner's** screen should look like.
+
+The codebase answered that question two different ways, and nothing recorded
+which one was right:
+
+- `tables-tab.tsx` and `tournament-card.tsx` **hide** the mutating controls. A
+  non-owner simply has no Delete button, no "Add table" form.
+- `details-tab.tsx` **disables** them — it renders the organizer's edit form with
+  `disabled={!canEdit}` on all nine controls, so a non-owner gets a greyed-out
+  editor.
+
+The event side panel (`event-editor.tsx`) started down the second path and never
+finished. Its own doc comment declared that for a non-creator "the editor becomes
+a read-only view of the event", but it only ever hid the Save and Delete buttons.
+The four sections underneath — Basics, Eligibility, Match settings, Table pools —
+kept rendering **live, enabled** inputs, switches, selects, and add/remove
+buttons. A non-owner could type into the panel, edit eligibility rules, and add
+table pools; none of it could be committed, because there was no Save button, so
+every keystroke was silently discarded on close.
+
+That bug is the argument. A disabled form and a hidden control are not two styles
+of the same idea:
+
+- A **disabled form still presents as an editor.** It has the shape, the field
+  boxes, and the affordances of something you are meant to fill in. It invites
+  the input it is going to refuse.
+- The failure is **silent**. A control that is enabled-but-pointless (the event
+  panel) discards work with no feedback at all. Even a correctly disabled control
+  is a dead end that never explains itself — the user is told "no" without being
+  told why, and grey-on-grey is a weak signal at that.
+- It **leaks the organizer's voice** to a reader. Copy written for the person in
+  control ("Edit the basics. Players see this on the public page…") is addressed
+  to someone who is not the organizer and cannot change any of it.
+- It is a **drift trap**. Twenty `disabled={!canEdit}` props are twenty chances
+  to forget one, and forgetting one restores exactly the bug above. That is not
+  hypothetical; it is what happened.
+
+## Decision
+
+**A viewer gets a rendering of the data. Only an editor gets controls.**
+
+Concretely, on any surface gated by an ownership/permission flag:
+
+1. **Render values, don't disable inputs.** When the user cannot edit, the
+   surface renders the data as text — a label and its value — not a form control
+   in a disabled state. There should be no `<input>`, `<select>`, `<textarea>`,
+   or `<switch>` in the accessibility tree at all.
+
+   **This extends to the form's furniture, not just its controls.** A field
+   **hint** ("Optional. Shown on the public registration page.") explains how to
+   fill in a control; with no control, there is nothing to explain. A **required
+   asterisk** marks a field the user must complete; it is nonsense on a field
+   nobody can fill in. Both are suppressed in the read-only rendering — dropped,
+   not reworded. Suppress them at the `Field` component rather than at each call
+   site, so a new field cannot reintroduce them by omission.
+
+2. **Hide mutating affordances; never disable them.** Save, Delete, Revert, "Add
+   rule", "Add pool", the row trash buttons — a user who cannot perform the
+   action does not see the button. (`tournament-card.tsx` already reasons this
+   way: "deleting is owner-only on the server, so a non-creator never sees a
+   button that would 403".) A disabled button is an unexplained dead end; an
+   absent one asks no questions.
+
+3. **The read-only view mirrors the editor's information architecture.** Same
+   sections, same order, same fields — so nothing is silently dropped and drift
+   between the two renderings is visible rather than dangerous. A field the
+   organizer left empty renders as an em-dash (`—`), not an omitted row: absent
+   and not-applicable must stay distinguishable, which matters most for exactly
+   the fields a player needs (entry fee, registration deadline, entrant cap).
+
+4. **Rows that are sentences render as sentences.** An eligibility predicate is
+   `[field] [operator] [value]` — three controls that are already a sentence
+   chopped into a grid. Read-only, it renders as prose: "Rating is under 1500".
+   The operator labels are already sentence fragments, so this composes from the
+   existing vocabulary rather than inventing copy.
+
+5. **Copy addresses the reader, not the organizer.** Imperatives written for the
+   person in control ("Edit event", "Click any event to edit") are swapped for
+   neutral copy when the user cannot edit.
+
+6. **Enforce it with a guard test, not with vigilance.** Each read-only-capable
+   section carries a test asserting that with `canEdit: false` it renders **zero**
+   interactive controls. This is what makes rule 1 durable: it fails loudly the
+   moment someone adds an ungated control, which is the drift that produced the
+   original bug.
+
+   **The sweep must be over the DOM, not over ARIA roles.** We learned this the
+   expensive way while implementing this ADR: a sweep of `textbox` / `combobox` /
+   `switch` / `button` catches only 3 of the event panel's 8 Basics controls,
+   because a `type="number"` input is a `spinbutton`, a `type="date"` or
+   `type="time"` input has **no role at all**, and a `ToggleGroupItem` is a
+   `radio`. Such a guard goes green with five live inputs still on screen — the
+   precise false-green this rule exists to prevent. Query the DOM
+   (`input, select, textarea, button, [role="switch"], [role="radio"], [tabindex],
+   [contenteditable]`), scoped to the component's root.
+
+We considered enforcing this structurally instead — separate `*-section.tsx` and
+`*-section-readonly.tsx` components, so a read-only component *cannot* render an
+input. That gives the guarantee by construction, but it duplicates the label and
+layout markup of every section and roughly triples the file count under the
+colocated-quartet convention. It also trades a dangerous drift (an editable field
+leaks) for a quiet one (a field is added to the editor and never to the view). We
+chose the single-component form with the guard test: the same protection, bought
+at the test layer instead of the file layer.
+
+## Consequences
+
+- Non-owners never see a form they cannot submit. The silently-discarded-input
+  class of bug is gone from these surfaces and is caught mechanically if it
+  returns.
+- `details-tab.tsx` loses its nine `disabled={!canEdit}` props and gains a
+  read-only rendering, so the two conflicting precedents in the codebase collapse
+  into one.
+- Read-only renderings must be kept in step with their editors as fields are
+  added. The guard test does not catch a *missing* field — only an *editable*
+  one. Mirroring the editor's structure (rule 3) is what keeps that omission
+  obvious to a reviewer.
+- This ADR is about **presentation only**. It changes nothing about
+  authorization: the server already 403s every mutating tournament endpoint for a
+  non-owner, and it must continue to, because hiding a control is a UX decision
+  and never a security boundary.

--- a/docs/adr/0015-read-only-is-a-view-not-a-disabled-form.md
+++ b/docs/adr/0015-read-only-is-a-view-not-a-disabled-form.md
@@ -66,8 +66,22 @@ Concretely, on any surface gated by an ownership/permission flag:
    fill in a control; with no control, there is nothing to explain. A **required
    asterisk** marks a field the user must complete; it is nonsense on a field
    nobody can fill in. Both are suppressed in the read-only rendering — dropped,
-   not reworded. Suppress them at the `Field` component rather than at each call
-   site, so a new field cannot reintroduce them by omission.
+   not reworded.
+
+   **`Field` owns the branch, not merely a flag.** A `Field` takes the value and
+   renders *either* its control *or* the value, deciding for itself; the call
+   site passes one `readOnly` and is done. This matters more than it looks. An
+   earlier draft of this ADR had `Field` suppress only the furniture while each
+   call site *separately* wrote `canEdit ? <Input/> : <ReadOnlyValue/>` — two
+   obligations per field, and `readOnly={!canEdit}` repeated a dozen times. That
+   is the very shape this ADR condemns: "twenty `disabled` props are twenty
+   chances to forget one" applies just as well to twelve `readOnly` props. Worse,
+   the two invariants are not equally protected — the control sweep (rule 6)
+   generalizes to any control anyone adds, but the furniture assertions are
+   per-named-field, so a new field that forgot the flag would leak an asterisk to
+   a reader and *nothing would catch it*. Folding the branch into `Field` makes
+   the leak structurally impossible at that boundary, which is strictly better
+   than catching it in a test.
 
 2. **Hide mutating affordances; never disable them.** Save, Delete, Revert, "Add
    rule", "Add pool", the row trash buttons — a user who cannot perform the
@@ -103,11 +117,20 @@ Concretely, on any surface gated by an ownership/permission flag:
    expensive way while implementing this ADR: a sweep of `textbox` / `combobox` /
    `switch` / `button` catches only 3 of the event panel's 8 Basics controls,
    because a `type="number"` input is a `spinbutton`, a `type="date"` or
-   `type="time"` input has **no role at all**, and a `ToggleGroupItem` is a
-   `radio`. Such a guard goes green with five live inputs still on screen — the
-   precise false-green this rule exists to prevent. Query the DOM
-   (`input, select, textarea, button, [role="switch"], [role="radio"], [tabindex],
-   [contenteditable]`), scoped to the component's root.
+   `type="time"` input has **no role at all**, and a `ToggleGroupItem` renders
+   `<button role="radio">` — an explicit role **overrides** the implicit one, so
+   the `button` query never matches it. Such a guard goes green with five live
+   inputs still on screen — the precise false-green this rule exists to prevent.
+
+   **The selector lives in exactly one place** — `web-client/src/test/read-only.ts`
+   — and every page object composes it. This is not tidiness; it is the rule
+   itself. When the selector was copy-pasted per page object, it forked **three
+   ways within this single change**, and one of those forks silently dropped
+   `[role="switch"]` and `[role="radio"]` while another omitted `a[href]` — so a
+   live link passed all six section guards. A guard test enforced by "remember to
+   copy the string verbatim" is enforced by vigilance, which is the thing this
+   rule exists to abolish. One constant, one place to extend when a `Slider` or a
+   `Combobox` arrives.
 
 We considered enforcing this structurally instead — separate `*-section.tsx` and
 `*-section-readonly.tsx` components, so a read-only component *cannot* render an
@@ -117,6 +140,29 @@ colocated-quartet convention. It also trades a dangerous drift (an editable fiel
 leaks) for a quiet one (a field is added to the editor and never to the view). We
 chose the single-component form with the guard test: the same protection, bought
 at the test layer instead of the file layer.
+
+### Which shape: branch per field, or branch the whole subtree?
+
+That framing is a false binary, and the code proves it — a third of these
+components use a third shape, correctly. The real choice is:
+
+- **Branch per field** (`basics-section`, `match-section`, `details-tab`) — when
+  the read-only view **mirrors** the editor field-for-field. The two renderings
+  share a skeleton, so sharing the markup is what keeps them honest. With `Field`
+  owning the branch, most of these need no `canEdit` in their JSX at all.
+- **Branch the whole subtree** — an early `if (!canEdit) return …` returning a
+  different tree (`predicate-row`, `pool-card`) — when the read-only
+  **information architecture genuinely differs** from the editor's. A predicate
+  is three controls in a grid but *one sentence* as prose; a pool is a grid of
+  table toggles but *a list of table names* as text. Forcing those through a
+  per-cell ternary would be worse: it would preserve a layout that only exists to
+  hold controls that are gone.
+
+The test to apply: **does the viewer's rendering have the same shape as the
+editor's, or a different one?** Same shape → branch per field, and let the shared
+markup prevent drift. Different shape → branch the subtree, and accept that the
+two branches share only their data. Reach for the second only when you can say
+what the *reader's* structure is, independent of the form's.
 
 ## Consequences
 

--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -113,3 +113,68 @@ Show field validation errors inline, directly below the field, in red. Set
 ```
 
 Do not use toasts, alerts, or other patterns for field-level validation errors.
+
+## Read-only surfaces
+
+When a surface is editable by some users and merely viewable by others (today:
+the tournament surfaces, gated by the server-computed `canEdit` flag on the
+tournament payload), **render a view — do not disable the form.** The reasoning
+is in [ADR 0015](../docs/adr/0015-read-only-is-a-view-not-a-disabled-form.md);
+the tooling is:
+
+- **`ReadOnlyValue`** (`src/components/tournaments/read-only-value.tsx`) is the
+  read-only counterpart to `Field`'s control slot — it renders the value as text
+  with the same row rhythm, and an em-dash (`—`) when the value is unset. Branch
+  at the control: `{canEdit ? <Input … /> : <ReadOnlyValue>{draft.name}</ReadOnlyValue>}`.
+  A read-only surface must put **no** `<input>` / `<select>` / `<textarea>` /
+  `<switch>` in the accessibility tree.
+- **Hide mutating affordances — never disable them.** Save, Delete, Revert, and
+  the add/remove row buttons are wrapped in `{canEdit && …}`, not given a
+  `disabled` prop. A disabled button is an unexplained dead end.
+- **Drop the form's furniture too, at `Field`.** Pass `readOnly` to `Field` and it
+  suppresses the **hint** and the **required asterisk**. A hint explains how to
+  fill in a control and an asterisk marks one you must complete — both are
+  nonsense next to a value nobody can edit. Suppressing them *in `Field`* rather
+  than at each call site means a newly-added field can't reintroduce them by
+  forgetting to.
+- **Swap organizer-voiced copy.** Imperatives written for the person in control
+  ("Edit event", "Click any event to edit") get neutral copy when `!canEdit`.
+- **Every read-only-capable component carries a guard test** asserting that with
+  `canEdit: false` it renders zero interactive controls. **Sweep the DOM, not just
+  ARIA roles** — a role-only sweep silently under-proves:
+
+  | Control | Role you'd guess | Role it actually has |
+  | --- | --- | --- |
+  | `<Input type="number">` | `textbox` | **`spinbutton`** |
+  | `<Input type="date">` / `type="time"` | `textbox` | **none at all** |
+  | `ToggleGroupItem` | `button` | **`radio`** |
+
+  The toggle case is the nastiest, because an **explicit `role` overrides the
+  implicit one**: `ToggleGroupItem` renders `<button role="radio">`, so
+  `queryAllByRole('button')` never matches it. A whole live toggle group sails
+  through a role sweep — measured, not theorised: with the status ToggleGroup left
+  live in the read-only branch, the four-role sweep found **0** controls and
+  passed, while the DOM sweep found **5**.
+
+  So a sweep of `textbox`/`combobox`/`switch`/`button` can pass with live date,
+  number, and toggle inputs still on screen — a false green of exactly the kind
+  this rule exists to prevent. Assert on the DOM instead, scoped to the
+  component's root (and make sure that root actually wraps every field):
+
+  ```tsx
+  it('renders no interactive controls for a non-owner', () => {
+    render(<BasicsSection event={anEvent()} canEdit={false} onChange={vi.fn()} />)
+    expect(
+      page.root().querySelectorAll(
+        'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]',
+      ),
+    ).toHaveLength(0)
+  })
+  ```
+
+  This is what keeps the rule true as fields are added — it fails loudly the
+  moment someone reaches for `disabled` out of habit. A role sweep may be kept
+  *alongside* it, but never instead of it.
+
+Hiding a control is a UX decision, **never** a security boundary: the API
+independently 403s every owner-only endpoint, and must continue to.

--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -122,26 +122,55 @@ tournament payload), **render a view — do not disable the form.** The reasonin
 is in [ADR 0015](../docs/adr/0015-read-only-is-a-view-not-a-disabled-form.md);
 the tooling is:
 
-- **`ReadOnlyValue`** (`src/components/tournaments/read-only-value.tsx`) is the
-  read-only counterpart to `Field`'s control slot — it renders the value as text
-  with the same row rhythm, and an em-dash (`—`) when the value is unset. Branch
-  at the control: `{canEdit ? <Input … /> : <ReadOnlyValue>{draft.name}</ReadOnlyValue>}`.
-  A read-only surface must put **no** `<input>` / `<select>` / `<textarea>` /
-  `<switch>` in the accessibility tree.
+- **`Field` owns the branch.** Give a `Field` row its control *and* the value it
+  holds, plus one `readOnly` — it renders one or the other, and drops the form's
+  furniture (the **hint** and the **required asterisk**) with it. One flag, one
+  obligation; a call site cannot leak a live control, an asterisk, or a hint to a
+  reader by forgetting a conditional of its own:
+
+  ```tsx
+  <Field label="Entry fee" required readOnly={!canEdit} value={event.entryFee}>
+    {(id) => <Input id={id} type="number" … />}
+  </Field>
+  ```
+
+  The `value` is what a *reader* needs, not what the control needs: an option's
+  label (`labelFor` in `data/options.ts`), a formatted date (`fmtDate` in
+  `data/helpers.ts`) — never the enum key or the `YYYY-MM-DD` an
+  `<input type="date">` takes.
+- **`ReadOnlyValue`** (`src/components/tournaments/read-only-value.tsx`) is what
+  `Field` renders in that branch, and stays usable directly for the controls that
+  aren't a "label + one control + one value" row (a `Switch`, a `ToggleGroup`, the
+  pool table chips): the value as text, with the same row rhythm, and an em-dash
+  (`EM_DASH`, `data/helpers.ts`) when it is unset. A read-only surface must put
+  **no** `<input>` / `<select>` / `<textarea>` / `<switch>` in the accessibility
+  tree.
 - **Hide mutating affordances — never disable them.** Save, Delete, Revert, and
   the add/remove row buttons are wrapped in `{canEdit && …}`, not given a
   `disabled` prop. A disabled button is an unexplained dead end.
-- **Drop the form's furniture too, at `Field`.** Pass `readOnly` to `Field` and it
-  suppresses the **hint** and the **required asterisk**. A hint explains how to
-  fill in a control and an asterisk marks one you must complete — both are
-  nonsense next to a value nobody can edit. Suppressing them *in `Field`* rather
-  than at each call site means a newly-added field can't reintroduce them by
-  forgetting to.
 - **Swap organizer-voiced copy.** Imperatives written for the person in control
   ("Edit event", "Click any event to edit") get neutral copy when `!canEdit`.
 - **Every read-only-capable component carries a guard test** asserting that with
-  `canEdit: false` it renders zero interactive controls. **Sweep the DOM, not just
-  ARIA roles** — a role-only sweep silently under-proves:
+  `canEdit: false` it renders zero interactive controls. There is **one** sweep,
+  in `src/test/read-only.ts` — never a selector re-typed in a page object. Compose
+  it:
+
+  ```tsx
+  // in the page object
+  getFormElements() {
+    return interactiveElementsIn(container.getByTestId('basics-section'))
+  },
+
+  // in the test
+  it('renders no interactive controls for a non-owner', () => {
+    basicsSectionPage.render({ event: buildEvent(), canEdit: false })
+    expect(basicsSectionPage.getFormElements()).toHaveLength(0)
+  })
+  ```
+
+  (Scoped to the component's root — make sure that root actually wraps every
+  field.) `interactiveElementsIn` sweeps the **DOM**, not ARIA roles, because a
+  role-only sweep silently under-proves:
 
   | Control | Role you'd guess | Role it actually has |
   | --- | --- | --- |
@@ -153,28 +182,13 @@ the tooling is:
   implicit one**: `ToggleGroupItem` renders `<button role="radio">`, so
   `queryAllByRole('button')` never matches it. A whole live toggle group sails
   through a role sweep — measured, not theorised: with the status ToggleGroup left
-  live in the read-only branch, the four-role sweep found **0** controls and
-  passed, while the DOM sweep found **5**.
+  live in the read-only branch, a four-role sweep found **0** controls and passed,
+  while the DOM sweep found **5**. `interactiveControlsIn` (the role sweep) may be
+  kept *alongside* it, but never instead of it.
 
-  So a sweep of `textbox`/`combobox`/`switch`/`button` can pass with live date,
-  number, and toggle inputs still on screen — a false green of exactly the kind
-  this rule exists to prevent. Assert on the DOM instead, scoped to the
-  component's root (and make sure that root actually wraps every field):
-
-  ```tsx
-  it('renders no interactive controls for a non-owner', () => {
-    render(<BasicsSection event={anEvent()} canEdit={false} onChange={vi.fn()} />)
-    expect(
-      page.root().querySelectorAll(
-        'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]',
-      ),
-    ).toHaveLength(0)
-  })
-  ```
-
-  This is what keeps the rule true as fields are added — it fails loudly the
-  moment someone reaches for `disabled` out of habit. A role sweep may be kept
-  *alongside* it, but never instead of it.
+  The sweep lives in one module because it forked three ways the first time it was
+  copy-pasted — leaving an `<a href>`-shaped hole in six of the eight guards. Add
+  a control kind to `INTERACTIVE_SELECTOR` there and every guard tightens at once.
 
 Hiding a control is a UX decision, **never** a security boundary: the API
 independently 403s every owner-only endpoint, and must continue to.

--- a/web-client/src/components/tournaments/data/helpers.test.ts
+++ b/web-client/src/components/tournaments/data/helpers.test.ts
@@ -2,6 +2,7 @@ import {
   daysBetween,
   effectiveDateRange,
   fmtDateRange,
+  fmtTimeWindow,
   formatPredicate,
   predicateSentence,
   findPoolConflicts,
@@ -20,6 +21,26 @@ describe('fmtDateRange', () => {
 
   it('returns a single date when the days are equal', () => {
     expect(fmtDateRange('2026-06-13', '2026-06-13')).toBe('Jun 13, 2026')
+  })
+})
+
+describe('fmtTimeWindow', () => {
+  it('joins both bounds with an en dash', () => {
+    // U+2013 between the times; U+2014 (EM_DASH) is only the unset marker.
+    expect(fmtTimeWindow('09:00', '12:00')).toBe('09:00–12:00')
+  })
+
+  it('shows a lone start on its own, with no dangling dash', () => {
+    expect(fmtTimeWindow('09:00', '')).toBe('09:00')
+  })
+
+  it('shows a lone end on its own, with no leading dash', () => {
+    expect(fmtTimeWindow('', '12:00')).toBe('12:00')
+  })
+
+  it('renders a wholly unset window as an em-dash', () => {
+    expect(fmtTimeWindow('', '')).toBe('—')
+    expect(fmtTimeWindow(null, undefined)).toBe('—')
   })
 })
 

--- a/web-client/src/components/tournaments/data/helpers.test.ts
+++ b/web-client/src/components/tournaments/data/helpers.test.ts
@@ -3,6 +3,7 @@ import {
   effectiveDateRange,
   fmtDateRange,
   formatPredicate,
+  predicateSentence,
   findPoolConflicts,
 } from './helpers'
 import { buildPool, buildTournament, buildEvent } from './seed.factory'
@@ -69,6 +70,16 @@ describe('formatPredicate', () => {
   it('labels a between rule with the range', () => {
     const p: Predicate = { id: 'p', field: 'age', op: 'between', value: [13, 17] }
     expect(formatPredicate(p)).toBe('Age in [13–17]')
+  })
+
+  // The chip and the sentence share one vocabulary, so they must agree on the
+  // unset case too: an unfinished enum rule reads as the em-dash both use, never
+  // as the string "null" that `String(p.value)` used to leak onto the card.
+  it('renders an unfinished enum rule as an em-dash, not "null"', () => {
+    const p: Predicate = { id: 'p', field: 'gender', op: 'is', value: null }
+    expect(formatPredicate(p)).toBe('Gender = —')
+    expect(formatPredicate(p)).not.toContain('null')
+    expect(predicateSentence(p)).toBe('Gender is —')
   })
 })
 

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -35,6 +35,26 @@ export function fmtDateShort(iso: string | null | undefined): string {
   })
 }
 
+/** An `HH:MM–HH:MM` time window, tolerant of a half-set (or wholly unset) slot.
+ *
+ * The naive `` `${start}–${end}` `` template renders a *hole* when a bound is
+ * missing — "09:00–" — which is punctuation pretending to be data. An unset
+ * value reads as the em-dash, one contract with the rest of this module (ADR
+ * 0015, rule 3). One bound alone is real information, so it is shown alone.
+ *
+ * Note the two dashes are different characters and are not interchangeable: the
+ * separator between two times is an **en** dash (`–`, U+2013); `EM_DASH` (`—`,
+ * U+2014) is the marker for "no value at all". */
+export function fmtTimeWindow(
+  start: string | null | undefined,
+  end: string | null | undefined,
+): string {
+  if (start && end) return `${start}–${end}`
+  if (start) return start
+  if (end) return end
+  return EM_DASH
+}
+
 /** A compact, human range: collapses same-day, same-month, and full spans. */
 export function fmtDateRange(
   a: string | null | undefined,

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -79,7 +79,12 @@ export function effectiveDateRange(t: Tournament): {
  * ("Female"), never the key it is stored under ("F"). Shared by both predicate
  * formatters below — the one lookup they genuinely have in common. */
 const enumValueLabel = (schema: PredicateFieldSchema, p: Predicate): string =>
-  labelFor(schema.options ?? [], String(p.value), String(p.value))
+  // An unfinished enum rule (`value: null`) is unset, so it reads as the em-dash
+  // both voices use — never `String(null)`, which rendered the literal "null" on
+  // the event card.
+  p.value == null
+    ? EM_DASH
+    : labelFor(schema.options ?? [], String(p.value), String(p.value))
 
 /** A **compact** summary of one eligibility predicate, e.g. `Age < 18` — the
  * chip form, sized for an event card's badge row.

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -3,8 +3,14 @@
 // dodge timezone drift), derived date ranges, predicate labels, and table
 // double-booking detection.
 
-import { PRED_FIELDS } from './options'
+import { labelFor, PRED_FIELDS, PRED_OPS_BY_TYPE } from './options'
+import type { PredicateFieldSchema } from './options'
 import type { Predicate, Pool, Tournament, TournamentEvent } from './types'
+
+/** U+2014. "Unset renders as an em-dash" is a single contract (ADR 0015, rule
+ * 3) — absent and not-applicable must stay distinguishable — so it gets a single
+ * definition, shared by the formatters here and by `ReadOnlyValue`. */
+export const EM_DASH = '—'
 
 /** Parse a date-only `YYYY-MM-DD` string into a local-midnight Date. */
 function parseDateOnly(iso: string): Date {
@@ -13,7 +19,7 @@ function parseDateOnly(iso: string): Date {
 }
 
 export function fmtDate(iso: string | null | undefined): string {
-  if (!iso) return '—'
+  if (!iso) return EM_DASH
   return parseDateOnly(iso).toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
@@ -22,7 +28,7 @@ export function fmtDate(iso: string | null | undefined): string {
 }
 
 export function fmtDateShort(iso: string | null | undefined): string {
-  if (!iso) return '—'
+  if (!iso) return EM_DASH
   return parseDateOnly(iso).toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
@@ -34,7 +40,7 @@ export function fmtDateRange(
   a: string | null | undefined,
   b: string | null | undefined,
 ): string {
-  if (!a || !b) return '—'
+  if (!a || !b) return EM_DASH
   if (a === b) return fmtDate(a)
   const [ay, am] = a.split('-').map(Number)
   const [by, bm] = b.split('-').map(Number)
@@ -69,10 +75,22 @@ export function effectiveDateRange(t: Tournament): {
   return { start: dates[0], end: dates[dates.length - 1] }
 }
 
-/** A human-readable summary of one eligibility predicate, e.g. `Age < 18`. */
+/** An enum predicate's value, as the option label the editor's own picker shows
+ * ("Female"), never the key it is stored under ("F"). Shared by both predicate
+ * formatters below — the one lookup they genuinely have in common. */
+const enumValueLabel = (schema: PredicateFieldSchema, p: Predicate): string =>
+  labelFor(schema.options ?? [], String(p.value), String(p.value))
+
+/** A **compact** summary of one eligibility predicate, e.g. `Age < 18` — the
+ * chip form, sized for an event card's badge row.
+ *
+ * Deliberately *not* the same output as `predicateSentence` below: a chip wants
+ * `USATT rating in [1200–2400]`, a panel wants the prose the rule already reads
+ * as. Two voices, one vocabulary — both compose their labels out of `options.ts`
+ * (`labelFor`) and both render an unset value as the same em-dash. */
 export function formatPredicate(p: Predicate): string {
   const f = PRED_FIELDS[p.field]
-  if (!f) return '—'
+  if (!f) return EM_DASH
   if (f.type === 'number') {
     const v = p.value
     const ops: Record<string, string> = {
@@ -89,14 +107,57 @@ export function formatPredicate(p: Predicate): string {
     if (ops[p.op]) return `${f.label} ${ops[p.op]} ${v ?? '?'}`
   }
   if (f.type === 'enum') {
-    const label =
-      f.options?.find((o) => o.value === p.value)?.label ?? String(p.value)
-    return `${f.label} ${p.op === 'is' ? '=' : '≠'} ${label}`
+    return `${f.label} ${p.op === 'is' ? '=' : '≠'} ${enumValueLabel(f, p)}`
   }
   if (f.type === 'bool') {
     return p.op === 'true' ? `Must be ${f.label}` : `Must not be ${f.label}`
   }
-  return '—'
+  return EM_DASH
+}
+
+/** The bool field's value, as prose. It reads as the tail of its operator
+ * ("must be" + "a club member"), which is why the editor's value cell shows it
+ * verbatim rather than as a control — and why `predicateSentence` can borrow it
+ * instead of inventing copy. */
+export const BOOL_PREDICATE_VALUE = 'a club member'
+
+const num = (n: number | null | undefined): string =>
+  n === null || n === undefined ? EM_DASH : String(n)
+
+/** The value half of the sentence, in the same words the editor's value control
+ * shows. */
+function valueText(schema: PredicateFieldSchema, p: Predicate): string {
+  if (schema.type === 'enum') {
+    return p.value == null ? EM_DASH : enumValueLabel(schema, p)
+  }
+  if (p.op === 'between') {
+    const [lo, hi] = Array.isArray(p.value) ? p.value : [null, null]
+    return `${num(lo)} and ${num(hi)}`
+  }
+  return num(typeof p.value === 'number' ? p.value : null)
+}
+
+/** The rule as one **sentence**: `[field] [operator] [value]` was always a
+ * sentence chopped into a grid, so read-only it is simply put back together —
+ * "USATT rating is between 1200 and 1500" (ADR 0015, rule 4). Every word comes
+ * from the labels the editor's own three controls display, so there is no second
+ * vocabulary to keep in step.
+ *
+ * The bool field is the exception: it is the *object* of its operator, so the
+ * literal three-cell join would read "Club member must be a club member". It
+ * keeps the operator and the prose value only — "Must be a club member".
+ *
+ * Lives here, beside `formatPredicate`, so that adding a predicate field or
+ * operator is a one-file change rather than a hunt through a component. */
+export function predicateSentence(p: Predicate): string {
+  const schema = PRED_FIELDS[p.field]
+  if (!schema) return EM_DASH
+
+  const op = labelFor(PRED_OPS_BY_TYPE[schema.type], p.op, p.op)
+  if (schema.type === 'bool') {
+    return `${op.charAt(0).toUpperCase()}${op.slice(1)} ${BOOL_PREDICATE_VALUE}`
+  }
+  return `${schema.label} ${op} ${valueText(schema, p)}`
 }
 
 export interface PoolConflict {

--- a/web-client/src/components/tournaments/data/options.ts
+++ b/web-client/src/components/tournaments/data/options.ts
@@ -3,6 +3,23 @@
 
 import type { DrawType, EventFormat, MatchLength } from './types'
 
+/** The label an option list gives `value`, or `fallback` when the list has no
+ * entry for it. A viewer reads the option's label ("RR → KO"), never the enum
+ * key it is stored under ("rr-then-ko"), so every surface that renders a stored
+ * value needs this lookup — it was hand-rolled five times before it lived here.
+ *
+ * The fallback is an argument rather than a default because the two policies in
+ * use differ deliberately: a read-only `Field` passes `null`, so an unknown key
+ * renders as `ReadOnlyValue`'s em-dash; a card passes the raw value, so it shows
+ * *something* rather than blanking a whole row. */
+export function labelFor<V, F>(
+  options: readonly { value: V; label: string }[],
+  value: V,
+  fallback: F,
+): string | F {
+  return options.find((o) => o.value === value)?.label ?? fallback
+}
+
 export const FORMAT_OPTIONS: { value: EventFormat; label: string }[] = [
   { value: 'singles', label: 'Singles' },
   { value: 'doubles', label: 'Doubles' },

--- a/web-client/src/components/tournaments/field.factory.tsx
+++ b/web-client/src/components/tournaments/field.factory.tsx
@@ -1,13 +1,32 @@
+import type { ReactNode } from 'react'
+
 import { Input } from '@/components/ui/input'
 
-import type { FieldProps } from './field'
+import type { FieldBase, FieldProps } from './field'
+import type { ReadOnlyValueContent } from './read-only-value'
 
-/** Props for `Field` — a required "Name" row wrapping a plain text input. */
-export function buildFieldProps(overrides: Partial<FieldProps> = {}): FieldProps {
-  return {
+/** Overrides for `buildFieldProps`. Flat, unlike `FieldProps` itself: a test may
+ * name `readOnly` and `value` independently, and the factory reassembles them
+ * into the union the component demands. */
+export type FieldOverrides = Partial<FieldBase> & {
+  readOnly?: boolean
+  value?: ReadOnlyValueContent
+  valueClassName?: string
+  children?: (controlId: string) => ReactNode
+}
+
+/** Props for `Field` — a required "Name" row wrapping a plain text input.
+ * Naming `readOnly` puts the row in the read-only-capable branch, where the
+ * component requires a `value`; omitting it keeps the row an editor. */
+export function buildFieldProps(overrides: FieldOverrides = {}): FieldProps {
+  const { readOnly, value, valueClassName, ...rest } = overrides
+  const editor = {
     label: 'Name',
     required: true,
-    children: (id) => <Input id={id} defaultValue="" />,
-    ...overrides,
+    children: (id: string) => <Input id={id} defaultValue="" />,
+    ...rest,
   }
+  return readOnly === undefined
+    ? editor
+    : { ...editor, readOnly, value: value ?? null, valueClassName }
 }

--- a/web-client/src/components/tournaments/field.page.tsx
+++ b/web-client/src/components/tournaments/field.page.tsx
@@ -12,6 +12,13 @@ const scoped = (container: Container) => ({
   queryHint(text: string) {
     return container.queryByText(text)
   },
+  /** The label row's own text. The required asterisk is a `<span>` inside the
+   * `<label>` with no separating space ("Name*"), so it is only visible in the
+   * label's `textContent` — never as a text node of its own. */
+  getLabelText(label: string) {
+    return container.getByText(new RegExp(label), { selector: 'label' })
+      .textContent
+  },
 })
 
 /** Test page-object for `Field` — the label/control/hint form row. */

--- a/web-client/src/components/tournaments/field.page.tsx
+++ b/web-client/src/components/tournaments/field.page.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within, type Container } from '@/test/utilities'
 
-import { Field, type FieldProps } from './field'
-import { buildFieldProps } from './field.factory'
+import { Field } from './field'
+import { buildFieldProps, type FieldOverrides } from './field.factory'
 import { READ_ONLY_VALUE_TESTID } from './read-only-value.page'
 
 const scoped = (container: Container) => ({
@@ -26,6 +26,11 @@ const scoped = (container: Container) => ({
   getLabelText(label: string, { exact = false }: { exact?: boolean } = {}) {
     return container.getByText(label, { exact, selector: 'label' }).textContent
   },
+  /** The `<label>` element itself — for asserting on the association (`for`),
+   * which a read-only row must not claim: it renders no control to point at. */
+  getLabel(label: string, { exact = false }: { exact?: boolean } = {}) {
+    return container.getByText(label, { exact, selector: 'label' })
+  },
   /** The value a read-only row renders in place of its control, found by the
    * row's label so the assertion survives a re-ordering of the rows. Composed by
    * every surface with `Field` rows, rather than re-derived in each. */
@@ -39,7 +44,7 @@ const scoped = (container: Container) => ({
 
 /** Test page-object for `Field` — the label/control/hint form row. */
 export const fieldPage = {
-  render(overrides: Partial<FieldProps> = {}) {
+  render(overrides: FieldOverrides = {}) {
     render(<Field {...buildFieldProps(overrides)} />)
   },
 

--- a/web-client/src/components/tournaments/field.page.tsx
+++ b/web-client/src/components/tournaments/field.page.tsx
@@ -1,12 +1,17 @@
-import { render, screen, type Container } from '@/test/utilities'
+import { render, screen, within, type Container } from '@/test/utilities'
 
 import { Field, type FieldProps } from './field'
 import { buildFieldProps } from './field.factory'
+import { READ_ONLY_VALUE_TESTID } from './read-only-value.page'
 
 const scoped = (container: Container) => ({
   /** The control wired to the field's label, by accessible name. */
   getControl(label: string) {
     return container.getByLabelText(new RegExp(label))
+  },
+  /** Absent in a read-only row: the row renders its value instead. */
+  queryControl(label: string) {
+    return container.queryByLabelText(new RegExp(label))
   },
   /** Hint / error text, when present. */
   queryHint(text: string) {
@@ -14,10 +19,21 @@ const scoped = (container: Container) => ({
   },
   /** The label row's own text. The required asterisk is a `<span>` inside the
    * `<label>` with no separating space ("Name*"), so it is only visible in the
-   * label's `textContent` — never as a text node of its own. */
-  getLabelText(label: string) {
-    return container.getByText(new RegExp(label), { selector: 'label' })
-      .textContent
+   * label's `textContent` — never as a text node of its own.
+   *
+   * `exact` matters where one label is a substring of another ("Name" vs "Venue
+   * name"): the loose match would find both and throw. */
+  getLabelText(label: string, { exact = false }: { exact?: boolean } = {}) {
+    return container.getByText(label, { exact, selector: 'label' }).textContent
+  },
+  /** The value a read-only row renders in place of its control, found by the
+   * row's label so the assertion survives a re-ordering of the rows. Composed by
+   * every surface with `Field` rows, rather than re-derived in each. */
+  getFieldValue(label: string) {
+    const row = container
+      .getByText(label, { exact: false, selector: 'label' })
+      .closest('div')!
+    return within(row).getByTestId(READ_ONLY_VALUE_TESTID)
   },
 })
 

--- a/web-client/src/components/tournaments/field.test.tsx
+++ b/web-client/src/components/tournaments/field.test.tsx
@@ -76,5 +76,17 @@ describe('Field', () => {
         fieldPage.queryHint('Hard cap. Waitlist opens past this.'),
       ).toBeNull()
     })
+
+    // A read-only row renders no control, so a `for` would point at nothing. An
+    // orphaned label is not an association — it just looks like one.
+    it('leaves no dangling label association when there is no control', () => {
+      fieldPage.render({ ...FURNITURE, readOnly: true })
+      expect(fieldPage.getLabel('Player limit')).not.toHaveAttribute('for')
+    })
+
+    it('associates the label with the control for an editor', () => {
+      fieldPage.render({ ...FURNITURE, readOnly: false })
+      expect(fieldPage.getLabel('Player limit')).toHaveAttribute('for')
+    })
   })
 })

--- a/web-client/src/components/tournaments/field.test.tsx
+++ b/web-client/src/components/tournaments/field.test.tsx
@@ -15,4 +15,34 @@ describe('Field', () => {
     fieldPage.render({ hint: 'Required', error: true })
     expect(fieldPage.queryHint('Required')).toHaveClass('text-[color:var(--loss)]')
   })
+
+  // ADR 0015: the hint and the asterisk are the form's *furniture*. They explain
+  // how to fill in a control and mark one you must complete — both nonsense next
+  // to a value nobody can edit. Suppressing them here rather than at each call
+  // site is what stops a newly added field from reintroducing them by omission,
+  // so both sides are asserted: an editor keeps them, a viewer never sees them.
+  describe('furniture', () => {
+    const FURNITURE = {
+      label: 'Player limit',
+      required: true,
+      hint: 'Hard cap. Waitlist opens past this.',
+    }
+
+    it('shows the required asterisk and the hint to an editor', () => {
+      fieldPage.render(FURNITURE)
+      expect(fieldPage.getLabelText('Player limit')).toContain('*')
+      expect(
+        fieldPage.queryHint('Hard cap. Waitlist opens past this.'),
+      ).toBeInTheDocument()
+    })
+
+    it('drops both for a read-only row, keeping the label', () => {
+      fieldPage.render({ ...FURNITURE, readOnly: true })
+      expect(fieldPage.getLabelText('Player limit')).toBe('Player limit')
+      expect(fieldPage.getLabelText('Player limit')).not.toContain('*')
+      expect(
+        fieldPage.queryHint('Hard cap. Waitlist opens past this.'),
+      ).toBeNull()
+    })
+  })
 })

--- a/web-client/src/components/tournaments/field.test.tsx
+++ b/web-client/src/components/tournaments/field.test.tsx
@@ -16,6 +16,38 @@ describe('Field', () => {
     expect(fieldPage.queryHint('Required')).toHaveClass('text-[color:var(--loss)]')
   })
 
+  // ADR 0015: `Field` owns the read-only *branch*, not merely a flag. The row is
+  // handed both its control and the value it holds, and decides between them —
+  // so a call site cannot leak a live control to a reader by forgetting a
+  // `canEdit ? … : …` of its own. That leak is structurally impossible here
+  // rather than merely swept for.
+  describe('readOnly', () => {
+    it('renders the control for an editor', () => {
+      fieldPage.render({
+        label: 'Entry fee',
+        value: 30,
+        children: (id) => <Input id={id} defaultValue={30} />,
+      })
+      expect(fieldPage.getControl('Entry fee')).toBeInTheDocument()
+    })
+
+    it('renders the value instead of the control for a viewer', () => {
+      fieldPage.render({
+        label: 'Entry fee',
+        readOnly: true,
+        value: 30,
+        children: (id) => <Input id={id} defaultValue={30} />,
+      })
+      expect(fieldPage.getFieldValue('Entry fee')).toHaveTextContent('30')
+      expect(fieldPage.queryControl('Entry fee')).toBeNull()
+    })
+
+    it('renders an em-dash for a value the organizer left unset', () => {
+      fieldPage.render({ label: 'Entry fee', readOnly: true, value: null })
+      expect(fieldPage.getFieldValue('Entry fee')).toHaveTextContent('—')
+    })
+  })
+
   // ADR 0015: the hint and the asterisk are the form's *furniture*. They explain
   // how to fill in a control and mark one you must complete — both nonsense next
   // to a value nobody can edit. Suppressing them here rather than at each call

--- a/web-client/src/components/tournaments/field.tsx
+++ b/web-client/src/components/tournaments/field.tsx
@@ -10,6 +10,10 @@ export interface FieldProps {
   hint?: ReactNode
   /** When true, `hint` is rendered as an error (red). */
   error?: boolean
+  /** When true the row wraps a *value* rather than a control (the caller has
+   * rendered a `ReadOnlyValue` instead of an input), so the form's furniture —
+   * the `hint` and the `required` asterisk — is suppressed. See below. */
+  readOnly?: boolean
   children: (controlId: string) => ReactNode
   className?: string
 }
@@ -18,16 +22,25 @@ export interface FieldProps {
  * across the tournament forms. `children` receives the generated control id:
  * a real input wires it as `id` (the label's `htmlFor` targets it); a
  * non-input control (e.g. a radio `ToggleGroup`) instead points
- * `aria-labelledby` at the label's `${id}-label` id. */
+ * `aria-labelledby` at the label's `${id}-label` id.
+ *
+ * `readOnly` drops the row's form furniture (ADR 0015): a **hint** explains how
+ * to fill in a control, and with no control there is nothing to explain; a
+ * **required asterisk** marks a field you must complete, which is nonsense on a
+ * field nobody can fill in. Both are dropped, not reworded. Callers keep passing
+ * `hint` / `required` unconditionally — the suppression lives here, so a newly
+ * added field cannot reintroduce them by forgetting a call-site conditional. */
 export const Field = ({
   label,
   required,
   hint,
   error,
+  readOnly,
   children,
   className,
 }: FieldProps) => {
   const id = useId()
+  const showHint = hint && !readOnly
   return (
     <div className={cn('flex flex-col gap-1.5', className)}>
       <Label
@@ -36,10 +49,12 @@ export const Field = ({
         className="text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase"
       >
         {label}
-        {required && <span className="text-[color:var(--ball-500)]">*</span>}
+        {required && !readOnly && (
+          <span className="text-[color:var(--ball-500)]">*</span>
+        )}
       </Label>
       {children(id)}
-      {hint && (
+      {showHint && (
         <p
           className={cn(
             'text-[11px]',

--- a/web-client/src/components/tournaments/field.tsx
+++ b/web-client/src/components/tournaments/field.tsx
@@ -5,28 +5,52 @@ import { cn } from '@/lib/utils'
 
 import { ReadOnlyValue, type ReadOnlyValueContent } from './read-only-value'
 
-export interface FieldProps {
+export interface FieldBase {
   label: string
   required?: boolean
   /** Helper or error text shown below the control. */
   hint?: ReactNode
   /** When true, `hint` is rendered as an error (red). */
   error?: boolean
-  /** When true the row renders its `value` instead of its control, and drops the
-   * form's furniture (the `hint` and the `required` asterisk). See below. */
-  readOnly?: boolean
+  className?: string
+}
+
+/** A row that can be read-only **must** say what it holds. The two props are one
+ * decision, so the type makes them one: opt into `readOnly` and `value` is
+ * required. Were they independent optionals, a row could pass `readOnly` and
+ * forget `value` — and would then render an em-dash, which by ADR 0015 rule 3
+ * means *the organizer set nothing*. That is real data misreported as absent,
+ * silently: the guard sweep still passes (no control is rendered) and the
+ * per-field value assertions don't know the new row exists. Exactly the class of
+ * quiet wrongness this ADR was written to end.
+ *
+ * Note the discriminant is the **presence** of `readOnly`, not its value — call
+ * sites pass `readOnly={!canEdit}`, a `boolean`, which no `true`/`false` union
+ * could narrow. */
+type FieldReadable = {
+  readOnly: boolean
   /** What the row *holds* — rendered in place of the control when `readOnly`.
    * Formatted for a reader by the caller (an option's label, a formatted date),
    * since only the caller knows what the raw value means. */
-  value?: ReadOnlyValueContent
+  value: ReadOnlyValueContent
   /** Class for the read-only rendering, when it needs to match the control it
    * stands in for (a `font-mono` time, a multi-line description). */
   valueClassName?: string
-  /** The control, for an editor. Not called in the read-only branch — a row that
-   * is only ever a view may omit it. */
+  /** The control, for an editor. Not called in the read-only branch — and a row
+   * that is *only* ever a view (one inside a subtree the editor never renders,
+   * like a read-only pool card) has no control to give. */
   children?: (controlId: string) => ReactNode
-  className?: string
 }
+
+/** A row that is always an editor (a create form, say) needs no reader's value. */
+type FieldEditorOnly = {
+  readOnly?: undefined
+  value?: undefined
+  valueClassName?: undefined
+  children: (controlId: string) => ReactNode
+}
+
+export type FieldProps = FieldBase & (FieldReadable | FieldEditorOnly)
 
 /** Uppercase-overline label + control + hint, the standard form row used
  * across the tournament forms. `children` receives the generated control id:
@@ -73,7 +97,9 @@ export const Field = ({
     <div className={cn('flex flex-col gap-1.5', className)}>
       <Label
         id={`${id}-label`}
-        htmlFor={id}
+        // Read-only renders no control, so there is no element with this id to
+        // point at — a dangling `for` is an orphaned label, not an association.
+        htmlFor={readOnly ? undefined : id}
         className="text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase"
       >
         {label}

--- a/web-client/src/components/tournaments/field.tsx
+++ b/web-client/src/components/tournaments/field.tsx
@@ -3,6 +3,8 @@ import { useId, type ReactNode } from 'react'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
 
+import { ReadOnlyValue, type ReadOnlyValueContent } from './read-only-value'
+
 export interface FieldProps {
   label: string
   required?: boolean
@@ -10,11 +12,19 @@ export interface FieldProps {
   hint?: ReactNode
   /** When true, `hint` is rendered as an error (red). */
   error?: boolean
-  /** When true the row wraps a *value* rather than a control (the caller has
-   * rendered a `ReadOnlyValue` instead of an input), so the form's furniture —
-   * the `hint` and the `required` asterisk — is suppressed. See below. */
+  /** When true the row renders its `value` instead of its control, and drops the
+   * form's furniture (the `hint` and the `required` asterisk). See below. */
   readOnly?: boolean
-  children: (controlId: string) => ReactNode
+  /** What the row *holds* — rendered in place of the control when `readOnly`.
+   * Formatted for a reader by the caller (an option's label, a formatted date),
+   * since only the caller knows what the raw value means. */
+  value?: ReadOnlyValueContent
+  /** Class for the read-only rendering, when it needs to match the control it
+   * stands in for (a `font-mono` time, a multi-line description). */
+  valueClassName?: string
+  /** The control, for an editor. Not called in the read-only branch — a row that
+   * is only ever a view may omit it. */
+  children?: (controlId: string) => ReactNode
   className?: string
 }
 
@@ -24,18 +34,36 @@ export interface FieldProps {
  * non-input control (e.g. a radio `ToggleGroup`) instead points
  * `aria-labelledby` at the label's `${id}-label` id.
  *
- * `readOnly` drops the row's form furniture (ADR 0015): a **hint** explains how
- * to fill in a control, and with no control there is nothing to explain; a
- * **required asterisk** marks a field you must complete, which is nonsense on a
- * field nobody can fill in. Both are dropped, not reworded. Callers keep passing
- * `hint` / `required` unconditionally — the suppression lives here, so a newly
- * added field cannot reintroduce them by forgetting a call-site conditional. */
+ * **`readOnly` makes the row a view, and `Field` owns that branch** (ADR 0015).
+ * The caller passes `readOnly` and a `value`; the row decides for itself whether
+ * to render the control or the value, and drops the form's furniture with it —
+ * a **hint** explains how to fill in a control, and with no control there is
+ * nothing to explain; a **required asterisk** marks a field you must complete,
+ * which is nonsense on a field nobody can fill in. Both are dropped, not
+ * reworded, and callers keep declaring them unconditionally.
+ *
+ * One flag, one obligation. A `canEdit ? <Input/> : <ReadOnlyValue/>` at every
+ * call site would be a second one — and "twenty `disabled` props are twenty
+ * chances to forget one" is just as true of a dozen `readOnly` branches. Here the
+ * leak is structurally impossible rather than merely tested for:
+ *
+ * ```tsx
+ * <Field label="Entry fee" readOnly={!canEdit} value={event.entryFee}>
+ *   {(id) => <Input id={id} type="number" … />}
+ * </Field>
+ * ```
+ *
+ * (Controls that aren't a "label + one control + one value" row — a `Switch`, a
+ * `ToggleGroup`, the pool table chips — don't come through `Field`; the guard
+ * test in rule 6 is what covers those.) */
 export const Field = ({
   label,
   required,
   hint,
   error,
   readOnly,
+  value,
+  valueClassName,
   children,
   className,
 }: FieldProps) => {
@@ -53,7 +81,11 @@ export const Field = ({
           <span className="text-[color:var(--ball-500)]">*</span>
         )}
       </Label>
-      {children(id)}
+      {readOnly ? (
+        <ReadOnlyValue className={valueClassName}>{value}</ReadOnlyValue>
+      ) : (
+        children?.(id)
+      )}
       {showHint && (
         <p
           className={cn(

--- a/web-client/src/components/tournaments/read-only-value.factory.tsx
+++ b/web-client/src/components/tournaments/read-only-value.factory.tsx
@@ -1,0 +1,12 @@
+import type { ReadOnlyValueProps } from './read-only-value'
+
+/** Props for `ReadOnlyValue` — a set value, as a viewer sees a field the
+ * organizer filled in. */
+export function buildReadOnlyValueProps(
+  overrides: Partial<ReadOnlyValueProps> = {},
+): ReadOnlyValueProps {
+  return {
+    children: 'Open Singles',
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/read-only-value.page.tsx
+++ b/web-client/src/components/tournaments/read-only-value.page.tsx
@@ -1,0 +1,45 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { ReadOnlyValue, type ReadOnlyValueProps } from './read-only-value'
+import { buildReadOnlyValueProps } from './read-only-value.factory'
+
+/** The roles a form control would take in the accessibility tree. A read-only
+ * surface must render none of them (ADR 0015). */
+const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
+
+const scoped = (container: Container) => ({
+  /** The rendered value, as text. Always present — an unset value renders an
+   * em-dash rather than nothing. */
+  getValue() {
+    return container.getByTestId('tournament-read-only-value')
+  },
+  /** Every interactive control in scope, across the roles a form control could
+   * claim. Empty is the whole point of the component. */
+  getInteractiveControls() {
+    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+  },
+  /** Anything focusable — the tab-order escape hatch a plain `role` sweep would
+   * miss (a `tabindex`, an anchor, a bare `<input>` with no accessible name). */
+  getFocusableElements() {
+    return container
+      .getByTestId('tournament-read-only-value')
+      .parentElement!.querySelectorAll(
+        'input, select, textarea, button, a[href], [tabindex], [contenteditable="true"]',
+      )
+  },
+})
+
+/** Test page-object for `ReadOnlyValue` — the read-only counterpart to
+ * `Field`'s control slot. Tests pass the value through `render({ children })`;
+ * `getValue()` reads back what a viewer actually sees. */
+export const readOnlyValuePage = {
+  render(overrides: Partial<ReadOnlyValueProps> = {}) {
+    render(<ReadOnlyValue {...buildReadOnlyValueProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/read-only-value.page.tsx
+++ b/web-client/src/components/tournaments/read-only-value.page.tsx
@@ -1,31 +1,31 @@
+import { interactiveControlsIn, interactiveElementsIn } from '@/test/read-only'
 import { render, screen, type Container } from '@/test/utilities'
 
 import { ReadOnlyValue, type ReadOnlyValueProps } from './read-only-value'
 import { buildReadOnlyValueProps } from './read-only-value.factory'
 
-/** The roles a form control would take in the accessibility tree. A read-only
- * surface must render none of them (ADR 0015). */
-const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
+/** The testid `ReadOnlyValue` stamps on its rendering. Every page object that
+ * reads a value back goes through this constant rather than re-typing it. */
+export const READ_ONLY_VALUE_TESTID = 'tournament-read-only-value'
 
 const scoped = (container: Container) => ({
   /** The rendered value, as text. Always present — an unset value renders an
    * em-dash rather than nothing. */
   getValue() {
-    return container.getByTestId('tournament-read-only-value')
+    return container.getByTestId(READ_ONLY_VALUE_TESTID)
   },
-  /** Every interactive control in scope, across the roles a form control could
-   * claim. Empty is the whole point of the component. */
+  /** Every interactive control in scope, swept by role. Empty is the whole point
+   * of the component. Supplement only — `getFormElements()` is the guarantee. */
   getInteractiveControls() {
-    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+    return interactiveControlsIn(container)
   },
-  /** Anything focusable — the tab-order escape hatch a plain `role` sweep would
-   * miss (a `tabindex`, an anchor, a bare `<input>` with no accessible name). */
-  getFocusableElements() {
-    return container
-      .getByTestId('tournament-read-only-value')
-      .parentElement!.querySelectorAll(
-        'input, select, textarea, button, a[href], [tabindex], [contenteditable="true"]',
-      )
+  /** Every interactive element in scope, swept by DOM (`@/test/read-only`) — the
+   * tab-order escape hatch a role sweep would miss (a `tabindex`, an anchor, a
+   * bare `<input>` with no accessible name). */
+  getFormElements() {
+    return interactiveElementsIn(
+      container.getByTestId(READ_ONLY_VALUE_TESTID).parentElement!,
+    )
   },
 })
 

--- a/web-client/src/components/tournaments/read-only-value.test.tsx
+++ b/web-client/src/components/tournaments/read-only-value.test.tsx
@@ -42,7 +42,7 @@ describe('ReadOnlyValue', () => {
   it('puts no interactive control in the accessibility tree', () => {
     readOnlyValuePage.render({ children: 'Open Singles' })
     expect(readOnlyValuePage.getInteractiveControls()).toHaveLength(0)
-    expect(readOnlyValuePage.getFocusableElements()).toHaveLength(0)
+    expect(readOnlyValuePage.getFormElements()).toHaveLength(0)
   })
 
   it('holds the row height and type scale of the input it replaces', () => {

--- a/web-client/src/components/tournaments/read-only-value.test.tsx
+++ b/web-client/src/components/tournaments/read-only-value.test.tsx
@@ -1,0 +1,61 @@
+import type { ReadOnlyValueContent } from './read-only-value'
+import { readOnlyValuePage } from './read-only-value.page'
+
+/** U+2014 — the character the ADR pins for an empty field. */
+const EM_DASH = '—'
+
+describe('ReadOnlyValue', () => {
+  it('renders a string value as plain text', () => {
+    readOnlyValuePage.render({ children: 'Open Singles' })
+    expect(readOnlyValuePage.getValue().textContent).toBe('Open Singles')
+  })
+
+  it('renders a number value as plain text', () => {
+    readOnlyValuePage.render({ children: 32 })
+    expect(readOnlyValuePage.getValue().textContent).toBe('32')
+  })
+
+  // An unset field renders an em-dash rather than an omitted row: absent and
+  // not-applicable must stay distinguishable (ADR 0015).
+  it.each<[string, ReadOnlyValueContent]>([
+    ['null', null],
+    ['undefined', undefined],
+    ['an empty string', ''],
+    ['a whitespace-only string', '   '],
+  ])('renders an em-dash when the value is %s', (_label, value) => {
+    readOnlyValuePage.render({ children: value })
+    expect(readOnlyValuePage.getValue().textContent).toBe(EM_DASH)
+  })
+
+  // The boundary a falsy check gets wrong: these are values the organizer
+  // chose, not an empty field. `false` is the sharper case — React renders a
+  // bare `{false}` as nothing at all.
+  it.each<[string, ReadOnlyValueContent, string]>([
+    ['zero', 0, '0'],
+    ['false', false, 'false'],
+    ['true', true, 'true'],
+  ])('renders %s as itself rather than as an em-dash', (_label, value, text) => {
+    readOnlyValuePage.render({ children: value })
+    expect(readOnlyValuePage.getValue().textContent).toBe(text)
+  })
+
+  it('puts no interactive control in the accessibility tree', () => {
+    readOnlyValuePage.render({ children: 'Open Singles' })
+    expect(readOnlyValuePage.getInteractiveControls()).toHaveLength(0)
+    expect(readOnlyValuePage.getFocusableElements()).toHaveLength(0)
+  })
+
+  it('holds the row height and type scale of the input it replaces', () => {
+    readOnlyValuePage.render()
+    expect(readOnlyValuePage.getValue()).toHaveClass(
+      'h-10',
+      'items-center',
+      'text-sm',
+    )
+  })
+
+  it('accepts a caller className alongside its own', () => {
+    readOnlyValuePage.render({ className: 'font-mono' })
+    expect(readOnlyValuePage.getValue()).toHaveClass('font-mono', 'text-sm')
+  })
+})

--- a/web-client/src/components/tournaments/read-only-value.tsx
+++ b/web-client/src/components/tournaments/read-only-value.tsx
@@ -1,0 +1,53 @@
+import { cn } from '@/lib/utils'
+
+/** Anything a form control would hold. `null`/`undefined` mean "the organizer
+ * left this empty" — they are values, not a missing prop. */
+export type ReadOnlyValueContent = string | number | boolean | null | undefined
+
+export interface ReadOnlyValueProps {
+  children: ReadOnlyValueContent
+  className?: string
+}
+
+/** Shown when the value is unset — absent and not-applicable must stay
+ * distinguishable, so an empty field renders as an em-dash rather than as
+ * nothing at all (ADR 0015). */
+const EM_DASH = '—'
+
+/** A value is unset when it is `null`, `undefined`, or a string with nothing in
+ * it but whitespace. Note what is *not* unset: `0` and `false` are values the
+ * organizer chose, and render as themselves — the reason this is a ladder and
+ * not a falsy check. */
+const isUnset = (value: ReadOnlyValueContent): boolean =>
+  value === null ||
+  value === undefined ||
+  (typeof value === 'string' && value.trim() === '')
+
+/** The read-only counterpart to `Field`'s control slot: renders the value as
+ * plain text, at the same height and type scale as the `Input` it replaces, so
+ * a viewer's form rows line up with an editor's.
+ *
+ * Nothing focusable and no form element goes in the accessibility tree — a
+ * viewer gets a rendering of the data, never a disabled editor (ADR 0015).
+ *
+ * ```tsx
+ * <Field label="Entry fee">
+ *   {() => <ReadOnlyValue>{draft.entryFee}</ReadOnlyValue>}
+ * </Field>
+ * ```
+ *
+ * Booleans render as `"true"` / `"false"`; a surface that wants "Yes" / "No"
+ * (or any other copy) formats the value before passing it in. What the
+ * primitive guarantees is that `false` is never mistaken for empty. */
+export const ReadOnlyValue = ({ children, className }: ReadOnlyValueProps) => (
+  <p
+    data-testid="tournament-read-only-value"
+    className={cn(
+      'flex h-10 items-center text-sm text-[color:var(--fg-1)]',
+      isUnset(children) && 'text-[color:var(--fg-muted)]',
+      className,
+    )}
+  >
+    {isUnset(children) ? EM_DASH : String(children)}
+  </p>
+)

--- a/web-client/src/components/tournaments/read-only-value.tsx
+++ b/web-client/src/components/tournaments/read-only-value.tsx
@@ -1,5 +1,7 @@
 import { cn } from '@/lib/utils'
 
+import { EM_DASH } from './data/helpers'
+
 /** Anything a form control would hold. `null`/`undefined` mean "the organizer
  * left this empty" — they are values, not a missing prop. */
 export type ReadOnlyValueContent = string | number | boolean | null | undefined
@@ -8,11 +10,6 @@ export interface ReadOnlyValueProps {
   children: ReadOnlyValueContent
   className?: string
 }
-
-/** Shown when the value is unset — absent and not-applicable must stay
- * distinguishable, so an empty field renders as an em-dash rather than as
- * nothing at all (ADR 0015). */
-const EM_DASH = '—'
 
 /** A value is unset when it is `null`, `undefined`, or a string with nothing in
  * it but whitespace. Note what is *not* unset: `0` and `false` are values the

--- a/web-client/src/components/tournaments/tournament-detail-page.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.page.tsx
@@ -17,6 +17,14 @@ const scoped = (container: Container) => ({
   getLifecycleButton(name: RegExp) {
     return container.getByRole('button', { name })
   },
+  /** The Days stat's figure and its unit, read as one string. The unit is a
+   * styled `<span>` sitting beside the figure, so the DOM text carries no space
+   * ("2days") even though a CSS margin renders one — assert against the DOM, not
+   * against what the eye sees. */
+  getDaysStat() {
+    return container.getByText('Days', { selector: 'div' }).previousElementSibling
+      ?.textContent
+  },
   queryLifecycleButton(name: RegExp) {
     return container.queryByRole('button', { name })
   },

--- a/web-client/src/components/tournaments/tournament-detail-page.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.test.tsx
@@ -4,6 +4,33 @@ import { buildEvent, buildTournament } from './data/seed.factory'
 import { tournamentDetailPagePage } from './tournament-detail-page.page'
 
 describe('TournamentDetailPage', () => {
+  // The stat strip prints its own unit, so it owns the plural. Both sides are
+  // asserted: a fix that simply hardcoded "day" would read "2 day" for a
+  // weekend tournament, which is the same bug wearing the other shoe.
+  describe('the Days stat', () => {
+    it('reads "day" for a one-day tournament', () => {
+      tournamentDetailPagePage.render({
+        tournament: buildTournament({
+          startDate: '2026-08-22',
+          endDate: '2026-08-22',
+          events: [],
+        }),
+      })
+      expect(tournamentDetailPagePage.getDaysStat()).toBe('1day')
+    })
+
+    it('reads "days" for a multi-day tournament', () => {
+      tournamentDetailPagePage.render({
+        tournament: buildTournament({
+          startDate: '2026-08-22',
+          endDate: '2026-08-23',
+          events: [],
+        }),
+      })
+      expect(tournamentDetailPagePage.getDaysStat()).toBe('2days')
+    })
+  })
+
   it('shows the lifecycle action matching the status', () => {
     tournamentDetailPagePage.render({
       tournament: buildTournament({ status: 'draft' }),

--- a/web-client/src/components/tournaments/tournament-detail-page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.tsx
@@ -90,6 +90,7 @@ export const TournamentDetailPage = ({
 
   const canEdit = tournament.canEdit
   const range = effectiveDateRange(tournament)
+  const days = daysBetween(range.start, range.end)
   const entries = tournament.events.reduce((s, e) => s + (e.entered || 0), 0)
   const pools = tournament.events.reduce((s, e) => s + e.pools.length, 0)
 
@@ -188,8 +189,8 @@ export const TournamentDetailPage = ({
           <HeroStat label="Pools" value={pools} icon={<Layers size={16} />} />
           <HeroStat
             label="Days"
-            value={range.start ? daysBetween(range.start, range.end) : EM_DASH}
-            suffix={range.start ? 'days' : undefined}
+            value={range.start ? days : EM_DASH}
+            suffix={range.start ? (days === 1 ? 'day' : 'days') : undefined}
             icon={<Calendar size={16} />}
           />
         </div>

--- a/web-client/src/components/tournaments/tournament-detail-page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.tsx
@@ -19,6 +19,7 @@ import { ConfirmDeleteDialog } from './confirm-delete-dialog'
 import {
   daysBetween,
   effectiveDateRange,
+  EM_DASH,
   emptyEvent,
   fmtDateRange,
   genId,
@@ -187,7 +188,7 @@ export const TournamentDetailPage = ({
           <HeroStat label="Pools" value={pools} icon={<Layers size={16} />} />
           <HeroStat
             label="Days"
-            value={range.start ? daysBetween(range.start, range.end) : '—'}
+            value={range.start ? daysBetween(range.start, range.end) : EM_DASH}
             suffix={range.start ? 'days' : undefined}
             icon={<Calendar size={16} />}
           />

--- a/web-client/src/components/tournaments/tournament-detail-page/details-tab.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/details-tab.page.tsx
@@ -3,12 +3,68 @@ import { render, screen, type Container } from '@/test/utilities'
 import { DetailsTab, type DetailsTabProps } from './details-tab'
 import { buildDetailsTabProps } from './details-tab.factory'
 
+/** The roles a form control would take in the accessibility tree. Kept only as
+ * a supplement: the role sweep alone *under-proves*, because a `type="number"`
+ * input is a `spinbutton`, a `type="date"` input has no role at all, and a
+ * `ToggleGroupItem` is a `radio` rather than a `button`. */
+const INTERACTIVE_ROLES = [
+  'textbox',
+  'combobox',
+  'switch',
+  'button',
+  'radio',
+  'spinbutton',
+] as const
+
+/** Every interactive element, by tag rather than by role — the sweep that
+ * actually holds the line (ADR 0015, `web-client/CLAUDE.md`). It catches the
+ * element whatever role it claims, including the roleless ones. */
+const FORM_ELEMENTS =
+  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
+
 const scoped = (container: Container) => ({
   getNameInput() {
     return container.getByLabelText(/Name/)
   },
+  /** The "Name" field's label row, as `textContent` — which is where the
+   * required asterisk actually shows up ("Name*"). It cannot be asserted through
+   * the *query*: `getByText` matches a node's direct text children only, and the
+   * asterisk is a nested `<span>`, so "Name" finds the label whether or not it is
+   * marked required. Exact, or this would also match the "Venue name" row. */
+  getNameLabelText() {
+    return container.getByText('Name', { exact: true, selector: 'label' })
+      .textContent
+  },
+  /** The Description hint — form furniture, so absent for a viewer (ADR 0015). */
+  queryDescriptionHint() {
+    return container.queryByText(
+      /Optional\. Shown on the public registration page\./,
+    )
+  },
   querySaveButton() {
     return container.queryByRole('button', { name: /Save changes/ })
+  },
+  getRevertButton() {
+    return container.getByRole('button', { name: /Revert/ })
+  },
+  /** The read-only rendering of the fields, in document order — what a
+   * non-creator sees where the creator gets controls (ADR 0015). */
+  getReadOnlyValues() {
+    const values: HTMLElement[] = container.queryAllByTestId(
+      'tournament-read-only-value',
+    )
+    return values.map((el) => el.textContent)
+  },
+  /** Every interactive control in the tab, swept by role. Supplement only —
+   * assert on `getFormElements()` for the guarantee. */
+  getInteractiveControls() {
+    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+  },
+  /** Every form element in the tab, by tag. Empty is the whole point of the
+   * read-only view. */
+  getFormElements() {
+    const root: HTMLElement = container.getByTestId('details-tab')
+    return root.querySelectorAll(FORM_ELEMENTS)
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/details-tab.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/details-tab.page.tsx
@@ -1,28 +1,15 @@
+import { interactiveControlsIn, interactiveElementsIn } from '@/test/read-only'
 import { render, screen, type Container } from '@/test/utilities'
 
+import { fieldPage } from '../field.page'
+import { READ_ONLY_VALUE_TESTID } from '../read-only-value.page'
 import { DetailsTab, type DetailsTabProps } from './details-tab'
 import { buildDetailsTabProps } from './details-tab.factory'
 
-/** The roles a form control would take in the accessibility tree. Kept only as
- * a supplement: the role sweep alone *under-proves*, because a `type="number"`
- * input is a `spinbutton`, a `type="date"` input has no role at all, and a
- * `ToggleGroupItem` is a `radio` rather than a `button`. */
-const INTERACTIVE_ROLES = [
-  'textbox',
-  'combobox',
-  'switch',
-  'button',
-  'radio',
-  'spinbutton',
-] as const
-
-/** Every interactive element, by tag rather than by role — the sweep that
- * actually holds the line (ADR 0015, `web-client/CLAUDE.md`). It catches the
- * element whatever role it claims, including the roleless ones. */
-const FORM_ELEMENTS =
-  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
-
 const scoped = (container: Container) => ({
+  /** Reuse the `Field` row queries — the tab is a grid of `Field` rows. */
+  ...fieldPage.within(container),
+
   getNameInput() {
     return container.getByLabelText(/Name/)
   },
@@ -32,8 +19,7 @@ const scoped = (container: Container) => ({
    * asterisk is a nested `<span>`, so "Name" finds the label whether or not it is
    * marked required. Exact, or this would also match the "Venue name" row. */
   getNameLabelText() {
-    return container.getByText('Name', { exact: true, selector: 'label' })
-      .textContent
+    return fieldPage.within(container).getLabelText('Name', { exact: true })
   },
   /** The Description hint — form furniture, so absent for a viewer (ADR 0015). */
   queryDescriptionHint() {
@@ -50,21 +36,19 @@ const scoped = (container: Container) => ({
   /** The read-only rendering of the fields, in document order — what a
    * non-creator sees where the creator gets controls (ADR 0015). */
   getReadOnlyValues() {
-    const values: HTMLElement[] = container.queryAllByTestId(
-      'tournament-read-only-value',
-    )
+    const values: HTMLElement[] =
+      container.queryAllByTestId(READ_ONLY_VALUE_TESTID)
     return values.map((el) => el.textContent)
   },
   /** Every interactive control in the tab, swept by role. Supplement only —
-   * assert on `getFormElements()` for the guarantee. */
+   * `getFormElements()` is the guarantee. */
   getInteractiveControls() {
-    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+    return interactiveControlsIn(container)
   },
-  /** Every form element in the tab, by tag. Empty is the whole point of the
-   * read-only view. */
+  /** Every interactive element in the tab, swept by DOM (`@/test/read-only`).
+   * Empty is the whole point of the read-only view. */
   getFormElements() {
-    const root: HTMLElement = container.getByTestId('details-tab')
-    return root.querySelectorAll(FORM_ELEMENTS)
+    return interactiveElementsIn(container.getByTestId('details-tab'))
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/details-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/details-tab.test.tsx
@@ -1,5 +1,7 @@
 import userEvent from '@testing-library/user-event'
 
+import { screen } from '@/test/utilities'
+
 import { buildTournament } from '../data/seed.factory'
 import { detailsTabPage } from './details-tab.page'
 
@@ -22,12 +24,101 @@ describe('DetailsTab', () => {
     )
   })
 
-  it('disables the fields and hides save for a non-creator', () => {
+  it('reverts the draft back to the committed tournament', async () => {
     detailsTabPage.render({
       tournament: buildTournament({ name: 'Bay Area Open 2026' }),
+    })
+
+    await userEvent.type(detailsTabPage.getNameInput(), '!')
+    expect(detailsTabPage.getNameInput()).toHaveValue('Bay Area Open 2026!')
+
+    await userEvent.click(detailsTabPage.getRevertButton())
+    expect(detailsTabPage.getNameInput()).toHaveValue('Bay Area Open 2026')
+    expect(detailsTabPage.querySaveButton()).toBeNull()
+  })
+
+  // The form's furniture, which only the organizer gets. Paired with the
+  // read-only case below so neither can be satisfied by deleting the feature: an
+  // assertion that a viewer sees no hint would also pass if the hint were ripped
+  // out of the form altogether, which is not the change.
+  it('marks Name required and explains the description to the creator', () => {
+    detailsTabPage.render({ tournament: buildTournament() })
+    expect(detailsTabPage.getNameLabelText()).toBe('Name*')
+    expect(detailsTabPage.queryDescriptionHint()).toBeInTheDocument()
+  })
+
+  it('renders no required asterisk and no hint for a non-creator', () => {
+    detailsTabPage.render({ tournament: buildTournament(), canEdit: false })
+    // The label stays — it names the value. The asterisk is what goes: it marks
+    // a field you must complete, and a reader completes nothing (ADR 0015).
+    expect(detailsTabPage.getNameLabelText()).toBe('Name')
+    expect(detailsTabPage.queryDescriptionHint()).toBeNull()
+    expect(screen.queryByText('*')).toBeNull()
+  })
+
+  // The guard test of ADR 0015: a non-owner gets a rendering of the data, never
+  // a form wearing a disabled costume. `queryAllByRole` still finds a *disabled*
+  // control, so this fails against a `disabled={!canEdit}` editor — which is
+  // exactly the drift it exists to catch.
+  //
+  // The sweep is over the DOM, not over ARIA roles: the tab's status control is
+  // a `ToggleGroup`, whose items are `radio`s rather than `button`s, so a
+  // role-only sweep of textbox/combobox/switch/button would go green with the
+  // whole toggle group still live. Assert on the elements themselves.
+  it('renders no interactive controls for a non-creator', () => {
+    detailsTabPage.render({
+      tournament: buildTournament(),
       canEdit: false,
     })
-    expect(detailsTabPage.getNameInput()).toBeDisabled()
+
+    expect(detailsTabPage.getFormElements()).toHaveLength(0)
+    expect(detailsTabPage.getInteractiveControls()).toHaveLength(0)
+  })
+
+  it('renders the details as values, and addresses the reader, for a non-creator', () => {
+    detailsTabPage.render({
+      tournament: buildTournament({
+        name: 'Bay Area Open 2026',
+        status: 'published',
+        description: 'Two-day open.',
+      }),
+      canEdit: false,
+    })
+
+    expect(
+      screen.getByText('The basics for this tournament.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(/Players see this on the public page/),
+    ).toBeNull()
+    // A hint explains how to fill in a control; with no control there is
+    // nothing to explain, so the read-only view drops it.
+    expect(
+      screen.queryByText(/Optional. Shown on the public registration page/),
+    ).toBeNull()
+
+    expect(detailsTabPage.getReadOnlyValues()).toEqual([
+      'Bay Area Open 2026',
+      'Two-day open.',
+      'Published',
+      'Berkeley TT Club',
+      '2727 Milvia St',
+      'Berkeley',
+      'CA',
+      '94703',
+      'USA',
+    ])
     expect(detailsTabPage.querySaveButton()).toBeNull()
+  })
+
+  it('renders an em-dash for a field the organizer left empty', () => {
+    detailsTabPage.render({
+      tournament: buildTournament({ description: '' }),
+      canEdit: false,
+    })
+
+    // The row is present and shows an em-dash: "the organizer set nothing" has
+    // to stay distinguishable from "this does not apply".
+    expect(detailsTabPage.getReadOnlyValues()).toContain('—')
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/details-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/details-tab.tsx
@@ -7,9 +7,9 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 
+import { labelFor } from '../data/options'
 import type { Address, Tournament, TournamentStatus } from '../data/types'
 import { Field } from '../field'
-import { ReadOnlyValue } from '../read-only-value'
 import { SectionHeader } from './section-header'
 
 export interface DetailsTabProps {
@@ -27,18 +27,16 @@ const STATUS_OPTIONS: { value: TournamentStatus; label: string }[] = [
   { value: 'archived', label: 'Archived' },
 ]
 
-const statusLabel = (status: TournamentStatus) =>
-  STATUS_OPTIONS.find((o) => o.value === status)?.label ?? status
-
 /** The Details tab: the creator edits the tournament's name, description,
  * status, and venue address — changes stage in a draft and commit on Save.
  * Everyone else reads the same fields as rendered values (ADR 0015): a viewer
  * gets a rendering of the data, only an editor gets controls.
  *
- * The rows declare `required` and `hint` unconditionally and pass
- * `readOnly={!canEdit}`; `Field` drops that furniture for a viewer. There is one
- * mechanism, not a conditional per call site — a field added here cannot
- * reintroduce an asterisk or a hint to a reader by forgetting one. */
+ * Each row hands `Field` both its control and the value it holds, and passes one
+ * `readOnly={!canEdit}`; `Field` picks between them and drops the form's
+ * furniture (the asterisk, the hint) with it. There is one mechanism and one
+ * flag, not a conditional per call site — a field added here cannot leak a
+ * control, an asterisk, or a hint to a reader by forgetting one. */
 export const DetailsTab = ({
   tournament,
   canEdit,
@@ -63,28 +61,28 @@ export const DetailsTab = ({
     setDraft((d) => ({ ...d, address: { ...d.address, ...patch } }))
   const save = () => onUpdate(draft)
 
-  /** The address rows are the same shape six times over: an `Input` for the
-   * creator, the value itself for everyone else. */
+  /** The address rows are the same shape six times over: an `Input` over the
+   * same value, which `Field` renders as text for a reader. */
   const addressField = (
     label: string,
     key: keyof Address,
     className?: string,
   ) => (
-    <Field label={label} key={key} readOnly={!canEdit}>
-      {(id) =>
-        canEdit ? (
-          <Input
-            id={id}
-            className={className}
-            value={draft.address[key]}
-            onChange={(e) => updateAddress({ [key]: e.target.value })}
-          />
-        ) : (
-          <ReadOnlyValue className={className}>
-            {draft.address[key]}
-          </ReadOnlyValue>
-        )
-      }
+    <Field
+      label={label}
+      key={key}
+      readOnly={!canEdit}
+      value={draft.address[key]}
+      valueClassName={className}
+    >
+      {(id) => (
+        <Input
+          id={id}
+          className={className}
+          value={draft.address[key]}
+          onChange={(e) => updateAddress({ [key]: e.target.value })}
+        />
+      )}
     </Field>
   )
 
@@ -119,66 +117,58 @@ export const DetailsTab = ({
             <div className="text-[15px] font-bold text-[color:var(--fg-1)]">
               About
             </div>
-            <Field label="Name" required readOnly={!canEdit}>
-              {(id) =>
-                canEdit ? (
-                  <Input
-                    id={id}
-                    value={draft.name}
-                    onChange={(e) => update({ name: e.target.value })}
-                  />
-                ) : (
-                  <ReadOnlyValue>{draft.name}</ReadOnlyValue>
-                )
-              }
+            <Field label="Name" required readOnly={!canEdit} value={draft.name}>
+              {(id) => (
+                <Input
+                  id={id}
+                  value={draft.name}
+                  onChange={(e) => update({ name: e.target.value })}
+                />
+              )}
             </Field>
             <Field
               label="Description"
               hint="Optional. Shown on the public registration page."
               readOnly={!canEdit}
+              value={draft.description}
+              // Taller than a single-line row so the value mirrors the textarea
+              // it stands in for, and wraps rather than clipping the prose.
+              valueClassName="h-auto min-h-10 items-start whitespace-pre-wrap"
             >
-              {(id) =>
-                canEdit ? (
-                  <Textarea
-                    id={id}
-                    rows={4}
-                    value={draft.description}
-                    placeholder="Two-day open. USATT-sanctioned."
-                    onChange={(e) => update({ description: e.target.value })}
-                  />
-                ) : (
-                  // Taller than a single-line row so it mirrors the textarea it
-                  // stands in for, and wraps rather than clipping the prose.
-                  <ReadOnlyValue className="h-auto min-h-10 items-start whitespace-pre-wrap">
-                    {draft.description}
-                  </ReadOnlyValue>
-                )
-              }
+              {(id) => (
+                <Textarea
+                  id={id}
+                  rows={4}
+                  value={draft.description}
+                  placeholder="Two-day open. USATT-sanctioned."
+                  onChange={(e) => update({ description: e.target.value })}
+                />
+              )}
             </Field>
-            <Field label="Status" readOnly={!canEdit}>
-              {(id) =>
-                canEdit ? (
-                  <ToggleGroup
-                    type="single"
-                    aria-labelledby={`${id}-label`}
-                    value={draft.status}
-                    onValueChange={(v) =>
-                      v && update({ status: v as TournamentStatus })
-                    }
-                    className="w-fit"
-                  >
-                    {STATUS_OPTIONS.map((o) => (
-                      <ToggleGroupItem key={o.value} value={o.value}>
-                        {o.label}
-                      </ToggleGroupItem>
-                    ))}
-                  </ToggleGroup>
-                ) : (
-                  // The label, not the wire value: a reader sees "Published",
-                  // the same word the toggle would have shown as selected.
-                  <ReadOnlyValue>{statusLabel(draft.status)}</ReadOnlyValue>
-                )
-              }
+            {/* The label, not the wire value: a reader sees "Published", the
+                same word the toggle would have shown as selected. */}
+            <Field
+              label="Status"
+              readOnly={!canEdit}
+              value={labelFor(STATUS_OPTIONS, draft.status, draft.status)}
+            >
+              {(id) => (
+                <ToggleGroup
+                  type="single"
+                  aria-labelledby={`${id}-label`}
+                  value={draft.status}
+                  onValueChange={(v) =>
+                    v && update({ status: v as TournamentStatus })
+                  }
+                  className="w-fit"
+                >
+                  {STATUS_OPTIONS.map((o) => (
+                    <ToggleGroupItem key={o.value} value={o.value}>
+                      {o.label}
+                    </ToggleGroupItem>
+                  ))}
+                </ToggleGroup>
+              )}
             </Field>
           </div>
         </Card>

--- a/web-client/src/components/tournaments/tournament-detail-page/details-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/details-tab.tsx
@@ -9,12 +9,13 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 
 import type { Address, Tournament, TournamentStatus } from '../data/types'
 import { Field } from '../field'
+import { ReadOnlyValue } from '../read-only-value'
 import { SectionHeader } from './section-header'
 
 export interface DetailsTabProps {
   tournament: Tournament
-  /** When false (a non-creator), every field is disabled and the Save action
-   * is hidden — the tab is a read-only view of the tournament details. */
+  /** When false (a non-creator), the tab renders the tournament's details as
+   * values rather than as a disabled form: no controls, no Save (ADR 0015). */
   canEdit: boolean
   onUpdate: (tournament: Tournament) => void
 }
@@ -26,8 +27,18 @@ const STATUS_OPTIONS: { value: TournamentStatus; label: string }[] = [
   { value: 'archived', label: 'Archived' },
 ]
 
-/** The Details tab: edit the tournament's name, description, status, and venue
- * address. Changes stage in a draft and commit on Save. */
+const statusLabel = (status: TournamentStatus) =>
+  STATUS_OPTIONS.find((o) => o.value === status)?.label ?? status
+
+/** The Details tab: the creator edits the tournament's name, description,
+ * status, and venue address — changes stage in a draft and commit on Save.
+ * Everyone else reads the same fields as rendered values (ADR 0015): a viewer
+ * gets a rendering of the data, only an editor gets controls.
+ *
+ * The rows declare `required` and `hint` unconditionally and pass
+ * `readOnly={!canEdit}`; `Field` drops that furniture for a viewer. There is one
+ * mechanism, not a conditional per call site — a field added here cannot
+ * reintroduce an asterisk or a hint to a reader by forgetting one. */
 export const DetailsTab = ({
   tournament,
   canEdit,
@@ -52,11 +63,40 @@ export const DetailsTab = ({
     setDraft((d) => ({ ...d, address: { ...d.address, ...patch } }))
   const save = () => onUpdate(draft)
 
+  /** The address rows are the same shape six times over: an `Input` for the
+   * creator, the value itself for everyone else. */
+  const addressField = (
+    label: string,
+    key: keyof Address,
+    className?: string,
+  ) => (
+    <Field label={label} key={key} readOnly={!canEdit}>
+      {(id) =>
+        canEdit ? (
+          <Input
+            id={id}
+            className={className}
+            value={draft.address[key]}
+            onChange={(e) => updateAddress({ [key]: e.target.value })}
+          />
+        ) : (
+          <ReadOnlyValue className={className}>
+            {draft.address[key]}
+          </ReadOnlyValue>
+        )
+      }
+    </Field>
+  )
+
   return (
-    <div>
+    <div data-testid="details-tab">
       <SectionHeader
         title="Tournament details"
-        subtitle="Edit the basics. Players see this on the public page and registration emails."
+        subtitle={
+          canEdit
+            ? 'Edit the basics. Players see this on the public page and registration emails.'
+            : 'The basics for this tournament.'
+        }
         action={
           canEdit &&
           dirty && (
@@ -79,48 +119,66 @@ export const DetailsTab = ({
             <div className="text-[15px] font-bold text-[color:var(--fg-1)]">
               About
             </div>
-            <Field label="Name" required>
-              {(id) => (
-                <Input
-                  id={id}
-                  disabled={!canEdit}
-                  value={draft.name}
-                  onChange={(e) => update({ name: e.target.value })}
-                />
-              )}
+            <Field label="Name" required readOnly={!canEdit}>
+              {(id) =>
+                canEdit ? (
+                  <Input
+                    id={id}
+                    value={draft.name}
+                    onChange={(e) => update({ name: e.target.value })}
+                  />
+                ) : (
+                  <ReadOnlyValue>{draft.name}</ReadOnlyValue>
+                )
+              }
             </Field>
             <Field
               label="Description"
               hint="Optional. Shown on the public registration page."
+              readOnly={!canEdit}
             >
-              {(id) => (
-                <Textarea
-                  id={id}
-                  rows={4}
-                  disabled={!canEdit}
-                  value={draft.description}
-                  placeholder="Two-day open. USATT-sanctioned."
-                  onChange={(e) => update({ description: e.target.value })}
-                />
-              )}
+              {(id) =>
+                canEdit ? (
+                  <Textarea
+                    id={id}
+                    rows={4}
+                    value={draft.description}
+                    placeholder="Two-day open. USATT-sanctioned."
+                    onChange={(e) => update({ description: e.target.value })}
+                  />
+                ) : (
+                  // Taller than a single-line row so it mirrors the textarea it
+                  // stands in for, and wraps rather than clipping the prose.
+                  <ReadOnlyValue className="h-auto min-h-10 items-start whitespace-pre-wrap">
+                    {draft.description}
+                  </ReadOnlyValue>
+                )
+              }
             </Field>
-            <Field label="Status">
-              {(id) => (
-                <ToggleGroup
-                  type="single"
-                  aria-labelledby={`${id}-label`}
-                  disabled={!canEdit}
-                  value={draft.status}
-                  onValueChange={(v) => v && update({ status: v as TournamentStatus })}
-                  className="w-fit"
-                >
-                  {STATUS_OPTIONS.map((o) => (
-                    <ToggleGroupItem key={o.value} value={o.value}>
-                      {o.label}
-                    </ToggleGroupItem>
-                  ))}
-                </ToggleGroup>
-              )}
+            <Field label="Status" readOnly={!canEdit}>
+              {(id) =>
+                canEdit ? (
+                  <ToggleGroup
+                    type="single"
+                    aria-labelledby={`${id}-label`}
+                    value={draft.status}
+                    onValueChange={(v) =>
+                      v && update({ status: v as TournamentStatus })
+                    }
+                    className="w-fit"
+                  >
+                    {STATUS_OPTIONS.map((o) => (
+                      <ToggleGroupItem key={o.value} value={o.value}>
+                        {o.label}
+                      </ToggleGroupItem>
+                    ))}
+                  </ToggleGroup>
+                ) : (
+                  // The label, not the wire value: a reader sees "Published",
+                  // the same word the toggle would have shown as selected.
+                  <ReadOnlyValue>{statusLabel(draft.status)}</ReadOnlyValue>
+                )
+              }
             </Field>
           </div>
         </Card>
@@ -130,69 +188,14 @@ export const DetailsTab = ({
             <div className="text-[15px] font-bold text-[color:var(--fg-1)]">
               Venue &amp; address
             </div>
-            <Field label="Venue name">
-              {(id) => (
-                <Input
-                  id={id}
-                  disabled={!canEdit}
-                  value={draft.address.venue}
-                  onChange={(e) => updateAddress({ venue: e.target.value })}
-                />
-              )}
-            </Field>
-            <Field label="Street">
-              {(id) => (
-                <Input
-                  id={id}
-                  disabled={!canEdit}
-                  value={draft.address.street}
-                  onChange={(e) => updateAddress({ street: e.target.value })}
-                />
-              )}
-            </Field>
+            {addressField('Venue name', 'venue')}
+            {addressField('Street', 'street')}
             <div className="grid grid-cols-[2fr_1fr_1fr] gap-3">
-              <Field label="City">
-                {(id) => (
-                  <Input
-                    id={id}
-                    disabled={!canEdit}
-                    value={draft.address.city}
-                    onChange={(e) => updateAddress({ city: e.target.value })}
-                  />
-                )}
-              </Field>
-              <Field label="Region">
-                {(id) => (
-                  <Input
-                    id={id}
-                    disabled={!canEdit}
-                    value={draft.address.region}
-                    onChange={(e) => updateAddress({ region: e.target.value })}
-                  />
-                )}
-              </Field>
-              <Field label="Postal">
-                {(id) => (
-                  <Input
-                    id={id}
-                    className="font-mono"
-                    disabled={!canEdit}
-                    value={draft.address.postal}
-                    onChange={(e) => updateAddress({ postal: e.target.value })}
-                  />
-                )}
-              </Field>
+              {addressField('City', 'city')}
+              {addressField('Region', 'region')}
+              {addressField('Postal', 'postal', 'font-mono')}
             </div>
-            <Field label="Country">
-              {(id) => (
-                <Input
-                  id={id}
-                  disabled={!canEdit}
-                  value={draft.address.country}
-                  onChange={(e) => updateAddress({ country: e.target.value })}
-                />
-              )}
-            </Field>
+            {addressField('Country', 'country')}
           </div>
         </Card>
       </div>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
@@ -7,6 +7,13 @@ const scoped = (container: Container) => ({
   getSectionTab(label: string) {
     return container.getByRole('tab', { name: label })
   },
+  /** The header overline above the event's name: "New event" / "Edit event" for
+   * the creator, plain "Event" for a viewer. Read by test-id rather than by text
+   * — "Event" is a substring of both editor labels *and* of the event names in
+   * the title beneath it, so a text query would match the wrong node. */
+  getOverline() {
+    return container.getByTestId('event-editor-overline')
+  },
   getSaveButton() {
     return container.getByRole('button', { name: /Create event|Save changes/ })
   },

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -40,4 +40,30 @@ describe('EventEditor', () => {
     expect(eventEditorPage.queryDeleteButton()).toBeNull()
     expect(eventEditorPage.getDismissButton()).toHaveTextContent('Done')
   })
+
+  // The overline names what the panel *is*. "Edit event" is addressed to the
+  // person in control (ADR 0015, rule 5) — a viewer is being shown an event, not
+  // invited to edit one. Both sides are asserted, so the editor's own labels
+  // cannot be deleted to satisfy the viewer's.
+  describe('the header overline', () => {
+    it('says "Edit event" to the creator of an existing event', () => {
+      eventEditorPage.render({ event: buildEvent({ id: 'ev-1' }) })
+      expect(eventEditorPage.getOverline()).toHaveTextContent('Edit event')
+    })
+
+    it('says "New event" to the creator of a new one', () => {
+      eventEditorPage.render({ event: buildEvent({ id: 'new-123' }) })
+      expect(eventEditorPage.getOverline()).toHaveTextContent('New event')
+    })
+
+    it('says just "Event" to a non-creator', () => {
+      eventEditorPage.render({
+        event: buildEvent({ id: 'ev-1' }),
+        canEdit: false,
+      })
+      // Exact: "Edit event" would satisfy a substring match on "event".
+      expect(eventEditorPage.getOverline()).toHaveTextContent(/^Event$/)
+      expect(eventEditorPage.getOverline()).not.toHaveTextContent(/Edit/)
+    })
+  })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -66,6 +66,11 @@ export const EventEditor = ({
 
   const isNew = !event || event.id.startsWith('new')
 
+  // "Edit event" is an imperative addressed to the person in control. A viewer
+  // is not one — the panel is a rendering of the event, so it says so
+  // (ADR 0015, rule 5).
+  const overline = !canEdit ? 'Event' : isNew ? 'New event' : 'Edit event'
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
@@ -73,8 +78,11 @@ export const EventEditor = ({
         className="w-full gap-0 p-0 sm:w-[820px] sm:max-w-[820px]"
       >
         <SheetHeader className="border-b border-[color:var(--border-subtle)]">
-          <SheetDescription className="text-[11px] font-semibold tracking-[0.14em] uppercase">
-            {isNew ? 'New event' : 'Edit event'}
+          <SheetDescription
+            data-testid="event-editor-overline"
+            className="text-[11px] font-semibold tracking-[0.14em] uppercase"
+          >
+            {overline}
           </SheetDescription>
           <SheetTitle className="truncate text-[20px]">
             {draft?.name || 'Untitled event'}
@@ -92,16 +100,33 @@ export const EventEditor = ({
                 ))}
               </TabsList>
               <TabsContent value="basics">
-                <BasicsSection event={draft} onChange={setDraft} />
+                <BasicsSection
+                  event={draft}
+                  canEdit={canEdit}
+                  onChange={setDraft}
+                />
               </TabsContent>
               <TabsContent value="eligibility">
-                <EligibilitySection event={draft} onChange={setDraft} />
+                <EligibilitySection
+                  event={draft}
+                  canEdit={canEdit}
+                  onChange={setDraft}
+                />
               </TabsContent>
               <TabsContent value="match">
-                <MatchSection event={draft} onChange={setDraft} />
+                <MatchSection
+                  event={draft}
+                  canEdit={canEdit}
+                  onChange={setDraft}
+                />
               </TabsContent>
               <TabsContent value="pools">
-                <PoolsSection event={draft} tables={tables} onChange={setDraft} />
+                <PoolsSection
+                  event={draft}
+                  tables={tables}
+                  canEdit={canEdit}
+                  onChange={setDraft}
+                />
               </TabsContent>
             </Tabs>
           </div>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.factory.tsx
@@ -1,9 +1,10 @@
 import { buildEvent } from '../../data/seed.factory'
 import type { BasicsSectionProps } from './basics-section'
 
-/** Props for `BasicsSection` — the seeded Open Singles event. */
+/** Props for `BasicsSection` — the seeded Open Singles event, editable (the
+ * creator's view). Pass `canEdit: false` for a viewer's read-only rendering. */
 export function buildBasicsSectionProps(
   overrides: Partial<BasicsSectionProps> = {},
 ): BasicsSectionProps {
-  return { event: buildEvent(), onChange: () => {}, ...overrides }
+  return { event: buildEvent(), canEdit: true, onChange: () => {}, ...overrides }
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
@@ -1,7 +1,22 @@
-import { render, screen, type Container } from '@/test/utilities'
+import { render, screen, within, type Container } from '@/test/utilities'
 
 import { BasicsSection, type BasicsSectionProps } from './basics-section'
 import { buildBasicsSectionProps } from './basics-section.factory'
+
+/** The roles a form control would take in the accessibility tree. A read-only
+ * surface must render none of them (ADR 0015). */
+const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
+
+/** The role sweep alone under-proves this section: a `type="number"` input is a
+ * `spinbutton` and a `type="date"`/`type="time"` input has no role at all, so a
+ * forgotten numeric or date field would slip through it. This catches the
+ * element itself, whatever role it claims.
+ *
+ * The full selector documented in `web-client/CLAUDE.md`, verbatim: a shortened
+ * one is a sweep with a hole in it — a `ToggleGroupItem` (`[role="radio"]`) or a
+ * hand-rolled focusable `[tabindex]` div would walk straight through. */
+const FORM_ELEMENTS =
+  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
 
 const scoped = (container: Container) => ({
   getNameInput() {
@@ -12,6 +27,38 @@ const scoped = (container: Container) => ({
   },
   getFormatTrigger() {
     return container.getByRole('combobox', { name: 'Format' })
+  },
+  /** The read-only value rendered in place of a field's control, found by the
+   * field's label so the assertion survives a re-ordering of the rows. */
+  getFieldValue(label: string) {
+    const row = container
+      .getByText(label, { exact: false, selector: 'label' })
+      .closest('div')!
+    return within(row).getByTestId('tournament-read-only-value')
+  },
+  /** A field's label row as text. The required asterisk is a `<span>` inside the
+   * `<label>` with no separating space ("Event name*"), so it shows up only in
+   * the label's `textContent` — never as a text node you could query for. */
+  getLabelText(label: string) {
+    return container.getByText(label, { exact: false, selector: 'label' })
+      .textContent
+  },
+  /** The "Hard cap…" helper text under Player limit — form furniture, and so
+   * absent from the read-only view (ADR 0015). */
+  queryPlayerLimitHint() {
+    return container.queryByText(/Hard cap\. Waitlist opens past this\./)
+  },
+  /** Every interactive control in the section. Empty is the point of the
+   * read-only view. */
+  getInteractiveControls() {
+    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+  },
+  /** Every form element in the section, by tag rather than by role — the
+   * escape hatch the role sweep misses. */
+  getFormElements() {
+    return container
+      .getByTestId('basics-section')
+      .querySelectorAll(FORM_ELEMENTS)
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
@@ -1,24 +1,15 @@
-import { render, screen, within, type Container } from '@/test/utilities'
+import { interactiveControlsIn, interactiveElementsIn } from '@/test/read-only'
+import { render, screen, type Container } from '@/test/utilities'
 
+import { fieldPage } from '../../field.page'
 import { BasicsSection, type BasicsSectionProps } from './basics-section'
 import { buildBasicsSectionProps } from './basics-section.factory'
 
-/** The roles a form control would take in the accessibility tree. A read-only
- * surface must render none of them (ADR 0015). */
-const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
-
-/** The role sweep alone under-proves this section: a `type="number"` input is a
- * `spinbutton` and a `type="date"`/`type="time"` input has no role at all, so a
- * forgotten numeric or date field would slip through it. This catches the
- * element itself, whatever role it claims.
- *
- * The full selector documented in `web-client/CLAUDE.md`, verbatim: a shortened
- * one is a sweep with a hole in it — a `ToggleGroupItem` (`[role="radio"]`) or a
- * hand-rolled focusable `[tabindex]` div would walk straight through. */
-const FORM_ELEMENTS =
-  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
-
 const scoped = (container: Container) => ({
+  /** Reuse the `Field` row queries (label text, the read-only value under a
+   * label) — this section is nothing but `Field` rows. */
+  ...fieldPage.within(container),
+
   getNameInput() {
     return container.getByLabelText(/Event name/)
   },
@@ -28,37 +19,20 @@ const scoped = (container: Container) => ({
   getFormatTrigger() {
     return container.getByRole('combobox', { name: 'Format' })
   },
-  /** The read-only value rendered in place of a field's control, found by the
-   * field's label so the assertion survives a re-ordering of the rows. */
-  getFieldValue(label: string) {
-    const row = container
-      .getByText(label, { exact: false, selector: 'label' })
-      .closest('div')!
-    return within(row).getByTestId('tournament-read-only-value')
-  },
-  /** A field's label row as text. The required asterisk is a `<span>` inside the
-   * `<label>` with no separating space ("Event name*"), so it shows up only in
-   * the label's `textContent` — never as a text node you could query for. */
-  getLabelText(label: string) {
-    return container.getByText(label, { exact: false, selector: 'label' })
-      .textContent
-  },
   /** The "Hard cap…" helper text under Player limit — form furniture, and so
    * absent from the read-only view (ADR 0015). */
   queryPlayerLimitHint() {
     return container.queryByText(/Hard cap\. Waitlist opens past this\./)
   },
-  /** Every interactive control in the section. Empty is the point of the
-   * read-only view. */
+  /** Every interactive control in the section, swept by role. Supplement only —
+   * `getFormElements()` is the guarantee. */
   getInteractiveControls() {
-    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+    return interactiveControlsIn(container)
   },
-  /** Every form element in the section, by tag rather than by role — the
-   * escape hatch the role sweep misses. */
+  /** Every interactive element in the section, swept by DOM (`@/test/read-only`).
+   * Empty is the point of the read-only view. */
   getFormElements() {
-    return container
-      .getByTestId('basics-section')
-      .querySelectorAll(FORM_ELEMENTS)
+    return interactiveElementsIn(container.getByTestId('basics-section'))
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
@@ -70,10 +70,27 @@ describe('BasicsSection', () => {
       )
       expect(basicsSectionPage.getFieldValue('Entry fee')).toHaveTextContent('45')
       expect(basicsSectionPage.getFieldValue('Date')).toHaveTextContent(
-        '2026-06-13',
+        'Jun 13, 2026',
       )
       expect(basicsSectionPage.getFieldValue('Start')).toHaveTextContent('09:00')
       expect(basicsSectionPage.getFieldValue('End')).toHaveTextContent('18:00')
+    })
+
+    // `YYYY-MM-DD` is what an `<input type="date">` wants, not what a person
+    // reads — a viewer gets the date in the same words the event card that
+    // opened this panel used. (The times have no such helper and stay raw
+    // everywhere, card included.)
+    it('reads the date in words, not as the wire format', () => {
+      basicsSectionPage.render({
+        event: buildEvent({
+          slot: { date: '2026-07-01', start: '09:00', end: '13:00' },
+        }),
+        canEdit: false,
+      })
+      expect(basicsSectionPage.getFieldValue('Date')).toHaveTextContent(
+        'Jul 1, 2026',
+      )
+      expect(screen.queryByText('2026-07-01')).toBeNull()
     })
 
     // A free event is a real value the organizer chose — it must not be

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from '@/test/utilities'
+import { fireEvent, screen } from '@/test/utilities'
 
 import { buildEvent } from '../../data/seed.factory'
 import { basicsSectionPage } from './basics-section.page'
@@ -21,5 +21,116 @@ describe('BasicsSection', () => {
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ maxPlayers: 48 }),
     )
+  })
+
+  // The furniture the *editor* keeps. Paired with the read-only case below, so
+  // "a viewer sees no asterisk" cannot be satisfied by deleting the asterisk.
+  it('marks the required fields and explains the player limit to the creator', () => {
+    basicsSectionPage.render({ event: buildEvent() })
+    expect(basicsSectionPage.getLabelText('Event name')).toContain('*')
+    expect(basicsSectionPage.getLabelText('Format')).toContain('*')
+    expect(basicsSectionPage.queryPlayerLimitHint()).toBeInTheDocument()
+  })
+
+  describe('for a non-owner (read-only)', () => {
+    // The guard test (ADR 0015): a viewer gets a rendering of the data, never a
+    // disabled editor. It fails loudly the moment someone adds an ungated
+    // control — which is the drift that produced the original bug.
+    it('renders no interactive controls', () => {
+      basicsSectionPage.render({ event: buildEvent(), canEdit: false })
+      expect(basicsSectionPage.getInteractiveControls()).toHaveLength(0)
+      expect(basicsSectionPage.getFormElements()).toHaveLength(0)
+    })
+
+    it('renders every field as a value', () => {
+      basicsSectionPage.render({
+        event: buildEvent({
+          name: 'Open Singles',
+          format: 'doubles',
+          drawType: 'rr-then-ko',
+          maxPlayers: 64,
+          entryFee: 45,
+          slot: { date: '2026-06-13', start: '09:00', end: '18:00' },
+        }),
+        canEdit: false,
+      })
+
+      expect(basicsSectionPage.getFieldValue('Event name')).toHaveTextContent(
+        'Open Singles',
+      )
+      // The option's label, not the raw enum key.
+      expect(basicsSectionPage.getFieldValue('Format')).toHaveTextContent(
+        'Doubles',
+      )
+      expect(basicsSectionPage.getFieldValue('Draw type')).toHaveTextContent(
+        'RR → KO',
+      )
+      expect(basicsSectionPage.getFieldValue('Player limit')).toHaveTextContent(
+        '64',
+      )
+      expect(basicsSectionPage.getFieldValue('Entry fee')).toHaveTextContent('45')
+      expect(basicsSectionPage.getFieldValue('Date')).toHaveTextContent(
+        '2026-06-13',
+      )
+      expect(basicsSectionPage.getFieldValue('Start')).toHaveTextContent('09:00')
+      expect(basicsSectionPage.getFieldValue('End')).toHaveTextContent('18:00')
+    })
+
+    // A free event is a real value the organizer chose — it must not be
+    // mistaken for an empty one.
+    it('renders a zero entry fee as zero, not as unset', () => {
+      basicsSectionPage.render({
+        event: buildEvent({ entryFee: 0 }),
+        canEdit: false,
+      })
+      expect(basicsSectionPage.getFieldValue('Entry fee')).toHaveTextContent('0')
+    })
+
+    // `Number('')` is `NaN`, so a cleared numeric field reaches the view as NaN.
+    // It is unset — an em-dash — never the literal string "NaN", and never 0.
+    it('renders a cleared player limit and entry fee as an em-dash', () => {
+      basicsSectionPage.render({
+        event: buildEvent({ maxPlayers: NaN, entryFee: NaN }),
+        canEdit: false,
+      })
+      expect(basicsSectionPage.getFieldValue('Player limit')).toHaveTextContent(
+        '—',
+      )
+      expect(basicsSectionPage.getFieldValue('Entry fee')).toHaveTextContent('—')
+      expect(screen.queryByText(/NaN/)).toBeNull()
+    })
+
+    // An unset window is absent, not zero-length.
+    it('renders an empty time slot as em-dashes', () => {
+      basicsSectionPage.render({
+        event: buildEvent({ slot: { date: '', start: '', end: '' } }),
+        canEdit: false,
+      })
+      expect(basicsSectionPage.getFieldValue('Date')).toHaveTextContent('—')
+      expect(basicsSectionPage.getFieldValue('Start')).toHaveTextContent('—')
+      expect(basicsSectionPage.getFieldValue('End')).toHaveTextContent('—')
+    })
+
+    // The editor's subtitle is an imperative addressed to an organizer; a
+    // viewer is not one (ADR 0015, rule 5).
+    it('addresses the reader, not the organizer', () => {
+      basicsSectionPage.render({ event: buildEvent(), canEdit: false })
+      expect(screen.getByText('Format, entry and schedule.')).toBeInTheDocument()
+      expect(screen.queryByText(/Name it, decide the format/)).toBeNull()
+    })
+
+    // The form's *furniture*, not just its controls (ADR 0015). A hint explains
+    // how to fill in a control and an asterisk marks one you must complete —
+    // both are nonsense on a field nobody can edit. `Field` drops them; the
+    // labels themselves stay, because the row still names its value.
+    it('renders no required asterisk and no hint', () => {
+      basicsSectionPage.render({ event: buildEvent(), canEdit: false })
+
+      expect(basicsSectionPage.getLabelText('Event name')).toBe('Event name')
+      expect(basicsSectionPage.getLabelText('Format')).toBe('Format')
+      expect(basicsSectionPage.queryPlayerLimitHint()).toBeNull()
+      // Nothing anywhere in the section wears one.
+      expect(screen.queryByText('*')).toBeNull()
+    })
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
@@ -3,86 +3,147 @@ import { Input } from '@/components/ui/input'
 import { DRAW_TYPE_OPTIONS, FORMAT_OPTIONS } from '../../data/options'
 import type { DrawType, EventFormat, TournamentEvent } from '../../data/types'
 import { Field } from '../../field'
+import { ReadOnlyValue } from '../../read-only-value'
 import { SectionHeader } from '../section-header'
 import { OptionSelect } from './option-select'
 
 export interface BasicsSectionProps {
   event: TournamentEvent
+  /** When false (a non-creator), the section renders values instead of
+   * controls — a viewer gets a rendering of the data, never a disabled form
+   * (ADR 0015). */
+  canEdit: boolean
   onChange: (next: TournamentEvent) => void
 }
 
+/** The numeric fields are edited through `Number(e.target.value)`, so clearing
+ * one leaves `NaN` on the draft. To a reader that is an *unset* field — an
+ * em-dash — not the literal string "NaN" (what `ReadOnlyValue` would print) and
+ * not `0` (a real, different answer: free to enter). */
+const numericValue = (n: number): number | null => (Number.isNaN(n) ? null : n)
+
+/** A viewer reads the option's label ("RR → KO"), never the enum key it is
+ * stored under ("rr-then-ko"). */
+const optionLabel = (
+  options: { value: string; label: string }[],
+  value: string,
+): string | null => options.find((o) => o.value === value)?.label ?? null
+
 /** The event editor's "Basics" tab: name, format, draw type, caps, and the
- * time-slot window. */
-export const BasicsSection = ({ event, onChange }: BasicsSectionProps) => {
+ * time-slot window. For a non-creator each control is replaced by its value —
+ * the `Field` label rows are identical either way, so the two renderings line
+ * up (ADR 0015).
+ *
+ * `readOnly={!canEdit}` on every `Field` is what drops the form's furniture (the
+ * required asterisks and the "Hard cap…" hint): the rows still declare `required`
+ * and `hint` unconditionally, and `Field` suppresses them for a viewer. */
+export const BasicsSection = ({
+  event,
+  canEdit,
+  onChange,
+}: BasicsSectionProps) => {
   const set = (patch: Partial<TournamentEvent>) => onChange({ ...event, ...patch })
   const setSlot = (patch: Partial<TournamentEvent['slot']>) =>
     set({ slot: { ...event.slot, ...patch } })
+  const readOnly = !canEdit
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex flex-col gap-5" data-testid="basics-section">
       <SectionHeader
         title="The basics"
-        subtitle="Name it, decide the format, set the window."
+        subtitle={
+          canEdit
+            ? 'Name it, decide the format, set the window.'
+            : 'Format, entry and schedule.'
+        }
       />
 
-      <Field label="Event name" required>
-        {(id) => (
-          <Input
-            id={id}
-            autoFocus
-            value={event.name}
-            placeholder="Open Singles"
-            onChange={(e) => set({ name: e.target.value })}
-          />
-        )}
+      <Field label="Event name" required readOnly={readOnly}>
+        {(id) =>
+          canEdit ? (
+            <Input
+              id={id}
+              autoFocus
+              value={event.name}
+              placeholder="Open Singles"
+              onChange={(e) => set({ name: e.target.value })}
+            />
+          ) : (
+            <ReadOnlyValue>{event.name}</ReadOnlyValue>
+          )
+        }
       </Field>
 
       <div className="grid grid-cols-2 gap-4">
-        <Field label="Format" required>
-          {() => (
-            <OptionSelect
-              ariaLabel="Format"
-              value={event.format}
-              options={FORMAT_OPTIONS}
-              onChange={(v) => set({ format: v as EventFormat })}
-            />
-          )}
+        <Field label="Format" required readOnly={readOnly}>
+          {() =>
+            canEdit ? (
+              <OptionSelect
+                ariaLabel="Format"
+                value={event.format}
+                options={FORMAT_OPTIONS}
+                onChange={(v) => set({ format: v as EventFormat })}
+              />
+            ) : (
+              <ReadOnlyValue>
+                {optionLabel(FORMAT_OPTIONS, event.format)}
+              </ReadOnlyValue>
+            )
+          }
         </Field>
-        <Field label="Draw type">
-          {() => (
-            <OptionSelect
-              ariaLabel="Draw type"
-              value={event.drawType}
-              options={DRAW_TYPE_OPTIONS}
-              onChange={(v) => set({ drawType: v as DrawType })}
-            />
-          )}
+        <Field label="Draw type" readOnly={readOnly}>
+          {() =>
+            canEdit ? (
+              <OptionSelect
+                ariaLabel="Draw type"
+                value={event.drawType}
+                options={DRAW_TYPE_OPTIONS}
+                onChange={(v) => set({ drawType: v as DrawType })}
+              />
+            ) : (
+              <ReadOnlyValue>
+                {optionLabel(DRAW_TYPE_OPTIONS, event.drawType)}
+              </ReadOnlyValue>
+            )
+          }
         </Field>
       </div>
 
       <div className="grid grid-cols-2 gap-4">
-        <Field label="Player limit" hint="Hard cap. Waitlist opens past this.">
-          {(id) => (
-            <Input
-              id={id}
-              type="number"
-              min={2}
-              max={512}
-              value={event.maxPlayers}
-              onChange={(e) => set({ maxPlayers: Number(e.target.value) })}
-            />
-          )}
+        <Field
+          label="Player limit"
+          hint="Hard cap. Waitlist opens past this."
+          readOnly={readOnly}
+        >
+          {(id) =>
+            canEdit ? (
+              <Input
+                id={id}
+                type="number"
+                min={2}
+                max={512}
+                value={event.maxPlayers}
+                onChange={(e) => set({ maxPlayers: Number(e.target.value) })}
+              />
+            ) : (
+              <ReadOnlyValue>{numericValue(event.maxPlayers)}</ReadOnlyValue>
+            )
+          }
         </Field>
-        <Field label="Entry fee">
-          {(id) => (
-            <Input
-              id={id}
-              type="number"
-              min={0}
-              value={event.entryFee}
-              onChange={(e) => set({ entryFee: Number(e.target.value) })}
-            />
-          )}
+        <Field label="Entry fee" readOnly={readOnly}>
+          {(id) =>
+            canEdit ? (
+              <Input
+                id={id}
+                type="number"
+                min={0}
+                value={event.entryFee}
+                onChange={(e) => set({ entryFee: Number(e.target.value) })}
+              />
+            ) : (
+              <ReadOnlyValue>{numericValue(event.entryFee)}</ReadOnlyValue>
+            )
+          }
         </Field>
       </div>
 
@@ -94,37 +155,53 @@ export const BasicsSection = ({ event, onChange }: BasicsSectionProps) => {
       </div>
 
       <div className="grid grid-cols-[1.4fr_1fr_1fr] gap-4">
-        <Field label="Date">
-          {(id) => (
-            <Input
-              id={id}
-              type="date"
-              value={event.slot.date}
-              onChange={(e) => setSlot({ date: e.target.value })}
-            />
-          )}
+        <Field label="Date" readOnly={readOnly}>
+          {(id) =>
+            canEdit ? (
+              <Input
+                id={id}
+                type="date"
+                value={event.slot.date}
+                onChange={(e) => setSlot({ date: e.target.value })}
+              />
+            ) : (
+              <ReadOnlyValue>{event.slot.date}</ReadOnlyValue>
+            )
+          }
         </Field>
-        <Field label="Start">
-          {(id) => (
-            <Input
-              id={id}
-              type="time"
-              className="font-mono"
-              value={event.slot.start}
-              onChange={(e) => setSlot({ start: e.target.value })}
-            />
-          )}
+        <Field label="Start" readOnly={readOnly}>
+          {(id) =>
+            canEdit ? (
+              <Input
+                id={id}
+                type="time"
+                className="font-mono"
+                value={event.slot.start}
+                onChange={(e) => setSlot({ start: e.target.value })}
+              />
+            ) : (
+              <ReadOnlyValue className="font-mono">
+                {event.slot.start}
+              </ReadOnlyValue>
+            )
+          }
         </Field>
-        <Field label="End">
-          {(id) => (
-            <Input
-              id={id}
-              type="time"
-              className="font-mono"
-              value={event.slot.end}
-              onChange={(e) => setSlot({ end: e.target.value })}
-            />
-          )}
+        <Field label="End" readOnly={readOnly}>
+          {(id) =>
+            canEdit ? (
+              <Input
+                id={id}
+                type="time"
+                className="font-mono"
+                value={event.slot.end}
+                onChange={(e) => setSlot({ end: e.target.value })}
+              />
+            ) : (
+              <ReadOnlyValue className="font-mono">
+                {event.slot.end}
+              </ReadOnlyValue>
+            )
+          }
         </Field>
       </div>
     </div>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
@@ -1,9 +1,9 @@
 import { Input } from '@/components/ui/input'
 
-import { DRAW_TYPE_OPTIONS, FORMAT_OPTIONS } from '../../data/options'
+import { fmtDate } from '../../data/helpers'
+import { DRAW_TYPE_OPTIONS, FORMAT_OPTIONS, labelFor } from '../../data/options'
 import type { DrawType, EventFormat, TournamentEvent } from '../../data/types'
 import { Field } from '../../field'
-import { ReadOnlyValue } from '../../read-only-value'
 import { SectionHeader } from '../section-header'
 import { OptionSelect } from './option-select'
 
@@ -22,21 +22,18 @@ export interface BasicsSectionProps {
  * not `0` (a real, different answer: free to enter). */
 const numericValue = (n: number): number | null => (Number.isNaN(n) ? null : n)
 
-/** A viewer reads the option's label ("RR → KO"), never the enum key it is
- * stored under ("rr-then-ko"). */
-const optionLabel = (
-  options: { value: string; label: string }[],
-  value: string,
-): string | null => options.find((o) => o.value === value)?.label ?? null
-
 /** The event editor's "Basics" tab: name, format, draw type, caps, and the
- * time-slot window. For a non-creator each control is replaced by its value —
- * the `Field` label rows are identical either way, so the two renderings line
- * up (ADR 0015).
+ * time-slot window. Each row declares its control *and* the value it holds;
+ * `readOnly` is what picks between them, so a viewer's rows line up with an
+ * editor's and neither can drift (ADR 0015).
  *
- * `readOnly={!canEdit}` on every `Field` is what drops the form's furniture (the
- * required asterisks and the "Hard cap…" hint): the rows still declare `required`
- * and `hint` unconditionally, and `Field` suppresses them for a viewer. */
+ * That single flag also drops the form's furniture (the required asterisks and
+ * the "Hard cap…" hint): the rows still declare `required` and `hint`
+ * unconditionally, and `Field` suppresses them for a viewer.
+ *
+ * The read-only `value` is what a *reader* needs, not what the control needs: an
+ * option's label rather than the enum key it is stored under, and a formatted
+ * date rather than the `YYYY-MM-DD` an `<input type="date">` wants. */
 export const BasicsSection = ({
   event,
   canEdit,
@@ -58,54 +55,47 @@ export const BasicsSection = ({
         }
       />
 
-      <Field label="Event name" required readOnly={readOnly}>
-        {(id) =>
-          canEdit ? (
-            <Input
-              id={id}
-              autoFocus
-              value={event.name}
-              placeholder="Open Singles"
-              onChange={(e) => set({ name: e.target.value })}
-            />
-          ) : (
-            <ReadOnlyValue>{event.name}</ReadOnlyValue>
-          )
-        }
+      <Field label="Event name" required readOnly={readOnly} value={event.name}>
+        {(id) => (
+          <Input
+            id={id}
+            autoFocus
+            value={event.name}
+            placeholder="Open Singles"
+            onChange={(e) => set({ name: e.target.value })}
+          />
+        )}
       </Field>
 
       <div className="grid grid-cols-2 gap-4">
-        <Field label="Format" required readOnly={readOnly}>
-          {() =>
-            canEdit ? (
-              <OptionSelect
-                ariaLabel="Format"
-                value={event.format}
-                options={FORMAT_OPTIONS}
-                onChange={(v) => set({ format: v as EventFormat })}
-              />
-            ) : (
-              <ReadOnlyValue>
-                {optionLabel(FORMAT_OPTIONS, event.format)}
-              </ReadOnlyValue>
-            )
-          }
+        <Field
+          label="Format"
+          required
+          readOnly={readOnly}
+          value={labelFor(FORMAT_OPTIONS, event.format, null)}
+        >
+          {() => (
+            <OptionSelect
+              ariaLabel="Format"
+              value={event.format}
+              options={FORMAT_OPTIONS}
+              onChange={(v) => set({ format: v as EventFormat })}
+            />
+          )}
         </Field>
-        <Field label="Draw type" readOnly={readOnly}>
-          {() =>
-            canEdit ? (
-              <OptionSelect
-                ariaLabel="Draw type"
-                value={event.drawType}
-                options={DRAW_TYPE_OPTIONS}
-                onChange={(v) => set({ drawType: v as DrawType })}
-              />
-            ) : (
-              <ReadOnlyValue>
-                {optionLabel(DRAW_TYPE_OPTIONS, event.drawType)}
-              </ReadOnlyValue>
-            )
-          }
+        <Field
+          label="Draw type"
+          readOnly={readOnly}
+          value={labelFor(DRAW_TYPE_OPTIONS, event.drawType, null)}
+        >
+          {() => (
+            <OptionSelect
+              ariaLabel="Draw type"
+              value={event.drawType}
+              options={DRAW_TYPE_OPTIONS}
+              onChange={(v) => set({ drawType: v as DrawType })}
+            />
+          )}
         </Field>
       </div>
 
@@ -114,36 +104,33 @@ export const BasicsSection = ({
           label="Player limit"
           hint="Hard cap. Waitlist opens past this."
           readOnly={readOnly}
+          value={numericValue(event.maxPlayers)}
         >
-          {(id) =>
-            canEdit ? (
-              <Input
-                id={id}
-                type="number"
-                min={2}
-                max={512}
-                value={event.maxPlayers}
-                onChange={(e) => set({ maxPlayers: Number(e.target.value) })}
-              />
-            ) : (
-              <ReadOnlyValue>{numericValue(event.maxPlayers)}</ReadOnlyValue>
-            )
-          }
+          {(id) => (
+            <Input
+              id={id}
+              type="number"
+              min={2}
+              max={512}
+              value={event.maxPlayers}
+              onChange={(e) => set({ maxPlayers: Number(e.target.value) })}
+            />
+          )}
         </Field>
-        <Field label="Entry fee" readOnly={readOnly}>
-          {(id) =>
-            canEdit ? (
-              <Input
-                id={id}
-                type="number"
-                min={0}
-                value={event.entryFee}
-                onChange={(e) => set({ entryFee: Number(e.target.value) })}
-              />
-            ) : (
-              <ReadOnlyValue>{numericValue(event.entryFee)}</ReadOnlyValue>
-            )
-          }
+        <Field
+          label="Entry fee"
+          readOnly={readOnly}
+          value={numericValue(event.entryFee)}
+        >
+          {(id) => (
+            <Input
+              id={id}
+              type="number"
+              min={0}
+              value={event.entryFee}
+              onChange={(e) => set({ entryFee: Number(e.target.value) })}
+            />
+          )}
         </Field>
       </div>
 
@@ -155,53 +142,54 @@ export const BasicsSection = ({
       </div>
 
       <div className="grid grid-cols-[1.4fr_1fr_1fr] gap-4">
-        <Field label="Date" readOnly={readOnly}>
-          {(id) =>
-            canEdit ? (
-              <Input
-                id={id}
-                type="date"
-                value={event.slot.date}
-                onChange={(e) => setSlot({ date: e.target.value })}
-              />
-            ) : (
-              <ReadOnlyValue>{event.slot.date}</ReadOnlyValue>
-            )
-          }
+        {/* The editor's value is the raw `YYYY-MM-DD` an `<input type="date">`
+            takes; a reader gets the same date in the words the event card uses
+            ("Jun 13, 2026"), never the wire format. */}
+        <Field
+          label="Date"
+          readOnly={readOnly}
+          value={fmtDate(event.slot.date)}
+        >
+          {(id) => (
+            <Input
+              id={id}
+              type="date"
+              value={event.slot.date}
+              onChange={(e) => setSlot({ date: e.target.value })}
+            />
+          )}
         </Field>
-        <Field label="Start" readOnly={readOnly}>
-          {(id) =>
-            canEdit ? (
-              <Input
-                id={id}
-                type="time"
-                className="font-mono"
-                value={event.slot.start}
-                onChange={(e) => setSlot({ start: e.target.value })}
-              />
-            ) : (
-              <ReadOnlyValue className="font-mono">
-                {event.slot.start}
-              </ReadOnlyValue>
-            )
-          }
+        <Field
+          label="Start"
+          readOnly={readOnly}
+          value={event.slot.start}
+          valueClassName="font-mono"
+        >
+          {(id) => (
+            <Input
+              id={id}
+              type="time"
+              className="font-mono"
+              value={event.slot.start}
+              onChange={(e) => setSlot({ start: e.target.value })}
+            />
+          )}
         </Field>
-        <Field label="End" readOnly={readOnly}>
-          {(id) =>
-            canEdit ? (
-              <Input
-                id={id}
-                type="time"
-                className="font-mono"
-                value={event.slot.end}
-                onChange={(e) => setSlot({ end: e.target.value })}
-              />
-            ) : (
-              <ReadOnlyValue className="font-mono">
-                {event.slot.end}
-              </ReadOnlyValue>
-            )
-          }
+        <Field
+          label="End"
+          readOnly={readOnly}
+          value={event.slot.end}
+          valueClassName="font-mono"
+        >
+          {(id) => (
+            <Input
+              id={id}
+              type="time"
+              className="font-mono"
+              value={event.slot.end}
+              onChange={(e) => setSlot({ end: e.target.value })}
+            />
+          )}
         </Field>
       </div>
     </div>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.factory.tsx
@@ -1,12 +1,14 @@
 import { buildEvent } from '../../data/seed.factory'
 import type { EligibilitySectionProps } from './eligibility-section'
 
-/** Props for `EligibilitySection` — an open event (no rules) by default. */
+/** Props for `EligibilitySection` — an open event (no rules), editable (the
+ * creator's view). Pass `canEdit: false` for a viewer's read-only rendering. */
 export function buildEligibilitySectionProps(
   overrides: Partial<EligibilitySectionProps> = {},
 ): EligibilitySectionProps {
   return {
     event: buildEvent({ predicates: [] }),
+    canEdit: true,
     onChange: () => {},
     ...overrides,
   }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.page.tsx
@@ -1,3 +1,4 @@
+import { interactiveControlsIn, interactiveElementsIn } from '@/test/read-only'
 import { render, screen, type Container } from '@/test/utilities'
 
 import {
@@ -6,17 +7,6 @@ import {
 } from './eligibility-section'
 import { buildEligibilitySectionProps } from './eligibility-section.factory'
 import { predicateRowPage } from './eligibility-section/predicate-row.page'
-
-/** The roles a form control would take in the accessibility tree. A read-only
- * surface must render none of them (ADR 0015). */
-const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
-
-/** The role sweep alone under-proves this section: a rule row's value control is
- * a `type="number"` input, which is a `spinbutton` rather than a `textbox`, so a
- * live rule builder would sail straight through it. This catches the element
- * itself, whatever role it claims (ADR 0015, rule 6). */
-const FORM_ELEMENTS =
-  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
 
 const scoped = (container: Container) => ({
   /** Reuse the predicate-row queries (scoped to the section). Spread first: the
@@ -43,17 +33,15 @@ const scoped = (container: Container) => ({
   getFootnote() {
     return container.getByTestId('eligibility-footnote')
   },
-  /** Every interactive control in the section. Empty is the point of the
-   * read-only view. */
+  /** Every interactive control in the section, swept by role. Supplement only —
+   * `getFormElements()` is the guarantee. */
   getInteractiveControls() {
-    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+    return interactiveControlsIn(container)
   },
-  /** Every form element in the section, by tag/widget role rather than by the
-   * four canonical roles — the escape hatch the role sweep misses. */
+  /** Every interactive element in the section, swept by DOM (`@/test/read-only`).
+   * Empty is the point of the read-only view. */
   getFormElements() {
-    return container
-      .getByTestId('eligibility-section')
-      .querySelectorAll(FORM_ELEMENTS)
+    return interactiveElementsIn(container.getByTestId('eligibility-section'))
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.page.tsx
@@ -7,15 +7,54 @@ import {
 import { buildEligibilitySectionProps } from './eligibility-section.factory'
 import { predicateRowPage } from './eligibility-section/predicate-row.page'
 
+/** The roles a form control would take in the accessibility tree. A read-only
+ * surface must render none of them (ADR 0015). */
+const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
+
+/** The role sweep alone under-proves this section: a rule row's value control is
+ * a `type="number"` input, which is a `spinbutton` rather than a `textbox`, so a
+ * live rule builder would sail straight through it. This catches the element
+ * itself, whatever role it claims (ADR 0015, rule 6). */
+const FORM_ELEMENTS =
+  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
+
 const scoped = (container: Container) => ({
+  /** Reuse the predicate-row queries (scoped to the section). Spread first: the
+   * section's own sweeps below are scoped to the *section* root, and must win
+   * over the row-scoped ones of the same name. */
+  ...predicateRowPage.within(container),
+
   getAddRuleButton() {
     return container.getByRole('button', { name: /Add (a )?rule/ })
+  },
+  /** Absent for a viewer: a mutating affordance is hidden, never disabled. */
+  queryAddRuleButton() {
+    return container.queryByRole('button', { name: /Add (a )?rule/ })
   },
   queryRows() {
     return container.queryAllByTestId('predicate-row')
   },
-  /** Reuse the predicate-row queries (scoped to the section). */
-  ...predicateRowPage.within(container),
+  /** The Field / Operator / Value column headers — form furniture that means
+   * nothing without the controls beneath it. */
+  queryColumnHeaders() {
+    return container.queryByTestId('predicate-column-headers')
+  },
+  /** The "All N rules must match" footnote. */
+  getFootnote() {
+    return container.getByTestId('eligibility-footnote')
+  },
+  /** Every interactive control in the section. Empty is the point of the
+   * read-only view. */
+  getInteractiveControls() {
+    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+  },
+  /** Every form element in the section, by tag/widget role rather than by the
+   * four canonical roles — the escape hatch the role sweep misses. */
+  getFormElements() {
+    return container
+      .getByTestId('eligibility-section')
+      .querySelectorAll(FORM_ELEMENTS)
+  },
 })
 
 /** Test page-object for `EligibilitySection`. */

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.test.tsx
@@ -1,8 +1,20 @@
 import userEvent from '@testing-library/user-event'
 
-import { buildEvent } from '../../data/seed.factory'
-import { buildPredicate } from '../../data/seed.factory'
+import { screen } from '@/test/utilities'
+
+import { buildEvent, buildPredicate } from '../../data/seed.factory'
 import { eligibilitySectionPage } from './eligibility-section.page'
+
+/** A rating rule and a between-rule — the two shapes a viewer reads. */
+const twoRules = () => [
+  buildPredicate({ id: 'pr-1', field: 'rating', op: '<', value: 1500 }),
+  buildPredicate({
+    id: 'pr-2',
+    field: 'rating',
+    op: 'between',
+    value: [1200, 1500],
+  }),
+]
 
 describe('EligibilitySection', () => {
   it('shows the open-to-all empty state with no rules', () => {
@@ -20,5 +32,114 @@ describe('EligibilitySection', () => {
 
     await userEvent.click(eligibilitySectionPage.getAddRuleButton())
     expect(onChange.mock.calls.at(-1)?.[0].predicates).toHaveLength(2)
+  })
+
+  // The viewer's subtitle is a strict *prefix* of the organizer's, so neither
+  // side can be proved with a substring match — it would match both. Each side
+  // is pinned on what discriminates it: the reader's on the exact sentence, the
+  // organizer's on the config-speak clause only they can act on.
+  describe('the subtitle', () => {
+    const SHARED = 'Players must satisfy every rule to enter.'
+
+    it('tells the organizer what an empty rule set does', () => {
+      eligibilitySectionPage.render({ event: buildEvent() })
+      expect(screen.getByText(/Empty = open to all\./)).toBeInTheDocument()
+      // The organizer's subtitle is the shared sentence *plus* that clause, so
+      // the exact shared sentence must not be the whole of any node.
+      expect(screen.queryByText(SHARED, { exact: true })).toBeNull()
+    })
+
+    it('drops the config-speak for a non-owner', () => {
+      eligibilitySectionPage.render({ event: buildEvent(), canEdit: false })
+      expect(screen.getByText(SHARED, { exact: true })).toBeInTheDocument()
+      expect(screen.queryByText(/Empty = open to all/)).toBeNull()
+    })
+  })
+
+  describe('for a non-owner (read-only)', () => {
+    // The guard test (ADR 0015, rule 6). Rendered *with* rules on purpose: an
+    // empty event has nothing but the Add button, so a sweep over the default
+    // would never touch the rule builder's selects and number inputs — the
+    // controls most likely to be left live.
+    it('renders no interactive controls', () => {
+      eligibilitySectionPage.render({
+        event: buildEvent({ predicates: twoRules() }),
+        canEdit: false,
+      })
+      // The DOM sweep first: it is the load-bearing one, so it is the one whose
+      // red is worth seeing.
+      expect(eligibilitySectionPage.getFormElements()).toHaveLength(0)
+      expect(eligibilitySectionPage.getInteractiveControls()).toHaveLength(0)
+    })
+
+    it('reads each rule as a sentence', () => {
+      eligibilitySectionPage.render({
+        event: buildEvent({ predicates: twoRules() }),
+        canEdit: false,
+      })
+
+      const [first, second] = eligibilitySectionPage.queryRows()
+      expect(first).toHaveTextContent('USATT rating is less than 1500')
+      expect(second).toHaveTextContent('USATT rating is between 1200 and 1500')
+    })
+
+    // Column headers label controls. With no controls they label nothing.
+    it('drops the Field / Operator / Value column headers', () => {
+      eligibilitySectionPage.render({
+        event: buildEvent({ predicates: twoRules() }),
+        canEdit: false,
+      })
+      expect(eligibilitySectionPage.queryColumnHeaders()).toBeNull()
+    })
+
+    // Hidden, never disabled: a disabled button is an unexplained dead end.
+    it('hides the Add rule and Remove rule buttons', () => {
+      eligibilitySectionPage.render({
+        event: buildEvent({ predicates: twoRules() }),
+        canEdit: false,
+      })
+      expect(eligibilitySectionPage.queryAddRuleButton()).toBeNull()
+      expect(
+        screen.queryByRole('button', { name: 'Remove rule' }),
+      ).toBeNull()
+    })
+
+    // "Combine with AND" is config-speak — it explains how the builder assembles
+    // the rules, which is not something a reader is doing.
+    it('states the rule count without the AND config-speak', () => {
+      eligibilitySectionPage.render({
+        event: buildEvent({ predicates: twoRules() }),
+        canEdit: false,
+      })
+      expect(eligibilitySectionPage.getFootnote()).toHaveTextContent(
+        'All 2 rules must match.',
+      )
+      expect(eligibilitySectionPage.getFootnote()).not.toHaveTextContent(
+        /Combine with/,
+      )
+      expect(screen.queryByText('AND')).toBeNull()
+    })
+
+    it('keeps the singular for a lone rule', () => {
+      eligibilitySectionPage.render({
+        event: buildEvent({ predicates: [buildPredicate()] }),
+        canEdit: false,
+      })
+      expect(eligibilitySectionPage.getFootnote()).toHaveTextContent(
+        'All 1 rule must match.',
+      )
+    })
+
+    // The empty state already reads correctly for a viewer — it just must not
+    // offer them a rule to add.
+    it('shows the open-to-all empty state with no Add button', () => {
+      eligibilitySectionPage.render({
+        event: buildEvent({ predicates: [] }),
+        canEdit: false,
+      })
+      expect(screen.getByText('Open to all players')).toBeInTheDocument()
+      expect(eligibilitySectionPage.queryAddRuleButton()).toBeNull()
+      expect(eligibilitySectionPage.getFormElements()).toHaveLength(0)
+    })
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section.tsx
@@ -10,13 +10,19 @@ import { PredicateRow } from './eligibility-section/predicate-row'
 
 export interface EligibilitySectionProps {
   event: TournamentEvent
+  /** When false (a non-creator), the rule *builder* becomes a rule *list*: each
+   * rule reads as a sentence and every mutating affordance is hidden — a viewer
+   * gets a rendering of the data, never a disabled form (ADR 0015). */
+  canEdit: boolean
   onChange: (next: TournamentEvent) => void
 }
 
-/** The event editor's "Eligibility" tab — a free-form, ANDed rule builder.
- * No rules means the event is open to everyone. */
+/** The event editor's "Eligibility" tab — a free-form, ANDed rule builder for
+ * the creator; for everyone else, the same rules read back as prose. No rules
+ * means the event is open to everyone, which reads the same either way. */
 export const EligibilitySection = ({
   event,
+  canEdit,
   onChange,
 }: EligibilitySectionProps) => {
   const preds = event.predicates
@@ -29,15 +35,24 @@ export const EligibilitySection = ({
     ])
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex flex-col gap-5" data-testid="eligibility-section">
       <SectionHeader
         title="Eligibility rules"
-        subtitle="Players must satisfy every rule to enter. Empty = open to all."
+        // "Empty = open to all" tells the organizer what leaving the builder
+        // empty will do — config-speak for someone who cannot empty it. What is
+        // true for a reader either way is the first sentence.
+        subtitle={
+          canEdit
+            ? 'Players must satisfy every rule to enter. Empty = open to all.'
+            : 'Players must satisfy every rule to enter.'
+        }
         action={
-          <Button variant="outline" size="sm" onClick={addRule}>
-            <Plus size={14} />
-            Add rule
-          </Button>
+          canEdit && (
+            <Button variant="outline" size="sm" onClick={addRule}>
+              <Plus size={14} />
+              Add rule
+            </Button>
+          )
         }
       />
 
@@ -47,37 +62,61 @@ export const EligibilitySection = ({
           title="Open to all players"
           hint="No restrictions. Anyone in the system can register for this event."
           action={
-            <Button variant="outline" onClick={addRule}>
-              <Plus size={16} />
-              Add a rule
-            </Button>
+            canEdit && (
+              <Button variant="outline" onClick={addRule}>
+                <Plus size={16} />
+                Add a rule
+              </Button>
+            )
           }
         />
       ) : (
         <div className="flex flex-col gap-3">
-          <div className="grid grid-cols-[160px_180px_1fr_auto] gap-2 pb-1 text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">
-            <div>Field</div>
-            <div>Operator</div>
-            <div>Value</div>
-            <div />
-          </div>
+          {/* Column headers are form furniture: they label the controls beneath
+              them, and a viewer has none. */}
+          {canEdit && (
+            <div
+              data-testid="predicate-column-headers"
+              className="grid grid-cols-[160px_180px_1fr_auto] gap-2 pb-1 text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase"
+            >
+              <div>Field</div>
+              <div>Operator</div>
+              <div>Value</div>
+              <div />
+            </div>
+          )}
           {preds.map((p, i) => (
             <PredicateRow
               key={p.id}
               predicate={p}
+              canEdit={canEdit}
               onChange={(np) =>
                 setPreds(preds.map((x, j) => (j === i ? np : x)))
               }
               onRemove={() => setPreds(preds.filter((_, j) => j !== i))}
             />
           ))}
-          <div className="mt-1 flex items-center gap-2.5 rounded-[6px] border border-[color:rgba(255,122,26,0.2)] bg-[color:var(--bg-accent-soft)] px-3.5 py-2.5">
+          <div
+            data-testid="eligibility-footnote"
+            className="mt-1 flex items-center gap-2.5 rounded-[6px] border border-[color:rgba(255,122,26,0.2)] bg-[color:var(--bg-accent-soft)] px-3.5 py-2.5"
+          >
             <Filter size={14} className="text-[color:var(--ball-500)]" />
             <span className="text-[13px] text-[color:var(--fg-2)]">
               All{' '}
               <strong className="text-[color:var(--fg-1)]">{preds.length}</strong>{' '}
-              {preds.length === 1 ? 'rule' : 'rules'} must match. Combine with{' '}
-              <code className="font-mono text-[color:var(--ball-500)]">AND</code>.
+              {preds.length === 1 ? 'rule' : 'rules'} must match.
+              {/* How the builder combines them is the organizer's concern; a
+                  reader only needs to know that all of them apply. */}
+              {canEdit && (
+                <>
+                  {' '}
+                  Combine with{' '}
+                  <code className="font-mono text-[color:var(--ball-500)]">
+                    AND
+                  </code>
+                  .
+                </>
+              )}
             </span>
           </div>
         </div>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.factory.tsx
@@ -1,12 +1,14 @@
 import { buildPredicate } from '../../../data/seed.factory'
 import type { PredicateRowProps } from './predicate-row'
 
-/** Props for `PredicateRow` — a `rating < 1500` numeric rule. */
+/** Props for `PredicateRow` — a `rating < 1500` numeric rule, editable (the
+ * creator's view). Pass `canEdit: false` for a viewer's read-only sentence. */
 export function buildPredicateRowProps(
   overrides: Partial<PredicateRowProps> = {},
 ): PredicateRowProps {
   return {
     predicate: buildPredicate(),
+    canEdit: true,
     onChange: () => {},
     onRemove: () => {},
     ...overrides,

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.page.tsx
@@ -1,18 +1,8 @@
+import { interactiveControlsIn, interactiveElementsIn } from '@/test/read-only'
 import { render, screen, type Container } from '@/test/utilities'
 
 import { PredicateRow, type PredicateRowProps } from './predicate-row'
 import { buildPredicateRowProps } from './predicate-row.factory'
-
-/** The roles a form control would take in the accessibility tree. A read-only
- * row must render none of them (ADR 0015). */
-const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
-
-/** The role sweep alone under-proves this row: its value control is a
- * `type="number"` input (a `spinbutton`, not a `textbox`) and its field/operator
- * pickers are `OptionSelect`s. This catches the element itself, whatever role it
- * claims — the DOM sweep ADR 0015 rule 6 calls for. */
-const FORM_ELEMENTS =
-  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
 
 const scoped = (container: Container) => ({
   getRow() {
@@ -33,15 +23,15 @@ const scoped = (container: Container) => ({
   getFieldTrigger() {
     return container.getByRole('combobox', { name: 'Field' })
   },
-  /** Every interactive control in the row. Empty is the point of the read-only
-   * view. */
+  /** Every interactive control in the row, swept by role. Supplement only —
+   * `getFormElements()` is the guarantee. */
   getInteractiveControls() {
-    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+    return interactiveControlsIn(container)
   },
-  /** Every form element in the row, by tag/widget role rather than by the four
-   * canonical roles — the escape hatch the role sweep misses. */
+  /** Every interactive element in the row, swept by DOM (`@/test/read-only`).
+   * Empty is the point of the read-only view. */
   getFormElements() {
-    return container.getByTestId('predicate-row').querySelectorAll(FORM_ELEMENTS)
+    return interactiveElementsIn(container.getByTestId('predicate-row'))
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.page.tsx
@@ -3,6 +3,17 @@ import { render, screen, type Container } from '@/test/utilities'
 import { PredicateRow, type PredicateRowProps } from './predicate-row'
 import { buildPredicateRowProps } from './predicate-row.factory'
 
+/** The roles a form control would take in the accessibility tree. A read-only
+ * row must render none of them (ADR 0015). */
+const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
+
+/** The role sweep alone under-proves this row: its value control is a
+ * `type="number"` input (a `spinbutton`, not a `textbox`) and its field/operator
+ * pickers are `OptionSelect`s. This catches the element itself, whatever role it
+ * claims — the DOM sweep ADR 0015 rule 6 calls for. */
+const FORM_ELEMENTS =
+  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
+
 const scoped = (container: Container) => ({
   getRow() {
     return container.getByTestId('predicate-row')
@@ -16,8 +27,21 @@ const scoped = (container: Container) => ({
   getRemoveButton() {
     return container.getByRole('button', { name: 'Remove rule' })
   },
+  queryRemoveButton() {
+    return container.queryByRole('button', { name: 'Remove rule' })
+  },
   getFieldTrigger() {
     return container.getByRole('combobox', { name: 'Field' })
+  },
+  /** Every interactive control in the row. Empty is the point of the read-only
+   * view. */
+  getInteractiveControls() {
+    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+  },
+  /** Every form element in the row, by tag/widget role rather than by the four
+   * canonical roles — the escape hatch the role sweep misses. */
+  getFormElements() {
+    return container.getByTestId('predicate-row').querySelectorAll(FORM_ELEMENTS)
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.test.tsx
@@ -34,4 +34,93 @@ describe('PredicateRow', () => {
     await userEvent.click(predicateRowPage.getRemoveButton())
     expect(onRemove).toHaveBeenCalledTimes(1)
   })
+
+  describe('for a non-owner (read-only)', () => {
+    // The guard test (ADR 0015, rule 6): a viewer gets a rendering of the data,
+    // never a disabled editor. The DOM sweep, not a role sweep — the value
+    // control here is a `type="number"` input, i.e. a `spinbutton`, which the
+    // four canonical roles miss entirely.
+    it('renders no interactive controls', () => {
+      predicateRowPage.render({
+        predicate: buildPredicate({ field: 'rating', op: '<', value: 1500 }),
+        canEdit: false,
+      })
+      // The DOM sweep first: it is the load-bearing one, so it is the one whose
+      // red is worth seeing.
+      expect(predicateRowPage.getFormElements()).toHaveLength(0)
+      expect(predicateRowPage.getInteractiveControls()).toHaveLength(0)
+      expect(predicateRowPage.queryRemoveButton()).toBeNull()
+    })
+
+    // Rule 4: the row is `[field] [operator] [value]` — already a sentence
+    // chopped into a grid — so read-only it renders as the sentence, composed
+    // from the very labels the editor's three controls show.
+    it('reads a numeric rule as a sentence', () => {
+      predicateRowPage.render({
+        predicate: buildPredicate({ field: 'rating', op: '<', value: 1500 }),
+        canEdit: false,
+      })
+      expect(predicateRowPage.getRow()).toHaveTextContent(
+        'USATT rating is less than 1500',
+      )
+    })
+
+    // The two-element value array — the likeliest to render wrong.
+    it('reads a between rule as one sentence with both bounds', () => {
+      predicateRowPage.render({
+        predicate: buildPredicate({
+          field: 'rating',
+          op: 'between',
+          value: [1200, 1500],
+        }),
+        canEdit: false,
+      })
+      expect(predicateRowPage.getRow()).toHaveTextContent(
+        'USATT rating is between 1200 and 1500',
+      )
+    })
+
+    it('reads an enum rule with the option label, not the stored key', () => {
+      predicateRowPage.render({
+        predicate: buildPredicate({ field: 'gender', op: 'is', value: 'F' }),
+        canEdit: false,
+      })
+      expect(predicateRowPage.getRow()).toHaveTextContent('Gender is Female')
+      expect(predicateRowPage.getRow()).not.toHaveTextContent('F is')
+    })
+
+    // The bool row already renders prose ("a club member") in the editor; the
+    // field is the operator's own object, so the sentence is the operator plus
+    // that prose — never "Club member must be a club member".
+    it('reads a boolean rule as prose', () => {
+      predicateRowPage.render({
+        predicate: buildPredicate({ field: 'club', op: 'true', value: true }),
+        canEdit: false,
+      })
+      expect(predicateRowPage.getRow()).toHaveTextContent(
+        'Must be a club member',
+      )
+    })
+
+    it('reads a negated boolean rule as prose', () => {
+      predicateRowPage.render({
+        predicate: buildPredicate({ field: 'club', op: 'false', value: false }),
+        canEdit: false,
+      })
+      expect(predicateRowPage.getRow()).toHaveTextContent(
+        'Must not be a club member',
+      )
+    })
+
+    // An organizer can leave a rule's value empty; unset is an em-dash, not the
+    // string "null" (the same contract `ReadOnlyValue` keeps).
+    it('reads an unset value as an em-dash', () => {
+      predicateRowPage.render({
+        predicate: buildPredicate({ field: 'age', op: '>=', value: null }),
+        canEdit: false,
+      })
+      expect(predicateRowPage.getRow()).toHaveTextContent('Age is at least —')
+      expect(predicateRowPage.getRow()).not.toHaveTextContent('null')
+    })
+  })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.tsx
@@ -2,11 +2,8 @@ import { Trash2 } from 'lucide-react'
 
 import { Input } from '@/components/ui/input'
 
-import {
-  PRED_FIELDS,
-  PRED_OPS_BY_TYPE,
-  type PredicateFieldSchema,
-} from '../../../data/options'
+import { BOOL_PREDICATE_VALUE, predicateSentence } from '../../../data/helpers'
+import { PRED_FIELDS, PRED_OPS_BY_TYPE } from '../../../data/options'
 import type { Predicate, PredicateValue } from '../../../data/types'
 import { OptionSelect } from '../option-select'
 
@@ -14,7 +11,10 @@ export interface PredicateRowProps {
   predicate: Predicate
   /** When false (a non-creator), the row renders as one readable sentence
    * instead of three controls — a viewer gets a rendering of the data, never a
-   * disabled form (ADR 0015). */
+   * disabled form (ADR 0015). The sentence itself is `predicateSentence` in
+   * `data/helpers.ts`, beside the chip formatter it shares its vocabulary with:
+   * a new predicate field or operator is a one-file change there, not a hunt
+   * through this component. */
   canEdit: boolean
   onChange: (predicate: Predicate) => void
   onRemove: () => void
@@ -25,61 +25,10 @@ const FIELD_OPTIONS = Object.entries(PRED_FIELDS).map(([value, schema]) => ({
   label: schema.label,
 }))
 
-/** The bool field's value, as prose. It reads as the tail of its operator
- * ("must be" + "a club member"), which is why the editor's value cell shows it
- * verbatim rather than a control. */
-const BOOL_VALUE = 'a club member'
-
-/** An unset value — the organizer left this bound empty (cf. `ReadOnlyValue`). */
-const EM_DASH = '—'
-
 function numberOrNull(raw: string): number | null {
   if (raw === '') return null
   const n = Number(raw)
   return Number.isNaN(n) ? null : n
-}
-
-const num = (n: number | null | undefined): string =>
-  n === null || n === undefined ? EM_DASH : String(n)
-
-const opLabel = (schema: PredicateFieldSchema, op: string): string =>
-  PRED_OPS_BY_TYPE[schema.type].find((o) => o.value === op)?.label ?? op
-
-/** The value half of the sentence, in the same words the editor's value control
- * shows: an enum reads as its option label ("Female"), never the stored key. */
-function valueText(schema: PredicateFieldSchema, p: Predicate): string {
-  if (schema.type === 'enum') {
-    const options = schema.options ?? []
-    return (
-      options.find((o) => o.value === p.value)?.label ??
-      (p.value == null ? EM_DASH : String(p.value))
-    )
-  }
-  if (p.op === 'between') {
-    const [lo, hi] = Array.isArray(p.value) ? p.value : [null, null]
-    return `${num(lo)} and ${num(hi)}`
-  }
-  return num(typeof p.value === 'number' ? p.value : null)
-}
-
-/** The rule as one sentence: `[field] [operator] [value]` was always a sentence
- * chopped into a grid, so read-only it is simply put back together — "USATT
- * rating is between 1200 and 1500" (ADR 0015, rule 4). Every word comes from the
- * labels the editor's own three controls display, so there is no second
- * vocabulary to keep in step.
- *
- * The bool field is the exception: it is the *object* of its operator, so the
- * literal three-cell join would read "Club member must be a club member". It
- * keeps the operator and the prose value only — "Must be a club member". */
-function predicateSentence(p: Predicate): string {
-  const schema = PRED_FIELDS[p.field]
-  if (!schema) return EM_DASH
-
-  const op = opLabel(schema, p.op)
-  if (schema.type === 'bool') {
-    return `${op.charAt(0).toUpperCase()}${op.slice(1)} ${BOOL_VALUE}`
-  }
-  return `${schema.label} ${op} ${valueText(schema, p)}`
 }
 
 /** One ANDed eligibility rule. For the creator: a field picker, an operator
@@ -193,7 +142,7 @@ export const PredicateRow = ({
         )}
         {schema?.type === 'bool' && (
           <div className="py-2.5 text-[13px] text-[color:var(--fg-3)]">
-            {BOOL_VALUE}
+            {BOOL_PREDICATE_VALUE}
           </div>
         )}
       </div>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/eligibility-section/predicate-row.tsx
@@ -5,12 +5,17 @@ import { Input } from '@/components/ui/input'
 import {
   PRED_FIELDS,
   PRED_OPS_BY_TYPE,
+  type PredicateFieldSchema,
 } from '../../../data/options'
 import type { Predicate, PredicateValue } from '../../../data/types'
 import { OptionSelect } from '../option-select'
 
 export interface PredicateRowProps {
   predicate: Predicate
+  /** When false (a non-creator), the row renders as one readable sentence
+   * instead of three controls — a viewer gets a rendering of the data, never a
+   * disabled form (ADR 0015). */
+  canEdit: boolean
   onChange: (predicate: Predicate) => void
   onRemove: () => void
 }
@@ -20,17 +25,70 @@ const FIELD_OPTIONS = Object.entries(PRED_FIELDS).map(([value, schema]) => ({
   label: schema.label,
 }))
 
+/** The bool field's value, as prose. It reads as the tail of its operator
+ * ("must be" + "a club member"), which is why the editor's value cell shows it
+ * verbatim rather than a control. */
+const BOOL_VALUE = 'a club member'
+
+/** An unset value — the organizer left this bound empty (cf. `ReadOnlyValue`). */
+const EM_DASH = '—'
+
 function numberOrNull(raw: string): number | null {
   if (raw === '') return null
   const n = Number(raw)
   return Number.isNaN(n) ? null : n
 }
 
-/** One ANDed eligibility rule: a field picker, an operator picker, a
- * type-appropriate value control, and a remove button. Switching the field
- * resets the operator and value to that field-type's defaults. */
+const num = (n: number | null | undefined): string =>
+  n === null || n === undefined ? EM_DASH : String(n)
+
+const opLabel = (schema: PredicateFieldSchema, op: string): string =>
+  PRED_OPS_BY_TYPE[schema.type].find((o) => o.value === op)?.label ?? op
+
+/** The value half of the sentence, in the same words the editor's value control
+ * shows: an enum reads as its option label ("Female"), never the stored key. */
+function valueText(schema: PredicateFieldSchema, p: Predicate): string {
+  if (schema.type === 'enum') {
+    const options = schema.options ?? []
+    return (
+      options.find((o) => o.value === p.value)?.label ??
+      (p.value == null ? EM_DASH : String(p.value))
+    )
+  }
+  if (p.op === 'between') {
+    const [lo, hi] = Array.isArray(p.value) ? p.value : [null, null]
+    return `${num(lo)} and ${num(hi)}`
+  }
+  return num(typeof p.value === 'number' ? p.value : null)
+}
+
+/** The rule as one sentence: `[field] [operator] [value]` was always a sentence
+ * chopped into a grid, so read-only it is simply put back together — "USATT
+ * rating is between 1200 and 1500" (ADR 0015, rule 4). Every word comes from the
+ * labels the editor's own three controls display, so there is no second
+ * vocabulary to keep in step.
+ *
+ * The bool field is the exception: it is the *object* of its operator, so the
+ * literal three-cell join would read "Club member must be a club member". It
+ * keeps the operator and the prose value only — "Must be a club member". */
+function predicateSentence(p: Predicate): string {
+  const schema = PRED_FIELDS[p.field]
+  if (!schema) return EM_DASH
+
+  const op = opLabel(schema, p.op)
+  if (schema.type === 'bool') {
+    return `${op.charAt(0).toUpperCase()}${op.slice(1)} ${BOOL_VALUE}`
+  }
+  return `${schema.label} ${op} ${valueText(schema, p)}`
+}
+
+/** One ANDed eligibility rule. For the creator: a field picker, an operator
+ * picker, a type-appropriate value control, and a remove button — switching the
+ * field resets the operator and value to that field-type's defaults. For a
+ * viewer: the same rule, read back as a sentence. */
 export const PredicateRow = ({
   predicate,
+  canEdit,
   onChange,
   onRemove,
 }: PredicateRowProps) => {
@@ -56,6 +114,17 @@ export const PredicateRow = ({
   const between = Array.isArray(predicate.value)
     ? predicate.value
     : [null, null]
+
+  if (!canEdit) {
+    return (
+      <p
+        data-testid="predicate-row"
+        className="rounded-[6px] border border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)] px-3.5 py-2.5 text-[13px] text-[color:var(--fg-1)]"
+      >
+        {predicateSentence(predicate)}
+      </p>
+    )
+  }
 
   return (
     <div
@@ -124,7 +193,7 @@ export const PredicateRow = ({
         )}
         {schema?.type === 'bool' && (
           <div className="py-2.5 text-[13px] text-[color:var(--fg-3)]">
-            a club member
+            {BOOL_VALUE}
           </div>
         )}
       </div>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.factory.tsx
@@ -1,12 +1,14 @@
 import { buildEvent } from '../../data/seed.factory'
 import type { MatchSectionProps } from './match-section'
 
-/** Props for `MatchSection` — a rated Bo5 event. */
+/** Props for `MatchSection` — a rated Bo5 event, editable (the creator's
+ * view). Pass `canEdit: false` for a viewer's read-only rendering. */
 export function buildMatchSectionProps(
   overrides: Partial<MatchSectionProps> = {},
 ): MatchSectionProps {
   return {
     event: buildEvent({ match: { rated: true, lengthGames: 5 } }),
+    canEdit: true,
     onChange: () => {},
     ...overrides,
   }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.page.tsx
@@ -1,19 +1,9 @@
+import { interactiveControlsIn, interactiveElementsIn } from '@/test/read-only'
 import { render, screen, within, type Container } from '@/test/utilities'
 
+import { READ_ONLY_VALUE_TESTID } from '../../read-only-value.page'
 import { MatchSection, type MatchSectionProps } from './match-section'
 import { buildMatchSectionProps } from './match-section.factory'
-
-/** The roles a form control would take in the accessibility tree. A read-only
- * surface must render none of them (ADR 0015). */
-const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
-
-/** The role sweep alone under-proves this section: the length picker's toggle
- * items are `radio`s, which the four canonical roles don't cover. This catches
- * the element itself, whatever role it claims — the full selector documented in
- * `web-client/CLAUDE.md`, verbatim, so a focusable `[tabindex]` div cannot walk
- * through a sweep that was trimmed to only the controls this section has today. */
-const FORM_ELEMENTS =
-  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
 
 const scoped = (container: Container) => ({
   getRatedSwitch() {
@@ -30,26 +20,24 @@ const scoped = (container: Container) => ({
   /** The rated state as a viewer sees it — prose, not a dead toggle. */
   getRatedValue() {
     return within(container.getByTestId('match-rated-card')).getByTestId(
-      'tournament-read-only-value',
+      READ_ONLY_VALUE_TESTID,
     )
   },
   /** The best-of length as a viewer sees it. */
   getLengthValue() {
     return within(container.getByTestId('match-length-card')).getByTestId(
-      'tournament-read-only-value',
+      READ_ONLY_VALUE_TESTID,
     )
   },
-  /** Every interactive control in the section. Empty is the point of the
-   * read-only view. */
+  /** Every interactive control in the section, swept by role. Supplement only —
+   * `getFormElements()` is the guarantee. */
   getInteractiveControls() {
-    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+    return interactiveControlsIn(container)
   },
-  /** Every form element in the section, by tag/widget role rather than by the
-   * four canonical roles — the escape hatch the role sweep misses. */
+  /** Every interactive element in the section, swept by DOM (`@/test/read-only`).
+   * Empty is the point of the read-only view. */
   getFormElements() {
-    return container
-      .getByTestId('match-section')
-      .querySelectorAll(FORM_ELEMENTS)
+    return interactiveElementsIn(container.getByTestId('match-section'))
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.page.tsx
@@ -1,7 +1,19 @@
-import { render, screen, type Container } from '@/test/utilities'
+import { render, screen, within, type Container } from '@/test/utilities'
 
 import { MatchSection, type MatchSectionProps } from './match-section'
 import { buildMatchSectionProps } from './match-section.factory'
+
+/** The roles a form control would take in the accessibility tree. A read-only
+ * surface must render none of them (ADR 0015). */
+const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
+
+/** The role sweep alone under-proves this section: the length picker's toggle
+ * items are `radio`s, which the four canonical roles don't cover. This catches
+ * the element itself, whatever role it claims — the full selector documented in
+ * `web-client/CLAUDE.md`, verbatim, so a focusable `[tabindex]` div cannot walk
+ * through a sweep that was trimmed to only the controls this section has today. */
+const FORM_ELEMENTS =
+  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
 
 const scoped = (container: Container) => ({
   getRatedSwitch() {
@@ -9,6 +21,35 @@ const scoped = (container: Container) => ({
   },
   getLengthOption(label: string) {
     return container.getByRole('radio', { name: label })
+  },
+  /** The rated card's description. Rendered in both modes, but its copy differs:
+   * the organizer is told how to change it, the viewer only what it means. */
+  getRatedDescription() {
+    return container.getByTestId('match-rated-description')
+  },
+  /** The rated state as a viewer sees it — prose, not a dead toggle. */
+  getRatedValue() {
+    return within(container.getByTestId('match-rated-card')).getByTestId(
+      'tournament-read-only-value',
+    )
+  },
+  /** The best-of length as a viewer sees it. */
+  getLengthValue() {
+    return within(container.getByTestId('match-length-card')).getByTestId(
+      'tournament-read-only-value',
+    )
+  },
+  /** Every interactive control in the section. Empty is the point of the
+   * read-only view. */
+  getInteractiveControls() {
+    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+  },
+  /** Every form element in the section, by tag/widget role rather than by the
+   * four canonical roles — the escape hatch the role sweep misses. */
+  getFormElements() {
+    return container
+      .getByTestId('match-section')
+      .querySelectorAll(FORM_ELEMENTS)
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.test.tsx
@@ -34,4 +34,59 @@ describe('MatchSection', () => {
       expect.objectContaining({ match: { rated: true, lengthGames: 7 } }),
     )
   })
+
+  // The organizer has the toggle, so the copy telling them when to reach for it
+  // still earns its place. Asserted so that neutering it for the viewer can't be
+  // achieved by deleting the sentence outright (ADR 0015, rule 5).
+  it('tells the owner when to turn rating off', () => {
+    matchSectionPage.render({ canEdit: true })
+    expect(matchSectionPage.getRatedDescription()).toHaveTextContent(
+      'Results count toward player ratings. Turn off for casual events.',
+    )
+  })
+
+  describe('for a non-owner (read-only)', () => {
+    // The guard test (ADR 0015). The `radio` sweep in `getFormElements` is what
+    // catches the length picker — the four canonical roles do not cover it.
+    it('renders no interactive controls', () => {
+      matchSectionPage.render({ event: buildEvent(), canEdit: false })
+      expect(matchSectionPage.getInteractiveControls()).toHaveLength(0)
+      expect(matchSectionPage.getFormElements()).toHaveLength(0)
+    })
+
+    // A dead toggle says nothing; prose says whether the event is rated.
+    it('renders the rated state as prose', () => {
+      matchSectionPage.render({
+        event: buildEvent({ match: { rated: true, lengthGames: 5 } }),
+        canEdit: false,
+      })
+      expect(matchSectionPage.getRatedValue()).toHaveTextContent('Rated')
+    })
+
+    it('renders an unrated event as prose', () => {
+      matchSectionPage.render({
+        event: buildEvent({ match: { rated: false, lengthGames: 3 } }),
+        canEdit: false,
+      })
+      expect(matchSectionPage.getRatedValue()).toHaveTextContent('Not rated')
+    })
+
+    // "Turn off for casual events" instructs a reader who has no toggle to turn
+    // off — the organizer's voice leaking into the viewer's screen. The
+    // descriptive half stays: it still tells them what "Rated" means here.
+    it('drops the imperative from the rated description, keeping the description', () => {
+      matchSectionPage.render({ canEdit: false })
+      const description = matchSectionPage.getRatedDescription()
+      expect(description).toHaveTextContent('Results count toward player ratings.')
+      expect(description).not.toHaveTextContent('Turn off for casual events')
+    })
+
+    it('renders the match length as its label', () => {
+      matchSectionPage.render({
+        event: buildEvent({ match: { rated: true, lengthGames: 7 } }),
+        canEdit: false,
+      })
+      expect(matchSectionPage.getLengthValue()).toHaveTextContent('Bo7')
+    })
+  })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.tsx
@@ -3,7 +3,7 @@ import { Switch } from '@/components/ui/switch'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { cn } from '@/lib/utils'
 
-import { MATCH_LENGTH_OPTIONS } from '../../data/options'
+import { labelFor, MATCH_LENGTH_OPTIONS } from '../../data/options'
 import type { MatchLength, TournamentEvent } from '../../data/types'
 import { ReadOnlyValue } from '../../read-only-value'
 import { SectionHeader } from '../section-header'
@@ -35,8 +35,9 @@ export const MatchSection = ({
   const setMatch = (patch: Partial<TournamentEvent['match']>) =>
     onChange({ ...event, match: { ...m, ...patch } })
 
-  const lengthLabel =
-    MATCH_LENGTH_OPTIONS.find((o) => o.value === m.lengthGames)?.label ?? null
+  // The option's label ("Bo5"), never the raw count — and `null` for an unknown
+  // length, so `ReadOnlyValue` reads it as unset rather than blank.
+  const lengthLabel = labelFor(MATCH_LENGTH_OPTIONS, m.lengthGames, null)
 
   return (
     <div className="flex flex-col gap-5" data-testid="match-section">

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/match-section.tsx
@@ -5,46 +5,76 @@ import { cn } from '@/lib/utils'
 
 import { MATCH_LENGTH_OPTIONS } from '../../data/options'
 import type { MatchLength, TournamentEvent } from '../../data/types'
+import { ReadOnlyValue } from '../../read-only-value'
 import { SectionHeader } from '../section-header'
 
 export interface MatchSectionProps {
   event: TournamentEvent
+  /** When false (a non-creator), the section renders values instead of
+   * controls — a viewer gets a rendering of the data, never a disabled form
+   * (ADR 0015). */
+  canEdit: boolean
   onChange: (next: TournamentEvent) => void
 }
 
 /** The event editor's "Match settings" tab — a rated toggle and a best-of
- * length picker, with a per-length "first to N" breakdown. */
-export const MatchSection = ({ event, onChange }: MatchSectionProps) => {
+ * length picker, with a per-length "first to N" breakdown. For a non-creator
+ * the toggle and the picker are replaced by their values: a boolean reads as
+ * prose ("Not rated"), never as a dead switch (ADR 0015).
+ *
+ * The rated card's description drops its organizer-facing imperative ("Turn off
+ * for casual events") for a viewer, who has no toggle to turn off, and keeps
+ * only the descriptive half — copy addresses the reader, not the organizer
+ * (ADR 0015, rule 5). */
+export const MatchSection = ({
+  event,
+  canEdit,
+  onChange,
+}: MatchSectionProps) => {
   const m = event.match
   const setMatch = (patch: Partial<TournamentEvent['match']>) =>
     onChange({ ...event, match: { ...m, ...patch } })
 
+  const lengthLabel =
+    MATCH_LENGTH_OPTIONS.find((o) => o.value === m.lengthGames)?.label ?? null
+
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex flex-col gap-5" data-testid="match-section">
       <SectionHeader
         title="Match settings"
         subtitle="How each individual match is played in this event."
       />
 
-      <Card className="px-4">
+      <Card className="px-4" data-testid="match-rated-card">
         <div className="flex items-center justify-between gap-4">
           <div>
             <div className="text-[15px] font-semibold text-[color:var(--fg-1)]">
               Rated
             </div>
-            <div className="mt-0.5 text-[13px] text-[color:var(--fg-3)]">
-              Results count toward player ratings. Turn off for casual events.
+            <div
+              className="mt-0.5 text-[13px] text-[color:var(--fg-3)]"
+              data-testid="match-rated-description"
+            >
+              {canEdit
+                ? 'Results count toward player ratings. Turn off for casual events.'
+                : 'Results count toward player ratings.'}
             </div>
           </div>
-          <Switch
-            aria-label="Rated"
-            checked={m.rated}
-            onCheckedChange={(rated) => setMatch({ rated })}
-          />
+          {canEdit ? (
+            <Switch
+              aria-label="Rated"
+              checked={m.rated}
+              onCheckedChange={(rated) => setMatch({ rated })}
+            />
+          ) : (
+            <ReadOnlyValue className="shrink-0">
+              {m.rated ? 'Rated' : 'Not rated'}
+            </ReadOnlyValue>
+          )}
         </div>
       </Card>
 
-      <Card className="px-4">
+      <Card className="px-4" data-testid="match-length-card">
         <div>
           <div className="text-[15px] font-semibold text-[color:var(--fg-1)]">
             Match length
@@ -58,20 +88,24 @@ export const MatchSection = ({ event, onChange }: MatchSectionProps) => {
           </div>
         </div>
 
-        <ToggleGroup
-          type="single"
-          value={String(m.lengthGames)}
-          onValueChange={(v) => {
-            if (v) setMatch({ lengthGames: Number(v) as MatchLength })
-          }}
-          className="w-fit"
-        >
-          {MATCH_LENGTH_OPTIONS.map((o) => (
-            <ToggleGroupItem key={o.value} value={String(o.value)}>
-              {o.label}
-            </ToggleGroupItem>
-          ))}
-        </ToggleGroup>
+        {canEdit ? (
+          <ToggleGroup
+            type="single"
+            value={String(m.lengthGames)}
+            onValueChange={(v) => {
+              if (v) setMatch({ lengthGames: Number(v) as MatchLength })
+            }}
+            className="w-fit"
+          >
+            {MATCH_LENGTH_OPTIONS.map((o) => (
+              <ToggleGroupItem key={o.value} value={String(o.value)}>
+                {o.label}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+        ) : (
+          <ReadOnlyValue className="font-mono">{lengthLabel}</ReadOnlyValue>
+        )}
 
         <div className="grid grid-cols-4 gap-2">
           {MATCH_LENGTH_OPTIONS.map((o) => {

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.factory.tsx
@@ -1,13 +1,15 @@
 import { buildEvent, buildTables } from '../../data/seed.factory'
 import type { PoolsSectionProps } from './pools-section'
 
-/** Props for `PoolsSection` — the seeded one-pool event with 12 tables. */
+/** Props for `PoolsSection` — the seeded one-pool event with 12 tables, editable
+ * (the creator's view). Pass `canEdit: false` for a viewer's read-only list. */
 export function buildPoolsSectionProps(
   overrides: Partial<PoolsSectionProps> = {},
 ): PoolsSectionProps {
   return {
     event: buildEvent(),
     tables: buildTables(12),
+    canEdit: true,
     onChange: () => {},
     ...overrides,
   }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
@@ -1,18 +1,9 @@
+import { interactiveControlsIn, interactiveElementsIn } from '@/test/read-only'
 import { render, screen, type Container } from '@/test/utilities'
 
 import { PoolsSection, type PoolsSectionProps } from './pools-section'
 import { buildPoolsSectionProps } from './pools-section.factory'
 import { poolCardPage } from './pools-section/pool-card.page'
-
-/** The roles a form control would take in the accessibility tree. A read-only
- * section must render none of them (ADR 0015). */
-const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
-
-/** The role sweep alone under-proves this section: each pool card's window is
- * three `type="date"` / `type="time"` inputs, which have **no ARIA role at all**.
- * This catches the element itself, whatever role it claims (ADR 0015, rule 6). */
-const FORM_ELEMENTS =
-  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
 
 const scoped = (container: Container) => ({
   /** Reuse the pool-card queries (scoped to the section). Spread first: the
@@ -34,17 +25,15 @@ const scoped = (container: Container) => ({
   queryConflictAlert() {
     return container.queryByRole('alert')
   },
-  /** Every interactive control in the section. Empty is the point of the
-   * read-only view. */
+  /** Every interactive control in the section, swept by role. Supplement only —
+   * `getFormElements()` is the guarantee. */
   getInteractiveControls() {
-    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+    return interactiveControlsIn(container)
   },
-  /** Every form element in the section, by tag/widget role rather than by the
-   * four canonical roles — the escape hatch the role sweep misses. */
+  /** Every interactive element in the section, swept by DOM (`@/test/read-only`).
+   * Empty is the point of the read-only view. */
   getFormElements() {
-    return container
-      .getByTestId('pools-section')
-      .querySelectorAll(FORM_ELEMENTS)
+    return interactiveElementsIn(container.getByTestId('pools-section'))
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
@@ -4,9 +4,29 @@ import { PoolsSection, type PoolsSectionProps } from './pools-section'
 import { buildPoolsSectionProps } from './pools-section.factory'
 import { poolCardPage } from './pools-section/pool-card.page'
 
+/** The roles a form control would take in the accessibility tree. A read-only
+ * section must render none of them (ADR 0015). */
+const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
+
+/** The role sweep alone under-proves this section: each pool card's window is
+ * three `type="date"` / `type="time"` inputs, which have **no ARIA role at all**.
+ * This catches the element itself, whatever role it claims (ADR 0015, rule 6). */
+const FORM_ELEMENTS =
+  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
+
 const scoped = (container: Container) => ({
+  /** Reuse the pool-card queries (scoped to the section). Spread first: the
+   * section's own sweeps below are scoped to the *section* root, and must win
+   * over the card-scoped ones of the same name — a card-scoped sweep throws once
+   * there is more than one pool. */
+  ...poolCardPage.within(container),
+
   getAddPoolButton() {
     return container.getByRole('button', { name: /Add (first )?pool/ })
+  },
+  /** Absent for a viewer: a mutating affordance is hidden, never disabled. */
+  queryAddPoolButton() {
+    return container.queryByRole('button', { name: /Add (first )?pool/ })
   },
   queryPoolCards() {
     return container.queryAllByTestId('pool-card')
@@ -14,7 +34,18 @@ const scoped = (container: Container) => ({
   queryConflictAlert() {
     return container.queryByRole('alert')
   },
-  ...poolCardPage.within(container),
+  /** Every interactive control in the section. Empty is the point of the
+   * read-only view. */
+  getInteractiveControls() {
+    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+  },
+  /** Every form element in the section, by tag/widget role rather than by the
+   * four canonical roles — the escape hatch the role sweep misses. */
+  getFormElements() {
+    return container
+      .getByTestId('pools-section')
+      .querySelectorAll(FORM_ELEMENTS)
+  },
 })
 
 /** Test page-object for `PoolsSection`. */

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
@@ -111,7 +111,8 @@ describe('PoolsSection', () => {
 
       const [first, second] = poolsSectionPage.queryPoolCards()
       expect(first).toHaveTextContent('Pool A')
-      expect(first).toHaveTextContent('2026-06-13')
+      // In words, not the `YYYY-MM-DD` the editor's date input takes.
+      expect(first).toHaveTextContent('Jun 13, 2026')
       expect(first).toHaveTextContent('09:00')
       expect(first).toHaveTextContent('12:30')
       expect(first).toHaveTextContent('T1, T2')

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
@@ -1,7 +1,42 @@
 import userEvent from '@testing-library/user-event'
 
+import { screen } from '@/test/utilities'
+
 import { buildEvent, buildPool } from '../../data/seed.factory'
 import { poolsSectionPage } from './pools-section.page'
+
+/** A morning pool and an afternoon pool — what a viewer actually reads. */
+const twoPools = () => [
+  buildPool({
+    id: 'p-1',
+    name: 'Pool A',
+    slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
+    tableIds: ['t1', 't2'],
+  }),
+  buildPool({
+    id: 'p-2',
+    name: 'Pool B',
+    slot: { date: '2026-06-13', start: '13:00', end: '17:00' },
+    tableIds: ['t3'],
+  }),
+]
+
+/** Two *overlapping* pools sharing table t1 — a double-booking, the state that
+ * raises the conflict Alert. */
+const conflictingPools = () => [
+  buildPool({
+    id: 'a',
+    name: 'Pool A',
+    slot: { date: '2026-06-13', start: '09:00', end: '12:00' },
+    tableIds: ['t1'],
+  }),
+  buildPool({
+    id: 'b',
+    name: 'Pool B',
+    slot: { date: '2026-06-13', start: '11:00', end: '14:00' },
+    tableIds: ['t1'],
+  }),
+]
 
 describe('PoolsSection', () => {
   it('appends a pool when Add pool is clicked', async () => {
@@ -30,22 +65,7 @@ describe('PoolsSection', () => {
 
   it('warns when two overlapping pools share a table', () => {
     poolsSectionPage.render({
-      event: buildEvent({
-        pools: [
-          buildPool({
-            id: 'a',
-            name: 'Pool A',
-            slot: { date: '2026-06-13', start: '09:00', end: '12:00' },
-            tableIds: ['t1'],
-          }),
-          buildPool({
-            id: 'b',
-            name: 'Pool B',
-            slot: { date: '2026-06-13', start: '11:00', end: '14:00' },
-            tableIds: ['t1'],
-          }),
-        ],
-      }),
+      event: buildEvent({ pools: conflictingPools() }),
     })
     expect(poolsSectionPage.queryConflictAlert()).toHaveTextContent('double-booked')
   })
@@ -54,5 +74,92 @@ describe('PoolsSection', () => {
     poolsSectionPage.render({ event: buildEvent({ pools: [] }) })
     expect(poolsSectionPage.queryPoolCards()).toHaveLength(0)
     expect(document.body).toHaveTextContent('No pools yet')
+  })
+
+  describe('for a non-owner (read-only)', () => {
+    // The guard test (ADR 0015, rule 6). Rendered *with* pools on purpose: an
+    // event with none has nothing but the Add button, so a sweep over the empty
+    // state would never touch a pool card's date/time inputs or its wall of
+    // table toggles — precisely the controls most likely to be left live.
+    it('renders no interactive controls', () => {
+      poolsSectionPage.render({
+        event: buildEvent({ pools: twoPools() }),
+        canEdit: false,
+      })
+      // The DOM sweep first: it is the load-bearing one, so it is the one whose
+      // red is worth seeing.
+      expect(poolsSectionPage.getFormElements()).toHaveLength(0)
+      expect(poolsSectionPage.getInteractiveControls()).toHaveLength(0)
+    })
+
+    // The per-table toggles are gone, not disabled — a viewer reads the tables
+    // a pool reserves, they do not un-reserve one.
+    it('renders no per-table toggles', () => {
+      poolsSectionPage.render({
+        event: buildEvent({ pools: twoPools() }),
+        canEdit: false,
+      })
+      expect(screen.queryByRole('button', { name: 'T1' })).toBeNull()
+      expect(screen.queryByRole('button', { name: 'T12' })).toBeNull()
+    })
+
+    it('reads each pool as its name, its window and its tables', () => {
+      poolsSectionPage.render({
+        event: buildEvent({ pools: twoPools() }),
+        canEdit: false,
+      })
+
+      const [first, second] = poolsSectionPage.queryPoolCards()
+      expect(first).toHaveTextContent('Pool A')
+      expect(first).toHaveTextContent('2026-06-13')
+      expect(first).toHaveTextContent('09:00')
+      expect(first).toHaveTextContent('12:30')
+      expect(first).toHaveTextContent('T1, T2')
+      expect(second).toHaveTextContent('Pool B')
+      expect(second).toHaveTextContent('T3')
+    })
+
+    // A double-booking is a flaw in the organizer's configuration and only they
+    // can fix it. Shown to a reader it is an unactionable warning about someone
+    // else's tournament. The owner's Alert is proved above ("warns when two
+    // overlapping pools share a table") off the same fixture, so this cannot be
+    // satisfied by deleting the Alert outright.
+    it('hides the double-booking warning', () => {
+      poolsSectionPage.render({
+        event: buildEvent({ pools: conflictingPools() }),
+        canEdit: false,
+      })
+      expect(poolsSectionPage.queryConflictAlert()).toBeNull()
+      expect(document.body).not.toHaveTextContent('double-booked')
+      // The pools themselves still read back — it is the diagnostic that goes,
+      // not the data.
+      expect(poolsSectionPage.queryPoolCards()).toHaveLength(2)
+    })
+
+    // Hidden, never disabled: a disabled button is an unexplained dead end.
+    it('hides the Add pool and Remove pool buttons', () => {
+      poolsSectionPage.render({
+        event: buildEvent({ pools: twoPools() }),
+        canEdit: false,
+      })
+      expect(poolsSectionPage.queryAddPoolButton()).toBeNull()
+      expect(screen.queryByRole('button', { name: 'Remove pool' })).toBeNull()
+    })
+
+    // "No pools yet" / "Add a pool to…" is the organizer's to-do list. A viewer
+    // is being told a fact about the event, and is offered nothing to add.
+    it('states that no tables are reserved, with no Add button', () => {
+      poolsSectionPage.render({
+        event: buildEvent({ pools: [] }),
+        canEdit: false,
+      })
+      expect(screen.getByText('No table pools')).toBeInTheDocument()
+      expect(
+        screen.getByText('No tables are reserved for this event.'),
+      ).toBeInTheDocument()
+      expect(document.body).not.toHaveTextContent('No pools yet')
+      expect(poolsSectionPage.queryAddPoolButton()).toBeNull()
+      expect(poolsSectionPage.getFormElements()).toHaveLength(0)
+    })
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
@@ -13,13 +13,22 @@ export interface PoolsSectionProps {
   event: TournamentEvent
   /** The tables available to this tournament. */
   tables: TournamentTable[]
+  /** When false (a non-creator), the pool *editor* becomes a pool *list*: each
+   * pool reads back as its name, its window and its reserved tables, and every
+   * mutating affordance is hidden (ADR 0015). */
+  canEdit: boolean
   onChange: (next: TournamentEvent) => void
 }
 
 /** The event editor's "Table pools" tab: each pool reserves a slice of tables
  * for a window, with a warning when tables are double-booked across overlapping
  * pools. */
-export const PoolsSection = ({ event, tables, onChange }: PoolsSectionProps) => {
+export const PoolsSection = ({
+  event,
+  tables,
+  canEdit,
+  onChange,
+}: PoolsSectionProps) => {
   const pools = event.pools
   const setPools = (next: Pool[]) => onChange({ ...event, pools: next })
   const conflicts = findPoolConflicts(pools)
@@ -39,19 +48,26 @@ export const PoolsSection = ({ event, tables, onChange }: PoolsSectionProps) => 
     ])
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4" data-testid="pools-section">
       <SectionHeader
         title="Table pools"
         subtitle="Each pool reserves a slice of tables for a window of time."
         action={
-          <Button size="sm" onClick={addPool}>
-            <Plus size={14} />
-            Add pool
-          </Button>
+          canEdit && (
+            <Button size="sm" onClick={addPool}>
+              <Plus size={14} />
+              Add pool
+            </Button>
+          )
         }
       />
 
-      {conflicts.length > 0 && (
+      {/* A double-booking is a flaw in the *configuration*, and only the
+          organizer can fix it. To a reader it is an unactionable warning about
+          someone else's tournament — noise, not information — so they are not
+          shown it. (It is non-interactive, so this is a copy/UX call, not a
+          control leak: the guard sweep passes either way.) */}
+      {canEdit && conflicts.length > 0 && (
         <Alert className="border-[color:var(--warn)]/40 bg-[color:var(--warn)]/10">
           <TriangleAlert className="text-[color:var(--warn)]" />
           <AlertTitle className="text-[color:var(--warn)]">
@@ -68,14 +84,23 @@ export const PoolsSection = ({ event, tables, onChange }: PoolsSectionProps) => 
       )}
 
       {pools.length === 0 ? (
+        // "No pools yet" is a to-do — it reads as a gap the organizer is meant
+        // to close. A viewer is being told a fact about the event instead, and
+        // is offered nothing to add.
         <EmptyState
-          title="No pools yet"
-          hint="Add a pool to reserve tables for this event."
+          title={canEdit ? 'No pools yet' : 'No table pools'}
+          hint={
+            canEdit
+              ? 'Add a pool to reserve tables for this event.'
+              : 'No tables are reserved for this event.'
+          }
           action={
-            <Button onClick={addPool}>
-              <Plus size={16} />
-              Add first pool
-            </Button>
+            canEdit && (
+              <Button onClick={addPool}>
+                <Plus size={16} />
+                Add first pool
+              </Button>
+            )
           }
         />
       ) : (
@@ -85,6 +110,7 @@ export const PoolsSection = ({ event, tables, onChange }: PoolsSectionProps) => 
               key={p.id}
               pool={p}
               tables={tables}
+              canEdit={canEdit}
               onChange={(np) => setPools(pools.map((x, j) => (j === i ? np : x)))}
               onRemove={() => setPools(pools.filter((_, j) => j !== i))}
             />

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
@@ -31,7 +31,9 @@ export const PoolsSection = ({
 }: PoolsSectionProps) => {
   const pools = event.pools
   const setPools = (next: Pool[]) => onChange({ ...event, pools: next })
-  const conflicts = findPoolConflicts(pools)
+  // Double-booking is a diagnostic only the organizer can act on, so a viewer
+  // is neither shown it nor pays to compute it.
+  const conflicts = canEdit ? findPoolConflicts(pools) : []
   // Count distinct tables, not conflict pairs: one table double-booked across
   // several overlapping pools yields multiple conflict entries.
   const conflictTableCount = new Set(conflicts.map((c) => c.table)).size

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.factory.tsx
@@ -1,13 +1,15 @@
 import { buildPool, buildTables } from '../../../data/seed.factory'
 import type { PoolCardProps } from './pool-card'
 
-/** Props for `PoolCard` — Pool A with four of six tables selected. */
+/** Props for `PoolCard` — Pool A with four of six tables selected, editable (the
+ * creator's view). Pass `canEdit: false` for a viewer's read-only rendering. */
 export function buildPoolCardProps(
   overrides: Partial<PoolCardProps> = {},
 ): PoolCardProps {
   return {
     pool: buildPool(),
     tables: buildTables(6),
+    canEdit: true,
     onChange: () => {},
     onRemove: () => {},
     ...overrides,

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.page.tsx
@@ -1,7 +1,18 @@
-import { render, screen, type Container } from '@/test/utilities'
+import { render, screen, within, type Container } from '@/test/utilities'
 
 import { PoolCard, type PoolCardProps } from './pool-card'
 import { buildPoolCardProps } from './pool-card.factory'
+
+/** The roles a form control would take in the accessibility tree. A read-only
+ * card must render none of them (ADR 0015). */
+const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
+
+/** The role sweep alone under-proves this card: its window is three
+ * `type="date"` / `type="time"` inputs, which have **no ARIA role at all** — a
+ * whole live date/time row sails straight through a role sweep. This catches the
+ * element itself, whatever role it claims (ADR 0015, rule 6). */
+const FORM_ELEMENTS =
+  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
 
 const scoped = (container: Container) => ({
   getCard() {
@@ -9,6 +20,9 @@ const scoped = (container: Container) => ({
   },
   getNameInput() {
     return container.getByLabelText('Pool name')
+  },
+  queryNameInput() {
+    return container.queryByLabelText('Pool name')
   },
   getTableToggle(label: string) {
     return container.getByRole('button', { name: label, pressed: false })
@@ -18,6 +32,37 @@ const scoped = (container: Container) => ({
   },
   getRemoveButton() {
     return container.getByRole('button', { name: 'Remove pool' })
+  },
+  /** Absent for a viewer: a mutating affordance is hidden, never disabled. */
+  queryRemoveButton() {
+    return container.queryByRole('button', { name: 'Remove pool' })
+  },
+  /** The pool's name, read back as text (the read-only counterpart of the name
+   * box). */
+  getName() {
+    return container.getByTestId('pool-name')
+  },
+  /** The tables this pool reserves, read back as a list. */
+  getReservedTables() {
+    return container.getByTestId('pool-tables')
+  },
+  /** The read-only value rendered in place of a window field's control, found by
+   * the field's label so the assertion survives a re-ordering of the row. */
+  getFieldValue(label: string) {
+    const row = container
+      .getByText(label, { exact: false, selector: 'label' })
+      .closest('div')!
+    return within(row).getByTestId('tournament-read-only-value')
+  },
+  /** Every interactive control in the card. Empty is the point of the read-only
+   * view. */
+  getInteractiveControls() {
+    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+  },
+  /** Every form element in the card, by tag/widget role rather than by the four
+   * canonical roles — the escape hatch the role sweep misses. */
+  getFormElements() {
+    return container.getByTestId('pool-card').querySelectorAll(FORM_ELEMENTS)
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.page.tsx
@@ -1,20 +1,15 @@
-import { render, screen, within, type Container } from '@/test/utilities'
+import { interactiveControlsIn, interactiveElementsIn } from '@/test/read-only'
+import { render, screen, type Container } from '@/test/utilities'
 
+import { fieldPage } from '../../../field.page'
 import { PoolCard, type PoolCardProps } from './pool-card'
 import { buildPoolCardProps } from './pool-card.factory'
 
-/** The roles a form control would take in the accessibility tree. A read-only
- * card must render none of them (ADR 0015). */
-const INTERACTIVE_ROLES = ['textbox', 'combobox', 'switch', 'button'] as const
-
-/** The role sweep alone under-proves this card: its window is three
- * `type="date"` / `type="time"` inputs, which have **no ARIA role at all** — a
- * whole live date/time row sails straight through a role sweep. This catches the
- * element itself, whatever role it claims (ADR 0015, rule 6). */
-const FORM_ELEMENTS =
-  'input, select, textarea, button, [role="switch"], [role="radio"], [tabindex], [contenteditable]'
-
 const scoped = (container: Container) => ({
+  /** Reuse the `Field` row queries — the pool's window is three `Field` rows,
+   * whose read-only values `getFieldValue(label)` reads back. */
+  ...fieldPage.within(container),
+
   getCard() {
     return container.getByTestId('pool-card')
   },
@@ -46,23 +41,15 @@ const scoped = (container: Container) => ({
   getReservedTables() {
     return container.getByTestId('pool-tables')
   },
-  /** The read-only value rendered in place of a window field's control, found by
-   * the field's label so the assertion survives a re-ordering of the row. */
-  getFieldValue(label: string) {
-    const row = container
-      .getByText(label, { exact: false, selector: 'label' })
-      .closest('div')!
-    return within(row).getByTestId('tournament-read-only-value')
-  },
-  /** Every interactive control in the card. Empty is the point of the read-only
-   * view. */
+  /** Every interactive control in the card, swept by role. Supplement only —
+   * `getFormElements()` is the guarantee. */
   getInteractiveControls() {
-    return INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))
+    return interactiveControlsIn(container)
   },
-  /** Every form element in the card, by tag/widget role rather than by the four
-   * canonical roles — the escape hatch the role sweep misses. */
+  /** Every interactive element in the card, swept by DOM (`@/test/read-only`).
+   * Empty is the point of the read-only view. */
   getFormElements() {
-    return container.getByTestId('pool-card').querySelectorAll(FORM_ELEMENTS)
+    return interactiveElementsIn(container.getByTestId('pool-card'))
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.test.tsx
@@ -25,4 +25,72 @@ describe('PoolCard', () => {
     await userEvent.click(poolCardPage.getRemoveButton())
     expect(onRemove).toHaveBeenCalledTimes(1)
   })
+
+  describe('for a non-owner (read-only)', () => {
+    // The guard test (ADR 0015, rule 6): a viewer gets a rendering of the data,
+    // never a disabled editor. The DOM sweep, not a role sweep — this card's
+    // window is three `type="date"` / `type="time"` inputs, and those carry no
+    // ARIA role at all, so the four canonical roles would miss a live date row
+    // entirely and go green with the whole window still editable.
+    it('renders no interactive controls', () => {
+      poolCardPage.render({ canEdit: false })
+      // The DOM sweep first: it is the load-bearing one, so it is the one whose
+      // red is worth seeing.
+      expect(poolCardPage.getFormElements()).toHaveLength(0)
+      expect(poolCardPage.getInteractiveControls()).toHaveLength(0)
+    })
+
+    it('reads the pool name as text, not a name box', () => {
+      poolCardPage.render({
+        pool: buildPool({ name: 'Pool A' }),
+        canEdit: false,
+      })
+      expect(poolCardPage.getName()).toHaveTextContent('Pool A')
+      expect(poolCardPage.queryNameInput()).toBeNull()
+    })
+
+    it('reads the window back under the same Date / Start / End labels', () => {
+      poolCardPage.render({
+        pool: buildPool({
+          slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
+        }),
+        canEdit: false,
+      })
+      expect(poolCardPage.getFieldValue('Date')).toHaveTextContent('2026-06-13')
+      expect(poolCardPage.getFieldValue('Start')).toHaveTextContent('09:00')
+      expect(poolCardPage.getFieldValue('End')).toHaveTextContent('12:30')
+    })
+
+    // The reserved tables are the point of a pool. Read-only they are a list of
+    // the very labels the toggles showed — no second vocabulary.
+    it('lists the tables the pool reserves', () => {
+      poolCardPage.render({
+        pool: buildPool({ tableIds: ['t1', 't2', 't5'] }),
+        canEdit: false,
+      })
+      expect(poolCardPage.getReservedTables()).toHaveTextContent('T1, T2, T5')
+    })
+
+    // Catalogue order, not the order the organizer happened to click them in.
+    it('lists the tables in catalogue order', () => {
+      poolCardPage.render({
+        pool: buildPool({ tableIds: ['t5', 't1'] }),
+        canEdit: false,
+      })
+      expect(poolCardPage.getReservedTables()).toHaveTextContent('T1, T5')
+    })
+
+    // A pool that reserves nothing is unset, not blank: an em-dash, so absent
+    // stays distinguishable from not-applicable (ADR 0015, rule 3).
+    it('reads a pool with no tables as an em-dash', () => {
+      poolCardPage.render({ pool: buildPool({ tableIds: [] }), canEdit: false })
+      expect(poolCardPage.getReservedTables()).toHaveTextContent('—')
+    })
+
+    // Hidden, never disabled: a disabled button is an unexplained dead end.
+    it('hides the remove button', () => {
+      poolCardPage.render({ canEdit: false })
+      expect(poolCardPage.queryRemoveButton()).toBeNull()
+    })
+  })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.test.tsx
@@ -1,5 +1,7 @@
 import userEvent from '@testing-library/user-event'
 
+import { screen } from '@/test/utilities'
+
 import { buildPool } from '../../../data/seed.factory'
 import { poolCardPage } from './pool-card.page'
 
@@ -49,6 +51,9 @@ describe('PoolCard', () => {
       expect(poolCardPage.queryNameInput()).toBeNull()
     })
 
+    // The date reads in words, never as the `YYYY-MM-DD` the editor's
+    // `<input type="date">` takes. The times have no such helper and stay raw
+    // here, on the event card, and everywhere else.
     it('reads the window back under the same Date / Start / End labels', () => {
       poolCardPage.render({
         pool: buildPool({
@@ -56,9 +61,12 @@ describe('PoolCard', () => {
         }),
         canEdit: false,
       })
-      expect(poolCardPage.getFieldValue('Date')).toHaveTextContent('2026-06-13')
+      expect(poolCardPage.getFieldValue('Date')).toHaveTextContent(
+        'Jun 13, 2026',
+      )
       expect(poolCardPage.getFieldValue('Start')).toHaveTextContent('09:00')
       expect(poolCardPage.getFieldValue('End')).toHaveTextContent('12:30')
+      expect(screen.queryByText('2026-06-13')).toBeNull()
     })
 
     // The reserved tables are the point of a pool. Read-only they are a list of

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.tsx
@@ -4,6 +4,7 @@ import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 
+import { fmtDate } from '../../../data/helpers'
 import type { Pool, TournamentTable } from '../../../data/types'
 import { Field } from '../../../field'
 import { ReadOnlyValue } from '../../../read-only-value'
@@ -83,27 +84,25 @@ export const PoolCard = ({
           <TableCount count={pool.tableIds.length} />
         </div>
 
-        {/* `readOnly` on each row is what keeps the form's furniture out of the
-            view: these rows carry no hint or asterisk today, but a `Field` that
-            grows one must not leak it here (ADR 0015). */}
+        {/* `readOnly` on each row is what renders the value instead of a control
+            and keeps the form's furniture out of the view: these rows carry no
+            hint or asterisk today, but a `Field` that grows one must not leak it
+            here (ADR 0015). The date reads in words — the wire format is the
+            editor's `<input type="date">` value, not a reader's. */}
         <div className={WINDOW_ROW}>
-          <Field label="Date" readOnly>
-            {() => <ReadOnlyValue>{pool.slot.date}</ReadOnlyValue>}
-          </Field>
-          <Field label="Start" readOnly>
-            {() => (
-              <ReadOnlyValue className="font-mono">
-                {pool.slot.start}
-              </ReadOnlyValue>
-            )}
-          </Field>
-          <Field label="End" readOnly>
-            {() => (
-              <ReadOnlyValue className="font-mono">
-                {pool.slot.end}
-              </ReadOnlyValue>
-            )}
-          </Field>
+          <Field label="Date" readOnly value={fmtDate(pool.slot.date)} />
+          <Field
+            label="Start"
+            readOnly
+            value={pool.slot.start}
+            valueClassName="font-mono"
+          />
+          <Field
+            label="End"
+            readOnly
+            value={pool.slot.end}
+            valueClassName="font-mono"
+          />
         </div>
 
         <div className="px-3.5 pb-3.5">

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.tsx
@@ -6,18 +6,60 @@ import { cn } from '@/lib/utils'
 
 import type { Pool, TournamentTable } from '../../../data/types'
 import { Field } from '../../../field'
+import { ReadOnlyValue } from '../../../read-only-value'
 
 export interface PoolCardProps {
   pool: Pool
   /** The tables available to this tournament. */
   tables: TournamentTable[]
+  /** When false (a non-creator), the card renders the pool as text — its name,
+   * its window, and the tables it reserves — instead of a name box, three
+   * date/time fields and a wall of table toggles (ADR 0015). */
+  canEdit: boolean
   onChange: (pool: Pool) => void
   onRemove: () => void
 }
 
-/** A single table pool: a name, a date/start/end window, and a multi-select of
- * the tournament's tables (rendered as toggle chips). */
-export const PoolCard = ({ pool, tables, onChange, onRemove }: PoolCardProps) => {
+/** The card's chrome, shared by both renderings so the two cannot drift apart
+ * (ADR 0015, rule 3: the read-only view mirrors the editor's layout). */
+const HEADER_ROW =
+  'flex items-center gap-2.5 border-b border-[color:var(--border-subtle)] p-3.5'
+const OVERLINE =
+  'mb-1.5 text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase'
+const WINDOW_ROW = 'grid grid-cols-3 gap-3 p-3.5'
+
+/** How many tables the pool holds — a fact about the pool, so a viewer reads it
+ * too. */
+const TableCount = ({ count }: { count: number }) => (
+  <span className="rounded-full bg-[color:var(--bg-raised)] px-2 py-0.5 font-mono text-[11px] text-[color:var(--fg-2)]">
+    {count} {count === 1 ? 'table' : 'tables'}
+  </span>
+)
+
+/** The reserved tables as one line — the same labels the toggles show ("T1, T2,
+ * T5"), so there is no second vocabulary to keep in step. Driven off the table
+ * catalogue rather than off `pool.tableIds`, so the list reads in catalogue
+ * order and an id with no table behind it simply isn't named.
+ *
+ * An empty string is what `ReadOnlyValue` treats as unset — a pool that reserves
+ * nothing renders as an em-dash, not as a blank. */
+const reservedTableLabels = (pool: Pool, tables: TournamentTable[]): string =>
+  tables
+    .filter((t) => pool.tableIds.includes(t.id))
+    .map((t) => t.label)
+    .join(', ')
+
+/** A single table pool. For the creator: a name box, a date/start/end window,
+ * and a multi-select of the tournament's tables (rendered as toggle chips). For
+ * a viewer: the same pool read back as text — its name, its window, and the
+ * tables it reserves — with no control to reach for (ADR 0015). */
+export const PoolCard = ({
+  pool,
+  tables,
+  canEdit,
+  onChange,
+  onRemove,
+}: PoolCardProps) => {
   const setSlot = (patch: Partial<Pool['slot']>) =>
     onChange({ ...pool, slot: { ...pool.slot, ...patch } })
 
@@ -29,19 +71,63 @@ export const PoolCard = ({ pool, tables, onChange, onRemove }: PoolCardProps) =>
         : [...pool.tableIds, id],
     })
 
+  if (!canEdit) {
+    return (
+      <Card className="gap-0 p-0" data-testid="pool-card">
+        <div className={HEADER_ROW}>
+          <div data-testid="pool-name" className="min-w-0 flex-1">
+            <ReadOnlyValue className="h-8 text-[15px] font-semibold">
+              {pool.name}
+            </ReadOnlyValue>
+          </div>
+          <TableCount count={pool.tableIds.length} />
+        </div>
+
+        {/* `readOnly` on each row is what keeps the form's furniture out of the
+            view: these rows carry no hint or asterisk today, but a `Field` that
+            grows one must not leak it here (ADR 0015). */}
+        <div className={WINDOW_ROW}>
+          <Field label="Date" readOnly>
+            {() => <ReadOnlyValue>{pool.slot.date}</ReadOnlyValue>}
+          </Field>
+          <Field label="Start" readOnly>
+            {() => (
+              <ReadOnlyValue className="font-mono">
+                {pool.slot.start}
+              </ReadOnlyValue>
+            )}
+          </Field>
+          <Field label="End" readOnly>
+            {() => (
+              <ReadOnlyValue className="font-mono">
+                {pool.slot.end}
+              </ReadOnlyValue>
+            )}
+          </Field>
+        </div>
+
+        <div className="px-3.5 pb-3.5">
+          <div className={OVERLINE}>Tables in pool</div>
+          <div data-testid="pool-tables">
+            <ReadOnlyValue className="h-auto min-h-8 font-mono">
+              {reservedTableLabels(pool, tables)}
+            </ReadOnlyValue>
+          </div>
+        </div>
+      </Card>
+    )
+  }
+
   return (
     <Card className="gap-0 p-0" data-testid="pool-card">
-      <div className="flex items-center gap-2.5 border-b border-[color:var(--border-subtle)] p-3.5">
+      <div className={HEADER_ROW}>
         <Input
           aria-label="Pool name"
           value={pool.name}
           onChange={(e) => onChange({ ...pool, name: e.target.value })}
           className="h-8 flex-1 border-transparent bg-transparent text-[15px] font-semibold shadow-none focus-visible:border-[color:var(--border-default)]"
         />
-        <span className="rounded-full bg-[color:var(--bg-raised)] px-2 py-0.5 font-mono text-[11px] text-[color:var(--fg-2)]">
-          {pool.tableIds.length}{' '}
-          {pool.tableIds.length === 1 ? 'table' : 'tables'}
-        </span>
+        <TableCount count={pool.tableIds.length} />
         <button
           type="button"
           aria-label="Remove pool"
@@ -52,7 +138,7 @@ export const PoolCard = ({ pool, tables, onChange, onRemove }: PoolCardProps) =>
         </button>
       </div>
 
-      <div className="grid grid-cols-3 gap-3 p-3.5">
+      <div className={WINDOW_ROW}>
         <Field label="Date">
           {(id) => (
             <Input
@@ -88,9 +174,7 @@ export const PoolCard = ({ pool, tables, onChange, onRemove }: PoolCardProps) =>
       </div>
 
       <div className="px-3.5 pb-3.5">
-        <div className="mb-1.5 text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">
-          Tables in pool
-        </div>
+        <div className={OVERLINE}>Tables in pool</div>
         <div className="flex flex-wrap gap-1.5">
           {tables.map((t) => {
             const selected = pool.tableIds.includes(t.id)

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab.test.tsx
@@ -1,5 +1,7 @@
 import userEvent from '@testing-library/user-event'
 
+import { screen } from '@/test/utilities'
+
 import { buildTournament, buildEvent } from '../data/seed.factory'
 import { eventsTabPage } from './events-tab.page'
 
@@ -40,5 +42,24 @@ describe('EventsTab', () => {
     })
     expect(document.body).toHaveTextContent('No events yet')
     expect(eventsTabPage.queryNewEventButtons()).toHaveLength(0)
+  })
+
+  // Clicking a card opens the editor for the organizer and a read-only view for
+  // everyone else, so the subtitle promises what the click delivers (ADR 0015,
+  // rule 5). Asserted both ways: the discriminating word is the verb.
+  describe('the "click any event" subtitle', () => {
+    it('invites the creator to edit', () => {
+      eventsTabPage.render({ tournament: buildTournament() })
+      expect(screen.getByText(/Click any event to edit\./)).toBeInTheDocument()
+      expect(screen.queryByText(/Click any event for details\./)).toBeNull()
+    })
+
+    it('offers a non-creator details, not editing', () => {
+      eventsTabPage.render({ tournament: buildTournament(), canEdit: false })
+      expect(
+        screen.getByText(/Click any event for details\./),
+      ).toBeInTheDocument()
+      expect(screen.queryByText(/Click any event to edit\./)).toBeNull()
+    })
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab.tsx
@@ -28,7 +28,14 @@ export const EventsTab = ({
     <div>
       <SectionHeader
         title="Events"
-        subtitle="Singles, doubles, age- and rating-restricted brackets. Click any event to edit."
+        // A card opens the editor for the organizer and a read-only view for
+        // everyone else, so the invitation to click says what clicking will
+        // actually get you (ADR 0015, rule 5).
+        subtitle={
+          canEdit
+            ? 'Singles, doubles, age- and rating-restricted brackets. Click any event to edit.'
+            : 'Singles, doubles, age- and rating-restricted brackets. Click any event for details.'
+        }
         action={
           canEdit && (
             <Button onClick={onNewEvent}>

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event'
 
-import { buildEvent, buildPredicate } from '../../data/seed.factory'
+import { buildEvent, buildPool, buildPredicate } from '../../data/seed.factory'
 import { eventCardPage } from './event-card.page'
 
 describe('EventCard', () => {
@@ -24,6 +24,52 @@ describe('EventCard', () => {
     })
     expect(document.body).toHaveTextContent('52')
     expect(document.body).toHaveTextContent('/ 64')
+  })
+
+  it('shows the time slot as a window', () => {
+    eventCardPage.render({
+      event: buildEvent({
+        slot: { date: '2026-06-13', start: '09:00', end: '12:00' },
+      }),
+    })
+    expect(document.body).toHaveTextContent('Jun 13 · 09:00–12:00')
+  })
+
+  // An unset bound used to leave the template's punctuation behind — "09:00–"
+  // with a dangling en dash, or a bare "–" with neither bound set.
+  it('shows a lone start without a dangling dash', () => {
+    eventCardPage.render({
+      event: buildEvent({ slot: { date: '2026-06-13', start: '09:00', end: '' } }),
+    })
+    expect(document.body).toHaveTextContent('Jun 13 · 09:00')
+    expect(document.body).not.toHaveTextContent('09:00–')
+  })
+
+  it('shows an em-dash when the whole window is unset', () => {
+    eventCardPage.render({
+      event: buildEvent({ slot: { date: '2026-06-13', start: '', end: '' } }),
+    })
+    expect(document.body).toHaveTextContent('Jun 13 · —')
+  })
+
+  // "1 pool · 1 tables" — the table count was hardcoded plural while the pool
+  // count beside it pluralized correctly. (The counts are sibling spans laid out
+  // with a CSS gap, so the text runs together: "1 pool·1 table".)
+  it('renders a singular table count for a single-table event', () => {
+    eventCardPage.render({
+      event: buildEvent({ pools: [buildPool({ tableIds: ['t1'] })] }),
+    })
+    expect(document.body).toHaveTextContent('1 pool·1 table')
+    // "1 table" is a substring of "1 tables", so the positive assertion alone
+    // would pass against the bug.
+    expect(document.body).not.toHaveTextContent('1 tables')
+  })
+
+  it('renders a plural table count for a multi-table event', () => {
+    eventCardPage.render({
+      event: buildEvent({ pools: [buildPool({ tableIds: ['t1', 't2'] })] }),
+    })
+    expect(document.body).toHaveTextContent('1 pool·2 tables')
   })
 
   it('opens the editor when clicked', async () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 
-import { fmtDateShort, formatPredicate } from '../../data/helpers'
+import { fmtDateShort, fmtTimeWindow, formatPredicate } from '../../data/helpers'
 import { DRAW_TYPE_OPTIONS, FORMAT_OPTIONS, labelFor } from '../../data/options'
 import type { TournamentEvent } from '../../data/types'
 
@@ -78,7 +78,7 @@ export const EventCard = ({ event: ev, canEdit, onOpen }: EventCardProps) => {
               Time slot
             </div>
             <div className="mt-1 font-mono text-[13px] tabular-nums text-[color:var(--fg-1)]">
-              {fmtDateShort(ev.slot.date)} · {ev.slot.start}–{ev.slot.end}
+              {fmtDateShort(ev.slot.date)} · {fmtTimeWindow(ev.slot.start, ev.slot.end)}
             </div>
             <div className="mt-1.5 flex items-center gap-1.5 text-[11px] whitespace-nowrap text-[color:var(--fg-3)]">
               <Layers size={12} />
@@ -86,7 +86,9 @@ export const EventCard = ({ event: ev, canEdit, onOpen }: EventCardProps) => {
                 {ev.pools.length} {ev.pools.length === 1 ? 'pool' : 'pools'}
               </span>
               <span>·</span>
-              <span className="font-mono">{tableCount} tables</span>
+              <span className="font-mono">
+                {tableCount} {tableCount === 1 ? 'table' : 'tables'}
+              </span>
             </div>
           </div>
 

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.tsx
@@ -5,7 +5,7 @@ import { Card } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 
 import { fmtDateShort, formatPredicate } from '../../data/helpers'
-import { DRAW_TYPE_OPTIONS, FORMAT_OPTIONS } from '../../data/options'
+import { DRAW_TYPE_OPTIONS, FORMAT_OPTIONS, labelFor } from '../../data/options'
 import type { TournamentEvent } from '../../data/types'
 
 export interface EventCardProps {
@@ -24,10 +24,11 @@ export const EventCard = ({ event: ev, canEdit, onOpen }: EventCardProps) => {
     ? Math.min(100, Math.round(((ev.entered || 0) / ev.maxPlayers) * 100))
     : 0
   const isFull = ev.entered >= ev.maxPlayers
-  const formatLabel =
-    FORMAT_OPTIONS.find((f) => f.value === ev.format)?.label ?? ev.format
-  const drawLabel =
-    DRAW_TYPE_OPTIONS.find((d) => d.value === ev.drawType)?.label ?? ev.drawType
+  // Falling back to the stored key, not to `null`: a card must never blank out a
+  // row, so an unknown key shows *something* (cf. the read-only `Field`s, which
+  // pass `null` and let the em-dash say "unset").
+  const formatLabel = labelFor(FORMAT_OPTIONS, ev.format, ev.format)
+  const drawLabel = labelFor(DRAW_TYPE_OPTIONS, ev.drawType, ev.drawType)
   const tableCount = new Set(ev.pools.flatMap((p) => p.tableIds)).size
   // The card opens the editor, which is read-only for a non-owner — so the
   // affordance reads "View" (not "Edit") when the viewer can't mutate.

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.test.tsx
@@ -54,4 +54,25 @@ describe('TablesTab', () => {
     // The table list itself stays visible (read-only).
     expect(document.body).toHaveTextContent('T1')
   })
+
+  // The subtitle's second sentence is an instruction only the organizer can
+  // follow (ADR 0015, rule 5: copy addresses the reader). Both halves of this
+  // pair matter: dropping the sentence for *everyone* would satisfy the
+  // non-creator assertion alone.
+  it('keeps the organizer-voiced subtitle for the creator', () => {
+    tablesTabPage.render({ catalogue: buildTables(3), canEdit: true })
+
+    expect(document.body).toHaveTextContent(
+      'The physical tables available at this venue. Add them to pools when configuring events.',
+    )
+  })
+
+  it('drops the organizer-voiced subtitle for a non-creator', () => {
+    tablesTabPage.render({ catalogue: buildTables(3), canEdit: false })
+
+    expect(document.body).toHaveTextContent(
+      'The physical tables available at this venue.',
+    )
+    expect(document.body).not.toHaveTextContent('Add them to pools')
+  })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.tsx
@@ -15,7 +15,8 @@ export interface TablesTabProps {
   /** This tournament's table catalogue (the venue tables it owns). */
   catalogue: TournamentTable[]
   /** When false (a non-creator), the add-table form and per-row Remove buttons
-   * are hidden and the tab is a read-only list of tables. */
+   * are hidden, the organizer-voiced half of the subtitle is dropped, and the
+   * tab is a read-only list of tables. */
   canEdit: boolean
   /** Emit the next catalogue. The catalogue IS the assigned set — the API has
    * no separate global table list, so removing a table drops it outright and
@@ -61,7 +62,15 @@ export const TablesTab = ({
     <div>
       <SectionHeader
         title="Tables"
-        subtitle="The physical tables available at this venue. Add them to pools when configuring events."
+        // "Add them to pools when configuring events" is an imperative only the
+        // organizer can act on — a reader who cannot edit is told to do
+        // something they have no control to do (ADR 0015, rule 5). The
+        // descriptive first sentence is true for both voices, so it stays.
+        subtitle={
+          canEdit
+            ? 'The physical tables available at this venue. Add them to pools when configuring events.'
+            : 'The physical tables available at this venue.'
+        }
       />
 
       <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3">

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -147,7 +147,7 @@ function seed(): TournamentDetailRead[] {
         {
           id: 'ev-cc-open',
           tournament_id: 'club-champs-2026',
-          name: 'Championship Singles',
+          name: "Women's Championship Singles",
           format: 'singles',
           draw_type: 'single-elim',
           max_players: 32,
@@ -155,8 +155,43 @@ function seed(): TournamentDetailRead[] {
           entered: 28,
           slot: { date: '2026-07-01', start: '17:00', end: '21:00' },
           match_settings: { rated: true, length_games: 5 },
-          predicates: [],
-          pools: [],
+          // The only non-owned row in the seed, so it is the only place the
+          // read-only event panel can be seen in `npm run dev`. These rules
+          // deliberately cover every branch of the read-only prose: a bool
+          // ("Must be a club member"), a plain numeric comparison ("Age is at
+          // least 16"), a `between` (a two-element value array — "USATT rating
+          // is between 1200 and 2400"), and an enum (renders its option label,
+          // "Gender is Female", not the stored `F`).
+          predicates: [
+            { id: 'pr-cc-1', field: 'club', op: 'true', value: true },
+            { id: 'pr-cc-2', field: 'age', op: '>=', value: 16 },
+            { id: 'pr-cc-3', field: 'rating', op: 'between', value: [1200, 2400] },
+            { id: 'pr-cc-4', field: 'gender', op: 'is', value: 'F' },
+          ],
+          // Two group-stage pools on disjoint tables, then a knockout that
+          // reuses the show tables once the groups are done. No pair both
+          // overlaps in time and shares a table, so this seed raises no
+          // double-booking diagnostic (see `findPoolConflicts`).
+          pools: [
+            {
+              id: 'p-cc-1',
+              name: 'Group A',
+              slot: { date: '2026-07-01', start: '17:00', end: '19:00' },
+              table_ids: ['t1', 't2', 't3'],
+            },
+            {
+              id: 'p-cc-2',
+              name: 'Group B',
+              slot: { date: '2026-07-01', start: '17:00', end: '19:00' },
+              table_ids: ['t4', 't5', 't6'],
+            },
+            {
+              id: 'p-cc-3',
+              name: 'Knockout',
+              slot: { date: '2026-07-01', start: '19:15', end: '21:00' },
+              table_ids: ['t1', 't2'],
+            },
+          ],
           created_at: '2026-05-20T10:05:00Z',
           updated_at: '2026-06-12T08:00:00Z',
         },

--- a/web-client/src/test/read-only.ts
+++ b/web-client/src/test/read-only.ts
@@ -1,0 +1,42 @@
+// The one sweep every read-only guard test uses (ADR 0015, rule 6): "enforce it
+// with a guard test, not with vigilance". A selector copy-pasted into each page
+// object is enforced by vigilance — and it forked three ways the first time it
+// was written, leaving an `<a href>`-shaped hole in six of the guards. There is
+// one definition here, and every page object composes it.
+
+import type { Container } from './utilities'
+
+/** Every interactive element, swept by **DOM**, not by ARIA role — the sweep
+ * that actually holds the line. A role sweep silently under-proves: a
+ * `type="number"` input is a `spinbutton`, a `type="date"`/`type="time"` input
+ * has **no role at all**, and a `ToggleGroupItem` renders `<button role="radio">`
+ * (an explicit role overrides the implicit one, so `queryAllByRole('button')`
+ * never matches it). A whole live toggle group sails through a role sweep.
+ *
+ * The list is deliberately a **union**, not the controls a given surface happens
+ * to use today: it must catch the control someone adds tomorrow. Hence `a[href]`
+ * (a link is a real affordance, and a read-only *view* is not a navigation
+ * surface) and `[role="slider"]` (shadcn's `Slider`), neither of which any
+ * surface renders yet. */
+export const INTERACTIVE_SELECTOR =
+  'input, select, textarea, button, a[href], [role="switch"], [role="radio"], [role="slider"], [tabindex], [contenteditable]'
+
+/** The roles a form control claims in the accessibility tree. Kept only as a
+ * *supplement* to the DOM sweep — never instead of it, for the reasons above. */
+export const INTERACTIVE_ROLES = [
+  'textbox',
+  'combobox',
+  'switch',
+  'button',
+  'radio',
+  'spinbutton',
+] as const
+
+/** Every interactive element under `root`. A read-only surface renders none:
+ * a viewer gets a rendering of the data, never a disabled editor. */
+export const interactiveElementsIn = (root: HTMLElement): Element[] =>
+  Array.from(root.querySelectorAll(INTERACTIVE_SELECTOR))
+
+/** The role-swept supplement to `interactiveElementsIn`. */
+export const interactiveControlsIn = (container: Container): HTMLElement[] =>
+  INTERACTIVE_ROLES.flatMap((role) => container.queryAllByRole(role))

--- a/web-client/src/test/read-only.ts
+++ b/web-client/src/test/read-only.ts
@@ -17,9 +17,15 @@ import type { Container } from './utilities'
  * to use today: it must catch the control someone adds tomorrow. Hence `a[href]`
  * (a link is a real affordance, and a read-only *view* is not a navigation
  * surface) and `[role="slider"]` (shadcn's `Slider`), neither of which any
- * surface renders yet. */
+ * surface renders yet.
+ *
+ * `tabindex="-1"` is excluded: it is *not* in the tab order and is not an
+ * affordance — Radix puts it on focus guards, scroll containers and tabpanels.
+ * Matching it would fail a guard on chrome rather than on a control, and a guard
+ * that cries wolf gets loosened, which is how it dies. A genuinely interactive
+ * element carrying `tabindex="-1"` is still caught by its tag or its role. */
 export const INTERACTIVE_SELECTOR =
-  'input, select, textarea, button, a[href], [role="switch"], [role="radio"], [role="slider"], [tabindex], [contenteditable]'
+  'input, select, textarea, button, a[href], [role="switch"], [role="radio"], [role="slider"], [tabindex]:not([tabindex="-1"]), [contenteditable]'
 
 /** The roles a form control claims in the accessibility tree. Kept only as a
  * *supplement* to the DOM sweep — never instead of it, for the reasons above. */


### PR DESCRIPTION
## The bug

A non-owner opening a tournament **event** got a working editor. The side panel hid only its Save and Delete buttons — all four tabs still rendered **live, enabled** inputs, switches, selects and add/remove buttons. So a non-owner could type into the panel, edit eligibility rules, add table pools… and **every keystroke was silently discarded on close**, because there was no Save to commit it.

The panel's own doc comment already claimed a non-creator got "a read-only view of the event". It was half-implemented.

The **Details tab** had the milder version: nine `disabled={!canEdit}` props, i.e. the organizer's edit form rendered to everyone, greyed out — plus copy addressed to the organizer ("Edit the basics. Players see this on the public page…") shown to someone who is neither.

**The server was never at risk.** Every mutating tournament/event endpoint already 403s a non-owner (`_require_owner`). This was purely a client-side defect. Nothing in `api/` changes, so there is no OpenAPI/iOS regen.

## The decision — [ADR 0015](docs/adr/0015-read-only-is-a-view-not-a-disabled-form.md)

**A viewer gets a rendering of the data. Only an editor gets controls.**

The repo had two conflicting precedents living side by side (`tables-tab` *hid* owner-only controls; `details-tab` *disabled* them) and nothing recorded which was right — which is exactly how the event panel ended up half-done. The ADR settles it, and `web-client/CLAUDE.md` gains a `## Read-only surfaces` section pointing at the tooling.

## What a non-owner now sees

- **Values, not controls** — zero `input`/`select`/`switch`/`button` in the accessibility tree across all four tabs.
- **Eligibility rules as sentences** — "USATT rating is between 1200 and 2400", "Gender is Female" — composed from the *existing* field/operator labels, so no vocabulary is invented.
- **Table pools as text** — name, window, reserved tables.
- **Em-dash for unset values**, so "the organizer set nothing" stays distinguishable from "not applicable". `0` is a real entry fee and renders as `0`.
- **No form furniture** — no required asterisks, no hints. A hint explains how to fill in a control; an asterisk marks one you must complete. Both are nonsense next to a value nobody can edit.
- **Reader-facing copy** — "Event", not "Edit event"; "Click any event for details."

The **owner's editor is untouched** — verified in-browser at every step.

## Two things the review caught that are worth reading

**1. The guard test was a false green.** Each read-only surface carries a test asserting zero interactive controls. The obvious sweep — `queryAllByRole` over `textbox`/`combobox`/`switch`/`button` — **under-proves badly**: a `type="number"` input is a `spinbutton`, a `type="date"` input has **no ARIA role at all**, and a `ToggleGroupItem` renders `<button role="radio">` where the explicit role *overrides* the implicit one. Measured: a live status ToggleGroup produces **0** hits on a role sweep and **5** on a DOM sweep; of the pool card's 11 controls a role sweep sees 8.

Worse, once written per-page-object the selector **forked three ways inside this single PR**, and one fork let a live `<a href>` pass all six section guards. It now lives once, in `src/test/read-only.ts`.

**2. `Field` owns the branch, not just a flag.** An earlier draft had `Field` suppress the furniture while each call site *separately* branched the control — two obligations per field, `readOnly={!canEdit}` written twelve times. That is precisely what the ADR condemns, and unlike the control sweep the furniture assertions are per-named-field, so a forgotten flag would leak an asterisk with nothing to catch it. `Field` now takes the value and renders one or the other, making the leak structurally impossible at that boundary.

Also fixed en route: read-only dates rendered raw ISO (`2026-07-01` in the panel while the card that opened it said `Jul 1`).

## Testing

| Suite | Result |
|---|---|
| vitest | **187 files / 1365 tests** (+53 over `main`) |
| `tsc -b` + vite build | clean |
| eslint | 0 errors |
| web-client e2e (Playwright, MSW-off) | **139 passed** |

Root `e2e/` skipped deliberately: it has **zero** tournament references and this branch changes no API contract, so it cannot exercise the change.

Every guard test is a genuine red-to-green — each fails against the pre-change code, several were mutation-tested (e.g. deleting the sentence *for everyone* is caught by the owner-side assertion, so the fix can't be faked by removing the feature).

The MSW seed's non-owned tournament gains rules and pools — before, this entire feature demoed as two empty states.

## Note for QA

Ownership is per-creator and **the API seeds no tournaments**, so this needs **two accounts**: create a tournament + event + rules + pools as user A, then view it as user B. Testing as the creator and concluding "it's still editable" is correct behavior, and the one way to get a false negative on the whole change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mGWeKjf118B3nHSahSbdi