### PR TITLE
Launch fast-follow sweep: 10 UI bugs across the shell, New Match, settings and notifications

### DIFF
--- a/web-client/e2e/app-shell.spec.ts
+++ b/web-client/e2e/app-shell.spec.ts
@@ -1,0 +1,396 @@
+/**
+ * Regression guard for GitHub issue #887: the mobile navigation drawer was
+ * closed with a CSS transform alone (`translateX(-100%)`), and **offscreen is
+ * not hidden**. At 375px with the drawer visually shut, 48 controls — "Close
+ * navigation" and every nav link — stayed focusable, tabbable and exposed to
+ * assistive tech. A keyboard or screen-reader user could walk straight into a
+ * menu that was not there.
+ *
+ * These assertions can only live here. jsdom has no layout: it cannot see a
+ * transform, `visibility`, or a media query, so a vitest test would pass against
+ * the broken code. The proof is a real browser telling us whether it will hand
+ * focus to an element.
+ *
+ * The counterpart risk is the fix over-reaching: above 960px the *same*
+ * `<aside>` is the permanent desktop sidebar, so the last describe below pins
+ * that it is still fully navigable.
+ *
+ * The suite runs with MSW OFF (`playwright.config.ts` webServer env
+ * `VITE_ENABLE_MSW: 'false'`), so the API is stubbed via `page.route`.
+ */
+import { expect, test, type Page, type Route } from '@playwright/test'
+import type { components } from '../src/api/schema'
+import {
+  notificationFeed,
+  notificationPreferences,
+  notificationTaxonomy,
+  sessionResponse,
+} from '../src/test/factories'
+
+const SESSION = sessionResponse({ user: { username: 'rita.kovac' } })
+
+/** An empty inbox: the notifications page renders its designed empty state and
+ * no row auto-marks itself read, so the page settles without further writes. */
+const NOTIFICATION_FEED = notificationFeed({ items: [], unread_count: 0 })
+const UNREAD_COUNT = {
+  unread_count: 0,
+} satisfies components['schemas']['UnreadCountResponse']
+const PREFERENCES = notificationPreferences()
+const TAXONOMY = notificationTaxonomy()
+
+// `satisfies` (not `:`) so tsc fails if the OpenAPI schema drifts away from this
+// stub — the e2e suite is MSW-off, so nothing else would catch it.
+const DASHBOARD = {
+  attention: [],
+  attention_total_count: 0,
+  waiting_count: 0,
+  rating: null,
+  completed_match_count: 0,
+  recent_results: [],
+} satisfies components['schemas']['DashboardResponse']
+
+/** The page-load reads of every route this spec visits, keyed by path. */
+const STUBS: Record<string, unknown> = {
+  '/v1/session': SESSION,
+  '/v1/dashboard': DASHBOARD,
+  '/v1/notifications': NOTIFICATION_FEED,
+  '/v1/notifications/unread-count': UNREAD_COUNT,
+  '/v1/notification-preferences': PREFERENCES,
+  '/v1/notification-taxonomy': TAXONOMY,
+}
+
+async function installMocks(page: Page) {
+  await page.route('**/api/v1/**', (route: Route) => {
+    const path = new URL(route.request().url()).pathname.replace(/^\/api/, '')
+    const stub = STUBS[path]
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      // Anything else the AppShell happens to fetch on load.
+      body: JSON.stringify(stub ?? []),
+    })
+  })
+}
+
+/** Everything a Tab press can land on. Straight from the #887 measurement. */
+const FOCUSABLE =
+  'a[href],button:not([disabled]),input:not([disabled]),select,textarea,[tabindex]:not([tabindex="-1"])'
+
+/**
+ * How many of the drawer's controls the browser will *actually* focus.
+ *
+ * Asking the browser to focus each one and seeing where `activeElement` lands is
+ * the only mechanism-agnostic probe: it comes out right whether the drawer is
+ * hidden with `visibility`, `display`, `inert`, `hidden`, or nothing at all. A
+ * test that asserted on the CSS declaration instead would be re-typing the
+ * implementation rather than checking the behaviour a keyboard user gets.
+ */
+async function focusableDrawerControls(page: Page) {
+  return page.evaluate((sel) => {
+    const drawer = document.getElementById('app-shell-sidebar')
+    if (!drawer) throw new Error('#app-shell-sidebar is not in the document')
+    const controls = Array.from(drawer.querySelectorAll<HTMLElement>(sel))
+    const focusable: string[] = []
+    for (const el of controls) {
+      el.focus()
+      if (document.activeElement === el) {
+        focusable.push((el.textContent || el.getAttribute('aria-label') || el.tagName).trim())
+        el.blur()
+      }
+    }
+    // `total` guards every "focusable is 0" assertion against passing vacuously
+    // — an empty drawer would also report zero focusable controls.
+    return { total: controls.length, focusable }
+  }, FOCUSABLE)
+}
+
+/**
+ * The #887 metric itself, over the whole document: controls parked outside the
+ * viewport that a Tab press would still reach. This read 48 before the fix.
+ */
+async function offscreenTabbableCount(page: Page) {
+  return page.evaluate((sel) => {
+    return Array.from(document.querySelectorAll<HTMLElement>(sel)).filter((el) => {
+      const r = el.getBoundingClientRect()
+      if (r.right >= 0 && r.left <= window.innerWidth) return false
+      el.focus()
+      const reachable = document.activeElement === el
+      el.blur()
+      return reachable
+    }).length
+  }, FOCUSABLE)
+}
+
+async function gotoWithSidebar(page: Page, path: string) {
+  await installMocks(page)
+  await page.goto(path)
+  // The nav is permission-gated, so it only fills in once /v1/session resolves.
+  // Wait on a link that is always present (matched with `includeHidden`, since
+  // when the drawer is shut the whole point is that it is *not* exposed).
+  await page
+    .locator('#app-shell-sidebar')
+    .getByRole('link', { name: 'Dashboard', includeHidden: true })
+    .waitFor({ state: 'attached' })
+}
+
+async function gotoDashboard(page: Page) {
+  await gotoWithSidebar(page, '/dashboard')
+}
+
+test.describe('Mobile navigation drawer (#887)', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
+
+  test('a closed drawer offers no focusable control and nothing offscreen is tabbable', async ({
+    page,
+  }) => {
+    await gotoDashboard(page)
+
+    const { total, focusable } = await focusableDrawerControls(page)
+
+    // Not vacuous: the drawer really does hold controls — they just aren't
+    // reachable.
+    expect(total, 'controls present in the closed drawer').toBeGreaterThan(3)
+    expect(focusable, 'focusable controls inside the closed drawer').toEqual([])
+
+    // The issue's own measurement: this was 48.
+    expect(
+      await offscreenTabbableCount(page),
+      'offscreen-but-tabbable controls on the page',
+    ).toBe(0)
+  })
+
+  test('a closed drawer is not exposed to assistive tech', async ({ page }) => {
+    await gotoDashboard(page)
+
+    // `getByRole` matches only what ARIA considers non-hidden, so a zero count
+    // here IS "absent from the accessibility tree".
+    const drawer = page.locator('#app-shell-sidebar')
+    await expect(drawer).toBeHidden()
+    await expect(drawer.getByRole('link', { name: 'Matches' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Close navigation' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Open navigation' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+  })
+
+  test('the hamburger aria-controls resolves to the drawer', async ({ page }) => {
+    await gotoDashboard(page)
+
+    // It declared `aria-controls="app-shell-sidebar"` while no element carried
+    // that id — a dangling reference (#887).
+    const target = await page
+      .getByRole('button', { name: 'Open navigation' })
+      .getAttribute('aria-controls')
+    expect(target).toBe('app-shell-sidebar')
+    await expect(page.locator(`#${target}`)).toHaveCount(1)
+  })
+
+  test('opening the drawer restores every control, and closing it takes them away again', async ({
+    page,
+  }) => {
+    await gotoDashboard(page)
+
+    await page.getByRole('button', { name: 'Open navigation' }).click()
+
+    const drawer = page.locator('#app-shell-sidebar')
+    await expect(drawer).toBeVisible()
+    await expect(drawer.getByRole('link', { name: 'Matches' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Open navigation' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    )
+
+    // Everything in the open drawer is reachable — including the close button,
+    // which is the control a keyboard user needs to get back out.
+    const open = await focusableDrawerControls(page)
+    expect(open.focusable.length, 'focusable controls in the open drawer').toBe(open.total)
+    expect(open.focusable).toContain('Close navigation')
+    await drawer.getByRole('link', { name: 'Matches' }).focus()
+    await expect(drawer.getByRole('link', { name: 'Matches' })).toBeFocused()
+
+    // Shut it again: `visibility` is transitioned, so the controls go away when
+    // the slide-out lands, not on the click. Poll rather than sample once.
+    await page.getByRole('button', { name: 'Close navigation' }).click()
+    await expect(drawer).toBeHidden()
+    await expect
+      .poll(
+        async () => (await focusableDrawerControls(page)).focusable.length,
+        { message: 'focusable controls after re-closing the drawer' },
+      )
+      .toBe(0)
+    expect(await offscreenTabbableCount(page)).toBe(0)
+  })
+})
+
+/**
+ * #930: on `/notifications/settings` the sidebar told a screen reader it was on
+ * three pages at once — Notifications, Inbox *and* Preferences — because
+ * TanStack's `<Link>` marks every prefix match active. The eye saw one item lit
+ * the whole time; only the accessibility layer lied, and it said you were in the
+ * inbox while you were reading the preferences page.
+ *
+ * Both halves are asserted on every route. `aria-current` is read straight out
+ * of the rendered DOM, and "still lit" is read as a **computed colour** rather
+ * than a class name — a real browser is the only place that can tell us the
+ * section highlight survived the a11y fix, which is the thing that must NOT
+ * change. (The class-level version of this lives in the vitest suite.)
+ */
+test.describe('Exactly one current page (#930)', () => {
+  test.use({ viewport: { width: 1280, height: 800 } })
+
+  const SIDEBAR = '#app-shell-sidebar'
+
+  /** `label=value` for every sidebar link exposing itself as current. Reading
+   * the *value* (not just counting) is deliberate: `aria-current="true"` on a
+   * section ancestor would be wrong too — an ancestor announces nothing. */
+  async function currentPageLinks(page: Page) {
+    return page
+      .locator(`${SIDEBAR} a[aria-current]`)
+      .evaluateAll((els) =>
+        els.map(
+          (el) =>
+            `${el.textContent?.trim()}=${el.getAttribute('aria-current')}`,
+        ),
+      )
+  }
+
+  /** The icon colour the browser actually paints for a top-level nav item. An
+   * unlit item is `var(--fg-3)`; a lit one — an active leaf or an active section
+   * parent — is `var(--ball-400)`. */
+  async function navIconColor(page: Page, label: string) {
+    return page
+      .locator(SIDEBAR)
+      .getByRole('link', { name: label, exact: true })
+      .locator('.app-shell__nav-icon')
+      .evaluate((el) => getComputedStyle(el).color)
+  }
+
+  /** A design token, resolved to the `rgb()` the browser paints, inside the
+   * theme that owns it — so the assertion below names the *tint* rather than a
+   * hard-coded triple that a palette change would silently invalidate. */
+  async function resolvedColorToken(page: Page, token: string) {
+    return page.locator('.app-shell').evaluate((host, name) => {
+      const probe = document.createElement('span')
+      probe.style.color = `var(${name})`
+      host.appendChild(probe)
+      const color = getComputedStyle(probe).color
+      probe.remove()
+      return color
+    }, token)
+  }
+
+  test('announces only the leaf on a sub-route, while the section stays lit', async ({
+    page,
+  }) => {
+    await gotoWithSidebar(page, '/notifications/settings')
+    await expect(
+      page.locator(SIDEBAR).getByRole('link', { name: 'Preferences' }),
+    ).toBeVisible()
+
+    // Was ["Notifications=page", "Inbox=page", "Preferences=page"].
+    expect(await currentPageLinks(page)).toEqual(['Preferences=page'])
+
+    // The other half of the bargain: you can still SEE which section you are in.
+    const notifications = page
+      .locator(SIDEBAR)
+      .getByRole('link', { name: 'Notifications', exact: true })
+    await expect(notifications).toHaveClass(/is-parent-active/)
+    // Not just the class — the paint. The parent's icon still carries the
+    // section-lit accent, and is not the muted tint of an item you are not in.
+    const lit = await navIconColor(page, 'Notifications')
+    expect(lit).toBe(await resolvedColorToken(page, '--ball-400'))
+    expect(lit).not.toBe(await navIconColor(page, 'Dashboard'))
+  })
+
+  test('announces Inbox on the notifications index, where the parent shares its URL', async ({
+    page,
+  }) => {
+    await gotoWithSidebar(page, '/notifications')
+    await expect(
+      page.locator(SIDEBAR).getByRole('link', { name: 'Inbox' }),
+    ).toBeVisible()
+
+    // The hard case: Notifications and Inbox are the *same* URL, so no amount of
+    // URL matching can pick a winner — only the leaf may announce itself.
+    expect(await currentPageLinks(page)).toEqual(['Inbox=page'])
+    await expect(
+      page
+        .locator(SIDEBAR)
+        .getByRole('link', { name: 'Notifications', exact: true }),
+    ).toHaveClass(/is-parent-active/)
+  })
+
+  test('announces the item itself on a plain top-level route', async ({
+    page,
+  }) => {
+    await gotoWithSidebar(page, '/dashboard')
+
+    // A childless item IS the leaf, so it keeps saying so — the fix narrows the
+    // announcement, it does not remove it.
+    expect(await currentPageLinks(page)).toEqual(['Dashboard=page'])
+  })
+
+  /**
+   * The top-level items are no longer a bare `<Link>` — the shell now builds the
+   * anchor itself from `useLinkProps()` so it can withhold `aria-current` from a
+   * section parent. That anchor must still be a *router* link: drop the props the
+   * hook hands back and every nav click becomes a full page load, which no other
+   * test in this repo would notice (the URL still changes, the page still
+   * renders — it is just slow and blows the client state away).
+   *
+   * A marker on `window` is the probe: a reload wipes it, a client-side
+   * navigation does not. And since the route changes without a remount, this is
+   * also the only test where `aria-current` has to *follow* the navigation
+   * rather than being computed on a cold load.
+   */
+  test('navigates client-side, and the announcement follows the route', async ({
+    page,
+  }) => {
+    await gotoWithSidebar(page, '/dashboard')
+    await page.evaluate(() => {
+      ;(window as Window & { __noReload?: boolean }).__noReload = true
+    })
+
+    await page
+      .locator(SIDEBAR)
+      .getByRole('link', { name: 'Notifications', exact: true })
+      .click()
+
+    await expect(page).toHaveURL(/\/notifications$/)
+    expect(
+      await page.evaluate(
+        () => (window as Window & { __noReload?: boolean }).__noReload === true,
+      ),
+      'the page was not reloaded — the sidebar still navigates through the router',
+    ).toBe(true)
+
+    // Dashboard has stopped claiming to be the current page, and the section we
+    // landed in hands the claim to its leaf, not to itself.
+    expect(await currentPageLinks(page)).toEqual(['Inbox=page'])
+  })
+})
+
+test.describe('Desktop sidebar (#887 must not over-reach)', () => {
+  test.use({ viewport: { width: 1280, height: 800 } })
+
+  test('stays visible and fully navigable', async ({ page }) => {
+    await gotoDashboard(page)
+
+    const drawer = page.locator('#app-shell-sidebar')
+    await expect(drawer).toBeVisible()
+    // No drawer affordance above the breakpoint — this is a permanent sidebar.
+    await expect(page.getByRole('button', { name: 'Open navigation' })).toBeHidden()
+
+    const links = drawer.locator('a[href]')
+    const count = await links.count()
+    expect(count, 'nav links in the desktop sidebar').toBeGreaterThan(3)
+    for (let i = 0; i < count; i++) {
+      await links.nth(i).focus()
+      await expect(links.nth(i), `nav link #${i} is focusable`).toBeFocused()
+    }
+
+    await expect(drawer.getByRole('link', { name: 'Matches' })).toBeVisible()
+    expect(await offscreenTabbableCount(page)).toBe(0)
+  })
+})

--- a/web-client/e2e/app-shell.spec.ts
+++ b/web-client/e2e/app-shell.spec.ts
@@ -20,6 +20,7 @@
  */
 import { expect, test, type Page, type Route } from '@playwright/test'
 import type { components } from '../src/api/schema'
+import { INTERACTIVE_SELECTOR } from '../src/test/read-only'
 import {
   notificationFeed,
   notificationPreferences,
@@ -72,9 +73,16 @@ async function installMocks(page: Page) {
   })
 }
 
-/** Everything a Tab press can land on. Straight from the #887 measurement. */
-const FOCUSABLE =
-  'a[href],button:not([disabled]),input:not([disabled]),select,textarea,[tabindex]:not([tabindex="-1"])'
+/** Everything a Tab press can land on.
+ *
+ * The one selector, imported — not a copy. `read-only.ts` exists because this
+ * string forked three ways the first time it was pasted around, and a fork
+ * written here would already have been the weaker one: it would have missed
+ * `[role="switch"]` and `[role="radio"]`, so a toggle added to the sidebar
+ * tomorrow would sail straight through this #887 guard. No disabled-filtering is
+ * needed on top — the probe below asks the browser to focus each node and keeps
+ * only what it actually lands on, which discards anything unfocusable anyway. */
+const FOCUSABLE = INTERACTIVE_SELECTOR
 
 /**
  * How many of the drawer's controls the browser will *actually* focus.

--- a/web-client/e2e/app-shell.spec.ts
+++ b/web-client/e2e/app-shell.spec.ts
@@ -394,3 +394,84 @@ test.describe('Desktop sidebar (#887 must not over-reach)', () => {
     expect(await offscreenTabbableCount(page)).toBe(0)
   })
 })
+
+/**
+ * The topbar "Alpha" notice — a non-modal Radix popover.
+ *
+ * **#891 (the real bug)**: the open panel contained **zero** buttons. On a 375px
+ * viewport it renders as a ~320×272 slab over most of the page, and its only
+ * exits were an outside click and Escape — neither of which is something you can
+ * see, and one of which a touch user does not have. The button-count assertion
+ * below is the measurement from the issue, and it is the discriminating test:
+ * it fails against the pre-fix shell.
+ *
+ * **#885 (not reproducible)**: "the alpha dialog does not close on Escape". It
+ * does — verified in a browser on `main`, at both viewports, before anything was
+ * changed. The Escape tests here are a **regression guard** for behaviour Radix's
+ * `DismissableLayer` already gives us; they passed before this change too. They
+ * exist so that a future `onEscapeKeyDown` preventDefault or a global key handler
+ * that swallows Escape turns the suite red.
+ *
+ * Both viewports are exercised because the panel's harm (#891) is a mobile-layout
+ * harm, while the a11y contract must hold everywhere.
+ */
+test.describe('Alpha notice (#891 close control, #885 Escape guard)', () => {
+  const ALPHA_TRIGGER = 'About the alpha release'
+
+  /** The popover's content: Radix gives it `role="dialog"`. */
+  const notice = (page: Page) => page.getByRole('dialog')
+
+  async function openAlphaNotice(page: Page) {
+    await page.getByRole('button', { name: ALPHA_TRIGGER }).click()
+    await expect(notice(page)).toBeVisible()
+  }
+
+  for (const [device, viewport] of [
+    ['mobile', { width: 375, height: 667 }],
+    ['desktop', { width: 1280, height: 800 }],
+  ] as const) {
+    test.describe(device, () => {
+      test.use({ viewport })
+
+      test('closes on a click of its visible, labelled close control (#891)', async ({
+        page,
+      }) => {
+        await gotoDashboard(page)
+        await openAlphaNotice(page)
+
+        // The #891 measurement: this list was empty. Reading the *names* rather
+        // than the count also pins that the control announces itself — an
+        // unlabelled icon button would be no use to a screen-reader user.
+        const buttons = notice(page).getByRole('button')
+        expect(
+          await buttons.evaluateAll((els) =>
+            els.map((el) => el.getAttribute('aria-label') ?? el.textContent?.trim()),
+          ),
+          'buttons inside the open alpha notice',
+        ).toEqual(['Close alpha notice'])
+
+        const close = notice(page).getByRole('button', { name: 'Close alpha notice' })
+        // `.click()` is itself the proof a real user could reach it: Playwright
+        // refuses to click an element that is hidden, zero-sized, or covered.
+        await expect(close).toBeVisible()
+        await close.click()
+
+        await expect(notice(page)).toHaveCount(0)
+        // Focus comes back to the badge rather than being stranded on a removed
+        // node — a keyboard user can carry on tabbing from where they were.
+        await expect(page.getByRole('button', { name: ALPHA_TRIGGER })).toBeFocused()
+      })
+
+      test('still closes on Escape — regression guard, not a fix (#885)', async ({
+        page,
+      }) => {
+        await gotoDashboard(page)
+        await openAlphaNotice(page)
+
+        await page.keyboard.press('Escape')
+
+        await expect(notice(page)).toHaveCount(0)
+      })
+    })
+  }
+})

--- a/web-client/e2e/matches/match-details.spec.ts
+++ b/web-client/e2e/matches/match-details.spec.ts
@@ -228,6 +228,49 @@ test.describe('Match Details', () => {
         });
     });
 
+    // #888: the page rendered its own `<main className="md-page">` inside the
+    // app shell's `<main className="app-shell__content">`, so a screen reader's
+    // landmark list held two "main" regions, one nested in the other. The issue
+    // was filed as a mobile bug; it was not — the wrapper was unconditional, and
+    // the page reproduced it identically at 1280x800. Both viewports are pinned
+    // below so a re-introduced responsive wrapper can't sneak it back in on one
+    // of them. (The shared axe helper deliberately drops the `best-practice`
+    // tag, which is where `landmark-one-main` lives — hence this targeted
+    // assertion rather than a broader scan.)
+    test.describe('landmarks', () => {
+        const VIEWPORTS = [
+            { name: 'desktop', size: { width: 1280, height: 800 } },
+            { name: 'mobile', size: { width: 375, height: 667 } },
+        ] as const;
+
+        for (const { name, size } of VIEWPORTS) {
+            test.describe(name, () => {
+                test.use({ viewport: size });
+
+                test(`exposes exactly one main landmark at ${name} (${size.width}x${size.height})`, async ({
+                    page,
+                }) => {
+                    await matchDetailsPage.mock(decidedMatch(COMPLETED_WIN_ID));
+                    await matchDetailsPage.goTo(COMPLETED_WIN_ID);
+
+                    // Guard: the match content is on screen, so the counts below
+                    // are of the finished page and not of an empty shell.
+                    await expect(
+                        page.getByRole('region', {
+                            name: 'rita.kovac defeated silva.r by 3 games to 1',
+                        }),
+                    ).toBeVisible();
+
+                    // What assistive tech actually enumerates: main landmarks,
+                    // whether claimed by the <main> tag or by role="main".
+                    await expect(page.getByRole('main')).toHaveCount(1);
+                    // And that one is not wrapping another.
+                    await expect(page.locator('main main')).toHaveCount(0);
+                });
+            });
+        }
+    });
+
     // #952: the card told a player "Unrated" in one panel and "1500 → 1268
     // (−232)" in another, inches apart. A first rated match does not *lose* you
     // 232 points — it *establishes* you at 1268. Proven here, in a real browser,

--- a/web-client/e2e/opponent-picker.spec.ts
+++ b/web-client/e2e/opponent-picker.spec.ts
@@ -131,6 +131,33 @@ test.describe('Opponent picker — search', () => {
     ])
   })
 
+  test('a matching result is not highlighted or announced as selected until the user says so (#894)', async ({
+    page,
+  }) => {
+    // The other half of the launch-blocker: typing "hamilton" lit the one
+    // matching row up exactly like a hover — and told screen readers it was
+    // `aria-selected` — while the card above still said "solo match".
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.openSearch()
+    await nm.search('hamilton')
+    await expect(nm.searchResult(MARGARET.username)).toBeVisible()
+
+    // Nothing has been chosen, so nothing looks or reads as chosen.
+    await expect(page.locator('.nm-item.active')).toHaveCount(0)
+    await expect(page.locator('.nm-item[aria-selected="true"]')).toHaveCount(0)
+    await expect(nm.summaryTop).toContainText(/no opponent selected/i)
+
+    // Arrowing to the row highlights it — and still does not claim it is chosen.
+    await page.keyboard.press('ArrowDown')
+    await expect(page.locator('.nm-item.active')).toHaveCount(1)
+    await expect(page.locator('.nm-item[aria-selected="true"]')).toHaveCount(0)
+
+    // Enter is what commits it.
+    await page.keyboard.press('Enter')
+    await expect(nm.selectedOpponentName).toHaveText(MARGARET.username)
+  })
+
   test('shows a no-match message for an unknown name', async ({ page }) => {
     const nm = await NewMatchPage.open(page, { players: ROSTER })
 
@@ -138,6 +165,123 @@ test.describe('Opponent picker — search', () => {
     await nm.search('nobody-here')
 
     await expect(nm.searchNoMatch).toBeVisible()
+  })
+
+  test('a search that matches nobody reads as unresolved, not as a ready solo match (#893)', async ({
+    page,
+  }) => {
+    // The launch-blocker, in the browser where it was found: a user hunting for
+    // an opponent typed a name, found nobody, and the card still said "Ready:
+    // You · solo match" over a button that said "Start match" — so pressing it
+    // silently created a solo match they never asked for.
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.openSearch()
+    // An empty search box is not a hunt in progress — solo is still the honest
+    // default and nothing is relabelled.
+    await expect(nm.startButton).toBeVisible()
+
+    await nm.search('zzzzzz')
+    await expect(nm.searchNoMatch).toBeVisible()
+
+    // Now it is: the summary stops claiming readiness, and the button says what
+    // pressing it would actually do. It stays enabled — a solo match is a fine
+    // thing to want, it just must not be a surprise.
+    await expect(nm.summaryTop).toContainText(/no opponent selected/i)
+    await expect(nm.summaryTop).not.toContainText(/ready/i)
+    await expect(nm.soloStartButton).toBeEnabled()
+    await expect(nm.startButton).toBeHidden()
+
+    // Committing to someone resolves it, leftover query and all.
+    await nm.search('hamilton')
+    await nm.searchResult(MARGARET.username).click()
+    await expect(nm.selectedOpponentName).toHaveText(MARGARET.username)
+    await expect(nm.startButton).toBeVisible()
+    await expect(nm.soloStartButton).toBeHidden()
+  })
+
+  test('offers a visible way back to the recent opponents, and takes it (#895)', async ({
+    page,
+  }) => {
+    // Entering search used to be one-way: the recent chips vanished and neither
+    // clearing the box nor Escape brought them back. Recents are the fastest
+    // path to a rematch, so losing them made setup feel sticky.
+    const nm = await NewMatchPage.open(page, {
+      players: ROSTER,
+      recentOpponents: [ADA, GRACE],
+    })
+
+    await expect(nm.playerChip(ADA.username)).toBeVisible()
+    await expect(nm.backToRecentButton).toBeHidden()
+
+    await nm.openSearch()
+    await nm.search('zzzzzz')
+    await expect(nm.searchNoMatch).toBeVisible()
+    // Mid-hunt, the card reads as `seeking` (#893).
+    await expect(nm.soloStartButton).toBeVisible()
+
+    await nm.backToRecent()
+
+    // The grid is back, and so is the affordance that opened search.
+    await expect(nm.playerChip(ADA.username)).toBeVisible()
+    await expect(nm.playerChip(GRACE.username)).toBeVisible()
+    await expect(nm.searchAllButton).toBeVisible()
+    await expect(nm.backToRecentButton).toBeHidden()
+
+    // Abandoning the hunt is not a decision to play alone: the card drops back
+    // to `none`, so the button stops threatening a solo match (#893 × #895).
+    await expect(nm.startButton).toBeVisible()
+    await expect(nm.soloStartButton).toBeHidden()
+    await expect(nm.summaryTop).not.toContainText(/no opponent selected/i)
+
+    // And the recovered grid is live — one click and the rematch is set up.
+    await nm.pickPlayer(GRACE.username)
+    await expect(nm.selectedOpponentName).toHaveText(GRACE.username)
+  })
+
+  test('search still works after a trip back to the recent opponents (#895)', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+
+    await nm.openSearch()
+    await nm.search('hamilton')
+    await expect(nm.searchResult(MARGARET.username)).toBeVisible()
+
+    await nm.backToRecent()
+    await expect(nm.playerChip(ADA.username)).toBeVisible()
+
+    // Re-entering search opens a clean box — the abandoned query does not come
+    // back with it — and the pick still commits.
+    await nm.openSearch()
+    await expect(nm.searchHint).toBeVisible()
+    await nm.search('hamilton')
+    await nm.searchResult(MARGARET.username).click()
+    await expect(nm.selectedOpponentName).toHaveText(MARGARET.username)
+
+    await nm.start()
+    await expect(page).toHaveURL(SCORING_URL)
+    expect(nm.store.createdMatches).toEqual([
+      { opponent_user_id: MARGARET.id, best_of: 5, rated: false },
+    ])
+  })
+
+  test('leaves a failed search behind instead of trapping the player in it (#895)', async ({
+    page,
+  }) => {
+    const nm = await NewMatchPage.open(page, { players: ROSTER })
+    nm.store.failNextSearch({ status: 500, detail: 'search unavailable' })
+
+    await nm.openSearch()
+    await nm.search('ada')
+    await expect(nm.pickerError).toBeVisible()
+
+    // "Try again" is not the only exit from a broken search — the way back to
+    // recents survives the error fallback, and leaving clears it.
+    await nm.backToRecent()
+
+    await expect(nm.pickerError).toBeHidden()
+    await expect(nm.playerChip(ADA.username)).toBeVisible()
   })
 
   test('surfaces the error boundary when a search request fails', async ({

--- a/web-client/e2e/page-objects/matches/new-match.page.ts
+++ b/web-client/e2e/page-objects/matches/new-match.page.ts
@@ -18,6 +18,13 @@ export class NewMatchPage {
   readonly heading: Locator
   readonly youName: Locator
   readonly startButton: Locator
+  /**
+   * What the same submit control calls itself while the user is mid-search with
+   * nothing committed (#893). Its own locator, not a variant of `startButton`:
+   * "Start solo match" deliberately does NOT match `/start match/i`, so a spec
+   * asserting `startButton` is absent is asserting the honest relabel happened.
+   */
+  readonly soloStartButton: Locator
   readonly cancelButton: Locator
   readonly error: Locator
   readonly ratedSwitch: Locator
@@ -36,6 +43,8 @@ export class NewMatchPage {
   /** "No one matches …" message in the typeahead dropdown. */
   readonly searchNoMatch: Locator
   readonly searchAllButton: Locator
+  /** The visible exit from search mode, back to the recent grid (#895). */
+  readonly backToRecentButton: Locator
 
   static async open(
     page: Page,
@@ -56,6 +65,9 @@ export class NewMatchPage {
     this.heading = page.getByRole('heading', { level: 1, name: /new match/i })
     this.youName = page.locator('.nm-you-strip .name')
     this.startButton = page.getByRole('button', { name: /start match/i })
+    this.soloStartButton = page.getByRole('button', {
+      name: /start solo match/i,
+    })
     this.cancelButton = page.getByRole('button', { name: /^cancel$/i })
     this.error = page.locator('.nm-error')
     this.ratedSwitch = page.getByRole('switch', { name: /rated match/i })
@@ -70,6 +82,9 @@ export class NewMatchPage {
     this.searchNoMatch = page.getByText(/no one matches/i)
     this.searchAllButton = page.getByRole('button', {
       name: /search all players/i,
+    })
+    this.backToRecentButton = page.getByRole('button', {
+      name: /back to recent opponents/i,
     })
   }
 
@@ -93,6 +108,10 @@ export class NewMatchPage {
 
   async openSearch(): Promise<void> {
     await this.searchAllButton.click()
+  }
+
+  async backToRecent(): Promise<void> {
+    await this.backToRecentButton.click()
   }
 
   async search(term: string): Promise<void> {

--- a/web-client/e2e/settings.spec.ts
+++ b/web-client/e2e/settings.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * The settings page at a phone-sized viewport (#890).
+ *
+ * QA measured 394px of content in a 360px viewport on UAT: the page scrolled
+ * sideways. The culprit is the page **header** — a no-wrap flex row holding a
+ * 64px display `<h1>` ("SETTINGS", one unbreakable word, so its min-content
+ * floor is its full rendered width) beside a username pill pinned at
+ * `flex-shrink: 0`. Their sum plus the gap exceeds a 360px viewport's content
+ * box. There was no mobile rule for the header at all.
+ *
+ * **The overflow scales with the username's length**, so a short-username test
+ * PASSES AGAINST THE BUG — measured here: with a 3-char name the header fit and
+ * the page did not scroll; with the 34-char name below the document measured
+ * **579px in a 360px viewport**. The regression case therefore uses a genuinely
+ * long (but schema-valid, ≤40 char) username, the way the real UAT account did.
+ * After the fix both measure 360/360.
+ *
+ * jsdom has no layout, so vitest structurally cannot catch this. It has to be a
+ * real browser measuring `document.documentElement.scrollWidth`.
+ *
+ * This suite runs with MSW OFF (see `playwright.config.ts` webServer env
+ * `VITE_ENABLE_MSW: 'false'`), so the session is stubbed with `page.route` —
+ * which is also how the long username gets injected.
+ */
+import { expect, test, type Page } from '@playwright/test'
+import { sessionResponse } from '../src/test/factories'
+
+/** The server's maximum: 40 chars, matching `^[a-z0-9](?:[a-z0-9._-]{1,38}[a-z0-9])?$`.
+ * This is the payload of the whole spec: with a short name the bug does not
+ * reproduce at all, so a short-username test would sail straight past it. */
+const LONG_USERNAME = 'bartholomew.montgomery-fitzwilliams-iii2'
+
+/** iPhone-class narrow viewport — the width QA reported the overflow at. */
+const NARROW = { width: 360, height: 740 }
+const DESKTOP = { width: 1280, height: 900 }
+
+async function withSession(page: Page, username: string) {
+  const body = JSON.stringify(
+    sessionResponse({
+      user: {
+        id: '3a6d18f2-91b4-4e07-bd25-6c8f04a2e913',
+        username,
+        email: 'player@example.com',
+        confirmed_at: '2026-05-12T09:00:00Z',
+      },
+    }),
+  )
+  await page.route('**/api/v1/**', async (route) => {
+    const path = new URL(route.request().url()).pathname
+    if (path.endsWith('/v1/session')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body,
+      })
+      return
+    }
+    // Everything else the shell happens to fetch (notification bell, etc.).
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '[]',
+    })
+  })
+  // The email section's CAPTCHA pulls a script from Cloudflare. Fulfil it with
+  // a no-op so the suite never depends on the network — the widget then renders
+  // its inline "couldn't load" state, which is narrow either way. (The real
+  // Turnstile iframe is ~300px wide but lives inside a card with
+  // `overflow: hidden`, so it is clipped, not propagated: it cannot widen the
+  // document. That is exactly why the issue's blame on #sec-email was wrong.)
+  await page.route('https://challenges.cloudflare.com/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'text/javascript', body: '' }),
+  )
+}
+
+/** The horizontal-overflow measurement, as the browser sees it. */
+async function measureWidths(page: Page) {
+  return page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }))
+}
+
+async function gotoSettings(page: Page, username = LONG_USERNAME) {
+  await withSession(page, username)
+  await page.goto('/settings')
+  await expect(
+    page.getByRole('heading', { level: 1, name: 'Settings' }),
+  ).toBeVisible()
+  // The pill renders from the same session payload; wait for it so we never
+  // measure a header that is still one element short. (Scoped to the pill:
+  // the app shell's own user name carries the same text, hidden on mobile.)
+  await expect(page.getByTestId('settings-user-pill')).toContainText(username)
+}
+
+test.describe('Settings page — narrow viewport', () => {
+  test('does not scroll horizontally at 360px with a long username', async ({
+    page,
+  }) => {
+    await page.setViewportSize(NARROW)
+    await gotoSettings(page)
+
+    const { scrollWidth, clientWidth } = await measureWidths(page)
+    expect(
+      scrollWidth,
+      `document is ${scrollWidth}px wide in a ${clientWidth}px viewport — the settings page scrolls sideways`,
+    ).toBeLessThanOrEqual(clientWidth)
+  })
+
+  test('keeps the header inside the viewport at 360px with a long username', async ({
+    page,
+  }) => {
+    await page.setViewportSize(NARROW)
+    await gotoSettings(page)
+
+    const heading = page.getByRole('heading', { level: 1, name: 'Settings' })
+    const pill = page.getByTestId('settings-user-pill')
+
+    for (const [name, box] of [
+      ['heading', await heading.boundingBox()],
+      ['username pill', await pill.boundingBox()],
+    ] as const) {
+      expect(box, `${name} should have a box`).not.toBeNull()
+      expect(
+        box!.x + box!.width,
+        `${name} right edge overhangs the 360px viewport`,
+      ).toBeLessThanOrEqual(NARROW.width)
+    }
+  })
+
+  test('does not scroll horizontally at 360px with a short username', async ({
+    page,
+  }) => {
+    // Measured: this case PASSED against the bug (the header happened to fit),
+    // which is exactly the trap the long-username case above exists to avoid.
+    // Kept as a plain guard — and as a marker that it proves nothing on its own.
+    await page.setViewportSize(NARROW)
+    await gotoSettings(page, 'ada')
+
+    const { scrollWidth, clientWidth } = await measureWidths(page)
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth)
+  })
+})
+
+test.describe('Settings page — desktop', () => {
+  test('still renders the display heading beside the username pill', async ({
+    page,
+  }) => {
+    await page.setViewportSize(DESKTOP)
+    await gotoSettings(page)
+
+    const { scrollWidth, clientWidth } = await measureWidths(page)
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth)
+
+    const heading = page.getByRole('heading', { level: 1, name: 'Settings' })
+    const pill = page.getByTestId('settings-user-pill')
+    const h = (await heading.boundingBox())!
+    const p = (await pill.boundingBox())!
+
+    // Same row: the pill sits to the right of the heading, vertically overlapping it.
+    expect(p.x).toBeGreaterThan(h.x + h.width)
+    expect(p.y).toBeLessThan(h.y + h.height)
+    expect(h.y).toBeLessThan(p.y + p.height)
+
+    // And the heading keeps its full 64px display size on desktop.
+    const fontSize = await heading.evaluate(
+      (el) => getComputedStyle(el).fontSize,
+    )
+    expect(fontSize).toBe('64px')
+  })
+})

--- a/web-client/src/components/app-shell.page.tsx
+++ b/web-client/src/components/app-shell.page.tsx
@@ -47,6 +47,19 @@ const scoped = (container: Container) => {
     )
 
   return {
+    /** The `<aside>` itself — the drawer on mobile, the sidebar on desktop. */
+    getSidebar() {
+      return sidebar()
+    },
+    /**
+     * The topbar hamburger. Its `aria-controls` must resolve to the sidebar's
+     * `id`; whether the *closed* drawer is actually out of the tab order is a
+     * question about layout, so it's pinned in `e2e/app-shell.spec.ts` — jsdom
+     * cannot see the CSS that hides it.
+     */
+    getMenuButton() {
+      return container.getByRole('button', { name: 'Open navigation' })
+    },
     /**
      * Any nav link in the sidebar by its label — top-level ("Matches") or
      * sub-nav ("Preferences"); the labels are unique across both levels.
@@ -85,6 +98,26 @@ const scoped = (container: Container) => {
     getActiveSubNavLabels() {
       return labels('.app-shell__sub-nav-link.is-active')
     },
+    /**
+     * Labels of every sidebar link — both levels — announced to assistive tech
+     * as the current page. This is the *semantic* layer, not the visual one, and
+     * the two deliberately disagree: on `/notifications/settings` the parent is
+     * lit but says nothing, so this returns `['Preferences']` while
+     * `getParentActiveNavLabels()` returns `['Notifications']`. ARIA has exactly
+     * one current page, so this list should never hold more than one label
+     * (#930).
+     */
+    getCurrentPageNavLabels() {
+      return labels('a[aria-current="page"]')
+    },
+    /** Every value of `aria-current` in the sidebar — `aria-current="true"` on a
+     * section ancestor would be just as wrong as a second `"page"`, and only a
+     * value-blind sweep can see it. */
+    getAriaCurrentValues() {
+      return Array.from(
+        sidebar().querySelectorAll<HTMLAnchorElement>('a[aria-current]'),
+      ).map((el) => `${labelOf(el)}=${el.getAttribute('aria-current')}`)
+    },
   }
 }
 
@@ -95,13 +128,17 @@ const scoped = (container: Container) => {
  * router and the session query both resolve asynchronously, so tests start with
  * `await appShellPage.findNavLink(...)`.
  *
- * Active state is asserted through the BEM classes, not `aria-current`: a
- * TanStack `<Link>` stamps `aria-current="page"` (plus `data-status="active"`)
- * on *every* link whose `to` is a prefix of the location — its default
- * `activeOptions.exact` is `false` — so the parent items and the Inbox child
- * all carry it regardless of what the shell decides. The `is-active` /
- * `is-parent-active` classes are the shell's own contract (they drive the CSS
- * and the e2e locators), so they're what these accessors read.
+ * The shell has **two** notions of "current", and they are read separately:
+ *
+ * - **Visual** — the `is-active` / `is-parent-active` BEM classes the shell
+ *   computes itself (`getActiveNavLabels`, `getParentActiveNavLabels`,
+ *   `getActiveSubNavLabels`). A section parent is lit across its whole subtree.
+ * - **Semantic** — `aria-current="page"` (`getCurrentPageNavLabels`,
+ *   `getAriaCurrentValues`). Only the leaf; a parent announces nothing.
+ *
+ * They must be asserted together. The classes drive the CSS and no CSS reads
+ * `aria-current`, so a change that quietly dimmed the parent would still satisfy
+ * an `aria-current`-only test, and vice versa (#930).
  */
 export const appShellPage = {
   render(pathname: string, overrides: Partial<AppShellProps> = {}) {

--- a/web-client/src/components/app-shell.page.tsx
+++ b/web-client/src/components/app-shell.page.tsx
@@ -6,6 +6,7 @@ import {
   createRouter,
 } from '@tanstack/react-router'
 import { http, HttpResponse } from 'msw'
+import userEvent from '@testing-library/user-event'
 
 import { mockSession } from '@/mocks/handlers'
 import { server } from '@/mocks/server'
@@ -45,6 +46,8 @@ const scoped = (container: Container) => {
     Array.from(sidebar().querySelectorAll<HTMLAnchorElement>(selector)).map(
       labelOf,
     )
+  const alphaTrigger = (): HTMLElement =>
+    container.getByRole('button', { name: 'About the alpha release' })
 
   return {
     /** The `<aside>` itself — the drawer on mobile, the sidebar on desktop. */
@@ -117,6 +120,49 @@ const scoped = (container: Container) => {
       return Array.from(
         sidebar().querySelectorAll<HTMLAnchorElement>('a[aria-current]'),
       ).map((el) => `${labelOf(el)}=${el.getAttribute('aria-current')}`)
+    },
+
+    // --- The alpha notice (topbar) ---------------------------------------
+    //
+    // Radix portals the popover's content to `document.body`, *outside* the
+    // shell's tree, so the notice accessors read from `screen` rather than
+    // from `container`. Only the trigger — a real topbar child — is scoped.
+
+    /** The topbar "Alpha" badge that opens the notice. */
+    getAlphaTrigger() {
+      return alphaTrigger()
+    },
+    /** Click the badge and wait for the notice. Radix renders popover content
+     * with `role="dialog"` (it is not modal — Escape and an outside click both
+     * dismiss it — but the role is a dialog all the same). */
+    async openAlphaNotice() {
+      await userEvent.click(alphaTrigger())
+      return await screen.findByRole('dialog')
+    },
+    /** The open notice, or `null` once it is dismissed. */
+    queryAlphaNotice() {
+      return screen.queryByRole('dialog')
+    },
+    /**
+     * The notice's close control, addressed by its accessible name — the whole
+     * point of #891 is that a control exists *and* announces itself. Throws
+     * when there is none, which is exactly what the pre-fix shell did.
+     */
+    getAlphaCloseButton() {
+      return within(screen.getByRole('dialog')).getByRole('button', {
+        name: 'Close alpha notice',
+      })
+    },
+    /**
+     * Every button inside the open notice. Before #891 this was **empty** — the
+     * panel covered most of a 375px viewport with nothing to press. Asserting
+     * the list (not just "a close button exists") also catches a second, unnamed
+     * dismiss affordance sneaking in.
+     */
+    getAlphaNoticeButtonNames() {
+      return within(screen.getByRole('dialog'))
+        .queryAllByRole('button')
+        .map((el) => el.getAttribute('aria-label') ?? labelOf(el))
     },
   }
 }

--- a/web-client/src/components/app-shell.test.tsx
+++ b/web-client/src/components/app-shell.test.tsx
@@ -1,3 +1,6 @@
+import userEvent from '@testing-library/user-event'
+import { waitFor } from '@/test/utilities'
+
 import { appShellPage } from './app-shell.page'
 
 /**
@@ -230,5 +233,70 @@ describe('AppShell sidebar', () => {
     expect(appShellPage.getParentActiveNavLabels()).toEqual(['Administration'])
     // Deeper than "Users", so no child claims the strict-equality highlight.
     expect(appShellPage.getActiveSubNavLabels()).toEqual([])
+  })
+})
+
+/**
+ * The topbar's "Alpha" notice — a **non-modal** Radix popover (the shared
+ * `ui/popover.tsx` passes no `modal` prop, so Radix defaults to
+ * `modal={false}`).
+ *
+ * Two different bugs meet here, and only one of them was real:
+ *
+ * - **#891 — no visible close control.** Measured in a browser: the open panel
+ *   contained **zero** buttons. On a 375px viewport it is a 320×272 slab over
+ *   most of the page, dismissable only by an outside click or a key a touch user
+ *   does not have. The close-control test below is the *discriminating* one — it
+ *   fails against the pre-fix shell.
+ * - **#885 — "does not close on Escape".** It does. Escape was verified working
+ *   in a browser on desktop and mobile before any change was made, and it passes
+ *   here both before and after the #891 fix: Radix's `DismissableLayer` handles
+ *   it and nothing in the shell intercepts `onEscapeKeyDown`. The Escape test is
+ *   therefore a **regression guard**, not a fix — its job is to fail if someone
+ *   later adds an `onEscapeKeyDown` preventDefault or a global key handler that
+ *   swallows it. It is deliberately non-discriminating today.
+ */
+describe('AppShell alpha notice', () => {
+  it('offers a labelled close control that dismisses it (#891)', async () => {
+    appShellPage.render('/dashboard')
+    await appShellPage.findNavLink('Dashboard')
+    await appShellPage.openAlphaNotice()
+
+    // Before the fix this list was `[]` — the panel had no button at all.
+    expect(appShellPage.getAlphaNoticeButtonNames()).toEqual([
+      'Close alpha notice',
+    ])
+    const close = appShellPage.getAlphaCloseButton()
+    // Named *and* actually on screen: an sr-only-only affordance would leave a
+    // sighted touch user exactly where #891 found them.
+    expect(close).toBeVisible()
+
+    await userEvent.click(close)
+
+    await waitFor(() => expect(appShellPage.queryAlphaNotice()).toBeNull())
+  })
+
+  it('hands focus back to the Alpha badge once the notice is closed (#891)', async () => {
+    appShellPage.render('/dashboard')
+    await appShellPage.findNavLink('Dashboard')
+    await appShellPage.openAlphaNotice()
+
+    await userEvent.click(appShellPage.getAlphaCloseButton())
+
+    // Dismissing must not strand focus on a detached node — the keyboard user
+    // lands back on the control they opened it from.
+    await waitFor(() =>
+      expect(appShellPage.getAlphaTrigger()).toHaveFocus(),
+    )
+  })
+
+  it('still dismisses on Escape — regression guard, not a fix (#885)', async () => {
+    appShellPage.render('/dashboard')
+    await appShellPage.findNavLink('Dashboard')
+    await appShellPage.openAlphaNotice()
+
+    await userEvent.keyboard('{Escape}')
+
+    await waitFor(() => expect(appShellPage.queryAlphaNotice()).toBeNull())
   })
 })

--- a/web-client/src/components/app-shell.test.tsx
+++ b/web-client/src/components/app-shell.test.tsx
@@ -5,9 +5,9 @@ import { appShellPage } from './app-shell.page'
  * (prefix match, guarded by a trailing slash); sub-nav children stay on strict
  * equality so only one child lights at a time.
  *
- * Assertions read the `is-active` / `is-parent-active` classes — see the page
- * object for why `aria-current` (which TanStack's `<Link>` stamps on every
- * prefix match of its own accord) can't stand in for them.
+ * Two layers, asserted separately: the `is-active` / `is-parent-active` classes
+ * are what the eye sees, `aria-current="page"` is what a screen reader hears —
+ * and they deliberately disagree on a sub-route (#930). See the page object.
  */
 describe('AppShell sidebar', () => {
   it('lights Players on a player detail route beneath it', async () => {
@@ -104,6 +104,120 @@ describe('AppShell sidebar', () => {
     )
     expect(appShellPage.getParentActiveNavLabels()).toEqual(['Administration'])
     expect(appShellPage.getActiveNavLabels()).toEqual([])
+  })
+
+  // #887. The hamburger has always declared `aria-controls="app-shell-sidebar"`,
+  // but nothing in the tree carried that id, so the reference dangled. The rest
+  // of that fix (a closed drawer being out of the tab order and the a11y tree)
+  // is CSS, and so is unprovable here — jsdom has no layout. See
+  // `e2e/app-shell.spec.ts` for the assertion that actually pins the behaviour.
+  it('points the hamburger aria-controls at a sidebar that exists', async () => {
+    appShellPage.render('/dashboard')
+    await appShellPage.findNavLink('Dashboard')
+
+    const target = appShellPage.getMenuButton().getAttribute('aria-controls')
+    expect(target).toBeTruthy()
+    expect(document.getElementById(target!)).toBe(appShellPage.getSidebar())
+  })
+
+  /**
+   * #930. On `/notifications/settings` the sidebar announced three current
+   * pages at once — Notifications, Inbox *and* Preferences (measured in a
+   * browser: `["Notifications=page", "Inbox=page", "Preferences=page"]`), because
+   * TanStack's `<Link>` marks every prefix match active by default. The visuals
+   * were right the whole time; only the accessibility layer lied, telling a
+   * screen-reader user they were in the inbox.
+   *
+   * Every test here asserts BOTH layers. Counting `aria-current` alone would go
+   * green on a "fix" that also dimmed the parent highlight — which is the one
+   * thing that must not change.
+   */
+  describe('announces exactly one current page (#930)', () => {
+    it('announces only the leaf on the notification settings route, while the parent stays lit', async () => {
+      appShellPage.render('/notifications/settings')
+      await appShellPage.findNavLink('Preferences')
+
+      // Was ['Notifications=page', 'Inbox=page', 'Preferences=page'].
+      // Read by value, not just by count: `aria-current="true"` on the section
+      // ancestor would be wrong too — an ancestor announces *nothing*.
+      expect(appShellPage.getAriaCurrentValues()).toEqual(['Preferences=page'])
+      expect(appShellPage.getCurrentPageNavLabels()).toEqual(['Preferences'])
+      expect(appShellPage.getNavLink('Inbox')).not.toHaveAttribute(
+        'aria-current',
+      )
+      expect(appShellPage.getNavLink('Notifications')).not.toHaveAttribute(
+        'aria-current',
+      )
+
+      // …and the other half of the bargain: the section is still visibly lit.
+      expect(appShellPage.getNavLink('Notifications')).toHaveClass(
+        'is-parent-active',
+      )
+      expect(appShellPage.getParentActiveNavLabels()).toEqual(['Notifications'])
+      expect(appShellPage.getActiveSubNavLabels()).toEqual(['Preferences'])
+    })
+
+    it('announces Inbox — and only Inbox — on the notifications index, while the parent stays lit', async () => {
+      appShellPage.render('/notifications')
+      await appShellPage.findNavLink('Inbox')
+
+      // The mirror case: here Inbox *is* the leaf. The parent shares the
+      // pathname exactly, so this is the one place a prefix match and an exact
+      // match could still both fire — they must not.
+      expect(appShellPage.getAriaCurrentValues()).toEqual(['Inbox=page'])
+      expect(appShellPage.getNavLink('Notifications')).not.toHaveAttribute(
+        'aria-current',
+      )
+
+      expect(appShellPage.getNavLink('Notifications')).toHaveClass(
+        'is-parent-active',
+      )
+      expect(appShellPage.getActiveSubNavLabels()).toEqual(['Inbox'])
+    })
+
+    it('announces only the leaf in the admin section, while Administration stays lit', async () => {
+      appShellPage.render('/admin/roles')
+      await appShellPage.findNavLink('Roles')
+
+      expect(appShellPage.getAriaCurrentValues()).toEqual(['Roles=page'])
+      expect(appShellPage.getNavLink('Overview')).not.toHaveAttribute(
+        'aria-current',
+      )
+      expect(appShellPage.getNavLink('Administration')).toHaveClass(
+        'is-parent-active',
+      )
+    })
+
+    it('announces a childless top-level item on its own route', async () => {
+      appShellPage.render('/matches')
+      await appShellPage.findNavLink('Matches')
+
+      expect(appShellPage.getAriaCurrentValues()).toEqual(['Matches=page'])
+      expect(appShellPage.getActiveNavLabels()).toEqual(['Matches'])
+    })
+
+    it('keeps announcing the item when the URL carries search params', async () => {
+      // `exact` alone would compare search params *fully* as well, so a link
+      // with no search of its own (every link in this sidebar) would stop
+      // matching `/matches?page=2` — trading three wrong answers for none.
+      // Hence `includeSearch: false`.
+      appShellPage.render('/matches?page=2')
+      await appShellPage.findNavLink('Matches')
+
+      expect(appShellPage.getAriaCurrentValues()).toEqual(['Matches=page'])
+      expect(appShellPage.getActiveNavLabels()).toEqual(['Matches'])
+    })
+
+    it('announces nothing on a detail route no nav item points at, but keeps the section lit', async () => {
+      appShellPage.render('/players/u_7')
+      await appShellPage.findNavLink('Players')
+
+      // Deliberate: you are not *on* the players page, so no link is the
+      // current page. Silence is correct; "Players" claiming to be the page you
+      // are reading is not. The highlight still tells your eye where you are.
+      expect(appShellPage.getAriaCurrentValues()).toEqual([])
+      expect(appShellPage.getActiveNavLabels()).toEqual(['Players'])
+    })
   })
 
   it('still tints the parent on a route deeper than any listed child', async () => {

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
-import { Link, useRouterState } from '@tanstack/react-router'
+import { Link, useLinkProps, useRouterState } from '@tanstack/react-router'
 import {
   Bell,
   ChevronDown,
@@ -186,6 +186,87 @@ function isUnder(pathname: string, to: string) {
   return pathname === to || pathname.startsWith(`${to}/`)
 }
 
+/**
+ * What the *screen reader* hears — deliberately narrower than what the eye sees.
+ *
+ * A TanStack `<Link>` stamps `aria-current="page"` on every link whose `to` is a
+ * *prefix* of the location (`activeOptions.exact` defaults to `false`). Left at
+ * that default, `/notifications/settings` announced THREE current pages at once
+ * — Notifications, Inbox and Preferences — so a screen-reader user was told they
+ * were in the inbox while looking at the preferences page (#930). ARIA has
+ * exactly one current page; the leaf is it. A section ancestor announces
+ * nothing at all, not even `aria-current="true"`.
+ *
+ * This is the *semantic* layer only. The visual highlight — a parent staying lit
+ * over its whole subtree — is computed by `isUnder()` above and applied as
+ * `is-active` / `is-parent-active`; no CSS reads `aria-current` or
+ * `data-status`, so tightening this cannot dim anything.
+ *
+ * `includeSearch: false` because these links carry no search of their own: with
+ * the router's default the exact match would compare search params *fully*, and
+ * `/matches?page=2` would announce no current page at all — trading three lies
+ * for a silence.
+ */
+const EXACT_LINK_ONLY: { exact: true; includeSearch: false } = {
+  exact: true,
+  includeSearch: false,
+}
+
+/**
+ * A top-level nav link. Renders exactly what `<Link>` renders — `<Link>` *is*
+ * `useLinkProps()` plus an `<a>` — with one attribute under the shell's control
+ * instead of the router's: `aria-current`.
+ *
+ * We have to reach for the hook because `exact` alone cannot finish the job.
+ * A section parent and its index child point at the **same URL** (Notifications
+ * and Inbox are both `/notifications`; Administration and Overview are both
+ * `/admin`), so on the index route an exact match fires for both and two links
+ * announce themselves as the current page. No comparison of URLs can separate
+ * them — they *are* the same URL. What separates them is that one is an ancestor
+ * and the other the leaf, which only the shell knows. And the router hard-codes
+ * `aria-current="page"` onto every link it considers active, spread in after
+ * `activeProps`, so a prop cannot take it back off.
+ *
+ * So: a section parent drops the attribute; a childless item is itself the leaf
+ * and keeps whatever the router computed. Everything else here — the href, the
+ * preloading, the click handling, `data-status` — is still the router's, and
+ * none of it touches the visual state, which is the `is-*` classes below.
+ */
+function TopLevelNavLink({
+  item,
+  isActive,
+  closeOnMobile,
+}: {
+  item: NavItem
+  isActive: boolean
+  closeOnMobile: () => void
+}) {
+  const { 'aria-current': routerAriaCurrent, ...linkProps } = useLinkProps({
+    to: item.to,
+    activeOptions: EXACT_LINK_ONLY,
+    className: cn(
+      'app-shell__nav-link',
+      // A parent defers the full treatment to its children and keeps only
+      // the icon tint.
+      isActive && !item.children && 'is-active',
+      isActive && item.children && 'is-parent-active',
+    ),
+    onClick: closeOnMobile,
+  })
+
+  return (
+    <a
+      {...linkProps}
+      // A section ancestor announces nothing — not even `aria-current="true"`.
+      // ARIA has exactly one current page, and it is the leaf (#930).
+      aria-current={item.children ? undefined : routerAriaCurrent}
+    >
+      <span className="app-shell__nav-icon">{item.icon}</span>
+      {item.label}
+    </a>
+  )
+}
+
 function renderNavItem(item: NavItem, pathname: string, closeOnMobile: () => void) {
   // One notion of "you are in this section", used for all three decisions
   // below. Deriving the parent tint from an exhaustive child match instead
@@ -194,26 +275,22 @@ function renderNavItem(item: NavItem, pathname: string, closeOnMobile: () => voi
   const isActive = isUnder(pathname, item.to)
   return (
     <li key={item.label}>
-      <Link
-        to={item.to}
-        className={cn(
-          'app-shell__nav-link',
-          // A parent defers the full treatment to its children and keeps only
-          // the icon tint.
-          isActive && !item.children && 'is-active',
-          isActive && item.children && 'is-parent-active',
-        )}
-        onClick={closeOnMobile}
-      >
-        <span className="app-shell__nav-icon">{item.icon}</span>
-        {item.label}
-      </Link>
+      <TopLevelNavLink
+        item={item}
+        isActive={isActive}
+        closeOnMobile={closeOnMobile}
+      />
       {item.children && isActive ? (
         <ul className="app-shell__sub-nav-list">
           {item.children.map((child) => (
             <li key={child.label}>
               <Link
                 to={child.to}
+                // The children are leaves, so they announce themselves — but
+                // only on their own route. Without `exact`, Inbox
+                // (`/notifications`) also claimed to be the current page on
+                // `/notifications/settings`, which sits beneath it (#930).
+                activeOptions={EXACT_LINK_ONLY}
                 className={cn(
                   'app-shell__sub-nav-link',
                   pathname === child.to && 'is-active',
@@ -282,6 +359,10 @@ export function AppShell({ children }: AppShellProps) {
   return (
     <div className="app-shell dark fortymm-theme">
       <aside
+        // The id the topbar hamburger's `aria-controls` points at. Without it
+        // that reference dangled, so AT was told the button controlled a region
+        // that did not exist (#887).
+        id="app-shell-sidebar"
         className={`app-shell__sidebar${sidebarOpen ? ' is-open' : ''}`}
         aria-label="Main navigation"
       >

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -12,6 +12,7 @@ import {
   TriangleAlert,
   Trophy,
   Users,
+  X,
 } from 'lucide-react'
 import { useSession } from '@/api/session'
 import { Wordmark } from '@/components/wordmark'
@@ -20,8 +21,10 @@ import { PERM } from '@/lib/permissions'
 import { NotificationBell } from './notifications/notification-bell'
 import { UserMenu } from './user-menu'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import {
   Popover,
+  PopoverClose,
   PopoverContent,
   PopoverDescription,
   PopoverHeader,
@@ -465,6 +468,24 @@ export function AppShell({ children }: AppShellProps) {
                       FortyMM is under active development — expect rough edges.
                     </PopoverDescription>
                   </span>
+                  {/*
+                    #891: the notice had no visible way out. It is a non-modal
+                    popover, so Escape and an outside click already dismissed it
+                    — but neither is an affordance you can *see*, and on a 375px
+                    viewport this panel covers most of the page. Same shape as
+                    the dialog's close (ghost icon button, X), named the way the
+                    sidebar's is ("Close navigation").
+                  */}
+                  <PopoverClose asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="-mt-1 -mr-1 ml-auto shrink-0 text-muted-foreground hover:text-foreground"
+                      aria-label="Close alpha notice"
+                    >
+                      <X />
+                    </Button>
+                  </PopoverClose>
                 </PopoverHeader>
                 <ul className="list-disc space-y-1.5 py-3.5 pr-3.5 pl-8 text-xs leading-relaxed text-muted-foreground">
                   <li>Features may change or break without warning.</li>

--- a/web-client/src/components/dashboard/first-match/first-match-card.test.tsx
+++ b/web-client/src/components/dashboard/first-match/first-match-card.test.tsx
@@ -83,6 +83,22 @@ describe('FirstMatchCard', () => {
     ).toBeInTheDocument()
   })
 
+  it('offers no "back to recent opponents" escape — there is no grid to go back to (#895)', async () => {
+    renderFirstMatchCard()
+
+    await screen.findByRole('combobox')
+
+    // /matches/new gets a visible way out of search mode back to its recent
+    // grid. This hero *starts* in search and has no recents framing, so the
+    // same control here would dump the user somewhere they have never been.
+    expect(
+      screen.queryByRole('button', { name: /back to recent opponents/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /search all players/i }),
+    ).not.toBeInTheDocument()
+  })
+
   it('reveals the format fields and a rated summary once an opponent is picked', async () => {
     renderFirstMatchCard()
 

--- a/web-client/src/components/dashboard/first-match/first-match-card.tsx
+++ b/web-client/src/components/dashboard/first-match/first-match-card.tsx
@@ -11,6 +11,7 @@ import {
   opponentFromPlayer,
   type Opponent,
 } from '@/components/matches/match-setup/opponent'
+import { opponentSelection } from '@/components/matches/match-setup/opponent-selection'
 import { useStartMatch } from '@/components/matches/match-setup/use-start-match'
 import { Card } from '@/components/dashboard/your-game-row/card'
 import { C, MONO, UI } from '@/components/dashboard/dashboard-tokens'
@@ -153,7 +154,13 @@ export const FirstMatchCard = () => {
           className="nm-btn nm-btn-primary"
           disabled={!opponent || submitting}
           aria-busy={submitting}
-          onClick={() => submit({ opponent, bestOf, rated })}
+          // No `seeking` arm to model here: this hero *requires* an opponent
+          // (the button above is gated on one), so it can never walk the user
+          // into an unintended solo match the way /matches/new could (#893) —
+          // its selection is only ever `picked` or `none`.
+          onClick={() =>
+            submit({ selection: opponentSelection(opponent, ''), bestOf, rated })
+          }
         >
           {submitting ? 'Starting…' : 'Start scoring'}
           {!submitting && <ArrowRight size={16} strokeWidth={2.5} />}

--- a/web-client/src/components/dashboard/first-match/first-match-card.tsx
+++ b/web-client/src/components/dashboard/first-match/first-match-card.tsx
@@ -159,7 +159,11 @@ export const FirstMatchCard = () => {
           // into an unintended solo match the way /matches/new could (#893) —
           // its selection is only ever `picked` or `none`.
           onClick={() =>
-            submit({ selection: opponentSelection(opponent, ''), bestOf, rated })
+            submit({
+              selection: opponentSelection(opponent, false),
+              bestOf,
+              rated,
+            })
           }
         >
           {submitting ? 'Starting…' : 'Start scoring'}

--- a/web-client/src/components/matches/match-details.test.tsx
+++ b/web-client/src/components/matches/match-details.test.tsx
@@ -151,6 +151,33 @@ describe("MatchDetails — scoreboard seam", () => {
   });
 });
 
+describe("MatchDetails — landmarks", () => {
+  it("contributes no main landmark of its own — the app shell owns the page's only one (#888)", async () => {
+    // The page used to wrap itself in `<main className="md-page">`, which the
+    // app shell then rendered *inside* its own `<main className="app-shell__
+    // content">`: two main landmarks on every match-detail page, at every
+    // viewport. This suite renders the page without the shell, so the count of
+    // mains it contributes is exactly zero; the one-main-per-page count is
+    // pinned in a real browser (with the shell around it, at both mobile and
+    // desktop) by e2e/matches/match-details.spec.ts.
+    matchDetailsPage.mockMatch("m-1", decidedMatch());
+
+    const { container } = matchDetailsPage.render("m-1");
+
+    // Guard: the page has actually rendered, so the absences below aren't
+    // vacuous.
+    await waitFor(() => matchDetailsPage.scoreboard.getRegion());
+
+    expect(container.querySelectorAll("main")).toHaveLength(0);
+    // Belt and braces — the landmark can also be claimed by an explicit role.
+    expect(container.querySelectorAll('[role="main"]')).toHaveLength(0);
+
+    // The layout survives the tag swap: it hangs off the classes, which stay
+    // on the wrapper that replaced the <main>.
+    expect(container.querySelector("div.md-page.md-page--y")).toBeInTheDocument();
+  });
+});
+
 describe("MatchDetails — page wiring", () => {
   it("renders the hero scoreline from the participant sides counts", async () => {
     const match = matchDetails({

--- a/web-client/src/components/matches/match-details.tsx
+++ b/web-client/src/components/matches/match-details.tsx
@@ -22,7 +22,12 @@ export function MatchDetails({ matchId }: { matchId: string }) {
   // immediately and each piece suspends independently — no page-level fetch.
   return (
     <div className="match-details">
-      <main className="md-page md-page--y">
+      {/* A plain <div>, not a <main>: the app shell (`app-shell__content`)
+          already is the page's `main` landmark, and this wrapper nested a
+          second one inside it — landmark navigation announced two "main"s on
+          every match-detail page, at every viewport (#888). The layout hangs
+          off the `md-page` classes, not the tag, so the render is unchanged. */}
+      <div className="md-page md-page--y">
         <div className="md-header">
           <Breadcrumb matchId={matchId} />
           <div className="md-header__right">
@@ -48,7 +53,7 @@ export function MatchDetails({ matchId }: { matchId: string }) {
             <HeadToHead matchId={matchId} />
           </aside>
         </div>
-      </main>
+      </div>
     </div>
   )
 }

--- a/web-client/src/components/matches/match-setup/match-setup.css
+++ b/web-client/src/components/matches/match-setup/match-setup.css
@@ -19,6 +19,34 @@
   --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.55);
 }
 
+/* --- Picker shell: the search-mode header holding the way back (#895) --- */
+.nm-search-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-start;
+  margin-bottom: 12px;
+}
+.nm-back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  margin-left: -6px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  font: 600 11px var(--font-ui);
+  color: var(--ball-500);
+  cursor: pointer;
+}
+.nm-back-btn:hover {
+  text-decoration: underline;
+}
+.nm-back-btn:focus-visible {
+  outline: 2px solid var(--ball-500);
+  outline-offset: 2px;
+}
+
 /* --- Typeahead picker --- */
 .nm-search {
   position: relative;

--- a/web-client/src/components/matches/match-setup/opponent-selection.ts
+++ b/web-client/src/components/matches/match-setup/opponent-selection.ts
@@ -19,24 +19,29 @@ import type { Opponent } from './opponent'
  */
 export type OpponentSelection =
   | { kind: 'none' }
-  | { kind: 'seeking'; query: string }
+  | { kind: 'seeking' }
   | { kind: 'picked'; opponent: Opponent }
 
 /**
  * Resolve the selection from the two things the card can observe: the opponent
- * it has committed to (picked, or preseeded from `?opponent=`), and the
- * picker's current uncommitted search text.
+ * it has committed to (picked, or preseeded from `?opponent=`), and whether the
+ * picker currently holds an uncommitted search.
  *
  * A committed opponent always wins: once you've picked someone, whatever is
  * left in the search box is irrelevant.
+ *
+ * `seeking` carries no payload on purpose. It is the *fact* of an unresolved
+ * search, not its text — and taking the boolean rather than the string is what
+ * keeps the card off the keystroke path: mirroring the query up re-rendered the
+ * whole form on every character and re-registered the `useBlocker` guard with
+ * it, to fill a field nothing ever read.
  */
 export function opponentSelection(
   opponent: Opponent | null,
-  searchQuery: string,
+  isSeeking: boolean,
 ): OpponentSelection {
   if (opponent !== null) return { kind: 'picked', opponent }
-  const query = searchQuery.trim()
-  return query.length > 0 ? { kind: 'seeking', query } : { kind: 'none' }
+  return isSeeking ? { kind: 'seeking' } : { kind: 'none' }
 }
 
 /**

--- a/web-client/src/components/matches/match-setup/opponent-selection.ts
+++ b/web-client/src/components/matches/match-setup/opponent-selection.ts
@@ -1,0 +1,59 @@
+import type { Opponent } from './opponent'
+
+/**
+ * Who the match-setup form is being set up against: one value, three
+ * mutually-exclusive cases (`DEFINITION_OF_COMPLETE.md` — non-fetch view state
+ * with mutually exclusive cases is a sum type, the client-side twin of "no
+ * tri-state booleans").
+ *
+ * The case that didn't exist before (#893) is **`seeking`**. When
+ * `Opponent | null` was the whole model, "I typed a name and found nobody" and
+ * "I want a solo match" were *the same value* — `null` — so a user still
+ * hunting for an opponent was told "Ready: You · solo match" and Start match
+ * created a solo match they never asked for. The card structurally could not
+ * tell the two apart. Splitting the `null` in two is what lets it.
+ *
+ * `seeking` is a **non-empty**, uncommitted query. An empty search box is
+ * `none`, not `seeking`: merely opening the search must not nag the user or
+ * relabel the button — with nothing typed, solo is still the honest default.
+ */
+export type OpponentSelection =
+  | { kind: 'none' }
+  | { kind: 'seeking'; query: string }
+  | { kind: 'picked'; opponent: Opponent }
+
+/**
+ * Resolve the selection from the two things the card can observe: the opponent
+ * it has committed to (picked, or preseeded from `?opponent=`), and the
+ * picker's current uncommitted search text.
+ *
+ * A committed opponent always wins: once you've picked someone, whatever is
+ * left in the search box is irrelevant.
+ */
+export function opponentSelection(
+  opponent: Opponent | null,
+  searchQuery: string,
+): OpponentSelection {
+  if (opponent !== null) return { kind: 'picked', opponent }
+  const query = searchQuery.trim()
+  return query.length > 0 ? { kind: 'seeking', query } : { kind: 'none' }
+}
+
+/**
+ * The opponent the match will actually be created against — `null` for
+ * `seeking` exactly as for `none`, because an uncommitted query is not an
+ * opponent.
+ *
+ * Every "unrated unless there's an opponent" rule reads through this one
+ * accessor (the rated field, the summary line, the submit payload), so the
+ * places that enforce it cannot drift apart on what `seeking` means: a seeking
+ * match is unrated and solo, just like `none`.
+ */
+export function selectedOpponent(selection: OpponentSelection): Opponent | null {
+  return selection.kind === 'picked' ? selection.opponent : null
+}
+
+/** Rating needs a *committed* opponent — a `seeking` match can't be rated. */
+export function isRatable(selection: OpponentSelection): boolean {
+  return selection.kind === 'picked'
+}

--- a/web-client/src/components/matches/match-setup/use-start-match.test.tsx
+++ b/web-client/src/components/matches/match-setup/use-start-match.test.tsx
@@ -282,7 +282,7 @@ describe('useStartMatch', () => {
 
     await act(() =>
       submit({
-        selection: { kind: 'seeking', query: 'zzzzzz' },
+        selection: { kind: 'seeking' },
         bestOf: 5,
         rated: false,
       }),
@@ -312,7 +312,7 @@ describe('useStartMatch', () => {
 
     await act(() =>
       submit({
-        selection: { kind: 'seeking', query: 'zzzzzz' },
+        selection: { kind: 'seeking' },
         bestOf: 5,
         rated: true,
       }),

--- a/web-client/src/components/matches/match-setup/use-start-match.test.tsx
+++ b/web-client/src/components/matches/match-setup/use-start-match.test.tsx
@@ -79,7 +79,7 @@ describe('useStartMatch', () => {
     const hook = renderStartMatch()
     const { submit } = await hook.ready()
 
-    await act(() => submit({ opponent: null, bestOf: 5, rated: false }))
+    await act(() => submit({ selection: { kind: 'none' }, bestOf: 5, rated: false }))
 
     expect(hook.router.state.location.pathname).toMatch(
       /^\/matches\/.+\/games\/1\/scores\/new$/,
@@ -112,8 +112,8 @@ describe('useStartMatch', () => {
     const { submit } = await hook.ready()
 
     await act(async () => {
-      submit({ opponent: null, bestOf: 5, rated: false })
-      submit({ opponent: null, bestOf: 5, rated: false })
+      submit({ selection: { kind: 'none' }, bestOf: 5, rated: false })
+      submit({ selection: { kind: 'none' }, bestOf: 5, rated: false })
       await new Promise((r) => setTimeout(r, 0))
     })
 
@@ -148,7 +148,7 @@ describe('useStartMatch', () => {
     // away (unmounting the Probe/hook) before the create resolves.
     let submitPromise: unknown
     act(() => {
-      submitPromise = submit({ opponent: null, bestOf: 5, rated: false })
+      submitPromise = submit({ selection: { kind: 'none' }, bestOf: 5, rated: false })
     })
     await act(async () => {
       await hook.router.navigate({
@@ -199,7 +199,7 @@ describe('useStartMatch', () => {
     const { submit: submit1 } = await hook1.ready()
     let submit1Promise: unknown
     act(() => {
-      submit1Promise = submit1({ opponent: null, bestOf: 5, rated: false })
+      submit1Promise = submit1({ selection: { kind: 'none' }, bestOf: 5, rated: false })
     })
     await act(async () => {
       await hook1.router.navigate({
@@ -216,7 +216,7 @@ describe('useStartMatch', () => {
     // not latched by anything the spent instance 1 left behind.
     const hook2 = renderStartMatch()
     const { submit: submit2 } = await hook2.ready()
-    await act(() => submit2({ opponent: null, bestOf: 5, rated: false }))
+    await act(() => submit2({ selection: { kind: 'none' }, bestOf: 5, rated: false }))
     expect(hook2.router.state.location.pathname).toMatch(
       /^\/matches\/.+\/games\/1\/scores\/new$/,
     )
@@ -254,10 +254,72 @@ describe('useStartMatch', () => {
     const { submit } = await hook.ready()
 
     await act(() =>
-      submit({ opponent: buildOpponent(), bestOf: 5, rated: true }),
+      submit({
+        selection: { kind: 'picked', opponent: buildOpponent() },
+        bestOf: 5,
+        rated: true,
+      }),
     )
 
     const result = await hook.ready()
     expect(result.apiError).toBe('Could not start the match right now.')
+  })
+
+  it('sends a seeking selection as a solo, unrated match — an uncommitted query is not an opponent (#893)', async () => {
+    // The send-time coercion is one of the places that has to agree on what a
+    // half-typed search means: nothing. It coerces exactly like `none` — no
+    // opponent id invented from the query, no rating.
+    let captured: unknown = null
+    server.use(
+      http.post('*/v1/matches', async ({ request }) => {
+        captured = await request.json()
+        const seed = newMatchSeed({ bestOf: 5, rated: false, opponent: null })
+        return HttpResponse.json(projectMatchDetails(seed), { status: 201 })
+      }),
+    )
+    const hook = renderStartMatch()
+    const { submit } = await hook.ready()
+
+    await act(() =>
+      submit({
+        selection: { kind: 'seeking', query: 'zzzzzz' },
+        bestOf: 5,
+        rated: false,
+      }),
+    )
+
+    expect(captured).toEqual({
+      opponent_user_id: null,
+      best_of: 5,
+      rated: false,
+    })
+  })
+
+  it('refuses to create a rated match from a seeking selection, exactly as from none (#893)', async () => {
+    // Defense in depth, and the schema's half of "a seeking match is unrated":
+    // if a stale `rated: true` ever reached submit while the user was still
+    // searching, the refinement rejects it inline rather than POSTing a rated
+    // match with no opponent.
+    let posts = 0
+    server.use(
+      http.post('*/v1/matches', () => {
+        posts += 1
+        return HttpResponse.json({}, { status: 201 })
+      }),
+    )
+    const hook = renderStartMatch()
+    const { submit } = await hook.ready()
+
+    await act(() =>
+      submit({
+        selection: { kind: 'seeking', query: 'zzzzzz' },
+        bestOf: 5,
+        rated: true,
+      }),
+    )
+
+    const result = await hook.ready()
+    expect(result.apiError).toMatch(/rated match needs an opponent/i)
+    expect(posts).toBe(0)
   })
 })

--- a/web-client/src/components/matches/match-setup/use-start-match.ts
+++ b/web-client/src/components/matches/match-setup/use-start-match.ts
@@ -5,11 +5,19 @@ import { z } from 'zod'
 import { ApiError } from '@/api/client'
 import { nextScoringDestination, useCreateMatch } from '@/api/matches'
 
-import type { Opponent } from './opponent'
+import {
+  isRatable,
+  selectedOpponent,
+  type OpponentSelection,
+} from './opponent-selection'
 
 // Rated matches need an opponent; the API enforces this independently. The
 // client toggle is disabled when no opponent is picked, so this only fires
 // in a near-impossible race — keep the refinement for defense in depth.
+//
+// `hasOpponent` comes from `isRatable(selection)`, so a `seeking` selection (a
+// typed-but-uncommitted search, #893) is treated exactly like `none`: not an
+// opponent, therefore not rateable.
 const matchFormSchema = z
   .object({
     hasOpponent: z.boolean(),
@@ -23,7 +31,13 @@ const matchFormSchema = z
   })
 
 export interface StartMatchInput {
-  opponent: Opponent | null
+  /**
+   * The full selection, not a bare `Opponent | null` — the send-time coercion
+   * below is one of the places that has to agree on "no opponent ⇒ solo and
+   * unrated", and taking the sum type is what stops it disagreeing with the UI
+   * about what a `seeking` selection means (#893).
+   */
+  selection: OpponentSelection
   bestOf: number
   rated: boolean
 }
@@ -86,10 +100,13 @@ export function useStartMatch(): UseStartMatchResult {
     }
   }, [])
 
-  async function submit({ opponent, bestOf, rated }: StartMatchInput) {
+  async function submit({ selection, bestOf, rated }: StartMatchInput) {
     setSubmitted(true)
+    // One reading of the selection, shared by the refinement and the payload —
+    // `seeking` collapses to "no opponent" here, and only here.
+    const opponent = selectedOpponent(selection)
     const validation = matchFormSchema.safeParse({
-      hasOpponent: opponent !== null,
+      hasOpponent: isRatable(selection),
       rated,
       bestOf,
     })
@@ -110,7 +127,7 @@ export function useStartMatch(): UseStartMatchResult {
       const created = await createMatch.mutateAsync({
         opponent_user_id: opponent?.id ?? null,
         best_of: bestOf,
-        rated: opponent !== null && rated,
+        rated: isRatable(selection) && rated,
       })
       // Latch the #81 duplicate-create guard BEFORE the mount gate so
       // `hasSucceeded()` and the "this form is spent" contract are unchanged

--- a/web-client/src/components/matches/opponent-picker.page.tsx
+++ b/web-client/src/components/matches/opponent-picker.page.tsx
@@ -20,6 +20,19 @@ const scoped = (container: Container) => ({
   querySearchAll() {
     return container.queryByRole('button', { name: /search all players/i })
   },
+  /**
+   * The "Back to recent opponents" affordance — the visible exit from search
+   * mode (#895). Only rendered for a caller that *has* a recent grid to go back
+   * to, so this is `null` on the `defaultToSearch` entry.
+   */
+  queryBackToRecent() {
+    return container.queryByRole('button', {
+      name: /back to recent opponents/i,
+    })
+  },
+  findBackToRecent() {
+    return container.findByRole('button', { name: /back to recent opponents/i })
+  },
   /** The search combobox, present only once the search view is open. */
   queryCombobox() {
     return container.queryByRole('combobox')

--- a/web-client/src/components/matches/opponent-picker.test.tsx
+++ b/web-client/src/components/matches/opponent-picker.test.tsx
@@ -109,6 +109,116 @@ describe('OpponentPicker', () => {
     expect(opponentPickerPage.getCombobox()).toHaveFocus()
   })
 
+  describe('back to recent opponents (#895)', () => {
+    it('returns to the recent grid when the back control is activated', async () => {
+      const user = userEvent.setup()
+      mockRecentOne()
+      opponentPickerPage.mockSearch(() => HttpResponse.json([]))
+      opponentPickerPage.render()
+
+      await opponentPickerPage.findChip(/ada\.lovelace/)
+      await user.click(opponentPickerPage.querySearchAll()!)
+      expect(opponentPickerPage.queryCombobox()).toBeInTheDocument()
+
+      // The exit search mode never had: an explicit, visible way back.
+      await user.click(await opponentPickerPage.findBackToRecent())
+
+      expect(
+        await opponentPickerPage.findChip(/ada\.lovelace/),
+      ).toBeInTheDocument()
+      expect(opponentPickerPage.queryCombobox()).not.toBeInTheDocument()
+      expect(opponentPickerPage.querySearchAll()).toBeInTheDocument()
+      expect(opponentPickerPage.queryBackToRecent()).not.toBeInTheDocument()
+    })
+
+    it('reports the abandoned query as empty so the card stops reading as "seeking"', async () => {
+      const user = userEvent.setup()
+      mockRecentOne()
+      opponentPickerPage.mockSearch(() => HttpResponse.json([]))
+      const queries: string[] = []
+      opponentPickerPage.render({ onQueryChange: (q) => queries.push(q) })
+
+      await opponentPickerPage.findChip(/ada\.lovelace/)
+      await user.click(opponentPickerPage.querySearchAll()!)
+      await user.type(opponentPickerPage.getCombobox(), 'liskov')
+      expect(queries.at(-1)).toBe('liskov')
+
+      await user.click(await opponentPickerPage.findBackToRecent())
+
+      // Backing out of search is abandoning the hunt — the parent must hear the
+      // query die, or its `seeking` state outlives the search box (#893/#895).
+      expect(queries.at(-1)).toBe('')
+    })
+
+    it('does not keep the abandoned query when search is re-entered', async () => {
+      const user = userEvent.setup()
+      mockRecentOne()
+      opponentPickerPage.mockSearch(() => HttpResponse.json([]))
+      opponentPickerPage.render()
+
+      await opponentPickerPage.findChip(/ada\.lovelace/)
+      await user.click(opponentPickerPage.querySearchAll()!)
+      await user.type(opponentPickerPage.getCombobox(), 'liskov')
+      await user.click(await opponentPickerPage.findBackToRecent())
+      await opponentPickerPage.findChip(/ada\.lovelace/)
+
+      // Search still works on the way back in, from a clean box and focused.
+      await user.click(opponentPickerPage.querySearchAll()!)
+      expect(opponentPickerPage.getCombobox()).toHaveValue('')
+      expect(opponentPickerPage.getCombobox()).toHaveFocus()
+    })
+
+    it('moves focus to "Search all players" so the keyboard user keeps their place', async () => {
+      const user = userEvent.setup()
+      mockRecentOne()
+      opponentPickerPage.mockSearch(() => HttpResponse.json([]))
+      opponentPickerPage.render()
+
+      await opponentPickerPage.findChip(/ada\.lovelace/)
+      await user.click(opponentPickerPage.querySearchAll()!)
+      await user.click(await opponentPickerPage.findBackToRecent())
+
+      // The back control unmounts itself — focus lands on the control that
+      // opened search, not on the document body.
+      await opponentPickerPage.findChip(/ada\.lovelace/)
+      expect(opponentPickerPage.querySearchAll()).toHaveFocus()
+    })
+
+    it('escapes a failed search back to the recent grid', async () => {
+      const user = userEvent.setup()
+      mockRecentOne()
+      opponentPickerPage.mockSearch(() => HttpResponse.json([], { status: 500 }))
+      opponentPickerPage.render()
+
+      await opponentPickerPage.findChip(/ada\.lovelace/)
+      await user.click(opponentPickerPage.querySearchAll()!)
+      await user.type(opponentPickerPage.getCombobox(), 'liskov')
+      await opponentPickerPage.findAlert()
+
+      // "Try again" is not the only way out of a broken search — the back
+      // control sits outside the boundary and still works, and leaving search
+      // clears the boundary's error rather than pinning the fallback in place.
+      await user.click(await opponentPickerPage.findBackToRecent())
+
+      expect(
+        await opponentPickerPage.findChip(/ada\.lovelace/),
+      ).toBeInTheDocument()
+    })
+
+    it('offers no way "back" to a caller that opened straight into search', async () => {
+      const user = userEvent.setup()
+      opponentPickerPage.mockSearch(() => HttpResponse.json([]))
+      // The dashboard's first-match hero: it has no recent-opponents framing of
+      // its own, so a "Back to recent opponents" control would strand the user.
+      opponentPickerPage.render({ defaultToSearch: true })
+
+      expect(opponentPickerPage.queryBackToRecent()).not.toBeInTheDocument()
+
+      await user.type(opponentPickerPage.getCombobox(), 'liskov')
+      expect(opponentPickerPage.queryBackToRecent()).not.toBeInTheDocument()
+    })
+  })
+
   it('surfaces a failed recent-opponents load in the error boundary (#96)', async () => {
     let calls = 0
     opponentPickerPage.mockRecent(() => {

--- a/web-client/src/components/matches/opponent-picker.tsx
+++ b/web-client/src/components/matches/opponent-picker.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react'
+import { ArrowLeft } from 'lucide-react'
 
 import type { Player } from '@/api/matches'
 
@@ -10,6 +11,20 @@ import '@/components/matches/match-setup/match-setup.css'
 export interface OpponentPickerProps {
   /** Called when the user picks a player from the recent grid or the search. */
   onPick: (player: Player) => void
+  /**
+   * Called with the search text on every keystroke — the picker's *second*
+   * channel out, alongside `onPick` (#893).
+   *
+   * `onPick` alone only ever tells a parent about a **committed** choice, which
+   * left the match-setup card unable to distinguish "typed a name, matched
+   * nobody" from "deliberately wants a solo match" — both were simply the
+   * absence of a pick. This reports the uncommitted query so the card can model
+   * that middle state (`OpponentSelection`'s `seeking`) and say so, instead of
+   * quietly promising a solo match. Optional: a caller that doesn't model it
+   * (the dashboard hero, which gates its submit on a picked opponent anyway)
+   * can ignore it.
+   */
+  onQueryChange?: (query: string) => void
   /** Open straight into the search typeahead instead of the recent-opponents
    * grid — for callers with no "recent" framing of their own (e.g. the
    * dashboard's first-match hero card). Defaults to false. */
@@ -23,39 +38,98 @@ export interface OpponentPickerProps {
  * `showSearch` and `query` live here, *above* the `OpponentPickerBoundary`, so
  * a failed search's "Try again" — which resets the boundary and remounts its
  * children — preserves the typed query and the search view instead of dropping
- * back to the recent grid (#96). The `focusOnMountRef` ref likewise survives a
- * reset remount, so error recovery doesn't yank focus back to the input (#131).
+ * back to the recent grid (#96). The focus refs likewise survive a reset
+ * remount, so error recovery doesn't yank focus around (#131).
  *
- * The ref starts `true` on the `defaultToSearch` entry (the dashboard hero opens
- * straight into search), so the input is focused on first mount without a click;
- * on the recent-grid entry it's flipped `true` by `onSearchAll` instead.
+ * `focusSearchInputRef` starts `true` on the `defaultToSearch` entry (the
+ * dashboard hero opens straight into search), so the input is focused on first
+ * mount without a click; on the recent-grid entry it's flipped `true` by
+ * `onSearchAll` instead.
+ *
+ * **Search mode has a visible exit (#895).** The transition into search was
+ * one-way: with the recent grid gone and nothing but the search box on screen,
+ * neither clearing the query nor Escape brought the fastest path to a rematch
+ * back, and there was no control that said it would. So there is one now, and
+ * it is an explicit control — *not* an Escape binding (Escape deliberately
+ * hides the listbox and keeps the query, #97) and *not* an auto-restore when
+ * the box empties (backspacing mid-correction must not yank the grid out from
+ * under the user, and "clear" means clear). Leaving search reports an empty
+ * query upward, so a card modelling the picker's `seeking` state (#893) reads
+ * as `none` again rather than promising a solo match nobody is hunting for.
+ *
+ * A caller that opened *straight into* search has no recent grid behind it —
+ * "back" would land the user somewhere they've never been — so it gets no back
+ * control at all.
  */
 export const OpponentPicker = ({
   onPick,
+  onQueryChange,
   defaultToSearch = false,
 }: OpponentPickerProps) => {
   const [showSearch, setShowSearch] = useState(defaultToSearch)
   const [query, setQuery] = useState('')
-  const focusOnMountRef = useRef(defaultToSearch)
+  const focusSearchInputRef = useRef(defaultToSearch)
+  const focusSearchAllRef = useRef(false)
+
+  // Only the recent-grid entry has somewhere to go back to.
+  const canReturnToRecent = !defaultToSearch
+
+  // The query stays owned here (it must survive a boundary reset, #96) and is
+  // *mirrored* out to the parent — hence set-then-notify rather than a lift.
+  function changeQuery(next: string) {
+    setQuery(next)
+    onQueryChange?.(next)
+  }
+
+  function openSearch() {
+    setShowSearch(true)
+    focusSearchInputRef.current = true
+  }
+
+  function returnToRecent() {
+    setShowSearch(false)
+    // Abandoning the search abandons the query with it — both the box the user
+    // comes back to and the parent's mirror of it (#893).
+    changeQuery('')
+    // The back control unmounts itself, so hand focus to the control that took
+    // the user into search rather than dropping it on the body.
+    focusSearchAllRef.current = true
+  }
 
   return (
-    <OpponentPickerBoundary>
-      {showSearch ? (
-        <OpponentTypeahead
-          query={query}
-          onQueryChange={setQuery}
-          onPick={onPick}
-          focusOnMountRef={focusOnMountRef}
-        />
-      ) : (
-        <RecentOpponents
-          onPick={onPick}
-          onSearchAll={() => {
-            setShowSearch(true)
-            focusOnMountRef.current = true
-          }}
-        />
+    <div className="nm-picker">
+      {showSearch && canReturnToRecent && (
+        <div className="nm-search-head">
+          <button
+            type="button"
+            className="nm-back-btn"
+            onClick={returnToRecent}
+          >
+            <ArrowLeft size={14} strokeWidth={2.5} aria-hidden="true" />
+            Back to recent opponents
+          </button>
+        </div>
       )}
-    </OpponentPickerBoundary>
+      {/* Outside the boundary on purpose: a search that failed into the error
+          fallback is exactly when the user most needs a way out, and "Try
+          again" shouldn't be the only one. `resetKeys` clears that error as the
+          view switches, so the fallback doesn't outlive the view that threw. */}
+      <OpponentPickerBoundary resetKeys={[showSearch]}>
+        {showSearch ? (
+          <OpponentTypeahead
+            query={query}
+            onQueryChange={changeQuery}
+            onPick={onPick}
+            focusOnMountRef={focusSearchInputRef}
+          />
+        ) : (
+          <RecentOpponents
+            onPick={onPick}
+            onSearchAll={openSearch}
+            focusOnMountRef={focusSearchAllRef}
+          />
+        )}
+      </OpponentPickerBoundary>
+    </div>
   )
 }

--- a/web-client/src/components/matches/opponent-picker.tsx
+++ b/web-client/src/components/matches/opponent-picker.tsx
@@ -97,7 +97,10 @@ export const OpponentPicker = ({
   }
 
   return (
-    <div className="nm-picker">
+    // Purely structural: the back control has to sit outside the boundary (see
+    // below), so the two need a common parent. No class — it carries no style,
+    // and a named one would imply it did.
+    <div>
       {showSearch && canReturnToRecent && (
         <div className="nm-search-head">
           <button

--- a/web-client/src/components/matches/opponent-picker/opponent-picker-boundary.tsx
+++ b/web-client/src/components/matches/opponent-picker/opponent-picker-boundary.tsx
@@ -40,12 +40,27 @@ function OpponentPickerError({ resetErrorBoundary }: FallbackProps) {
  * The picker's `query` / `showSearch` state lives *above* this boundary (in
  * `OpponentPicker`), so a reset remounts the children without dropping the
  * typed search (#96).
+ *
+ * `resetKeys` is how the caller says "this is a different view now": the picker
+ * passes its `showSearch`, so switching between the recent grid and search
+ * clears a failed view's error instead of pinning the fallback over the view
+ * the user just moved to (#895). "Try again" stays the in-place recovery.
  */
-export function OpponentPickerBoundary({ children }: { children: ReactNode }) {
+export function OpponentPickerBoundary({
+  children,
+  resetKeys,
+}: {
+  children: ReactNode
+  resetKeys?: unknown[]
+}) {
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
-        <ErrorBoundary FallbackComponent={OpponentPickerError} onReset={reset}>
+        <ErrorBoundary
+          FallbackComponent={OpponentPickerError}
+          onReset={reset}
+          resetKeys={resetKeys}
+        >
           {children}
         </ErrorBoundary>
       )}

--- a/web-client/src/components/matches/opponent-picker/opponent-typeahead.page.tsx
+++ b/web-client/src/components/matches/opponent-picker/opponent-typeahead.page.tsx
@@ -34,6 +34,22 @@ const scoped = (container: Container) => ({
   getOptions() {
     return container.queryAllByRole('option')
   },
+  /**
+   * The options carrying the *visual* highlight (the `.active` class) — the
+   * keyboard/hover cursor. Deliberately separate from `getSelectedOptions`:
+   * highlighted is not selected (#894).
+   */
+  getHighlightedOptions() {
+    return container
+      .queryAllByRole('option')
+      .filter((o: HTMLElement) => o.classList.contains('active'))
+  },
+  /** The options announced to assistive tech as *selected* (#894). */
+  getSelectedOptions() {
+    return container
+      .queryAllByRole('option')
+      .filter((o: HTMLElement) => o.getAttribute('aria-selected') === 'true')
+  },
   findOption(name: string | RegExp) {
     return container.findByRole('option', { name })
   },

--- a/web-client/src/components/matches/opponent-picker/opponent-typeahead.test.tsx
+++ b/web-client/src/components/matches/opponent-picker/opponent-typeahead.test.tsx
@@ -168,9 +168,28 @@ describe('OpponentTypeahead', () => {
     await opponentTypeaheadPage.findOption(/ada\.lovelace/)
     await user.keyboard('{Enter}')
 
-    // Enter commits the *highlighted* option; with none, it commits nothing —
-    // it must not quietly pick whoever happens to be first.
+    // Enter commits the *highlighted* option; with none highlighted and several
+    // to choose between, it commits nothing — it must not quietly pick whoever
+    // happens to be first.
     expect(picked).toBeNull()
+  })
+
+  it('takes the only candidate on Enter — one result is not ambiguous (#894)', async () => {
+    const user = userEvent.setup()
+    let picked: string | null = null
+    opponentTypeaheadPage.mockSearch(() =>
+      HttpResponse.json([buildPlayer({ id: 'pl-1', username: 'ada.lovelace' })]),
+    )
+    opponentTypeaheadPage.render({ onPick: (p) => (picked = p.username) })
+
+    await user.type(opponentTypeaheadPage.getCombobox(), 'ada.lovelace')
+    await opponentTypeaheadPage.findOption(/ada\.lovelace/)
+    await user.keyboard('{Enter}')
+
+    // Typing a name you already know and pressing Enter is the ordinary
+    // keyboard path. Refusing to auto-highlight (#894) must not turn that into
+    // a dead key: with a single candidate there is nothing to disambiguate.
+    expect(picked).toBe('ada.lovelace')
   })
 
   it('hides the listbox on Escape without clearing the query, and reopens on ArrowDown (#97)', async () => {

--- a/web-client/src/components/matches/opponent-picker/opponent-typeahead.test.tsx
+++ b/web-client/src/components/matches/opponent-picker/opponent-typeahead.test.tsx
@@ -2,6 +2,7 @@ import { HttpResponse } from 'msw'
 import userEvent from '@testing-library/user-event'
 
 import { buildPlayer } from '@/mocks/factories/players/player.factory'
+import { fireEvent } from '@/test/utilities'
 
 import { opponentTypeaheadPage } from './opponent-typeahead.page'
 
@@ -52,40 +53,95 @@ describe('OpponentTypeahead', () => {
 
     expect(opponentTypeaheadPage.queryListbox()).toBeInTheDocument()
     expect(options).toHaveLength(3)
-    // First option is active by default and the combobox points at it.
-    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('highlights no option when results arrive, until the user navigates (#894)', async () => {
+    // Results appearing is not a choice. Nobody asked for the first row, so it
+    // must not sit there looking picked while the card upstream still has no
+    // opponent.
+    const { user, options } = await openWithResults()
+
+    expect(opponentTypeaheadPage.getHighlightedOptions()).toHaveLength(0)
+    expect(opponentTypeaheadPage.activeDescendantId()).toBeNull()
+
+    // Arrowing in is the first act of intent — now, and only now, row 1 lights up.
+    await user.keyboard('{ArrowDown}')
+    expect(opponentTypeaheadPage.getHighlightedOptions()).toEqual([options[0]])
     expect(opponentTypeaheadPage.activeDescendantId()).toBe(options[0].id)
+  })
+
+  it('highlights the row the cursor moves over, without selecting it (#894)', async () => {
+    const { options } = await openWithResults()
+
+    fireEvent.mouseMove(options[2])
+
+    expect(opponentTypeaheadPage.getHighlightedOptions()).toEqual([options[2]])
+    expect(opponentTypeaheadPage.activeDescendantId()).toBe(options[2].id)
+    expect(opponentTypeaheadPage.getSelectedOptions()).toHaveLength(0)
+  })
+
+  it('re-arms to no highlight on the next keystroke (#894)', async () => {
+    const { user, options } = await openWithResults()
+
+    await user.keyboard('{ArrowDown}')
+    expect(opponentTypeaheadPage.getHighlightedOptions()).toEqual([options[0]])
+
+    // Typing on means the hunt is still on: the previous highlight is dropped
+    // rather than silently re-pointed at whatever now sits in that slot.
+    await user.type(opponentTypeaheadPage.getCombobox(), 'd')
+    expect(opponentTypeaheadPage.getHighlightedOptions()).toHaveLength(0)
+    expect(opponentTypeaheadPage.activeDescendantId()).toBeNull()
+  })
+
+  it('never announces a highlighted-but-uncommitted option as selected (#894)', async () => {
+    // The highlight is published on the combobox via aria-activedescendant —
+    // the ARIA 1.2 combobox pattern — and never as aria-selected on the option,
+    // which would tell a screen reader an opponent had been chosen.
+    const { user, options } = await openWithResults()
+
+    await user.keyboard('{ArrowDown}{ArrowDown}')
+
+    expect(opponentTypeaheadPage.getHighlightedOptions()).toEqual([options[1]])
+    expect(opponentTypeaheadPage.activeDescendantId()).toBe(options[1].id)
+    expect(opponentTypeaheadPage.getSelectedOptions()).toHaveLength(0)
   })
 
   it('moves the active option with ArrowDown / ArrowUp and tracks it via aria-activedescendant (#94)', async () => {
     const { user, options } = await openWithResults()
     const combobox = opponentTypeaheadPage.getCombobox()
 
-    await user.keyboard('{ArrowDown}')
-    expect(options[1]).toHaveAttribute('aria-selected', 'true')
+    await user.keyboard('{ArrowDown}{ArrowDown}')
     expect(opponentTypeaheadPage.activeDescendantId()).toBe(options[1].id)
+    expect(opponentTypeaheadPage.getHighlightedOptions()).toEqual([options[1]])
 
     await user.keyboard('{ArrowUp}')
-    expect(options[0]).toHaveAttribute('aria-selected', 'true')
     expect(opponentTypeaheadPage.activeDescendantId()).toBe(options[0].id)
+    expect(opponentTypeaheadPage.getHighlightedOptions()).toEqual([options[0]])
     expect(combobox).toHaveFocus()
+  })
+
+  it('wraps ArrowUp from no highlight round to the last option', async () => {
+    const { user, options } = await openWithResults()
+
+    await user.keyboard('{ArrowUp}')
+    expect(opponentTypeaheadPage.activeDescendantId()).toBe(options[2].id)
   })
 
   it('does not move past the last option on ArrowDown', async () => {
     const { user, options } = await openWithResults()
 
     await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}')
-    expect(options[2]).toHaveAttribute('aria-selected', 'true')
+    expect(opponentTypeaheadPage.activeDescendantId()).toBe(options[2].id)
   })
 
   it('jumps to the last option with End and the first with Home (#100)', async () => {
     const { user, options } = await openWithResults()
 
     await user.keyboard('{End}')
-    expect(options[2]).toHaveAttribute('aria-selected', 'true')
+    expect(opponentTypeaheadPage.activeDescendantId()).toBe(options[2].id)
 
     await user.keyboard('{Home}')
-    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+    expect(opponentTypeaheadPage.activeDescendantId()).toBe(options[0].id)
   })
 
   it('selects the active option on Enter', async () => {
@@ -96,9 +152,25 @@ describe('OpponentTypeahead', () => {
 
     await user.type(opponentTypeaheadPage.getCombobox(), 'a')
     await opponentTypeaheadPage.findOption(/ada\.lovelace/)
-    await user.keyboard('{ArrowDown}{Enter}')
+    // Two ArrowDowns: the first highlights row 1, the second moves to row 2.
+    await user.keyboard('{ArrowDown}{ArrowDown}{Enter}')
 
     expect(picked).toBe('grace.hopper')
+  })
+
+  it('picks nobody on Enter while no option is highlighted (#894)', async () => {
+    const user = userEvent.setup()
+    let picked: string | null = null
+    opponentTypeaheadPage.mockSearch(() => HttpResponse.json(THREE_PLAYERS))
+    opponentTypeaheadPage.render({ onPick: (p) => (picked = p.username) })
+
+    await user.type(opponentTypeaheadPage.getCombobox(), 'a')
+    await opponentTypeaheadPage.findOption(/ada\.lovelace/)
+    await user.keyboard('{Enter}')
+
+    // Enter commits the *highlighted* option; with none, it commits nothing —
+    // it must not quietly pick whoever happens to be first.
+    expect(picked).toBeNull()
   })
 
   it('hides the listbox on Escape without clearing the query, and reopens on ArrowDown (#97)', async () => {

--- a/web-client/src/components/matches/opponent-picker/opponent-typeahead.tsx
+++ b/web-client/src/components/matches/opponent-picker/opponent-typeahead.tsx
@@ -36,6 +36,14 @@ export interface OpponentTypeaheadProps {
  * `role="option"` rows, with `aria-activedescendant` tracking the
  * keyboard-highlighted option. Supports Arrow / Home / End / Enter / Escape
  * (#97/#100) and never steals focus on a remount (#131).
+ *
+ * **Highlight is not selection (#894).** `activeIdx` is `null` until the user
+ * arrows to a row or moves the cursor over one — merely *matching* a search is
+ * not a choice, so no row is pre-highlighted when results land (and the
+ * highlight is dropped again on the next keystroke). The highlight reaches
+ * assistive tech only as this combobox's `aria-activedescendant`; the options
+ * themselves stay `aria-selected="false"`, because nothing here is selected
+ * until a pick is committed to the card above.
  */
 export const OpponentTypeahead = ({
   query,
@@ -46,7 +54,10 @@ export const OpponentTypeahead = ({
   // Open on mount: the typeahead is only mounted once the user has chosen to
   // search, so the dropdown (hint, then results) should show straight away.
   const [open, setOpen] = useState(true)
-  const [activeIdx, setActiveIdx] = useState(0)
+  // `null` = no option highlighted. The two cases are mutually exclusive, and a
+  // sentinel index (0, or -1) is what let the old picker announce row 1 as
+  // chosen the instant results arrived (#894).
+  const [activeIdx, setActiveIdx] = useState<number | null>(null)
   const wrapRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const listboxId = useId()
@@ -77,48 +88,60 @@ export const OpponentTypeahead = ({
 
   function changeQuery(value: string) {
     onQueryChange(value)
-    setActiveIdx(0)
+    // Still hunting: drop the highlight rather than re-arm it onto whoever the
+    // next result set happens to put in that slot (#894).
+    setActiveIdx(null)
     setOpen(true)
   }
 
   function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     // ArrowDown reopens a listbox that Escape dismissed without clearing the
-    // query (#97) — so the input is never a dead end.
+    // query (#97) — so the input is never a dead end. Arrowing *is* intent, so
+    // it enters the list at the top rather than reopening to no highlight.
     if (e.key === 'ArrowDown' && !open) {
       e.preventDefault()
       setOpen(true)
-      setActiveIdx(0)
+      setActiveIdx(results.length > 0 ? 0 : null)
       return
     }
     if (!open) return
 
     const last = results.length - 1
+    const hasResults = results.length > 0
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault()
-        setActiveIdx((i) => Math.min(last, i + 1))
+        // Entering the list from no highlight lands on the first option.
+        if (hasResults) {
+          setActiveIdx((i) => (i === null ? 0 : Math.min(last, i + 1)))
+        }
         break
       case 'ArrowUp':
         e.preventDefault()
-        setActiveIdx((i) => Math.max(0, i - 1))
+        // …and from no highlight, ArrowUp enters it from the bottom.
+        if (hasResults) {
+          setActiveIdx((i) => (i === null ? last : Math.max(0, i - 1)))
+        }
         break
       case 'Home':
         // Jump to the first option (#100).
-        if (results.length > 0) {
+        if (hasResults) {
           e.preventDefault()
           setActiveIdx(0)
         }
         break
       case 'End':
         // Jump to the last option (#100).
-        if (results.length > 0) {
+        if (hasResults) {
           e.preventDefault()
           setActiveIdx(last)
         }
         break
       case 'Enter': {
         e.preventDefault()
-        const picked = results[activeIdx]
+        // Enter commits the highlighted option — with none highlighted it
+        // commits nobody, instead of quietly picking whoever is first (#894).
+        const picked = activeIdx === null ? undefined : results[activeIdx]
         if (picked) onPick(picked)
         break
       }
@@ -135,8 +158,12 @@ export const OpponentTypeahead = ({
   // while the next term loads, so this only fires on the very first search.
   const loadingFirstResults = isFetching && results.length === 0
   const optionId = (i: number) => `${listboxId}-opt-${i}`
+  // Only ever points at a row the user actually highlighted, and only at one
+  // that is still on screen (a stale index can outlive its result set).
   const activeDescendant =
-    open && results.length > 0 ? optionId(activeIdx) : undefined
+    open && activeIdx !== null && results[activeIdx]
+      ? optionId(activeIdx)
+      : undefined
 
   function renderBody() {
     if (!term) {

--- a/web-client/src/components/matches/opponent-picker/opponent-typeahead.tsx
+++ b/web-client/src/components/matches/opponent-picker/opponent-typeahead.tsx
@@ -139,9 +139,19 @@ export const OpponentTypeahead = ({
         break
       case 'Enter': {
         e.preventDefault()
-        // Enter commits the highlighted option — with none highlighted it
-        // commits nobody, instead of quietly picking whoever is first (#894).
-        const picked = activeIdx === null ? undefined : results[activeIdx]
+        // Enter commits the highlighted option. With none highlighted it must
+        // not quietly pick whoever happens to be first (#894) — but neither
+        // should it do *nothing*: typing a name you already know and pressing
+        // Enter is the ordinary keyboard path, and swallowing that key is a
+        // dead end with no feedback. So when the search has narrowed to a
+        // single candidate there is nothing to disambiguate, and Enter takes
+        // it. Two or more, and the user has to say which.
+        const picked =
+          activeIdx !== null
+            ? results[activeIdx]
+            : results.length === 1
+              ? results[0]
+              : undefined
         if (picked) onPick(picked)
         break
       }

--- a/web-client/src/components/matches/opponent-picker/opponent-typeahead/opponent-option.page.tsx
+++ b/web-client/src/components/matches/opponent-picker/opponent-typeahead/opponent-option.page.tsx
@@ -15,8 +15,9 @@ const scoped = (container: Container) => ({
 
 /**
  * Test page-object for `OpponentOption` — a single listbox option. Covers the
- * combobox-option semantics (role, `aria-selected`), the decorative-avatar
- * accessible name, and the graceful fallback for degenerate usernames.
+ * combobox-option semantics (role; highlight via the `active` class, never
+ * `aria-selected` — #894), the decorative-avatar accessible name, and the
+ * graceful fallback for degenerate usernames.
  */
 export const opponentOptionPage = {
   render(overrides: Partial<OpponentOptionProps> = {}) {

--- a/web-client/src/components/matches/opponent-picker/opponent-typeahead/opponent-option.test.tsx
+++ b/web-client/src/components/matches/opponent-picker/opponent-typeahead/opponent-option.test.tsx
@@ -30,14 +30,17 @@ describe('OpponentOption', () => {
 
     const option = opponentOptionPage.getOption(/grace\.hopper/)
     expect(option).toHaveClass('active')
-    expect(option).toHaveAttribute('aria-selected', 'false')
+    // Absent, not "false": an explicit false is *announced* ("not selected") on
+    // every row a screen-reader user arrows past. ARIA 1.2 defaults `option` to
+    // undefined for exactly this case — a listbox with no persistent selection.
+    expect(option).not.toHaveAttribute('aria-selected')
   })
 
   it('marks itself unselected and unhighlighted when inactive', () => {
     opponentOptionPage.render({ active: false })
 
     const option = opponentOptionPage.getOption(/ada\.lovelace/)
-    expect(option).toHaveAttribute('aria-selected', 'false')
+    expect(option).not.toHaveAttribute('aria-selected')
     expect(option).not.toHaveClass('active')
   })
 

--- a/web-client/src/components/matches/opponent-picker/opponent-typeahead/opponent-option.test.tsx
+++ b/web-client/src/components/matches/opponent-picker/opponent-typeahead/opponent-option.test.tsx
@@ -18,15 +18,19 @@ describe('OpponentOption', () => {
     expect(option).toHaveAccessibleName('grace.hopper, RATING 1500')
   })
 
-  it('reflects the active state via aria-selected and the active class (#94)', () => {
+  it('shows the active highlight without announcing itself as selected (#894)', () => {
+    // The keyboard/hover highlight is *not* a selection: it reaches assistive
+    // tech as the combobox's aria-activedescendant, and an option that merely
+    // has the cursor on it must keep saying it is unselected — otherwise the
+    // typeahead announces an opponent the match has not been given.
     opponentOptionPage.render({
       player: buildPlayer({ username: 'grace.hopper' }),
       active: true,
     })
 
     const option = opponentOptionPage.getOption(/grace\.hopper/)
-    expect(option).toHaveAttribute('aria-selected', 'true')
     expect(option).toHaveClass('active')
+    expect(option).toHaveAttribute('aria-selected', 'false')
   })
 
   it('marks itself unselected and unhighlighted when inactive', () => {

--- a/web-client/src/components/matches/opponent-picker/opponent-typeahead/opponent-option.tsx
+++ b/web-client/src/components/matches/opponent-picker/opponent-typeahead/opponent-option.tsx
@@ -35,11 +35,18 @@ export interface OpponentOptionProps {
  * than the initials read twice (#99); the visible text degrades gracefully for
  * empty / emoji-only usernames (#101).
  *
- * `aria-selected` is always `false` — an option here is never *selected* (#894).
- * Picking one commits the opponent to the match-setup card above and closes the
- * listbox, so no row is ever both rendered and chosen; the only in-list state is
- * the `active` highlight, and publishing that as `aria-selected` told screen
- * readers an opponent had been chosen while the card still said "solo match".
+ * `aria-selected` is **absent**, not `false` — an option here is never *selected*
+ * (#894). Picking one commits the opponent to the match-setup card above and
+ * closes the listbox, so no row is ever both rendered and chosen; the only
+ * in-list state is the `active` highlight, and publishing that as
+ * `aria-selected` told screen readers an opponent had been chosen while the card
+ * still said "solo match".
+ *
+ * Omitted rather than set to `false` because ARIA 1.2 made `undefined` the
+ * default for `option` precisely so a listbox with no persistent selection need
+ * not annotate every row: an explicit `false` is *announced* ("not selected"),
+ * on all five results, every time you arrow through them. The highlight reaches
+ * assistive tech through the combobox's `aria-activedescendant` instead.
  */
 export const OpponentOption = ({
   id,
@@ -53,7 +60,7 @@ export const OpponentOption = ({
       type="button"
       id={id}
       role="option"
-      aria-selected={false}
+      aria-selected={undefined}
       aria-label={playerAccessibleName(player)}
       className={cn('nm-item', active && 'active')}
       onMouseMove={onHover}

--- a/web-client/src/components/matches/opponent-picker/opponent-typeahead/opponent-option.tsx
+++ b/web-client/src/components/matches/opponent-picker/opponent-typeahead/opponent-option.tsx
@@ -13,7 +13,11 @@ export interface OpponentOptionProps {
   id: string
   /** The player this option represents. */
   player: Player
-  /** Whether this is the active (keyboard-highlighted) option. */
+  /**
+   * Whether this row carries the highlight — the keyboard/pointer cursor. It is
+   * **not** a selection (#894): it styles the row and is published to assistive
+   * tech by the *combobox*, via `aria-activedescendant` pointing at this `id`.
+   */
   active: boolean
   /** Select this player. */
   onPick: () => void
@@ -30,6 +34,12 @@ export interface OpponentOptionProps {
  * avatar is decorative so the accessible name is just "username, role" rather
  * than the initials read twice (#99); the visible text degrades gracefully for
  * empty / emoji-only usernames (#101).
+ *
+ * `aria-selected` is always `false` — an option here is never *selected* (#894).
+ * Picking one commits the opponent to the match-setup card above and closes the
+ * listbox, so no row is ever both rendered and chosen; the only in-list state is
+ * the `active` highlight, and publishing that as `aria-selected` told screen
+ * readers an opponent had been chosen while the card still said "solo match".
  */
 export const OpponentOption = ({
   id,
@@ -43,7 +53,7 @@ export const OpponentOption = ({
       type="button"
       id={id}
       role="option"
-      aria-selected={active}
+      aria-selected={false}
       aria-label={playerAccessibleName(player)}
       className={cn('nm-item', active && 'active')}
       onMouseMove={onHover}

--- a/web-client/src/components/matches/opponent-picker/recent-opponents.tsx
+++ b/web-client/src/components/matches/opponent-picker/recent-opponents.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, type MutableRefObject } from 'react'
+
 import { useRecentOpponents, type Player } from '@/api/matches'
 import { useSession } from '@/api/session'
 import { UserAvatar } from '@/components/ui/user-avatar'
@@ -13,6 +15,15 @@ export interface RecentOpponentsProps {
   onPick: (player: Player) => void
   /** Switch to the full player search. */
   onSearchAll: () => void
+  /**
+   * Focus "Search all players" once, when the grid comes *back* — i.e. after
+   * the user leaves search mode via the back control, which unmounts the
+   * control they just pressed (#895). Same one-shot ref the typeahead uses for
+   * its input: owned above the error boundary and cleared on use, so an
+   * error-recovery remount doesn't yank focus (#131). Fires only once the grid
+   * has loaded, since the button doesn't exist under the skeleton.
+   */
+  focusOnMountRef?: MutableRefObject<boolean>
 }
 
 function RecentSkeleton() {
@@ -41,6 +52,7 @@ function RecentSkeleton() {
 export const RecentOpponents = ({
   onPick,
   onSearchAll,
+  focusOnMountRef,
 }: RecentOpponentsProps) => {
   // Wait for the session before fetching players — otherwise a first-visit
   // direct-load races the session cookie and 401s into the error boundary
@@ -50,6 +62,14 @@ export const RecentOpponents = ({
   const recent = useRecentOpponents({ enabled: session.isSuccess })
   const players = recent.data ?? []
   const isLoading = recent.isPending
+  const searchAllRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!isLoading && focusOnMountRef?.current) {
+      focusOnMountRef.current = false
+      searchAllRef.current?.focus()
+    }
+  }, [isLoading, focusOnMountRef])
 
   return (
     <div>
@@ -59,6 +79,7 @@ export const RecentOpponents = ({
             now sees an empty grid, and search is their way forward (#167). */}
         {!isLoading && (
           <button
+            ref={searchAllRef}
             type="button"
             className="search-btn"
             onClick={onSearchAll}

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.factory.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.factory.tsx
@@ -1,3 +1,4 @@
+import type { NotificationPreferences } from '@/api/notifications'
 import {
   notificationPreferences,
   notificationTaxonomy,
@@ -16,5 +17,31 @@ export function buildPreferencesViewProps(
     onToggleChannel: () => {},
     onToggleCell: () => {},
     ...overrides,
+  }
+}
+
+/** A guest who has wired nothing up: no confirmed email address, no registered
+ * push device. The server still resolves both masters to `enabled: true` (the
+ * default) but marks them `setup_required` with a destination that says so —
+ * so this is the state in which an "on" switch would be lying (#892). */
+export function preferencesAwaitingSetup(): NotificationPreferences {
+  const base = notificationPreferences()
+  return {
+    ...base,
+    channels: base.channels.map((channel) => {
+      if (channel.channel === 'email')
+        return {
+          ...channel,
+          setup_required: true,
+          destination: 'Add an email in settings',
+        }
+      if (channel.channel === 'push')
+        return {
+          ...channel,
+          setup_required: true,
+          destination: 'No devices yet',
+        }
+      return channel
+    }),
   }
 }

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.test.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.test.tsx
@@ -1,5 +1,6 @@
 import type { NotificationChannel } from '@/api/notifications'
 import { notificationPreferences } from '@/test/factories'
+import { preferencesAwaitingSetup } from './preferences-view.factory'
 import { preferencesViewPage } from './preferences-view.page'
 
 /** Flip one channel's `setup_required` to surface (or clear) its nudge. */
@@ -130,6 +131,77 @@ describe('PreferencesView', () => {
     expect(
       preferencesViewPage.queryNudgeCta('Set up push'),
     ).not.toBeInTheDocument()
+  })
+
+  // #892: a switch sitting "on" beside "No devices yet" claims a delivery path
+  // that doesn't exist. A channel awaiting setup reads off and can't be flipped
+  // until the nudge beside it has been followed.
+  describe('a channel awaiting setup', () => {
+    it('renders the email and push switches off and not switchable', async () => {
+      preferencesViewPage.render({ preferences: preferencesAwaitingSetup() })
+      await preferencesViewPage.findHeading()
+
+      for (const label of ['Email', 'Push']) {
+        const master = preferencesViewPage.channelSwitch(label)
+        expect(master).not.toBeChecked()
+        expect(master).toBeDisabled()
+      }
+    })
+
+    it('keeps the setup nudge visible as the way out', async () => {
+      preferencesViewPage.render({ preferences: preferencesAwaitingSetup() })
+      await preferencesViewPage.findHeading()
+
+      expect(preferencesViewPage.nudgeCta('Add email')).toHaveAttribute(
+        'href',
+        '/settings#sec-email',
+      )
+      expect(preferencesViewPage.nudgeCta('Set up push')).toHaveAttribute(
+        'href',
+        '/settings#sec-notifications',
+      )
+    })
+
+    it('renders its matrix cells off and not switchable', async () => {
+      preferencesViewPage.render({ preferences: preferencesAwaitingSetup() })
+      await preferencesViewPage.findHeading()
+
+      for (const channel of ['Email', 'Push']) {
+        const cell = preferencesViewPage.cell('Rating changes', channel)
+        expect(cell).not.toBeChecked()
+        expect(cell).toBeDisabled()
+      }
+    })
+
+    it('renders even a locked-on matrix cell off, since it cannot deliver', async () => {
+      preferencesViewPage.render({ preferences: preferencesAwaitingSetup() })
+      await preferencesViewPage.findHeading()
+
+      // Match reminders are locked on for push — but there is no device to push
+      // to, so the cell must not claim otherwise.
+      const cell = preferencesViewPage.cell('Match reminders', 'Push')
+      expect(cell).not.toBeChecked()
+      expect(cell).toBeDisabled()
+    })
+
+    it('leaves a channel that is set up fully switchable', async () => {
+      const onToggleChannel = vi.fn()
+      preferencesViewPage.render({
+        preferences: withSetupRequired('email', true),
+        onToggleChannel,
+      })
+      await preferencesViewPage.findHeading()
+
+      // Push has a registered device: it stays on, enabled, and toggleable, and
+      // its matrix cells stay live.
+      const push = preferencesViewPage.channelSwitch('Push')
+      expect(push).toBeChecked()
+      expect(push).toBeEnabled()
+      expect(preferencesViewPage.cell('Rating changes', 'Push')).toBeEnabled()
+
+      await preferencesViewPage.toggleChannel('Push')
+      expect(onToggleChannel).toHaveBeenCalledWith('push', false)
+    })
   })
 
   it('shows no setup nudge for a fully configured account', async () => {

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
@@ -25,6 +25,31 @@ export interface PreferencesViewProps {
   ) => void
 }
 
+type ChannelState = NotificationPreferences['channels'][number]
+
+/** The channel is deliverable *in principle* but this user hasn't finished the
+ * prerequisite — no confirmed email, no registered push device. The server
+ * computes it and hands us the way out in `destination` / the setup nudge. */
+function isAwaitingSetup(channel: ChannelState) {
+  return channel.available && channel.setup_required
+}
+
+/** Can a notification actually reach the user on this channel right now? Both
+ * server flags have to say yes: `available` (we can deliver on it at all — SMS
+ * can't) *and* not `setup_required` (this user has somewhere for it to land).
+ *
+ * Everything the switches claim keys off this, not off `available` alone. An
+ * "on" switch beside "No devices yet" promises a delivery path that does not
+ * exist (#892), so a channel awaiting setup renders **off and disabled** —
+ * `enabled` is the user's stored intent, which we can't honour yet. The nudge
+ * under the card is the way out, and it's why a disabled control is the right
+ * shape here rather than the read-only view of ADR 0015: this isn't a
+ * permission gate, it's a prerequisite the user can clear themselves, and the
+ * nudge supplies the "why" a bare disabled control would withhold. */
+function isDeliverable(channel: ChannelState) {
+  return channel.available && !isAwaitingSetup(channel)
+}
+
 /** The notifications settings page: channel "sign-up" cards plus the
  * per-category × per-channel mute matrix. Pure — state + handlers come in. */
 export function PreferencesView({
@@ -38,6 +63,9 @@ export function PreferencesView({
   const channelByKey = new Map(channels.map((c) => [c.channel, c]))
   const channelLabel = new Map(taxonomy.channels.map((c) => [c.key, c.label]))
   const categoryLabel = new Map(taxonomy.types.map((t) => [t.key, t.label]))
+  const deliverable = new Map(
+    channels.map((c) => [c.channel, isDeliverable(c)] as const),
+  )
 
   return (
     <div className="mx-auto max-w-[840px] px-6 pt-9 pb-20">
@@ -59,11 +87,14 @@ export function PreferencesView({
         {channels.map((channel) => {
           const { Icon } = CHANNEL_VISUAL[channel.channel]
           const label = channelLabel.get(channel.channel) ?? channel.channel
-          const interactive = !channel.locked && channel.available
-          const nudge =
-            channel.available && channel.setup_required
-              ? channelSetupNudge(channel.channel, pendingEmail)
-              : undefined
+          const awaitingSetup = isAwaitingSetup(channel)
+          // A channel with nowhere to deliver reads as off, whatever the stored
+          // master says — and can't be switched on until setup is done.
+          const on = channel.enabled && !awaitingSetup
+          const interactive = !channel.locked && isDeliverable(channel)
+          const nudge = awaitingSetup
+            ? channelSetupNudge(channel.channel, pendingEmail)
+            : undefined
           // The server's email destination ("Add an email in settings") is
           // wrong once an address is on file but unconfirmed — reflect the
           // pending state instead.
@@ -76,7 +107,7 @@ export function PreferencesView({
               <div
                 className={cn(
                   'flex items-center gap-3 rounded-xl border bg-[color:var(--bg-card)] p-4 transition-opacity',
-                  channel.enabled
+                  on
                     ? 'border-[color:var(--border-default)]'
                     : 'border-[color:var(--border-subtle)] opacity-70',
                 )}
@@ -84,10 +115,10 @@ export function PreferencesView({
                 <span
                   className="flex size-9 shrink-0 items-center justify-center rounded-[10px]"
                   style={{
-                    background: channel.enabled
+                    background: on
                       ? 'rgba(255,122,26,0.12)'
                       : 'var(--bg-raised)',
-                    color: channel.enabled ? 'var(--ball-500)' : 'var(--fg-3)',
+                    color: on ? 'var(--ball-500)' : 'var(--fg-3)',
                   }}
                 >
                   <Icon size={20} />
@@ -101,7 +132,7 @@ export function PreferencesView({
                   </span>
                 </span>
                 <Switch
-                  checked={channel.enabled}
+                  checked={on}
                   disabled={!interactive}
                   onCheckedChange={(value) =>
                     onToggleChannel(channel.channel, value === true)
@@ -131,11 +162,12 @@ export function PreferencesView({
           {channels.map((channel) => {
             const { Icon } = CHANNEL_VISUAL[channel.channel]
             const label = channelLabel.get(channel.channel) ?? channel.channel
+            const on = channel.enabled && isDeliverable(channel)
             return (
               <div
                 key={channel.channel}
                 className="flex flex-col items-center gap-1.5 py-2.5"
-                style={{ opacity: channel.enabled ? 1 : 0.6 }}
+                style={{ opacity: on ? 1 : 0.6 }}
               >
                 <Icon size={17} className="text-[color:var(--fg-2)]" />
                 <span className="font-mono text-[10px] tracking-wide text-[color:var(--fg-3)] uppercase">
@@ -173,16 +205,22 @@ export function PreferencesView({
               </div>
               {row.cells.map((cell) => {
                 const master = channelByKey.get(cell.channel)
-                const masterOn = master?.enabled ?? false
-                const available = master?.available ?? false
-                const disabled = cell.locked || !available || !masterOn
+                // Same rule as the master switch above, one level down: a cell
+                // can only claim delivery its channel can actually make. With
+                // the channel awaiting setup, `canDeliver` is false, so the
+                // cell reads off and can't be flipped — including the cells
+                // locked on (match reminders), which is exactly the promise the
+                // channel can't keep yet.
+                const canDeliver = deliverable.get(cell.channel) ?? false
+                const masterOn = (master?.enabled ?? false) && canDeliver
+                const disabled = cell.locked || !canDeliver || !masterOn
                 return (
                   <div
                     key={cell.channel}
                     className="flex items-center justify-center py-3.5"
                   >
                     <Checkbox
-                      checked={cell.enabled}
+                      checked={cell.enabled && canDeliver}
                       disabled={disabled}
                       onCheckedChange={(value) =>
                         onToggleCell(row.category, cell.channel, value === true)

--- a/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page/preferences-view.tsx
@@ -47,7 +47,18 @@ function isAwaitingSetup(channel: ChannelState) {
  * permission gate, it's a prerequisite the user can clear themselves, and the
  * nudge supplies the "why" a bare disabled control would withhold. */
 function isDeliverable(channel: ChannelState) {
-  return channel.available && !isAwaitingSetup(channel)
+  return channel.available && !channel.setup_required
+}
+
+/** Is this channel *effectively* on — the user wants it **and** we can deliver?
+ *
+ * The one place that question is answered. It used to be spelled three ways (the
+ * card, the matrix header, the matrix cell), and the spellings had already
+ * drifted: the card asked only whether setup was pending, so a channel the server
+ * marked unavailable-but-enabled would have lit its switch on — #892 again, in
+ * the half of the component #892 didn't touch. A rule written once cannot drift. */
+function isOn(channel: ChannelState) {
+  return channel.enabled && isDeliverable(channel)
 }
 
 /** The notifications settings page: channel "sign-up" cards plus the
@@ -63,9 +74,6 @@ export function PreferencesView({
   const channelByKey = new Map(channels.map((c) => [c.channel, c]))
   const channelLabel = new Map(taxonomy.channels.map((c) => [c.key, c.label]))
   const categoryLabel = new Map(taxonomy.types.map((t) => [t.key, t.label]))
-  const deliverable = new Map(
-    channels.map((c) => [c.channel, isDeliverable(c)] as const),
-  )
 
   return (
     <div className="mx-auto max-w-[840px] px-6 pt-9 pb-20">
@@ -90,7 +98,7 @@ export function PreferencesView({
           const awaitingSetup = isAwaitingSetup(channel)
           // A channel with nowhere to deliver reads as off, whatever the stored
           // master says — and can't be switched on until setup is done.
-          const on = channel.enabled && !awaitingSetup
+          const on = isOn(channel)
           const interactive = !channel.locked && isDeliverable(channel)
           const nudge = awaitingSetup
             ? channelSetupNudge(channel.channel, pendingEmail)
@@ -162,7 +170,7 @@ export function PreferencesView({
           {channels.map((channel) => {
             const { Icon } = CHANNEL_VISUAL[channel.channel]
             const label = channelLabel.get(channel.channel) ?? channel.channel
-            const on = channel.enabled && isDeliverable(channel)
+            const on = isOn(channel)
             return (
               <div
                 key={channel.channel}
@@ -207,13 +215,13 @@ export function PreferencesView({
                 const master = channelByKey.get(cell.channel)
                 // Same rule as the master switch above, one level down: a cell
                 // can only claim delivery its channel can actually make. With
-                // the channel awaiting setup, `canDeliver` is false, so the
-                // cell reads off and can't be flipped — including the cells
-                // locked on (match reminders), which is exactly the promise the
-                // channel can't keep yet.
-                const canDeliver = deliverable.get(cell.channel) ?? false
-                const masterOn = (master?.enabled ?? false) && canDeliver
-                const disabled = cell.locked || !canDeliver || !masterOn
+                // the channel awaiting setup its master is off, so the cell
+                // reads off and can't be flipped — including the cells locked
+                // on (match reminders), which is exactly the promise the channel
+                // can't keep yet.
+                const canDeliver = master ? isDeliverable(master) : false
+                const masterOn = master ? isOn(master) : false
+                const disabled = cell.locked || !masterOn
                 return (
                   <div
                     key={cell.channel}

--- a/web-client/src/components/pagination-footer.page.tsx
+++ b/web-client/src/components/pagination-footer.page.tsx
@@ -34,6 +34,17 @@ const scoped = (container: Container) => ({
   queryPageLink(n: number) {
     return container.queryByRole('link', { name: String(n) })
   },
+  /**
+   * Every clickable page token, whatever its number. Use this to assert the
+   * *absence* of a pager: an empty list must offer no page to click (#889).
+   */
+  queryPageLinks() {
+    return container.queryAllByRole('link')
+  },
+  /** The pager itself — `Pagination` renders `<nav aria-label="pagination">`. */
+  queryPager() {
+    return container.queryByRole('navigation', { name: /pagination/i })
+  },
 })
 
 /**

--- a/web-client/src/components/pagination-footer.test.tsx
+++ b/web-client/src/components/pagination-footer.test.tsx
@@ -48,6 +48,35 @@ describe('PaginationFooter', () => {
     )
   })
 
+  it('offers no page link when there are no matches', () => {
+    // Callers clamp their page count with `Math.max(1, …)`, so an empty list
+    // arrives here as `totalPages: 1` — and used to render a live page-`1`
+    // anchor beside "of 0 matches", pointing at a page that does not exist
+    // (#889). Zero results, zero pages to click.
+    paginationFooterPage.render({ page: 1, total: 0, pageSize: 25, totalPages: 1 })
+
+    expect(paginationFooterPage.queryPageLink(1)).not.toBeInTheDocument()
+    expect(paginationFooterPage.queryPageLinks()).toHaveLength(0)
+  })
+
+  it('hides the pager entirely when there are no matches', () => {
+    paginationFooterPage.render({ page: 1, total: 0, pageSize: 25, totalPages: 1 })
+
+    expect(paginationFooterPage.queryPager()).not.toBeInTheDocument()
+  })
+
+  it('still shows the page token for a single page of results', () => {
+    // The guard keys off "no results", not "one page" — a 3-player list is a
+    // legitimate single-page list and keeps its (active) page-1 token.
+    paginationFooterPage.render({ page: 1, total: 3, pageSize: 25, totalPages: 1 })
+
+    expect(paginationFooterPage.getPageLink(1)).toBeInTheDocument()
+    expect(paginationFooterPage.getPageLink(1)).toHaveAttribute(
+      'aria-current',
+      'page',
+    )
+  })
+
   it('disables First and Previous on page 1', () => {
     paginationFooterPage.render({ page: 1, totalPages: 3 })
 

--- a/web-client/src/components/pagination-footer.tsx
+++ b/web-client/src/components/pagination-footer.tsx
@@ -57,6 +57,16 @@ export const PaginationFooter = ({
   const atFirst = safePage <= 1
   const atLast = safePage >= totalPages
 
+  // No results means there is no page to go to, so the pager is suppressed
+  // entirely and the footer is just its "Showing 0–0 of 0 {noun}" readout
+  // (#889). The guard has to live here rather than in `paginationRange`: every
+  // caller clamps its page count with `Math.max(1, …)`, so the range helper is
+  // handed `totalPages: 1` and never sees the zero. `total` — the true result
+  // count, the one the readout prints — is the only thing that tells "no
+  // results" apart from a legitimate single-page list, which still gets its
+  // page-1 token.
+  const isEmpty = total === 0
+
   return (
     <div className="footer">
       <div className="footer-info">
@@ -64,74 +74,76 @@ export const PaginationFooter = ({
         <span className="mono">{total}</span> {noun}
       </div>
       <div className="footer-spacer" />
-      <Pagination className="mx-0 w-auto justify-end">
-        <PaginationContent>
-          <PaginationItem>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              disabled={atFirst}
-              onClick={() => setPage(1)}
-              aria-label="First page"
-            >
-              <ChevronsLeft size={14} strokeWidth={2.4} />
-            </Button>
-          </PaginationItem>
-          <PaginationItem>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              disabled={atFirst}
-              onClick={() => setPage(safePage - 1)}
-              aria-label="Previous page"
-            >
-              <ChevronLeft size={14} strokeWidth={2.4} />
-            </Button>
-          </PaginationItem>
-          {tokens.map((t, i) =>
-            t === 'ellipsis' ? (
-              <PaginationItem key={i}>
-                <PaginationEllipsis />
-              </PaginationItem>
-            ) : (
-              <PaginationItem key={i}>
-                <PaginationLink
-                  href="#"
-                  isActive={t === safePage}
-                  onClick={(e) => {
-                    e.preventDefault()
-                    setPage(t)
-                  }}
-                >
-                  {t}
-                </PaginationLink>
-              </PaginationItem>
-            ),
-          )}
-          <PaginationItem>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              disabled={atLast}
-              onClick={() => setPage(safePage + 1)}
-              aria-label="Next page"
-            >
-              <ChevronRight size={14} strokeWidth={2.4} />
-            </Button>
-          </PaginationItem>
-          <PaginationItem>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              disabled={atLast}
-              onClick={() => setPage(totalPages)}
-              aria-label="Last page"
-            >
-              <ChevronsRight size={14} strokeWidth={2.4} />
-            </Button>
-          </PaginationItem>
-        </PaginationContent>
-      </Pagination>
+      {!isEmpty && (
+        <Pagination className="mx-0 w-auto justify-end">
+          <PaginationContent>
+            <PaginationItem>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                disabled={atFirst}
+                onClick={() => setPage(1)}
+                aria-label="First page"
+              >
+                <ChevronsLeft size={14} strokeWidth={2.4} />
+              </Button>
+            </PaginationItem>
+            <PaginationItem>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                disabled={atFirst}
+                onClick={() => setPage(safePage - 1)}
+                aria-label="Previous page"
+              >
+                <ChevronLeft size={14} strokeWidth={2.4} />
+              </Button>
+            </PaginationItem>
+            {tokens.map((t, i) =>
+              t === 'ellipsis' ? (
+                <PaginationItem key={i}>
+                  <PaginationEllipsis />
+                </PaginationItem>
+              ) : (
+                <PaginationItem key={i}>
+                  <PaginationLink
+                    href="#"
+                    isActive={t === safePage}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      setPage(t)
+                    }}
+                  >
+                    {t}
+                  </PaginationLink>
+                </PaginationItem>
+              ),
+            )}
+            <PaginationItem>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                disabled={atLast}
+                onClick={() => setPage(safePage + 1)}
+                aria-label="Next page"
+              >
+                <ChevronRight size={14} strokeWidth={2.4} />
+              </Button>
+            </PaginationItem>
+            <PaginationItem>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                disabled={atLast}
+                onClick={() => setPage(totalPages)}
+                aria-label="Last page"
+              >
+                <ChevronsRight size={14} strokeWidth={2.4} />
+              </Button>
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      )}
     </div>
   )
 }

--- a/web-client/src/components/ui/popover.tsx
+++ b/web-client/src/components/ui/popover.tsx
@@ -43,6 +43,30 @@ function PopoverAnchor({
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
 }
 
+/**
+ * The dismiss control for a popover — the counterpart of `DialogClose`. Radix
+ * closes the popover on click, so a call site only supplies the button:
+ *
+ * ```tsx
+ * <PopoverClose asChild>
+ *   <Button variant="ghost" size="icon-sm" aria-label="Close alpha notice">
+ *     <XIcon />
+ *   </Button>
+ * </PopoverClose>
+ * ```
+ *
+ * A popover is non-modal here (`PopoverContent` passes no `modal` prop, so
+ * Radix defaults to `modal={false}`), which means clicking outside and Escape
+ * dismiss it — but neither is a *visible* affordance. Touch users and anyone
+ * scanning for an "x" get nothing, so a popover that covers content owes them
+ * this (#891).
+ */
+function PopoverClose({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Close>) {
+  return <PopoverPrimitive.Close data-slot="popover-close" {...props} />
+}
+
 function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -79,6 +103,7 @@ function PopoverDescription({
 export {
   Popover,
   PopoverAnchor,
+  PopoverClose,
   PopoverContent,
   PopoverDescription,
   PopoverHeader,

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1034,18 +1034,34 @@ body.dark.fortymm-theme {
     display: flex;
   }
 
+  /* Below this breakpoint the sidebar is a *drawer*, and a closed drawer must
+     be gone — not merely parked offscreen. `transform: translateX(-100%)` alone
+     left all 48 of its controls (the close button and every nav link) focusable,
+     tabbable and in the accessibility tree, so a keyboard or screen-reader user
+     could walk into a menu that is visually shut (#887).
+
+     `visibility: hidden` is what takes them out of both. It's used here rather
+     than `inert` on the element because the fix has to be scoped to *this* media
+     query: above 960px the very same <aside> is the permanent desktop sidebar,
+     and an attribute would blank that out too. Visibility is transitionable and
+     interpolates as a step — `visible` the instant the drawer opens, and held
+     `visible` for the full slide-out before it flips — so the animation is
+     unchanged in both directions. */
   .app-shell__sidebar {
     position: fixed;
     left: 0;
     top: 0;
     height: 100vh;
     transform: translateX(-100%);
+    visibility: hidden;
     transition: transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
-      box-shadow 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+      box-shadow 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
+      visibility 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
     box-shadow: none;
   }
   .app-shell__sidebar.is-open {
     transform: translateX(0);
+    visibility: visible;
     box-shadow: 24px 0 60px rgba(0, 0, 0, 0.6);
   }
   .app-shell__sidebar-close {

--- a/web-client/src/routes/_app/matches/new.test.tsx
+++ b/web-client/src/routes/_app/matches/new.test.tsx
@@ -1070,6 +1070,198 @@ describe('NewMatchPage — opponent search', () => {
   })
 })
 
+describe('NewMatchPage — searching for an opponent (#893)', () => {
+  // A user hunting for an opponent must never be told the match is "Ready", nor
+  // walked into a solo match by a button that still says "Start match". The card
+  // models the opponent slot as none | seeking | picked, and a non-empty,
+  // uncommitted query is `seeking`: unresolved, not solo-by-choice.
+  function recentWithOne() {
+    return http.get('*/v1/players/recent', () =>
+      HttpResponse.json([{ id: 'pl-1', username: 'ada.lovelace' }]),
+    )
+  }
+  function searchFinds(...players: { id: string; username: string }[]) {
+    return http.get('*/v1/players/search', () => HttpResponse.json(players))
+  }
+
+  /** The primary submit control, whatever it currently calls itself. */
+  function startButton() {
+    return screen.getByRole('button', { name: /start (solo )?match/i })
+  }
+  function summaryTop(container: HTMLElement) {
+    return container.querySelector('.nm-summary .top')!
+  }
+
+  async function openSearch(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(
+      await screen.findByRole('button', { name: /search all players/i }),
+    )
+    return screen.getByPlaceholderText(/search by username/i)
+  }
+
+  it('reads as unresolved — not "Ready … solo match" — when the typed name matches nobody', async () => {
+    const user = userEvent.setup()
+    server.use(recentWithOne(), searchFinds())
+    const { container } = renderNewMatch()
+
+    await user.type(await openSearch(user), 'zzzzzz')
+    expect(await screen.findByText(/no one matches/i)).toBeInTheDocument()
+
+    // The summary tells the truth: nobody is selected. It does NOT claim the
+    // match is ready to go against nobody.
+    expect(summaryTop(container)).toHaveTextContent(/no opponent selected/i)
+    expect(summaryTop(container)).toHaveTextContent(/this will be a solo match/i)
+    expect(summaryTop(container)).not.toHaveTextContent(/ready/i)
+
+    // And the button says what pressing it would actually do. It stays enabled
+    // (house rule: never gate submit on validity) — this is honesty, not a lock.
+    expect(startButton()).toHaveAccessibleName('Start solo match')
+    expect(startButton()).toBeEnabled()
+    expect(
+      screen.queryByRole('button', { name: /^start match$/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('leaves an empty search box alone: opening the search does not relabel the button or nag', async () => {
+    const user = userEvent.setup()
+    server.use(recentWithOne(), searchFinds())
+    const { container } = renderNewMatch()
+
+    await openSearch(user)
+
+    // Nothing typed — solo is still the honest default, so the card reads
+    // exactly as it did before the search opened.
+    expect(screen.getByText(/start typing to search/i)).toBeInTheDocument()
+    expect(startButton()).toHaveAccessibleName('Start match')
+    expect(summaryTop(container)).toHaveTextContent(/ready/i)
+    expect(summaryTop(container)).toHaveTextContent(/solo match/i)
+    expect(summaryTop(container)).not.toHaveTextContent(/no opponent selected/i)
+  })
+
+  it('goes back to a plain solo match when the unmatched query is cleared', async () => {
+    const user = userEvent.setup()
+    server.use(recentWithOne(), searchFinds())
+    const { container } = renderNewMatch()
+
+    await user.type(await openSearch(user), 'zzzzzz')
+    expect(await screen.findByText(/no one matches/i)).toBeInTheDocument()
+    expect(startButton()).toHaveAccessibleName('Start solo match')
+
+    // Clearing the box returns the slot to `none` — an empty search is not a
+    // hunt in progress.
+    await user.click(screen.getByRole('button', { name: /clear search/i }))
+    expect(startButton()).toHaveAccessibleName('Start match')
+    expect(summaryTop(container)).not.toHaveTextContent(/no opponent selected/i)
+  })
+
+  it('restores "Start match" and unlocks Rated once a searched player is picked', async () => {
+    const user = userEvent.setup()
+    server.use(
+      recentWithOne(),
+      searchFinds({ id: 'pl-9', username: 'barbara.liskov' }),
+    )
+    const { container } = renderNewMatch()
+
+    await user.type(await openSearch(user), 'liskov')
+    // Mid-search, before the pick: unresolved, and Rated is unavailable.
+    expect(await screen.findByRole('option', { name: /barbara\.liskov/i }))
+      .toBeInTheDocument()
+    expect(startButton()).toHaveAccessibleName('Start solo match')
+    expect(screen.getByRole('switch', { name: /rated match/i })).toBeDisabled()
+
+    await user.click(screen.getByRole('option', { name: /barbara\.liskov/i }))
+
+    // Committing to someone resolves the slot: the leftover query is
+    // irrelevant, the summary names the opponent, and Rated is live again.
+    expect(startButton()).toHaveAccessibleName('Start match')
+    expect(summaryTop(container)).toHaveTextContent(/ready/i)
+    expect(summaryTop(container)).toHaveTextContent(/barbara\.liskov/i)
+    expect(screen.getByRole('switch', { name: /rated match/i })).toBeEnabled()
+  })
+
+  it('does not strand the card in "seeking" after a searched-for opponent is changed', async () => {
+    const user = userEvent.setup()
+    server.use(
+      recentWithOne(),
+      searchFinds({ id: 'pl-9', username: 'barbara.liskov' }),
+    )
+    renderNewMatch()
+
+    await user.type(await openSearch(user), 'liskov')
+    await user.click(
+      await screen.findByRole('option', { name: /barbara\.liskov/i }),
+    )
+    expect(startButton()).toHaveAccessibleName('Start match')
+
+    // "Change" unmounts the picker and brings it back with an empty search box.
+    // The card's mirrored copy of the query has to die with it — otherwise the
+    // stale 'liskov' would leave the button saying "Start solo match" over a
+    // recent-opponents grid nobody is searching.
+    await user.click(screen.getByRole('button', { name: /^change$/i }))
+    expect(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    ).toBeInTheDocument()
+    expect(startButton()).toHaveAccessibleName('Start match')
+  })
+
+  it('leaves "seeking" behind when the user backs out of search to the recent grid (#895)', async () => {
+    const user = userEvent.setup()
+    server.use(recentWithOne(), searchFinds())
+    const { container } = renderNewMatch()
+
+    await user.type(await openSearch(user), 'zzzzzz')
+    expect(await screen.findByText(/no one matches/i)).toBeInTheDocument()
+    expect(startButton()).toHaveAccessibleName('Start solo match')
+
+    // Backing out of search abandons the hunt: the recent grid comes back, and
+    // with it the card's `none` reading. A stale mirrored query would leave the
+    // button saying "Start solo match" over a grid nobody is searching.
+    await user.click(
+      screen.getByRole('button', { name: /back to recent opponents/i }),
+    )
+
+    expect(
+      await screen.findByRole('button', { name: /ada\.lovelace/i }),
+    ).toBeInTheDocument()
+    expect(startButton()).toHaveAccessibleName('Start match')
+    expect(summaryTop(container)).toHaveTextContent(/ready/i)
+    expect(summaryTop(container)).not.toHaveTextContent(/no opponent selected/i)
+  })
+
+  it('still creates a solo, unrated match when the seeking user presses the button anyway', async () => {
+    const user = userEvent.setup()
+    let captured: unknown = null
+    server.use(
+      recentWithOne(),
+      searchFinds(),
+      http.post('*/v1/matches', async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json(pendingMatch(), { status: 201 })
+      }),
+    )
+    renderNewMatch()
+
+    await user.type(await openSearch(user), 'zzzzzz')
+    expect(await screen.findByText(/no one matches/i)).toBeInTheDocument()
+
+    // The control is not disabled — a solo match is a legitimate thing to want,
+    // and the label now says that is what you'd get. Pressing it does exactly
+    // that: no opponent invented from the query, no rating.
+    await user.click(screen.getByRole('button', { name: /start solo match/i }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Scoring route m-test game 1'),
+      ).toBeInTheDocument(),
+    )
+    expect(captured).toEqual({
+      opponent_user_id: null,
+      best_of: 5,
+      rated: false,
+    })
+  })
+})
+
 describe('NewMatchPage — mobile label layout (#388)', () => {
   // These guard the DOM contract the responsive CSS in new.css relies on to
   // keep labels and captions from crowding on a 375px screen. jsdom doesn't

--- a/web-client/src/routes/_app/matches/new.tsx
+++ b/web-client/src/routes/_app/matches/new.tsx
@@ -16,6 +16,11 @@ import {
   opponentFromPlayer,
   type Opponent,
 } from '@/components/matches/match-setup/opponent'
+import {
+  opponentSelection,
+  selectedOpponent,
+  type OpponentSelection,
+} from '@/components/matches/match-setup/opponent-selection'
 import { usePreselectedOpponent } from '@/components/matches/match-setup/use-preselected-opponent'
 import { useStartMatch } from '@/components/matches/match-setup/use-start-match'
 import { DiscardMatchSetupDialog } from '@/components/matches/match-setup/discard-match-setup-dialog'
@@ -88,6 +93,19 @@ function MatchCard() {
   // solo match (`null`) — overrides it from then on.
   const [pick, setPick] = useState<Opponent | null | undefined>(undefined)
   const opponent = pick === undefined ? preselected.opponent : pick
+
+  // The picker's uncommitted search text, mirrored up here via its
+  // `onQueryChange` channel. Deliberately its own state and NOT folded into the
+  // `pick` tri-state above: `pick`'s `undefined` carries a different, load-bearing
+  // meaning ("untouched → the URL preseed stands"), and it is what the discard
+  // dialog's dirty check keys off (#75). Half-typing a name is not a touch of the
+  // opponent slot — nothing is configured yet — so it must not arm that dialog.
+  const [searchQuery, setSearchQuery] = useState('')
+
+  // The two observations above, resolved into the one thing the rest of the card
+  // reads: none | seeking | picked (#893). Everything downstream — the rated
+  // field, the summary, the submit payload — is a function of this.
+  const selection = opponentSelection(opponent, searchQuery)
 
   const [bestOf, setBestOf] =
     useState<BestOfFieldProps['bestOf']>(DEFAULT_BEST_OF)
@@ -163,14 +181,24 @@ function MatchCard() {
             // rated-needs-opponent refinement with a disabled toggle the user
             // can't switch off, or (b) silently re-engage rating when a new
             // opponent is picked.
+            //
+            // It also clears the mirrored query: the picker unmounted when the
+            // opponent was picked, so it comes back with an empty search box —
+            // a stale mirror would leave the card in `seeking` while showing
+            // the recent grid.
             onChange={() => {
               setPick(null)
               setRated(false)
+              setSearchQuery('')
             }}
           />
         ) : (
           <OpponentPicker
-            onPick={(player) => setPick(opponentFromPlayer(player))}
+            onPick={(player) => {
+              setPick(opponentFromPlayer(player))
+              setSearchQuery('')
+            }}
+            onQueryChange={setSearchQuery}
           />
         )}
       </div>
@@ -180,18 +208,20 @@ function MatchCard() {
         <RatedField
           rated={rated}
           setRated={setRated}
-          opponent={opponent}
+          // `seeking` is not an opponent, so the toggle stays unavailable while
+          // the user is still hunting — same as `none`.
+          opponent={selectedOpponent(selection)}
           isGuest={isGuest}
         />
       </div>
 
       <SubmitRow
-        opponent={opponent}
+        selection={selection}
         bestOf={bestOf}
         rated={rated}
         error={submitted ? apiError : null}
         submitting={submitting}
-        onSubmit={() => submit({ opponent, bestOf, rated })}
+        onSubmit={() => submit({ selection, bestOf, rated })}
         onCancel={() => navigate({ to: '/dashboard' })}
       />
 
@@ -226,8 +256,37 @@ function OpponentSkeleton() {
 /*  Submit row                                                        */
 /* ------------------------------------------------------------------ */
 
+/**
+ * The summary's headline. Each arm of the selection gets its own sentence —
+ * in particular `seeking`, which used to be indistinguishable from `none` and
+ * so was told "Ready: You · solo match" while the user was still searching
+ * (#893). It is not ready, and saying so is the whole fix.
+ */
+function summaryHeadline(selection: OpponentSelection) {
+  switch (selection.kind) {
+    case 'picked':
+      return (
+        <>
+          Ready: <b>You</b> vs <b>{selection.opponent.name}</b>
+        </>
+      )
+    case 'seeking':
+      return (
+        <span className="opp-tbd">
+          No opponent selected · this will be a solo match
+        </span>
+      )
+    case 'none':
+      return (
+        <>
+          Ready: <b>You</b> <span className="opp-tbd">· solo match</span>
+        </>
+      )
+  }
+}
+
 function SubmitRow({
-  opponent,
+  selection,
   bestOf,
   rated,
   error,
@@ -235,7 +294,7 @@ function SubmitRow({
   onSubmit,
   onCancel,
 }: {
-  opponent: Opponent | null
+  selection: OpponentSelection
   bestOf: number
   rated: boolean
   error: string | null
@@ -243,25 +302,22 @@ function SubmitRow({
   onSubmit: () => void
   onCancel: () => void
 }) {
+  const opponent = selectedOpponent(selection)
   const effectivelyRated = rated && opponent !== null
   const gamesToWin = Math.ceil(bestOf / 2)
   const lengthCopy =
     bestOf === 1 ? 'Single game' : `Best of ${bestOf} · first to ${gamesToWin}`
+  // Honesty, not a lock: the button stays enabled (house rule — never gate
+  // submit on validity), but while the user is mid-search it says exactly what
+  // pressing it would do. Starting a solo match is a legitimate choice; being
+  // walked into one is not.
+  const startLabel =
+    selection.kind === 'seeking' ? 'Start solo match' : 'Start match'
 
   return (
     <div className="nm-summary">
       <div className="read">
-        <div className="top">
-          {opponent ? (
-            <>
-              Ready: <b>You</b> vs <b>{opponent.name}</b>
-            </>
-          ) : (
-            <>
-              Ready: <b>You</b> <span className="opp-tbd">· solo match</span>
-            </>
-          )}
-        </div>
+        <div className="top">{summaryHeadline(selection)}</div>
         <div className="sub">
           {lengthCopy}{' '}
           <span className="dot">·</span>{' '}
@@ -298,7 +354,7 @@ function SubmitRow({
           {submitting && (
             <Loader2 className="fmm-icon-spin" size={16} strokeWidth={2.5} />
           )}
-          {submitting ? 'Starting…' : 'Start match'}
+          {submitting ? 'Starting…' : startLabel}
           {!submitting && <ArrowRight size={16} strokeWidth={2.5} />}
         </button>
       </div>

--- a/web-client/src/routes/_app/matches/new.tsx
+++ b/web-client/src/routes/_app/matches/new.tsx
@@ -17,6 +17,7 @@ import {
   type Opponent,
 } from '@/components/matches/match-setup/opponent'
 import {
+  isRatable,
   opponentSelection,
   selectedOpponent,
   type OpponentSelection,
@@ -94,18 +95,21 @@ function MatchCard() {
   const [pick, setPick] = useState<Opponent | null | undefined>(undefined)
   const opponent = pick === undefined ? preselected.opponent : pick
 
-  // The picker's uncommitted search text, mirrored up here via its
-  // `onQueryChange` channel. Deliberately its own state and NOT folded into the
-  // `pick` tri-state above: `pick`'s `undefined` carries a different, load-bearing
-  // meaning ("untouched → the URL preseed stands"), and it is what the discard
-  // dialog's dirty check keys off (#75). Half-typing a name is not a touch of the
-  // opponent slot — nothing is configured yet — so it must not arm that dialog.
-  const [searchQuery, setSearchQuery] = useState('')
+  // Whether the picker currently holds an uncommitted search — the *fact*, not
+  // the text. Storing the edge rather than mirroring every keystroke keeps this
+  // card off the typing path: a per-character `setState` here re-rendered the
+  // whole form and tore down and re-registered the `useBlocker` guard with it.
+  // Deliberately its own state and NOT folded into the `pick` tri-state above:
+  // `pick`'s `undefined` carries a different, load-bearing meaning ("untouched →
+  // the URL preseed stands"), and it is what the discard dialog's dirty check
+  // keys off (#75). Half-typing a name is not a touch of the opponent slot —
+  // nothing is configured yet — so it must not arm that dialog.
+  const [isSeeking, setIsSeeking] = useState(false)
 
   // The two observations above, resolved into the one thing the rest of the card
   // reads: none | seeking | picked (#893). Everything downstream — the rated
   // field, the summary, the submit payload — is a function of this.
-  const selection = opponentSelection(opponent, searchQuery)
+  const selection = opponentSelection(opponent, isSeeking)
 
   const [bestOf, setBestOf] =
     useState<BestOfFieldProps['bestOf']>(DEFAULT_BEST_OF)
@@ -189,16 +193,20 @@ function MatchCard() {
             onChange={() => {
               setPick(null)
               setRated(false)
-              setSearchQuery('')
+              setIsSeeking(false)
             }}
           />
         ) : (
           <OpponentPicker
             onPick={(player) => {
               setPick(opponentFromPlayer(player))
-              setSearchQuery('')
+              setIsSeeking(false)
             }}
-            onQueryChange={setSearchQuery}
+            // Only the empty/non-empty edge crosses this boundary. React bails
+            // out of a `useState` set to the value it already holds, so the card
+            // re-renders when the search starts and when it ends — not once per
+            // character.
+            onQueryChange={(query) => setIsSeeking(query.trim().length > 0)}
           />
         )}
       </div>
@@ -302,8 +310,7 @@ function SubmitRow({
   onSubmit: () => void
   onCancel: () => void
 }) {
-  const opponent = selectedOpponent(selection)
-  const effectivelyRated = rated && opponent !== null
+  const effectivelyRated = rated && isRatable(selection)
   const gamesToWin = Math.ceil(bestOf / 2)
   const lengthCopy =
     bestOf === 1 ? 'Single game' : `Best of ${bestOf} · first to ${gamesToWin}`

--- a/web-client/src/routes/_app/settings.css
+++ b/web-client/src/routes/_app/settings.css
@@ -137,6 +137,100 @@
   }
 }
 
+/* ---------- Page header ----------
+   These styles used to live inline on the JSX (`style={{ ... }}`), which made
+   them un-media-queryable — and the header was the one thing on this page that
+   needed a mobile rule. It is a row of two items that cannot give way on their
+   own: the display <h1> is a single unbreakable word (so its min-content floor
+   is its full rendered width) and the username pill was pinned at
+   `flex-shrink: 0`. At 360px their sum overflowed the ~328px content box and
+   the whole document scrolled sideways — by more the longer the username, which
+   is why a short-name check sails past it (#890).
+
+   The fix is two-part, and both parts are load-bearing:
+     1. the row WRAPS, so the pill drops below the heading when they can't share
+        a line, and
+     2. the pill may SHRINK and its name TRUNCATES, so even a 40-character
+        username (the server's max) can't push past the viewport on its own line.
+   The heading also scales down with the viewport via clamp(), but only below
+   ~533px — desktop keeps the full 64px display size. */
+.fmm-settings .fmm-page-header {
+  margin-bottom: 28px;
+}
+
+.fmm-settings .fmm-page-header__crumbs {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+.fmm-settings .fmm-page-header__crumbs-sep {
+  color: var(--ink-600);
+}
+.fmm-settings .fmm-page-header__crumbs-current {
+  color: var(--fg-2);
+}
+
+.fmm-settings .fmm-page-header__row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  /* Wrap, or the two unshrinkable-by-default items force a horizontal scroll. */
+  flex-wrap: wrap;
+}
+
+.fmm-settings .fmm-page-header__title {
+  font-family: var(--font-display);
+  /* 64px on desktop; scales down only once the viewport is narrower than
+     ~533px, with a 44px floor so it still reads as the page's hero. */
+  font-size: clamp(2.75rem, 12vw, 4rem);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--fg-1);
+  margin: 0;
+  line-height: 1;
+  min-width: 0;
+}
+
+.fmm-settings .fmm-page-header__pill {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px 6px 6px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-pill);
+  /* Shrinkable and never wider than its line: a long username truncates
+     rather than widening the document. */
+  min-width: 0;
+  max-width: 100%;
+}
+
+.fmm-settings .fmm-page-header__pill-name {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+  letter-spacing: 0.02em;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fmm-settings .fmm-page-header__lede {
+  margin-top: 14px;
+  margin-bottom: 0;
+  color: var(--fg-3);
+  font-size: var(--text-base);
+  max-width: 560px;
+}
+
 /* ---------- Inputs ---------- */
 .fmm-settings .fmm-input {
   width: 100%;

--- a/web-client/src/routes/_app/settings.css
+++ b/web-client/src/routes/_app/settings.css
@@ -212,6 +212,12 @@
   max-width: 100%;
 }
 
+/* The claimed-account tick. The pill's *name* is what gives way when the row is
+   tight (below); the tick must not, or it would be squashed to nothing. */
+.fmm-settings .fmm-page-header__pill > svg {
+  flex-shrink: 0;
+}
+
 .fmm-settings .fmm-page-header__pill-name {
   font-family: var(--font-mono);
   font-size: var(--text-sm);

--- a/web-client/src/routes/_app/settings.tsx
+++ b/web-client/src/routes/_app/settings.tsx
@@ -389,13 +389,7 @@ function PageHeader({
           <div className="fmm-page-header__pill-name" title={display}>
             {display}
           </div>
-          {claimed && (
-            <Check
-              size={14}
-              color="var(--serve-500)"
-              style={{ flexShrink: 0 }}
-            />
-          )}
+          {claimed && <Check size={14} color="var(--serve-500)" />}
         </div>
       </div>
       <p className="fmm-page-header__lede">

--- a/web-client/src/routes/_app/settings.tsx
+++ b/web-client/src/routes/_app/settings.tsx
@@ -369,82 +369,36 @@ function PageHeader({
   username: string
   claimed: boolean
 }) {
+  // Styles live in settings.css (`.fmm-page-header*`), not inline: this row has
+  // to respond to the viewport (see the comment there) and an inline `style`
+  // object cannot carry a media query (#890).
+  const display = username || '…'
   return (
-    <header style={{ marginBottom: 28 }}>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 12,
-          marginBottom: 14,
-          fontSize: 'var(--text-xs)',
-          color: 'var(--fg-muted)',
-          letterSpacing: '0.14em',
-          textTransform: 'uppercase',
-          fontWeight: 600,
-        }}
-      >
+    <header className="fmm-page-header">
+      <div className="fmm-page-header__crumbs">
         <span className="ball-dot" style={{ width: 7, height: 7 }} />
         Workspace
-        <span style={{ color: 'var(--ink-600)' }}>/</span>
-        <span style={{ color: 'var(--fg-2)' }}>Settings</span>
+        <span className="fmm-page-header__crumbs-sep">/</span>
+        <span className="fmm-page-header__crumbs-current">Settings</span>
       </div>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'flex-end',
-          gap: 16,
-          justifyContent: 'space-between',
-        }}
-      >
-        <h1
-          style={{
-            fontFamily: 'var(--font-display)',
-            fontSize: 64,
-            letterSpacing: '0.02em',
-            textTransform: 'uppercase',
-            color: 'var(--fg-1)',
-            margin: 0,
-            lineHeight: 1,
-          }}
-        >
-          Settings
-        </h1>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-            padding: '6px 12px 6px 6px',
-            background: 'var(--bg-card)',
-            border: '1px solid var(--border-subtle)',
-            borderRadius: 'var(--r-pill)',
-            flexShrink: 0,
-          }}
-        >
-          <UserAvatar name={username || '…'} size={26} dim={!claimed} />
-          <div
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 'var(--text-sm)',
-              color: 'var(--fg-2)',
-              letterSpacing: '0.02em',
-            }}
-          >
-            {username || '…'}
+      <div className="fmm-page-header__row">
+        <h1 className="fmm-page-header__title">Settings</h1>
+        <div className="fmm-page-header__pill" data-testid="settings-user-pill">
+          <UserAvatar name={display} size={26} dim={!claimed} />
+          {/* `title` so a truncated long username is still readable on hover. */}
+          <div className="fmm-page-header__pill-name" title={display}>
+            {display}
           </div>
-          {claimed && <Check size={14} color="var(--serve-500)" />}
+          {claimed && (
+            <Check
+              size={14}
+              color="var(--serve-500)"
+              style={{ flexShrink: 0 }}
+            />
+          )}
         </div>
       </div>
-      <p
-        style={{
-          marginTop: 14,
-          marginBottom: 0,
-          color: 'var(--fg-3)',
-          fontSize: 'var(--text-base)',
-          maxWidth: 560,
-        }}
-      >
+      <p className="fmm-page-header__lede">
         Save each section on its own — we don't bundle changes you didn't ask for.
       </p>
     </header>


### PR DESCRIPTION
Clears ten issues from the `launch-fast-follow` group, including the one open **launch-blocker** (#893). All web-client; no API change, so no OpenAPI regen.

Closes #893
Closes #894
Closes #895
Closes #887
Closes #930
Closes #888
Closes #892
Closes #890
Closes #891
Closes #889

(Separate lines deliberately — a comma-separated `Closes #a, #b` closes only the first, which has left tickets silently open here before.)

## What changed, by slice

**New Match never silently starts a solo match** (#893 launch-blocker, #894, #895)

`opponent: Opponent | null` was the entire selection model, and the picker's state was sealed below the match-setup card with only an `onPick` channel out — so the card *structurally could not* tell "typed `zzzzzz`, found nobody" from "deliberately wants a solo match". They were the same value. One missing state, surfacing as three bugs.

Selection is now a sum type — `none | seeking | picked`. While seeking, the summary says no opponent is selected and the button reads **"Start solo match"**. The button stays `disabled={submitting}` only: the fix is honesty, not a lock, so a solo match is still one click away — you just can't start one by accident. The typeahead no longer auto-highlights the first result with zero user intent, no longer publishes a highlight as `aria-selected`, and a bare Enter with nothing highlighted now picks *nobody* rather than silently committing row 1. Leaving search mode was never implemented at all (`setShowSearch(false)` had no call site anywhere in the repo) — there's now a visible "Back to recent opponents" control, rendered outside the error boundary so a *failed* search is escapable too.

**The app shell tells assistive tech the same story it tells the eye** (#887, #930, #888)

The closed mobile drawer was hidden by a CSS transform alone — offscreen, but still focusable, tabbable and in the a11y tree (a Tab-walk landed inside the shut drawer 12 times). Three sidebar links announced themselves as the current page at once. Match detail nested a `main` landmark inside the shell's.

**On #930:** `activeOptions={{ exact: true }}` alone *cannot* fix this, and I want that on the record. A section parent and its index child point at the **same URL** (Notifications and Inbox are both `/notifications`), so an exact match fires for both — and the router spreads its own `aria-current` *after* `activeProps`, so no prop can remove it. The top-level anchor is therefore built from `useLinkProps()` with that one attribute withheld. Client-side navigation, intent-preloading and cmd/middle-click were all verified intact in a browser.

**A notification channel never claims a delivery path it hasn't got** (#892)

The API already models this correctly and the client ignored it: `available` ("can we deliver on this channel at all") and `setup_required` ("deliverable, but this user has no confirmed email / no device") are separate flags, and the view consulted only the first. A guest's Push and Email switches rendered **checked and enabled**, beside the text "No devices yet".

**Settings fits a phone; the alpha notice can be dismissed** (#890, #891)

The settings overflow **was not** where the issue said. `#sec-email` sits inside a card with `overflow: hidden` and cannot widen the document; the culprit was the page header. The overflow **scales with username length** — 2px with a short name, 219px at the server's 40-char maximum — so a short-username test passes against the unfixed page. The regression test pins the 40-char boundary. The alpha notice had *zero* buttons in it; `PopoverClose` was never even re-exported from the shared UI module.

**An empty list offers no page to turn to** (#889)

## Corrections to the issues themselves

- **#888 is not a mobile bug.** It nests identically at 1280px. The issue's framing is just when QA happened to look.
- **#890 blames the wrong element** (see above).
- **#885 does not reproduce.** Escape *does* dismiss the alpha notice — verified twice by independent passes driving a real browser against the base commit, at both viewports and with focus moved outside the popover. This PR adds a **regression guard** pinning that behaviour rather than a fix. #885 should be closed as not-reproducible; I did not close it, as that wasn't mine to do.

## Testing

| suite | result |
| --- | --- |
| vitest | 241 files / 1987 tests passed |
| web-client e2e | 200 passed |
| build (`tsc -b` + vite) | clean |
| lint | 0 errors |

Every chore was implemented by a domain-expert agent and then graded by a **separate** agent that re-ran its tests against the base commit to confirm they actually go red without the fix. That caught: a test that passed against the unfixed page (#890's short username), an over-correction that would have disabled *working* notification channels, a plausible wrong fix the pager suite had to reject (`totalPages <= 1`), and — twice — a stale Vite module rendering a fixed-looking page against unfixed code.

`/simplify` then caught a **latent re-run of #892**: the fix had only been applied to half the component, and the card's formula would still light the switch on for an undeliverable channel. It also found the match-setup card re-rendering (and re-registering TanStack's `useBlocker`) on every keystroke, to fill a field with zero readers.

⚠️ **Known flaky spec:** `e2e/matches/mobile-match-list-scroll.spec.ts` (#702) went red once under parallel load and passed on two isolated runs plus two subsequent full runs. Pre-existing timing sensitivity, not introduced here — flagging rather than burying it.

## Follow-ups (not done here, deliberately)

- The nav anchor forks `<Link>` via `useLinkProps`. The router exports `createLink` as the documented extension point — worth migrating so future router normalizations are inherited.
- `pagination-footer` takes both `total` and `totalPages`, and three callers each duplicate the `Math.max(1, ...)` clamp. Deriving page count in the footer would delete the triplication.
- The shared axe helper excludes `best-practice`, where `landmark-one-main` lives — which is *why* #888 shipped. Per an explicit decision this sweep used targeted assertions instead; the systemic hole is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfXUrzaXhA8cjAkTfaA1U9