### PR TITLE
Give seeded MSW match ids the UUID shape the router requires (#958)

### DIFF
--- a/web-client/e2e/page-objects/score-entry.page.ts
+++ b/web-client/e2e/page-objects/score-entry.page.ts
@@ -6,17 +6,17 @@ type NavigateOptions = {
   // When true, navigates to the edit route instead of the create route.
   edit?: boolean
   // Pin the opponent username so the input aria-label resolves. The default
-  // tracks the seed for `m-2207`.
+  // tracks the in-progress seed.
   opponentUsername?: string
 }
 
-// Stable identifiers mirroring `m-2207` from src/mocks/match-store.ts (1-1
-// mid-match). Hard-coded here so the e2e doesn't have to reach into the mock
-// module. The match id is a real UUID, not the `m-2207` placeholder, because
-// the scoring routes guard the param shape and short-circuit to the friendly
-// not-found page for anything that isn't UUID-shaped (#385) — production match
-// ids are UUIDs (`gen_random_uuid()`), so the e2e seed must be too or the page
-// never renders.
+// Stable identifiers mirroring the in-progress seed in src/mocks/match-store.ts
+// (`SEED_MATCH_IDS.inProgress`, 1-1 mid-match). Hard-coded here so the e2e
+// doesn't have to reach into the mock module. The match id is a real UUID
+// because the scoring routes guard the param shape and short-circuit to the
+// friendly not-found page for anything that isn't UUID-shaped (#385) —
+// production match ids are UUIDs (`gen_random_uuid()`), so any seed, here or in
+// the mock store (#958), must be one too or the page never renders.
 export const SEED = {
   matchId: '22070000-0000-4000-8000-000000000000',
   // After the decouple-scoring refactor games 1 + 2 are scratchpad scores;

--- a/web-client/e2e/score-entry.spec.ts
+++ b/web-client/e2e/score-entry.spec.ts
@@ -12,9 +12,10 @@ type Seed = {
   games: Game[]
 }
 
-// The seed shape exercised by the score-entry e2e. Mirrors `m-2207` from
-// `src/mocks/match-store.ts` (1-1 mid-match), but under a UUID-shaped id (see
-// SEED.matchId) so it survives the scoring routes' param-shape guard (#385).
+// The seed shape exercised by the score-entry e2e. Mirrors the in-progress seed
+// in `src/mocks/match-store.ts` (`SEED_MATCH_IDS.inProgress`, 1-1 mid-match),
+// under a UUID-shaped id of its own (see SEED.matchId) so it survives the
+// scoring routes' param-shape guard (#385).
 // Per the decouple-scoring refactor, only scored games have rows — the next
 // un-scored slot is exposed via current_game.game_number.
 function buildSeed(): Seed {

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -34,6 +34,7 @@ import {
   validateScore,
   type SeedMatch,
 } from './match-store'
+import { mockUuid } from './mock-uuid'
 import { notificationHandlers } from './notifications-store'
 import { createRbacState, dispatchRbac, type RbacState } from './rbac-engine'
 import { DEMO_SEED } from './rbac-store'
@@ -689,7 +690,7 @@ function playerRatingHistory(
   const anchor = {
     at: isoDaysAgo(days + 4 + (seed % 25)),
     rating: anchorRating,
-    match_id: `m-anchor-${summary.id}`,
+    match_id: mockUuid(`match:anchor:${summary.id}`),
   }
   const points = Array.from({ length: count }, (_, i) => {
     const progress = (i + 1) / count
@@ -702,7 +703,7 @@ function playerRatingHistory(
           ? rating
           : Math.round(anchorRating + net * progress + wobble),
       at: isoDaysAgo(Math.max(1, days * (1 - progress))),
-      match_id: `m-${summary.id}-${i}`,
+      match_id: mockUuid(`match:rating-point:${summary.id}:${i}`),
     }
   })
   const peak = points.reduce((best, point) =>

--- a/web-client/src/mocks/match-store.test.ts
+++ b/web-client/src/mocks/match-store.test.ts
@@ -1,4 +1,6 @@
+import { isMatchId } from '@/lib/match-id'
 import {
+  buildInitialSeeds,
   mockMatches,
   newMatchSeed,
   projectMatchDetails,
@@ -105,5 +107,37 @@ describe('projectRating (the dashboard rating card the mock feeds)', () => {
 
     expect(typeof rating?.delta).toBe('number')
     expect(rating?.delta).not.toBe(0)
+  })
+})
+
+describe('match ids the router can actually address (#958)', () => {
+  // The `$matchId` routes reject a non-UUID id before they fetch, so an id the
+  // mock world invents is only usable if it is shaped like one the API mints.
+  // Every seeded match used to be `m-…`, which meant every match-detail page
+  // 404'd under `npm run dev` and the surface was unreachable in the mocks.
+  it('gives every seeded match an id the $matchId routes accept', () => {
+    const ids = buildInitialSeeds().map((seed) => seed.id)
+
+    expect(ids.length).toBeGreaterThan(0)
+    expect(ids.filter((id) => !isMatchId(id))).toEqual([])
+  })
+
+  it('gives a match created in the mock world one too, so the scoring screen it redirects into can load it', () => {
+    const seed = newMatchSeed({
+      bestOf: 3,
+      rated: true,
+      opponent: { id: 'pl-nguyen', username: 'nguyen.t' },
+    })
+
+    expect(isMatchId(seed.id)).toBe(true)
+  })
+
+  it('mints a distinct id per created match', () => {
+    const input = { bestOf: 3, rated: false, opponent: null }
+
+    const first = newMatchSeed(input)
+    const second = newMatchSeed(input)
+
+    expect(first.id).not.toBe(second.id)
   })
 })

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -1,5 +1,6 @@
 import type { components } from '@/api/schema'
 import { compactGames, isDecidedMatch } from '@/lib/scoring'
+import { mockUuid } from '@/mocks/mock-uuid'
 
 type MatchStatus = components['schemas']['MatchStatus']
 type MatchDetails = components['schemas']['app__schemas__match__MatchDetails']
@@ -989,12 +990,24 @@ export function statusCountsOf(seeds: SeedMatch[]): Record<string, number> {
   return counts
 }
 
-/** Seed snapshot used at module load. `m-2207` is the deterministic
- * in-progress match the score-entry e2e hard-codes into its URL. */
+/** Ids of the seeded matches. UUIDs, because that's what the API mints and
+ * what the `$matchId` routes will accept — a friendlier `m-2207` 404s before
+ * the page ever fetches (#958). Exported so anything that deep-links a seeded
+ * match (the notification feed) points at one that exists. */
+export const SEED_MATCH_IDS = {
+  pending: mockUuid('match:pending-1'),
+  inProgress: mockUuid('match:in-progress-2207'),
+  completedWin: mockUuid('match:completed-win-1'),
+  completedLoss: mockUuid('match:completed-loss-1'),
+  completedWin2: mockUuid('match:completed-win-2'),
+} as const
+
+/** Seed snapshot used at module load. `inProgress` is the deterministic
+ * in-progress match — the one to open when you want a half-scored board. */
 export function buildInitialSeeds(): SeedMatch[] {
   return [
     {
-      id: 'm-pending-1',
+      id: SEED_MATCH_IDS.pending,
       status: 'pending',
       best_of: 5,
       affects_rating: true,
@@ -1005,7 +1018,7 @@ export function buildInitialSeeds(): SeedMatch[] {
       results: [],
     },
     {
-      id: 'm-2207',
+      id: SEED_MATCH_IDS.inProgress,
       status: 'in_progress',
       best_of: 5,
       affects_rating: true,
@@ -1027,7 +1040,7 @@ export function buildInitialSeeds(): SeedMatch[] {
       results: [],
     },
     {
-      id: 'm-completed-win-1',
+      id: SEED_MATCH_IDS.completedWin,
       status: 'completed',
       best_of: 5,
       affects_rating: true,
@@ -1072,7 +1085,7 @@ export function buildInitialSeeds(): SeedMatch[] {
       ],
     },
     {
-      id: 'm-completed-loss-1',
+      id: SEED_MATCH_IDS.completedLoss,
       status: 'completed',
       best_of: 3,
       affects_rating: true,
@@ -1104,7 +1117,7 @@ export function buildInitialSeeds(): SeedMatch[] {
       ],
     },
     {
-      id: 'm-completed-win-2',
+      id: SEED_MATCH_IDS.completedWin2,
       status: 'completed',
       best_of: 3,
       affects_rating: true,
@@ -1193,6 +1206,10 @@ export function validateScore(side1: number, side2: number): string | null {
   return null
 }
 
+/** Distinguishes the matches one dev session creates, so two started in the
+ * same tick can't land on the same id. */
+let matchSeq = 0
+
 /** Hardcoded current-user id used by `POST /v1/matches` to populate side 1.
  * Games aren't pre-created — POST .../scores/new inserts them lazily. */
 export function newMatchSeed(input: {
@@ -1200,7 +1217,10 @@ export function newMatchSeed(input: {
   rated: boolean
   opponent: { id: string; username: string } | null
 }): SeedMatch {
-  const id = `m-${Date.now().toString(36)}`
+  // A UUID, like the API mints — anything else and the scoring routes this
+  // redirects into would reject the id before fetching (#958).
+  matchSeq += 1
+  const id = mockUuid(`match:new:${matchSeq}`)
   const seed: SeedMatch = {
     id,
     status: 'in_progress',

--- a/web-client/src/mocks/mock-uuid.ts
+++ b/web-client/src/mocks/mock-uuid.ts
@@ -1,0 +1,37 @@
+/** Stable UUIDs for mock data.
+ *
+ * Match ids are UUIDs on the API, and the `$matchId` routes reject anything
+ * else before they fetch (`@/lib/match-id`). Mock ids therefore have to be
+ * UUID-shaped or the mock world can't reach its own match pages (#958) — a
+ * hand-written `m-2207` 404s under `npm run dev` even though the seed exists.
+ *
+ * `mockUuid` derives one deterministically from a readable label, so a seed
+ * keeps the same id across reloads (bookmarkable dev URLs, stable e2e stubs)
+ * while call sites still say what the match *is* rather than a bare hex blob.
+ */
+
+/** FNV-1a. Cheap, well-spread, and enough for fixture ids. */
+function fnv1a(s: string): number {
+  let h = 0x811c9dc5
+  for (let i = 0; i < s.length; i += 1) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return h >>> 0
+}
+
+/** A deterministic v4-shaped UUID for `label`. Distinct labels get distinct
+ * ids; the same label always gets the same id. */
+export function mockUuid(label: string): string {
+  const hex = [0, 1, 2, 3]
+    .map((i) => fnv1a(`${label}:${i}`).toString(16).padStart(8, '0'))
+    .join('')
+  // Pin the version (4) and variant (8) nibbles so these parse as real v4s.
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    `4${hex.slice(13, 16)}`,
+    `8${hex.slice(17, 20)}`,
+    hex.slice(20, 32),
+  ].join('-')
+}

--- a/web-client/src/mocks/notifications-store.test.ts
+++ b/web-client/src/mocks/notifications-store.test.ts
@@ -1,0 +1,30 @@
+import { isMatchId } from '@/lib/match-id'
+import { findMatch } from '@/mocks/match-store'
+
+/** The seeded feed, as the dev bell fetches it. */
+async function fetchSeededFeed(): Promise<{ items: { link: string | null }[] }> {
+  const response = await fetch(`${window.location.origin}/v1/notifications`)
+  return response.json()
+}
+
+/** The `<id>` in a `/matches/<id>` link, or null for a link that goes elsewhere. */
+function matchIdIn(link: string | null): string | null {
+  const match = link?.match(/^\/matches\/([^/?#]+)/)
+  return match ? match[1] : null
+}
+
+describe('the seeded notification feed (#958)', () => {
+  // A deep link is a promise that tapping it lands somewhere. The seeded
+  // "Accept your score" notification pointed at `/matches/m-1`, which broke
+  // that promise twice over: `m-1` is not a UUID, so the route rejected it
+  // before fetching — and no match with that id existed in the store anyway.
+  it('deep-links only to matches the router accepts and the store actually holds', async () => {
+    const feed = await fetchSeededFeed()
+
+    const matchIds = feed.items.map((item) => matchIdIn(item.link)).filter((id) => id !== null)
+
+    expect(matchIds.length).toBeGreaterThan(0)
+    expect(matchIds.filter((id) => !isMatchId(id))).toEqual([])
+    expect(matchIds.filter((id) => findMatch(id) === undefined)).toEqual([])
+  })
+})

--- a/web-client/src/mocks/notifications-store.ts
+++ b/web-client/src/mocks/notifications-store.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw'
 import type { components } from '@/api/schema'
+import { SEED_MATCH_IDS } from '@/mocks/match-store'
 import {
   notificationPreferences,
   notificationTaxonomy,
@@ -20,7 +21,9 @@ let feed: NotificationItem[] = [
     category: 'result_confirm',
     title: 'Accept your score',
     body: 'def. Patel, M. — you logged 3–1. Tap to accept.',
-    link: '/matches/m-1',
+    // A match that actually exists in the store, addressed the way the router
+    // expects. `/matches/m-1` pointed at nothing and 404'd on both counts (#958).
+    link: `/matches/${SEED_MATCH_IDS.inProgress}`,
     action_label: 'Review',
     delta: null,
     read_at: null,

--- a/web-client/src/routes/_app/matches/index.test.tsx
+++ b/web-client/src/routes/_app/matches/index.test.tsx
@@ -124,7 +124,7 @@ describe('MatchesPage', () => {
 
   it('paints the winning side green on a completed row', async () => {
     renderMatchesPage()
-    // Seed match m-completed-win-1 has side-1 (rita.kovac) winning vs silva.r.
+    // The completed-win seed has side-1 (rita.kovac) winning vs silva.r.
     const winner = await screen.findByText('silva.r')
     // The losing side's name is rendered without is-winner; the winning side
     // (the seed user) on that row carries it.


### PR DESCRIPTION
Closes #958.

## The bug

The `$matchId` routes reject an id that isn't UUID-shaped *before* they fetch (`src/lib/match-id.ts`, added in #385/#494 so a malformed id can't 422 the API). But every seeded match in the mock store was an `m-…` string, so under `npm run dev` **every match-detail and scoring page 404'd** — the entire match surface was unreachable in the mock world, including pages that have real bugs on them (#951).

## The fix

Mint mock match ids with a new `mockUuid(label)` helper (`src/mocks/mock-uuid.ts`): a deterministic, v4-shaped UUID derived from a readable label, so a seed keeps a **stable** id across reloads (bookmarkable dev URLs) while call sites still say what the match *is* rather than carrying a bare hex blob.

Covers every id the mock world hands the router:
- the five seeds in `match-store.ts`, now behind an exported `SEED_MATCH_IDS`;
- the id `newMatchSeed` mints for a match **created** in dev (was `m-${Date.now()}`, so the scoring screen it redirects into 404'd too);
- the rating-history points' `match_id`s in `handlers.ts`.

The seeded "Accept your score" notification deep-linked to `/matches/m-1`, which broke twice over: not a UUID, *and* no match with that id existed in the store. It now points at a seed that does.

## Guard tests

Both go red on the old ids (verified, not assumed):
- every id the store hands out satisfies the router's own `isMatchId` — seeds and freshly created matches alike;
- the notification feed only deep-links matches the store actually holds.

## Verification

Loaded the real thing against `npm run dev` in a browser, not just tests:

| Flow | Before | After |
| --- | --- | --- |
| `/matches/<seed>` detail | 404 | renders (1–1 vs nguyen.t) |
| List row → scoring screen | 404 | renders |
| Notification "Accept your score" | 404 | lands on the match |
| New match → game 1 score entry | 404 | renders |
| Non-UUID id (`/matches/m-2207`) | 404 | **still 404s** — the guard is intact |

No console errors. `vitest` 1891 passed, `tsc -b` clean, `eslint` 0 errors, `e2e/score-entry.spec.ts` 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2Xmz8p2ozJ65wwc7p3XMb