### PR TITLE
Restyle the player details page to the mockup (hero especially)

### DIFF
--- a/web-client/src/components/players/player-match-history.css
+++ b/web-client/src/components/players/player-match-history.css
@@ -13,6 +13,21 @@
   overflow: hidden;
 }
 
+/* The content column. The profile centres and pads itself at its root (see
+ * `.player-profile--overview`, player-profile.css), so the shared
+ * `.player-profile__body` no longer carries the column for both surfaces — the
+ * pane asks for it here, by its own name. Stated positively and in its own
+ * stylesheet on purpose: as a `:not(--overview)` over in the profile's file, this
+ * page's gutter would be defined by the *absence* of another page's modifier,
+ * and renaming that modifier would silently send this page edge-to-edge. */
+@media (min-width: 960px) {
+  .player-profile--pane .player-profile__body {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 24px clamp(20px, 4vw, 40px) 48px;
+  }
+}
+
 .player-history__header {
   display: flex;
   flex-direction: column;

--- a/web-client/src/components/players/player-match-history.css
+++ b/web-client/src/components/players/player-match-history.css
@@ -1,7 +1,7 @@
 /* Full match-history surface (`/players/$userId/matches`). It wears the same
  * `.player-profile` root class as the profile — which is what supplies the
- * table, chip and pagination-footer styles — and swaps the profile's tall
- * Bebas hero for this compact header. */
+ * table, chip and pagination-footer styles — and swaps the profile's hero card
+ * for this compact header. */
 
 /* The fixed-height pane. This page — a long table under a pinned pagination
  * footer — is the surface that actually wants it, so it now asks for it by name

--- a/web-client/src/components/players/player-profile.css
+++ b/web-client/src/components/players/player-profile.css
@@ -191,31 +191,44 @@
 /* The Δ from the player's most recent rated match. Rendered only when there IS
  * one — a player with no rating history gets no chip, never a "+0".
  *
- * A soft-tinted pill, no outline — it rides beside the rating, and a hard border
- * at this size competes with the number it is annotating. Recent-matches rows
- * reuse the class for their Δ column and strip the pill back off (below): in a
- * dense table a run of pills is stripes, not data. */
+ * The base class is the *figure*: a mono, tabular, win/loss-coloured number, which
+ * is all the Recent-matches column wants. The hero's pill chrome is added below. */
 .player-profile__delta {
   display: inline-flex;
   align-items: center;
-  height: 26px;
-  padding: 0 10px;
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.02em;
-  border-radius: 999px;
-  margin-bottom: 7px;
 }
 
 .player-profile__delta--win {
   color: var(--serve-500);
-  background: color-mix(in srgb, var(--win) 14%, transparent);
 }
 
 .player-profile__delta--loss {
   color: var(--loss);
+}
+
+/* The pill chrome belongs to the *hero's* Δ alone. It used to live on the base
+ * class, which meant the Recent-matches column — the class's only other use —
+ * had to unset five declarations to get its figure back; a run of tinted pills
+ * down a dense column reads as stripes, and the row already says won/lost on its
+ * status dot. Styling the one place that wants the pill beats styling both and
+ * undoing one. */
+.player-profile__rating-row .player-profile__delta {
+  height: 26px;
+  padding: 0 10px;
+  border-radius: 999px;
+  margin-bottom: 7px;
+}
+
+.player-profile__rating-row .player-profile__delta--win {
+  background: color-mix(in srgb, var(--win) 14%, transparent);
+}
+
+.player-profile__rating-row .player-profile__delta--loss {
   background: color-mix(in srgb, var(--loss) 14%, transparent);
 }
 
@@ -374,7 +387,6 @@
 
 .player-profile__form-chip--skeleton {
   background: var(--bg-raised);
-  border-color: var(--bg-raised);
   animation: player-profile-shimmer 1.4s ease-in-out infinite;
 }
 
@@ -459,7 +471,8 @@
  * on row 2 — the price of sharing row 1 with career, and the reason the two
  * columns start on the same line at all.
  *
- * The hero above stays full-bleed; it is the body that is centred and capped. */
+ * The hero is a card in this same column now — `--overview` centres and caps the
+ * whole page, hero included — so the body no longer does the centring alone. */
 /* Stacked (phone): the cards are separate surfaces now, so they are separated by
  * a gap rather than by a rule under each. */
 .player-profile--overview .player-profile__body {
@@ -477,15 +490,6 @@
     grid-template-rows: repeat(4, auto);
     gap: 20px;
     align-items: start;
-  }
-
-  /* The overview centres and pads itself at the root (`--overview`, above), so
-   * the body must not do it a second time. The full-history route has no such
-   * root rule and still wants the column here. */
-  .player-profile:not(.player-profile--overview) .player-profile__body {
-    max-width: 1240px;
-    margin: 0 auto;
-    padding: 24px clamp(20px, 4vw, 40px) 48px;
   }
 
   /* A grid item is not a flex item: the `flex: 1` / `flex: 0 0 auto` the cards
@@ -549,6 +553,10 @@
  * `border-bottom`, the `:last-child` exception) is gone with it: separate
  * surfaces are separated by the gap. */
 .player-profile--overview .player-profile__section {
+  /* The gutter the card's inner blocks read (`--card-pad`). Tertiary cards
+   * override it below; the blocks themselves never spell a number. */
+  --card-pad: 26px;
+
   background: var(--bg-card);
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-lg);
@@ -559,31 +567,12 @@
 .player-profile--overview .confidence-card,
 .player-profile--overview .leagues-card,
 .player-profile--overview .head-to-head {
+  --card-pad: 20px;
+
   background: var(--bg-panel);
   border-radius: var(--r-md);
   box-shadow: none;
   padding-bottom: 20px;
-}
-
-/* The cards supply their own padding now, so the inner blocks that used to hold
- * the page gutter (`clamp(20px, 5vw, 40px)`, which on a desktop was 40px *inside
- * a 1fr card*) shed it. */
-.player-profile--overview .career-card__body,
-.player-profile--overview .rating-chart__summary,
-.player-profile--overview .rating-chart__plot,
-.player-profile--overview .rating-chart__unrated,
-.player-profile--overview .rating-chart__error,
-.player-profile--overview .recent-matches__empty,
-.player-profile--overview .recent-matches__skeleton {
-  padding-left: 26px;
-  padding-right: 26px;
-}
-
-.player-profile--overview .confidence-card__body,
-.player-profile--overview .head-to-head__body,
-.player-profile--overview .leagues-card__rows {
-  padding-left: 20px;
-  padding-right: 20px;
 }
 
 .player-profile__section-header {
@@ -937,14 +926,14 @@
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--fg-3);
-  padding: 12px clamp(20px, 5vw, 40px);
+  padding: 12px 10px;
   border-bottom: 1px solid var(--border-subtle);
   white-space: nowrap;
   user-select: none;
 }
 
 .recent-matches__table tbody td {
-  padding: 12px clamp(20px, 5vw, 40px);
+  padding: 12px 10px;
   border-bottom: 1px solid var(--border-subtle);
   font-size: 14px;
   color: var(--fg-1);
@@ -1075,43 +1064,25 @@
  *
  * Opponent leads; Score, Δ and When are figures and are read up their right-hand
  * edge, so they are right-aligned and the eye can run down them. */
-.player-profile--overview .recent-matches__table thead th,
-.player-profile--overview .recent-matches__table tbody td {
-  padding: 12px 10px;
+.recent-matches__table :is(th, td):first-child {
+  padding-left: var(--card-pad);
 }
 
-.player-profile--overview .recent-matches__table thead th:first-child,
-.player-profile--overview .recent-matches__table tbody td:first-child {
-  padding-left: 26px;
+.recent-matches__table :is(th, td):last-child {
+  padding-right: var(--card-pad);
 }
 
-.player-profile--overview .recent-matches__table thead th:last-child,
-.player-profile--overview .recent-matches__table tbody td:last-child {
-  padding-right: 26px;
-}
-
-.player-profile--overview .recent-matches__table thead th:not(:first-child),
-.player-profile--overview .recent-matches__table tbody td:not(:first-child) {
+.recent-matches__table :is(th, td):not(:first-child) {
   text-align: right;
 }
 
-/* A run of tinted pills down a dense column reads as stripes; the row already
- * says won/lost on its status dot, so the Δ is left as a coloured figure. */
-.player-profile--overview .recent-matches__row .player-profile__delta {
-  height: auto;
-  padding: 0;
-  margin-bottom: 0;
-  background: none;
-  border-radius: 0;
-}
-
 /* The card's border is the line under the last row. */
-.player-profile--overview .recent-matches__table tbody tr:last-child td {
+.recent-matches__table tbody tr:last-child td {
   border-bottom: none;
 }
 
 .recent-matches__empty {
-  padding: 40px clamp(20px, 5vw, 40px);
+  padding: 40px var(--card-pad);
   text-align: center;
   font-size: 14px;
   font-weight: 600;
@@ -1122,7 +1093,7 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
-  padding: 0 clamp(20px, 5vw, 40px);
+  padding: 0 var(--card-pad);
 }
 
 .recent-matches__skeleton-row {
@@ -1159,7 +1130,7 @@
 /* The ring and the figures share a row; the tiles take the full width beneath
  * it. */
 .career-card__body {
-  padding: 0 clamp(20px, 5vw, 40px);
+  padding: 0 var(--card-pad);
 }
 
 .career-card__headline {
@@ -1357,7 +1328,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 10px;
-  padding: 0 clamp(20px, 5vw, 40px);
+  padding: 0 var(--card-pad);
 }
 
 /* The status dot + the level, in words. */
@@ -1503,7 +1474,7 @@
 .leagues-card__rows {
   display: flex;
   flex-direction: column;
-  padding: 0 clamp(20px, 5vw, 40px);
+  padding: 0 var(--card-pad);
   margin: 0;
   list-style: none;
 }
@@ -1523,7 +1494,6 @@
    * full-width band, not an inset chip. */
   padding: 10px 8px;
   margin: 0 -8px;
-  width: calc(100% + 16px);
   border-radius: var(--r-sm);
   color: var(--fg-1);
   text-decoration: none;
@@ -1604,10 +1574,15 @@
   padding-left: 4px;
 }
 
+/* The skeleton row used to borrow its fill from `.leagues-card__row`'s
+ * `background`, which went away when the rows were flattened into hairlines —
+ * leaving a shimmer over nothing. It carries its own fill now, and is sized to
+ * the real row (37px) rather than to the boxed one it used to stand in for. */
 .leagues-card__row--skeleton {
   display: block;
-  height: 45px;
-  border-color: transparent;
+  height: 37px;
+  background: var(--bg-raised);
+  border-radius: var(--r-sm);
   animation: player-profile-shimmer 1.4s ease-in-out infinite;
 }
 
@@ -1625,7 +1600,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  padding: 0 clamp(20px, 5vw, 40px);
+  padding: 0 var(--card-pad);
 }
 
 /* ----- You vs them: the lead ----- */
@@ -1753,37 +1728,16 @@
   padding: 0;
 }
 
+/* A name is user-supplied and can be far longer than the phone is wide. It
+ * shrinks to the 120px floor — which still lines the bars up for the ordinary
+ * short name — and ellipsises rather than pushing the profile sideways (the same
+ * class of bug as the un-wrapped matches table above). */
 .head-to-head__opponent {
   grid-column: 1;
   grid-row: 1;
-}
-
-.head-to-head__record {
-  grid-column: 2;
-  grid-row: 1;
-}
-
-.head-to-head__meetings {
-  grid-column: 3;
-  grid-row: 1;
-}
-
-.head-to-head__bar {
-  grid-column: 1 / -1;
-  grid-row: 2;
-}
-
-/* `flex: 0 1 auto`, not `0 0 auto`: a name is user-supplied and can be far longer
- * than the phone is wide, and a row that refuses to shrink around it pushes the
- * whole page sideways (the same class of bug as the un-wrapped matches table
- * above). It shrinks to the 120px floor — which still lines the bars up for the
- * ordinary short name — and the name itself ellipsises rather than the profile
- * scrolling. */
-.head-to-head__opponent {
   font-size: 14px;
   font-weight: 600;
   color: var(--fg-1);
-  flex: 0 1 auto;
   min-width: 120px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1793,6 +1747,8 @@
 /* The record said again, geometrically: how much of this rivalry the player has
  * won. Decorative — the record beside it is what a screen reader reads. */
 .head-to-head__bar {
+  grid-column: 1 / -1;
+  grid-row: 2;
   height: 4px;
   border-radius: 999px;
   background: var(--ink-700);
@@ -1810,6 +1766,8 @@
 }
 
 .head-to-head__record {
+  grid-column: 2;
+  grid-row: 1;
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
   font-size: 13px;
@@ -1818,6 +1776,8 @@
 }
 
 .head-to-head__meetings {
+  grid-column: 3;
+  grid-row: 1;
   font-size: 12px;
   color: var(--fg-3);
   white-space: nowrap;
@@ -1928,7 +1888,7 @@
 }
 
 .rating-chart__summary {
-  padding: 0 clamp(20px, 5vw, 40px);
+  padding: 0 var(--card-pad);
   margin: 0 0 10px;
   font-size: 13px;
   line-height: 1.5;
@@ -1937,7 +1897,7 @@
 }
 
 .rating-chart__plot {
-  padding: 0 clamp(20px, 5vw, 40px);
+  padding: 0 var(--card-pad);
 }
 
 .rating-chart__canvas {
@@ -2052,7 +2012,7 @@
 /* No rating, no chart (CONTEXT.md, "Rating"): the slot says what would end that,
  * rather than drawing an axis with nothing on it. */
 .rating-chart__unrated {
-  padding: 8px clamp(20px, 5vw, 40px) 4px;
+  padding: 8px var(--card-pad) 4px;
 }
 
 /* No `…__unrated-title` rule, and no element for one: the panel is deliberately a

--- a/web-client/src/components/players/player-profile.css
+++ b/web-client/src/components/players/player-profile.css
@@ -3,6 +3,26 @@
  * (match-list-page, dashboard) so it sits naturally inside the AppShell. */
 
 .player-profile {
+  /* The radius/shadow scale is declared per *surface* in this codebase — the
+   * shared `.fortymm-theme` block (index.css) carries the colour ramps and
+   * `--shadow-lg`/`--shadow-glow`, but not these. `.match-details`,
+   * `.fortymm-landing`, `.simulator` and the settings page each declare the same
+   * scale over themselves; the profile is the surface that was consuming
+   * `var(--r-lg)` and `var(--shadow-sm)` without ever declaring them, so every
+   * card below computed to `radius: 0` and inherited Tailwind's much weaker
+   * `--shadow-sm` instead of the house one. (Worth hoisting all five copies into
+   * `.fortymm-theme` one day — the login and RBAC surfaces have the same latent
+   * hole — but that restyles pages this branch has no business touching.) */
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+
+  /* The specular highlight on the hero ball — a tint above `--ball-400` that the
+   * shared ramp has no token for. Declared here so the hero's gradient and its
+   * glow spell it once (`profile-hero-display.tsx` reads it from this scope). */
+  --ball-highlight: #ffb57a;
+
   display: flex;
   flex-direction: column;
   background: var(--bg-app);
@@ -39,6 +59,7 @@
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-lg);
   background: var(--bg-card);
+  box-shadow: var(--shadow-sm);
 }
 
 /* Identity on the left, standing on the right. Each half is its own
@@ -190,12 +211,12 @@
 
 .player-profile__delta--win {
   color: var(--serve-500);
-  background: var(--bg-live-soft);
+  background: color-mix(in srgb, var(--win) 14%, transparent);
 }
 
 .player-profile__delta--loss {
   color: var(--loss);
-  background: rgba(255, 77, 109, 0.14);
+  background: color-mix(in srgb, var(--loss) 14%, transparent);
 }
 
 /* Rank ("#3 of 42"), peak, percentile. Only the lines the player actually has —
@@ -273,12 +294,12 @@
 
 .player-profile__form-chip--w {
   color: var(--serve-500);
-  background: var(--bg-live-soft);
+  background: color-mix(in srgb, var(--win) 14%, transparent);
 }
 
 .player-profile__form-chip--l {
   color: var(--loss);
-  background: rgba(255, 77, 109, 0.14);
+  background: color-mix(in srgb, var(--loss) 14%, transparent);
 }
 
 /* The rating is the largest thing on the page and needs no chrome to say so.
@@ -1039,6 +1060,13 @@
   color: var(--fg-1);
 }
 
+/* It reads as a button now, so it needs a button's focus ring — as a bare text
+ * link the browser's default outline was enough. Matches `.leagues-card__row`. */
+.recent-matches__view-all:focus-visible {
+  outline: 2px solid var(--ball-500);
+  outline-offset: 2px;
+}
+
 /* ----- The table, inside a card -----
  * The cells used to carry the page gutter (up to 40px a side) because the table
  * was full-bleed. Inside a card they carry a column gutter instead, and only the
@@ -1778,7 +1806,7 @@
   display: block;
   height: 100%;
   border-radius: 999px;
-  background: rgba(0, 226, 154, 0.55);
+  background: color-mix(in srgb, var(--serve-500) 55%, transparent);
 }
 
 .head-to-head__record {

--- a/web-client/src/components/players/player-profile.css
+++ b/web-client/src/components/players/player-profile.css
@@ -1611,9 +1611,10 @@
  * chose, which on a phone can be longer than the line. `anywhere` lets it break
  * mid-token rather than run off the side of the card. */
 .head-to-head__versus-line {
-  font-family: var(--font-display);
-  font-size: 20px;
-  line-height: 1.3;
+  font-family: var(--font-ui);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.35;
   color: var(--fg-1);
   overflow-wrap: anywhere;
 }

--- a/web-client/src/components/players/player-profile.css
+++ b/web-client/src/components/players/player-profile.css
@@ -16,24 +16,29 @@
    * `.player-profile--pane` (player-match-history.css). */
 }
 
+/* ============ The overview's content column ============ */
+/* The profile is centred and capped as a whole — hero included. It used to be a
+ * full-bleed banner over a centred body, which is why the hero's tone had to
+ * carry the page on its own (a dot-grid and an orange wash); as a card in the
+ * column it is one surface among six and needs none of that. */
+.player-profile--overview {
+  width: 100%;
+  box-sizing: border-box;
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 28px clamp(16px, 4vw, 40px) 56px;
+}
+
 /* ============ Hero ============ */
+/* A card, like everything else on the page — no gradient, no dot-grid, no
+ * full-bleed rule under it. */
 .player-profile__hero {
   position: relative;
-  padding: 40px clamp(20px, 5vw, 40px) 32px;
-  border-bottom: 1px solid var(--border-subtle);
-  overflow: hidden;
-  background:
-    radial-gradient(
-      circle at 18% 40%,
-      rgba(255, 122, 26, 0.16) 0%,
-      rgba(255, 122, 26, 0) 45%
-    ),
-    radial-gradient(
-      circle at center,
-      rgba(255, 122, 26, 0.12) 1.5px,
-      transparent 2px
-    );
-  background-size: auto, 40px 40px;
+  padding: 24px 28px;
+  margin-bottom: 20px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-lg);
+  background: var(--bg-card);
 }
 
 /* Identity on the left, standing on the right. Each half is its own
@@ -55,21 +60,8 @@
 .player-profile__identity {
   display: flex;
   align-items: center;
-  gap: clamp(16px, 3vw, 24px);
+  gap: 22px;
   min-width: 0;
-}
-
-.player-profile__avatar-ring {
-  position: relative;
-  flex: none;
-}
-
-.player-profile__avatar-dashed {
-  position: absolute;
-  inset: -6px;
-  border-radius: 50%;
-  border: 1px dashed rgba(255, 122, 26, 0.4);
-  pointer-events: none;
 }
 
 .player-profile__name-wrap {
@@ -87,76 +79,133 @@
   margin-bottom: 6px;
 }
 
+/* The name is set in the UI face, not the Bebas display one: at 40px next to a
+ * mono rating it is a *name*, not a scoreboard moment, and shouting a username
+ * in caps mangles the ones that carry their own casing. */
 .player-profile__name {
-  font-family: var(--font-display);
-  font-size: clamp(40px, 7vw, 64px);
+  font-family: var(--font-ui);
+  font-size: clamp(28px, 3.4vw, 40px);
+  font-weight: 700;
   line-height: 1;
-  letter-spacing: 0.02em;
+  letter-spacing: -0.02em;
   color: var(--fg-1);
-  text-transform: uppercase;
   margin: 0;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .player-profile__name-dot {
   color: var(--ball-500);
 }
 
+/* "Player · Member since Mar 2024" — the line that used to be an overline above
+ * the name and a lone member-since line below it. */
+.player-profile__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 9px;
+  margin: 11px 0 0;
+  font-size: 13px;
+  color: var(--fg-3);
+}
+
+.player-profile__meta-sep {
+  color: var(--ink-500);
+}
+
+/* Wrapped, the row leaves its separator dangling at the end of the first line
+ * ("Player ·"). Narrow enough to wrap is narrow enough to stack, and a stack
+ * needs no separators. */
+@media (max-width: 480px) {
+  .player-profile__meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+
+  .player-profile__meta-sep {
+    display: none;
+  }
+}
+
 /* ============ Standing (rating · Δ · rank · peak · form) ============ */
+/* The right-hand half of the hero card, fenced off by a hairline rather than by
+ * distance — it is a second subject (where they *stand*), not a continuation of
+ * the first (who they *are*). */
 .player-profile__standing {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  gap: 10px;
+  align-items: flex-start;
+  gap: 0;
+  min-width: 224px;
+  padding-left: 28px;
+  border-left: 1px solid var(--border-subtle);
 }
 
+/* The divider is the seam between two grid columns; with one column there is no
+ * seam, and a rule up the left of the block would just be a stray line. */
 @media (max-width: 720px) {
   .player-profile__standing {
-    align-items: flex-start;
+    padding-left: 0;
+    padding-top: 20px;
+    border-left: none;
+    border-top: 1px solid var(--border-subtle);
   }
 }
 
 .player-profile__standing > .player-profile__overline {
   margin-bottom: 0;
+  font-size: 11px;
 }
 
+/* Baseline-ish: the Δ pill sits on the rating's baseline rather than centred on
+ * a 56px number, which would float it halfway up the digits. */
 .player-profile__rating-row {
   display: flex;
-  align-items: center;
-  gap: 10px;
+  align-items: flex-end;
+  gap: 12px;
+  margin-top: 4px;
 }
 
 /* The Δ from the player's most recent rated match. Rendered only when there IS
- * one — a player with no rating history gets no chip, never a "+0". */
+ * one — a player with no rating history gets no chip, never a "+0".
+ *
+ * A soft-tinted pill, no outline — it rides beside the rating, and a hard border
+ * at this size competes with the number it is annotating. Recent-matches rows
+ * reuse the class for their Δ column and strip the pill back off (below): in a
+ * dense table a run of pills is stripes, not data. */
 .player-profile__delta {
+  display: inline-flex;
+  align-items: center;
+  height: 26px;
+  padding: 0 10px;
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
   letter-spacing: 0.02em;
-  padding: 4px 10px;
   border-radius: 999px;
-  border: 1px solid transparent;
+  margin-bottom: 7px;
 }
 
 .player-profile__delta--win {
   color: var(--serve-500);
-  background: rgba(0, 226, 154, 0.12);
-  border-color: rgba(0, 226, 154, 0.4);
+  background: var(--bg-live-soft);
 }
 
 .player-profile__delta--loss {
   color: var(--loss);
-  background: rgba(255, 77, 109, 0.1);
-  border-color: rgba(255, 77, 109, 0.4);
+  background: rgba(255, 77, 109, 0.14);
 }
 
-/* Rank ("#3 of 42"), peak, percentile. Only the lines the player actually has. */
+/* Rank ("#3 of 42"), peak, percentile. Only the lines the player actually has —
+ * one quiet 12px line under the rating, not a row of stat blocks competing with
+ * it. */
 .player-profile__stats {
   display: flex;
   align-items: baseline;
-  gap: 18px;
-  margin: 0;
+  gap: 14px;
+  margin: 8px 0 0;
   flex-wrap: wrap;
 }
 
@@ -167,11 +216,11 @@
 }
 
 .player-profile__stat-k {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
   color: var(--fg-3);
 }
 
@@ -179,16 +228,34 @@
   margin: 0;
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   color: var(--fg-1);
+}
+
+/* The caption sits beside the chips, not over them: at ten chips the run is
+ * wider than it is tall, and a label above it would read as a section heading. */
+.player-profile__form-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.player-profile__form-label {
+  flex: none;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fg-3);
 }
 
 /* Ten results, newest first. (The /players roster shows five of the same wire
  * field — that slice lives there.) */
 .player-profile__form {
   display: inline-flex;
-  gap: 4px;
+  gap: 5px;
   flex-wrap: wrap;
 }
 
@@ -200,71 +267,59 @@
   height: 20px;
   border-radius: 5px;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 700;
-  border: 1px solid transparent;
 }
 
 .player-profile__form-chip--w {
   color: var(--serve-500);
-  background: rgba(0, 226, 154, 0.12);
-  border-color: rgba(0, 226, 154, 0.35);
+  background: var(--bg-live-soft);
 }
 
 .player-profile__form-chip--l {
   color: var(--loss);
-  background: rgba(255, 77, 109, 0.1);
-  border-color: rgba(255, 77, 109, 0.3);
+  background: rgba(255, 77, 109, 0.14);
 }
 
+/* The rating is the largest thing on the page and needs no chrome to say so.
+ * It reads in chalk, not ball-orange: orange is the page's *accent* (the name's
+ * dot, the chart's line, the selected league) and a 56px orange slab drowns
+ * every one of them. */
 .player-profile__hero-rating-chip {
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
-  font-size: clamp(32px, 5vw, 48px);
+  font-size: clamp(40px, 5vw, 56px);
   font-weight: 700;
-  color: var(--ball-500);
-  line-height: 1;
-  letter-spacing: 0.02em;
-  padding: 8px 22px 10px;
-  border-radius: 12px;
-  border: 1.5px solid var(--ball-500);
-  background: rgba(255, 122, 26, 0.06);
+  color: var(--fg-1);
+  line-height: 0.9;
+  letter-spacing: -0.01em;
 }
 
 /* A player who has never finished a rated match reads "Unrated" in the same
- * slot — a word, not a number, so it wears the muted tone rather than the
- * ball-orange rating chrome. */
+ * slot — a word, not a number, so it drops to the muted tone and a text size. */
 .player-profile__hero-rating-chip--unrated {
   font-family: var(--font-ui);
-  font-size: clamp(18px, 2.5vw, 24px);
+  font-size: clamp(20px, 2.5vw, 26px);
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.02em;
+  line-height: 1.2;
   color: var(--fg-3);
-  border-color: var(--border-subtle);
-  background: transparent;
-}
-
-.player-profile__member-since {
-  margin: 10px 0 0;
-  font-family: var(--font-ui);
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--fg-2);
 }
 
 /* ----- Hero skeletons (loading state) ----- */
 .player-profile__hero-avatar-skeleton {
   display: block;
-  width: 120px;
-  height: 120px;
+  flex: none;
+  width: 82px;
+  height: 82px;
   border-radius: 50%;
   background: var(--bg-raised);
   animation: player-profile-shimmer 1.4s ease-in-out infinite;
 }
 
 .player-profile__hero-name-skeleton {
-  width: clamp(220px, 45vw, 420px);
-  height: clamp(40px, 7vw, 64px);
+  width: clamp(200px, 32vw, 300px);
+  height: clamp(28px, 3.4vw, 40px);
   border-radius: 6px;
   background: var(--bg-raised);
   animation: player-profile-shimmer 1.4s ease-in-out infinite;
@@ -272,18 +327,18 @@
 
 .player-profile__hero-sub-skeleton {
   width: 180px;
-  height: 14px;
+  height: 13px;
   border-radius: 4px;
-  margin-top: 14px;
+  margin-top: 13px;
   background: var(--bg-raised);
   animation: player-profile-shimmer 1.4s ease-in-out infinite;
 }
 
 .player-profile__hero-rating-chip--skeleton {
-  width: 96px;
-  height: 56px;
+  width: 112px;
+  height: 48px;
+  border-radius: 8px;
   background: var(--bg-raised);
-  border-color: var(--bg-raised);
   animation: player-profile-shimmer 1.4s ease-in-out infinite;
 }
 
@@ -384,6 +439,12 @@
  * columns start on the same line at all.
  *
  * The hero above stays full-bleed; it is the body that is centred and capped. */
+/* Stacked (phone): the cards are separate surfaces now, so they are separated by
+ * a gap rather than by a rule under each. */
+.player-profile--overview .player-profile__body {
+  gap: 20px;
+}
+
 @media (min-width: 960px) {
   .player-profile__body {
     display: grid;
@@ -395,9 +456,12 @@
     grid-template-rows: repeat(4, auto);
     gap: 20px;
     align-items: start;
-    /* `box-sizing: border-box` is inherited from the base rule and must stay: the
-     * body is `width: 100%`, so a content-box here would add the page padding on
-     * top of that 100% and push the narrow column off the right edge. */
+  }
+
+  /* The overview centres and pads itself at the root (`--overview`, above), so
+   * the body must not do it a second time. The full-history route has no such
+   * root rule and still wants the column here. */
+  .player-profile:not(.player-profile--overview) .player-profile__body {
     max-width: 1240px;
     margin: 0 auto;
     padding: 24px clamp(20px, 4vw, 40px) 48px;
@@ -408,15 +472,6 @@
    * content. */
   .player-profile__body > .player-profile__section {
     min-width: 0;
-  }
-
-  /* The stacked layout separates the cards with a rule under each. In a gapped
-   * grid that rule reads as a line floating in whitespace, so the cards are
-   * separated by the gap alone — including the bottom one, which the stacked
-   * layout special-cases. */
-  .player-profile__body > .player-profile__section,
-  .player-profile__body > .recent-matches {
-    border-bottom: none;
   }
 
   /* ----- The wide, primary column ----- */
@@ -457,12 +512,90 @@
   }
 }
 
+/* ============ Card chrome (the overview only) ============ */
+/* Every section on the overview is a card. Two tiers, and the difference is the
+ * whole information hierarchy of the page:
+ *
+ * - **Primary** (rating chart, recent matches, career) — raised on `--bg-card`
+ *   with a shadow. They are what the page is *for*.
+ * - **Tertiary** (confidence, leagues, head-to-head) — recessed to `--bg-panel`,
+ *   a tighter radius and no shadow, so they read as supporting context sitting
+ *   *below* the surface rather than on it.
+ *
+ * Scoped to `--overview` because `.player-profile__section` is shared with the
+ * full-history route, whose one section is a full-bleed scrolling pane and must
+ * not become a card. Everything that was a rule *between* sections (each card's
+ * `border-bottom`, the `:last-child` exception) is gone with it: separate
+ * surfaces are separated by the gap. */
+.player-profile--overview .player-profile__section {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-sm);
+  padding-bottom: 22px;
+}
+
+.player-profile--overview .confidence-card,
+.player-profile--overview .leagues-card,
+.player-profile--overview .head-to-head {
+  background: var(--bg-panel);
+  border-radius: var(--r-md);
+  box-shadow: none;
+  padding-bottom: 20px;
+}
+
+/* The cards supply their own padding now, so the inner blocks that used to hold
+ * the page gutter (`clamp(20px, 5vw, 40px)`, which on a desktop was 40px *inside
+ * a 1fr card*) shed it. */
+.player-profile--overview .career-card__body,
+.player-profile--overview .rating-chart__summary,
+.player-profile--overview .rating-chart__plot,
+.player-profile--overview .rating-chart__unrated,
+.player-profile--overview .rating-chart__error,
+.player-profile--overview .recent-matches__empty,
+.player-profile--overview .recent-matches__skeleton {
+  padding-left: 26px;
+  padding-right: 26px;
+}
+
+.player-profile--overview .confidence-card__body,
+.player-profile--overview .head-to-head__body,
+.player-profile--overview .leagues-card__rows {
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
 .player-profile__section-header {
   display: flex;
   align-items: baseline;
   gap: 12px;
   padding: 20px clamp(20px, 5vw, 40px) 12px;
   flex: 0 0 auto;
+}
+
+.player-profile--overview .player-profile__section-header {
+  padding: 22px 26px 16px;
+}
+
+.player-profile--overview .confidence-card .player-profile__section-header,
+.player-profile--overview .leagues-card .player-profile__section-header,
+.player-profile--overview .head-to-head .player-profile__section-header {
+  padding: 18px 20px 14px;
+}
+
+/* The two primary cards are *titled*; the rest are *labelled*. A card carrying a
+ * chart or a table earns a real 18px heading — the tertiary cards keep the
+ * mono overline, which is what says "supporting stat" at a glance. Career is the
+ * hinge: primary in weight, but an overline, because its heading sits on a row
+ * with its own count. */
+.player-profile--overview .rating-chart .player-profile__section-title,
+.player-profile--overview .recent-matches .player-profile__section-title {
+  font-family: var(--font-ui);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  text-transform: none;
+  color: var(--fg-1);
 }
 
 /* Scrolls vertically inside the fixed-height .player-profile so the hero
@@ -533,24 +666,24 @@
   gap: 6px;
 }
 
+/* Softer than they were: inside a card, six outlined boxes per row across six
+ * rows is a wall of chrome, and the Score column is not the loudest thing on the
+ * card — the opponent is. Tint only, no outline. */
 .player-profile__game {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 4px 8px;
-  border-radius: 6px;
-  border: 1px solid transparent;
-  min-width: 34px;
+  padding: 3px 7px;
+  border-radius: 5px;
+  min-width: 30px;
 }
 
 .player-profile__game--won {
   background: rgba(0, 226, 154, 0.1);
-  border-color: rgba(0, 226, 154, 0.25);
 }
 
 .player-profile__game--lost {
-  background: rgba(255, 77, 109, 0.06);
-  border-color: rgba(255, 77, 109, 0.2);
+  background: rgba(255, 77, 109, 0.07);
 }
 
 .player-profile__game-mine {
@@ -740,7 +873,6 @@
  * the full-history route's scrolling pane is built on it.) */
 .recent-matches {
   flex: 0 0 auto;
-  border-bottom: 1px solid var(--border-subtle);
   /* Lets the card be NARROWER than the table inside it. A flex item's automatic
    * minimum size is its content's — `min-width: auto` — so without this the card
    * refuses to shrink below the table's min-content width, the scroll container
@@ -748,12 +880,6 @@
    * the page scrolls sideways instead of the table. This is the usual reason an
    * overflow wrapper "does nothing". */
   min-width: 0;
-}
-
-/* Whichever card the viewer-dependent order happens to leave at the bottom, the
- * page must not end on a rule hanging under the last one. */
-.player-profile__body > .player-profile__section:last-child {
-  border-bottom: none;
 }
 
 /* The table's own scroll container. Four `white-space: nowrap` columns are wider
@@ -887,23 +1013,73 @@
   font-style: italic;
 }
 
+/* The card's one action, and it reads as one: a full-width outlined button under
+ * the rows rather than a mono link tucked into the corner. */
 .recent-matches__view-all {
-  display: inline-flex;
+  display: flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
-  align-self: flex-start;
-  margin: 14px clamp(20px, 5vw, 40px);
-  font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
+  height: 38px;
+  margin: 16px 26px 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 500;
   color: var(--fg-2);
   text-decoration: none;
-  transition: color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition:
+    color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    background 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .recent-matches__view-all:hover {
-  color: var(--ball-500);
+  background: var(--bg-hover);
+  color: var(--fg-1);
+}
+
+/* ----- The table, inside a card -----
+ * The cells used to carry the page gutter (up to 40px a side) because the table
+ * was full-bleed. Inside a card they carry a column gutter instead, and only the
+ * outer edges reach for the card's own padding — so the four columns sit as a
+ * table rather than drifting apart across a 1fr column.
+ *
+ * Opponent leads; Score, Δ and When are figures and are read up their right-hand
+ * edge, so they are right-aligned and the eye can run down them. */
+.player-profile--overview .recent-matches__table thead th,
+.player-profile--overview .recent-matches__table tbody td {
+  padding: 12px 10px;
+}
+
+.player-profile--overview .recent-matches__table thead th:first-child,
+.player-profile--overview .recent-matches__table tbody td:first-child {
+  padding-left: 26px;
+}
+
+.player-profile--overview .recent-matches__table thead th:last-child,
+.player-profile--overview .recent-matches__table tbody td:last-child {
+  padding-right: 26px;
+}
+
+.player-profile--overview .recent-matches__table thead th:not(:first-child),
+.player-profile--overview .recent-matches__table tbody td:not(:first-child) {
+  text-align: right;
+}
+
+/* A run of tinted pills down a dense column reads as stripes; the row already
+ * says won/lost on its status dot, so the Δ is left as a coloured figure. */
+.player-profile--overview .recent-matches__row .player-profile__delta {
+  height: auto;
+  padding: 0;
+  margin-bottom: 0;
+  background: none;
+  border-radius: 0;
+}
+
+/* The card's border is the line under the last row. */
+.player-profile--overview .recent-matches__table tbody tr:last-child td {
+  border-bottom: none;
 }
 
 .recent-matches__empty {
@@ -946,19 +1122,22 @@
   /* Unlike the matches section, the card is content-sized — it must not stretch
    * to eat the page's spare height. */
   flex: 0 0 auto;
-  border-bottom: 1px solid var(--border-subtle);
-  padding-bottom: 24px;
 }
 
 .career-card__total {
   color: var(--fg-3);
 }
 
+/* The ring and the figures share a row; the tiles take the full width beneath
+ * it. */
 .career-card__body {
+  padding: 0 clamp(20px, 5vw, 40px);
+}
+
+.career-card__headline {
   display: flex;
   align-items: center;
-  gap: clamp(20px, 4vw, 36px);
-  padding: 0 clamp(20px, 5vw, 40px);
+  gap: 20px;
   flex-wrap: wrap;
 }
 
@@ -966,8 +1145,8 @@
 .career-card__ring {
   position: relative;
   flex: 0 0 auto;
-  width: 116px;
-  height: 116px;
+  width: 96px;
+  height: 96px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1002,11 +1181,13 @@
 /* The figure in the middle: "68.6%" — or "—" for a player who has decided
  * nothing. Never a "0%": that would say they lose every match they play. */
 .career-card__ring-figure {
-  font-family: var(--font-display);
-  font-size: 26px;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 21px;
+  font-weight: 700;
   line-height: 1;
   color: var(--fg-1);
-  letter-spacing: 0.01em;
+  letter-spacing: -0.01em;
 }
 
 .career-card__ring-caption {
@@ -1034,12 +1215,16 @@
   flex: 1;
 }
 
+/* "31 W · 16 L" — a record is a pair of figures, so it is set in mono beside the
+ * ring rather than shouted in Bebas. The ring is the card's display moment. */
 .career-card__record {
-  font-family: var(--font-display);
-  font-size: 28px;
-  line-height: 1;
-  color: var(--fg-1);
-  letter-spacing: 0.02em;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--fg-2);
+  letter-spacing: 0;
   margin: 0;
 }
 
@@ -1073,11 +1258,14 @@
   color: var(--fg-3);
 }
 
+/* Two tiles, two equal columns — under the ring row rather than beside the
+ * record, so they span the card instead of taking whatever width the record left
+ * over (which in the narrow column was not enough for two). */
 .career-card__tiles {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 10px;
-  flex-wrap: wrap;
-  margin-top: 4px;
+  margin-top: 18px;
 }
 
 .career-card__tile {
@@ -1134,8 +1322,6 @@
  * 0–100 anything — because that number does not exist. Don't add one. */
 .confidence-card {
   flex: 0 0 auto;
-  border-bottom: 1px solid var(--border-subtle);
-  padding-bottom: 24px;
 }
 
 .confidence-card__body {
@@ -1147,13 +1333,18 @@
 }
 
 /* The status dot + the level, in words. */
+/* "Settled" / "Firming up" / "Provisional" — a word about the reader's rating,
+ * not a scoreboard, so it is set in the UI face. In Bebas it came out as a
+ * shouted PROVISIONAL, which reads like a warning banner. */
 .confidence-card__level {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-family: var(--font-display);
-  font-size: 20px;
-  line-height: 1;
+  gap: 10px;
+  font-family: var(--font-ui);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.2;
+  margin: 0;
   color: var(--fg-1);
 }
 
@@ -1204,18 +1395,21 @@
 /* The Glicko-2 internals, collapsed: they are the machinery BEHIND confidence,
  * not names for it. */
 .confidence-card__drawer {
-  margin-top: 2px;
+  align-self: stretch;
+  margin-top: 6px;
+  padding-top: 14px;
+  border-top: 1px solid var(--ink-700);
   font-size: 12px;
   color: var(--fg-3);
 }
 
 .confidence-card__drawer-summary {
   cursor: pointer;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
   color: var(--fg-3);
 }
 
@@ -1276,14 +1470,11 @@
   /* Content-sized, like the Career card — it must not stretch to eat the page's
    * spare height. */
   flex: 0 0 auto;
-  border-bottom: 1px solid var(--border-subtle);
-  padding-bottom: 24px;
 }
 
 .leagues-card__rows {
   display: flex;
   flex-direction: column;
-  gap: 8px;
   padding: 0 clamp(20px, 5vw, 40px);
   margin: 0;
   list-style: none;
@@ -1293,25 +1484,31 @@
   display: block;
 }
 
+/* Rows, not boxes. Inside a recessed card a stack of outlined tiles is chrome on
+ * chrome — a hairline between them is enough to separate two leagues, and it
+ * leaves the *selected* row the only filled thing in the card. */
 .leagues-card__row {
   display: flex;
   align-items: center;
-  gap: 12px;
-  width: 100%;
-  padding: 12px 16px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 10px;
-  background: var(--bg-raised);
+  gap: 10px;
+  /* Bleed the hover/selected tint into the card's padding so the row reads as a
+   * full-width band, not an inset chip. */
+  padding: 10px 8px;
+  margin: 0 -8px;
+  width: calc(100% + 16px);
+  border-radius: var(--r-sm);
   color: var(--fg-1);
   text-decoration: none;
-  transition:
-    border-color 120ms ease,
-    background 120ms ease;
+  transition: background 120ms ease;
+}
+
+.leagues-card__row-item:not(:last-child) .leagues-card__row {
+  border-bottom: 1px solid var(--ink-700);
+  border-radius: var(--r-sm) var(--r-sm) 0 0;
 }
 
 .leagues-card__row:hover {
-  border-color: color-mix(in srgb, var(--ball-500) 45%, transparent);
-  background: color-mix(in srgb, var(--ball-500) 6%, var(--bg-raised));
+  background: var(--bg-hover);
 }
 
 .leagues-card__row:focus-visible {
@@ -1320,10 +1517,13 @@
 }
 
 /* The selected ladder — the one every rating on this page is about. Tinted AND
- * outlined, so it doesn't rely on a single cue. */
+ * dotted in ball-orange, so it never rests on a single cue. */
 .leagues-card__row--selected {
-  border-color: var(--ball-500);
-  background: color-mix(in srgb, var(--ball-500) 12%, var(--bg-raised));
+  background: color-mix(in srgb, var(--ball-500) 10%, transparent);
+}
+
+.leagues-card__row--selected:hover {
+  background: color-mix(in srgb, var(--ball-500) 14%, transparent);
 }
 
 .leagues-card__dot {
@@ -1391,8 +1591,6 @@
  * is no record and no CTA (you cannot play yourself), so only the list remains. */
 .head-to-head {
   flex: 0 0 auto;
-  border-bottom: 1px solid var(--border-subtle);
-  padding-bottom: 24px;
 }
 
 .head-to-head__body {
@@ -1506,14 +1704,44 @@
 .head-to-head__rows {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
+/* The name and the record share a line; the bar is drawn *under* them, full
+ * width. Inline — name | bar | record — the bar was squeezed to whatever the
+ * narrow column had spare, which for a long name was nothing, and three rows of
+ * stub bars compare nothing to anything. Placed explicitly rather than by DOM
+ * order, so the markup keeps reading name → bar → record. */
 .head-to-head__row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto auto;
   align-items: center;
-  gap: 12px;
-  padding: 8px 0;
+  column-gap: 8px;
+  row-gap: 7px;
+  padding: 0;
+}
+
+.head-to-head__opponent {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.head-to-head__record {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.head-to-head__meetings {
+  grid-column: 3;
+  grid-row: 1;
+}
+
+.head-to-head__bar {
+  grid-column: 1 / -1;
+  grid-row: 2;
 }
 
 /* `flex: 0 1 auto`, not `0 0 auto`: a name is user-supplied and can be far longer
@@ -1536,33 +1764,34 @@
 /* The record said again, geometrically: how much of this rivalry the player has
  * won. Decorative — the record beside it is what a screen reader reads. */
 .head-to-head__bar {
-  flex: 1 1 auto;
-  height: 6px;
-  min-width: 40px;
+  height: 4px;
   border-radius: 999px;
-  background: var(--bg-raised);
+  background: var(--ink-700);
   overflow: hidden;
 }
 
+/* Green, not ball-orange: the bar is a *share of wins*, and win is the one thing
+ * this app already says in serve-green everywhere else on the page (the form
+ * chips, the Δ, the win-rate ring). */
 .head-to-head__bar-fill {
   display: block;
   height: 100%;
   border-radius: 999px;
-  background: var(--ball-500);
+  background: rgba(0, 226, 154, 0.55);
 }
 
 .head-to-head__record {
   font-family: var(--font-mono);
-  font-size: 14px;
-  color: var(--fg-1);
-  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  color: var(--fg-2);
+  white-space: nowrap;
 }
 
 .head-to-head__meetings {
   font-size: 12px;
   color: var(--fg-3);
-  flex: 0 0 auto;
-  min-width: 78px;
+  white-space: nowrap;
   text-align: right;
 }
 
@@ -1593,8 +1822,6 @@
  * survives a 390px phone. */
 .rating-chart {
   flex: 0 0 auto;
-  border-bottom: 1px solid var(--border-subtle);
-  padding-bottom: 20px;
 }
 
 /* The heading, the change chip and the range tabs share one row — until they
@@ -1629,41 +1856,46 @@
   background: color-mix(in srgb, var(--loss) 14%, transparent);
 }
 
-/* The range tabs sit at the right-hand end of the header row, and wrap under it
- * on a narrow viewport rather than squeezing the heading out. */
+/* One segmented control, not three loose pills: the ranges are mutually
+ * exclusive, and a group with a single filled segment says that on sight. It
+ * sits at the right-hand end of the header row and drops below it on a narrow
+ * viewport rather than squeezing the heading out. */
 .rating-chart__tabs {
-  display: flex;
-  gap: 4px;
+  display: inline-flex;
+  gap: 2px;
   margin-left: auto;
-  flex-wrap: wrap;
+  padding: 3px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
 }
 
 .rating-chart__tab {
+  display: inline-flex;
+  align-items: center;
+  height: 26px;
+  padding: 0 12px;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
   color: var(--fg-3);
-  padding: 4px 10px;
-  border-radius: 999px;
-  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
   text-decoration: none;
   transition:
     color 120ms ease,
-    background 120ms ease,
-    border-color 120ms ease;
+    background 120ms ease;
 }
 
 .rating-chart__tab:hover {
   color: var(--fg-1);
-  border-color: var(--ball-500);
+  background: var(--bg-hover);
 }
 
-.rating-chart__tab--selected {
-  color: var(--bg-app);
+.rating-chart__tab--selected,
+.rating-chart__tab--selected:hover {
+  color: var(--ink-950);
   background: var(--ball-500);
-  border-color: var(--ball-500);
 }
 
 .rating-chart__summary {

--- a/web-client/src/components/players/player-profile.css
+++ b/web-client/src/components/players/player-profile.css
@@ -1,6 +1,8 @@
-/* Player-profile surface — Bebas hero + dense match list (no tabs).
+/* Player-profile surface — a hero card over a column of cards (no tabs).
  * Mirrors the broadcast/arena tonal scheme used elsewhere
- * (match-list-page, dashboard) so it sits naturally inside the AppShell. */
+ * (match-list-page, dashboard) so it sits naturally inside the AppShell.
+ * The hero's name used to be set in the Bebas display face; it is the UI face
+ * now, and nothing in the hero uses `--font-display` any more. */
 
 .player-profile {
   /* The radius/shadow scale is declared per *surface* in this codebase — the

--- a/web-client/src/components/players/player-profile.tsx
+++ b/web-client/src/components/players/player-profile.tsx
@@ -169,7 +169,13 @@ export function PlayerProfile({
   }
 
   return (
-    <div className="player-profile dark fortymm-theme">
+    // `--overview` is what makes the six sections *cards* (and centres the page
+    // in a content column). It is a modifier rather than a base style because
+    // the full-history route at `/players/$userId/matches` wears the same
+    // `.player-profile` root and the same `__section` / `__section-header`
+    // classes — for its table chrome — and must stay the flush, full-bleed pane
+    // it is. See `player-match-history.css`.
+    <div className="player-profile player-profile--overview dark fortymm-theme">
       <header className="player-profile__hero">
         <div className="player-profile__hero-row">
           <ProfileHero playerId={playerId} leagueId={leagueId} range={range} />

--- a/web-client/src/components/players/player-profile/career-card/career-card-fetcher/career-card-display.tsx
+++ b/web-client/src/components/players/player-profile/career-card/career-card-fetcher/career-card-display.tsx
@@ -44,31 +44,36 @@ export const CareerCardDisplay = ({ career }: CareerCardDisplayProps) => {
       </div>
 
       <div className="career-card__body">
-        <WinRateRing ring={career.ring} />
+        {/* Ring and record read together — they are the same fact twice, once as
+            a shape and once as a pair of numbers. The tiles are a separate,
+            lesser register and sit under both, spanning the card. */}
+        <div className="career-card__headline">
+          <WinRateRing ring={career.ring} />
 
-        <div className="career-card__figures">
-          <p className="career-card__record">{career.record}</p>
+          <div className="career-card__figures">
+            <p className="career-card__record">{career.record}</p>
 
-          {career.streak ? (
-            <span
-              className={cn(
-                'career-card__streak',
-                `career-card__streak--${career.streak.tone}`,
-              )}
-            >
-              {career.streak.label}
-            </span>
-          ) : (
-            <span className="career-card__streak career-card__streak--none">
-              No current streak
-            </span>
-          )}
-
-          <div className="career-card__tiles">
-            {career.tiles.map((tile) => (
-              <CareerTile key={tile.label} tile={tile} />
-            ))}
+            {career.streak ? (
+              <span
+                className={cn(
+                  'career-card__streak',
+                  `career-card__streak--${career.streak.tone}`,
+                )}
+              >
+                {career.streak.label}
+              </span>
+            ) : (
+              <span className="career-card__streak career-card__streak--none">
+                No current streak
+              </span>
+            )}
           </div>
+        </div>
+
+        <div className="career-card__tiles">
+          {career.tiles.map((tile) => (
+            <CareerTile key={tile.label} tile={tile} />
+          ))}
         </div>
       </div>
     </section>

--- a/web-client/src/components/players/player-profile/career-card/career-card-skeleton.tsx
+++ b/web-client/src/components/players/player-profile/career-card/career-card-skeleton.tsx
@@ -15,14 +15,16 @@ export const CareerCardSkeleton = () => (
       <span className="player-profile__section-title">Career</span>
     </div>
     <div className="career-card__body" aria-hidden="true">
-      <div className="career-card__ring career-card__ring--skeleton" />
-      <div className="career-card__figures">
-        <span className="career-card__skeleton-line" />
-        <span className="career-card__skeleton-line career-card__skeleton-line--pill" />
-        <div className="career-card__tiles">
-          <div className="career-card__tile career-card__tile--skeleton" />
-          <div className="career-card__tile career-card__tile--skeleton" />
+      <div className="career-card__headline">
+        <div className="career-card__ring career-card__ring--skeleton" />
+        <div className="career-card__figures">
+          <span className="career-card__skeleton-line" />
+          <span className="career-card__skeleton-line career-card__skeleton-line--pill" />
         </div>
+      </div>
+      <div className="career-card__tiles">
+        <div className="career-card__tile career-card__tile--skeleton" />
+        <div className="career-card__tile career-card__tile--skeleton" />
       </div>
     </div>
   </section>

--- a/web-client/src/components/players/player-profile/profile-hero/profile-hero-fetcher/profile-hero-display.tsx
+++ b/web-client/src/components/players/player-profile/profile-hero/profile-hero-fetcher/profile-hero-display.tsx
@@ -1,39 +1,66 @@
+import type { CSSProperties } from 'react'
+
 import { UserAvatar } from '@/components/ui/user-avatar'
 
 import { type ProfileHeroView } from './profile-hero-query'
+
+/**
+ * The hero avatar is the one place the ball itself stands in for a person: the
+ * profile has exactly one subject, so it wears the brand gradient rather than
+ * `UserAvatar`'s per-name hue — which exists to tell a *list* of people apart,
+ * and which the opponent avatars on Recent matches keep for that reason.
+ */
+const BALL: CSSProperties = {
+  background:
+    'radial-gradient(circle at 35% 30%, #ffb57a, #ff7a1a 55%, #b94700)',
+  color: 'var(--ink-950)',
+  boxShadow:
+    '0 0 0 1px rgba(255, 181, 122, 0.4), 0 0 32px rgba(255, 122, 26, 0.25)',
+}
 
 export interface ProfileHeroDisplayProps {
   hero: ProfileHeroView
 }
 
 /**
- * The identity half of the profile hero: avatar, username and when they joined.
+ * The identity half of the profile hero: avatar, username and a meta line.
  * Pure view-in, DOM-out — every label it renders was derived in
  * `selectProfileHero`.
  *
  * The username is rendered bare (web-client/CLAUDE.md — never `@`-prefixed) and
- * in its real casing; the display-caps are CSS (`text-transform`), so the
- * heading's accessible name is the username itself rather than a shouted
- * letter-by-letter reading of it. The trailing dot is pure Bebas flourish and is
- * hidden from the accessibility tree.
+ * in its real casing. The trailing dot is a brand flourish and is hidden from
+ * the accessibility tree.
+ *
+ * "Member since …" keeps an element of its own inside the meta line rather than
+ * being concatenated into one string with the role: it is the line a reader
+ * looks up on its own.
  */
 export const ProfileHeroDisplay = ({ hero }: ProfileHeroDisplayProps) => (
   <div className="player-profile__identity">
-    <div className="player-profile__avatar-ring">
-      <UserAvatar name={hero.username} size={120} ring />
-      <span aria-hidden="true" className="player-profile__avatar-dashed" />
-    </div>
+    <UserAvatar
+      name={hero.username}
+      size={82}
+      className="player-profile__avatar"
+      style={BALL}
+    />
     <div className="player-profile__name-wrap">
-      <div className="player-profile__overline">FortyMM Player</div>
       <h1 className="player-profile__name">
         {hero.username}
         <span aria-hidden="true" className="player-profile__name-dot">
           .
         </span>
       </h1>
-      {hero.memberSince && (
-        <p className="player-profile__member-since">{hero.memberSince}</p>
-      )}
+      <p className="player-profile__meta">
+        <span>Player</span>
+        {hero.memberSince && (
+          <>
+            <span aria-hidden="true" className="player-profile__meta-sep">
+              ·
+            </span>
+            <span>{hero.memberSince}</span>
+          </>
+        )}
+      </p>
     </div>
   </div>
 )

--- a/web-client/src/components/players/player-profile/profile-hero/profile-hero-fetcher/profile-hero-display.tsx
+++ b/web-client/src/components/players/player-profile/profile-hero/profile-hero-fetcher/profile-hero-display.tsx
@@ -12,10 +12,10 @@ import { type ProfileHeroView } from './profile-hero-query'
  */
 const BALL: CSSProperties = {
   background:
-    'radial-gradient(circle at 35% 30%, #ffb57a, #ff7a1a 55%, #b94700)',
+    'radial-gradient(circle at 35% 30%, var(--ball-highlight), var(--ball-500) 55%, var(--ball-700))',
   color: 'var(--ink-950)',
   boxShadow:
-    '0 0 0 1px rgba(255, 181, 122, 0.4), 0 0 32px rgba(255, 122, 26, 0.25)',
+    '0 0 0 1px color-mix(in srgb, var(--ball-highlight) 40%, transparent), 0 0 32px color-mix(in srgb, var(--ball-500) 25%, transparent)',
 }
 
 export interface ProfileHeroDisplayProps {
@@ -37,12 +37,10 @@ export interface ProfileHeroDisplayProps {
  */
 export const ProfileHeroDisplay = ({ hero }: ProfileHeroDisplayProps) => (
   <div className="player-profile__identity">
-    <UserAvatar
-      name={hero.username}
-      size={82}
-      className="player-profile__avatar"
-      style={BALL}
-    />
+    {/* `UserAvatar` paints its per-name hue as an *inline* background and spreads
+        the caller's `style` last, so the ball can only be handed to it this way —
+        a class would lose to the inline rule. The colours are still tokens. */}
+    <UserAvatar name={hero.username} size={82} style={BALL} />
     <div className="player-profile__name-wrap">
       <h1 className="player-profile__name">
         {hero.username}

--- a/web-client/src/components/players/player-profile/profile-hero/profile-hero-skeleton.tsx
+++ b/web-client/src/components/players/player-profile/profile-hero/profile-hero-skeleton.tsx
@@ -1,8 +1,8 @@
 /**
  * Loading placeholder for the hero's identity card, shown as its `<Suspense>`
  * fallback. Hand-mirrors `ProfileHeroDisplay`'s markup (Suspense unmounts the
- * real tree while it loads) so the avatar, name and member-since line occupy the
- * same boxes they will once the bundle resolves — revisit it if that structure
+ * real tree while it loads) so the avatar, name and meta line occupy the same
+ * boxes they will once the bundle resolves — revisit it if that structure
  * changes.
  */
 export const ProfileHeroSkeleton = () => (
@@ -12,12 +12,8 @@ export const ProfileHeroSkeleton = () => (
     aria-busy="true"
     aria-label="Loading player"
   >
-    <div className="player-profile__avatar-ring" aria-hidden="true">
-      <span className="player-profile__hero-avatar-skeleton" />
-      <span className="player-profile__avatar-dashed" />
-    </div>
+    <span className="player-profile__hero-avatar-skeleton" aria-hidden="true" />
     <div className="player-profile__name-wrap" aria-hidden="true">
-      <div className="player-profile__overline">FortyMM Player</div>
       <div className="player-profile__hero-name-skeleton" />
       <div className="player-profile__hero-sub-skeleton" />
     </div>

--- a/web-client/src/components/players/player-profile/rating-panel/rating-panel-fetcher/rating-panel-display.tsx
+++ b/web-client/src/components/players/player-profile/rating-panel/rating-panel-fetcher/rating-panel-display.tsx
@@ -62,7 +62,16 @@ export const RatingPanelDisplay = ({ standing }: RatingPanelDisplayProps) => {
         </dl>
       )}
 
-      {standing.form && <FormChips form={standing.form} />}
+      {standing.form && (
+        <div className="player-profile__form-row">
+          {/* `FormChips` already carries the run's accessible name ("Last 10"),
+              so the visible caption is decoration for the eye only. */}
+          <span className="player-profile__form-label" aria-hidden="true">
+            Form
+          </span>
+          <FormChips form={standing.form} />
+        </div>
+      )}
     </section>
   )
 }

--- a/web-client/src/components/players/player-profile/rating-panel/rating-panel-skeleton.tsx
+++ b/web-client/src/components/players/player-profile/rating-panel/rating-panel-skeleton.tsx
@@ -24,13 +24,16 @@ export const RatingPanelSkeleton = () => (
         </div>
       ))}
     </div>
-    <span className="player-profile__form" aria-hidden="true">
-      {Array.from({ length: 10 }, (_, i) => (
-        <span
-          className="player-profile__form-chip player-profile__form-chip--skeleton"
-          key={i}
-        />
-      ))}
-    </span>
+    <div className="player-profile__form-row" aria-hidden="true">
+      <span className="player-profile__form-label">Form</span>
+      <span className="player-profile__form">
+        {Array.from({ length: 10 }, (_, i) => (
+          <span
+            className="player-profile__form-chip player-profile__form-chip--skeleton"
+            key={i}
+          />
+        ))}
+      </span>
+    </div>
   </section>
 )


### PR DESCRIPTION
Styles `/players/$userId` to the `Player Details.dc.html` mockup (Claude Design project `0c7326c8`). Layout was already right (#915); this is the surface.

I read **"fix the header"** as the page **hero**, not the app top bar — the top bar already matches the mockup closely, and the hero was the one dramatically-wrong element. Easy to redirect if that's not what you meant.

## What changed

**The hero is a card.** It was a full-bleed banner — dot-grid, orange radial wash, a 64px Bebas name in caps, a purple hashed avatar, and the rating in an outlined orange box. Now: a card in the content column, the ball avatar, the name in Space Grotesk, a `Player · Member since …` meta line, and across a hairline the rating as a plain 56px mono figure + tinted Δ pill + captioned form chips.

**The six sections are cards**, in two tiers — primary (chart, recent matches, career) raised on `--bg-card` with a shadow; tertiary (confidence, leagues, head-to-head) recessed to `--bg-panel`. The rules *between* sections are gone; separate surfaces are separated by the gap.

The card chrome hangs off a new `--overview` modifier rather than the base classes, because `.player-profile__section` is **shared with the full-history route** (`/players/$userId/matches`), whose one section is a full-bleed scrolling pane and must not become a card. That page still renders as the flush pane it was. Its **score chips did change**, though: `.player-profile__game` is a shared class and I softened it (outline → tint) — I kept that, since the two surfaces should agree, but it is not a no-op.

Detail work: sentence-case 18px titles on the two primary cards, a segmented range control, right-aligned numeric columns with a de-pilled Δ, a full-width "View all" button, the win-rate ring and confidence level out of Bebas into mono/UI, head-to-head bars drawn full-width under the name in serve-green, flat league rows.

## Deliberate deviations from the mockup

- **No breadcrumb.** It needs the username, so it means a new bundle-reading Suspense component — an addition, not a restyle.
- **No All / Wins / Losses filter tabs** on Recent matches. That's behaviour, not style.
- **No confidence progress bar.** The mockup has one; `player-profile.css` explicitly says not to ("no bar, no meter, no 0–100 anything — because that number does not exist"). Honoured the repo decision.
- **Per-game score chips stay** (mockup collapses them to an aggregate `3–0`). Softened them — tint, no outline — but collapsing them would drop data.

## Verified

- `tsc -b` clean, eslint clean
- vitest: **1887 passed** (237 files)
- web-client Playwright e2e: **177 passed** — note there is **no player-profile e2e spec**, so those axe assertions cover other routes; this page's axe-cleanliness is untested (pre-existing gap, not introduced here)
- Eyeballed desktop @1440, mobile @390, and the shared-CSS match-history page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBWZo1FdB1XkGKWnBZVGEX


Also checked the profile's other viewer-aware modes on a non-`u-me` id: the never-met **invite CTA**, the versus-record line, and the **unrated** hero. The versus line was still Bebas uppercase after the restyle (`YOU'RE 2–2 AGAINST NGUYEN.T` above sentence-case copy) — fixed in the follow-up commit.



---

## What the pre-merge review pass caught

Three of these were real defects in the restyle, not style nits:

1. **The cards had square corners the whole time.** The restyle used `var(--r-lg)` / `var(--r-md)` / `var(--shadow-sm)`, but this codebase declares that scale **per surface** (`.match-details`, `.fortymm-landing`, `.simulator`, settings each carry their own copy) — not in the shared `.fortymm-theme` block. `.player-profile` consumed it without declaring it, so every card computed to `border-radius: 0` and picked up Tailwind's much weaker `--shadow-sm`. Confirmed by computed style in a browser, fixed, and re-verified (hero/section radius `0px` → `14px`). Screenshots alone did not make this obvious — worth knowing that login and RBAC have the same latent hole.
2. **`career-card-skeleton` still mirrored the old markup**, so the skeleton was 70px taller than the card it resolves into — a reflow at exactly the moment a skeleton exists to prevent one.
3. **The Leagues skeleton was invisible** — it borrowed its fill from `.leagues-card__row`'s background, which went away when I flattened the rows into hairlines.

Plus non-behavioural cleanups (card gutter as a `--card-pad` token; Δ pill chrome moved onto the hero's row so the table stops unsetting five declarations; head-to-head rules de-duplicated; the history route's column stated positively as `.player-profile--pane` in its own stylesheet rather than `:not(--overview)` in the profile's). All pixel-diffed as visually inert against the profile *and* the shared history route at 1440 and 390.

**Deferred (pre-existing, not from this branch):** at desktop width the shared `.player-profile__body` grid already leaks onto `/players/$userId/matches` — the single section auto-places into a 720px column beside a 419px empty one, overflows the pane's `overflow: hidden`, and clips rows past ~13 plus the pagination footer. Verified identical on `main` (`f5d6e94`), so this branch neither causes nor worsens it. It wants its own ticket (give the two routes distinct body/section classes).
