### PR TITLE
Say "View match" for a lone match on the profile Recent-matches link

### DIFF
--- a/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-query.test.ts
+++ b/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-query.test.ts
@@ -79,10 +79,10 @@ describe('recentMatchesQuery', () => {
     expect(view.viewAllLabel).toBe('View all 50 matches')
   })
 
-  it('says "match", singular, when there is only one', async () => {
+  it('drops the count and "all" for a lone match — "View all 1 match" reads wrong', async () => {
     const view = await selectFrom({ match_total: 1 })
 
-    expect(view.viewAllLabel).toBe('View all 1 match')
+    expect(view.viewAllLabel).toBe('View match')
   })
 
   it('carries the player id the history link needs', async () => {

--- a/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-query.ts
+++ b/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-query.ts
@@ -227,7 +227,9 @@ export const selectRecentMatches = (
     // and every state in them belongs on the card.
     rows: player.matches.items.map((row) => selectRow(row, timeZone)),
     total,
-    viewAllLabel: `View all ${total} ${total === 1 ? 'match' : 'matches'}`,
+    // "View all 1 match" reads wrong — "all" presupposes more than one — so the
+    // lone-match case drops both the count and the "all".
+    viewAllLabel: total === 1 ? 'View match' : `View all ${total} matches`,
   }
 }
 


### PR DESCRIPTION
## What

On the player profile's **Recent matches** card, the "View all N matches" link read **"View all 1 match"** when a player had exactly one match — "all" presupposes more than one, so it read wrong. It now reads **"View match"** for the single-match case; every other count is unchanged ("View all 2 matches", "View all 50 matches", …).

The full paginated match-history page is untouched — its pagination footer only renders past 25 rows, so it never reaches the singular.

## Changes
- `recent-matches-query.ts` — `viewAllLabel` special-cases `total === 1` → `"View match"`.
- `recent-matches-query.test.ts` — singular-case assertion updated to expect `"View match"`.

## Verification
- `vitest` recent-matches suite: 43 passed.
- `npm run lint`: 0 errors. `tsc -b`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)