### PR TITLE
A1 — TournamentEntry model + player self-registration end-to-end (#781)

### DIFF
--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -148,6 +148,52 @@ async def merge_user(
         .values(created_by_user_id=to_user_id)
     )
 
+    # Carry the guest's tournament entries onto the survivor. An entry is a
+    # registration in a real event (a draw gets seeded from it), and the FK is
+    # RESTRICT — but we TOMBSTONE the guest rather than deleting it, so ON DELETE
+    # never fires and an unhandled entry would simply stay registered to a ghost.
+    #
+    # Dedup, then re-point. The uniqueness guard on ``tournament_entries`` is
+    # PARTIAL — ``UNIQUE (event_id, user_id) WHERE status = 'entered'``
+    # (ADR-0016) — so the ONLY rows that can collide are a guest ACTIVE entry in
+    # an event the survivor is ALSO actively entered in. Drop the guest's losing
+    # row first: the survivor's entry stands, so the event's active-entry count is
+    # unchanged by the merge (it was one person all along).
+    #
+    # The predicate tests ``status``, not the (event, user) pair alone, because
+    # two *withdrawn* rows for the same pair are legal — soft-deleted history the
+    # partial index deliberately permits. Deleting those would destroy withdrawal
+    # history the index exists to keep.
+    await db.execute(
+        text(
+            """
+            DELETE FROM tournament_entries AS te
+            WHERE te.user_id = :from_id
+              AND te.status = 'entered'
+              AND EXISTS (
+                SELECT 1 FROM tournament_entries other
+                WHERE other.user_id = :to_id
+                  AND other.event_id = te.event_id
+                  AND other.status = 'entered'
+              )
+            """
+        ),
+        {"from_id": from_user_id, "to_id": to_user_id},
+    )
+    # Nothing left can collide, so the re-point is unconditional and total: every
+    # remaining guest entry — active or withdrawn — moves onto the survivor, and
+    # no row is left pointing at the tombstone for the cleanup below to sweep.
+    await db.execute(
+        text(
+            """
+            UPDATE tournament_entries
+            SET user_id = :to_id
+            WHERE user_id = :from_id
+            """
+        ),
+        {"from_id": from_user_id, "to_id": to_user_id},
+    )
+
     # Preserve the audit trail by re-pointing rather than letting the FK's
     # ON DELETE SET NULL null it out when the ephemeral user is deleted.
     await db.execute(

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -37,6 +37,7 @@ from app.models import (
     NotificationPreference,
     RatingHistory,
     Tournament,
+    TournamentEntryStatus,
     User,
     UserLeagueRating,
     UserRole,
@@ -47,6 +48,16 @@ from app.models import (
 # circular import (sessions imports this module). Session tokens are KEPT on the
 # tombstoned guest so its cookie still resolves; every other token is dropped.
 _SESSION_TOKEN_CONTEXT = "session"
+
+# The stored value of an *active* tournament entry, sourced from the enum rather
+# than written into the SQL below as a literal. The model, the routes and the
+# partial unique index all derive "active" from ``TournamentEntryStatus``; a
+# hardcoded ``'entered'`` here would silently stop matching if that value were
+# ever renamed, and the failure mode is nasty rather than obvious — the dedup's
+# EXISTS would find nothing, delete nothing, and the unconditional re-point that
+# follows would then collide with the partial unique index, raising
+# IntegrityError and failing the whole sign-in merge. Bind it, don't spell it.
+_ACTIVE_ENTRY_STATUS: str = TournamentEntryStatus.entered.value
 
 
 @dataclass(frozen=True)
@@ -163,22 +174,27 @@ async def merge_user(
     # The predicate tests ``status``, not the (event, user) pair alone, because
     # two *withdrawn* rows for the same pair are legal — soft-deleted history the
     # partial index deliberately permits. Deleting those would destroy withdrawal
-    # history the index exists to keep.
+    # history the index exists to keep. "Active" is bound as ``:active`` from
+    # ``_ACTIVE_ENTRY_STATUS`` (see above) so this SQL cannot drift from the enum.
     await db.execute(
         text(
             """
             DELETE FROM tournament_entries AS te
             WHERE te.user_id = :from_id
-              AND te.status = 'entered'
+              AND te.status = :active
               AND EXISTS (
                 SELECT 1 FROM tournament_entries other
                 WHERE other.user_id = :to_id
                   AND other.event_id = te.event_id
-                  AND other.status = 'entered'
+                  AND other.status = :active
               )
             """
         ),
-        {"from_id": from_user_id, "to_id": to_user_id},
+        {
+            "from_id": from_user_id,
+            "to_id": to_user_id,
+            "active": _ACTIVE_ENTRY_STATUS,
+        },
     )
     # Nothing left can collide, so the re-point is unconditional and total: every
     # remaining guest entry — active or withdrawn — moves onto the survivor, and

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -27,6 +27,7 @@ from app.models.tournament import (
     TournamentEvent,
     TournamentStatus,
 )
+from app.models.tournament_entry import TournamentEntry, TournamentEntryStatus
 from app.models.user import User
 from app.models.user_league_rating import UserLeagueRating
 from app.models.user_role import UserRole
@@ -59,6 +60,8 @@ __all__ = [
     "Role",
     "RolePermission",
     "Tournament",
+    "TournamentEntry",
+    "TournamentEntryStatus",
     "TournamentEvent",
     "TournamentStatus",
     "User",

--- a/api/app/models/tournament.py
+++ b/api/app/models/tournament.py
@@ -1,7 +1,7 @@
 import enum
 import uuid
 from datetime import date, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
     Date,
@@ -20,6 +20,9 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.tournament_entry import TournamentEntry
 
 
 class TournamentStatus(enum.Enum):
@@ -150,9 +153,9 @@ class TournamentEvent(Base):
     )
     max_players: Mapped[int] = mapped_column(Integer, nullable=False)
     entry_fee: Mapped[float] = mapped_column(Numeric(8, 2), nullable=False)
-    entered: Mapped[int] = mapped_column(
-        Integer, nullable=False, server_default=text("0")
-    )
+    # There is deliberately no ``entered`` column. The registration count is
+    # derived from the live ``entries`` below (ADR-0016) — a stored counter is a
+    # second copy of the truth that can drift from the rows it counts.
     slot: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
     match_settings: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
     predicates: Mapped[list[dict[str, Any]]] = mapped_column(
@@ -172,3 +175,10 @@ class TournamentEvent(Base):
     )
 
     tournament: Mapped["Tournament"] = relationship(back_populates="events")
+
+    entries: Mapped[list["TournamentEntry"]] = relationship(
+        back_populates="event",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        order_by="TournamentEntry.created_at",
+    )

--- a/api/app/models/tournament_entry.py
+++ b/api/app/models/tournament_entry.py
@@ -1,0 +1,91 @@
+import enum
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.tournament import TournamentEvent
+
+
+class TournamentEntryStatus(enum.Enum):
+    entered = "entered"
+    withdrawn = "withdrawn"
+
+
+class TournamentEntry(Base):
+    """One player's registration in a tournament event.
+
+    **Withdrawal is a soft-delete**: withdrawing flips ``status`` to
+    ``withdrawn`` and keeps the row, so an event's entry history survives. That
+    is why the uniqueness guard below is a *partial* unique index rather than a
+    plain one — a plain unique index on ``(event_id, user_id)`` would let the
+    withdrawn row permanently block the same player from ever re-entering. The
+    invariant we actually want is "at most one **active** entry per player per
+    event", with any number of historical withdrawn rows alongside it.
+
+    An event's ``entered`` count is derived from a live count of active entries;
+    it is not a stored column.
+    """
+
+    __tablename__ = "tournament_entries"
+    __table_args__ = (
+        # At most one *active* entry per player per event. Partial on
+        # ``status = 'entered'`` so withdrawing frees the (event, user) pair for
+        # re-entry while the withdrawn row stays on the books. A duplicate
+        # active entry raises IntegrityError, which the route turns into a 409 —
+        # race-free, because the database (not a read-then-write check) decides.
+        Index(
+            "uq_tournament_entries_event_id_user_id_active",
+            "event_id",
+            "user_id",
+            unique=True,
+            postgresql_where=text("status = 'entered'"),
+        ),
+        Index("ix_tournament_entries_event_id", "event_id"),
+        Index("ix_tournament_entries_user_id", "user_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    event_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tournament_events.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    seed: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    status: Mapped[TournamentEntryStatus] = mapped_column(
+        Enum(
+            TournamentEntryStatus,
+            name="tournament_entry_status",
+            values_callable=lambda e: [m.value for m in e],
+        ),
+        nullable=False,
+        server_default=TournamentEntryStatus.entered.value,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    event: Mapped["TournamentEvent"] = relationship(back_populates="entries")

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
 
 from app.models.tournament import DrawType, EventFormat, TournamentStatus
 
@@ -79,6 +79,23 @@ class Pool(BaseModel):
 # ----- read models ----------------------------------------------------------
 
 
+class TournamentEntrantRead(BaseModel):
+    """One *active* entry in an event. Withdrawn entries are not entrants: they
+    appear in neither this list nor the ``entered`` count.
+
+    ``id`` is the *entry's* id, not the player's: it is the address a client
+    withdraws through (``DELETE …/entries/{entry_id}``), so an entrant that a
+    client can see is an entrant it can act on.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    user_id: uuid.UUID
+    username: str
+    seed: int | None
+
+
 class TournamentEventRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -91,13 +108,25 @@ class TournamentEventRead(BaseModel):
     # Typed ``float`` so JSON emits a number, not a Decimal string. The
     # Numeric(8,2) column coerces cleanly into float at the read boundary.
     entry_fee: float
-    entered: int
     slot: Slot
     match_settings: MatchSettings
     predicates: list[Predicate]
     pools: list[Pool]
     created_at: datetime
     updated_at: datetime
+    # The event's active entrants, oldest entry first.
+    entrants: list[TournamentEntrantRead]
+
+    @computed_field  # type: ignore[prop-decorator]  # pydantic wraps the property
+    @property
+    def entered(self) -> int:
+        """The registration count. Derived — there is no stored counter (ADR-0016).
+
+        It is ``len(entrants)`` rather than a field of its own precisely so the
+        count and the list it counts cannot disagree: an event that says it has
+        52 entrants but lists 51 is not a representable state.
+        """
+        return len(self.entrants)
 
 
 class TournamentRead(BaseModel):
@@ -186,8 +215,8 @@ class TournamentEventUpdate(BaseModel):
     these fields back — ``name``/``format``/``draw_type``/``max_players``/
     ``entry_fee``/``slot``/``match_settings``/``predicates``/``pools`` — is NOT
     NULL, so an explicit ``null`` on any of them is rejected (422);
-    ``predicates``/``pools`` replace wholesale when present. ``entered`` is a
-    server-managed registration count and is intentionally NOT updatable here —
+    ``predicates``/``pools`` replace wholesale when present. ``entered`` is not
+    updatable — it is derived from the event's active entries, not stored — so
     sending it is a 422 via ``extra="forbid"``."""
 
     model_config = ConfigDict(extra="forbid")

--- a/api/app/tournament_queries.py
+++ b/api/app/tournament_queries.py
@@ -1,0 +1,66 @@
+"""Data access for the tournament read path.
+
+The one thing worth stating up front: an event's registration count is **not a
+stored column** (ADR-0016). It is derived from the event's live *active* entries,
+which are the same rows the read model lists as its entrants — so the count and
+the list are read together, once, and cannot disagree.
+
+The tournament LIST endpoint returns every tournament with all of its events, so
+the loader below is batched over **all** the event ids at once: one statement,
+regardless of how many events there are. A per-event count would be an N+1, and
+``tests/test_tournaments.py`` pins the statement count to keep it that way.
+"""
+
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import TournamentEntry, TournamentEntryStatus, User
+from app.schemas.tournament import TournamentEntrantRead
+
+
+async def active_entrants_by_event(
+    db: AsyncSession, event_ids: Sequence[uuid.UUID]
+) -> dict[uuid.UUID, list[TournamentEntrantRead]]:
+    """The active entrants of every event in ``event_ids``, keyed by event id.
+
+    ONE statement for the whole batch (none at all when there are no events).
+    Every id gets a key, so an event nobody has entered maps to ``[]`` — the
+    caller never has to guess whether a missing key means "no entrants" or "not
+    loaded". Withdrawn entries are filtered out here, at the only place that
+    reads them, so they can reach neither the entrants list nor the count that is
+    derived from it.
+    """
+    entrants: dict[uuid.UUID, list[TournamentEntrantRead]] = {
+        event_id: [] for event_id in event_ids
+    }
+    if not entrants:
+        return entrants
+    rows = (
+        await db.execute(
+            select(
+                TournamentEntry.id,
+                TournamentEntry.event_id,
+                TournamentEntry.user_id,
+                User.username,
+                TournamentEntry.seed,
+            )
+            .join(User, User.id == TournamentEntry.user_id)
+            .where(
+                TournamentEntry.event_id.in_(entrants),
+                TournamentEntry.status == TournamentEntryStatus.entered,
+            )
+            # Oldest entry first, matching the event's ``entries`` relationship,
+            # so the list is stable across reads.
+            .order_by(TournamentEntry.created_at, TournamentEntry.id)
+        )
+    ).all()
+    for entry_id, event_id, user_id, username, seed in rows:
+        entrants[event_id].append(
+            TournamentEntrantRead(
+                id=entry_id, user_id=user_id, username=username, seed=seed
+            )
+        )
+    return entrants

--- a/api/app/tournament_queries.py
+++ b/api/app/tournament_queries.py
@@ -49,7 +49,7 @@ async def active_entrants_by_event(
             )
             .join(User, User.id == TournamentEntry.user_id)
             .where(
-                TournamentEntry.event_id.in_(entrants),
+                TournamentEntry.event_id.in_(entrants.keys()),
                 TournamentEntry.status == TournamentEntryStatus.entered,
             )
             # Oldest entry first, matching the event's ``entries`` relationship,

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -3,14 +3,23 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
-from app.models import Tournament, TournamentEvent, User
+from app.models import (
+    EventFormat,
+    Tournament,
+    TournamentEntry,
+    TournamentEntryStatus,
+    TournamentEvent,
+    User,
+)
 from app.rbac import require_permission
 from app.schemas.tournament import (
     TournamentCreate,
     TournamentDetailRead,
+    TournamentEntrantRead,
     TournamentEventCreate,
     TournamentEventRead,
     TournamentEventUpdate,
@@ -18,19 +27,28 @@ from app.schemas.tournament import (
     TournamentUpdate,
 )
 from app.sessions import get_current_user
+from app.tournament_queries import active_entrants_by_event
 
-# Reads are gated on ``tournament.view`` and creation on ``tournament.create``
-# (both granted to the Beta-tester role in ``scripts/seed_rbac.py``). The
-# mutating routes — PATCH, DELETE, and every event mutation — carry NO
-# permission gate: they're owner-only, available solely to the user who created
-# the tournament (``_require_owner``). There is deliberately no
+# Reads are gated on ``tournament.view``, creation on ``tournament.create``, and
+# entering an event as a player on ``tournament.enter`` (all three granted to the
+# Beta-tester role in ``scripts/seed_rbac.py``). The owner-facing mutating routes
+# — PATCH, DELETE, and every event mutation — carry NO permission gate: they're
+# owner-only, available solely to the user who created the tournament
+# (``_require_owner``). There is deliberately no
 # ``tournament.edit``/``tournament.delete``/``tournament.publish`` permission;
 # managing a tournament you created is a property of ownership, not a role grant.
+# Player self-registration is the exception that needs its own permission: a
+# player entering *themselves* is not the tournament's owner, so it cannot go
+# through ``_require_owner``.
 TOURNAMENT_VIEW = "tournament.view"
 TOURNAMENT_CREATE = "tournament.create"
+TOURNAMENT_ENTER = "tournament.enter"
 
 require_view = require_permission(TOURNAMENT_VIEW)
 require_create = require_permission(TOURNAMENT_CREATE)
+# Returns the signed-in user, so the enter route gets its gate and its caller
+# from one dependency — and cannot enter anyone other than that caller.
+require_enter = require_permission(TOURNAMENT_ENTER)
 
 router = APIRouter(prefix="/v1")
 
@@ -79,12 +97,44 @@ def _serialize(
     )
 
 
+def _serialize_event(
+    e: TournamentEvent,
+    *,
+    entrants: list[TournamentEntrantRead],
+) -> TournamentEventRead:
+    # ``entrants`` is not on the ORM row in the shape the read model wants (it
+    # needs the entrant's username, and only the *active* entries), so the fields
+    # are listed explicitly rather than validated straight off the attributes —
+    # which would also fire a lazy load. The event's ``entered`` count is not
+    # listed at all: it is a computed field over ``entrants`` (ADR-0016), so
+    # there is nothing here that could disagree with the list.
+    return TournamentEventRead.model_validate(
+        {
+            "id": e.id,
+            "tournament_id": e.tournament_id,
+            "name": e.name,
+            "format": e.format,
+            "draw_type": e.draw_type,
+            "max_players": e.max_players,
+            "entry_fee": e.entry_fee,
+            "slot": e.slot,
+            "match_settings": e.match_settings,
+            "predicates": e.predicates,
+            "pools": e.pools,
+            "created_at": e.created_at,
+            "updated_at": e.updated_at,
+            "entrants": entrants,
+        }
+    )
+
+
 def _serialize_detail(
     t: Tournament,
     *,
     created_by_username: str,
     current_user_id: uuid.UUID,
     events: list[TournamentEvent],
+    entrants_by_event: dict[uuid.UUID, list[TournamentEntrantRead]],
 ) -> TournamentDetailRead:
     # The full aggregate: tournament fields plus its events (each event's JSONB
     # value-objects validate into Pydantic models here, at this single boundary).
@@ -95,7 +145,9 @@ def _serialize_detail(
                 created_by_username=created_by_username,
                 current_user_id=current_user_id,
             ),
-            "events": [TournamentEventRead.model_validate(e) for e in events],
+            "events": [
+                _serialize_event(e, entrants=entrants_by_event[e.id]) for e in events
+            ],
         }
     )
 
@@ -129,6 +181,26 @@ async def _get_event_or_404(
     return event
 
 
+async def _get_entry_or_404(
+    db: AsyncSession, event_id: uuid.UUID, entry_id: uuid.UUID
+) -> TournamentEntry:
+    # Scoped by event id as well as entry id, the same way _get_event_or_404 is
+    # scoped by tournament: an entry that exists but hangs off a *different* event
+    # is not addressable through this URL, so the mismatch is a 404 rather than a
+    # withdrawal from the event the caller didn't name.
+    entry = (
+        await db.execute(
+            select(TournamentEntry).where(
+                TournamentEntry.id == entry_id,
+                TournamentEntry.event_id == event_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Entry not found.")
+    return entry
+
+
 def _require_owner(t: Tournament, current_user: User) -> None:
     if t.created_by_user_id != current_user.id:
         raise HTTPException(
@@ -150,9 +222,13 @@ async def list_tournaments(
     current_user: User = Depends(get_current_user),
 ) -> list[TournamentDetailRead]:
     # The list page's cards render event-derived stats (event count, total
-    # entries, table count), so the list returns the full aggregate — events
-    # included — rather than a thinner summary. Two queries, no N+1: the
-    # tournaments+usernames join, then all their events grouped in memory.
+    # entries, table count), so the list returns the full aggregate — events and
+    # their entrants included — rather than a thinner summary. THREE queries, no
+    # N+1, whatever the number of tournaments or events: the tournaments+usernames
+    # join, then all their events, then all those events' active entrants in one
+    # batch. A per-event entry count would be the N+1 this shape exists to avoid,
+    # and a statement-count tripwire in tests/test_tournaments.py fails if one
+    # comes back.
     rows = (
         await db.execute(
             select(Tournament, User.username)
@@ -164,8 +240,9 @@ async def list_tournaments(
     events_by_tournament: dict[uuid.UUID, list[TournamentEvent]] = {
         tid: [] for tid in tournament_ids
     }
+    events: list[TournamentEvent] = []
     if tournament_ids:
-        events = (
+        events = list(
             (
                 await db.execute(
                     select(TournamentEvent)
@@ -178,12 +255,14 @@ async def list_tournaments(
         )
         for event in events:
             events_by_tournament[event.tournament_id].append(event)
+    entrants_by_event = await active_entrants_by_event(db, [e.id for e in events])
     return [
         _serialize_detail(
             tournament,
             created_by_username=username,
             current_user_id=current_user.id,
             events=events_by_tournament[tournament.id],
+            entrants_by_event=entrants_by_event,
         )
         for tournament, username in rows
     ]
@@ -245,8 +324,10 @@ async def get_tournament(
     if row is None:
         raise HTTPException(status_code=404, detail="Tournament not found.")
     tournament, username = row
-    # A second query loads this tournament's events in creation order.
-    events = (
+    # A second query loads this tournament's events in creation order, and a
+    # third batches every one of those events' active entrants — the same
+    # one-statement-per-collection shape the list endpoint uses.
+    events = list(
         (
             await db.execute(
                 select(TournamentEvent)
@@ -257,11 +338,13 @@ async def get_tournament(
         .scalars()
         .all()
     )
+    entrants_by_event = await active_entrants_by_event(db, [e.id for e in events])
     return _serialize_detail(
         tournament,
         created_by_username=username,
         current_user_id=current_user.id,
-        events=list(events),
+        events=events,
+        entrants_by_event=entrants_by_event,
     )
 
 
@@ -332,7 +415,6 @@ async def create_event(
         draw_type=payload.draw_type,
         max_players=payload.max_players,
         entry_fee=payload.entry_fee,
-        entered=0,
         slot=payload.slot.model_dump(),
         match_settings=payload.match_settings.model_dump(),
         predicates=[p.model_dump() for p in payload.predicates],
@@ -341,7 +423,9 @@ async def create_event(
     db.add(event)
     await db.commit()
     await db.refresh(event)
-    return TournamentEventRead.model_validate(event)
+    # A just-created event has no entries, so its entrants are empty and its
+    # derived ``entered`` count is 0 — no query needed to learn that.
+    return _serialize_event(event, entrants=[])
 
 
 @router.patch(
@@ -365,7 +449,11 @@ async def update_event(
         setattr(event, key, value)
     await db.commit()
     await db.refresh(event)
-    return TournamentEventRead.model_validate(event)
+    # An edited event keeps whatever entrants it already had — reload them rather
+    # than answering with an empty list (and a ``entered`` of 0) that would be a
+    # lie for any event people have entered.
+    entrants = (await active_entrants_by_event(db, [event.id]))[event.id]
+    return _serialize_event(event, entrants=entrants)
 
 
 @router.delete(
@@ -382,5 +470,125 @@ async def delete_event(
     _require_owner(tournament, current_user)
     event = await _get_event_or_404(db, tournament_id, event_id)
     await db.delete(event)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ----- entry routes --------------------------------------------------------
+
+
+@router.post(
+    "/tournaments/{tournament_id}/events/{event_id}/entries",
+    response_model=TournamentEntrantRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def enter_event(
+    tournament_id: uuid.UUID,
+    event_id: uuid.UUID,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_enter),
+) -> TournamentEntrantRead:
+    """Register the signed-in player in a singles event.
+
+    Self-registration only: the entry created is always the caller's own, which
+    is why the request carries no body — there is no field in which to name
+    someone else. Entering a player who is not you is a director's job, and a
+    different endpoint.
+
+    Entering an event you are already in is a `409`; withdrawing first frees you
+    to enter it again. Doubles and teams events are a `400`: an entry is one row
+    per player, with nowhere to record a partner or a team.
+    """
+    # Load first, then decide — the same 404-before-anything-else ordering the
+    # owner-only routes use. This route has no ownership check to run afterwards:
+    # a player entering themselves is by definition not the tournament's owner,
+    # so the authorization is the ``tournament.enter`` gate above plus the fact
+    # that ``current_user`` is the only user this handler can enter.
+    await _get_tournament_or_404(db, tournament_id)
+    event = await _get_event_or_404(db, tournament_id, event_id)
+    if event.format is not EventFormat.singles:
+        # Not a policy — a modelling limit (ADR-0016). One row per user cannot
+        # express a doubles pairing or a team, so rather than record half a pair
+        # we refuse. ``is not singles`` rather than ``== doubles`` so a new format
+        # is rejected by default instead of silently falling through.
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Only singles events can be entered directly, "
+                f"not {event.format.value}."
+            ),
+        )
+
+    entry = TournamentEntry(event_id=event.id, user_id=current_user.id)
+    db.add(entry)
+    try:
+        await db.commit()
+    except IntegrityError:
+        # The partial unique index on (event_id, user_id) WHERE status='entered'
+        # is what rejected this, and letting the database decide is the point: a
+        # pre-flight SELECT would leave a window in which two concurrent requests
+        # both see "not entered" and both insert. ``from None`` drops the DBAPI
+        # error, so nothing about the schema reaches the response body. Because
+        # the index is partial, a player whose only prior entry is *withdrawn*
+        # does not land here — they enter again, cleanly.
+        await db.rollback()
+        raise HTTPException(
+            status_code=409, detail="You have already entered this event."
+        ) from None
+
+    return TournamentEntrantRead(
+        id=entry.id,
+        user_id=current_user.id,
+        username=current_user.username,
+        seed=entry.seed,
+    )
+
+
+@router.delete(
+    "/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def withdraw_from_event(
+    tournament_id: uuid.UUID,
+    event_id: uuid.UUID,
+    entry_id: uuid.UUID,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_enter),
+) -> Response:
+    """Withdraw the signed-in player's own entry from an event.
+
+    The entry is **soft-deleted**: its status flips to `withdrawn` and the row
+    survives, so the event keeps its withdrawal history — and, because the
+    uniqueness guard is a *partial* index over active entries only, the player is
+    free to enter the same event again afterwards.
+
+    You may only withdraw your own entry; someone else's is a `403`. Withdrawing
+    an entry that is already withdrawn is a no-op, not an error: this is `DELETE`,
+    and asking for a state the resource is already in is a success.
+    """
+    # Load-then-authorize, as everywhere else here: the tournament, the event
+    # under it, and the entry under that event must all exist before ownership is
+    # considered — so a wrong (tournament, event, entry) triple is a 404, and 403
+    # means "this entry is real, but it isn't yours".
+    await _get_tournament_or_404(db, tournament_id)
+    event = await _get_event_or_404(db, tournament_id, event_id)
+    entry = await _get_entry_or_404(db, event.id, entry_id)
+    if entry.user_id != current_user.id:
+        # The ``tournament.enter`` gate says "may self-register at all"; it cannot
+        # say *whose* entry this is. Withdrawing another player from an event is a
+        # director's job (#784), on a different endpoint with its own permission.
+        raise HTTPException(
+            status_code=403,
+            detail="You can only withdraw your own entry.",
+        )
+
+    # Idempotent by construction: withdrawing is an assignment, not a decrement,
+    # so applying it to an already-withdrawn entry writes the value it already
+    # holds. SQLAlchemy emits no UPDATE for an unchanged attribute, and the
+    # response is the same 204 either way. Nor can this UPDATE violate the partial
+    # unique index — it only ever *removes* a row from the index's predicate — so,
+    # unlike the enter route, there is no IntegrityError here to catch and no
+    # database error that could reach the response body.
+    entry.status = TournamentEntryStatus.withdrawn
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
+++ b/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
@@ -126,12 +126,11 @@ def upgrade() -> None:
         sa.Column("draw_type", draw_type_enum, nullable=False),
         sa.Column("max_players", sa.Integer(), nullable=False),
         sa.Column("entry_fee", sa.Numeric(precision=8, scale=2), nullable=False),
-        sa.Column(
-            "entered",
-            sa.Integer(),
-            nullable=False,
-            server_default=sa.text("0"),
-        ),
+        # No ``entered`` column: an event's entry count is DERIVED from a live
+        # count of its active ``tournament_entries`` rows (ADR-0016). A stored
+        # counter is a second copy of the truth that can drift from the rows it
+        # counts — edited out of this migration in place, per the pre-deploy
+        # convention in api/CLAUDE.md.
         sa.Column("slot", postgresql.JSONB(), nullable=False),
         sa.Column("match_settings", postgresql.JSONB(), nullable=False),
         sa.Column(

--- a/api/migrations/versions/20260711_0000_0011_create_tournament_entries_table.py
+++ b/api/migrations/versions/20260711_0000_0011_create_tournament_entries_table.py
@@ -1,0 +1,100 @@
+"""create tournament entries table
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-07-11 00:00:00.000000
+
+Per the pre-deploy convention in api/CLAUDE.md, edits to this migration
+happen in place. No backfill — assumes a fresh / empty DB.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0011"
+down_revision: Union[str, None] = "0010"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Created explicitly in upgrade() via `.create(...)` and referenced with
+# create_type=False so neither op.create_table nor autogenerate creates it a
+# second time (same pattern as the tournament enums in 0010).
+tournament_entry_status_enum = postgresql.ENUM(
+    "entered",
+    "withdrawn",
+    name="tournament_entry_status",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    tournament_entry_status_enum.create(bind, checkfirst=True)
+
+    op.create_table(
+        "tournament_entries",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "event_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tournament_events.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("seed", sa.Integer(), nullable=True),
+        sa.Column(
+            "status",
+            tournament_entry_status_enum,
+            nullable=False,
+            server_default="entered",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    # At most one *active* entry per player per event. PARTIAL on
+    # `status = 'entered'`: withdrawal is a soft-delete, so a plain unique index
+    # would leave the withdrawn row squatting on the (event, user) pair and lock
+    # the player out of ever re-entering. Duplicate active entries raise
+    # IntegrityError, which the entry route turns into a 409.
+    op.create_index(
+        "uq_tournament_entries_event_id_user_id_active",
+        "tournament_entries",
+        ["event_id", "user_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'entered'"),
+    )
+    op.create_index(
+        "ix_tournament_entries_event_id", "tournament_entries", ["event_id"]
+    )
+    op.create_index("ix_tournament_entries_user_id", "tournament_entries", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tournament_entries_user_id", table_name="tournament_entries")
+    op.drop_index("ix_tournament_entries_event_id", table_name="tournament_entries")
+    op.drop_index(
+        "uq_tournament_entries_event_id_user_id_active",
+        table_name="tournament_entries",
+    )
+    op.drop_table("tournament_entries")
+
+    bind = op.get_bind()
+    tournament_entry_status_enum.drop(bind, checkfirst=True)

--- a/api/scripts/seed_rbac.py
+++ b/api/scripts/seed_rbac.py
@@ -6,19 +6,20 @@ chain it into the api command after `alembic upgrade head`.
 """
 
 import asyncio
+from typing import NamedTuple
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.db import get_engine
 from app.models import Permission, Role, RolePermission
-
 
 PERMISSIONS = [
     ("administration.view", "Open the Administration area and see the overview."),
     ("authorization.manage", "Manage roles, permissions, and user role assignments."),
     ("tournament.view", "See the tournament list and tournament details."),
     ("tournament.create", "Create a new tournament."),
+    ("tournament.enter", "Enter a tournament event as a player."),
     ("notifications.broadcast", "Send broadcast notifications to players."),
 ]
 
@@ -30,90 +31,106 @@ ROLES = [
     ),
     (
         "Beta tester",
-        "Early-access testers who can view and create tournaments. Editing,"
+        "Early-access testers who can view, create, and enter tournaments. Editing,"
         " publishing, and deleting a tournament is reserved for its creator.",
-        ["tournament.view", "tournament.create"],
+        ["tournament.view", "tournament.create", "tournament.enter"],
     ),
 ]
+
+
+class SeedCounts(NamedTuple):
+    """How many rows a seed run actually inserted. All zero on a re-run."""
+
+    permissions: int
+    roles: int
+    links: int
+
+
+async def upsert_rbac(db: AsyncSession) -> SeedCounts:
+    """Insert the permissions, roles, and grants above that ``db`` lacks.
+
+    Idempotent: rows already present are left untouched, so a re-run inserts
+    nothing and returns all-zero counts. Caller commits.
+    """
+    perms_by_name: dict[str, Permission] = {
+        p.name: p
+        for p in (
+            await db.execute(
+                select(Permission).where(
+                    Permission.name.in_([n for n, _ in PERMISSIONS])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    }
+
+    created_perms = 0
+    for name, desc in PERMISSIONS:
+        if name in perms_by_name:
+            continue
+        p = Permission(name=name, description=desc)
+        db.add(p)
+        perms_by_name[name] = p
+        created_perms += 1
+
+    roles_by_name: dict[str, Role] = {
+        r.name: r
+        for r in (
+            await db.execute(
+                select(Role).where(Role.name.in_([n for n, _, _ in ROLES]))
+            )
+        )
+        .scalars()
+        .all()
+    }
+
+    created_roles = 0
+    for name, desc, _ in ROLES:
+        if name in roles_by_name:
+            continue
+        r = Role(name=name, description=desc)
+        db.add(r)
+        roles_by_name[name] = r
+        created_roles += 1
+
+    await db.flush()
+
+    existing_links = {
+        (row.role_id, row.permission_id)
+        for row in (
+            await db.execute(
+                select(RolePermission).where(
+                    RolePermission.role_id.in_([r.id for r in roles_by_name.values()])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    }
+
+    added_links = 0
+    for name, _, perm_names in ROLES:
+        role = roles_by_name[name]
+        for pn in perm_names:
+            perm = perms_by_name[pn]
+            if (role.id, perm.id) in existing_links:
+                continue
+            db.add(RolePermission(role_id=role.id, permission_id=perm.id))
+            added_links += 1
+
+    return SeedCounts(permissions=created_perms, roles=created_roles, links=added_links)
 
 
 async def seed() -> None:
     engine = get_engine()
     sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
     async with sessionmaker() as db:
-        perms_by_name: dict[str, Permission] = {
-            p.name: p
-            for p in (
-                await db.execute(
-                    select(Permission).where(
-                        Permission.name.in_([n for n, _ in PERMISSIONS])
-                    )
-                )
-            )
-            .scalars()
-            .all()
-        }
-
-        created_perms = 0
-        for name, desc in PERMISSIONS:
-            if name in perms_by_name:
-                continue
-            p = Permission(name=name, description=desc)
-            db.add(p)
-            perms_by_name[name] = p
-            created_perms += 1
-
-        roles_by_name: dict[str, Role] = {
-            r.name: r
-            for r in (
-                await db.execute(
-                    select(Role).where(Role.name.in_([n for n, _, _ in ROLES]))
-                )
-            )
-            .scalars()
-            .all()
-        }
-
-        created_roles = 0
-        for name, desc, _ in ROLES:
-            if name in roles_by_name:
-                continue
-            r = Role(name=name, description=desc)
-            db.add(r)
-            roles_by_name[name] = r
-            created_roles += 1
-
-        await db.flush()
-
-        existing_links = {
-            (row.role_id, row.permission_id)
-            for row in (
-                await db.execute(
-                    select(RolePermission).where(
-                        RolePermission.role_id.in_(
-                            [r.id for r in roles_by_name.values()]
-                        )
-                    )
-                )
-            )
-            .scalars()
-            .all()
-        }
-
-        added_links = 0
-        for name, _, perm_names in ROLES:
-            role = roles_by_name[name]
-            for pn in perm_names:
-                perm = perms_by_name[pn]
-                if (role.id, perm.id) in existing_links:
-                    continue
-                db.add(RolePermission(role_id=role.id, permission_id=perm.id))
-                added_links += 1
-
+        counts = await upsert_rbac(db)
         await db.commit()
         print(
-            f"Seed complete: +{created_perms} permissions, "
-            f"+{created_roles} roles, +{added_links} role/permission links."
+            f"Seed complete: +{counts.permissions} permissions, "
+            f"+{counts.roles} roles, +{counts.links} role/permission links."
         )
 
 

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -4,7 +4,7 @@ The leading underscore keeps pytest from auto-collecting this as a test module;
 fixtures still belong in ``conftest.py``.
 """
 
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
@@ -14,7 +14,7 @@ from sqlalchemy import event, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from app.main import app as fastapi_app
-from app.models import User
+from app.models import Permission, Role, RolePermission, User, UserRole
 from app.notifications.apns import Environment, SendOutcome, SendResult
 from app.notifications.dependencies import get_push_sender
 from app.notifications.jobs import DELIVER_NOTIFICATION_JOB
@@ -83,6 +83,34 @@ async def make_user(db_session: AsyncSession, username: str) -> User:
     await db_session.commit()
     await db_session.refresh(user)
     return user
+
+
+async def grant_permissions(
+    db_session: AsyncSession, user: User, names: Sequence[str]
+) -> None:
+    """Grant ``names`` to ``user`` through real RBAC rows, so tests exercise the
+    genuine permission gate rather than overriding it.
+
+    Each Permission row is reused if an earlier call already created it, and the
+    user gets a role of their own carrying exactly ``names`` — so two users in
+    one test can hold different subsets (view-only vs view+enter, say), which is
+    what proves a route is gated on the permission it claims and not merely on
+    "is signed in".
+    """
+    role = Role(name=f"grant-{user.id}", description="Per-user test grant.")
+    db_session.add(role)
+    await db_session.flush()
+    for name in names:
+        permission = (
+            await db_session.execute(select(Permission).where(Permission.name == name))
+        ).scalar_one_or_none()
+        if permission is None:
+            permission = Permission(name=name, description=name)
+            db_session.add(permission)
+            await db_session.flush()
+        db_session.add(RolePermission(role_id=role.id, permission_id=permission.id))
+    db_session.add(UserRole(user_id=user.id, role_id=role.id))
+    await db_session.commit()
 
 
 def make_client() -> AsyncClient:

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -27,6 +27,8 @@ from app.models import (
     RatingHistorySource,
     Role,
     Tournament,
+    TournamentEntry,
+    TournamentEntryStatus,
     TournamentEvent,
     User,
     UserLeagueRating,
@@ -398,7 +400,6 @@ async def test_merge_repoints_tournament_ownership(db_session: AsyncSession):
             draw_type=DrawType.single_elim,
             max_players=32,
             entry_fee=40,
-            entered=0,
             slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
             match_settings={"rated": True, "length_games": 5},
             predicates=[],
@@ -428,6 +429,216 @@ async def test_merge_repoints_tournament_ownership(db_session: AsyncSession):
         .all()
     )
     assert [e.name for e in events] == ["Open Singles"]
+
+
+# ----- tournament entries -------------------------------------------------
+
+
+async def _make_event(db: AsyncSession, owner: User) -> TournamentEvent:
+    """A singles event on a tournament ``owner`` created. ``entered`` is left to
+    its server default — it is a dead counter being retired, and an entry's
+    existence is the truth."""
+    tournament = Tournament(
+        name="Guest Cup",
+        created_by_user_id=owner.id,
+        address={
+            "venue": "Berkeley TT Club",
+            "street": "2727 Milvia St",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94703",
+            "country": "USA",
+        },
+        table_catalogue=[{"id": "t1", "label": "Table 1", "court": "A"}],
+    )
+    event = TournamentEvent(
+        name="Open Singles",
+        format=EventFormat.singles,
+        draw_type=DrawType.single_elim,
+        max_players=32,
+        entry_fee=40,
+        slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
+        match_settings={"rated": True, "length_games": 5},
+        predicates=[],
+        pools=[],
+    )
+    tournament.events.append(event)
+    db.add(tournament)
+    await db.commit()
+    await db.refresh(event)
+    return event
+
+
+async def _enter(
+    db: AsyncSession,
+    event: TournamentEvent,
+    user: User,
+    *,
+    status: TournamentEntryStatus = TournamentEntryStatus.entered,
+) -> TournamentEntry:
+    entry = TournamentEntry(event_id=event.id, user_id=user.id, status=status)
+    db.add(entry)
+    await db.commit()
+    await db.refresh(entry)
+    return entry
+
+
+async def _entries_for(
+    db: AsyncSession, event: TournamentEvent
+) -> list[TournamentEntry]:
+    # ``merge_user`` re-points entries with a bulk statement, and the test
+    # sessionmaker sets ``expire_on_commit=False`` — so a plain SELECT would hand
+    # back the identity map's stale copies and happily "prove" the merge did
+    # nothing. ``populate_existing`` overwrites them from the row that came back,
+    # so what we assert on is what the database actually holds.
+    return list(
+        (
+            await db.execute(
+                select(TournamentEntry)
+                .where(TournamentEntry.event_id == event.id)
+                .order_by(TournamentEntry.created_at)
+                .execution_options(populate_existing=True)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def test_merge_repoints_tournament_entry_onto_survivor(
+    db_session: AsyncSession,
+):
+    """``tournament_entries.user_id`` is RESTRICT, but the merge TOMBSTONES the
+    guest rather than deleting it — so ON DELETE never fires and an unhandled
+    entry would be left registered to a ghost user (and would seed a draw with
+    it). The merge re-points it, and the event's active-entry count is unchanged:
+    the same one person is still entered."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    event = await _make_event(db_session, verified)
+
+    entry = await _enter(db_session, event, ephemeral)
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    await db_session.refresh(entry)
+    assert entry.user_id == verified.id
+    assert entry.status is TournamentEntryStatus.entered
+
+    entries = await _entries_for(db_session, event)
+    active = [e for e in entries if e.status is TournamentEntryStatus.entered]
+    assert len(active) == 1, "the event's active-entry count must not change"
+    # Nothing left pointing at the tombstone.
+    assert not [e for e in entries if e.user_id == ephemeral.id]
+
+
+async def test_merge_dedups_entry_when_both_users_entered_same_event(
+    db_session: AsyncSession,
+):
+    """The collision case. Both users hold an ACTIVE entry in the SAME event —
+    legal today (they are different ``user_id``s), fatal on a naive re-point: the
+    partial unique index ``(event_id, user_id) WHERE status = 'entered'`` would
+    reject the second ``(event, survivor, entered)`` row and blow the whole merge
+    up with an IntegrityError. The merge must instead drop the guest's losing row
+    and keep exactly one active entry — the survivor's."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    event = await _make_event(db_session, verified)
+
+    survivor_entry = await _enter(db_session, event, verified)
+    guest_entry = await _enter(db_session, event, ephemeral)
+    assert survivor_entry.id != guest_entry.id
+
+    # A naive ``UPDATE ... SET user_id = survivor`` raises IntegrityError here.
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    entries = await _entries_for(db_session, event)
+    assert [e.id for e in entries] == [survivor_entry.id], (
+        "the survivor's entry stands and the guest's duplicate is dropped"
+    )
+    assert entries[0].user_id == verified.id
+    assert entries[0].status is TournamentEntryStatus.entered
+
+
+async def test_merge_keeps_withdrawn_entry_when_survivor_is_actively_entered(
+    db_session: AsyncSession,
+):
+    """The index is PARTIAL, so a guest's WITHDRAWN row for an event the survivor
+    is actively entered in does not collide with anything — it must ride onto the
+    survivor, not be mistaken for the duplicate-active case and deleted. The
+    active count still comes out at one."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    event = await _make_event(db_session, verified)
+
+    withdrawn = await _enter(
+        db_session, event, ephemeral, status=TournamentEntryStatus.withdrawn
+    )
+    survivor_entry = await _enter(db_session, event, verified)
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    entries = await _entries_for(db_session, event)
+    assert {e.id for e in entries} == {withdrawn.id, survivor_entry.id}
+    assert all(e.user_id == verified.id for e in entries)
+    active = [e for e in entries if e.status is TournamentEntryStatus.entered]
+    assert [e.id for e in active] == [survivor_entry.id]
+
+
+async def test_merge_carries_both_users_withdrawn_entries_for_one_event(
+    db_session: AsyncSession,
+):
+    """Two WITHDRAWN rows for the same (event, user) pair are legal — the unique
+    index only covers ``status = 'entered'``. So both users' withdrawn history
+    must survive the merge on the survivor, with no active entry conjured and
+    nothing spuriously deduped."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    event = await _make_event(db_session, verified)
+
+    guest_withdrawn = await _enter(
+        db_session, event, ephemeral, status=TournamentEntryStatus.withdrawn
+    )
+    survivor_withdrawn = await _enter(
+        db_session, event, verified, status=TournamentEntryStatus.withdrawn
+    )
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    entries = await _entries_for(db_session, event)
+    assert {e.id for e in entries} == {guest_withdrawn.id, survivor_withdrawn.id}
+    assert all(e.user_id == verified.id for e in entries)
+    assert all(e.status is TournamentEntryStatus.withdrawn for e in entries)
+
+
+async def test_merge_repoints_active_entry_over_survivors_withdrawn_row(
+    db_session: AsyncSession,
+):
+    """The survivor withdrew from an event the guest is actively entered in. The
+    guest's ACTIVE row does NOT collide (the survivor has no active row), so it
+    re-points — the merged player stays entered, and the withdrawn row sits
+    alongside it."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    event = await _make_event(db_session, verified)
+
+    survivor_withdrawn = await _enter(
+        db_session, event, verified, status=TournamentEntryStatus.withdrawn
+    )
+    guest_active = await _enter(db_session, event, ephemeral)
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    entries = await _entries_for(db_session, event)
+    assert {e.id for e in entries} == {survivor_withdrawn.id, guest_active.id}
+    assert all(e.user_id == verified.id for e in entries)
+    active = [e for e in entries if e.status is TournamentEntryStatus.entered]
+    assert [e.id for e in active] == [guest_active.id]
 
 
 async def test_merge_repoints_rating_history_created_by(

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app import account_merge
 from app.account_merge import merge_user
 from app.leagues import add_user_to_default_league, get_default_league
 from app.match_voiding import void_match
@@ -613,6 +614,49 @@ async def test_merge_carries_both_users_withdrawn_entries_for_one_event(
     assert {e.id for e in entries} == {guest_withdrawn.id, survivor_withdrawn.id}
     assert all(e.user_id == verified.id for e in entries)
     assert all(e.status is TournamentEntryStatus.withdrawn for e in entries)
+
+
+async def test_entry_dedup_status_is_bound_from_the_enum_not_a_sql_literal(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    """Drift guard for the dedup's status predicate.
+
+    Which status counts as *active* must come from ``TournamentEntryStatus``, not
+    from an ``'entered'`` spelled into the raw SQL. A literal there passes every
+    other test in this file today and rots silently the day the enum's value is
+    renamed: the model, the routes and the partial unique index all follow the
+    enum, the SQL doesn't, so the dedup's EXISTS matches nothing, deletes nothing,
+    and the unconditional re-point that follows collides with the index — every
+    merge where both users actively entered the same event dies on IntegrityError.
+
+    Nothing static catches that, so pin it behaviourally: repoint the single seam
+    (``_ACTIVE_ENTRY_STATUS``) at ``withdrawn`` and assert the SQL *follows*. Under
+    the correct implementation the pair of withdrawn rows is now the colliding
+    pair, so the guest's is deduped away and one survives. Under a hardcoded
+    ``'entered'`` the seam is ignored, nothing is deduped, and both rows survive
+    (i.e. the test that would have caught the drift goes red).
+    """
+    monkeypatch.setattr(
+        account_merge, "_ACTIVE_ENTRY_STATUS", TournamentEntryStatus.withdrawn.value
+    )
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    event = await _make_event(db_session, verified)
+
+    await _enter(db_session, event, ephemeral, status=TournamentEntryStatus.withdrawn)
+    survivor_withdrawn = await _enter(
+        db_session, event, verified, status=TournamentEntryStatus.withdrawn
+    )
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    entries = await _entries_for(db_session, event)
+    assert [e.id for e in entries] == [survivor_withdrawn.id], (
+        "the dedup must treat whatever the enum says is active as active — "
+        "with the seam pointed at 'withdrawn', the withdrawn duplicate is the "
+        "one it drops; a hardcoded 'entered' in the SQL would drop nothing"
+    )
 
 
 async def test_merge_repoints_active_entry_over_survivors_withdrawn_row(

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -435,9 +435,8 @@ async def test_merge_repoints_tournament_ownership(db_session: AsyncSession):
 
 
 async def _make_event(db: AsyncSession, owner: User) -> TournamentEvent:
-    """A singles event on a tournament ``owner`` created. ``entered`` is left to
-    its server default — it is a dead counter being retired, and an entry's
-    existence is the truth."""
+    """A singles event on a tournament ``owner`` created. An event has no entry
+    counter to set: the count is derived from the entries themselves."""
     tournament = Tournament(
         name="Guest Cup",
         created_by_user_id=owner.id,
@@ -486,11 +485,12 @@ async def _enter(
 async def _entries_for(
     db: AsyncSession, event: TournamentEvent
 ) -> list[TournamentEntry]:
-    # ``merge_user`` re-points entries with a bulk statement, and the test
-    # sessionmaker sets ``expire_on_commit=False`` — so a plain SELECT would hand
-    # back the identity map's stale copies and happily "prove" the merge did
-    # nothing. ``populate_existing`` overwrites them from the row that came back,
-    # so what we assert on is what the database actually holds.
+    # ``merge_user`` re-points entries with a bulk statement, which the identity
+    # map never sees, and the test sessionmaker sets ``expire_on_commit=False`` —
+    # so a plain SELECT hands back stale copies still carrying the *pre-merge*
+    # ``user_id``, making a correct merge look as though it did nothing.
+    # ``populate_existing`` overwrites them from the row that came back, so what
+    # we assert on is what the database actually holds.
     return list(
         (
             await db.execute(

--- a/api/tests/test_rbac.py
+++ b/api/tests/test_rbac.py
@@ -11,7 +11,11 @@ from app.main import app
 from app.models import Permission, Role, RolePermission, Tournament, User, UserRole
 from app.rbac import _require_rbac
 from app.sessions import get_current_user
+from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_ENTER, TOURNAMENT_VIEW
+from scripts import seed_rbac
 from tests._helpers import CSRF_EVENT_HOOKS
+
+BETA_TESTER = "Beta tester"
 
 
 @pytest_asyncio.fixture
@@ -501,3 +505,78 @@ async def test_list_users_role_ids_sorted_by_role_name(
     listing = (await api_client.get("/v1/users")).json()
     fetched = next(u for u in listing if u["id"] == user["id"])
     assert fetched["role_ids"] == [ra["id"], rz["id"]]
+
+
+# ----- the RBAC seed script (scripts/seed_rbac.py) -------------------------
+#
+# The seed runs on every container boot (see the api command in the compose
+# files), so "grants what it should" and "inserts nothing on a re-run" are both
+# load-bearing.
+
+
+async def _role_permission_names(db: AsyncSession, role_name: str) -> list[str]:
+    names = (
+        (
+            await db.execute(
+                select(Permission.name)
+                .join(RolePermission, RolePermission.permission_id == Permission.id)
+                .join(Role, Role.id == RolePermission.role_id)
+                .where(Role.name == role_name)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return sorted(names)
+
+
+async def test_seed_grants_beta_tester_the_tournament_permissions(
+    db_session: AsyncSession,
+):
+    """A freshly seeded database lets a Beta tester enter a tournament as well
+    as view and create one — self-registration is gated on its own permission
+    (#781), since a player entering themselves is not the tournament's owner."""
+    counts = await seed_rbac.upsert_rbac(db_session)
+    await db_session.commit()
+    assert counts.permissions == len(seed_rbac.PERMISSIONS)
+    assert counts.roles == len(seed_rbac.ROLES)
+
+    granted = await _role_permission_names(db_session, BETA_TESTER)
+    assert granted == sorted([TOURNAMENT_VIEW, TOURNAMENT_CREATE, TOURNAMENT_ENTER])
+
+
+async def test_seed_is_idempotent(db_session: AsyncSession):
+    """Re-running the seed (every boot does) inserts nothing the second time."""
+    await seed_rbac.upsert_rbac(db_session)
+    await db_session.commit()
+
+    second = await seed_rbac.upsert_rbac(db_session)
+    await db_session.commit()
+    assert second == seed_rbac.SeedCounts(permissions=0, roles=0, links=0)
+
+    perms = (
+        (
+            await db_session.execute(
+                select(Permission).where(Permission.name == TOURNAMENT_ENTER)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(perms) == 1
+
+    links = (
+        (
+            await db_session.execute(
+                select(RolePermission).where(
+                    RolePermission.permission_id == perms[0].id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(links) == 1
+    assert await _role_permission_names(db_session, BETA_TESTER) == sorted(
+        [TOURNAMENT_VIEW, TOURNAMENT_CREATE, TOURNAMENT_ENTER]
+    )

--- a/api/tests/test_tournament_entries.py
+++ b/api/tests/test_tournament_entries.py
@@ -1,0 +1,652 @@
+"""Persistence and route tests for ``tournament_entries``.
+
+The load-bearing claim here is the **partial** unique index on
+``(event_id, user_id) WHERE status = 'entered'``. Withdrawal is a soft-delete —
+the row survives with ``status = 'withdrawn'`` — so a *plain* unique index would
+leave the withdrawn row squatting on the pair and permanently lock the player out
+of re-entering. ``test_withdrawn_player_may_enter_the_same_event_again`` (schema)
+and ``test_enter_withdraw_then_enter_again_all_succeed_through_the_routes`` (the
+whole journey over HTTP: enter → withdraw → enter again) are the tests that tell
+the two apart: they pass only if the index is partial — and the route one
+additionally fails if the duplicate check is a pre-flight ``SELECT`` instead of a
+caught ``IntegrityError``, or if withdrawal deletes the row instead of flipping
+its status.
+
+The persistence tests exercise the schema the **models** declare (the suite builds
+via ``Base.metadata.create_all``); that the **migration** declares the same schema
+is covered by running ``alembic upgrade head`` against a fresh database.
+
+The route tests drive the *real* permission gate — each client establishes a
+genuine session via ``GET /v1/session`` and is granted ``tournament.enter``
+through real RBAC rows — so "who may enter" is proven, not stubbed. Mutating
+requests carry the double-submit CSRF token via the client fixtures' event hooks.
+"""
+
+import uuid
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import delete, select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    DrawType,
+    EventFormat,
+    Tournament,
+    TournamentEntry,
+    TournamentEntryStatus,
+    TournamentEvent,
+    User,
+)
+from app.tournaments import TOURNAMENT_ENTER, TOURNAMENT_VIEW
+from tests._helpers import grant_permissions, make_client, make_user, start_session
+
+ACTIVE_ENTRY_INDEX = "uq_tournament_entries_event_id_user_id_active"
+
+
+async def _make_event(
+    db_session: AsyncSession, format: EventFormat = EventFormat.singles
+) -> TournamentEvent:
+    """An event of ``format`` under a tournament owned by its own throwaway
+    director. Written straight to the database rather than through the create
+    routes: those are owner-only and permission-gated, and dragging that setup in
+    would blur which grant the entry route is actually being tested against.
+
+    The JSONB value-objects carry *valid* payloads rather than partial dicts — the
+    read path validates them into ``Address``/``Slot``/``MatchSettings`` on the way
+    out, so a partial one would 500 any test that reads this tournament back
+    through ``GET /v1/tournaments/{id}`` (as the withdrawal-count test does).
+    """
+    director = await make_user(db_session, f"director-{uuid.uuid4().hex[:8]}")
+    tournament = Tournament(
+        name="Spring Open",
+        address={
+            "venue": "Berkeley TT Club",
+            "street": "1 Shattuck Ave",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94704",
+            "country": "USA",
+        },
+        created_by_user_id=director.id,
+    )
+    db_session.add(tournament)
+    await db_session.flush()
+
+    event = TournamentEvent(
+        tournament_id=tournament.id,
+        name="Open Singles",
+        format=format,
+        draw_type=DrawType.single_elim,
+        max_players=64,
+        entry_fee=Decimal("20.00"),
+        slot={"date": "2026-08-01", "start": "09:00", "end": "17:00"},
+        match_settings={"rated": True, "length_games": 5},
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+    return event
+
+
+@pytest_asyncio.fixture
+async def event(db_session: AsyncSession) -> TournamentEvent:
+    """A singles event under a tournament owned by its own throwaway director."""
+    return await _make_event(db_session)
+
+
+@pytest_asyncio.fixture
+async def doubles_event(db_session: AsyncSession) -> TournamentEvent:
+    return await _make_event(db_session, format=EventFormat.doubles)
+
+
+@pytest_asyncio.fixture
+async def player(db_session: AsyncSession) -> User:
+    return await make_user(db_session, f"player-{uuid.uuid4().hex[:8]}")
+
+
+async def _active_entries(
+    db_session: AsyncSession, event_id: uuid.UUID
+) -> list[TournamentEntry]:
+    rows = await db_session.execute(
+        select(TournamentEntry).where(
+            TournamentEntry.event_id == event_id,
+            TournamentEntry.status == TournamentEntryStatus.entered,
+        )
+    )
+    return list(rows.scalars())
+
+
+async def test_the_active_entry_index_is_unique_and_partial(
+    db_session: AsyncSession,
+) -> None:
+    """The guard is a UNIQUE index carrying a ``WHERE status = 'entered'``
+    predicate — not a plain unique index over the whole table."""
+    indexdef = (
+        await db_session.execute(
+            text(
+                "SELECT indexdef FROM pg_indexes "
+                "WHERE tablename = 'tournament_entries' AND indexname = :name"
+            ),
+            {"name": ACTIVE_ENTRY_INDEX},
+        )
+    ).scalar_one()
+
+    assert "CREATE UNIQUE INDEX" in indexdef, indexdef
+    assert "(event_id, user_id)" in indexdef, indexdef
+    assert "WHERE (status = 'entered'" in indexdef, indexdef
+
+
+async def test_an_entry_persists_with_its_defaults(
+    db_session: AsyncSession, event: TournamentEvent, player: User
+) -> None:
+    entry = TournamentEntry(event_id=event.id, user_id=player.id)
+    db_session.add(entry)
+    await db_session.commit()
+    await db_session.refresh(entry)
+
+    assert entry.id is not None
+    assert entry.status is TournamentEntryStatus.entered
+    assert entry.seed is None
+    assert entry.created_at.tzinfo is not None
+
+
+async def test_a_second_active_entry_for_the_same_player_is_rejected(
+    db_session: AsyncSession, event: TournamentEvent, player: User
+) -> None:
+    # Read the ids up front: the rollback below expires every instance in the
+    # session, and re-reading ``event.id`` afterwards would attempt lazy IO.
+    event_id, user_id = event.id, player.id
+
+    db_session.add(TournamentEntry(event_id=event_id, user_id=user_id))
+    await db_session.commit()
+
+    db_session.add(TournamentEntry(event_id=event_id, user_id=user_id))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+    assert len(await _active_entries(db_session, event_id)) == 1
+
+
+async def test_withdrawn_player_may_enter_the_same_event_again(
+    db_session: AsyncSession, event: TournamentEvent, player: User
+) -> None:
+    """Enter → withdraw → enter again, all three succeed.
+
+    This is the test a *plain* unique index fails: the withdrawn row still holds
+    the ``(event_id, user_id)`` pair, so the re-entry insert would collide.
+    """
+    first = TournamentEntry(event_id=event.id, user_id=player.id)
+    db_session.add(first)
+    await db_session.commit()
+
+    first.status = TournamentEntryStatus.withdrawn
+    await db_session.commit()
+
+    second = TournamentEntry(event_id=event.id, user_id=player.id)
+    db_session.add(second)
+    await db_session.commit()
+
+    # The withdrawn row survives alongside the new active one — soft-delete, not
+    # a row delete — and exactly one of the two is active.
+    all_rows = (
+        (
+            await db_session.execute(
+                select(TournamentEntry).where(TournamentEntry.event_id == event.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(all_rows) == 2
+    active = await _active_entries(db_session, event.id)
+    assert [e.id for e in active] == [second.id]
+
+
+async def test_two_withdrawn_rows_for_the_same_pair_coexist(
+    db_session: AsyncSession, event: TournamentEvent, player: User
+) -> None:
+    """The partial index constrains only *active* rows: the withdrawal history
+    for one player in one event may be arbitrarily long."""
+    for _ in range(2):
+        entry = TournamentEntry(event_id=event.id, user_id=player.id)
+        db_session.add(entry)
+        await db_session.commit()
+        entry.status = TournamentEntryStatus.withdrawn
+        await db_session.commit()
+
+    rows = (
+        (
+            await db_session.execute(
+                select(TournamentEntry).where(TournamentEntry.event_id == event.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    assert all(e.status is TournamentEntryStatus.withdrawn for e in rows)
+
+
+async def test_two_players_may_both_enter_the_same_event(
+    db_session: AsyncSession, event: TournamentEvent, player: User
+) -> None:
+    """The index keys on the *pair* — it must not collapse an event to one entrant."""
+    other = await make_user(db_session, f"player-{uuid.uuid4().hex[:8]}")
+    db_session.add_all(
+        [
+            TournamentEntry(event_id=event.id, user_id=player.id),
+            TournamentEntry(event_id=event.id, user_id=other.id),
+        ]
+    )
+    await db_session.commit()
+
+    assert len(await _active_entries(db_session, event.id)) == 2
+
+
+async def test_deleting_an_event_cascades_its_entries_away(
+    db_session: AsyncSession, event: TournamentEvent, player: User
+) -> None:
+    """A Core ``DELETE`` (not ``session.delete``) so this proves the database's
+    ``ON DELETE CASCADE``, not SQLAlchemy's ORM-side cascade."""
+    db_session.add(TournamentEntry(event_id=event.id, user_id=player.id))
+    await db_session.commit()
+
+    await db_session.execute(
+        delete(TournamentEvent).where(TournamentEvent.id == event.id)
+    )
+    await db_session.commit()
+
+    remaining = (
+        (
+            await db_session.execute(
+                select(TournamentEntry).where(TournamentEntry.event_id == event.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []
+
+
+async def test_deleting_a_user_with_an_entry_is_restricted(
+    db_session: AsyncSession, event: TournamentEvent, player: User
+) -> None:
+    """``ON DELETE RESTRICT`` on the user FK: an entrant cannot be deleted out
+    from under their entry (account-merge tombstones instead — see #781/1f)."""
+    db_session.add(TournamentEntry(event_id=event.id, user_id=player.id))
+    await db_session.commit()
+
+    with pytest.raises(IntegrityError):
+        await db_session.execute(delete(User).where(User.id == player.id))
+        await db_session.commit()
+    await db_session.rollback()
+
+
+# ----- the self-registration route ------------------------------------------
+
+
+def _entries_url(event: TournamentEvent) -> str:
+    return f"/v1/tournaments/{event.tournament_id}/events/{event.id}/entries"
+
+
+@pytest_asyncio.fixture
+async def entrant_client(
+    api_client: AsyncClient, db_session: AsyncSession
+) -> AsyncIterator[tuple[AsyncClient, User]]:
+    """A real session holding ``tournament.enter`` — and nothing else. The grant
+    is deliberately minimal: entering is not gated on ``tournament.view``, and a
+    client carrying extra permissions could not tell the two apart."""
+    user = await start_session(api_client, db_session)
+    await grant_permissions(db_session, user, (TOURNAMENT_ENTER,))
+    yield api_client, user
+
+
+async def test_entering_a_singles_event_returns_201_and_persists_the_row(
+    entrant_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    event: TournamentEvent,
+) -> None:
+    client, user = entrant_client
+
+    response = await client.post(_entries_url(event))
+
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["user_id"] == str(user.id)
+    assert body["username"] == user.username
+    assert body["seed"] is None
+
+    (row,) = await _active_entries(db_session, event.id)
+    assert row.user_id == user.id
+    # The response addresses the row it created: ``id`` is the *entry's* id, which
+    # is what a client will withdraw through (``DELETE …/entries/{entry_id}``).
+    assert body["id"] == str(row.id)
+
+
+async def test_entering_the_same_event_twice_is_a_409(
+    entrant_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    event: TournamentEvent,
+) -> None:
+    """Not a 500 (an uncaught IntegrityError), and not a second row."""
+    client, _ = entrant_client
+    # The 409 path rolls the shared session back, which expires the ORM instances
+    # — read the ids out as plain values first.
+    url, event_id = _entries_url(event), event.id
+
+    assert (await client.post(url)).status_code == 201
+
+    duplicate = await client.post(url)
+
+    assert duplicate.status_code == 409, duplicate.text
+    assert duplicate.json()["detail"] == "You have already entered this event."
+    assert len(await _active_entries(db_session, event_id)) == 1
+
+
+async def test_a_player_without_the_enter_permission_is_403(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    event: TournamentEvent,
+) -> None:
+    """Gated on ``tournament.enter`` specifically — a signed-in player who holds
+    ``tournament.view`` (so they can see the tournament they are trying to enter)
+    is still refused, and writes nothing."""
+    user = await start_session(api_client, db_session)
+    await grant_permissions(db_session, user, (TOURNAMENT_VIEW,))
+
+    response = await api_client.post(_entries_url(event))
+
+    assert response.status_code == 403, response.text
+    assert await _active_entries(db_session, event.id) == []
+
+
+async def test_entering_a_doubles_event_is_a_400(
+    entrant_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    doubles_event: TournamentEvent,
+) -> None:
+    """One row per user has nowhere to record a partner, so a doubles entry is
+    refused outright rather than recorded as half a pair (ADR-0016)."""
+    client, _ = entrant_client
+
+    response = await client.post(_entries_url(doubles_event))
+
+    assert response.status_code == 400, response.text
+    assert "singles" in response.json()["detail"]
+    assert await _active_entries(db_session, doubles_event.id) == []
+
+
+async def test_a_withdrawn_player_may_enter_again_through_the_route(
+    entrant_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    event: TournamentEvent,
+) -> None:
+    """The discriminating case for the whole slice: enter → withdraw → enter again
+    is 201, 201 — not 409.
+
+    A pre-flight ``SELECT`` for "has this player an entry?" would 409 the second
+    entry (the withdrawn row is still there); only catching the ``IntegrityError``
+    from the *partial* index gets this right. The withdrawal here is done to the
+    row directly, which isolates the *enter* route's half of the journey: the same
+    journey driven end to end through the real withdraw route is
+    ``test_enter_withdraw_then_enter_again_all_succeed_through_the_routes``.
+    """
+    client, user = entrant_client
+    url, event_id = _entries_url(event), event.id
+
+    first = await client.post(url)
+    assert first.status_code == 201
+
+    withdrawn_id = uuid.UUID(first.json()["id"])
+    entry = await db_session.get(TournamentEntry, withdrawn_id)
+    assert entry is not None
+    entry.status = TournamentEntryStatus.withdrawn
+    await db_session.commit()
+
+    second = await client.post(url)
+
+    assert second.status_code == 201, second.text
+    assert second.json()["id"] != str(withdrawn_id)
+    # Soft-delete, so both rows survive — but only the new one is active.
+    active = await _active_entries(db_session, event_id)
+    assert [str(e.id) for e in active] == [second.json()["id"]]
+    assert active[0].user_id == user.id
+
+
+async def test_entering_an_unknown_event_is_a_404(
+    entrant_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    event: TournamentEvent,
+) -> None:
+    """Load-then-authorize: a missing tournament or event is a 404, and an event
+    id that exists but belongs to a *different* tournament is one too — the pair
+    is what's addressed."""
+    client, _ = entrant_client
+    missing = uuid.uuid4()
+    other = await _make_event(db_session)
+
+    assert (
+        await client.post(f"/v1/tournaments/{missing}/events/{event.id}/entries")
+    ).status_code == 404
+    assert (
+        await client.post(
+            f"/v1/tournaments/{event.tournament_id}/events/{missing}/entries"
+        )
+    ).status_code == 404
+    # ``other`` really exists — it is only the (tournament, event) pairing that
+    # doesn't — so this 404 is the scoping check, not a missing row.
+    assert (
+        await client.post(
+            f"/v1/tournaments/{event.tournament_id}/events/{other.id}/entries"
+        )
+    ).status_code == 404
+
+
+# ----- the withdrawal route --------------------------------------------------
+
+
+def _entry_url(event: TournamentEvent, entry_id: uuid.UUID | str) -> str:
+    return f"{_entries_url(event)}/{entry_id}"
+
+
+async def _enter(client: AsyncClient, event: TournamentEvent) -> uuid.UUID:
+    """Enter ``event`` through the real route and return the new entry's id."""
+    response = await client.post(_entries_url(event))
+    assert response.status_code == 201, response.text
+    return uuid.UUID(response.json()["id"])
+
+
+async def _entries_of(
+    db_session: AsyncSession, event_id: uuid.UUID, user_id: uuid.UUID
+) -> list[TournamentEntry]:
+    """Every entry row for one (event, player) pair — active *and* withdrawn.
+
+    Deliberately unfiltered by status: the tests below assert on what soft-delete
+    leaves behind, and a helper that only ever returned active rows could not tell
+    a withdrawal apart from a row delete.
+    """
+    rows = await db_session.execute(
+        select(TournamentEntry)
+        .where(
+            TournamentEntry.event_id == event_id,
+            TournamentEntry.user_id == user_id,
+        )
+        .order_by(TournamentEntry.created_at, TournamentEntry.id)
+    )
+    return list(rows.scalars())
+
+
+async def test_withdrawing_soft_deletes_the_entry_and_keeps_the_row(
+    entrant_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    event: TournamentEvent,
+) -> None:
+    """The load-bearing assertion of 1d: the row **survives** the withdrawal.
+
+    Checking only that the entrant vanished from the read path would pass against
+    a hard ``DELETE`` too, and would prove nothing — so this queries the row by its
+    id and asserts it is still there, now ``withdrawn``. A hard delete fails on the
+    ``is not None``; a route that forgot to flip the status fails on the status.
+    """
+    client, user = entrant_client
+    entry_id, event_id = await _enter(client, event), event.id
+
+    response = await client.delete(_entry_url(event, entry_id))
+
+    assert response.status_code == 204, response.text
+    assert response.content == b""
+    # ``populate_existing`` because the route committed through a *different*
+    # session: without it the shared test session could answer from its identity
+    # map with the pre-withdrawal row and hide a route that changed nothing.
+    row = await db_session.get(TournamentEntry, entry_id, populate_existing=True)
+    assert row is not None, "the entry row was deleted — withdrawal must soft-delete"
+    assert row.status is TournamentEntryStatus.withdrawn
+    assert row.user_id == user.id
+    assert await _active_entries(db_session, event_id) == []
+
+
+async def test_enter_withdraw_then_enter_again_all_succeed_through_the_routes(
+    entrant_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    event: TournamentEvent,
+) -> None:
+    """The discriminating journey of the whole slice, end to end through the real
+    routes for the first time: 201 → 204 → **201, not 409**.
+
+    Everything about the design is aimed at this. A *plain* unique index fails it
+    (the withdrawn row still squats on the ``(event_id, user_id)`` pair). A
+    pre-flight ``SELECT`` for "has this player entered?" instead of the caught
+    ``IntegrityError`` fails it. A withdrawal that hard-deleted the row would pass
+    it — which is why the soft-delete test above exists alongside it, and why this
+    one also asserts both rows survive.
+    """
+    client, user = entrant_client
+    event_id, user_id = event.id, user.id
+
+    first = await _enter(client, event)
+    assert (await client.delete(_entry_url(event, first))).status_code == 204
+
+    second_response = await client.post(_entries_url(event))
+
+    assert second_response.status_code == 201, second_response.text
+    second = uuid.UUID(second_response.json()["id"])
+    assert second != first
+
+    rows = await _entries_of(db_session, event_id, user_id)
+    assert [(r.id, r.status) for r in rows] == [
+        (first, TournamentEntryStatus.withdrawn),
+        (second, TournamentEntryStatus.entered),
+    ]
+
+
+async def test_withdrawing_drops_the_derived_count_and_the_entrants_list(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    event: TournamentEvent,
+) -> None:
+    """What the player actually sees: the event's ``entered`` count falls back to 0
+    and they disappear from the entrants list.
+
+    The count is derived from the live *active* entries (ADR-0016), so this is the
+    read path proving it honours the soft-delete rather than counting tombstones.
+    Needs ``tournament.view`` as well as ``tournament.enter`` — reading a tournament
+    and entering one are separate grants.
+    """
+    user = await start_session(api_client, db_session)
+    await grant_permissions(db_session, user, (TOURNAMENT_VIEW, TOURNAMENT_ENTER))
+    entry_id = await _enter(api_client, event)
+
+    async def read_event() -> dict:
+        response = await api_client.get(f"/v1/tournaments/{event.tournament_id}")
+        assert response.status_code == 200, response.text
+        (found,) = [e for e in response.json()["events"] if e["id"] == str(event.id)]
+        return dict(found)
+
+    entered = await read_event()
+    assert entered["entered"] == 1
+    assert [e["user_id"] for e in entered["entrants"]] == [str(user.id)]
+
+    assert (await api_client.delete(_entry_url(event, entry_id))).status_code == 204
+
+    withdrawn = await read_event()
+    assert withdrawn["entered"] == 0
+    assert withdrawn["entrants"] == []
+
+
+async def test_withdrawing_another_players_entry_is_a_403(
+    entrant_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    event: TournamentEvent,
+) -> None:
+    """403 on someone else's entry — and it is the *ownership* check that refuses.
+
+    The rival holds ``tournament.enter`` too, so the ``require_enter`` gate lets
+    them through: a withdraw route with no ownership check at all would fail here.
+    Their entry is untouched afterwards, so the refusal is not a partial write.
+    """
+    client, _ = entrant_client
+    async with make_client() as rival_client:
+        rival = await start_session(rival_client, db_session)
+        await grant_permissions(db_session, rival, (TOURNAMENT_ENTER,))
+        rival_entry = await _enter(rival_client, event)
+        event_id, rival_id = event.id, rival.id
+
+        response = await client.delete(_entry_url(event, rival_entry))
+
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "You can only withdraw your own entry."
+    (row,) = await _entries_of(db_session, event_id, rival_id)
+    assert row.status is TournamentEntryStatus.entered
+
+
+async def test_withdrawing_an_already_withdrawn_entry_is_idempotent(
+    entrant_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    event: TournamentEvent,
+) -> None:
+    """Withdrawing twice is a 204 both times — asking for a state the resource is
+    already in is a success, not a conflict. And the second call writes nothing:
+    still exactly one row for the pair, still withdrawn."""
+    client, user = entrant_client
+    entry_id, event_id, user_id = await _enter(client, event), event.id, user.id
+
+    first = await client.delete(_entry_url(event, entry_id))
+    second = await client.delete(_entry_url(event, entry_id))
+
+    assert (first.status_code, second.status_code) == (204, 204), second.text
+    rows = await _entries_of(db_session, event_id, user_id)
+    assert [(r.id, r.status) for r in rows] == [
+        (entry_id, TournamentEntryStatus.withdrawn)
+    ]
+
+
+async def test_withdrawing_an_entry_that_isnt_addressable_here_is_a_404(
+    entrant_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    event: TournamentEvent,
+) -> None:
+    """Load-then-authorize, one level deeper than the enter route: an unknown entry
+    id is a 404, and so is a *real* entry of the caller's own reached through the
+    wrong event — the whole (tournament, event, entry) triple is what's addressed.
+    The misaddressed entry is left entered, so a 404 never withdraws anything.
+    """
+    client, user = entrant_client
+    other_event = await _make_event(db_session)
+    elsewhere = await _enter(client, other_event)
+    other_event_id, user_id = other_event.id, user.id
+
+    assert (await client.delete(_entry_url(event, uuid.uuid4()))).status_code == 404, (
+        "an entry id that exists nowhere"
+    )
+    assert (await client.delete(_entry_url(event, elsewhere))).status_code == 404, (
+        "a real entry of the caller's, but not in this event"
+    )
+
+    (row,) = await _entries_of(db_session, other_event_id, user_id)
+    assert row.status is TournamentEntryStatus.entered

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -10,24 +10,30 @@ carry the double-submit CSRF token via ``CSRF_EVENT_HOOKS`` (baked into both the
 ``api_client`` fixture and ``make_client``).
 """
 
+import uuid
 from collections.abc import AsyncIterator, Sequence
 from typing import Any
 
+import pytest
 import pytest_asyncio
 from httpx import AsyncClient
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from app.models import (
-    Permission,
-    Role,
-    RolePermission,
     Tournament,
+    TournamentEntry,
+    TournamentEntryStatus,
     User,
-    UserRole,
 )
-from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
-from tests._helpers import make_client, start_session
+from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW, list_tournaments
+from tests._helpers import (
+    counted_statements,
+    grant_permissions,
+    make_client,
+    make_user,
+    start_session,
+)
 
 
 async def _grant_tournament_perms(
@@ -35,24 +41,9 @@ async def _grant_tournament_perms(
     user: User,
     names: Sequence[str] = (TOURNAMENT_VIEW, TOURNAMENT_CREATE),
 ) -> None:
-    """Grant ``names`` to ``user`` via real RBAC rows. Each permission row is
-    reused if a prior call already created it; the user gets a dedicated role
-    carrying exactly ``names`` so different users can hold different subsets
-    (e.g. view-only vs view+create)."""
-    role = Role(name=f"grant-{user.id}", description="Per-user test grant.")
-    db_session.add(role)
-    await db_session.flush()
-    for name in names:
-        permission = (
-            await db_session.execute(select(Permission).where(Permission.name == name))
-        ).scalar_one_or_none()
-        if permission is None:
-            permission = Permission(name=name, description=name)
-            db_session.add(permission)
-            await db_session.flush()
-        db_session.add(RolePermission(role_id=role.id, permission_id=permission.id))
-    db_session.add(UserRole(user_id=user.id, role_id=role.id))
-    await db_session.commit()
+    """Grant ``names`` to ``user`` via real RBAC rows, defaulting to the pair the
+    tournament read/create routes gate on."""
+    await grant_permissions(db_session, user, names)
 
 
 @pytest_asyncio.fixture
@@ -318,7 +309,10 @@ async def test_create_event_round_trips_jsonb(
     assert body["max_players"] == 64
     # entry_fee is emitted as a JSON number, not a Decimal string.
     assert body["entry_fee"] == 45
+    # Nobody has entered a brand-new event: the derived count is 0 and the
+    # entrants list is empty (an empty list, not a missing key).
     assert body["entered"] == 0
+    assert body["entrants"] == []
     assert body["slot"] == {"date": "2026-06-13", "start": "09:00", "end": "18:00"}
     assert body["match_settings"] == {"rated": True, "length_games": 5}
     assert body["predicates"] == [
@@ -512,6 +506,216 @@ async def test_event_ops_on_missing_event_return_404(
     assert (
         await client.delete(f"/v1/tournaments/{created['id']}/events/{missing}")
     ).status_code == 404
+
+
+# ----- entrants and the derived ``entered`` count ---------------------------
+
+
+async def _enter(
+    db_session: AsyncSession,
+    event_id: str,
+    user: User,
+    *,
+    status: TournamentEntryStatus = TournamentEntryStatus.entered,
+    seed: int | None = None,
+) -> TournamentEntry:
+    """Persist an entry directly. The enter/withdraw *routes* land in #781/1c+1d;
+    the read path can't wait for them, so it writes the rows itself."""
+    entry = TournamentEntry(
+        event_id=uuid.UUID(event_id), user_id=user.id, status=status, seed=seed
+    )
+    db_session.add(entry)
+    await db_session.commit()
+    return entry
+
+
+async def test_tournament_events_has_no_entered_column(db_session: AsyncSession):
+    """The registration count is derived, so there is no column to derive it from
+    — and therefore no stored counter that can drift from the entries (ADR-0016).
+
+    Read from the live database rather than the model: this is a claim about the
+    schema, and the model attribute could be gone while the column lingered.
+    """
+    columns = set(
+        (
+            await db_session.execute(
+                text(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = 'tournament_events'"
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert "entered" not in columns, columns
+    # The query is real: the columns it *does* return are the ones we expect.
+    assert {"id", "max_players", "entry_fee"} <= columns
+
+
+async def test_detail_derives_entered_and_lists_only_active_entrants(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+):
+    """Two active entrants and one withdrawn one: ``entered`` is 2, and the
+    entrants list holds exactly the two active players. The withdrawn one appears
+    in neither — she is not an entrant, and she is not counted."""
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    event = (
+        await client.post(
+            f"/v1/tournaments/{created['id']}/events", json=_event_payload()
+        )
+    ).json()
+
+    ada = await make_user(db_session, "ada-entrant")
+    bo = await make_user(db_session, "bo-entrant")
+    cass = await make_user(db_session, "cass-withdrew")
+    ada_entry = await _enter(db_session, event["id"], ada, seed=1)
+    await _enter(db_session, event["id"], bo)
+    await _enter(db_session, event["id"], cass, status=TournamentEntryStatus.withdrawn)
+
+    detail = (await client.get(f"/v1/tournaments/{created['id']}")).json()
+    (read_event,) = detail["events"]
+
+    assert read_event["entered"] == 2
+    entrants = {e["username"]: e for e in read_event["entrants"]}
+    assert set(entrants) == {"ada-entrant", "bo-entrant"}
+    assert entrants["ada-entrant"]["user_id"] == str(ada.id)
+    assert entrants["ada-entrant"]["seed"] == 1
+    assert entrants["bo-entrant"]["seed"] is None
+    # Each entrant carries its ENTRY's id — the address a client withdraws
+    # through — not just the player's.
+    assert entrants["ada-entrant"]["id"] == str(ada_entry.id)
+    # And the count is the list's length by construction — they cannot disagree.
+    assert read_event["entered"] == len(read_event["entrants"])
+
+
+async def test_list_derives_entered_and_lists_only_active_entrants(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+):
+    """The same derivation on the list endpoint, which the tournaments-list card's
+    entry total reads."""
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    event = (
+        await client.post(
+            f"/v1/tournaments/{created['id']}/events", json=_event_payload()
+        )
+    ).json()
+
+    ada = await make_user(db_session, "ada-listed")
+    cass = await make_user(db_session, "cass-listed-withdrew")
+    await _enter(db_session, event["id"], ada)
+    await _enter(db_session, event["id"], cass, status=TournamentEntryStatus.withdrawn)
+
+    rows = (await client.get("/v1/tournaments")).json()
+    listed = next(r for r in rows if r["id"] == created["id"])
+    (read_event,) = listed["events"]
+
+    assert read_event["entered"] == 1
+    assert [e["username"] for e in read_event["entrants"]] == ["ada-listed"]
+
+
+async def test_patch_event_answers_with_its_existing_entrants(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+):
+    """Editing an event doesn't blank its entrants: the PATCH response carries the
+    people who had already entered, with the count to match."""
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    event = (
+        await client.post(
+            f"/v1/tournaments/{created['id']}/events", json=_event_payload()
+        )
+    ).json()
+    ada = await make_user(db_session, "ada-patched")
+    await _enter(db_session, event["id"], ada)
+
+    response = await client.patch(
+        f"/v1/tournaments/{created['id']}/events/{event['id']}",
+        json={"name": "Renamed Singles"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "Renamed Singles"
+    assert body["entered"] == 1
+    assert [e["username"] for e in body["entrants"]] == ["ada-patched"]
+
+
+# The pin, measured (print the statements below to re-measure): the tournaments +
+# usernames join, the events, and ONE batched load of every event's active
+# entrants. Three, whatever the number of events.
+EXPECTED_TOURNAMENT_LIST_STATEMENTS = 3
+
+
+@pytest.mark.parametrize("event_count", [1, 4])
+async def test_list_tournaments_statement_count_does_not_grow_with_events(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    event_count: int,
+):
+    """The list endpoint returns every tournament with all of its events, so the
+    entry counts and entrants MUST be gathered in one batched query — a
+    ``count(*)`` per event is an N+1 (ADR-0015, ADR-0016).
+
+    The two ``event_count`` cases are what makes this discriminating: a per-event
+    loop emits one statement per event, so it would measure 4 at one event and 7 at
+    four — failing the pin at four even if it slipped past at one. Each event
+    carries a different number of entrants, so a batched loader that silently
+    dropped the grouping would show up as wrong data, not just a low count.
+
+    Counting is scoped to the handler rather than the HTTP request on purpose: an
+    endpoint-level count would also sweep up session / auth statements that have
+    nothing to do with the N+1. It runs on a fresh session — see
+    ``counted_statements``.
+    """
+    client, user = authed_client
+    user_id = user.id  # read outside the counted block; see below
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    for n in range(event_count):
+        event = (
+            await client.post(
+                f"/v1/tournaments/{created['id']}/events",
+                json=_event_payload(name=f"Event {n}"),
+            )
+        ).json()
+        # n + 1 entrants on event n, so a broken grouping can't accidentally look
+        # right, plus a withdrawn one that must never be counted.
+        for i in range(n + 1):
+            await _enter(
+                db_session, event["id"], await make_user(db_session, f"player-{n}-{i}")
+            )
+        await _enter(
+            db_session,
+            event["id"],
+            await make_user(db_session, f"gone-{n}"),
+            status=TournamentEntryStatus.withdrawn,
+        )
+
+    async with counted_statements(engine) as (session, statements):
+        # A transient ``User`` carrying only the id the handler reads: touching the
+        # db_session-bound instance in here could emit a refresh SELECT on the same
+        # engine and be counted as if the handler had issued it.
+        listed = await list_tournaments(db=session, current_user=User(id=user_id))
+
+    for n, statement in enumerate(statements, start=1):
+        print(f"[{n}] {' '.join(statement.split())}")
+
+    assert len(statements) == EXPECTED_TOURNAMENT_LIST_STATEMENTS, statements
+    # And the block it counted really did the work: every event carries its own
+    # entrants, and the withdrawn player is nowhere.
+    (tournament,) = [t for t in listed if str(t.id) == created["id"]]
+    assert len(tournament.events) == event_count
+    assert [e.entered for e in tournament.events] == list(range(1, event_count + 1))
+    assert all(
+        len(e.entrants) == e.entered
+        and not any(x.username.startswith("gone-") for x in e.entrants)
+        for e in tournament.events
+    )
 
 
 # ----- permission gate -----------------------------------------------------

--- a/docs/adr/0016-a-tournament-entry-is-soft-deleted-and-its-count-is-derived.md
+++ b/docs/adr/0016-a-tournament-entry-is-soft-deleted-and-its-count-is-derived.md
@@ -1,0 +1,138 @@
+# 16. A tournament entry is soft-deleted, and an event's entry count is derived
+
+Date: 2026-07-11
+
+## Status
+
+Accepted
+
+## Context
+
+Tournament *setup* shipped in epic #595 — tournaments, events, tables, pools,
+eligibility predicates, RBAC. Nothing lets a player actually **enter** an event.
+Epic #780 ("Run the tournament") tracks the second half, and its first slice
+(#781) is the load-bearing one: draw generation (#785, #786) cannot seed a bracket
+until there are entrants to seed it with.
+
+Two things are true of the code this lands on top of, and both shaped the decision.
+
+**`TournamentEvent.entered` is a dead column.** It exists at every layer — the
+`tournament_events` table, `TournamentEventRead`, and three places in the UI (the
+event card's `52 / 64` numeral and fill bar, the "Entries" hero stat, and the
+tournaments-list card's total). It is explicitly *not* patchable, and the schema
+docstring calls it "server-managed". But the only writer in the entire API is the
+literal `entered=0` at event creation. Against the real API every one of those UI
+surfaces renders `0`, always. It is a counter with no incrementer — a placeholder
+that was waiting for exactly this change.
+
+**Every existing tournament mutation is owner-only.** Editing, publishing and
+deleting all funnel through `_require_owner`; `can_edit` is just
+`created_by_user_id == current_user.id`. This was deliberate — managing a
+tournament is a property of ownership, not a role grant.
+
+## Decision
+
+### An event's entry count is derived, never stored
+
+The `entered` column is **dropped** (fortymm is pre-deploy, so the original
+tournaments migration is edited in place rather than chained with an `ALTER`), and
+the count is computed from the live entries on read.
+
+`entered` keeps its name and its position in `TournamentEventRead`, so the response
+contract is unchanged and the three existing UI surfaces need no edit — they simply
+start showing real numbers instead of `0`.
+
+The tournament-list endpoint returns every tournament with all its events, so the
+counts are gathered in **one grouped query across all events**, not one count per
+event. This is the same N+1 rule ADR 0015 just enforced in match-details.
+
+### Withdrawal is a soft-delete, guarded by a *partial* unique index
+
+An entry carries a `status` of `entered` or `withdrawn`. Withdrawing flips the
+status; the row survives.
+
+The uniqueness guard is therefore a **partial** unique index:
+
+```sql
+UNIQUE (event_id, user_id) WHERE status = 'entered'
+```
+
+It says "at most one *active* entry per player per event" while permitting any
+number of historical withdrawn rows.
+
+### Self-registration gets its own permission
+
+A new `tournament.enter` permission, granted to the Beta-tester role, gates entry.
+
+### An entry is one row per user, so #781 is singles-only
+
+Entering a doubles or teams event is rejected server-side, and the UI offers no
+Enter control there.
+
+## Consequences
+
+### Deriving the count trades a join for a whole bug class
+
+The stored counter would have had to be incremented on entry, decremented on
+withdrawal, and held consistent under concurrent entries — a counter that can drift
+from the rows it counts, whose drift is invisible until someone notices the bracket
+has 63 players in a 64-slot event. Deriving it makes that class of bug
+unrepresentable: there is no second copy of the truth to disagree with the first.
+
+The cost is a `GROUP BY` on every tournament read. We are accepting it unmeasured,
+which ADR 0015 is a cautionary tale about — so, concretely: the count is bounded by
+`max_players` per event and the query is one statement regardless of event count. If
+it ever shows up in a profile, the fix is a materialised counter *with* the drift
+tests, not a return to the naive one.
+
+### The partial index is the whole reason withdrawal works
+
+This is the detail a reimplementation is most likely to get wrong, so it is worth
+stating baldly: **a plain `UNIQUE (event_id, user_id)` is a bug.** Combined with
+soft-delete, it would permanently lock a player out of an event they had ever
+withdrawn from — the second entry attempt would collide with their own tombstoned
+row. The enter → withdraw → re-enter journey walks straight into it, and it is the
+single most important scenario in this slice's tests.
+
+The alternatives were hard-delete on withdrawal (which works with a plain unique
+index, but throws away the withdrawal history a tournament director will eventually
+want) and reactivating the withdrawn row in place (which turns the create endpoint
+into an upsert). The partial index keeps the create path a plain `INSERT` and keeps
+the history.
+
+Because the index is partial, the duplicate-entry check is **race-free without a
+row lock**: two concurrent entries by the same player cannot both land, and the
+loser surfaces as an `IntegrityError` → 409. There is deliberately no
+`SELECT ... FOR UPDATE` here. Capacity (`max_players`) is a *different* race with a
+different answer, and it is #783's problem, not this ADR's.
+
+### Self-registration inverts the tournament auth model
+
+It is the first non-owner mutation in the tournaments area, so it structurally
+cannot use `_require_owner` — the whole point is that a player who does not own the
+tournament is writing to it. `tournament.enter` carries that, and the route
+additionally authorises that the entry being created or withdrawn is the caller's
+*own*. Director-managed entries (#784) are the case where someone writes an entry
+that is *not* their own, and that is exactly why it is a separate slice with a
+separate permission story rather than a flag on this one.
+
+### The account-merge trap
+
+`merge_user` **tombstones** the ephemeral user rather than deleting it, so
+`ON DELETE` never fires no matter what the FK says. A `user_id` FK that is not
+explicitly handled in `account_merge.py` therefore leaves rows pointing at a ghost
+user. Entries are re-pointed onto the survivor — and because of the partial unique
+index, an event that **both** users had actively entered would collide on re-point,
+so the loser's row is dropped. This is the same dedup-then-repoint shape
+`MatchSidePlayer` already uses.
+
+Nothing in #781's acceptance criteria mentions this. It is the one correctness-
+critical item the issue omits, which is why it is called out here.
+
+### Singles-only is a modelling limit, not a policy
+
+One row per user cannot express a doubles pairing or a team — there is nowhere to
+put the partner. Rather than ship a doubles flow that silently records half a pair,
+non-singles events reject entry outright. Whoever adds doubles will need a
+partner/team association, at which point `TournamentEntry` grows a sibling rather
+than a nullable column.

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -462,6 +462,38 @@ internal protocol APIProtocol: Sendable {
     /// - Remark: HTTP `DELETE /v1/tournaments/{tournament_id}/events/{event_id}`.
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/delete(delete_event_v1_tournaments__tournament_id__events__event_id__delete)`.
     func deleteEventV1TournamentsTournamentIdEventsEventIdDelete(_ input: Operations.DeleteEventV1TournamentsTournamentIdEventsEventIdDelete.Input) async throws -> Operations.DeleteEventV1TournamentsTournamentIdEventsEventIdDelete.Output
+    /// Enter Event
+    ///
+    /// Register the signed-in player in a singles event.
+    ///
+    /// Self-registration only: the entry created is always the caller's own, which
+    /// is why the request carries no body — there is no field in which to name
+    /// someone else. Entering a player who is not you is a director's job, and a
+    /// different endpoint.
+    ///
+    /// Entering an event you are already in is a `409`; withdrawing first frees you
+    /// to enter it again. Doubles and teams events are a `400`: an entry is one row
+    /// per player, with nowhere to record a partner or a team.
+    ///
+    /// - Remark: HTTP `POST /v1/tournaments/{tournament_id}/events/{event_id}/entries`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/post(enter_event_v1_tournaments__tournament_id__events__event_id__entries_post)`.
+    func enterEventV1TournamentsTournamentIdEventsEventIdEntriesPost(_ input: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input) async throws -> Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Output
+    /// Withdraw From Event
+    ///
+    /// Withdraw the signed-in player's own entry from an event.
+    ///
+    /// The entry is **soft-deleted**: its status flips to `withdrawn` and the row
+    /// survives, so the event keeps its withdrawal history — and, because the
+    /// uniqueness guard is a *partial* index over active entries only, the player is
+    /// free to enter the same event again afterwards.
+    ///
+    /// You may only withdraw your own entry; someone else's is a `403`. Withdrawing
+    /// an entry that is already withdrawn is a no-op, not an error: this is `DELETE`,
+    /// and asking for a state the resource is already in is a success.
+    ///
+    /// - Remark: HTTP `DELETE /v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/delete(withdraw_from_event_v1_tournaments__tournament_id__events__event_id__entries__entry_id__delete)`.
+    func withdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete(_ input: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Input) async throws -> Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Output
     /// Health
     ///
     /// - Remark: HTTP `GET /v1/health`.
@@ -1334,6 +1366,54 @@ extension APIProtocol {
         headers: Operations.DeleteEventV1TournamentsTournamentIdEventsEventIdDelete.Input.Headers = .init()
     ) async throws -> Operations.DeleteEventV1TournamentsTournamentIdEventsEventIdDelete.Output {
         try await deleteEventV1TournamentsTournamentIdEventsEventIdDelete(Operations.DeleteEventV1TournamentsTournamentIdEventsEventIdDelete.Input(
+            path: path,
+            headers: headers
+        ))
+    }
+    /// Enter Event
+    ///
+    /// Register the signed-in player in a singles event.
+    ///
+    /// Self-registration only: the entry created is always the caller's own, which
+    /// is why the request carries no body — there is no field in which to name
+    /// someone else. Entering a player who is not you is a director's job, and a
+    /// different endpoint.
+    ///
+    /// Entering an event you are already in is a `409`; withdrawing first frees you
+    /// to enter it again. Doubles and teams events are a `400`: an entry is one row
+    /// per player, with nowhere to record a partner or a team.
+    ///
+    /// - Remark: HTTP `POST /v1/tournaments/{tournament_id}/events/{event_id}/entries`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/post(enter_event_v1_tournaments__tournament_id__events__event_id__entries_post)`.
+    internal func enterEventV1TournamentsTournamentIdEventsEventIdEntriesPost(
+        path: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Path,
+        headers: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Headers = .init()
+    ) async throws -> Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Output {
+        try await enterEventV1TournamentsTournamentIdEventsEventIdEntriesPost(Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input(
+            path: path,
+            headers: headers
+        ))
+    }
+    /// Withdraw From Event
+    ///
+    /// Withdraw the signed-in player's own entry from an event.
+    ///
+    /// The entry is **soft-deleted**: its status flips to `withdrawn` and the row
+    /// survives, so the event keeps its withdrawal history — and, because the
+    /// uniqueness guard is a *partial* index over active entries only, the player is
+    /// free to enter the same event again afterwards.
+    ///
+    /// You may only withdraw your own entry; someone else's is a `403`. Withdrawing
+    /// an entry that is already withdrawn is a no-op, not an error: this is `DELETE`,
+    /// and asking for a state the resource is already in is a success.
+    ///
+    /// - Remark: HTTP `DELETE /v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/delete(withdraw_from_event_v1_tournaments__tournament_id__events__event_id__entries__entry_id__delete)`.
+    internal func withdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete(
+        path: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Input.Path,
+        headers: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Input.Headers = .init()
+    ) async throws -> Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Output {
+        try await withdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete(Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Input(
             path: path,
             headers: headers
         ))
@@ -5392,6 +5472,48 @@ internal enum Components {
                 case events
             }
         }
+        /// One *active* entry in an event. Withdrawn entries are not entrants: they
+        /// appear in neither this list nor the ``entered`` count.
+        ///
+        /// ``id`` is the *entry's* id, not the player's: it is the address a client
+        /// withdraws through (``DELETE …/entries/{entry_id}``), so an entrant that a
+        /// client can see is an entrant it can act on.
+        ///
+        /// - Remark: Generated from `#/components/schemas/TournamentEntrantRead`.
+        internal struct TournamentEntrantRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/TournamentEntrantRead/id`.
+            internal var id: Swift.String
+            /// - Remark: Generated from `#/components/schemas/TournamentEntrantRead/user_id`.
+            internal var userId: Swift.String
+            /// - Remark: Generated from `#/components/schemas/TournamentEntrantRead/username`.
+            internal var username: Swift.String
+            /// - Remark: Generated from `#/components/schemas/TournamentEntrantRead/seed`.
+            internal var seed: Swift.Int?
+            /// Creates a new `TournamentEntrantRead`.
+            ///
+            /// - Parameters:
+            ///   - id:
+            ///   - userId:
+            ///   - username:
+            ///   - seed:
+            internal init(
+                id: Swift.String,
+                userId: Swift.String,
+                username: Swift.String,
+                seed: Swift.Int? = nil
+            ) {
+                self.id = id
+                self.userId = userId
+                self.username = username
+                self.seed = seed
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case id
+                case userId = "user_id"
+                case username
+                case seed
+            }
+        }
         /// - Remark: Generated from `#/components/schemas/TournamentEventCreate`.
         internal struct TournamentEventCreate: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/name`.
@@ -5523,8 +5645,6 @@ internal enum Components {
             internal var maxPlayers: Swift.Int
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/entry_fee`.
             internal var entryFee: Swift.Double
-            /// - Remark: Generated from `#/components/schemas/TournamentEventRead/entered`.
-            internal var entered: Swift.Int
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/slot`.
             internal var slot: Components.Schemas.Slot
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/match_settings`.
@@ -5537,6 +5657,16 @@ internal enum Components {
             internal var createdAt: Foundation.Date
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/updated_at`.
             internal var updatedAt: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/TournamentEventRead/entrants`.
+            internal var entrants: [Components.Schemas.TournamentEntrantRead]
+            /// The registration count. Derived — there is no stored counter (ADR-0016).
+            ///
+            /// It is ``len(entrants)`` rather than a field of its own precisely so the
+            /// count and the list it counts cannot disagree: an event that says it has
+            /// 52 entrants but lists 51 is not a representable state.
+            ///
+            /// - Remark: Generated from `#/components/schemas/TournamentEventRead/entered`.
+            internal var entered: Swift.Int
             /// Creates a new `TournamentEventRead`.
             ///
             /// - Parameters:
@@ -5547,13 +5677,14 @@ internal enum Components {
             ///   - drawType:
             ///   - maxPlayers:
             ///   - entryFee:
-            ///   - entered:
             ///   - slot:
             ///   - matchSettings:
             ///   - predicates:
             ///   - pools:
             ///   - createdAt:
             ///   - updatedAt:
+            ///   - entrants:
+            ///   - entered: The registration count. Derived — there is no stored counter (ADR-0016).
             internal init(
                 id: Swift.String,
                 tournamentId: Swift.String,
@@ -5562,13 +5693,14 @@ internal enum Components {
                 drawType: Components.Schemas.DrawType,
                 maxPlayers: Swift.Int,
                 entryFee: Swift.Double,
-                entered: Swift.Int,
                 slot: Components.Schemas.Slot,
                 matchSettings: Components.Schemas.MatchSettings,
                 predicates: [Components.Schemas.Predicate],
                 pools: [Components.Schemas.Pool],
                 createdAt: Foundation.Date,
-                updatedAt: Foundation.Date
+                updatedAt: Foundation.Date,
+                entrants: [Components.Schemas.TournamentEntrantRead],
+                entered: Swift.Int
             ) {
                 self.id = id
                 self.tournamentId = tournamentId
@@ -5577,13 +5709,14 @@ internal enum Components {
                 self.drawType = drawType
                 self.maxPlayers = maxPlayers
                 self.entryFee = entryFee
-                self.entered = entered
                 self.slot = slot
                 self.matchSettings = matchSettings
                 self.predicates = predicates
                 self.pools = pools
                 self.createdAt = createdAt
                 self.updatedAt = updatedAt
+                self.entrants = entrants
+                self.entered = entered
             }
             internal enum CodingKeys: String, CodingKey {
                 case id
@@ -5593,21 +5726,22 @@ internal enum Components {
                 case drawType = "draw_type"
                 case maxPlayers = "max_players"
                 case entryFee = "entry_fee"
-                case entered
                 case slot
                 case matchSettings = "match_settings"
                 case predicates
                 case pools
                 case createdAt = "created_at"
                 case updatedAt = "updated_at"
+                case entrants
+                case entered
             }
         }
         /// Partial update for an event. Absent fields are unchanged. Every column
         /// these fields back — ``name``/``format``/``draw_type``/``max_players``/
         /// ``entry_fee``/``slot``/``match_settings``/``predicates``/``pools`` — is NOT
         /// NULL, so an explicit ``null`` on any of them is rejected (422);
-        /// ``predicates``/``pools`` replace wholesale when present. ``entered`` is a
-        /// server-managed registration count and is intentionally NOT updatable here —
+        /// ``predicates``/``pools`` replace wholesale when present. ``entered`` is not
+        /// updatable — it is derived from the event's active entries, not stored — so
         /// sending it is a 422 via ``extra="forbid"``.
         ///
         /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate`.
@@ -16971,6 +17105,389 @@ internal enum Operations {
             /// - Throws: An error if `self` is not `.unprocessableContent`.
             /// - SeeAlso: `.unprocessableContent`.
             internal var unprocessableContent: Operations.DeleteEventV1TournamentsTournamentIdEventsEventIdDelete.Output.UnprocessableContent {
+                get throws {
+                    switch self {
+                    case let .unprocessableContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unprocessableContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        internal enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            internal init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            internal var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            internal static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Enter Event
+    ///
+    /// Register the signed-in player in a singles event.
+    ///
+    /// Self-registration only: the entry created is always the caller's own, which
+    /// is why the request carries no body — there is no field in which to name
+    /// someone else. Entering a player who is not you is a director's job, and a
+    /// different endpoint.
+    ///
+    /// Entering an event you are already in is a `409`; withdrawing first frees you
+    /// to enter it again. Doubles and teams events are a `400`: an entry is one row
+    /// per player, with nowhere to record a partner or a team.
+    ///
+    /// - Remark: HTTP `POST /v1/tournaments/{tournament_id}/events/{event_id}/entries`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/post(enter_event_v1_tournaments__tournament_id__events__event_id__entries_post)`.
+    internal enum EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost {
+        internal static let id: Swift.String = "enter_event_v1_tournaments__tournament_id__events__event_id__entries_post"
+        internal struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/POST/path`.
+            internal struct Path: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/POST/path/tournament_id`.
+                internal var tournamentId: Swift.String
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/POST/path/event_id`.
+                internal var eventId: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - tournamentId:
+                ///   - eventId:
+                internal init(
+                    tournamentId: Swift.String,
+                    eventId: Swift.String
+                ) {
+                    self.tournamentId = tournamentId
+                    self.eventId = eventId
+                }
+            }
+            internal var path: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Path
+            /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/POST/header`.
+            internal struct Headers: Sendable, Hashable {
+                internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                internal init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            internal var headers: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            internal init(
+                path: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Path,
+                headers: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        internal enum Output: Sendable, Hashable {
+            internal struct Created: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/POST/responses/201/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/POST/responses/201/content/application\/json`.
+                    case json(Components.Schemas.TournamentEntrantRead)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.TournamentEntrantRead {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Output.Created.Body
+                /// Creates a new `Created`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Output.Created.Body) {
+                    self.body = body
+                }
+            }
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/post(enter_event_v1_tournaments__tournament_id__events__event_id__entries_post)/responses/201`.
+            ///
+            /// HTTP response code: `201 created`.
+            case created(Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Output.Created)
+            /// The associated value of the enum case if `self` is `.created`.
+            ///
+            /// - Throws: An error if `self` is not `.created`.
+            /// - SeeAlso: `.created`.
+            internal var created: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Output.Created {
+                get throws {
+                    switch self {
+                    case let .created(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "created",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct UnprocessableContent: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/POST/responses/422/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/POST/responses/422/content/application\/json`.
+                    case json(Components.Schemas.HTTPValidationError)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.HTTPValidationError {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Output.UnprocessableContent.Body
+                /// Creates a new `UnprocessableContent`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Output.UnprocessableContent.Body) {
+                    self.body = body
+                }
+            }
+            /// Validation Error
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/post(enter_event_v1_tournaments__tournament_id__events__event_id__entries_post)/responses/422`.
+            ///
+            /// HTTP response code: `422 unprocessableContent`.
+            case unprocessableContent(Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Output.UnprocessableContent)
+            /// The associated value of the enum case if `self` is `.unprocessableContent`.
+            ///
+            /// - Throws: An error if `self` is not `.unprocessableContent`.
+            /// - SeeAlso: `.unprocessableContent`.
+            internal var unprocessableContent: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Output.UnprocessableContent {
+                get throws {
+                    switch self {
+                    case let .unprocessableContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unprocessableContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        internal enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            internal init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            internal var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            internal static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Withdraw From Event
+    ///
+    /// Withdraw the signed-in player's own entry from an event.
+    ///
+    /// The entry is **soft-deleted**: its status flips to `withdrawn` and the row
+    /// survives, so the event keeps its withdrawal history — and, because the
+    /// uniqueness guard is a *partial* index over active entries only, the player is
+    /// free to enter the same event again afterwards.
+    ///
+    /// You may only withdraw your own entry; someone else's is a `403`. Withdrawing
+    /// an entry that is already withdrawn is a no-op, not an error: this is `DELETE`,
+    /// and asking for a state the resource is already in is a success.
+    ///
+    /// - Remark: HTTP `DELETE /v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/delete(withdraw_from_event_v1_tournaments__tournament_id__events__event_id__entries__entry_id__delete)`.
+    internal enum WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete {
+        internal static let id: Swift.String = "withdraw_from_event_v1_tournaments__tournament_id__events__event_id__entries__entry_id__delete"
+        internal struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/DELETE/path`.
+            internal struct Path: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/DELETE/path/tournament_id`.
+                internal var tournamentId: Swift.String
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/DELETE/path/event_id`.
+                internal var eventId: Swift.String
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/DELETE/path/entry_id`.
+                internal var entryId: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - tournamentId:
+                ///   - eventId:
+                ///   - entryId:
+                internal init(
+                    tournamentId: Swift.String,
+                    eventId: Swift.String,
+                    entryId: Swift.String
+                ) {
+                    self.tournamentId = tournamentId
+                    self.eventId = eventId
+                    self.entryId = entryId
+                }
+            }
+            internal var path: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Input.Path
+            /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/DELETE/header`.
+            internal struct Headers: Sendable, Hashable {
+                internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                internal init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            internal var headers: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            internal init(
+                path: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Input.Path,
+                headers: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        internal enum Output: Sendable, Hashable {
+            internal struct NoContent: Sendable, Hashable {
+                /// Creates a new `NoContent`.
+                internal init() {}
+            }
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/delete(withdraw_from_event_v1_tournaments__tournament_id__events__event_id__entries__entry_id__delete)/responses/204`.
+            ///
+            /// HTTP response code: `204 noContent`.
+            case noContent(Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Output.NoContent)
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/delete(withdraw_from_event_v1_tournaments__tournament_id__events__event_id__entries__entry_id__delete)/responses/204`.
+            ///
+            /// HTTP response code: `204 noContent`.
+            internal static var noContent: Self {
+                .noContent(.init())
+            }
+            /// The associated value of the enum case if `self` is `.noContent`.
+            ///
+            /// - Throws: An error if `self` is not `.noContent`.
+            /// - SeeAlso: `.noContent`.
+            internal var noContent: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Output.NoContent {
+                get throws {
+                    switch self {
+                    case let .noContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "noContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct UnprocessableContent: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/DELETE/responses/422/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/DELETE/responses/422/content/application\/json`.
+                    case json(Components.Schemas.HTTPValidationError)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.HTTPValidationError {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Output.UnprocessableContent.Body
+                /// Creates a new `UnprocessableContent`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Output.UnprocessableContent.Body) {
+                    self.body = body
+                }
+            }
+            /// Validation Error
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/delete(withdraw_from_event_v1_tournaments__tournament_id__events__event_id__entries__entry_id__delete)/responses/422`.
+            ///
+            /// HTTP response code: `422 unprocessableContent`.
+            case unprocessableContent(Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Output.UnprocessableContent)
+            /// The associated value of the enum case if `self` is `.unprocessableContent`.
+            ///
+            /// - Throws: An error if `self` is not `.unprocessableContent`.
+            /// - SeeAlso: `.unprocessableContent`.
+            internal var unprocessableContent: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Output.UnprocessableContent {
                 get throws {
                     switch self {
                     case let .unprocessableContent(response):

--- a/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
+++ b/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
@@ -1,0 +1,92 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+
+import {
+  EVENT,
+  TOURNAMENT_ID,
+  TournamentsStore,
+  type TournamentsStoreOptions,
+} from './tournaments-store'
+
+/**
+ * Page object for the tournament detail page's **Events tab** (the default tab,
+ * so no navigation beyond the URL).
+ *
+ * Every locator is keyed on the event NAME, because the tab is a list of
+ * near-identical cards: a bare `getByRole('button', { name: 'Enter' })` would be
+ * ambiguous the moment a second singles event exists, and a count assertion not
+ * scoped to a card would happily match a sibling's identical `2 / 64`.
+ */
+export class TournamentDetailPage {
+  constructor(private readonly page: Page) {}
+
+  /** Install the stateful stub, load the page, and wait for the Events tab to be
+   * really on screen. That last wait is load-bearing: every "there is no Enter
+   * control here" assertion in the spec passes *vacuously* against a page that
+   * has not rendered yet. */
+  static async navigateTo(page: Page, options: TournamentsStoreOptions = {}) {
+    const store = new TournamentsStore(options)
+    await store.install(page)
+    await page.goto(`/tournaments/${TOURNAMENT_ID}`)
+
+    const pom = new TournamentDetailPage(page)
+    await expect(pom.eventCard(EVENT.JOURNEY)).toBeVisible()
+    return { pom, store }
+  }
+
+  /** One event's row card. The stretched open-target button is a *sibling* of
+   * the `Card` (that is what keeps it out of the entrants list and off the Enter
+   * control), so it is deliberately NOT inside this locator. */
+  eventCard(eventName: string): Locator {
+    return this.page.locator('[data-slot=card]').filter({ hasText: eventName })
+  }
+
+  enterButton(eventName: string): Locator {
+    return this.page.getByRole('button', { name: `Enter ${eventName}` })
+  }
+
+  withdrawButton(eventName: string): Locator {
+    return this.page.getByRole('button', { name: `Withdraw from ${eventName}` })
+  }
+
+  /** The roster `<ul>`. Absent (count 0) in the `empty` and `entry-closed`
+   * states, which render a paragraph instead. */
+  entrantsList(eventName: string): Locator {
+    return this.page.getByRole('list', { name: `Entrants in ${eventName}` })
+  }
+
+  /** The full-card overlay that opens the editor. Its accessible name is
+   * `Edit {event}` for an owner, `View {event}` otherwise. */
+  openEditorOverlay(eventName: string): Locator {
+    return this.page.getByRole('button', { name: `Edit ${eventName}` })
+  }
+
+  /** The event editor — a Sheet, i.e. a `role="dialog"`. The one thing clicking
+   * Enter must NOT do. */
+  get eventEditor(): Locator {
+    return this.page.getByRole('dialog')
+  }
+
+  /** The tournament-level "Entries" hero stat: the sum of every event's derived
+   * count. It is a `Card` like the event rows are, so it is identified as "the
+   * card that says Entries but is not an event card" — event cards all carry a
+   * Time slot column. */
+  get heroEntries(): Locator {
+    return this.page
+      .locator('[data-slot=card]')
+      .filter({ hasText: 'Entries' })
+      .filter({ hasNotText: 'Time slot' })
+  }
+
+  /** Toasts — the app's error channel. The happy journey must raise none. */
+  get toasts(): Locator {
+    return this.page.locator('[data-sonner-toast]')
+  }
+
+  /** Assert an event card's `entered / max_players` numerals, scoped to the card
+   * so a sibling event's identical figures cannot satisfy it. */
+  async expectEntryCount(eventName: string, entered: number, max: number) {
+    await expect(this.eventCard(eventName)).toContainText(
+      new RegExp(`${entered}\\s*/\\s*${max}`),
+    )
+  }
+}

--- a/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
+++ b/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
@@ -54,6 +54,20 @@ export class TournamentDetailPage {
     return this.page.getByRole('list', { name: `Entrants in ${eventName}` })
   }
 
+  /** The roster's rows, in the order the card shows them — the entrant chips,
+   * then the `+N more` tail when it is truncating. Order is the point: the
+   * signed-in player's own chip is pinned to the front (#781), so `.first()` is
+   * where an entered player must be able to find themselves. */
+  entrantItems(eventName: string): Locator {
+    return this.entrantsList(eventName).getByRole('listitem')
+  }
+
+  /** The `+N more` tail — how many entrants the card is *not* showing. Text, not
+   * a control: the card's stretched overlay owns the only click here. */
+  truncationTail(eventName: string): Locator {
+    return this.entrantsList(eventName).getByText(/^\+\d+ more$/)
+  }
+
   /** The full-card overlay that opens the editor. Its accessible name is
    * `Edit {event}` for an owner, `View {event}` otherwise. */
   openEditorOverlay(eventName: string): Locator {

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -1,0 +1,302 @@
+import type { Page, Route } from '@playwright/test'
+
+import type { components } from '../../../src/api/schema'
+import { PERM } from '../../../src/lib/permissions'
+import {
+  buildTournamentDetailRead,
+  buildTournamentEventRead,
+  buildTournamentEntrantRead,
+} from '../../../src/mocks/factories/tournaments/tournament.factory'
+import { sessionResponse } from '../../../src/test/factories'
+
+type TournamentDetailRead = components['schemas']['TournamentDetailRead']
+type TournamentEventRead = components['schemas']['TournamentEventRead']
+type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
+type UnreadCountResponse = components['schemas']['UnreadCountResponse']
+
+/** The app shell's notification bell polls this on every page, tournaments
+ * included. It is nothing to do with entries — but with MSW off, an unanswered
+ * call falls through to the vite dev server, so the shell around the feature has
+ * to be fed too. */
+const UNREAD_COUNT: UnreadCountResponse = { unread_count: 0 }
+
+/**
+ * A **stateful** network stub for the tournament-entries journey, installed as
+ * Playwright `page.route` interceptors (this suite runs with MSW OFF).
+ *
+ * Stateful is not a nicety here, it is the whole requirement: the journey is
+ * enter → withdraw → **re-enter**, and each step's assertion is about what the
+ * *next* read returns. A static fixture cannot express "the roster now contains
+ * me and the count went up", so a spec built on one would assert the fixture,
+ * not the app.
+ *
+ * It is a **per-test instance**, never a module singleton: the suite runs
+ * `fullyParallel`, and a shared store would let one test's entry leak into
+ * another's "am I entered?" join.
+ *
+ * The wire shapes come from the same generated-schema-typed factories the MSW
+ * mocks use, so a change to the OpenAPI contract reds this file at review time
+ * rather than passing a stale shape into a green spec.
+ */
+
+export const TOURNAMENT_ID = 'bay-area-open-2026'
+
+/** The three events the spec drives, named so the specs never hard-code strings
+ * that must agree with the seed below. */
+export const EVENT = {
+  /** Singles, 2 existing entrants, 64 slots — the enter/withdraw/re-enter one. */
+  JOURNEY: 'Open Singles',
+  /** Singles, nobody entered — the designed *empty* roster state. */
+  EMPTY: 'U1500 Singles',
+  /** Doubles — the *entry-closed* roster state, and no Enter control at all. */
+  DOUBLES: 'Mixed Doubles',
+} as const
+
+/**
+ * ⚠️ The join key. The session payload carries a username and **no user id**, so
+ * "am I entered?" is decided by matching an entrant's `username` against the
+ * session's. The username the store stamps on an entry it mints MUST therefore
+ * be the same one the session reports — otherwise the player enters, the roster
+ * gains a stranger, Withdraw never appears, and the spec looks like an app bug.
+ * One constant, used for both.
+ */
+export const ME = { username: 'rita.kovac', userId: 'u-me' } as const
+
+/** Entrants that are *not* me — so the journey event starts with a real count to
+ * increment, and the roster has something to show before I join it. */
+const OTHERS: TournamentEntrantRead[] = [
+  buildTournamentEntrantRead({ id: 'entry-1', user_id: 'u-1', username: 'player.1' }),
+  buildTournamentEntrantRead({ id: 'entry-2', user_id: 'u-2', username: 'player.2' }),
+]
+
+/** All three roster states (`listed` / `empty` / `entry-closed`) on one page, on
+ * purpose: it is the real shape of an Events tab, and it lets one axe scan cover
+ * every state the roster can be in. */
+function seed(): TournamentDetailRead {
+  return buildTournamentDetailRead({
+    id: TOURNAMENT_ID,
+    events: [
+      buildTournamentEventRead({
+        id: 'ev-open-singles',
+        name: EVENT.JOURNEY,
+        format: 'singles',
+        max_players: 64,
+        entrants: OTHERS,
+      }),
+      buildTournamentEventRead({
+        id: 'ev-u1500',
+        name: EVENT.EMPTY,
+        format: 'singles',
+        max_players: 48,
+        entrants: [],
+        pools: [],
+      }),
+      buildTournamentEventRead({
+        id: 'ev-mixed-doubles',
+        name: EVENT.DOUBLES,
+        format: 'doubles',
+        max_players: 32,
+        entrants: [],
+        pools: [],
+      }),
+    ],
+  })
+}
+
+export interface TournamentsStoreOptions {
+  /** The signed-in player's permissions. Defaults to a beta tester (can enter).
+   * Pass `[PERM.TOURNAMENT_VIEW]` for the "no Enter control" case. */
+  permissions?: string[]
+}
+
+interface RecordedRequest {
+  method: string
+  path: string
+}
+
+export class TournamentsStore {
+  private detail: TournamentDetailRead
+  private entryCounter = 0
+  private gate: Promise<void> | null = null
+
+  /** Every intercepted request, for tallies like "exactly one POST landed". */
+  readonly requests: RecordedRequest[] = []
+  /** Requests this store has no route for. A spec asserts this stays empty — an
+   * unmocked call would otherwise fall through to a 404 and be read as an app
+   * bug (or, without the catch-all, get `index.html` back from vite). */
+  readonly unhandled: RecordedRequest[] = []
+
+  constructor(private readonly options: TournamentsStoreOptions = {}) {
+    this.detail = seed()
+  }
+
+  /** The event as the *server* would report it: the `entered` count derived from
+   * the live entrants, never stored (ADR-0016). A stub that carried its own
+   * counter could drift from its own roster and hide exactly the bug the derived
+   * count exists to prevent. */
+  private read(event: TournamentEventRead): TournamentEventRead {
+    return { ...event, entered: event.entrants.length }
+  }
+
+  private readDetail(): TournamentDetailRead {
+    return { ...this.detail, events: this.detail.events.map((e) => this.read(e)) }
+  }
+
+  /** The active entrants of an event, by event name — for assertions that want
+   * the server's view rather than the DOM's. */
+  entrantsOf(eventName: string): TournamentEntrantRead[] {
+    return this.detail.events.find((e) => e.name === eventName)?.entrants ?? []
+  }
+
+  countOf(method: string): number {
+    return this.requests.filter((r) => r.method === method).length
+  }
+
+  /**
+   * Hold every *mutating* response open until the returned callback is invoked —
+   * so a spec can look at the UI mid-flight (e.g. "Enter is disabled while the
+   * entry is in the air", which is the double-submit guard). Reads keep flowing,
+   * so the page still renders.
+   */
+  holdWrites(): () => void {
+    let release!: () => void
+    this.gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    return () => {
+      release()
+      this.gate = null
+    }
+  }
+
+  async install(page: Page) {
+    // The client resolves its base URL to `${origin}/api`, so this one glob
+    // catches everything the app asks for — session included. Anything NOT
+    // routed here would be served `index.html` by the vite dev server and blow
+    // up as a JSON parse error somewhere far from its cause.
+    await page.route('**/api/v1/**', (route) => this.handle(route))
+  }
+
+  private session() {
+    return sessionResponse({
+      user: {
+        username: ME.username,
+        permissions: this.options.permissions ?? [
+          PERM.TOURNAMENT_VIEW,
+          PERM.TOURNAMENT_ENTER,
+        ],
+      },
+    })
+  }
+
+  private async handle(route: Route) {
+    const request = route.request()
+    const method = request.method()
+    const path = new URL(request.url()).pathname.replace(/^\/api/, '')
+    this.requests.push({ method, path })
+
+    if (path === '/v1/session') {
+      return json(route, 200, this.session())
+    }
+    if (path === '/v1/notifications/unread-count') {
+      return json(route, 200, UNREAD_COUNT)
+    }
+
+    // Writes wait on the gate (reads never do) — see `holdWrites`.
+    if (method !== 'GET' && this.gate) await this.gate
+
+    if (method === 'GET' && path === '/v1/tournaments') {
+      return json(route, 200, [this.readDetail()])
+    }
+    if (method === 'GET' && path === `/v1/tournaments/${TOURNAMENT_ID}`) {
+      return json(route, 200, this.readDetail())
+    }
+
+    const enter = path.match(/^\/v1\/tournaments\/([^/]+)\/events\/([^/]+)\/entries$/)
+    if (method === 'POST' && enter) {
+      return this.enter(route, enter[2])
+    }
+
+    const withdraw = path.match(
+      /^\/v1\/tournaments\/([^/]+)\/events\/([^/]+)\/entries\/([^/]+)$/,
+    )
+    if (method === 'DELETE' && withdraw) {
+      return this.withdraw(route, withdraw[2], withdraw[3])
+    }
+
+    this.unhandled.push({ method, path })
+    return json(route, 404, { detail: `unmocked ${method} ${path}` })
+  }
+
+  /** `POST …/entries` — self-registration. No request body: the caller is always
+   * the entrant. Mirrors the API's refusals so the spec cannot pass against a
+   * stub more permissive than the server (400 non-singles, 409 duplicate). */
+  private async enter(route: Route, eventId: string) {
+    const event = this.detail.events.find((e) => e.id === eventId)
+    if (!event) return json(route, 404, { detail: 'event not found' })
+    if (event.format !== 'singles') {
+      return json(route, 400, { detail: 'only singles events can be entered' })
+    }
+    if (event.entrants.some((e) => e.user_id === ME.userId)) {
+      // The server's partial unique index, in miniature: at most one *active*
+      // entry per player per event.
+      return json(route, 409, { detail: 'already entered' })
+    }
+
+    this.entryCounter += 1
+    // A fresh entry id each time — as on the server, where re-entry after a
+    // withdrawal INSERTs a new row rather than resurrecting the tombstoned one.
+    // The withdraw address therefore changes, and a client that cached the old
+    // entry id would 404 on the second withdrawal.
+    const entrant = buildTournamentEntrantRead({
+      id: `entry-me-${this.entryCounter}`,
+      user_id: ME.userId,
+      username: ME.username,
+    })
+    this.mutateEvent(eventId, (e) => ({ ...e, entrants: [...e.entrants, entrant] }))
+    return json(route, 201, entrant)
+  }
+
+  /** `DELETE …/entries/{entry_id}` — withdrawal. The server soft-deletes; from
+   * the wire that is indistinguishable from dropping the row, since a withdrawn
+   * entry appears in neither the roster nor the count. Withdrawing an entry
+   * that is already gone is idempotent (204), exactly as on the server. */
+  private async withdraw(route: Route, eventId: string, entryId: string) {
+    const event = this.detail.events.find((e) => e.id === eventId)
+    if (!event) return json(route, 404, { detail: 'event not found' })
+
+    const entrant = event.entrants.find((e) => e.id === entryId)
+    if (!entrant) return noContent(route)
+    if (entrant.user_id !== ME.userId) {
+      return json(route, 403, { detail: 'not your entry' })
+    }
+
+    this.mutateEvent(eventId, (e) => ({
+      ...e,
+      entrants: e.entrants.filter((x) => x.id !== entryId),
+    }))
+    return noContent(route)
+  }
+
+  private mutateEvent(
+    eventId: string,
+    fn: (event: TournamentEventRead) => TournamentEventRead,
+  ) {
+    this.detail = {
+      ...this.detail,
+      events: this.detail.events.map((e) => (e.id === eventId ? fn(e) : e)),
+    }
+  }
+}
+
+function json(route: Route, status: number, body: unknown) {
+  return route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  })
+}
+
+function noContent(route: Route) {
+  return route.fulfill({ status: 204 })
+}

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -41,8 +41,8 @@ const UNREAD_COUNT: UnreadCountResponse = { unread_count: 0 }
 
 export const TOURNAMENT_ID = 'bay-area-open-2026'
 
-/** The three events the spec drives, named so the specs never hard-code strings
- * that must agree with the seed below. */
+/** The events the specs drive, named so the specs never hard-code strings that
+ * must agree with the seed below. */
 export const EVENT = {
   /** Singles, 2 existing entrants, 64 slots — the enter/withdraw/re-enter one. */
   JOURNEY: 'Open Singles',
@@ -50,7 +50,16 @@ export const EVENT = {
   EMPTY: 'U1500 Singles',
   /** Doubles — the *entry-closed* roster state, and no Enter control at all. */
   DOUBLES: 'Mixed Doubles',
+  /** Singles with more entrants than a card lists — the *truncated* roster.
+   * Opt-in (`crowded: true`), so the default seed's counts stay the ones the
+   * other specs narrate. */
+  CROWDED: 'Veterans Singles',
 } as const
+
+/** How many people are already in the crowded event before I enter it. Comfortably
+ * past the card's 8-chip cut-off, so my own entry — appended LAST, the server lists
+ * entrants oldest-entry-first — is truncated away unless the roster pins it (#781). */
+const CROWD_SIZE = 12
 
 /**
  * ⚠️ The join key. The session payload carries a username and **no user id**, so
@@ -69,10 +78,26 @@ const OTHERS: TournamentEntrantRead[] = [
   buildTournamentEntrantRead({ id: 'entry-2', user_id: 'u-2', username: 'player.2' }),
 ]
 
+/** A crowd of strangers, `player.1` … `player.N`, in entry order — the roster a
+ * late entrant lands behind. */
+function crowd(size: number): TournamentEntrantRead[] {
+  return Array.from({ length: size }, (_, i) =>
+    buildTournamentEntrantRead({
+      id: `entry-crowd-${i + 1}`,
+      user_id: `u-crowd-${i + 1}`,
+      username: `player.${i + 1}`,
+    }),
+  )
+}
+
 /** All three roster states (`listed` / `empty` / `entry-closed`) on one page, on
  * purpose: it is the real shape of an Events tab, and it lets one axe scan cover
- * every state the roster can be in. */
-function seed(): TournamentDetailRead {
+ * every state the roster can be in.
+ *
+ * The fourth — a roster *longer than the card lists* — is opt-in (`crowded`),
+ * because its dozen entrants would move the tournament-level Entries total that
+ * the journey spec asserts on. */
+function seed(crowded: boolean): TournamentDetailRead {
   return buildTournamentDetailRead({
     id: TOURNAMENT_ID,
     events: [
@@ -99,6 +124,18 @@ function seed(): TournamentDetailRead {
         entrants: [],
         pools: [],
       }),
+      ...(crowded
+        ? [
+            buildTournamentEventRead({
+              id: 'ev-veterans',
+              name: EVENT.CROWDED,
+              format: 'singles',
+              max_players: 64,
+              entrants: crowd(CROWD_SIZE),
+              pools: [],
+            }),
+          ]
+        : []),
     ],
   })
 }
@@ -107,6 +144,9 @@ export interface TournamentsStoreOptions {
   /** The signed-in player's permissions. Defaults to a beta tester (can enter).
    * Pass `[PERM.TOURNAMENT_VIEW]` for the "no Enter control" case. */
   permissions?: string[]
+  /** Add `EVENT.CROWDED` — a singles event already holding more entrants than a
+   * card can list, so entering it puts me past the truncation cut-off. */
+  crowded?: boolean
 }
 
 interface RecordedRequest {
@@ -127,7 +167,7 @@ export class TournamentsStore {
   readonly unhandled: RecordedRequest[] = []
 
   constructor(private readonly options: TournamentsStoreOptions = {}) {
-    this.detail = seed()
+    this.detail = seed(options.crowded ?? false)
   }
 
   /** The event as the *server* would report it: the `entered` count derived from

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -188,6 +188,37 @@ export class TournamentsStore {
     return this.detail.events.find((e) => e.name === eventName)?.entrants ?? []
   }
 
+  /**
+   * Enter **me** into an event *behind this page's back* — the second tab of the
+   * two-tab race (#943). No request is recorded, because none came from the page
+   * under test: from its point of view the server simply moved on without it, and
+   * whatever it is currently rendering is now stale.
+   *
+   * The next thing that page does with this event (clicking the Enter button it
+   * still shows) is therefore a duplicate entry, which the server refuses with a
+   * 409 — exactly as `enter()` below does.
+   */
+  enterElsewhere(eventName: string): TournamentEntrantRead {
+    const event = this.detail.events.find((e) => e.name === eventName)
+    if (!event) throw new Error(`no such event in the seed: ${eventName}`)
+    return this.addEntry(event.id)
+  }
+
+  /** Mint one active entry for ME on an event. A fresh entry id each time — as on
+   * the server, where re-entry after a withdrawal INSERTs a new row rather than
+   * resurrecting the tombstoned one. The withdraw address therefore changes, and
+   * a client that cached the old entry id would 404 on the second withdrawal. */
+  private addEntry(eventId: string): TournamentEntrantRead {
+    this.entryCounter += 1
+    const entrant = buildTournamentEntrantRead({
+      id: `entry-me-${this.entryCounter}`,
+      user_id: ME.userId,
+      username: ME.username,
+    })
+    this.mutateEvent(eventId, (e) => ({ ...e, entrants: [...e.entrants, entrant] }))
+    return entrant
+  }
+
   countOf(method: string): number {
     return this.requests.filter((r) => r.method === method).length
   }
@@ -279,22 +310,12 @@ export class TournamentsStore {
     }
     if (event.entrants.some((e) => e.user_id === ME.userId)) {
       // The server's partial unique index, in miniature: at most one *active*
-      // entry per player per event.
-      return json(route, 409, { detail: 'already entered' })
+      // entry per player per event. The API's wording, verbatim — a stale tab
+      // gets told this, so the copy is part of the contract under test.
+      return json(route, 409, { detail: 'You have already entered this event.' })
     }
 
-    this.entryCounter += 1
-    // A fresh entry id each time — as on the server, where re-entry after a
-    // withdrawal INSERTs a new row rather than resurrecting the tombstoned one.
-    // The withdraw address therefore changes, and a client that cached the old
-    // entry id would 404 on the second withdrawal.
-    const entrant = buildTournamentEntrantRead({
-      id: `entry-me-${this.entryCounter}`,
-      user_id: ME.userId,
-      username: ME.username,
-    })
-    this.mutateEvent(eventId, (e) => ({ ...e, entrants: [...e.entrants, entrant] }))
-    return json(route, 201, entrant)
+    return json(route, 201, this.addEntry(eventId))
   }
 
   /** `DELETE …/entries/{entry_id}` — withdrawal. The server soft-deletes; from

--- a/web-client/e2e/support/axe.ts
+++ b/web-client/e2e/support/axe.ts
@@ -1,0 +1,47 @@
+import AxeBuilder from '@axe-core/playwright'
+import { expect, type Page } from '@playwright/test'
+
+/**
+ * The accessibility gate for the web-client Playwright suite.
+ *
+ * DEFINITION_OF_COMPLETE asks for "axe-clean in every UI state (checked in
+ * web-client/e2e)". This is the first spec in the suite to do it, so the helper
+ * lives here rather than in one spec file — the next page to be brought up to
+ * standard should import it, not reinvent it.
+ *
+ * It runs against the **live page**, so it sees the real cascade and the real
+ * stacking order. That is the whole point: jsdom (vitest) has no layout and no
+ * paint, so colour-contrast, hidden-focusable and overlap rules are
+ * unrepresentable there.
+ */
+
+/** WCAG 2.0/2.1 level A + AA. Deliberately NOT `best-practice`: that tag folds
+ * in stylistic advice (heading-order, landmark-one-main) that would fail the app
+ * shell for reasons unrelated to the feature under test, and a gate nobody can
+ * pass gets deleted. Conformance rules only. */
+const WCAG_A_AA = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+
+/**
+ * Assert the page has no WCAG A/AA violations.
+ *
+ * `context` names the *state* being scanned (e.g. "after entering"), because a
+ * bare "expected [] to equal [...]" from a shared helper tells you nothing about
+ * which of a spec's six states broke.
+ */
+export async function expectAxeClean(page: Page, context: string) {
+  const { violations } = await new AxeBuilder({ page })
+    .withTags(WCAG_A_AA)
+    .analyze()
+
+  // Compare on a readable projection rather than `violations.length === 0`: a
+  // failure then names the rule, its impact, and the offending selector inline,
+  // instead of dumping axe's whole node graph or, worse, just a number.
+  const summary = violations.map((v) => ({
+    rule: v.id,
+    impact: v.impact,
+    help: v.help,
+    nodes: v.nodes.map((n) => n.target.join(' ')),
+  }))
+
+  expect(summary, `axe violations — ${context}`).toEqual([])
+}

--- a/web-client/e2e/tournaments/event-entry.spec.ts
+++ b/web-client/e2e/tournaments/event-entry.spec.ts
@@ -165,6 +165,62 @@ test.describe('Tournaments · entering an event', () => {
     await pom.expectEntryCount(EVENT.EMPTY, 1, 48)
   })
 
+  test('entering a BUSY event still shows me my own name — the roster cannot truncate me away', async ({
+    page,
+  }) => {
+    // #781's acceptance criterion, in the only witness that counts: the server
+    // lists entrants oldest-entry-first, so entering an event that already holds
+    // more people than the card lists appends me PAST the cut-off. The first-8
+    // slice told me I was in (count up, Withdraw offered) and showed me a roster
+    // I was not in.
+    const { pom, store } = await TournamentDetailPage.navigateTo(page, {
+      crowded: true,
+    })
+
+    // --- before: twelve strangers, the oldest eight shown, four hidden -------
+    await expect(pom.entrantsList(EVENT.CROWDED)).toContainText('player.1')
+    await expect(pom.entrantsList(EVENT.CROWDED)).not.toContainText(ME.username)
+    await expect(pom.truncationTail(EVENT.CROWDED)).toHaveText('+4 more')
+    await pom.expectEntryCount(EVENT.CROWDED, 12, 64)
+
+    // --- enter ---------------------------------------------------------------
+    await pom.enterButton(EVENT.CROWDED).click()
+
+    await expect(pom.withdrawButton(EVENT.CROWDED)).toBeVisible()
+    await pom.expectEntryCount(EVENT.CROWDED, 13, 64)
+
+    // THE assertion: I am thirteenth of thirteen, and on screen anyway — pinned
+    // to the front of the roster, and marked, because a chip that jumps the queue
+    // has to say why.
+    await expect(pom.entrantsList(EVENT.CROWDED)).toContainText(ME.username)
+    await expect(pom.entrantItems(EVENT.CROWDED).first()).toContainText(
+      ME.username,
+    )
+    await expect(pom.entrantItems(EVENT.CROWDED).first()).toContainText('(you)')
+
+    // …and the tail stays honest: 13 entrants, 8 chips (me + the 7 oldest) → 5
+    // hidden. Pinning me REORDERS the roster; it does not drop `player.8` out of
+    // the count, nor count me among the hidden.
+    await expect(pom.truncationTail(EVENT.CROWDED)).toHaveText('+5 more')
+    await expect(pom.entrantsList(EVENT.CROWDED)).toContainText('player.7')
+
+    // The server agrees I really am in it — and that it appended me last, which
+    // is precisely what made the bug invisible to the count-only assertions.
+    expect(store.entrantsOf(EVENT.CROWDED)).toHaveLength(13)
+    expect(store.entrantsOf(EVENT.CROWDED).at(-1)?.username).toBe(ME.username)
+    await expect(pom.toasts).toHaveCount(0)
+
+    // --- and back out --------------------------------------------------------
+    // Withdrawing takes my chip (and its tag) away again: the pin follows my
+    // ENTRY, it is not a sticky decoration.
+    await pom.withdrawButton(EVENT.CROWDED).click()
+
+    await expect(pom.enterButton(EVENT.CROWDED)).toBeVisible()
+    await expect(pom.entrantsList(EVENT.CROWDED)).not.toContainText(ME.username)
+    await expect(pom.entrantItems(EVENT.CROWDED).first()).toContainText('player.1')
+    await expect(pom.truncationTail(EVENT.CROWDED)).toHaveText('+4 more')
+  })
+
   test('a doubles event offers no Enter control, and says why instead of lying about it', async ({
     page,
   }) => {
@@ -239,5 +295,22 @@ test.describe('Tournaments · entering an event · accessibility', () => {
     await expect(pom.entrantsList(EVENT.JOURNEY)).toContainText(ME.username)
 
     await expectAxeClean(page, 'events tab after entering')
+  })
+
+  test('is axe-clean with a TRUNCATED roster — my pinned chip and the "+N more" tail', async ({
+    page,
+  }) => {
+    // The fourth roster state (#781): my own chip, marked and hoisted, next to a
+    // tail that is text rather than a control. Both are new markup inside the
+    // list — and both sit under the card's stretched overlay.
+    const { pom } = await TournamentDetailPage.navigateTo(page, { crowded: true })
+    await pom.enterButton(EVENT.CROWDED).click()
+
+    await expect(pom.entrantItems(EVENT.CROWDED).first()).toContainText(
+      ME.username,
+    )
+    await expect(pom.truncationTail(EVENT.CROWDED)).toBeVisible()
+
+    await expectAxeClean(page, 'events tab with a truncated roster')
   })
 })

--- a/web-client/e2e/tournaments/event-entry.spec.ts
+++ b/web-client/e2e/tournaments/event-entry.spec.ts
@@ -221,6 +221,62 @@ test.describe('Tournaments · entering an event', () => {
     await expect(pom.truncationTail(EVENT.CROWDED)).toHaveText('+4 more')
   })
 
+  test('a STALE tab that clicks Enter reconciles to the truth — it does not freeze on a render the 409 disproved', async ({
+    page,
+  }) => {
+    // The QA repro (#943), in the browser: the same player has this tournament
+    // open in two tabs. The other tab enters. THIS one still renders the world as
+    // it was — `0 / 48`, an Enter button, "No one has entered yet" — and clicking
+    // Enter is therefore a duplicate the server refuses with a 409.
+    //
+    // Only a browser can prove the whole of what has to happen next, because it is
+    // the *page* that must catch up: the count, the roster, the empty copy and the
+    // control are four independent renders off one refetch.
+    const { pom, store } = await TournamentDetailPage.navigateTo(page)
+    const card = pom.eventCard(EVENT.EMPTY)
+
+    await pom.expectEntryCount(EVENT.EMPTY, 0, 48)
+    await expect(pom.enterButton(EVENT.EMPTY)).toBeVisible()
+    await expect(card).toContainText(COPY.emptyLead)
+    await expect(pom.heroEntries).toContainText('2') // the journey event's two
+
+    // --- the other tab enters, and this page is none the wiser ---------------
+    store.enterElsewhere(EVENT.EMPTY)
+
+    // Still stale, and that is the point: the page has NOT refetched behind our
+    // backs (if it had, the assertions below would prove nothing at all).
+    await pom.expectEntryCount(EVENT.EMPTY, 0, 48)
+    await expect(pom.enterButton(EVENT.EMPTY)).toBeVisible()
+
+    // --- click Enter on the stale card ---------------------------------------
+    await pom.enterButton(EVENT.EMPTY).click()
+
+    // THE assertion. The POST 409s — and the card comes back TRUE rather than
+    // sitting frozen on its pre-click render: I am in the roster, the count says
+    // so, the empty copy is gone, and the control now offers the only action that
+    // is actually available to me.
+    await expect(pom.withdrawButton(EVENT.EMPTY)).toBeVisible()
+    await expect(pom.entrantsList(EVENT.EMPTY)).toContainText(ME.username)
+    await pom.expectEntryCount(EVENT.EMPTY, 1, 48)
+    await expect(card).not.toContainText(COPY.emptyLead)
+    await expect(pom.heroEntries).toContainText('3') // the whole page caught up
+
+    // The 409 is told gently: I *am* entered, and the screen now says so, so a red
+    // "Couldn't enter the event" on top of it would contradict the very card it
+    // was covering. One informational note, and no error.
+    await expect(pom.toasts).toHaveCount(1)
+    await expect(pom.toasts).toContainText('You were already entered in this event')
+    await expect(pom.toasts).not.toContainText("Couldn't")
+
+    // …and the reconciled view is a WORKING one, not a picture: the entry id it
+    // withdraws by came from the refetch, so Withdraw addresses the real entry.
+    await pom.withdrawButton(EVENT.EMPTY).click()
+
+    await expect(pom.enterButton(EVENT.EMPTY)).toBeVisible()
+    await pom.expectEntryCount(EVENT.EMPTY, 0, 48)
+    expect(store.entrantsOf(EVENT.EMPTY)).toEqual([])
+  })
+
   test('a doubles event offers no Enter control, and says why instead of lying about it', async ({
     page,
   }) => {

--- a/web-client/e2e/tournaments/event-entry.spec.ts
+++ b/web-client/e2e/tournaments/event-entry.spec.ts
@@ -1,0 +1,243 @@
+/**
+ * Tournament self-registration, through the real browser (ADR-0016).
+ *
+ * The tournaments area had no e2e coverage at all before this file. What it is
+ * here to prove, and what only a browser CAN prove:
+ *
+ *   1. **Re-entry after withdrawal.** enter → withdraw → **enter again**. This is
+ *      the single most important assertion in the slice: it is the entire reason
+ *      the database's unique index is *partial* rather than plain. A plain index
+ *      would lock a player out of any event they ever withdrew from, forever, and
+ *      every other test in the suite would still pass.
+ *
+ *   2. **Click isolation.** The Enter control sits inside a card whose whole body
+ *      is covered by a stretched "open the editor" overlay button. It clears that
+ *      overlay purely by z-index stacking. jsdom has no layout and no paint, so a
+ *      `userEvent.click` in vitest lands on the control *regardless* of stacking
+ *      — a unit test cannot fail this, no matter how wrong the CSS gets. If the
+ *      shared `Card` ever gains a stacking context and the overlay starts
+ *      swallowing Enter, this spec is the only thing in the repo that catches it.
+ *
+ *   3. **axe-clean** in each state the roster and the control can be in.
+ */
+import { expect, test } from '@playwright/test'
+
+import { TournamentDetailPage } from '../page-objects/tournaments/tournament-detail.page'
+import { EVENT, ME } from '../page-objects/tournaments/tournaments-store'
+import { PERM } from '../../src/lib/permissions'
+import { expectAxeClean } from '../support/axe'
+
+/** Roster copy, hard-coded test-side on purpose: importing the strings from the
+ * component would make the assertion a tautology (it would pass whatever the
+ * copy became). Straight ASCII apostrophe — `&apos;` renders as one. */
+const COPY = {
+  emptyLead: 'No one has entered yet.',
+  emptyBody: 'Players who enter this event will be listed here.',
+  closedLead: "Doubles events can't be entered yet.",
+  closedBody: 'Entry is open for singles only, so no one can sign up for this event.',
+}
+
+test.describe('Tournaments · entering an event', () => {
+  test('a permitted player enters, appears in the roster, withdraws — and enters AGAIN', async ({
+    page,
+  }) => {
+    const { pom, store } = await TournamentDetailPage.navigateTo(page)
+
+    // --- before: two other players are in, and I am not ---------------------
+    await expect(pom.entrantsList(EVENT.JOURNEY)).toContainText('player.1')
+    await expect(pom.entrantsList(EVENT.JOURNEY)).not.toContainText(ME.username)
+    await pom.expectEntryCount(EVENT.JOURNEY, 2, 64)
+    await expect(pom.heroEntries).toContainText('2')
+    await expect(pom.enterButton(EVENT.JOURNEY)).toBeVisible()
+
+    // --- enter ---------------------------------------------------------------
+    await pom.enterButton(EVENT.JOURNEY).click()
+
+    // The control flips to Withdraw, my name joins the roster, and the count —
+    // derived server-side from that same roster — goes up. All three come from
+    // the refetch the mutation invalidates, not from optimistic local state.
+    await expect(pom.withdrawButton(EVENT.JOURNEY)).toBeVisible()
+    await expect(pom.entrantsList(EVENT.JOURNEY)).toContainText(ME.username)
+    await pom.expectEntryCount(EVENT.JOURNEY, 3, 64)
+    await expect(pom.heroEntries).toContainText('3')
+
+    // --- withdraw ------------------------------------------------------------
+    await pom.withdrawButton(EVENT.JOURNEY).click()
+
+    await expect(pom.enterButton(EVENT.JOURNEY)).toBeVisible()
+    await expect(pom.entrantsList(EVENT.JOURNEY)).not.toContainText(ME.username)
+    await pom.expectEntryCount(EVENT.JOURNEY, 2, 64)
+    await expect(pom.heroEntries).toContainText('2')
+
+    // --- enter AGAIN ---------------------------------------------------------
+    // THE assertion. Against a plain `UNIQUE (event_id, user_id)` this is a 409:
+    // my own withdrawn row would collide with my new one and I would be locked
+    // out of an event I had merely changed my mind about.
+    await pom.enterButton(EVENT.JOURNEY).click()
+
+    await expect(pom.withdrawButton(EVENT.JOURNEY)).toBeVisible()
+    await expect(pom.entrantsList(EVENT.JOURNEY)).toContainText(ME.username)
+    await pom.expectEntryCount(EVENT.JOURNEY, 3, 64)
+
+    // Not a single toast: no step of this journey is an error, and a 409
+    // surfacing as "you're already entered" would toast rather than crash — so
+    // "no toast" is what distinguishes a real re-entry from a swallowed one.
+    await expect(pom.toasts).toHaveCount(0)
+
+    // And the server saw exactly the journey the UI claims: two entries, one
+    // withdrawal — never a second concurrent entry.
+    expect(store.countOf('POST')).toBe(2)
+    expect(store.countOf('DELETE')).toBe(1)
+    expect(store.entrantsOf(EVENT.JOURNEY).map((e) => e.username)).toEqual([
+      'player.1',
+      'player.2',
+      ME.username,
+    ])
+    // Nothing the page asked for went unmocked (an unmocked call would 404 and
+    // read as a feature bug).
+    expect(store.unhandled).toEqual([])
+  })
+
+  test('clicking Enter does not open the event editor — the stretched card overlay does not swallow it', async ({
+    page,
+  }) => {
+    const { pom, store } = await TournamentDetailPage.navigateTo(page)
+    await expect(pom.eventEditor).toHaveCount(0)
+
+    await pom.enterButton(EVENT.JOURNEY).click()
+
+    // The click must have LANDED (else "no dialog" proves nothing — a click that
+    // missed the button entirely would also open no dialog) …
+    await expect(pom.withdrawButton(EVENT.JOURNEY)).toBeVisible()
+    expect(store.countOf('POST')).toBe(1)
+    // … and it must not ALSO have hit the overlay underneath it.
+    await expect(pom.eventEditor).toHaveCount(0)
+
+    // Withdraw sits in the same slot, so it is exposed to the same overlay.
+    await pom.withdrawButton(EVENT.JOURNEY).click()
+    await expect(pom.enterButton(EVENT.JOURNEY)).toBeVisible()
+    await expect(pom.eventEditor).toHaveCount(0)
+
+    // The positive control for all of the above: the overlay IS there and DOES
+    // open the editor. Without this, a `toHaveCount(0)` on a dialog that can
+    // never open would be a spec that passes by tautology.
+    await pom.openEditorOverlay(EVENT.JOURNEY).click()
+    await expect(pom.eventEditor).toBeVisible()
+    await expect(pom.eventEditor).toContainText(EVENT.JOURNEY)
+  })
+
+  test('the Enter control is disabled while the entry is in flight (no double-submit)', async ({
+    page,
+  }) => {
+    const { pom, store } = await TournamentDetailPage.navigateTo(page)
+
+    const release = store.holdWrites()
+    await pom.enterButton(EVENT.JOURNEY).click()
+
+    // Held mid-flight: a second click cannot produce a second entry, because
+    // there is nothing left to click.
+    await expect(pom.enterButton(EVENT.JOURNEY)).toBeDisabled()
+
+    release()
+    await expect(pom.withdrawButton(EVENT.JOURNEY)).toBeVisible()
+    expect(store.countOf('POST')).toBe(1)
+    expect(store.entrantsOf(EVENT.JOURNEY)).toHaveLength(3)
+  })
+
+  test('an event nobody has entered shows designed empty copy — and is still enterable', async ({
+    page,
+  }) => {
+    const { pom } = await TournamentDetailPage.navigateTo(page)
+    const card = pom.eventCard(EVENT.EMPTY)
+
+    // Empty is a data state, not a gap and not an error.
+    await expect(card).toContainText(COPY.emptyLead)
+    await expect(card).toContainText(COPY.emptyBody)
+    await expect(pom.entrantsList(EVENT.EMPTY)).toHaveCount(0)
+    await pom.expectEntryCount(EVENT.EMPTY, 0, 48)
+
+    // "Nobody has entered" is an invitation, not a closed door: the control is
+    // offered, and taking it turns the empty copy into a real roster.
+    await pom.enterButton(EVENT.EMPTY).click()
+
+    await expect(pom.entrantsList(EVENT.EMPTY)).toContainText(ME.username)
+    await expect(card).not.toContainText(COPY.emptyLead)
+    await pom.expectEntryCount(EVENT.EMPTY, 1, 48)
+  })
+
+  test('a doubles event offers no Enter control, and says why instead of lying about it', async ({
+    page,
+  }) => {
+    const { pom } = await TournamentDetailPage.navigateTo(page)
+    const card = pom.eventCard(EVENT.DOUBLES)
+
+    // Positive first: the card is genuinely on screen, so the absence below is
+    // an absence of the control and not of the page.
+    await expect(card).toBeVisible()
+    await pom.expectEntryCount(EVENT.DOUBLES, 0, 32)
+
+    // Absent, not disabled: one entry row cannot express a pairing, so entering
+    // could only ever 400 server-side (ADR-0016).
+    await expect(pom.enterButton(EVENT.DOUBLES)).toHaveCount(0)
+    await expect(pom.withdrawButton(EVENT.DOUBLES)).toHaveCount(0)
+
+    // …and the roster says so, rather than "No one has entered yet", which would
+    // promise a door that does not exist.
+    await expect(card).toContainText(COPY.closedLead)
+    await expect(card).toContainText(COPY.closedBody)
+    await expect(card).not.toContainText(COPY.emptyLead)
+
+    // The editor still opens — the card is not inert, it just cannot be entered.
+    await pom.openEditorOverlay(EVENT.DOUBLES).click()
+    await expect(pom.eventEditor).toBeVisible()
+  })
+
+  test('a player without tournament.enter sees no Enter control anywhere', async ({
+    page,
+  }) => {
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      permissions: [PERM.TOURNAMENT_VIEW],
+    })
+
+    // The page is fully there — cards, rosters, counts…
+    await expect(pom.eventCard(EVENT.JOURNEY)).toBeVisible()
+    await expect(pom.entrantsList(EVENT.JOURNEY)).toContainText('player.1')
+    await pom.expectEntryCount(EVENT.JOURNEY, 2, 64)
+
+    // …it just offers nothing to click. Every event, both directions.
+    for (const name of [EVENT.JOURNEY, EVENT.EMPTY, EVENT.DOUBLES]) {
+      await expect(pom.enterButton(name)).toHaveCount(0)
+      await expect(pom.withdrawButton(name)).toHaveCount(0)
+    }
+  })
+})
+
+test.describe('Tournaments · entering an event · accessibility', () => {
+  test('is axe-clean before entering — with a listed, an empty and an entry-closed roster on screen', async ({
+    page,
+  }) => {
+    const { pom } = await TournamentDetailPage.navigateTo(page)
+
+    // The seed puts all three roster states on the page at once, so this single
+    // scan covers every one of them. Assert they are actually rendered first —
+    // an axe scan of a page missing two of its three states is a green that
+    // means nothing.
+    await expect(pom.entrantsList(EVENT.JOURNEY)).toBeVisible() // listed
+    await expect(pom.eventCard(EVENT.EMPTY)).toContainText(COPY.emptyLead) // empty
+    await expect(pom.eventCard(EVENT.DOUBLES)).toContainText(COPY.closedLead) // entry-closed
+    await expect(pom.enterButton(EVENT.JOURNEY)).toBeVisible()
+
+    await expectAxeClean(page, 'events tab before entering')
+  })
+
+  test('is axe-clean after entering — roster populated, Withdraw offered', async ({
+    page,
+  }) => {
+    const { pom } = await TournamentDetailPage.navigateTo(page)
+    await pom.enterButton(EVENT.JOURNEY).click()
+    await expect(pom.withdrawButton(EVENT.JOURNEY)).toBeVisible()
+    await expect(pom.entrantsList(EVENT.JOURNEY)).toContainText(ME.username)
+
+    await expectAxeClean(page, 'events tab after entering')
+  })
+})

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -40,6 +40,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@eslint/js": "^10.0.1",
         "@faker-js/faker": "^10.5.0",
         "@playwright/test": "^1.61.1",
@@ -137,6 +138,19 @@
       "version": "2.3.9",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -7329,6 +7343,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-dead-code-elimination": {

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -50,6 +50,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^10.0.1",
     "@faker-js/faker": "^10.5.0",
     "@playwright/test": "^1.61.1",

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -929,6 +929,64 @@ export interface paths {
         patch: operations["update_event_v1_tournaments__tournament_id__events__event_id__patch"];
         trace?: never;
     };
+    "/v1/tournaments/{tournament_id}/events/{event_id}/entries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enter Event
+         * @description Register the signed-in player in a singles event.
+         *
+         *     Self-registration only: the entry created is always the caller's own, which
+         *     is why the request carries no body — there is no field in which to name
+         *     someone else. Entering a player who is not you is a director's job, and a
+         *     different endpoint.
+         *
+         *     Entering an event you are already in is a `409`; withdrawing first frees you
+         *     to enter it again. Doubles and teams events are a `400`: an entry is one row
+         *     per player, with nowhere to record a partner or a team.
+         */
+        post: operations["enter_event_v1_tournaments__tournament_id__events__event_id__entries_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Withdraw From Event
+         * @description Withdraw the signed-in player's own entry from an event.
+         *
+         *     The entry is **soft-deleted**: its status flips to `withdrawn` and the row
+         *     survives, so the event keeps its withdrawal history — and, because the
+         *     uniqueness guard is a *partial* index over active entries only, the player is
+         *     free to enter the same event again afterwards.
+         *
+         *     You may only withdraw your own entry; someone else's is a `403`. Withdrawing
+         *     an entry that is already withdrawn is a no-op, not an error: this is `DELETE`,
+         *     and asking for a state the resource is already in is a success.
+         */
+        delete: operations["withdraw_from_event_v1_tournaments__tournament_id__events__event_id__entries__entry_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/health": {
         parameters: {
             query?: never;
@@ -2411,6 +2469,31 @@ export interface components {
             /** Events */
             events: components["schemas"]["TournamentEventRead"][];
         };
+        /**
+         * TournamentEntrantRead
+         * @description One *active* entry in an event. Withdrawn entries are not entrants: they
+         *     appear in neither this list nor the ``entered`` count.
+         *
+         *     ``id`` is the *entry's* id, not the player's: it is the address a client
+         *     withdraws through (``DELETE …/entries/{entry_id}``), so an entrant that a
+         *     client can see is an entrant it can act on.
+         */
+        TournamentEntrantRead: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * User Id
+             * Format: uuid
+             */
+            user_id: string;
+            /** Username */
+            username: string;
+            /** Seed */
+            seed: number | null;
+        };
         /** TournamentEventCreate */
         TournamentEventCreate: {
             /** Name */
@@ -2448,8 +2531,6 @@ export interface components {
             max_players: number;
             /** Entry Fee */
             entry_fee: number;
-            /** Entered */
-            entered: number;
             slot: components["schemas"]["Slot"];
             match_settings: components["schemas"]["MatchSettings"];
             /** Predicates */
@@ -2466,6 +2547,17 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
+            /** Entrants */
+            entrants: components["schemas"]["TournamentEntrantRead"][];
+            /**
+             * Entered
+             * @description The registration count. Derived — there is no stored counter (ADR-0016).
+             *
+             *     It is ``len(entrants)`` rather than a field of its own precisely so the
+             *     count and the list it counts cannot disagree: an event that says it has
+             *     52 entrants but lists 51 is not a representable state.
+             */
+            readonly entered: number;
         };
         /**
          * TournamentEventUpdate
@@ -2473,8 +2565,8 @@ export interface components {
          *     these fields back — ``name``/``format``/``draw_type``/``max_players``/
          *     ``entry_fee``/``slot``/``match_settings``/``predicates``/``pools`` — is NOT
          *     NULL, so an explicit ``null`` on any of them is rejected (422);
-         *     ``predicates``/``pools`` replace wholesale when present. ``entered`` is a
-         *     server-managed registration count and is intentionally NOT updatable here —
+         *     ``predicates``/``pools`` replace wholesale when present. ``entered`` is not
+         *     updatable — it is derived from the event's active entries, not stored — so
          *     sending it is a 422 via ``extra="forbid"``.
          */
         TournamentEventUpdate: {
@@ -4655,6 +4747,73 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["TournamentEventRead"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    enter_event_v1_tournaments__tournament_id__events__event_id__entries_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tournament_id: string;
+                event_id: string;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TournamentEntrantRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    withdraw_from_event_v1_tournaments__tournament_id__events__event_id__entries__entry_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tournament_id: string;
+                event_id: string;
+                entry_id: string;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -21,6 +21,7 @@ import {
 import {
   buildTournamentDetailRead,
   buildTournamentEntrantRead,
+  buildTournamentEventRead,
 } from '@/mocks/factories/tournaments/tournament.factory'
 import { server } from '@/mocks/server'
 import { resetTournamentsStore } from '@/mocks/tournaments-store'
@@ -38,7 +39,15 @@ type TournamentUpdate = components['schemas']['TournamentUpdate']
 
 vi.mock('sonner', async () => {
   const actual = await vi.importActual<typeof import('sonner')>('sonner')
-  return { ...actual, toast: { ...actual.toast, error: vi.fn() } }
+  return { ...actual, toast: { ...actual.toast, error: vi.fn(), info: vi.fn() } }
+})
+
+/** Both toast channels start clean: the entry cases assert not just which toast
+ * fired, but that the *other* one did not (a benign 409 that also raised a red
+ * error toast would satisfy a one-sided assertion). */
+beforeEach(() => {
+  vi.mocked(toast.error).mockClear()
+  vi.mocked(toast.info).mockClear()
 })
 
 describe('useTournaments', () => {
@@ -250,8 +259,29 @@ describe('useEnterEvent', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments', 't-1'] })
   })
 
-  it('surfaces a duplicate-entry 409 via a toast without throwing', async () => {
-    vi.mocked(toast.error).mockClear()
+  // The stale-tab race, at the level the bug lives: a 409 means the server and
+  // this screen disagree, so the *failed* mutation has to re-read the server too.
+  // Invalidating only `onSuccess` left the card frozen on the pre-click render it
+  // had just been proven wrong about.
+  it('invalidates on FAILURE too, so a 409 reconciles the view instead of freezing it', async () => {
+    mockEventEnterEndpoint(server, () =>
+      HttpResponse.json(
+        { detail: 'You have already entered this event.' },
+        { status: 409 },
+      ),
+    )
+    const { invalidateSpy, wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useEnterEvent('t-1'), { wrapper })
+    result.current.mutate('ev-1')
+
+    await waitForRaw(() => expect(result.current.isError).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments', 't-1'] })
+  })
+
+  it('treats a duplicate-entry 409 as benign: an informational note, not a red error', async () => {
     mockEventEnterEndpoint(server, () =>
       HttpResponse.json(
         { detail: 'You have already entered this event.' },
@@ -265,12 +295,151 @@ describe('useEnterEvent', () => {
 
     await waitForRaw(() => expect(result.current.isError).toBe(true))
 
+    // "You have already entered" is not a failure the player caused or can fix —
+    // they ARE entered, and the reconciled card now says so. An error toast on top
+    // of a screen that reads "Withdraw" would contradict it.
+    expect(toast.info).toHaveBeenCalledWith(
+      'You were already entered in this event',
+      expect.objectContaining({
+        description: "We've refreshed it with the latest entries.",
+      }),
+    )
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('still surfaces a GENUINE failure (a 400, a 5xx) as an error toast', async () => {
+    // The benign-409 carve-out must not become a swallow-everything: a doubles
+    // 400, and anything 5xx, are real errors and still shout.
+    mockEventEnterEndpoint(server, () =>
+      HttpResponse.json(
+        { detail: 'Only singles events can be entered directly, not doubles.' },
+        { status: 400 },
+      ),
+    )
+    const { wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useEnterEvent('t-1'), { wrapper })
+    result.current.mutate('ev-doubles')
+
+    await waitForRaw(() => expect(result.current.isError).toBe(true))
+
     expect(toast.error).toHaveBeenCalledWith(
       "Couldn't enter the event",
       expect.objectContaining({
-        description: 'You have already entered this event.',
+        description:
+          'Only singles events can be entered directly, not doubles.',
       }),
     )
+    expect(toast.info).not.toHaveBeenCalled()
+  })
+})
+
+// The QA repro (#943), end to end through the cache: two tabs, one player. Tab B
+// entered; THIS tab still holds the read from before that, so it renders `0 / 64`
+// and an Enter button. Clicking Enter 409s — and the card must come back TRUE
+// (1 entrant, me), not stay frozen on the render the 409 just disproved.
+describe('entering from a STALE view (the two-tab race)', () => {
+  const ME = buildTournamentEntrantRead({
+    id: 'entry-9',
+    user_id: 'u-me',
+    username: 'rita.kovac',
+  })
+
+  /** The tournament detail as this tab reads it: the FIRST read is the stale one
+   * (taken before tab B entered me); every read after it tells the truth. */
+  function mockDetailStaleThenTrue() {
+    let reads = 0
+    mockTournamentDetailEndpoint(server, () => {
+      const stale = reads === 0
+      reads += 1
+      return HttpResponse.json(
+        buildTournamentDetailRead({
+          id: 't-1',
+          events: [
+            buildTournamentEventRead({
+              id: 'ev-1',
+              entrants: stale ? [] : [ME],
+            }),
+          ],
+        }),
+      )
+    })
+  }
+
+  it('re-reads the tournament on the 409 — the count, the roster and the control all catch up', async () => {
+    mockDetailStaleThenTrue()
+    mockEventEnterEndpoint(server, () =>
+      // The server is right and the screen is wrong: this player is already in.
+      HttpResponse.json(
+        { detail: 'You have already entered this event.' },
+        { status: 409 },
+      ),
+    )
+    const { wrapper } = setupClient()
+
+    const { result } = renderHookRaw(
+      () => ({ detail: useTournament('t-1'), enter: useEnterEvent('t-1') }),
+      { wrapper },
+    )
+    const event = () => result.current.detail.data!.events[0]
+
+    // The stale render the QA pass saw: nobody entered, so the card offers Enter.
+    await waitForRaw(() => expect(result.current.detail.data).toBeTruthy())
+    expect(event().entered).toBe(0)
+    expect(event().entrants).toEqual([])
+
+    result.current.enter.mutate('ev-1')
+    await waitForRaw(() => expect(result.current.enter.isError).toBe(true))
+
+    // THE assertion. Before the fix this stays `0` forever — the mutation failed,
+    // nothing invalidated, and only a manual reload revealed the truth.
+    await waitForRaw(() => expect(event().entered).toBe(1))
+    expect(event().entrants.map((e) => e.username)).toEqual(['rita.kovac'])
+    // …which is what flips the control to Withdraw: `myEntrant` finds me now.
+    expect(event().entrants[0].id).toBe('entry-9')
+  })
+
+  // The other side of "reconcile on settle": when the FAILURE is an outage, the
+  // reconcile refetch fails too. That must not cost the player the page they were
+  // looking at — a network blip on a click is a toast, not a teardown. (The detail
+  // query only throws to the boundary while it has NO data; once it has rendered
+  // once, a failed background refetch keeps the last-good view.)
+  it('survives an outage: the reconcile refetch fails, the last-good view stays, the error toasts', async () => {
+    let reads = 0
+    mockTournamentDetailEndpoint(server, () => {
+      reads += 1
+      if (reads > 1) {
+        return HttpResponse.json({ detail: 'Server error.' }, { status: 500 })
+      }
+      return HttpResponse.json(
+        buildTournamentDetailRead({
+          id: 't-1',
+          events: [buildTournamentEventRead({ id: 'ev-1', entrants: [] })],
+        }),
+      )
+    })
+    mockEventEnterEndpoint(server, () =>
+      HttpResponse.json({ detail: 'Server error.' }, { status: 500 }),
+    )
+    const { wrapper } = setupClient()
+
+    const { result } = renderHookRaw(
+      () => ({ detail: useTournament('t-1'), enter: useEnterEvent('t-1') }),
+      { wrapper },
+    )
+
+    await waitForRaw(() => expect(result.current.detail.data).toBeTruthy())
+
+    result.current.enter.mutate('ev-1')
+    await waitForRaw(() => expect(result.current.enter.isError).toBe(true))
+    await waitForRaw(() => expect(reads).toBeGreaterThan(1))
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't enter the event",
+      expect.objectContaining({ description: 'Server error.' }),
+    )
+    // The page is still there, still showing what it last knew.
+    expect(result.current.detail.data!.events[0].entered).toBe(0)
   })
 })
 
@@ -316,6 +485,28 @@ describe('useWithdrawEntry', () => {
         description: 'You can only withdraw your own entry.',
       }),
     )
+  })
+
+  // Withdraw's stale-tab race lands on its SUCCESS path (a repeat withdrawal is an
+  // idempotent 204), which is why it looked fine while entering did not. That was
+  // luck, not design: a withdrawal that genuinely fails is the same "my view and
+  // the server disagree" moment, so it reconciles on settle too.
+  it('invalidates on failure too — a rejected withdrawal cannot leave a stale card', async () => {
+    mockEventWithdrawEndpoint(server, () =>
+      HttpResponse.json(
+        { detail: 'You can only withdraw your own entry.' },
+        { status: 403 },
+      ),
+    )
+    const { invalidateSpy, wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useWithdrawEntry('t-1'), { wrapper })
+    result.current.mutate({ eventId: 'ev-1', entryId: 'entry-other' })
+
+    await waitForRaw(() => expect(result.current.isError).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments', 't-1'] })
   })
 })
 

--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -1,28 +1,37 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
+  act,
   renderHook as renderHookRaw,
   waitFor as waitForRaw,
 } from '@testing-library/react'
 import { HttpResponse } from 'msw'
 import { toast } from 'sonner'
 import type { ReactNode } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderHook, waitFor } from '@/test/utilities'
 import {
+  mockEventEnterEndpoint,
+  mockEventWithdrawEndpoint,
   mockTournamentCreateEndpoint,
   mockTournamentDetailEndpoint,
   mockTournamentUpdateEndpoint,
   mockTournamentsListEndpoint,
 } from '@/mocks/endpoints/tournaments/tournaments.endpoint'
-import { buildTournamentDetailRead } from '@/mocks/factories/tournaments/tournament.factory'
+import {
+  buildTournamentDetailRead,
+  buildTournamentEntrantRead,
+} from '@/mocks/factories/tournaments/tournament.factory'
 import { server } from '@/mocks/server'
+import { resetTournamentsStore } from '@/mocks/tournaments-store'
 import type { components } from '@/api/schema'
 import {
   useCreateTournament,
+  useEnterEvent,
   useTournament,
   useTournaments,
   useUpdateTournament,
+  useWithdrawEntry,
 } from './api'
 
 type TournamentUpdate = components['schemas']['TournamentUpdate']
@@ -194,5 +203,192 @@ describe('useUpdateTournament', () => {
         description: 'You do not have permission to edit this tournament.',
       }),
     )
+  })
+})
+
+describe('useEnterEvent', () => {
+  it('posts to the event entries route with NO body — the caller is the entrant', async () => {
+    let seen: { url: string; body: string } | null = null
+    mockEventEnterEndpoint(server, async ({ request }) => {
+      seen = { url: request.url, body: await request.text() }
+      return HttpResponse.json(
+        buildTournamentEntrantRead({
+          id: 'entry-9',
+          user_id: 'u-me',
+          username: 'rita.kovac',
+        }),
+        { status: 201 },
+      )
+    })
+
+    const { result } = renderHook(() => useEnterEvent('t-1'))
+    const entrant = await result.current.mutateAsync('ev-1')
+
+    // The ENTRY id — the address a withdrawal is later sent to.
+    expect(entrant).toEqual({
+      id: 'entry-9',
+      userId: 'u-me',
+      username: 'rita.kovac',
+      seed: null,
+    })
+    expect(seen!.url).toContain('/v1/tournaments/t-1/events/ev-1/entries')
+    expect(seen!.body).toBe('')
+  })
+
+  it('invalidates the list and the detail so the count and the entrants both refresh', async () => {
+    mockEventEnterEndpoint(server, () =>
+      HttpResponse.json(buildTournamentEntrantRead(), { status: 201 }),
+    )
+    const { invalidateSpy, wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useEnterEvent('t-1'), { wrapper })
+    result.current.mutate('ev-1')
+
+    await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments', 't-1'] })
+  })
+
+  it('surfaces a duplicate-entry 409 via a toast without throwing', async () => {
+    vi.mocked(toast.error).mockClear()
+    mockEventEnterEndpoint(server, () =>
+      HttpResponse.json(
+        { detail: 'You have already entered this event.' },
+        { status: 409 },
+      ),
+    )
+    const { wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useEnterEvent('t-1'), { wrapper })
+    result.current.mutate('ev-1')
+
+    await waitForRaw(() => expect(result.current.isError).toBe(true))
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't enter the event",
+      expect.objectContaining({
+        description: 'You have already entered this event.',
+      }),
+    )
+  })
+})
+
+describe('useWithdrawEntry', () => {
+  it('deletes the ENTRY (not the event) and resolves on the bodiless 204', async () => {
+    let seenUrl = ''
+    mockEventWithdrawEndpoint(server, ({ request }) => {
+      seenUrl = request.url
+      return new HttpResponse(null, { status: 204 })
+    })
+    const { invalidateSpy, wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useWithdrawEntry('t-1'), { wrapper })
+    result.current.mutate({ eventId: 'ev-1', entryId: 'entry-9' })
+
+    await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(seenUrl).toContain(
+      '/v1/tournaments/t-1/events/ev-1/entries/entry-9',
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments', 't-1'] })
+  })
+
+  it("surfaces a 403 (someone else's entry) via a toast", async () => {
+    vi.mocked(toast.error).mockClear()
+    mockEventWithdrawEndpoint(server, () =>
+      HttpResponse.json(
+        { detail: 'You can only withdraw your own entry.' },
+        { status: 403 },
+      ),
+    )
+    const { wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useWithdrawEntry('t-1'), { wrapper })
+    result.current.mutate({ eventId: 'ev-1', entryId: 'entry-other' })
+
+    await waitForRaw(() => expect(result.current.isError).toBe(true))
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't withdraw from the event",
+      expect.objectContaining({
+        description: 'You can only withdraw your own entry.',
+      }),
+    )
+  })
+})
+
+// The round trip, driven through the DEFAULT handlers and the dev store rather
+// than a per-test stub: entering has to make the *next read* of that event show
+// the entrant AND an incremented count — a store that updated the list but not
+// the count (or vice versa) is exactly the drift the derived count exists to
+// make impossible.
+describe('entering and withdrawing, against the stateful mock store', () => {
+  beforeEach(() => resetTournamentsStore())
+
+  const TOURNAMENT = 'bay-area-open-2026'
+  const EVENT = 'ev-u1500' // seeded with nobody in it
+
+  it('adds the entrant and increments the count; withdrawing reverses both', async () => {
+    const { wrapper } = setupClient()
+    const { result } = renderHookRaw(
+      () => ({
+        detail: useTournament(TOURNAMENT),
+        enter: useEnterEvent(TOURNAMENT),
+        withdraw: useWithdrawEntry(TOURNAMENT),
+      }),
+      { wrapper },
+    )
+    const event = () =>
+      result.current.detail.data!.events.find((e) => e.id === EVENT)!
+
+    await waitForRaw(() => expect(result.current.detail.data).toBeTruthy())
+    expect(event().entered).toBe(0)
+    expect(event().entrants).toEqual([])
+
+    const entrant = await act(() => result.current.enter.mutateAsync(EVENT))
+
+    await waitForRaw(() => expect(event().entered).toBe(1))
+    expect(event().entrants.map((e) => e.username)).toEqual(['rita.kovac'])
+    expect(event().entrants[0].id).toBe(entrant.id)
+
+    await act(() =>
+      result.current.withdraw.mutateAsync({
+        eventId: EVENT,
+        entryId: entrant.id,
+      }),
+    )
+
+    await waitForRaw(() => expect(event().entered).toBe(0))
+    expect(event().entrants).toEqual([])
+  })
+
+  it('lets a withdrawn player enter the same event again — withdrawal is not a lockout', async () => {
+    const { wrapper } = setupClient()
+    const { result } = renderHookRaw(
+      () => ({
+        detail: useTournament(TOURNAMENT),
+        enter: useEnterEvent(TOURNAMENT),
+        withdraw: useWithdrawEntry(TOURNAMENT),
+      }),
+      { wrapper },
+    )
+    const event = () =>
+      result.current.detail.data!.events.find((e) => e.id === EVENT)!
+
+    await waitForRaw(() => expect(result.current.detail.data).toBeTruthy())
+
+    const first = await act(() => result.current.enter.mutateAsync(EVENT))
+    await act(() =>
+      result.current.withdraw.mutateAsync({
+        eventId: EVENT,
+        entryId: first.id,
+      }),
+    )
+    await act(() => result.current.enter.mutateAsync(EVENT))
+
+    await waitForRaw(() => expect(event().entered).toBe(1))
+    expect(event().entrants.map((e) => e.username)).toEqual(['rita.kovac'])
   })
 })

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildTournamentDetailRead,
+  buildTournamentEntrantRead,
+  buildTournamentEntrantReads,
   buildTournamentEventRead,
 } from '@/mocks/factories/tournaments/tournament.factory'
 import {
+  apiToEntrant,
   apiToEvent,
   apiToTournament,
   draftToCreateBody,
@@ -21,7 +24,7 @@ describe('apiToEvent', () => {
         draw_type: 'single-elim',
         max_players: 32,
         entry_fee: 35,
-        entered: 22,
+        entrants: buildTournamentEntrantReads(22),
         match_settings: { rated: false, length_games: 3 },
       }),
     )
@@ -29,8 +32,37 @@ describe('apiToEvent', () => {
     expect(event.drawType).toBe('single-elim')
     expect(event.maxPlayers).toBe(32)
     expect(event.entryFee).toBe(35)
+    // The count is the server's derived `entered` — and it agrees with the list
+    // it counts, because they are the same fact (ADR-0016).
     expect(event.entered).toBe(22)
+    expect(event.entrants).toHaveLength(22)
     expect(event.match).toEqual({ rated: false, lengthGames: 3 })
+  })
+
+  it('maps each entrant, keeping the ENTRY id a withdrawal is addressed to', () => {
+    const event = apiToEvent(
+      buildTournamentEventRead({
+        entrants: [
+          buildTournamentEntrantRead({
+            id: 'entry-9',
+            user_id: 'u-7',
+            username: 'rita.kovac',
+            seed: 3,
+          }),
+        ],
+      }),
+    )
+
+    expect(event.entrants).toEqual([
+      { id: 'entry-9', userId: 'u-7', username: 'rita.kovac', seed: 3 },
+    ])
+  })
+
+  it('maps an event nobody has entered to an empty list and a zero count', () => {
+    const event = apiToEvent(buildTournamentEventRead({ entrants: [] }))
+
+    expect(event.entrants).toEqual([])
+    expect(event.entered).toBe(0)
   })
 
   it('maps a pool, renaming table_ids to tableIds', () => {
@@ -79,6 +111,19 @@ describe('apiToEvent', () => {
     )
 
     expect(event.predicates[0].value).toEqual([1200, 1600])
+  })
+})
+
+describe('apiToEntrant', () => {
+  it('renames user_id and passes an unseeded entrant through', () => {
+    expect(
+      apiToEntrant({
+        id: 'entry-1',
+        user_id: 'u-1',
+        username: 'player.1',
+        seed: null,
+      }),
+    ).toEqual({ id: 'entry-1', userId: 'u-1', username: 'player.1', seed: null })
   })
 })
 
@@ -205,7 +250,14 @@ const event: TournamentEvent = {
   drawType: 'rr-then-ko',
   maxPlayers: 48,
   entryFee: 30,
-  entered: 41,
+  // Two active entrants, so the derived count is 2 — the count and the list are
+  // the same fact, and a fixture that disagreed with itself would be a lie the
+  // server cannot tell.
+  entered: 2,
+  entrants: [
+    { id: 'entry-1', userId: 'u-1', username: 'player.1', seed: 1 },
+    { id: 'entry-2', userId: 'u-2', username: 'player.2', seed: null },
+  ],
   slot: { date: '2026-06-14', start: '09:00', end: '16:00' },
   predicates: [{ id: 'pr-2', field: 'rating', op: '<', value: 1500 }],
   match: { rated: true, lengthGames: 3 },
@@ -247,8 +299,23 @@ describe('eventToCreateBody', () => {
       pools: wire.pools ?? [],
       id: event.id,
       tournament_id: 't-1',
-      // `entered` is server-managed and absent from the create body; supply the
-      // read-shape value directly so the round-trip assertion holds.
+      // The registrations are server-owned and absent from the create body;
+      // supply the read-shape entrants (the count derives from them) so the
+      // round-trip assertion holds.
+      entrants: [
+        buildTournamentEntrantRead({
+          id: 'entry-1',
+          user_id: 'u-1',
+          username: 'player.1',
+          seed: 1,
+        }),
+        buildTournamentEntrantRead({
+          id: 'entry-2',
+          user_id: 'u-2',
+          username: 'player.2',
+          seed: null,
+        }),
+      ],
       entered: event.entered,
       created_at: '2026-06-01T00:00:00Z',
       updated_at: '2026-06-01T00:00:00Z',
@@ -279,5 +346,10 @@ describe('eventToUpdateBody', () => {
   it('omits the server-owned entered count so a PATCH never clobbers it', () => {
     const body = eventToUpdateBody(event)
     expect('entered' in body).toBe(false)
+  })
+
+  it('omits the entrants too — registrations are written through the entries endpoints, never an event PATCH', () => {
+    const body = eventToUpdateBody(event)
+    expect('entrants' in body).toBe(false)
   })
 })

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -12,6 +12,7 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query'
+import { toast } from 'sonner'
 
 import { ApiError, api, unwrap } from '@/api/client'
 import { notifyError } from '@/lib/notify-error'
@@ -220,9 +221,18 @@ function tournamentDetailQuery(id: string) {
       return unwrap('load tournament', result)
     },
     // Bubble everything except a 404 (which resolved to null above and never
-    // reaches here as an error). A 403 reaches the RbacBoundary.
-    throwOnError: (error) =>
-      !(error instanceof ApiError && error.status === 404),
+    // reaches here as an error) — but only while there is NOTHING on screen. A
+    // 403 on load still reaches the RbacBoundary.
+    //
+    // `throwOnError` fires on *background refetch* failures too, not just the
+    // first load. Since the entry mutations now reconcile on settle (see below),
+    // a click during an outage would trigger a refetch that fails and throw the
+    // whole rendered tournament away — a network blip on Enter is a toast, not a
+    // teardown. With data in hand we keep the last-good view and let the
+    // mutation's own error toast carry the failure.
+    throwOnError: (error, query) =>
+      !(error instanceof ApiError && error.status === 404) &&
+      query.state.data === undefined,
     retry: false,
   })
 }
@@ -362,18 +372,42 @@ export function useDeleteEvent(tournamentId: string) {
 // + detail), and the refetched event carries both the updated `entrants` list
 // and the derived `entered` count. That is the whole invalidation set: the two
 // keys `invalidateTournament` already covers.
+//
+// Both mutations invalidate **`onSettled`, not `onSuccess`** — they reconcile
+// whether they succeeded or failed. A failed entry is precisely the moment the
+// screen is most likely to be lying: the 409 the server answers means "your view
+// and my state disagree" (someone — usually you, in another tab — already entered
+// you), so the only sane response is to re-read the server. Invalidating only on
+// success left the stale tab frozen on `0 / 64` + **Enter** + "No one has entered
+// yet" after the very request that proved all three wrong (#943). Withdraw's
+// stale-tab race happens to land on its *success* path (a repeat withdrawal is an
+// idempotent 204), so it looked fine — but that was luck, not design; it settles
+// into the same reconcile here on purpose.
+
+/** True for the entry endpoint's "You have already entered this event." — the
+ * only 409 `POST …/entries` raises (its partial unique index on the *active*
+ * entries; see `enter_event` in `api/app/tournaments.py`). It is not really a
+ * failure: it means the player IS entered, so the reconciled view is the answer,
+ * and shouting a red error over a screen that now says "Withdraw" would be the
+ * lie. Anything else — 400, 403, 5xx, network-down — is a genuine error and still
+ * toasts. */
+function isAlreadyEntered(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 409
+}
 
 /** Enter the *signed-in* player into an event. There is no request body — the
  * caller is the entrant (self-registration; a director entering someone else is
  * a separate, later endpoint). Resolves to the created `Entrant`, whose `id` is
  * the entry id a later withdrawal is addressed to.
  *
- * The server rejects a second *active* entry with a 409 and a non-singles event
- * with a 400; both surface as a toast here. A caller that wants to treat the 409
- * as benign (a two-tab race, where the player IS in fact entered) can await
- * `mutateAsync` and inspect the `ApiError` status itself. */
+ * A non-singles event is a 400 and surfaces as an error toast. A duplicate entry
+ * is a 409, which is treated as *benign*: the tournament is re-read (as on every
+ * settle) and the player gets a quiet, informational "you were already entered"
+ * note over the now-truthful card, not an error. A caller that wants to handle
+ * the 409 itself can still await `mutateAsync` and inspect the `ApiError`. */
 export function useEnterEvent(tournamentId: string) {
   const qc = useQueryClient()
+  const toastError = notifyError('enter the event')
   return useMutation({
     mutationFn: async (eventId: string): Promise<Entrant> => {
       const entrant = unwrap(
@@ -389,8 +423,17 @@ export function useEnterEvent(tournamentId: string) {
       )
       return apiToEntrant(entrant)
     },
-    onSuccess: () => invalidateTournament(qc, tournamentId),
-    onError: notifyError('enter the event'),
+    // Reconcile on BOTH paths — see the note above.
+    onSettled: () => invalidateTournament(qc, tournamentId),
+    onError: (error) => {
+      if (isAlreadyEntered(error)) {
+        toast.info('You were already entered in this event', {
+          description: "We've refreshed it with the latest entries.",
+        })
+        return
+      }
+      toastError(error)
+    },
   })
 }
 
@@ -419,7 +462,10 @@ export function useWithdrawEntry(tournamentId: string) {
         { allowEmpty: true },
       )
     },
-    onSuccess: () => invalidateTournament(qc, tournamentId),
+    // Reconcile on BOTH paths — see the note above. A failed withdrawal (a 403 on
+    // an entry that is no longer mine, a 404 on one the server has re-keyed) is a
+    // view/state disagreement just like the entry 409 is.
+    onSettled: () => invalidateTournament(qc, tournamentId),
     onError: notifyError('withdraw from the event'),
   })
 }

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -17,6 +17,7 @@ import { ApiError, api, unwrap } from '@/api/client'
 import { notifyError } from '@/lib/notify-error'
 import type { components } from '@/api/schema'
 import type {
+  Entrant,
   Pool,
   Predicate,
   PredicateValue,
@@ -28,6 +29,7 @@ import type {
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
 type TournamentRead = components['schemas']['TournamentRead']
 type TournamentEventRead = components['schemas']['TournamentEventRead']
+type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
 type TournamentCreate = components['schemas']['TournamentCreate']
 type TournamentUpdate = components['schemas']['TournamentUpdate']
 type TournamentEventCreate = components['schemas']['TournamentEventCreate']
@@ -51,7 +53,14 @@ function apiToPredicate(p: ApiPredicate): Predicate {
 
 // ----- adapters: API (snake_case) <-> prototype (camelCase) ----------------
 
-/** Map an API event payload to the prototype's `TournamentEvent`. */
+/** Map an API entrant to the prototype's `Entrant`. */
+export function apiToEntrant(e: TournamentEntrantRead): Entrant {
+  return { id: e.id, userId: e.user_id, username: e.username, seed: e.seed }
+}
+
+/** Map an API event payload to the prototype's `TournamentEvent`. `entered`
+ * comes straight off the wire: the server derives it from the same active
+ * entries it lists in `entrants`, so the two always agree. */
 export function apiToEvent(e: TournamentEventRead): TournamentEvent {
   return {
     id: e.id,
@@ -61,6 +70,7 @@ export function apiToEvent(e: TournamentEventRead): TournamentEvent {
     maxPlayers: e.max_players,
     entryFee: e.entry_fee,
     entered: e.entered,
+    entrants: e.entrants.map(apiToEntrant),
     slot: e.slot,
     predicates: e.predicates.map(apiToPredicate),
     match: { rated: e.match_settings.rated, lengthGames: e.match_settings.length_games },
@@ -342,5 +352,74 @@ export function useDeleteEvent(tournamentId: string) {
     },
     onSuccess: () => invalidateTournament(qc, tournamentId),
     onError: notifyError('delete the event'),
+  })
+}
+
+// ----- entries (self-registration, ADR-0016) -------------------------------
+//
+// Entrants arrive nested in the tournament detail/list payloads, so entering and
+// withdrawing need no query of their own — they invalidate the tournament (list
+// + detail), and the refetched event carries both the updated `entrants` list
+// and the derived `entered` count. That is the whole invalidation set: the two
+// keys `invalidateTournament` already covers.
+
+/** Enter the *signed-in* player into an event. There is no request body — the
+ * caller is the entrant (self-registration; a director entering someone else is
+ * a separate, later endpoint). Resolves to the created `Entrant`, whose `id` is
+ * the entry id a later withdrawal is addressed to.
+ *
+ * The server rejects a second *active* entry with a 409 and a non-singles event
+ * with a 400; both surface as a toast here. A caller that wants to treat the 409
+ * as benign (a two-tab race, where the player IS in fact entered) can await
+ * `mutateAsync` and inspect the `ApiError` status itself. */
+export function useEnterEvent(tournamentId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (eventId: string): Promise<Entrant> => {
+      const entrant = unwrap(
+        'enter event',
+        await api.POST(
+          '/v1/tournaments/{tournament_id}/events/{event_id}/entries',
+          {
+            params: {
+              path: { tournament_id: tournamentId, event_id: eventId },
+            },
+          },
+        ),
+      )
+      return apiToEntrant(entrant)
+    },
+    onSuccess: () => invalidateTournament(qc, tournamentId),
+    onError: notifyError('enter the event'),
+  })
+}
+
+/** Withdraw one of the signed-in player's own entries (a soft-delete on the
+ * server: the entry survives as history, and the player may enter again). Keyed
+ * by the ENTRY's id — take it from the entrant in the event's `entrants` list.
+ * Repeating a withdrawal is a no-op, not an error. */
+export function useWithdrawEntry(tournamentId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: { eventId: string; entryId: string }) => {
+      unwrap(
+        'withdraw from event',
+        await api.DELETE(
+          '/v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}',
+          {
+            params: {
+              path: {
+                tournament_id: tournamentId,
+                event_id: input.eventId,
+                entry_id: input.entryId,
+              },
+            },
+          },
+        ),
+        { allowEmpty: true },
+      )
+    },
+    onSuccess: () => invalidateTournament(qc, tournamentId),
+    onError: notifyError('withdraw from the event'),
   })
 }

--- a/web-client/src/components/tournaments/data/helpers.test.ts
+++ b/web-client/src/components/tournaments/data/helpers.test.ts
@@ -4,9 +4,51 @@ import {
   fmtDateRange,
   formatPredicate,
   findPoolConflicts,
+  myEntrant,
 } from './helpers'
-import { buildPool, buildTournament, buildEvent } from './seed.factory'
+import {
+  buildEntrant,
+  buildPool,
+  buildTournament,
+  buildEvent,
+} from './seed.factory'
 import type { Predicate } from './types'
+
+describe('myEntrant', () => {
+  const mine = buildEntrant({
+    id: 'entry-me',
+    userId: 'u-me',
+    username: 'rita.kovac',
+  })
+  const theirs = buildEntrant({
+    id: 'entry-them',
+    userId: 'u-2',
+    username: 'lee.wong',
+  })
+
+  it('finds my own entry — the id a withdrawal is addressed to', () => {
+    const event = buildEvent({ entrants: [theirs, mine] })
+
+    expect(myEntrant(event, 'rita.kovac')).toEqual(mine)
+  })
+
+  it('is undefined when I am not entered, so the control offers Enter', () => {
+    const event = buildEvent({ entrants: [theirs] })
+
+    expect(myEntrant(event, 'rita.kovac')).toBeUndefined()
+  })
+
+  it('is undefined for an event nobody has entered', () => {
+    expect(myEntrant(buildEvent({ entrants: [] }), 'rita.kovac')).toBeUndefined()
+  })
+
+  it('is undefined without a username (no session yet) rather than guessing', () => {
+    const event = buildEvent({ entrants: [mine] })
+
+    expect(myEntrant(event, undefined)).toBeUndefined()
+    expect(myEntrant(event, null)).toBeUndefined()
+  })
+})
 
 describe('fmtDateRange', () => {
   it('collapses a same-month span to one month label', () => {

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -4,7 +4,31 @@
 // double-booking detection.
 
 import { PRED_FIELDS } from './options'
-import type { Predicate, Pool, Tournament, TournamentEvent } from './types'
+import type {
+  Entrant,
+  Predicate,
+  Pool,
+  Tournament,
+  TournamentEvent,
+} from './types'
+
+/**
+ * The signed-in player's own active entry in an event, or `undefined` when they
+ * are not entered — i.e. the "Enter or Withdraw?" decision, and the entry id a
+ * withdrawal is addressed to.
+ *
+ * It matches on USERNAME, not user id, on purpose: the session payload
+ * (`SessionUser`) carries only `username` + `permissions` — the web client never
+ * learns its own user id — while an entrant carries both. Usernames are unique,
+ * so this is exact; it is just the only join key the two payloads share.
+ */
+export function myEntrant(
+  event: TournamentEvent,
+  username: string | null | undefined,
+): Entrant | undefined {
+  if (!username) return undefined
+  return event.entrants.find((e) => e.username === username)
+}
 
 /** Parse a date-only `YYYY-MM-DD` string into a local-midnight Date. */
 function parseDateOnly(iso: string): Date {
@@ -167,7 +191,9 @@ export function emptyEvent(t: Tournament): TournamentEvent {
     drawType: 'single-elim',
     maxPlayers: 32,
     entryFee: 30,
+    // A draft event nobody has entered: no entrants, so the derived count is 0.
     entered: 0,
+    entrants: [],
     slot: { date: defaultDate, start: '09:00', end: '13:00' },
     predicates: [],
     match: { rated: true, lengthGames: 5 },

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -4,6 +4,7 @@
 // that callers tweak via overrides.
 
 import type {
+  Entrant,
   Pool,
   Predicate,
   Tournament,
@@ -41,24 +42,52 @@ export function buildPool(overrides: Partial<Pool> = {}): Pool {
   }
 }
 
-/** A rated Bo5 Open Singles event, half full, one pool. */
-export function buildEvent(
-  overrides: Partial<TournamentEvent> = {},
-): TournamentEvent {
+/** One entrant — `player.1`, holding entry `entry-1`, unseeded. */
+export function buildEntrant(overrides: Partial<Entrant> = {}): Entrant {
   return {
+    id: 'entry-1',
+    userId: 'u-1',
+    username: 'player.1',
+    seed: null,
+    ...overrides,
+  }
+}
+
+/** `count` distinct entrants — for the cases that care how MANY players are in
+ * an event rather than who they are. */
+export function buildEntrants(count: number): Entrant[] {
+  return Array.from({ length: count }, (_, i) =>
+    buildEntrant({
+      id: `entry-${i + 1}`,
+      userId: `u-${i + 1}`,
+      username: `player.${i + 1}`,
+    }),
+  )
+}
+
+/** A rated Bo5 Open Singles event, half full (52 of 64), one pool.
+ *
+ * `entered` is NOT an override: it is derived from `entrants`, exactly as the
+ * server derives it (ADR-0016), so a fixture cannot claim 52 entries while
+ * listing none. Want a different count? Pass different `entrants`. */
+export function buildEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  const event = {
     id: 'ev-open-singles',
     name: 'Open Singles',
     format: 'singles',
     drawType: 'rr-then-ko',
     maxPlayers: 64,
     entryFee: 45,
-    entered: 52,
+    entrants: buildEntrants(52),
     slot: { date: '2026-06-13', start: '09:00', end: '18:00' },
     predicates: [],
     match: { rated: true, lengthGames: 5 },
     pools: [buildPool()],
     ...overrides,
-  }
+  } satisfies Omit<TournamentEvent, 'entered'>
+  return { ...event, entered: event.entrants.length }
 }
 
 /** The published "Bay Area Open 2026" with a single Open Singles event. */

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -63,6 +63,18 @@ export interface Pool {
   tableIds: string[]
 }
 
+/** One *active* entry in an event. Withdrawn entries are not entrants — they
+ * appear in neither this list nor the `entered` count (ADR-0016).
+ *
+ * `id` is the ENTRY's id, not the player's: it's the address a withdrawal is
+ * sent to, so an entrant you can see is an entrant you can act on. */
+export interface Entrant {
+  id: string
+  userId: string
+  username: string
+  seed: number | null
+}
+
 export interface TournamentEvent {
   id: string
   name: string
@@ -70,7 +82,11 @@ export interface TournamentEvent {
   drawType: DrawType
   maxPlayers: number
   entryFee: number
+  /** The registration count. Server-derived from the active entries — it is
+   * `entrants.length`, never a stored counter, so the count and the list it
+   * counts cannot disagree. Read it; never write it. */
   entered: number
+  entrants: Entrant[]
   slot: Slot
   predicates: Predicate[]
   match: MatchSettings

--- a/web-client/src/components/tournaments/tournament-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-card.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event'
 
-import { buildTournament, buildEvent } from './data/seed.factory'
+import { buildEntrants, buildTournament, buildEvent } from './data/seed.factory'
 import { tournamentCardPage } from './tournament-card.page'
 
 describe('TournamentCard', () => {
@@ -9,9 +9,11 @@ describe('TournamentCard', () => {
       tournament: buildTournament({
         name: 'Bay Area Open 2026',
         tableIds: ['t1', 't2', 't3'],
+        // The entry count is derived from the entrants, so the fixture states
+        // the entrants and the count follows — there is no second copy to skew.
         events: [
-          buildEvent({ id: 'a', entered: 52 }),
-          buildEvent({ id: 'b', entered: 22 }),
+          buildEvent({ id: 'a', entrants: buildEntrants(52) }),
+          buildEvent({ id: 'b', entrants: buildEntrants(22) }),
         ],
       }),
     })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab.test.tsx
@@ -6,7 +6,12 @@ import { buildTournamentEntrantRead } from '@/mocks/factories/tournaments/tourna
 import { server } from '@/mocks/server'
 import { waitFor } from '@/test/utilities'
 
-import { buildTournament, buildEvent } from '../data/seed.factory'
+import {
+  buildTournament,
+  buildEntrant,
+  buildEntrants,
+  buildEvent,
+} from '../data/seed.factory'
 import { eventsTabPage } from './events-tab.page'
 
 describe('EventsTab', () => {
@@ -106,5 +111,38 @@ describe('EventsTab', () => {
       // stretched open-overlay is only truly asserted in the browser (2e).
       expect(onOpenEvent).not.toHaveBeenCalled()
     })
+  })
+
+  // The tab is where the session is READ (one query, every card): the roster's
+  // "which entrant is me" join is only as good as the username that reaches it.
+  it('tells every card who the viewer is, so they see themselves in a busy roster', async () => {
+    // The 52-entrant Open Singles with the default MSW session's player
+    // (`rita.kovac`) entered LAST — the exact shape of #781, where the card
+    // showed the first 8 and left her looking for herself in vain.
+    eventsTabPage.render({
+      tournament: buildTournament({
+        events: [
+          buildEvent({
+            name: 'Open Singles',
+            entrants: [
+              ...buildEntrants(52),
+              buildEntrant({
+                id: 'entry-me',
+                userId: 'u-me',
+                username: 'rita.kovac',
+              }),
+            ],
+          }),
+        ],
+      }),
+    })
+
+    // `find`, not `query`: the username arrives with the session.
+    expect(
+      await eventsTabPage.findEntrant('Open Singles', 'rita.kovac'),
+    ).toBeInTheDocument()
+    expect(
+      eventsTabPage.queryTruncationTail('Open Singles'),
+    ).toHaveTextContent('+45 more')
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab.test.tsx
@@ -1,4 +1,10 @@
 import userEvent from '@testing-library/user-event'
+import { HttpResponse } from 'msw'
+
+import { mockEventEnterEndpoint } from '@/mocks/endpoints/tournaments/tournaments.endpoint'
+import { buildTournamentEntrantRead } from '@/mocks/factories/tournaments/tournament.factory'
+import { server } from '@/mocks/server'
+import { waitFor } from '@/test/utilities'
 
 import { buildTournament, buildEvent } from '../data/seed.factory'
 import { eventsTabPage } from './events-tab.page'
@@ -40,5 +46,65 @@ describe('EventsTab', () => {
     })
     expect(document.body).toHaveTextContent('No events yet')
     expect(eventsTabPage.queryNewEventButtons()).toHaveLength(0)
+  })
+
+  // The default MSW session is `rita.kovac`, a beta tester holding
+  // `tournament.enter` — and she is not among the seeded entrants.
+  describe('the self-registration control on each card', () => {
+    it('offers Enter on a singles event', async () => {
+      eventsTabPage.render({
+        tournament: buildTournament({
+          events: [buildEvent({ name: 'Open Singles' })],
+        }),
+      })
+
+      expect(
+        await eventsTabPage.findEnterButton('Open Singles'),
+      ).toBeInTheDocument()
+    })
+
+    it('offers none on a doubles event', async () => {
+      eventsTabPage.render({
+        tournament: buildTournament({
+          events: [
+            buildEvent({ name: 'Open Singles' }),
+            buildEvent({
+              id: 'ev-open-doubles',
+              name: 'Open Doubles',
+              format: 'doubles',
+            }),
+          ],
+        }),
+      })
+
+      // The singles card's control is the gate: once it is on screen the
+      // session has landed, so the doubles card's absence is a real absence.
+      await eventsTabPage.findEnterButton('Open Singles')
+      expect(eventsTabPage.queryEnterButton('Open Doubles')).toBeNull()
+    })
+
+    it('enters the event on click — and does NOT open the editor', async () => {
+      let entered = 0
+      mockEventEnterEndpoint(server, () => {
+        entered += 1
+        return HttpResponse.json(buildTournamentEntrantRead(), { status: 201 })
+      })
+      const onOpenEvent = vi.fn()
+      eventsTabPage.render({
+        tournament: buildTournament({
+          id: 't-1',
+          events: [buildEvent({ name: 'Open Singles' })],
+        }),
+        onOpenEvent,
+      })
+
+      await userEvent.click(await eventsTabPage.findEnterButton('Open Singles'))
+
+      await waitFor(() => expect(entered).toBe(1))
+      // Handler wiring only. jsdom has no layout or paint, so this passes
+      // regardless of z-index — the control's click-isolation from the card's
+      // stretched open-overlay is only truly asserted in the browser (2e).
+      expect(onOpenEvent).not.toHaveBeenCalled()
+    })
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab.tsx
@@ -6,6 +6,7 @@ import type { Tournament, TournamentEvent } from '../data/types'
 import { EmptyState } from '../empty-state'
 import { SectionHeader } from './section-header'
 import { EventCard } from './events-tab/event-card'
+import { EnterEventControl } from './events-tab/enter-event-control'
 
 export interface EventsTabProps {
   tournament: Tournament
@@ -60,6 +61,13 @@ export const EventsTab = ({
               event={ev}
               canEdit={canEdit}
               onOpen={() => onOpenEvent(ev)}
+              // Self-registration is a *player's* affordance, not the owner's:
+              // it is gated on `tournament.enter`, not on `canEdit`. The control
+              // decides for itself whether it applies (permission, singles) and
+              // renders nothing when it doesn't.
+              action={
+                <EnterEventControl tournamentId={tournament.id} event={ev} />
+              }
             />
           ))}
         </div>

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab.tsx
@@ -1,5 +1,6 @@
 import { Plus, Trophy } from 'lucide-react'
 
+import { useSession } from '@/api/session'
 import { Button } from '@/components/ui/button'
 
 import type { Tournament, TournamentEvent } from '../data/types'
@@ -25,6 +26,13 @@ export const EventsTab = ({
   onOpenEvent,
   onNewEvent,
 }: EventsTabProps) => {
+  // Who the viewer is, read once for the whole tab and handed to every card: the
+  // roster needs it to pin the player's own chip into a truncated list (#781),
+  // and "which entrant is me" is a join on the USERNAME — the session carries no
+  // user id (see `myEntrant`). `EnterEventControl` reads the same session for the
+  // same join, so the chip and the Enter/Withdraw control can never disagree.
+  const username = useSession().data?.data.user.username
+
   return (
     <div>
       <SectionHeader
@@ -60,6 +68,7 @@ export const EventsTab = ({
               key={ev.id}
               event={ev}
               canEdit={canEdit}
+              username={username}
               onOpen={() => onOpenEvent(ev)}
               // Self-registration is a *player's* affordance, not the owner's:
               // it is gated on `tournament.enter`, not on `canEdit`. The control

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/enter-event-control.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/enter-event-control.factory.tsx
@@ -1,0 +1,15 @@
+import { buildEvent } from '../../data/seed.factory'
+import type { EnterEventControlProps } from './enter-event-control'
+
+/** Props for `EnterEventControl` — the seeded Open Singles event on the seeded
+ * tournament. The signed-in player is NOT among its entrants by default (they
+ * are `player.1`…`player.52`), so the default scenario is "offer Enter". */
+export function buildEnterEventControlProps(
+  overrides: Partial<EnterEventControlProps> = {},
+): EnterEventControlProps {
+  return {
+    tournamentId: 'bay-area-open-2026',
+    event: buildEvent(),
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/enter-event-control.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/enter-event-control.page.tsx
@@ -1,0 +1,77 @@
+import { http, HttpResponse } from 'msw'
+
+import { PERM } from '@/lib/permissions'
+import { server } from '@/mocks/server'
+import { sessionResponse } from '@/test/factories'
+import { SessionProbe } from '@/test/session-probe'
+import { render, screen, type Container } from '@/test/utilities'
+
+import { EnterEventControl, type EnterEventControlProps } from './enter-event-control'
+import { buildEnterEventControlProps } from './enter-event-control.factory'
+
+/** The signed-in player these tests act as, unless a case says otherwise. */
+export const SIGNED_IN_USERNAME = 'rita.kovac'
+
+const scoped = (container: Container) => ({
+  /** The Enter control for `eventName` — absent when the player is entered, is
+   * unpermitted, or the event isn't singles. */
+  queryEnterButton(eventName: string) {
+    return container.queryByRole('button', { name: `Enter ${eventName}` })
+  },
+  findEnterButton(eventName: string) {
+    return container.findByRole('button', { name: `Enter ${eventName}` })
+  },
+  /** The Withdraw control for `eventName` — shown only when the signed-in player
+   * holds an active entry in it. */
+  queryWithdrawButton(eventName: string) {
+    return container.queryByRole('button', { name: `Withdraw from ${eventName}` })
+  },
+  findWithdrawButton(eventName: string) {
+    return container.findByRole('button', { name: `Withdraw from ${eventName}` })
+  },
+  /** Resolves once the session has landed (`SessionProbe`) — gate absence
+   * assertions on this, or they pass vacuously while it is still in flight. */
+  findSessionReady() {
+    return container.findByTestId('session-ready')
+  },
+})
+
+/**
+ * Test page-object for `EnterEventControl`. The control reads `/v1/session` for
+ * the player's permissions **and** their username (membership is a username
+ * join — the session has no user id), so `render` stubs the session per
+ * scenario; the enter/withdraw endpoints are stubbed per test.
+ */
+export const enterEventControlPage = {
+  /**
+   * Stub the session, then render the control (alongside the session probe).
+   * Defaults to a beta tester who holds `tournament.enter`; pass `permissions: []`
+   * for the unpermitted case, or a different `username` to change who you are.
+   */
+  render(
+    overrides: Partial<EnterEventControlProps> = {},
+    session: { permissions?: string[]; username?: string } = {},
+  ) {
+    const {
+      permissions = [PERM.TOURNAMENT_VIEW, PERM.TOURNAMENT_ENTER],
+      username = SIGNED_IN_USERNAME,
+    } = session
+    server.use(
+      http.get('*/v1/session', () =>
+        HttpResponse.json(sessionResponse({ user: { username, permissions } })),
+      ),
+    )
+    render(
+      <>
+        <SessionProbe />
+        <EnterEventControl {...buildEnterEventControlProps(overrides)} />
+      </>,
+    )
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/enter-event-control.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/enter-event-control.test.tsx
@@ -1,0 +1,142 @@
+import userEvent from '@testing-library/user-event'
+import { delay, HttpResponse } from 'msw'
+
+import {
+  mockEventEnterEndpoint,
+  mockEventWithdrawEndpoint,
+} from '@/mocks/endpoints/tournaments/tournaments.endpoint'
+import { buildTournamentEntrantRead } from '@/mocks/factories/tournaments/tournament.factory'
+import { server } from '@/mocks/server'
+import { PERM } from '@/lib/permissions'
+import { waitFor } from '@/test/utilities'
+
+import { buildEntrant, buildEvent } from '../../data/seed.factory'
+import {
+  enterEventControlPage as page,
+  SIGNED_IN_USERNAME,
+} from './enter-event-control.page'
+
+/** The seeded Open Singles event with the signed-in player in it — entry
+ * `entry-me`, alongside a couple of other players' entries (whose ids the
+ * withdrawal must never pick up). */
+const enteredEvent = buildEvent({
+  name: 'Open Singles',
+  entrants: [
+    buildEntrant({ id: 'entry-1', userId: 'u-1', username: 'player.1' }),
+    buildEntrant({
+      id: 'entry-me',
+      userId: 'u-me',
+      username: SIGNED_IN_USERNAME,
+    }),
+    buildEntrant({ id: 'entry-2', userId: 'u-2', username: 'player.2' }),
+  ],
+})
+
+describe('EnterEventControl', () => {
+  it('offers Enter to a permitted player who is not in the event', async () => {
+    page.render({ event: buildEvent({ name: 'Open Singles' }) })
+
+    expect(await page.findEnterButton('Open Singles')).toBeInTheDocument()
+    expect(page.queryWithdrawButton('Open Singles')).toBeNull()
+  })
+
+  it('offers Withdraw once that player is one of the entrants', async () => {
+    page.render({ event: enteredEvent })
+
+    expect(await page.findWithdrawButton('Open Singles')).toBeInTheDocument()
+    expect(page.queryEnterButton('Open Singles')).toBeNull()
+  })
+
+  it('offers nothing to a player without tournament.enter — absent, not disabled', async () => {
+    page.render(
+      { event: buildEvent({ name: 'Open Singles' }) },
+      { permissions: [PERM.TOURNAMENT_VIEW] },
+    )
+
+    // The session must have LANDED before "there is no button" means anything:
+    // permissions read as absent while it is still in flight.
+    await page.findSessionReady()
+
+    expect(page.queryEnterButton('Open Singles')).toBeNull()
+    expect(page.queryWithdrawButton('Open Singles')).toBeNull()
+  })
+
+  it('offers nothing on a doubles event, even to a permitted player', async () => {
+    page.render({
+      event: buildEvent({ name: 'Open Doubles', format: 'doubles' }),
+    })
+
+    await page.findSessionReady()
+
+    expect(page.queryEnterButton('Open Doubles')).toBeNull()
+    expect(page.queryWithdrawButton('Open Doubles')).toBeNull()
+  })
+
+  it('offers nothing on a teams event, even to a permitted player', async () => {
+    page.render({
+      event: buildEvent({ name: 'Club Teams', format: 'teams' }),
+    })
+
+    await page.findSessionReady()
+
+    expect(page.queryEnterButton('Club Teams')).toBeNull()
+    expect(page.queryWithdrawButton('Club Teams')).toBeNull()
+  })
+
+  it('enters THIS event when Enter is clicked', async () => {
+    let seenUrl = ''
+    mockEventEnterEndpoint(server, ({ request }) => {
+      seenUrl = request.url
+      return HttpResponse.json(buildTournamentEntrantRead(), { status: 201 })
+    })
+    page.render({
+      tournamentId: 't-1',
+      event: buildEvent({ id: 'ev-u1500', name: 'U1500 Singles' }),
+    })
+
+    await userEvent.click(await page.findEnterButton('U1500 Singles'))
+
+    await waitFor(() =>
+      expect(seenUrl).toContain('/v1/tournaments/t-1/events/ev-u1500/entries'),
+    )
+  })
+
+  it("withdraws the player's OWN entry when Withdraw is clicked", async () => {
+    let seenUrl = ''
+    mockEventWithdrawEndpoint(server, ({ request }) => {
+      seenUrl = request.url
+      return new HttpResponse(null, { status: 204 })
+    })
+    page.render({ tournamentId: 't-1', event: enteredEvent })
+
+    await userEvent.click(await page.findWithdrawButton('Open Singles'))
+
+    // `entry-me`, not `entry-1`/`entry-2` — an entry is addressed by ITS id, and
+    // the player's own is found by joining on their username.
+    await waitFor(() =>
+      expect(seenUrl).toContain(
+        `/v1/tournaments/t-1/events/${enteredEvent.id}/entries/entry-me`,
+      ),
+    )
+  })
+
+  it('enters once, not twice, when Enter is double-clicked', async () => {
+    let calls = 0
+    mockEventEnterEndpoint(server, async () => {
+      calls += 1
+      // Hold the request open so the second click lands while the first is
+      // still in flight — the exact race the guard exists for.
+      await delay('infinite')
+      return HttpResponse.json(buildTournamentEntrantRead(), { status: 201 })
+    })
+    page.render({ event: buildEvent({ name: 'Open Singles' }) })
+    const enter = await page.findEnterButton('Open Singles')
+
+    await userEvent.click(enter)
+    await userEvent.click(enter)
+
+    expect(calls).toBe(1)
+    // ...because the control locks itself while the entry is in flight.
+    expect(enter).toBeDisabled()
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/enter-event-control.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/enter-event-control.tsx
@@ -1,0 +1,81 @@
+import { LogIn, LogOut } from 'lucide-react'
+
+import { useHasPermission, useSession } from '@/api/session'
+import { Button } from '@/components/ui/button'
+import { PERM } from '@/lib/permissions'
+
+import { useEnterEvent, useWithdrawEntry } from '../../data/api'
+import { myEntrant } from '../../data/helpers'
+import type { TournamentEvent } from '../../data/types'
+
+export interface EnterEventControlProps {
+  tournamentId: string
+  event: TournamentEvent
+}
+
+/**
+ * The event card's self-registration control: **Enter** when the signed-in
+ * player is not in the event, **Withdraw** when they are (ADR-0016).
+ *
+ * It renders **nothing at all** — not a disabled button — when the player lacks
+ * `tournament.enter`, or when the event is doubles/teams. Both of those requests
+ * can only ever fail server-side (403 / 400), so offering a control that cannot
+ * work would be a lie. Nothing here is a *capacity* gate: a full event still
+ * offers Enter, because capacity is enforced (and refused) server-side later
+ * (#783).
+ *
+ * The entry count on the card is derived from the same `entrants` this reads, and
+ * both mutations invalidate the tournament — so the count and the control refresh
+ * themselves from the refetched event. This component tracks no count of its own.
+ */
+export const EnterEventControl = ({
+  tournamentId,
+  event,
+}: EnterEventControlProps) => {
+  const canEnter = useHasPermission(PERM.TOURNAMENT_ENTER)
+  // The session carries a username but NO user id, so membership is a join on
+  // the username — see `myEntrant`.
+  const username = useSession().data?.data.user.username
+  const enter = useEnterEvent(tournamentId)
+  const withdraw = useWithdrawEntry(tournamentId)
+
+  // `useHasPermission` is false while the session is in flight, so this also
+  // holds the control back until we know who the player is — which is what we
+  // want: we can't tell Enter from Withdraw without them.
+  if (!canEnter || event.format !== 'singles') return null
+
+  const entry = myEntrant(event, username)
+  // One in-flight request at a time: a double-click on Enter must not produce a
+  // second entry (the server would 409 it, but the user would see an error for
+  // doing nothing wrong).
+  const isPending = enter.isPending || withdraw.isPending
+
+  if (entry) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        aria-label={`Withdraw from ${event.name}`}
+        disabled={isPending}
+        onClick={() =>
+          withdraw.mutate({ eventId: event.id, entryId: entry.id })
+        }
+      >
+        <LogOut size={14} />
+        Withdraw
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      size="sm"
+      aria-label={`Enter ${event.name}`}
+      disabled={isPending}
+      onClick={() => enter.mutate(event.id)}
+    >
+      <LogIn size={14} />
+      Enter
+    </Button>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.factory.tsx
@@ -1,12 +1,13 @@
 import { buildEvent } from '../../data/seed.factory'
 import type { EntrantsListProps } from './entrants-list'
 
-/** Props for `EntrantsList` — the seeded Open Singles event and its 52 entrants.
+/** Props for `EntrantsList` — the seeded Open Singles event and its 52 entrants,
+ * seen by a signed-out viewer (no `username`, so no chip is anyone's own).
  * Override `event` with `buildEvent({ entrants: [...] })` for the empty and
  * short-roster cases (`entered` is derived from `entrants`, so a fixture cannot
- * disagree with itself). */
+ * disagree with itself), and pass `username` to view the roster AS one of them. */
 export function buildEntrantsListProps(
   overrides: Partial<EntrantsListProps> = {},
 ): EntrantsListProps {
-  return { event: buildEvent(), ...overrides }
+  return { event: buildEvent(), username: null, ...overrides }
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.factory.tsx
@@ -1,0 +1,12 @@
+import { buildEvent } from '../../data/seed.factory'
+import type { EntrantsListProps } from './entrants-list'
+
+/** Props for `EntrantsList` — the seeded Open Singles event and its 52 entrants.
+ * Override `event` with `buildEvent({ entrants: [...] })` for the empty and
+ * short-roster cases (`entered` is derived from `entrants`, so a fixture cannot
+ * disagree with itself). */
+export function buildEntrantsListProps(
+  overrides: Partial<EntrantsListProps> = {},
+): EntrantsListProps {
+  return { event: buildEvent(), ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.page.tsx
@@ -20,6 +20,14 @@ export const ENTRY_CLOSED_COPY = {
   teams: "Teams events can't be entered yet.",
 } as const
 
+/** The tag on the signed-in player's own chip. Spelled out here rather than
+ * imported, for the same reason as the copy above. */
+export const YOU_TAG = '(you)'
+
+/** The `+N more` tail's shape. Anchored, so `+4 more` cannot satisfy an
+ * assertion about `+44 more`. */
+const TAIL_PATTERN = /^\+\d+ more$/
+
 const scoped = (container: Container) => {
   /** The roster for `eventName`. A real `list`, named per event because a tab
    * shows many cards at once. Absent when the event has no entrants: that case
@@ -48,9 +56,24 @@ const scoped = (container: Container) => {
     findEntrant(eventName: string, username: string) {
       return within(getEntrantsList(eventName)).findByText(username)
     },
+    /** The usernames the roster actually SHOWS, in the order it shows them (the
+     * `+N more` tail is not one of them). Order is the assertion: the signed-in
+     * player's own chip is pinned to the front, and everyone else stays
+     * oldest-entry-first behind it. */
+    getEntrantNames(eventName: string): string[] {
+      return within(getEntrantsList(eventName))
+        .getAllByRole('listitem')
+        .filter((li) => !TAIL_PATTERN.test(li.textContent ?? ''))
+        .map((li) => li.firstElementChild?.textContent ?? li.textContent ?? '')
+    },
+    /** The `(you)` tag marking the signed-in player's own chip — `null` when the
+     * viewer is signed out or is not in this event. */
+    queryYouTag(eventName: string) {
+      return within(getEntrantsList(eventName)).queryByText(YOU_TAG)
+    },
     /** The `+N more` tail shown when the roster is longer than the card lists. */
     queryTruncationTail(eventName: string) {
-      return within(getEntrantsList(eventName)).queryByText(/^\+\d+ more$/)
+      return within(getEntrantsList(eventName)).queryByText(TAIL_PATTERN)
     },
     /** Every button in the roster — always none. The list is inert: the card's
      * stretched open target is the only thing here that takes a click. */

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.page.tsx
@@ -1,0 +1,93 @@
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import { EntrantsList, type EntrantsListProps } from './entrants-list'
+import { buildEntrantsListProps } from './entrants-list.factory'
+
+/**
+ * The designed copy for each of the two "no entrants" states, written out here
+ * rather than imported from the component: a test that asserts a constant against
+ * itself asserts nothing. An empty container has no copy at all, so these strings
+ * are what tell the states apart — from a blank gap, and from each other.
+ *
+ * `NO_ENTRANTS_COPY` invites you to be the first; `ENTRY_CLOSED_COPY` says the
+ * door does not exist. Showing the first on a doubles event would be a lie, so
+ * the two are asserted separately and mutually.
+ */
+export const NO_ENTRANTS_COPY = 'No one has entered yet.'
+
+export const ENTRY_CLOSED_COPY = {
+  doubles: "Doubles events can't be entered yet.",
+  teams: "Teams events can't be entered yet.",
+} as const
+
+const scoped = (container: Container) => {
+  /** The roster for `eventName`. A real `list`, named per event because a tab
+   * shows many cards at once. Absent when the event has no entrants: that case
+   * renders the empty copy instead of an empty list. */
+  const getEntrantsList = (eventName: string) =>
+    container.getByRole('list', { name: `Entrants in ${eventName}` })
+
+  return {
+    getEntrantsList,
+    queryEntrantsList(eventName: string) {
+      return container.queryByRole('list', { name: `Entrants in ${eventName}` })
+    },
+    findEntrantsList(eventName: string) {
+      return container.findByRole('list', { name: `Entrants in ${eventName}` })
+    },
+    /** Every row of the roster, in order — the entrants the card actually
+     * shows, plus the `+N more` tail when it is truncating. */
+    getEntrantItems(eventName: string) {
+      return within(getEntrantsList(eventName)).getAllByRole('listitem')
+    },
+    /** One entrant of `eventName` by username — `null` when they are not listed
+     * (withdrawn, never entered, or past the truncation cut-off). */
+    queryEntrant(eventName: string, username: string) {
+      return within(getEntrantsList(eventName)).queryByText(username)
+    },
+    findEntrant(eventName: string, username: string) {
+      return within(getEntrantsList(eventName)).findByText(username)
+    },
+    /** The `+N more` tail shown when the roster is longer than the card lists. */
+    queryTruncationTail(eventName: string) {
+      return within(getEntrantsList(eventName)).queryByText(/^\+\d+ more$/)
+    },
+    /** Every button in the roster — always none. The list is inert: the card's
+     * stretched open target is the only thing here that takes a click. */
+    queryAllButtons() {
+      return container.queryAllByRole('button')
+    },
+    /** The designed empty state — the copy itself, not merely the absence of a
+     * list, so a blank gap cannot pass for it. (Exact match on purpose: the
+     * lead line is its own element, and a substring match would also hit the
+     * paragraph wrapping it.) Shown only for a *singles* event nobody has
+     * entered — a doubles/teams event gets `queryEntryClosedCopy` instead. */
+    queryEmptyCopy() {
+      return container.queryByText(NO_ENTRANTS_COPY)
+    },
+    findEmptyCopy() {
+      return container.findByText(NO_ENTRANTS_COPY)
+    },
+    /** The designed "this format can't be entered" state, for a doubles or teams
+     * event. */
+    queryEntryClosedCopy(format: keyof typeof ENTRY_CLOSED_COPY) {
+      return container.queryByText(ENTRY_CLOSED_COPY[format])
+    },
+    findEntryClosedCopy(format: keyof typeof ENTRY_CLOSED_COPY) {
+      return container.findByText(ENTRY_CLOSED_COPY[format])
+    },
+  }
+}
+
+/** Test page-object for `EntrantsList`. */
+export const entrantsListPage = {
+  render(overrides: Partial<EntrantsListProps> = {}) {
+    render(<EntrantsList {...buildEntrantsListProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.test.tsx
@@ -1,0 +1,178 @@
+import { buildEntrant, buildEntrants, buildEvent } from '../../data/seed.factory'
+import {
+  ENTRY_CLOSED_COPY,
+  entrantsListPage as page,
+  NO_ENTRANTS_COPY,
+} from './entrants-list.page'
+
+const EVENT = 'Open Singles'
+
+describe('EntrantsList', () => {
+  it("lists the event's entrants by name", () => {
+    page.render({
+      event: buildEvent({
+        name: EVENT,
+        entrants: [
+          buildEntrant({ id: 'e-1', username: 'rita.kovac' }),
+          buildEntrant({ id: 'e-2', username: 'sam.oduya' }),
+        ],
+      }),
+    })
+
+    expect(page.queryEntrant(EVENT, 'rita.kovac')).toBeInTheDocument()
+    expect(page.queryEntrant(EVENT, 'sam.oduya')).toBeInTheDocument()
+    expect(page.getEntrantItems(EVENT)).toHaveLength(2)
+  })
+
+  it('renders the roster as a real list, named for its event', () => {
+    // Semantics, not looks: a screen reader announces "Entrants in Open
+    // Singles, list, 2 items" — and the per-event name keeps one card's roster
+    // distinguishable from the next one's on a tab full of them.
+    page.render({
+      event: buildEvent({ name: EVENT, entrants: buildEntrants(2) }),
+    })
+
+    expect(page.getEntrantsList(EVENT)).toBeInTheDocument()
+  })
+
+  describe('a singles event nobody has entered', () => {
+    it('shows the designed empty copy, not an empty container', () => {
+      page.render({ event: buildEvent({ name: EVENT, entrants: [] }) })
+
+      // The COPY is the assertion. "Zero list items" would also be true of a
+      // blank gap, which is exactly the failure this state exists to prevent.
+      expect(page.queryEmptyCopy()).toBeInTheDocument()
+      expect(document.body).toHaveTextContent(NO_ENTRANTS_COPY)
+      expect(document.body).toHaveTextContent(
+        'Players who enter this event will be listed here.',
+      )
+    })
+
+    it('renders no empty list alongside the copy', () => {
+      page.render({ event: buildEvent({ name: EVENT, entrants: [] }) })
+
+      expect(page.queryEntrantsList(EVENT)).toBeNull()
+    })
+  })
+
+  // "Nobody has entered" and "nobody CAN enter" are different states, and the
+  // difference is the whole point: a doubles event is not waiting for its first
+  // entrant — the API refuses entry to it (one row cannot express a pairing,
+  // ADR-0016) and the card offers no Enter control. Telling a player "no one has
+  // entered yet" there invites them through a door that does not exist.
+  describe('an event whose format cannot be entered', () => {
+    it.each([
+      { format: 'doubles', name: 'Mixed Doubles' },
+      { format: 'teams', name: 'Club Teams' },
+    ] as const)(
+      'tells a $format event honestly that entry is not open',
+      ({ format, name }) => {
+        page.render({ event: buildEvent({ name, format, entrants: [] }) })
+
+        expect(page.queryEntryClosedCopy(format)).toBeInTheDocument()
+        expect(document.body).toHaveTextContent(ENTRY_CLOSED_COPY[format])
+        expect(document.body).toHaveTextContent(
+          'Entry is open for singles only, so no one can sign up for this event.',
+        )
+      },
+    )
+
+    it('does NOT show the "be the first" empty copy', () => {
+      page.render({
+        event: buildEvent({
+          name: 'Mixed Doubles',
+          format: 'doubles',
+          entrants: [],
+        }),
+      })
+
+      expect(page.queryEmptyCopy()).toBeNull()
+      expect(document.body).not.toHaveTextContent(NO_ENTRANTS_COPY)
+    })
+
+    it('says nothing about the format when it does have entrants', () => {
+      // Belt and braces for director-entry (#784): if a doubles event ever comes
+      // back with people in it, the roster lists them — it does not insist the
+      // event is unenterable while showing its entrants.
+      page.render({
+        event: buildEvent({
+          name: 'Mixed Doubles',
+          format: 'doubles',
+          entrants: [buildEntrant({ username: 'rita.kovac' })],
+        }),
+      })
+
+      expect(page.queryEntrant('Mixed Doubles', 'rita.kovac')).toBeInTheDocument()
+      expect(page.queryEntryClosedCopy('doubles')).toBeNull()
+    })
+
+    it('renders no blank gap — the state has copy, not silence', () => {
+      page.render({
+        event: buildEvent({
+          name: 'Mixed Doubles',
+          format: 'doubles',
+          entrants: [],
+        }),
+      })
+
+      expect(page.queryEntrantsList('Mixed Doubles')).toBeNull()
+      expect(page.queryAllButtons()).toHaveLength(0)
+    })
+  })
+
+  // CONTRACT TEST — an honest one. This component does NOT filter withdrawn
+  // players out, and must not: the server derives `entrants` (and the `entered`
+  // count) from the ACTIVE entries alone (ADR-0016), so a withdrawn player is
+  // already absent from the payload the card is handed. What this pins is that
+  // the list renders exactly what it is given — no more (it doesn't invent the
+  // withdrawn player back) and no less. If the read model ever started shipping
+  // withdrawn entries, this test would NOT catch it; the api suite in 1e is what
+  // guards that end of the contract.
+  it('does not show a player who has withdrawn', () => {
+    const stayed = buildEntrant({ id: 'e-1', username: 'rita.kovac' })
+    const withdrew = buildEntrant({ id: 'e-2', username: 'sam.oduya' })
+    // The event as the server reports it AFTER `sam.oduya` withdrew: their entry
+    // row still exists, but it is not an entrant any more.
+    page.render({ event: buildEvent({ name: EVENT, entrants: [stayed] }) })
+
+    expect(page.queryEntrant(EVENT, stayed.username)).toBeInTheDocument()
+    expect(page.queryEntrant(EVENT, withdrew.username)).toBeNull()
+    expect(page.getEntrantItems(EVENT)).toHaveLength(1)
+  })
+
+  describe('an event with more entrants than the card can show', () => {
+    it('lists the first few and says how many it is not showing', () => {
+      // 52 entrants in a 64-slot draw — the seeded Open Singles. The card is a
+      // summary row; a 52-chip roster would push the next event off the screen.
+      page.render({
+        event: buildEvent({ name: EVENT, entrants: buildEntrants(52) }),
+      })
+
+      expect(page.queryEntrant(EVENT, 'player.1')).toBeInTheDocument()
+      expect(page.queryEntrant(EVENT, 'player.8')).toBeInTheDocument()
+      expect(page.queryEntrant(EVENT, 'player.9')).toBeNull()
+      // The count it hides is stated, not silently dropped: 52 - 8 = 44.
+      expect(page.queryTruncationTail(EVENT)).toHaveTextContent('+44 more')
+    })
+
+    it('keeps the tail non-interactive — the card owns the only click', () => {
+      // The whole card is covered by a stretched open-target <button>. A "show
+      // more" control here would be a second interactive element fighting it
+      // (and, under that overlay, an unclickable one). The tail is text.
+      page.render({
+        event: buildEvent({ name: EVENT, entrants: buildEntrants(52) }),
+      })
+
+      expect(page.queryAllButtons()).toHaveLength(0)
+    })
+
+    it('shows every entrant, with no tail, when they all fit', () => {
+      page.render({
+        event: buildEvent({ name: EVENT, entrants: buildEntrants(8) }),
+      })
+
+      expect(page.getEntrantItems(EVENT)).toHaveLength(8)
+      expect(page.queryTruncationTail(EVENT)).toBeNull()
+    })
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.test.tsx
@@ -175,4 +175,120 @@ describe('EntrantsList', () => {
       expect(page.queryTruncationTail(EVENT)).toBeNull()
     })
   })
+
+  /**
+   * #781's acceptance criterion, verbatim: "a signed-in player can enter an event
+   * and **see themselves listed**."
+   *
+   * The server lists entrants oldest-entry-first, so entering an event that
+   * already holds `MAX_VISIBLE` people appends you to the END of the roster —
+   * past the truncation cut-off. Under a plain `slice(0, MAX_VISIBLE)` the count
+   * ticked up and the control flipped to Withdraw, but your name was nowhere in
+   * the list: you were told you were in, and shown a list you were not in.
+   *
+   * Every earlier test missed it because the only ones that asserted "my name is
+   * in the roster" ran against an event with ZERO entrants — where the cut-off
+   * cannot bite. So these all run against a BUSY event, on purpose.
+   */
+  describe('the signed-in player, in an event busier than the card can show', () => {
+    const ME = 'rita.kovac'
+    const myEntry = buildEntrant({
+      id: 'entry-me',
+      userId: 'u-me',
+      username: ME,
+    })
+
+    /** The seeded 52-entrant Open Singles, the moment I enter it: I am the 53rd
+     * and newest entry, so the server hands me back LAST. */
+    const busyEventIAmIn = () =>
+      buildEvent({ name: EVENT, entrants: [...buildEntrants(52), myEntry] })
+
+    it('sees their own name, however many people entered ahead of them', () => {
+      page.render({ event: busyEventIAmIn(), username: ME })
+
+      expect(page.queryEntrant(EVENT, ME)).toBeInTheDocument()
+    })
+
+    it('sees it FIRST, with everyone else still oldest-entry-first behind it', () => {
+      page.render({ event: busyEventIAmIn(), username: ME })
+
+      expect(page.getEntrantNames(EVENT)).toEqual([
+        ME,
+        'player.1',
+        'player.2',
+        'player.3',
+        'player.4',
+        'player.5',
+        'player.6',
+        'player.7',
+      ])
+    })
+
+    it('marks the chip as theirs — a chip that jumped the queue says why', () => {
+      page.render({ event: busyEventIAmIn(), username: ME })
+
+      expect(page.queryYouTag(EVENT)).toBeInTheDocument()
+    })
+
+    it('still counts the hidden entrants exactly, with self hoisted out of them', () => {
+      // 53 entrants, 8 chips shown (me + the 7 oldest) → 45 hidden. Pinning me is
+      // a REORDER: it must neither drop `player.8` from the count (44) nor count
+      // me among the hidden (46).
+      page.render({ event: busyEventIAmIn(), username: ME })
+
+      // 8 chips + the tail.
+      expect(page.getEntrantItems(EVENT)).toHaveLength(9)
+      expect(page.queryTruncationTail(EVENT)).toHaveTextContent('+45 more')
+    })
+
+    it('keeps the roster inert — the card still owns the only click', () => {
+      page.render({ event: busyEventIAmIn(), username: ME })
+
+      expect(page.queryAllButtons()).toHaveLength(0)
+    })
+  })
+
+  describe('a roster with nobody of mine in it', () => {
+    it('is untouched for a signed-in player who has not entered', () => {
+      // Nothing to pin, so nothing moves: the oldest 8, the honest tail (52 - 8),
+      // and no chip claimed as anyone's.
+      page.render({
+        event: buildEvent({ name: EVENT, entrants: buildEntrants(52) }),
+        username: 'rita.kovac',
+      })
+
+      expect(page.getEntrantNames(EVENT)[0]).toBe('player.1')
+      expect(page.queryEntrant(EVENT, 'player.8')).toBeInTheDocument()
+      expect(page.queryTruncationTail(EVENT)).toHaveTextContent('+44 more')
+      expect(page.queryYouTag(EVENT)).toBeNull()
+    })
+
+    it('is untouched for a signed-out viewer, who is nobody', () => {
+      page.render({
+        event: buildEvent({ name: EVENT, entrants: buildEntrants(52) }),
+        username: null,
+      })
+
+      expect(page.getEntrantNames(EVENT)[0]).toBe('player.1')
+      expect(page.queryTruncationTail(EVENT)).toHaveTextContent('+44 more')
+      expect(page.queryYouTag(EVENT)).toBeNull()
+    })
+  })
+
+  it('marks my chip in a small event too — where nothing needed hoisting', () => {
+    // Three entrants, all visible either way. The pin is not *load-bearing* here,
+    // but the mark still is: one rule, not two.
+    const me = buildEntrant({ id: 'entry-me', userId: 'u-me', username: 'rita.kovac' })
+    page.render({
+      event: buildEvent({
+        name: EVENT,
+        entrants: [buildEntrant({ id: 'e-1', username: 'player.1' }), me],
+      }),
+      username: 'rita.kovac',
+    })
+
+    expect(page.getEntrantNames(EVENT)).toEqual(['rita.kovac', 'player.1'])
+    expect(page.queryYouTag(EVENT)).toBeInTheDocument()
+    expect(page.queryTruncationTail(EVENT)).toBeNull()
+  })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.tsx
@@ -1,0 +1,172 @@
+import { Badge } from '@/components/ui/badge'
+
+import { FORMAT_OPTIONS } from '../../data/options'
+import type { Entrant, TournamentEvent } from '../../data/types'
+
+/**
+ * How many entrants a card lists before it collapses the rest into a "+N more"
+ * tail.
+ *
+ * An event can hold up to `max_players` people (the dev store seeds one with 52,
+ * and a 64-slot draw is normal), and the card is a *summary row* in a list of
+ * events — a 64-chip roster would push the next card off the screen and bury the
+ * card's own controls. So the card shows the first few and says, honestly, how
+ * many it is not showing. The full roster belongs to the event view / draw sheet
+ * that seeding (#785) brings with it, not to a row card.
+ *
+ * The tail is deliberately **text, not a "show more" button**: the card is
+ * covered by a stretched open-target overlay, so any control here would be a
+ * second interactive element competing with it — and a scroll box instead would
+ * trip axe's `scrollable-region-focusable` rule and swallow the wheel under that
+ * same overlay.
+ */
+const MAX_VISIBLE = 8
+
+/**
+ * What the roster has to say — as a sum type, because "no entrants" is not one
+ * state but two, and they mean opposite things:
+ *
+ * - `empty` — an event you *can* enter, that nobody has entered yet. An
+ *   invitation: be the first.
+ * - `entry-closed` — a doubles or teams event. Nobody can enter it **at all**: one
+ *   entry row cannot express a pairing, so the API rejects entry and the card
+ *   offers no Enter control (ADR-0016). "No one has entered yet" would be a lie
+ *   here — it promises a door that does not exist.
+ *
+ * Collapsing the two into `entrants.length === 0` is the client-side twin of a
+ * tri-state boolean: it makes one optimistic sentence cover a case where it is
+ * false. Hence the discriminated union — the renderer switches on it, and a
+ * fourth state (a full event, say) becomes a compiler error rather than a
+ * silently wrong sentence.
+ */
+type RosterState =
+  | { kind: 'listed'; visible: Entrant[]; hidden: number }
+  | { kind: 'empty' }
+  | { kind: 'entry-closed'; formatLabel: string }
+
+function rosterState(event: TournamentEvent): RosterState {
+  // Entrants first, whatever the format: the roster renders what the server gives
+  // it. A non-singles event cannot accrue entrants *today*, but if director-entry
+  // (#784) ever puts people in one, listing them beats insisting it is closed.
+  if (event.entrants.length > 0) {
+    const visible = event.entrants.slice(0, MAX_VISIBLE)
+    return {
+      kind: 'listed',
+      visible,
+      hidden: event.entrants.length - visible.length,
+    }
+  }
+  if (event.format !== 'singles') {
+    const formatLabel =
+      FORMAT_OPTIONS.find((f) => f.value === event.format)?.label ?? event.format
+    return { kind: 'entry-closed', formatLabel }
+  }
+  return { kind: 'empty' }
+}
+
+export interface EntrantsListProps {
+  event: TournamentEvent
+}
+
+/**
+ * The roster on an event card: who is *actually* in this event.
+ *
+ * The list is exactly `event.entrants`. Withdrawn players are already absent from
+ * it — the server derives both the list and the `entered` count from the ACTIVE
+ * entries only (ADR-0016) — so there is nothing to filter here, and filtering
+ * would be a second, drift-prone copy of that rule.
+ *
+ * Having no entrants is a **data state, not a gap**: it renders designed copy
+ * rather than an empty `<ul>` — and *which* copy depends on whether the event can
+ * be entered at all (see `RosterState`). Nothing is ever hidden: a blank card
+ * section is precisely the failure the empty-state rule exists to prevent, so the
+ * non-singles case gets honest copy rather than silence.
+ *
+ * Entering and withdrawing move a name in and out of this list for free — both
+ * mutations invalidate the tournament, so the card re-renders from the refetched
+ * event. This component owns no state and no controls: it is inert, which is what
+ * lets it sit under the card's stretched open-target overlay.
+ *
+ * Seeds (`Entrant.seed`) are not shown: nothing assigns them until draw
+ * generation (#785), so today they are uniformly `null`.
+ */
+export const EntrantsList = ({ event }: EntrantsListProps) => {
+  const state = rosterState(event)
+
+  return (
+    <div className="border-t border-[color:var(--border-subtle)] px-[18px] py-3">
+      <div className="text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">
+        Entrants
+      </div>
+      <RosterBody state={state} eventName={event.name} />
+    </div>
+  )
+}
+
+const RosterBody = ({
+  state,
+  eventName,
+}: {
+  state: RosterState
+  eventName: string
+}) => {
+  switch (state.kind) {
+    case 'listed':
+      return (
+        // Named per event, not merely "Entrants": a tab holds many cards, and a
+        // screen reader running the list rotor needs to tell one roster from the
+        // next.
+        <ul
+          aria-label={`Entrants in ${eventName}`}
+          className="mt-2 flex flex-wrap items-center gap-1.5"
+        >
+          {state.visible.map((entrant) => (
+            <Badge
+              key={entrant.id}
+              asChild
+              variant="ghost"
+              className="border-[color:var(--border-subtle)]"
+            >
+              {/* Rendered as the <li> itself (`asChild`), so the list stays a
+                  list: <ul> may only parent <li>. */}
+              <li>{entrant.username}</li>
+            </Badge>
+          ))}
+          {state.hidden > 0 && (
+            <li className="text-[12px] text-[color:var(--fg-3)]">
+              +{state.hidden} more
+            </li>
+          )}
+        </ul>
+      )
+
+    case 'empty':
+      return (
+        <p className="mt-1.5 text-[13px] text-[color:var(--fg-3)]">
+          <span className="font-medium text-[color:var(--fg-2)]">
+            No one has entered yet.
+          </span>{' '}
+          Players who enter this event will be listed here.
+        </p>
+      )
+
+    case 'entry-closed':
+      return (
+        <p className="mt-1.5 text-[13px] text-[color:var(--fg-3)]">
+          <span className="font-medium text-[color:var(--fg-2)]">
+            {state.formatLabel} events can&apos;t be entered yet.
+          </span>{' '}
+          Entry is open for singles only, so no one can sign up for this event.
+        </p>
+      )
+
+    default: {
+      // Adding a state to `RosterState` without giving it copy is a TYPE error
+      // here, not a blank card section: without this, an unhandled variant would
+      // fall out of the switch as `undefined`, which React renders as nothing —
+      // silently, and green.
+      const exhaustive: never = state
+      return exhaustive
+    }
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/entrants-list.tsx
@@ -1,5 +1,7 @@
 import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
 
+import { myEntrant } from '../../data/helpers'
 import { FORMAT_OPTIONS } from '../../data/options'
 import type { Entrant, TournamentEvent } from '../../data/types'
 
@@ -40,20 +42,49 @@ const MAX_VISIBLE = 8
  * silently wrong sentence.
  */
 type RosterState =
-  | { kind: 'listed'; visible: Entrant[]; hidden: number }
+  | {
+      kind: 'listed'
+      visible: Entrant[]
+      hidden: number
+      /** The signed-in player's own entry id, when they are one of the entrants
+       * — the chip to mark as theirs. `null` for a signed-out viewer, or one who
+       * is not in this event. */
+      myEntryId: string | null
+    }
   | { kind: 'empty' }
   | { kind: 'entry-closed'; formatLabel: string }
 
-function rosterState(event: TournamentEvent): RosterState {
+function rosterState(
+  event: TournamentEvent,
+  username: string | null | undefined,
+): RosterState {
   // Entrants first, whatever the format: the roster renders what the server gives
   // it. A non-singles event cannot accrue entrants *today*, but if director-entry
   // (#784) ever puts people in one, listing them beats insisting it is closed.
   if (event.entrants.length > 0) {
-    const visible = event.entrants.slice(0, MAX_VISIBLE)
+    const mine = myEntrant(event, username)
+    // The signed-in player's own chip is PINNED to the front of the visible slice
+    // (#781). The server lists entrants oldest-entry-first, so entering an event
+    // that already has `MAX_VISIBLE` people appends you past the truncation
+    // cut-off: the count ticked up, the control flipped to Withdraw — and a plain
+    // `slice(0, MAX_VISIBLE)` then showed you a roster you were not in. Being told
+    // you are in and shown a list you are not in is the one thing this component
+    // must never do.
+    //
+    // Hoisting REORDERS the roster; it adds nobody and drops nobody (self is
+    // deduped by entry id), so everyone else stays oldest-first behind you.
+    const ordered = mine
+      ? [mine, ...event.entrants.filter((e) => e.id !== mine.id)]
+      : event.entrants
+    const visible = ordered.slice(0, MAX_VISIBLE)
     return {
       kind: 'listed',
       visible,
+      // Derived from what is actually SHOWN, never from `MAX_VISIBLE`: that is
+      // what keeps the tail exact whether or not self was pulled out of it, with
+      // no off-by-one to get wrong.
       hidden: event.entrants.length - visible.length,
+      myEntryId: mine?.id ?? null,
     }
   }
   if (event.format !== 'singles') {
@@ -66,15 +97,25 @@ function rosterState(event: TournamentEvent): RosterState {
 
 export interface EntrantsListProps {
   event: TournamentEvent
+  /**
+   * The signed-in player's username — the join key for "which of these entrants
+   * is me" (`myEntrant`: the session carries a username but no user id). Absent
+   * for a signed-out viewer, or while the session is still in flight; then the
+   * roster is simply the server's order, with nobody marked.
+   */
+  username?: string | null
 }
 
 /**
  * The roster on an event card: who is *actually* in this event.
  *
- * The list is exactly `event.entrants`. Withdrawn players are already absent from
- * it — the server derives both the list and the `entered` count from the ACTIVE
- * entries only (ADR-0016) — so there is nothing to filter here, and filtering
- * would be a second, drift-prone copy of that rule.
+ * The list is exactly the people in `event.entrants` — nobody added, nobody
+ * dropped; only the ORDER is the component's own (see `rosterState`: the
+ * signed-in player's chip is pinned to the front, so a truncated roster can
+ * never hide you from yourself). Withdrawn players are already absent from the
+ * payload — the server derives both the list and the `entered` count from the
+ * ACTIVE entries only (ADR-0016) — so there is nothing to filter here, and
+ * filtering would be a second, drift-prone copy of that rule.
  *
  * Having no entrants is a **data state, not a gap**: it renders designed copy
  * rather than an empty `<ul>` — and *which* copy depends on whether the event can
@@ -90,8 +131,8 @@ export interface EntrantsListProps {
  * Seeds (`Entrant.seed`) are not shown: nothing assigns them until draw
  * generation (#785), so today they are uniformly `null`.
  */
-export const EntrantsList = ({ event }: EntrantsListProps) => {
-  const state = rosterState(event)
+export const EntrantsList = ({ event, username }: EntrantsListProps) => {
+  const state = rosterState(event, username)
 
   return (
     <div className="border-t border-[color:var(--border-subtle)] px-[18px] py-3">
@@ -120,18 +161,33 @@ const RosterBody = ({
           aria-label={`Entrants in ${eventName}`}
           className="mt-2 flex flex-wrap items-center gap-1.5"
         >
-          {state.visible.map((entrant) => (
-            <Badge
-              key={entrant.id}
-              asChild
-              variant="ghost"
-              className="border-[color:var(--border-subtle)]"
-            >
-              {/* Rendered as the <li> itself (`asChild`), so the list stays a
-                  list: <ul> may only parent <li>. */}
-              <li>{entrant.username}</li>
-            </Badge>
-          ))}
+          {state.visible.map((entrant) => {
+            const isMe = entrant.id === state.myEntryId
+            return (
+              <Badge
+                key={entrant.id}
+                asChild
+                variant="ghost"
+                className={cn(
+                  'border-[color:var(--border-subtle)]',
+                  // Your own chip carries the accent treatment the card uses for
+                  // its "Rated" badge — the pinned chip is a *reorder*, so it has
+                  // to say why it jumped the queue.
+                  isMe &&
+                    'border-[color:rgba(255,122,26,0.3)] bg-[color:var(--bg-accent-soft)] text-[color:var(--ball-500)]',
+                )}
+              >
+                {/* Rendered as the <li> itself (`asChild`), so the list stays a
+                    list: <ul> may only parent <li>. The username is its own
+                    element, so the "(you)" tag reads as a separate word to a
+                    screen reader instead of fusing into the name. */}
+                <li>
+                  <span>{entrant.username}</span>
+                  {isMe && <span className="opacity-80">(you)</span>}
+                </li>
+              </Badge>
+            )
+          })}
           {state.hidden > 0 && (
             <li className="text-[12px] text-[color:var(--fg-3)]">
               +{state.hidden} more

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.factory.tsx
@@ -1,7 +1,8 @@
 import { buildEvent } from '../../data/seed.factory'
 import type { EventCardProps } from './event-card'
 
-/** Props for `EventCard` — the seeded Open Singles event. */
+/** Props for `EventCard` — the seeded Open Singles event, hosting no control of
+ * its own (pass `action` to give the card one). */
 export function buildEventCardProps(
   overrides: Partial<EventCardProps> = {},
 ): EventCardProps {

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.page.tsx
@@ -2,20 +2,66 @@ import { render, screen, type Container } from '@/test/utilities'
 
 import { EventCard, type EventCardProps } from './event-card'
 import { buildEventCardProps } from './event-card.factory'
+import { entrantsListPage } from './entrants-list.page'
 
 const scoped = (container: Container) => ({
+  // The roster the card renders (`EntrantsList`): `getEntrantsList`,
+  // `queryEntrant`, `queryEmptyCopy`, `queryTruncationTail`, … all keyed by
+  // event name. Spread first, so the card's own accessors below win any name
+  // clash.
+  ...entrantsListPage.within(container),
+
   /** The full-card open target — labelled `Edit <event>` for an owner, or
    * `View <event>` for a non-owner (read-only). Pass the verb to assert the
    * read-only case. */
   getOpenButton(name: string, verb: 'Edit' | 'View' = 'Edit') {
     return container.getByRole('button', { name: `${verb} ${name}` })
   },
+  /** A control the card hosts in its action slot, by accessible name. */
+  getActionControl(name: string | RegExp) {
+    return container.getByRole('button', { name })
+  },
+  /** The self-registration control the card hosts (`EnterEventControl`). Named
+   * per event (`Enter <event>` / `Withdraw from <event>`) so it stays
+   * unambiguous across a list of cards — and distinct from the card's own
+   * `Edit`/`View <event>` open target. Absent for an unpermitted player and on
+   * non-singles events. */
+  findEnterButton(eventName: string) {
+    return container.findByRole('button', { name: `Enter ${eventName}` })
+  },
+  queryEnterButton(eventName: string) {
+    return container.queryByRole('button', { name: `Enter ${eventName}` })
+  },
+  findWithdrawButton(eventName: string) {
+    return container.findByRole('button', { name: `Withdraw from ${eventName}` })
+  },
+  queryWithdrawButton(eventName: string) {
+    return container.queryByRole('button', { name: `Withdraw from ${eventName}` })
+  },
+  /** Every button the card renders — a card hosting no control of its own has
+   * exactly one: the stretched open target. */
+  queryAllButtons() {
+    return container.queryAllByRole('button')
+  },
 })
 
-/** Test page-object for `EventCard`. */
+/**
+ * Test page-object for `EventCard`. The card exposes the stretched open target
+ * (named `Edit`/`View <event>`) plus whatever control it is given to host.
+ */
 export const eventCardPage = {
   render(overrides: Partial<EventCardProps> = {}) {
     render(<EventCard {...buildEventCardProps(overrides)} />)
+  },
+
+  /**
+   * Every `<button>` rendered as a DOM descendant of another `<button>` —
+   * invalid HTML, a keyboard trap, and an axe violation. The card hosts its own
+   * controls as *siblings* of the stretched open target, so this must always be
+   * empty. Structural on purpose: no role query can see nesting.
+   */
+  queryNestedButtons() {
+    return Array.from(document.querySelectorAll('button button'))
   },
 
   within(container: Container = screen) {

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.test.tsx
@@ -146,6 +146,31 @@ describe('EventCard', () => {
       expect(eventCardPage.queryEntrantsList('U1500 Singles')).toBeNull()
     })
 
+    // The seam: the card is where the viewer's username reaches the roster. Drop
+    // the prop and the roster silently forgets who is looking at it — which is
+    // exactly the state #781 shipped in.
+    it('hands the roster the viewer, so an entered player sees themselves in a busy event', () => {
+      eventCardPage.render({
+        event: buildEvent({
+          name: 'Open Singles',
+          entrants: [
+            ...buildEntrants(52),
+            buildEntrant({ id: 'entry-me', userId: 'u-me', username: 'rita.kovac' }),
+          ],
+        }),
+        username: 'rita.kovac',
+      })
+
+      // 53rd of 53, and still on screen — because the card told the roster who
+      // "me" is.
+      expect(
+        eventCardPage.queryEntrant('Open Singles', 'rita.kovac'),
+      ).toBeInTheDocument()
+      expect(
+        eventCardPage.queryTruncationTail('Open Singles'),
+      ).toHaveTextContent('+45 more')
+    })
+
     it('tells a doubles card entry is not open, rather than "be the first"', () => {
       // A doubles card offers no Enter control (2c) because the API refuses
       // entry — so its roster must not imply the player could be the first in.

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.test.tsx
@@ -1,6 +1,11 @@
 import userEvent from '@testing-library/user-event'
 
-import { buildEvent, buildPredicate } from '../../data/seed.factory'
+import {
+  buildEntrant,
+  buildEntrants,
+  buildEvent,
+  buildPredicate,
+} from '../../data/seed.factory'
 import { eventCardPage } from './event-card.page'
 
 describe('EventCard', () => {
@@ -20,7 +25,7 @@ describe('EventCard', () => {
 
   it('shows entries out of the player cap', () => {
     eventCardPage.render({
-      event: buildEvent({ entered: 52, maxPlayers: 64 }),
+      event: buildEvent({ entrants: buildEntrants(52), maxPlayers: 64 }),
     })
     expect(document.body).toHaveTextContent('52')
     expect(document.body).toHaveTextContent('/ 64')
@@ -42,5 +47,126 @@ describe('EventCard', () => {
       eventCardPage.getOpenButton('Open Singles', 'View'),
     ).toBeInTheDocument()
     expect(document.body).toHaveTextContent('View')
+  })
+
+  it('opens the editor from the keyboard alone', async () => {
+    const onOpen = vi.fn()
+    eventCardPage.render({ event: buildEvent({ name: 'Open Singles' }), onOpen })
+
+    await userEvent.tab()
+
+    expect(eventCardPage.getOpenButton('Open Singles')).toHaveFocus()
+    await userEvent.keyboard('{Enter}')
+    expect(onOpen).toHaveBeenCalledTimes(1)
+
+    await userEvent.keyboard(' ')
+    expect(onOpen).toHaveBeenCalledTimes(2)
+  })
+
+  // The card hosts its own control (Enter / Withdraw). It must be a sibling of
+  // the stretched open target, never nested inside it: a button in a button is
+  // invalid HTML, a keyboard trap, and would swallow the control's own click.
+  describe('hosting a control of its own', () => {
+    it('renders it as a sibling of the open target, not nested inside it', () => {
+      eventCardPage.render({
+        event: buildEvent({ name: 'Open Singles' }),
+        action: <button type="button">Enter</button>,
+      })
+
+      expect(eventCardPage.queryNestedButtons()).toHaveLength(0)
+      expect(eventCardPage.getActionControl('Enter')).toBeInTheDocument()
+      expect(
+        eventCardPage.getOpenButton('Open Singles').contains(
+          eventCardPage.getActionControl('Enter'),
+        ),
+      ).toBe(false)
+    })
+
+    it('gives the control its own click — it does not open the editor', async () => {
+      const onOpen = vi.fn()
+      const onAction = vi.fn()
+      eventCardPage.render({
+        event: buildEvent({ name: 'Open Singles' }),
+        onOpen,
+        action: (
+          <button type="button" onClick={onAction}>
+            Enter
+          </button>
+        ),
+      })
+
+      await userEvent.click(eventCardPage.getActionControl('Enter'))
+
+      expect(onAction).toHaveBeenCalledTimes(1)
+      expect(onOpen).not.toHaveBeenCalled()
+    })
+
+    it('keeps both the control and the open target keyboard-reachable', async () => {
+      eventCardPage.render({
+        event: buildEvent({ name: 'Open Singles' }),
+        action: <button type="button">Enter</button>,
+      })
+
+      await userEvent.tab()
+      expect(eventCardPage.getActionControl('Enter')).toHaveFocus()
+
+      await userEvent.tab()
+      expect(eventCardPage.getOpenButton('Open Singles')).toHaveFocus()
+    })
+  })
+
+  // The card shows the roster behind its `entered` numeral. These pin that the
+  // card MOUNTS it — `EntrantsList`'s own suite pins how it behaves.
+  describe('the entrants roster', () => {
+    it("lists the event's entrants by name", () => {
+      eventCardPage.render({
+        event: buildEvent({
+          name: 'Open Singles',
+          entrants: [
+            buildEntrant({ id: 'e-1', username: 'rita.kovac' }),
+            buildEntrant({ id: 'e-2', username: 'sam.oduya' }),
+          ],
+        }),
+      })
+
+      expect(
+        eventCardPage.queryEntrant('Open Singles', 'rita.kovac'),
+      ).toBeInTheDocument()
+      expect(
+        eventCardPage.queryEntrant('Open Singles', 'sam.oduya'),
+      ).toBeInTheDocument()
+    })
+
+    it('shows the designed empty copy when nobody has entered', () => {
+      eventCardPage.render({
+        event: buildEvent({ name: 'U1500 Singles', entrants: [] }),
+      })
+
+      expect(eventCardPage.queryEmptyCopy()).toBeInTheDocument()
+      expect(eventCardPage.queryEntrantsList('U1500 Singles')).toBeNull()
+    })
+
+    it('tells a doubles card entry is not open, rather than "be the first"', () => {
+      // A doubles card offers no Enter control (2c) because the API refuses
+      // entry — so its roster must not imply the player could be the first in.
+      eventCardPage.render({
+        event: buildEvent({
+          name: 'Mixed Doubles',
+          format: 'doubles',
+          entrants: [],
+        }),
+      })
+
+      expect(eventCardPage.queryEntryClosedCopy('doubles')).toBeInTheDocument()
+      expect(eventCardPage.queryEmptyCopy()).toBeNull()
+    })
+  })
+
+  it('renders no action slot when it is given no control', () => {
+    eventCardPage.render({ event: buildEvent({ name: 'Open Singles' }) })
+
+    expect(eventCardPage.queryNestedButtons()).toHaveLength(0)
+    // The bare card is exactly one button: the stretched open target.
+    expect(eventCardPage.queryAllButtons()).toHaveLength(1)
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.tsx
@@ -15,6 +15,10 @@ export interface EventCardProps {
   /** When false (a non-owner), the card opens a read-only editor — the
    * affordance reads "View" instead of "Edit". */
   canEdit: boolean
+  /** The signed-in player's username, handed to the roster so it can pin their
+   * own chip into the visible slice (#781). Absent when signed out, or while
+   * the session is still in flight. */
+  username?: string | null
   onOpen: () => void
   /**
    * The card's own interactive control (e.g. Enter / Withdraw), rendered in the
@@ -38,11 +42,12 @@ export interface EventCardProps {
 export const EventCard = ({
   event: ev,
   canEdit,
+  username,
   onOpen,
   action,
 }: EventCardProps) => {
   const fillPct = ev.maxPlayers
-    ? Math.min(100, Math.round(((ev.entered || 0) / ev.maxPlayers) * 100))
+    ? Math.min(100, Math.round((ev.entered / ev.maxPlayers) * 100))
     : 0
   const isFull = ev.entered >= ev.maxPlayers
   const formatLabel =
@@ -121,7 +126,7 @@ export const EventCard = ({
                   isFull ? 'text-[color:var(--warn)]' : 'text-[color:var(--fg-1)]',
                 )}
               >
-                {ev.entered || 0}
+                {ev.entered}
               </span>
               <span className="font-mono text-[13px] text-[color:var(--fg-3)]">
                 / {ev.maxPlayers}
@@ -159,9 +164,11 @@ export const EventCard = ({
         </div>
 
         {/* Who is actually in this event — the roster behind the `entered`
-            numeral above. Inert (no controls of its own), so it sits happily
-            under the stretched open target. */}
-        <EntrantsList event={ev} />
+            numeral above. It takes the viewer's username so an entered player
+            always sees their own chip, however long the roster is (#781). Inert
+            (no controls of its own), so it sits happily under the stretched open
+            target. */}
+        <EntrantsList event={ev} username={username} />
       </Card>
 
       {/* Full-card open target: a sibling of the card, sitting beneath the

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight, Eye, Layers, Pencil, TrendingUp } from 'lucide-react'
+import type { ReactNode } from 'react'
 
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
@@ -7,6 +8,7 @@ import { cn } from '@/lib/utils'
 import { fmtDateShort, formatPredicate } from '../../data/helpers'
 import { DRAW_TYPE_OPTIONS, FORMAT_OPTIONS } from '../../data/options'
 import type { TournamentEvent } from '../../data/types'
+import { EntrantsList } from './entrants-list'
 
 export interface EventCardProps {
   event: TournamentEvent
@@ -14,12 +16,31 @@ export interface EventCardProps {
    * affordance reads "View" instead of "Edit". */
   canEdit: boolean
   onOpen: () => void
+  /**
+   * The card's own interactive control (e.g. Enter / Withdraw), rendered in the
+   * action column. It is a **sibling** of the stretched open target, never a
+   * descendant of it — a `<button>` inside a `<button>` is invalid HTML and a
+   * keyboard trap — and it is raised above the overlay so it takes its own
+   * clicks instead of opening the editor.
+   */
+  action?: ReactNode
 }
 
 /** A row card for one event on the tournament's Events tab: title with rated /
- * best-of badges, eligibility chips, the time slot, pool/table counts, and an
- * entries fill bar. The whole card opens the editor. */
-export const EventCard = ({ event: ev, canEdit, onOpen }: EventCardProps) => {
+ * best-of badges, eligibility chips, the time slot, pool/table counts, an
+ * entries fill bar, and the roster of entrants those numbers count. The whole
+ * card opens the editor.
+ *
+ * Clicking the card is a stretched button overlaid on the (non-interactive)
+ * card body — the same idiom as `TournamentCard` — rather than a `<button>`
+ * wrapping the body, so the card can host controls of its own (`action`)
+ * without nesting buttons. */
+export const EventCard = ({
+  event: ev,
+  canEdit,
+  onOpen,
+  action,
+}: EventCardProps) => {
   const fillPct = ev.maxPlayers
     ? Math.min(100, Math.round(((ev.entered || 0) / ev.maxPlayers) * 100))
     : 0
@@ -118,6 +139,17 @@ export const EventCard = ({ event: ev, canEdit, onOpen }: EventCardProps) => {
           </div>
 
           <div className="flex items-center gap-2">
+            {/* The card's own control sits above the stretched open target, so
+                it takes its own clicks instead of opening the editor.
+                `empty:hidden` because the hosted control decides for itself
+                whether it applies (e.g. no Enter for a doubles event) and may
+                render nothing — an empty flex item would still take the parent's
+                `gap-2` and shift the row. */}
+            {action && (
+              <div className="relative z-10 flex items-center empty:hidden">
+                {action}
+              </div>
+            )}
             <span className="pointer-events-none inline-flex h-8 items-center gap-1.5 rounded-[10px] border border-[color:var(--border-default)] px-3 text-[13px] font-medium text-[color:var(--fg-1)]">
               <ActionIcon size={14} />
               {actionLabel}
@@ -125,13 +157,20 @@ export const EventCard = ({ event: ev, canEdit, onOpen }: EventCardProps) => {
             <ChevronRight size={16} className="text-[color:var(--fg-3)]" />
           </div>
         </div>
+
+        {/* Who is actually in this event — the roster behind the `entered`
+            numeral above. Inert (no controls of its own), so it sits happily
+            under the stretched open target. */}
+        <EntrantsList event={ev} />
       </Card>
 
+      {/* Full-card open target: a sibling of the card, sitting beneath the
+          card's own controls. */}
       <button
         type="button"
         aria-label={`${actionLabel} ${ev.name}`}
         onClick={onOpen}
-        className="absolute inset-0 rounded-xl outline-offset-2"
+        className="absolute inset-0 z-0 rounded-xl outline-offset-2"
       />
     </div>
   )

--- a/web-client/src/lib/permissions.ts
+++ b/web-client/src/lib/permissions.ts
@@ -6,12 +6,18 @@
 export const PERM = {
   ADMIN_VIEW: 'administration.view',
   AUTH_MANAGE: 'authorization.manage',
-  // Tournaments split: viewing the area and creating tournaments are the only
-  // permission grants. Editing, deleting, and publishing a tournament are
-  // owner-only on the server (the creator), driven by the `canEdit` flag on the
-  // tournament payload — there is intentionally no edit/delete/publish perm.
+  // Tournaments split: viewing the area, creating tournaments, and entering an
+  // event as a player are the permission grants. Editing, deleting, and
+  // publishing a tournament are owner-only on the server (the creator), driven
+  // by the `canEdit` flag on the tournament payload — there is intentionally no
+  // edit/delete/publish perm.
+  //
+  // TOURNAMENT_ENTER is the odd one out: it gates a *non-owner* mutation (a
+  // player self-registering into someone else's tournament), so it can't ride on
+  // `canEdit`. See ADR-0016.
   TOURNAMENT_VIEW: 'tournament.view',
   TOURNAMENT_CREATE: 'tournament.create',
+  TOURNAMENT_ENTER: 'tournament.enter',
   NOTIFICATIONS_BROADCAST: 'notifications.broadcast',
 } as const
 

--- a/web-client/src/mocks/endpoints/tournaments/tournaments.endpoint.ts
+++ b/web-client/src/mocks/endpoints/tournaments/tournaments.endpoint.ts
@@ -133,3 +133,46 @@ export const mockEventDeleteEndpoint = (
   backend.use(
     http.delete('*/v1/tournaments/:tournamentId/events/:eventId', resolver),
   )
+
+/** Resolver for the enter-event endpoint — the created `TournamentEntrantRead`
+ * (201), or an error envelope: 409 (already entered), 400 (not a singles event),
+ * 403 (no `tournament.enter` permission). The request has **no body**: the caller
+ * is the entrant. */
+export type EventEnterResolver = HttpResponseResolver<
+  { tournamentId: string; eventId: string },
+  never,
+  components['schemas']['TournamentEntrantRead'] | ErrorBody
+>
+
+/** POST /v1/tournaments/{id}/events/{eventId}/entries — enter the event. */
+export const mockEventEnterEndpoint = (
+  backend: Backend,
+  resolver: EventEnterResolver,
+) =>
+  backend.use(
+    http.post(
+      '*/v1/tournaments/:tournamentId/events/:eventId/entries',
+      resolver,
+    ),
+  )
+
+/** Resolver for the withdraw endpoint — a 204 with no body (including when the
+ * entry was already withdrawn: withdrawal is idempotent), or an error envelope
+ * on a 403 (someone else's entry) / 404. */
+export type EventWithdrawResolver = HttpResponseResolver<
+  { tournamentId: string; eventId: string; entryId: string },
+  never,
+  ErrorBody | null
+>
+
+/** DELETE /v1/tournaments/{id}/events/{eventId}/entries/{entryId} — withdraw. */
+export const mockEventWithdrawEndpoint = (
+  backend: Backend,
+  resolver: EventWithdrawResolver,
+) =>
+  backend.use(
+    http.delete(
+      '*/v1/tournaments/:tournamentId/events/:eventId/entries/:entryId',
+      resolver,
+    ),
+  )

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -2,6 +2,7 @@ import type { components } from '@/api/schema'
 
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
 type TournamentEventRead = components['schemas']['TournamentEventRead']
+type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
 type TournamentTable = components['schemas']['TournamentTable']
 
 /** A single physical table, `T1` on court 1. */
@@ -11,15 +12,47 @@ export function buildTournamentTable(
   return { id: 't1', label: 'T1', court: '1', ...overrides }
 }
 
+/** One active entrant. `id` is the ENTRY's id — the address a withdrawal is
+ * sent to (`DELETE …/entries/{entry_id}`) — not the player's. */
+export function buildTournamentEntrantRead(
+  overrides: Partial<TournamentEntrantRead> = {},
+): TournamentEntrantRead {
+  return {
+    id: 'entry-1',
+    user_id: 'u-rita',
+    username: 'rita.kovac',
+    seed: null,
+    ...overrides,
+  }
+}
+
+/** `count` distinct entrants (`entry-1`/`player.1`, `entry-2`/`player.2`, …) —
+ * for the cases that care about how MANY entrants an event has, not who. */
+export function buildTournamentEntrantReads(
+  count: number,
+): TournamentEntrantRead[] {
+  return Array.from({ length: count }, (_, i) =>
+    buildTournamentEntrantRead({
+      id: `entry-${i + 1}`,
+      user_id: `u-${i + 1}`,
+      username: `player.${i + 1}`,
+    }),
+  )
+}
+
 /**
  * A rated Bo5 "Open Singles" event with one morning pool, as returned by the
  * tournament detail/list endpoints. Defaults are internally consistent so a
  * bare call is a meaningful row.
+ *
+ * `entered` is NOT an override: like the server (ADR-0016) it is derived from
+ * `entrants`, so this factory cannot mint an event whose count disagrees with
+ * its list. Want an event with 22 entries? Give it 22 `entrants`.
  */
 export function buildTournamentEventRead(
-  overrides: Partial<TournamentEventRead> = {},
+  overrides: Partial<Omit<TournamentEventRead, 'entered'>> = {},
 ): TournamentEventRead {
-  return {
+  const event = {
     id: 'ev-open-singles',
     tournament_id: 'bay-area-open-2026',
     name: 'Open Singles',
@@ -27,7 +60,7 @@ export function buildTournamentEventRead(
     draw_type: 'rr-then-ko',
     max_players: 64,
     entry_fee: 45,
-    entered: 52,
+    entrants: [],
     slot: { date: '2026-06-13', start: '09:00', end: '18:00' },
     match_settings: { rated: true, length_games: 5 },
     predicates: [],
@@ -42,7 +75,8 @@ export function buildTournamentEventRead(
     created_at: '2026-06-01T09:05:00Z',
     updated_at: '2026-06-09T12:00:00Z',
     ...overrides,
-  }
+  } satisfies Omit<TournamentEventRead, 'entered'>
+  return { ...event, entered: event.entrants.length }
 }
 
 /**

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -28,10 +28,12 @@ import {
   createTournament,
   deleteEvent as deleteTournamentEvent,
   deleteTournament as deleteTournamentSeed,
+  enterEvent as enterTournamentEvent,
   findTournament,
   listTournaments,
   updateEvent as updateTournamentEvent,
   updateTournament,
+  withdrawEntry as withdrawTournamentEntry,
 } from './tournaments-store'
 import { PERM } from '@/lib/permissions'
 
@@ -42,14 +44,16 @@ export const mockSession = sessionResponse({
     // its children on their own permission. Grant ADMIN_VIEW so the section
     // expands, AUTH_MANAGE for the RBAC pages, TOURNAMENT_VIEW +
     // TOURNAMENT_CREATE so the Tournaments item appears, its page loads, and the
-    // "New tournament" action shows, and NOTIFICATIONS_BROADCAST so the
-    // Broadcast item appears and its (now permission-gated) tool renders under
-    // `npm run dev`.
+    // "New tournament" action shows, TOURNAMENT_ENTER so the dev user is a beta
+    // tester who can self-register into a singles event, and
+    // NOTIFICATIONS_BROADCAST so the Broadcast item appears and its (now
+    // permission-gated) tool renders under `npm run dev`.
     permissions: [
       PERM.ADMIN_VIEW,
       PERM.AUTH_MANAGE,
       PERM.TOURNAMENT_VIEW,
       PERM.TOURNAMENT_CREATE,
+      PERM.TOURNAMENT_ENTER,
       PERM.NOTIFICATIONS_BROADCAST,
     ],
   },
@@ -953,6 +957,50 @@ export const handlers = [
         )
       }
       return HttpResponse.json(result.event, { status: 201 })
+    },
+  ),
+  // Entries (ADR-0016). Self-registration only: there is no request body — the
+  // caller IS the entrant. Registered before the bare `:eventId` routes so MSW
+  // never mistakes an entries path for an event path. A withdrawal is addressed
+  // by the *entry's* id (the `id` on each entrant), and is idempotent.
+  http.post(
+    '*/v1/tournaments/:tournamentId/events/:eventId/entries',
+    async ({ params }) => {
+      await delay(250)
+      const result = enterTournamentEvent(
+        String(params.tournamentId),
+        String(params.eventId),
+      )
+      if (!result.ok) {
+        if (result.status === 400) {
+          return detail('Only singles events can be entered.', 400)
+        }
+        if (result.status === 409) {
+          return detail('You have already entered this event.', 409)
+        }
+        return detail('Event not found.', 404)
+      }
+      return HttpResponse.json(result.entrant, { status: 201 })
+    },
+  ),
+  http.delete(
+    '*/v1/tournaments/:tournamentId/events/:eventId/entries/:entryId',
+    async ({ params }) => {
+      await delay(250)
+      const result = withdrawTournamentEntry(
+        String(params.tournamentId),
+        String(params.eventId),
+        String(params.entryId),
+      )
+      if (!result.ok) {
+        return detail(
+          result.status === 403
+            ? 'You can only withdraw your own entry.'
+            : 'Event not found.',
+          result.status,
+        )
+      }
+      return new HttpResponse(null, { status: 204 })
     },
   ),
   http.patch(

--- a/web-client/src/mocks/rbac-store.ts
+++ b/web-client/src/mocks/rbac-store.ts
@@ -1,7 +1,7 @@
 import type { SeedSpec } from './rbac-engine'
 
 const ALL = [
-  'p_tv', 'p_tc', 'p_te', 'p_td', 'p_tp',
+  'p_tv', 'p_tc', 'p_te', 'p_td', 'p_tp', 'p_tn',
   'p_dv', 'p_dg', 'p_de', 'p_dp', 'p_dl',
   'p_cv', 'p_ca', 'p_cs', 'p_co',
   'p_pv', 'p_pc', 'p_pe', 'p_pd', 'p_pm',
@@ -18,6 +18,7 @@ export const DEMO_SEED: SeedSpec = {
     { id: 'p_te', name: 'tournament.edit', description: 'Rename, reschedule, change format.' },
     { id: 'p_td', name: 'tournament.delete', description: 'Permanently remove a tournament.' },
     { id: 'p_tp', name: 'tournament.publish', description: 'Publish a tournament to the spectator view.' },
+    { id: 'p_tn', name: 'tournament.enter', description: 'Enter yourself into a singles event, and withdraw again.' },
     { id: 'p_dv', name: 'draws.view', description: 'View brackets and seeds.' },
     { id: 'p_dg', name: 'draws.generate', description: 'Run the SMT solver to build a draw.' },
     { id: 'p_de', name: 'draws.edit', description: 'Re-seed or manually swap matchups.' },
@@ -50,7 +51,7 @@ export const DEMO_SEED: SeedSpec = {
       name: 'Tournament Director',
       description: 'Runs events end-to-end. Cannot edit org-wide settings.',
       permission_ids: [
-        'p_tv', 'p_tc', 'p_te', 'p_tp',
+        'p_tv', 'p_tc', 'p_te', 'p_tp', 'p_tn',
         'p_dv', 'p_dg', 'p_de', 'p_dp', 'p_dl',
         'p_cv', 'p_ca', 'p_cs', 'p_co',
         'p_pv', 'p_pc', 'p_pe', 'p_pm',

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -1,0 +1,161 @@
+// The dev store models entries the way the server does (ADR-0016): the `entered`
+// count is DERIVED from the active entrants, so the two can never disagree, and
+// withdrawing frees the player to enter again.
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  createEvent,
+  enterEvent,
+  findTournament,
+  resetTournamentsStore,
+  updateEvent,
+  withdrawEntry,
+} from './tournaments-store'
+
+const TOURNAMENT = 'bay-area-open-2026'
+const EMPTY_SINGLES = 'ev-u1500' // seeded with no entrants
+const FULLISH_SINGLES = 'ev-open-singles' // seeded with 52 other players
+const DOUBLES = 'ev-mixed-doubles'
+
+function event(eventId: string) {
+  const found = findTournament(TOURNAMENT)!.events.find((e) => e.id === eventId)
+  if (!found) throw new Error(`no seeded event ${eventId}`)
+  return found
+}
+
+beforeEach(() => resetTournamentsStore())
+
+describe('the seeded read shape', () => {
+  it('derives entered from the entrants it lists, never a stored number', () => {
+    expect(event(FULLISH_SINGLES).entrants).toHaveLength(52)
+    expect(event(FULLISH_SINGLES).entered).toBe(52)
+    expect(event(EMPTY_SINGLES).entrants).toEqual([])
+    expect(event(EMPTY_SINGLES).entered).toBe(0)
+  })
+})
+
+describe('enterEvent', () => {
+  it('makes the next read of the event show the entrant AND an incremented count', () => {
+    const result = enterEvent(TOURNAMENT, EMPTY_SINGLES)
+
+    expect(result.ok).toBe(true)
+    const after = event(EMPTY_SINGLES)
+    expect(after.entrants.map((e) => e.username)).toEqual(['rita.kovac'])
+    expect(after.entered).toBe(1)
+  })
+
+  it('increments a busy event from 52 to 53 — count and list stay in step', () => {
+    enterEvent(TOURNAMENT, FULLISH_SINGLES)
+
+    const after = event(FULLISH_SINGLES)
+    expect(after.entered).toBe(53)
+    expect(after.entrants).toHaveLength(53)
+  })
+
+  it('409s a second active entry rather than adding a second row', () => {
+    enterEvent(TOURNAMENT, EMPTY_SINGLES)
+
+    expect(enterEvent(TOURNAMENT, EMPTY_SINGLES)).toEqual({
+      ok: false,
+      status: 409,
+    })
+    expect(event(EMPTY_SINGLES).entered).toBe(1)
+  })
+
+  it('400s a doubles event — one row per user cannot express a pairing', () => {
+    expect(enterEvent(TOURNAMENT, DOUBLES)).toEqual({ ok: false, status: 400 })
+    expect(event(DOUBLES).entered).toBe(0)
+  })
+
+  it('404s an unknown tournament or event', () => {
+    expect(enterEvent('nope', EMPTY_SINGLES)).toEqual({ ok: false, status: 404 })
+    expect(enterEvent(TOURNAMENT, 'ev-nope')).toEqual({ ok: false, status: 404 })
+  })
+
+  it('is allowed on a tournament the entrant does not own — entry is not creator-gated', () => {
+    const notMine = findTournament('club-champs-2026')!
+    expect(notMine.can_edit).toBe(false)
+
+    const result = enterEvent('club-champs-2026', 'ev-cc-open')
+
+    expect(result.ok).toBe(true)
+    const found = findTournament('club-champs-2026')!.events.find(
+      (e) => e.id === 'ev-cc-open',
+    )!
+    expect(found.entered).toBe(29)
+  })
+})
+
+describe('withdrawEntry', () => {
+  it('removes the entrant AND decrements the count', () => {
+    const entered = enterEvent(TOURNAMENT, EMPTY_SINGLES)
+    if (!entered.ok) throw new Error('setup failed')
+
+    expect(
+      withdrawEntry(TOURNAMENT, EMPTY_SINGLES, entered.entrant.id),
+    ).toEqual({ ok: true })
+    const after = event(EMPTY_SINGLES)
+    expect(after.entrants).toEqual([])
+    expect(after.entered).toBe(0)
+  })
+
+  it('lets the player enter again afterwards — a withdrawal is not a lockout', () => {
+    const first = enterEvent(TOURNAMENT, EMPTY_SINGLES)
+    if (!first.ok) throw new Error('setup failed')
+    withdrawEntry(TOURNAMENT, EMPTY_SINGLES, first.entrant.id)
+
+    expect(enterEvent(TOURNAMENT, EMPTY_SINGLES).ok).toBe(true)
+    expect(event(EMPTY_SINGLES).entered).toBe(1)
+  })
+
+  it('is idempotent — withdrawing an already-withdrawn entry is not an error', () => {
+    const first = enterEvent(TOURNAMENT, EMPTY_SINGLES)
+    if (!first.ok) throw new Error('setup failed')
+    withdrawEntry(TOURNAMENT, EMPTY_SINGLES, first.entrant.id)
+
+    expect(
+      withdrawEntry(TOURNAMENT, EMPTY_SINGLES, first.entrant.id),
+    ).toEqual({ ok: true })
+    expect(event(EMPTY_SINGLES).entered).toBe(0)
+  })
+
+  it("403s someone else's entry, leaving the count alone", () => {
+    const theirs = event(FULLISH_SINGLES).entrants[0]
+
+    expect(withdrawEntry(TOURNAMENT, FULLISH_SINGLES, theirs.id)).toEqual({
+      ok: false,
+      status: 403,
+    })
+    expect(event(FULLISH_SINGLES).entered).toBe(52)
+  })
+})
+
+describe('the rest of the event surface still holds', () => {
+  it('creates an event with no entrants and a zero count', () => {
+    const result = createEvent(TOURNAMENT, {
+      name: 'Novice Singles',
+      format: 'singles',
+      draw_type: 'single-elim',
+      max_players: 16,
+      entry_fee: 10,
+      slot: { date: '2026-06-14', start: '09:00', end: '12:00' },
+      match_settings: { rated: false, length_games: 3 },
+    })
+    if (!result.ok) throw new Error('create failed')
+
+    expect(result.event.entrants).toEqual([])
+    expect(result.event.entered).toBe(0)
+  })
+
+  it('leaves the registrations untouched when the event is edited', () => {
+    enterEvent(TOURNAMENT, EMPTY_SINGLES)
+
+    const result = updateEvent(TOURNAMENT, EMPTY_SINGLES, { name: 'Renamed' })
+    if (!result.ok) throw new Error('update failed')
+
+    expect(result.event.name).toBe('Renamed')
+    expect(result.event.entered).toBe(1)
+    expect(event(EMPTY_SINGLES).entrants).toHaveLength(1)
+  })
+})

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -3,6 +3,14 @@
 // module's array, and everything resets on reload. PATCH/DELETE (tournament and
 // event) enforce the same creator-only rule the real API does — a
 // `can_edit: false` row (created by someone else) returns 403.
+//
+// Entries (ADR-0016) are modelled the way the server models them: an event
+// stores its *active entrants* and NOTHING ELSE — the `entered` count is derived
+// (`entrants.length`) at read time by `readEvent` below, so the count and the
+// list it counts cannot drift apart. Withdrawing drops the entrant, which is
+// indistinguishable, from the wire, from the server's soft-delete: a withdrawn
+// entry appears in neither the list nor the count, and the player may enter
+// again afterwards (the server's partial unique index; here, simply a fresh row).
 
 import type { components } from '@/api/schema'
 
@@ -14,9 +22,21 @@ type TournamentUpdate = components['schemas']['TournamentUpdate']
 type TournamentEventCreate = components['schemas']['TournamentEventCreate']
 type TournamentEventUpdate = components['schemas']['TournamentEventUpdate']
 type TournamentTable = components['schemas']['TournamentTable']
+type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
+
+/** What the store actually holds for an event: everything the wire shape has
+ * *except* the derived `entered` count. Deriving it on read (rather than storing
+ * a number) makes "the counter says 52, the list has 51" unrepresentable — the
+ * same reason the API dropped the column. */
+type StoredEvent = Omit<TournamentEventRead, 'entered'>
+type StoredTournament = Omit<TournamentDetailRead, 'events'> & {
+  events: StoredEvent[]
+}
 
 // The dev current user — must line up with the mocked session in handlers.ts so
-// `can_edit` reads true for rows this user owns.
+// `can_edit` reads true for rows this user owns, and so an entry created here is
+// recognised as *mine* (the client matches on username: the session carries no
+// user id).
 const DEV_USER_ID = 'u-me'
 const DEV_USERNAME = 'rita.kovac'
 
@@ -28,7 +48,19 @@ function tables(count: number): TournamentTable[] {
   }))
 }
 
-function seed(): TournamentDetailRead[] {
+/** `count` other players already entered in an event — enough to make the fill
+ * bars and the "Entries" hero stat meaningful in `npm run dev`. Deliberately
+ * never the dev user, so the Enter control is offered on every seeded event. */
+function otherEntrants(eventId: string, count: number): TournamentEntrantRead[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `entry-${eventId}-${i + 1}`,
+    user_id: `u-other-${i + 1}`,
+    username: `player.${i + 1}`,
+    seed: i < 8 ? i + 1 : null,
+  }))
+}
+
+function seed(): StoredTournament[] {
   return [
     {
       id: 'bay-area-open-2026',
@@ -60,7 +92,7 @@ function seed(): TournamentDetailRead[] {
           draw_type: 'rr-then-ko',
           max_players: 64,
           entry_fee: 45,
-          entered: 52,
+          entrants: otherEntrants('ev-open-singles', 52),
           slot: { date: '2026-06-13', start: '09:00', end: '18:00' },
           match_settings: { rated: true, length_games: 5 },
           predicates: [],
@@ -82,6 +114,8 @@ function seed(): TournamentDetailRead[] {
           updated_at: '2026-06-09T12:00:00Z',
         },
         {
+          // Deliberately empty: the designed empty entrants state, and the event
+          // whose count a dev demo ticks from 0 to 1.
           id: 'ev-u1500',
           tournament_id: 'bay-area-open-2026',
           name: 'U1500 Singles',
@@ -89,12 +123,31 @@ function seed(): TournamentDetailRead[] {
           draw_type: 'rr-then-ko',
           max_players: 48,
           entry_fee: 30,
-          entered: 41,
+          entrants: [],
           slot: { date: '2026-06-14', start: '09:00', end: '16:00' },
           match_settings: { rated: true, length_games: 3 },
           predicates: [{ id: 'pr-2', field: 'rating', op: '<', value: 1500 }],
           pools: [],
           created_at: '2026-06-01T09:06:00Z',
+          updated_at: '2026-06-09T12:00:00Z',
+        },
+        {
+          // A doubles event: entry is a singles-only affair (one row per user
+          // cannot express a pairing — ADR-0016), so the API 400s here and the
+          // UI offers no Enter control. Seeded so that case is visible in dev.
+          id: 'ev-mixed-doubles',
+          tournament_id: 'bay-area-open-2026',
+          name: 'Mixed Doubles',
+          format: 'doubles',
+          draw_type: 'single-elim',
+          max_players: 32,
+          entry_fee: 25,
+          entrants: [],
+          slot: { date: '2026-06-14', start: '10:00', end: '15:00' },
+          match_settings: { rated: false, length_games: 3 },
+          predicates: [],
+          pools: [],
+          created_at: '2026-06-01T09:07:00Z',
           updated_at: '2026-06-09T12:00:00Z',
         },
       ],
@@ -145,6 +198,8 @@ function seed(): TournamentDetailRead[] {
       updated_at: '2026-06-12T08:00:00Z',
       events: [
         {
+          // On a tournament the dev user does NOT own: entering is gated on the
+          // `tournament.enter` permission, not on ownership, so Enter still shows.
           id: 'ev-cc-open',
           tournament_id: 'club-champs-2026',
           name: 'Championship Singles',
@@ -152,7 +207,7 @@ function seed(): TournamentDetailRead[] {
           draw_type: 'single-elim',
           max_players: 32,
           entry_fee: 40,
-          entered: 28,
+          entrants: otherEntrants('ev-cc-open', 28),
           slot: { date: '2026-07-01', start: '17:00', end: '21:00' },
           match_settings: { rated: true, length_games: 5 },
           predicates: [],
@@ -165,9 +220,20 @@ function seed(): TournamentDetailRead[] {
   ]
 }
 
-let tournaments: TournamentDetailRead[] = seed()
+let tournaments: StoredTournament[] = seed()
 
-/** Reset the store to its seed — used by the dev worker bootstrap if needed. */
+/** Project a stored event onto the wire shape, deriving the `entered` count from
+ * the entrants — the one place the count comes from. */
+function readEvent(event: StoredEvent): TournamentEventRead {
+  return { ...event, entered: event.entrants.length }
+}
+
+function readDetail(t: StoredTournament): TournamentDetailRead {
+  return { ...t, events: t.events.map(readEvent) }
+}
+
+/** Reset the store to its seed — used by the dev worker bootstrap if needed, and
+ * by tests that drive the store through the default handlers. */
 export function resetTournamentsStore() {
   tournaments = seed()
 }
@@ -177,11 +243,13 @@ export function listTournaments(): TournamentDetailRead[] {
   return tournaments
     .slice()
     .sort((a, b) => b.created_at.localeCompare(a.created_at))
+    .map(readDetail)
 }
 
 /** A single tournament's detail, or `undefined` if missing. */
 export function findTournament(id: string): TournamentDetailRead | undefined {
-  return tournaments.find((t) => t.id === id)
+  const found = tournaments.find((t) => t.id === id)
+  return found === undefined ? undefined : readDetail(found)
 }
 
 let createCounter = 0
@@ -202,7 +270,7 @@ function slugId(name: string): string {
 export function createTournament(body: TournamentCreate): TournamentRead {
   const now = new Date().toISOString()
   const id = slugId(body.name)
-  const created: TournamentDetailRead = {
+  const created: StoredTournament = {
     id,
     name: body.name,
     description: body.description ?? null,
@@ -232,11 +300,28 @@ export type EventResult =
 
 export type DeleteResult = { ok: true } | { ok: false; status: 403 | 404 }
 
+/** Entering can fail four ways, mirroring the API: 404 (no such tournament or
+ * event), 400 (not a singles event), 409 (already actively entered). A 403 for a
+ * missing `tournament.enter` permission is the session's business, not the
+ * store's — the dev session always holds it. */
+export type EnterResult =
+  | { ok: true; entrant: TournamentEntrantRead }
+  | { ok: false; status: 400 | 404 | 409 }
+
+/** Withdrawing fails with a 403 when the entry is someone else's; withdrawing an
+ * entry that is already gone is idempotent (`ok`), as on the server. */
+export type WithdrawResult = { ok: true } | { ok: false; status: 403 | 404 }
+
 /** Strip the embedded `events` so the create/update handlers return the bare
  * `TournamentRead` the real API does. */
-function readOf({ events, ...read }: TournamentDetailRead): TournamentRead {
+function readOf({ events, ...read }: StoredTournament): TournamentRead {
   void events
   return read
+}
+
+/** Swap one tournament in the store for an updated copy. */
+function replace(next: StoredTournament) {
+  tournaments = tournaments.map((t) => (t.id === next.id ? next : t))
 }
 
 /** Patch a tournament's top-level fields. Non-owned rows (`can_edit: false`)
@@ -248,7 +333,7 @@ export function updateTournament(
   const existing = tournaments.find((t) => t.id === id)
   if (!existing) return { ok: false, status: 404 }
   if (!existing.can_edit) return { ok: false, status: 403 }
-  const next: TournamentDetailRead = {
+  const next: StoredTournament = {
     ...existing,
     name: patch.name ?? existing.name,
     description:
@@ -264,7 +349,7 @@ export function updateTournament(
         : patch.table_catalogue,
     updated_at: new Date().toISOString(),
   }
-  tournaments = tournaments.map((t) => (t.id === id ? next : t))
+  replace(next)
   return { ok: true, tournament: readOf(next) }
 }
 
@@ -289,7 +374,7 @@ export function createEvent(
   if (!existing.can_edit) return { ok: false, status: 403 }
   eventCounter += 1
   const now = new Date().toISOString()
-  const event: TournamentEventRead = {
+  const event: StoredEvent = {
     id: `ev-new-${eventCounter}`,
     tournament_id: tournamentId,
     name: body.name,
@@ -297,7 +382,9 @@ export function createEvent(
     draw_type: body.draw_type,
     max_players: body.max_players,
     entry_fee: body.entry_fee,
-    entered: 0,
+    // A brand-new event has no entrants, so its derived count is 0. There is no
+    // `entered` to set — that's the point.
+    entrants: [],
     slot: body.slot,
     match_settings: body.match_settings,
     predicates: body.predicates ?? [],
@@ -305,9 +392,8 @@ export function createEvent(
     created_at: now,
     updated_at: now,
   }
-  const next = { ...existing, events: [...existing.events, event] }
-  tournaments = tournaments.map((t) => (t.id === tournamentId ? next : t))
-  return { ok: true, event }
+  replace({ ...existing, events: [...existing.events, event] })
+  return { ok: true, event: readEvent(event) }
 }
 
 /** Patch an event (full replace of the provided fields). Creator-only. */
@@ -321,29 +407,27 @@ export function updateEvent(
   if (!existing.can_edit) return { ok: false, status: 403 }
   const event = existing.events.find((e) => e.id === eventId)
   if (!event) return { ok: false, status: 404 }
-  const next: TournamentEventRead = {
+  const next: StoredEvent = {
     ...event,
     name: patch.name ?? event.name,
     format: patch.format ?? event.format,
     draw_type: patch.draw_type ?? event.draw_type,
     max_players: patch.max_players ?? event.max_players,
     entry_fee: patch.entry_fee ?? event.entry_fee,
-    // entered is server-managed — not in the PATCH body; keep the existing value.
-    entered: event.entered,
+    // Entrants are not in the PATCH body — an editor edit never touches the
+    // registrations, so the derived count survives the edit untouched.
+    entrants: event.entrants,
     slot: patch.slot ?? event.slot,
     match_settings: patch.match_settings ?? event.match_settings,
     predicates: patch.predicates ?? event.predicates,
     pools: patch.pools ?? event.pools,
     updated_at: new Date().toISOString(),
   }
-  const nextTournament = {
+  replace({
     ...existing,
     events: existing.events.map((e) => (e.id === eventId ? next : e)),
-  }
-  tournaments = tournaments.map((t) =>
-    t.id === tournamentId ? nextTournament : t,
-  )
-  return { ok: true, event: next }
+  })
+  return { ok: true, event: readEvent(next) }
 }
 
 /** Delete an event. Creator-only. */
@@ -356,10 +440,74 @@ export function deleteEvent(
   if (!existing.can_edit) return { ok: false, status: 403 }
   const event = existing.events.find((e) => e.id === eventId)
   if (!event) return { ok: false, status: 404 }
-  const next = {
+  replace({
     ...existing,
     events: existing.events.filter((e) => e.id !== eventId),
+  })
+  return { ok: true }
+}
+
+let entryCounter = 0
+
+/** Enter the dev user into an event — the caller is always the entrant (there is
+ * no request body; self-registration only). Not creator-gated: the whole point
+ * is that a player writes to a tournament they don't own. */
+export function enterEvent(
+  tournamentId: string,
+  eventId: string,
+): EnterResult {
+  const existing = tournaments.find((t) => t.id === tournamentId)
+  if (!existing) return { ok: false, status: 404 }
+  const event = existing.events.find((e) => e.id === eventId)
+  if (!event) return { ok: false, status: 404 }
+  // One row per user can't express a doubles pairing or a team (ADR-0016).
+  if (event.format !== 'singles') return { ok: false, status: 400 }
+  // The server's partial unique index, in miniature: at most one *active* entry
+  // per player per event. A second one is a 409, never a second row.
+  if (event.entrants.some((e) => e.user_id === DEV_USER_ID)) {
+    return { ok: false, status: 409 }
   }
-  tournaments = tournaments.map((t) => (t.id === tournamentId ? next : t))
+  entryCounter += 1
+  const entrant: TournamentEntrantRead = {
+    id: `entry-me-${entryCounter}`,
+    user_id: DEV_USER_ID,
+    username: DEV_USERNAME,
+    seed: null,
+  }
+  const next: StoredEvent = { ...event, entrants: [...event.entrants, entrant] }
+  replace({
+    ...existing,
+    events: existing.events.map((e) => (e.id === eventId ? next : e)),
+  })
+  return { ok: true, entrant }
+}
+
+/** Withdraw one entry. A player may only withdraw their *own* (someone else's is
+ * a 403). Withdrawing an entry that is no longer active is idempotent — the
+ * server soft-deletes, so a repeat DELETE is still a 204; here the row is simply
+ * already gone. Dropping it (rather than tombstoning) is faithful on the wire:
+ * a withdrawn entry appears in neither the list nor the count, and the player can
+ * enter again straight away. */
+export function withdrawEntry(
+  tournamentId: string,
+  eventId: string,
+  entryId: string,
+): WithdrawResult {
+  const existing = tournaments.find((t) => t.id === tournamentId)
+  if (!existing) return { ok: false, status: 404 }
+  const event = existing.events.find((e) => e.id === eventId)
+  if (!event) return { ok: false, status: 404 }
+  const entrant = event.entrants.find((e) => e.id === entryId)
+  // Already withdrawn (or never existed): idempotent, exactly as on the server.
+  if (!entrant) return { ok: true }
+  if (entrant.user_id !== DEV_USER_ID) return { ok: false, status: 403 }
+  const next: StoredEvent = {
+    ...event,
+    entrants: event.entrants.filter((e) => e.id !== entryId),
+  }
+  replace({
+    ...existing,
+    events: existing.events.map((e) => (e.id === eventId ? next : e)),
+  })
   return { ok: true }
 }

--- a/web-client/src/test/session-probe.tsx
+++ b/web-client/src/test/session-probe.tsx
@@ -1,0 +1,15 @@
+import { useSession } from '@/api/session'
+
+/**
+ * A test-only marker that appears once `/v1/session` has resolved.
+ *
+ * Permission-gated UI that renders **nothing** when unauthorized is a trap to
+ * assert on: `useHasPermission` also reads `false` while the session is still in
+ * flight, so a bare "expect the control to be absent" passes during loading and
+ * proves nothing. Render this alongside the component under test and `await` the
+ * marker first — then the absence is a real absence.
+ */
+export function SessionProbe() {
+  const { data } = useSession()
+  return data ? <span data-testid="session-ready" /> : null
+}


### PR DESCRIPTION
Closes #781. First slice of the **Run the tournament** epic (#780) — the load-bearing one, since draws (#785/#786) need entrants to seed.

A player can now enter a tournament event, see themselves in the entrants list, withdraw, and enter again. Decisions are recorded in **[ADR 0016](docs/adr/0016-a-tournament-entry-is-soft-deleted-and-its-count-is-derived.md)**.

## The two decisions worth reviewing

**1. `entered` is derived, never stored.** It was a dead column: the only writer in the entire API was a literal `entered=0` at event creation, yet three UI surfaces rendered it — so against the real API they showed `0`, always. The column is dropped (migration `0010` edited in place, pre-deploy) and the read model computes `entered` as a Pydantic `@computed_field` returning `len(entrants)`. The count and the list are now *the same fact*, so "says 52, lists 51" is unrepresentable rather than merely unlikely. Counts load in **one grouped query**, not one per event (pinned by a statement-count test parametrized over 1 and 4 events — at 1 event a per-event loop still passes, which is why the parametrization matters).

`entered` keeps its name, type, and required-ness in the response, so the card's fill bar, the hero stat and the list card need no edit — they just start showing real numbers.

**2. Withdrawal is a soft-delete behind a *partial* unique index.**

```sql
UNIQUE (event_id, user_id) WHERE status = 'entered'
```

This is the detail most likely to be got wrong: **a plain `UNIQUE (event_id, user_id)` is a bug.** Combined with soft-delete it would permanently lock out any player who ever withdrew — their second entry would collide with their own tombstoned row. The enter → withdraw → **re-enter** journey walks straight into it, and it's the single most important assertion in the branch (covered at the DB, the route, and end-to-end in the browser).

The partial index also makes the duplicate check **race-free without a row lock**: the 409 comes from catching the index's `IntegrityError`, not a pre-check `SELECT`. (Verified discriminatingly — swapping in a pre-check leaves the duplicate-409 test green while the *re-entry* test goes red.)

## Also here

- **`tournament.enter` permission**, seeded onto the Beta-tester role. Self-registration is the first **non-owner** mutation in tournaments, so it structurally cannot use the existing `_require_owner` gate.
- **Singles only.** One row per user can't express a doubles pairing — there's nowhere to put the partner. Non-singles entry is a 400, and the UI offers no control there.
- **Account-merge handling**, which #781's acceptance criteria omit: `merge_user` *tombstones* rather than deletes, so `ON DELETE` never fires and entries would strand on a ghost user. They re-point onto the survivor, dropping the row that would collide on the partial index — while *not* deduping two withdrawn rows, which the partial index makes legal.
- **The roster's empty state is a sum type** (`listed` / `empty` / `entry-closed`, compiler-enforced). A doubles event says "Doubles events can't be entered yet.", not "No one has entered yet." — nobody *can* enter one, so inviting them to be first is a lie.
- **The first e2e coverage the tournaments section has ever had**, and **axe wired into the Playwright suite** (it wasn't wired anywhere in the repo).

## Not here — deliberately, they're later slices

`max_players` capacity enforcement and eligibility predicates (**#783**); status/lifecycle gating, e.g. whether you may enter a `draft` tournament (**#782**); director-managed entries (**#784**).

## Verification

API `664 passed` · mypy clean · ruff clean · web-client `1399` vitest · `147` e2e (139 pre-existing + 8 new) · tsc + lint clean · OpenAPI regen idempotent (`schema.d.ts` + `Types.swift` committed).

Every chore was checked by an independent agent that re-ran its command, re-derived its claim, and mutation-tested its guards. Two things that caught: the pytest suite builds its schema via `Base.metadata.create_all` and **never exercises the migration**, so the dropped column was confirmed against a freshly-migrated Postgres; and jsdom has no layout or paint, so the Enter control's click-isolation from the card's stretched overlay **cannot** be proven by a unit test — it's pinned in the browser instead.

## Follow-ups (not blocking)

- The client has no user id (`SessionUser` is username + permissions), so "am I entered?" joins on **username**. The BFF-idiomatic fix is a viewer-relative field on the read model (`my_entry_id`), like the existing `can_edit`.
- The tournaments data module doesn't Zod-parse responses — pre-existing, and already recorded as a systemic gap in the upgrade tracker (dimension F is ❌ on every page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApDQ29hRiw3zHzYuZgaa43