### PR TITLE
Hold web-client on TypeScript 6 until typescript-eslint supports 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # TypeScript 7 is the native port and drops the JS compiler API that our
+      # toolchain builds on: typescript-eslint declares `typescript <6.1.0` and
+      # openapi-typescript still calls `ts.factory`, so both `npm run lint` and
+      # `npm run gen:api` die on it. Drop this once typescript-eslint ships a
+      # release whose peer range admits 7.x.
+      - dependency-name: typescript
+        versions:
+          - ">=7.0.0"
     groups:
       web-client-minor-patch:
         update-types:


### PR DESCRIPTION
## Why

Dependabot #976 (typescript 6.0.3 → 7.0.2) **cannot be merged**, and won't be able to be for a while. TypeScript 7 is the native (Go) port: it no longer exposes the JS compiler API that two pieces of our toolchain are built on.

Two jobs fail on #976, both for this reason:

| Job | Failure |
| --- | --- |
| `checks` (`npm run lint`) | `TypeError: Cannot read properties of undefined (reading 'Cjs')` in `@typescript-eslint/typescript-estree` |
| `verify` (`npm run gen:api`) | `TypeError: Cannot read properties of undefined (reading 'createKeywordTypeNode')` — `openapi-typescript` calling `ts.factory` |

The decisive constraint isn't the crashes, it's the published peer range: `typescript-eslint@8.63.0` — the latest release, and every canary — declares `typescript: ">=4.8.4 <6.1.0"`. TS 7 is *deliberately* excluded upstream. No published version lifts that ceiling, so typed linting simply cannot run on TS 7 today.

The workarounds are all worse than waiting: aliasing a second TypeScript for eslint, or dropping typed lint / the `gen:api` drift guard, would ship a half-adopted TS 7 that isn't actually type-linted.

## What this does

Adds a dependabot `ignore` for `typescript >=7.0.0` in the `/web-client` npm block, so 7.x stops being proposed every week. TS 6.x minor/patch bumps still flow normally.

Remove the ignore once typescript-eslint ships a release whose peer range admits 7.x — that's the long pole; `openapi-typescript` will likely catch up sooner.

Closes out #976 (closed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UARLwiGRWUMAcbBuyX7Eii