### PR TITLE
Every user holds a default User role

### DIFF
--- a/api/app/domain/roles.py
+++ b/api/app/domain/roles.py
@@ -1,0 +1,21 @@
+"""Domain facts about the default role every user holds, independent of any one
+surface that stores or serializes it.
+
+Storage-agnostic and framework-agnostic: no SQLAlchemy, no Pydantic, no FastAPI.
+Both the persistence side (``app.roles`` — guest-mint's grant, the seed's
+convergence) and the wire side (``app.schemas.rbac.RoleRead.is_default``) import
+the name from here, so the schema layer stays dependency-light instead of
+dragging the ORM in to read one string.
+
+The name is load-bearing — guest-mint looks the role up by it, and the
+delete/rename guard defends it — so it lives in exactly one constant. See
+``docs/adr/0016-every-user-holds-the-default-user-role.md``.
+"""
+
+from __future__ import annotations
+
+DEFAULT_ROLE_NAME = "User"
+DEFAULT_ROLE_DESCRIPTION = (
+    "Held by every user. Carries no permissions by default — add one here to "
+    "grant it to the whole population, including anonymous visitors."
+)

--- a/api/app/rbac.py
+++ b/api/app/rbac.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db import get_session
 from app.leagues import add_user_to_default_league
 from app.models import Permission, Role, RolePermission, User, UserRole
+from app.roles import DEFAULT_ROLE_NAME, grant_default_role
 from app.schemas.rbac import (
     PermissionCreate,
     PermissionRead,
@@ -346,6 +347,22 @@ async def update_role(
 
     data = payload.model_dump(exclude_unset=True)
 
+    if role.name == DEFAULT_ROLE_NAME and "name" in data and data["name"] != role.name:
+        # The default role's name is guest-mint's lookup key (`app.roles`), so
+        # renaming it would make `grant_default_role` raise and 500 every future
+        # visitor's `GET /v1/session` (ADR-0016). Only a *change* is refused: the
+        # admin UI PATCHes the whole role, so a no-op name alongside a
+        # permissions/description edit must still go through — those stay freely
+        # editable, which is the entire point of this role.
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f'The "{DEFAULT_ROLE_NAME}" role is held by everyone on the '
+                "platform and cannot be renamed. You can change the permissions "
+                "it grants and its description."
+            ),
+        )
+
     new_permission_ids: list[uuid.UUID] | None = None
     if "permission_ids" in data:
         # Explicit `null` means "no change"; explicit `[]` means "clear all".
@@ -396,6 +413,20 @@ async def delete_role(
     role_id: uuid.UUID, db: AsyncSession = Depends(get_session)
 ) -> Response:
     role = await _get_role_or_404(db, role_id)
+    if role.name == DEFAULT_ROLE_NAME:
+        # Defense in depth — the UI also disables this button. Without this
+        # guard, deleting the default role cascades through user_roles
+        # (ON DELETE CASCADE) and silently strips it from every user on the
+        # platform, irreversibly. Its permissions stay freely editable via
+        # PATCH — that is the entire point of the role (ADR-0016).
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f'The "{DEFAULT_ROLE_NAME}" role is held by everyone on the '
+                "platform and cannot be deleted. You can change the "
+                "permissions it grants instead."
+            ),
+        )
     await db.delete(role)
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
@@ -426,6 +457,11 @@ async def create_user(
     try:
         await db.flush()
         await add_user_to_default_league(db, user.id)
+        # A user minted through the admin door is still a user (ADR-0016), so it
+        # holds the default role like every other. Raises (→ 500) if the role row
+        # is missing — deliberately not folded into the IntegrityError branch,
+        # which means "that username is taken", not "the seed never ran".
+        default_role = await grant_default_role(db, user.id)
         await db.commit()
     except IntegrityError:
         await db.rollback()
@@ -433,7 +469,7 @@ async def create_user(
             status_code=409, detail="Username already exists."
         ) from None
     await db.refresh(user)
-    return _serialize_user(user, [])
+    return _serialize_user(user, [default_role.id])
 
 
 @router.get("/users/{user_id}", response_model=RbacUserRead)

--- a/api/app/rbac.py
+++ b/api/app/rbac.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db import get_session
 from app.leagues import add_user_to_default_league
 from app.models import Permission, Role, RolePermission, User, UserRole
-from app.roles import DEFAULT_ROLE_NAME, grant_default_role
+from app.roles import DEFAULT_ROLE_NAME, get_default_role, grant_default_role
 from app.schemas.rbac import (
     PermissionCreate,
     PermissionRead,
@@ -494,6 +494,21 @@ async def set_user_roles(
     if user is None:
         raise HTTPException(status_code=404, detail="User not found.")
     role_ids = await _validate_role_ids(db, payload.role_ids)
+    # This is a full replace for every *other* role, but the default `User` role
+    # is held by everyone on the platform (ADR-0016) — so it survives regardless
+    # of what the caller sent. Silently retain it rather than 4xx: the admin UI
+    # disables that checkbox, and a raw API caller simply shouldn't be able to
+    # strip it either. Excluding a user would quietly break the "everyone holds
+    # it" invariant and cut them out of any capability later hung off the role.
+    default_role = await get_default_role(db)
+    if default_role is None:
+        # A missing seed row is a broken deployment (→ 500), mirroring
+        # `grant_default_role` — soft-skipping would leave a role-less user.
+        raise RuntimeError(
+            f"No {DEFAULT_ROLE_NAME!r} role to retain. Run scripts/seed_rbac.py."
+        )
+    if default_role.id not in role_ids:
+        role_ids = [*role_ids, default_role.id]
     await db.execute(delete(UserRole).where(UserRole.user_id == user.id))
     for rid in role_ids:
         db.add(UserRole(user_id=user.id, role_id=rid))

--- a/api/app/roles.py
+++ b/api/app/roles.py
@@ -1,0 +1,100 @@
+"""The default role every user holds.
+
+`User` is a lever, not a capability: it ships with zero permissions so that
+granting something to the entire population later is one row in the admin UI
+(add the permission to this role) rather than a migration or a code change.
+See `docs/adr/0016-every-user-holds-the-default-user-role.md`.
+
+The name is load-bearing — guest-mint looks the role up by it, and the
+delete/rename guard defends it — so it lives here, in one constant, rather than
+in the seed script.
+"""
+
+import uuid
+from typing import NamedTuple
+
+from sqlalchemy import literal, select
+from sqlalchemy.dialects.postgresql import UUID, insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Role, User, UserRole
+
+DEFAULT_ROLE_NAME = "User"
+DEFAULT_ROLE_DESCRIPTION = (
+    "Held by every user. Carries no permissions by default — add one here to "
+    "grant it to the whole population, including anonymous visitors."
+)
+
+
+class DefaultRoleConvergence(NamedTuple):
+    """What `converge_default_role` had to change to reach the invariant."""
+
+    role_created: bool
+    grants_added: int
+
+
+async def get_default_role(db: AsyncSession) -> Role | None:
+    result = await db.execute(select(Role).where(Role.name == DEFAULT_ROLE_NAME))
+    return result.scalar_one_or_none()
+
+
+async def grant_default_role(db: AsyncSession, user_id: uuid.UUID) -> Role:
+    """Grant the default role to a freshly-minted user, returning the role.
+
+    Called from the two places a ``users`` row is born — guest-mint
+    (``app.sessions._create_session``) and admin create (``app.rbac.create_user``)
+    — so "every user holds the default role" is true from the first instant of
+    their existence. Purely additive: it adds one ``user_roles`` row and touches
+    no other grant.
+
+    **Raises** ``RuntimeError`` when the role row is missing, rather than
+    soft-skipping. A missing seed row is a broken deployment: soft-skipping would
+    mint a cohort of role-less users that nobody notices until a permission is
+    hung off the role months later. Surfaces as a 500 — mirrors
+    ``add_user_to_default_league``'s hard failure on a missing default league.
+
+    Does not commit; the caller owns the surrounding transaction.
+    """
+    role = await get_default_role(db)
+    if role is None:
+        raise RuntimeError(
+            f"No {DEFAULT_ROLE_NAME!r} role to grant. Run scripts/seed_rbac.py."
+        )
+    db.add(UserRole(user_id=user_id, role_id=role.id))
+    return role
+
+
+async def converge_default_role(db: AsyncSession) -> DefaultRoleConvergence:
+    """Make two things true of `db`: the default role exists, and every user
+    holds it.
+
+    Idempotent — the role is located by name, and the backfill is a set-based
+    `INSERT … SELECT … ON CONFLICT DO NOTHING`, so a second run adds no rows. It
+    only ever *adds*: a user's other roles are left alone, and permissions an
+    admin has since hung off the default role are not stripped (that would
+    defeat the point of the lever).
+
+    Does not commit; the caller owns the surrounding transaction.
+    """
+    role = await get_default_role(db)
+    role_created = role is None
+    if role is None:
+        role = Role(name=DEFAULT_ROLE_NAME, description=DEFAULT_ROLE_DESCRIPTION)
+        db.add(role)
+        # The id is a Python-side default applied at flush; we read it below.
+        await db.flush()
+
+    role_id: uuid.UUID = role.id
+    granted = await db.execute(
+        insert(UserRole)
+        .from_select(
+            ["user_id", "role_id"],
+            select(User.id, literal(role_id, type_=UUID(as_uuid=True))),
+        )
+        .on_conflict_do_nothing()
+        .returning(UserRole.user_id)
+    )
+    return DefaultRoleConvergence(
+        role_created=role_created,
+        grants_added=len(granted.scalars().all()),
+    )

--- a/api/app/roles.py
+++ b/api/app/roles.py
@@ -1,13 +1,15 @@
-"""The default role every user holds.
+"""Persisting the default role every user holds.
 
 `User` is a lever, not a capability: it ships with zero permissions so that
 granting something to the entire population later is one row in the admin UI
 (add the permission to this role) rather than a migration or a code change.
 See `docs/adr/0016-every-user-holds-the-default-user-role.md`.
 
-The name is load-bearing — guest-mint looks the role up by it, and the
-delete/rename guard defends it — so it lives here, in one constant, rather than
-in the seed script.
+The name itself is load-bearing — guest-mint looks the role up by it, and the
+delete/rename guard defends it — so it lives in exactly one constant, in
+``app.domain.roles``, which the Pydantic schema layer can read without pulling
+the ORM in behind it. Re-exported here so callers already holding the
+persistence module keep one import.
 """
 
 import uuid
@@ -17,13 +19,21 @@ from sqlalchemy import literal, select
 from sqlalchemy.dialects.postgresql import UUID, insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.domain.roles import DEFAULT_ROLE_DESCRIPTION, DEFAULT_ROLE_NAME
 from app.models import Role, User, UserRole
 
-DEFAULT_ROLE_NAME = "User"
-DEFAULT_ROLE_DESCRIPTION = (
-    "Held by every user. Carries no permissions by default — add one here to "
-    "grant it to the whole population, including anonymous visitors."
-)
+# Required, not decorative: `mypy --strict` implies `no_implicit_reexport`, so
+# `app.rbac`'s existing `from app.roles import DEFAULT_ROLE_NAME` is an
+# attr-defined error unless this module re-exports the two constants it now
+# imports from `app.domain.roles` rather than defining.
+__all__ = [
+    "DEFAULT_ROLE_DESCRIPTION",
+    "DEFAULT_ROLE_NAME",
+    "DefaultRoleConvergence",
+    "converge_default_role",
+    "get_default_role",
+    "grant_default_role",
+]
 
 
 class DefaultRoleConvergence(NamedTuple):
@@ -68,6 +78,12 @@ async def converge_default_role(db: AsyncSession) -> DefaultRoleConvergence:
     """Make two things true of `db`: the default role exists, and every user
     holds it.
 
+    "Every user" means every *live* user. Tombstones — the merged-away guests
+    ``app.account_merge.merge_user`` soft-deletes — are excluded: that merge ends
+    by deleting the guest's ``user_roles`` rows on purpose, so backfilling them
+    would resurrect the role on a ghost account on the very next seed run and put
+    it back in the admin Users list holding it.
+
     Idempotent — the role is located by name, and the backfill is a set-based
     `INSERT … SELECT … ON CONFLICT DO NOTHING`, so a second run adds no rows. It
     only ever *adds*: a user's other roles are left alone, and permissions an
@@ -89,7 +105,9 @@ async def converge_default_role(db: AsyncSession) -> DefaultRoleConvergence:
         insert(UserRole)
         .from_select(
             ["user_id", "role_id"],
-            select(User.id, literal(role_id, type_=UUID(as_uuid=True))),
+            select(User.id, literal(role_id, type_=UUID(as_uuid=True))).where(
+                User.merged_into_user_id.is_(None)
+            ),
         )
         .on_conflict_do_nothing()
         .returning(UserRole.user_id)

--- a/api/app/schemas/rbac.py
+++ b/api/app/schemas/rbac.py
@@ -3,7 +3,11 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 
-from app.roles import DEFAULT_ROLE_NAME
+# Read from the ORM-free domain module, never from `app.roles`: that one imports
+# `app.models`, so importing it here would drag the whole SQLAlchemy ORM into the
+# schema layer — the one layer that must stay importable from anywhere — for a
+# single string, and would become an import cycle the day a model imports a schema.
+from app.domain.roles import DEFAULT_ROLE_NAME
 
 # Permission names follow a `resource.action` convention (e.g. `tournament.publish`).
 # Allowed chars per segment: lowercase letters, digits, underscores. At least

--- a/api/app/schemas/rbac.py
+++ b/api/app/schemas/rbac.py
@@ -1,7 +1,9 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
+
+from app.roles import DEFAULT_ROLE_NAME
 
 # Permission names follow a `resource.action` convention (e.g. `tournament.publish`).
 # Allowed chars per segment: lowercase letters, digits, underscores. At least
@@ -62,6 +64,22 @@ class RoleRead(RoleBase):
     created_at: datetime
     updated_at: datetime
     permission_ids: list[uuid.UUID]
+
+    # Derived from the name, never stored (ADR-0016): the name *is* the fact —
+    # it's what guest-mint looks the role up by — so a column would be a second
+    # source of truth needing its own "exactly one default role" invariant.
+    # Computed here rather than in the router's serializer so that every
+    # endpoint returning a role carries the flag and it cannot drift from
+    # `name`. The admin Roles page uses it to disable this role's Delete and
+    # rename controls up front instead of letting an admin discover the 400.
+    #
+    # The `type: ignore` is Pydantic's documented workaround: mypy rejects any
+    # decorator stacked on top of `@property`.
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def is_default(self) -> bool:
+        """Whether this is the default role held by every user on the platform."""
+        return self.name == DEFAULT_ROLE_NAME
 
 
 class RbacUserCreate(BaseModel):

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -31,6 +31,7 @@ from app.models import (
 )
 from app.rate_limiting import RedisRateLimiter
 from app.ratings.jobs import RECOMPUTE_AFTER_MERGE_JOB
+from app.roles import grant_default_role
 from app.schemas.session import (
     ConfirmEmailRequest,
     ConsumeLoginRequest,
@@ -470,6 +471,10 @@ async def _create_session(db: AsyncSession) -> tuple[User, str]:
     await db.flush()
 
     await add_user_to_default_league(db, user.id)
+    # Guest-mint is where "everyone" is decided: there is no signup, so this is
+    # the moment a person joins the site. Raises (→ 500) if the role is missing;
+    # see app/roles.py and ADR-0016.
+    await grant_default_role(db, user.id)
 
     raw_token = secrets.token_urlsafe(32)
     db.add(

--- a/api/scripts/seed_rbac.py
+++ b/api/scripts/seed_rbac.py
@@ -114,14 +114,14 @@ async def seed() -> None:
                 db.add(RolePermission(role_id=role.id, permission_id=perm.id))
                 added_links += 1
 
-        default_role = await converge_default_role(db)
+        default_role_created, default_grants_added = await converge_default_role(db)
 
         await db.commit()
         print(
             f"Seed complete: +{created_perms} permissions, "
-            f"+{created_roles + int(default_role.role_created)} roles, "
+            f"+{created_roles + int(default_role_created)} roles, "
             f"+{added_links} role/permission links, "
-            f"+{default_role.grants_added} default-role grants."
+            f"+{default_grants_added} default-role grants."
         )
 
 

--- a/api/scripts/seed_rbac.py
+++ b/api/scripts/seed_rbac.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.db import get_engine
 from app.models import Permission, Role, RolePermission
+from app.roles import converge_default_role
 
 
 PERMISSIONS = [
@@ -22,6 +23,9 @@ PERMISSIONS = [
     ("notifications.broadcast", "Send broadcast notifications to players."),
 ]
 
+# The default `User` role is *not* listed here: it carries no permissions and
+# every user holds it, so `app.roles.converge_default_role` owns both its row
+# and the grants. Roles below are opt-in bundles an admin assigns by hand.
 ROLES = [
     (
         "Administrator",
@@ -110,10 +114,14 @@ async def seed() -> None:
                 db.add(RolePermission(role_id=role.id, permission_id=perm.id))
                 added_links += 1
 
+        default_role = await converge_default_role(db)
+
         await db.commit()
         print(
             f"Seed complete: +{created_perms} permissions, "
-            f"+{created_roles} roles, +{added_links} role/permission links."
+            f"+{created_roles + int(default_role.role_created)} roles, "
+            f"+{added_links} role/permission links, "
+            f"+{default_role.grants_added} default-role grants."
         )
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -17,13 +17,14 @@ import app.models  # noqa: F401  -- ensures models register on Base.metadata
 from app import queue as queue_module
 from app.db import Base, get_session
 from app.main import app as fastapi_app
-from app.models import League, LeagueVisibility, NotificationType, RatingStrategy
+from app.models import League, LeagueVisibility, NotificationType, RatingStrategy, Role
 from app.models import NotificationChannel as NotificationChannelModel
 from app.notifications.taxonomy import (
     CHANNEL_AVAILABLE,
     NotificationCategory,
 )
 from app.notifications.taxonomy import NotificationChannel as ChannelEnum
+from app.roles import DEFAULT_ROLE_DESCRIPTION, DEFAULT_ROLE_NAME
 from tests._helpers import CSRF_EVENT_HOOKS
 
 
@@ -281,6 +282,25 @@ async def default_league(
     db_session.add(league)
     await db_session.commit()
     return league
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def default_role(db_session: AsyncSession) -> Role:
+    """Seed the default `User` role every user holds (ADR-0016).
+
+    Autouse because both user-minting paths (`GET /v1/session` and
+    `POST /v1/users`) now grant it and **raise** when it's absent — a missing
+    role row is a broken deployment, not a soft-skip. `scripts/seed_rbac.py`
+    inserts it in real deployments; tests build via ``Base.metadata.create_all``
+    so we re-seed here, exactly as ``default_league`` does.
+
+    Tests that want the "role is missing" branch can ``await
+    db_session.delete(...)`` this row before triggering the path under test.
+    """
+    role = Role(name=DEFAULT_ROLE_NAME, description=DEFAULT_ROLE_DESCRIPTION)
+    db_session.add(role)
+    await db_session.commit()
+    return role
 
 
 @pytest_asyncio.fixture

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -33,6 +33,7 @@ from app.models import (
     UserRole,
     UserToken,
 )
+from app.roles import grant_default_role
 from app.sessions import SESSION_TOKEN_CONTEXT
 from tests._helpers import start_session
 
@@ -567,6 +568,82 @@ async def test_merge_role_held_by_both_does_not_collide(db_session: AsyncSession
         .all()
     )
     assert ephemeral_role_ids == []
+
+
+async def test_merge_collapses_the_default_role_both_sides_hold(
+    db_session: AsyncSession, default_role: Role
+):
+    """Every user now holds the default role (ADR-0016), so *every* merge is a
+    both-sides-hold-the-same-role merge — the case the NOT EXISTS guard exists
+    for. Granting through the production seam (``grant_default_role``) rather
+    than hand-adding rows is what makes this exercise the real thing.
+
+    The survivor must end up holding it exactly once: not twice (a PK collision,
+    or a duplicate row), and not zero times (a dropped grant)."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+
+    await grant_default_role(db_session, ephemeral.id)
+    await grant_default_role(db_session, verified.id)
+    await db_session.commit()
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    survivor_role_ids = (
+        (
+            await db_session.execute(
+                select(UserRole.role_id).where(UserRole.user_id == verified.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert survivor_role_ids == [default_role.id]
+
+    ephemeral_role_ids = (
+        (
+            await db_session.execute(
+                select(UserRole.role_id).where(UserRole.user_id == ephemeral.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert ephemeral_role_ids == []
+
+
+async def test_merge_keeps_the_default_role_and_carries_an_extra_one(
+    db_session: AsyncSession, default_role: Role
+):
+    """The realistic shape now: both sides hold the default role and the guest
+    also holds something the survivor doesn't. The de-dupe must not swallow the
+    extra grant along with the duplicate one."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+
+    extra = Role(name="tournament-director")
+    db_session.add(extra)
+    await grant_default_role(db_session, ephemeral.id)
+    await grant_default_role(db_session, verified.id)
+    await db_session.flush()
+    db_session.add(UserRole(user_id=ephemeral.id, role_id=extra.id))
+    await db_session.commit()
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    survivor_role_ids = (
+        (
+            await db_session.execute(
+                select(UserRole.role_id).where(UserRole.user_id == verified.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert set(survivor_role_ids) == {default_role.id, extra.id}
+    assert len(survivor_role_ids) == 2
 
 
 # ----- counts -------------------------------------------------------------

--- a/api/tests/test_rbac.py
+++ b/api/tests/test_rbac.py
@@ -1,6 +1,7 @@
 import uuid
 from collections.abc import AsyncIterator
 
+import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
@@ -10,6 +11,7 @@ from app.db import get_session
 from app.main import app
 from app.models import Permission, Role, RolePermission, Tournament, User, UserRole
 from app.rbac import _require_rbac
+from app.roles import DEFAULT_ROLE_NAME
 from app.sessions import get_current_user
 from tests._helpers import CSRF_EVENT_HOOKS
 
@@ -223,7 +225,11 @@ async def test_list_roles_returns_permission_ids(
     await api_client.post("/v1/roles", json={"name": "bravo"})
 
     rows = (await api_client.get("/v1/roles")).json()
-    assert [r["name"] for r in rows] == ["alpha", "bravo"]
+    # The seeded default role (ADR-0016) is always present; ignore it here.
+    assert [r["name"] for r in rows if r["name"] != DEFAULT_ROLE_NAME] == [
+        "alpha",
+        "bravo",
+    ]
     by_name = {r["name"]: r for r in rows}
     assert by_name["alpha"]["permission_ids"] == [p["id"]]
     assert by_name["bravo"]["permission_ids"] == []
@@ -294,18 +300,135 @@ async def test_delete_role_cascades_user_assignments(
     assert remaining == []
 
 
+async def test_delete_default_role_is_refused(
+    api_client: AsyncClient, db_session: AsyncSession, default_role: Role
+):
+    """Deleting the default role would cascade its grants away (ADR-0016)."""
+    # A real user, so there is a real `user_roles` grant to lose.
+    await api_client.post("/v1/users", json={"username": "alice"})
+    grants_before = len((await db_session.execute(select(UserRole))).scalars().all())
+    assert grants_before == 1
+
+    refused = await api_client.delete(f"/v1/roles/{default_role.id}")
+    assert refused.status_code == 400
+    assert refused.json()["detail"] == (
+        f'The "{DEFAULT_ROLE_NAME}" role is held by everyone on the platform '
+        "and cannot be deleted. You can change the permissions it grants "
+        "instead."
+    )
+
+    # The role survives …
+    listed = (await api_client.get("/v1/roles")).json()
+    assert [r["name"] for r in listed] == [DEFAULT_ROLE_NAME]
+    # … and so does every grant of it.
+    grants_after = (await db_session.execute(select(UserRole))).scalars().all()
+    assert len(grants_after) == grants_before
+    assert grants_after[0].role_id == default_role.id
+
+
+async def test_update_default_role_permissions_is_allowed(
+    api_client: AsyncClient, default_role: Role
+):
+    """The whole point of the default role: hang a permission off it."""
+    perm = (await api_client.post("/v1/permissions", json={"name": "perm.a"})).json()
+
+    patched = await api_client.patch(
+        f"/v1/roles/{default_role.id}",
+        json={"permission_ids": [perm["id"]], "description": "now grants perm.a"},
+    )
+    assert patched.status_code == 200
+    body = patched.json()
+    assert body["permission_ids"] == [perm["id"]]
+    assert body["description"] == "now grants perm.a"
+
+
+async def test_update_default_role_allows_an_unchanged_name_in_the_body(
+    api_client: AsyncClient, default_role: Role
+):
+    """The admin UI PATCHes the whole role — a no-op name is not a rename."""
+    perm = (await api_client.post("/v1/permissions", json={"name": "perm.a"})).json()
+
+    patched = await api_client.patch(
+        f"/v1/roles/{default_role.id}",
+        json={
+            "name": DEFAULT_ROLE_NAME,
+            "description": "still the default",
+            "permission_ids": [perm["id"]],
+        },
+    )
+    assert patched.status_code == 200
+    body = patched.json()
+    assert body["name"] == DEFAULT_ROLE_NAME
+    assert body["description"] == "still the default"
+    assert body["permission_ids"] == [perm["id"]]
+
+
+async def test_rename_default_role_is_refused(
+    api_client: AsyncClient, db_session: AsyncSession, default_role: Role
+):
+    """Renaming the default role would break guest-mint's lookup (ADR-0016)."""
+    refused = await api_client.patch(
+        f"/v1/roles/{default_role.id}", json={"name": "Peasant"}
+    )
+    assert refused.status_code == 400
+    assert refused.json()["detail"] == (
+        f'The "{DEFAULT_ROLE_NAME}" role is held by everyone on the platform '
+        "and cannot be renamed. You can change the permissions it grants and "
+        "its description."
+    )
+
+    await db_session.refresh(default_role)
+    assert default_role.name == DEFAULT_ROLE_NAME
+    fetched = (await api_client.get(f"/v1/roles/{default_role.id}")).json()
+    assert fetched["name"] == DEFAULT_ROLE_NAME
+
+
 # ----- users ---------------------------------------------------------------
 
 
-async def test_create_and_list_users(api_client: AsyncClient):
+async def test_create_and_list_users(api_client: AsyncClient, default_role: Role):
     created = await api_client.post("/v1/users", json={"username": "ada"})
     assert created.status_code == 201
     body = created.json()
     assert body["username"] == "ada"
-    assert body["role_ids"] == []
+    # A user minted through the admin door holds the default role, like every
+    # other user (ADR-0016) — and the response says so.
+    assert body["role_ids"] == [str(default_role.id)]
 
     rows = (await api_client.get("/v1/users")).json()
     assert any(u["username"] == "ada" for u in rows)
+
+
+async def test_create_user_grants_the_default_role_and_nothing_else(
+    api_client: AsyncClient, db_session: AsyncSession, default_role: Role
+):
+    created = (await api_client.post("/v1/users", json={"username": "ada"})).json()
+
+    role_ids = (
+        await db_session.execute(
+            select(UserRole.role_id).where(UserRole.user_id == uuid.UUID(created["id"]))
+        )
+    ).scalars()
+    assert list(role_ids) == [default_role.id]
+
+
+async def test_create_user_raises_when_the_default_role_is_missing(
+    api_client: AsyncClient, db_session: AsyncSession, default_role: Role
+):
+    """A missing seed row is a broken deployment: mint loudly fails (500) rather
+    than quietly producing a role-less user (ADR-0016)."""
+    await db_session.delete(default_role)
+    await db_session.commit()
+
+    with pytest.raises(RuntimeError, match=DEFAULT_ROLE_NAME):
+        await api_client.post("/v1/users", json={"username": "ada"})
+
+    # The mint raised before committing, so no role-less user was left behind.
+    await db_session.rollback()
+    orphan = (
+        await db_session.execute(select(User).where(User.username == "ada"))
+    ).scalar_one_or_none()
+    assert orphan is None
 
 
 async def test_create_user_rejects_duplicate(api_client: AsyncClient):

--- a/api/tests/test_rbac.py
+++ b/api/tests/test_rbac.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
@@ -285,7 +285,7 @@ async def test_update_role_partial_keeps_permissions(api_client: AsyncClient):
 
 
 async def test_delete_role_cascades_user_assignments(
-    api_client: AsyncClient, db_session: AsyncSession
+    api_client: AsyncClient, db_session: AsyncSession, default_role: Role
 ):
     role = (await api_client.post("/v1/roles", json={"name": "doomed"})).json()
     user = (await api_client.post("/v1/users", json={"username": "alice"})).json()
@@ -296,8 +296,10 @@ async def test_delete_role_cascades_user_assignments(
     deleted = await api_client.delete(f"/v1/roles/{role['id']}")
     assert deleted.status_code == 204
 
+    # Deleting the doomed role cascades away its grant; the default `User` role
+    # the PUT retained (ADR-0016) is all that remains.
     remaining = (await db_session.execute(select(UserRole))).scalars().all()
-    assert remaining == []
+    assert [r.role_id for r in remaining] == [default_role.id]
 
 
 async def test_delete_default_role_is_refused(
@@ -480,7 +482,7 @@ async def test_create_user_rejects_duplicate(api_client: AsyncClient):
 
 
 async def test_set_user_roles_replaces_assignments(
-    api_client: AsyncClient, db_session: AsyncSession
+    api_client: AsyncClient, db_session: AsyncSession, default_role: Role
 ):
     user = (await api_client.post("/v1/users", json={"username": "alex"})).json()
     r1 = (await api_client.post("/v1/roles", json={"name": "one"})).json()
@@ -491,14 +493,20 @@ async def test_set_user_roles_replaces_assignments(
         json={"role_ids": [r1["id"], r2["id"]]},
     )
     assert response.status_code == 200
-    assert set(response.json()["role_ids"]) == {r1["id"], r2["id"]}
+    # r1 and r2 are set exactly; the default role is retained alongside them.
+    assert set(response.json()["role_ids"]) == {
+        r1["id"],
+        r2["id"],
+        str(default_role.id),
+    }
 
+    # r2 is genuinely removed — the default role is the only extra that survives.
     response = await api_client.put(
         f"/v1/users/{user['id']}/roles", json={"role_ids": [r1["id"]]}
     )
-    assert response.json()["role_ids"] == [r1["id"]]
+    assert set(response.json()["role_ids"]) == {r1["id"], str(default_role.id)}
     rows = (await db_session.execute(select(UserRole))).scalars().all()
-    assert len(rows) == 1
+    assert {r.role_id for r in rows} == {uuid.UUID(r1["id"]), default_role.id}
 
 
 async def test_set_user_roles_rejects_unknown_role(api_client: AsyncClient):
@@ -508,6 +516,94 @@ async def test_set_user_roles_rejects_unknown_role(api_client: AsyncClient):
         json={"role_ids": ["00000000-0000-0000-0000-000000000000"]},
     )
     assert response.status_code == 400
+
+
+async def test_set_user_roles_empty_body_retains_the_default_role(
+    api_client: AsyncClient, db_session: AsyncSession, default_role: Role
+):
+    """A full-replace PUT that omits the default role must not strip it: everyone
+    holds `User` (ADR-0016), and the endpoint is the backstop behind the disabled
+    UI checkbox. Silently retained, not a 4xx."""
+    user = (await api_client.post("/v1/users", json={"username": "alex"})).json()
+    other = (await api_client.post("/v1/roles", json={"name": "other"})).json()
+    await api_client.put(
+        f"/v1/users/{user['id']}/roles", json={"role_ids": [other["id"]]}
+    )
+
+    response = await api_client.put(
+        f"/v1/users/{user['id']}/roles", json={"role_ids": []}
+    )
+    assert response.status_code == 200
+    # The response reflects the retained role …
+    assert response.json()["role_ids"] == [str(default_role.id)]
+    # … and so does the database.
+    rows = (
+        (
+            await db_session.execute(
+                select(UserRole).where(UserRole.user_id == uuid.UUID(user["id"]))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [r.role_id for r in rows] == [default_role.id]
+
+
+async def test_set_user_roles_retains_default_alongside_a_partial_body(
+    api_client: AsyncClient, default_role: Role
+):
+    """A body naming only some non-default roles still leaves the user holding
+    `User` — and the other role is set exactly as asked."""
+    user = (await api_client.post("/v1/users", json={"username": "alex"})).json()
+    other = (await api_client.post("/v1/roles", json={"name": "other"})).json()
+
+    response = await api_client.put(
+        f"/v1/users/{user['id']}/roles", json={"role_ids": [other["id"]]}
+    )
+    assert response.status_code == 200
+    assert set(response.json()["role_ids"]) == {other["id"], str(default_role.id)}
+
+
+async def test_set_user_roles_does_not_duplicate_an_explicit_default_role(
+    api_client: AsyncClient, db_session: AsyncSession, default_role: Role
+):
+    """A caller that *does* include the default role gets one grant, not two."""
+    user = (await api_client.post("/v1/users", json={"username": "alex"})).json()
+
+    response = await api_client.put(
+        f"/v1/users/{user['id']}/roles",
+        json={"role_ids": [str(default_role.id)]},
+    )
+    assert response.status_code == 200
+    assert response.json()["role_ids"] == [str(default_role.id)]
+    rows = (
+        (
+            await db_session.execute(
+                select(UserRole).where(UserRole.user_id == uuid.UUID(user["id"]))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [r.role_id for r in rows] == [default_role.id]
+
+
+async def test_set_user_roles_raises_when_the_default_role_is_missing(
+    api_client: AsyncClient, db_session: AsyncSession, default_role: Role
+):
+    """A missing seed row is a broken deployment: the endpoint hard-fails (500)
+    rather than quietly producing a user without `User` (ADR-0016), mirroring
+    `grant_default_role` / admin user-mint."""
+    user = (await api_client.post("/v1/users", json={"username": "alex"})).json()
+    # Drop the grant then the role so the delete isn't blocked by the FK.
+    await db_session.execute(
+        delete(UserRole).where(UserRole.role_id == default_role.id)
+    )
+    await db_session.delete(default_role)
+    await db_session.commit()
+
+    with pytest.raises(RuntimeError, match=DEFAULT_ROLE_NAME):
+        await api_client.put(f"/v1/users/{user['id']}/roles", json={"role_ids": []})
 
 
 async def test_list_users_includes_role_ids(
@@ -655,7 +751,7 @@ async def test_list_roles_permission_ids_sorted_by_name(
 
 
 async def test_list_users_role_ids_sorted_by_role_name(
-    api_client: AsyncClient,
+    api_client: AsyncClient, default_role: Role
 ):
     rz = (await api_client.post("/v1/roles", json={"name": "zeta"})).json()
     ra = (await api_client.post("/v1/roles", json={"name": "alpha"})).json()
@@ -665,4 +761,7 @@ async def test_list_users_role_ids_sorted_by_role_name(
     )
     listing = (await api_client.get("/v1/users")).json()
     fetched = next(u for u in listing if u["id"] == user["id"])
-    assert fetched["role_ids"] == [ra["id"], rz["id"]]
+    # The user also holds the retained default role (ADR-0016); filter it out so
+    # this stays a test of the ORDER BY Role.name sort, not of collation.
+    non_default = [rid for rid in fetched["role_ids"] if rid != str(default_role.id)]
+    assert non_default == [ra["id"], rz["id"]]

--- a/api/tests/test_rbac.py
+++ b/api/tests/test_rbac.py
@@ -383,6 +383,48 @@ async def test_rename_default_role_is_refused(
     assert fetched["name"] == DEFAULT_ROLE_NAME
 
 
+async def test_list_roles_flags_only_the_default_role(
+    api_client: AsyncClient, default_role: Role
+):
+    """`is_default` is derived from the name, so exactly one role carries it."""
+    await api_client.post("/v1/roles", json={"name": "Beta tester"})
+    await api_client.post("/v1/roles", json={"name": "Administrator"})
+
+    rows = (await api_client.get("/v1/roles")).json()
+    assert {r["name"]: r["is_default"] for r in rows} == {
+        DEFAULT_ROLE_NAME: True,
+        "Beta tester": False,
+        "Administrator": False,
+    }
+
+
+async def test_get_role_flags_the_default_role(
+    api_client: AsyncClient, default_role: Role
+):
+    other = (await api_client.post("/v1/roles", json={"name": "Beta tester"})).json()
+
+    fetched_default = (await api_client.get(f"/v1/roles/{default_role.id}")).json()
+    assert fetched_default["is_default"] is True
+
+    fetched_other = (await api_client.get(f"/v1/roles/{other['id']}")).json()
+    assert fetched_other["is_default"] is False
+
+
+async def test_create_and_update_responses_carry_is_default(
+    api_client: AsyncClient, default_role: Role
+):
+    """The client never sees a role payload without the flag — write paths too."""
+    created = await api_client.post("/v1/roles", json={"name": "Beta tester"})
+    assert created.status_code == 201
+    assert created.json()["is_default"] is False
+
+    patched = await api_client.patch(
+        f"/v1/roles/{default_role.id}", json={"description": "still the default"}
+    )
+    assert patched.status_code == 200
+    assert patched.json()["is_default"] is True
+
+
 # ----- users ---------------------------------------------------------------
 
 

--- a/api/tests/test_seed_default_role.py
+++ b/api/tests/test_seed_default_role.py
@@ -1,0 +1,170 @@
+"""The RBAC seed converges any database onto the default `User` role.
+
+`scripts/seed_rbac.py` builds its own engine from settings, so the logic under
+test lives in `app.roles.converge_default_role` and is exercised here directly
+against the test session — the same call the script makes.
+"""
+
+import uuid
+
+import pytest_asyncio
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import Base
+from app.models import Permission, Role, RolePermission, User, UserRole
+from app.roles import DEFAULT_ROLE_NAME, converge_default_role, get_default_role
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def unseeded(db_session: AsyncSession, default_role: Role) -> None:
+    """Start from a database the seed has never touched.
+
+    ``conftest``'s autouse ``default_role`` fixture pre-seeds the role (the
+    user-minting paths raise without it). These tests are about the seed *itself*
+    converging an arbitrary database, so drop it back out first — depending on
+    the fixture guarantees it ran, and therefore that we delete it after it was
+    created, not before.
+    """
+    await db_session.delete(default_role)
+    await db_session.commit()
+
+
+async def _count(db: AsyncSession, model: type[Base]) -> int:
+    result = await db.execute(select(func.count()).select_from(model))
+    return result.scalar_one()
+
+
+async def _role_ids_of(db: AsyncSession, user_id: uuid.UUID) -> set[uuid.UUID]:
+    result = await db.execute(
+        select(UserRole.role_id).where(UserRole.user_id == user_id)
+    )
+    return set(result.scalars().all())
+
+
+async def _make_users(db: AsyncSession, *usernames: str) -> list[User]:
+    users = [User(username=name) for name in usernames]
+    db.add_all(users)
+    await db.flush()
+    return users
+
+
+async def test_creates_the_role_and_grants_it_to_every_existing_user(
+    db_session: AsyncSession,
+) -> None:
+    users = await _make_users(db_session, "ada", "grace", "alan")
+
+    outcome = await converge_default_role(db_session)
+    await db_session.commit()
+
+    assert outcome.role_created is True
+    assert outcome.grants_added == 3
+
+    role = await get_default_role(db_session)
+    assert role is not None
+    assert role.name == DEFAULT_ROLE_NAME
+
+    assert await _count(db_session, UserRole) == 3
+    for user in users:
+        assert await _role_ids_of(db_session, user.id) == {role.id}
+
+
+async def test_the_default_role_carries_zero_permissions(
+    db_session: AsyncSession,
+) -> None:
+    # A permission exists in the database — the role must still pick up none.
+    db_session.add(Permission(name="tournament.view", description="See tournaments."))
+    await _make_users(db_session, "ada")
+
+    await converge_default_role(db_session)
+    await db_session.commit()
+
+    role = await get_default_role(db_session)
+    assert role is not None
+    links = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(RolePermission)
+            .where(RolePermission.role_id == role.id)
+        )
+    ).scalar_one()
+    assert links == 0
+
+
+async def test_a_second_run_adds_no_rows(db_session: AsyncSession) -> None:
+    await _make_users(db_session, "ada", "grace")
+    await converge_default_role(db_session)
+    await db_session.commit()
+
+    roles_before = await _count(db_session, Role)
+    grants_before = await _count(db_session, UserRole)
+
+    outcome = await converge_default_role(db_session)
+    await db_session.commit()
+
+    assert outcome == (False, 0)
+    assert await _count(db_session, Role) == roles_before
+    assert await _count(db_session, UserRole) == grants_before
+
+
+async def test_a_user_with_another_role_ends_up_holding_both(
+    db_session: AsyncSession,
+) -> None:
+    (admin,) = await _make_users(db_session, "ada")
+    administrator = Role(name="Administrator", description="Runs the place.")
+    db_session.add(administrator)
+    await db_session.flush()
+    db_session.add(UserRole(user_id=admin.id, role_id=administrator.id))
+    await db_session.commit()
+
+    outcome = await converge_default_role(db_session)
+    await db_session.commit()
+
+    assert outcome.grants_added == 1
+    default = await get_default_role(db_session)
+    assert default is not None
+    assert await _role_ids_of(db_session, admin.id) == {administrator.id, default.id}
+
+
+async def test_users_minted_since_the_last_run_are_backfilled(
+    db_session: AsyncSession,
+) -> None:
+    await _make_users(db_session, "ada")
+    await converge_default_role(db_session)
+    await db_session.commit()
+
+    (latecomer,) = await _make_users(db_session, "grace")
+    outcome = await converge_default_role(db_session)
+    await db_session.commit()
+
+    assert outcome == (False, 1)
+    default = await get_default_role(db_session)
+    assert default is not None
+    assert await _role_ids_of(db_session, latecomer.id) == {default.id}
+    assert await _count(db_session, UserRole) == 2
+
+
+async def test_permissions_hung_off_the_role_survive_a_re_run(
+    db_session: AsyncSession,
+) -> None:
+    """The role is a lever: an admin adds a permission to it to grant that
+    capability to everyone. A later seed run must not strip it back to empty."""
+    await _make_users(db_session, "ada")
+    await converge_default_role(db_session)
+    await db_session.commit()
+
+    role = await get_default_role(db_session)
+    assert role is not None
+    perm = Permission(name="tournament.view", description="See tournaments.")
+    db_session.add(perm)
+    await db_session.flush()
+    db_session.add(RolePermission(role_id=role.id, permission_id=perm.id))
+    await db_session.commit()
+
+    await converge_default_role(db_session)
+    await db_session.commit()
+
+    result = await db_session.execute(
+        select(RolePermission.permission_id).where(RolePermission.role_id == role.id)
+    )
+    assert list(result.scalars().all()) == [perm.id]

--- a/api/tests/test_seed_default_role.py
+++ b/api/tests/test_seed_default_role.py
@@ -6,6 +6,7 @@ against the test session — the same call the script makes.
 """
 
 import uuid
+from datetime import UTC, datetime
 
 import pytest_asyncio
 from sqlalchemy import func, select
@@ -142,6 +143,36 @@ async def test_users_minted_since_the_last_run_are_backfilled(
     assert default is not None
     assert await _role_ids_of(db_session, latecomer.id) == {default.id}
     assert await _count(db_session, UserRole) == 2
+
+
+async def test_a_merged_away_tombstone_is_not_re_granted_the_role(
+    db_session: AsyncSession,
+) -> None:
+    """A tombstone holds no roles on purpose — the seed must not resurrect them.
+
+    ``app.account_merge.merge_user`` re-points the guest's grants onto the
+    survivor and then deletes whatever ``user_roles`` rows are left, so a
+    merged-away guest deliberately ends up holding zero roles. Backfilling every
+    row in ``users`` would hand the default role straight back to that ghost on
+    the next seed run, undoing the cleanup and listing it in the admin Users page
+    as a holder.
+    """
+    survivor, ghost = await _make_users(db_session, "ada", "ada-guest")
+    # The post-merge shape: tombstoned (both merge columns set), zero user_roles.
+    ghost.merged_into_user_id = survivor.id
+    ghost.merged_at = datetime.now(UTC)
+    await db_session.commit()
+
+    outcome = await converge_default_role(db_session)
+    await db_session.commit()
+
+    default = await get_default_role(db_session)
+    assert default is not None
+    assert await _role_ids_of(db_session, ghost.id) == set()
+    # The live user still gets it; only the tombstone is skipped.
+    assert outcome.grants_added == 1
+    assert await _role_ids_of(db_session, survivor.id) == {default.id}
+    assert await _count(db_session, UserRole) == 1
 
 
 async def test_permissions_hung_off_the_role_survive_a_re_run(

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db import get_session
 from app.main import app
 from app.models import Permission, Role, RolePermission, User, UserRole, UserToken
+from app.roles import DEFAULT_ROLE_NAME
 from app.sessions import (
     CSRF_COOKIE_NAME,
     CSRF_HEADER_NAME,
@@ -70,6 +71,49 @@ async def test_creates_session_when_no_cookie(
     ).scalar_one()
     assert token.user_id == user.id
     assert token.context == SESSION_TOKEN_CONTEXT
+
+
+async def test_minted_guest_holds_the_default_role_and_nothing_else(
+    api_client: AsyncClient, db_session: AsyncSession, default_role: Role
+):
+    """The whole point of ADR-0016: there is no signup, so the first-ever
+    ``GET /v1/session`` is the moment a person joins the site — and they leave it
+    holding the default role."""
+    response = await api_client.get("/v1/session")
+    assert response.status_code == 200
+    username = response.json()["data"]["user"]["username"]
+
+    user = (
+        await db_session.execute(select(User).where(User.username == username))
+    ).scalar_one()
+    role_ids = (
+        await db_session.execute(
+            select(UserRole.role_id).where(UserRole.user_id == user.id)
+        )
+    ).scalars()
+    assert list(role_ids) == [default_role.id]
+
+    # The role carries no permissions, so the session payload is unchanged —
+    # no client sees this.
+    assert response.json()["data"]["user"]["permissions"] == []
+
+
+async def test_session_mint_raises_when_the_default_role_is_missing(
+    api_client: AsyncClient, db_session: AsyncSession, default_role: Role
+):
+    """A missing seed row is a broken deployment. Guest-mint fails loudly (500)
+    rather than soft-skipping and minting a role-less user nobody notices until a
+    permission is hung off the role months later (ADR-0016)."""
+    await db_session.delete(default_role)
+    await db_session.commit()
+
+    with pytest.raises(RuntimeError, match=DEFAULT_ROLE_NAME):
+        await api_client.get("/v1/session")
+
+    # Nothing was committed, so no role-less user was left behind.
+    await db_session.rollback()
+    users = (await db_session.execute(select(User))).scalars().all()
+    assert users == []
 
 
 async def test_returns_existing_session_when_cookie_valid(

--- a/docs/adr/0016-every-user-holds-the-default-user-role.md
+++ b/docs/adr/0016-every-user-holds-the-default-user-role.md
@@ -1,0 +1,120 @@
+# 16. Every user holds the default `User` role, granted at mint
+
+Date: 2026-07-11
+
+## Status
+
+Accepted
+
+## Context
+
+RBAC in fortymm is permission-based, not role-based: `require_permission(name)`
+(`api/app/rbac.py`) joins `permissions → role_permissions → user_roles` and asks
+whether *this user* holds *this permission name*. Roles exist only as a bundle of
+permissions to hang off a user. `GET /v1/session` flattens the join and returns
+permission **names** only — the client never sees a role.
+
+Two facts about the current system shaped this decision:
+
+1. **Nothing assigns anyone a role.** `api/scripts/seed_rbac.py` seeds
+   `permissions`, `roles`, and `role_permissions` — but never `user_roles`. The
+   only write to `user_roles` is `PUT /v1/users/{user_id}/roles`, itself gated on
+   `authorization.manage`. The first `authorization.manage` holder must therefore
+   be granted out-of-band, by hand, in SQL.
+
+2. **There is no signup.** Identity is guest-first: a `users` row is minted on a
+   visitor's first `GET /v1/session` (`_create_session`). Email confirmation
+   (`POST /v1/me/email/confirm`) and magic-link sign-in (`POST /v1/login/consume`)
+   *attach an email to an already-existing row* — they never create one. "The
+   moment someone joins the site" and "the moment a `users` row is minted" are the
+   same moment, and it happens before the visitor has done anything.
+
+We want a lever: a single role that everyone holds, so that granting a capability
+to the whole population is a one-row change in the admin UI (add the permission to
+the role) rather than a migration or a code change.
+
+## Decision
+
+**Seed a role named `User`, carrying zero permissions, and grant it to every user
+at the moment their row is minted.**
+
+Five things this pins down.
+
+### The grant is materialized, not virtual
+
+Every user gets a real `user_roles` row. The rejected alternative was a *virtual*
+default — leave `user_roles` alone and have the permission resolver always fold in
+the default role's permissions for everyone. Virtual costs no hot-path write and
+no backfill, but it makes the default role invisible in the admin Users page
+(nobody is listed as holding it) and it special-cases the one resolver that every
+authorization decision in the app flows through. A materialized row means there is
+exactly one way a user comes to hold a permission, and `PUT /v1/users/{id}/roles`
+keeps meaning what it says.
+
+### Everyone means every visitor
+
+The grant happens at guest-mint, so it reaches anonymous traffic — bots and
+crawlers included. This is deliberate: it is the only reading of "everyone" that
+holds, given that a user row exists before the human has identified themselves.
+The consequence to keep in mind when *using* the lever: **any permission added to
+`User` is granted to anonymous visitors**, not just to people who have confirmed
+an email. A capability that must be reserved for claimed accounts does not belong
+on this role.
+
+Admin-created users (`POST /v1/users`) get it too — a user minted through the
+admin door is still a user.
+
+### It ships with zero permissions
+
+`User` grants nothing on day one. It is a lever, not a capability. Because
+`/v1/session` exposes permission names and this role adds none, the change is
+invisible to the web client and to iOS: no session payload changes, no generated
+types change, no UI changes.
+
+### A missing seed row is a hard failure
+
+`_create_session` looks the role up by name. If the row is absent — a fresh
+database, or an app that serves traffic before the seed hook has run — session
+creation **raises**, and every visitor gets a 500. We do not soft-skip.
+
+A soft skip would trade a loud, immediate, obviously-wrong failure for a silent
+one: users minted role-less during the window, invisible until months later when a
+permission is hung off `User` and an arbitrary cohort mysteriously doesn't have
+it. "The default role exists" is an invariant of a correctly-deployed system, and
+the seed step already runs ahead of the API in every environment
+(`docker-compose.dev.yml`, `docker-compose.qa.yml`, the UAT migrate-job Helm hook).
+Breaking loudly is how that ordering stays true.
+
+### The role is protected from deletion and rename
+
+`DELETE /v1/roles/{id}` and `PATCH /v1/roles/{id}` refuse to remove the default
+role or change its name — the name is the lookup key that guest-mint depends on,
+and deleting the role would silently strip it from every user via the `ON DELETE
+CASCADE` on `user_roles`. This mirrors the existing guard that stops an admin
+deleting the last `authorization.manage` holder (themselves).
+
+Its **permissions** stay freely editable. That is the entire point of the role.
+
+To make the role legible rather than merely protected, the role read payload
+carries an `is_default` flag **derived from the name** — not stored. A boolean
+column would be a second source of truth for a fact the name already settles, and
+it would need its own "exactly one default role" invariant to police. Deriving it
+means the admin Roles page can badge the role and disable its Delete control
+proactively (the precedent set by the self-delete guard on the Users page) with
+nothing new to keep in sync.
+
+## Consequences
+
+- Granting a capability to the whole population is now an admin-UI action: add the
+  permission to `User`. No code, no migration.
+- The name `User` becomes load-bearing. It lives in exactly one constant, shared
+  by the seed script, the guest-mint grant, and the delete/rename guard.
+- Session creation gains one INSERT on the hot path. It is on the write path that
+  already inserts a `users` row and a `user_tokens` row, so it does not add a
+  round-trip class that wasn't there.
+- Account merge already re-points `user_roles` with a `NOT EXISTS` de-dupe, so a
+  merge where both sides hold `User` collapses cleanly to one row. That behaviour
+  is now exercised by every merge rather than by none.
+- Existing user rows are backfilled once. Per the project's pre-deploy convention
+  the data is disposable, but the backfill means a developer's existing local
+  database doesn't quietly hold a population of role-less users.

--- a/docs/adr/0016-every-user-holds-the-default-user-role.md
+++ b/docs/adr/0016-every-user-holds-the-default-user-role.md
@@ -95,6 +95,18 @@ deleting the last `authorization.manage` holder (themselves).
 
 Its **permissions** stay freely editable. That is the entire point of the role.
 
+### Per-user membership is protected too
+
+The delete/rename guards defend the role's *existence*, but the per-user role
+editor (`PUT /v1/users/{id}/roles`, a full replace) could still strip `User`
+from one account at a time — quietly breaking the "everyone holds it" invariant
+for that user, and silently excluding them from any capability later hung off the
+role. So the assignment endpoint **always retains the default role**: whatever set
+of role ids it is handed, the default role's membership survives. The admin Users
+editor disables that one checkbox up front (as the Roles page disables Delete),
+and the endpoint enforces it as the backstop. Every *other* role remains freely
+assignable and removable.
+
 To make the role legible rather than merely protected, the role read payload
 carries an `is_default` flag **derived from the name** — not stored. A boolean
 column would be a second source of truth for a fact the name already settles, and

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -4915,6 +4915,10 @@ internal enum Components {
             internal var updatedAt: Foundation.Date
             /// - Remark: Generated from `#/components/schemas/RoleRead/permission_ids`.
             internal var permissionIds: [Swift.String]
+            /// Whether this is the default role held by every user on the platform.
+            ///
+            /// - Remark: Generated from `#/components/schemas/RoleRead/is_default`.
+            internal var isDefault: Swift.Bool
             /// Creates a new `RoleRead`.
             ///
             /// - Parameters:
@@ -4924,13 +4928,15 @@ internal enum Components {
             ///   - createdAt:
             ///   - updatedAt:
             ///   - permissionIds:
+            ///   - isDefault: Whether this is the default role held by every user on the platform.
             internal init(
                 name: Swift.String,
                 description: Swift.String? = nil,
                 id: Swift.String,
                 createdAt: Foundation.Date,
                 updatedAt: Foundation.Date,
-                permissionIds: [Swift.String]
+                permissionIds: [Swift.String],
+                isDefault: Swift.Bool
             ) {
                 self.name = name
                 self.description = description
@@ -4938,6 +4944,7 @@ internal enum Components {
                 self.createdAt = createdAt
                 self.updatedAt = updatedAt
                 self.permissionIds = permissionIds
+                self.isDefault = isDefault
             }
             internal enum CodingKeys: String, CodingKey {
                 case name
@@ -4946,6 +4953,7 @@ internal enum Components {
                 case createdAt = "created_at"
                 case updatedAt = "updated_at"
                 case permissionIds = "permission_ids"
+                case isDefault = "is_default"
             }
         }
         /// - Remark: Generated from `#/components/schemas/RoleUpdate`.

--- a/web-client/e2e/page-objects/rbac/roles.page.ts
+++ b/web-client/e2e/page-objects/rbac/roles.page.ts
@@ -25,9 +25,11 @@ export class RolesPage extends RbacPage {
   get emptyState(): Locator {
     return this.page.getByText('No roles yet')
   }
-  /** Role row in the left sidebar */
+  /** Role row in the left sidebar. Keyed by test id, not by text: every row
+   * carries a "N users" count, and `hasText` is a case-insensitive substring —
+   * so filtering for a role literally named `User` would match every row. */
   roleRow(name: string): Locator {
-    return this.page.locator('.rbac-row').filter({ hasText: name }).first()
+    return this.page.getByTestId(`role-row-${name}`)
   }
   /** Permission row in the editor (matches by perm name) */
   permRow(name: string): Locator {
@@ -52,6 +54,23 @@ export class RolesPage extends RbacPage {
   }
   get confirmDeleteButton(): Locator {
     return this.page.getByRole('button', { name: 'Delete role' })
+  }
+  /** The "Default" badge inside a role's sidebar row — absent on a normal role. */
+  roleRowBadge(name: string): Locator {
+    return this.page.getByTestId(`role-row-${name}`).getByText('Default', { exact: true })
+  }
+  /** The "Default" badge in the detail header of the selected role. */
+  get detailBadge(): Locator {
+    return this.page.getByTestId('role-detail').getByText('Default', { exact: true })
+  }
+  /** The span wrapping the Delete button — it carries the "why not" tooltip,
+   * since a disabled button is pointer-events-none and would never show one. */
+  get deleteTooltipHost(): Locator {
+    return this.page.getByTestId('delete-role-tooltip')
+  }
+  /** The checkbox that grants `permName` to the selected role. */
+  permToggle(permName: string): Locator {
+    return this.page.getByTestId(`perm-toggle-${permName}`)
   }
   get newRoleNameInput(): Locator {
     return this.page.getByPlaceholder(/Volunteer scorer/i)

--- a/web-client/e2e/rbac-roles.spec.ts
+++ b/web-client/e2e/rbac-roles.spec.ts
@@ -169,3 +169,74 @@ test.describe('Administration · Roles', () => {
     await expect.poll(() => store.getUser('u2')!.role_ids).toEqual(['r_score'])
   })
 })
+
+// ADR-0016: `User` is held by every account on the platform. The API refuses to
+// delete or rename it; the page doesn't offer either. Its permissions stay
+// editable — that's what the role is *for*.
+const DEFAULT_ROLE_SEED = {
+  permissions: [{ id: 'p_tv', name: 'tournament.view', description: 'View tournaments.' }],
+  roles: [
+    { id: 'r_user', name: 'User', description: 'Held by everyone.', permission_ids: [], is_default: true },
+    { id: 'r_score', name: 'Scorekeeper', description: 'Tap in points.', permission_ids: ['p_tv'] },
+  ],
+  users: [{ id: 'u1', username: 'alex', role_ids: ['r_user', 'r_score'] }],
+}
+
+test.describe('Administration · Roles · the default role', () => {
+  test('badges it and refuses to offer Delete, explaining why', async ({ page }) => {
+    const { pom } = await RolesPage.navigateTo(page, DEFAULT_ROLE_SEED)
+
+    await expect(pom.roleRowBadge('User')).toBeVisible()
+    await expect(pom.roleRowBadge('Scorekeeper')).toHaveCount(0)
+
+    await pom.roleRow('User').click()
+    await expect(pom.detailBadge).toBeVisible()
+    await expect(pom.deleteButton).toBeDisabled()
+    await expect(pom.deleteTooltipHost).toHaveAttribute(
+      'title',
+      /held by everyone on the platform and can't be deleted/i,
+    )
+  })
+
+  test('locks its name in the edit modal but keeps the description editable', async ({ page }) => {
+    const { pom, store } = await RolesPage.navigateTo(page, DEFAULT_ROLE_SEED)
+    await pom.roleRow('User').click()
+    await pom.editButton.click()
+
+    await expect(pom.editNameInput).toBeDisabled()
+    const description = page.getByLabel('Description')
+    await description.fill('Everyone gets this.')
+    await pom.editSaveButton.click()
+
+    // The PATCH carries the unchanged name alongside the new description — the
+    // API only refuses a name that actually *changes*, so this must go through.
+    await expect.poll(() => store.getRole('r_user')!.description).toBe('Everyone gets this.')
+    expect(store.getRole('r_user')!.name).toBe('User')
+  })
+
+  test('keeps its permission checkboxes tickable', async ({ page }) => {
+    const { pom, store } = await RolesPage.navigateTo(page, DEFAULT_ROLE_SEED)
+    await pom.roleRow('User').click()
+
+    await pom.permToggle('tournament.view').click()
+
+    await expect.poll(() => store.getRole('r_user')!.permission_ids).toEqual(['p_tv'])
+  })
+
+  test('leaves a normal role renameable and deletable', async ({ page }) => {
+    const { pom, store } = await RolesPage.navigateTo(page, DEFAULT_ROLE_SEED)
+    await pom.roleRow('Scorekeeper').click()
+
+    await pom.editButton.click()
+    await expect(pom.editNameInput).toBeEnabled()
+    await pom.editNameInput.fill('Umpire')
+    await pom.editSaveButton.click()
+    await expect.poll(() => store.getRole('r_score')!.name).toBe('Umpire')
+
+    await expect(pom.deleteButton).toBeEnabled()
+    await pom.deleteButton.click()
+    await pom.confirmDeleteButton.click()
+
+    await expect.poll(() => store.listRoles().map((r) => r.name)).toEqual(['User'])
+  })
+})

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -2272,6 +2272,11 @@ export interface components {
             updated_at: string;
             /** Permission Ids */
             permission_ids: string[];
+            /**
+             * Is Default
+             * @description Whether this is the default role held by every user on the platform.
+             */
+            readonly is_default: boolean;
         };
         /** RoleUpdate */
         RoleUpdate: {

--- a/web-client/src/components/rbac/roles-page.factory.ts
+++ b/web-client/src/components/rbac/roles-page.factory.ts
@@ -1,0 +1,47 @@
+import type { SeedSpec } from '@/mocks/rbac-engine'
+
+/**
+ * A deterministic RBAC universe for the Roles page: **one default role and one
+ * plain one**, so every assertion has its negative twin. A suite seeded with
+ * only the default role would pass against a page that badges (and locks down)
+ * every role indiscriminately.
+ *
+ * The engine sorts roles by name, so `Owner` sorts ahead of `User` and is the
+ * role the page selects on first paint.
+ */
+export const PERM_VIEW = 'p_view'
+export const PERM_CREATE = 'p_create'
+export const DEFAULT_ROLE_ID = 'r_default'
+export const PLAIN_ROLE_ID = 'r_plain'
+
+export function buildRolesSeed(overrides: SeedSpec = {}): SeedSpec {
+  return {
+    permissions: [
+      { id: PERM_VIEW, name: 'tournament.view', description: 'See tournaments.' },
+      { id: PERM_CREATE, name: 'tournament.create', description: 'Spin up a tournament.' },
+    ],
+    roles: [
+      {
+        id: DEFAULT_ROLE_ID,
+        name: 'User',
+        description: 'Held by every user. Carries no permissions by default.',
+        permission_ids: [],
+        is_default: true,
+      },
+      {
+        id: PLAIN_ROLE_ID,
+        name: 'Owner',
+        description: 'Full control of the workspace.',
+        permission_ids: [PERM_VIEW, PERM_CREATE],
+        is_default: false,
+      },
+    ],
+    users: [
+      // Every user holds the default role (ADR-0016) — including this one, who
+      // also happens to be an owner.
+      { id: 'u1', username: 'tim.nguyen', role_ids: [DEFAULT_ROLE_ID, PLAIN_ROLE_ID] },
+      { id: 'u2', username: 'eun.han', role_ids: [DEFAULT_ROLE_ID] },
+    ],
+    ...overrides,
+  }
+}

--- a/web-client/src/components/rbac/roles-page.page.tsx
+++ b/web-client/src/components/rbac/roles-page.page.tsx
@@ -1,0 +1,91 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen, within as rtlWithin, type Container } from '@/test/utilities'
+import { server } from '@/mocks/server'
+import { rbacHandlersFor } from '@/mocks/handlers'
+import { createRbacState, type RbacState, type SeedSpec } from '@/mocks/rbac-engine'
+import { RolesPage } from './roles-page'
+import { buildRolesSeed } from './roles-page.factory'
+
+const scoped = (container: Container) => ({
+  /** A role's row in the left-hand list. */
+  findRoleRow(name: string) {
+    return container.findByTestId(`role-row-${name}`)
+  },
+  queryRoleRow(name: string) {
+    return container.queryByTestId(`role-row-${name}`)
+  },
+  /** The detail panel for whichever role is currently selected. */
+  findDetail() {
+    return container.findByTestId('role-detail')
+  },
+  /** The Delete control in the detail header. */
+  findDeleteButton() {
+    return container.findByRole('button', { name: /delete/i })
+  },
+  findEditButton() {
+    return container.findByRole('button', { name: /^edit$/i })
+  },
+  /** The edit modal's Name input — disabled for the default role. Its absence
+   * is how a test knows the modal closed (it closes only on success). */
+  findNameInput() {
+    return container.findByLabelText('Name')
+  },
+  queryNameInput() {
+    return container.queryByLabelText('Name')
+  },
+  findDescriptionInput() {
+    return container.findByLabelText('Description')
+  },
+  findSaveButton() {
+    return container.findByRole('button', { name: /save changes/i })
+  },
+  /** The checkbox that grants `permName` to the selected role. */
+  findPermToggle(permName: string) {
+    return container.findByTestId(`perm-toggle-${permName}`)
+  },
+  queryDefaultBadge() {
+    return container.queryByText('Default')
+  },
+  /** Anything carrying `text` as a native tooltip (`title`). */
+  queryTooltip(text: string | RegExp) {
+    return container.queryByTitle(text)
+  },
+})
+
+/**
+ * Test page-object for the admin `RolesPage`. It seeds a caller-owned RBAC
+ * state (defaulting to one default + one plain role) and points MSW at it, so
+ * the page reads and writes through the same mock engine the e2e suite uses —
+ * a PATCH or DELETE the API would refuse is refused here too.
+ */
+export const rolesPage = {
+  /** Seed MSW, render, and hand back the live mock state so a test can assert
+   * on what the page actually persisted. */
+  render(seed: SeedSpec = buildRolesSeed()): RbacState {
+    const state = createRbacState(seed)
+    server.use(...rbacHandlersFor(state))
+    render(<RolesPage />)
+    return state
+  },
+
+  user() {
+    return userEvent.setup()
+  },
+
+  /** Select a role in the sidebar and resolve its detail panel. */
+  async select(name: string) {
+    const row = await this.findRoleRow(name)
+    await userEvent.click(row)
+    const detail = await this.findDetail()
+    await rtlWithin(detail).findByRole('heading', { level: 1, name })
+    return detail
+  },
+
+  /** Scope every accessor to a subtree — e.g. one sidebar row, or the detail
+   * panel — so "the default badge" means *that* role's badge. */
+  within(node?: HTMLElement) {
+    return scoped(node ? rtlWithin(node) : screen)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/rbac/roles-page.test.tsx
+++ b/web-client/src/components/rbac/roles-page.test.tsx
@@ -1,0 +1,141 @@
+import { waitFor } from '@/test/utilities'
+import { rolesPage } from './roles-page.page'
+import { DEFAULT_ROLE_ID, PERM_VIEW, buildRolesSeed } from './roles-page.factory'
+
+// ADR-0016: one role — `User` — is held by every account on the platform. The
+// API refuses to delete or rename it (400), so the page must not offer either.
+// Everything else about it, above all its permissions, stays editable: ticking a
+// permission onto this role is how an admin grants a capability to everyone.
+describe('RolesPage — the default role', () => {
+  it('badges the default role, and only it', async () => {
+    rolesPage.render()
+
+    const defaultRow = await rolesPage.findRoleRow('User')
+    const plainRow = await rolesPage.findRoleRow('Owner')
+
+    expect(rolesPage.within(defaultRow).queryDefaultBadge()).toBeInTheDocument()
+    expect(rolesPage.within(plainRow).queryDefaultBadge()).not.toBeInTheDocument()
+  })
+
+  it('badges it in the detail panel too, so a selected role reads as special', async () => {
+    rolesPage.render()
+
+    const detail = await rolesPage.select('User')
+
+    expect(rolesPage.within(detail).queryDefaultBadge()).toBeInTheDocument()
+  })
+
+  it('disables Delete and says why', async () => {
+    rolesPage.render()
+
+    const detail = await rolesPage.select('User')
+    const scope = rolesPage.within(detail)
+
+    expect(await scope.findDeleteButton()).toBeDisabled()
+    // The tooltip hangs off a wrapper: a disabled button is pointer-events-none,
+    // so its own `title` would never surface on hover.
+    expect(scope.queryTooltip(/held by everyone on the platform and can't be deleted/i)).toBeInTheDocument()
+  })
+
+  it('locks the name field in the edit modal and says why', async () => {
+    const user = rolesPage.user()
+    rolesPage.render()
+
+    const detail = await rolesPage.select('User')
+    await user.click(await rolesPage.within(detail).findEditButton())
+
+    expect(await rolesPage.findNameInput()).toBeDisabled()
+    expect(rolesPage.queryTooltip(/can't be renamed/i)).toBeInTheDocument()
+    // The description is the one field on this role a rename guard must not touch.
+    expect(await rolesPage.findDescriptionInput()).toBeEnabled()
+  })
+
+  it('still saves a description edit — the rename guard must not swallow the whole form', async () => {
+    const user = rolesPage.user()
+    const state = rolesPage.render()
+
+    const detail = await rolesPage.select('User')
+    await user.click(await rolesPage.within(detail).findEditButton())
+
+    const description = await rolesPage.findDescriptionInput()
+    await user.clear(description)
+    await user.type(description, 'Everyone gets this.')
+    await user.click(await rolesPage.findSaveButton())
+
+    // The modal closes only on success, so its absence *is* the success signal.
+    await waitFor(() => {
+      expect(state.roles.get(DEFAULT_ROLE_ID)?.description).toBe('Everyone gets this.')
+    })
+    await waitFor(() => {
+      expect(rolesPage.queryNameInput()).not.toBeInTheDocument()
+    })
+    expect(state.roles.get(DEFAULT_ROLE_ID)?.name).toBe('User')
+  })
+
+  it('keeps its permission checkboxes interactive — that is the whole point of it', async () => {
+    const user = rolesPage.user()
+    const state = rolesPage.render()
+
+    await rolesPage.select('User')
+    const toggle = await rolesPage.findPermToggle('tournament.view')
+    expect(toggle).toBeEnabled()
+
+    await user.click(toggle)
+
+    await waitFor(() => {
+      expect(state.roles.get(DEFAULT_ROLE_ID)?.permission_ids).toContain(PERM_VIEW)
+    })
+    await waitFor(() => expect(toggle).toBeChecked())
+
+    // …and untickable again.
+    await user.click(toggle)
+    await waitFor(() => {
+      expect(state.roles.get(DEFAULT_ROLE_ID)?.permission_ids).not.toContain(PERM_VIEW)
+    })
+  })
+})
+
+describe('RolesPage — a role nobody special', () => {
+  it('deletes as before: Delete is enabled and untooltipped', async () => {
+    rolesPage.render()
+
+    const detail = await rolesPage.select('Owner')
+    const scope = rolesPage.within(detail)
+
+    expect(await scope.findDeleteButton()).toBeEnabled()
+    expect(scope.queryTooltip(/can't be deleted/i)).not.toBeInTheDocument()
+    expect(scope.queryDefaultBadge()).not.toBeInTheDocument()
+  })
+
+  it('renames as before: the edit modal leaves the name field editable', async () => {
+    const user = rolesPage.user()
+    const state = rolesPage.render()
+
+    const detail = await rolesPage.select('Owner')
+    await user.click(await rolesPage.within(detail).findEditButton())
+
+    const name = await rolesPage.findNameInput()
+    expect(name).toBeEnabled()
+
+    await user.clear(name)
+    await user.type(name, 'Founder')
+    await user.click(await rolesPage.findSaveButton())
+
+    await waitFor(() => {
+      expect(rolesPage.queryRoleRow('Founder')).toBeInTheDocument()
+    })
+    expect([...state.roles.values()].map((r) => r.name)).toContain('Founder')
+  })
+
+  it('renders a badgeless list when no default role exists at all', async () => {
+    rolesPage.render(
+      buildRolesSeed({
+        roles: [{ id: 'r_only', name: 'Owner', permission_ids: [], is_default: false }],
+      }),
+    )
+
+    await rolesPage.findRoleRow('Owner')
+
+    expect(rolesPage.queryDefaultBadge()).not.toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/rbac/roles-page.tsx
+++ b/web-client/src/components/rbac/roles-page.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner'
 import { z } from 'zod'
 import { Check, Copy, Folder, Pencil, Plus, Search, Shield, Trash2, Users, X } from 'lucide-react'
 import { ApiError } from '@/api/client'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
@@ -51,6 +52,19 @@ import {
 } from './queries'
 import { Avatar, EmptyState, Field, Stat } from './primitives'
 import { colorFor, fmtDate, fmtDateRel, groupPermissions } from './helpers'
+
+// The default role is held by every user on the platform, so the API refuses to
+// delete it (that would cascade the grant away from everyone) or rename it (the
+// name is guest-mint's lookup key) — ADR-0016. Those refusals are 400s; the page
+// doesn't offer the action in the first place, the way the Users page disables
+// self-removal. Permissions and description stay freely editable: granting a
+// capability to the whole population by ticking it onto this role is the entire
+// point of it.
+const DEFAULT_ROLE_HINT = 'Held by every user on the platform.'
+const DEFAULT_ROLE_DELETE_HINT =
+  "This role is held by everyone on the platform and can't be deleted. You can change the permissions it grants instead."
+const DEFAULT_ROLE_RENAME_HINT =
+  "Held by everyone on the platform, so it can't be renamed. Its permissions and description are still yours to change."
 
 export function RolesPage() {
   const { data: roles = [], isLoading: rolesLoading } = useRoles()
@@ -229,6 +243,7 @@ function RoleRow({
     <div
       onClick={onClick}
       className="rbac-row"
+      data-testid={`role-row-${role.name}`}
       data-active={active || undefined}
       style={{
         padding: '14px 18px 14px 15px',
@@ -248,6 +263,11 @@ function RoleRow({
           }}
         />
         <div style={{ flex: 1, fontSize: 14, fontWeight: 600, color: 'var(--fg-1)' }}>{role.name}</div>
+        {role.is_default && (
+          <Badge variant="secondary" title={DEFAULT_ROLE_HINT}>
+            Default
+          </Badge>
+        )}
       </div>
       <div
         style={{
@@ -335,7 +355,7 @@ function RoleDetail({
   }
 
   return (
-    <div>
+    <div data-testid="role-detail">
       <div style={{ padding: '24px 32px 20px', borderBottom: '1px solid var(--border-subtle)' }}>
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: 14 }}>
           <div
@@ -354,7 +374,14 @@ function RoleDetail({
             <Shield size={20} color={accent} strokeWidth={1.75} />
           </div>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <h1 style={titleStyle}>{role.name}</h1>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+              <h1 style={titleStyle}>{role.name}</h1>
+              {role.is_default && (
+                <Badge variant="secondary" title={DEFAULT_ROLE_HINT}>
+                  Default
+                </Badge>
+              )}
+            </div>
             <div style={descStyle(!!role.description)}>
               {role.description || 'No description'}
             </div>
@@ -384,9 +411,23 @@ function RoleDetail({
             >
               <Copy size={14} /> Duplicate
             </Button>
-            <Button variant="destructive" size="sm" onClick={() => setConfirmDelete(true)}>
-              <Trash2 size={14} /> Delete
-            </Button>
+            {/* A disabled Button is `pointer-events-none`, so a `title` on the
+                button itself would never surface on hover — the wrapper carries
+                the tooltip so the refusal is explained where it's felt. */}
+            <span
+              data-testid="delete-role-tooltip"
+              title={role.is_default ? DEFAULT_ROLE_DELETE_HINT : undefined}
+              style={{ display: 'inline-flex' }}
+            >
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={role.is_default}
+                onClick={() => setConfirmDelete(true)}
+              >
+                <Trash2 size={14} /> Delete
+              </Button>
+            </span>
           </div>
         </div>
 
@@ -512,7 +553,11 @@ function EditRoleModal({
       <DialogContent className="max-h-[calc(100vh-2rem)] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Edit role</DialogTitle>
-          <DialogDescription>Rename this role or update its description.</DialogDescription>
+          <DialogDescription>
+            {role.is_default
+              ? 'Update this role’s description. Its name is fixed.'
+              : 'Rename this role or update its description.'}
+          </DialogDescription>
         </DialogHeader>
         <Form {...form}>
           <form onSubmit={handleSubmit} noValidate>
@@ -524,8 +569,20 @@ function EditRoleModal({
                   <FormItem>
                     <FormLabel>Name</FormLabel>
                     <FormControl>
-                      <Input autoFocus {...field} />
+                      {/* The default role's name is load-bearing (ADR-0016), so
+                          the field is locked. The DOM `disabled` doesn't touch
+                          RHF's value, so the unchanged name still submits — and
+                          the API only refuses a name that actually *changes*,
+                          which keeps this same PATCH free to edit the
+                          description. */}
+                      <Input
+                        autoFocus={!role.is_default}
+                        disabled={role.is_default}
+                        title={role.is_default ? DEFAULT_ROLE_RENAME_HINT : undefined}
+                        {...field}
+                      />
                     </FormControl>
+                    {role.is_default && <FormDescription>{DEFAULT_ROLE_RENAME_HINT}</FormDescription>}
                     <FormMessage />
                   </FormItem>
                 )}
@@ -537,7 +594,14 @@ function EditRoleModal({
                   <FormItem>
                     <FormLabel>Description</FormLabel>
                     <FormControl>
-                      <Textarea style={{ minHeight: 80 }} {...field} value={field.value ?? ''} />
+                      {/* On the default role the name field is disabled, so the
+                          description is the first thing a keyboard user can edit. */}
+                      <Textarea
+                        autoFocus={role.is_default}
+                        style={{ minHeight: 80 }}
+                        {...field}
+                        value={field.value ?? ''}
+                      />
                     </FormControl>
                     <FormDescription>What does this role let people do?</FormDescription>
                     <FormMessage />
@@ -669,6 +733,8 @@ function PermRow({ p, on, onToggle }: { p: Permission; on: boolean; onToggle: ()
         checked={on}
         onCheckedChange={onToggle}
         onClick={(e) => e.stopPropagation()}
+        data-testid={`perm-toggle-${p.name}`}
+        aria-label={p.name}
       />
       <PermissionCode name={p.name} active={on} />
       <div style={{ flex: 1, minWidth: 0, fontSize: 12.5, color: 'var(--fg-3)', lineHeight: 1.4 }}>

--- a/web-client/src/components/rbac/users-page.factory.ts
+++ b/web-client/src/components/rbac/users-page.factory.ts
@@ -1,0 +1,43 @@
+import type { SeedSpec } from '@/mocks/rbac-engine'
+
+/**
+ * A deterministic RBAC universe for the Users page: **one default role and one
+ * plain one**, so every assertion about the locked default checkbox has its
+ * negative twin in the still-toggleable plain role. A suite seeded with only
+ * the default role would pass against a page that disabled *every* checkbox.
+ *
+ * The seeded user holds only the default role, leaving the plain role free to
+ * be ticked on (and saved) by a test.
+ */
+export const DEFAULT_ROLE_ID = 'r_default'
+export const PLAIN_ROLE_ID = 'r_plain'
+export const USER_ID = 'u_eun'
+
+export function buildUsersSeed(overrides: SeedSpec = {}): SeedSpec {
+  return {
+    permissions: [
+      { id: 'p_view', name: 'tournament.view', description: 'See tournaments.' },
+    ],
+    roles: [
+      {
+        id: DEFAULT_ROLE_ID,
+        name: 'User',
+        description: 'Held by every user. Carries no permissions by default.',
+        permission_ids: [],
+        is_default: true,
+      },
+      {
+        id: PLAIN_ROLE_ID,
+        name: 'Owner',
+        description: 'Full control of the workspace.',
+        permission_ids: ['p_view'],
+        is_default: false,
+      },
+    ],
+    users: [
+      // Holds only the default role (ADR-0016) — so Owner is free to toggle on.
+      { id: USER_ID, username: 'eun.han', role_ids: [DEFAULT_ROLE_ID] },
+    ],
+    ...overrides,
+  }
+}

--- a/web-client/src/components/rbac/users-page.page.tsx
+++ b/web-client/src/components/rbac/users-page.page.tsx
@@ -1,0 +1,70 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen, within as rtlWithin, type Container } from '@/test/utilities'
+import { server } from '@/mocks/server'
+import { rbacHandlersFor } from '@/mocks/handlers'
+import { createRbacState, type RbacState, type SeedSpec } from '@/mocks/rbac-engine'
+import { UsersPage } from './users-page'
+import { buildUsersSeed } from './users-page.factory'
+
+const scoped = (container: Container) => ({
+  /** A user's row in the table. */
+  findUserRow(username: string) {
+    return container.findByTestId(`user-row-${username}`)
+  },
+  /** The role-assignment checkbox for `roleName` in the open drawer. Named via
+   * the checkbox's `aria-label`, so it's the role's *own* control, not the
+   * "select all" or a permission toggle. */
+  findRoleCheckbox(roleName: string) {
+    return container.findByRole('checkbox', { name: roleName })
+  },
+  /** The Save button in the drawer footer (labelled "Save changes" when dirty,
+   * "No changes" otherwise). */
+  findSaveButton() {
+    return container.findByRole('button', { name: /save changes/i })
+  },
+  queryNoChangesButton() {
+    return container.queryByRole('button', { name: /no changes/i })
+  },
+  /** Anything carrying `text` as a native tooltip (`title`) — the wrapper span
+   * around a disabled checkbox, mirroring the delete-role-tooltip host. */
+  queryTooltip(text: string | RegExp) {
+    return container.queryByTitle(text)
+  },
+})
+
+/**
+ * Test page-object for the admin `UsersPage`. It seeds a caller-owned RBAC
+ * state (defaulting to one default role + one plain one, and a user holding
+ * only the default) and points MSW at it, so the page reads and writes through
+ * the same mock engine the e2e suite uses — a PUT the API would rewrite is
+ * rewritten here too.
+ *
+ * The role editor lives in a `Sheet`, which portals to `document.body`, so all
+ * accessors bind to `screen` rather than the render container.
+ */
+export const usersPage = {
+  render(seed: SeedSpec = buildUsersSeed()): RbacState {
+    const state = createRbacState(seed)
+    server.use(...rbacHandlersFor(state))
+    render(<UsersPage />)
+    return state
+  },
+
+  user() {
+    return userEvent.setup()
+  },
+
+  /** Click a user's row and resolve the open role-editor drawer. */
+  async open(username: string) {
+    const row = await this.findUserRow(username)
+    await userEvent.click(row)
+    // The sr-only heading inside the drawer confirms it mounted for this user.
+    await screen.findByRole('heading', { name: `User ${username}` })
+  },
+
+  within(node?: HTMLElement) {
+    return scoped(node ? rtlWithin(node) : screen)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/rbac/users-page.test.tsx
+++ b/web-client/src/components/rbac/users-page.test.tsx
@@ -1,0 +1,57 @@
+import { waitFor } from '@/test/utilities'
+import { usersPage } from './users-page.page'
+import { DEFAULT_ROLE_ID, PLAIN_ROLE_ID, USER_ID } from './users-page.factory'
+
+// ADR-0016: `User` is held by every account on the platform. A full-replace
+// PUT could otherwise strip it from one user, so the per-user editor disables
+// that one checkbox up front (the Roles page disables Delete on the same role)
+// while every other role stays freely assignable.
+describe('UsersPage — the default role in the assignment editor', () => {
+  it('renders the default role checked and disabled, with a tooltip', async () => {
+    usersPage.render()
+
+    await usersPage.open('eun.han')
+
+    const checkbox = await usersPage.findRoleCheckbox('User')
+    expect(checkbox).toBeChecked()
+    expect(checkbox).toBeDisabled()
+    // The tooltip hangs off a wrapper span: a disabled checkbox is
+    // pointer-events-none, so its own `title` would never surface on hover.
+    expect(
+      usersPage.queryTooltip(/held by everyone on the platform and can't be removed/i),
+    ).toBeInTheDocument()
+  })
+
+  it('leaves a non-default role fully interactive and saves it', async () => {
+    const user = usersPage.user()
+    const state = usersPage.render()
+
+    await usersPage.open('eun.han')
+
+    const owner = await usersPage.findRoleCheckbox('Owner')
+    expect(owner).toBeEnabled()
+    expect(owner).not.toBeChecked()
+
+    await user.click(owner)
+    await user.click(await usersPage.findSaveButton())
+
+    // The save persists both the newly-ticked role and the retained default —
+    // the disabled checkbox keeps it selected, and the mock backstops it too.
+    await waitFor(() => {
+      const roleIds = state.users.get(USER_ID)?.role_ids ?? []
+      expect(roleIds).toContain(PLAIN_ROLE_ID)
+      expect(roleIds).toContain(DEFAULT_ROLE_ID)
+    })
+  })
+
+  it('opens with nothing dirtied — the locked default role never counts as a change', async () => {
+    usersPage.render()
+
+    await usersPage.open('eun.han')
+
+    // The user holds only the default role, which the editor keeps checked but
+    // disabled. With no togglable state changed, Save reads "No changes".
+    expect(await usersPage.findRoleCheckbox('User')).toBeDisabled()
+    expect(usersPage.queryNoChangesButton()).toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/rbac/users-page.tsx
+++ b/web-client/src/components/rbac/users-page.tsx
@@ -45,6 +45,15 @@ import {
 import { Avatar, EmptyState, Field, PageHeader, Stat, StatsGrid } from './primitives'
 import { colorFor, fmtDate, fmtDateRel } from './helpers'
 
+// The default role is held by every account on the platform (ADR-0016). A
+// full-replace assignment could otherwise strip it from one user, silently
+// excluding them from any capability later hung off the role — so the API
+// always retains it and the editor doesn't offer the removal in the first
+// place, the way the Roles page disables Delete on the same role. The checkbox
+// stays *checked* (the user does hold it) and disabled.
+const DEFAULT_ROLE_ASSIGN_HINT =
+  "This role is held by everyone on the platform and can't be removed."
+
 export function UsersPage() {
   const { data: users = [], isLoading: usersLoading } = useRbacUsers()
   const { data: roles = [] } = useRoles()
@@ -236,7 +245,7 @@ function UserRow({
   onClick: () => void
 }) {
   return (
-    <div onClick={onClick} className="rbac-row" style={userRowStyle}>
+    <div onClick={onClick} className="rbac-row" data-testid={`user-row-${u.username}`} style={userRowStyle}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, minWidth: 0 }}>
         <Avatar name={u.username} size={34} />
         <div style={{ minWidth: 0 }}>
@@ -505,27 +514,42 @@ function UserDrawerBody({
 
 function RoleAssignRow({ role, on, onToggle }: { role: Role; on: boolean; onToggle: () => void }) {
   const accent = colorFor(role.name)
+  // The default role can't be detached (ADR-0016): render it checked (the user
+  // holds it) and disabled. Every other role stays freely toggleable.
+  const locked = role.is_default
+  const checked = locked ? true : on
   return (
     <div
-      onClick={onToggle}
+      onClick={locked ? undefined : onToggle}
       className="rbac-row"
       style={{
         display: 'flex',
         alignItems: 'center',
         gap: 12,
         padding: '12px 14px',
-        cursor: 'pointer',
-        background: on ? `${accent}10` : 'var(--bg-card)',
-        border: `1px solid ${on ? accent + '55' : 'var(--border-subtle)'}`,
+        cursor: locked ? 'default' : 'pointer',
+        background: checked ? `${accent}10` : 'var(--bg-card)',
+        border: `1px solid ${checked ? accent + '55' : 'var(--border-subtle)'}`,
         borderRadius: 'var(--r-md, 10px)',
         transition: 'all 120ms cubic-bezier(0.2, 0.8, 0.2, 1)',
       }}
     >
-      <Checkbox
-        checked={on}
-        onCheckedChange={onToggle}
-        onClick={(e) => e.stopPropagation()}
-      />
+      {/* A disabled checkbox is `pointer-events-none`, so its own `title` would
+          never surface on hover — the wrapper carries the tooltip, mirroring the
+          delete-role-tooltip host on the Roles page. */}
+      <span
+        data-testid={`assign-role-tooltip-${role.name}`}
+        title={locked ? DEFAULT_ROLE_ASSIGN_HINT : undefined}
+        style={{ display: 'inline-flex' }}
+      >
+        <Checkbox
+          checked={checked}
+          disabled={locked}
+          onCheckedChange={locked ? undefined : onToggle}
+          onClick={(e) => e.stopPropagation()}
+          aria-label={role.name}
+        />
+      </span>
       <div
         style={{
           width: 8,
@@ -533,11 +557,11 @@ function RoleAssignRow({ role, on, onToggle }: { role: Role; on: boolean; onTogg
           borderRadius: '50%',
           background: accent,
           flexShrink: 0,
-          boxShadow: on ? `0 0 8px ${accent}88` : 'none',
+          boxShadow: checked ? `0 0 8px ${accent}88` : 'none',
         }}
       />
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontSize: 13, fontWeight: 600, color: on ? 'var(--fg-1)' : 'var(--fg-2)' }}>{role.name}</div>
+        <div style={{ fontSize: 13, fontWeight: 600, color: checked ? 'var(--fg-1)' : 'var(--fg-2)' }}>{role.name}</div>
         <div
           style={{
             fontSize: 11,

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -21,7 +21,7 @@ import {
   type SeedMatch,
 } from './match-store'
 import { notificationHandlers } from './notifications-store'
-import { createRbacState, dispatchRbac } from './rbac-engine'
+import { createRbacState, dispatchRbac, type RbacState } from './rbac-engine'
 import { DEMO_SEED } from './rbac-store'
 import {
   createEvent as createTournamentEvent,
@@ -339,18 +339,37 @@ async function readJson(request: Request): Promise<unknown> {
   }
 }
 
-async function rbacHandler({ request }: { request: Request }) {
-  const url = new URL(request.url)
-  const path = url.pathname.replace(/^\/api/, '')
-  const body = await readJson(request)
-  const result = dispatchRbac(state, request.method, path, body)
-  if (!result) {
-    return HttpResponse.json({ detail: `unmocked ${request.method} ${path}` }, { status: 404 })
+function rbacHandlerFor(rbacState: RbacState) {
+  return async ({ request }: { request: Request }) => {
+    const url = new URL(request.url)
+    const path = url.pathname.replace(/^\/api/, '')
+    const body = await readJson(request)
+    const result = dispatchRbac(rbacState, request.method, path, body)
+    if (!result) {
+      return HttpResponse.json({ detail: `unmocked ${request.method} ${path}` }, { status: 404 })
+    }
+    if (result.status === 204) return new HttpResponse(null, { status: 204 })
+    return HttpResponse.json(result.body as Parameters<typeof HttpResponse.json>[0], {
+      status: result.status,
+    })
   }
-  if (result.status === 204) return new HttpResponse(null, { status: 204 })
-  return HttpResponse.json(result.body as Parameters<typeof HttpResponse.json>[0], {
-    status: result.status,
-  })
+}
+
+/**
+ * The RBAC routes bound to a caller-owned `RbacState`. The default handlers use
+ * the shared `DEMO_SEED` state; a test that needs a deterministic universe
+ * (e.g. "exactly one default role and one plain one") builds its own state and
+ * `server.use(...)`es these over the top.
+ */
+export function rbacHandlersFor(rbacState: RbacState) {
+  const handler = rbacHandlerFor(rbacState)
+  return RBAC_PATHS.flatMap((path) => [
+    http.get(path, handler),
+    http.post(path, handler),
+    http.patch(path, handler),
+    http.put(path, handler),
+    http.delete(path, handler),
+  ])
 }
 
 const RBAC_PATHS = [
@@ -1034,11 +1053,5 @@ export const handlers = [
   }),
   ...notificationHandlers,
 
-  ...RBAC_PATHS.flatMap((path) => [
-    http.get(path, rbacHandler),
-    http.post(path, rbacHandler),
-    http.patch(path, rbacHandler),
-    http.put(path, rbacHandler),
-    http.delete(path, rbacHandler),
-  ]),
+  ...rbacHandlersFor(state),
 ]

--- a/web-client/src/mocks/rbac-engine.test.ts
+++ b/web-client/src/mocks/rbac-engine.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { createRbacState, dispatchRbac, type RbacUser, type Role } from './rbac-engine'
+
+// These tests pin the mock RBAC engine to the *real* server's behaviour
+// (api/app/rbac.py, ADR-0016). Drift here is a false green: a component test
+// would pass against MSW and fail against the API.
+
+const SEED = {
+  roles: [
+    { id: 'r_user', name: 'User', permission_ids: [], is_default: true },
+    { id: 'r_admin', name: 'Admin', permission_ids: [] },
+  ],
+  users: [{ id: 'u1', username: 'alex', role_ids: ['r_user', 'r_admin'] }],
+}
+
+describe('dispatchRbac · POST /v1/users', () => {
+  it('grants the default role to a newly-created user', () => {
+    const state = createRbacState(SEED)
+
+    const result = dispatchRbac(state, 'POST', '/v1/users', { username: 'rita.kovac' })
+
+    expect(result?.status).toBe(201)
+    const created = result?.body as RbacUser
+    expect(created.role_ids).toEqual(['r_user'])
+    expect(state.users.get(created.id)?.role_ids).toEqual(['r_user'])
+  })
+
+  it('mints a role-less user when the seed has no default role', () => {
+    const state = createRbacState({ roles: [{ id: 'r_admin', name: 'Admin' }], users: [] })
+
+    const result = dispatchRbac(state, 'POST', '/v1/users', { username: 'rita.kovac' })
+
+    expect(result?.status).toBe(201)
+    expect((result?.body as RbacUser).role_ids).toEqual([])
+  })
+})
+
+describe('dispatchRbac · default-role refusals', () => {
+  // Byte-for-byte the details `delete_role` / `update_role` raise in
+  // api/app/rbac.py. The tails differ: delete offers only the permissions,
+  // rename offers the permissions and the description.
+  it('refuses to delete the default role with the API’s copy', () => {
+    const state = createRbacState(SEED)
+
+    const result = dispatchRbac(state, 'DELETE', '/v1/roles/r_user', null)
+
+    expect(result).toEqual({
+      status: 400,
+      body: {
+        detail:
+          'The "User" role is held by everyone on the platform and cannot be deleted. ' +
+          'You can change the permissions it grants instead.',
+      },
+    })
+    expect(state.roles.has('r_user')).toBe(true)
+  })
+
+  it('refuses to rename the default role with the API’s copy', () => {
+    const state = createRbacState(SEED)
+
+    const result = dispatchRbac(state, 'PATCH', '/v1/roles/r_user', { name: 'Everyone' })
+
+    expect(result).toEqual({
+      status: 400,
+      body: {
+        detail:
+          'The "User" role is held by everyone on the platform and cannot be renamed. ' +
+          'You can change the permissions it grants and its description.',
+      },
+    })
+    expect(state.roles.get('r_user')?.name).toBe('User')
+  })
+
+  it('still edits the default role’s description and permissions', () => {
+    const state = createRbacState(SEED)
+
+    const result = dispatchRbac(state, 'PATCH', '/v1/roles/r_user', {
+      name: 'User',
+      description: 'Everyone holds this.',
+      permission_ids: ['p_tv'],
+    })
+
+    expect(result?.status).toBe(200)
+    const updated = result?.body as Role
+    expect(updated.description).toBe('Everyone holds this.')
+    expect(updated.permission_ids).toEqual(['p_tv'])
+  })
+})

--- a/web-client/src/mocks/rbac-engine.test.ts
+++ b/web-client/src/mocks/rbac-engine.test.ts
@@ -86,3 +86,42 @@ describe('dispatchRbac · default-role refusals', () => {
     expect(updated.permission_ids).toEqual(['p_tv'])
   })
 })
+
+describe('dispatchRbac · PUT /v1/users/{id}/roles retains the default role', () => {
+  // The UI disables the default-role checkbox, so the front end can never omit
+  // it. The only way a caller *could* strip it is by hand-crafting the PUT body
+  // — exactly what the real endpoint refuses (ADR-0016). This pins the mock to
+  // that backstop: it goes red the moment the engine lets the role be stripped.
+  it('re-adds the default role when the body omits it', () => {
+    const state = createRbacState(SEED)
+
+    const result = dispatchRbac(state, 'PUT', '/v1/users/u1/roles', { role_ids: ['r_admin'] })
+
+    expect(result?.status).toBe(200)
+    const updated = result?.body as RbacUser
+    expect(updated.role_ids).toContain('r_user')
+    expect(updated.role_ids).toContain('r_admin')
+    expect(state.users.get('u1')?.role_ids).toContain('r_user')
+  })
+
+  it('drops a non-default role while keeping the default one', () => {
+    const state = createRbacState(SEED)
+
+    const result = dispatchRbac(state, 'PUT', '/v1/users/u1/roles', { role_ids: [] })
+
+    expect(result?.status).toBe(200)
+    expect((result?.body as RbacUser).role_ids).toEqual(['r_user'])
+  })
+
+  it('does not invent a default role when the seed has none', () => {
+    const state = createRbacState({
+      roles: [{ id: 'r_admin', name: 'Admin' }],
+      users: [{ id: 'u1', username: 'alex', role_ids: ['r_admin'] }],
+    })
+
+    const result = dispatchRbac(state, 'PUT', '/v1/users/u1/roles', { role_ids: [] })
+
+    expect(result?.status).toBe(200)
+    expect((result?.body as RbacUser).role_ids).toEqual([])
+  })
+})

--- a/web-client/src/mocks/rbac-engine.ts
+++ b/web-client/src/mocks/rbac-engine.ts
@@ -69,6 +69,14 @@ function invalidPermissionName(name: string | undefined): DispatchResult | null 
   return null
 }
 
+/** Mirrors the 400 detail the API answers with (api/app/rbac.py, ADR-0016). */
+function defaultRoleRefusal(name: string, verb: 'deleted' | 'renamed'): string {
+  return (
+    `The "${name}" role is held by everyone on the platform and cannot be ` +
+    `${verb}. You can change the permissions it grants${verb === 'renamed' ? ' and its description' : ''} instead.`
+  )
+}
+
 const sortedPermissions = (s: RbacState) =>
   [...s.permissions.values()].sort((a, b) => a.name.localeCompare(b.name))
 const sortedRoles = (s: RbacState) =>
@@ -163,6 +171,13 @@ export function dispatchRbac(
     if (!existing) return { status: 404, body: { detail: 'role not found' } }
     if (method === 'GET') return { status: 200, body: existing }
     if (method === 'PATCH') {
+      // Mirrors the API's default-role guard (api/app/rbac.py, ADR-0016): only a
+      // *change* of name is refused. The edit modal always PATCHes `name`
+      // alongside `description`, so a no-op name must still go through —
+      // description and permissions stay freely editable on the default role.
+      if (existing.is_default && body.name !== undefined && body.name !== existing.name) {
+        return { status: 400, body: { detail: defaultRoleRefusal(existing.name, 'renamed') } }
+      }
       if (
         body.name &&
         [...state.roles.values()].some((r) => r.id !== id && r.name === body.name)
@@ -179,6 +194,12 @@ export function dispatchRbac(
       return { status: 200, body: updated }
     }
     if (method === 'DELETE') {
+      // The API refuses this outright — deleting the default role would cascade
+      // the grant away from every user. The UI disables the button; this is the
+      // backstop that keeps the mock honest about what the server would answer.
+      if (existing.is_default) {
+        return { status: 400, body: { detail: defaultRoleRefusal(existing.name, 'deleted') } }
+      }
       state.roles.delete(id)
       for (const u of state.users.values()) {
         u.role_ids = u.role_ids.filter((rid) => rid !== id)

--- a/web-client/src/mocks/rbac-engine.ts
+++ b/web-client/src/mocks/rbac-engine.ts
@@ -69,12 +69,23 @@ function invalidPermissionName(name: string | undefined): DispatchResult | null 
   return null
 }
 
-/** Mirrors the 400 detail the API answers with (api/app/rbac.py, ADR-0016). */
+/**
+ * Mirrors, byte-for-byte, the 400 details `delete_role` / `update_role` answer
+ * with (api/app/rbac.py, ADR-0016). The two messages diverge in their tail —
+ * delete offers the permissions as the alternative ("instead"), rename offers
+ * the permissions *and* the description — so they're spelled out per verb
+ * rather than share a template that has to reconstruct the difference.
+ */
 function defaultRoleRefusal(name: string, verb: 'deleted' | 'renamed'): string {
-  return (
-    `The "${name}" role is held by everyone on the platform and cannot be ` +
-    `${verb}. You can change the permissions it grants${verb === 'renamed' ? ' and its description' : ''} instead.`
-  )
+  const held = `The "${name}" role is held by everyone on the platform and cannot be`
+  return verb === 'deleted'
+    ? `${held} deleted. You can change the permissions it grants instead.`
+    : `${held} renamed. You can change the permissions it grants and its description.`
+}
+
+/** The role every user holds. Absent from a seed that deliberately has none. */
+function defaultRole(state: RbacState): Role | undefined {
+  return [...state.roles.values()].find((r) => r.is_default)
 }
 
 const sortedPermissions = (s: RbacState) =>
@@ -216,7 +227,16 @@ export function dispatchRbac(
     if ([...state.users.values()].some((u) => u.username === body.username)) {
       return { status: 409, body: { detail: 'username already exists' } }
     }
-    const u = makeUser({ username: body.username! })
+    // A user minted through the admin door is still a user, so it holds the
+    // default role from birth like every other (ADR-0016) — the API's
+    // `create_user` grants it and answers with it in `role_ids`. A seed with no
+    // default role is a legal universe for a test to construct, and mints a
+    // role-less user; only the *server* treats a missing role row as fatal.
+    const granted = defaultRole(state)
+    const u = makeUser({
+      username: body.username!,
+      role_ids: granted ? [granted.id] : [],
+    })
     state.users.set(u.id, u)
     return { status: 201, body: u }
   }

--- a/web-client/src/mocks/rbac-engine.ts
+++ b/web-client/src/mocks/rbac-engine.ts
@@ -256,7 +256,14 @@ export function dispatchRbac(
     const id = m[1]
     const existing = state.users.get(id)
     if (!existing) return { status: 404, body: { detail: 'user not found' } }
-    existing.role_ids = [...(body.role_ids ?? [])]
+    const next = [...(body.role_ids ?? [])]
+    // The API always retains the default role on this full-replace endpoint
+    // (ADR-0016): whatever set of ids it's handed, the role every account holds
+    // survives. The editor disables that checkbox, but this backstop keeps the
+    // mock honest — a test can't strip the role here when the server won't.
+    const dflt = defaultRole(state)
+    if (dflt && !next.includes(dflt.id)) next.push(dflt.id)
+    existing.role_ids = next
     return { status: 200, body: existing }
   }
 

--- a/web-client/src/mocks/rbac-store.ts
+++ b/web-client/src/mocks/rbac-store.ts
@@ -44,6 +44,18 @@ export const DEMO_SEED: SeedSpec = {
     { id: 'p_sx', name: 'system.export', description: 'Download backups and reports.' },
   ],
   roles: [
+    // The default role (ADR-0016): every user holds it from the moment their
+    // row is minted, it ships with zero permissions, and the API refuses to
+    // rename or delete it. `is_default` is what the Roles page badges and
+    // guards on.
+    {
+      id: 'r_user',
+      name: 'User',
+      description:
+        'Held by every user. Carries no permissions by default — add one here to grant it to the whole population, including anonymous visitors.',
+      permission_ids: [],
+      is_default: true,
+    },
     { id: 'r_owner', name: 'Owner', description: 'Full control of the workspace. Granted to founding admins.', permission_ids: ALL },
     {
       id: 'r_td',
@@ -64,19 +76,20 @@ export const DEMO_SEED: SeedSpec = {
     { id: 'r_read', name: 'Read-only', description: 'Sees everything, changes nothing.', permission_ids: VIEW },
     { id: 'r_weekend', name: 'Weekend Volunteer', description: 'One-off scorer role for weekend tournaments.', permission_ids: ['p_tv', 'p_dv', 'p_cv', 'p_cs', 'p_pv'] },
   ],
+  // Everyone holds `r_user` — that is what "default role" means (ADR-0016).
   users: [
-    { id: 'u1', username: 'tim.nguyen', role_ids: ['r_owner'] },
-    { id: 'u2', username: 'alex.johansen', role_ids: ['r_td'] },
-    { id: 'u3', username: 'maya.okafor', role_ids: ['r_td', 'r_club'] },
-    { id: 'u4', username: 'riley.park', role_ids: ['r_score'] },
-    { id: 'u5', username: 'sam.patel', role_ids: ['r_score', 'r_umpire'] },
-    { id: 'u6', username: 'lin.chen', role_ids: ['r_umpire'] },
-    { id: 'u7', username: 'robin.kim', role_ids: ['r_club'] },
-    { id: 'u8', username: 'dean.silva', role_ids: ['r_read'] },
-    { id: 'u9', username: 'carlos.rossi', role_ids: ['r_read'] },
-    { id: 'u10', username: 'jamie.tran', role_ids: ['r_weekend', 'r_umpire'] },
-    { id: 'u11', username: 'priya.desai', role_ids: ['r_score'] },
-    { id: 'u12', username: 'marcus.webb', role_ids: ['r_weekend'] },
-    { id: 'u13', username: 'eun.han', role_ids: [] },
+    { id: 'u1', username: 'tim.nguyen', role_ids: ['r_user', 'r_owner'] },
+    { id: 'u2', username: 'alex.johansen', role_ids: ['r_user', 'r_td'] },
+    { id: 'u3', username: 'maya.okafor', role_ids: ['r_user', 'r_td', 'r_club'] },
+    { id: 'u4', username: 'riley.park', role_ids: ['r_user', 'r_score'] },
+    { id: 'u5', username: 'sam.patel', role_ids: ['r_user', 'r_score', 'r_umpire'] },
+    { id: 'u6', username: 'lin.chen', role_ids: ['r_user', 'r_umpire'] },
+    { id: 'u7', username: 'robin.kim', role_ids: ['r_user', 'r_club'] },
+    { id: 'u8', username: 'dean.silva', role_ids: ['r_user', 'r_read'] },
+    { id: 'u9', username: 'carlos.rossi', role_ids: ['r_user', 'r_read'] },
+    { id: 'u10', username: 'jamie.tran', role_ids: ['r_user', 'r_weekend', 'r_umpire'] },
+    { id: 'u11', username: 'priya.desai', role_ids: ['r_user', 'r_score'] },
+    { id: 'u12', username: 'marcus.webb', role_ids: ['r_user', 'r_weekend'] },
+    { id: 'u13', username: 'eun.han', role_ids: ['r_user'] },
   ],
 }

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -104,6 +104,9 @@ export function permission(overrides: Partial<Permission> = {}): Permission {
   }
 }
 
+// `is_default` is derived server-side from the role's name (ADR-0016): exactly
+// one role — the one every user holds — carries it. Default it to false so a
+// seed opts *in* to being the default role rather than out.
 export function role(overrides: Partial<Role> = {}): Role {
   return {
     id: nextId('r'),
@@ -112,6 +115,7 @@ export function role(overrides: Partial<Role> = {}): Role {
     permission_ids: [],
     created_at: ISO,
     updated_at: ISO,
+    is_default: false,
     ...overrides,
   }
 }


### PR DESCRIPTION
## What

Adds a default role — **`User`** — that every account on fortymm holds, granted the moment the account is minted. It ships with **zero permissions**: it's a lever, not a capability. Granting a capability to the entire population is now a tick-box in Admin → Roles rather than a migration or a code change.

## Why this is shaped the way it is

Two facts about the existing system drove the design, and both are worth knowing before reading the diff:

1. **Nothing assigned anyone a role.** The seed wrote `permissions`, `roles`, and `role_permissions`, but never a single `user_roles` row. The only write was `PUT /v1/users/{id}/roles`, itself gated on `authorization.manage` — so the first admin has to be granted by hand in SQL. This is the first automatic grant in the system.

2. **There is no signup.** Identity is guest-first: a `users` row is minted on a visitor's *first* `GET /v1/session`. Email confirmation and magic-link sign-in attach an email to an already-existing row. So "everyone who joins" and "every visitor" are the same set, and the grant lands on the session-mint hot path.

Decisions are recorded in `docs/adr/0016-every-user-holds-the-default-user-role.md`.

## Changes

**Slice 1 — the lever works**
- The RBAC seed converges any database onto a zero-permission `User` role and backfills every existing user onto it (set-based, idempotent).
- Both user-minting paths — guest-session creation and admin user creation — grant it. **A missing role row raises** rather than silently minting a role-less user, which would stay invisible until a permission is hung off the role months later.
- The role is protected from **deletion** (it would cascade the grant away from every user) and from **rename** (the name is the mint-time lookup key — renaming it would 500 every future visitor's first request). Its permissions and description stay freely editable.

**Slice 2 — it's legible in the admin UI**
- The role read payload carries `is_default`, **derived from the name** via a Pydantic computed field. No column, no migration — a stored boolean would be a second source of truth for a fact the name already settles.
- Admin → Roles badges the default role, disables its Delete with a tooltip, and locks its name field, mirroring the Users page's existing self-delete guard. The API's 400 remains the backstop.

## Notes for review

- The grant reaches **anonymous visitors**, since a user row exists before anyone identifies themselves. Consequence when *using* the lever: a permission added to `User` is granted to anonymous traffic, so a capability that must be reserved for claimed accounts does not belong on this role. Called out in the ADR.
- `is_default` is non-optional in the regenerated types, so `schema.d.ts` and `Types.swift` both move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8vQbwsb3AkJewKYGQkmUS