### PR TITLE
Fix #901: give the notifications empty state a next action

### DIFF
--- a/web-client/src/components/notifications/notifications-page/notifications-empty.factory.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-empty.factory.tsx
@@ -1,0 +1,11 @@
+import type { NotificationsEmptyProps } from './notifications-empty'
+
+export function buildNotificationsEmptyProps(
+  overrides: Partial<NotificationsEmptyProps> = {},
+): NotificationsEmptyProps {
+  return {
+    state: { kind: 'inbox-empty' },
+    onShowAll: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/notifications/notifications-page/notifications-empty.factory.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-empty.factory.tsx
@@ -5,7 +5,6 @@ export function buildNotificationsEmptyProps(
 ): NotificationsEmptyProps {
   return {
     state: { kind: 'inbox-empty' },
-    onShowAll: () => {},
     ...overrides,
   }
 }

--- a/web-client/src/components/notifications/notifications-page/notifications-empty.page.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-empty.page.tsx
@@ -15,27 +15,35 @@ export const EMPTY_STATE_LINK_TARGETS = [
   '/notifications/settings',
 ]
 
-/** The headline both empty states share. Declared once: every harness that
- * needs it — router-mounted or not, this component's or the view's — reads it
- * from here rather than re-typing the copy. */
-const HEADLINE = 'All caught up.'
+/** The inbox-empty headline. A filter that matches nothing deliberately does
+ * NOT say this — it names the filter instead — so this string identifies the
+ * inbox-empty state specifically, not "some empty state". */
+const INBOX_EMPTY_HEADLINE = 'All caught up.'
+
+/** The filter-empty headline, which names the filter that matched nothing. */
+const filterEmptyHeadline = (filterLabel: string) =>
+  `Nothing under ${filterLabel}.`
 
 const scoped = (container: Container) => ({
-  /** The headline under a router — async, since the router resolves its initial
-   * match after first paint, so nothing is in the DOM yet. */
+  /** The inbox-empty headline under a router — async, since the router resolves
+   * its initial match after first paint, so nothing is in the DOM yet. */
   findHeadline() {
-    return container.findByText(HEADLINE)
+    return container.findByText(INBOX_EMPTY_HEADLINE)
   },
-  /** The headline in a plain (router-free) render — see the view's page object,
-   * whose link-free states mount without one. */
+  /** The inbox-empty headline in a plain (router-free) render. */
   queryHeadline() {
-    return container.queryByText(HEADLINE)
+    return container.queryByText(INBOX_EMPTY_HEADLINE)
   },
   queryGoPlayCopy() {
     return container.queryByText('Nothing here. Go play.')
   },
   queryFilterCopy(filterLabel: string) {
-    return container.queryByText(`Nothing under ${filterLabel}.`)
+    return container.queryByText(filterEmptyHeadline(filterLabel))
+  },
+  /** The filter-empty headline under a router — the async twin of
+   * `queryFilterCopy`, for harnesses that mount one. */
+  findFilterCopy(filterLabel: string) {
+    return container.findByText(filterEmptyHeadline(filterLabel))
   },
   queryLogMatchLink() {
     return container.queryByRole('link', { name: 'Log a match' })

--- a/web-client/src/components/notifications/notifications-page/notifications-empty.page.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-empty.page.tsx
@@ -1,0 +1,55 @@
+import userEvent from '@testing-library/user-event'
+import { renderWithRoutes } from '@/test/router'
+import { screen, type Container } from '@/test/utilities'
+import {
+  NotificationsEmpty,
+  type NotificationsEmptyProps,
+} from './notifications-empty'
+import { buildNotificationsEmptyProps } from './notifications-empty.factory'
+
+const scoped = (container: Container) => ({
+  /** The headline, shared by both empty states. Async: the router resolves its
+   * initial match asynchronously, so nothing is in the DOM on first paint. */
+  findHeadline() {
+    return container.findByText('All caught up.')
+  },
+  querySubcopy(text: string | RegExp) {
+    return container.queryByText(text)
+  },
+  queryLogMatchLink() {
+    return container.queryByRole('link', { name: 'Log a match' })
+  },
+  queryPreferencesLink() {
+    return container.queryByRole('link', { name: 'Notification preferences' })
+  },
+  queryShowAll() {
+    return container.queryByRole('button', { name: 'Show all notifications' })
+  },
+  getShowAll() {
+    return container.getByRole('button', { name: 'Show all notifications' })
+  },
+})
+
+/**
+ * Test page-object for `NotificationsEmpty`. The inbox-empty state renders
+ * typed `<Link>`s, so it mounts under a minimal router registering their
+ * targets. Tests must start with `await notificationsEmptyPage.findHeadline()`.
+ */
+export const notificationsEmptyPage = {
+  render(overrides: Partial<NotificationsEmptyProps> = {}) {
+    return renderWithRoutes(
+      <NotificationsEmpty {...buildNotificationsEmptyProps(overrides)} />,
+      { linkTargets: ['/matches/new', '/notifications/settings'] },
+    )
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  async clickShowAll() {
+    await userEvent.click(this.getShowAll())
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/notifications/notifications-page/notifications-empty.page.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-empty.page.tsx
@@ -15,11 +15,21 @@ export const EMPTY_STATE_LINK_TARGETS = [
   '/notifications/settings',
 ]
 
+/** The headline both empty states share. Declared once: every harness that
+ * needs it — router-mounted or not, this component's or the view's — reads it
+ * from here rather than re-typing the copy. */
+const HEADLINE = 'All caught up.'
+
 const scoped = (container: Container) => ({
-  /** The headline, shared by both empty states. Async: the router resolves its
-   * initial match asynchronously, so nothing is in the DOM on first paint. */
+  /** The headline under a router — async, since the router resolves its initial
+   * match after first paint, so nothing is in the DOM yet. */
   findHeadline() {
-    return container.findByText('All caught up.')
+    return container.findByText(HEADLINE)
+  },
+  /** The headline in a plain (router-free) render — see the view's page object,
+   * whose link-free states mount without one. */
+  queryHeadline() {
+    return container.queryByText(HEADLINE)
   },
   queryGoPlayCopy() {
     return container.queryByText('Nothing here. Go play.')

--- a/web-client/src/components/notifications/notifications-page/notifications-empty.page.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-empty.page.tsx
@@ -7,14 +7,25 @@ import {
 } from './notifications-empty'
 import { buildNotificationsEmptyProps } from './notifications-empty.factory'
 
+/** The routes the inbox-empty CTAs link to. Exported so any harness mounting
+ * this component registers the same set — a `<Link>` whose target the router
+ * doesn't know throws at render. */
+export const EMPTY_STATE_LINK_TARGETS = [
+  '/matches/new',
+  '/notifications/settings',
+]
+
 const scoped = (container: Container) => ({
   /** The headline, shared by both empty states. Async: the router resolves its
    * initial match asynchronously, so nothing is in the DOM on first paint. */
   findHeadline() {
     return container.findByText('All caught up.')
   },
-  querySubcopy(text: string | RegExp) {
-    return container.queryByText(text)
+  queryGoPlayCopy() {
+    return container.queryByText('Nothing here. Go play.')
+  },
+  queryFilterCopy(filterLabel: string) {
+    return container.queryByText(`Nothing under ${filterLabel}.`)
   },
   queryLogMatchLink() {
     return container.queryByRole('link', { name: 'Log a match' })
@@ -39,7 +50,7 @@ export const notificationsEmptyPage = {
   render(overrides: Partial<NotificationsEmptyProps> = {}) {
     return renderWithRoutes(
       <NotificationsEmpty {...buildNotificationsEmptyProps(overrides)} />,
-      { linkTargets: ['/matches/new', '/notifications/settings'] },
+      { linkTargets: EMPTY_STATE_LINK_TARGETS },
     )
   },
 

--- a/web-client/src/components/notifications/notifications-page/notifications-empty.test.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-empty.test.tsx
@@ -30,15 +30,23 @@ describe('NotificationsEmpty', () => {
 
     it('names the filter rather than telling a user with notifications to go play', async () => {
       notificationsEmptyPage.render({ state: filterEmpty() })
-      await notificationsEmptyPage.findHeadline()
+      await notificationsEmptyPage.findFilterCopy('Unread')
 
-      expect(notificationsEmptyPage.queryFilterCopy('Unread')).toBeInTheDocument()
       expect(notificationsEmptyPage.queryGoPlayCopy()).not.toBeInTheDocument()
+    })
+
+    // The user's notifications are still sitting there, one pill away — claiming
+    // they're "all caught up" contradicts the very line beneath it (QA, #901).
+    it('does not borrow the empty inbox\'s "All caught up." reassurance', async () => {
+      notificationsEmptyPage.render({ state: filterEmpty() })
+      await notificationsEmptyPage.findFilterCopy('Unread')
+
+      expect(notificationsEmptyPage.queryHeadline()).not.toBeInTheDocument()
     })
 
     it('offers to clear the filter instead of starting a match', async () => {
       notificationsEmptyPage.render({ state: filterEmpty() })
-      await notificationsEmptyPage.findHeadline()
+      await notificationsEmptyPage.findFilterCopy('Unread')
 
       expect(notificationsEmptyPage.queryShowAll()).toBeInTheDocument()
       expect(notificationsEmptyPage.queryLogMatchLink()).not.toBeInTheDocument()
@@ -47,7 +55,7 @@ describe('NotificationsEmpty', () => {
     it('clears the filter when "Show all" is clicked', async () => {
       const onShowAll = vi.fn()
       notificationsEmptyPage.render({ state: filterEmpty(onShowAll) })
-      await notificationsEmptyPage.findHeadline()
+      await notificationsEmptyPage.findFilterCopy('Unread')
 
       await notificationsEmptyPage.clickShowAll()
       expect(onShowAll).toHaveBeenCalledTimes(1)

--- a/web-client/src/components/notifications/notifications-page/notifications-empty.test.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-empty.test.tsx
@@ -25,22 +25,19 @@ describe('NotificationsEmpty', () => {
   })
 
   describe('with a filter matching nothing', () => {
-    const filtered = { kind: 'filter-empty', filterLabel: 'Unread' } as const
+    const filterEmpty = (onShowAll = () => {}) =>
+      ({ kind: 'filter-empty', filterLabel: 'Unread', onShowAll }) as const
 
     it('names the filter rather than telling a user with notifications to go play', async () => {
-      notificationsEmptyPage.render({ state: filtered })
+      notificationsEmptyPage.render({ state: filterEmpty() })
       await notificationsEmptyPage.findHeadline()
 
-      expect(
-        notificationsEmptyPage.querySubcopy('Nothing under Unread.'),
-      ).toBeInTheDocument()
-      expect(
-        notificationsEmptyPage.querySubcopy('Nothing here. Go play.'),
-      ).not.toBeInTheDocument()
+      expect(notificationsEmptyPage.queryFilterCopy('Unread')).toBeInTheDocument()
+      expect(notificationsEmptyPage.queryGoPlayCopy()).not.toBeInTheDocument()
     })
 
     it('offers to clear the filter instead of starting a match', async () => {
-      notificationsEmptyPage.render({ state: filtered })
+      notificationsEmptyPage.render({ state: filterEmpty() })
       await notificationsEmptyPage.findHeadline()
 
       expect(notificationsEmptyPage.queryShowAll()).toBeInTheDocument()
@@ -49,7 +46,7 @@ describe('NotificationsEmpty', () => {
 
     it('clears the filter when "Show all" is clicked', async () => {
       const onShowAll = vi.fn()
-      notificationsEmptyPage.render({ state: filtered, onShowAll })
+      notificationsEmptyPage.render({ state: filterEmpty(onShowAll) })
       await notificationsEmptyPage.findHeadline()
 
       await notificationsEmptyPage.clickShowAll()

--- a/web-client/src/components/notifications/notifications-page/notifications-empty.test.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-empty.test.tsx
@@ -1,0 +1,59 @@
+import { notificationsEmptyPage } from './notifications-empty.page'
+
+describe('NotificationsEmpty', () => {
+  describe('with an empty inbox', () => {
+    it('offers a way back into the product (#901)', async () => {
+      notificationsEmptyPage.render({ state: { kind: 'inbox-empty' } })
+      await notificationsEmptyPage.findHeadline()
+
+      expect(notificationsEmptyPage.queryLogMatchLink()).toHaveAttribute(
+        'href',
+        '/matches/new',
+      )
+      expect(notificationsEmptyPage.queryPreferencesLink()).toHaveAttribute(
+        'href',
+        '/notifications/settings',
+      )
+    })
+
+    it('does not offer to clear a filter that is not applied', async () => {
+      notificationsEmptyPage.render({ state: { kind: 'inbox-empty' } })
+      await notificationsEmptyPage.findHeadline()
+
+      expect(notificationsEmptyPage.queryShowAll()).not.toBeInTheDocument()
+    })
+  })
+
+  describe('with a filter matching nothing', () => {
+    const filtered = { kind: 'filter-empty', filterLabel: 'Unread' } as const
+
+    it('names the filter rather than telling a user with notifications to go play', async () => {
+      notificationsEmptyPage.render({ state: filtered })
+      await notificationsEmptyPage.findHeadline()
+
+      expect(
+        notificationsEmptyPage.querySubcopy('Nothing under Unread.'),
+      ).toBeInTheDocument()
+      expect(
+        notificationsEmptyPage.querySubcopy('Nothing here. Go play.'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('offers to clear the filter instead of starting a match', async () => {
+      notificationsEmptyPage.render({ state: filtered })
+      await notificationsEmptyPage.findHeadline()
+
+      expect(notificationsEmptyPage.queryShowAll()).toBeInTheDocument()
+      expect(notificationsEmptyPage.queryLogMatchLink()).not.toBeInTheDocument()
+    })
+
+    it('clears the filter when "Show all" is clicked', async () => {
+      const onShowAll = vi.fn()
+      notificationsEmptyPage.render({ state: filtered, onShowAll })
+      await notificationsEmptyPage.findHeadline()
+
+      await notificationsEmptyPage.clickShowAll()
+      expect(onShowAll).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/web-client/src/components/notifications/notifications-page/notifications-empty.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-empty.tsx
@@ -20,8 +20,12 @@ export interface NotificationsEmptyProps {
   state: NotificationsEmptyState
 }
 
-/** The notifications list's empty state: the same reassurance either way, but a
- * next action that fits which empty it is. */
+/** The notifications list's empty state: a headline that tells the truth about
+ * which empty it is, and a next action that fits it.
+ *
+ * Only an empty *inbox* is "All caught up." A filter that matches nothing must
+ * not borrow that reassurance — the user's notifications are still sitting
+ * there, one pill away, and QA rightly read the pair as contradicting itself. */
 export function NotificationsEmpty({ state }: NotificationsEmptyProps) {
   return (
     <div className="px-5 py-14 text-center">
@@ -29,12 +33,14 @@ export function NotificationsEmpty({ state }: NotificationsEmptyProps) {
         <Inbox size={26} />
       </span>
       <p className="text-base font-semibold text-[color:var(--fg-2)]">
-        All caught up.
+        {state.kind === 'inbox-empty'
+          ? 'All caught up.'
+          : `Nothing under ${state.filterLabel}.`}
       </p>
       <p className="mt-1 text-[13px] text-[color:var(--fg-3)]">
         {state.kind === 'inbox-empty'
           ? 'Nothing here. Go play.'
-          : `Nothing under ${state.filterLabel}.`}
+          : 'Your other notifications are still in the inbox.'}
       </p>
       <div className="mt-5 flex flex-wrap items-center justify-center gap-2.5">
         {state.kind === 'inbox-empty' ? (

--- a/web-client/src/components/notifications/notifications-page/notifications-empty.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-empty.tsx
@@ -7,20 +7,22 @@ import { Button } from '@/components/ui/button'
  * *different* next actions, so they're a sum type rather than a pair of
  * booleans: telling someone whose Unread filter is clear to "go play" would be
  * wrong — they have notifications, just none under this filter (#901).
+ *
+ * `onShowAll` rides on the `filter-empty` arm because an empty inbox has no
+ * filter to clear — the type carries the invariant, so no call site can pass a
+ * filter-clearing callback that nothing can reach.
  */
 export type NotificationsEmptyState =
   | { kind: 'inbox-empty' }
-  | { kind: 'filter-empty'; filterLabel: string }
+  | { kind: 'filter-empty'; filterLabel: string; onShowAll: () => void }
 
 export interface NotificationsEmptyProps {
   state: NotificationsEmptyState
-  /** Clears the active filter. Only reachable from the `filter-empty` state. */
-  onShowAll: () => void
 }
 
 /** The notifications list's empty state: the same reassurance either way, but a
  * next action that fits which empty it is. */
-export function NotificationsEmpty({ state, onShowAll }: NotificationsEmptyProps) {
+export function NotificationsEmpty({ state }: NotificationsEmptyProps) {
   return (
     <div className="px-5 py-14 text-center">
       <span className="mb-3.5 inline-flex size-14 items-center justify-center rounded-full bg-[color:var(--bg-card)] text-[color:var(--fg-muted)]">
@@ -29,33 +31,32 @@ export function NotificationsEmpty({ state, onShowAll }: NotificationsEmptyProps
       <p className="text-base font-semibold text-[color:var(--fg-2)]">
         All caught up.
       </p>
-
-      {state.kind === 'inbox-empty' ? (
-        <>
-          <p className="mt-1 text-[13px] text-[color:var(--fg-3)]">
-            Nothing here. Go play.
-          </p>
-          <div className="mt-5 flex flex-wrap items-center justify-center gap-2.5">
+      <p className="mt-1 text-[13px] text-[color:var(--fg-3)]">
+        {state.kind === 'inbox-empty'
+          ? 'Nothing here. Go play.'
+          : `Nothing under ${state.filterLabel}.`}
+      </p>
+      <div className="mt-5 flex flex-wrap items-center justify-center gap-2.5">
+        {state.kind === 'inbox-empty' ? (
+          <>
             <Button asChild size="sm">
               <Link to="/matches/new">Log a match</Link>
             </Button>
             <Button asChild variant="outline" size="sm">
               <Link to="/notifications/settings">Notification preferences</Link>
             </Button>
-          </div>
-        </>
-      ) : (
-        <>
-          <p className="mt-1 text-[13px] text-[color:var(--fg-3)]">
-            Nothing under {state.filterLabel}.
-          </p>
-          <div className="mt-5 flex justify-center">
-            <Button type="button" variant="outline" size="sm" onClick={onShowAll}>
-              Show all notifications
-            </Button>
-          </div>
-        </>
-      )}
+          </>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={state.onShowAll}
+          >
+            Show all notifications
+          </Button>
+        )}
+      </div>
     </div>
   )
 }

--- a/web-client/src/components/notifications/notifications-page/notifications-empty.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-empty.tsx
@@ -1,0 +1,61 @@
+import { Link } from '@tanstack/react-router'
+import { Inbox } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Which empty the inbox is. The two cases are mutually exclusive and want
+ * *different* next actions, so they're a sum type rather than a pair of
+ * booleans: telling someone whose Unread filter is clear to "go play" would be
+ * wrong — they have notifications, just none under this filter (#901).
+ */
+export type NotificationsEmptyState =
+  | { kind: 'inbox-empty' }
+  | { kind: 'filter-empty'; filterLabel: string }
+
+export interface NotificationsEmptyProps {
+  state: NotificationsEmptyState
+  /** Clears the active filter. Only reachable from the `filter-empty` state. */
+  onShowAll: () => void
+}
+
+/** The notifications list's empty state: the same reassurance either way, but a
+ * next action that fits which empty it is. */
+export function NotificationsEmpty({ state, onShowAll }: NotificationsEmptyProps) {
+  return (
+    <div className="px-5 py-14 text-center">
+      <span className="mb-3.5 inline-flex size-14 items-center justify-center rounded-full bg-[color:var(--bg-card)] text-[color:var(--fg-muted)]">
+        <Inbox size={26} />
+      </span>
+      <p className="text-base font-semibold text-[color:var(--fg-2)]">
+        All caught up.
+      </p>
+
+      {state.kind === 'inbox-empty' ? (
+        <>
+          <p className="mt-1 text-[13px] text-[color:var(--fg-3)]">
+            Nothing here. Go play.
+          </p>
+          <div className="mt-5 flex flex-wrap items-center justify-center gap-2.5">
+            <Button asChild size="sm">
+              <Link to="/matches/new">Log a match</Link>
+            </Button>
+            <Button asChild variant="outline" size="sm">
+              <Link to="/notifications/settings">Notification preferences</Link>
+            </Button>
+          </div>
+        </>
+      ) : (
+        <>
+          <p className="mt-1 text-[13px] text-[color:var(--fg-3)]">
+            Nothing under {state.filterLabel}.
+          </p>
+          <div className="mt-5 flex justify-center">
+            <Button type="button" variant="outline" size="sm" onClick={onShowAll}>
+              Show all notifications
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/web-client/src/components/notifications/notifications-page/notifications-view.page.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.page.tsx
@@ -1,6 +1,10 @@
 import userEvent from '@testing-library/user-event'
 import { renderWithRoutes } from '@/test/router'
 import { render, screen, type Container } from '@/test/utilities'
+import {
+  EMPTY_STATE_LINK_TARGETS,
+  notificationsEmptyPage,
+} from './notifications-empty.page'
 import { NotificationsView, type NotificationsViewProps } from './notifications-view'
 import { buildNotificationsViewProps } from './notifications-view.factory'
 
@@ -21,23 +25,16 @@ const scoped = (container: Container) => ({
   queryEmptyState() {
     return container.queryByText('All caught up.')
   },
-  /** The empty state under a router — async, since the router resolves its
-   * initial match after first paint. See `renderEmptyInbox`. */
-  findEmptyState() {
-    return container.findByText('All caught up.')
-  },
-  queryLogMatchLink() {
-    return container.queryByRole('link', { name: 'Log a match' })
-  },
-  queryShowAll() {
-    return container.queryByRole('button', { name: 'Show all notifications' })
-  },
   queryTitle(title: string) {
     return container.queryByText(title)
   },
   rowByTitle(title: string) {
     return container.getByText(title).closest('button') as HTMLButtonElement
   },
+  /** The empty state's own surface (`findHeadline`, `queryLogMatchLink`,
+   * `queryShowAll`, …) — composed from its page object rather than re-derived,
+   * so the CTA names live in one place. */
+  ...notificationsEmptyPage.within(container),
 })
 
 export const notificationsViewPage = {
@@ -66,7 +63,7 @@ export const notificationsViewPage = {
       <NotificationsView
         {...buildNotificationsViewProps({ items: [], unreadCount: 0, ...overrides })}
       />,
-      { linkTargets: ['/matches/new', '/notifications/settings'] },
+      { linkTargets: EMPTY_STATE_LINK_TARGETS },
     )
   },
 
@@ -81,9 +78,7 @@ export const notificationsViewPage = {
     await userEvent.click(this.getMarkAllRead())
   },
   async clickShowAll() {
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Show all notifications' }),
-    )
+    await userEvent.click(this.getShowAll())
   },
   async clickRow(title: string) {
     await userEvent.click(this.rowByTitle(title))

--- a/web-client/src/components/notifications/notifications-page/notifications-view.page.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.page.tsx
@@ -1,4 +1,5 @@
 import userEvent from '@testing-library/user-event'
+import { renderWithRoutes } from '@/test/router'
 import { render, screen, type Container } from '@/test/utilities'
 import { NotificationsView, type NotificationsViewProps } from './notifications-view'
 import { buildNotificationsViewProps } from './notifications-view.factory'
@@ -20,6 +21,17 @@ const scoped = (container: Container) => ({
   queryEmptyState() {
     return container.queryByText('All caught up.')
   },
+  /** The empty state under a router — async, since the router resolves its
+   * initial match after first paint. See `renderEmptyInbox`. */
+  findEmptyState() {
+    return container.findByText('All caught up.')
+  },
+  queryLogMatchLink() {
+    return container.queryByRole('link', { name: 'Log a match' })
+  },
+  queryShowAll() {
+    return container.queryByRole('button', { name: 'Show all notifications' })
+  },
   queryTitle(title: string) {
     return container.queryByText(title)
   },
@@ -40,6 +52,24 @@ export const notificationsViewPage = {
     }
   },
 
+  /**
+   * `render`, but mounted under a memory router.
+   *
+   * Only the *inbox-empty* state (no notifications at all) renders typed
+   * `<Link>`s, and a `<Link>` needs a router registering its target — so this is
+   * the harness for a feed with no items. Every other state, the filter-empty
+   * one included, is link-free and uses the plain `render` above. The router
+   * resolves asynchronously: start with `await findEmptyState()`.
+   */
+  renderEmptyInbox(overrides: Partial<NotificationsViewProps> = {}) {
+    return renderWithRoutes(
+      <NotificationsView
+        {...buildNotificationsViewProps({ items: [], unreadCount: 0, ...overrides })}
+      />,
+      { linkTargets: ['/matches/new', '/notifications/settings'] },
+    )
+  },
+
   within(container: Container = screen) {
     return scoped(container)
   },
@@ -49,6 +79,11 @@ export const notificationsViewPage = {
   },
   async clickMarkAllRead() {
     await userEvent.click(this.getMarkAllRead())
+  },
+  async clickShowAll() {
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Show all notifications' }),
+    )
   },
   async clickRow(title: string) {
     await userEvent.click(this.rowByTitle(title))

--- a/web-client/src/components/notifications/notifications-page/notifications-view.page.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.page.tsx
@@ -22,9 +22,6 @@ const scoped = (container: Container) => ({
   queryUnreadBadge() {
     return container.queryByText(/\d+ unread/)
   },
-  queryEmptyState() {
-    return container.queryByText('All caught up.')
-  },
   queryTitle(title: string) {
     return container.queryByText(title)
   },

--- a/web-client/src/components/notifications/notifications-page/notifications-view.test.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.test.tsx
@@ -73,7 +73,10 @@ describe('NotificationsView', () => {
 
   it('shows the empty state when a filter matches nothing', () => {
     notificationsViewPage.render({ filter: 'match_reminder' })
-    expect(notificationsViewPage.queryHeadline()).toBeInTheDocument()
+    // Identified by its action, not by "All caught up." — that headline belongs
+    // to the empty inbox, and a filtered-out list is not caught up.
+    expect(notificationsViewPage.queryShowAll()).toBeInTheDocument()
+    expect(notificationsViewPage.queryHeadline()).not.toBeInTheDocument()
   })
 
   it('falls back to a generic label for a filter the taxonomy does not name', () => {

--- a/web-client/src/components/notifications/notifications-page/notifications-view.test.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.test.tsx
@@ -1,3 +1,4 @@
+import { notificationTaxonomy } from '@/test/factories'
 import { buildNotificationsItems } from './notifications-view.factory'
 import { notificationsViewPage } from './notifications-view.page'
 
@@ -72,7 +73,22 @@ describe('NotificationsView', () => {
 
   it('shows the empty state when a filter matches nothing', () => {
     notificationsViewPage.render({ filter: 'match_reminder' })
-    expect(notificationsViewPage.queryEmptyState()).toBeInTheDocument()
+    expect(notificationsViewPage.queryHeadline()).toBeInTheDocument()
+  })
+
+  it('falls back to a generic label for a filter the taxonomy does not name', () => {
+    // The taxonomy is server-driven, so a filter can outlive the category that
+    // named it (a dropped type, a hand-edited URL). Name it generically rather
+    // than printing "Nothing under undefined."
+    notificationsViewPage.render({
+      filter: 'match_reminder',
+      categoryTypes: notificationTaxonomy().types.filter(
+        (type) => type.key !== 'match_reminder',
+      ),
+    })
+    expect(
+      notificationsViewPage.queryFilterCopy('this filter'),
+    ).toBeInTheDocument()
   })
 
   // What only the *view* knows is which empty it is looking at. The CTAs

--- a/web-client/src/components/notifications/notifications-page/notifications-view.test.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.test.tsx
@@ -75,6 +75,29 @@ describe('NotificationsView', () => {
     expect(notificationsViewPage.queryEmptyState()).toBeInTheDocument()
   })
 
+  it('offers to clear the filter — not to go play — when a filter matches nothing (#901)', async () => {
+    const onFilterChange = vi.fn()
+    notificationsViewPage.render({ filter: 'match_reminder', onFilterChange })
+    // These notifications exist, they just aren't in this category: the way out
+    // is the filter, not a new match.
+    expect(notificationsViewPage.queryShowAll()).toBeInTheDocument()
+    expect(notificationsViewPage.queryLogMatchLink()).not.toBeInTheDocument()
+
+    await notificationsViewPage.clickShowAll()
+    expect(onFilterChange).toHaveBeenCalledWith('all')
+  })
+
+  it('offers a next action when the inbox is empty (#901)', async () => {
+    notificationsViewPage.renderEmptyInbox()
+    await notificationsViewPage.findEmptyState()
+
+    expect(notificationsViewPage.queryLogMatchLink()).toHaveAttribute(
+      'href',
+      '/matches/new',
+    )
+    expect(notificationsViewPage.queryShowAll()).not.toBeInTheDocument()
+  })
+
   it('reports the unread count', () => {
     notificationsViewPage.render({ unreadCount: 4 })
     expect(notificationsViewPage.queryUnreadBadge()).toHaveTextContent('4 unread')

--- a/web-client/src/components/notifications/notifications-page/notifications-view.test.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.test.tsx
@@ -75,26 +75,25 @@ describe('NotificationsView', () => {
     expect(notificationsViewPage.queryEmptyState()).toBeInTheDocument()
   })
 
-  it('offers to clear the filter — not to go play — when a filter matches nothing (#901)', async () => {
+  // What only the *view* knows is which empty it is looking at. The CTAs
+  // themselves are `NotificationsEmpty`'s contract, tested there.
+  it('reads a filter that matches nothing as filter-empty, and wires Show all (#901)', async () => {
     const onFilterChange = vi.fn()
     notificationsViewPage.render({ filter: 'match_reminder', onFilterChange })
     // These notifications exist, they just aren't in this category: the way out
     // is the filter, not a new match.
     expect(notificationsViewPage.queryShowAll()).toBeInTheDocument()
-    expect(notificationsViewPage.queryLogMatchLink()).not.toBeInTheDocument()
+    expect(notificationsViewPage.queryGoPlayCopy()).not.toBeInTheDocument()
 
     await notificationsViewPage.clickShowAll()
     expect(onFilterChange).toHaveBeenCalledWith('all')
   })
 
-  it('offers a next action when the inbox is empty (#901)', async () => {
+  it('reads a feed with no items at all as inbox-empty (#901)', async () => {
     notificationsViewPage.renderEmptyInbox()
-    await notificationsViewPage.findEmptyState()
+    await notificationsViewPage.findHeadline()
 
-    expect(notificationsViewPage.queryLogMatchLink()).toHaveAttribute(
-      'href',
-      '/matches/new',
-    )
+    expect(notificationsViewPage.queryLogMatchLink()).toBeInTheDocument()
     expect(notificationsViewPage.queryShowAll()).not.toBeInTheDocument()
   })
 

--- a/web-client/src/components/notifications/notifications-page/notifications-view.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.tsx
@@ -68,6 +68,7 @@ export function NotificationsView({
   // opposite next actions — see `NotificationsEmpty` (#901). A filter can only
   // come up empty while it is narrowing something, so `filter-empty` always has
   // a filter worth clearing.
+  const filterLabel = filters.find((f) => f.key === filter)?.label ?? 'this filter'
   const emptyState: NotificationsEmptyState | null =
     shown.length > 0
       ? null
@@ -75,8 +76,8 @@ export function NotificationsView({
         ? { kind: 'inbox-empty' }
         : {
             kind: 'filter-empty',
-            filterLabel:
-              filters.find((f) => f.key === filter)?.label ?? 'this filter',
+            filterLabel,
+            onShowAll: () => onFilterChange('all'),
           }
 
   return (
@@ -129,10 +130,7 @@ export function NotificationsView({
 
       <div className="overflow-hidden rounded-[14px] border border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)]">
         {emptyState ? (
-          <NotificationsEmpty
-            state={emptyState}
-            onShowAll={() => onFilterChange('all')}
-          />
+          <NotificationsEmpty state={emptyState} />
         ) : (
           <ul>
             {shown.map((item, i) => (

--- a/web-client/src/components/notifications/notifications-page/notifications-view.tsx
+++ b/web-client/src/components/notifications/notifications-page/notifications-view.tsx
@@ -1,4 +1,3 @@
-import { Inbox } from 'lucide-react'
 import type {
   NotificationItem,
   NotificationTaxonomy,
@@ -6,6 +5,10 @@ import type {
 import { cn } from '@/lib/utils'
 import type { NotificationCategory } from '../notification-meta'
 import { NotificationRow } from '../notification-row'
+import {
+  NotificationsEmpty,
+  type NotificationsEmptyState,
+} from './notifications-empty'
 
 export type NotificationFilter = 'all' | 'unread' | NotificationCategory
 
@@ -61,6 +64,20 @@ export function NotificationsView({
     { key: 'unread', label: 'Unread' },
     ...categoryTypes.map((type) => ({ key: type.key, label: type.short })),
   ]
+  // An empty *list* is two different situations wearing one face, and they want
+  // opposite next actions — see `NotificationsEmpty` (#901). A filter can only
+  // come up empty while it is narrowing something, so `filter-empty` always has
+  // a filter worth clearing.
+  const emptyState: NotificationsEmptyState | null =
+    shown.length > 0
+      ? null
+      : items.length === 0
+        ? { kind: 'inbox-empty' }
+        : {
+            kind: 'filter-empty',
+            filterLabel:
+              filters.find((f) => f.key === filter)?.label ?? 'this filter',
+          }
 
   return (
     <div className="mx-auto max-w-[760px] px-6 pt-9 pb-20">
@@ -111,18 +128,11 @@ export function NotificationsView({
       </div>
 
       <div className="overflow-hidden rounded-[14px] border border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)]">
-        {shown.length === 0 ? (
-          <div className="px-5 py-14 text-center">
-            <span className="mb-3.5 inline-flex size-14 items-center justify-center rounded-full bg-[color:var(--bg-card)] text-[color:var(--fg-muted)]">
-              <Inbox size={26} />
-            </span>
-            <p className="text-base font-semibold text-[color:var(--fg-2)]">
-              All caught up.
-            </p>
-            <p className="mt-1 text-[13px] text-[color:var(--fg-3)]">
-              Nothing here. Go play.
-            </p>
-          </div>
+        {emptyState ? (
+          <NotificationsEmpty
+            state={emptyState}
+            onShowAll={() => onFilterChange('all')}
+          />
         ) : (
           <ul>
             {shown.map((item, i) => (


### PR DESCRIPTION
## Summary

The `/notifications` empty state said `All caught up.` / `Nothing here. Go play.` and offered **no next action** (#901).

The single empty branch was actually two situations wearing one face, and they want *opposite* next actions. Naively bolting a "Log a match" CTA onto the existing branch would also surface it when a **filter** matches nothing — telling a user who *does* have notifications to go play. So the branch is now a sum type:

| State | Copy | Action |
| --- | --- | --- |
| `inbox-empty` (no notifications at all) | "All caught up." / "Nothing here. Go play." | **Log a match** → `/matches/new`, **Notification preferences** → `/notifications/settings` |
| `filter-empty` (items exist, none match the filter) | "All caught up." / "Nothing under _Unread_." | **Show all notifications** → clears the filter |

Extracted to its own quartet (`notifications-empty.{tsx,page.tsx,factory.tsx,test.tsx}`). `NotificationsView` stays pure — it computes the state and passes it down. `onShowAll` rides on the `filter-empty` arm of the sum, so an empty inbox cannot be handed a filter-clearing callback that nothing can reach.

Notes:
- **"All caught up." stays the shared headline**, so the notification-bell dropdown (which shares the copy but is out of scope for this issue) is untouched, along with its assertions.
- Only `inbox-empty` renders typed `<Link>`s, so only its tests need the shared `renderWithRoutes` harness; `filter-empty` is a plain button and the existing view tests stay router-free.
- No API change; no new copy in the seed data.

## Reviewed and deliberately not done

`/simplify` ran four cleanup agents over the diff. Applied: composing the child page object into the parent (the CTA name was written four times), folding `onShowAll` into the sum, hoisting the duplicated chrome and the `filterLabel` lookup. Three findings were **skipped on purpose**, flagged here so a reviewer doesn't have to ask:

- **Not reusing `tournaments/empty-state.tsx`.** It exists and has an `action` slot, but it's a *dashed-border card with its own `--bg-card` background* — the notifications empty state renders **inside** the panel's own bordered `--bg-panel` container, and uses a circular icon chip it doesn't have. Adopting it is a visual change plus a new `variant` prop on a component with 11 call sites. The repo actually has **three** unrelated `EmptyState` implementations (`tournaments/`, `rbac/primitives.tsx`, a file-local one in `match-list-table.tsx`) and none is in `src/components/ui/` — unifying them is a real ticket, but not this one.
- **Not teaching `src/test/router.tsx` to rerender.** `renderWithRoutes` can't re-render with new props (the host route closes over `ui`), which is why the view's page object needs a separate `renderEmptyInbox` rather than always mounting a router. That's a genuine gap in shared test infra used by 13 page objects — worth fixing, out of scope here.
- **Not sharing this component with the bell dropdown.** Its empty branch is byte-identical and always the `inbox-empty` case, so it could reuse this — but it already has a "See all notifications" footer, so it isn't the dead end the page was, and #901 scoped it out.

Efficiency review found nothing: the `emptyState` ternary short-circuits (no allocation when the list is non-empty) and memoizing at this list size would be premature.

## Test plan

- [x] `tsc --noEmit` / `npm run build` (`tsc -b && vite build`) — clean. This also proves the `<Link to>` targets are real routes: TanStack types links against the generated route tree, so a bad path wouldn't compile.
- [x] `vitest run` — **238 files / 1894 tests passed**, including 8 new cases: both CTAs' `href`s in the empty inbox, filter-empty naming the filter and *not* saying "go play", "Show all" firing `onFilterChange('all')`, and each state not offering the other's action.
- [x] `npm run lint` — 0 errors (1 pre-existing warning in `public/mockServiceWorker.js`, untouched).
- [x] `npm run test:e2e` (web-client Playwright) — **177 passed**.
- n/a API / iOS / OpenAPI regen — the diff touches only `web-client/src/components/notifications/`.

Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmQza439NcGgP6Wmk55uzw