### PR TITLE
Fix the dangling "· ," venue separator, and drop the raw UUID chip

### DIFF
--- a/web-client/src/components/tournaments/data/helpers.test.ts
+++ b/web-client/src/components/tournaments/data/helpers.test.ts
@@ -3,12 +3,14 @@ import {
   effectiveDateRange,
   fmtDateRange,
   fmtTimeWindow,
+  fmtVenueLine,
   formatPredicate,
   predicateSentence,
   findPoolConflicts,
   myEntrant,
 } from './helpers'
 import {
+  buildAddress,
   buildEntrant,
   buildPool,
   buildTournament,
@@ -83,6 +85,57 @@ describe('fmtTimeWindow', () => {
   it('renders a wholly unset window as an em-dash', () => {
     expect(fmtTimeWindow('', '')).toBe('—')
     expect(fmtTimeWindow(null, undefined)).toBe('—')
+  })
+})
+
+// Every address part is optional, so every separator in this line is a JOIN
+// between two present values — never a literal in a template. The old template
+// form printed its punctuation regardless, so a venue-less tournament read as a
+// bare "· ," (#994). Each case below names the punctuation that must NOT appear.
+describe('fmtVenueLine', () => {
+  it('joins venue, city, and region when all three are present', () => {
+    expect(fmtVenueLine(buildAddress())).toBe('Berkeley TT Club · Berkeley, CA')
+  })
+
+  it('shows a lone venue with no trailing dot or comma', () => {
+    const line = fmtVenueLine(buildAddress({ city: '', region: '' }))
+
+    expect(line).toBe('Berkeley TT Club')
+    expect(line).not.toContain('·')
+    expect(line).not.toContain(',')
+  })
+
+  it('shows a lone city and region with no leading dot', () => {
+    const line = fmtVenueLine(buildAddress({ venue: '' }))
+
+    expect(line).toBe('Berkeley, CA')
+    expect(line).not.toContain('·')
+  })
+
+  it('shows a venue and city with no trailing comma when the region is blank', () => {
+    const line = fmtVenueLine(buildAddress({ region: '' }))
+
+    expect(line).toBe('Berkeley TT Club · Berkeley')
+    expect(line).not.toContain(',')
+  })
+
+  it('shows a lone region with no leading comma', () => {
+    expect(fmtVenueLine(buildAddress({ venue: '', city: '' }))).toBe('CA')
+  })
+
+  // The bug's headline case: nothing to punctuate, so nothing at all — the
+  // empty string is the caller's cue to render NO venue line (no icon, no row).
+  it('is empty when every part is blank, rather than a bare "· ,"', () => {
+    expect(fmtVenueLine(buildAddress({ venue: '', city: '', region: '' }))).toBe('')
+  })
+
+  // A trimmed-to-nothing value is a blank value: a stray space typed into the
+  // Venue field must not resurrect the separator it has nothing to separate.
+  it('treats whitespace-only parts as blank', () => {
+    expect(
+      fmtVenueLine(buildAddress({ venue: '  ', city: '\t', region: ' \n ' })),
+    ).toBe('')
+    expect(fmtVenueLine(buildAddress({ venue: ' ' }))).toBe('Berkeley, CA')
   })
 })
 

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -6,6 +6,7 @@
 import { labelFor, PRED_FIELDS, PRED_OPS_BY_TYPE } from './options'
 import type { PredicateFieldSchema } from './options'
 import type {
+  Address,
   Entrant,
   Predicate,
   Pool,
@@ -77,6 +78,30 @@ export function fmtTimeWindow(
   if (start) return start
   if (end) return end
   return EM_DASH
+}
+
+/** Join the values that are actually there, dropping the blank (and
+ * whitespace-only) ones — so a separator only ever appears BETWEEN two present
+ * values, and never has to stand in for a missing one. */
+const joinPresent = (parts: string[], sep: string): string =>
+  parts.map((p) => p.trim()).filter(Boolean).join(sep)
+
+/** A tournament's venue line — `Berkeley TT Club · Berkeley, CA` — built by
+ * filtering the address parts and joining the survivors, NOT by interpolating
+ * each part into a template with its separator baked in (#994, #972).
+ *
+ * Every address part is optional (`Address` types them as plain strings, blank
+ * = `''`), so the template form rendered its punctuation whether or not it had
+ * anything to punctuate: a venue-less tournament read as a bare `· ,` and a
+ * venue with no city as `BETAVENUE · ,`. Punctuation is not data.
+ *
+ * Returns `''` when nothing is present — a caller must render NO venue line at
+ * all in that case (no icon, no empty row), which is why this is not the
+ * em-dash that `ReadOnlyValue` and the formatters above use: those label a
+ * field whose row exists regardless; this one decides whether the row exists. */
+export function fmtVenueLine(address: Address): string {
+  const locality = joinPresent([address.city, address.region], ', ')
+  return joinPresent([address.venue, locality], ' · ')
 }
 
 /** A compact, human range: collapses same-day, same-month, and full spans. */

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -4,6 +4,7 @@
 // that callers tweak via overrides.
 
 import type {
+  Address,
   Entrant,
   Pool,
   Predicate,
@@ -11,6 +12,22 @@ import type {
   TournamentEvent,
   TournamentTable,
 } from './types'
+
+/** The seeded venue address. Every part is optional in the domain (blank =
+ * `''`), so the partial and wholly-blank cases are expressed by overriding
+ * parts to `''` — `buildAddress({ venue: '', city: '', region: '' })` — rather
+ * than by hand-rolling a second literal at each call site. */
+export function buildAddress(overrides: Partial<Address> = {}): Address {
+  return {
+    venue: 'Berkeley TT Club',
+    street: '2727 Milvia St',
+    city: 'Berkeley',
+    region: 'CA',
+    postal: '94703',
+    country: 'USA',
+    ...overrides,
+  }
+}
 
 /** A single physical table, `T1` on court 1. */
 export function buildTable(
@@ -104,14 +121,7 @@ export function buildTournament(
     startDate: '2026-06-13',
     endDate: '2026-06-14',
     description: 'Two-day open. USATT-sanctioned, ratings-eligible.',
-    address: {
-      venue: 'Berkeley TT Club',
-      street: '2727 Milvia St',
-      city: 'Berkeley',
-      region: 'CA',
-      postal: '94703',
-      country: 'USA',
-    },
+    address: buildAddress(),
     tableIds: ['t1', 't2', 't3', 't4', 't5', 't6', 't7', 't8'],
     events: [buildEvent()],
     ...overrides,

--- a/web-client/src/components/tournaments/tournament-card.page.tsx
+++ b/web-client/src/components/tournaments/tournament-card.page.tsx
@@ -17,6 +17,12 @@ const scoped = (container: Container) => ({
   queryDeleteButton(name: string) {
     return container.queryByRole('button', { name: `Delete ${name}` })
   },
+  /** The venue line (pin icon + address). The whole row — icon included — is
+   * absent when the tournament has no venue, city, or region, so this is a
+   * `query`: its absence is the assertion (#994). */
+  queryVenueLine() {
+    return container.queryByTestId('tournament-venue-line')
+  },
   /** The card's status pill, reusing the badge's own query. */
   ...statusBadgePage.within(container),
 })

--- a/web-client/src/components/tournaments/tournament-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-card.test.tsx
@@ -1,6 +1,11 @@
 import userEvent from '@testing-library/user-event'
 
-import { buildEntrants, buildTournament, buildEvent } from './data/seed.factory'
+import {
+  buildAddress,
+  buildEntrants,
+  buildTournament,
+  buildEvent,
+} from './data/seed.factory'
 import { tournamentCardPage } from './tournament-card.page'
 
 describe('TournamentCard', () => {
@@ -22,7 +27,40 @@ describe('TournamentCard', () => {
     expect(tournamentCardPage.getBadge()).toHaveTextContent('Published')
     // 52 + 22 entries; 2 events; 3 tables.
     expect(document.body).toHaveTextContent('74')
-    expect(document.body).toHaveTextContent('Berkeley TT Club')
+    expect(tournamentCardPage.queryVenueLine()).toHaveTextContent(
+      'Berkeley TT Club · Berkeley, CA',
+    )
+  })
+
+  // The address parts are all optional, and the separators are joins between
+  // the parts that are there — never literals in a template. The template form
+  // printed a bare "· ," for a venue-less tournament (#994).
+  describe('the venue line', () => {
+    it('drops the separators the missing parts would have hung off', () => {
+      tournamentCardPage.render({
+        tournament: buildTournament({
+          address: buildAddress({ city: '', region: '' }),
+        }),
+      })
+
+      const line = tournamentCardPage.queryVenueLine()
+      expect(line).toHaveTextContent('Berkeley TT Club')
+      expect(line?.textContent).not.toContain('·')
+      expect(line?.textContent).not.toContain(',')
+    })
+
+    it('renders no venue line at all — pin included — when there is no address', () => {
+      tournamentCardPage.render({
+        tournament: buildTournament({
+          name: 'GAMMA-UNANNOUNCED',
+          address: buildAddress({ venue: '', city: '', region: '' }),
+        }),
+      })
+
+      expect(tournamentCardPage.queryVenueLine()).toBeNull()
+      // Not "a bare · , " — the card is left with no punctuation to strand.
+      expect(document.body).not.toHaveTextContent('·')
+    })
   })
 
   it('opens the tournament when the card is clicked', async () => {

--- a/web-client/src/components/tournaments/tournament-card.tsx
+++ b/web-client/src/components/tournaments/tournament-card.tsx
@@ -3,7 +3,7 @@ import { MapPin, Trash2 } from 'lucide-react'
 import { Card } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 
-import { effectiveDateRange, fmtDateRange } from './data/helpers'
+import { effectiveDateRange, fmtDateRange, fmtVenueLine } from './data/helpers'
 import type { Tournament } from './data/types'
 import { StatusBadge } from './status-badge'
 
@@ -38,6 +38,10 @@ export const TournamentCard = ({
 }: TournamentCardProps) => {
   const range = effectiveDateRange(t)
   const entries = t.events.reduce((sum, e) => sum + (e.entered || 0), 0)
+  // Empty when the tournament has no venue, city, or region — and then the
+  // whole line goes, pin and all. A row holding only its own punctuation is not
+  // information (#994).
+  const venue = fmtVenueLine(t.address)
 
   return (
     <div className="group/tcard relative">
@@ -58,10 +62,15 @@ export const TournamentCard = ({
           <div className="text-[20px] leading-tight font-bold tracking-[-0.01em] text-[color:var(--fg-1)]">
             {t.name}
           </div>
-          <div className="mt-1 flex items-center gap-1 text-[13px] text-[color:var(--fg-3)]">
-            <MapPin size={12} />
-            {t.address.venue} · {t.address.city}, {t.address.region}
-          </div>
+          {venue && (
+            <div
+              data-testid="tournament-venue-line"
+              className="mt-1 flex items-center gap-1 text-[13px] text-[color:var(--fg-3)]"
+            >
+              <MapPin size={12} />
+              {venue}
+            </div>
+          )}
         </div>
 
         <div className="mt-1 grid grid-cols-3 gap-2.5 border-t border-[color:var(--border-subtle)] pt-3">

--- a/web-client/src/components/tournaments/tournament-detail-page.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.page.tsx
@@ -28,6 +28,12 @@ const scoped = (container: Container) => ({
   queryLifecycleButton(name: RegExp) {
     return container.queryByRole('button', { name })
   },
+  /** The header's venue meta item (pin icon + address). The whole item — icon
+   * included — is absent when venue, city, and region are all blank, so this is
+   * a `query`: its absence is the assertion (#994). */
+  queryVenueLine() {
+    return container.queryByTestId('tournament-venue-line')
+  },
   ...eventsTabPage.within(container),
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.test.tsx
@@ -6,10 +6,59 @@ import { buildTournamentDetailRead } from '@/mocks/factories/tournaments/tournam
 import { server } from '@/mocks/server'
 import { waitFor } from '@/test/utilities'
 
-import { buildEvent, buildTournament } from './data/seed.factory'
+import { buildAddress, buildEvent, buildTournament } from './data/seed.factory'
 import { tournamentDetailPagePage } from './tournament-detail-page.page'
 
 describe('TournamentDetailPage', () => {
+  // Same doctrine as the card's: the separators are joins between the address
+  // parts that are present, so a partial address strands no punctuation and an
+  // empty one renders no meta item at all (#994, #972).
+  describe('the header venue line', () => {
+    it('joins the address parts that are present', () => {
+      tournamentDetailPagePage.render({ tournament: buildTournament() })
+
+      expect(tournamentDetailPagePage.queryVenueLine()).toHaveTextContent(
+        'Berkeley TT Club · Berkeley, CA',
+      )
+    })
+
+    it('drops the comma the missing region would have hung off', () => {
+      tournamentDetailPagePage.render({
+        tournament: buildTournament({ address: buildAddress({ region: '' }) }),
+      })
+
+      const line = tournamentDetailPagePage.queryVenueLine()
+      expect(line).toHaveTextContent('Berkeley TT Club · Berkeley')
+      expect(line?.textContent).not.toContain(',')
+    })
+
+    it('renders no venue meta item — pin included — when there is no address', () => {
+      tournamentDetailPagePage.render({
+        tournament: buildTournament({
+          address: buildAddress({ venue: '', city: '', region: '' }),
+        }),
+      })
+
+      // Absent, not blank: the item carries the pin and the punctuation, so a
+      // rendered-but-empty one would still read as the bug's bare "· ,". (The
+      // interpunct legitimately appears elsewhere on the page — the event card's
+      // own meta — so this asserts the item, not the character.)
+      expect(tournamentDetailPagePage.queryVenueLine()).toBeNull()
+    })
+  })
+
+  // A database identifier is not user-facing copy: the header used to print the
+  // tournament's raw UUID in a `#` chip (#972). It is gone, not relabelled.
+  it('never shows the tournament\'s raw id', () => {
+    tournamentDetailPagePage.render({
+      tournament: buildTournament({ id: '8330f9f7-c64c-4f9d-910d-56b77bde88cb' }),
+    })
+
+    expect(document.body).not.toHaveTextContent(
+      '8330f9f7-c64c-4f9d-910d-56b77bde88cb',
+    )
+  })
+
   // The stat strip prints its own unit, so it owns the plural. Both sides are
   // asserted: a fix that simply hardcoded "day" would read "2 day" for a
   // weekend tournament, which is the same bug wearing the other shoe.

--- a/web-client/src/components/tournaments/tournament-detail-page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.tsx
@@ -1,13 +1,5 @@
 import { useState } from 'react'
-import {
-  Calendar,
-  Hash,
-  Layers,
-  MapPin,
-  Table2,
-  Trophy,
-  Users,
-} from 'lucide-react'
+import { Calendar, Layers, MapPin, Table2, Trophy, Users } from 'lucide-react'
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
@@ -18,6 +10,7 @@ import {
   EM_DASH,
   emptyEvent,
   fmtDateRange,
+  fmtVenueLine,
   genId,
 } from './data/helpers'
 import { lifecycleEdgeFor } from './data/lifecycle'
@@ -51,13 +44,18 @@ export interface TournamentDetailPageProps {
 
 function MetaItem({
   icon,
+  testId,
   children,
 }: {
   icon: React.ReactNode
+  testId?: string
   children: React.ReactNode
 }) {
   return (
-    <span className="inline-flex min-w-0 items-center gap-2 text-[14px] text-[color:var(--fg-2)]">
+    <span
+      data-testid={testId}
+      className="inline-flex min-w-0 items-center gap-2 text-[14px] text-[color:var(--fg-2)]"
+    >
       <span className="text-[color:var(--fg-3)]">{icon}</span>
       {children}
     </span>
@@ -91,6 +89,10 @@ export const TournamentDetailPage = ({
   const days = daysBetween(range.start, range.end)
   const entries = tournament.events.reduce((s, e) => s + (e.entered || 0), 0)
   const pools = tournament.events.reduce((s, e) => s + e.pools.length, 0)
+  // Empty when venue, city, and region are all blank — and then the meta item
+  // is not rendered at all, pin included. Punctuation with nothing to punctuate
+  // ("· ,") is a rendering bug, not a placeholder (#994).
+  const venue = fmtVenueLine(tournament.address)
 
   const openEvent = (ev: TournamentEvent) => {
     setEditorEvent(ev)
@@ -143,20 +145,11 @@ export const TournamentDetailPage = ({
               </span>
             )}
           </MetaItem>
-          <MetaItem icon={<MapPin size={14} />}>
-            <span className="text-[color:var(--fg-1)]">
-              {tournament.address.venue}
-            </span>
-            <span className="mx-1.5 text-[color:var(--fg-3)]">·</span>
-            <span>
-              {tournament.address.city}, {tournament.address.region}
-            </span>
-          </MetaItem>
-          <MetaItem icon={<Hash size={14} />}>
-            <span className="font-mono text-[12px] text-[color:var(--fg-3)]">
-              {tournament.id}
-            </span>
-          </MetaItem>
+          {venue && (
+            <MetaItem icon={<MapPin size={14} />} testId="tournament-venue-line">
+              <span className="truncate text-[color:var(--fg-1)]">{venue}</span>
+            </MetaItem>
+          )}
         </div>
 
         <div className="grid grid-cols-5 gap-3">


### PR DESCRIPTION
Closes #994
Closes #972

## The bug

Venue / city / region are all optional on a tournament, but both render sites interpolated each part into a template with **its separator baked in**:

```tsx
{t.address.venue} · {t.address.city}, {t.address.region}
```

So a venue-less tournament rendered its punctuation with nothing to punctuate — literally `· ,` — and a partially-filled address read `BETAVENUE · ,`. Visible on the tournaments **list card** and the **detail header**.

## The fix

Separators are **joins between present values**, not fixed literals. One shared pure helper, `fmtVenueLine(address)`, filters the address parts and joins the survivors:

- `locality` = `[city, region]` → drop blanks → join `", "`
- `line` = `[venue, locality]` → drop blanks → join `" · "`

It returns `''` when nothing is present, and both call sites then render **no venue line at all** — pin icon included. A row holding only its own punctuation is not information. (Deliberately not the `EM_DASH` the neighbouring formatters return: those label a field whose row exists regardless; this one decides *whether the row exists*.)

Whitespace-only values count as blank.

## Also: the raw UUID chip (the other half of #972)

The detail header showed the tournament's raw UUID (`# 8330f9f7-c64c-…`) in a user-facing chip. It's a database identifier a user can't act on — removed, not replaced. That closes #972 outright rather than half of it.

## Verification

- The two new card tests were confirmed to **fail against the old template** and pass against the fix — they bite.
- `vitest run` → **239 files / 1919 tests passed**
- `tsc -b` → clean · `npm run lint` → 0 errors
- `playwright test e2e/tournaments` → 28 passed (header markup moved; axe-clean header specs still pass)

No API or schema change — `schema.d.ts` untouched, no regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vxD239tezUS3WvQUtBfQj