### PR TITLE
Generate & persist round-robin pool draws (#786)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -299,8 +299,9 @@ _Avoid_: sets won, points won (points are not modelled), game win rate.
 **Meeting**:
 One decided **match** between two named players. The count of meetings and their
 outcomes make up a **head-to-head**.
-_Avoid_: encounter, fixture, matchup (a *head-to-head* is the record; a *meeting*
-is one match in it).
+_Avoid_: encounter, matchup (a *head-to-head* is the record; a *meeting* is one
+match in it), fixture (a **fixture** is a tournament draw's *pre-play* pairing —
+a meeting is a decided match).
 
 **Head-to-head**:
 One player's record of **meetings** against another — how many times they have
@@ -384,6 +385,42 @@ bottom of the list.
 _Avoid_: seed, top seed, position, row number (the roster's leftmost column may
 be *styled* with tournament "seed" flavor, but the underlying concept is a
 rating rank, never the player's index on the current page).
+
+## Tournaments
+
+**Draw**:
+The complete set of **fixtures** an event's draw type prescribes for its
+entrants — a bracket, a set of pools, or (later) rounds of pairings. A draw is
+**cut** (the deliberate, reviewable act of generating it; re-cutting replaces
+it wholesale and is refused once there is any evidence of play), and it is
+**current** when its fixtures cover exactly the event's active entrants —
+an entry landing after the cut makes the draw **stale**. Going live requires
+every event's draw to exist and be current; a draw may be cut and re-cut
+freely before that.
+_Avoid_: bracket (one draw type's shape, not the general concept), schedule
+(when a fixture is *played* is the schedule's concern, not the draw's).
+
+**Fixture**:
+A planned pairing in a **draw**: a round and a position (and a **pool**, when
+the draw is pooled), whose sides may still be unknown. A fixture is not a
+**match** — it *materializes* into one the moment both of its sides are known,
+and the match then runs the normal propose/accept lifecycle. A fixture is
+**pending** (some side still unknown), **ready** (both sides known — its match
+exists), or **decided** (its match completed and the winner recorded on the
+fixture).
+_Avoid_: slot (a *Slot* is a window of time), tournament match (a fixture is
+the pre-play pairing; the match is the contest it becomes), tie.
+
+**Pool**:
+One concept with two faces, deliberately not split: a reserved slice of the
+venue (a set of tables for a window of time) *and*, once a round-robin draw is
+cut, the group of entrants who play all-play-all on that slice. The set of pools
+an event has is frozen the moment a draw exists — pools can no longer be added,
+removed, or renamed — but a pool's venue attributes (its tables, its time
+window) stay editable mid-event, because the venue changes under a running
+tournament (a table breaks, a table frees up).
+_Avoid_: group (a pool is not a grouping abstraction separate from the venue
+slice), division.
 
 ## Dashboard
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -231,8 +231,9 @@ _Avoid_: sets won, points won (points are not modelled), game win rate.
 **Meeting**:
 One decided **match** between two named players. The count of meetings and their
 outcomes make up a **head-to-head**.
-_Avoid_: encounter, fixture, matchup (a *head-to-head* is the record; a *meeting*
-is one match in it).
+_Avoid_: encounter, matchup (a *head-to-head* is the record; a *meeting* is one
+match in it), fixture (a **fixture** is a tournament draw's *pre-play* pairing —
+a meeting is a decided match).
 
 **Head-to-head**:
 One player's record of **meetings** against another — how many times they have
@@ -316,6 +317,42 @@ bottom of the list.
 _Avoid_: seed, top seed, position, row number (the roster's leftmost column may
 be *styled* with tournament "seed" flavor, but the underlying concept is a
 rating rank, never the player's index on the current page).
+
+## Tournaments
+
+**Draw**:
+The complete set of **fixtures** an event's draw type prescribes for its
+entrants — a bracket, a set of pools, or (later) rounds of pairings. A draw is
+**cut** (the deliberate, reviewable act of generating it; re-cutting replaces
+it wholesale and is refused once there is any evidence of play), and it is
+**current** when its fixtures cover exactly the event's active entrants —
+an entry landing after the cut makes the draw **stale**. Going live requires
+every event's draw to exist and be current; a draw may be cut and re-cut
+freely before that.
+_Avoid_: bracket (one draw type's shape, not the general concept), schedule
+(when a fixture is *played* is the schedule's concern, not the draw's).
+
+**Fixture**:
+A planned pairing in a **draw**: a round and a position (and a **pool**, when
+the draw is pooled), whose sides may still be unknown. A fixture is not a
+**match** — it *materializes* into one the moment both of its sides are known,
+and the match then runs the normal propose/accept lifecycle. A fixture is
+**pending** (some side still unknown), **ready** (both sides known — its match
+exists), or **decided** (its match completed and the winner recorded on the
+fixture).
+_Avoid_: slot (a *Slot* is a window of time), tournament match (a fixture is
+the pre-play pairing; the match is the contest it becomes), tie.
+
+**Pool**:
+One concept with two faces, deliberately not split: a reserved slice of the
+venue (a set of tables for a window of time) *and*, once a round-robin draw is
+cut, the group of entrants who play all-play-all on that slice. The set of pools
+an event has is frozen the moment a draw exists — pools can no longer be added,
+removed, or renamed — but a pool's venue attributes (its tables, its time
+window) stay editable mid-event, because the venue changes under a running
+tournament (a table breaks, a table frees up).
+_Avoid_: group (a pool is not a grouping abstraction separate from the venue
+slice), division.
 
 ## Dashboard
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -414,11 +414,12 @@ the pre-play pairing; the match is the contest it becomes), tie.
 **Pool**:
 One concept with two faces, deliberately not split: a reserved slice of the
 venue (a set of tables for a window of time) *and*, once a round-robin draw is
-cut, the group of entrants who play all-play-all on that slice. The set of pools
-an event has is frozen the moment a draw exists — pools can no longer be added,
-removed, or renamed — but a pool's venue attributes (its tables, its time
-window) stay editable mid-event, because the venue changes under a running
-tournament (a table breaks, a table frees up).
+cut, the group of entrants who play all-play-all on that slice. The set of pool
+**identities** an event has is frozen the moment a draw exists — pools can no
+longer be added, removed, or re-identified, because every **fixture** names the
+pool it belongs to — but a pool's venue attributes (its tables, its time window)
+and its display name stay editable mid-event, because the venue changes under a
+running tournament (a table breaks, a table frees up).
 _Avoid_: group (a pool is not a grouping abstraction separate from the venue
 slice), division.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -184,9 +184,21 @@ _Avoid_: home league, main league, global league.
 
 **Entry**:
 A player's place in one tournament **event**. Soft-deleted on withdrawal, so a
-player may re-enter (ADR-0016).
+player may re-enter (ADR-0016). An entry knows **who created it**: `NULL` means the
+player entered themselves, otherwise it names the director who added them
+(ADR-0784). Those are the only two ways an entry comes to exist, and the second is
+not a different endpoint — it is the same one, told who to enter.
 _Avoid_: registration, signup, ticket (an entry is the row; *registration* is the
 window it may be created in).
+
+**Director entry**:
+The tournament **owner** adding a player to an event on their behalf — a phone
+entry, or someone without an account yet. It runs through the *same* endpoint, the
+same eligibility evaluator, the same capacity lock and the same **refusal codes** as
+a player's own (ADR-0784): absent an override, a director's mistake is caught by
+exactly the rules that catch a stranger's. An owner naming their *own* id is not a
+director entry — that is self-registration, and it is spelled `NULL`.
+_Avoid_: admin add, force add (there is no override yet — see #985).
 
 **Entrant**:
 A player holding an **active** entry — `status = entered`. The count of entrants is
@@ -197,7 +209,10 @@ it counts.
 **Registration window**:
 The span in which entries may be created, which is exactly the tournament being
 `published` (ADR-0017). A `draft` has not opened, a `live` one has locked, an
-`archived` one has ended. Entering *and* withdrawing both obey it.
+`archived` one has ended. Entering *and* withdrawing both obey it — **including the
+director's** (ADR-0784). So once a tournament is `live` nobody can be added or
+removed, not even by the owner: that is deliberate, and it is why #985 (the
+override, for walk-ins and no-shows) exists.
 _Avoid_: open, deadline (there is no date; the window is a function of the status).
 
 **Eligibility**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -405,9 +405,12 @@ A planned pairing in a **draw**: a round and a position (and a **pool**, when
 the draw is pooled), whose sides may still be unknown. A fixture is not a
 **match** — it *materializes* into one the moment both of its sides are known,
 and the match then runs the normal propose/accept lifecycle. A fixture is
-**pending** (some side still unknown), **ready** (both sides known — its match
-exists), or **decided** (its match completed and the winner recorded on the
-fixture).
+**pending** (some side still unknown), **ready** (both sides known and **no
+match yet** — the signal to create one), **materialized** (its match exists and
+is being played), or **decided** (its match completed and the winner recorded on
+the fixture). *Ready* is the state that ends the moment the match is created:
+`advance()` is idempotent precisely because a fixture that already has a
+`match_id` is no longer ready, and so is never proposed twice.
 _Avoid_: slot (a *Slot* is a window of time), tournament match (a fixture is
 the pre-play pairing; the match is the contest it becomes), tie.
 

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -5,4 +5,9 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .coverage
+coverage.json
+htmlcov/
 .mypy_cache/
+# mutmut copies the tree into `mutants/` and keeps its results in `.mutmut-cache`.
+mutants/
+.mutmut-cache

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -38,11 +38,13 @@ from app.models import (
     RatingHistory,
     Tournament,
     TournamentEntryStatus,
+    TournamentEvent,
     User,
     UserLeagueRating,
     UserRole,
     UserToken,
 )
+from app.tournament_draws import uncut_draw
 
 # Must match ``app.sessions.SESSION_TOKEN_CONTEXT``. Hardcoded to avoid a
 # circular import (sessions imports this module). Session tokens are KEPT on the
@@ -167,34 +169,11 @@ async def merge_user(
     # Dedup, then re-point. The uniqueness guard on ``tournament_entries`` is
     # PARTIAL — ``UNIQUE (event_id, user_id) WHERE status = 'entered'``
     # (ADR-0016) — so the ONLY rows that can collide are a guest ACTIVE entry in
-    # an event the survivor is ALSO actively entered in. Drop the guest's losing
-    # row first: the survivor's entry stands, so the event's active-entry count is
-    # unchanged by the merge (it was one person all along).
-    #
-    # The predicate tests ``status``, not the (event, user) pair alone, because
-    # two *withdrawn* rows for the same pair are legal — soft-deleted history the
-    # partial index deliberately permits. Deleting those would destroy withdrawal
-    # history the index exists to keep. "Active" is bound as ``:active`` from
-    # ``_ACTIVE_ENTRY_STATUS`` (see above) so this SQL cannot drift from the enum.
-    await db.execute(
-        text(
-            """
-            DELETE FROM tournament_entries AS te
-            WHERE te.user_id = :from_id
-              AND te.status = :active
-              AND EXISTS (
-                SELECT 1 FROM tournament_entries other
-                WHERE other.user_id = :to_id
-                  AND other.event_id = te.event_id
-                  AND other.status = :active
-              )
-            """
-        ),
-        {
-            "from_id": from_user_id,
-            "to_id": to_user_id,
-            "active": _ACTIVE_ENTRY_STATUS,
-        },
+    # an event the survivor is ALSO actively entered in. Resolving that collision
+    # (drop the guest's losing row, carry its registration order, un-cut the draw
+    # it invalidated) is the whole of ``_resolve_entry_collisions``.
+    await _resolve_entry_collisions(
+        db, from_user_id=from_user_id, to_user_id=to_user_id
     )
     # Nothing left can collide, so the re-point is unconditional and total: every
     # remaining guest entry — active or withdrawn — moves onto the survivor, and
@@ -469,6 +448,155 @@ async def merge_user(
     matches_moved -= matches_voided
 
     return MergeSummary(matches_moved=matches_moved, matches_voided=matches_voided)
+
+
+async def _resolve_entry_collisions(
+    db: AsyncSession,
+    *,
+    from_user_id: uuid.UUID,
+    to_user_id: uuid.UUID,
+) -> None:
+    """Resolve every **entry collision** this merge exposes: an event both
+    identities are ACTIVELY entered in. One human, two registrations — and the
+    merge is the moment we learn it (ADR-0786, "An account merge that
+    double-counted a human invalidates the draw").
+
+    Three things happen, in this order, and each is load-bearing:
+
+    1. **The survivor's entry inherits the earlier registration and any seed.**
+       The survivor's row is the one that stands, but it is not the one whose
+       *facts* are necessarily right: registration order is the draw's ordering
+       tie-break (``app.draws.order_entrants`` — seed ascending where set, then
+       ``created_at``), so keeping the later of the two timestamps would silently
+       move that player down a future draw. ``LEAST`` takes the earlier;
+       ``COALESCE`` keeps the survivor's seed and adopts the guest's only where
+       the survivor has none (a seed the director set on the row we are keeping is
+       not the merge's to overwrite).
+    2. **The guest's losing row is deleted.** The survivor's entry stands, so the
+       event's active-entry count is unchanged by the merge (it was one person all
+       along). The predicate tests ``status``, not the (event, user) pair alone,
+       because two *withdrawn* rows for the same pair are legal — soft-deleted
+       history the partial index deliberately permits, and which the unconditional
+       re-point in ``merge_user`` carries across untouched.
+    3. **The event's draw is un-cut** (its fixtures deleted; the director re-cuts).
+
+    Step 3 is the one that is not obvious. ``tournament_fixtures`` references
+    entries with ``ON DELETE CASCADE``, so step 2 alone would silently take any
+    fixtures seating the guest's entry with it, punching holes in a cut draw. The
+    tempting repair — re-point those fixtures onto the *surviving* entry — is
+    wrong, and dangerously so: it seats one human in two slots of the same pool
+    (everyone else plays them twice; drawn against themselves, the fixture is
+    self-play), and because the go-live currency check compares entrant **sets**,
+    the corrupted draw would satisfy that check and go live. So the draw is
+    regenerated, never patched: it was cut from a field that double-counted a
+    human, so its pool sizes and snake seeding were computed against N+1 entrants
+    and it is wrong throughout. The un-cut is scoped to the colliding events —
+    another event of the same tournament keeps the draw it legitimately holds.
+
+    The merge itself is **never refused** (consistent with the self-play-collision
+    doctrine): nobody is locked out of their own account by a registration.
+
+    *Out of scope, deliberately:* a collision on an event whose play has already
+    begun (a fixture with a ``winner_entry_id`` or a ``match_id`` —
+    ``draw_has_play``). Un-cutting there would eat a recorded result, so that case
+    needs the self-play-collision machinery (transfer the match, then void it)
+    rather than this. It is **unreachable today** — nothing materializes a fixture
+    into a match until #788 — and building it now would mean guessing at machinery
+    that does not exist. When #788 lands, this is the gap to close.
+
+    "Active" is bound as ``:active`` from ``_ACTIVE_ENTRY_STATUS`` (see the module
+    top) in every statement here, so none of them can drift from the enum that the
+    model, the routes and the partial unique index all follow.
+
+    Does not commit — runs inside ``merge_user``'s caller's transaction, which is
+    what makes the delete and the un-cut one atomic act.
+    """
+    params = {
+        "from_id": from_user_id,
+        "to_id": to_user_id,
+        "active": _ACTIVE_ENTRY_STATUS,
+    }
+
+    # The events to un-cut, read BEFORE the delete — afterwards the guest's row is
+    # gone and the collision is no longer visible.
+    collided_event_ids = set(
+        (
+            await db.execute(
+                text(
+                    """
+                    SELECT guest.event_id
+                    FROM tournament_entries AS guest
+                    JOIN tournament_entries AS survivor
+                      ON survivor.event_id = guest.event_id
+                     AND survivor.user_id = :to_id
+                     AND survivor.status = :active
+                    WHERE guest.user_id = :from_id
+                      AND guest.status = :active
+                    """
+                ),
+                params,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not collided_event_ids:
+        return
+
+    # (1) Registration order and seed follow the earlier registration onto the
+    # survivor.
+    await db.execute(
+        text(
+            """
+            UPDATE tournament_entries AS survivor
+            SET created_at = LEAST(survivor.created_at, guest.created_at),
+                seed = COALESCE(survivor.seed, guest.seed)
+            FROM tournament_entries AS guest
+            WHERE survivor.user_id = :to_id
+              AND survivor.status = :active
+              AND guest.user_id = :from_id
+              AND guest.status = :active
+              AND guest.event_id = survivor.event_id
+            """
+        ),
+        params,
+    )
+
+    # (2) Drop the guest's losing row.
+    await db.execute(
+        text(
+            """
+            DELETE FROM tournament_entries AS te
+            WHERE te.user_id = :from_id
+              AND te.status = :active
+              AND EXISTS (
+                SELECT 1 FROM tournament_entries other
+                WHERE other.user_id = :to_id
+                  AND other.event_id = te.event_id
+                  AND other.status = :active
+              )
+            """
+        ),
+        params,
+    )
+
+    # (3) Un-cut the draws the double-counted field invalidated. ``uncut_draw`` is
+    # the one place a draw is deleted (ADR-0786) — a hand-rolled DELETE here would
+    # be a second spelling of "this event has no draw" to keep in step with the
+    # first.
+    events = (
+        (
+            await db.execute(
+                select(TournamentEvent).where(
+                    TournamentEvent.id.in_(collided_event_ids)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for event in events:
+        await uncut_draw(db, event)
 
 
 async def _self_play_collision(

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -210,6 +210,55 @@ async def merge_user(
         {"from_id": from_user_id, "to_id": to_user_id},
     )
 
+    # Now the *other* users FK on the same table: ``added_by_user_id`` — who put
+    # this player in the event (ADR-0784). The guest may have been a DIRECTOR who
+    # entered other people; the entries they created are still perfectly valid
+    # registrations of real players, so there is nothing here to delete. What must
+    # not survive is the pointer: the guest is about to become a tombstone, and an
+    # entry left saying "added by <ghost>" would render as an adder who no longer
+    # exists. The adder and the survivor are the same human — so the adder FOLLOWS
+    # the merge, exactly as tournament *ownership* does above.
+    #
+    # Must run AFTER the ``user_id`` re-point, because it reads the post-merge
+    # ``user_id`` — which is what the CASE is for. If the guest director is merged
+    # into the very player they entered (I create a tournament as a guest, add
+    # "Rita" from search, then sign in and turn out to BE Rita), then after the
+    # merge one person both added and is the entry: that is self-registration, and
+    # self-registration is spelled NULL. Writing ``added_by = user_id`` instead
+    # would leave two different encodings of "entered themselves" in the column and
+    # let "added by the director" appear on a director-less entry. Collapse it.
+    # (``test_merge_collapses_a_guest_who_both_added_and_is_the_entry`` is what pins
+    # that ordering: reorder these two statements and both direction tests go red.)
+    #
+    # The WHERE catches **both** ids, and the second one is not decoration — it is
+    # the mirror of the case above, and it is the merge's own doing. Take a director
+    # D with a real account who enters a GUEST player P (``user_id = P``,
+    # ``added_by = D``); P then signs in and turns out to BE D. The re-point above
+    # rewrites ``user_id`` to D — and a WHERE that only looked for ``:from_id``
+    # would not match this row at all, leaving ``added_by == user_id == D``: the very
+    # contradictory encoding this CASE exists to prevent, *manufactured by the merge*
+    # rather than merely passed through it. Matching ``:to_id`` as well lets the same
+    # CASE collapse it to NULL. The extra rows that predicate sweeps in — an entry
+    # already added by the survivor, whose entrant is somebody else — are re-pointed
+    # from ``to_id`` to ``to_id``, which is a no-op by construction.
+    #
+    # So the invariant is: after this statement, no row whose ``user_id`` or
+    # ``added_by_user_id`` was touched by this merge can say ``added_by == user_id``.
+    #
+    # Note this deliberately does NOT re-point rows whose *entry* was dropped by
+    # the dedup DELETE above — they no longer exist, so there is nothing to point.
+    await db.execute(
+        text(
+            """
+            UPDATE tournament_entries
+            SET added_by_user_id =
+                CASE WHEN user_id = :to_id THEN NULL ELSE :to_id END
+            WHERE added_by_user_id IN (:from_id, :to_id)
+            """
+        ),
+        {"from_id": from_user_id, "to_id": to_user_id},
+    )
+
     # Preserve the audit trail by re-pointing rather than letting the FK's
     # ON DELETE SET NULL null it out when the ephemeral user is deleted.
     await db.execute(

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -38,7 +38,6 @@ from app.models import (
     RatingHistory,
     Tournament,
     TournamentEntryStatus,
-    TournamentEvent,
     User,
     UserLeagueRating,
     UserRole,
@@ -583,20 +582,9 @@ async def _resolve_entry_collisions(
     # (3) Un-cut the draws the double-counted field invalidated. ``uncut_draw`` is
     # the one place a draw is deleted (ADR-0786) — a hand-rolled DELETE here would
     # be a second spelling of "this event has no draw" to keep in step with the
-    # first.
-    events = (
-        (
-            await db.execute(
-                select(TournamentEvent).where(
-                    TournamentEvent.id.in_(collided_event_ids)
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
-    for event in events:
-        await uncut_draw(db, event)
+    # first. It takes the ids straight: the events themselves are never needed, so
+    # loading them would be a SELECT run purely to read back the ids we already hold.
+    await uncut_draw(db, collided_event_ids)
 
 
 async def _self_play_collision(

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -1,0 +1,433 @@
+"""Draw planning — the *pure* domain behind cutting and advancing a draw (ADR-0786).
+
+A **draw** is the complete set of **fixtures** an event's draw type prescribes for
+its entrants; a **fixture** is one planned pairing (a round and a position, plus a
+**pool** when the draw is pooled), whose sides may still be unknown. This module
+knows how to *plan* those fixtures. It does not persist them: it holds no session,
+issues no query, imports no FastAPI and no SQLAlchemy construct. Its inputs and
+outputs are small frozen value objects, so a strategy is testable with a literal
+list and re-runnable anywhere (a REPL, a script, a test) without a database.
+
+Each :class:`~app.models.tournament.DrawType` is a strategy behind
+:class:`DrawStrategy`, with two pure operations:
+
+``plan_initial(config, ordered_entrants)``
+    Cuts the draw — the fixtures as they stand the moment they are first written.
+
+``advance(fixtures)``
+    Reads the persisted fixtures *as they currently stand* and returns the
+    side-fills that the decided fixtures now imply, plus the fixtures that have
+    become **ready** (both sides known, no match yet). It is re-run after *every*
+    result and at go-live rather than fired by carefully-chosen events, which only
+    works because it is **idempotent**: apply its plan, feed the resulting state
+    back in, and the second plan is empty (:attr:`AdvancePlan.is_empty`).
+
+Two things the schema deliberately does not store, and this module therefore owns:
+
+- **Topology.** There is no ``next_slot_id``. Single-elim's successor is arithmetic
+  on ``(round, position)``, round-robin has no successor at all, and swiss cannot
+  know its next round until the current one finishes. ``advance()`` recomputes what
+  it needs from the rows.
+- **Byes.** A bye is the *absence of a fixture row*, never a row with a ``NULL``
+  side. ``NULL`` means exactly one thing — "TBD, ``advance()`` will fill it" — so an
+  odd round-robin pool simply has fewer fixtures in some rounds.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import NewType, Protocol
+
+from app.models.tournament import DrawType
+
+# Distinct id types, so the checker rejects handing a fixture id to something that
+# wants an entry id. They are plain ``uuid.UUID`` at runtime.
+EntryId = NewType("EntryId", uuid.UUID)
+FixtureId = NewType("FixtureId", uuid.UUID)
+MatchId = NewType("MatchId", uuid.UUID)
+#: A pool is a JSONB value-object on the event, not a row — its id is a *string ref*
+#: into ``TournamentEvent.pools``, which is why this is a ``str`` and not a UUID FK.
+PoolId = NewType("PoolId", str)
+
+
+class DrawError(Exception):
+    """Base class for every refusal this module can raise.
+
+    One base so the HTTP layer has a single thing to catch and turn into a 422: the
+    draw endpoint's callers are asking for something the domain will not produce, not
+    tripping over a bug. Strategies never signal a refusal by returning ``None`` or an
+    empty plan — an un-cuttable draw is an *error*, and a silent empty draw would look
+    exactly like a legitimately empty one.
+    """
+
+
+class UnsupportedDrawType(DrawError):
+    """This draw type has no strategy yet.
+
+    Raised by :func:`strategy_for`, whose ``match`` is exhaustive with no catch-all —
+    so a new :class:`DrawType` member is a *type* error until it is handled here, and
+    a member that is handled-but-unimplemented is a catchable domain error rather than
+    a 500.
+    """
+
+    def __init__(self, draw_type: DrawType) -> None:
+        self.draw_type = draw_type
+        super().__init__(f"Draw type {draw_type.value!r} is not implemented yet.")
+
+
+class DegenerateDraw(DrawError):
+    """The requested cut would produce a draw that isn't a competition.
+
+    A pool holding a single entrant has nobody to play (and a pool holding none is a
+    ghost), so we refuse the cut rather than silently emit a pool of one. The director
+    fixes the input — fewer pools, or more entrants — and re-cuts.
+    """
+
+
+class Side(enum.Enum):
+    """Which of a fixture's two sides — ``entry_a_id`` or ``entry_b_id``."""
+
+    a = "a"
+    b = "b"
+
+
+@dataclass(frozen=True, slots=True)
+class Entrant:
+    """An active entry, as the ordering rule needs to see it.
+
+    Deliberately not the ``TournamentEntry`` row: this module must be constructible
+    from literals. The caller (the persistence layer) is responsible for passing only
+    **active** entries — withdrawal is a soft-delete, and a withdrawn entry has no
+    place in a draw.
+    """
+
+    entry_id: EntryId
+    #: ``None`` = unseeded. Nothing sets a seed today (a director-only seeding endpoint
+    #: is its own slice), so in practice every entrant is unseeded and the draw is
+    #: ordered by registration order — which is what club-night reality does anyway.
+    seed: int | None
+    #: Registration order. Aware, like every datetime that crosses this boundary.
+    created_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class OrderedEntrant:
+    """An entrant in its settled draw order — the output of :func:`order_entrants` and
+    the only entrant shape a strategy sees.
+
+    A distinct type from :class:`Entrant` on purpose: a strategy cannot be handed an
+    unordered pile and quietly cut a draw from it, because the ordering *is* the
+    seeding. ``position`` is 1-based, so entrant 1 is the top seed.
+    """
+
+    entry_id: EntryId
+    position: int
+
+
+@dataclass(frozen=True, slots=True)
+class DrawConfig:
+    """What a cut needs to know about the event itself.
+
+    ``pool_ids`` are the ids of the event's configured pools, **in the event's own pool
+    order** — that order is what the snake seeds against, so it must not be re-sorted.
+    Empty for an un-pooled draw type (single-elim), where every fixture's ``pool_id``
+    is ``NULL``. The pool *id set* freezes while a draw exists, which is what lets a
+    fixture's string ref stay valid without a foreign key.
+    """
+
+    draw_type: DrawType
+    pool_ids: tuple[PoolId, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedFixture:
+    """One fixture a cut wants written — the pre-persistence twin of a
+    ``TournamentFixture`` row, minus the ids the database mints.
+
+    A side is ``None`` only when it is genuinely **TBD** (single-elim's later rounds).
+    It is *never* ``None`` to mean "bye": a bye is the absence of this object.
+    """
+
+    #: ``None`` = the draw is un-pooled (or this is the KO stage of an rr-then-ko).
+    pool_id: PoolId | None
+    #: 1-based.
+    round: int
+    #: 1-based within its (pool, round).
+    position: int
+    entry_a_id: EntryId | None = None
+    entry_b_id: EntryId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FixtureState:
+    """A persisted fixture as it currently stands — the whole input to
+    :meth:`DrawStrategy.advance`.
+
+    ``advance`` is a pure function of this state, which is what makes re-running it
+    after every result safe: there is no accumulated bookkeeping to get out of step,
+    and no event it can miss.
+    """
+
+    fixture_id: FixtureId
+    pool_id: PoolId | None
+    round: int
+    position: int
+    entry_a_id: EntryId | None
+    entry_b_id: EntryId | None
+    #: Set when the fixture's match completed — the fixture is then **decided**.
+    winner_entry_id: EntryId | None = None
+    #: Set once the fixture **materialized** into a real match. ``None`` before that.
+    match_id: MatchId | None = None
+
+    @property
+    def is_pending(self) -> bool:
+        """Some side is still unknown."""
+        return self.entry_a_id is None or self.entry_b_id is None
+
+
+@dataclass(frozen=True, slots=True)
+class SideFill:
+    """Fill one side of one fixture with the entry that has become known for it.
+
+    One side per object, and the entry is non-optional: there is no way to express
+    "fill this side with nothing", so an ``advance()`` cannot blank a side it has
+    already filled.
+    """
+
+    fixture_id: FixtureId
+    side: Side
+    entry_id: EntryId
+
+
+@dataclass(frozen=True, slots=True)
+class AdvancePlan:
+    """Everything the current fixture state implies: sides that became known, and the
+    fixtures that are now **ready** to materialize into matches.
+
+    ``ready_fixture_ids`` names fixtures with **both sides known that do not yet have a
+    match** — including the ones this same plan's ``side_fills`` are about to complete.
+    The "no match yet" half is what makes the plan idempotent: apply it, and the next
+    run over the resulting state sees materialized fixtures and returns an empty plan
+    (:attr:`is_empty`), rather than proposing the same matches forever.
+
+    Materialization itself is gated on the tournament being ``live`` — a *plan* is not
+    permission to create matches, and nothing consumes this list yet.
+    """
+
+    side_fills: tuple[SideFill, ...] = ()
+    ready_fixture_ids: tuple[FixtureId, ...] = ()
+
+    @property
+    def is_empty(self) -> bool:
+        """Nothing to do — the state is already fully advanced."""
+        return not self.side_fills and not self.ready_fixture_ids
+
+
+class DrawStrategy(Protocol):
+    """How one draw type cuts and advances its draw.
+
+    Pure: no I/O, no session, no clock.
+    """
+
+    def plan_initial(
+        self, config: DrawConfig, ordered_entrants: Sequence[OrderedEntrant]
+    ) -> list[PlannedFixture]:
+        """Cut the draw: the fixtures this draw type prescribes for these entrants.
+
+        Deterministic — the same entrants in the same order always yield the same
+        fixtures, so a re-cut is reproducible and reviewable. Raises
+        :class:`DegenerateDraw` rather than emitting a draw that isn't a competition.
+        """
+        ...
+
+    def advance(self, fixtures: Sequence[FixtureState]) -> AdvancePlan:
+        """What the current state of these fixtures implies. Idempotent: run against a
+        state its own last plan was applied to, it returns an empty plan."""
+        ...
+
+
+def order_entrants(entrants: Iterable[Entrant]) -> list[OrderedEntrant]:
+    """The draw order: **seed ascending where set, then registration order** for the
+    unseeded rest.
+
+    There is deliberately **no rating fallback and no randomness**. Ratings are
+    league-scoped (``UserLeagueRating``) while tournaments are standalone, so "the
+    player's rating" is not a thing this domain can read; and a random tie-break would
+    make a re-cut produce a different draw from the same field, which is exactly what
+    the explicit-cut model exists to prevent. The entry id is the final tie-break, so
+    two entries registered in the same instant still order the same way every time.
+
+    The caller passes **active** entries only (withdrawal is a soft-delete).
+    """
+    ordered = sorted(
+        entrants,
+        key=lambda e: (
+            # Seeded before unseeded: `False < True`.
+            e.seed is None,
+            # Only meaningful for the seeded; the unseeded all share this 0 and fall
+            # through to registration order.
+            e.seed if e.seed is not None else 0,
+            e.created_at,
+            str(e.entry_id),
+        ),
+    )
+    return [
+        OrderedEntrant(entry_id=e.entry_id, position=i)
+        for i, e in enumerate(ordered, 1)
+    ]
+
+
+@dataclass(frozen=True, slots=True)
+class RoundRobinStrategy:
+    """All-play-all within each pool: every pair in a pool meets exactly once, and
+    nobody plays twice in the same round.
+
+    The cut is two steps. First the ordered entrants are **snaked** across the event's
+    pools — pool A takes seeds 1, 2P, 2P+1, …; pool B takes 2, 2P−1, … — which spreads
+    the strength evenly and leaves pool sizes differing by at most one. Then each pool's
+    fixtures are laid out by the **circle method**: fix one entrant, rotate the rest,
+    and every rotation is one round of simultaneous pairings. An odd pool rotates
+    against a phantom, and the pairing against it is simply **not emitted** — that is
+    what a bye is here (a row with a ``NULL`` side would mean "TBD", which is a lie
+    about a fixture that will never be played).
+
+    Both sides of every fixture are known at cut time, so this draw has nothing to
+    advance *into*: :meth:`advance` fills no sides, and only reports readiness.
+    """
+
+    def plan_initial(
+        self, config: DrawConfig, ordered_entrants: Sequence[OrderedEntrant]
+    ) -> list[PlannedFixture]:
+        pools = _snake(ordered_entrants, config.pool_ids)
+        return [
+            fixture
+            for pool_id, members in pools
+            for fixture in _circle_method(pool_id, members)
+        ]
+
+    def advance(self, fixtures: Sequence[FixtureState]) -> AdvancePlan:
+        """Round-robin fixtures are fully determined at the cut, so there is never a
+        side to fill: every pairing was known the moment the draw existed. All this can
+        report is which fixtures are ready to become matches — which, on a freshly cut
+        draw, is all of them, and on an already-materialized one is none of them."""
+        return AdvancePlan(side_fills=(), ready_fixture_ids=ready_fixtures(fixtures))
+
+
+def ready_fixtures(fixtures: Sequence[FixtureState]) -> tuple[FixtureId, ...]:
+    """The fixtures that should now become matches: **both sides known**, no match yet,
+    not already decided.
+
+    Shared by every strategy, because "ready" is a property of the fixture, not of the
+    draw type. Excluding the already-materialized is what makes an ``advance()`` plan
+    idempotent; excluding the decided keeps a fixture whose match was later unlinked
+    (``match_id`` is ``ON DELETE SET NULL``) from rising from the dead and being played
+    twice. Ordered by ``(pool, round, position)`` so the plan itself is deterministic.
+    """
+    ready = [
+        f
+        for f in fixtures
+        if not f.is_pending and f.match_id is None and f.winner_entry_id is None
+    ]
+    ready.sort(key=lambda f: (f.pool_id is None, f.pool_id or "", f.round, f.position))
+    return tuple(f.fixture_id for f in ready)
+
+
+def strategy_for(draw_type: DrawType) -> DrawStrategy:
+    """The strategy that cuts and advances this draw type.
+
+    An exhaustive ``match`` with **no catch-all**: adding a member to
+    :class:`DrawType` makes this function fail to type-check until the member is
+    handled, so a new format cannot reach production silently unimplemented. The
+    formats that have no strategy yet raise :class:`UnsupportedDrawType` — a catchable
+    domain error the draw endpoint turns into a 422, not a 500 and not a ``None`` for
+    the caller to trip over.
+    """
+    match draw_type:
+        case DrawType.round_robin:
+            return RoundRobinStrategy()
+        case (
+            DrawType.single_elim
+            | DrawType.double_elim
+            | DrawType.rr_then_ko
+            | DrawType.swiss
+        ):
+            raise UnsupportedDrawType(draw_type)
+
+
+def _snake(
+    ordered_entrants: Sequence[OrderedEntrant], pool_ids: Sequence[PoolId]
+) -> list[tuple[PoolId, tuple[EntryId, ...]]]:
+    """Deal the ordered entrants across the pools in **snake** order — 1, 2, …, P, then
+    back P, P−1, …, 1 — so the top seeds are spread one per pool and the second tier
+    lands behind them in reverse. Pool sizes differ by at most one by construction: the
+    deal only ever fills a row before starting the next.
+
+    Refuses a pool of fewer than two: a lone entrant has nobody to play, and emitting
+    the pool anyway would hide a director's mistake behind a plausible-looking draw.
+    """
+    pool_count = len(pool_ids)
+    if pool_count == 0:
+        raise DegenerateDraw("A round-robin draw needs at least one pool.")
+
+    members: list[list[EntryId]] = [[] for _ in pool_ids]
+    for index, entrant in enumerate(ordered_entrants):
+        row, offset = divmod(index, pool_count)
+        # Odd rows deal backwards — that is the snake.
+        column = offset if row % 2 == 0 else pool_count - 1 - offset
+        members[column].append(entrant.entry_id)
+
+    # Asked of the dealt pools themselves, not of arithmetic on N and P: the refusal
+    # should hold whatever the distribution does.
+    if any(len(pool_members) < 2 for pool_members in members):
+        raise DegenerateDraw(
+            f"{len(ordered_entrants)} entrants across {pool_count} pool(s) would leave "
+            "a pool with fewer than 2 entrants, who would have nobody to play."
+        )
+
+    return [
+        (pool_id, tuple(pool_members))
+        for pool_id, pool_members in zip(pool_ids, members, strict=True)
+    ]
+
+
+def _circle_method(pool_id: PoolId, members: Sequence[EntryId]) -> list[PlannedFixture]:
+    """Every pair in this pool exactly once, laid out in rounds in which nobody plays
+    twice — the circle method: pin the first entrant, rotate the others one seat per
+    round, and pair across the circle.
+
+    An odd pool gets a **phantom** seat so the circle still has an even circumference;
+    whoever is drawn against the phantom that round sits out, and their pairing is not
+    emitted. That is the whole of "byes are absence" — no ``is_bye`` flag, no ``NULL``
+    side, just a round with one fewer fixture. ``position`` therefore stays contiguous
+    (1..k) within each round.
+    """
+    circle: list[EntryId | None] = list(members)
+    if len(circle) % 2 == 1:
+        circle.append(None)  # the phantom
+    seats = len(circle)
+
+    fixtures: list[PlannedFixture] = []
+    for round_number in range(1, seats):
+        position = 0
+        for seat in range(seats // 2):
+            home, away = circle[seat], circle[seats - 1 - seat]
+            if home is None or away is None:
+                continue  # a bye is the absence of a fixture row
+            position += 1
+            fixtures.append(
+                PlannedFixture(
+                    pool_id=pool_id,
+                    round=round_number,
+                    position=position,
+                    entry_a_id=home,
+                    entry_b_id=away,
+                )
+            )
+        # Rotate every seat but the first, one step clockwise.
+        circle = [circle[0], circle[-1], *circle[1:-1]]
+
+    return fixtures

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -130,16 +130,32 @@ class OrderedEntrant:
 
 @dataclass(frozen=True, slots=True)
 class DrawConfig:
-    """What a cut needs to know about the event itself.
+    """What a cut needs to know about the event itself — which is its **pools**, and
+    nothing else.
+
+    Deliberately **not** the draw type. The draw type is what chose the strategy
+    (:func:`strategy_for`, which runs *before* this config is ever built), so a strategy
+    reading it back off its own config would be a second source of truth for a decision
+    already made — and a second source that can *disagree*: with a ``draw_type`` field
+    here, ``RoundRobinStrategy().plan_initial(DrawConfig(draw_type=DrawType.swiss, …))``
+    was a sentence you could write, and the field it named was read by nobody. (It was
+    genuinely dead: mutation-testing set it to ``None`` and killed no test, and no test
+    *could* have killed it.) The danger is not the dead field, it is the live one it
+    invites — the next strategy (rr-then-ko, swiss) branching on ``config.draw_type``
+    in the belief that it is authoritative, on an event whose real draw type is the one
+    that picked the strategy. Its absence is what makes that unsayable.
 
     ``pool_ids`` are the ids of the event's configured pools, **in the event's own pool
     order** — that order is what the snake seeds against, so it must not be re-sorted.
     Empty for an un-pooled draw type (single-elim), where every fixture's ``pool_id``
     is ``NULL``. The pool *id set* freezes while a draw exists, which is what lets a
-    fixture's string ref stay valid without a foreign key.
+    fixture's string ref stay valid without a foreign key. No id among them is ever the
+    empty string — ``Pool.id`` is a ``ValueObjectId`` (``min_length=1``) at the write
+    boundary, which is what keeps ``ready_fixtures``' "pooled?" test (``pool_id is
+    None``) and its sort key (``pool_id or ""``) answering the same question the same
+    way.
     """
 
-    draw_type: DrawType
     pool_ids: tuple[PoolId, ...] = ()
 
 
@@ -326,6 +342,18 @@ def ready_fixtures(fixtures: Sequence[FixtureState]) -> tuple[FixtureId, ...]:
     idempotent; excluding the decided keeps a fixture whose match was later unlinked
     (``match_id`` is ``ON DELETE SET NULL``) from rising from the dead and being played
     twice. Ordered by ``(pool, round, position)`` so the plan itself is deterministic.
+
+    The sort key asks two questions of ``pool_id`` — "is it pooled?" (``pool_id is
+    None``, which sorts the un-pooled last) and "which pool?" (``pool_id or ""``) — and
+    the two agree only because an id is never ``""``. It was: ``Pool.id`` was a bare
+    ``str``, and a fixture drawn into an empty-id pool answered *pooled* to the first
+    question while colliding with the un-pooled group's ``""`` in the second. The floor
+    that closes it is at the write boundary (``ValueObjectId``, ``min_length=1``), not
+    here — an ``if not pool_id`` in this sort would be a runtime check standing in for a
+    state that should not exist. Which is why the ``""`` fallback is now *unobservable*:
+    it is reached only by the ``None`` group, which the first key element has already
+    partitioned off, so its value cannot change an order. (Mutation testing agrees —
+    replacing it with any other string survives, and after this it is *supposed* to.)
     """
     ready = [
         f

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -28,6 +28,7 @@ from app.models.tournament import (
     TournamentStatus,
 )
 from app.models.tournament_entry import TournamentEntry, TournamentEntryStatus
+from app.models.tournament_fixture import TournamentFixture
 from app.models.user import User
 from app.models.user_league_rating import UserLeagueRating
 from app.models.user_role import UserRole
@@ -63,6 +64,7 @@ __all__ = [
     "TournamentEntry",
     "TournamentEntryStatus",
     "TournamentEvent",
+    "TournamentFixture",
     "TournamentStatus",
     "User",
     "UserLeagueRating",

--- a/api/app/models/tournament.py
+++ b/api/app/models/tournament.py
@@ -24,6 +24,7 @@ from app.db import Base
 
 if TYPE_CHECKING:
     from app.models.tournament_entry import TournamentEntry
+    from app.models.tournament_fixture import TournamentFixture
 
 
 class TournamentStatus(enum.Enum):
@@ -205,4 +206,30 @@ class TournamentEvent(Base):
         cascade="all, delete-orphan",
         passive_deletes=True,
         order_by="TournamentEntry.created_at",
+    )
+
+    # The event's draw: every fixture the cut produced (ADR-0786). Empty until the
+    # draw is cut; a re-cut replaces the set wholesale, which is what
+    # ``delete-orphan`` buys.
+    #
+    # Ordered pool → round → position — the SAME total order the read path's
+    # ``fixtures_by_event`` loader applies, and the one the fixtures' own
+    # ``UNIQUE (event_id, pool_id, round, position)`` makes a total order at all. The
+    # ``pool_id`` used to be missing from this list, which left the relationship
+    # ordering a *pooled* draw by round and position alone: pool A's round 1 and pool
+    # B's round 1 would interleave, so the same draw would come back in two different
+    # sequences depending on which of the two ways a caller happened to read it. A
+    # bracket has one order, and there is no reader that wants the other one.
+    #
+    # NULLs last, explicitly, rather than relying on Postgres' ASC default: a NULL
+    # ``pool_id`` is a real value here ("this fixture belongs to no pool" — an
+    # rr-then-ko event's KO stage), and it belongs after the pools that feed it.
+    fixtures: Mapped[list["TournamentFixture"]] = relationship(
+        back_populates="event",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        order_by=(
+            "TournamentFixture.pool_id.asc().nulls_last(), "
+            "TournamentFixture.round, TournamentFixture.position"
+        ),
     )

--- a/api/app/models/tournament_entry.py
+++ b/api/app/models/tournament_entry.py
@@ -39,6 +39,11 @@ class TournamentEntry(Base):
 
     An event's ``entered`` count is derived from a live count of active entries;
     it is not a stored column.
+
+    ``added_by_user_id`` records **how the entry came to exist** — ``NULL`` means
+    the player entered themselves, a user id means a director entered them
+    (ADR-0784). That is a fact about the past which cannot be reconstructed later
+    if we decline to store it now, so it is stored, not derived.
     """
 
     __tablename__ = "tournament_entries"
@@ -57,6 +62,9 @@ class TournamentEntry(Base):
         ),
         Index("ix_tournament_entries_event_id", "event_id"),
         Index("ix_tournament_entries_user_id", "user_id"),
+        # ``merge_user`` re-points this column by ``WHERE added_by_user_id = :from``
+        # on every guest sign-in, so it is a lookup key and not merely an FK.
+        Index("ix_tournament_entries_added_by_user_id", "added_by_user_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -73,6 +81,21 @@ class TournamentEntry(Base):
         UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="RESTRICT"),
         nullable=False,
+    )
+    #: Who put this player in the event. ``NULL`` is not "unknown" — it is the
+    #: encoding of *self-registration*: the player entered themselves. A non-null
+    #: id is the director who entered them (ADR-0784).
+    #:
+    #: ``RESTRICT``, like ``user_id`` above and ``match_results.accepted_by_user_id``:
+    #: deliberately NOT ``SET NULL``, because nulling this column on a user delete
+    #: would not lose a fact, it would *rewrite* one — a director-added entry would
+    #: silently start claiming the player registered themselves. Account merge
+    #: tombstones rather than deletes, so ``ON DELETE`` never fires on the path that
+    #: actually happens; ``merge_user`` re-points this column explicitly.
+    added_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=True,
     )
     seed: Mapped[int | None] = mapped_column(Integer, nullable=True)
     status: Mapped[TournamentEntryStatus] = mapped_column(

--- a/api/app/models/tournament_fixture.py
+++ b/api/app/models/tournament_fixture.py
@@ -1,0 +1,152 @@
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.tournament import TournamentEvent
+
+
+class TournamentFixture(Base):
+    """One planned pairing of an event's draw — a round and a position (and a pool,
+    when the draw is pooled), whose sides may still be unknown. A fixture is **not**
+    a match: it *materializes* into one once both sides are known (a later slice).
+
+    One table holds every draw type's fixtures, because topology is the *strategy's*
+    knowledge, not the schema's (ADR-0786). There is deliberately no ``next_slot_id``:
+    single-elim's successor is arithmetic on ``(round, position)``, round-robin has no
+    successor at all, and swiss cannot know its next round until the current one
+    finishes. Storing the topology would be a second copy of the truth that churns on
+    every re-cut, so ``advance()`` recomputes it from these rows instead.
+
+    **A ``NULL`` side means exactly one thing: TBD** — ``advance()`` will fill it when
+    the feeding fixture is decided. Byes are *not* a NULL side; they are the **absence
+    of a row** (a byed seed simply has no round-1 fixture and is placed directly into
+    round 2). That is why there is no ``is_bye`` flag: it would make NULL mean two
+    things, and the "is this side unknown, or is it a bye?" question would have to be
+    answered by reading a second column.
+
+    ``pool_id`` is a **string ref, not a foreign key**: pools are JSONB value-objects
+    on the event (``{id, name, slot, table_ids}`` — a slice of the venue), so there is
+    no table to point at. Integrity is procedural: the event's pool *id set* freezes
+    while a draw exists. ``NULL`` means the draw is un-pooled (single-elim), or that
+    this is the KO stage of an rr-then-ko event.
+
+    The ``UNIQUE (event_id, pool_id, round, position)`` below is the identity a re-cut
+    reconciles on, and it is declared **NULLS NOT DISTINCT** (Postgres 15+). Under the
+    default (NULLS DISTINCT) a ``NULL`` ``pool_id`` would compare unequal to itself, so
+    an *un-pooled* draw — single-elim, every KO fixture — would have **no uniqueness
+    guard at all** and could persist the same ``(event, round, position)`` twice. Since
+    ``NULL`` here is a real value in the domain ("this draw has no pools"), not a
+    missing one, it must be compared as one.
+    """
+
+    __tablename__ = "tournament_fixtures"
+    __table_args__ = (
+        # The identity of a fixture within its draw. NULLS NOT DISTINCT so the guard
+        # also covers un-pooled draws, where ``pool_id`` is NULL for every row — see
+        # the class docstring.
+        UniqueConstraint(
+            "event_id",
+            "pool_id",
+            "round",
+            "position",
+            name="uq_tournament_fixtures_event_id_pool_id_round_position",
+            postgresql_nulls_not_distinct=True,
+        ),
+        # Every read of a draw is "the fixtures of this event" — ``advance()`` loads
+        # the whole set, and the detail BFF loads it per event.
+        Index("ix_tournament_fixtures_event_id", "event_id"),
+        # A completed match is the trigger to write ``winner_entry_id`` back and re-run
+        # ``advance()``, and that path arrives holding a match id, not a fixture id.
+        Index("ix_tournament_fixtures_match_id", "match_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    event_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tournament_events.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    #: Names a ``Pool`` value-object in the event's own ``pools`` JSONB — deliberately
+    #: not a FK (there is no pools table). ``NULL`` = the draw is un-pooled.
+    pool_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    #: 1-based.
+    round: Mapped[int] = mapped_column(Integer, nullable=False)
+    #: 1-based within its round (and pool, when pooled).
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    #: ``NULL`` = TBD, never a bye (byes are the absence of a row).
+    #:
+    #: ``CASCADE``, not ``RESTRICT``, because of the **event-delete** path:
+    #: ``DELETE /tournaments/{id}/events/{id}`` deletes the event with
+    #: ``passive_deletes``, so the database cascades to ``tournament_entries`` and
+    #: ``tournament_fixtures`` in one statement. ``RESTRICT`` is checked immediately
+    #: (it cannot be deferred), so it would make that delete depend on the order
+    #: Postgres happens to fire the two cascades in.
+    #:
+    #: Withdrawal is a *soft*-delete, so it does not touch these rows — but an entry
+    #: **can** be hard-deleted elsewhere: ``merge_user`` (``app/account_merge.py``)
+    #: DELETEs a guest's duplicate *active* entry when the surviving account is already
+    #: entered in the same event. Under this CASCADE that would silently take any
+    #: fixtures referencing the guest's entry with it, punching a hole in a cut draw.
+    #: The fix belongs in the merge path, not here — and it is **not** to re-point these
+    #: columns onto the survivor's entry. That would seat one human in two slots of the
+    #: same pool, and because the go-live currency check compares entrant *sets*, the
+    #: corrupted draw would silently satisfy it and go live. The merge instead **un-cuts
+    #: the event's draw** (a draw cut from a field that double-counted a human is wrong
+    #: throughout — its pool sizes and seeding were computed against N+1 entrants), and
+    #: the director re-cuts. See ADR-786. Tracked as its own chore; nothing writes
+    #: fixture rows yet, so the hazard is dormant until then.
+    entry_a_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tournament_entries.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    entry_b_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tournament_entries.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    #: Written back when this fixture's match completes (a later slice); until then the
+    #: fixture is pending or ready, never decided.
+    winner_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tournament_entries.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    #: Set when the fixture materializes into a real match — which only happens once
+    #: the tournament is ``live`` (ADR-0786). ``NULL`` before then.
+    match_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("matches.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    event: Mapped["TournamentEvent"] = relationship(back_populates="fixtures")

--- a/api/app/models/tournament_fixture.py
+++ b/api/app/models/tournament_fixture.py
@@ -113,8 +113,8 @@ class TournamentFixture(Base):
     #: corrupted draw would silently satisfy it and go live. The merge instead **un-cuts
     #: the event's draw** (a draw cut from a field that double-counted a human is wrong
     #: throughout — its pool sizes and seeding were computed against N+1 entrants), and
-    #: the director re-cuts. See ADR-786. Tracked as its own chore; nothing writes
-    #: fixture rows yet, so the hazard is dormant until then.
+    #: the director re-cuts. See ADR-786; ``_resolve_entry_collisions`` is where it is
+    #: done.
     entry_a_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("tournament_entries.id", ondelete="CASCADE"),

--- a/api/app/rbac.py
+++ b/api/app/rbac.py
@@ -34,7 +34,19 @@ from app.uniqueness import name_taken
 RBAC_PERMISSION = "authorization.manage"
 
 
-async def _user_has_permission(db: AsyncSession, user_id: uuid.UUID, name: str) -> bool:
+async def user_has_permission(db: AsyncSession, user_id: uuid.UUID, name: str) -> bool:
+    """Does ``user_id`` hold ``name``, through any role they have?
+
+    Public, because ``require_permission`` is not always the right shape to ask it
+    in. A route whose authorization *forks on the request* — ``POST …/entries``,
+    where an absent ``user_id`` is a player self-registering (permission) and a
+    present one is the owner entering somebody (ownership, ADR-0784) — cannot hang
+    the permission off the router: the dependency runs before the handler has seen
+    the body, and would refuse the owner for lacking a grant that has nothing to do
+    with the thing they are doing. Such a route asks the question itself, in the arm
+    of the fork it belongs to — with *this* function, so there is still exactly one
+    definition of "holds the permission" and the fork cannot grow a second opinion.
+    """
     result = await db.execute(
         select(Permission.id)
         .join(RolePermission, RolePermission.permission_id == Permission.id)
@@ -50,7 +62,7 @@ def require_permission(name: str) -> Callable[..., Awaitable[User]]:
         user: User = Depends(get_current_user),
         db: AsyncSession = Depends(get_session),
     ) -> User:
-        if not await _user_has_permission(db, user.id, name):
+        if not await user_has_permission(db, user.id, name):
             raise HTTPException(status_code=403, detail="Forbidden.")
         return user
 

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -516,6 +516,39 @@ class TournamentTransitionCreate(BaseModel):
     to: TournamentStatus
 
 
+class TournamentEntryCreate(BaseModel):
+    """*Who* to enter — the body of ``POST …/entries``, and the whole of it.
+
+    **The body is optional, and its presence selects the actor** (ADR-0784):
+
+    * **omitted** → you are entering *yourself*. Self-registration, gated on the
+      ``tournament.enter`` permission — the request every player already sends, which
+      carries no body at all and must keep working unchanged.
+    * **``user_id`` present** → a *director* is entering somebody, which only the
+      tournament's **owner** may do.
+
+    One endpoint, not two, because both actors must run the same eligibility
+    evaluator, take the same capacity lock and produce the same four refusal codes
+    (``EntryRefusal``, ADR-0968). A twin route would make the *next* refusal a thing
+    to add twice, and the two call sites of the evaluator a thing to keep from
+    drifting.
+
+    Naming **your own** ``user_id`` is self-registration, not a director entry — the
+    same guard, and the same ``added_by_user_id = NULL`` on the row. "The player
+    entered themselves" has exactly one encoding, and ``added_by == user_id`` is not
+    it (see ``TournamentEntry.added_by_user_id``).
+
+    There is deliberately **no ``force``**: a director's entry is refused by the same
+    rules a player's is — a full event and a rating cap catch a director's typo exactly
+    as they catch a stranger's. Absent an override, that *is* the safety model, and the
+    override is a ticket of its own (#985), not a flag smuggled in here.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: uuid.UUID
+
+
 class TournamentEventCreate(BaseModel):
     """A new event. Its two numbers are bounded by what their columns can hold —
     ``EventMaxPlayers`` and ``EventEntryFee``, shared verbatim with

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -104,6 +104,32 @@ EventEntryFee = Annotated[
 
 # ----- value-objects (typed JSONB) -----------------------------------------
 
+ValueObjectId = Annotated[str, Field(min_length=1)]
+"""The **identity** of a JSONB value-object — a pool, a table in the venue catalogue.
+
+These ids are *string refs*, not foreign keys: pools and tables have no tables of their
+own, so a pool is addressed by a client-supplied string and nothing in the database
+constrains it. That is precisely why the constraint has to be stated *here*: the empty
+string is not an identity, and it was a **representable** one — ``Pool(id="")``
+validated, and an event could be created and patched holding it.
+
+It is not a theoretical illegal state. A fixture names its pool by this string
+(ADR-0786) and the rest of the system asks two questions of that ref, which an empty id
+answers *inconsistently*: "is this fixture pooled?" is ``pool_id is not None`` — and
+``""`` is not ``None``, so **yes** — while the sort that orders a draw's fixtures reads
+``pool_id or ""`` (``app.draws.ready_fixtures``), where ``""`` is indistinguishable from
+the un-pooled group it deliberately sorts apart. One fixture, pooled by one rule and
+un-pooled by the other, and a draw whose order depends on which one you ask. A ``str``
+with no floor admits that state; a ``min_length=1`` makes it unsayable — at the
+boundary, in the type, rather than as a runtime check downstream (api/CLAUDE.md, "make
+illegal states unrepresentable").
+
+Unlike the pool-id *uniqueness* rule (``_pool_ids_are_unique``, an ``AfterValidator``
+that contributes nothing to the JSON schema), this **does** change the OpenAPI shape:
+``minLength: 1`` is a real JSON-schema keyword, so the generated clients learn the rule
+too — which is a feature. A rule the client can express is a rule the organizer meets
+under the field instead of in a 422."""
+
 
 class Address(BaseModel):
     """A tournament venue address. Stored as a JSONB value-object."""
@@ -219,11 +245,19 @@ class Predicate(BaseModel):
 
 
 class TournamentTable(BaseModel):
-    """A physical table in the venue catalogue, referenced by id from pools."""
+    """A physical table in the venue catalogue, referenced by id from pools.
+
+    Its ``id`` is a ``ValueObjectId`` for the same reason a pool's is: a pool holds a
+    list of these strings (``table_ids``) and nothing else connects the two, so an id
+    that is the empty string is a table nothing can name — and a ``table_ids`` entry of
+    ``""`` would "resolve" against it. It is the same string-ref pattern with the same
+    hole, and closing it in one place and not the other would leave the boundary
+    half-drawn.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
-    id: str
+    id: ValueObjectId
     label: str
     court: str
 
@@ -234,13 +268,20 @@ class Pool(BaseModel):
     Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
     by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
     these ids. Which is only a coherent thing to say if an id names one pool — see
-    ``EventPools``, the type the event's list of them actually has.
+    ``EventPools``, the type the event's list of them actually has — and if an id is a
+    thing at all, which is what ``ValueObjectId`` says: the empty string is not one, and
+    a fixture drawn into it is pooled by one rule and un-pooled by another.
+
+    Its ``name`` has the same floor for the plainer reason: a pool is *called*
+    something — it is what the director clicks, what the conflict warnings quote, and
+    what a player reads off a wall. ``""`` is not a name, and an event whose pools list
+    is three blank rows is not a thing anyone could act on.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    id: str
-    name: str
+    id: ValueObjectId
+    name: str = Field(min_length=1)
     slot: Slot
     table_ids: list[str]
 

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -295,6 +295,10 @@ def named_list(names: list[str]) -> str:
     the go-live precondition's events) alike — so a director cannot tell, from the
     punctuation, which layer refused them.
 
+    They are named by **name**, never by id. The ids are what the guards actually
+    compared, but "pool p-b7f2 cannot be removed" (or "event 3f9c-… has no draw") tells
+    a director looking at a page of named pools and named events nothing to act on.
+
     It lives *here*, at the boundary, because the boundary is the lower layer: a
     validator on ``EventPools`` runs before any route does, and ``app.tournaments``
     already imports this module (the reverse import would be a cycle).

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -1,4 +1,5 @@
 import uuid
+from collections import Counter
 from datetime import date, datetime
 from decimal import ROUND_DOWN, Decimal
 from typing import Annotated, Any, Literal
@@ -228,7 +229,13 @@ class TournamentTable(BaseModel):
 
 
 class Pool(BaseModel):
-    """A slice of tables reserved for a window of time within an event."""
+    """A slice of tables reserved for a window of time within an event.
+
+    Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
+    by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
+    these ids. Which is only a coherent thing to say if an id names one pool — see
+    ``EventPools``, the type the event's list of them actually has.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -236,6 +243,81 @@ class Pool(BaseModel):
     name: str
     slot: Slot
     table_ids: list[str]
+
+
+def named_list(names: list[str]) -> str:
+    """The things a refusal is about, as a human would say them: ``“Pool B”``, or
+    ``“Pool B” and “Pool C”``, or ``“Pool B”, “Pool C” and “Pool D”``.
+
+    One formatter for every refusal that names a *set* of things — this module's 422s
+    (a duplicated pool id) and ``app.tournaments``' 409s (the pool-set freeze's pools,
+    the go-live precondition's events) alike — so a director cannot tell, from the
+    punctuation, which layer refused them.
+
+    It lives *here*, at the boundary, because the boundary is the lower layer: a
+    validator on ``EventPools`` runs before any route does, and ``app.tournaments``
+    already imports this module (the reverse import would be a cycle).
+    """
+    quoted = [f"“{name}”" for name in names]
+    if len(quoted) == 1:
+        return quoted[0]
+    return f"{', '.join(quoted[:-1])} and {quoted[-1]}"
+
+
+def _pool_ids_are_unique(pools: list[Pool]) -> list[Pool]:
+    """Refuse an event's pools when two of them claim the same ``id`` (422).
+
+    A pool id is an **identity**, and everything downstream of these value-objects is
+    built on the assumption that it identifies one pool. Nothing enforced it: pools are
+    JSONB with client-supplied string ids, there is no pools table and so no unique
+    index, and ``[A, A]`` was stored verbatim (measured: **201**). The bill arrived at
+    the cut, which deals the field across the event's pool ids and writes a fixture per
+    pairing — two pools with one id deal onto the same ``(event_id, pool_id, round,
+    position)``, the fixture table's unique constraint fires, and the director gets a
+    **500** from the driver
+    (``uq_tournament_fixtures_event_id_pool_id_round_position``, reproduced before this
+    validator existed). A boundary that admits what the interior cannot hold is not a
+    boundary.
+
+    It is a rule about the **list**, not about a ``Pool``, so it is a validator on the
+    list type — and it is stated **once**, on the alias both write schemas share, for
+    the reason the numeric bounds are shared (see ``EventMaxPlayers``): "the patch path
+    is the hole" is the same bug wearing a different verb. Guarding only ``create``
+    would leave the event to be born clean and then edited into the 500 — and the patch
+    path is the *worse* of the two, because the pool-set freeze that protects a cut draw
+    compares **sets**: ``[A, A, B]`` against a cut event holding ``{A, B}`` is the same
+    set, so the freeze waved it through (measured: **200**) and the next cut died. The
+    guard that exists to protect the draw was admitting the payload that poisons it.
+
+    The duplicated **ids** are named, not the pools' names: an id is what is duplicated,
+    two pools sharing one id may well have different names, and the id is what the
+    director must edit. The refusal is a 422 rather than a 409 because this is a
+    malformed payload in any state the event could possibly be in — an event with no
+    draw at all still cannot have two pools called ``p-a``.
+    """
+    counted = Counter(pool.id for pool in pools)
+    duplicated = [pool_id for pool_id, count in counted.items() if count > 1]
+    if duplicated:
+        raise ValueError(
+            f"A pool id identifies one pool: {named_list(duplicated)} "
+            f"{'is' if len(duplicated) == 1 else 'are'} used by more than one pool of "
+            "this event. Give each pool an id of its own."
+        )
+    return pools
+
+
+EventPools = Annotated[list[Pool], AfterValidator(_pool_ids_are_unique)]
+"""An event's pools: any number of them, no two sharing an ``id``.
+
+Shared verbatim by ``TournamentEventCreate`` and ``TournamentEventUpdate``, so the
+uniqueness rule cannot drift between the two verbs — sharing the alias is what makes
+them impossible to drift apart, exactly as it is for ``EventMaxPlayers``.
+
+An ``AfterValidator``, deliberately: it runs on the parsed ``list[Pool]`` (so it reads
+``pool.id``, not ``pool["id"]``) and it contributes **nothing** to the JSON schema, so
+the OpenAPI shape of ``pools`` is unchanged and the generated clients keep the array
+they already had. A rule a client cannot express in a schema keyword is not a reason to
+let the server hold a state it cannot survive."""
 
 
 # ----- read models ----------------------------------------------------------
@@ -352,6 +434,47 @@ class TournamentEntrantRead(BaseModel):
     rating: float | None
 
 
+class TournamentFixtureRead(BaseModel):
+    """One planned pairing of an event's draw (ADR-0786): a round and a position —
+    plus a pool, when the draw is pooled — whose sides may still be unknown.
+
+    A fixture is **not** a match. It materializes into one later (#788), and until it
+    does ``match_id`` is ``null``.
+
+    **Every ``null`` on this model is a fact, not a missing field**, and a client that
+    dropped them would lose the draw's whole point:
+
+    * ``entry_a_id`` / ``entry_b_id`` — ``null`` means **TBD**: the feeding fixture has
+      not been decided yet, and ``advance()`` will fill this side in. It never means a
+      bye — a bye is the *absence of a fixture row*, not a fixture with an empty side
+      (ADR-0786), so there is no ``is_bye`` flag here to tell the two apart.
+    * ``winner_entry_id`` — ``null`` while the fixture is undecided.
+    * ``match_id`` — ``null`` until the fixture becomes a real match, which only happens
+      once the tournament is ``live``.
+    * ``pool_id`` — ``null`` means this fixture belongs to no pool: the draw is
+      un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
+      set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
+      JSONB, not a foreign key, because pools are value-objects with no table.
+
+    The entries are carried as **ids only**. The name and username behind
+    ``entry_a_id`` are already on this page — the event's ``entrants`` list carries
+    them, keyed by that very id — so a client joins the two. Copying the username onto
+    the fixture as well would be carrying a field and its own derivation
+    (api/CLAUDE.md), and the copy that drifts is the one a player reads off a bracket.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    pool_id: str | None
+    round: int
+    position: int
+    entry_a_id: uuid.UUID | None
+    entry_b_id: uuid.UUID | None
+    winner_entry_id: uuid.UUID | None
+    match_id: uuid.UUID | None
+
+
 class TournamentEventRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -392,6 +515,19 @@ class TournamentEventRead(BaseModel):
     # a pair that can disagree (api/CLAUDE.md). So ``open`` means "the event admits
     # you", not "the button is live": the client composes the three.
     entry_state: EventEntryState
+    # The event's DRAW: its fixtures, in pool → round → position order (ADR-0786).
+    #
+    # It rides on this payload rather than on a ``GET …/draw`` of its own, because the
+    # tournament-detail page is one page and the repo's BFF rule gives it one endpoint
+    # (root CLAUDE.md). A separate draw endpoint would make every event's bracket a
+    # second round-trip the page cannot start until this one lands — a suspense
+    # waterfall, which is a defect here, not a design.
+    #
+    # **Empty is the designed state of an event whose draw has not been cut**, not an
+    # error and not a ``null``: an event with no draw is the normal condition of every
+    # event ever created (cutting is an explicit act, ADR-0786), so it answers ``[]``
+    # and the client renders "no draw yet" from a list it can iterate either way.
+    fixtures: list[TournamentFixtureRead]
 
     @computed_field  # type: ignore[prop-decorator]  # pydantic wraps the property
     @property
@@ -578,7 +714,10 @@ class TournamentEventCreate(BaseModel):
     slot: Slot
     match_settings: MatchSettings
     predicates: list[Predicate] = Field(default_factory=list)
-    pools: list[Pool] = Field(default_factory=list)
+    # ``EventPools``, not ``list[Pool]``: no two of an event's pools may share an ``id``
+    # (a fixture names its pool by that string, and a duplicate id 500'd the cut). The
+    # same alias the patch schema carries, so the rule holds on both verbs.
+    pools: EventPools = Field(default_factory=list)
 
 
 class TournamentEventUpdate(BaseModel):
@@ -612,7 +751,11 @@ class TournamentEventUpdate(BaseModel):
     slot: Slot | None = None
     match_settings: MatchSettings | None = None
     predicates: list[Predicate] | None = None
-    pools: list[Pool] | None = None
+    # The create schema's pools, exactly: a payload that could smuggle a duplicate id in
+    # by PATCH would defeat create's boundary entirely — and it is the patch path the
+    # pool-set freeze cannot cover, since it compares SETS and ``[A, A, B]`` is the same
+    # set as ``{A, B}``. See ``_pool_ids_are_unique``.
+    pools: EventPools | None = None
 
     @field_validator(
         "name",

--- a/api/app/tournament_draws.py
+++ b/api/app/tournament_draws.py
@@ -1,0 +1,386 @@
+"""Persisting a draw: the cut, the un-cut, and the guard that protects them
+(ADR-0786).
+
+``app.draws`` is the *pure* half of this — it plans fixtures from an ordered field and
+knows nothing about a session. This module is the half that touches the database: it
+reads the event's field, hands it to the strategy, and writes what comes back. The
+split is what lets every rule about *what a draw looks like* be tested with literals,
+and leaves this module with only the three things a database is actually needed for:
+
+- **the field** (``active_draw_entrants``) — the *active* entries, in the shape
+  ``order_entrants`` wants. Withdrawal is a soft-delete, so a withdrawn entry is not an
+  entrant (ADR-0016) and has no place in a draw.
+- **the guard** (``draw_has_play``) — whether this draw shows any evidence of play.
+- **the freeze** (``event_has_draw`` / ``event_pool_ids``) — whether a draw exists at
+  all, and the pool ids it was cut across. The two facts the event ``PATCH`` needs to
+  refuse a pools payload that would orphan the fixtures (there is no FK to stop it).
+- **the currency** (``draw_currency_by_event``) — whether each event's draw still
+  describes the field it was cut from. The fact the ``published → live`` precondition
+  is decided on (ADR-0786).
+- **the write** (``cut_draw`` / ``uncut_draw``).
+
+Neither write commits. The caller owns the transaction, because a cut is only safe
+inside the tournament's row lock: the field it reads and the fixtures it derives from
+that field must not be separated by another writer's entry (see the route).
+"""
+
+import enum
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import delete, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.draws import (
+    DrawConfig,
+    Entrant,
+    EntryId,
+    PoolId,
+    order_entrants,
+    strategy_for,
+)
+from app.models import (
+    TournamentEntry,
+    TournamentEntryStatus,
+    TournamentEvent,
+    TournamentFixture,
+)
+from app.schemas.tournament import Pool
+
+
+async def active_draw_entrants(db: AsyncSession, event_id: uuid.UUID) -> list[Entrant]:
+    """The event's field, as the draw domain needs to see it: one :class:`Entrant` per
+    **active** entry.
+
+    Withdrawn entries are filtered out here, at the one place the cut reads them, for
+    the same reason the entrants list filters them (ADR-0016): a withdrawn player is not
+    an entrant, and a draw cut from a field that included them would seat a person who
+    has left the event — and every pool's size would be computed against a field that
+    does not exist.
+
+    Only the three columns the ordering rule reads (``order_entrants``: seed ascending
+    where set, then registration order, then the id as the final tie-break). The row
+    itself deliberately does not cross into the domain — ``app.draws`` is constructible
+    from literals, which is what makes every rule about the shape of a draw testable
+    without a database.
+    """
+    rows = (
+        await db.execute(
+            select(
+                TournamentEntry.id,
+                TournamentEntry.seed,
+                TournamentEntry.created_at,
+            ).where(
+                TournamentEntry.event_id == event_id,
+                TournamentEntry.status == TournamentEntryStatus.entered,
+            )
+        )
+    ).all()
+    return [
+        Entrant(entry_id=EntryId(entry_id), seed=seed, created_at=created_at)
+        for entry_id, seed, created_at in rows
+    ]
+
+
+def draw_config(event: TournamentEvent) -> DrawConfig:
+    """What the cut needs to know about the event itself: its draw type, and the ids of
+    the pools it has configured — **in the event's own pool order**, which is the order
+    the snake seeds against.
+
+    The pools are *parsed*, not indexed: ``TournamentEvent.pools`` is JSONB, and
+    ``p["id"]`` on an untyped dict is a ``KeyError`` waiting for the one malformed row
+    (api/CLAUDE.md — "parse, don't validate"). ``Pool`` is the same model the write
+    boundary validated them with, so a pool that could be *stored* can be read here.
+
+    Every configured pool is passed, whatever the draw type. An un-pooled strategy
+    (single-elim, #785) ignores them and writes ``NULL`` pool refs; a pooled one deals
+    the field across exactly these ids — which is what makes a fixture's ``pool_id`` a
+    string ref that resolves against the event the client is already holding.
+    """
+    return DrawConfig(
+        draw_type=event.draw_type,
+        pool_ids=tuple(PoolId(Pool.model_validate(pool).id) for pool in event.pools),
+    )
+
+
+async def event_has_draw(db: AsyncSession, event_id: uuid.UUID) -> bool:
+    """Whether this event has a draw at all — whether the cut has happened.
+
+    The question the **pool-set freeze** turns on (ADR-0786). A fixture's ``pool_id`` is
+    a string ref into the event's own ``pools`` JSONB and *not* a foreign key — there is
+    no pools table for it to point at — so nothing in the database stops a ``PATCH``
+    from replacing the pools out from under a cut draw and leaving every fixture in the
+    event referring to a pool that no longer exists. "Integrity is procedural, not
+    schematic": this is the read that procedure is built on.
+
+    Deliberately **not** ``draw_has_play``. Play is the gate on *destroying* a draw
+    (re-cutting, un-cutting); the mere *existence* of one is the gate on moving the
+    pools under it. The two are different questions with different answers, and a draw
+    that has been cut but not yet played — the ordinary state of a tournament on the
+    morning of — is exactly where the pool-set freeze does its work: nothing has been
+    played, so the play guard would wave the change through, and every fixture would
+    still be orphaned.
+
+    A ``COUNT``, not a load: the answer is a yes/no, and a 200-fixture round-robin
+    should not be pulled into memory to learn it.
+    """
+    fixtures = (
+        await db.execute(
+            select(func.count())
+            .select_from(TournamentFixture)
+            .where(TournamentFixture.event_id == event_id)
+        )
+    ).scalar_one()
+    return fixtures > 0
+
+
+def event_pool_ids(event: TournamentEvent) -> set[PoolId]:
+    """The ids of the pools this event *currently* has — the set the freeze protects.
+
+    Parsed through :class:`Pool`, exactly as ``draw_config`` parses them, rather than
+    indexed as ``p["id"]`` on an untyped JSONB dict (api/CLAUDE.md — "parse, don't
+    validate"). It is the same model the write boundary validated these rows with, so
+    a pool that could be *stored* can be read back here; a malformed one fails loudly
+    at the boundary instead of raising a ``KeyError`` somewhere downstream.
+
+    A **set**, because identity is all the freeze is about. The pools' ORDER is free to
+    change under a cut draw (it is only read at the cut, where it seeds the snake), and
+    so is everything else about them — a pool's tables, its window, its name. Only the
+    ids are load-bearing after the cut, because only the ids are what the fixtures hold.
+    """
+    return {PoolId(Pool.model_validate(pool).id) for pool in event.pools}
+
+
+async def draw_has_play(db: AsyncSession, event_id: uuid.UUID) -> bool:
+    """Whether this event's draw shows any **evidence of play** — the one thing a cut,
+    a re-cut and an un-cut are refused for (ADR-0786).
+
+    Evidence is either half of what play leaves behind on a fixture:
+
+    * a ``winner_entry_id`` — the fixture is *decided*; a result has been recorded; or
+    * a ``match_id`` — the fixture has *materialized* into a real match, which may
+      already carry games on its scratchpad or a proposed result.
+
+    The ``match_id`` half is what makes this guard deliberately **stricter** than "some
+    matches have been played" (issue #785's phrasing): a merely-linked match blocks a
+    re-cut, because replacing the draw wholesale would orphan that match and the scores
+    already entered on it. A draw must never silently eat a score. The cost of being
+    strict is a director who linked a match by accident having to unlink it; the cost of
+    being lax is a player's recorded result vanishing.
+
+    A ``COUNT`` rather than a load of the fixtures: the guard's answer is a yes/no, and
+    loading a 200-fixture round-robin to learn it would grow with the draw it is
+    guarding. It is read inside the tournament's row lock, so what it sees is what the
+    last committed writer wrote.
+    """
+    played = (
+        await db.execute(
+            select(func.count())
+            .select_from(TournamentFixture)
+            .where(
+                TournamentFixture.event_id == event_id,
+                or_(
+                    TournamentFixture.winner_entry_id.is_not(None),
+                    TournamentFixture.match_id.is_not(None),
+                ),
+            )
+        )
+    ).scalar_one()
+    return played > 0
+
+
+class DrawCurrency(enum.Enum):
+    """Where an event's draw stands **relative to its field** — the three states the
+    go-live precondition is decided on (ADR-0786).
+
+    A draw is a plan made against a field of entrants, and registration stays open right
+    up to the moment a tournament goes live — so the plan can be out of date by the time
+    it is needed. These are the only three things that can be true of it, and they are a
+    closed set rather than a pair of booleans (``has_draw`` / ``is_current``) precisely
+    because two booleans can spell a fourth state that does not exist: "no draw, but
+    current".
+
+    * ``current`` — the fixtures seat exactly the event's active entrants. Ready.
+    * ``uncut`` — the event has no fixtures at all. Nobody has cut its draw.
+    * ``stale`` — it has a draw, but the field moved under it: somebody entered
+      after the cut, somebody withdrew after it, or both.
+    """
+
+    current = "current"
+    uncut = "uncut"
+    stale = "stale"
+
+
+async def draw_currency_by_event(
+    db: AsyncSession, event_ids: Sequence[uuid.UUID]
+) -> dict[uuid.UUID, DrawCurrency]:
+    """Where every event in ``event_ids`` stands, keyed by event id.
+
+    **A set comparison, never a count.** Currency is "these fixtures seat exactly
+    these entrants", so the active entry ids are compared against the entry ids the
+    event's fixtures actually reference. Comparing *sizes* would look like the same
+    rule and pass the same happy-path test, while waving through the one case that
+    matters most: one player withdraws and another enters between the cut and
+    go-live. Same count, a different field, and a draw that seats a player who has
+    left while the player who replaced them is seated nowhere — a tournament that
+    starts with a match nobody can play
+    (``test_a_swap_between_the_cut_and_go_live_is_stale``).
+
+    Both halves of the comparison are **entry ids**, not user ids, because an entry
+    is what a fixture holds and what a withdrawal soft-deletes: a player who
+    withdraws and re-enters gets a *new* entry, so their old id leaves the active
+    set — and correctly makes the draw stale, since the fixtures still seat the
+    entry they left by.
+
+    A ``NULL`` side counts as nothing: it means TBD (a KO round whose feeder is
+    undecided), never a bye and never an absent player. The seated set is therefore
+    the union of the non-NULL ``entry_a_id`` / ``entry_b_id`` refs — which, for
+    every strategy that exists today (and every one designed: a byed seed is placed
+    directly into round 2, so it is still *seated somewhere*), is exactly the set of
+    entrants the draw covers.
+
+    ``uncut`` is decided on the fixtures EXISTING, not on the seated set being
+    empty. The two come apart on the event nobody has entered: no entrants and no
+    fixtures compare equal (∅ == ∅) and would report ``current`` — an event with no
+    draw at all, called ready to start. Such an event cannot even *be* cut (the
+    strategy refuses a field that small), so the empty comparison would be pure
+    fiction, and it would be the fiction that carried an unplayable event into
+    ``live``.
+
+    TWO statements for the whole batch, whatever the number of events (none at all
+    when there are none), for the same reason every other loader here is batched:
+    this runs on the go-live path with the tournament's row lock held, and a
+    per-event pair of queries would hold that lock for a time that grows with the
+    tournament.
+    """
+    if not event_ids:
+        return {}
+    active: dict[uuid.UUID, set[uuid.UUID]] = {
+        event_id: set() for event_id in event_ids
+    }
+    seated: dict[uuid.UUID, set[uuid.UUID]] = {
+        event_id: set() for event_id in event_ids
+    }
+    # Whether a draw exists AT ALL is its own fact, read off the rows rather than
+    # inferred from ``seated`` being empty — see the docstring.
+    cut: set[uuid.UUID] = set()
+
+    entries = (
+        await db.execute(
+            select(TournamentEntry.event_id, TournamentEntry.id).where(
+                TournamentEntry.event_id.in_(active.keys()),
+                # Withdrawn entries are not entrants (ADR-0016), so a draw is not stale
+                # merely for failing to seat somebody who has left — it is stale for
+                # *still* seating them, which is what the comparison below catches.
+                TournamentEntry.status == TournamentEntryStatus.entered,
+            )
+        )
+    ).all()
+    for event_id, entry_id in entries:
+        active[event_id].add(entry_id)
+
+    fixtures = (
+        await db.execute(
+            select(
+                TournamentFixture.event_id,
+                TournamentFixture.entry_a_id,
+                TournamentFixture.entry_b_id,
+            ).where(TournamentFixture.event_id.in_(seated.keys()))
+        )
+    ).all()
+    for event_id, entry_a_id, entry_b_id in fixtures:
+        cut.add(event_id)
+        seated[event_id].update(
+            entry_id for entry_id in (entry_a_id, entry_b_id) if entry_id is not None
+        )
+
+    return {
+        event_id: (
+            DrawCurrency.uncut
+            if event_id not in cut
+            else DrawCurrency.current
+            if seated[event_id] == active[event_id]
+            else DrawCurrency.stale
+        )
+        for event_id in active
+    }
+
+
+async def cut_draw(db: AsyncSession, event: TournamentEvent) -> None:
+    """Cut (or re-cut) this event's draw: plan the fixtures its draw type prescribes for
+    its active field, and make them the event's fixtures — **all of them, and only
+    them**.
+
+    A re-cut **replaces wholesale**, and it does so by deleting first and inserting
+    second, in the caller's single transaction. It is deliberately not a reconcile:
+    placement is frozen at the cut (ADR-0786), so the fixtures of the *previous* draw
+    are not something to be patched into agreement with the new field — they are a plan
+    that was made against a field that no longer exists, and every one of them may have
+    moved. Matching on ``(pool, round, position)`` and updating the sides in place would
+    keep the old rows' ids while silently changing who they seat, which is the same
+    thing with a worse audit trail.
+
+    One transaction is what makes "wholesale" true rather than aspirational: the DELETE
+    and the INSERTs commit together, so there is no instant in which the event holds
+    half of one draw and half of another. Which is why neither this function nor
+    ``uncut_draw`` commits — a helpful ``await db.commit()`` inside the DELETE would
+    open exactly that window.
+
+    Raises :class:`~app.draws.DrawError` — the base the route turns into a 422 — and
+    writes nothing when it does. The strategy is chosen *first*, so an unimplemented
+    draw type is refused before the field is even read: there is no arrangement of
+    entrants that would make a swiss draw cuttable today. And the whole plan is made
+    *before* the DELETE, so a refused re-cut cannot leave a director with the draw they
+    had thrown away and none of the one they could not have.
+
+    That last property has **two** locks on it, and it is worth knowing that they are
+    two, because a test can only ever see one of them fail: the ordering here, and the
+    transaction itself (the route rolls back on a ``DrawError``, and nothing on that
+    path has committed). Reordering these two lines would not break
+    ``test_a_refused_re_cut_leaves_the_standing_draw_untouched`` — the rollback would
+    still save it — so do not read that test's green as permission to. The ordering is
+    the one that survives somebody deciding a service function ought to commit.
+
+    **The caller must hold the tournament's row lock**, and must commit. The field this
+    reads is the field the fixtures are derived from, and an entry that lands between
+    the two would produce a draw that never matched any real field of players.
+    """
+    strategy = strategy_for(event.draw_type)
+    planned = strategy.plan_initial(
+        draw_config(event), order_entrants(await active_draw_entrants(db, event.id))
+    )
+    await uncut_draw(db, event)
+    db.add_all(
+        [
+            TournamentFixture(
+                event_id=event.id,
+                pool_id=fixture.pool_id,
+                round=fixture.round,
+                position=fixture.position,
+                entry_a_id=fixture.entry_a_id,
+                entry_b_id=fixture.entry_b_id,
+            )
+            for fixture in planned
+        ]
+    )
+
+
+async def uncut_draw(db: AsyncSession, event: TournamentEvent) -> None:
+    """Un-cut this event's draw: delete its fixtures, so the event has no draw again.
+
+    A bulk DELETE rather than ``event.fixtures.clear()`` on the ``delete-orphan``
+    relationship: the collection would have to be loaded first (a SELECT of every
+    fixture, then one DELETE apiece), and this is the statement that runs before every
+    re-cut of a full round-robin. The relationship's cascade still stands for the paths
+    that *do* go through the ORM — deleting the event itself.
+
+    Deleting nothing is not an error. An event whose draw was never cut is already in
+    the state this asks for, which is why the un-cut route answers 204 either way: it is
+    a DELETE, and asking for a state the resource already holds is a success.
+
+    Does not commit — the caller owns the transaction, because on the re-cut path this
+    DELETE and the INSERTs that follow it are one atomic replacement.
+    """
+    await db.execute(
+        delete(TournamentFixture).where(TournamentFixture.event_id == event.id)
+    )

--- a/api/app/tournament_draws.py
+++ b/api/app/tournament_draws.py
@@ -83,14 +83,21 @@ async def active_draw_entrants(db: AsyncSession, event_id: uuid.UUID) -> list[En
 
 
 def draw_config(event: TournamentEvent) -> DrawConfig:
-    """What the cut needs to know about the event itself: its draw type, and the ids of
-    the pools it has configured — **in the event's own pool order**, which is the order
-    the snake seeds against.
+    """What the cut needs to know about the event itself: the ids of the pools it has
+    configured — **in the event's own pool order**, which is the order the snake seeds
+    against.
+
+    It does **not** carry the event's ``draw_type``, though it once did. The draw type
+    is what ``cut_draw`` picks the *strategy* with (``strategy_for(event.draw_type)``),
+    and it does so before this config exists; copying it in here as well gave the domain
+    a second place to learn a fact it had already acted on — one that no strategy read,
+    and that a future one could read and be lied to by. See :class:`DrawConfig`.
 
     The pools are *parsed*, not indexed: ``TournamentEvent.pools`` is JSONB, and
     ``p["id"]`` on an untyped dict is a ``KeyError`` waiting for the one malformed row
     (api/CLAUDE.md — "parse, don't validate"). ``Pool`` is the same model the write
-    boundary validated them with, so a pool that could be *stored* can be read here.
+    boundary validated them with, so a pool that could be *stored* can be read here —
+    and its ``min_length=1`` id is why a ``PoolId`` reaching the domain is never ``""``.
 
     Every configured pool is passed, whatever the draw type. An un-pooled strategy
     (single-elim, #785) ignores them and writes ``NULL`` pool refs; a pooled one deals
@@ -98,7 +105,6 @@ def draw_config(event: TournamentEvent) -> DrawConfig:
     string ref that resolves against the event the client is already holding.
     """
     return DrawConfig(
-        draw_type=event.draw_type,
         pool_ids=tuple(PoolId(Pool.model_validate(pool).id) for pool in event.pools),
     )
 

--- a/api/app/tournament_draws.py
+++ b/api/app/tournament_draws.py
@@ -11,8 +11,8 @@ and leaves this module with only the three things a database is actually needed 
   ``order_entrants`` wants. Withdrawal is a soft-delete, so a withdrawn entry is not an
   entrant (ADR-0016) and has no place in a draw.
 - **the guard** (``draw_has_play``) — whether this draw shows any evidence of play.
-- **the freeze** (``event_has_draw`` / ``event_pool_ids``) — whether a draw exists at
-  all, and the pool ids it was cut across. The two facts the event ``PATCH`` needs to
+- **the freeze** (``event_has_draw`` / ``event_pools``) — whether a draw exists at
+  all, and the pools it was cut across. The two facts the event ``PATCH`` needs to
   refuse a pools payload that would orphan the fixtures (there is no FK to stop it).
 - **the currency** (``draw_currency_by_event``) — whether each event's draw still
   describes the field it was cut from. The fact the ``published → live`` precondition
@@ -26,7 +26,7 @@ that field must not be separated by another writer's entry (see the route).
 
 import enum
 import uuid
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 
 from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -140,8 +140,8 @@ async def event_has_draw(db: AsyncSession, event_id: uuid.UUID) -> bool:
     return fixtures > 0
 
 
-def event_pool_ids(event: TournamentEvent) -> set[PoolId]:
-    """The ids of the pools this event *currently* has — the set the freeze protects.
+def event_pools(event: TournamentEvent) -> list[Pool]:
+    """The pools this event *currently* has, parsed — the ones the freeze protects.
 
     Parsed through :class:`Pool`, exactly as ``draw_config`` parses them, rather than
     indexed as ``p["id"]`` on an untyped JSONB dict (api/CLAUDE.md — "parse, don't
@@ -149,12 +149,18 @@ def event_pool_ids(event: TournamentEvent) -> set[PoolId]:
     a pool that could be *stored* can be read back here; a malformed one fails loudly
     at the boundary instead of raising a ``KeyError`` somewhere downstream.
 
-    A **set**, because identity is all the freeze is about. The pools' ORDER is free to
-    change under a cut draw (it is only read at the cut, where it seeds the snake), and
-    so is everything else about them — a pool's tables, its window, its name. Only the
-    ids are load-bearing after the cut, because only the ids are what the fixtures hold.
+    Returns the **pools**, not just their ids, though identity is all the freeze
+    compares: a refusal has to *name* the pools it is about (``named_list``), and a
+    caller handed a bare ``set[PoolId]`` has no way back to the names — it would parse
+    every pool a second time to recover them. One parse, and the id set is a
+    comprehension away.
+
+    The ids are the only load-bearing part after the cut, because the ids are what the
+    fixtures hold. Everything else here — a pool's tables, its window, its name, and
+    the ORDER of the list (read only at the cut, where it seeds the snake) — is free to
+    change under a standing draw.
     """
-    return {PoolId(Pool.model_validate(pool).id) for pool in event.pools}
+    return [Pool.model_validate(pool) for pool in event.pools]
 
 
 async def draw_has_play(db: AsyncSession, event_id: uuid.UUID) -> bool:
@@ -355,7 +361,7 @@ async def cut_draw(db: AsyncSession, event: TournamentEvent) -> None:
     planned = strategy.plan_initial(
         draw_config(event), order_entrants(await active_draw_entrants(db, event.id))
     )
-    await uncut_draw(db, event)
+    await uncut_draw(db, [event.id])
     db.add_all(
         [
             TournamentFixture(
@@ -371,8 +377,16 @@ async def cut_draw(db: AsyncSession, event: TournamentEvent) -> None:
     )
 
 
-async def uncut_draw(db: AsyncSession, event: TournamentEvent) -> None:
-    """Un-cut this event's draw: delete its fixtures, so the event has no draw again.
+async def uncut_draw(db: AsyncSession, event_ids: Collection[uuid.UUID]) -> None:
+    """Un-cut these events' draws: delete their fixtures, so they have no draw again.
+
+    Takes **ids, not events**, and takes a collection of them, because the fixtures are
+    addressed by ``event_id`` and nothing else about an event is read. The account-merge
+    path (:func:`app.account_merge._resolve_entry_collisions`) knows only the ids of the
+    events a double-counted human invalidated, and would otherwise have to SELECT whole
+    ``TournamentEvent`` rows purely to hand them back one attribute apiece — and then
+    issue a DELETE per event where one suffices. Unordered, because a DELETE ... IN has
+    no order to respect.
 
     A bulk DELETE rather than ``event.fixtures.clear()`` on the ``delete-orphan``
     relationship: the collection would have to be loaded first (a SELECT of every
@@ -380,13 +394,16 @@ async def uncut_draw(db: AsyncSession, event: TournamentEvent) -> None:
     re-cut of a full round-robin. The relationship's cascade still stands for the paths
     that *do* go through the ORM — deleting the event itself.
 
-    Deleting nothing is not an error. An event whose draw was never cut is already in
-    the state this asks for, which is why the un-cut route answers 204 either way: it is
-    a DELETE, and asking for a state the resource already holds is a success.
+    Deleting nothing is not an error, and neither is being given nothing to delete. An
+    event whose draw was never cut is already in the state this asks for, which is why
+    the un-cut route answers 204 either way: it is a DELETE, and asking for a state the
+    resource already holds is a success.
 
     Does not commit — the caller owns the transaction, because on the re-cut path this
     DELETE and the INSERTs that follow it are one atomic replacement.
     """
+    if not event_ids:
+        return
     await db.execute(
-        delete(TournamentFixture).where(TournamentFixture.event_id == event.id)
+        delete(TournamentFixture).where(TournamentFixture.event_id.in_(event_ids))
     )

--- a/api/app/tournament_queries.py
+++ b/api/app/tournament_queries.py
@@ -22,11 +22,12 @@ from app.models import (
     TournamentEntry,
     TournamentEntryStatus,
     TournamentEvent,
+    TournamentFixture,
     User,
     UserLeagueRating,
 )
 from app.ratings.rated import is_rated_member
-from app.schemas.tournament import TournamentEntrantRead
+from app.schemas.tournament import TournamentEntrantRead, TournamentFixtureRead
 
 
 async def active_entrants_by_event(
@@ -118,6 +119,69 @@ async def active_entrants_by_event(
             )
         )
     return entrants
+
+
+async def fixtures_by_event(
+    db: AsyncSession, event_ids: Sequence[uuid.UUID]
+) -> dict[uuid.UUID, list[TournamentFixtureRead]]:
+    """The draw of every event in ``event_ids`` — its fixtures (ADR-0786) — keyed by
+    event id, each event's in **pool → round → position** order.
+
+    ONE statement for the whole batch (none at all when there are no events), which is
+    the whole reason this is a loader and not a ``selectinload`` of the event's
+    ``fixtures`` relationship or, worse, a read of ``event.fixtures`` inside the
+    serializer's per-event loop. The tournament LIST endpoint returns every tournament
+    with all of its events, so a per-event fetch would be a query per *event on the
+    page*, and it would arrive invisibly: nothing about the response would look wrong.
+    The statement-count tripwires in ``tests/test_tournaments.py`` fail if one appears.
+    Same shape, and the same reasoning, as ``active_entrants_by_event`` above.
+
+    **Every id gets a key**, so an event whose draw has not been cut maps to ``[]``. The
+    caller never has to tell "no draw" apart from "not loaded", and the read model can
+    make empty a designed state rather than a null to branch on — which matters more
+    here than it does for entrants, because an un-cut draw is the *normal* condition of
+    an event (cutting is an explicit act, ADR-0786), not an edge case.
+
+    **The ordering is the query's, not the caller's**, and it is a total order: pool,
+    then round, then position — over columns that ``UNIQUE (event_id, pool_id, round,
+    position)`` already guarantees are unique together, so the sequence is the same on
+    every read and a client can render a bracket without sorting it first. A NULL
+    ``pool_id`` sorts LAST, which puts an rr-then-ko event's KO stage after the pools it
+    is fed from (and costs an un-pooled draw nothing — every row is NULL there, so round
+    and position decide it alone).
+
+    Sorted in Postgres rather than in Python because a NULL is not comparable to a
+    string: ``sorted(key=lambda f: (f.pool_id, ...))`` is a ``TypeError`` the moment an
+    un-pooled fixture meets a pooled one, and the defensive coalesce that usually
+    follows (``f.pool_id or ""``) would quietly sort the KO stage FIRST.
+
+    The rows are validated into read models here, at the loader — the same boundary the
+    entrants cross — so no ORM instance and no lazily-loadable relationship escapes into
+    the serializer.
+    """
+    fixtures: dict[uuid.UUID, list[TournamentFixtureRead]] = {
+        event_id: [] for event_id in event_ids
+    }
+    if not fixtures:
+        return fixtures
+    rows = (
+        (
+            await db.execute(
+                select(TournamentFixture)
+                .where(TournamentFixture.event_id.in_(fixtures.keys()))
+                .order_by(
+                    TournamentFixture.pool_id.asc().nulls_last(),
+                    TournamentFixture.round,
+                    TournamentFixture.position,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for fixture in rows:
+        fixtures[fixture.event_id].append(TournamentFixtureRead.model_validate(fixture))
+    return fixtures
 
 
 async def active_entry_count(db: AsyncSession, event_id: uuid.UUID) -> int:

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -7,8 +7,10 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
+from app.draws import DegenerateDraw, DrawError, PoolId, UnsupportedDrawType
 from app.leagues import resolve_league
 from app.models import (
+    DrawType,
     EventFormat,
     Tournament,
     TournamentEntry,
@@ -23,6 +25,7 @@ from app.schemas.tournament import (
     EventEntryOpen,
     EventEntryRatingIneligible,
     EventEntryState,
+    Pool,
     TournamentCreate,
     TournamentDetailRead,
     TournamentEntrantRead,
@@ -30,11 +33,22 @@ from app.schemas.tournament import (
     TournamentEventCreate,
     TournamentEventRead,
     TournamentEventUpdate,
+    TournamentFixtureRead,
     TournamentRead,
     TournamentTransitionCreate,
     TournamentUpdate,
+    named_list,
 )
 from app.sessions import get_current_user
+from app.tournament_draws import (
+    DrawCurrency,
+    cut_draw,
+    draw_currency_by_event,
+    draw_has_play,
+    event_has_draw,
+    event_pool_ids,
+    uncut_draw,
+)
 from app.tournament_eligibility import (
     Eligible,
     RatingIneligible,
@@ -47,6 +61,7 @@ from app.tournament_queries import (
     active_entry_count,
     entrant_rating,
     entrant_ratings_by_league,
+    fixtures_by_event,
 )
 
 # Reads are gated on ``tournament.view``, creation on ``tournament.create``, and
@@ -92,9 +107,12 @@ require_create = require_permission(TOURNAMENT_CREATE)
 # idempotent no-op: the only caller that sends it is a stale one, and answering
 # 200 would tell it that it did something when somebody else did).
 #
-# One table, at one dispatch point, is also where slice B (#785) hangs the
-# go-live precondition ("requires a generated draw") — a per-target rule that
-# would otherwise have to be remembered in a route of its own.
+# One table, at one dispatch point, is also where the go-live precondition hangs
+# (``_enforce_ready_to_go_live``, ADR-0786): a tournament may only *start* with at
+# least one event, each with a draw that seats exactly its current entrants. That is
+# a rule about the TARGET rather than the edge — it says nothing about who may publish
+# or archive — and it lives beside this table, in the one handler that consults it,
+# rather than in a route of its own that somebody would have to remember to call.
 LEGAL_TRANSITIONS: frozenset[tuple[TournamentStatus, TournamentStatus]] = frozenset(
     {
         (TournamentStatus.draft, TournamentStatus.published),
@@ -221,6 +239,7 @@ def _serialize_event(
     e: TournamentEvent,
     *,
     entrants: list[TournamentEntrantRead],
+    fixtures: list[TournamentFixtureRead],
     rating: float | None,
 ) -> TournamentEventRead:
     # ``entrants`` is not on the ORM row in the shape the read model wants (it
@@ -233,6 +252,15 @@ def _serialize_event(
     # ``entry_state`` is the caller's, and it is computed from the entrants already
     # loaded plus the caller's ``rating`` on this tournament's league — passed in,
     # never fetched here, so no serializer can turn into an N+1.
+    #
+    # ``fixtures`` — the event's draw (ADR-0786) — is passed in for exactly that
+    # reason. ``e.fixtures`` is right there on the ORM instance and would read
+    # *correctly*: a lazy load would fetch the rows and the response would be
+    # identical. It would also fire one SELECT per event, on the LIST endpoint that
+    # returns every event of every tournament — an N+1 that no assertion about the
+    # body can see. It is loaded once, in a batch, by ``fixtures_by_event``, which
+    # also owns the pool → round → position ordering, so the serializer never sorts
+    # and no two call sites can order a bracket differently.
     return TournamentEventRead.model_validate(
         {
             "id": e.id,
@@ -250,6 +278,7 @@ def _serialize_event(
             "updated_at": e.updated_at,
             "entrants": entrants,
             "entry_state": _entry_state(e, entered=len(entrants), rating=rating),
+            "fixtures": fixtures,
         }
     )
 
@@ -261,6 +290,7 @@ def _serialize_detail(
     current_user_id: uuid.UUID,
     events: list[TournamentEvent],
     entrants_by_event: dict[uuid.UUID, list[TournamentEntrantRead]],
+    fixtures_by_event: dict[uuid.UUID, list[TournamentFixtureRead]],
     rating: float | None,
 ) -> TournamentDetailRead:
     # The full aggregate: tournament fields plus its events (each event's JSONB
@@ -278,7 +308,12 @@ def _serialize_detail(
                 current_user_id=current_user_id,
             ),
             "events": [
-                _serialize_event(e, entrants=entrants_by_event[e.id], rating=rating)
+                _serialize_event(
+                    e,
+                    entrants=entrants_by_event[e.id],
+                    fixtures=fixtures_by_event[e.id],
+                    rating=rating,
+                )
                 for e in events
             ],
         }
@@ -492,6 +527,19 @@ def _enforce_league_editable(t: Tournament) -> None:
     )
 
 
+# The refusals here name a SET of things — the pool-set freeze's pools, the go-live
+# precondition's events — and they name them by NAME. A director reads names, not ids:
+# the ids are what the guards actually compared, but "pool p-b7f2 cannot be removed" (or
+# "event 3f9c-… has no draw") tells the person looking at a page of named pools and
+# named events nothing they can act on.
+#
+# ``named_list`` is the one formatter for all of them, and it lives in
+# ``app.schemas.tournament`` because the boundary needs it too (the duplicate-pool-id
+# 422 names the ids it found twice) and the boundary is the lower layer — this module
+# already imports that one, so the reverse would be a cycle. One formatter, so a
+# director cannot tell from the punctuation which guard refused them.
+
+
 # The statuses in which a tournament has been ANNOUNCED to the world. Publishing
 # is the act that makes a tournament public (ADR-0017), and nothing walks
 # backwards out of it, so everything from ``published`` onward is announced and
@@ -551,15 +599,16 @@ async def list_tournaments(
     current_user: User = Depends(get_current_user),
 ) -> list[TournamentDetailRead]:
     # The list page's cards render event-derived stats (event count, total
-    # entries, table count), so the list returns the full aggregate — events and
-    # their entrants included — rather than a thinner summary. FOUR queries, no
-    # N+1, whatever the number of tournaments or events: the tournaments+usernames
+    # entries, table count), so the list returns the full aggregate — events, their
+    # entrants and their draws included — rather than a thinner summary. FIVE queries,
+    # no N+1, whatever the number of tournaments or events: the tournaments+usernames
     # join, then all their events, then all those events' active entrants in one
-    # batch, then the caller's rating on every distinct league those tournaments run
-    # on (which every event's ``entry_state`` is judged against, ADR-0783). A
-    # per-event entry count or a per-tournament rating would be the N+1 this shape
-    # exists to avoid, and a statement-count tripwire in tests/test_tournaments.py
-    # fails if one comes back.
+    # batch, then all those events' fixtures in one batch (ADR-0786), then the caller's
+    # rating on every distinct league those tournaments run on (which every event's
+    # ``entry_state`` is judged against, ADR-0783). A per-event entry count, a
+    # per-event draw, or a per-tournament rating would be the N+1 this shape exists to
+    # avoid, and a statement-count tripwire in tests/test_tournaments.py fails if one
+    # comes back.
     #
     # Scoped by ``_visible_to``: somebody else's draft is not the caller's to see,
     # so it never enters the result set — and, because the filter is a WHERE clause
@@ -593,7 +642,14 @@ async def list_tournaments(
         )
         for event in events:
             events_by_tournament[event.tournament_id].append(event)
-    entrants_by_event = await active_entrants_by_event(db, [e.id for e in events])
+    event_ids = [e.id for e in events]
+    entrants_by_event = await active_entrants_by_event(db, event_ids)
+    # And ONE batch for every one of those events' fixtures — its draw (ADR-0786).
+    # Batched for the same reason the entrants are: the list returns every event of
+    # every tournament, so reading ``event.fixtures`` in the loop would be a SELECT per
+    # event. Uncut draws come back as ``[]``, so an event nobody has cut a draw for
+    # costs nothing and answers with an empty list rather than a null.
+    event_fixtures = await fixtures_by_event(db, event_ids)
     # ONE batch for the caller's ratings, keyed by league — deduplicated, because
     # every tournament on the default league shares the one number, and because the
     # ladders a page happens to list is not a reason to ask the same question twice.
@@ -607,6 +663,7 @@ async def list_tournaments(
             current_user_id=current_user.id,
             events=events_by_tournament[tournament.id],
             entrants_by_event=entrants_by_event,
+            fixtures_by_event=event_fixtures,
             rating=ratings[tournament.league_id],
         )
         for tournament, username in rows
@@ -706,8 +763,18 @@ async def get_tournament(
         .scalars()
         .all()
     )
-    entrants_by_event = await active_entrants_by_event(db, [e.id for e in events])
-    # A FOURTH and last query: the caller's rating on the tournament's league, read
+    event_ids = [e.id for e in events]
+    entrants_by_event = await active_entrants_by_event(db, event_ids)
+    # A FOURTH query batches every one of those events' fixtures — their DRAWS
+    # (ADR-0786). The draw rides on this page rather than on a ``GET …/draw`` of its
+    # own: one endpoint per page (root CLAUDE.md), so the bracket cannot become a
+    # second round-trip that the page has to wait for. Batched across the events for
+    # the same reason the entrants are — a draw read per event is an N+1 that grows
+    # with the very thing the page is describing — and it is the loader, not this
+    # route, that orders them (pool → round → position) and answers ``[]`` for an
+    # event whose draw has not been cut.
+    event_fixtures = await fixtures_by_event(db, event_ids)
+    # A FIFTH and last query: the caller's rating on the tournament's league, read
     # ONCE for the whole page. It is what every event's ``entry_state`` is judged
     # against (ADR-0783), and a tournament has exactly one ladder — so a rating read
     # inside the per-event loop would issue a query per event to learn the same
@@ -719,6 +786,7 @@ async def get_tournament(
         current_user_id=current_user.id,
         events=events,
         entrants_by_event=entrants_by_event,
+        fixtures_by_event=event_fixtures,
         rating=rating,
     )
 
@@ -796,6 +864,138 @@ async def delete_tournament(
 # ----- lifecycle routes ----------------------------------------------------
 
 
+# The one thing a tournament with no events can never do. Publishing one stays legal
+# — announcing a tournament before its events are written up is ordinary — but
+# *starting* it is not: there is nothing to run, no draw to have, and (without this)
+# nothing for the per-event checks below to fail on, so an empty tournament would sail
+# through a precondition that is vacuously true of it and land in ``live`` (ADR-0786;
+# the hole the #782 hand-off flagged).
+_NOTHING_TO_START = (
+    "This tournament has no events, so there is nothing to start. Add an event and cut "
+    "its draw, then start the tournament."
+)
+
+
+def _go_live_refusal(*, uncut: list[str], stale: list[str]) -> HTTPException:
+    """The 409 for a tournament whose draws are not ready to be played (ADR-0786).
+
+    409, not 403, for the reason ADR-0017 fixed for this whole module: the caller is
+    the owner and going live is theirs to do — it is the *tournament* that is in the
+    wrong state for it. The same request succeeds the moment the draws are cut, which
+    is what a conflict means and what a 403 would deny.
+
+    **It names the events**, because a refusal a director cannot act on is barely
+    better than a 500: "some event has no draw" leaves them clicking through a
+    ten-event tournament looking for it. Names, not ids (``named_list``) — the ids
+    are what this guard compared, but they are not what the director is looking at.
+
+    The two failures are kept apart in the sentence, because they are two different
+    jobs. An **uncut** event needs a first cut. A **stale** one has a draw the
+    director may well have reviewed and approved — it is simply older than the field,
+    because somebody entered or withdrew after it was cut — and needs re-cutting,
+    which will move players around inside it. Collapsing the two into "cut the draws"
+    would tell the director of a stale event that nothing they did was kept.
+    """
+    clauses = []
+    if uncut:
+        clauses.append(
+            f"{named_list(uncut)} {'has' if len(uncut) == 1 else 'have'} no draw yet"
+        )
+    if stale:
+        clauses.append(
+            f"{named_list(stale)} "
+            + (
+                "has a draw that no longer matches its entrants"
+                if len(stale) == 1
+                else "have draws that no longer match their entrants"
+            )
+        )
+    return HTTPException(
+        status_code=409,
+        detail=(
+            "This tournament cannot start yet: "
+            + "; and ".join(clauses)
+            + ". A draw is cut from the field as it stands at the time, and "
+            "registration stays open right up to the moment a tournament goes live — "
+            "so cut the draw for each event named (again, if somebody entered or "
+            "withdrew since it was last cut), then start the tournament."
+        ),
+    )
+
+
+async def _enforce_ready_to_go_live(db: AsyncSession, tournament: Tournament) -> None:
+    """Raise the 409 unless every event of this tournament has a draw, and every one of
+    those draws still describes the field it will be played by (ADR-0786).
+
+    **The** ``published → live`` **precondition** — the per-target rule ADR-0017 left
+    room for at its single dispatch point, and the reason that room was left. Going
+    live is what seals the field (registration closes with it) and, from #788, what
+    turns every ready fixture into a real match. Both are irreversible in practice and
+    both are computed from the draw — so the draw has to be *right* at the instant the
+    tournament starts, not merely to have existed at some point before it.
+
+    Three ways it is not, and each of the three is refused:
+
+    * **No events at all.** ``_NOTHING_TO_START``. It has to be checked, and checked
+      first, because the per-event rules below say nothing about a tournament with no
+      events: "every event has a current draw" is *true* of a tournament with none.
+    * **An event with no draw** (``uncut``) — nothing to play.
+    * **An event whose draw is stale** — its fixtures no longer seat exactly its
+      active entrants. Registration stays open all the way to go-live, so a draw cut
+      on Tuesday is a plan for Tuesday's field: a player who entered on Wednesday is
+      in no fixture (they would sit out the tournament they paid for), and a player
+      who withdrew is still seated in one (their opponents get a match nobody plays).
+
+    **Read under the tournament's row lock, which the transition route has already
+    taken** — this function does not take a second one, and must not. That lock is the
+    whole mechanism: every writer of the entrant field (the entry route, the withdraw
+    route) queues on that same row first, so an entry cannot land between this check
+    and the ``UPDATE`` that follows it. Postgres runs READ COMMITTED, so unlocked, the
+    currency this reads would be the currency of *its own statement's snapshot* — and
+    a tournament could go live, on a draw this function had just certified as current,
+    into a field with one more player in it than the draw seats. The check would have
+    been true when it was made and false by the time it mattered, which is the only
+    kind of guard worse than none.
+
+    A ``match`` with ``assert_never``, not an ``if``: a fourth thing that can be true
+    of a draw (a fixture pointing at a pool the event no longer has, say) is a type
+    error here until somebody decides whether it may go live, rather than falling
+    through to ``current`` — a precondition must never fail in the permissive
+    direction.
+    """
+    events = (
+        await db.execute(
+            select(TournamentEvent.id, TournamentEvent.name)
+            .where(TournamentEvent.tournament_id == tournament.id)
+            # The page's order, so the refusal names the events in the order the
+            # director is looking at them.
+            .order_by(TournamentEvent.created_at)
+        )
+    ).all()
+    if not events:
+        raise HTTPException(status_code=409, detail=_NOTHING_TO_START)
+    # ONE batched read for the whole tournament (two statements, whatever the number
+    # of events): this runs with the row lock held, and a per-event query would hold
+    # it for a time that grows with the tournament.
+    currency = await draw_currency_by_event(db, [event_id for event_id, _ in events])
+    uncut: list[str] = []
+    stale: list[str] = []
+    for event_id, name in events:
+        state = currency[event_id]
+        match state:
+            case DrawCurrency.current:
+                continue
+            case DrawCurrency.uncut:
+                uncut.append(name)
+            case DrawCurrency.stale:
+                stale.append(name)
+            case _:
+                assert_never(state)
+    if not uncut and not stale:
+        return
+    raise _go_live_refusal(uncut=uncut, stale=stale)
+
+
 @router.post(
     "/tournaments/{tournament_id}/transitions",
     response_model=TournamentRead,
@@ -815,6 +1015,17 @@ async def create_tournament_transition(
     backwards, skipping a stage, moving out of the terminal `archived`, and
     re-asserting the status the tournament already holds — a request to publish
     an already-published tournament is a stale client, not a no-op.
+
+    **Going live has a precondition** (ADR-0786): the tournament must have at least
+    one event, and every event must have a **draw** whose fixtures seat exactly its
+    current entrants. Three things are refused with a `409` that names the events at
+    fault — a tournament with **no events** (there is nothing to start), an event with
+    **no draw**, and an event whose draw is **stale**, cut before somebody entered or
+    withdrew. Cut (or re-cut) the draws it names, then go live. Registration is open
+    right up to that moment, which is exactly why a draw can go stale under it.
+
+    **Publishing** an empty tournament is unaffected and stays legal: announcing a
+    tournament early is fine, starting an empty one is not.
 
     Owner-only, like every other tournament mutation.
     """
@@ -858,7 +1069,25 @@ async def create_tournament_transition(
         )
         raise HTTPException(status_code=409, detail=detail)
 
+    # THE per-target precondition, at the one dispatch point ADR-0017 reserved for it —
+    # the edge table above says *where* you may go, and this says whether the tournament
+    # is in a fit state to get there. Only ``live`` has one (ADR-0786): a tournament may
+    # be published with no events and no draws (announcing early is fine), and archiving
+    # asks nothing of the draws it is putting away.
+    #
+    # Inside the row lock this handler already holds, and it must stay inside it: the
+    # currency it checks is a fact about the entrant field, and every writer of that
+    # field queues on this same row — so an entry cannot land between the check and the
+    # ``UPDATE`` below. A second lock is neither taken nor needed.
+    if payload.to is TournamentStatus.live:
+        await _enforce_ready_to_go_live(db, tournament)
+
     tournament.status = payload.to
+    # #788 (materialization) hangs HERE, as the transition's final act: once the status
+    # is ``live``, the first ``advance()`` turns every ready fixture into a real match,
+    # in the same transaction as the status write. Nothing creates matches yet —
+    # fixtures are the whole of a draw today — and the precondition above is what
+    # guarantees that when it does, it will have a complete, current draw to work from.
     await db.commit()
     await db.refresh(tournament)
     # The owner is the current user (``_require_owner`` just said so), so the
@@ -901,7 +1130,10 @@ async def create_event(
     await db.commit()
     await db.refresh(event)
     # A just-created event has no entries, so its entrants are empty and its
-    # derived ``entered`` count is 0 — no query needed to learn that.
+    # derived ``entered`` count is 0 — no query needed to learn that. Its draw is
+    # empty for the same reason and with the same certainty: fixtures are only ever
+    # written by the cut (ADR-0786), which is an explicit act on an event that already
+    # exists, so an event one statement old cannot have any. ``[]``, not a query.
     #
     # Its ``entry_state`` is still the CALLER's, computed exactly as it is on the
     # read paths (the director who just created the event is a player too, and the
@@ -909,7 +1141,187 @@ async def create_event(
     # tournament's league: answering with a state the endpoint had guessed rather
     # than computed is how the read and the guard come apart.
     rating = await entrant_rating(db, tournament.league_id, current_user.id)
-    return _serialize_event(event, entrants=[], rating=rating)
+    return _serialize_event(event, entrants=[], fixtures=[], rating=rating)
+
+
+def _pool_set_refusal(removed: list[str], added: list[str]) -> HTTPException:
+    """The 409 for a pools payload that would change *which pools* a cut event has.
+
+    409, not 403 (ADR-0017's refusal-code doctrine): the caller is the owner and the
+    request is well-formed — it is the *resource* that is in the wrong state for it. The
+    same payload becomes legal the moment the draw is removed, which is precisely what a
+    conflict means and what a 403 would deny.
+
+    Both halves are named, because a re-**id**'d pool is exactly one removal plus one
+    addition and the director has to be told which of their pools went missing:
+
+    * a **removed** pool leaves its fixtures pointing at a pool that no longer exists —
+      the dangling ref no foreign key is there to catch (ADR-0786);
+    * an **added** pool arrives with **no fixtures**, because the draw was dealt across
+      the pools the event had at the cut, and nothing re-deals it.
+
+    The sentence ends with the way out (remove the draw, change the pools, cut again)
+    and with what is still allowed, because a refusal that only says "no" leaves a
+    director who has to move a broken table with nowhere to go — and the answer is that
+    they don't need us: tables, times and names were never frozen.
+    """
+    clauses = []
+    if removed:
+        clauses.append(
+            f"{named_list(removed)} already has fixtures drawn into it, "
+            "which this change would leave pointing at a pool that no longer exists"
+        )
+    if added:
+        clauses.append(
+            f"{named_list(added)} would arrive with no fixtures in it, "
+            "because the draw was cut across the pools this event had at the time"
+        )
+    return HTTPException(
+        status_code=409,
+        detail=(
+            "This event's draw is already cut, so its set of pools is frozen: "
+            + "; and ".join(clauses)
+            + ". A pool's tables, its time and its name can all still be changed. "
+            "To add, remove or re-identify a pool, remove the draw first, then cut it "
+            "again."
+        ),
+    )
+
+
+async def _enforce_pool_set_frozen(
+    db: AsyncSession, event: TournamentEvent, payload: TournamentEventUpdate
+) -> None:
+    """Raise the 409 once a ``pools`` payload would change *which pools* an event with a
+    cut draw has (ADR-0786).
+
+    A fixture names its pool by a **string ref** into this same event's ``pools`` JSONB,
+    and there is no pools table for it to foreign-key. So the database cannot refuse the
+    edit that orphans it, and the integrity of that reference is procedural — it is this
+    function, and nothing else. Remove a pool (or change its ``id``, which is a removal
+    with an addition standing where it was) and every fixture drawn into it refers to
+    nothing; add one and it arrives with no fixtures, because the draw was dealt across
+    the pools that existed at the cut.
+
+    What is frozen is the **id set**, and only the id set. A pool's ``table_ids``, its
+    ``slot`` and its ``name`` stay editable with a draw standing, on purpose — this is
+    the case the freeze exists to *permit*, not to prevent. Venues move under a running
+    tournament (a table breaks and is pulled, one frees up early, a pool slips an hour),
+    and a director who cannot record that has to un-cut a draw that is *correct* —
+    losing the placements — to move a table. A rename is likewise allowed: identity
+    lives in the ``id``, so "Pool A" becoming "Morning Pool" is a display change and
+    every fixture still resolves.
+
+    Asked **before** anything is written (and, like every judge-then-write guard in this
+    module, under the tournament's row lock), so a refusal leaves both the pools and the
+    fixtures exactly as they were. Not merely rolled back — never written: a guard that
+    fired after the ``setattr`` loop would be relying on the transaction to undo it, and
+    the day somebody makes an intermediate ``commit`` for convenience the refusal starts
+    persisting the very thing it refuses.
+
+    With **no draw cut** this is a no-op and ``pools`` replaces wholesale, as it always
+    has. There are no fixtures to orphan, and the pools of an un-drawn event are just
+    configuration; ``DELETE …/draw`` un-freezes the set by construction for the same
+    reason.
+    """
+    # An absent ``pools`` key is the only way this is ``None`` — an explicit ``null`` is
+    # a 422 at the schema (the column is NOT NULL) — so "not sent" is the whole meaning
+    # of it, and an event whose pools are not being replaced has nothing to enforce.
+    if payload.pools is None:
+        return
+    # The freeze turns on the draw EXISTING, not on it having been played: an unplayed
+    # draw is the ordinary state of a tournament that has not started, and it is just as
+    # orphanable as a played one.
+    if not await event_has_draw(db, event.id):
+        return
+    existing = event_pool_ids(event)
+    incoming = {PoolId(pool.id) for pool in payload.pools}
+    if existing == incoming:
+        return
+    # Named by their names, from whichever side of the change still knows them: a pool
+    # being removed is only described by the row we hold, and one being added only by
+    # the payload.
+    removed = [
+        Pool.model_validate(pool).name
+        for pool in event.pools
+        if Pool.model_validate(pool).id not in incoming
+    ]
+    added = [pool.name for pool in payload.pools if pool.id not in existing]
+    raise _pool_set_refusal(removed, added)
+
+
+def _draw_type_refusal(current: DrawType) -> HTTPException:
+    """The 409 for a ``draw_type`` change on an event whose draw is already cut.
+
+    Same doctrine as the pool-set freeze, one field over (ADR-0017): 409, not 403 — the
+    caller is the owner and the payload is well-formed; it is the *resource* that is in
+    the wrong state, and the same request becomes legal the moment the draw is removed.
+
+    And it says how, because the alternative is a director who is **stuck**. The draw
+    type is what chose the strategy that dealt these fixtures, so an event that is
+    ``single-elim`` while holding pooled round-robin fixtures cannot even be re-cut back
+    into agreement with itself: today ``single-elim`` has no strategy, so the re-cut is
+    a 422, and the only way out is to patch the draw type *back* to a value the director
+    never asked for — which they have to guess. The refusal names the way out instead.
+    """
+    return HTTPException(
+        status_code=409,
+        detail=(
+            f"This event's draw is already cut, so its draw type is frozen: its "
+            f"fixtures were dealt as a “{current.value}” draw, and changing the type "
+            "would leave the event claiming a shape its draw does not have. To change "
+            "the draw type, remove the draw first, then cut it again."
+        ),
+    )
+
+
+async def _enforce_draw_type_frozen(
+    db: AsyncSession, event: TournamentEvent, payload: TournamentEventUpdate
+) -> None:
+    """Raise the 409 once a ``draw_type`` payload would change the draw type of an event
+    that **has a draw** (ADR-0786).
+
+    A draw type is not a label on an event — it is the strategy that dealt the event's
+    fixtures, and the fixtures are the shape that strategy prescribes. Patch it under a
+    standing draw and the two facts contradict each other: a ``single-elim`` event
+    holding pooled round-robin fixtures (measured — the PATCH answered **200**), whose
+    bracket no client can render and whose draw no strategy would ever have produced.
+
+    The **go-live currency check cannot catch it**, which is why this guard has to
+    exist rather than being someone else's problem: currency compares the *entrant set*
+    the fixtures seat against the event's active entrants (``draw_currency_by_event``),
+    and re-labelling the draw type moves neither. The corrupted event reads as
+    ``current`` and starts.
+
+    Sibling of ``_enforce_pool_set_frozen``, and the same shape of rule: what a cut draw
+    freezes is *the facts its fixtures were derived from* — the pools they were dealt
+    across, and the strategy that dealt them. Everything else about the event (its name,
+    its fee, its rules, a pool's tables and window) stays editable, because a director
+    must never have to destroy a correct draw to record an ordinary change.
+
+    **Presence is not enough — the change is what is refused.** A ``draw_type`` equal to
+    the one the event already has changes nothing, so it is not a conflict, and a guard
+    that fired on the mere presence of the key would refuse a page that PATCHes the
+    whole event form back (draw type included) to move a pool's tables — the very edit
+    the freeze exists to permit. (This is where it differs from
+    ``_enforce_league_editable``, which *does* refuse the field it already holds: there,
+    the field is settled by a
+    lifecycle status no request of the caller's can move, so the only client that sends
+    it is a stale one. Here, the way out — remove the draw — is on the caller's own
+    keyboard.)
+
+    Asked **before** anything is written, like every judge-then-write guard in this
+    module, and under the tournament's row lock: a refusal leaves the draw type and the
+    fixtures exactly as they were, never written and then rolled back.
+    """
+    if payload.draw_type is None or payload.draw_type is event.draw_type:
+        return
+    # Only now the query — and only for a payload that really moves the draw type. It is
+    # the same ``event_has_draw`` the pool freeze asks, and a payload that changes both
+    # asks it twice: two COUNTs on an indexed column, both under a lock we already hold,
+    # in exchange for two guards that each read as one rule.
+    if not await event_has_draw(db, event.id):
+        return
+    raise _draw_type_refusal(event.draw_type)
 
 
 @router.patch(
@@ -923,13 +1335,54 @@ async def update_event(
     db: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
 ) -> TournamentEventRead:
-    # The owner-scoped load is the guard (404 then 403) — the event, not the
-    # tournament, is the row this route edits. But the tournament is kept, not
-    # discarded: its ``league_id`` is the ladder the event's refreshed ``entry_state``
-    # is judged on (ADR-0783), and it is already loaded, so re-fetching it would be a
-    # second query for a row we are holding.
-    tournament = await _get_owned_tournament_or_404(db, tournament_id, current_user)
+    """Edit an event. Absent fields are left alone; `predicates` and `pools` replace
+    wholesale when sent. No two pools may share an `id`, in any state (`422`) — a pool
+    id identifies one pool, and the fixtures of a draw name their pool by it.
+
+    **Once the event's draw is cut, two things freeze** (ADR-0786) — the facts its
+    fixtures were derived from:
+
+    * **its set of pools.** A `pools` payload must carry exactly the pool `id`s the
+      event already has, or it is refused with a `409`: a removed (or re-`id`'d) pool
+      would leave the fixtures drawn into it pointing at nothing, and an added one would
+      arrive with no fixtures, since the draw was dealt across the pools that existed at
+      the cut.
+    * **its `draw_type`.** The draw type chose the strategy that dealt those fixtures,
+      so changing it under a standing draw is a `409` too: the event would claim a shape
+      its draw does not have. Re-sending the draw type the event already has is not a
+      change, and is not refused.
+
+    Nothing else freezes. The event's name, fee, rules and `max_players`, and each
+    pool's `table_ids`, `slot` and `name`, all stay editable with a draw standing —
+    venues change under a running tournament, and recording that must never cost a
+    director the draw. To change the pools themselves or the draw type, remove the draw
+    (`DELETE …/draw`), edit, and cut again. With no draw cut, `pools` and `draw_type`
+    are ordinary fields.
+
+    Owner-only.
+    """
+    # The row lock first, then the owner check — the same pair, in the same order, that
+    # the transition route and the tournament PATCH take, and that the draw verbs take
+    # (which is what keeps them all free of a deadlock cycle). This route is a
+    # judge-then-write path now: ``_enforce_pool_set_frozen`` reads whether a draw
+    # exists and then writes the pools that draw's fixtures refer to. Postgres runs READ
+    # COMMITTED, so unlocked, a cut committing between those two would be a cut across
+    # pools this request is in the middle of replacing — a draw born orphaned, refused
+    # by nothing.
+    #
+    # The tournament is kept, not discarded: its ``league_id`` is the ladder the event's
+    # refreshed ``entry_state`` is judged on (ADR-0783), and it is already loaded, so
+    # re-fetching it would be a second query for a row we are holding.
+    tournament = await _get_tournament_for_update_or_404(db, tournament_id)
+    _require_owner(tournament, current_user)
     event = await _get_event_or_404(db, tournament_id, event_id)
+    # 404 → 403 → 409, the ordering ADR-0017 fixed: the state of this event's draw is
+    # never the reason a stranger's request is refused. And it is asked before the loop
+    # below, so a refusal writes nothing at all.
+    await _enforce_pool_set_frozen(db, event, payload)
+    # The draw's other frozen fact, judged in the same window and for the same reason:
+    # the strategy that dealt the fixtures is not a label to be re-typed under them.
+    await _enforce_draw_type_frozen(db, event, payload)
     # As in update_tournament: model_dump(exclude_unset=True) serializes the
     # nested value-objects (slot/match_settings/predicates/pools) to plain
     # dicts/lists, so one setattr loop covers the JSONB columns and scalars.
@@ -939,13 +1392,17 @@ async def update_event(
     await db.refresh(event)
     # An edited event keeps whatever entrants it already had — reload them rather
     # than answering with an empty list (and a ``entered`` of 0) that would be a
-    # lie for any event people have entered.
+    # lie for any event people have entered. Its DRAW survives the edit too (a PATCH
+    # is not a re-cut, ADR-0786), so its fixtures are reloaded for the same reason:
+    # answering ``[]`` here would tell the director their draw had just been thrown
+    # away, and the page would render it that way.
     entrants = (await active_entrants_by_event(db, [event.id]))[event.id]
+    fixtures = (await fixtures_by_event(db, [event.id]))[event.id]
     # And its ``entry_state`` is recomputed from the event as it now stands: an owner
     # who has just tightened a rule or lowered ``max_players`` is answered with what
     # the event says NOW, not with what it said before their edit.
     rating = await entrant_rating(db, tournament.league_id, current_user.id)
-    return _serialize_event(event, entrants=entrants, rating=rating)
+    return _serialize_event(event, entrants=entrants, fixtures=fixtures, rating=rating)
 
 
 @router.delete(
@@ -1537,5 +1994,240 @@ async def withdraw_from_event(
     # unlike the enter route, there is no IntegrityError here to catch and no
     # database error that could reach the response body.
     entry.status = TournamentEntryStatus.withdrawn
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ----- the draw (ADR-0786) --------------------------------------------------
+#
+# One sub-resource, two verbs: POST cuts (or re-cuts) an event's draw, DELETE un-cuts
+# it. The draw is *read* on the tournament-detail BFF, with the event that owns it —
+# one endpoint per page (root CLAUDE.md) — so there is deliberately no ``GET …/draw``
+# here to make a bracket a second round-trip.
+#
+# Both verbs are owner-only and take the tournament's row lock, and both are refused for
+# exactly one reason: **evidence of play**. Not the tournament's status — status-gating
+# was considered and rejected (ADR-0786), because it forbids the legitimate day-of move
+# (a no-show is withdrawn before the first ball, and the director re-cuts) while
+# protecting nothing the play guard does not already protect.
+
+
+def _draw_refusal(error: DrawError) -> HTTPException:
+    """The 422 for a draw the domain will not produce — in words a director can read.
+
+    A ``DrawError`` is not a bug: it is the domain saying that what was asked for is not
+    a competition (``DegenerateDraw``) or is not a format we can cut yet
+    (``UnsupportedDrawType``). So it is a 422 — the request is well-formed and
+    authorized, but its *content* (this event's pools, this event's field, this event's
+    draw type) cannot be turned into a draw — rather than the 500 an uncaught exception
+    would be, and rather than a 409, which would invite a retry that will fail
+    identically until the director changes the event.
+
+    A ``match`` over the error, not ``str(error)`` over whatever arrives:
+
+    * ``UnsupportedDrawType`` carries the ``draw_type`` **structurally**, so the
+      sentence is composed here from the fact rather than parsed out of a message. Its
+      own ``str()`` ("… is not implemented yet") is written for the developer who has
+      to go implement it; the director needs to be told which of *their* events cannot
+      be cut, and that the rest of the tournament is unaffected.
+    * ``DegenerateDraw`` is the one error whose message is **domain-authored copy**, and
+      it is passed through on purpose: only the strategy knows *which* degeneracy it hit
+      — no pools at all, or a snake that would leave some pool with one player and
+      nobody to play — and the numbers in that sentence ("5 entrants across 3 pool(s)")
+      are the numbers the director has to change. Recomposing it here would be a second
+      copy of a rule this route does not own, and the copy that drifts is the one a
+      director reads.
+    * The fallback arm is a **generic** sentence, never the exception's own. A
+      ``DrawError`` subclass added tomorrow gets a vague refusal rather than leaking a
+      message nobody wrote for a human — refusing vaguely is a bug report; leaking
+      internals is a defect that reaches the UI. (Its author gives it its own arm, the
+      same way ``_registration_refusal_detail`` buys its totality.)
+    """
+    match error:
+        case UnsupportedDrawType():
+            detail = (
+                f"A {error.draw_type.value} draw cannot be cut yet. "
+                "Change the event's draw type to one that can, or wait for support."
+            )
+        case DegenerateDraw():
+            detail = str(error)
+        case _:
+            detail = "This event's draw cannot be cut as the event stands."
+    return HTTPException(status_code=422, detail=detail)
+
+
+async def _enforce_draw_unplayed(db: AsyncSession, event: TournamentEvent) -> None:
+    """Raise the 409 once an event's draw shows **evidence of play** — the single gate
+    on both cutting and un-cutting a draw (ADR-0786).
+
+    It is what makes a re-cut safe. A cut replaces the draw wholesale, so a draw with a
+    decided fixture (a recorded winner) or a materialized one (a linked match, which may
+    already carry games on its scratchpad) cannot be re-cut without throwing away
+    results that players actually produced. The draw must never silently eat a score, so
+    the refusal is on the *evidence*, not on the tournament's status: a director may cut
+    and re-cut as often as they like right up until the first fixture becomes real.
+
+    Read under the tournament's row lock, like every other judge-then-write guard in
+    this module (``_enforce_event_has_room``): the evidence this reads is the evidence
+    the write below is authorized by, and an unlocked read would sit in a different
+    instant from it.
+
+    409, not 403: the caller is the owner and the draw is theirs — it is the draw that
+    is past the point where a re-cut means anything. "Not you" would be a lie; the truth
+    is "not now, not any more".
+
+    One sentence for both verbs, because it is one fact. A re-cut and an un-cut are
+    refused for the same reason (the fixtures that would be destroyed are the ones that
+    have been played), and two sentences saying so would be two things to keep true.
+    """
+    if not await draw_has_play(db, event.id):
+        return
+    raise HTTPException(
+        status_code=409,
+        detail=(
+            "This event's draw is already under way — at least one fixture has a match "
+            "or a recorded winner — so it can no longer be cut or removed."
+        ),
+    )
+
+
+async def _get_owned_event_for_draw_or_404(
+    db: AsyncSession,
+    tournament_id: uuid.UUID,
+    event_id: uuid.UUID,
+    current_user: User,
+) -> TournamentEvent:
+    """The event whose draw is about to be written, loaded under the tournament's row
+    lock and the owner check — the refusal ordering both draw verbs share.
+
+    **404 → 403 → 409**, the ordering ADR-0017 fixed and every route in this module
+    keeps: a tournament that does not exist (or an event that is not under it) is a 404
+    before ownership is considered, so a stranger probing ids learns nothing; a
+    non-owner is a 403 before the draw's *state* is looked at, so the refusal never
+    leaks whether an event has been played. The 409 (``_enforce_draw_unplayed``) is the
+    caller's own, and comes last.
+
+    The tournament is loaded through the **locking** loader — the same lock, on the same
+    row, taken first, that the entry, withdrawal, transition and PATCH routes take
+    (which is what keeps them free of a deadlock cycle) — and ``_require_owner`` is then
+    asked here, exactly as ``update_tournament`` and the transition route do.
+
+    The lock is not decoration. A cut reads the event's active field and writes fixtures
+    *derived from it*; Postgres runs READ COMMITTED, so an unlocked read answers from
+    its own statement's snapshot, and an entry (or a withdrawal) committing between the
+    read and the INSERT would leave a persisted draw that never matched any real field
+    of players — a pool of the wrong size, an entrant seated nowhere, or one seated in a
+    draw they had left. Every writer of the entrant field already queues on this row, so
+    taking it here is what puts the cut in the same queue: the loser blocks and re-reads
+    the field the winner *committed*.
+    """
+    tournament = await _get_tournament_for_update_or_404(db, tournament_id)
+    _require_owner(tournament, current_user)
+    return await _get_event_or_404(db, tournament_id, event_id)
+
+
+@router.post(
+    "/tournaments/{tournament_id}/events/{event_id}/draw",
+    response_model=list[TournamentFixtureRead],
+    status_code=status.HTTP_201_CREATED,
+)
+async def cut_event_draw(
+    tournament_id: uuid.UUID,
+    event_id: uuid.UUID,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> list[TournamentFixtureRead]:
+    """Cut this event's draw — generate its **fixtures** from its entrants — and answer
+    with them.
+
+    Cutting is an explicit, reviewable act, and it is **not** tied to the tournament's
+    status: a draw may be cut and re-cut freely while a director inspects the pools and
+    the seeding. Nothing else creates fixtures, and going live requires every event to
+    have one (ADR-0786).
+
+    **Re-cutting replaces the draw wholesale.** The previous fixtures are deleted and a
+    fresh set is planned from the event's *current* active entrants — the old ones are
+    not patched, and their ids do not survive. That is the point: a draw is a plan made
+    against a field, and once the field has changed (somebody entered, somebody
+    withdrew) the whole plan is re-made, pool sizes and seeding included.
+
+    Entrants are ordered by **seed** ascending where one is set, then by **registration
+    order**. Nothing is random, so the same field always cuts the same draw.
+
+    Refused with a `409` once the draw shows any **evidence of play** — any fixture with
+    a recorded winner, or any fixture that has become a real match. A re-cut would throw
+    those away, and a draw must never silently eat a score.
+
+    Refused with a `422` when this event cannot produce a draw at all: its draw type has
+    no generator yet (only round-robin does today), it has **no pools** configured for a
+    pooled draw type, or its field is too small for the pools it has — a pool with fewer
+    than two players has nobody to play. The message names what to change.
+
+    Owner-only. Fixtures come back in pool → round → position order, exactly as the
+    tournament-detail page carries them.
+    """
+    # 404 → 403 first (and the tournament's row lock with them), so the draw's own
+    # state is never the reason a stranger's request is refused.
+    event = await _get_owned_event_for_draw_or_404(
+        db, tournament_id, event_id, current_user
+    )
+    # Then the one gate on the write: has this draw been played? Asked before anything
+    # is planned or deleted, so a refused re-cut leaves the standing draw exactly as it
+    # was — the guard's whole promise.
+    await _enforce_draw_unplayed(db, event)
+    try:
+        # Plans, deletes and re-inserts inside THIS transaction — the lock above is
+        # still held, so the field it reads cannot move under it, and the DELETE and
+        # the INSERTs land together or not at all. A DrawError is raised before the
+        # DELETE, so a 422 destroys nothing either.
+        await cut_draw(db, event)
+    except DrawError as error:
+        # The domain refusing to produce a draw is not a bug — it is an answer, and it
+        # is the caller's to act on. ``from None`` so no traceback shape reaches the
+        # client; the sentence is composed in ``_draw_refusal``.
+        await db.rollback()
+        raise _draw_refusal(error) from None
+    await db.commit()
+    # Read the draw back through the SAME loader the detail page reads it through, so
+    # the fixtures this mutation answers with are byte-for-byte the ones the page will
+    # show — same shape, same pool → round → position order. Composing the response
+    # from the objects just added would be a second serialization of the same rows,
+    # ordered by whatever the planner happened to emit.
+    return (await fixtures_by_event(db, [event.id]))[event.id]
+
+
+@router.delete(
+    "/tournaments/{tournament_id}/events/{event_id}/draw",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def uncut_event_draw(
+    tournament_id: uuid.UUID,
+    event_id: uuid.UUID,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    """Un-cut this event's draw: delete its fixtures, leaving the event with no draw.
+
+    The way back from a draw the director does not want. The event, its entrants and the
+    rest of the tournament are untouched — only the fixtures go — and the director is
+    free to change the pools and cut again.
+
+    Refused with a `409` on the same **evidence of play** that refuses a re-cut: a
+    fixture with a recorded winner, or one that has become a real match. Undoing a draw
+    that has been played would delete the fixtures those results belong to.
+
+    An event with **no draw is already in the state this asks for**, so removing a draw
+    that was never cut is a `204`, not a `404`: this is a DELETE, and it is idempotent.
+
+    Owner-only.
+    """
+    # The same 404 → 403 → 409 ordering, and the same row lock, as the cut: this verb
+    # deletes what that verb writes, and the guard that protects the fixtures cannot
+    # depend on which route is asking.
+    event = await _get_owned_event_for_draw_or_404(
+        db, tournament_id, event_id, current_user
+    )
+    await _enforce_draw_unplayed(db, event)
+    await uncut_draw(db, event)
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -25,7 +25,6 @@ from app.schemas.tournament import (
     EventEntryOpen,
     EventEntryRatingIneligible,
     EventEntryState,
-    Pool,
     TournamentCreate,
     TournamentDetailRead,
     TournamentEntrantRead,
@@ -46,7 +45,7 @@ from app.tournament_draws import (
     draw_currency_by_event,
     draw_has_play,
     event_has_draw,
-    event_pool_ids,
+    event_pools,
     uncut_draw,
 )
 from app.tournament_eligibility import (
@@ -525,19 +524,6 @@ def _enforce_league_editable(t: Tournament) -> None:
             "while it is a draft."
         ),
     )
-
-
-# The refusals here name a SET of things — the pool-set freeze's pools, the go-live
-# precondition's events — and they name them by NAME. A director reads names, not ids:
-# the ids are what the guards actually compared, but "pool p-b7f2 cannot be removed" (or
-# "event 3f9c-… has no draw") tells the person looking at a page of named pools and
-# named events nothing they can act on.
-#
-# ``named_list`` is the one formatter for all of them, and it lives in
-# ``app.schemas.tournament`` because the boundary needs it too (the duplicate-pool-id
-# 422 names the ids it found twice) and the boundary is the lower layer — this module
-# already imports that one, so the reverse would be a cycle. One formatter, so a
-# director cannot tell from the punctuation which guard refused them.
 
 
 # The statuses in which a tournament has been ANNOUNCED to the world. Publishing
@@ -1233,18 +1219,18 @@ async def _enforce_pool_set_frozen(
     # orphanable as a played one.
     if not await event_has_draw(db, event.id):
         return
-    existing = event_pool_ids(event)
+    # Parsed ONCE, and kept: the id set decides *whether* to refuse, and the pools
+    # themselves say *which* — a refusal names them (``named_list``), and re-parsing the
+    # JSONB to recover the names would be the same validation run twice per pool.
+    current = event_pools(event)
+    existing = {PoolId(pool.id) for pool in current}
     incoming = {PoolId(pool.id) for pool in payload.pools}
     if existing == incoming:
         return
     # Named by their names, from whichever side of the change still knows them: a pool
     # being removed is only described by the row we hold, and one being added only by
     # the payload.
-    removed = [
-        Pool.model_validate(pool).name
-        for pool in event.pools
-        if Pool.model_validate(pool).id not in incoming
-    ]
+    removed = [pool.name for pool in current if PoolId(pool.id) not in incoming]
     added = [pool.name for pool in payload.pools if pool.id not in existing]
     raise _pool_set_refusal(removed, added)
 
@@ -2228,6 +2214,6 @@ async def uncut_event_draw(
         db, tournament_id, event_id, current_user
     )
     await _enforce_draw_unplayed(db, event)
-    await uncut_draw(db, event)
+    await uncut_draw(db, [event.id])
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -17,7 +17,7 @@ from app.models import (
     TournamentStatus,
     User,
 )
-from app.rbac import require_permission
+from app.rbac import require_permission, user_has_permission
 from app.schemas.tournament import (
     EventEntryFull,
     EventEntryOpen,
@@ -26,6 +26,7 @@ from app.schemas.tournament import (
     TournamentCreate,
     TournamentDetailRead,
     TournamentEntrantRead,
+    TournamentEntryCreate,
     TournamentEventCreate,
     TournamentEventRead,
     TournamentEventUpdate,
@@ -59,15 +60,24 @@ from app.tournament_queries import (
 # Player self-registration is the exception that needs its own permission: a
 # player entering *themselves* is not the tournament's owner, so it cannot go
 # through ``_require_owner``.
+#
+# The two ENTRY routes hold BOTH of those authorizations at once, because a single
+# endpoint serves both actors (ADR-0784): a player entering themselves is gated on
+# ``tournament.enter``, and a director entering somebody else — or withdrawing an
+# entry that is not their own — is gated on ownership. Which gate applies is decided
+# by the request, so neither can be a router dependency (a dependency runs before the
+# handler has seen the body, and would refuse an owner for lacking a grant that has
+# nothing to do with what they are doing). Both routes therefore take
+# ``get_current_user`` and ask ``_require_enter_permission`` / ``_require_owner`` in
+# the arm of the fork that owns them. The authorizations are disjoint — a stranger
+# self-registering is not the owner; an owner adding somebody else is not
+# self-registering — so this is a fork, not a tangle.
 TOURNAMENT_VIEW = "tournament.view"
 TOURNAMENT_CREATE = "tournament.create"
 TOURNAMENT_ENTER = "tournament.enter"
 
 require_view = require_permission(TOURNAMENT_VIEW)
 require_create = require_permission(TOURNAMENT_CREATE)
-# Returns the signed-in user, so the enter route gets its gate and its caller
-# from one dependency — and cannot enter anyone other than that caller.
-require_enter = require_permission(TOURNAMENT_ENTER)
 
 # The tournament lifecycle, in full (ADR-0017):
 #
@@ -395,12 +405,58 @@ async def _get_entry_or_404(
     return entry
 
 
+async def _get_entrant_or_404(db: AsyncSession, user_id: uuid.UUID) -> User:
+    """The player a director named in the body — the one they are entering (ADR-0784).
+
+    Tombstoned (merged-away) users are excluded, exactly as ``/v1/players/search``
+    excludes them: a ghost is a user no listing, search or auth query will ever return,
+    so entering one would put a player in the draw who cannot sign in, cannot be
+    notified and cannot play. The merge re-points every *existing* entry onto the
+    survivor; the way to keep new ones off the tombstone is to refuse to write them.
+
+    A 404 rather than a 422: the id is well-formed, it simply names nobody enterable.
+    It is raised only *after* ``_require_owner``, so a stranger poking at the endpoint
+    learns nothing about which user ids exist.
+    """
+    user = (
+        await db.execute(
+            select(User).where(
+                User.id == user_id,
+                User.merged_into_user_id.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=404, detail="Player not found.")
+    return user
+
+
 def _require_owner(t: Tournament, current_user: User) -> None:
     if t.created_by_user_id != current_user.id:
         raise HTTPException(
             status_code=403,
             detail="You can only modify tournaments you created.",
         )
+
+
+async def _require_enter_permission(db: AsyncSession, current_user: User) -> None:
+    """The self-registration arm's gate: the caller must hold ``tournament.enter``.
+
+    Byte-for-byte what ``Depends(require_permission(TOURNAMENT_ENTER))`` raised when
+    it was a router dependency — the same query (``user_has_permission``), the same
+    403, the same ``"Forbidden."`` — because it is the same authorization. What moved
+    is only *where* it is asked: a dependency cannot see the request body, and the
+    body is what says whether this caller is self-registering at all (ADR-0784). An
+    owner entering somebody else must not be refused for lacking a permission about
+    entering *themselves*.
+
+    So it is asked FIRST, before the tournament is even loaded, on the self path — the
+    dependency's position, kept. The director's ownership check is the mirror image
+    and is deliberately asked *last*, after the 404s, because ownership is a fact about
+    a tournament that has to exist before it can be owned.
+    """
+    if not await user_has_permission(db, current_user.id, TOURNAMENT_ENTER):
+        raise HTTPException(status_code=403, detail="Forbidden.")
 
 
 def _enforce_league_editable(t: Tournament) -> None:
@@ -1173,40 +1229,80 @@ async def _enforce_rating_eligible(
 async def enter_event(
     tournament_id: uuid.UUID,
     event_id: uuid.UUID,
+    payload: TournamentEntryCreate | None = None,
     db: AsyncSession = Depends(get_session),
-    current_user: User = Depends(require_enter),
+    current_user: User = Depends(get_current_user),
 ) -> TournamentEntrantRead:
-    """Register the signed-in player in a singles event.
+    """Enter a player in a singles event — yourself, or (as the tournament's owner)
+    somebody else.
 
-    Self-registration only: the entry created is always the caller's own, which
-    is why the request carries no body — there is no field in which to name
-    someone else. Entering a player who is not you is a director's job, and a
-    different endpoint.
+    **The body is optional, and its presence chooses the actor** (ADR-0784):
+
+    * **no body** → you are entering *yourself*. Requires the `tournament.enter`
+      permission. This is the request every player already sends, and it is unchanged.
+    * **`user_id`** → you are the **director** entering that player. Requires that you
+      **own** the tournament; anyone else naming a `user_id` that is not their own is a
+      `403`. An id that names no (live) player is a `404`.
+
+    Naming *your own* `user_id` is self-registration, not a director entry: same
+    permission, and the entry records no adder.
 
     Registration is open only while the tournament is **`published`** — its status
     *is* its registration window (ADR-0017). Entering an event of a `draft`
     tournament (not announced yet), a `live` one (the field is fixed; the draw is
     cut from it), or an `archived` one (it is over) is a `409` — not a `403`: you
-    are permitted, the tournament is simply in the wrong state.
+    are permitted, the tournament is simply in the wrong state. **That holds for the
+    director too**: there is no override, so a director can neither add a walk-in nor
+    remove a no-show once the tournament is live.
 
-    An event's **eligibility rules** are decided against your rating on the
-    tournament's league, and you must satisfy **every** one of them: failing a rule
+    An event's **eligibility rules** are decided against the entrant's rating on the
+    tournament's league, and they must satisfy **every** one of them: failing a rule
     (the 1650-rated player entering the "Under 1500" event) is a `409`. A player who
     holds **no rating** on that league — nobody has a rating until they finish a rated
     match — **passes every rule**, so a brand-new player is not shut out of the
     beginners' event that exists for them.
 
-    Entering an event you are already in is a `409`; withdrawing first frees you
+    Entering an event the player is already in is a `409`; withdrawing first frees them
     to enter it again. Entering an event that already holds its `max_players`
     entrants is a `409` too — someone withdrawing frees the slot. Doubles and teams
     events are a `400`: an entry is one row per player, with nowhere to record a
     partner or a team.
+
+    **A director's entry is judged by exactly these rules.** The same evaluator, the
+    same capacity lock, the same four refusal codes: a director adding a player to a
+    full event, or one over the event's rating cap, is refused precisely as the player
+    would be.
     """
+    # ----- the fork (ADR-0784) ----------------------------------------------
+    #
+    # One line, decided from the body alone, before anything is loaded: WHO is being
+    # entered. Everything downstream reads ``entrant`` and does not care how it got
+    # there — the eligibility evaluator, the capacity lock and the four refusal codes
+    # are the same rules for a director as for a player, which is the whole reason this
+    # is one endpoint and not two (a twin route would make the next refusal a thing to
+    # add twice).
+    #
+    # Naming your OWN ``user_id`` is self-registration. It has to be: "the player
+    # entered themselves" is spelled ``added_by_user_id = NULL``, and letting an owner
+    # write ``added_by == user_id`` would create a second, contradictory encoding of
+    # the same fact — one the entrants list would render as "added by the director" on
+    # an entry whose director is the player. (``merge_user``'s CASE already collapses
+    # that shape when a merge would otherwise produce it; the route must not mint it in
+    # the first place. Deliberately no ``CHECK`` constraint enforces this: the INSERT
+    # below catches ``IntegrityError`` and reads it as ``already_entered``, so a
+    # constraint violation here would surface as a false "already entered" refusal.)
+    entrant_id = current_user.id if payload is None else payload.user_id
+    self_registration = entrant_id == current_user.id
+    if self_registration:
+        # Asked here, at the top, exactly where the router dependency used to run:
+        # a player who does not hold ``tournament.enter`` is refused before the
+        # handler learns anything about the tournament. The director's arm is gated
+        # by ownership instead, and its check comes *after* the 404s below — you
+        # cannot own a tournament that does not exist.
+        await _require_enter_permission(db, current_user)
+
     # Load first, then decide — the same 404-before-anything-else ordering the
-    # owner-only routes use. This route has no ownership check to run afterwards:
-    # a player entering themselves is by definition not the tournament's owner,
-    # so the authorization is the ``tournament.enter`` gate above plus the fact
-    # that ``current_user`` is the only user this handler can enter.
+    # owner-only routes use.
     #
     # The tournament is loaded *locked*, and locked first: it is the row whose
     # status decides this request, and it must not change between the check below
@@ -1216,6 +1312,20 @@ async def enter_event(
     # committed outcome.
     tournament = await _get_tournament_for_update_or_404(db, tournament_id)
     event = await _get_event_or_404(db, tournament_id, event_id)
+
+    if self_registration:
+        # The caller is the entrant, and nobody added them — that is what NULL means.
+        entrant, added_by_user_id = current_user, None
+    else:
+        # The director's arm. Ownership is the gate (403 for anyone else naming
+        # somebody else's id), and it is judged after the 404s above so that a
+        # stranger's refusal never leaks whether the tournament or event exists.
+        _require_owner(tournament, current_user)
+        entrant, added_by_user_id = (
+            await _get_entrant_or_404(db, entrant_id),
+            current_user.id,
+        )
+
     if event.format is not EventFormat.singles:
         # Not a policy — a modelling limit (ADR-0016). One row per user cannot
         # express a doubles pairing or a team, so rather than record half a pair
@@ -1258,7 +1368,13 @@ async def enter_event(
     # INSERT (see below). The rating it judged against comes back out, because the
     # entrant this route answers with carries it — the number that admitted you and the
     # number reported beside your name are the same number, read once.
-    rating = await _enforce_rating_eligible(db, tournament, event, current_user)
+    #
+    # ``entrant``, not ``current_user``: the rules judge the person being ENTERED. A
+    # director adding a 1650 player to the "Under 1500" event is refused with the same
+    # ``rating_ineligible`` code that player would have got, and judging the DIRECTOR's
+    # rating here would silently make ownership an eligibility bypass — a ``force`` flag
+    # nobody voted for, arriving through a typo.
+    rating = await _enforce_rating_eligible(db, tournament, event, entrant)
 
     # Capacity, counted UNDER THE LOCK taken above (ADR-0783, §4) — the count and the
     # INSERT below are one serialised unit, which is the only reason two entrants
@@ -1272,7 +1388,14 @@ async def enter_event(
     # window, which is the fact that governs every event of that tournament.
     await _enforce_event_has_room(db, event)
 
-    entry = TournamentEntry(event_id=event.id, user_id=current_user.id)
+    # ``added_by_user_id`` is the fork's one lasting trace: NULL on the self path (the
+    # player entered themselves), the director's id on the other (ADR-0784). It is a
+    # fact about the past that cannot be reconstructed later, so it is stored now.
+    entry = TournamentEntry(
+        event_id=event.id,
+        user_id=entrant.id,
+        added_by_user_id=added_by_user_id,
+    )
     db.add(entry)
     try:
         await db.commit()
@@ -1284,6 +1407,11 @@ async def enter_event(
         # error, so nothing about the schema reaches the response body. Because
         # the index is partial, a player whose only prior entry is *withdrawn*
         # does not land here — they enter again, cleanly.
+        #
+        # It is the index, and only the index, that can raise here — which is why
+        # ``added_by_user_id`` deliberately carries no CHECK constraint (see the fork
+        # above): a second constraint on this INSERT would be reported to the client as
+        # a false "you have already entered this event".
         await db.rollback()
         raise entry_refused(
             EntryRefusal.already_entered,
@@ -1292,8 +1420,11 @@ async def enter_event(
 
     return TournamentEntrantRead(
         id=entry.id,
-        user_id=current_user.id,
-        username=current_user.username,
+        # The ENTRANT — who is the caller on the self path and somebody else on the
+        # director's. The 201 describes the row that was written, not the person who
+        # wrote it, so a director's POST answers with the player they just entered.
+        user_id=entrant.id,
+        username=entrant.username,
         seed=entry.seed,
         # The rating the eligibility guard above already read on this tournament's
         # ladder — not a fresh one. The entrant that comes back from the POST is the
@@ -1311,16 +1442,19 @@ async def withdraw_from_event(
     event_id: uuid.UUID,
     entry_id: uuid.UUID,
     db: AsyncSession = Depends(get_session),
-    current_user: User = Depends(require_enter),
+    current_user: User = Depends(get_current_user),
 ) -> Response:
-    """Withdraw the signed-in player's own entry from an event.
+    """Withdraw an entry from an event — your own, or (as the tournament's owner) any
+    entry in it.
 
     The entry is **soft-deleted**: its status flips to `withdrawn` and the row
     survives, so the event keeps its withdrawal history — and, because the
     uniqueness guard is a *partial* index over active entries only, the player is
     free to enter the same event again afterwards.
 
-    You may only withdraw your own entry; someone else's is a `403`.
+    **Who may withdraw an entry** (ADR-0784) mirrors who may create one: the player
+    themselves (with the `tournament.enter` permission), or the tournament's **owner**,
+    for any entry in it. Anybody else is a `403`.
 
     Withdrawal, like entry, is open only while the tournament is **`published`** —
     its status *is* its registration window (ADR-0017). Withdrawing an *active*
@@ -1328,7 +1462,9 @@ async def withdraw_from_event(
     from the field they were part of, so it is a `409`, as it is for a `draft`
     tournament (registration has not opened) and an `archived` one (it is over).
     A `409`, not a `403`: you are permitted, the tournament is simply in the wrong
-    state.
+    state. **The owner obeys that window too** — withdrawal stays symmetric with entry,
+    so a director can no more remove a no-show from a live tournament than add a
+    walk-in to one.
 
     **Withdrawing an entry that is already withdrawn is a `204` in every status**,
     `live` and `archived` included — a no-op, not an error: this is `DELETE`, and
@@ -1339,7 +1475,7 @@ async def withdraw_from_event(
     # Load-then-authorize, as everywhere else here: the tournament, the event
     # under it, and the entry under that event must all exist before ownership is
     # considered — so a wrong (tournament, event, entry) triple is a 404, and 403
-    # means "this entry is real, but it isn't yours".
+    # means "this entry is real, but it isn't yours to take back".
     #
     # The tournament comes back locked, and first — the same lock, in the same
     # order, as the enter, transition and PATCH routes take (which is what keeps the
@@ -1349,10 +1485,22 @@ async def withdraw_from_event(
     tournament = await _get_tournament_for_update_or_404(db, tournament_id)
     event = await _get_event_or_404(db, tournament_id, event_id)
     entry = await _get_entry_or_404(db, event.id, entry_id)
-    if entry.user_id != current_user.id:
-        # The ``tournament.enter`` gate says "may self-register at all"; it cannot
-        # say *whose* entry this is. Withdrawing another player from an event is a
-        # director's job (#784), on a different endpoint with its own permission.
+
+    # The same fork the enter route makes, read off the ENTRY rather than off a body:
+    # this is the caller's own entry, or it is somebody's the owner is removing
+    # (ADR-0784). Two authorizations, disjoint, and neither is a router dependency —
+    # which entry it is cannot be known until the row is loaded.
+    if entry.user_id == current_user.id:
+        # Withdrawing your own entry is the mirror of self-registering, and it is gated
+        # the same way: ``tournament.enter``. (The owner's arm below deliberately does
+        # NOT require it — managing the field of a tournament you created is a property
+        # of ownership, not a role grant.)
+        await _require_enter_permission(db, current_user)
+    elif tournament.created_by_user_id != current_user.id:
+        # Not yours, and not your tournament. The message stays true for everyone who
+        # can ever read it: the only caller refused here is a non-owner reaching for an
+        # entry that is not theirs, and for them their own entry really is all they may
+        # withdraw.
         #
         # Ordering: this 403 precedes the status 409 below, so withdrawing someone
         # else's entry from a *live* tournament is "not yours", not "not now".

--- a/api/migrations/versions/20260711_0000_0011_create_tournament_entries_table.py
+++ b/api/migrations/versions/20260711_0000_0011_create_tournament_entries_table.py
@@ -55,6 +55,19 @@ def upgrade() -> None:
             sa.ForeignKey("users.id", ondelete="RESTRICT"),
             nullable=False,
         ),
+        # Who put this player in the event. NULL means the player entered
+        # themselves; a user id means a director entered them (ADR-0784). NULL is
+        # the *encoding of self-registration*, not "unknown" — which is why the FK
+        # is RESTRICT rather than SET NULL: nulling it on a user delete would not
+        # lose a fact, it would rewrite one. (Account merge tombstones rather than
+        # deletes, so ON DELETE never fires there; ``merge_user`` re-points this
+        # column explicitly.)
+        sa.Column(
+            "added_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=True,
+        ),
         sa.Column("seed", sa.Integer(), nullable=True),
         sa.Column(
             "status",
@@ -85,9 +98,19 @@ def upgrade() -> None:
         "ix_tournament_entries_event_id", "tournament_entries", ["event_id"]
     )
     op.create_index("ix_tournament_entries_user_id", "tournament_entries", ["user_id"])
+    # merge_user re-points this column by `WHERE added_by_user_id = :from_id` on
+    # every guest sign-in, so it is a lookup key, not merely an FK.
+    op.create_index(
+        "ix_tournament_entries_added_by_user_id",
+        "tournament_entries",
+        ["added_by_user_id"],
+    )
 
 
 def downgrade() -> None:
+    op.drop_index(
+        "ix_tournament_entries_added_by_user_id", table_name="tournament_entries"
+    )
     op.drop_index("ix_tournament_entries_user_id", table_name="tournament_entries")
     op.drop_index("ix_tournament_entries_event_id", table_name="tournament_entries")
     op.drop_index(

--- a/api/migrations/versions/20260712_0000_0012_create_tournament_fixtures_table.py
+++ b/api/migrations/versions/20260712_0000_0012_create_tournament_fixtures_table.py
@@ -1,0 +1,127 @@
+"""create tournament fixtures table
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-07-12 00:00:00.000000
+
+One table holds every draw type's fixtures (ADR-0786). Per the pre-deploy
+convention in api/CLAUDE.md, edits to this migration happen in place. No
+backfill — assumes a fresh / empty DB.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0012"
+down_revision: Union[str, None] = "0011"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tournament_fixtures",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "event_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tournament_events.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # A *string ref* into the event's ``pools`` JSONB value-objects, deliberately
+        # NOT a foreign key — pools are value-objects on the event, not rows, so there
+        # is nothing to point at (ADR-0786). Integrity is procedural: the event's pool
+        # id set freezes while a draw exists. NULL = the draw is un-pooled
+        # (single-elim), or this is the KO stage of an rr-then-ko event.
+        sa.Column("pool_id", sa.Text(), nullable=True),
+        sa.Column("round", sa.Integer(), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        # NULL means exactly one thing: TBD — ``advance()`` fills it when the feeding
+        # fixture is decided. A bye is NOT a NULL side; it is the *absence of a row*.
+        # Hence no ``is_bye`` flag.
+        #
+        # CASCADE, not RESTRICT, because of the event-delete path: deleting an event
+        # cascades to tournament_entries and tournament_fixtures in one statement, and
+        # RESTRICT (checked immediately, undeferrable) would make that delete depend on
+        # the order Postgres fires the two cascades in. NOTE: merge_user hard-deletes a
+        # guest's duplicate active entry, which under this CASCADE would take its
+        # fixtures with it — the merge path handles that by *un-cutting* the event's
+        # draw, never by re-pointing these columns onto the survivor (that would seat one
+        # human in two pool slots and silently pass the go-live currency check). See
+        # ADR-786 and the model docstring; separate chore.
+        sa.Column(
+            "entry_a_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tournament_entries.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "entry_b_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tournament_entries.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        # Written back when this fixture's match completes (a later slice).
+        sa.Column(
+            "winner_entry_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tournament_entries.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        # Set when the fixture materializes into a real match, which only happens once
+        # the tournament is live (ADR-0786).
+        sa.Column(
+            "match_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("matches.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # The identity a re-cut reconciles on. NULLS NOT DISTINCT (Postgres 15+):
+        # under the default, a NULL pool_id compares unequal to itself, which would
+        # leave un-pooled draws (single-elim — every row has pool_id IS NULL) with no
+        # uniqueness guard whatsoever. NULL is a real domain value here ("this draw has
+        # no pools"), so it is compared as one.
+        sa.UniqueConstraint(
+            "event_id",
+            "pool_id",
+            "round",
+            "position",
+            name="uq_tournament_fixtures_event_id_pool_id_round_position",
+            postgresql_nulls_not_distinct=True,
+        ),
+    )
+    # Every read of a draw is "the fixtures of this event".
+    op.create_index(
+        "ix_tournament_fixtures_event_id", "tournament_fixtures", ["event_id"]
+    )
+    # A completed match writes ``winner_entry_id`` back and re-runs ``advance()``; that
+    # path arrives holding a match id, not a fixture id.
+    op.create_index(
+        "ix_tournament_fixtures_match_id", "tournament_fixtures", ["match_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tournament_fixtures_match_id", table_name="tournament_fixtures")
+    op.drop_index("ix_tournament_fixtures_event_id", table_name="tournament_fixtures")
+    op.drop_table("tournament_fixtures")

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
 dev = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.24",
+    "pytest-cov>=6.0",
+    "mutmut>=3.2",
     "httpx>=0.27.0",
     "fakeredis[lua]>=2.20",
     "testcontainers[postgres]>=4.8",
@@ -44,6 +46,61 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"
+
+[tool.coverage.run]
+source = ["app"]
+# **Load-bearing, not boilerplate.** SQLAlchemy's asyncio layer runs its sync-style
+# internals inside a greenlet (``greenlet_spawn``), and a greenlet switch swaps the
+# thread state coverage's tracer hangs off — so without this, tracing is silently lost
+# the moment a request first `await`s the database. Everything after that await goes
+# unrecorded: whole route bodies that the suite plainly exercises get reported as
+# uncovered (measured, on the same green suite: `app/tournaments.py` read 77% without
+# this line and 98% with it, and `create_event` — which every tournament test POSTs to —
+# read as entirely unexecuted). The numbers are not merely pessimistic, they are wrong,
+# and they are wrong in the direction that makes you go and write tests for lines that
+# were already covered.
+concurrency = ["thread", "greenlet"]
+
+[tool.mutmut]
+# Mutation testing — the DEFINITION_OF_COMPLETE gate for service/domain modules (≥80%).
+#
+#     TEST_DATABASE_URL=postgresql+asyncpg://... mutmut run --max-children 1
+#     mutmut results        # what survived
+#     mutmut show <mutant>  # the diff that survived
+#
+# Both flags are load-bearing, and neither is a preference:
+#
+# * TEST_DATABASE_URL, because `app/tournament_draws.py` is the half of the draw that
+#   touches the database, so its tests need one — and without this every mutant spins up
+#   its own testcontainers Postgres (~10s each, several hundred mutants).
+# * --max-children 1, because mutmut's children would otherwise share that one database
+#   and truncate each other's tables mid-test. The failures that causes are counted as
+#   MUTANTS KILLED — a contaminated run reports a *higher* score than an honest one, so
+#   the number would be wrong in the direction nobody checks.
+source_paths = ["app"]
+# The draw's two halves: `app/draws.py` is the pure planner (no session, no query) and
+# `app/tournament_draws.py` is the persistence around it. Add other service/domain
+# modules here as they come under the gate.
+only_mutate = ["app/draws.py", "app/tournament_draws.py"]
+# The tests that exercise them, and only those: mutmut re-runs the selection per mutant,
+# so pointing it at the whole suite would re-prove the notification taxonomy a few
+# hundred times.
+#
+# "And only those" is the cheap half of that sentence; "the tests that exercise them" is
+# the half that has to be *checked*, because a selection that misses a test file does not
+# fail — it reports a **survivor**, and a survivor is read as a hole in the suite. This
+# selection missed `tests/test_account_merge.py`, which is where `uncut_draw` is called
+# from `app/account_merge.py` (the merge un-cuts the draws its collision-resolution
+# invalidated) and where `cut_draw` is called directly to set that state up. A mutant in
+# `uncut_draw` duly "survived" a suite that already killed it, and the reflex a survivor
+# provokes is to go and write a test that exists. Grep the mutated modules for their
+# importers before trusting this list.
+pytest_add_cli_args_test_selection = [
+    "tests/test_draws.py",
+    "tests/test_tournaments.py",
+    "tests/test_tournament_fixtures.py",
+    "tests/test_account_merge.py",
+]
 
 [tool.ruff]
 target-version = "py313"

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
@@ -31,6 +31,7 @@ from app.models import (
     TournamentEntry,
     TournamentEntryStatus,
     TournamentEvent,
+    TournamentFixture,
     User,
     UserLeagueRating,
     UserRole,
@@ -38,6 +39,7 @@ from app.models import (
 )
 from app.roles import grant_default_role
 from app.sessions import SESSION_TOKEN_CONTEXT
+from app.tournament_draws import cut_draw
 from tests._helpers import start_session
 
 
@@ -487,16 +489,29 @@ async def _enter(
     *,
     status: TournamentEntryStatus = TournamentEntryStatus.entered,
     added_by: User | None = None,
+    seed: int | None = None,
+    created_at: datetime | None = None,
 ) -> TournamentEntry:
     """``added_by=None`` is not "unspecified" — it is self-registration, the
     default state of every entry (ADR-0784). Pass a user to make it a *director*
-    entry: that user put this player in the event."""
+    entry: that user put this player in the event.
+
+    ``created_at`` is settable because registration order is **load-bearing** — it
+    is the draw's ordering tie-break (``app.draws.order_entrants``) — so the
+    collision tests below need to say which of two entries came first rather than
+    hope the server clock separated two commits."""
     entry = TournamentEntry(
         event_id=event.id,
         user_id=user.id,
         status=status,
         added_by_user_id=added_by.id if added_by is not None else None,
+        seed=seed,
     )
+    if created_at is not None:
+        # Assigned rather than passed to the constructor: ``created_at`` carries a
+        # server default, and handing it an explicit ``None`` would insert NULL into
+        # a NOT NULL column instead of falling back to ``now()``.
+        entry.created_at = created_at
     db.add(entry)
     await db.commit()
     await db.refresh(entry)
@@ -894,6 +909,338 @@ async def test_merge_repoints_active_entry_over_survivors_withdrawn_row(
     assert all(e.user_id == verified.id for e in entries)
     active = [e for e in entries if e.status is TournamentEntryStatus.entered]
     assert [e.id for e in active] == [guest_active.id]
+
+
+# ----- entry collisions vs. a cut draw ------------------------------------
+#
+# The hazard the tests below pin (ADR-0786): ``tournament_fixtures`` references
+# ``tournament_entries`` with ON DELETE CASCADE, and the collision dedup above
+# HARD-DELETES the guest's duplicate active entry. Left alone, that silently
+# cascades away every fixture seating the guest — holes in a cut draw. The merge
+# instead un-cuts the event's draw, because a draw cut from a field that
+# double-counted a human is wrong throughout (its pool sizes and snake seeding
+# were computed against N+1 entrants), and carries the guest's earlier
+# registration onto the surviving entry, because registration order is the draw's
+# ordering tie-break.
+
+
+async def _make_rr_event(
+    db: AsyncSession,
+    owner: User,
+    *,
+    tournament: Tournament | None = None,
+    name: str = "Open Singles",
+) -> TournamentEvent:
+    """A **cuttable** event: round-robin with one pool. ``_make_event`` above is
+    single-elim, whose strategy is not implemented yet (``UnsupportedDrawType``),
+    so a draw cannot be cut from it.
+
+    One pool, not two, so that *every* entrant is seated in a fixture against every
+    other — which is what makes "the guest's entry is in this draw" true by
+    construction rather than by luck of the snake. Pass ``tournament`` to hang a
+    second event off the same tournament (the un-cut must be scoped to the event
+    that collided, not the tournament).
+    """
+    if tournament is None:
+        tournament = Tournament(
+            name="Guest Cup",
+            league_id=await _default_league_id(db),
+            created_by_user_id=owner.id,
+            address={
+                "venue": "Berkeley TT Club",
+                "street": "2727 Milvia St",
+                "city": "Berkeley",
+                "region": "CA",
+                "postal": "94703",
+                "country": "USA",
+            },
+            table_catalogue=[{"id": "t1", "label": "Table 1", "court": "A"}],
+        )
+    slot = {"date": "2026-06-13", "start": "09:00", "end": "18:00"}
+    event = TournamentEvent(
+        name=name,
+        format=EventFormat.singles,
+        draw_type=DrawType.round_robin,
+        max_players=32,
+        entry_fee=40,
+        slot=slot,
+        match_settings={"rated": True, "length_games": 5},
+        predicates=[],
+        pools=[{"id": "pool-a", "name": "Pool A", "slot": slot, "table_ids": ["t1"]}],
+    )
+    tournament.events.append(event)
+    db.add(tournament)
+    await db.commit()
+    await db.refresh(event)
+    return event
+
+
+async def _cut(db: AsyncSession, event: TournamentEvent) -> list[TournamentFixture]:
+    """Cut the event's draw and hand back the fixtures it wrote. ``cut_draw`` does
+    not commit (the route owns the transaction), so this does."""
+    await cut_draw(db, event)
+    await db.commit()
+    return await _fixtures_for(db, event)
+
+
+async def _fixtures_for(
+    db: AsyncSession, event: TournamentEvent
+) -> list[TournamentFixture]:
+    # ``populate_existing`` for the same reason ``_entries_for`` uses it: the merge
+    # writes with bulk statements the identity map never sees, and the test
+    # sessionmaker does not expire on commit — a plain SELECT would hand back stale
+    # copies of rows the un-cut deleted.
+    return list(
+        (
+            await db.execute(
+                select(TournamentFixture)
+                .where(TournamentFixture.event_id == event.id)
+                .execution_options(populate_existing=True)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+def _seats(fixtures: list[TournamentFixture]) -> set[tuple]:
+    """The identity + contents of each fixture — what a re-point onto the survivor
+    (or a cascade hole) would change, and a genuinely untouched draw would not."""
+    return {
+        (f.id, f.pool_id, f.round, f.position, f.entry_a_id, f.entry_b_id)
+        for f in fixtures
+    }
+
+
+async def _fixtures_referencing(db: AsyncSession, entry_id: uuid.UUID) -> int:
+    """How many fixtures **anywhere** name this entry, on any of its three entry
+    columns. A merge that re-pointed the guest's fixtures onto the survivor would
+    leave this at zero too — which is why the tests assert it *alongside* the
+    event's fixture count, never instead of it."""
+    return len(
+        (
+            await db.execute(
+                select(TournamentFixture.id).where(
+                    (TournamentFixture.entry_a_id == entry_id)
+                    | (TournamentFixture.entry_b_id == entry_id)
+                    | (TournamentFixture.winner_entry_id == entry_id)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def test_merge_uncuts_the_draw_when_the_collision_double_counted_a_human(
+    db_session: AsyncSession,
+):
+    """The whole point (ADR-0786). Guest and survivor are BOTH actively entered in an
+    event whose draw is already cut — so the cut draw seats one human twice, and every
+    pool size and seeding decision in it was computed against a field of N+1.
+
+    The dedup deletes the guest's duplicate entry, and ``tournament_fixtures`` cascades
+    on that delete — so doing nothing else would leave the draw **holed**: fixtures
+    silently gone from a draw the director still believes is cut. The tempting repair
+    (re-point the guest's fixtures onto the surviving entry) is worse than the holes: it
+    seats one person in two slots of the same pool, and because the go-live currency
+    check compares entrant *sets*, the corrupted draw would satisfy it and go live.
+
+    So the draw is **un-cut**: zero fixtures, and the director re-cuts from the field
+    that actually exists.
+    """
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    other = await _make_verified(db_session, "pete@example.com")
+    event = await _make_rr_event(db_session, verified)
+
+    earlier = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+    guest_entry = await _enter(db_session, event, ephemeral, created_at=earlier)
+    survivor_entry = await _enter(
+        db_session, event, verified, created_at=earlier + timedelta(hours=2)
+    )
+    await _enter(db_session, event, other, created_at=earlier + timedelta(hours=3))
+
+    before = await _cut(db_session, event)
+    assert len(before) == 3, "a one-pool round-robin of three seats three fixtures"
+    assert await _fixtures_referencing(db_session, guest_entry.id) == 2, (
+        "precondition: the guest's entry really is in this draw — without it the "
+        "assertions below would pass against a draw that never seated them"
+    )
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    assert await _fixtures_for(db_session, event) == [], (
+        "the draw must be UN-CUT, not holed: a field that double-counted a human is "
+        "wrong throughout, so it is re-cut, never patched"
+    )
+    assert await _fixtures_referencing(db_session, guest_entry.id) == 0
+    assert await _fixtures_referencing(db_session, survivor_entry.id) == 0, (
+        "and the guest's fixtures must not have been re-pointed onto the survivor — "
+        "that seats one human in two slots and would pass the go-live currency check"
+    )
+
+    entries = await _entries_for(db_session, event)
+    active = [e for e in entries if e.status is TournamentEntryStatus.entered]
+    assert {e.id for e in active} == {
+        survivor_entry.id,
+        *(e.id for e in entries if e.user_id == other.id),
+    }
+    mine = [e for e in active if e.user_id == verified.id]
+    assert [e.id for e in mine] == [survivor_entry.id], (
+        "one person, one active entry — the survivor's row is the one that stands"
+    )
+
+
+async def test_merge_carries_the_earlier_registration_onto_the_surviving_entry(
+    db_session: AsyncSession,
+):
+    """Registration order is **load-bearing**: it is the draw's ordering tie-break for
+    the unseeded (``app.draws.order_entrants`` — seed ascending where set, then
+    ``created_at``). The guest registered FIRST and the survivor second, so keeping the
+    survivor's row untouched would silently move that player *down* the next draw — a
+    place they lose by having signed in.
+
+    So the survivor's entry inherits the earlier ``created_at``, and the guest's seed
+    where the survivor has none (a seed is a director's decision about this player, and
+    it does not evaporate because they turned out to already have an account).
+    """
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    event = await _make_rr_event(db_session, verified)
+
+    earlier = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+    later = datetime(2026, 6, 2, 9, 0, tzinfo=UTC)
+    await _enter(db_session, event, ephemeral, created_at=earlier, seed=3)
+    survivor_entry = await _enter(db_session, event, verified, created_at=later)
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    entries = await _entries_for(db_session, event)
+    assert [e.id for e in entries] == [survivor_entry.id]
+    assert entries[0].created_at == earlier, (
+        "the surviving entry must carry the EARLIER of the two registrations — "
+        "keeping the survivor's own timestamp demotes them in the next draw"
+    )
+    assert entries[0].seed == 3, (
+        "an unseeded survivor adopts the guest's seed; the seeding is a fact about "
+        "the player, not about which of their two sessions holds the row"
+    )
+
+
+async def test_merge_keeps_the_survivors_seed_when_both_entries_carry_one(
+    db_session: AsyncSession,
+):
+    """The other arm of the seed rule. The survivor's row is the one that stands, so
+    where BOTH entries carry a seed, the survivor's wins — the merge is not licensed to
+    overwrite a seed the director set on the row it is keeping. (The earlier
+    ``created_at`` still carries: the two are independent.)"""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    event = await _make_rr_event(db_session, verified)
+
+    earlier = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+    await _enter(db_session, event, ephemeral, created_at=earlier, seed=7)
+    survivor_entry = await _enter(
+        db_session,
+        event,
+        verified,
+        created_at=earlier + timedelta(days=1),
+        seed=2,
+    )
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    entries = await _entries_for(db_session, event)
+    assert [e.id for e in entries] == [survivor_entry.id]
+    assert entries[0].seed == 2, "the survivor's own seed stands"
+    assert entries[0].created_at == earlier
+
+
+async def test_a_merge_without_a_collision_leaves_a_cut_draw_completely_intact(
+    db_session: AsyncSession,
+):
+    """The other half of the contract, and the one an over-eager fix would break. Only
+    the GUEST was entered — there is no collision, nothing is double-counted, and the
+    merge simply re-points ``tournament_entries.user_id`` onto the survivor. The entry
+    ids do not change, so the draw cut from them still seats exactly the field it always
+    did.
+
+    Un-cutting *this* draw would destroy a perfectly good one every time a director who
+    entered a player signs in. Same fixture ids, same count, same contents.
+    """
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    other = await _make_verified(db_session, "pete@example.com")
+    event = await _make_rr_event(db_session, verified)
+
+    guest_entry = await _enter(db_session, event, ephemeral)
+    await _enter(db_session, event, other)
+
+    before = await _cut(db_session, event)
+    assert len(before) == 1, "two entrants in one pool meet exactly once"
+    before_seats = _seats(before)
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    after = await _fixtures_for(db_session, event)
+    assert _seats(after) == before_seats, (
+        "no collision, no double count — the draw must be untouched: same fixture "
+        "ids, same sides. The entry the guest held simply belongs to the survivor now."
+    )
+    entries = await _entries_for(db_session, event)
+    assert guest_entry.id in {e.id for e in entries}
+    assert {e.user_id for e in entries} == {verified.id, other.id}
+
+
+async def test_the_uncut_is_scoped_to_the_event_that_collided(
+    db_session: AsyncSession,
+):
+    """The un-cut is a fact about one **event**, not about the tournament or the player.
+    A second event of the same tournament, drawn from a field that never double-counted
+    anybody, is a good draw — and losing it would make every merge a tournament-wide
+    demolition.
+    """
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    other = await _make_verified(db_session, "pete@example.com")
+
+    collided = await _make_rr_event(db_session, verified, name="Open Singles")
+    tournament = (
+        await db_session.execute(
+            select(Tournament)
+            .where(Tournament.id == collided.tournament_id)
+            .options(selectinload(Tournament.events))
+        )
+    ).scalar_one()
+    bystander = await _make_rr_event(
+        db_session, verified, tournament=tournament, name="Over 40s"
+    )
+
+    # The collision, on the first event only.
+    await _enter(db_session, event=collided, user=ephemeral)
+    await _enter(db_session, event=collided, user=verified)
+    await _enter(db_session, event=collided, user=other)
+    # The second event's field is unremarkable: the survivor and a bystander.
+    await _enter(db_session, event=bystander, user=verified)
+    await _enter(db_session, event=bystander, user=other)
+
+    assert len(await _cut(db_session, collided)) == 3
+    bystander_seats = _seats(await _cut(db_session, bystander))
+    assert len(bystander_seats) == 1
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    assert await _fixtures_for(db_session, collided) == []
+    assert _seats(await _fixtures_for(db_session, bystander)) == bystander_seats, (
+        "the un-cut must be scoped to the event whose field double-counted a human — "
+        "a sibling event's good draw is not the merge's to throw away"
+    )
 
 
 async def test_merge_repoints_rating_history_created_by(

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -486,8 +486,17 @@ async def _enter(
     user: User,
     *,
     status: TournamentEntryStatus = TournamentEntryStatus.entered,
+    added_by: User | None = None,
 ) -> TournamentEntry:
-    entry = TournamentEntry(event_id=event.id, user_id=user.id, status=status)
+    """``added_by=None`` is not "unspecified" — it is self-registration, the
+    default state of every entry (ADR-0784). Pass a user to make it a *director*
+    entry: that user put this player in the event."""
+    entry = TournamentEntry(
+        event_id=event.id,
+        user_id=user.id,
+        status=status,
+        added_by_user_id=added_by.id if added_by is not None else None,
+    )
     db.add(entry)
     await db.commit()
     await db.refresh(entry)
@@ -543,6 +552,197 @@ async def test_merge_repoints_tournament_entry_onto_survivor(
     assert len(active) == 1, "the event's active-entry count must not change"
     # Nothing left pointing at the tombstone.
     assert not [e for e in entries if e.user_id == ephemeral.id]
+
+
+async def test_merge_repoints_the_entry_adder_onto_survivor(
+    db_session: AsyncSession,
+):
+    """The *second* users FK on ``tournament_entries``: ``added_by_user_id``, who
+    put this player in the event (ADR-0784).
+
+    A guest DIRECTOR entered somebody, then signed in. The entry itself is not in
+    question — a real player is really entered, and their ``user_id`` is not the
+    guest's to move. What must not survive is the *pointer*: the guest is about to
+    become a tombstone, and an unhandled FK would leave the entry saying "added by
+    <ghost>" — a user that no listing, search or auth query will ever return. The
+    adder and the survivor are the same human, so the adder follows the merge.
+    """
+    director_guest = await _make_ephemeral(db_session, "drifting-grouse")
+    director = await _make_verified(db_session, "rita@example.com")
+    player = await _make_verified(db_session, "pete@example.com")
+    event = await _make_event(db_session, director_guest)
+
+    entry = await _enter(db_session, event, player, added_by=director_guest)
+
+    await merge_user(db_session, from_user_id=director_guest.id, to_user_id=director.id)
+    await db_session.commit()
+
+    await db_session.refresh(entry)
+    assert entry.added_by_user_id == director.id, (
+        "the adder must point at the LIVE survivor, not the tombstoned guest"
+    )
+    # The entrant is a third party and is untouched: this merge is about who
+    # *added* them, not about who they are.
+    assert entry.user_id == player.id
+    assert entry.status is TournamentEntryStatus.entered
+
+    entries = await _entries_for(db_session, event)
+    assert not [e for e in entries if e.added_by_user_id == director_guest.id]
+
+
+async def test_merge_nulls_the_adder_when_the_director_turns_out_to_be_the_entrant(
+    db_session: AsyncSession,
+):
+    """The degenerate case of the re-point, and the reason it is a ``CASE`` rather
+    than a flat ``SET added_by_user_id = :to_id``.
+
+    I run a tournament as a guest and add "Rita" (an existing account) from the
+    player search. Then I sign in — and I *am* Rita. Post-merge, one person both
+    added the entry and is the entry. That is self-registration, and
+    self-registration is spelled ``NULL`` (ADR-0784). A flat re-point would instead
+    write ``added_by_user_id == user_id``, a second, contradictory encoding of "she
+    entered herself" that the entrants list would render as "added by the
+    director" — a director who is the player.
+    """
+    director_guest = await _make_ephemeral(db_session, "drifting-grouse")
+    rita = await _make_verified(db_session, "rita@example.com")
+    event = await _make_event(db_session, director_guest)
+
+    entry = await _enter(db_session, event, rita, added_by=director_guest)
+
+    await merge_user(db_session, from_user_id=director_guest.id, to_user_id=rita.id)
+    await db_session.commit()
+
+    await db_session.refresh(entry)
+    assert entry.user_id == rita.id
+    assert entry.added_by_user_id is None, (
+        "one person adding themselves IS self-registration — collapse it to NULL"
+    )
+
+
+async def test_merge_leaves_the_adder_alone_when_the_ENTRANT_is_the_one_merged(
+    db_session: AsyncSession,
+):
+    """The mirror image, and the guard against the re-point over-firing: here it is
+    the *player* who was a guest, and the director is a bystander. The entry's
+    ``user_id`` moves to the survivor; the record of who added them must not be
+    touched — least of all nulled, which would erase a director entry into a
+    self-registration that never happened."""
+    player_guest = await _make_ephemeral(db_session, "drifting-grouse")
+    player = await _make_verified(db_session, "pete@example.com")
+    director = await _make_verified(db_session, "rita@example.com")
+    event = await _make_event(db_session, director)
+
+    entry = await _enter(db_session, event, player_guest, added_by=director)
+
+    await merge_user(db_session, from_user_id=player_guest.id, to_user_id=player.id)
+    await db_session.commit()
+
+    await db_session.refresh(entry)
+    assert entry.user_id == player.id
+    assert entry.added_by_user_id == director.id
+
+
+async def test_merge_collapses_a_guest_who_both_added_and_is_the_entry(
+    db_session: AsyncSession,
+):
+    """**The statement ORDER inside ``merge_user`` is load-bearing, and this is the only
+    test that pins it.**
+
+    ``merge_user`` re-points ``tournament_entries.user_id`` onto the survivor, and only
+    *then* runs the ``CASE`` over ``added_by_user_id`` — a CASE whose condition
+    (``user_id = :to_id``) reads the **post-merge** ``user_id``. Swap the two statements
+    and every other test in this file still passes, because in all of them the entry's
+    ``user_id`` is either already the survivor's or is never the adder's.
+
+    The shape that tells the two orders apart is the one where the guest is **both** the
+    entrant and the adder — ``user_id == added_by == from_id``:
+
+    * **Correct order.** ``user_id`` becomes ``to_id``; the CASE then sees
+      ``user_id = to_id`` and writes **NULL** — one person adding themselves *is*
+      self-registration, and self-registration is spelled NULL (ADR-0784).
+    * **Reversed.** The CASE runs while ``user_id`` is still the guest's, so it does not
+      match ``to_id`` and writes ``added_by = to_id``; the re-point then sets
+      ``user_id = to_id`` as well. The merge has *manufactured* ``added_by == user_id``
+      — the second, contradictory encoding of "they entered themselves" that the CASE
+      exists to prevent, rendered by the entrants list as "added by the director" on an
+      entry whose director is the player.
+
+    The row is written **directly**, and deliberately so: the entry route refuses to
+    mint this shape (an owner naming their own ``user_id`` is self-registration, stored
+    NULL — ``test_the_owner_entering_themselves_by_user_id_records_no_adder``), and
+    there is no CHECK constraint standing behind it either, because the entry route maps
+    ``IntegrityError`` to a ``already_entered`` 409 and a constraint violation would
+    surface to a player as a false "you have already entered this event". Normalising in
+    the handler is what keeps the column clean; *this* is what keeps the merge from
+    quietly undoing that.
+    """
+    guest = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    event = await _make_event(db_session, guest)
+
+    # The guest is the entrant AND the adder: user_id == added_by_user_id == from_id.
+    entry = await _enter(db_session, event, guest, added_by=guest)
+
+    await merge_user(db_session, from_user_id=guest.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    await db_session.refresh(entry)
+    assert entry.user_id == verified.id
+    assert entry.added_by_user_id is None, (
+        "the CASE must read the POST-merge user_id: run it before the user_id re-point "
+        "and it writes added_by = user_id, the very encoding it exists to collapse"
+    )
+    assert entry.added_by_user_id != entry.user_id
+
+
+async def test_merge_collapses_the_adder_when_the_ENTRANT_merges_into_the_director(
+    db_session: AsyncSession,
+):
+    """The **mirror** of the case above, and the one the merge could *manufacture*.
+
+    There, the guest was both the entrant and the adder before the merge. Here neither
+    id is contradictory to begin with — the merge makes it so:
+
+    * Director **D** (a real account) enters **guest player P** through
+      ``POST …/entries`` (ADR-0784), so the row is ``user_id = P``, ``added_by = D``.
+      Both perfectly ordinary; this is the shape the director's arm of the entry route
+      writes every time it is used.
+    * P signs in — and turns out to BE D (the director had a guest session of their own
+      on the club laptop). ``merge_user(from=P, to=D)``.
+    * The ``user_id`` re-point rewrites ``user_id`` to D. ``added_by`` is *already* D.
+
+    One person is now both the entrant and the adder, so — exactly as in the case above
+    — this is self-registration and must be spelled ``NULL``. A CASE guarded by
+    ``WHERE added_by_user_id = :from_id`` alone never even looks at this row (its adder
+    is the *survivor*, not the guest), and leaves ``added_by == user_id``: the second,
+    contradictory encoding of "she entered herself", written by the merge itself.
+    ``WHERE added_by_user_id IN (:from_id, :to_id)`` is what closes it.
+
+    Note what this is NOT: the entrant merging into a *bystander* director must leave
+    the adder alone (``test_merge_leaves_the_adder_alone_when_the_ENTRANT_is_the_one_
+    merged``). The difference is whether the director and the survivor are the same
+    person — which is the only thing that makes "added by the director" a lie.
+    """
+    player_guest = await _make_ephemeral(db_session, "drifting-grouse")
+    director = await _make_verified(db_session, "rita@example.com")
+    event = await _make_event(db_session, director)
+
+    # The row the director's entry route writes: a real player, added by a real
+    # director. Nothing contradictory about it — yet.
+    entry = await _enter(db_session, event, player_guest, added_by=director)
+
+    # ...and the guest player turns out to be the director.
+    await merge_user(db_session, from_user_id=player_guest.id, to_user_id=director.id)
+    await db_session.commit()
+
+    await db_session.refresh(entry)
+    assert entry.user_id == director.id
+    assert entry.added_by_user_id is None, (
+        "the merge just made the adder and the entrant one person — that is "
+        "self-registration, and it is spelled NULL, never added_by == user_id"
+    )
+    assert entry.added_by_user_id != entry.user_id
 
 
 async def test_merge_dedups_entry_when_both_users_entered_same_event(

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -1,0 +1,483 @@
+"""Unit tests for the pure draw-planning domain (``app.draws``, ADR-0786).
+
+No database, no app — every test here builds its input from literals, which is the
+point of keeping the strategies pure.
+"""
+
+import uuid
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from itertools import combinations
+
+import pytest
+
+from app.draws import (
+    AdvancePlan,
+    DegenerateDraw,
+    DrawConfig,
+    DrawError,
+    Entrant,
+    EntryId,
+    FixtureId,
+    FixtureState,
+    MatchId,
+    OrderedEntrant,
+    PlannedFixture,
+    PoolId,
+    RoundRobinStrategy,
+    UnsupportedDrawType,
+    order_entrants,
+    strategy_for,
+)
+from app.models.tournament import DrawType
+
+REGISTRATION_OPENED = datetime(2026, 7, 1, 9, 0, tzinfo=UTC)
+
+
+def _entry_id(n: int) -> EntryId:
+    """A stable, readable entry id — ``…-0000000000NN``."""
+    return EntryId(uuid.UUID(int=n))
+
+
+def _entrant(n: int, *, seed: int | None = None, minutes: int = 0) -> Entrant:
+    return Entrant(
+        entry_id=_entry_id(n),
+        seed=seed,
+        created_at=REGISTRATION_OPENED + timedelta(minutes=minutes),
+    )
+
+
+def _ordered(count: int) -> list[OrderedEntrant]:
+    """``count`` entrants in draw order: entrant ``i`` is seed ``i`` (1-based)."""
+    return [
+        OrderedEntrant(entry_id=_entry_id(i), position=i) for i in range(1, count + 1)
+    ]
+
+
+def _seed_of(entry_id: EntryId | None) -> int:
+    """Invert :func:`_ordered` — the seed number behind an entry id."""
+    assert entry_id is not None
+    return entry_id.int
+
+
+def _pool_ids(count: int) -> tuple[PoolId, ...]:
+    """``('A', 'B', …)`` — pool ids are string refs into the event's JSONB pools."""
+    return tuple(PoolId(chr(ord("A") + i)) for i in range(count))
+
+
+def _config(pool_count: int) -> DrawConfig:
+    return DrawConfig(draw_type=DrawType.round_robin, pool_ids=_pool_ids(pool_count))
+
+
+def _members_by_pool(fixtures: list[PlannedFixture]) -> dict[PoolId | None, set[int]]:
+    """Pool membership is *derived from the fixtures* — there is no assignment table
+    (ADR-0786), so this is how the rest of the system will read it too."""
+    members: dict[PoolId | None, set[int]] = {}
+    for f in fixtures:
+        members.setdefault(f.pool_id, set()).update(
+            {_seed_of(f.entry_a_id), _seed_of(f.entry_b_id)}
+        )
+    return members
+
+
+def _pairs_by_pool(
+    fixtures: list[PlannedFixture],
+) -> dict[PoolId | None, list[tuple[int, int]]]:
+    """Every fixture as a seed pair, normalized so (1,2) and (2,1) are the same pair."""
+    pairs: dict[PoolId | None, list[tuple[int, int]]] = {}
+    for f in fixtures:
+        a, b = _seed_of(f.entry_a_id), _seed_of(f.entry_b_id)
+        pairs.setdefault(f.pool_id, []).append((min(a, b), max(a, b)))
+    return pairs
+
+
+# The matrix the draw must hold for: (entrants, pools) → the exact snake membership,
+# spelled out by hand rather than recomputed, so a broken snake cannot agree with a
+# broken expectation. Pool A takes 1, 2P, 2P+1, …; pool B takes 2, 2P−1, …
+SNAKE_MATRIX: list[tuple[int, int, dict[str, list[int]]]] = [
+    (5, 1, {"A": [1, 2, 3, 4, 5]}),
+    (6, 2, {"A": [1, 4, 5], "B": [2, 3, 6]}),
+    (7, 2, {"A": [1, 4, 5], "B": [2, 3, 6, 7]}),
+    (9, 3, {"A": [1, 6, 7], "B": [2, 5, 8], "C": [3, 4, 9]}),
+]
+MATRIX_IDS = [f"N={n},P={p}" for n, p, _ in SNAKE_MATRIX]
+
+
+class TestOrderEntrants:
+    def test_seeded_ascend_before_unseeded_which_follow_registration_order(
+        self,
+    ) -> None:
+        # Deliberately shuffled input: the *order it arrives in* must not matter.
+        entrants = [
+            _entrant(1, minutes=30),  # unseeded, registered 3rd
+            _entrant(2, seed=2, minutes=90),  # seeded 2, registered last
+            _entrant(3, minutes=10),  # unseeded, registered 2nd
+            _entrant(4, seed=1, minutes=60),  # seeded 1, registered 4th
+            _entrant(5, minutes=5),  # unseeded, registered 1st
+        ]
+
+        assert [e.entry_id for e in order_entrants(entrants)] == [
+            _entry_id(4),  # seed 1
+            _entry_id(2),  # seed 2
+            _entry_id(5),  # then the unseeded, oldest registration first
+            _entry_id(3),
+            _entry_id(1),
+        ]
+
+    def test_positions_are_one_based_and_contiguous(self) -> None:
+        ordered = order_entrants([_entrant(i, minutes=i) for i in range(1, 5)])
+
+        assert [e.position for e in ordered] == [1, 2, 3, 4]
+
+    def test_all_unseeded_is_pure_registration_order(self) -> None:
+        ordered = order_entrants(
+            [_entrant(1, minutes=50), _entrant(2, minutes=10), _entrant(3, minutes=30)]
+        )
+
+        assert [e.entry_id for e in ordered] == [
+            _entry_id(2),
+            _entry_id(3),
+            _entry_id(1),
+        ]
+
+    def test_a_seed_never_loses_to_an_earlier_registration(self) -> None:
+        # The unseeded entrant registered first; the seed still leads the draw.
+        ordered = order_entrants(
+            [_entrant(1, minutes=0), _entrant(2, seed=7, minutes=99)]
+        )
+
+        assert [e.entry_id for e in ordered] == [_entry_id(2), _entry_id(1)]
+
+    def test_identical_registration_instants_still_order_deterministically(
+        self,
+    ) -> None:
+        # Same created_at (one transaction, one clock read) — the entry id breaks the
+        # tie, because a re-cut must reproduce the draw exactly. No randomness anywhere.
+        entrants = [_entrant(i, minutes=0) for i in (3, 1, 2)]
+
+        first = order_entrants(entrants)
+        second = order_entrants(list(reversed(entrants)))
+
+        assert first == second
+        assert [e.entry_id for e in first] == [_entry_id(1), _entry_id(2), _entry_id(3)]
+
+    def test_no_entrants_is_an_empty_order_not_an_error(self) -> None:
+        assert order_entrants([]) == []
+
+
+class TestStrategyRegistry:
+    def test_round_robin_resolves_to_the_round_robin_strategy(self) -> None:
+        assert isinstance(strategy_for(DrawType.round_robin), RoundRobinStrategy)
+
+    @pytest.mark.parametrize(
+        "draw_type",
+        [
+            DrawType.single_elim,
+            DrawType.double_elim,
+            DrawType.rr_then_ko,
+            DrawType.swiss,
+        ],
+    )
+    def test_unimplemented_types_raise_a_typed_catchable_domain_error(
+        self, draw_type: DrawType
+    ) -> None:
+        with pytest.raises(UnsupportedDrawType) as excinfo:
+            strategy_for(draw_type)
+
+        # The route needs to know *which* type it refused, to say so in the 422.
+        assert excinfo.value.draw_type is draw_type
+        # And it must be catchable as the one domain base a route handler switches on.
+        assert isinstance(excinfo.value, DrawError)
+
+    def test_every_draw_type_is_handled_one_way_or_the_other(self) -> None:
+        # The match has no catch-all, so an unhandled member would fall through and
+        # return None. Nothing may resolve to None — it must be a strategy or a refusal.
+        for draw_type in DrawType:
+            try:
+                assert strategy_for(draw_type) is not None
+            except UnsupportedDrawType:
+                pass
+
+
+class TestRoundRobinCut:
+    @pytest.mark.parametrize(
+        ("entrants", "pools", "expected"), SNAKE_MATRIX, ids=MATRIX_IDS
+    )
+    def test_entrants_are_snaked_across_the_pools(
+        self, entrants: int, pools: int, expected: dict[str, list[int]]
+    ) -> None:
+        fixtures = RoundRobinStrategy().plan_initial(_config(pools), _ordered(entrants))
+
+        members = _members_by_pool(fixtures)
+        assert {str(k): sorted(v) for k, v in members.items()} == expected
+
+    @pytest.mark.parametrize(
+        ("entrants", "pools", "expected"), SNAKE_MATRIX, ids=MATRIX_IDS
+    )
+    def test_pool_sizes_differ_by_at_most_one_and_cover_every_entrant(
+        self, entrants: int, pools: int, expected: dict[str, list[int]]
+    ) -> None:
+        fixtures = RoundRobinStrategy().plan_initial(_config(pools), _ordered(entrants))
+
+        sizes = [len(m) for m in _members_by_pool(fixtures).values()]
+        assert len(sizes) == pools
+        assert max(sizes) - min(sizes) <= 1
+        assert sum(sizes) == entrants
+
+    @pytest.mark.parametrize(
+        ("entrants", "pools", "expected"), SNAKE_MATRIX, ids=MATRIX_IDS
+    )
+    def test_every_within_pool_pair_meets_exactly_once_and_no_cross_pool_pair_exists(
+        self, entrants: int, pools: int, expected: dict[str, list[int]]
+    ) -> None:
+        fixtures = RoundRobinStrategy().plan_initial(_config(pools), _ordered(entrants))
+
+        pairs_by_pool = _pairs_by_pool(fixtures)
+        assert set(pairs_by_pool) == {PoolId(p) for p in expected}
+
+        for pool_id, seeds in expected.items():
+            pairs = pairs_by_pool[PoolId(pool_id)]
+            n = len(seeds)
+            # All-play-all: exactly n(n-1)/2 fixtures...
+            assert len(pairs) == n * (n - 1) // 2
+            # ...no pair twice...
+            assert max(Counter(pairs).values()) == 1
+            # ...and precisely the pairs of THIS pool's members — which is also what
+            # rules out any cross-pool pairing, since no other seed appears at all.
+            assert set(pairs) == {
+                (min(a, b), max(a, b)) for a, b in combinations(sorted(seeds), 2)
+            }
+
+    @pytest.mark.parametrize(
+        ("entrants", "pools", "expected"), SNAKE_MATRIX, ids=MATRIX_IDS
+    )
+    def test_nobody_plays_twice_in_the_same_round_of_their_pool(
+        self, entrants: int, pools: int, expected: dict[str, list[int]]
+    ) -> None:
+        fixtures = RoundRobinStrategy().plan_initial(_config(pools), _ordered(entrants))
+
+        per_round: dict[tuple[PoolId | None, int], list[int]] = {}
+        for f in fixtures:
+            per_round.setdefault((f.pool_id, f.round), []).extend(
+                [_seed_of(f.entry_a_id), _seed_of(f.entry_b_id)]
+            )
+
+        for (pool_id, round_number), seeds in per_round.items():
+            assert len(seeds) == len(set(seeds)), (
+                f"pool {pool_id} round {round_number} plays someone twice: {seeds}"
+            )
+
+    @pytest.mark.parametrize(
+        ("entrants", "pools", "expected"), SNAKE_MATRIX, ids=MATRIX_IDS
+    )
+    def test_rounds_and_positions_are_one_based_and_contiguous(
+        self, entrants: int, pools: int, expected: dict[str, list[int]]
+    ) -> None:
+        fixtures = RoundRobinStrategy().plan_initial(_config(pools), _ordered(entrants))
+
+        for pool_id, seeds in expected.items():
+            pool_fixtures = [f for f in fixtures if f.pool_id == PoolId(pool_id)]
+            n = len(seeds)
+            # An even pool plays n-1 rounds; an odd one needs n (each entrant sits out
+            # exactly once), which is the whole reason a bye exists.
+            expected_rounds = n - 1 if n % 2 == 0 else n
+            rounds = sorted({f.round for f in pool_fixtures})
+            assert rounds == list(range(1, expected_rounds + 1))
+
+            for round_number in rounds:
+                positions = sorted(
+                    f.position for f in pool_fixtures if f.round == round_number
+                )
+                # 1-based and gapless *within the round* — a dropped bye must not leave
+                # a hole in the numbering.
+                assert positions == list(range(1, len(positions) + 1))
+
+    @pytest.mark.parametrize(
+        ("entrants", "pools", "expected"), SNAKE_MATRIX, ids=MATRIX_IDS
+    )
+    def test_a_bye_is_the_absence_of_a_fixture_never_a_null_side(
+        self, entrants: int, pools: int, expected: dict[str, list[int]]
+    ) -> None:
+        fixtures = RoundRobinStrategy().plan_initial(_config(pools), _ordered(entrants))
+
+        # NULL means "TBD" and nothing else; a round-robin fixture is never TBD.
+        assert all(
+            f.entry_a_id is not None and f.entry_b_id is not None for f in fixtures
+        )
+
+        for pool_id, seeds in expected.items():
+            n = len(seeds)
+            if n % 2 == 0:
+                continue
+            # An odd pool sits one entrant out per round: (n-1)/2 fixtures, not n/2
+            # rounded up, and certainly not a phantom row.
+            per_round = Counter(
+                f.round for f in fixtures if f.pool_id == PoolId(pool_id)
+            )
+            assert set(per_round.values()) == {(n - 1) // 2}
+
+    def test_the_same_input_cuts_the_same_draw_twice(self) -> None:
+        # Re-cutting is a sanctioned, reviewable act — it must be reproducible, which
+        # is why the ordering has no rating fallback and no randomness.
+        strategy = RoundRobinStrategy()
+        config, entrants = _config(3), _ordered(9)
+
+        assert strategy.plan_initial(config, entrants) == strategy.plan_initial(
+            config, entrants
+        )
+
+    def test_a_fresh_strategy_instance_cuts_the_same_draw(self) -> None:
+        config, entrants = _config(2), _ordered(7)
+
+        assert RoundRobinStrategy().plan_initial(
+            config, entrants
+        ) == RoundRobinStrategy().plan_initial(config, entrants)
+
+    def test_the_smallest_legal_pool_is_two_entrants_playing_once(self) -> None:
+        fixtures = RoundRobinStrategy().plan_initial(_config(1), _ordered(2))
+
+        assert fixtures == [
+            PlannedFixture(
+                pool_id=PoolId("A"),
+                round=1,
+                position=1,
+                entry_a_id=_entry_id(1),
+                entry_b_id=_entry_id(2),
+            )
+        ]
+
+    @pytest.mark.parametrize(
+        ("entrants", "pools"),
+        [
+            (1, 1),  # a lone entrant has nobody to play
+            (0, 1),  # a ghost pool
+            (3, 2),  # the snake would leave pool B with one entrant
+            (5, 3),  # ...and pool C with one
+        ],
+    )
+    def test_a_pool_of_fewer_than_two_is_refused(
+        self, entrants: int, pools: int
+    ) -> None:
+        with pytest.raises(DegenerateDraw) as excinfo:
+            RoundRobinStrategy().plan_initial(_config(pools), _ordered(entrants))
+
+        assert isinstance(excinfo.value, DrawError)
+
+    def test_a_draw_with_no_pools_is_refused(self) -> None:
+        with pytest.raises(DegenerateDraw):
+            RoundRobinStrategy().plan_initial(
+                DrawConfig(draw_type=DrawType.round_robin, pool_ids=()), _ordered(4)
+            )
+
+    def test_pools_are_named_by_the_events_own_pool_ids(self) -> None:
+        # A pool id is a string ref into the event's JSONB pools, not an index we mint.
+        config = DrawConfig(
+            draw_type=DrawType.round_robin,
+            pool_ids=(PoolId("pool-morning"), PoolId("pool-evening")),
+        )
+
+        fixtures = RoundRobinStrategy().plan_initial(config, _ordered(6))
+
+        assert {f.pool_id for f in fixtures} == {
+            PoolId("pool-morning"),
+            PoolId("pool-evening"),
+        }
+
+
+def _persisted(
+    planned: list[PlannedFixture], *, materialized: bool = False
+) -> list[FixtureState]:
+    """The planned fixtures as they'd read back after ``plan_initial`` was persisted."""
+    return [
+        FixtureState(
+            fixture_id=FixtureId(uuid.UUID(int=1000 + i)),
+            pool_id=f.pool_id,
+            round=f.round,
+            position=f.position,
+            entry_a_id=f.entry_a_id,
+            entry_b_id=f.entry_b_id,
+            match_id=MatchId(uuid.UUID(int=2000 + i)) if materialized else None,
+        )
+        for i, f in enumerate(planned)
+    ]
+
+
+class TestRoundRobinAdvance:
+    def test_a_freshly_cut_draw_is_ready_in_its_entirety_and_fills_nothing(
+        self,
+    ) -> None:
+        # Round-robin pairings are fully determined at the cut, so advance() has no side
+        # to fill — every fixture is ready the moment the tournament goes live.
+        planned = RoundRobinStrategy().plan_initial(_config(2), _ordered(7))
+        fixtures = _persisted(planned)
+
+        plan = RoundRobinStrategy().advance(fixtures)
+
+        assert plan.side_fills == ()
+        assert set(plan.ready_fixture_ids) == {f.fixture_id for f in fixtures}
+        assert not plan.is_empty
+
+    def test_ready_ids_are_ordered_by_pool_round_position(self) -> None:
+        fixtures = _persisted(
+            RoundRobinStrategy().plan_initial(_config(2), _ordered(6))
+        )
+        by_id = {f.fixture_id: f for f in fixtures}
+
+        # Feed them in deliberately scrambled — the plan must not inherit input order.
+        plan = RoundRobinStrategy().advance(list(reversed(fixtures)))
+
+        keys = [
+            (by_id[fid].pool_id or "", by_id[fid].round, by_id[fid].position)
+            for fid in plan.ready_fixture_ids
+        ]
+        assert keys == sorted(keys)
+
+    def test_advancing_an_already_materialized_draw_is_a_no_op(self) -> None:
+        # THE idempotence claim: apply the plan (matches now exist), re-run advance, and
+        # it proposes nothing. That is what lets advance() run after every result.
+        planned = RoundRobinStrategy().plan_initial(_config(2), _ordered(6))
+
+        plan = RoundRobinStrategy().advance(_persisted(planned, materialized=True))
+
+        assert plan == AdvancePlan()
+        assert plan.is_empty
+
+    def test_advance_is_a_pure_function_of_the_state(self) -> None:
+        fixtures = _persisted(
+            RoundRobinStrategy().plan_initial(_config(1), _ordered(5))
+        )
+        strategy = RoundRobinStrategy()
+
+        assert strategy.advance(fixtures) == strategy.advance(fixtures)
+
+    def test_a_decided_fixture_is_not_ready_again(self) -> None:
+        # match_id is ON DELETE SET NULL, so a decided fixture can lose its match link.
+        # It must not rise from the dead and be played a second time.
+        decided = FixtureState(
+            fixture_id=FixtureId(uuid.UUID(int=1)),
+            pool_id=PoolId("A"),
+            round=1,
+            position=1,
+            entry_a_id=_entry_id(1),
+            entry_b_id=_entry_id(2),
+            winner_entry_id=_entry_id(1),
+            match_id=None,
+        )
+
+        assert RoundRobinStrategy().advance([decided]).is_empty
+
+    def test_a_fixture_with_an_unknown_side_is_never_ready(self) -> None:
+        pending = FixtureState(
+            fixture_id=FixtureId(uuid.UUID(int=1)),
+            pool_id=None,
+            round=2,
+            position=1,
+            entry_a_id=_entry_id(1),
+            entry_b_id=None,  # TBD
+        )
+
+        assert pending.is_pending
+        assert RoundRobinStrategy().advance([pending]).is_empty
+
+    def test_an_empty_draw_advances_to_an_empty_plan(self) -> None:
+        assert RoundRobinStrategy().advance([]) == AdvancePlan()

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -4,6 +4,7 @@ No database, no app — every test here builds its input from literals, which is
 point of keeping the strategies pure.
 """
 
+import dataclasses
 import uuid
 from collections import Counter
 from datetime import UTC, datetime, timedelta
@@ -27,6 +28,7 @@ from app.draws import (
     RoundRobinStrategy,
     UnsupportedDrawType,
     order_entrants,
+    ready_fixtures,
     strategy_for,
 )
 from app.models.tournament import DrawType
@@ -66,7 +68,7 @@ def _pool_ids(count: int) -> tuple[PoolId, ...]:
 
 
 def _config(pool_count: int) -> DrawConfig:
-    return DrawConfig(draw_type=DrawType.round_robin, pool_ids=_pool_ids(pool_count))
+    return DrawConfig(pool_ids=_pool_ids(pool_count))
 
 
 def _members_by_pool(fixtures: list[PlannedFixture]) -> dict[PoolId | None, set[int]]:
@@ -148,6 +150,30 @@ class TestOrderEntrants:
 
         assert [e.entry_id for e in ordered] == [_entry_id(2), _entry_id(1)]
 
+    def test_the_seeds_own_order_beats_their_registration_order(self) -> None:
+        # The seeds are ordered BY SEED, not by when they registered — and the two are
+        # made to disagree here on purpose, because a field where they agree cannot tell
+        # the two rules apart. Seed 1 registered dead last, seed 3 first; the draw is
+        # 1, 2, 3 regardless, which is the whole point of a seed.
+        #
+        # (This is the case the ordering key's second element exists for. Collapse it to
+        # a constant — the seeded then tie, and fall through to ``created_at`` — and
+        # every other ordering test here still passes: they all seed in registration
+        # order. Mutation testing is what found that, and this is what it found.)
+        ordered = order_entrants(
+            [
+                _entrant(1, seed=3, minutes=0),
+                _entrant(2, seed=2, minutes=30),
+                _entrant(3, seed=1, minutes=60),
+            ]
+        )
+
+        assert [e.entry_id for e in ordered] == [
+            _entry_id(3),  # seed 1, registered last
+            _entry_id(2),  # seed 2
+            _entry_id(1),  # seed 3, registered first
+        ]
+
     def test_identical_registration_instants_still_order_deterministically(
         self,
     ) -> None:
@@ -188,6 +214,11 @@ class TestStrategyRegistry:
         assert excinfo.value.draw_type is draw_type
         # And it must be catchable as the one domain base a route handler switches on.
         assert isinstance(excinfo.value, DrawError)
+        # Its ``str()`` is the *developer's* sentence — the director's is composed by
+        # the route from ``draw_type`` — but it still has to name the type, or the log
+        # line and the traceback say only that something, somewhere, is unimplemented.
+        assert draw_type.value in str(excinfo.value)
+        assert "not implemented yet" in str(excinfo.value)
 
     def test_every_draw_type_is_handled_one_way_or_the_other(self) -> None:
         # The match has no catch-all, so an unhandled member would fall through and
@@ -197,6 +228,28 @@ class TestStrategyRegistry:
                 assert strategy_for(draw_type) is not None
             except UnsupportedDrawType:
                 pass
+
+    def test_the_draw_type_lives_in_exactly_one_place_and_it_is_not_the_config(
+        self,
+    ) -> None:
+        """``strategy_for`` (above) is where a draw type is *read*, and picking the
+        strategy is the whole of what it decides. ``DrawConfig`` used to carry a copy of
+        it as well — populated by ``draw_config``, read by no strategy, and chosen from
+        the event's own column *before* the config was ever built.
+
+        A second source of truth for a settled decision, and one that could contradict
+        the strategy holding it: ``RoundRobinStrategy().plan_initial(DrawConfig(
+        draw_type=DrawType.swiss, …))`` was a sentence you could write, and nothing
+        anywhere would notice. Nothing *could*: mutation testing set that field to
+        ``None`` and killed no test, because no line of production code read it.
+
+        So this asserts on the config's **shape**, not on a behaviour — there is no
+        behaviour to assert on, which is precisely the finding. It is the only assertion
+        that can fail when the field comes back, and it is what stops the next strategy
+        (rr-then-ko, swiss) from branching on ``config.draw_type`` in the belief that it
+        is authoritative.
+        """
+        assert [field.name for field in dataclasses.fields(DrawConfig)] == ["pool_ids"]
 
 
 class TestRoundRobinCut:
@@ -346,33 +399,66 @@ class TestRoundRobinCut:
             )
         ]
 
+    # The refusal's message is not diagnostics — it is **copy**. ``_draw_refusal``
+    # passes a ``DegenerateDraw``'s ``str()`` through to the 422 body verbatim, on
+    # purpose (only the strategy knows *which* degeneracy it hit), so the sentence
+    # authored here is the sentence a director reads, and the numbers in it are the
+    # numbers they have to change. It is pinned where it is written.
     @pytest.mark.parametrize(
-        ("entrants", "pools"),
+        ("entrants", "pools", "message"),
         [
-            (1, 1),  # a lone entrant has nobody to play
-            (0, 1),  # a ghost pool
-            (3, 2),  # the snake would leave pool B with one entrant
-            (5, 3),  # ...and pool C with one
+            pytest.param(
+                1,
+                1,
+                "1 entrants across 1 pool(s) would leave a pool with fewer than 2 "
+                "entrants, who would have nobody to play.",
+                id="a-lone-entrant-has-nobody-to-play",
+            ),
+            pytest.param(
+                0,
+                1,
+                "0 entrants across 1 pool(s) would leave a pool with fewer than 2 "
+                "entrants, who would have nobody to play.",
+                id="a-ghost-pool",
+            ),
+            pytest.param(
+                3,
+                2,
+                "3 entrants across 2 pool(s) would leave a pool with fewer than 2 "
+                "entrants, who would have nobody to play.",
+                id="the-snake-would-leave-pool-B-with-one",
+            ),
+            pytest.param(
+                5,
+                3,
+                "5 entrants across 3 pool(s) would leave a pool with fewer than 2 "
+                "entrants, who would have nobody to play.",
+                id="...and-pool-C-with-one",
+            ),
         ],
     )
     def test_a_pool_of_fewer_than_two_is_refused(
-        self, entrants: int, pools: int
+        self, entrants: int, pools: int, message: str
     ) -> None:
         with pytest.raises(DegenerateDraw) as excinfo:
             RoundRobinStrategy().plan_initial(_config(pools), _ordered(entrants))
 
         assert isinstance(excinfo.value, DrawError)
+        # Both numbers, because either one of them is a thing the director can move:
+        # cut fewer pools, or go and find another player.
+        assert str(excinfo.value) == message
 
     def test_a_draw_with_no_pools_is_refused(self) -> None:
-        with pytest.raises(DegenerateDraw):
-            RoundRobinStrategy().plan_initial(
-                DrawConfig(draw_type=DrawType.round_robin, pool_ids=()), _ordered(4)
-            )
+        with pytest.raises(DegenerateDraw) as excinfo:
+            RoundRobinStrategy().plan_initial(DrawConfig(pool_ids=()), _ordered(4))
+
+        # A different degeneracy and a different sentence: no arrangement of the field
+        # fixes this one, so it names the pools rather than the entrants.
+        assert str(excinfo.value) == "A round-robin draw needs at least one pool."
 
     def test_pools_are_named_by_the_events_own_pool_ids(self) -> None:
         # A pool id is a string ref into the event's JSONB pools, not an index we mint.
         config = DrawConfig(
-            draw_type=DrawType.round_robin,
             pool_ids=(PoolId("pool-morning"), PoolId("pool-evening")),
         )
 
@@ -481,3 +567,79 @@ class TestRoundRobinAdvance:
 
     def test_an_empty_draw_advances_to_an_empty_plan(self) -> None:
         assert RoundRobinStrategy().advance([]) == AdvancePlan()
+
+
+class TestReadyFixtures:
+    """``ready_fixtures`` is shared by every strategy — "ready" is a property of the
+    fixture, not of the draw type — so it is tested as the total function it is, against
+    inputs no single strategy produces on its own."""
+
+    def _state(
+        self,
+        n: int,
+        *,
+        pool_id: PoolId | None,
+        round: int,
+        position: int,
+    ) -> FixtureState:
+        return FixtureState(
+            fixture_id=FixtureId(uuid.UUID(int=n)),
+            pool_id=pool_id,
+            round=round,
+            position=position,
+            entry_a_id=_entry_id(1),
+            entry_b_id=_entry_id(2),
+        )
+
+    def test_pooled_fixtures_are_ready_before_un_pooled_ones(self) -> None:
+        # The mixed set is the one a pooled-then-knockout draw will hand this: the pool
+        # fixtures carry a pool ref, the KO fixtures behind them carry NULL. A ``None``
+        # does not compare against a ``str``, so the sort key has to *decide* where the
+        # un-pooled sit rather than fall over — and where they sit has to be a fact, not
+        # whatever order the rows came back in.
+        ko = self._state(1, pool_id=None, round=1, position=1)
+        b1 = self._state(2, pool_id=PoolId("B"), round=1, position=1)
+        a2 = self._state(3, pool_id=PoolId("A"), round=1, position=2)
+        a1 = self._state(4, pool_id=PoolId("A"), round=1, position=1)
+        a_round2 = self._state(5, pool_id=PoolId("A"), round=2, position=1)
+
+        # Fed in scrambled — and it is the *stated* order that is asserted, not merely
+        # that the output is self-consistently sorted (which a reversed rule would also
+        # be).
+        ready = ready_fixtures([ko, a_round2, b1, a2, a1])
+
+        assert ready == (
+            a1.fixture_id,
+            a2.fixture_id,
+            a_round2.fixture_id,
+            b1.fixture_id,
+            ko.fixture_id,  # the un-pooled sort last, behind every pool
+        )
+
+    def test_readiness_ignores_the_draw_type_that_planned_the_fixture(self) -> None:
+        # Same three states, asked of the shared helper and of the strategy: a fixture
+        # that is ready is ready, and a strategy cannot make it less so.
+        ready = self._state(1, pool_id=PoolId("A"), round=1, position=1)
+        materialized = FixtureState(
+            fixture_id=FixtureId(uuid.UUID(int=2)),
+            pool_id=PoolId("A"),
+            round=1,
+            position=2,
+            entry_a_id=_entry_id(3),
+            entry_b_id=_entry_id(4),
+            match_id=MatchId(uuid.UUID(int=99)),
+        )
+        pending = FixtureState(
+            fixture_id=FixtureId(uuid.UUID(int=3)),
+            pool_id=None,
+            round=2,
+            position=1,
+            entry_a_id=_entry_id(1),
+            entry_b_id=None,
+        )
+        fixtures = [ready, materialized, pending]
+
+        assert ready_fixtures(fixtures) == (ready.fixture_id,)
+        assert RoundRobinStrategy().advance(fixtures) == AdvancePlan(
+            side_fills=(), ready_fixture_ids=(ready.fixture_id,)
+        )

--- a/api/tests/test_tournament_entries.py
+++ b/api/tests/test_tournament_entries.py
@@ -75,12 +75,18 @@ async def _make_event(
     max_players: int | None = 64,
     predicates: list[dict[str, Any]] | None = None,
     league: League | None = None,
+    owner: User | None = None,
 ) -> TournamentEvent:
     """An event of ``format`` under a tournament in ``status``, owned by its own
     throwaway director. Written straight to the database rather than through the
     create routes: those are owner-only and permission-gated, and dragging that
     setup in would blur which grant the entry route is actually being tested
     against.
+
+    ``owner`` defaults to a throwaway director *nobody in the test is signed in as* —
+    which is what keeps the self-registration tests honest: the entrant is never
+    accidentally the owner, so none of them can be passing through the director's arm
+    of the fork (ADR-0784). The director tests pass the owner they mean.
 
     ``status`` defaults to ``published`` because that is the one status in which
     registration is open (ADR-0017): every test here that enters or withdraws needs
@@ -106,7 +112,8 @@ async def _make_event(
     the way of every test that is about something else. The eligibility tests pass the
     rule they mean, and ``league`` lets them say which ladder it is judged on.
     """
-    director = await make_user(db_session, f"director-{uuid.uuid4().hex[:8]}")
+    if owner is None:
+        owner = await make_user(db_session, f"director-{uuid.uuid4().hex[:8]}")
     # Every tournament names the ladder its eligibility is judged on (ADR-0783);
     # the column is NOT NULL. Most tests here don't turn on *which* league, so it is
     # the default one the autouse fixture seeds — the eligibility tests that do care
@@ -126,7 +133,7 @@ async def _make_event(
             "country": "USA",
         },
         league_id=league.id,
-        created_by_user_id=director.id,
+        created_by_user_id=owner.id,
     )
     db_session.add(tournament)
     await db_session.flush()
@@ -161,7 +168,20 @@ async def doubles_event(db_session: AsyncSession) -> TournamentEvent:
 
 @pytest_asyncio.fixture
 async def player(db_session: AsyncSession) -> User:
-    return await make_user(db_session, f"player-{uuid.uuid4().hex[:8]}")
+    """A player who may enter — a real ``tournament.enter`` grant, through real RBAC
+    rows.
+
+    Most tests use them only as a *seeded* entrant, for whom the grant is irrelevant.
+    It is here for the ones that drive ``enter_event`` / ``withdraw_from_event`` as
+    functions (the lock races below): the self-registration arm of the fork asks for
+    that permission *inside* the handler (ADR-0784 — it cannot be a router dependency,
+    because the dependency runs before the body that says which arm this is), so a
+    player without it is refused before the lock is ever taken, and the race the test
+    means to stage never happens.
+    """
+    user = await make_user(db_session, f"player-{uuid.uuid4().hex[:8]}")
+    await grant_permissions(db_session, user, (TOURNAMENT_ENTER,))
+    return user
 
 
 async def _active_entries(
@@ -224,6 +244,10 @@ async def test_an_entry_persists_with_its_defaults(
     assert entry.status is TournamentEntryStatus.entered
     assert entry.seed is None
     assert entry.created_at.tzinfo is not None
+    # NULL is the encoding of self-registration, and it is the *default* — a row
+    # written without naming an adder says "the player entered themselves"
+    # (ADR-0784), which is what every entry made before directors existed is.
+    assert entry.added_by_user_id is None
 
 
 async def test_a_second_active_entry_for_the_same_player_is_rejected(
@@ -359,6 +383,52 @@ async def test_deleting_a_user_with_an_entry_is_restricted(
     await db_session.rollback()
 
 
+async def test_an_entry_records_the_director_who_added_it(
+    db_session: AsyncSession, event: TournamentEvent, player: User
+) -> None:
+    """The other half of the ``added_by_user_id`` contract (ADR-0784): a non-null
+    adder is a director entry, and it is a distinct row-state from the NULL of
+    self-registration. No route reaches this yet (chore 9a) — the column exists so
+    that when one does, the fact is recordable rather than lost."""
+    director = await make_user(db_session, f"director-{uuid.uuid4().hex[:8]}")
+
+    entry = TournamentEntry(
+        event_id=event.id, user_id=player.id, added_by_user_id=director.id
+    )
+    db_session.add(entry)
+    await db_session.commit()
+    await db_session.refresh(entry)
+
+    assert entry.added_by_user_id == director.id
+    assert entry.user_id == player.id
+
+
+async def test_deleting_the_director_who_added_an_entry_is_restricted(
+    db_session: AsyncSession, event: TournamentEvent, player: User
+) -> None:
+    """``added_by_user_id`` is ``ON DELETE RESTRICT``, not ``SET NULL``.
+
+    ``SET NULL`` would be the tempting choice for a nullable audit column, and it
+    is the wrong one *here* precisely because NULL is not "unknown": it means
+    "the player entered themselves". Nulling this column on a delete would not
+    lose a fact, it would rewrite one — the entry would start claiming a
+    self-registration that never happened. So the database refuses the delete, and
+    the merge path (which tombstones rather than deletes) re-points it explicitly.
+    """
+    director = await make_user(db_session, f"director-{uuid.uuid4().hex[:8]}")
+    db_session.add(
+        TournamentEntry(
+            event_id=event.id, user_id=player.id, added_by_user_id=director.id
+        )
+    )
+    await db_session.commit()
+
+    with pytest.raises(IntegrityError):
+        await db_session.execute(delete(User).where(User.id == director.id))
+        await db_session.commit()
+    await db_session.rollback()
+
+
 # ----- the self-registration route ------------------------------------------
 
 
@@ -395,6 +465,10 @@ async def test_entering_a_singles_event_returns_201_and_persists_the_row(
 
     (row,) = await _active_entries(db_session, event.id)
     assert row.user_id == user.id
+    # Self-registration records NO adder (ADR-0784). The route hard-codes the
+    # caller as the entrant, so the one thing that must be true of the row it
+    # writes is that nobody "added" the player — they added themselves.
+    assert row.added_by_user_id is None
     # The response addresses the row it created: ``id`` is the *entry's* id, which
     # is what a client will withdraw through (``DELETE …/entries/{entry_id}``).
     assert body["id"] == str(row.id)
@@ -1143,7 +1217,9 @@ async def test_an_entry_cannot_land_after_the_tournament_has_gone_live(
                 await session.execute(select(User).where(User.id == player_id))
             ).scalar_one()
             try:
-                await enter_event(tournament_id, event_id, session, entrant)
+                # ``None`` is the body: self-registration (ADR-0784). The director's
+                # arm of the same handler takes a ``TournamentEntryCreate``.
+                await enter_event(tournament_id, event_id, None, session, entrant)
                 return "entered"
             except HTTPException as exc:
                 return exc.status_code
@@ -1365,7 +1441,7 @@ async def test_an_uncapped_event_takes_no_capacity_count(
         entrant = (
             await session.execute(select(User).where(User.id == player_id))
         ).scalar_one()
-        await enter_event(tournament_id, event_id, session, entrant)
+        await enter_event(tournament_id, event_id, None, session, entrant)
 
     assert not any(
         "count(" in statement.lower() and "tournament_entries" in statement
@@ -1398,7 +1474,7 @@ async def test_the_capacity_count_is_taken_under_the_tournament_row_lock(
         entrant = (
             await session.execute(select(User).where(User.id == player_id))
         ).scalar_one()
-        await enter_event(tournament_id, event_id, session, entrant)
+        await enter_event(tournament_id, event_id, None, session, entrant)
 
     lock = _statement_index(
         statements, lambda s: "FOR UPDATE" in s, label="the tournament row lock"
@@ -1454,6 +1530,11 @@ async def test_two_entrants_racing_for_the_last_slot_yield_exactly_one_entry(
     event = await _make_event(db_session, max_players=1)
     tournament_id, event_id = event.tournament_id, event.id
     rival = await make_user(db_session, f"rival-{uuid.uuid4().hex[:8]}")
+    # Both contenders hold ``tournament.enter``: the self-registration arm of the fork
+    # checks it inside the handler now (ADR-0784), and a contender without it would be
+    # refused before it ever reached the lock — which would leave the "two entrants,
+    # one slot" race with only one entrant in it, and green for the wrong reason.
+    await grant_permissions(db_session, rival, (TOURNAMENT_ENTER,))
     contenders = [player.id, rival.id]
     make_session = async_sessionmaker(engine, expire_on_commit=False)
 
@@ -1463,7 +1544,7 @@ async def test_two_entrants_racing_for_the_last_slot_yield_exactly_one_entry(
                 await session.execute(select(User).where(User.id == user_id))
             ).scalar_one()
             try:
-                await enter_event(tournament_id, event_id, session, entrant)
+                await enter_event(tournament_id, event_id, None, session, entrant)
                 return "entered"
             except HTTPException as exc:
                 # The refusal's *code*, not just its status: a 409 that came from
@@ -1777,3 +1858,407 @@ async def test_the_rating_refusal_outranks_the_event_full_refusal(
 
     assert response.status_code == 409, response.text
     assert response.json()["detail"]["code"] == "rating_ineligible"
+
+
+# ----- the director's half of the same endpoint (ADR-0784) --------------------
+#
+# ``POST …/entries`` takes an OPTIONAL body, and its presence chooses the actor: no
+# ``user_id`` is a player self-registering (gated on ``tournament.enter``), a
+# ``user_id`` is the tournament's OWNER entering somebody (gated on ownership). Same
+# endpoint, deliberately — a twin route would mean the next refusal has to be added
+# twice and the two call sites of the eligibility evaluator can drift, which is the
+# exact class of bug ADR-0968 exists to delete.
+#
+# So the load-bearing claims of this section are not really "the director can add a
+# player". They are: the director's entry runs through the SAME evaluator, the SAME
+# capacity lock and the SAME four refusal codes as a player's — absent a ``force``
+# flag (deliberately deferred, #985), that IS the whole safety model — and
+# self-registration is byte-for-byte what it was.
+
+
+@pytest_asyncio.fixture
+async def director_client(
+    api_client: AsyncClient, db_session: AsyncSession
+) -> AsyncIterator[tuple[AsyncClient, User]]:
+    """A real session holding **no permissions at all** — its only authority is that
+    it OWNS the tournaments the tests below build for it.
+
+    The empty grant is the point. A director entering somebody else is authorized by
+    ownership, not by ``tournament.enter``: that permission says "may self-register",
+    and refusing an owner for lacking it would be refusing them a grant that has
+    nothing to do with what they are doing. If the enter route's permission check were
+    still a router dependency — running before the handler has seen the body, and so
+    before anything knows which arm of the fork this is — every test in this section
+    would 403.
+    """
+    user = await start_session(api_client, db_session)
+    yield api_client, user
+
+
+async def _entrants_of(client: AsyncClient, event: TournamentEvent) -> list[dict]:
+    """The event's entrants as the read path reports them. Needs ``tournament.view``."""
+    response = await client.get(f"/v1/tournaments/{event.tournament_id}")
+    assert response.status_code == 200, response.text
+    (found,) = [e for e in response.json()["events"] if e["id"] == str(event.id)]
+    return [dict(entrant) for entrant in found["entrants"]]
+
+
+async def test_the_owner_enters_another_player_who_appears_as_an_entrant(
+    director_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    player: User,
+) -> None:
+    """**The chore, in one test.** The owner names a ``user_id``; that player is
+    entered, is answered as the created entrant, and shows up in the entrants list.
+
+    Two things beyond the 201 are worth naming. The owner holds **no**
+    ``tournament.enter`` grant (see ``director_client``) and is admitted anyway —
+    ownership is the authorization for this arm. And the row records **who added it**:
+    ``added_by_user_id`` is the director, not NULL, because "a director entered them"
+    and "they entered themselves" are different facts and the column is where the
+    difference lives (ADR-0784).
+    """
+    client, owner = director_client
+    await grant_permissions(db_session, owner, (TOURNAMENT_VIEW,))
+    event = await _make_event(db_session, owner=owner)
+
+    response = await client.post(_entries_url(event), json={"user_id": str(player.id)})
+
+    assert response.status_code == 201, response.text
+    body = response.json()
+    # The 201 describes the row that was written — the PLAYER — not the person who
+    # wrote it. A director's POST that answered with the director would be a lie the
+    # client would render as an entrant.
+    assert body["user_id"] == str(player.id)
+    assert body["username"] == player.username
+
+    (row,) = await _active_entries(db_session, event.id)
+    assert row.user_id == player.id
+    assert row.added_by_user_id == owner.id
+    assert body["id"] == str(row.id)
+
+    assert [e["user_id"] for e in await _entrants_of(client, event)] == [str(player.id)]
+
+
+async def test_a_non_owner_naming_another_players_user_id_is_a_403(
+    entrant_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    player: User,
+) -> None:
+    """A stranger cannot enter somebody else, and holding ``tournament.enter`` does not
+    help: that permission is the *self-registration* gate, and this request is not a
+    self-registration.
+
+    403, not 409: "you are not the director of this tournament" is a fact about who is
+    asking, and it will not change when somebody withdraws. And nothing is written —
+    ``_all_entries`` is unfiltered, so a handler that inserted and only then checked
+    ownership fails here.
+    """
+    client, _ = entrant_client
+    event = await _make_event(db_session)
+    event_id = event.id
+
+    response = await client.post(_entries_url(event), json={"user_id": str(player.id)})
+
+    assert response.status_code == 403, response.text
+    assert await _all_entries(db_session, event_id) == []
+
+
+async def test_the_owner_withdraws_an_entry_that_is_not_their_own(
+    director_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    player: User,
+) -> None:
+    """The withdraw route unifies the same way (ADR-0784): your own entry, **or any
+    entry if you own the tournament**.
+
+    The owner holds no ``tournament.enter`` here either — withdrawing a player from a
+    tournament you created is a property of ownership. Soft-delete, as always: the row
+    survives, ``withdrawn``, and the entrants list drops them.
+    """
+    client, owner = director_client
+    await grant_permissions(db_session, owner, (TOURNAMENT_VIEW,))
+    event = await _make_event(db_session, owner=owner)
+    entry_id = await _seed_entry(db_session, event, player)
+
+    response = await client.delete(_entry_url(event, entry_id))
+
+    assert response.status_code == 204, response.text
+    assert (
+        await _reread(db_session, entry_id)
+    ).status is TournamentEntryStatus.withdrawn
+    assert await _entrants_of(client, event) == []
+
+
+async def test_the_owner_entering_themselves_by_user_id_records_no_adder(
+    director_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The degenerate self-add, **normalised**: an owner who names their OWN ``user_id``
+    is self-registering, and self-registration is spelled ``added_by_user_id = NULL``.
+
+    Writing ``added_by == user_id`` instead would be a second, contradictory encoding of
+    "the player entered themselves" — one the entrants list would render as "added by
+    the director" on an entry whose director *is* the player. ``merge_user`` already
+    collapses that shape when a merge would otherwise produce it; the route must not
+    mint it in the first place.
+
+    It follows that the owner needs ``tournament.enter`` here — because this *is* the
+    self-registration path, not a director entry. Same guard, same row, whether the body
+    is absent or names you.
+    """
+    client, owner = director_client
+    await grant_permissions(db_session, owner, (TOURNAMENT_ENTER,))
+    event = await _make_event(db_session, owner=owner)
+
+    response = await client.post(_entries_url(event), json={"user_id": str(owner.id)})
+
+    assert response.status_code == 201, response.text
+    (row,) = await _active_entries(db_session, event.id)
+    assert row.user_id == owner.id
+    assert row.added_by_user_id is None, (
+        "an owner entering themselves IS self-registration — it must not be stored as "
+        "added_by == user_id, a second encoding of the same fact"
+    )
+
+
+async def test_naming_your_own_user_id_is_self_registration_for_a_non_owner_too(
+    entrant_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    event: TournamentEvent,
+) -> None:
+    """The fork turns on WHO is named, not on who owns the tournament: a plain player
+    who spells out their own ``user_id`` is self-registering — 201 on the strength of
+    ``tournament.enter``, with no adder recorded — and is emphatically not refused by
+    the director arm's ownership check.
+
+    The identity test is what makes ``added_by == user_id`` unrepresentable *by any
+    caller*, not merely by the owner."""
+    client, user = entrant_client
+
+    response = await client.post(_entries_url(event), json={"user_id": str(user.id)})
+
+    assert response.status_code == 201, response.text
+    (row,) = await _active_entries(db_session, event.id)
+    assert (row.user_id, row.added_by_user_id) == (user.id, None)
+
+
+async def test_the_owner_still_needs_the_enter_permission_to_enter_themselves(
+    director_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The self-registration gate is intact, and owning the tournament does not
+    substitute for it: an owner with no ``tournament.enter`` who POSTs with **no body**
+    is refused exactly as any other player would be.
+
+    This is the test that catches the tempting simplification — "the owner may do
+    anything to their own tournament" — which would quietly hand the director an
+    entry path that skips the permission every other self-registration goes through.
+    """
+    client, owner = director_client
+    event = await _make_event(db_session, owner=owner)
+    event_id = event.id
+
+    response = await client.post(_entries_url(event))
+
+    assert response.status_code == 403, response.text
+    assert await _all_entries(db_session, event_id) == []
+
+
+async def test_a_directors_entry_into_a_full_event_is_refused_with_event_full(
+    director_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    player: User,
+) -> None:
+    """**No ``force``, and this is what that means** (ADR-0784): a director adding a
+    player to an event that already holds ``max_players`` is refused with the *same*
+    ``event_full`` code the player would have got, and no row is written.
+
+    Absent an override flag, running the director through the same guards IS the entire
+    safety model. A route that skipped capacity "because the director knows best" would
+    overfill the field the draw is cut from — silently, and only for the one caller
+    whose mistakes nobody else can catch.
+    """
+    client, owner = director_client
+    event = await _make_event(db_session, owner=owner, max_players=1)
+    event_id = event.id
+    sitting = await make_user(db_session, f"sitting-{uuid.uuid4().hex[:8]}")
+    await _seed_entry(db_session, event, sitting)
+
+    response = await client.post(_entries_url(event), json={"user_id": str(player.id)})
+
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"]["code"] == "event_full"
+    assert len(await _all_entries(db_session, event_id)) == 1
+
+
+async def test_a_directors_entry_over_the_rating_cap_is_rating_ineligible(
+    director_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    player: User,
+    default_league: League,
+) -> None:
+    """The other half of "no ``force``": the event's rating rules judge the player being
+    ENTERED, and a director adding a 1650 player to the "Under 1500" event is refused
+    with the same ``rating_ineligible`` code.
+
+    The director themselves is unrated — so a handler that judged the *caller's* rating
+    (the obvious copy-paste of the self-registration line) would sail through, because
+    an unrated player passes every rule (ADR-0783 §3). That is the bug this test is
+    shaped to catch: eligibility as an accidental function of who is holding the phone.
+    """
+    client, owner = director_client
+    await _rate(db_session, player, default_league, 1650.0)
+    event = await _make_event(db_session, owner=owner, predicates=CAP_UNDER_1500)
+    event_id = event.id
+
+    response = await client.post(_entries_url(event), json={"user_id": str(player.id)})
+
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"]["code"] == "rating_ineligible"
+    assert await _all_entries(db_session, event_id) == []
+
+
+@pytest.mark.parametrize(
+    "tournament_status",
+    [TournamentStatus.draft, TournamentStatus.live, TournamentStatus.archived],
+)
+async def test_a_director_obeys_the_registration_window_a_player_obeys(
+    director_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    player: User,
+    tournament_status: TournamentStatus,
+) -> None:
+    """The director gets no window of their own: the tournament's status is the
+    registration window (ADR-0017) for them too, so adding a player outside
+    ``published`` is the same ``registration_closed`` 409.
+
+    ``live`` is the case with teeth, and it is **deliberate rather than an oversight**:
+    it means #784 does not solve walk-ins. The override that would — and the no-show
+    withdrawal beside it — is one coherent ticket (#985), not a flag smuggled in here.
+    """
+    client, owner = director_client
+    event = await _make_event(db_session, owner=owner, status=tournament_status)
+    event_id = event.id
+
+    response = await client.post(_entries_url(event), json={"user_id": str(player.id)})
+
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"]["code"] == "registration_closed"
+    assert await _all_entries(db_session, event_id) == []
+
+
+async def test_the_owner_cannot_withdraw_an_entry_once_the_tournament_is_live(
+    director_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    player: User,
+) -> None:
+    """Withdrawal stays **symmetric** with entry: the owner obeys the same window, so a
+    no-show cannot be removed from a live tournament either.
+
+    The asymmetric alternative — the owner may withdraw at any time, but only add during
+    registration — is the more useful product and was still rejected: it is an override
+    leaking back in through the withdraw door, with different rules and no flag to name
+    it (ADR-0784). 409, and the entry is untouched.
+    """
+    client, owner = director_client
+    event = await _make_event(db_session, owner=owner, status=TournamentStatus.live)
+    entry_id = await _seed_entry(db_session, event, player)
+
+    response = await client.delete(_entry_url(event, entry_id))
+
+    assert response.status_code == 409, response.text
+    assert (await _reread(db_session, entry_id)).status is TournamentEntryStatus.entered
+
+
+async def test_entering_a_user_id_that_names_nobody_is_a_404(
+    director_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A well-formed id that names no player: a 404 about the *player*, not a 500 from
+    the FK, and not a 422 (the request's shape is fine — it is the world that has no
+    such user)."""
+    client, owner = director_client
+    event = await _make_event(db_session, owner=owner)
+    event_id = event.id
+
+    response = await client.post(
+        _entries_url(event), json={"user_id": str(uuid.uuid4())}
+    )
+
+    assert response.status_code == 404, response.text
+    assert await _all_entries(db_session, event_id) == []
+
+
+async def test_a_tombstoned_user_cannot_be_entered(
+    director_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    player: User,
+) -> None:
+    """A merged-away guest is a ghost — no listing, search or auth query will ever
+    return them — so entering one would seed the draw with a player who cannot sign in,
+    be notified, or turn up. The lookup excludes them exactly as ``/v1/players/search``
+    does, and the refusal is the same 404 as an id that names nobody: as far as this
+    endpoint is concerned, nobody is who they name."""
+    client, owner = director_client
+    survivor = await make_user(db_session, f"survivor-{uuid.uuid4().hex[:8]}")
+    player.merged_into_user_id = survivor.id
+    await db_session.commit()
+    event = await _make_event(db_session, owner=owner)
+    event_id, ghost_id = event.id, player.id
+
+    response = await client.post(_entries_url(event), json={"user_id": str(ghost_id)})
+
+    assert response.status_code == 404, response.text
+    assert await _all_entries(db_session, event_id) == []
+
+
+async def test_a_director_entering_the_same_player_twice_is_already_entered(
+    director_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    player: User,
+) -> None:
+    """The duplicate guard is the same partial unique index, reached through the same
+    caught ``IntegrityError``: the director's second attempt is an ``already_entered``
+    409, not a 500 and not a second row.
+
+    It is also why ``added_by_user_id`` deliberately carries **no** CHECK constraint
+    (ADR-0784): a constraint violation on this INSERT would be caught here and reported
+    as "you have already entered this event" — a refusal that would be simply false.
+    """
+    client, owner = director_client
+    event = await _make_event(db_session, owner=owner)
+    url, event_id = _entries_url(event), event.id
+    body = {"user_id": str(player.id)}
+
+    assert (await client.post(url, json=body)).status_code == 201
+
+    duplicate = await client.post(url, json=body)
+
+    assert duplicate.status_code == 409, duplicate.text
+    assert duplicate.json()["detail"]["code"] == "already_entered"
+    assert len(await _active_entries(db_session, event_id)) == 1
+
+
+async def test_an_unknown_field_in_the_entry_body_is_a_422(
+    director_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    player: User,
+) -> None:
+    """``extra="forbid"`` on the request model, and the one worth naming: ``force``.
+
+    A client that sends ``{"user_id": …, "force": true}`` expecting the override to
+    exist gets a 422, not a silently-ignored flag and an entry that was quietly judged
+    by the rules it thought it was bypassing. The override is #985's to design; until
+    then, the honest answer to a request for it is "no such field".
+    """
+    client, owner = director_client
+    event = await _make_event(db_session, owner=owner)
+    event_id = event.id
+
+    response = await client.post(
+        _entries_url(event), json={"user_id": str(player.id), "force": True}
+    )
+
+    assert response.status_code == 422, response.text
+    assert await _all_entries(db_session, event_id) == []

--- a/api/tests/test_tournament_fixtures.py
+++ b/api/tests/test_tournament_fixtures.py
@@ -1,0 +1,376 @@
+"""Persistence tests for ``tournament_fixtures``.
+
+The load-bearing claim is the ``UNIQUE (event_id, pool_id, round, position)``
+constraint — the identity a re-cut reconciles on (ADR-0786). The tests below are
+written to fail if that constraint is missing *or* if it is scoped wrongly: a
+duplicate ``(event, pool, round, position)`` must be refused by the database, while
+the same ``(round, position)`` in a **different pool** (or a different event) must be
+accepted, because pooled draws number their fixtures per-pool.
+
+The constraint is **NULLS NOT DISTINCT**, and that is load-bearing rather than
+decorative: an un-pooled draw (single-elim — the whole of #785) has ``pool_id IS NULL``
+on *every* row, and under Postgres's default NULLS-DISTINCT semantics NULL compares
+unequal to itself, so such a draw would have **no uniqueness guard at all**.
+``test_duplicate_round_and_position_in_an_un_pooled_draw_is_rejected`` is the test that
+tells the two apart — it fails against a default (NULLS DISTINCT) constraint.
+
+They also pin the two encodings the schema deliberately relies on: a ``NULL`` side
+means TBD (never a bye — a bye is the *absence* of a row), and a ``NULL`` ``pool_id``
+means the draw is un-pooled.
+
+These exercise the schema the **models** declare (the suite builds via
+``Base.metadata.create_all``); that the **migration** declares the same schema is
+covered by running ``alembic upgrade head`` against a fresh database.
+"""
+
+import uuid
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.leagues import get_default_league
+from app.models import (
+    DrawType,
+    EventFormat,
+    Tournament,
+    TournamentEntry,
+    TournamentEvent,
+    TournamentFixture,
+    TournamentStatus,
+    User,
+)
+from tests._helpers import make_user
+
+FIXTURE_IDENTITY_CONSTRAINT = "uq_tournament_fixtures_event_id_pool_id_round_position"
+
+
+async def _make_event(db_session: AsyncSession) -> TournamentEvent:
+    """A round-robin event under a published tournament owned by a throwaway director.
+
+    Written straight to the database rather than through the create routes: nothing
+    here is about who may create a tournament, and the draw endpoints don't exist yet.
+    """
+    owner = await make_user(db_session, f"director-{uuid.uuid4().hex[:8]}")
+    league = await get_default_league(db_session)
+    assert league is not None, "the autouse default_league fixture seeds this"
+
+    tournament = Tournament(
+        name="Spring Open",
+        status=TournamentStatus.published,
+        address={
+            "venue": "Berkeley TT Club",
+            "street": "1 Shattuck Ave",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94704",
+            "country": "USA",
+        },
+        league_id=league.id,
+        created_by_user_id=owner.id,
+    )
+    db_session.add(tournament)
+    await db_session.flush()
+
+    event = TournamentEvent(
+        tournament_id=tournament.id,
+        name="Open Singles",
+        format=EventFormat.singles,
+        draw_type=DrawType.round_robin,
+        max_players=64,
+        entry_fee=Decimal("20.00"),
+        slot={"date": "2026-08-01", "start": "09:00", "end": "17:00"},
+        match_settings={"rated": True, "length_games": 5},
+        pools=[
+            {"id": "pool-a", "name": "Pool A", "slot": {}, "table_ids": []},
+            {"id": "pool-b", "name": "Pool B", "slot": {}, "table_ids": []},
+        ],
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+    return event
+
+
+async def _make_entry(db_session: AsyncSession, event: TournamentEvent) -> User:
+    player = await make_user(db_session, f"player-{uuid.uuid4().hex[:8]}")
+    db_session.add(TournamentEntry(event_id=event.id, user_id=player.id))
+    await db_session.commit()
+    return player
+
+
+@pytest_asyncio.fixture
+async def event(db_session: AsyncSession) -> TournamentEvent:
+    return await _make_event(db_session)
+
+
+async def test_a_fixture_persists_with_both_sides_tbd(
+    db_session: AsyncSession, event: TournamentEvent
+) -> None:
+    """A cut draw may contain fixtures whose sides are not known yet — that is what a
+    ``NULL`` side is *for*, and it is the only thing it means."""
+    db_session.add(
+        TournamentFixture(event_id=event.id, pool_id=None, round=2, position=1)
+    )
+    await db_session.commit()
+
+    stored = (
+        await db_session.execute(
+            select(TournamentFixture).where(TournamentFixture.event_id == event.id)
+        )
+    ).scalar_one()
+    assert stored.entry_a_id is None
+    assert stored.entry_b_id is None
+    assert stored.winner_entry_id is None
+    assert stored.match_id is None
+    assert stored.pool_id is None
+    assert stored.created_at.tzinfo is not None
+    assert stored.updated_at.tzinfo is not None
+
+
+async def test_a_fixture_holds_its_two_entries(
+    db_session: AsyncSession, event: TournamentEvent
+) -> None:
+    entry_a = (
+        await db_session.execute(
+            select(TournamentEntry).where(
+                TournamentEntry.user_id == (await _make_entry(db_session, event)).id
+            )
+        )
+    ).scalar_one()
+    entry_b = (
+        await db_session.execute(
+            select(TournamentEntry).where(
+                TournamentEntry.user_id == (await _make_entry(db_session, event)).id
+            )
+        )
+    ).scalar_one()
+
+    db_session.add(
+        TournamentFixture(
+            event_id=event.id,
+            pool_id="pool-a",
+            round=1,
+            position=1,
+            entry_a_id=entry_a.id,
+            entry_b_id=entry_b.id,
+        )
+    )
+    await db_session.commit()
+
+    stored = (
+        await db_session.execute(
+            select(TournamentFixture).where(TournamentFixture.event_id == event.id)
+        )
+    ).scalar_one()
+    assert {stored.entry_a_id, stored.entry_b_id} == {entry_a.id, entry_b.id}
+
+
+async def test_duplicate_round_and_position_in_the_same_pool_is_rejected(
+    db_session: AsyncSession, event: TournamentEvent
+) -> None:
+    """The identity of a fixture within its draw. Two rows claiming
+    ``(event, pool-a, round 1, position 1)`` is a corrupt draw, and the *database* —
+    not a read-then-write check — is what refuses it."""
+    db_session.add(
+        TournamentFixture(event_id=event.id, pool_id="pool-a", round=1, position=1)
+    )
+    await db_session.commit()
+
+    db_session.add(
+        TournamentFixture(event_id=event.id, pool_id="pool-a", round=1, position=1)
+    )
+    with pytest.raises(IntegrityError) as excinfo:
+        await db_session.commit()
+    assert FIXTURE_IDENTITY_CONSTRAINT in str(excinfo.value)
+    await db_session.rollback()
+
+
+async def test_duplicate_round_and_position_in_an_un_pooled_draw_is_rejected(
+    db_session: AsyncSession, event: TournamentEvent
+) -> None:
+    """The un-pooled case — a single-elim draw, where ``pool_id`` is ``NULL`` on every
+    fixture. This is the test the ``NULLS NOT DISTINCT`` clause exists for: under
+    Postgres's *default* semantics ``NULL != NULL``, so a plain unique constraint would
+    let this duplicate through and leave the entire single-elim draw type unguarded.
+    Fails against a default (NULLS DISTINCT) constraint."""
+    db_session.add(
+        TournamentFixture(event_id=event.id, pool_id=None, round=1, position=1)
+    )
+    await db_session.commit()
+
+    db_session.add(
+        TournamentFixture(event_id=event.id, pool_id=None, round=1, position=1)
+    )
+    with pytest.raises(IntegrityError) as excinfo:
+        await db_session.commit()
+    assert FIXTURE_IDENTITY_CONSTRAINT in str(excinfo.value)
+    await db_session.rollback()
+
+
+async def test_an_un_pooled_round_and_position_in_a_different_event_is_accepted(
+    db_session: AsyncSession, event: TournamentEvent
+) -> None:
+    """NULLS NOT DISTINCT tightens the guard *within* an event; it must not leak across
+    events. Two single-elim events each have a ``(NULL pool, round 1, position 1)``, and
+    both rows are legitimate."""
+    other_event = await _make_event(db_session)
+
+    db_session.add(
+        TournamentFixture(event_id=event.id, pool_id=None, round=1, position=1)
+    )
+    db_session.add(
+        TournamentFixture(event_id=other_event.id, pool_id=None, round=1, position=1)
+    )
+    await db_session.commit()
+
+    stored = (await db_session.execute(select(TournamentFixture))).scalars().all()
+    assert sorted(str(f.event_id) for f in stored) == sorted(
+        [str(event.id), str(other_event.id)]
+    )
+    assert all(f.pool_id is None for f in stored)
+
+
+async def test_the_same_round_and_position_in_a_different_pool_is_accepted(
+    db_session: AsyncSession, event: TournamentEvent
+) -> None:
+    """Pooled draws number their fixtures **per pool**: every pool of a round-robin has
+    a round 1, position 1. A unique constraint that left ``pool_id`` out would reject
+    this legitimate row, so this test is what pins the constraint's *scope*."""
+    db_session.add(
+        TournamentFixture(event_id=event.id, pool_id="pool-a", round=1, position=1)
+    )
+    db_session.add(
+        TournamentFixture(event_id=event.id, pool_id="pool-b", round=1, position=1)
+    )
+    await db_session.commit()
+
+    stored = (
+        (
+            await db_session.execute(
+                select(TournamentFixture).where(TournamentFixture.event_id == event.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert sorted(f.pool_id or "" for f in stored) == ["pool-a", "pool-b"]
+
+
+async def test_the_same_round_and_position_in_a_different_event_is_accepted(
+    db_session: AsyncSession, event: TournamentEvent
+) -> None:
+    """Fixture identity is scoped to its event: two events' draws both have a
+    ``(pool-a, round 1, position 1)``. A constraint that omitted ``event_id`` would
+    reject the second event's draw."""
+    other_event = await _make_event(db_session)
+
+    db_session.add(
+        TournamentFixture(event_id=event.id, pool_id="pool-a", round=1, position=1)
+    )
+    db_session.add(
+        TournamentFixture(
+            event_id=other_event.id, pool_id="pool-a", round=1, position=1
+        )
+    )
+    await db_session.commit()
+
+    assert (
+        len((await db_session.execute(select(TournamentFixture))).scalars().all()) == 2
+    )
+
+
+async def test_deleting_the_event_takes_its_fixtures_with_it(
+    db_session: AsyncSession, event: TournamentEvent
+) -> None:
+    """The fixtures are part of the event, not free-standing rows — and the FK cascade
+    must survive the *entry* FKs, whose rows the same delete is also cascading away."""
+    player = await _make_entry(db_session, event)
+    entry = (
+        await db_session.execute(
+            select(TournamentEntry).where(TournamentEntry.user_id == player.id)
+        )
+    ).scalar_one()
+    db_session.add(
+        TournamentFixture(
+            event_id=event.id,
+            pool_id="pool-a",
+            round=1,
+            position=1,
+            entry_a_id=entry.id,
+        )
+    )
+    await db_session.commit()
+
+    stored_event = (
+        await db_session.execute(
+            select(TournamentEvent).where(TournamentEvent.id == event.id)
+        )
+    ).scalar_one()
+    await db_session.delete(stored_event)
+    await db_session.commit()
+
+    assert (await db_session.execute(select(TournamentFixture))).scalars().all() == []
+
+
+async def test_the_events_fixtures_relationship_is_ordered_pool_round_position(
+    db_session: AsyncSession, event: TournamentEvent
+) -> None:
+    """``TournamentEvent.fixtures`` comes back in the **one** canonical draw order —
+    pool → round → position — which is the order the read path's ``fixtures_by_event``
+    loader already returns.
+
+    A draw has one order. The relationship used to sort by ``(round, position)`` alone,
+    which for a *pooled* draw interleaved the pools: pool A's round 1 next to pool B's
+    round 1. So the same fixtures came back in two different sequences depending on
+    which of the two ways a caller happened to read them, and the one that rendered a
+    scrambled bracket was whichever one a future feature reached for first. Nothing
+    consumed the relationship at the time, which is exactly why it was worth fixing
+    before something did.
+
+    The rows are inserted in deliberately the wrong order (pool B before pool A, round 2
+    before round 1, the un-pooled fixture first), because insertion order is what an
+    unordered read returns — a fixture seeded in the right order could not tell a broken
+    ``order_by`` from a working one.
+
+    The un-pooled fixture (``pool_id`` NULL — an rr-then-ko event's KO stage) sorts
+    LAST, after the pools that feed it. NULL is a real value here ("this fixture belongs
+    to no pool"), not a missing one, so it has a defined place in the order rather than
+    wherever the dialect's default happens to put it.
+    """
+    for pool_id, round_number, position in [
+        (None, 1, 1),
+        ("pool-b", 1, 1),
+        ("pool-a", 2, 1),
+        ("pool-a", 1, 2),
+        ("pool-a", 1, 1),
+    ]:
+        db_session.add(
+            TournamentFixture(
+                event_id=event.id,
+                pool_id=pool_id,
+                round=round_number,
+                position=position,
+            )
+        )
+    await db_session.commit()
+
+    loaded = (
+        await db_session.execute(
+            select(TournamentEvent)
+            .where(TournamentEvent.id == event.id)
+            .options(selectinload(TournamentEvent.fixtures))
+        )
+    ).scalar_one()
+
+    assert [(f.pool_id, f.round, f.position) for f in loaded.fixtures] == [
+        ("pool-a", 1, 1),
+        ("pool-a", 1, 2),
+        ("pool-a", 2, 1),
+        ("pool-b", 1, 1),
+        (None, 1, 1),
+    ]

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -14,13 +14,14 @@ import asyncio
 import json
 import uuid
 from collections.abc import AsyncIterator, Sequence
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
 import pytest
 import pytest_asyncio
 from fastapi import HTTPException
-from httpx import AsyncClient
+from httpx import AsyncClient, Response
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
@@ -29,11 +30,14 @@ from app.leagues import seed_user_league_rating
 from app.models import (
     League,
     LeagueVisibility,
+    Match,
+    MatchSettings,
     RatingStrategy,
     Tournament,
     TournamentEntry,
     TournamentEntryStatus,
     TournamentEvent,
+    TournamentFixture,
     TournamentStatus,
     User,
     UserLeagueRating,
@@ -42,8 +46,10 @@ from app.models.tournament import DrawType, EventFormat
 from app.schemas.tournament import (
     EventEntryFull,
     EventEntryRatingIneligible,
+    TournamentEventUpdate,
     TournamentTransitionCreate,
 )
+from app.tournament_draws import DrawCurrency, draw_currency_by_event
 from app.tournament_entry_refusals import EntryRefusal
 from app.tournaments import (
     TOURNAMENT_CREATE,
@@ -51,8 +57,11 @@ from app.tournaments import (
     _get_owned_tournament_or_404,
     _get_tournament_for_update_or_404,
     create_tournament_transition,
+    cut_event_draw,
     get_tournament,
     list_tournaments,
+    uncut_event_draw,
+    update_event,
 )
 from tests._helpers import (
     counted_statements,
@@ -1142,15 +1151,60 @@ async def _enter(
     *,
     status: TournamentEntryStatus = TournamentEntryStatus.entered,
     seed: int | None = None,
+    created_at: datetime | None = None,
 ) -> TournamentEntry:
     """Persist an entry directly. The enter/withdraw *routes* land in #781/1c+1d;
-    the read path can't wait for them, so it writes the rows itself."""
+    the read path can't wait for them, so it writes the rows itself.
+
+    ``created_at`` is REGISTRATION ORDER, and the draw's ordering rule falls back to it
+    for every unseeded entrant (ADR-0786). It is settable here so a test about that
+    order can *state* the order rather than infer it from how fast the rows were
+    written: left to the column's ``now()`` default, two entries written in the same
+    breath differ by microseconds, and a draw asserted against that is a test that
+    passes on the clock's goodwill.
+    """
     entry = TournamentEntry(
         event_id=uuid.UUID(event_id), user_id=user.id, status=status, seed=seed
     )
+    if created_at is not None:
+        entry.created_at = created_at
     db_session.add(entry)
     await db_session.commit()
     return entry
+
+
+async def _cut(
+    db_session: AsyncSession,
+    event_id: str,
+    *,
+    round: int,
+    position: int,
+    pool_id: str | None = None,
+    entry_a: TournamentEntry | None = None,
+    entry_b: TournamentEntry | None = None,
+) -> TournamentFixture:
+    """Persist ONE fixture directly, at the coordinates given.
+
+    Sides default to ``None`` — TBD, the state most of a freshly cut draw is in
+    (ADR-0786) — and ``pool_id`` defaults to ``None``, an un-pooled fixture.
+
+    It sits beside ``_enter`` because it is the same kind of thing: the way a test
+    puts the database into a state the *routes* would take several acts to reach. The
+    read-path tests needed it before a cut route existed; the statement-count pins need
+    it to describe a *drawn* event; and the play-guard tests need it to write the one
+    state nothing can produce yet (a fixture with a winner, or with a match).
+    """
+    fixture = TournamentFixture(
+        event_id=uuid.UUID(event_id),
+        pool_id=pool_id,
+        round=round,
+        position=position,
+        entry_a_id=entry_a.id if entry_a is not None else None,
+        entry_b_id=entry_b.id if entry_b is not None else None,
+    )
+    db_session.add(fixture)
+    await db_session.commit()
+    return fixture
 
 
 async def test_tournament_events_has_no_entered_column(db_session: AsyncSession):
@@ -1270,11 +1324,12 @@ async def test_patch_event_answers_with_its_existing_entrants(
 
 
 # The pin, measured (print the statements below to re-measure): the tournaments +
-# usernames join, the events, ONE batched load of every event's active entrants, and
-# ONE batched load of the caller's rating on every league those tournaments run on
-# (which each event's ``entry_state`` is judged against, ADR-0783). Four, whatever the
-# number of tournaments and events.
-EXPECTED_TOURNAMENT_LIST_STATEMENTS = 4
+# usernames join, the events, ONE batched load of every event's active entrants, ONE
+# batched load of every event's fixtures — its draw (ADR-0786) — and ONE batched load of
+# the caller's rating on every league those tournaments run on (which each event's
+# ``entry_state`` is judged against, ADR-0783). Five, whatever the number of tournaments
+# and events.
+EXPECTED_TOURNAMENT_LIST_STATEMENTS = 5
 
 
 @pytest.mark.parametrize("event_count", [1, 4])
@@ -1298,6 +1353,15 @@ async def test_list_tournaments_statement_count_does_not_grow_with_events(
     N+1 this test exists to prevent: every event's ``entry_state`` is judged against
     the caller's rating on the tournament's ladder (ADR-0783), and a rating fetched
     inside the per-event loop reads the same number once per event.
+
+    And every event here carries a **cut draw**, which is what makes the pin cover the
+    fixtures loader at all. It did not, until it did: with no fixtures anywhere in the
+    fixture, an N+1 conditioned on an event actually *having* a draw — ``if
+    event.fixtures:`` in the serializer, a loader that skips the empty ones — cost this
+    test nothing and left it green, while the real page paid a query per drawn event.
+    A pin whose data has none of the thing it is pinning is not a pin. (The detail
+    endpoint's twin, ``test_detail_statement_count_does_not_grow_with_drawn_events``,
+    was written that way from the start; this one is now.)
 
     Counting is scoped to the handler rather than the HTTP request on purpose: an
     endpoint-level count would also sweep up session / auth statements that have
@@ -1326,6 +1390,11 @@ async def test_list_tournaments_statement_count_does_not_grow_with_events(
             await make_user(db_session, f"gone-{n}"),
             status=TournamentEntryStatus.withdrawn,
         )
+        # Two fixtures per event — a DRAWN event (ADR-0786). Two, not one, so a loader
+        # that read a single row per event would show up as missing data rather than as
+        # a low count.
+        await _cut(db_session, event["id"], pool_id="p-a", round=1, position=1)
+        await _cut(db_session, event["id"], pool_id="p-a", round=1, position=2)
 
     async with counted_statements(engine) as (session, statements):
         # A transient ``User`` carrying only the id the handler reads: touching the
@@ -1338,13 +1407,18 @@ async def test_list_tournaments_statement_count_does_not_grow_with_events(
 
     assert len(statements) == EXPECTED_TOURNAMENT_LIST_STATEMENTS, statements
     # And the block it counted really did the work: every event carries its own
-    # entrants, and the withdrawn player is nowhere.
+    # entrants and its own draw, and the withdrawn player is nowhere.
     (tournament,) = [t for t in listed if str(t.id) == created["id"]]
     assert len(tournament.events) == event_count
     assert [e.entered for e in tournament.events] == list(range(1, event_count + 1))
     assert all(
         len(e.entrants) == e.entered
         and not any(x.username.startswith("gone-") for x in e.entrants)
+        for e in tournament.events
+    )
+    assert all(
+        [(f.pool_id, f.round, f.position) for f in e.fixtures]
+        == [("p-a", 1, 1), ("p-a", 1, 2)]
         for e in tournament.events
     )
 
@@ -1718,6 +1792,73 @@ async def _status_of(client: AsyncClient, tournament_id: str) -> str:
     return status_value
 
 
+async def _event_with_entrants(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    tournament_id: str,
+    *,
+    name: str = "Open Singles",
+    players: int = 2,
+) -> tuple[str, list[TournamentEntry]]:
+    """A **round-robin** event under ``tournament_id``, with ``players`` active entrants
+    and **no draw yet** — the state a director is in just before they cut one.
+
+    Round-robin because it is the one draw type with a strategy today, so this event can
+    be handed to the real ``POST …/draw`` (``_cut_the_draw``): the go-live precondition
+    is a claim about the fixtures the *cut route* writes, and a test that hand-rolled
+    them with ``_cut`` would be asserting against a draw of its own invention.
+
+    ``predicates=[]`` — the eligibility rules are not what is under test here, and the
+    default payload's "under 1500" rule has nothing to say about the unrated players
+    below.
+    """
+    created = await client.post(
+        f"/v1/tournaments/{tournament_id}/events",
+        json=_event_payload(name=name, draw_type="round-robin", predicates=[]),
+    )
+    assert created.status_code == 201, created.text
+    event_id: str = created.json()["id"]
+    entries = [
+        await _enter(
+            db_session,
+            event_id,
+            await make_user(db_session, f"player-{uuid.uuid4().hex[:12]}"),
+        )
+        for _ in range(players)
+    ]
+    return event_id, entries
+
+
+async def _cut_the_draw(client: AsyncClient, tournament_id: str, event_id: str) -> None:
+    """Cut the event's draw through the real route, so the fixtures the precondition
+    reads are the fixtures the product writes."""
+    response = await client.post(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}/draw"
+    )
+    assert response.status_code == 201, response.text
+
+
+async def _withdraw(db_session: AsyncSession, entry: TournamentEntry) -> None:
+    """Withdraw an entry the way the route does — a soft delete (ADR-0016), so the row
+    (and every fixture pointing at it) survives."""
+    entry.status = TournamentEntryStatus.withdrawn
+    await db_session.commit()
+
+
+async def _ready_to_start(
+    client: AsyncClient, db_session: AsyncSession, *, players: int = 2
+) -> tuple[str, str, list[TournamentEntry]]:
+    """A tournament that could go live right now: one event, ``players`` entrants, and a
+    draw cut from exactly them. Left in whatever status it was created in (``draft``) —
+    the caller decides where on the lifecycle it sits."""
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    event_id, entries = await _event_with_entrants(
+        client, db_session, created["id"], players=players
+    )
+    await _cut_the_draw(client, created["id"], event_id)
+    return created["id"], event_id, entries
+
+
 @pytest.mark.parametrize(("start", "target"), _edge_params(_LEGAL_EDGES))
 async def test_transition_legal_edge_moves_the_tournament_and_persists(
     authed_client: tuple[AsyncClient, User],
@@ -1726,18 +1867,25 @@ async def test_transition_legal_edge_moves_the_tournament_and_persists(
     target: TournamentStatus,
 ):
     """Each of the three forward edges is accepted, answers with the moved
-    tournament, and the move is still there on the next read."""
+    tournament, and the move is still there on the next read.
+
+    The tournament is built **ready to start** — an event, its entrants, and a draw cut
+    from exactly them — because one of the three edges (``published → live``) now has a
+    precondition, and a tournament with no draw cannot walk it (ADR-0786). The other two
+    edges ask nothing of the draw and are indifferent to its presence
+    (``test_publish_and_archive_ask_nothing_of_the_draws`` pins that they stay so).
+    """
     client, _ = authed_client
-    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
-    await _set_status(db_session, created["id"], start)
+    tournament_id, _event_id, _entries = await _ready_to_start(client, db_session)
+    await _set_status(db_session, tournament_id, start)
 
     response = await client.post(
-        f"/v1/tournaments/{created['id']}/transitions", json={"to": target.value}
+        f"/v1/tournaments/{tournament_id}/transitions", json={"to": target.value}
     )
 
     assert response.status_code == 201, response.text
     assert response.json()["status"] == target.value
-    assert await _status_of(client, created["id"]) == target.value
+    assert await _status_of(client, tournament_id) == target.value
 
 
 @pytest.mark.parametrize(("start", "target"), _edge_params(_ILLEGAL_EDGES))
@@ -1990,6 +2138,401 @@ async def test_two_identical_transitions_racing_leave_exactly_one_winner(
             )
         ).scalar_one()
         assert final.status is TournamentStatus.published
+
+
+# ----- the go-live precondition (ADR-0786) -----------------------------------
+#
+# ``published → live`` is the one edge with a precondition, and it hangs at the same
+# dispatch point as the edge table itself (ADR-0017 reserved the spot). A tournament may
+# only START with at least one event, each carrying a draw whose fixtures seat exactly
+# its current entrants. Registration stays open right up to go-live, so "has a draw" is
+# not enough: the draw has to still be a plan for the field that will play it.
+#
+# The tests below are written against the *set* of entrants, not their number, because
+# that is the distinction the guard turns on — and the one a plausible-looking count
+# check gets wrong (see ``test_a_swap_between_the_cut_and_go_live_is_stale``).
+
+
+async def _go_live(client: AsyncClient, tournament_id: str) -> Any:
+    return await client.post(
+        f"/v1/tournaments/{tournament_id}/transitions", json={"to": "live"}
+    )
+
+
+async def test_going_live_with_no_events_is_refused(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+):
+    """A tournament with **no events** cannot start: there is nothing to run.
+
+    The case that makes the per-event rules below sound: "every event has a current
+    draw" is *vacuously true* of a tournament with no events, so without this check an
+    empty tournament would sail straight into ``live`` — the hole the #782 hand-off
+    flagged, closed by ADR-0786.
+    """
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    await _set_status(db_session, created["id"], TournamentStatus.published)
+
+    response = await _go_live(client, created["id"])
+
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"] == (
+        "This tournament has no events, so there is nothing to start. Add an event "
+        "and cut its draw, then start the tournament."
+    )
+    assert await _status_of(client, created["id"]) == "published"
+
+
+async def test_publishing_a_tournament_with_no_events_still_succeeds(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+):
+    """Announcing early is fine; starting nothing is not (ADR-0786).
+
+    The other half of the rule above, and the half a guard placed on the *tournament*
+    rather than on the ``live`` target would have broken: a director writes the events
+    up after the dates are announced, and publishing is what opens registration.
+    """
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+
+    response = await client.post(
+        f"/v1/tournaments/{created['id']}/transitions", json={"to": "published"}
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["status"] == "published"
+    assert await _status_of(client, created["id"]) == "published"
+
+
+async def test_going_live_with_an_uncut_draw_names_the_event(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+):
+    """An event nobody has cut a draw for refuses the whole tournament — and the refusal
+    says **which** event, by name.
+
+    A director with ten events cannot act on "some event has no draw", and the id the
+    guard actually compared is not what they are looking at, so neither the event id nor
+    any other raw uuid appears in the sentence.
+    """
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    event_id, _entries = await _event_with_entrants(
+        client, db_session, created["id"], name="Under 1200"
+    )
+    await _set_status(db_session, created["id"], TournamentStatus.published)
+
+    response = await _go_live(client, created["id"])
+
+    assert response.status_code == 409, response.text
+    detail = response.json()["detail"]
+    assert "“Under 1200” has no draw yet" in detail
+    assert event_id not in detail
+    assert await _status_of(client, created["id"]) == "published"
+
+
+async def test_going_live_with_an_event_nobody_entered_is_refused(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+):
+    """**The ∅ == ∅ case.** An event with *no entrants* and *no draw* is refused, by
+    name, exactly as any other undrawn event is.
+
+    It is the case a currency check written as "do the fixtures seat the entrants?" gets
+    wrong in the *permissive* direction, and it is the only one where being wrong means
+    a tournament starts: an event nobody has entered seats nobody and has nobody to
+    seat, so the two sets compare **equal** — ∅ == ∅ — and a draw that does not exist
+    reads as ``current``. The tournament goes live on an event that cannot be played
+    (its draw could not even be cut: the strategy refuses a field that small).
+
+    ``draw_currency_by_event`` therefore decides ``uncut`` on the **fixtures existing**,
+    read off the rows, and not on the seated set being empty. That is a deliberate line
+    of that function and this is the test that holds it there: rewrite the ``uncut`` arm
+    as ``if not seated[event_id]`` — which passes every other go-live test in this file,
+    because every one of them has entrants — and only this one reds.
+    """
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    event_id, entries = await _event_with_entrants(
+        client, db_session, created["id"], name="Under 1200", players=0
+    )
+    assert entries == [], "the whole point of this test is that NOBODY entered"
+    await _set_status(db_session, created["id"], TournamentStatus.published)
+
+    response = await _go_live(client, created["id"])
+
+    assert response.status_code == 409, response.text
+    detail = response.json()["detail"]
+    assert "“Under 1200” has no draw yet" in detail
+    assert event_id not in detail
+    assert await _status_of(client, created["id"]) == "published"
+
+
+async def test_an_entry_after_the_cut_makes_the_draw_stale_and_a_re_cut_fixes_it(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+):
+    """The headline case: the draw was cut, and *then* somebody entered.
+
+    The new player is in no fixture — they would sit out the tournament they entered —
+    so the tournament is refused, by name, until the draw is cut again. And after the
+    re-cut the very same request succeeds: the refusal is a *conflict* (409), not a
+    permission (403), and the way out of it is exactly the one the sentence names.
+    """
+    client, _ = authed_client
+    tournament_id, event_id, _entries = await _ready_to_start(client, db_session)
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    # The late entrant, arriving after the draw was cut — which registration being open
+    # in ``published`` makes an ordinary thing, not an exotic one.
+    await _enter(db_session, event_id, await make_user(db_session, "late-arrival"))
+
+    refused = await _go_live(client, tournament_id)
+
+    assert refused.status_code == 409, refused.text
+    detail = refused.json()["detail"]
+    assert "“Open Singles” has a draw that no longer matches its entrants" in detail
+    assert await _status_of(client, tournament_id) == "published"
+
+    # The way out the refusal names: cut the draw again, from the field as it stands.
+    await _cut_the_draw(client, tournament_id, event_id)
+    started = await _go_live(client, tournament_id)
+
+    assert started.status_code == 201, started.text
+    assert await _status_of(client, tournament_id) == "live"
+
+
+async def test_a_withdrawal_after_the_cut_makes_the_draw_stale(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+):
+    """A player *leaving* after the cut is staleness too — the direction an
+    "is everybody seated?" check would miss.
+
+    The draw still seats the player who withdrew, so their opponents are holding
+    fixtures nobody will play. Nothing is missing from the draw; something surplus is in
+    it, and the set comparison catches that as readily as the other direction.
+    """
+    client, _ = authed_client
+    tournament_id, event_id, entries = await _ready_to_start(
+        client, db_session, players=3
+    )
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+
+    await _withdraw(db_session, entries[0])
+
+    response = await _go_live(client, tournament_id)
+
+    assert response.status_code == 409, response.text
+    assert (
+        "“Open Singles” has a draw that no longer matches its entrants"
+        in response.json()["detail"]
+    )
+    assert await _status_of(client, tournament_id) == "published"
+
+    # And the re-cut still gets them started — with a draw for the field that is
+    # actually there.
+    await _cut_the_draw(client, tournament_id, event_id)
+    assert (await _go_live(client, tournament_id)).status_code == 201
+
+
+async def test_a_swap_between_the_cut_and_go_live_is_stale(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+):
+    """**The discriminating case.** One player withdraws and another enters between the
+    cut and go-live: the field has *the same number of players in it* and is not the
+    same field.
+
+    A currency check written as a count — "the draw has as many entrants as the event
+    does" — passes this, and it is precisely the state that must not start: the draw
+    seats a player who has left (their opponents get a match nobody will play) and seats
+    the player who replaced them nowhere (they sit out the event they entered). The
+    entrant *count* is asserted to be unchanged below, so this test fails the moment the
+    guard is weakened into counting.
+    """
+    client, _ = authed_client
+    tournament_id, event_id, entries = await _ready_to_start(client, db_session)
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+
+    before = await client.get(f"/v1/tournaments/{tournament_id}")
+    assert before.json()["events"][0]["entered"] == 2
+
+    # The swap: one out, one in. Same count, different people.
+    await _withdraw(db_session, entries[0])
+    await _enter(db_session, event_id, await make_user(db_session, "the-replacement"))
+
+    after = await client.get(f"/v1/tournaments/{tournament_id}")
+    assert after.json()["events"][0]["entered"] == 2, (
+        "the whole point of this test is that the COUNT did not move"
+    )
+
+    response = await _go_live(client, tournament_id)
+
+    assert response.status_code == 409, response.text
+    assert (
+        "“Open Singles” has a draw that no longer matches its entrants"
+        in response.json()["detail"]
+    )
+    assert await _status_of(client, tournament_id) == "published"
+
+
+async def test_the_refusal_names_every_offending_event_and_spares_the_ready_one(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+):
+    """Three events — one ready, one never cut, one gone stale — and the refusal names
+    the two that are broken, each under the sentence that says what is wrong with it.
+
+    Two failures, two jobs: an uncut event needs a first cut; a stale one has a draw the
+    director may have reviewed and approved, which is simply older than the field. And
+    the event that IS ready is not named at all — a refusal that listed every event
+    would send the director to re-cut a draw that is perfectly good.
+    """
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    tournament_id = created["id"]
+
+    ready_id, _ = await _event_with_entrants(
+        client, db_session, tournament_id, name="Open Singles"
+    )
+    await _cut_the_draw(client, tournament_id, ready_id)
+
+    await _event_with_entrants(client, db_session, tournament_id, name="Under 1200")
+
+    stale_id, _ = await _event_with_entrants(
+        client, db_session, tournament_id, name="Over 40s"
+    )
+    await _cut_the_draw(client, tournament_id, stale_id)
+    await _enter(
+        db_session, stale_id, await make_user(db_session, "over-40s-latecomer")
+    )
+
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+
+    response = await _go_live(client, tournament_id)
+
+    assert response.status_code == 409, response.text
+    detail = response.json()["detail"]
+    assert "“Under 1200” has no draw yet" in detail
+    assert "“Over 40s” has a draw that no longer matches its entrants" in detail
+    assert "Open Singles" not in detail
+    assert await _status_of(client, tournament_id) == "published"
+
+
+async def test_publish_and_archive_ask_nothing_of_the_draws(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+):
+    """The precondition is on the ``live`` **target**, and nowhere else.
+
+    A tournament whose events have no draws at all still publishes (registration has to
+    open before anybody can enter, let alone be drawn) and still archives (a tournament
+    that is over is not asked to tidy its draws before it can be put away). Only
+    starting needs a draw.
+    """
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    await _event_with_entrants(client, db_session, created["id"], name="Under 1200")
+
+    published = await client.post(
+        f"/v1/tournaments/{created['id']}/transitions", json={"to": "published"}
+    )
+    assert published.status_code == 201, published.text
+
+    # Straight to ``live`` in the database — the edge under test here is the one *out*
+    # of it, and walking in through the route would need the very draw this test is
+    # asserting is not required.
+    await _set_status(db_session, created["id"], TournamentStatus.live)
+    archived = await client.post(
+        f"/v1/tournaments/{created['id']}/transitions", json={"to": "archived"}
+    )
+
+    assert archived.status_code == 201, archived.text
+    assert await _status_of(client, created["id"]) == "archived"
+
+
+async def _hold_a_late_entry(
+    session: AsyncSession,
+    tournament_id: uuid.UUID,
+    event_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    """A player's entry, taken up to but not including its commit — exactly as the entry
+    route takes it: the **tournament's** row ``FOR UPDATE`` first, then the INSERT.
+
+    That uncommitted instant is where the race lives, and holding it open is what lets
+    the test below drive the interesting interleaving deterministically, instead of
+    firing both sides and hoping the scheduler obliges — a ``gather`` of the two passes
+    even against a *removed* guard, because go-live happens to win every time.
+
+    """
+    await session.execute(
+        select(Tournament).where(Tournament.id == tournament_id).with_for_update()
+    )
+    session.add(TournamentEntry(event_id=event_id, user_id=user_id))
+    await session.flush()
+
+
+async def test_go_live_blocks_on_an_in_flight_entry_and_then_finds_the_draw_stale(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+):
+    """The precondition is judged **inside the go-live row lock**, against the field as
+    last *committed* — so an entry in flight cannot slip between the check and the
+    ``UPDATE``.
+
+    A player's entry holds the tournament's row lock, uncommitted, with its INSERT
+    already made. The owner presses go-live — and *blocks*, because the transition route
+    reads that same row ``FOR UPDATE`` (``starting.done()`` catches it if it does not).
+    When the entry commits, go-live's read returns, its currency check runs on the
+    field that now includes the new player, and it refuses: the draw seats one fewer
+    player than the event has.
+
+    Without the lock — or with the check hoisted above it — go-live would read the
+    field from its own snapshot, certify a draw that was current *at that instant*,
+    and commit. Both requests succeed, and the tournament starts on a draw that leaves
+    a paying entrant in no fixture. READ COMMITTED offers nothing here; the shared lock
+    on the tournament row is the entire mechanism, and this is the test that says so.
+    """
+    client, owner = authed_client
+    tournament_id, event_id, _entries = await _ready_to_start(client, db_session)
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    latecomer = await make_user(db_session, "the-latecomer")
+
+    tournament_uuid = uuid.UUID(tournament_id)
+    event_uuid = uuid.UUID(event_id)
+    owner_id, latecomer_id = owner.id, latecomer.id
+    make_session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def go_live() -> int | str:
+        async with make_session() as session:
+            actor = (
+                await session.execute(select(User).where(User.id == owner_id))
+            ).scalar_one()
+            try:
+                moved = await create_tournament_transition(
+                    tournament_uuid,
+                    TournamentTransitionCreate(to=TournamentStatus.live),
+                    session,
+                    actor,
+                )
+                return moved.status.value
+            except HTTPException as exc:
+                return exc.status_code
+
+    async with make_session() as entering:
+        await _hold_a_late_entry(entering, tournament_uuid, event_uuid, latecomer_id)
+        starting = asyncio.create_task(go_live())
+        # Every chance to finish — and it cannot, because it is parked on the
+        # tournament's row lock, inside the handler, before it has judged anything.
+        await asyncio.sleep(0.25)
+        if starting.done():
+            pytest.fail(
+                "go-live did not block on the tournament's row lock: it ran to "
+                f"completion against an in-flight entry ({starting.result()!r})"
+            )
+        await entering.commit()
+        outcome = await starting
+
+    assert outcome == 409, outcome
+    assert await _status_of(client, tournament_id) == "published"
+    async with make_session() as verify:
+        currency = (await draw_currency_by_event(verify, [event_uuid]))[event_uuid]
+    assert currency is DrawCurrency.stale
 
 
 # ----- the league a tournament is judged on (ADR-0783) ----------------------
@@ -2807,10 +3350,11 @@ async def test_the_list_and_the_detail_agree_about_an_entrants_rating(
 
 # The pin, measured: the tournament + username join, its events, ONE batched load of
 # those events' active entrants (their ratings on the tournament's ladder ride along on
-# that same statement — see ``active_entrants_by_event``), and ONE read of the caller's
-# rating on the tournament's league. Four, whatever the number of events, and whatever
-# the number of entrants in them.
-EXPECTED_TOURNAMENT_DETAIL_STATEMENTS = 4
+# that same statement — see ``active_entrants_by_event``), ONE batched load of those
+# events' fixtures — their draws (ADR-0786) — and ONE read of the caller's rating on the
+# tournament's league. Five, whatever the number of events, whatever the number of
+# entrants in them, and whatever the size of their draws.
+EXPECTED_TOURNAMENT_DETAIL_STATEMENTS = 5
 
 
 @pytest.mark.parametrize("event_count", [1, 4])
@@ -2926,3 +3470,1727 @@ async def test_detail_statement_count_does_not_grow_with_entrants(
     assert [e.rating is not None for e in entrants] == [
         n % 2 == 0 for _ in detail.events for n in range(entrant_count)
     ]
+
+
+# ----- the draw on the detail page (ADR-0786) -------------------------------
+#
+# A draw is the event's **fixtures**: planned pairings, each at a (pool, round,
+# position), whose sides may still be TBD. They ride on the tournament-detail BFF
+# rather than on a ``GET …/draw`` of their own — one endpoint per page (root
+# CLAUDE.md), so a bracket is never a second round-trip the page has to wait for.
+#
+# Nothing writes fixtures yet (the cut endpoint is 1c), so these tests write the rows
+# themselves — exactly as the entrants tests did before the entry route existed.
+
+
+def _coords(event: dict[str, Any]) -> list[tuple[str | None, int, int]]:
+    """An event's draw as the sequence of coordinates it came back in."""
+    return [(f["pool_id"], f["round"], f["position"]) for f in event["fixtures"]]
+
+
+async def _events_by_name(
+    client: AsyncClient, tournament_id: str
+) -> dict[str, dict[str, Any]]:
+    return {e["name"]: e for e in await _events_of(client, tournament_id)}
+
+
+async def test_an_events_draw_comes_back_in_pool_round_position_order(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The draw is ordered by the server, deterministically: pool, then round, then
+    position — the three columns that identify a fixture within its draw.
+
+    The rows are written in deliberately the WRONG order (round 2 before round 1, pool
+    B before pool A, the KO fixture first of all), because insertion order is what a
+    read that forgot to order by anything would come back in — and on a draw cut in one
+    pass, insertion order and the right order would happen to coincide. A test seeded
+    in the right order could not tell the two apart, and would pass against a read with
+    no ORDER BY at all.
+
+    The un-pooled fixture (``pool_id`` NULL — the KO stage of this rr-then-ko event)
+    sorts LAST, after the pools that feed it. NULL is a real value in this domain ("this
+    fixture belongs to no pool"), not a missing one, so it has a defined place in the
+    order rather than an incidental one.
+    """
+    client, _ = authed_client
+    tournament_id, (drawn, _) = await _tournament_with_events(
+        client,
+        _event_payload(name="Open Singles"),
+        _event_payload(name="Under 1500"),
+    )
+
+    await _cut(db_session, drawn["id"], pool_id="p-b", round=2, position=1)
+    await _cut(db_session, drawn["id"], pool_id=None, round=1, position=1)
+    await _cut(db_session, drawn["id"], pool_id="p-b", round=1, position=2)
+    await _cut(db_session, drawn["id"], pool_id="p-a", round=1, position=1)
+    await _cut(db_session, drawn["id"], pool_id="p-b", round=1, position=1)
+
+    events = await _events_by_name(client, tournament_id)
+
+    assert _coords(events["Open Singles"]) == [
+        ("p-a", 1, 1),
+        ("p-b", 1, 1),
+        ("p-b", 1, 2),
+        ("p-b", 2, 1),
+        (None, 1, 1),
+    ]
+
+
+async def test_an_event_whose_draw_is_uncut_carries_an_empty_list(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """An event with no draw is not an error and not a ``null`` — it is an event whose
+    draw has not been cut, which is the normal state of every event ever created
+    (cutting is an explicit act, ADR-0786). It answers ``[]``.
+
+    Its neighbour on the same tournament *is* cut, so this also pins the grouping: a
+    loader that batched the fixtures but lost the event key would spill one event's draw
+    onto the other, and a test with a single event could not see that.
+    """
+    client, _ = authed_client
+    tournament_id, (drawn, undrawn) = await _tournament_with_events(
+        client,
+        _event_payload(name="Open Singles"),
+        _event_payload(name="Under 1500"),
+    )
+    await _cut(db_session, drawn["id"], pool_id="p-a", round=1, position=1)
+
+    events = await _events_by_name(client, tournament_id)
+
+    assert _coords(events["Open Singles"]) == [("p-a", 1, 1)]
+    assert events["Under 1500"]["fixtures"] == []
+
+
+async def test_a_tbd_side_comes_back_as_null_rather_than_a_missing_key(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A fixture's ``null`` side is its whole meaning: **TBD** — the feeding fixture is
+    not decided yet (ADR-0786). It must survive serialization as a ``null``, not be
+    dropped from the payload as an absent key: a client cannot render a bracket slot it
+    was never told about, and "the key is missing" and "the side is unknown" are not the
+    same fact.
+
+    ``winner_entry_id`` and ``match_id`` are the same story — undecided, and not yet a
+    match. The exact key set is asserted, so a field silently dropped (or a username
+    silently *added*) fails here.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _event_payload())
+    ada = await make_user(db_session, "ada-drawn")
+    entry = await _enter(db_session, event["id"], ada)
+    await _cut(
+        db_session, event["id"], pool_id="p-a", round=1, position=1, entry_a=entry
+    )
+
+    (read,) = await _events_of(client, tournament_id)
+    (fixture,) = read["fixtures"]
+
+    assert set(fixture) == {
+        "id",
+        "pool_id",
+        "round",
+        "position",
+        "entry_a_id",
+        "entry_b_id",
+        "winner_entry_id",
+        "match_id",
+    }
+    assert fixture["entry_a_id"] == str(entry.id)
+    # The three facts that are not known yet — each present, each null.
+    assert fixture["entry_b_id"] is None
+    assert fixture["winner_entry_id"] is None
+    assert fixture["match_id"] is None
+
+
+async def test_a_fixtures_sides_are_entry_ids_the_events_entrants_list_resolves(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The contract that lets the fixture carry ids alone: **every entry id a fixture
+    names is on the same event's ``entrants`` list**, so a client joins the two and
+    reads the player's name off the one copy of it.
+
+    The fixture deliberately does NOT repeat the username. A second copy of a name is a
+    field and its own derivation (api/CLAUDE.md), and the copy that drifts is the one a
+    player reads off a bracket. This test is what makes that safe: it fails if a fixture
+    can reference an entry the page cannot resolve.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _event_payload())
+    ada = await make_user(db_session, "ada-seeded")
+    grace = await make_user(db_session, "grace-seeded")
+    ada_entry = await _enter(db_session, event["id"], ada)
+    grace_entry = await _enter(db_session, event["id"], grace)
+    await _cut(
+        db_session,
+        event["id"],
+        pool_id="p-a",
+        round=1,
+        position=1,
+        entry_a=ada_entry,
+        entry_b=grace_entry,
+    )
+
+    (read,) = await _events_of(client, tournament_id)
+    (fixture,) = read["fixtures"]
+
+    entrants = {e["id"]: e["username"] for e in read["entrants"]}
+    named = [fixture["entry_a_id"], fixture["entry_b_id"]]
+    assert all(entry_id in entrants for entry_id in named), (named, entrants)
+    assert [entrants[entry_id] for entry_id in named] == ["ada-seeded", "grace-seeded"]
+
+
+async def test_the_list_and_the_detail_agree_about_an_events_draw(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Both reads go through the one batched loader, so the tournaments list cannot show
+    a draw the detail page disagrees with — including its order."""
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _event_payload())
+    await _cut(db_session, event["id"], pool_id="p-b", round=1, position=1)
+    await _cut(db_session, event["id"], pool_id="p-a", round=1, position=1)
+
+    rows = (await client.get("/v1/tournaments")).json()
+    listed = next(r for r in rows if r["id"] == tournament_id)
+    (listed_event,) = listed["events"]
+    (detail_event,) = await _events_of(client, tournament_id)
+
+    assert _coords(listed_event) == [("p-a", 1, 1), ("p-b", 1, 1)]
+    assert listed_event["fixtures"] == detail_event["fixtures"]
+
+
+async def test_patching_an_event_answers_with_the_draw_it_still_has(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A PATCH is not a re-cut (ADR-0786): the event's draw survives an edit, so the
+    response carries it. Answering ``[]`` here would tell the director their draw had
+    just been thrown away — and the page, which renders what the mutation returned,
+    would show it that way."""
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _event_payload())
+    await _cut(db_session, event["id"], pool_id="p-a", round=1, position=1)
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"name": "Renamed Singles"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert _coords(response.json()) == [("p-a", 1, 1)]
+
+
+async def test_a_new_event_is_born_with_an_empty_draw(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """An event one statement old cannot have a draw — fixtures are only ever written by
+    the cut, an explicit act on an event that already exists (ADR-0786) — so create
+    answers ``[]`` without asking the database."""
+    client, _ = authed_client
+    _, (event,) = await _tournament_with_events(client, _event_payload())
+
+    assert event["fixtures"] == []
+
+
+@pytest.mark.parametrize("event_count", [1, 4])
+async def test_detail_statement_count_does_not_grow_with_drawn_events(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    event_count: int,
+) -> None:
+    """Every event on the page now carries its draw, and the obvious way to fetch one
+    is ``event.fixtures`` inside the serializer's loop — a SELECT per event, on the
+    page whose whole job is to describe a field of events. That N+1 is invisible in
+    every assertion about the *response*: the draws would all come back, correctly,
+    and in the right order.
+
+    What this pin catches that the two sibling pins cannot: **every event in their**
+    fixtures has an *uncut* draw. So a fetch conditioned on an event actually having
+    fixtures — or a loader that skipped the empty ones — costs them nothing and leaves
+    them green, while the real page pays a query per drawn event. Hence the deliberate
+    cut draw on every event here, and the two ``event_count`` cases: a per-event fetch
+    measures 6 statements at one event and 9 at four, so it fails the pin at four even
+    if it slipped past at one.
+    """
+    client, user = authed_client
+    user_id = user.id  # read outside the counted block
+    tournament_id, events = await _tournament_with_events(
+        client,
+        *(_event_payload(name=f"Event {n}") for n in range(event_count)),
+    )
+    for n, event in enumerate(events):
+        entrant = await make_user(db_session, f"drawn-{n}")
+        entry = await _enter(db_session, event["id"], entrant)
+        # Two fixtures per event, so a loader that read only the first row per event
+        # would show up as missing data rather than as a low count.
+        await _cut(
+            db_session, event["id"], pool_id="p-a", round=1, position=1, entry_a=entry
+        )
+        await _cut(db_session, event["id"], pool_id="p-a", round=1, position=2)
+
+    async with counted_statements(engine) as (session, statements):
+        detail = await get_tournament(
+            tournament_id=uuid.UUID(tournament_id),
+            db=session,
+            current_user=User(id=user_id),
+        )
+
+    for n, statement in enumerate(statements, start=1):
+        print(f"[{n}] {' '.join(statement.split())}")
+
+    assert len(statements) == EXPECTED_TOURNAMENT_DETAIL_STATEMENTS, statements
+    # And the counted block really did the work: every event came back with its own
+    # two-fixture draw, in order.
+    assert len(detail.events) == event_count
+    assert all(
+        [(f.pool_id, f.round, f.position) for f in e.fixtures]
+        == [("p-a", 1, 1), ("p-a", 1, 2)]
+        for e in detail.events
+    )
+
+
+# ----- cutting and un-cutting the draw (ADR-0786) ---------------------------
+#
+# ``POST …/events/{id}/draw`` cuts (or re-cuts) an event's draw; ``DELETE`` un-cuts it.
+# Owner-only, refused on evidence of play, and never on the tournament's status.
+#
+# The draw itself is planned by ``app.draws``, whose rules (the snake deal, the circle
+# method, byes-as-absence, the ordering) are pinned against literals in
+# ``tests/test_draws.py``. What these tests own is everything the pure module cannot
+# see: that the right FIELD reaches it (active entries, in the right order), that what
+# comes back is PERSISTED (and replaces what was there), who may ask for it, and the
+# guard that stops a played draw from being thrown away.
+
+# The pools a round-robin event is cut across. Two, so the snake has somewhere to snake
+# to and a fixture's ``pool_id`` is a ref that has to resolve against the right one.
+POOL_A: dict[str, Any] = {
+    "id": "p-a",
+    "name": "Pool A",
+    "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+    "table_ids": ["t1"],
+}
+POOL_B: dict[str, Any] = {
+    "id": "p-b",
+    "name": "Pool B",
+    "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+    "table_ids": ["t2"],
+}
+
+
+def _rr_payload(*pools: dict[str, Any], **overrides: Any) -> dict[str, Any]:
+    """A **round-robin** event over ``pools`` — the one draw type that has a strategy
+    today (ADR-0786). The shared ``_event_payload`` is deliberately an ``rr-then-ko``,
+    which has none, so a draw test that used it would be testing the 422.
+
+    ``draw_type`` is overridable (the unimplemented-type tests need exactly this event
+    with a different generator on it), so it goes through ``overrides``."""
+    return _event_payload(
+        **{"draw_type": "round-robin", "pools": list(pools), **overrides}
+    )
+
+
+def _draw_url(tournament_id: str, event_id: str) -> str:
+    return f"/v1/tournaments/{tournament_id}/events/{event_id}/draw"
+
+
+async def _seed_field(
+    db_session: AsyncSession,
+    event_id: str,
+    count: int,
+    *,
+    prefix: str = "p",
+    seeded: bool = True,
+) -> list[TournamentEntry]:
+    """``count`` active entries, in a draw order this test *states* rather than races
+    for: seeds 1..N by default, and staggered registration times besides.
+
+    The draw's order is seed-ascending, then registration order (ADR-0786). Both are
+    pinned here so the pool each entrant snakes into is a fact of the fixture, not of
+    how quickly the rows happened to be inserted.
+    """
+    start = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+    return [
+        await _enter(
+            db_session,
+            event_id,
+            await make_user(db_session, f"{prefix}{n}"),
+            seed=n if seeded else None,
+            created_at=start + timedelta(minutes=n),
+        )
+        for n in range(1, count + 1)
+    ]
+
+
+async def _fixture_rows(
+    db_session: AsyncSession, event_id: str
+) -> list[TournamentFixture]:
+    """The event's fixtures, straight from the database, in the canonical order.
+
+    Read from the ROW, never from the response: a route that answered with a plan it
+    never persisted would satisfy every assertion made about its body.
+    """
+    return list(
+        (
+            await db_session.execute(
+                select(TournamentFixture)
+                .where(TournamentFixture.event_id == uuid.UUID(event_id))
+                .order_by(
+                    TournamentFixture.pool_id.asc().nulls_last(),
+                    TournamentFixture.round,
+                    TournamentFixture.position,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+def _snapshot(fixtures: Sequence[TournamentFixture]) -> list[tuple[Any, ...]]:
+    """Every column of every fixture — the whole row, not a summary of it.
+
+    What "the refusal changed nothing" has to mean: the same rows, with the same ids,
+    holding the same values. A count would pass against a route that deleted the draw
+    and re-cut an identically-shaped one, which is precisely the harm the play guard
+    exists to prevent.
+    """
+    return [
+        (
+            f.id,
+            f.event_id,
+            f.pool_id,
+            f.round,
+            f.position,
+            f.entry_a_id,
+            f.entry_b_id,
+            f.winner_entry_id,
+            f.match_id,
+        )
+        for f in fixtures
+    ]
+
+
+def _pairs(fixtures: Sequence[TournamentFixture]) -> set[frozenset[uuid.UUID | None]]:
+    """The pairings a draw actually contains, ignoring which side is which."""
+    return {frozenset({f.entry_a_id, f.entry_b_id}) for f in fixtures}
+
+
+async def _make_match(db_session: AsyncSession, creator: User, league: League) -> Match:
+    """A bare match row — the thing a fixture *materializes* into (#788).
+
+    Nothing creates one from a fixture yet, which is exactly why this exists: the play
+    guard has to hold before the path that would trip it does, or it lands already
+    broken.
+    """
+    match = Match(
+        match_settings=MatchSettings(team_size=1, best_of=5, affects_rating=False),
+        league_id=league.id,
+        created_by_user_id=creator.id,
+    )
+    db_session.add(match)
+    await db_session.commit()
+    return match
+
+
+async def test_cutting_a_draw_persists_the_fixtures_the_strategy_planned(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The owner cuts a two-pool round-robin over five players, and the draw it plans is
+    the draw that lands in the database.
+
+    Five over two pools is the smallest field that exercises the whole substrate at
+    once: the snake deals it unevenly (3 and 2, seeds 1/4/5 against 2/3 — the top two
+    seeds land in different pools, which is what a snake is *for*), the odd pool needs
+    the circle method's phantom, and the bye that phantom produces is an **absent row**
+    rather than a fixture with a NULL side (ADR-0786) — so pool A's three rounds hold
+    one fixture each, not two with a hole in one.
+
+    Asserted against the DATABASE as well as the response, because a route that planned
+    a draw and answered with it without ever writing it would pass every assertion about
+    the body — and the next page load would show no draw at all.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    p1, p2, p3, p4, p5 = await _seed_field(db_session, event["id"], 5)
+    # A withdrawn player, who is not an entrant (ADR-0016) and must be in no fixture:
+    # cutting a draw from a field that includes people who have LEFT the event would
+    # seat somebody who is not playing, and size every pool against a field that does
+    # not exist.
+    await _enter(
+        db_session,
+        event["id"],
+        await make_user(db_session, "gone"),
+        status=TournamentEntryStatus.withdrawn,
+    )
+
+    response = await client.post(_draw_url(tournament_id, event["id"]))
+
+    assert response.status_code == 201, response.text
+    body = response.json()
+    rows = await _fixture_rows(db_session, event["id"])
+    # The response IS the persisted draw — same rows, same ids, same order.
+    assert [uuid.UUID(f["id"]) for f in body] == [f.id for f in rows]
+    # Pool A (seeds 1, 4, 5) is the odd one: three rounds, one fixture each, because the
+    # entrant drawn against the phantom that round simply has no fixture. Pool B (seeds
+    # 2, 3) is a single pairing. Ordered pool → round → position.
+    assert [(f.pool_id, f.round, f.position) for f in rows] == [
+        ("p-a", 1, 1),
+        ("p-a", 2, 1),
+        ("p-a", 3, 1),
+        ("p-b", 1, 1),
+    ]
+    # All-play-all *within* each pool, and nobody paired across pools.
+    assert _pairs(rows) == {
+        frozenset({p1.id, p4.id}),
+        frozenset({p1.id, p5.id}),
+        frozenset({p4.id, p5.id}),
+        frozenset({p2.id, p3.id}),
+    }
+    # Both sides of every round-robin fixture are known at the cut, and nothing is
+    # played yet: no TBDs, no winners, no matches.
+    assert all(
+        f.entry_a_id is not None
+        and f.entry_b_id is not None
+        and f.winner_entry_id is None
+        and f.match_id is None
+        for f in rows
+    )
+    # Exactly the five active entrants are seated — so the withdrawn player, who has an
+    # entry row in this very event, is in no fixture at all.
+    seated = {f.entry_a_id for f in rows} | {f.entry_b_id for f in rows}
+    assert seated == {p1.id, p2.id, p3.id, p4.id, p5.id}
+
+
+async def test_an_unseeded_field_is_drawn_in_registration_order(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Nothing sets a seed today (ADR-0786), so the draw a real club night gets is the
+    one ordered by **registration order** — and this is the test that the entry rows'
+    ``created_at`` is what reaches the planner, not the order Postgres felt like
+    returning them in.
+
+    Four unseeded players, registered 1→4 and written in that order, over two pools: the
+    snake puts 1 and 4 together and 2 and 3 together. A cut that read the field in *any*
+    other order (the table's physical order, the id order) would deal them differently,
+    and there is no way to see that from the shape of the draw alone — both pools hold
+    one fixture either way. So the pairings are what is asserted.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    first, second, third, fourth = await _seed_field(
+        db_session, event["id"], 4, seeded=False
+    )
+
+    response = await client.post(_draw_url(tournament_id, event["id"]))
+
+    assert response.status_code == 201, response.text
+    rows = await _fixture_rows(db_session, event["id"])
+    assert _pairs(rows) == {
+        frozenset({first.id, fourth.id}),  # pool A: the snake's 1 and 4
+        frozenset({second.id, third.id}),  # pool B: its 2 and 3
+    }
+
+
+async def test_a_second_cut_replaces_the_draw_wholesale(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Re-cutting after the field changed **replaces** the draw: the old fixtures are
+    gone — their ids with them — not amended in place, and not merely added to.
+
+    That is the whole promise of the explicit cut (ADR-0786): a draw is a plan made
+    against a field, so when the field changes the plan is re-made. A reconcile that
+    kept the old rows and updated their sides would be the same draw wearing the same
+    ids while seating different people — the fixture a director bookmarked would
+    silently become somebody else's match.
+
+    Asserted by IDENTITY, not by shape: the id sets before and after are disjoint, and
+    every old id is gone from the table. A count would pass against a route that left
+    the two old fixtures alone and appended the new ones, which is exactly the bug.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    await _seed_field(db_session, event["id"], 4)
+
+    first_cut = await client.post(_draw_url(tournament_id, event["id"]))
+    assert first_cut.status_code == 201, first_cut.text
+    before = {f.id for f in await _fixture_rows(db_session, event["id"])}
+    # Two pools of two: one fixture each.
+    assert len(before) == 2
+
+    # A fifth player enters after the cut — the draw is now STALE, which is the whole
+    # reason to re-cut.
+    await _enter(
+        db_session,
+        event["id"],
+        await make_user(db_session, "latecomer"),
+        seed=5,
+        created_at=datetime(2026, 6, 1, 10, 0, tzinfo=UTC),
+    )
+
+    second_cut = await client.post(_draw_url(tournament_id, event["id"]))
+
+    assert second_cut.status_code == 201, second_cut.text
+    rows = await _fixture_rows(db_session, event["id"])
+    after = {f.id for f in rows}
+    # Not one row of the old draw survived — disjoint id sets, and the old ids are not
+    # merely displaced, they are DELETED.
+    assert after.isdisjoint(before), (before, after)
+    survivors = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(TournamentFixture)
+            .where(TournamentFixture.id.in_(before))
+        )
+    ).scalar_one()
+    assert survivors == 0
+    # And the new draw is the one the new field implies: pool A now holds three players
+    # (three fixtures), pool B two (one).
+    assert [(f.pool_id, f.round, f.position) for f in rows] == [
+        ("p-a", 1, 1),
+        ("p-a", 2, 1),
+        ("p-a", 3, 1),
+        ("p-b", 1, 1),
+    ]
+    assert {uuid.UUID(f["id"]) for f in second_cut.json()} == after
+    # The page shows the same thing the mutation answered with — same rows, same order.
+    (read,) = await _events_of(client, tournament_id)
+    assert read["fixtures"] == second_cut.json()
+
+
+async def test_un_cutting_deletes_the_draw_and_is_idempotent(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """DELETE removes the event's fixtures and leaves everything else standing — and
+    doing it twice is still a 204.
+
+    An event with no draw is already in the state the second DELETE asks for, and this
+    is a DELETE: asking for a state the resource already holds is a success, not a 404
+    (the same reasoning that makes withdrawing an already-withdrawn entry a 204).
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    entries = await _seed_field(db_session, event["id"], 4)
+    await client.post(_draw_url(tournament_id, event["id"]))
+    assert await _fixture_rows(db_session, event["id"]) != []
+
+    response = await client.delete(_draw_url(tournament_id, event["id"]))
+
+    assert response.status_code == 204, response.text
+    assert await _fixture_rows(db_session, event["id"]) == []
+    # The entrants are untouched — un-cutting a draw un-does the DRAW, not the field.
+    (read,) = await _events_of(client, tournament_id)
+    assert read["fixtures"] == []
+    assert {e["id"] for e in read["entrants"]} == {str(e.id) for e in entries}
+
+    # Again: the event has no draw, and that is what was asked for.
+    again = await client.delete(_draw_url(tournament_id, event["id"]))
+    assert again.status_code == 204, again.text
+
+
+# ----- who may cut ----------------------------------------------------------
+
+
+async def test_a_non_owner_cannot_cut_or_un_cut_a_draw(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Cutting a draw is a property of OWNING the tournament — no permission grants it.
+
+    The stranger here holds ``tournament.view`` + ``tournament.create``, so they are a
+    fully-permitted user of the platform; what they are not is the director of this
+    tournament. Both verbs answer 403, and the standing draw is untouched — a refusal
+    that had deleted the fixtures first would be a 403 in name only.
+    """
+    owner_client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        owner_client, _rr_payload(POOL_A, POOL_B)
+    )
+    await _seed_field(db_session, event["id"], 4)
+    await owner_client.post(_draw_url(tournament_id, event["id"]))
+    before = _snapshot(await _fixture_rows(db_session, event["id"]))
+
+    async with make_client() as stranger:
+        user = await start_session(stranger, db_session)
+        await _grant_tournament_perms(db_session, user)
+
+        assert (
+            await stranger.post(_draw_url(tournament_id, event["id"]))
+        ).status_code == 403
+        assert (
+            await stranger.delete(_draw_url(tournament_id, event["id"]))
+        ).status_code == 403
+
+    assert _snapshot(await _fixture_rows(db_session, event["id"])) == before
+
+
+async def test_an_anonymous_caller_cannot_cut_or_un_cut_a_draw(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """No session, no draw: both verbs are 401 before ownership is even a question."""
+    owner_client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        owner_client, _rr_payload(POOL_A, POOL_B)
+    )
+    await _seed_field(db_session, event["id"], 4)
+    await owner_client.post(_draw_url(tournament_id, event["id"]))
+    before = _snapshot(await _fixture_rows(db_session, event["id"]))
+
+    async with make_client() as anonymous:  # no ``start_session``: no cookie at all
+        assert (
+            await anonymous.post(_draw_url(tournament_id, event["id"]))
+        ).status_code == 401
+        assert (
+            await anonymous.delete(_draw_url(tournament_id, event["id"]))
+        ).status_code == 401
+
+    assert _snapshot(await _fixture_rows(db_session, event["id"])) == before
+
+
+@pytest.mark.parametrize("verb", ["post", "delete"])
+async def test_a_draw_on_a_tournament_or_event_that_does_not_exist_is_404(
+    authed_client: tuple[AsyncClient, User],
+    verb: str,
+) -> None:
+    """404 before 403 before 409 (ADR-0017), and the event must belong to the named
+    tournament: a right event id under the wrong tournament id is not addressable
+    through this URL, so it is a 404 rather than a cut of the event the caller did not
+    name."""
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    other_id, _ = await _tournament_with_events(client)
+    missing = str(uuid.uuid4())
+    call = getattr(client, verb)
+
+    assert (await call(_draw_url(missing, event["id"]))).status_code == 404
+    assert (await call(_draw_url(tournament_id, missing))).status_code == 404
+    # The event exists, and so does the tournament — but not together.
+    assert (await call(_draw_url(other_id, event["id"]))).status_code == 404
+
+
+# ----- the draws this event cannot produce (422) ----------------------------
+
+
+@pytest.mark.parametrize(
+    "draw_type", ["single-elim", "double-elim", "rr-then-ko", "swiss"]
+)
+async def test_cutting_an_unimplemented_draw_type_is_422(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    draw_type: str,
+) -> None:
+    """Only round-robin has a strategy today (ADR-0786). The other four are a designed
+    422 that NAMES the draw type — not a 500 from an unhandled exception, and not an
+    empty draw the director would have to notice was empty.
+
+    422, because the request is well-formed and authorized: it is this event's *content*
+    — the draw type it was configured with — that cannot become a draw. Nothing is
+    written, and the field is left alone.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B, draw_type=draw_type)
+    )
+    await _seed_field(db_session, event["id"], 4)
+
+    response = await client.post(_draw_url(tournament_id, event["id"]))
+
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert draw_type in detail, detail
+    # The sentence is for the director, and it says what to do about it. It is NOT the
+    # exception's own ("… is not implemented yet"), which is written for the developer
+    # who has to go implement it.
+    assert "cannot be cut yet" in detail, detail
+    assert await _fixture_rows(db_session, event["id"]) == []
+
+
+@pytest.mark.parametrize(
+    ("pools", "entrants", "expected"),
+    [
+        pytest.param(
+            (),
+            4,
+            "A round-robin draw needs at least one pool.",
+            id="no-pools",
+        ),
+        pytest.param(
+            (POOL_A, POOL_B),
+            3,
+            "3 entrants across 2 pool(s) would leave a pool with fewer than 2 "
+            "entrants, who would have nobody to play.",
+            id="a-pool-of-one",
+        ),
+        pytest.param(
+            (POOL_A,),
+            0,
+            "0 entrants across 1 pool(s) would leave a pool with fewer than 2 "
+            "entrants, who would have nobody to play.",
+            id="no-entrants-at-all",
+        ),
+    ],
+)
+async def test_cutting_a_draw_that_is_not_a_competition_is_422(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    pools: tuple[dict[str, Any], ...],
+    entrants: int,
+    expected: str,
+) -> None:
+    """A draw the domain will not produce, because it would not be a competition: an
+    event with no pools to deal into, a field too small for the pools it has (somebody
+    would be alone in a pool, with nobody to play), and the empty field that is both.
+
+    Each is a 422 whose ``detail`` names the numbers the director has to change — the
+    pool count and the size of the field — because "invalid draw" tells them nothing
+    about which of the two to move.
+
+    And each writes NOTHING. That is the property the re-cut path depends on: the plan
+    is made before the old draw is deleted, so a refusal cannot leave an event with the
+    fixtures it had thrown away and none of the ones it could not make.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(*pools))
+    await _seed_field(db_session, event["id"], entrants)
+
+    response = await client.post(_draw_url(tournament_id, event["id"]))
+
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"] == expected
+    assert await _fixture_rows(db_session, event["id"]) == []
+
+
+async def test_a_refused_re_cut_leaves_the_standing_draw_untouched(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The 422 that matters most: an event that HAS a draw, re-cut into a configuration
+    the domain refuses.
+
+    Two players withdraw from a cut two-pool event, leaving a field of two that cannot
+    fill two pools. The re-cut is refused — and the draw the event already had is still
+    there, row for row. A director who mis-clicks into a refusal must not lose the draw
+    they had; the 422 has to be a refusal, not a demolition that failed to rebuild.
+
+    What this test can and cannot see, stated because it was measured: the property has
+    **two** independent protections — ``cut_draw`` plans before it deletes, and the
+    route rolls the transaction back — so removing *either one* leaves this test green
+    (both were mutated; both stayed green). It fails only against a cut that deleted the
+    old draw and **committed** before planning the new one, which is the shape the bug
+    actually takes when somebody makes a service function commit for convenience. Read
+    its green as "the draw survives a 422", not as "the ordering in ``cut_draw`` is
+    pinned" — it isn't, and the comment there says so.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    entries = await _seed_field(db_session, event["id"], 4)
+    await client.post(_draw_url(tournament_id, event["id"]))
+    before = _snapshot(await _fixture_rows(db_session, event["id"]))
+    assert before != []
+
+    for entry in entries[:2]:
+        entry.status = TournamentEntryStatus.withdrawn
+    await db_session.commit()
+
+    response = await client.post(_draw_url(tournament_id, event["id"]))
+
+    assert response.status_code == 422, response.text
+    assert _snapshot(await _fixture_rows(db_session, event["id"])) == before
+
+
+# ----- the play guard (409) -------------------------------------------------
+
+
+@pytest.mark.parametrize("evidence", ["winner", "match"])
+@pytest.mark.parametrize("verb", ["post", "delete"])
+async def test_a_played_draw_can_be_neither_re_cut_nor_un_cut(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    default_league: League,
+    evidence: str,
+    verb: str,
+) -> None:
+    """Evidence of play seals the draw — for BOTH verbs, and for both kinds of evidence.
+
+    A cut replaces the draw wholesale and an un-cut destroys it, so either one, run
+    over a fixture that has been played, throws away a result a player actually
+    produced. The refusal is a 409: the caller is the owner and the draw is theirs; it
+    is the draw that is past the point where re-cutting means anything.
+
+    The two kinds of evidence are deliberately not one:
+
+    * a **recorded winner** — the fixture is decided;
+    * a **linked match** — the fixture has materialized, and that match may already
+      carry games on its scratchpad or a proposed result. This half is why the guard is
+      *stricter* than "matches already played" (issue #785's phrasing): the draw must
+      never silently eat entered scores, and a match with a score on it is not
+      something the API can tell apart from one without, from here.
+
+    Nothing can *produce* either state yet — materialization is #788 — so the test
+    writes it directly. That is the point of writing the guard now: it has to be
+    standing before the path that trips it exists, or it lands already broken.
+
+    The refusal must leave the draw **byte-for-byte** unchanged: every id, every side,
+    every column (``_snapshot``). "Still some rows" would pass against a route that
+    deleted the draw and re-cut an identical-looking one, and the ids the results hang
+    off would be gone.
+    """
+    client, owner = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    await _seed_field(db_session, event["id"], 4)
+    await client.post(_draw_url(tournament_id, event["id"]))
+
+    played, *_ = await _fixture_rows(db_session, event["id"])
+    if evidence == "winner":
+        played.winner_entry_id = played.entry_a_id
+    else:
+        played.match_id = (await _make_match(db_session, owner, default_league)).id
+    await db_session.commit()
+    before = _snapshot(await _fixture_rows(db_session, event["id"]))
+
+    response = await getattr(client, verb)(_draw_url(tournament_id, event["id"]))
+
+    assert response.status_code == 409, response.text
+    assert "already under way" in response.json()["detail"]
+    assert _snapshot(await _fixture_rows(db_session, event["id"])) == before
+
+
+async def test_the_play_guard_is_scoped_to_the_event_being_cut(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """One event's play does not seal another's draw.
+
+    A tournament runs several events at once, and the under-13s starting does not mean
+    the open singles' late entrant can no longer be drawn in. A guard that asked "has
+    anything in this tournament been played?" would freeze every draw on the day the
+    first match started — which is exactly when a director still needs to re-cut around
+    the no-shows.
+    """
+    client, _ = authed_client
+    tournament_id, (played_event, other_event) = await _tournament_with_events(
+        client,
+        _rr_payload(POOL_A, POOL_B, name="Under 13s"),
+        _rr_payload(POOL_A, POOL_B, name="Open Singles"),
+    )
+    await _seed_field(db_session, played_event["id"], 4, prefix="u13-")
+    await _seed_field(db_session, other_event["id"], 4, prefix="open-")
+    await client.post(_draw_url(tournament_id, played_event["id"]))
+    await client.post(_draw_url(tournament_id, other_event["id"]))
+
+    played, *_ = await _fixture_rows(db_session, played_event["id"])
+    played.winner_entry_id = played.entry_a_id
+    await db_session.commit()
+
+    # The played event is sealed…
+    sealed = await client.post(_draw_url(tournament_id, played_event["id"]))
+    assert sealed.status_code == 409, sealed.text
+    # …and its neighbour is not.
+    open_recut = await client.post(_draw_url(tournament_id, other_event["id"]))
+    assert open_recut.status_code == 201, open_recut.text
+
+
+# ----- the row lock behind the cut ------------------------------------------
+
+
+async def test_both_draw_verbs_take_the_tournaments_row_lock(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+) -> None:
+    """A cut reads the event's active field and writes fixtures **derived from it**, so
+    it is a judge-then-write path and it takes the tournament's row lock — the same
+    lock, on the same row, taken first, that entering, withdrawing, transitioning and
+    PATCHing already take (which keeps the five of them free of a deadlock cycle).
+
+    Without it the read and the write sit in different instants (Postgres runs READ
+    COMMITTED), and an entry committing between them leaves a persisted draw that never
+    matched any real field: a pool sized for four players holding five, or an entrant
+    who registered in time and is seated nowhere. Every writer of that field already
+    queues on this row; the lock is what puts the cut in the same queue.
+
+    The un-cut takes it too. It reads the play evidence and then deletes what that
+    evidence protects — the same judge-then-write shape — and taking the one lock in the
+    one order is also what keeps the two draw verbs from racing each other.
+
+    Pinned on the *statement*, as ``test_only_the_mutating_loader_takes_the_row_lock``
+    pins the lifecycle's: a lock that quietly stopped being asked for would reopen the
+    race in silence, and no assertion about a response body would notice.
+    """
+    client, owner = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    await _seed_field(db_session, event["id"], 4)
+    owner_id = owner.id
+
+    async with counted_statements(engine) as (session, statements):
+        await cut_event_draw(
+            tournament_id=uuid.UUID(tournament_id),
+            event_id=uuid.UUID(event["id"]),
+            db=session,
+            current_user=User(id=owner_id),
+        )
+    assert any("FOR UPDATE" in s for s in statements), statements
+
+    async with counted_statements(engine) as (session, statements):
+        await uncut_event_draw(
+            tournament_id=uuid.UUID(tournament_id),
+            event_id=uuid.UUID(event["id"]),
+            db=session,
+            current_user=User(id=owner_id),
+        )
+    assert any("FOR UPDATE" in s for s in statements), statements
+
+
+# ----- the pool-set freeze (409) --------------------------------------------
+#
+# A fixture names its pool by a string ref into the event's own ``pools`` JSONB, and
+# there is no pools table to foreign-key (ADR-0786). So the DATABASE cannot refuse the
+# edit that orphans a fixture — the event PATCH must, and these are the tests of it.
+#
+# What freezes once a draw is cut is the pool **id set**, and only that. Everything else
+# about a pool — its tables, its window, its name — stays editable with a draw standing,
+# because venues move under running tournaments. Both halves are load-bearing: a freeze
+# that also froze the tables would force a director to destroy a *correct* draw just to
+# record a broken table, which is worse than the bug it was guarding against.
+
+# A third pool, for the payloads that try to grow the event's pool set.
+POOL_C: dict[str, Any] = {
+    "id": "p-c",
+    "name": "Pool C",
+    "slot": {"date": "2026-06-13", "start": "13:00", "end": "16:30"},
+    "table_ids": ["t3"],
+}
+
+
+async def _pools_of(db_session: AsyncSession, event_id: str) -> list[dict[str, Any]]:
+    """The event's ``pools``, read straight from the JSONB column.
+
+    A column-only ``SELECT``, deliberately: it never touches the identity map, so what
+    comes back is what the *row* holds and not a stale ORM instance the test session
+    happened to be holding from before the request.
+
+    This is what "the refusal changed nothing" has to be asserted against. "The event
+    still has pools" would pass against a guard that 409'd *after* writing them.
+    """
+    pools = (
+        await db_session.execute(
+            select(TournamentEvent.pools).where(
+                TournamentEvent.id == uuid.UUID(event_id)
+            )
+        )
+    ).scalar_one()
+    return list(pools)
+
+
+async def _cut_two_pool_event(
+    client: AsyncClient, db_session: AsyncSession
+) -> tuple[str, dict[str, Any]]:
+    """A two-pool round-robin over four players, with its draw **cut** — the state the
+    freeze applies in. Four fixtures, two in each pool, every one of them holding a
+    ``pool_id`` that resolves against the event's pools."""
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    await _seed_field(db_session, event["id"], 4)
+    cut = await client.post(_draw_url(tournament_id, event["id"]))
+    assert cut.status_code == 201, cut.text
+    return tournament_id, event
+
+
+@pytest.mark.parametrize(
+    ("edit", "description"),
+    [
+        pytest.param({"table_ids": ["t7", "t8"]}, "a table breaks", id="tables"),
+        pytest.param(
+            {"slot": {"date": "2026-06-13", "start": "10:30", "end": "14:00"}},
+            "the pool runs late",
+            id="window",
+        ),
+        pytest.param({"name": "Morning Pool"}, "the director renames it", id="name"),
+    ],
+)
+async def test_a_cut_draw_still_lets_a_pools_venue_attributes_be_edited(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    edit: dict[str, Any],
+    description: str,
+) -> None:
+    """The case the freeze exists to **permit**. With the draw cut, the director changes
+    a pool's tables, its time window, or its name — and the PATCH succeeds.
+
+    This is the whole point of freezing the id *set* rather than the pools: venues
+    change under a running tournament. A table breaks and is pulled; another frees up
+    early; a pool slips an hour. A director who could not record that without un-cutting
+    the draw would have to destroy a draw that is *correct* — losing every placement —
+    to move a table, and would simply stop using the app on the day.
+
+    The rename is the subtle one. A name is identity-*adjacent* and it is not identity:
+    "Pool A" becoming "Morning Pool" keeps the ``id`` the fixtures actually hold, so
+    every one of them still resolves. It is a display change, and it is allowed.
+
+    The fixtures are asserted **untouched** (``_snapshot``, every column of every row)
+    and not merely present: an edit that quietly re-cut the draw to "keep it consistent"
+    would satisfy a count and would have thrown away the placements anyway.
+    """
+    client, _ = authed_client
+    tournament_id, event = await _cut_two_pool_event(client, db_session)
+    before = _snapshot(await _fixture_rows(db_session, event["id"]))
+    edited = [{**POOL_A, **edit}, POOL_B]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"pools": edited},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["pools"] == edited
+    assert await _pools_of(db_session, event["id"]) == edited
+    assert _snapshot(await _fixture_rows(db_session, event["id"])) == before
+
+
+@pytest.mark.parametrize(
+    ("pools", "named"),
+    [
+        pytest.param([POOL_A, POOL_B, POOL_C], ["Pool C"], id="added"),
+        pytest.param([POOL_A], ["Pool B"], id="removed"),
+        pytest.param([], ["Pool A", "Pool B"], id="cleared"),
+        pytest.param(
+            [POOL_A, {**POOL_B, "id": "p-b2"}], ["Pool B"], id="re-identified"
+        ),
+    ],
+)
+async def test_a_cut_draw_refuses_a_pools_patch_that_changes_which_pools_exist(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    pools: list[dict[str, Any]],
+    named: list[str],
+) -> None:
+    """The freeze itself: with a draw standing, a ``pools`` payload must carry exactly
+    the pool ids the event already has.
+
+    Each arm is a different way to break the same reference, and none of them is a thing
+    the database can refuse (``pool_id`` is a string ref into JSONB, not a foreign key):
+
+    * **added** — the new pool arrives with no fixtures, because the draw was dealt
+      across the pools that existed at the cut and nothing re-deals it;
+    * **removed** / **cleared** — every fixture drawn into the departing pool now names
+      a pool that does not exist;
+    * **re-identified** — a pool that keeps its name and changes its ``id`` is *both* of
+      the above at once, and it is the one a director would never see coming. The pools
+      page looks unchanged; the fixtures are all orphaned.
+
+    409, not 403 (ADR-0017): the caller is the owner and the payload is well-formed — it
+    is the event that is in the wrong *state* for it, and the same payload becomes legal
+    the moment the draw is removed.
+
+    The refusal must change **nothing**, and both halves of "nothing" are asserted: the
+    pools JSONB is the same list of dicts it was (not "still non-empty"), and the
+    fixtures are the same rows, column for column. That is not decoration — it was
+    measured. A guard that judged the pools correctly but raised *after* the ``setattr``
+    loop (leaving the rollback to clean up) was mutated in, and it still 409s: only the
+    pools-JSONB assertion reds, because the dirty write is flushed ahead of the read. A
+    status-code-only test passes that guard — which would persist the very edit it
+    refuses the day somebody added a ``commit`` somewhere convenient.
+    """
+    client, _ = authed_client
+    tournament_id, event = await _cut_two_pool_event(client, db_session)
+    fixtures_before = _snapshot(await _fixture_rows(db_session, event["id"]))
+    pools_before = await _pools_of(db_session, event["id"])
+    assert pools_before == [POOL_A, POOL_B]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"pools": pools},
+    )
+
+    assert response.status_code == 409, response.text
+    # The copy names the pools that are in the way, by NAME: a director reads names, and
+    # "the pool set is frozen" without saying which pool moved is unactionable.
+    detail = response.json()["detail"]
+    for name in named:
+        assert name in detail, detail
+    assert await _pools_of(db_session, event["id"]) == pools_before
+    assert _snapshot(await _fixture_rows(db_session, event["id"])) == fixtures_before
+
+
+async def test_a_refused_pools_patch_writes_none_of_the_rest_of_the_payload_either(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The refusal is total, not partial: a PATCH that renames the event *and* removes a
+    pool changes neither.
+
+    The event's other fields are not innocent bystanders that may as well land — the
+    payload is one request and it is refused as one. This is the test that fails against
+    a guard placed *after* the ``setattr`` loop and rescued only by the rollback, and
+    against one that checked the pools while letting the rest through.
+    """
+    client, _ = authed_client
+    tournament_id, event = await _cut_two_pool_event(client, db_session)
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"name": "Renamed Event", "pools": [POOL_A]},
+    )
+
+    assert response.status_code == 409, response.text
+    (name,) = (
+        (
+            await db_session.execute(
+                select(TournamentEvent.name).where(
+                    TournamentEvent.id == uuid.UUID(event["id"])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert name == event["name"]
+    assert await _pools_of(db_session, event["id"]) == [POOL_A, POOL_B]
+
+
+async def test_an_event_with_no_draw_replaces_its_pools_wholesale(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """No draw, no freeze: the pools of an un-drawn event are configuration, and they
+    replace wholesale exactly as they always have.
+
+    The pools are swapped for an entirely different set — different ids, different count
+    — which is the payload the freeze refuses on a cut event. There are no fixtures to
+    orphan, so there is nothing to refuse, and a guard that fired on the *pools* rather
+    than on the *draw* would break every director who is still setting the event up.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"pools": [POOL_C]},
+    )
+
+    assert response.status_code == 200, response.text
+    assert await _pools_of(db_session, event["id"]) == [POOL_C]
+
+
+async def test_removing_the_draw_un_freezes_the_pool_set(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The way out, end to end: the PATCH the freeze refused is the PATCH that succeeds
+    once the draw is gone.
+
+    ``DELETE …/draw`` un-freezes the pool set — by construction, since the freeze is a
+    fact about the fixtures existing — and that is what makes the 409 a *conflict*
+    rather than a prohibition: the director has somewhere to go. The refusal's own copy
+    tells them to come this way, so the path it names had better work.
+    """
+    client, _ = authed_client
+    tournament_id, event = await _cut_two_pool_event(client, db_session)
+    url = f"/v1/tournaments/{tournament_id}/events/{event['id']}"
+    repooled = [POOL_A, POOL_B, POOL_C]
+
+    refused = await client.patch(url, json={"pools": repooled})
+    assert refused.status_code == 409, refused.text
+
+    uncut = await client.delete(_draw_url(tournament_id, event["id"]))
+    assert uncut.status_code == 204, uncut.text
+
+    accepted = await client.patch(url, json={"pools": repooled})
+
+    assert accepted.status_code == 200, accepted.text
+    assert await _pools_of(db_session, event["id"]) == repooled
+    assert await _fixture_rows(db_session, event["id"]) == []
+
+
+async def test_a_patch_that_does_not_send_pools_is_untouched_by_the_freeze(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A cut draw does not freeze the *event* — only its set of pools.
+
+    The director may still rename the event, move its entry fee, tighten its rules. A
+    guard that fired on any PATCH of an event with a draw (rather than on a ``pools``
+    payload that changes the id set) would pass every test above and would lock the
+    whole event on the day it was drawn.
+    """
+    client, _ = authed_client
+    tournament_id, event = await _cut_two_pool_event(client, db_session)
+    before = _snapshot(await _fixture_rows(db_session, event["id"]))
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"name": "Open Singles (redrawn)"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["name"] == "Open Singles (redrawn)"
+    assert await _pools_of(db_session, event["id"]) == [POOL_A, POOL_B]
+    assert _snapshot(await _fixture_rows(db_session, event["id"])) == before
+
+
+async def test_the_pool_freeze_is_scoped_to_the_event_being_patched(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """One event's draw does not freeze another event's pools.
+
+    A tournament runs several events at once and they are drawn on different days. The
+    under-13s being drawn must not stop the director from still building the open
+    singles' pools — which is what a guard that asked "does this *tournament* have any
+    fixtures?" would do.
+    """
+    client, _ = authed_client
+    tournament_id, (drawn, undrawn) = await _tournament_with_events(
+        client,
+        _rr_payload(POOL_A, POOL_B, name="Under 13s"),
+        _rr_payload(POOL_A, POOL_B, name="Open Singles"),
+    )
+    await _seed_field(db_session, drawn["id"], 4, prefix="u13-")
+    await client.post(_draw_url(tournament_id, drawn["id"]))
+
+    # The drawn event's pool set is frozen…
+    sealed = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{drawn['id']}",
+        json={"pools": [POOL_A, POOL_B, POOL_C]},
+    )
+    assert sealed.status_code == 409, sealed.text
+    # …and its neighbour's, which has no draw, is not.
+    free = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{undrawn['id']}",
+        json={"pools": [POOL_C]},
+    )
+    assert free.status_code == 200, free.text
+    assert await _pools_of(db_session, undrawn["id"]) == [POOL_C]
+
+
+async def test_the_event_patch_takes_the_tournaments_row_lock(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+) -> None:
+    """The event PATCH is a judge-then-write path now, so it takes the tournament's row
+    lock — the same lock, on the same row, taken first, that the draw verbs, the
+    transition, the entry and the withdrawal take (which is what keeps them free of a
+    deadlock cycle).
+
+    The freeze reads whether a draw exists and then writes the pools that draw's
+    fixtures refer to. Postgres runs READ COMMITTED, so without the lock those two sit
+    in different instants: a cut committing between them is a draw cut across pools this
+    request is in the middle of replacing — fixtures orphaned at birth, refused by
+    nothing, and neither request wrong on its own.
+
+    Pinned on the *statement*, like ``test_only_the_mutating_loader_takes_the_row_lock``
+    and ``test_both_draw_verbs_take_the_tournaments_row_lock``: a lock that quietly
+    stopped being taken would reopen the race in silence, and no assertion about a
+    response body would notice.
+    """
+    client, owner = authed_client
+    tournament_id, event = await _cut_two_pool_event(client, db_session)
+    owner_id = owner.id
+
+    async with counted_statements(engine) as (session, statements):
+        await update_event(
+            tournament_id=uuid.UUID(tournament_id),
+            event_id=uuid.UUID(event["id"]),
+            payload=TournamentEventUpdate(name="Open Singles (moved)"),
+            db=session,
+            current_user=User(id=owner_id),
+        )
+    assert any("FOR UPDATE" in s for s in statements), statements
+
+
+# ----- a pool id identifies one pool (422) -----------------------------------
+#
+# The freeze above protects the pool ids a draw was cut across. It rests on an
+# assumption nothing enforced: that an id names ONE pool. Pools are JSONB with
+# client-supplied string ids — there is no pools table, so no unique index — and an
+# event with two pools called ``p-a`` was stored verbatim (measured: 201). The bill
+# arrived at the cut, which deals the field across the event's pool ids: two pools with
+# one id deal onto the same ``(event_id, pool_id, round, position)``, and the fixture
+# table's unique constraint answers the director with a **500**.
+#
+# Worse, the freeze itself let the poison in by PATCH, because it compares SETS:
+# ``[A, A, B]`` against a cut event holding ``{A, B}`` is the same set, so the guard
+# that exists to protect the draw waved through the payload that breaks it (measured:
+# 200, then the next cut 500'd). So the rule lives at the BOUNDARY — one validator on
+# the ``pools`` list type both write schemas share, covering create and patch in one
+# place, in every state the event can be in.
+
+
+def _pools_error(response: Response) -> str:
+    """The 422's message for the ``pools`` field, as one string.
+
+    A pydantic 422 is a *list* of errors keyed by ``loc``; the copy the director reads
+    is the ``msg``. Reading it out of the right ``loc`` is what stops this test from
+    passing on some *other* field's refusal.
+    """
+    errors = response.json()["detail"]
+    return " ".join(
+        error["msg"] for error in errors if error["loc"][:2] == ["body", "pools"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("pools", "named"),
+    [
+        pytest.param([POOL_A, POOL_A], ["p-a"], id="the-same-pool-twice"),
+        pytest.param([POOL_A, {**POOL_B, "id": "p-a"}], ["p-a"], id="two-pools-one-id"),
+        pytest.param(
+            [POOL_A, POOL_A, POOL_B, POOL_B], ["p-a", "p-b"], id="two-ids-duplicated"
+        ),
+    ],
+)
+async def test_creating_an_event_with_duplicate_pool_ids_is_refused(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    pools: list[dict[str, Any]],
+    named: list[str],
+) -> None:
+    """An event cannot be **born** holding two pools with the same id.
+
+    ``two-pools-one-id`` is the arm that matters: two genuinely different pools
+    (different names, different tables, different windows) that happen to share an
+    ``id``. The pools page looks perfectly sane, and the draw is undrawable. Duplicating
+    a whole pool is the same fault with an easier tell.
+
+    The refusal names the duplicated **id**, not a pool name: an id is what is
+    duplicated, the two pools sharing it may be named anything, and the id is the thing
+    the director has to go and change.
+
+    422, not 409 — this is a malformed payload in *every* state the event could be in.
+    An event with no draw at all still cannot have two pools called ``p-a``; there is no
+    later moment at which this body becomes legal, which is exactly what separates it
+    from the pool-set freeze's conflict.
+
+    And the refusal creates **nothing**: a 422 that had already written the event would
+    be a 422 in name only.
+    """
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+
+    response = await client.post(
+        f"/v1/tournaments/{created['id']}/events", json=_rr_payload(*pools)
+    )
+
+    assert response.status_code == 422, response.text
+    message = _pools_error(response)
+    for pool_id in named:
+        assert f"“{pool_id}”" in message, message
+    assert await _events_of(client, created["id"]) == []
+
+
+async def test_a_pools_patch_that_duplicates_an_id_never_reaches_the_cut_draw(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """**The discriminating case**, and the one the set-based freeze cannot see.
+
+    ``[A, A, B]`` against a cut event holding ``{A, B}`` is, as a *set*, exactly the
+    pools the event already has. ``_enforce_pool_set_frozen`` compares sets — because
+    identity is all it is about — so it finds nothing removed and nothing added, and it
+    waved this payload through: measured **200**, the duplicate stored verbatim, and the
+    *next* cut dead on ``uq_tournament_fixtures_event_id_pool_id_round_position`` (a
+    **500**). The guard that exists to protect the draw was admitting the payload that
+    poisons it.
+
+    A boundary rule is what closes it, because the freeze is the wrong instrument: it
+    can only ever compare which pools exist, and this payload does not change that.
+
+    The proof is not the status code. It is the **re-cut afterwards**: the same event,
+    cut again, still answers 201. A guard that 409'd or 422'd and *wrote the pools
+    anyway* would satisfy every assertion about the response and still hand the director
+    the 500 the moment they cut — so the cut is where this test looks.
+    """
+    client, _ = authed_client
+    tournament_id, event = await _cut_two_pool_event(client, db_session)
+    fixtures_before = _snapshot(await _fixture_rows(db_session, event["id"]))
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"pools": [POOL_A, POOL_A, POOL_B]},
+    )
+
+    assert response.status_code == 422, response.text
+    assert "“p-a”" in _pools_error(response)
+    # Nothing written: the pools are the two they were, and the fixtures are the same
+    # rows, column for column.
+    assert await _pools_of(db_session, event["id"]) == [POOL_A, POOL_B]
+    assert _snapshot(await _fixture_rows(db_session, event["id"])) == fixtures_before
+    # And the cut the duplicate would have detonated still works.
+    re_cut = await client.post(_draw_url(tournament_id, event["id"]))
+    assert re_cut.status_code == 201, re_cut.text
+
+
+async def test_an_undrawn_event_also_refuses_a_pools_patch_that_duplicates_an_id(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The rule is the **boundary's**, not the freeze's: an event with no draw at all —
+    where the pool set is not frozen and pools replace wholesale — still cannot be given
+    two pools with one id.
+
+    A guard implemented inside ``_enforce_pool_set_frozen`` would pass the test above
+    and fail this one, leaving every un-drawn event free to store the duplicate and 500
+    on its first cut. The event is not yet drawn, and the pools it will be drawn across
+    are already nonsense.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"pools": [POOL_C, POOL_C]},
+    )
+
+    assert response.status_code == 422, response.text
+    assert "“p-c”" in _pools_error(response)
+    assert await _pools_of(db_session, event["id"]) == [POOL_A, POOL_B]
+
+
+# ----- the draw-type freeze (409) -------------------------------------------
+#
+# A draw type is not a label on an event: it is the strategy that DEALT the event's
+# fixtures, and the fixtures are the shape that strategy prescribes. Patch it under a
+# standing draw and the event contradicts itself — a ``single-elim`` event holding
+# pooled round-robin fixtures (measured: the PATCH answered 200) — and nothing
+# downstream catches it, because the go-live currency check compares the ENTRANT SET the
+# fixtures seat, which a re-label does not move. So the corrupted event reads as
+# ``current`` and starts.
+#
+# Same doctrine as the pool-set freeze, one field over: what a cut draw freezes is the
+# facts its fixtures were derived from.
+
+
+async def _draw_type_of(db_session: AsyncSession, event_id: str) -> DrawType:
+    """The event's ``draw_type``, read straight from the column — never from a response
+    body, and never from an ORM instance the test session may be holding stale."""
+    return (
+        await db_session.execute(
+            select(TournamentEvent.draw_type).where(
+                TournamentEvent.id == uuid.UUID(event_id)
+            )
+        )
+    ).scalar_one()
+
+
+async def test_a_cut_draw_freezes_the_draw_type(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The freeze itself: with a draw standing, the draw type cannot be changed.
+
+    409, not 403 (ADR-0017): the caller is the owner and the payload is well-formed — it
+    is the *event* that is in the wrong state, and the same request becomes legal the
+    moment the draw is removed. That is what the refusal's copy tells them to do, and it
+    is not decoration: today ``single-elim`` has no strategy, so an event patched into
+    it while holding round-robin fixtures cannot even be re-cut back into agreement with
+    itself (the re-cut 422s), and the director is stuck guessing which draw type to
+    patch it *back* to.
+
+    The refusal must change **nothing**, and both halves are asserted from the database:
+    the stored ``draw_type`` and every column of every fixture. A status-code-only
+    assertion would pass a guard that wrote the value and let the rollback clean up —
+    which persists the very edit it refuses the day somebody adds a convenient
+    ``commit``.
+    """
+    client, _ = authed_client
+    tournament_id, event = await _cut_two_pool_event(client, db_session)
+    fixtures_before = _snapshot(await _fixture_rows(db_session, event["id"]))
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"draw_type": "single-elim"},
+    )
+
+    assert response.status_code == 409, response.text
+    detail = response.json()["detail"]
+    assert "“round-robin”" in detail, detail
+    assert "remove the draw" in detail, detail
+    assert await _draw_type_of(db_session, event["id"]) is DrawType.round_robin
+    assert _snapshot(await _fixture_rows(db_session, event["id"])) == fixtures_before
+
+
+async def test_a_refused_draw_type_patch_writes_none_of_the_rest_of_the_payload_either(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The refusal is total: a PATCH that renames the event *and* re-types its draw
+    changes neither.
+
+    The payload is one request and it is refused as one. This is the test that fails
+    against a guard placed *after* the ``setattr`` loop and rescued only by the
+    rollback.
+    """
+    client, _ = authed_client
+    tournament_id, event = await _cut_two_pool_event(client, db_session)
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"name": "Renamed Event", "draw_type": "single-elim"},
+    )
+
+    assert response.status_code == 409, response.text
+    stored = (
+        await db_session.execute(
+            select(TournamentEvent.name, TournamentEvent.draw_type).where(
+                TournamentEvent.id == uuid.UUID(event["id"])
+            )
+        )
+    ).one()
+    assert stored == (event["name"], DrawType.round_robin)
+
+
+async def test_an_undrawn_event_still_changes_its_draw_type(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """No draw, no freeze. An event nobody has cut yet is *configuration*, and its draw
+    type is the most ordinary thing about it for a director to still be deciding.
+
+    A guard that fired on the field rather than on the draw would lock the draw type at
+    creation — and there would be no way to change it at all, since there are no
+    fixtures to remove.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"draw_type": "single-elim"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["draw_type"] == "single-elim"
+    assert await _draw_type_of(db_session, event["id"]) is DrawType.single_elim
+
+
+async def test_re_sending_the_same_draw_type_with_a_venue_edit_still_succeeds(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """**Presence is not the rule — the change is.** A PATCH that carries the draw type
+    the event *already has*, alongside a legitimate venue edit, succeeds.
+
+    This is the case a guard written as "``draw_type`` in the payload and a draw exists
+    → 409" would break, and it is not exotic: a client that PATCHes the whole event form
+    back sends every field it rendered, draw type included. Refusing it would make the
+    pool-venue edit — the very thing the freeze above exists to *permit* — unreachable
+    from that page, and a table that broke on the morning of the tournament would cost
+    the director their draw.
+
+    Re-asserting a value that is already there changes nothing, so it is not a conflict.
+    (It differs from the league freeze, which *does* refuse the value it already holds:
+    that field is settled by a status no request of the caller's can move, so the only
+    client that sends it is a stale one. Here the way out — remove the draw — is on the
+    caller's own keyboard.)
+    """
+    client, _ = authed_client
+    tournament_id, event = await _cut_two_pool_event(client, db_session)
+    fixtures_before = _snapshot(await _fixture_rows(db_session, event["id"]))
+    moved = [{**POOL_A, "table_ids": ["t7"]}, POOL_B]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"draw_type": "round-robin", "pools": moved},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["draw_type"] == "round-robin"
+    assert await _draw_type_of(db_session, event["id"]) is DrawType.round_robin
+    assert await _pools_of(db_session, event["id"]) == moved
+    assert _snapshot(await _fixture_rows(db_session, event["id"])) == fixtures_before
+
+
+async def test_removing_the_draw_un_freezes_the_draw_type(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The way out, end to end: the PATCH the freeze refused is the PATCH that succeeds
+    once the draw is gone.
+
+    That is what makes the 409 a *conflict* rather than a prohibition — the director has
+    somewhere to go, and the refusal's own copy sends them this way, so the path it
+    names had better work.
+    """
+    client, _ = authed_client
+    tournament_id, event = await _cut_two_pool_event(client, db_session)
+    url = f"/v1/tournaments/{tournament_id}/events/{event['id']}"
+
+    refused = await client.patch(url, json={"draw_type": "single-elim"})
+    assert refused.status_code == 409, refused.text
+
+    uncut = await client.delete(_draw_url(tournament_id, event["id"]))
+    assert uncut.status_code == 204, uncut.text
+
+    accepted = await client.patch(url, json={"draw_type": "single-elim"})
+
+    assert accepted.status_code == 200, accepted.text
+    assert await _draw_type_of(db_session, event["id"]) is DrawType.single_elim
+    assert await _fixture_rows(db_session, event["id"]) == []
+
+
+async def test_the_draw_type_freeze_is_scoped_to_the_event_being_patched(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """One event's draw does not freeze another event's draw type.
+
+    The under-13s being drawn must not stop the director from still deciding how the
+    open singles will be run — which is what a guard that asked "does this *tournament*
+    have any fixtures?" would do.
+    """
+    client, _ = authed_client
+    tournament_id, (drawn, undrawn) = await _tournament_with_events(
+        client,
+        _rr_payload(POOL_A, POOL_B, name="Under 13s"),
+        _rr_payload(POOL_A, POOL_B, name="Open Singles"),
+    )
+    await _seed_field(db_session, drawn["id"], 4, prefix="u13-")
+    await _cut_the_draw(client, tournament_id, drawn["id"])
+
+    sealed = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{drawn['id']}",
+        json={"draw_type": "single-elim"},
+    )
+    assert sealed.status_code == 409, sealed.text
+
+    free = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{undrawn['id']}",
+        json={"draw_type": "single-elim"},
+    )
+
+    assert free.status_code == 200, free.text
+    assert await _draw_type_of(db_session, undrawn["id"]) is DrawType.single_elim
+    assert await _draw_type_of(db_session, drawn["id"]) is DrawType.round_robin

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -26,6 +26,7 @@ from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
+from app.draws import DrawError
 from app.leagues import seed_user_league_rating
 from app.models import (
     League,
@@ -1152,6 +1153,7 @@ async def _enter(
     status: TournamentEntryStatus = TournamentEntryStatus.entered,
     seed: int | None = None,
     created_at: datetime | None = None,
+    entry_id: uuid.UUID | None = None,
 ) -> TournamentEntry:
     """Persist an entry directly. The enter/withdraw *routes* land in #781/1c+1d;
     the read path can't wait for them, so it writes the rows itself.
@@ -1162,10 +1164,19 @@ async def _enter(
     written: left to the column's ``now()`` default, two entries written in the same
     breath differ by microseconds, and a draw asserted against that is a test that
     passes on the clock's goodwill.
+
+    ``entry_id`` is settable for the same reason, one rung further down: the ordering
+    rule's LAST tie-break is the entry id, so a draw test that leaves the ids to
+    ``uuid4`` cannot tell "ordered by registration" from "ordered by id" except by
+    luck — the two agree at random, and with a small field they agree often. Minting the
+    ids in a *known* order (see the unseeded-registration-order draw test, which mints
+    them backwards) is what makes the two rules distinguishable.
     """
     entry = TournamentEntry(
         event_id=uuid.UUID(event_id), user_id=user.id, status=status, seed=seed
     )
+    if entry_id is not None:
+        entry.id = entry_id
     if created_at is not None:
         entry.created_at = created_at
     db_session.add(entry)
@@ -2535,6 +2546,106 @@ async def test_go_live_blocks_on_an_in_flight_entry_and_then_finds_the_draw_stal
     assert currency is DrawCurrency.stale
 
 
+async def test_two_events_each_with_a_current_draw_go_live_together(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Currency is a fact about **one event**, and a tournament with two of them goes
+    live when both are current.
+
+    The precondition asks "do these fixtures seat exactly these entrants" of every event
+    it is starting, and the loader answers for all of them in one batched pair of
+    statements. Batched — so the two events' entries come back from the *same* query,
+    and the whole of the correctness is in keying them apart afterwards. Read that
+    result as one undifferentiated field and each event's draw is measured against
+    **both** events' entrants: each seats four of the eight, each is called stale, and a
+    tournament whose draws are both perfectly current is refused with a 409 telling the
+    director to re-cut the draws they already cut. They could re-cut them all night.
+
+    Every other currency test has a single event, where "the event's entries" and "every
+    entry in the table" are the same set.
+    (Measured: dropping the ``event_id.in_(...)`` filter from ``draw_currency_by_event``
+    survived the entire suite.)
+    """
+    client, _ = authed_client
+    tournament_id, (one, two) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B), _rr_payload(POOL_A, POOL_B)
+    )
+    await _seed_field(db_session, one["id"], 4, prefix="one")
+    await _seed_field(db_session, two["id"], 4, prefix="two")
+    await _cut_the_draw(client, tournament_id, one["id"])
+    await _cut_the_draw(client, tournament_id, two["id"])
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+
+    response = await _go_live(client, tournament_id)
+
+    assert response.status_code == 201, response.text
+    assert response.json()["status"] == "live"
+    assert await _status_of(client, tournament_id) == "live"
+
+
+async def test_going_live_is_undisturbed_by_another_tournaments_entries(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A tournament goes live on **its own** field. Somebody else's entries are in the
+    same table, and they must not reach the query that judges this one.
+
+    The currency loader keys its result by the ``event_id`` on each row it reads, so an
+    unfiltered read is not merely wasteful — it comes back holding rows for events the
+    caller never asked about, and there is nowhere to put them. Not a wrong answer: no
+    answer. A 500 on go-live, for every tournament in the database after the first one
+    to take an entry.
+
+    Which is precisely why no single-tournament test can see it. The suite truncates
+    between tests, so "every entry in the table" and "this tournament's entries" are
+    the same rows in almost every test written here — and this is the one where they
+    are not.
+    (Measured: dropping the ``event_id.in_(...)`` filter from ``draw_currency_by_event``
+    survived the entire suite, including a two-event tournament going live.)
+    """
+    client, _ = authed_client
+    tournament_id, _event_id, _entries = await _ready_to_start(client, db_session)
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+
+    # A wholly unrelated tournament, with an event and a field of its own. Nothing about
+    # it is this tournament's business — including, especially, on the way to live.
+    _other_id, (other_event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    await _seed_field(db_session, other_event["id"], 4, prefix="other")
+
+    response = await _go_live(client, tournament_id)
+
+    assert response.status_code == 201, response.text
+    assert response.json()["status"] == "live"
+    assert await _status_of(client, tournament_id) == "live"
+
+
+async def test_currency_of_no_events_is_an_empty_answer_and_no_query(
+    engine: AsyncEngine,
+) -> None:
+    """``draw_currency_by_event`` of an empty list answers ``{}`` — and asks the
+    database nothing at all to do it.
+
+    The batch loader's contract is "two statements for the whole batch, whatever the
+    number of events", and *none* is a number of events: a draft tournament with no
+    events reaches the go-live precondition, and this is the loader it reaches. The
+    short-circuit is the difference between an empty answer and an ``IN ()`` — a
+    predicate that is not merely wasteful but false for every row, and which no version
+    of this function should ever be asked to mean.
+
+    The statement count is the assertion, not decoration: an implementation that dropped
+    the guard would still return ``{}`` (there are no events to key the result by), and
+    would pass every assertion but this one.
+    """
+    async with counted_statements(engine) as (session, statements):
+        currency = await draw_currency_by_event(session, [])
+
+    assert currency == {}
+    assert statements == [], statements
+
+
 # ----- the league a tournament is judged on (ADR-0783) ----------------------
 #
 # A tournament's ``league_id`` is the rating ladder its events' eligibility rules
@@ -3805,6 +3916,8 @@ async def _seed_field(
     *,
     prefix: str = "p",
     seeded: bool = True,
+    seeds: Sequence[int] | None = None,
+    descending_ids: bool = False,
 ) -> list[TournamentEntry]:
     """``count`` active entries, in a draw order this test *states* rather than races
     for: seeds 1..N by default, and staggered registration times besides.
@@ -3812,6 +3925,18 @@ async def _seed_field(
     The draw's order is seed-ascending, then registration order (ADR-0786). Both are
     pinned here so the pool each entrant snakes into is a fact of the fixture, not of
     how quickly the rows happened to be inserted.
+
+    Two knobs exist to make the ordering rules *distinguishable from each other*, which
+    the default field deliberately cannot do — its seeds ascend in the same order its
+    registrations do, so "ordered by seed" and "ordered by registration" deal the same
+    draw and no assertion about the result can tell them apart:
+
+    * ``seeds`` gives the seeds explicitly, so a test can hand the field a seed order
+      that *contradicts* its registration order.
+    * ``descending_ids`` mints the entry ids backwards, so the last tie-break (the id)
+      disagrees with registration order too, rather than agreeing with it by chance.
+
+    The returned list is always in REGISTRATION order, whatever the seeds and ids say.
     """
     start = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
     return [
@@ -3819,11 +3944,33 @@ async def _seed_field(
             db_session,
             event_id,
             await make_user(db_session, f"{prefix}{n}"),
-            seed=n if seeded else None,
+            seed=(seeds[n - 1] if seeds is not None else n) if seeded else None,
             created_at=start + timedelta(minutes=n),
+            entry_id=uuid.UUID(int=1_000 + count - n) if descending_ids else None,
         )
         for n in range(1, count + 1)
     ]
+
+
+def _members_by_pool(
+    rows: list[TournamentFixture],
+) -> dict[str | None, set[uuid.UUID]]:
+    """Who ended up in which pool — read back off the fixtures, because there is no pool
+    membership table (ADR-0786): a pool *is* the fixtures drawn into it.
+
+    Pool-aware, unlike ``_pairs``, and that matters more than it looks: the snake of
+    four entrants over two pools is symmetric under reversal — deal them backwards and
+    the set of PAIRS is identical, only the pool each pair sits in changes. A
+    pairing-only assertion on a field that small therefore passes against a draw dealt
+    in the wrong order, which is exactly the bug the ordering tests exist to catch.
+    """
+    members: dict[str | None, set[uuid.UUID]] = {}
+    for row in rows:
+        seated = {row.entry_a_id, row.entry_b_id} - {None}
+        members.setdefault(row.pool_id, set()).update(
+            entry_id for entry_id in seated if entry_id is not None
+        )
+    return members
 
 
 async def _fixture_rows(
@@ -3978,28 +4125,122 @@ async def test_an_unseeded_field_is_drawn_in_registration_order(
     ``created_at`` is what reaches the planner, not the order Postgres felt like
     returning them in.
 
-    Four unseeded players, registered 1→4 and written in that order, over two pools: the
-    snake puts 1 and 4 together and 2 and 3 together. A cut that read the field in *any*
-    other order (the table's physical order, the id order) would deal them differently,
-    and there is no way to see that from the shape of the draw alone — both pools hold
-    one fixture either way. So the pairings are what is asserted.
+    Six unseeded players, registered 1→6, over two pools: the snake deals 1, 4, 5 into
+    pool A and 2, 3, 6 into pool B.
+
+    **The field is built to make every wrong order visibly wrong**, which takes some
+    doing, and it is the whole substance of this test:
+
+    * The **entry ids are minted backwards** (``descending_ids``), against registration
+      order. The ordering rule's last tie-break IS the entry id, so a cut that never
+      read ``created_at`` at all would fall through to the ids and deal a *different*
+      draw — whereas with the ``uuid4`` ids the rest of the suite uses, the two orders
+      agree at random, and a draw dealt by id looks right about one time in twenty.
+      (Measured: dropping ``created_at`` from the planner's input survived this test.)
+    * Six, not four. The four-over-two snake is **symmetric under reversal** — deal the
+      field backwards and the same two pairs come out, sitting in each other's pools —
+      so a reversed order is invisible to a pairing assertion on a field that small.
+    * And the assertion is **pool-aware** (``_members_by_pool``), because who a player
+      is drawn *against* is only half of what the snake decides; which pool they play
+      in is the other half, and it is the half a symmetric mis-deal gets wrong.
     """
     client, _ = authed_client
     tournament_id, (event,) = await _tournament_with_events(
         client, _rr_payload(POOL_A, POOL_B)
     )
-    first, second, third, fourth = await _seed_field(
-        db_session, event["id"], 4, seeded=False
+    field = await _seed_field(
+        db_session, event["id"], 6, seeded=False, descending_ids=True
+    )
+    first, second, third, fourth, fifth, sixth = field
+    # The ids really do disagree with the registrations — otherwise the test below is
+    # asserting against two rules that happen to agree, and proves neither.
+    assert [e.id for e in field] == sorted((e.id for e in field), reverse=True)
+
+    response = await client.post(_draw_url(tournament_id, event["id"]))
+
+    assert response.status_code == 201, response.text
+    rows = await _fixture_rows(db_session, event["id"])
+    assert _members_by_pool(rows) == {
+        "p-a": {first.id, fourth.id, fifth.id},  # the snake's 1, 4, 5
+        "p-b": {second.id, third.id, sixth.id},  # its 2, 3, 6
+    }
+
+
+async def test_a_seed_outranks_the_registration_it_contradicts(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The cut orders the field by **seed** where one is set — and this is the test that
+    the ``seed`` column is read at all.
+
+    The seeds here run *backwards* against the registrations: the player who registered
+    last is seed 1, and the one who registered first is seed 6. So the draw order is the
+    reverse of the registration order, and the snake deals seeds 1, 4, 5 into pool A —
+    which is to say the 6th, 3rd and 2nd players to register.
+
+    Every other draw test in this file seeds its field 1..N in registration order,
+    where the two rules agree and either one alone produces the right answer. Blank the
+    seed on the way out of the database and all of them still pass; this one does not.
+    (Measured — it is the mutant that survived: ``seed=None`` in
+    ``active_draw_entrants``.)
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    # Registered 1st..6th; seeded 6th..1st.
+    first, second, third, fourth, fifth, sixth = await _seed_field(
+        db_session, event["id"], 6, seeds=[6, 5, 4, 3, 2, 1]
     )
 
     response = await client.post(_draw_url(tournament_id, event["id"]))
 
     assert response.status_code == 201, response.text
     rows = await _fixture_rows(db_session, event["id"])
-    assert _pairs(rows) == {
-        frozenset({first.id, fourth.id}),  # pool A: the snake's 1 and 4
-        frozenset({second.id, third.id}),  # pool B: its 2 and 3
+    assert _members_by_pool(rows) == {
+        # Draw order is 6, 5, 4, 3, 2, 1 (by seed), so the snake's 1st, 4th and 5th are
+        # the players who registered 6th, 3rd and 2nd.
+        "p-a": {sixth.id, third.id, second.id},
+        "p-b": {fifth.id, fourth.id, first.id},
     }
+
+
+async def test_the_cut_reads_only_the_field_of_the_event_it_is_cutting(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A cut reads **this event's** entrants. Not the tournament's, and not the table's.
+
+    Two events under one tournament, each with its own four players. Cutting the first
+    must seat exactly its own four — and the second event, whose draw nobody asked for,
+    must still have none.
+
+    Every other draw test in this file builds a tournament with a **single** event, and
+    against a single event a cut that forgot to filter by ``event_id`` at all is
+    indistinguishable from a correct one: the only entries in the table are the ones it
+    should have read. This is the test that can tell the difference, and it is the
+    difference between a draw and a draw with eight strangers in it.
+    (Measured: dropping ``TournamentEntry.event_id == event_id`` from
+    ``active_draw_entrants``'s WHERE survived the entire suite.)
+    """
+    client, _ = authed_client
+    tournament_id, (event, other) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B), _rr_payload(POOL_A, POOL_B)
+    )
+    ours = await _seed_field(db_session, event["id"], 4, prefix="ours")
+    theirs = await _seed_field(db_session, other["id"], 4, prefix="theirs")
+
+    response = await client.post(_draw_url(tournament_id, event["id"]))
+
+    assert response.status_code == 201, response.text
+    rows = await _fixture_rows(db_session, event["id"])
+    seated = {f.entry_a_id for f in rows} | {f.entry_b_id for f in rows}
+    assert seated == {entry.id for entry in ours}
+    assert not seated & {entry.id for entry in theirs}
+    # Two pools of two: one fixture each. Eight entrants would have made six.
+    assert len(rows) == 2
+    # And the event nobody cut has no draw. A cut is one event's business.
+    assert await _fixture_rows(db_session, other["id"]) == []
 
 
 async def test_a_second_cut_replaces_the_draw_wholesale(
@@ -4279,6 +4520,58 @@ async def test_cutting_a_draw_that_is_not_a_competition_is_422(
     assert await _fixture_rows(db_session, event["id"]) == []
 
 
+async def test_a_draw_error_nobody_wrote_copy_for_refuses_without_leaking_its_message(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``DrawError`` subclass this route has never heard of is still a designed 422 —
+    with a **generic** sentence, never the exception's own.
+
+    ``_draw_refusal`` matches on the two errors that exist today and composes copy for
+    each. Its fallback arm is what a *third* one hits, and the rule there is that a
+    message written for a developer (or worse, one carrying a table name, a pool ref, a
+    line number) must not become the sentence a director reads. Refusing vaguely is a
+    bug report someone files; leaking internals is a defect that has already reached the
+    UI.
+
+    The only honest way to raise the base error is to invent the subclass the domain
+    does not have yet — which is precisely the future this arm exists for. A ``500``
+    here would be the alternative, and the 500 is the thing to avoid: the domain
+    *refused*, and a refusal is an answer.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    await _seed_field(db_session, event["id"], 4)
+
+    class SwissRoundNotSettled(DrawError):
+        """The DrawError of some slice that has not been written."""
+
+    async def _raise_an_unknown_draw_error(
+        db: AsyncSession, event: TournamentEvent
+    ) -> None:
+        raise SwissRoundNotSettled(
+            "tournament_fixtures.pool_id='p-a' has a NULL seat at (round=2, position=1)"
+        )
+
+    monkeypatch.setattr("app.tournaments.cut_draw", _raise_an_unknown_draw_error)
+
+    response = await client.post(_draw_url(tournament_id, event["id"]))
+
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail == "This event's draw cannot be cut as the event stands."
+    # Not one word of the exception's own message — not the column, not the ref, not the
+    # coordinates. The generic arm means generic.
+    assert "pool_id" not in detail
+    assert "NULL" not in detail
+    assert "p-a" not in detail
+    # And, like every other refusal on this path, it writes nothing.
+    assert await _fixture_rows(db_session, event["id"]) == []
+
+
 async def test_a_refused_re_cut_leaves_the_standing_draw_untouched(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
@@ -4505,6 +4798,44 @@ async def _pools_of(db_session: AsyncSession, event_id: str) -> list[dict[str, A
         )
     ).scalar_one()
     return list(pools)
+
+
+async def test_a_draw_of_one_fixture_still_freezes_the_pool_set(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """One pool, two players, **one fixture** — the smallest draw there is — freezes the
+    pool set exactly as a full one does.
+
+    What the freeze turns on is whether the event has *any* fixtures, and the boundary
+    between "any" and "none" is one. Every other freeze test cuts a four-fixture draw,
+    so a guard that had drifted to "more than one fixture" — a single character away,
+    and the kind of thing a refactor does on the way past — would pass all of them and
+    fail only here: the pools would be replaced under the draw, and its one fixture
+    would be left pointing at a pool the event no longer has. There is no foreign key
+    to catch it.
+    (Measured: ``event_has_draw``'s ``count > 0`` mutated to ``count > 1`` survived the
+    entire suite. This is the test that kills it.)
+
+    It is not an exotic shape, either — it is a club night with one pool and two players
+    who turned up.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+    await _seed_field(db_session, event["id"], 2)
+    cut = await client.post(_draw_url(tournament_id, event["id"]))
+    assert cut.status_code == 201, cut.text
+    fixtures_before = _snapshot(await _fixture_rows(db_session, event["id"]))
+    assert len(fixtures_before) == 1
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"pools": [POOL_B]},
+    )
+
+    assert response.status_code == 409, response.text
+    assert await _pools_of(db_session, event["id"]) == [POOL_A]
+    assert _snapshot(await _fixture_rows(db_session, event["id"])) == fixtures_before
 
 
 async def _cut_two_pool_event(
@@ -4975,6 +5306,157 @@ async def test_an_undrawn_event_also_refuses_a_pools_patch_that_duplicates_an_id
     assert response.status_code == 422, response.text
     assert "“p-c”" in _pools_error(response)
     assert await _pools_of(db_session, event["id"]) == [POOL_A, POOL_B]
+
+
+# ----- an id is not the empty string (422) -----------------------------------
+#
+# The rule above says an id names ONE pool. This one says an id is a *thing*:
+# ``Pool.id`` was a bare ``str``, so ``Pool(id="")`` validated, and an event could be
+# created and patched holding a pool with no id at all (measured: 201).
+#
+# An empty pool id is not a cosmetic defect, because a fixture names its pool by that
+# string (ADR-0786) and the domain asks two questions of the ref that DISAGREE about
+# ``""``. In ``app.draws.ready_fixtures``: "is this fixture pooled?" is ``pool_id is
+# None`` — and ``""`` is not ``None``, so *yes, pooled* — while the sort key that orders
+# the plan reads ``pool_id or ""``, where the empty id collapses onto the value the
+# UN-pooled fixtures sort under. One fixture, pooled by one rule and un-pooled by the
+# other, and a draw whose order depends on which of the two you asked.
+#
+# The fix is not a runtime check downstream, and not a defensive ``if not pool_id`` in
+# the sort: it is a floor on the type at the write boundary (``ValueObjectId``,
+# ``min_length=1``), so the state never exists to be reasoned about (api/CLAUDE.md,
+# "make illegal states unrepresentable"). Like every other rule about a pools payload it
+# holds on **both verbs** — an event that could not be born with an empty pool id but
+# could be *edited* into one is an event that can hold it.
+
+
+def _error_locs(response: Response) -> list[list[Any]]:
+    """Every ``loc`` a pydantic 422 named, as lists.
+
+    The refusal must be attributed to the FIELD, not merely to the request: a client
+    renders a validation error under the input that caused it, and a 422 that pointed at
+    ``body`` alone would leave the organizer hunting a blank box.
+    """
+    return [error["loc"] for error in response.json()["detail"]]
+
+
+@pytest.mark.parametrize(
+    ("pool", "field"),
+    [
+        pytest.param({**POOL_A, "id": ""}, "id", id="empty-id"),
+        pytest.param({**POOL_A, "name": ""}, "name", id="empty-name"),
+    ],
+)
+async def test_creating_an_event_with_an_empty_pool_id_or_name_is_refused(
+    authed_client: tuple[AsyncClient, User],
+    pool: dict[str, Any],
+    field: str,
+) -> None:
+    """An event cannot be **born** with a pool whose id — or whose name — is ``""``.
+
+    The id is the one with teeth (see the section comment: a fixture drawn into ``""``
+    is pooled and un-pooled at the same time). The name is refused for the plainer
+    reason that a pool is *called* something: it is what the director clicks, what the
+    double-booking warning quotes and what a player reads off a wall, and a list of
+    three blank rows is not a thing anyone can act on.
+
+    And the refusal writes nothing: a 422 that had already stored the event would be a
+    422 in name only.
+    """
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+
+    response = await client.post(
+        f"/v1/tournaments/{created['id']}/events", json=_rr_payload(pool, POOL_B)
+    )
+
+    assert response.status_code == 422, response.text
+    assert ["body", "pools", 0, field] in _error_locs(response), response.text
+    assert await _events_of(client, created["id"]) == []
+
+
+@pytest.mark.parametrize(
+    ("pool", "field"),
+    [
+        pytest.param({**POOL_C, "id": ""}, "id", id="empty-id"),
+        pytest.param({**POOL_C, "name": ""}, "name", id="empty-name"),
+    ],
+)
+async def test_a_pools_patch_that_empties_a_pool_id_or_name_is_refused(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    pool: dict[str, Any],
+    field: str,
+) -> None:
+    """The **other verb**, and the one that would otherwise be the hole: an event born
+    with two perfectly good pools, edited into holding one with no id.
+
+    Deliberately an **un-drawn** event, where the pool-set freeze does not apply at
+    all. On a *cut* event this payload changes the pool set (``{"", p-b}`` is not
+    ``{p-a, p-b}``), so the freeze would 409 it and the test would pass without the
+    boundary rule existing — proving nothing about the boundary. Here there is no draw
+    and no freeze:
+    pools replace wholesale, and the only thing between the column and ``""`` is the
+    schema.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"pools": [pool]},
+    )
+
+    assert response.status_code == 422, response.text
+    assert ["body", "pools", 0, field] in _error_locs(response), response.text
+    assert await _pools_of(db_session, event["id"]) == [POOL_A, POOL_B]
+
+
+async def test_creating_a_tournament_with_an_empty_table_id_is_refused(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """A table in the venue catalogue is the same string-ref pattern as a pool: a pool
+    holds a list of these ids (``table_ids``) and nothing else connects the two — no
+    table, no foreign key, no index. An id of ``""`` is a table nothing can name, and a
+    ``table_ids`` entry of ``""`` would "resolve" against it.
+
+    Closing the hole on pools and leaving it open on the thing pools point AT would be a
+    boundary drawn half way.
+    """
+    client, _ = authed_client
+
+    response = await client.post(
+        "/v1/tournaments",
+        json=_create_payload(
+            table_catalogue=[{"id": "", "label": "Table 1", "court": "A"}]
+        ),
+    )
+
+    assert response.status_code == 422, response.text
+    assert ["body", "table_catalogue", 0, "id"] in _error_locs(response), response.text
+
+
+async def test_patching_a_table_catalogue_with_an_empty_table_id_is_refused(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """The table catalogue's patch verb, for the reason every pools rule is stated
+    on both verbs: a tournament that could not be created with an id-less table and
+    could be edited into one is a tournament that holds an id-less table."""
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+
+    response = await client.patch(
+        f"/v1/tournaments/{created['id']}",
+        json={"table_catalogue": [{"id": "", "label": "Table 9", "court": "B"}]},
+    )
+
+    assert response.status_code == 422, response.text
+    assert ["body", "table_catalogue", 0, "id"] in _error_locs(response), response.text
+    # And the catalogue it was born with is the catalogue it still has.
+    reread = (await client.get(f"/v1/tournaments/{created['id']}")).json()
+    assert [table["id"] for table in reread["table_catalogue"]] == ["t1", "t2"]
 
 
 # ----- the draw-type freeze (409) -------------------------------------------

--- a/docs/adr/0784-director-entry-is-the-same-endpoint-gated-by-ownership.md
+++ b/docs/adr/0784-director-entry-is-the-same-endpoint-gated-by-ownership.md
@@ -1,0 +1,87 @@
+# 784. Director entry is the same endpoint, gated by ownership
+
+Date: 2026-07-12
+
+## Status
+
+Accepted
+
+## Context
+
+A tournament director needs to put players into an event themselves — a phone entry,
+someone without an account yet, or simply fixing a mistake before publishing.
+Today `POST .../entries` hard-codes the caller:
+
+```python
+entry = TournamentEntry(event_id=event.id, user_id=current_user.id)
+```
+
+It takes no request body at all, and a code comment in `tournaments.py` asserts that
+a director entry would be "a different endpoint". Withdrawal is likewise self-only,
+guarded by `"You can only withdraw your own entry."`
+
+## Decision
+
+**One endpoint. The presence of a `user_id` in the body selects the actor, and the
+actor selects the guard.**
+
+* **No `user_id`** → self-registration. Guarded by the `tournament.enter` permission.
+  Byte-for-byte today's behaviour.
+* **`user_id` present** → director entry. Guarded by `_require_owner`.
+
+`DELETE` unifies the same way: the current self-only guard relaxes to *"your own
+entry, **or any entry if you own the tournament**."*
+
+The two authorizations are cleanly disjoint — a stranger self-registering is not the
+owner; an owner adding someone else is not self-registering — so this is a single
+fork at the top of the handler, not a tangle.
+
+The reason to unify rather than twin is ADR-0968. Both callers must produce the same
+refusal codes, run the same eligibility evaluator, and take the same capacity lock.
+Two routes means the *next* refusal has to be added twice, and the two call sites of
+the evaluator must be kept from drifting — which is exactly the class of bug we just
+spent ADR-0968 deleting. Unifying makes there be one place refusals live.
+
+### `added_by_user_id`
+
+`TournamentEntry` gains **`added_by_user_id`** — nullable FK to `users`; `NULL`
+means the player entered themselves. It records how an entry came to exist, which is
+a fact that cannot be reconstructed later if we decline to store it now.
+
+As a new FK to `users.id`, it **must** be handled by the account-merge service
+(`api/CLAUDE.md`), or a merged director's entries break. That is part of this change,
+with a test, not a follow-up.
+
+### The director gets no override — yet
+
+The ticket floated a `force` flag letting the owner bypass eligibility and capacity.
+**We are not shipping it**, and the consequence is worth stating rather than
+discovering:
+
+**Without `force`, #784 does not solve walk-ins.** Registration closes at go-live, so
+once a tournament is `live` the director can neither add a walk-in nor remove a
+no-show — which are the on-the-day cases the ticket's own motivation names. What
+ships here is "the director may add and remove players **during registration**":
+phone entries, accounts that don't exist yet, mistakes caught before publish.
+
+Withdrawal stays **symmetric** with entry — the owner obeys the same registration
+window a player does. The asymmetric alternative (an owner may withdraw at any time,
+but only add during registration) is the more useful product, and we still rejected
+it: it is an override leaking back in through the withdraw door, with different
+rules and no flag to name it. The override story belongs in one coherent ticket, and
+that ticket now carries both the walk-in and the no-show case.
+
+## Consequences
+
+* The director's entries run through **the same evaluator, the same capacity lock and
+  the same four refusal codes** as a player's. A director's typo is caught by the
+  same rules that catch a stranger's — which, absent `force`, is the entire safety
+  model.
+* An entry knows who created it. The entrants list can say "added by the director".
+* A director cannot fix anything once the tournament is live. This is a real gap, it
+  is deliberate, and it is tracked — not an oversight to be discovered on a Saturday
+  morning at a tournament desk.
+* `GET /v1/players/search` is untouched. It excludes the caller, which would stop a
+  director finding *themselves* in the Add-player typeahead — but a director entering
+  themselves simply uses the ordinary Enter control, which already exists and already
+  works. We are not adding a flag to solve a problem we do not have.

--- a/docs/adr/0786-a-draw-is-cut-explicitly-and-advanced-idempotently.md
+++ b/docs/adr/0786-a-draw-is-cut-explicitly-and-advanced-idempotently.md
@@ -125,6 +125,33 @@ field of work — thus means *the first second of `live`*, and never earlier:
 players must not receive playable matches while registration is still open.
 The scheduler plans on **fixtures**, which exist pre-live.
 
+### An account merge that double-counted a human invalidates the draw
+
+A guest and the claimed account they merge into may *both* be actively entered
+in the same event. `merge_user` already resolves that collision by hard-deleting
+the guest's duplicate entry — which, with the fixtures table's `ON DELETE
+CASCADE`, would silently punch holes in a cut draw.
+
+The tempting repair — **re-point the guest's fixtures onto the surviving
+entry** — is wrong, and dangerously so. It seats one human in two slots of the
+same pool (everyone else plays them twice; drawn against themselves, the fixture
+is self-play), and because the go-live currency check compares entrant *sets*,
+the corrupted draw would **satisfy the check and go live**. The cascade's holes
+are the safer failure: they make the sets differ, and go-live refuses.
+
+So a merge collision **un-cuts the event's draw** (deletes its fixtures) and the
+director re-cuts. A draw cut from a field that double-counted a human is wrong
+throughout — its pool sizes and snake seeding were computed against N+1
+entrants — so it is regenerated, never patched. The merge itself is never
+refused (consistent with the self-play collision doctrine). The surviving entry
+inherits the **earlier** `created_at` and any seed, because registration order
+is the draw's ordering tie-break and must not shift silently.
+
+A merge collision on an event whose play has already begun cannot be resolved
+this way (the play guard forbids un-cutting) and is left for #788, where matches
+exist and the self-play-collision machinery — transfer then void — applies.
+Until then it is unreachable: no tournament match exists to have been played.
+
 ### Entrants are ordered by seed, then registration order
 
 `plan_initial` receives an already-ordered list: `seed` ascending where set,

--- a/docs/adr/0786-a-draw-is-cut-explicitly-and-advanced-idempotently.md
+++ b/docs/adr/0786-a-draw-is-cut-explicitly-and-advanced-idempotently.md
@@ -1,0 +1,157 @@
+# 786. A draw is cut explicitly and advanced idempotently
+
+Date: 2026-07-12 (numbered by issue #786 — sequential numbers collide across
+concurrent worktrees, as the duplicate 0008s in this directory attest)
+
+## Status
+
+Accepted — design for slices B/C of epic #780 (#785, #786, #788, #789), decided
+before implementation.
+
+## Context
+
+`DrawType` (single-elim / double-elim / round-robin / rr-then-ko / swiss) has
+been persisted since epic #595 and nothing consumes it. The B/C slices of epic
+#780 as originally written sketch an **event-driven, persist-once** model: B1
+generates a bracket with a stored `next_slot_id` per slot, C1 creates a real
+match when both sides of a slot are known, and C2 "propagates the winner to
+`next_slot_id`" when a result lands — per-draw-type advancement code hanging
+off match completion.
+
+The A slices are shipped and give us hard invariants to build on: registration
+is only open while `published`, go-live row-locks the tournament so no entry
+can land after it commits (#782), and there is a single lifecycle dispatch
+point (`LEGAL_TRANSITIONS`, ADR-0017) that explicitly reserved a home for a
+go-live precondition.
+
+Two facts complicated the issue text as written:
+
+- **Pools are venue value-objects, not rows.** `TournamentEvent.pools` is JSONB
+  (`{id, name, slot, table_ids}` — a slice of tables for a window of time),
+  wholesale-replaced by `PATCH`. There is nothing for a bracket row to foreign-key.
+- **There is no "the player's rating" to seed from.** Ratings are league-scoped
+  (`UserLeagueRating`) and tournaments are deliberately standalone, so B1's
+  "fallback: rating, then random-by-index" is unimplementable as written — and
+  randomness would break re-cut determinism besides.
+
+## Decision
+
+### Persisted fixtures are the truth once cut; strategies are pure planners
+
+A **fixture** (see `CONTEXT.md`) is one planned pairing of a draw: a round and
+position (plus a pool, when pooled), sides nullable while unknown. One table,
+`tournament_fixtures`, holds every draw type's fixtures, identified by
+`UNIQUE (event_id, pool_id, round, position)`.
+
+Each `DrawType` is a strategy behind a `Protocol` with two pure operations:
+
+- `plan_initial(config, ordered_entrants) → [PlannedFixture]` — cuts the draw.
+- `advance(fixtures) → AdvancePlan` — reads the persisted state and returns
+  side-fills for TBD fixtures plus the fixtures now ready to materialize.
+  **Idempotent**: against an unchanged state it returns an empty plan, so it is
+  re-run after *every* result (and at go-live) rather than triggered by
+  carefully-chosen events.
+
+Two alternatives were rejected:
+
+- **Full replan** (recompute the whole draw from live entries at each step) —
+  a withdrawal mid-pool would redistribute entrants who already have results.
+  Placement is frozen at the cut; the only sanctioned full replan is an
+  explicit re-cut.
+- **Event-driven pointer-chasing** (C2's "propagate winner to `next_slot_id`")
+  — that is per-type advancement code at every result site, and it cannot
+  express swiss at all (the next round *does not exist* until the previous one
+  completes; only an `advance()` that may create fixtures can model it).
+
+### The schema stores less than the issues asked for
+
+- **No `next_slot_id`.** Topology is the strategy's knowledge: single-elim's
+  successor is arithmetic on `(round, position)`; round-robin has none; swiss
+  computes pairings. Storing it is a second copy that churns on re-cut.
+- **`NULL` side means exactly "TBD — `advance()` will fill it".** Byes are
+  modeled as *absence*: a byed seed simply has no round-1 fixture and is placed
+  directly into round 2; an odd round-robin pool just has fewer fixtures per
+  round. No `is_bye` flag, no NULL-means-two-things.
+- **No entrant↔pool assignment table.** Pool membership is derived from the
+  fixtures themselves (same argument as ADR-0016's derived `entered` count).
+- **`pool_id` is a string ref, not a FK.** It names a `Pool` value-object in
+  the event's own JSONB — consistent with how pools already reference tables.
+  Integrity is procedural, not schematic: **the pool id set freezes while a
+  draw exists** (the pools `PATCH` keeps wholesale-replace but must preserve
+  the id set), while a pool's *venue attributes* (`table_ids`, its window)
+  stay editable mid-event, because venues change under running tournaments.
+  Promoting pools to rows is the known remedy if this guard ever leaks.
+
+For B3: rr-then-ko needs no new columns (pool fixtures carry a `pool_id`, KO
+fixtures carry `NULL`); double-elim will add a bracket/stage discriminator when
+it lands (pre-deploy, the migration is edited in place).
+
+### A draw is cut explicitly, gated by play — never by status
+
+`POST …/events/{event_id}/draw` (owner-only) cuts or re-cuts; `DELETE` un-cuts
+(and un-freezes the pool set). Both are refused only on **evidence of play**:
+any decided fixture, any linked match with a game on its scratchpad or a result
+proposed. Status-gating was rejected — it would forbid the legitimate day-of
+move (no-show before the first ball: withdraw, re-cut) while protecting
+nothing the play-guard doesn't. Note the guard is deliberately *stricter* than
+issue #785's "refuse if matches already played": a mere scratchpad game blocks
+re-cutting, because the draw must never silently eat entered scores.
+
+Go-live was deliberately **not** made to auto-cut missing draws: cutting is a
+reviewable act (the director inspects pools/seeding and re-cuts *before*
+committing), and a status transition that fans out into N generations has N
+confusing ways to fail.
+
+### Go-live requires every draw to exist and be *current*; matches materialize only in `live`
+
+Registration stays open while `published`, so a draw can be **stale** by
+go-live — cut before the last entrant arrived. The `published → live` edge
+therefore validates, inside the existing go-live row-lock, that every event's
+draw exists **and** its fixtures cover exactly the event's active entrants,
+409ing with the offending events otherwise. This is the precondition ADR-0017
+reserved space for.
+
+Materialization (a fixture with both sides known becoming a real propose/accept
+match, C1) is gated on the tournament being `live`, and **the go-live
+transition runs the first `advance()`** as its final act. Cut while published →
+fixtures only, previewable and re-cuttable; go live → every ready fixture
+becomes a real match in one stroke (for round-robin, the entire event). "Create
+matches as early as possible" — so the table scheduler (D1) sees the full
+field of work — thus means *the first second of `live`*, and never earlier:
+players must not receive playable matches while registration is still open.
+The scheduler plans on **fixtures**, which exist pre-live.
+
+### Entrants are ordered by seed, then registration order
+
+`plan_initial` receives an already-ordered list: `seed` ascending where set,
+then `created_at` (registration order) for the unseeded rest. Deterministic
+(idempotent re-cuts, testable), domain-local (no reach into league ratings).
+Nothing sets `seed` today; a director-only seed-assignment endpoint is a
+deliberately separate slice, and until it lands draws are seeded by
+registration order — which is what club-night reality does anyway.
+
+### #786 carries the substrate; #785 shrinks to a strategy
+
+Reversing the epic's B1→B2 order: round-robin exercises strictly more of the
+substrate (pool refs, the freeze, multi-pool distribution, a real if trivial
+`advance`). #786 ships the migration, model, `draws.py` (protocol + registry +
+`RoundRobinStrategy`), both draw endpoints, the freeze and currency guards, the
+detail-BFF growth and the Events-tab pools scaffold. #785 becomes
+`SingleElimStrategy` + bracket rendering, touching the registry's exhaustive
+`match` and nothing structural.
+
+## Consequences
+
+- C2's advancement is "write `winner_entry_id`, run `advance()`" — one
+  mechanism for every draw type, no per-type code at result sites.
+- Fixtures appear on the wire inside the existing tournament-detail BFF (each
+  event gains its draw), preserving the one-endpoint-per-page rule; the only
+  new routes are the two draw mutations.
+- A 5-entrant single-elim persists 4 rows; the 8-slot visual bracket frame and
+  "bye" labels are derived at render time from the fixtures' shape.
+- The registry's exhaustive `match` on `DrawType` makes each B3 format a type
+  error until implemented; unimplemented types 422 at the draw endpoint.
+- Pool standings (C2) are a read-model over decided fixtures — deliberately
+  *not* a strategy method. Swiss will need standings internally for pairing;
+  when it lands, its strategy computes what it needs without widening the
+  shared interface.

--- a/docs/adr/0786-a-draw-is-cut-explicitly-and-advanced-idempotently.md
+++ b/docs/adr/0786-a-draw-is-cut-explicitly-and-advanced-idempotently.md
@@ -106,10 +106,14 @@ confusing ways to fail.
 
 Registration stays open while `published`, so a draw can be **stale** by
 go-live — cut before the last entrant arrived. The `published → live` edge
-therefore validates, inside the existing go-live row-lock, that every event's
-draw exists **and** its fixtures cover exactly the event's active entrants,
-409ing with the offending events otherwise. This is the precondition ADR-0017
-reserved space for.
+therefore validates, inside the existing go-live row-lock, that the tournament
+has **at least one event** and that every event's draw exists **and** its
+fixtures cover exactly the event's active entrants, 409ing with the offending
+events otherwise. This is the precondition ADR-0017 reserved space for. (The
+≥1-event guard closes the hole the #782 hand-off flagged: with zero events the
+per-event check is vacuously satisfied, and an empty tournament could go live.
+Publishing an empty tournament stays legal — announcing early is fine; starting
+nothing is not.)
 
 Materialization (a fixture with both sides known becoming a real propose/accept
 match, C1) is gated on the tournament being `live`, and **the go-live

--- a/docs/adr/0786-a-draw-is-cut-explicitly-and-advanced-idempotently.md
+++ b/docs/adr/0786-a-draw-is-cut-explicitly-and-advanced-idempotently.md
@@ -52,6 +52,13 @@ Each `DrawType` is a strategy behind a `Protocol` with two pure operations:
   re-run after *every* result (and at go-live) rather than triggered by
   carefully-chosen events.
 
+  Idempotence forces the definition of **ready**: both sides known **and** not
+  already materialized (`match_id is None`) **and** not already decided
+  (`winner_entry_id is None`). Ready cannot mean merely "both sides known", or
+  every run would re-propose the whole event's matches forever. The
+  already-decided clause also stops a fixture whose match row was unlinked
+  (`match_id` is `ON DELETE SET NULL`) from rising from the dead.
+
 Two alternatives were rejected:
 
 - **Full replan** (recompute the whole draw from live entries at each step) —

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -554,6 +554,17 @@ internal protocol APIProtocol: Sendable {
     /// re-asserting the status the tournament already holds — a request to publish
     /// an already-published tournament is a stale client, not a no-op.
     ///
+    /// **Going live has a precondition** (ADR-0786): the tournament must have at least
+    /// one event, and every event must have a **draw** whose fixtures seat exactly its
+    /// current entrants. Three things are refused with a `409` that names the events at
+    /// fault — a tournament with **no events** (there is nothing to start), an event with
+    /// **no draw**, and an event whose draw is **stale**, cut before somebody entered or
+    /// withdrew. Cut (or re-cut) the draws it names, then go live. Registration is open
+    /// right up to that moment, which is exactly why a draw can go stale under it.
+    ///
+    /// **Publishing** an empty tournament is unaffected and stays legal: announcing a
+    /// tournament early is fine, starting an empty one is not.
+    ///
     /// Owner-only, like every other tournament mutation.
     ///
     /// - Remark: HTTP `POST /v1/tournaments/{tournament_id}/transitions`.
@@ -565,6 +576,32 @@ internal protocol APIProtocol: Sendable {
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/post(create_event_v1_tournaments__tournament_id__events_post)`.
     func createEventV1TournamentsTournamentIdEventsPost(_ input: Operations.CreateEventV1TournamentsTournamentIdEventsPost.Input) async throws -> Operations.CreateEventV1TournamentsTournamentIdEventsPost.Output
     /// Update Event
+    ///
+    /// Edit an event. Absent fields are left alone; `predicates` and `pools` replace
+    /// wholesale when sent. No two pools may share an `id`, in any state (`422`) — a pool
+    /// id identifies one pool, and the fixtures of a draw name their pool by it.
+    ///
+    /// **Once the event's draw is cut, two things freeze** (ADR-0786) — the facts its
+    /// fixtures were derived from:
+    ///
+    /// * **its set of pools.** A `pools` payload must carry exactly the pool `id`s the
+    ///   event already has, or it is refused with a `409`: a removed (or re-`id`'d) pool
+    ///   would leave the fixtures drawn into it pointing at nothing, and an added one would
+    ///   arrive with no fixtures, since the draw was dealt across the pools that existed at
+    ///   the cut.
+    /// * **its `draw_type`.** The draw type chose the strategy that dealt those fixtures,
+    ///   so changing it under a standing draw is a `409` too: the event would claim a shape
+    ///   its draw does not have. Re-sending the draw type the event already has is not a
+    ///   change, and is not refused.
+    ///
+    /// Nothing else freezes. The event's name, fee, rules and `max_players`, and each
+    /// pool's `table_ids`, `slot` and `name`, all stay editable with a draw standing —
+    /// venues change under a running tournament, and recording that must never cost a
+    /// director the draw. To change the pools themselves or the draw type, remove the draw
+    /// (`DELETE …/draw`), edit, and cut again. With no draw cut, `pools` and `draw_type`
+    /// are ordinary fields.
+    ///
+    /// Owner-only.
     ///
     /// - Remark: HTTP `PATCH /v1/tournaments/{tournament_id}/events/{event_id}`.
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/patch(update_event_v1_tournaments__tournament_id__events__event_id__patch)`.
@@ -652,6 +689,60 @@ internal protocol APIProtocol: Sendable {
     /// - Remark: HTTP `DELETE /v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}`.
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/{entry_id}/delete(withdraw_from_event_v1_tournaments__tournament_id__events__event_id__entries__entry_id__delete)`.
     func withdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete(_ input: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Input) async throws -> Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Output
+    /// Cut Event Draw
+    ///
+    /// Cut this event's draw — generate its **fixtures** from its entrants — and answer
+    /// with them.
+    ///
+    /// Cutting is an explicit, reviewable act, and it is **not** tied to the tournament's
+    /// status: a draw may be cut and re-cut freely while a director inspects the pools and
+    /// the seeding. Nothing else creates fixtures, and going live requires every event to
+    /// have one (ADR-0786).
+    ///
+    /// **Re-cutting replaces the draw wholesale.** The previous fixtures are deleted and a
+    /// fresh set is planned from the event's *current* active entrants — the old ones are
+    /// not patched, and their ids do not survive. That is the point: a draw is a plan made
+    /// against a field, and once the field has changed (somebody entered, somebody
+    /// withdrew) the whole plan is re-made, pool sizes and seeding included.
+    ///
+    /// Entrants are ordered by **seed** ascending where one is set, then by **registration
+    /// order**. Nothing is random, so the same field always cuts the same draw.
+    ///
+    /// Refused with a `409` once the draw shows any **evidence of play** — any fixture with
+    /// a recorded winner, or any fixture that has become a real match. A re-cut would throw
+    /// those away, and a draw must never silently eat a score.
+    ///
+    /// Refused with a `422` when this event cannot produce a draw at all: its draw type has
+    /// no generator yet (only round-robin does today), it has **no pools** configured for a
+    /// pooled draw type, or its field is too small for the pools it has — a pool with fewer
+    /// than two players has nobody to play. The message names what to change.
+    ///
+    /// Owner-only. Fixtures come back in pool → round → position order, exactly as the
+    /// tournament-detail page carries them.
+    ///
+    /// - Remark: HTTP `POST /v1/tournaments/{tournament_id}/events/{event_id}/draw`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/draw/post(cut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_post)`.
+    func cutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost(_ input: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Input) async throws -> Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Output
+    /// Uncut Event Draw
+    ///
+    /// Un-cut this event's draw: delete its fixtures, leaving the event with no draw.
+    ///
+    /// The way back from a draw the director does not want. The event, its entrants and the
+    /// rest of the tournament are untouched — only the fixtures go — and the director is
+    /// free to change the pools and cut again.
+    ///
+    /// Refused with a `409` on the same **evidence of play** that refuses a re-cut: a
+    /// fixture with a recorded winner, or one that has become a real match. Undoing a draw
+    /// that has been played would delete the fixtures those results belong to.
+    ///
+    /// An event with **no draw is already in the state this asks for**, so removing a draw
+    /// that was never cut is a `204`, not a `404`: this is a DELETE, and it is idempotent.
+    ///
+    /// Owner-only.
+    ///
+    /// - Remark: HTTP `DELETE /v1/tournaments/{tournament_id}/events/{event_id}/draw`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/draw/delete(uncut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_delete)`.
+    func uncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete(_ input: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Input) async throws -> Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Output
     /// Health
     ///
     /// - Remark: HTTP `GET /v1/health`.
@@ -1602,6 +1693,17 @@ extension APIProtocol {
     /// re-asserting the status the tournament already holds — a request to publish
     /// an already-published tournament is a stale client, not a no-op.
     ///
+    /// **Going live has a precondition** (ADR-0786): the tournament must have at least
+    /// one event, and every event must have a **draw** whose fixtures seat exactly its
+    /// current entrants. Three things are refused with a `409` that names the events at
+    /// fault — a tournament with **no events** (there is nothing to start), an event with
+    /// **no draw**, and an event whose draw is **stale**, cut before somebody entered or
+    /// withdrew. Cut (or re-cut) the draws it names, then go live. Registration is open
+    /// right up to that moment, which is exactly why a draw can go stale under it.
+    ///
+    /// **Publishing** an empty tournament is unaffected and stays legal: announcing a
+    /// tournament early is fine, starting an empty one is not.
+    ///
     /// Owner-only, like every other tournament mutation.
     ///
     /// - Remark: HTTP `POST /v1/tournaments/{tournament_id}/transitions`.
@@ -1633,6 +1735,32 @@ extension APIProtocol {
         ))
     }
     /// Update Event
+    ///
+    /// Edit an event. Absent fields are left alone; `predicates` and `pools` replace
+    /// wholesale when sent. No two pools may share an `id`, in any state (`422`) — a pool
+    /// id identifies one pool, and the fixtures of a draw name their pool by it.
+    ///
+    /// **Once the event's draw is cut, two things freeze** (ADR-0786) — the facts its
+    /// fixtures were derived from:
+    ///
+    /// * **its set of pools.** A `pools` payload must carry exactly the pool `id`s the
+    ///   event already has, or it is refused with a `409`: a removed (or re-`id`'d) pool
+    ///   would leave the fixtures drawn into it pointing at nothing, and an added one would
+    ///   arrive with no fixtures, since the draw was dealt across the pools that existed at
+    ///   the cut.
+    /// * **its `draw_type`.** The draw type chose the strategy that dealt those fixtures,
+    ///   so changing it under a standing draw is a `409` too: the event would claim a shape
+    ///   its draw does not have. Re-sending the draw type the event already has is not a
+    ///   change, and is not refused.
+    ///
+    /// Nothing else freezes. The event's name, fee, rules and `max_players`, and each
+    /// pool's `table_ids`, `slot` and `name`, all stay editable with a draw standing —
+    /// venues change under a running tournament, and recording that must never cost a
+    /// director the draw. To change the pools themselves or the draw type, remove the draw
+    /// (`DELETE …/draw`), edit, and cut again. With no draw cut, `pools` and `draw_type`
+    /// are ordinary fields.
+    ///
+    /// Owner-only.
     ///
     /// - Remark: HTTP `PATCH /v1/tournaments/{tournament_id}/events/{event_id}`.
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/patch(update_event_v1_tournaments__tournament_id__events__event_id__patch)`.
@@ -1752,6 +1880,76 @@ extension APIProtocol {
         headers: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Input.Headers = .init()
     ) async throws -> Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Output {
         try await withdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete(Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Input(
+            path: path,
+            headers: headers
+        ))
+    }
+    /// Cut Event Draw
+    ///
+    /// Cut this event's draw — generate its **fixtures** from its entrants — and answer
+    /// with them.
+    ///
+    /// Cutting is an explicit, reviewable act, and it is **not** tied to the tournament's
+    /// status: a draw may be cut and re-cut freely while a director inspects the pools and
+    /// the seeding. Nothing else creates fixtures, and going live requires every event to
+    /// have one (ADR-0786).
+    ///
+    /// **Re-cutting replaces the draw wholesale.** The previous fixtures are deleted and a
+    /// fresh set is planned from the event's *current* active entrants — the old ones are
+    /// not patched, and their ids do not survive. That is the point: a draw is a plan made
+    /// against a field, and once the field has changed (somebody entered, somebody
+    /// withdrew) the whole plan is re-made, pool sizes and seeding included.
+    ///
+    /// Entrants are ordered by **seed** ascending where one is set, then by **registration
+    /// order**. Nothing is random, so the same field always cuts the same draw.
+    ///
+    /// Refused with a `409` once the draw shows any **evidence of play** — any fixture with
+    /// a recorded winner, or any fixture that has become a real match. A re-cut would throw
+    /// those away, and a draw must never silently eat a score.
+    ///
+    /// Refused with a `422` when this event cannot produce a draw at all: its draw type has
+    /// no generator yet (only round-robin does today), it has **no pools** configured for a
+    /// pooled draw type, or its field is too small for the pools it has — a pool with fewer
+    /// than two players has nobody to play. The message names what to change.
+    ///
+    /// Owner-only. Fixtures come back in pool → round → position order, exactly as the
+    /// tournament-detail page carries them.
+    ///
+    /// - Remark: HTTP `POST /v1/tournaments/{tournament_id}/events/{event_id}/draw`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/draw/post(cut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_post)`.
+    internal func cutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost(
+        path: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Input.Path,
+        headers: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Input.Headers = .init()
+    ) async throws -> Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Output {
+        try await cutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost(Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Input(
+            path: path,
+            headers: headers
+        ))
+    }
+    /// Uncut Event Draw
+    ///
+    /// Un-cut this event's draw: delete its fixtures, leaving the event with no draw.
+    ///
+    /// The way back from a draw the director does not want. The event, its entrants and the
+    /// rest of the tournament are untouched — only the fixtures go — and the director is
+    /// free to change the pools and cut again.
+    ///
+    /// Refused with a `409` on the same **evidence of play** that refuses a re-cut: a
+    /// fixture with a recorded winner, or one that has become a real match. Undoing a draw
+    /// that has been played would delete the fixtures those results belong to.
+    ///
+    /// An event with **no draw is already in the state this asks for**, so removing a draw
+    /// that was never cut is a `204`, not a `404`: this is a DELETE, and it is idempotent.
+    ///
+    /// Owner-only.
+    ///
+    /// - Remark: HTTP `DELETE /v1/tournaments/{tournament_id}/events/{event_id}/draw`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/draw/delete(uncut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_delete)`.
+    internal func uncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete(
+        path: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Input.Path,
+        headers: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Input.Headers = .init()
+    ) async throws -> Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Output {
+        try await uncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete(Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Input(
             path: path,
             headers: headers
         ))
@@ -5430,6 +5628,11 @@ internal enum Components {
         }
         /// A slice of tables reserved for a window of time within an event.
         ///
+        /// Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
+        /// by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
+        /// these ids. Which is only a coherent thing to say if an id names one pool — see
+        /// ``EventPools``, the type the event's list of them actually has.
+        ///
         /// - Remark: Generated from `#/components/schemas/Pool`.
         internal struct Pool: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/Pool/id`.
@@ -6947,6 +7150,8 @@ internal enum Components {
             }
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/entry_state`.
             internal var entryState: Components.Schemas.TournamentEventRead.EntryStatePayload
+            /// - Remark: Generated from `#/components/schemas/TournamentEventRead/fixtures`.
+            internal var fixtures: [Components.Schemas.TournamentFixtureRead]
             /// The registration count. Derived — there is no stored counter (ADR-0016).
             ///
             /// It is ``len(entrants)`` rather than a field of its own precisely so the
@@ -6973,6 +7178,7 @@ internal enum Components {
             ///   - updatedAt:
             ///   - entrants:
             ///   - entryState:
+            ///   - fixtures:
             ///   - entered: The registration count. Derived — there is no stored counter (ADR-0016).
             internal init(
                 id: Swift.String,
@@ -6990,6 +7196,7 @@ internal enum Components {
                 updatedAt: Foundation.Date,
                 entrants: [Components.Schemas.TournamentEntrantRead],
                 entryState: Components.Schemas.TournamentEventRead.EntryStatePayload,
+                fixtures: [Components.Schemas.TournamentFixtureRead],
                 entered: Swift.Int
             ) {
                 self.id = id
@@ -7007,6 +7214,7 @@ internal enum Components {
                 self.updatedAt = updatedAt
                 self.entrants = entrants
                 self.entryState = entryState
+                self.fixtures = fixtures
                 self.entered = entered
             }
             internal enum CodingKeys: String, CodingKey {
@@ -7025,6 +7233,7 @@ internal enum Components {
                 case updatedAt = "updated_at"
                 case entrants
                 case entryState = "entry_state"
+                case fixtures
                 case entered
             }
         }
@@ -7233,6 +7442,92 @@ internal enum Components {
                     "predicates",
                     "pools"
                 ])
+            }
+        }
+        /// One planned pairing of an event's draw (ADR-0786): a round and a position —
+        /// plus a pool, when the draw is pooled — whose sides may still be unknown.
+        ///
+        /// A fixture is **not** a match. It materializes into one later (#788), and until it
+        /// does ``match_id`` is ``null``.
+        ///
+        /// **Every ``null`` on this model is a fact, not a missing field**, and a client that
+        /// dropped them would lose the draw's whole point:
+        ///
+        /// * ``entry_a_id`` / ``entry_b_id`` — ``null`` means **TBD**: the feeding fixture has
+        ///   not been decided yet, and ``advance()`` will fill this side in. It never means a
+        ///   bye — a bye is the *absence of a fixture row*, not a fixture with an empty side
+        ///   (ADR-0786), so there is no ``is_bye`` flag here to tell the two apart.
+        /// * ``winner_entry_id`` — ``null`` while the fixture is undecided.
+        /// * ``match_id`` — ``null`` until the fixture becomes a real match, which only happens
+        ///   once the tournament is ``live``.
+        /// * ``pool_id`` — ``null`` means this fixture belongs to no pool: the draw is
+        ///   un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
+        ///   set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
+        ///   JSONB, not a foreign key, because pools are value-objects with no table.
+        ///
+        /// The entries are carried as **ids only**. The name and username behind
+        /// ``entry_a_id`` are already on this page — the event's ``entrants`` list carries
+        /// them, keyed by that very id — so a client joins the two. Copying the username onto
+        /// the fixture as well would be carrying a field and its own derivation
+        /// (api/CLAUDE.md), and the copy that drifts is the one a player reads off a bracket.
+        ///
+        /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead`.
+        internal struct TournamentFixtureRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/id`.
+            internal var id: Swift.String
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/pool_id`.
+            internal var poolId: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/round`.
+            internal var round: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/position`.
+            internal var position: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/entry_a_id`.
+            internal var entryAId: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/entry_b_id`.
+            internal var entryBId: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/winner_entry_id`.
+            internal var winnerEntryId: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/match_id`.
+            internal var matchId: Swift.String?
+            /// Creates a new `TournamentFixtureRead`.
+            ///
+            /// - Parameters:
+            ///   - id:
+            ///   - poolId:
+            ///   - round:
+            ///   - position:
+            ///   - entryAId:
+            ///   - entryBId:
+            ///   - winnerEntryId:
+            ///   - matchId:
+            internal init(
+                id: Swift.String,
+                poolId: Swift.String? = nil,
+                round: Swift.Int,
+                position: Swift.Int,
+                entryAId: Swift.String? = nil,
+                entryBId: Swift.String? = nil,
+                winnerEntryId: Swift.String? = nil,
+                matchId: Swift.String? = nil
+            ) {
+                self.id = id
+                self.poolId = poolId
+                self.round = round
+                self.position = position
+                self.entryAId = entryAId
+                self.entryBId = entryBId
+                self.winnerEntryId = winnerEntryId
+                self.matchId = matchId
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case id
+                case poolId = "pool_id"
+                case round
+                case position
+                case entryAId = "entry_a_id"
+                case entryBId = "entry_b_id"
+                case winnerEntryId = "winner_entry_id"
+                case matchId = "match_id"
             }
         }
         /// - Remark: Generated from `#/components/schemas/TournamentRead`.
@@ -18312,6 +18607,17 @@ internal enum Operations {
     /// re-asserting the status the tournament already holds — a request to publish
     /// an already-published tournament is a stale client, not a no-op.
     ///
+    /// **Going live has a precondition** (ADR-0786): the tournament must have at least
+    /// one event, and every event must have a **draw** whose fixtures seat exactly its
+    /// current entrants. Three things are refused with a `409` that names the events at
+    /// fault — a tournament with **no events** (there is nothing to start), an event with
+    /// **no draw**, and an event whose draw is **stale**, cut before somebody entered or
+    /// withdrew. Cut (or re-cut) the draws it names, then go live. Registration is open
+    /// right up to that moment, which is exactly why a draw can go stale under it.
+    ///
+    /// **Publishing** an empty tournament is unaffected and stays legal: announcing a
+    /// tournament early is fine, starting an empty one is not.
+    ///
     /// Owner-only, like every other tournament mutation.
     ///
     /// - Remark: HTTP `POST /v1/tournaments/{tournament_id}/transitions`.
@@ -18689,6 +18995,32 @@ internal enum Operations {
         }
     }
     /// Update Event
+    ///
+    /// Edit an event. Absent fields are left alone; `predicates` and `pools` replace
+    /// wholesale when sent. No two pools may share an `id`, in any state (`422`) — a pool
+    /// id identifies one pool, and the fixtures of a draw name their pool by it.
+    ///
+    /// **Once the event's draw is cut, two things freeze** (ADR-0786) — the facts its
+    /// fixtures were derived from:
+    ///
+    /// * **its set of pools.** A `pools` payload must carry exactly the pool `id`s the
+    ///   event already has, or it is refused with a `409`: a removed (or re-`id`'d) pool
+    ///   would leave the fixtures drawn into it pointing at nothing, and an added one would
+    ///   arrive with no fixtures, since the draw was dealt across the pools that existed at
+    ///   the cut.
+    /// * **its `draw_type`.** The draw type chose the strategy that dealt those fixtures,
+    ///   so changing it under a standing draw is a `409` too: the event would claim a shape
+    ///   its draw does not have. Re-sending the draw type the event already has is not a
+    ///   change, and is not refused.
+    ///
+    /// Nothing else freezes. The event's name, fee, rules and `max_players`, and each
+    /// pool's `table_ids`, `slot` and `name`, all stay editable with a draw standing —
+    /// venues change under a running tournament, and recording that must never cost a
+    /// director the draw. To change the pools themselves or the draw type, remove the draw
+    /// (`DELETE …/draw`), edit, and cut again. With no draw cut, `pools` and `draw_type`
+    /// are ordinary fields.
+    ///
+    /// Owner-only.
     ///
     /// - Remark: HTTP `PATCH /v1/tournaments/{tournament_id}/events/{event_id}`.
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/patch(update_event_v1_tournaments__tournament_id__events__event_id__patch)`.
@@ -19466,6 +19798,406 @@ internal enum Operations {
             /// - Throws: An error if `self` is not `.unprocessableContent`.
             /// - SeeAlso: `.unprocessableContent`.
             internal var unprocessableContent: Operations.WithdrawFromEventV1TournamentsTournamentIdEventsEventIdEntriesEntryIdDelete.Output.UnprocessableContent {
+                get throws {
+                    switch self {
+                    case let .unprocessableContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unprocessableContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        internal enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            internal init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            internal var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            internal static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Cut Event Draw
+    ///
+    /// Cut this event's draw — generate its **fixtures** from its entrants — and answer
+    /// with them.
+    ///
+    /// Cutting is an explicit, reviewable act, and it is **not** tied to the tournament's
+    /// status: a draw may be cut and re-cut freely while a director inspects the pools and
+    /// the seeding. Nothing else creates fixtures, and going live requires every event to
+    /// have one (ADR-0786).
+    ///
+    /// **Re-cutting replaces the draw wholesale.** The previous fixtures are deleted and a
+    /// fresh set is planned from the event's *current* active entrants — the old ones are
+    /// not patched, and their ids do not survive. That is the point: a draw is a plan made
+    /// against a field, and once the field has changed (somebody entered, somebody
+    /// withdrew) the whole plan is re-made, pool sizes and seeding included.
+    ///
+    /// Entrants are ordered by **seed** ascending where one is set, then by **registration
+    /// order**. Nothing is random, so the same field always cuts the same draw.
+    ///
+    /// Refused with a `409` once the draw shows any **evidence of play** — any fixture with
+    /// a recorded winner, or any fixture that has become a real match. A re-cut would throw
+    /// those away, and a draw must never silently eat a score.
+    ///
+    /// Refused with a `422` when this event cannot produce a draw at all: its draw type has
+    /// no generator yet (only round-robin does today), it has **no pools** configured for a
+    /// pooled draw type, or its field is too small for the pools it has — a pool with fewer
+    /// than two players has nobody to play. The message names what to change.
+    ///
+    /// Owner-only. Fixtures come back in pool → round → position order, exactly as the
+    /// tournament-detail page carries them.
+    ///
+    /// - Remark: HTTP `POST /v1/tournaments/{tournament_id}/events/{event_id}/draw`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/draw/post(cut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_post)`.
+    internal enum CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost {
+        internal static let id: Swift.String = "cut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_post"
+        internal struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/POST/path`.
+            internal struct Path: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/POST/path/tournament_id`.
+                internal var tournamentId: Swift.String
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/POST/path/event_id`.
+                internal var eventId: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - tournamentId:
+                ///   - eventId:
+                internal init(
+                    tournamentId: Swift.String,
+                    eventId: Swift.String
+                ) {
+                    self.tournamentId = tournamentId
+                    self.eventId = eventId
+                }
+            }
+            internal var path: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Input.Path
+            /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/POST/header`.
+            internal struct Headers: Sendable, Hashable {
+                internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                internal init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            internal var headers: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            internal init(
+                path: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Input.Path,
+                headers: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        internal enum Output: Sendable, Hashable {
+            internal struct Created: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/POST/responses/201/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/POST/responses/201/content/application\/json`.
+                    case json([Components.Schemas.TournamentFixtureRead])
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: [Components.Schemas.TournamentFixtureRead] {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Output.Created.Body
+                /// Creates a new `Created`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Output.Created.Body) {
+                    self.body = body
+                }
+            }
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/draw/post(cut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_post)/responses/201`.
+            ///
+            /// HTTP response code: `201 created`.
+            case created(Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Output.Created)
+            /// The associated value of the enum case if `self` is `.created`.
+            ///
+            /// - Throws: An error if `self` is not `.created`.
+            /// - SeeAlso: `.created`.
+            internal var created: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Output.Created {
+                get throws {
+                    switch self {
+                    case let .created(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "created",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct UnprocessableContent: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/POST/responses/422/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/POST/responses/422/content/application\/json`.
+                    case json(Components.Schemas.HTTPValidationError)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.HTTPValidationError {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Output.UnprocessableContent.Body
+                /// Creates a new `UnprocessableContent`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Output.UnprocessableContent.Body) {
+                    self.body = body
+                }
+            }
+            /// Validation Error
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/draw/post(cut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_post)/responses/422`.
+            ///
+            /// HTTP response code: `422 unprocessableContent`.
+            case unprocessableContent(Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Output.UnprocessableContent)
+            /// The associated value of the enum case if `self` is `.unprocessableContent`.
+            ///
+            /// - Throws: An error if `self` is not `.unprocessableContent`.
+            /// - SeeAlso: `.unprocessableContent`.
+            internal var unprocessableContent: Operations.CutEventDrawV1TournamentsTournamentIdEventsEventIdDrawPost.Output.UnprocessableContent {
+                get throws {
+                    switch self {
+                    case let .unprocessableContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unprocessableContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        internal enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            internal init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            internal var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            internal static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Uncut Event Draw
+    ///
+    /// Un-cut this event's draw: delete its fixtures, leaving the event with no draw.
+    ///
+    /// The way back from a draw the director does not want. The event, its entrants and the
+    /// rest of the tournament are untouched — only the fixtures go — and the director is
+    /// free to change the pools and cut again.
+    ///
+    /// Refused with a `409` on the same **evidence of play** that refuses a re-cut: a
+    /// fixture with a recorded winner, or one that has become a real match. Undoing a draw
+    /// that has been played would delete the fixtures those results belong to.
+    ///
+    /// An event with **no draw is already in the state this asks for**, so removing a draw
+    /// that was never cut is a `204`, not a `404`: this is a DELETE, and it is idempotent.
+    ///
+    /// Owner-only.
+    ///
+    /// - Remark: HTTP `DELETE /v1/tournaments/{tournament_id}/events/{event_id}/draw`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/draw/delete(uncut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_delete)`.
+    internal enum UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete {
+        internal static let id: Swift.String = "uncut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_delete"
+        internal struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/DELETE/path`.
+            internal struct Path: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/DELETE/path/tournament_id`.
+                internal var tournamentId: Swift.String
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/DELETE/path/event_id`.
+                internal var eventId: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - tournamentId:
+                ///   - eventId:
+                internal init(
+                    tournamentId: Swift.String,
+                    eventId: Swift.String
+                ) {
+                    self.tournamentId = tournamentId
+                    self.eventId = eventId
+                }
+            }
+            internal var path: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Input.Path
+            /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/DELETE/header`.
+            internal struct Headers: Sendable, Hashable {
+                internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                internal init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            internal var headers: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            internal init(
+                path: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Input.Path,
+                headers: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Input.Headers = .init()
+            ) {
+                self.path = path
+                self.headers = headers
+            }
+        }
+        internal enum Output: Sendable, Hashable {
+            internal struct NoContent: Sendable, Hashable {
+                /// Creates a new `NoContent`.
+                internal init() {}
+            }
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/draw/delete(uncut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_delete)/responses/204`.
+            ///
+            /// HTTP response code: `204 noContent`.
+            case noContent(Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Output.NoContent)
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/draw/delete(uncut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_delete)/responses/204`.
+            ///
+            /// HTTP response code: `204 noContent`.
+            internal static var noContent: Self {
+                .noContent(.init())
+            }
+            /// The associated value of the enum case if `self` is `.noContent`.
+            ///
+            /// - Throws: An error if `self` is not `.noContent`.
+            /// - SeeAlso: `.noContent`.
+            internal var noContent: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Output.NoContent {
+                get throws {
+                    switch self {
+                    case let .noContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "noContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct UnprocessableContent: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/DELETE/responses/422/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/draw/DELETE/responses/422/content/application\/json`.
+                    case json(Components.Schemas.HTTPValidationError)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.HTTPValidationError {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Output.UnprocessableContent.Body
+                /// Creates a new `UnprocessableContent`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Output.UnprocessableContent.Body) {
+                    self.body = body
+                }
+            }
+            /// Validation Error
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/draw/delete(uncut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_delete)/responses/422`.
+            ///
+            /// HTTP response code: `422 unprocessableContent`.
+            case unprocessableContent(Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Output.UnprocessableContent)
+            /// The associated value of the enum case if `self` is `.unprocessableContent`.
+            ///
+            /// - Throws: An error if `self` is not `.unprocessableContent`.
+            /// - SeeAlso: `.unprocessableContent`.
+            internal var unprocessableContent: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Output.UnprocessableContent {
                 get throws {
                     switch self {
                     case let .unprocessableContent(response):

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -576,45 +576,62 @@ internal protocol APIProtocol: Sendable {
     func deleteEventV1TournamentsTournamentIdEventsEventIdDelete(_ input: Operations.DeleteEventV1TournamentsTournamentIdEventsEventIdDelete.Input) async throws -> Operations.DeleteEventV1TournamentsTournamentIdEventsEventIdDelete.Output
     /// Enter Event
     ///
-    /// Register the signed-in player in a singles event.
+    /// Enter a player in a singles event — yourself, or (as the tournament's owner)
+    /// somebody else.
     ///
-    /// Self-registration only: the entry created is always the caller's own, which
-    /// is why the request carries no body — there is no field in which to name
-    /// someone else. Entering a player who is not you is a director's job, and a
-    /// different endpoint.
+    /// **The body is optional, and its presence chooses the actor** (ADR-0784):
+    ///
+    /// * **no body** → you are entering *yourself*. Requires the `tournament.enter`
+    ///   permission. This is the request every player already sends, and it is unchanged.
+    /// * **`user_id`** → you are the **director** entering that player. Requires that you
+    ///   **own** the tournament; anyone else naming a `user_id` that is not their own is a
+    ///   `403`. An id that names no (live) player is a `404`.
+    ///
+    /// Naming *your own* `user_id` is self-registration, not a director entry: same
+    /// permission, and the entry records no adder.
     ///
     /// Registration is open only while the tournament is **`published`** — its status
     /// *is* its registration window (ADR-0017). Entering an event of a `draft`
     /// tournament (not announced yet), a `live` one (the field is fixed; the draw is
     /// cut from it), or an `archived` one (it is over) is a `409` — not a `403`: you
-    /// are permitted, the tournament is simply in the wrong state.
+    /// are permitted, the tournament is simply in the wrong state. **That holds for the
+    /// director too**: there is no override, so a director can neither add a walk-in nor
+    /// remove a no-show once the tournament is live.
     ///
-    /// An event's **eligibility rules** are decided against your rating on the
-    /// tournament's league, and you must satisfy **every** one of them: failing a rule
+    /// An event's **eligibility rules** are decided against the entrant's rating on the
+    /// tournament's league, and they must satisfy **every** one of them: failing a rule
     /// (the 1650-rated player entering the "Under 1500" event) is a `409`. A player who
     /// holds **no rating** on that league — nobody has a rating until they finish a rated
     /// match — **passes every rule**, so a brand-new player is not shut out of the
     /// beginners' event that exists for them.
     ///
-    /// Entering an event you are already in is a `409`; withdrawing first frees you
+    /// Entering an event the player is already in is a `409`; withdrawing first frees them
     /// to enter it again. Entering an event that already holds its `max_players`
     /// entrants is a `409` too — someone withdrawing frees the slot. Doubles and teams
     /// events are a `400`: an entry is one row per player, with nowhere to record a
     /// partner or a team.
+    ///
+    /// **A director's entry is judged by exactly these rules.** The same evaluator, the
+    /// same capacity lock, the same four refusal codes: a director adding a player to a
+    /// full event, or one over the event's rating cap, is refused precisely as the player
+    /// would be.
     ///
     /// - Remark: HTTP `POST /v1/tournaments/{tournament_id}/events/{event_id}/entries`.
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/post(enter_event_v1_tournaments__tournament_id__events__event_id__entries_post)`.
     func enterEventV1TournamentsTournamentIdEventsEventIdEntriesPost(_ input: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input) async throws -> Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Output
     /// Withdraw From Event
     ///
-    /// Withdraw the signed-in player's own entry from an event.
+    /// Withdraw an entry from an event — your own, or (as the tournament's owner) any
+    /// entry in it.
     ///
     /// The entry is **soft-deleted**: its status flips to `withdrawn` and the row
     /// survives, so the event keeps its withdrawal history — and, because the
     /// uniqueness guard is a *partial* index over active entries only, the player is
     /// free to enter the same event again afterwards.
     ///
-    /// You may only withdraw your own entry; someone else's is a `403`.
+    /// **Who may withdraw an entry** (ADR-0784) mirrors who may create one: the player
+    /// themselves (with the `tournament.enter` permission), or the tournament's **owner**,
+    /// for any entry in it. Anybody else is a `403`.
     ///
     /// Withdrawal, like entry, is open only while the tournament is **`published`** —
     /// its status *is* its registration window (ADR-0017). Withdrawing an *active*
@@ -622,7 +639,9 @@ internal protocol APIProtocol: Sendable {
     /// from the field they were part of, so it is a `409`, as it is for a `draft`
     /// tournament (registration has not opened) and an `archived` one (it is over).
     /// A `409`, not a `403`: you are permitted, the tournament is simply in the wrong
-    /// state.
+    /// state. **The owner obeys that window too** — withdrawal stays symmetric with entry,
+    /// so a director can no more remove a no-show from a live tournament than add a
+    /// walk-in to one.
     ///
     /// **Withdrawing an entry that is already withdrawn is a `204` in every status**,
     /// `live` and `archived` included — a no-op, not an error: this is `DELETE`, and
@@ -1643,53 +1662,72 @@ extension APIProtocol {
     }
     /// Enter Event
     ///
-    /// Register the signed-in player in a singles event.
+    /// Enter a player in a singles event — yourself, or (as the tournament's owner)
+    /// somebody else.
     ///
-    /// Self-registration only: the entry created is always the caller's own, which
-    /// is why the request carries no body — there is no field in which to name
-    /// someone else. Entering a player who is not you is a director's job, and a
-    /// different endpoint.
+    /// **The body is optional, and its presence chooses the actor** (ADR-0784):
+    ///
+    /// * **no body** → you are entering *yourself*. Requires the `tournament.enter`
+    ///   permission. This is the request every player already sends, and it is unchanged.
+    /// * **`user_id`** → you are the **director** entering that player. Requires that you
+    ///   **own** the tournament; anyone else naming a `user_id` that is not their own is a
+    ///   `403`. An id that names no (live) player is a `404`.
+    ///
+    /// Naming *your own* `user_id` is self-registration, not a director entry: same
+    /// permission, and the entry records no adder.
     ///
     /// Registration is open only while the tournament is **`published`** — its status
     /// *is* its registration window (ADR-0017). Entering an event of a `draft`
     /// tournament (not announced yet), a `live` one (the field is fixed; the draw is
     /// cut from it), or an `archived` one (it is over) is a `409` — not a `403`: you
-    /// are permitted, the tournament is simply in the wrong state.
+    /// are permitted, the tournament is simply in the wrong state. **That holds for the
+    /// director too**: there is no override, so a director can neither add a walk-in nor
+    /// remove a no-show once the tournament is live.
     ///
-    /// An event's **eligibility rules** are decided against your rating on the
-    /// tournament's league, and you must satisfy **every** one of them: failing a rule
+    /// An event's **eligibility rules** are decided against the entrant's rating on the
+    /// tournament's league, and they must satisfy **every** one of them: failing a rule
     /// (the 1650-rated player entering the "Under 1500" event) is a `409`. A player who
     /// holds **no rating** on that league — nobody has a rating until they finish a rated
     /// match — **passes every rule**, so a brand-new player is not shut out of the
     /// beginners' event that exists for them.
     ///
-    /// Entering an event you are already in is a `409`; withdrawing first frees you
+    /// Entering an event the player is already in is a `409`; withdrawing first frees them
     /// to enter it again. Entering an event that already holds its `max_players`
     /// entrants is a `409` too — someone withdrawing frees the slot. Doubles and teams
     /// events are a `400`: an entry is one row per player, with nowhere to record a
     /// partner or a team.
     ///
+    /// **A director's entry is judged by exactly these rules.** The same evaluator, the
+    /// same capacity lock, the same four refusal codes: a director adding a player to a
+    /// full event, or one over the event's rating cap, is refused precisely as the player
+    /// would be.
+    ///
     /// - Remark: HTTP `POST /v1/tournaments/{tournament_id}/events/{event_id}/entries`.
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/post(enter_event_v1_tournaments__tournament_id__events__event_id__entries_post)`.
     internal func enterEventV1TournamentsTournamentIdEventsEventIdEntriesPost(
         path: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Path,
-        headers: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Headers = .init()
+        headers: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Headers = .init(),
+        body: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Body? = nil
     ) async throws -> Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Output {
         try await enterEventV1TournamentsTournamentIdEventsEventIdEntriesPost(Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input(
             path: path,
-            headers: headers
+            headers: headers,
+            body: body
         ))
     }
     /// Withdraw From Event
     ///
-    /// Withdraw the signed-in player's own entry from an event.
+    /// Withdraw an entry from an event — your own, or (as the tournament's owner) any
+    /// entry in it.
     ///
     /// The entry is **soft-deleted**: its status flips to `withdrawn` and the row
     /// survives, so the event keeps its withdrawal history — and, because the
     /// uniqueness guard is a *partial* index over active entries only, the player is
     /// free to enter the same event again afterwards.
     ///
-    /// You may only withdraw your own entry; someone else's is a `403`.
+    /// **Who may withdraw an entry** (ADR-0784) mirrors who may create one: the player
+    /// themselves (with the `tournament.enter` permission), or the tournament's **owner**,
+    /// for any entry in it. Anybody else is a `403`.
     ///
     /// Withdrawal, like entry, is open only while the tournament is **`published`** —
     /// its status *is* its registration window (ADR-0017). Withdrawing an *active*
@@ -1697,7 +1735,9 @@ extension APIProtocol {
     /// from the field they were part of, so it is a `409`, as it is for a `draft`
     /// tournament (registration has not opened) and an `archived` one (it is over).
     /// A `409`, not a `403`: you are permitted, the tournament is simply in the wrong
-    /// state.
+    /// state. **The owner obeys that window too** — withdrawal stays symmetric with entry,
+    /// so a director can no more remove a no-show from a live tournament than add a
+    /// walk-in to one.
     ///
     /// **Withdrawing an entry that is already withdrawn is a `204` in every status**,
     /// `live` and `archived` included — a no-op, not an error: this is `DELETE`, and
@@ -6653,6 +6693,57 @@ internal enum Components {
                 case username
                 case seed
                 case rating
+            }
+        }
+        /// *Who* to enter — the body of ``POST …/entries``, and the whole of it.
+        ///
+        /// **The body is optional, and its presence selects the actor** (ADR-0784):
+        ///
+        /// * **omitted** → you are entering *yourself*. Self-registration, gated on the
+        ///   ``tournament.enter`` permission — the request every player already sends, which
+        ///   carries no body at all and must keep working unchanged.
+        /// * **``user_id`` present** → a *director* is entering somebody, which only the
+        ///   tournament's **owner** may do.
+        ///
+        /// One endpoint, not two, because both actors must run the same eligibility
+        /// evaluator, take the same capacity lock and produce the same four refusal codes
+        /// (``EntryRefusal``, ADR-0968). A twin route would make the *next* refusal a thing
+        /// to add twice, and the two call sites of the evaluator a thing to keep from
+        /// drifting.
+        ///
+        /// Naming **your own** ``user_id`` is self-registration, not a director entry — the
+        /// same guard, and the same ``added_by_user_id = NULL`` on the row. "The player
+        /// entered themselves" has exactly one encoding, and ``added_by == user_id`` is not
+        /// it (see ``TournamentEntry.added_by_user_id``).
+        ///
+        /// There is deliberately **no ``force``**: a director's entry is refused by the same
+        /// rules a player's is — a full event and a rating cap catch a director's typo exactly
+        /// as they catch a stranger's. Absent an override, that *is* the safety model, and the
+        /// override is a ticket of its own (#985), not a flag smuggled in here.
+        ///
+        /// - Remark: Generated from `#/components/schemas/TournamentEntryCreate`.
+        internal struct TournamentEntryCreate: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/TournamentEntryCreate/user_id`.
+            internal var userId: Swift.String
+            /// Creates a new `TournamentEntryCreate`.
+            ///
+            /// - Parameters:
+            ///   - userId:
+            internal init(userId: Swift.String) {
+                self.userId = userId
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case userId = "user_id"
+            }
+            internal init(from decoder: any Swift.Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.userId = try container.decode(
+                    Swift.String.self,
+                    forKey: .userId
+                )
+                try decoder.ensureNoAdditionalProperties(knownKeys: [
+                    "user_id"
+                ])
             }
         }
         /// A new event. Its two numbers are bounded by what their columns can hold —
@@ -18964,31 +19055,45 @@ internal enum Operations {
     }
     /// Enter Event
     ///
-    /// Register the signed-in player in a singles event.
+    /// Enter a player in a singles event — yourself, or (as the tournament's owner)
+    /// somebody else.
     ///
-    /// Self-registration only: the entry created is always the caller's own, which
-    /// is why the request carries no body — there is no field in which to name
-    /// someone else. Entering a player who is not you is a director's job, and a
-    /// different endpoint.
+    /// **The body is optional, and its presence chooses the actor** (ADR-0784):
+    ///
+    /// * **no body** → you are entering *yourself*. Requires the `tournament.enter`
+    ///   permission. This is the request every player already sends, and it is unchanged.
+    /// * **`user_id`** → you are the **director** entering that player. Requires that you
+    ///   **own** the tournament; anyone else naming a `user_id` that is not their own is a
+    ///   `403`. An id that names no (live) player is a `404`.
+    ///
+    /// Naming *your own* `user_id` is self-registration, not a director entry: same
+    /// permission, and the entry records no adder.
     ///
     /// Registration is open only while the tournament is **`published`** — its status
     /// *is* its registration window (ADR-0017). Entering an event of a `draft`
     /// tournament (not announced yet), a `live` one (the field is fixed; the draw is
     /// cut from it), or an `archived` one (it is over) is a `409` — not a `403`: you
-    /// are permitted, the tournament is simply in the wrong state.
+    /// are permitted, the tournament is simply in the wrong state. **That holds for the
+    /// director too**: there is no override, so a director can neither add a walk-in nor
+    /// remove a no-show once the tournament is live.
     ///
-    /// An event's **eligibility rules** are decided against your rating on the
-    /// tournament's league, and you must satisfy **every** one of them: failing a rule
+    /// An event's **eligibility rules** are decided against the entrant's rating on the
+    /// tournament's league, and they must satisfy **every** one of them: failing a rule
     /// (the 1650-rated player entering the "Under 1500" event) is a `409`. A player who
     /// holds **no rating** on that league — nobody has a rating until they finish a rated
     /// match — **passes every rule**, so a brand-new player is not shut out of the
     /// beginners' event that exists for them.
     ///
-    /// Entering an event you are already in is a `409`; withdrawing first frees you
+    /// Entering an event the player is already in is a `409`; withdrawing first frees them
     /// to enter it again. Entering an event that already holds its `max_players`
     /// entrants is a `409` too — someone withdrawing frees the slot. Doubles and teams
     /// events are a `400`: an entry is one row per player, with nowhere to record a
     /// partner or a team.
+    ///
+    /// **A director's entry is judged by exactly these rules.** The same evaluator, the
+    /// same capacity lock, the same four refusal codes: a director adding a player to a
+    /// full event, or one over the event's rating cap, is refused precisely as the player
+    /// would be.
     ///
     /// - Remark: HTTP `POST /v1/tournaments/{tournament_id}/events/{event_id}/entries`.
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/entries/post(enter_event_v1_tournaments__tournament_id__events__event_id__entries_post)`.
@@ -19027,17 +19132,44 @@ internal enum Operations {
                 }
             }
             internal var headers: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Headers
+            /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/POST/requestBody`.
+            internal enum Body: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/POST/requestBody/json`.
+                internal struct JsonPayload: Codable, Hashable, Sendable {
+                    /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/POST/requestBody/json/value1`.
+                    internal var value1: Components.Schemas.TournamentEntryCreate
+                    /// Creates a new `JsonPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - value1:
+                    internal init(value1: Components.Schemas.TournamentEntryCreate) {
+                        self.value1 = value1
+                    }
+                    internal init(from decoder: any Swift.Decoder) throws {
+                        self.value1 = try .init(from: decoder)
+                    }
+                    internal func encode(to encoder: any Swift.Encoder) throws {
+                        try self.value1.encode(to: encoder)
+                    }
+                }
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/events/{event_id}/entries/POST/requestBody/content/application\/json`.
+                case json(Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Body.JsonPayload)
+            }
+            internal var body: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Body?
             /// Creates a new `Input`.
             ///
             /// - Parameters:
             ///   - path:
             ///   - headers:
+            ///   - body:
             internal init(
                 path: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Path,
-                headers: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Headers = .init()
+                headers: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Headers = .init(),
+                body: Operations.EnterEventV1TournamentsTournamentIdEventsEventIdEntriesPost.Input.Body? = nil
             ) {
                 self.path = path
                 self.headers = headers
+                self.body = body
             }
         }
         internal enum Output: Sendable, Hashable {
@@ -19176,14 +19308,17 @@ internal enum Operations {
     }
     /// Withdraw From Event
     ///
-    /// Withdraw the signed-in player's own entry from an event.
+    /// Withdraw an entry from an event — your own, or (as the tournament's owner) any
+    /// entry in it.
     ///
     /// The entry is **soft-deleted**: its status flips to `withdrawn` and the row
     /// survives, so the event keeps its withdrawal history — and, because the
     /// uniqueness guard is a *partial* index over active entries only, the player is
     /// free to enter the same event again afterwards.
     ///
-    /// You may only withdraw your own entry; someone else's is a `403`.
+    /// **Who may withdraw an entry** (ADR-0784) mirrors who may create one: the player
+    /// themselves (with the `tournament.enter` permission), or the tournament's **owner**,
+    /// for any entry in it. Anybody else is a `403`.
     ///
     /// Withdrawal, like entry, is open only while the tournament is **`published`** —
     /// its status *is* its registration window (ADR-0017). Withdrawing an *active*
@@ -19191,7 +19326,9 @@ internal enum Operations {
     /// from the field they were part of, so it is a `409`, as it is for a `draft`
     /// tournament (registration has not opened) and an `archived` one (it is over).
     /// A `409`, not a `403`: you are permitted, the tournament is simply in the wrong
-    /// state.
+    /// state. **The owner obeys that window too** — withdrawal stays symmetric with entry,
+    /// so a director can no more remove a no-show from a live tournament than add a
+    /// walk-in to one.
     ///
     /// **Withdrawing an entry that is already withdrawn is a `204` in every status**,
     /// `live` and `archived` included — a no-op, not an error: this is `DELETE`, and

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -5631,7 +5631,14 @@ internal enum Components {
         /// Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
         /// by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
         /// these ids. Which is only a coherent thing to say if an id names one pool — see
-        /// ``EventPools``, the type the event's list of them actually has.
+        /// ``EventPools``, the type the event's list of them actually has — and if an id is a
+        /// thing at all, which is what ``ValueObjectId`` says: the empty string is not one, and
+        /// a fixture drawn into it is pooled by one rule and un-pooled by another.
+        ///
+        /// Its ``name`` has the same floor for the plainer reason: a pool is *called*
+        /// something — it is what the director clicks, what the conflict warnings quote, and
+        /// what a player reads off a wall. ``""`` is not a name, and an event whose pools list
+        /// is three blank rows is not a thing anyone could act on.
         ///
         /// - Remark: Generated from `#/components/schemas/Pool`.
         internal struct Pool: Codable, Hashable, Sendable {
@@ -7633,6 +7640,13 @@ internal enum Components {
             case archived = "archived"
         }
         /// A physical table in the venue catalogue, referenced by id from pools.
+        ///
+        /// Its ``id`` is a ``ValueObjectId`` for the same reason a pool's is: a pool holds a
+        /// list of these strings (``table_ids``) and nothing else connects the two, so an id
+        /// that is the empty string is a table nothing can name — and a ``table_ids`` entry of
+        /// ``""`` would "resolve" against it. It is the same string-ref pattern with the same
+        /// hole, and closing it in one place and not the other would leave the boundary
+        /// half-drawn.
         ///
         /// - Remark: Generated from `#/components/schemas/TournamentTable`.
         internal struct TournamentTable: Codable, Hashable, Sendable {

--- a/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
+++ b/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
@@ -112,14 +112,23 @@ export class TournamentDetailPage {
     return this.eventCard(eventName).getByTestId('ineligible-notice')
   }
 
-  /** EVERY button inside one event card — the locator the "no *disabled* Enter"
-   * claim actually needs. `enterButton()` is keyed on the accessible name, so it
-   * proves only that a button *called* "Enter X" is absent; this proves the card
-   * offers no control at all beyond its own open-target overlay (which is a sibling
-   * of the card, not inside it — see `eventCard`). ADR-0015: hide the affordance,
-   * never disable it. */
+  /** Every button inside one event card **except the draw panel's** — the locator the
+   * "no *disabled* Enter" claim actually needs. `enterButton()` is keyed on the
+   * accessible name, so it proves only that a button *called* "Enter X" is absent; this
+   * proves the card offers no ENTRY control at all beyond its own open-target overlay
+   * (which is a sibling of the card, not inside it — see `eventCard`). ADR-0015: hide
+   * the affordance, never disable it.
+   *
+   * The draw's verbs (Generate / Re-cut / Delete, ADR-0786) live inside the same card
+   * and are excluded on purpose: they are a *director's* controls, gated on the
+   * tournament's `can_edit` rather than on anything about entry, and a full or
+   * rating-ineligible event is exactly as drawable as any other. Folding them in would
+   * make this locator quietly assert "an owner may not cut a draw for a full event",
+   * which is not true and is not what any of its callers mean. */
   cardButtons(eventName: string): Locator {
-    return this.eventCard(eventName).getByRole('button')
+    return this.eventCard(eventName).locator(
+      'button:not([data-testid^="draw-panel-"] button)',
+    )
   }
 
   withdrawButton(eventName: string): Locator {

--- a/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
+++ b/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
@@ -73,6 +73,16 @@ export class TournamentDetailPage {
     })
   }
 
+  /** The header's inline **refusal** — where a rejected transition is reported now
+   * (#786): an `Alert` beside the button that was clicked, not a toast. It carries the
+   * client's title and, beneath it, the server's own sentence — which for a refused
+   * **Start tournament** is the one that *names the events* whose draws are missing or
+   * stale, i.e. the work list the director acts on. A toast would take that away after
+   * four seconds. */
+  get lifecycleNotice(): Locator {
+    return this.page.getByTestId('lifecycle-notice')
+  }
+
   /** Assert the pill reads exactly this status, and that the header offers
    * exactly the button that status has an edge for — the two halves of one claim
    * ("the view moved"), which drift apart if a spec only ever checks the badge. */

--- a/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
+++ b/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
@@ -96,6 +96,83 @@ export class TournamentDetailPage {
     await expect(this.anyLifecycleButton).toHaveCount(1)
   }
 
+  // ----- the draw panel (ADR-0786) -----------------------------------------
+  //
+  // Every locator here is scoped to ONE event card, because the tab renders a draw panel
+  // per event and the pools inside them are all called "Pool A": an unscoped
+  // `getByRole('region', { name: 'Pool A' })` would match two different events' pools and
+  // (rightly) throw on the ambiguity — or, worse, assert one event's draw and call it
+  // the other's.
+  //
+  // They are addressed by their **accessible names**, not by test ids, wherever the
+  // component gives them one. That is deliberate: the whole panel is a screen-reader
+  // artefact (a pool's roster is a named list, a round is a named list, a fixture is a
+  // list item that says "vs" out loud), so a locator that went around the accessibility
+  // tree would be testing a draw that a blind director cannot read.
+
+  /** One event's draw panel — the `<section>` headed "Draw" on its card. */
+  drawPanel(eventName: string): Locator {
+    return this.eventCard(eventName).getByRole('region', { name: 'Draw' })
+  }
+
+  /** The panel's designed EMPTY state: an event with no draw cut. Not a spinner and not
+   * an error — the state every event is born in. */
+  drawEmpty(eventName: string): Locator {
+    return this.eventCard(eventName).getByTestId('draw-empty')
+  }
+
+  /** The draw's three verbs, owner-only and named per event (the tab shows one panel per
+   * card, so a bare "Generate draw" would be four identical buttons). */
+  generateDrawButton(eventName: string): Locator {
+    return this.page.getByRole('button', {
+      name: `Generate draw for ${eventName}`,
+    })
+  }
+
+  recutDrawButton(eventName: string): Locator {
+    return this.page.getByRole('button', { name: `Re-cut draw for ${eventName}` })
+  }
+
+  deleteDrawButton(eventName: string): Locator {
+    return this.page.getByRole('button', { name: `Delete draw for ${eventName}` })
+  }
+
+  /** The panel's inline **refusal** — the `Alert` where the click was, carrying the
+   * server's own sentence (a 422 names what the director must change). Addressed by the
+   * testid prefix because the id carries the event's id, which a spec has no business
+   * knowing. */
+  drawNotice(eventName: string): Locator {
+    return this.eventCard(eventName).locator('[data-testid^="draw-notice-"]')
+  }
+
+  /** One pool of a cut draw, by the name the event gives it ("Pool A"). */
+  poolDraw(eventName: string, poolName: string): Locator {
+    return this.eventCard(eventName).getByRole('region', { name: poolName })
+  }
+
+  /** The chips naming who the draw dealt into a pool — its membership, which nothing
+   * stores: it is derived from the pool's own fixtures (ADR-0786). */
+  poolEntrants(eventName: string, poolName: string): Locator {
+    return this.poolDraw(eventName, poolName)
+      .getByRole('list', { name: `Entrants in ${poolName}` })
+      .getByRole('listitem')
+  }
+
+  /** One round's fixtures within a pool, in position order. An odd pool's rounds hold
+   * FEWER of them — the player drawn against the phantom seat sits that round out, and
+   * that absence is the entire representation of a bye. */
+  roundFixtures(eventName: string, poolName: string, round: number): Locator {
+    return this.poolDraw(eventName, poolName)
+      .getByRole('list', { name: `Round ${round} fixtures in ${poolName}` })
+      .getByRole('listitem')
+  }
+
+  /** Every fixture line of one event's draw, across all its pools — for counting the
+   * whole draw, and for sweeping it for words that must never appear on one ("bye"). */
+  fixtureLines(eventName: string): Locator {
+    return this.drawPanel(eventName).locator('[data-testid^="fixture-line-"]')
+  }
+
   // ----- the event card's entry control ------------------------------------
 
   enterButton(eventName: string): Locator {
@@ -185,6 +262,24 @@ export class TournamentDetailPage {
    * `Edit {event}` for an owner, `View {event}` otherwise. */
   openEditorOverlay(eventName: string): Locator {
     return this.page.getByRole('button', { name: `Edit ${eventName}` })
+  }
+
+  /**
+   * Open one event's editor by clicking its card — **on the header**, where a director
+   * would.
+   *
+   * Not at the overlay's geometric centre, which is where a bare `.click()` goes: the
+   * open target is a `z-0` sibling stretched under the card, and the card raises its own
+   * *controls* above it (`relative z-10`) — the Enter button, and the whole **draw
+   * panel**, whose Generate / Re-cut / Delete would otherwise never receive a click. So
+   * on a DRAWN card — a tall one — the centre of the overlay lands inside the pools
+   * scaffold, and the click does nothing.
+   *
+   * That is the correct behaviour, not a bug to route around: a fixture line is not a
+   * link to the event editor. It is simply why this click is positioned.
+   */
+  async openEditor(eventName: string) {
+    await this.openEditorOverlay(eventName).click({ position: { x: 30, y: 20 } })
   }
 
   /** The event editor — a Sheet, i.e. a `role="dialog"`. The one thing clicking
@@ -318,6 +413,85 @@ export class TournamentDetailPage {
   async chooseOperator(label: string) {
     await this.ruleOperator.click()
     await this.page.getByRole('option', { name: label }).click()
+  }
+
+  // ----- the editor, with a draw standing (ADR-0786) ------------------------
+  //
+  // Two of the editor's controls freeze once an event's draw is cut — its **draw type**
+  // (the strategy that dealt the fixtures) and its **set of pools** (each fixture names
+  // one by id). They are DISABLED WITH A REASON, never hidden: unlike the viewer's
+  // missing buttons, these are one deleted draw away from working, so hiding them would
+  // hide the way out along with the control (ADR-0015 forbids the *unexplained* dead
+  // end — the reason in text is what makes this one not that).
+
+  /** The Basics tab's draw-type select. Present-but-disabled under a cut draw, so it is
+   * located by role: the state under test is a control that is there, readable, and
+   * dead. */
+  get drawTypeSelect(): Locator {
+    return this.page.getByRole('combobox', { name: 'Draw type' })
+  }
+
+  /** The Table pools tab's one explanation of the freeze — the `Alert` that both the Add
+   * button and every Remove button point at with `aria-describedby`. */
+  get poolsFrozenNotice(): Locator {
+    return this.page.getByTestId('pools-frozen-notice')
+  }
+
+  get addPoolButton(): Locator {
+    return this.page.getByRole('button', { name: 'Add pool' })
+  }
+
+  /** Every pool's trash button. Plural on purpose: "the removes are all dead" is the
+   * claim, and a locator that named one pool could only ever prove it of that one. */
+  get removePoolButtons(): Locator {
+    return this.page.getByRole('button', { name: 'Remove pool' })
+  }
+
+  /** One pool's card in the editor, by position — the pools are a list, and the editor
+   * names them only by an editable text box. */
+  poolCard(index: number): Locator {
+    return this.page.getByTestId('pool-card').nth(index)
+  }
+
+  /** A table chip inside one pool card ("T3"), which toggles that table into the pool.
+   * **Still live with a draw standing** — that is the point of freezing only the pool
+   * *set*: a table breaks mid-event and the director has to be able to record it without
+   * destroying a correct draw. */
+  poolTableChip(poolIndex: number, label: string): Locator {
+    return this.poolCard(poolIndex).getByRole('button', { name: label, exact: true })
+  }
+
+  /** One pool's name box. **The only control on this tab that can author a pool the
+   * server refuses**: the id and the default name are minted, but this box can be
+   * emptied — and `Pool.name` is `min_length=1`. Scoped to the card, because the pools
+   * are a list of identically-labelled boxes. */
+  poolNameInput(index: number): Locator {
+    return this.poolCard(index).getByLabel('Pool name')
+  }
+
+  /** The red messages under the pool name boxes — the Table pools counterpart of
+   * `ruleErrors` and `basicsError`. Plural: which card is red is the claim. */
+  get poolNameErrors(): Locator {
+    return this.page.getByTestId('pool-name-error')
+  }
+
+  /**
+   * The element a control POINTS AT with `aria-describedby` — i.e. the sentence a screen
+   * reader actually reads out when it lands on it, as opposed to whatever text happens
+   * to sit near it on screen.
+   *
+   * It is the only channel a **disabled** control has: it is not focusable, and it holds
+   * no tooltip anyone will ever hear. A reason rendered under a dead trigger and not
+   * pointed at is a reason for sighted directors only — which is exactly what the
+   * draw-type select was doing while the pools section, one tab over, wired the identical
+   * freeze correctly.
+   *
+   * Resolves to a locator that matches NOTHING when the control describes nothing, so an
+   * assertion on it fails loudly rather than passing vacuously.
+   */
+  async describedBy(control: Locator): Promise<Locator> {
+    const id = await control.getAttribute('aria-describedby')
+    return this.page.locator(id ? `[id="${id}"]` : '#describes-nothing')
   }
 
   /** The tournament-level "Entries" hero stat: the sum of every event's derived

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -7,12 +7,15 @@ import {
   buildTournamentEventRead,
   buildTournamentEntrantRead,
   entryStateFor,
+  planRoundRobinFixtures,
 } from '../../../src/mocks/factories/tournaments/tournament.factory'
 import { sessionResponse } from '../../../src/test/factories'
 
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
 type TournamentEventRead = components['schemas']['TournamentEventRead']
 type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
+type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
+type Pool = components['schemas']['Pool']
 /** The wire's status enum — the specs drive the store with it, so it is the
  * generated schema's, not a re-typed union of four strings. */
 export type TournamentStatus = TournamentDetailRead['status']
@@ -98,6 +101,15 @@ export const EVENT = {
    * degenerate roster: every chip marked, and the list must still render (ADR-0783
    * §3). */
   ALL_UNRATED: 'Beginners Singles',
+  /** The **drawable** seed's second event (`drawable: true`): singles, round-robin,
+   * five entrants across two pools — the event the draw specs cut. Five and not four,
+   * across two pools and not one, because that is the smallest field that puts every
+   * thing a director reads a draw for on the card at once: two pools (one of 3, one of
+   * 2 — the snake, not blocks), several rounds, and an ODD pool, whose rounds hold
+   * fewer fixtures because the player drawn against the phantom seat sits that round out
+   * (ADR-0786: a bye is the ABSENCE of a fixture, and a scaffold that invented a "bye"
+   * row would have to be caught here or nowhere). */
+  POOLS: 'Pool Play Singles',
 } as const
 
 /** How many people are already in the crowded event before I enter it. Comfortably
@@ -192,6 +204,81 @@ function crowd(
   )
 }
 
+// ----- the drawable seed (ADR-0786) ----------------------------------------
+//
+// A tournament whose events a draw can actually be CUT for — `drawable: true`. It
+// REPLACES the entry-shaped events above rather than adding to them, and that is not a
+// convenience: an event nobody has entered (`EVENT.EMPTY`) and a doubles event can never
+// hold a draw that covers their entrants, so a tournament holding one can never go live,
+// whatever the director does. The default seed is therefore permanently un-startable —
+// which is the truth about it, and is why the go-live specs need a different tournament
+// rather than a different assertion.
+
+/** The one pool of the drawable seed's `JOURNEY` event. Two entrants, one pool: the
+ * smallest cuttable event there is (a pool of fewer than two is a 422 — a lone entrant
+ * has nobody to play). */
+const JOURNEY_POOLS: Pool[] = [
+  {
+    id: 'p-journey-a',
+    name: 'Pool A',
+    slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
+    table_ids: ['t1', 't2'],
+  },
+]
+
+/** The two pools of `EVENT.POOLS`. Their ids are spelled ONCE and handed to both the
+ * event and its planner: a fixture's `pool_id` is a string ref into its event's own
+ * `pools` (ADR-0786 — pools are JSONB value-objects, not rows), so a seed that spelled
+ * them twice could spell them differently and every fixture would point at a pool that
+ * does not exist. */
+const PLAY_POOLS: Pool[] = [
+  {
+    id: 'p-play-a',
+    name: 'Pool A',
+    slot: { date: '2026-06-13', start: '09:00', end: '11:00' },
+    table_ids: ['t1', 't2'],
+  },
+  {
+    id: 'p-play-b',
+    name: 'Pool B',
+    slot: { date: '2026-06-13', start: '11:00', end: '13:00' },
+    table_ids: ['t3', 't4'],
+  },
+]
+
+/** How many players are in `EVENT.POOLS` before anybody enters through the UI. Five
+ * across two pools snakes to 3 + 2 — see `EVENT.POOLS`. */
+const PLAY_FIELD = 5
+
+/** The round-robin tournament: two events, both cuttable, nothing cut yet. `drawn`
+ * decides which of them arrive with a draw already standing.
+ *
+ * `JOURNEY` keeps its name, its cap and its two entrants, so the lifecycle specs' count
+ * assertions (`2 / 64` → `3 / 64`) read the same here as in the default seed — the one
+ * thing that changes about it is that its draw type is now one a draw can be cut for. */
+function drawableEvents(): TournamentEventRead[] {
+  return [
+    buildTournamentEventRead({
+      id: 'ev-open-singles',
+      name: EVENT.JOURNEY,
+      format: 'singles',
+      draw_type: 'round-robin',
+      max_players: 64,
+      entrants: OTHERS,
+      pools: JOURNEY_POOLS,
+    }),
+    buildTournamentEventRead({
+      id: 'ev-pool-play',
+      name: EVENT.POOLS,
+      format: 'singles',
+      draw_type: 'round-robin',
+      max_players: 32,
+      entrants: crowd(PLAY_FIELD),
+      pools: PLAY_POOLS,
+    }),
+  ]
+}
+
 /** All three roster states (`listed` / `empty` / `entry-closed`) on one page, on
  * purpose: it is the real shape of an Events tab, and it lets one axe scan cover
  * every state the roster can be in.
@@ -201,6 +288,14 @@ function crowd(
  * the journey spec asserts on. */
 function seed(options: TournamentsStoreOptions): TournamentDetailRead {
   const crowded = options.crowded ?? false
+  if (options.drawable ?? false) {
+    return buildTournamentDetailRead({
+      id: TOURNAMENT_ID,
+      status: options.status ?? 'published',
+      can_edit: options.canEdit ?? true,
+      events: drawableEvents(),
+    })
+  }
   return buildTournamentDetailRead({
     id: TOURNAMENT_ID,
     status: options.status ?? 'published',
@@ -343,6 +438,32 @@ export interface TournamentsStoreOptions {
    * only way to reach "an entered player on a *live* tournament", since entering
    * one through the UI is (rightly) refused. */
   enteredIn?: string[]
+  /** Seed the **round-robin** tournament instead of the entry-shaped one (ADR-0786):
+   * `EVENT.JOURNEY` and `EVENT.POOLS`, both of them events a draw can be cut for.
+   *
+   * It REPLACES the default events rather than adding to them — see `drawableEvents`.
+   * The default seed holds an event with no entrants and a doubles event, and no draw
+   * can ever cover either, so that tournament can never go live: a spec about the draw,
+   * or about starting a tournament, needs a tournament that *could* be started. */
+  drawable?: boolean
+  /** Events whose draw is already CUT when the page loads — by name, and only from the
+   * drawable seed (a draw cannot be cut for an event whose draw type has no generator,
+   * and the stub refuses one exactly as the server does).
+   *
+   * Cut with the same planner the cut ROUTE uses, from the same entrants and the same
+   * pools, so a seeded draw is one this stub could have dealt — never a hand-written
+   * list of fixtures no cut would ever produce. */
+  drawn?: string[]
+}
+
+/** The options for a tournament that can actually be **started**: every event drawable,
+ * and every draw cut. Exported as one constant rather than re-typed per spec, because it
+ * is a *rule* and not a preference — go-live refuses a tournament with an event whose
+ * draw is missing (ADR-0786), so a spec that wanted to walk the lifecycle and named only
+ * one of the two events would be refused, and would look like a bug in the header. */
+export const READY_TO_START: TournamentsStoreOptions = {
+  drawable: true,
+  drawn: [EVENT.JOURNEY, EVENT.POOLS],
 }
 
 /**
@@ -377,6 +498,221 @@ const REGISTRATION_CLOSED_DETAIL: Record<
   archived: 'This tournament has ended, so its events can no longer be entered.',
 }
 
+// ----- the draw, and the go-live precondition it gates (ADR-0786) -----------
+//
+// ⚠️ This stub used to be **more permissive than the server** in two ways at once, and
+// each of them would have let a lying UI ship: every event's `fixtures` defaulted to
+// `[]` (so no browser spec could ever reach a *drawn* state — the pools scaffold, the
+// frozen editor and the axe scan over both were unreachable), and `published → live` was
+// accepted unconditionally (so the precondition the server enforces could not be
+// exercised, and a Start button that worked here would 409 in front of a director on the
+// morning of their tournament). Both are closed below, with the server's own rules and
+// the server's own sentences — the copy is what the director reads.
+
+/** Where one event's draw stands (`DrawCurrency`, `api/app/tournament_draws.py`).
+ *
+ * A **set comparison, never a count**: currency is "these fixtures seat exactly these
+ * entrants". Sizes agreeing would wave through the case that matters most — one player
+ * withdraws and another enters between the cut and go-live, leaving the same count, a
+ * different field, and a draw that seats somebody who has left while their replacement is
+ * seated nowhere. */
+function drawCurrency(event: TournamentEventRead): 'current' | 'uncut' | 'stale' {
+  // Decided on the fixtures EXISTING, not on the seated set being empty: an event nobody
+  // has entered has neither, and ∅ == ∅ would call it `current` — an event with no draw
+  // at all, certified ready to start.
+  if (event.fixtures.length === 0) return 'uncut'
+  const seated = new Set<string>()
+  for (const fixture of event.fixtures) {
+    // A `null` side is TBD (a KO round whose feeder is undecided), never a bye and never
+    // an absent player — so it seats nobody.
+    if (fixture.entry_a_id !== null) seated.add(fixture.entry_a_id)
+    if (fixture.entry_b_id !== null) seated.add(fixture.entry_b_id)
+  }
+  const active = event.entrants.map((e) => e.id)
+  const same =
+    active.length === seated.size && active.every((id) => seated.has(id))
+  return same ? 'current' : 'stale'
+}
+
+/** The things a refusal is about, as a human would say them: `“Pool B”`, or
+ * `“Pool B” and “Pool C”` (`named_list`, `api/app/schemas/tournament.py`). */
+function namedList(names: string[]): string {
+  const quoted = names.map((name) => `“${name}”`)
+  if (quoted.length === 1) return quoted[0]
+  return `${quoted.slice(0, -1).join(', ')} and ${quoted[quoted.length - 1]}`
+}
+
+/** The server's sentence for a tournament with nothing to run. */
+const NOTHING_TO_START =
+  'This tournament has no events, so there is nothing to start. Add an event and cut ' +
+  'its draw, then start the tournament.'
+
+/** Why this tournament cannot start yet, in the server's own words — or `null` when it
+ * can (`_enforce_ready_to_go_live`). **It names the events**, and the two failures are
+ * kept apart in the sentence because they are two different jobs: an uncut event needs a
+ * first cut, while a stale one has a draw the director may well have reviewed and merely
+ * needs to re-cut. */
+function goLiveRefusal(tournament: TournamentDetailRead): string | null {
+  if (tournament.events.length === 0) return NOTHING_TO_START
+
+  const uncut: string[] = []
+  const stale: string[] = []
+  for (const event of tournament.events) {
+    const currency = drawCurrency(event)
+    if (currency === 'uncut') uncut.push(event.name)
+    else if (currency === 'stale') stale.push(event.name)
+  }
+  if (uncut.length === 0 && stale.length === 0) return null
+
+  const clauses: string[] = []
+  if (uncut.length > 0) {
+    clauses.push(
+      `${namedList(uncut)} ${uncut.length === 1 ? 'has' : 'have'} no draw yet`,
+    )
+  }
+  if (stale.length > 0) {
+    clauses.push(
+      `${namedList(stale)} ${
+        stale.length === 1
+          ? 'has a draw that no longer matches its entrants'
+          : 'have draws that no longer match their entrants'
+      }`,
+    )
+  }
+  return (
+    'This tournament cannot start yet: ' +
+    clauses.join('; and ') +
+    '. A draw is cut from the field as it stands at the time, and registration stays ' +
+    'open right up to the moment a tournament goes live — so cut the draw for each ' +
+    'event named (again, if somebody entered or withdrew since it was last cut), then ' +
+    'start the tournament.'
+  )
+}
+
+/** The server's sentence for a draw that has been played (`_enforce_draw_unplayed`).
+ * Unreachable from a browser today — nothing in the client materializes a fixture into a
+ * match (#788) — and mirrored anyway, because the guard is what the panel's 409 copy is
+ * written against, and a stub that answered **201** here would be the stub quietly being
+ * more permissive than the server. */
+const DRAW_UNDER_WAY_DETAIL =
+  "This event's draw is already under way — at least one fixture has a match " +
+  'or a recorded winner — so it can no longer be cut or removed.'
+
+/** Evidence of play: a fixture with a recorded winner, or one that has become a real
+ * match. */
+function drawHasPlay(event: TournamentEventRead): boolean {
+  return event.fixtures.some(
+    (f) => f.winner_entry_id !== null || f.match_id !== null,
+  )
+}
+
+/** The entrants in **draw order** — seed ascending where one is set, then registration
+ * order (ADR-0786) — which is the list the planner is handed. A stable sort over the
+ * stub's own (registration-ordered) list. */
+function drawOrder(entrants: TournamentEntrantRead[]): TournamentEntrantRead[] {
+  return [...entrants].sort(
+    (a, b) =>
+      (a.seed ?? Number.MAX_SAFE_INTEGER) - (b.seed ?? Number.MAX_SAFE_INTEGER),
+  )
+}
+
+/** The **snake**: which pool each entrant is dealt into (`api/app/draws.py`) — row by row
+ * across the pools, reversing every other row, so the top seeds land one per pool and
+ * pool sizes differ by at most one.
+ *
+ * Only the SIZES are wanted here (the planner deals the fixtures itself), and they are
+ * wanted because the 422 is asked of the pools the snake actually produced, never of
+ * arithmetic on N and P: it is the dealt pool that would have a lone entrant in it. */
+function snakedSizes(count: number, poolCount: number): number[] {
+  const sizes = Array.from({ length: poolCount }, () => 0)
+  for (let index = 0; index < count; index += 1) {
+    const row = Math.floor(index / poolCount)
+    const offset = index % poolCount
+    const column = row % 2 === 0 ? offset : poolCount - 1 - offset
+    sizes[column] += 1
+  }
+  return sizes
+}
+
+/** Why this event cannot be cut as it stands, in the server's words — or `null` when it
+ * can. The 422s are the planner's, and they are the ones a director actually meets:
+ * an unsupported draw type (round-robin is the only generator today — single-elim is
+ * #785), no pools to deal into, and a pool the snake would leave with fewer than two
+ * entrants, who would have nobody to play. */
+function cutRefusal(event: TournamentEventRead): string | null {
+  if (event.draw_type !== 'round-robin') {
+    return (
+      `A ${event.draw_type} draw cannot be cut yet. ` +
+      "Change the event's draw type to one that can, or wait for support."
+    )
+  }
+  if (event.pools.length === 0) {
+    return 'A round-robin draw needs at least one pool.'
+  }
+  const sizes = snakedSizes(event.entrants.length, event.pools.length)
+  if (sizes.some((size) => size < 2)) {
+    return (
+      `${event.entrants.length} entrants across ${event.pools.length} pool(s) would ` +
+      'leave a pool with fewer than 2 entrants, who would have nobody to play.'
+    )
+  }
+  return null
+}
+
+/** Plan an event's draw exactly as the cut route does — from its entrants in draw order,
+ * across its own pools. Used for BOTH the seeded draws (`drawn`) and the route, so a
+ * fixture on screen is always one this stub could have dealt. */
+function planDraw(event: TournamentEventRead): TournamentFixtureRead[] {
+  return planRoundRobinFixtures(
+    drawOrder(event.entrants).map((e) => e.id),
+    event.pools.map((p) => p.id),
+  )
+}
+
+/** Why this event PATCH is refused by a standing draw — or `null` when it is not
+ * (`_enforce_pool_set_frozen` / `_enforce_draw_type_frozen`, both a 409).
+ *
+ * Two facts are frozen while fixtures exist, and **only** these two:
+ * - the **set of pool ids**, because a fixture names its pool by a string ref into that
+ *   very list — remove one (or re-`id` it) and its fixtures point at nothing;
+ * - the **draw type**, because it is not a label on an event but the strategy that DEALT
+ *   these fixtures.
+ *
+ * Everything else about a pool — its name, its tables, its window — stays editable, and
+ * so does the rest of the event. */
+function frozenDetail(event: TournamentEventRead, body: unknown): string | null {
+  if (event.fixtures.length === 0) return null
+  const patch = body as {
+    pools?: { id: string }[] | null
+    draw_type?: string | null
+  } | null
+
+  if (patch?.pools) {
+    const before = new Set(event.pools.map((p) => p.id))
+    const after = new Set(patch.pools.map((p) => p.id))
+    const same =
+      before.size === after.size && [...before].every((id) => after.has(id))
+    if (!same) {
+      return (
+        "This event's draw is already cut, so its set of pools is frozen: " +
+        'a pool cannot be added, removed or re-identified while fixtures refer to it. ' +
+        'To add, remove or re-identify a pool, remove the draw first, then cut it again.'
+      )
+    }
+  }
+
+  if (patch?.draw_type && patch.draw_type !== event.draw_type) {
+    return (
+      "This event's draw is already cut, so its draw type is frozen: its fixtures were " +
+      `dealt as a “${event.draw_type}” draw, and changing the type would leave the event ` +
+      'claiming a shape its draw does not have. To change the draw type, remove the draw ' +
+      'first, then cut it again.'
+    )
+  }
+
+  return null
+}
+
 interface RecordedRequest {
   method: string
   path: string
@@ -406,6 +742,16 @@ export class TournamentsStore {
     // mine — which is exactly the state the "locked, not Withdraw" case is about.
     for (const name of options.enteredIn ?? []) {
       this.addEntry(this.eventNamed(name).id)
+    }
+    // The seeded draws (`drawn`) are cut AFTER the seeded entries, and through the same
+    // planner the route uses: a draw is a plan made against the field as it stands, so
+    // one cut before those entries landed would be born stale — and a spec that meant to
+    // start a tournament would be refused for a reason it never asked for.
+    for (const name of options.drawn ?? []) {
+      const event = this.eventNamed(name)
+      const refusal = cutRefusal(event)
+      if (refusal) throw new Error(`cannot seed a draw for ${name}: ${refusal}`)
+      this.mutateEvent(event.id, (e) => ({ ...e, fixtures: planDraw(e) }))
     }
   }
 
@@ -450,6 +796,20 @@ export class TournamentsStore {
    * the server's view rather than the DOM's. */
   entrantsOf(eventName: string): TournamentEntrantRead[] {
     return this.detail.events.find((e) => e.name === eventName)?.entrants ?? []
+  }
+
+  /** The fixtures of an event's draw, as the SERVER now holds them — so a spec can
+   * assert the draw was really cut (and really thrown away), rather than that some
+   * markup appeared and disappeared. Empty for an event with no draw. */
+  fixturesOf(eventName: string): TournamentFixtureRead[] {
+    return this.detail.events.find((e) => e.name === eventName)?.fixtures ?? []
+  }
+
+  /** An event's pools as the server now holds them — for the other half of the freeze:
+   * a pool's *tables* really did change under a standing draw, and the draw really did
+   * survive it. */
+  poolsOf(eventName: string): Pool[] {
+    return this.detail.events.find((e) => e.name === eventName)?.pools ?? []
   }
 
   /**
@@ -651,6 +1011,17 @@ export class TournamentsStore {
       return this.enter(route, enter[2])
     }
 
+    // The draw's two verbs (ADR-0786). Matched before the bare `:eventId` PATCH below —
+    // as MSW registers them, and for the same reason: `…/events/{id}/draw` must never be
+    // read as an event whose id is "draw".
+    const draw = path.match(/^\/v1\/tournaments\/([^/]+)\/events\/([^/]+)\/draw$/)
+    if (method === 'POST' && draw) {
+      return this.cutDraw(route, draw[2])
+    }
+    if (method === 'DELETE' && draw) {
+      return this.uncutDraw(route, draw[2])
+    }
+
     // The event editor's two writes. They were unmocked until #783's QA pass, which
     // is not a coincidence: nothing in this suite had ever *saved* an event, so
     // nothing had ever watched the editor receive an answer — and the answer it was
@@ -676,13 +1047,15 @@ export class TournamentsStore {
 
   /**
    * `POST …/transitions` — the ONE way a status moves (ADR-0017). Mirrors the
-   * server's three refusals, in its order: 403 for a non-owner (`can_edit`), then
-   * 409 for an edge that is not in the table.
+   * server's refusals, in its order: 403 for a non-owner (`can_edit`), then 409 for an
+   * edge that is not in the table — and then, for `published → live` alone, the **draw
+   * precondition** (ADR-0786): a tournament starts only with at least one event and
+   * every event's draw cut AND current.
    *
-   * The 409's `detail` is the API's, verbatim, because it is what the user is
-   * shown — the toast's description is the error's message, so a stub that
-   * invented its own wording would test the toast against a string the server
-   * never sends.
+   * The 409's `detail` is the API's, verbatim, because it is what the user is shown —
+   * the header renders the sentence inline, and for a refused start that sentence is a
+   * WORK LIST (it names the events), so a stub that invented its own wording would test
+   * the notice against a string the server never sends.
    */
   private async transition(route: Route, body: unknown) {
     const to = (body as { to?: TournamentStatus } | null)?.to
@@ -709,6 +1082,17 @@ export class TournamentsStore {
       })
     }
 
+    // THE per-target precondition (ADR-0786), judged after the edge and only for `live`.
+    // This stub used to have no such branch: `published → live` was accepted whatever
+    // state the draws were in, so a Start button that could only ever 409 in production
+    // sailed through every browser spec we had. Refused BEFORE the write, so a refused
+    // start leaves the tournament exactly where it was — `published`, which is what the
+    // header goes on rendering.
+    if (to === 'live') {
+      const refusal = goLiveRefusal(this.readDetail())
+      if (refusal) return json(route, 409, { detail: refusal })
+    }
+
     this.detail = { ...this.detail, status: to }
     // **201**, as the route is declared (`status_code=status.HTTP_201_CREATED` —
     // a transition CREATES a move, it does not update a field), and as the MSW
@@ -717,6 +1101,59 @@ export class TournamentsStore {
     // that is not the one it will meet.
     return json(route, 201, this.readDetail())
   }
+
+  /**
+   * `POST …/events/{event_id}/draw` — cut (or re-cut) an event's draw.
+   *
+   * A re-cut replaces the draw **wholesale**: the old fixtures are dropped and a fresh
+   * set is planned from the event's *current* entrants, so their ids do not survive
+   * (which is what a spec asserts to tell a real re-cut from a no-op).
+   *
+   * Refused in the API's order — 404, 403, the play guard's 409, then the planner's 422
+   * — and each refusal carries the server's own sentence, because for the 422 the
+   * sentence IS the answer: it names the thing the director has to change.
+   */
+  private async cutDraw(route: Route, eventId: string) {
+    const event = this.detail.events.find((e) => e.id === eventId)
+    if (!event) return json(route, 404, { detail: 'event not found' })
+    if (!this.detail.can_edit) {
+      return json(route, 403, { detail: 'Only the creator can cut this draw.' })
+    }
+    // Asked BEFORE anything is planned or dropped, so a refused re-cut leaves the
+    // standing draw exactly as it was.
+    if (drawHasPlay(event)) {
+      return json(route, 409, { detail: DRAW_UNDER_WAY_DETAIL })
+    }
+    const refusal = cutRefusal(event)
+    if (refusal) return json(route, 422, { detail: refusal })
+
+    const fixtures = planDraw(event)
+    this.mutateEvent(eventId, (e) => ({ ...e, fixtures }))
+    // **201** with the fixtures, as the route is declared — the client parses them
+    // (`parseFixtures`, `data/api.ts`) before it reconciles off the refetch, so a body
+    // of the wrong shape fails here rather than in production.
+    return json(route, 201, fixtures)
+  }
+
+  /** `DELETE …/events/{event_id}/draw` — un-cut an event's draw. **Idempotent**: an
+   * event with no draw is already in the state this asks for, so it is a 204, never a
+   * 404. The one refusal is the cut's play guard — undoing a draw that has been played
+   * would delete the fixtures those results belong to. */
+  private async uncutDraw(route: Route, eventId: string) {
+    const event = this.detail.events.find((e) => e.id === eventId)
+    if (!event) return json(route, 404, { detail: 'event not found' })
+    if (!this.detail.can_edit) {
+      return json(route, 403, {
+        detail: 'Only the creator can remove this draw.',
+      })
+    }
+    if (drawHasPlay(event)) {
+      return json(route, 409, { detail: DRAW_UNDER_WAY_DETAIL })
+    }
+    this.mutateEvent(eventId, (e) => ({ ...e, fixtures: [] }))
+    return noContent(route)
+  }
+
 
   /** `POST …/entries` — self-registration. No request body: the caller is always
    * the entrant. Mirrors the API's refusals so the spec cannot pass against a
@@ -822,12 +1259,29 @@ export class TournamentsStore {
     return json(route, 201, this.read(created))
   }
 
-  /** `PATCH …/events/{event_id}` — edit an event, with the same 422. */
+  /** `PATCH …/events/{event_id}` — edit an event, with the same 422, and with the two
+   * **freezes** a cut draw puts on it (ADR-0786, a 409 each): the event's set of pools
+   * and its draw type.
+   *
+   * The editor declines to *build* either change while a draw stands (the controls are
+   * disabled, with the reason), so a spec should never reach these — they are here
+   * because a stub that answered **200** to a pool-set change would be more permissive
+   * than the server, and the day the freeze regressed, the editor would silently orphan
+   * every fixture in `npm run dev` and in this suite, and 409 only in production.
+   *
+   * ⚠️ It is the CHANGE that is refused, never the mere presence of the key: the editor
+   * PATCHes the whole form back — `pools` and `draw_type` included — to move a pool's
+   * tables, which is exactly the edit the freeze exists to permit (a table breaks
+   * mid-event and has to be recorded without destroying a correct draw). A stub that
+   * fired on the key would fail the "tables stay editable" spec, and would be wrong. */
   private async updateEvent(route: Route, eventId: string, body: unknown) {
     const event = this.detail.events.find((e) => e.id === eventId)
     if (!event) return json(route, 404, { detail: 'event not found' })
     if (this.faultingWrites) return serverFault(route)
     if (this.refusingWrites || nameTooLong(body)) return this.unprocessableName(route)
+
+    const frozen = frozenDetail(event, body)
+    if (frozen) return json(route, 409, { detail: frozen })
 
     const fields = body as Partial<Omit<TournamentEventRead, 'entered'>>
     // `entrants` and `entered` are the server's, not the editor's — the write body

--- a/web-client/e2e/tournaments/event-editor.spec.ts
+++ b/web-client/e2e/tournaments/event-editor.spec.ts
@@ -68,6 +68,13 @@ const SAY = {
  */
 const PYDANTIC = 'String should have at most 255 characters'
 
+/** Its sibling, for the newest floor the server drew (`Pool.name`, `min_length=1`) — the
+ * words a cleared pool name used to come back as, in the banner, naming no field. The
+ * form refuses that save now, so this string has nowhere to come *from*; it is asserted
+ * absent all the same, because "we stopped sending it" and "we stopped printing it" are
+ * two different claims and only one of them is about the organizer. */
+const PYDANTIC_POOL = 'String should have at least 1 character'
+
 /** Longer than the `VARCHAR(255)` the server allows. It no longer *reaches* the
  * server — that is the point of the second QA pass — so it now proves the opposite
  * thing: nothing is sent. */
@@ -674,6 +681,79 @@ test.describe('Tournaments · the rule builder on a phone (375×667)', () => {
   })
 })
 
+/**
+ * The Table pools tab — the last control in this editor that could still author a 422
+ * (#786). A pool's id and its default name are **minted**, so the happy path could never
+ * make a blank one; the name **box**, however, can be emptied, and `Pool.name` is now
+ * `min_length=1` at the server's boundary.
+ *
+ * Asserted in a browser because the claim is about a REQUEST: not that the message is
+ * rendered (jsdom says that), but that nothing is sent — `countOf('PATCH')` is the
+ * difference between a form that refuses a save and a form that makes one and then
+ * apologises.
+ */
+test.describe('Tournaments · a pool with no name', () => {
+  test('a BLANK pool name is refused in the form — no request, and the red is on the card', async ({
+    page,
+  }) => {
+    const { pom, store } = await TournamentDetailPage.navigateTo(page)
+
+    await pom.openEditorOverlay(EVENT.JOURNEY).click()
+    await pom.editorTab('Table pools').click()
+    await pom.poolNameInput(0).fill('')
+
+    await pom.saveEventButton.click()
+
+    // Told, under the box that is empty — the same sentence the event's own name uses,
+    // because to the organizer it is the same news.
+    await expect(pom.poolNameErrors).toHaveCount(1)
+    await expect(pom.poolNameErrors.first()).toHaveText(SAY.nameRequired)
+    await expect(pom.poolNameInput(0)).toHaveAttribute('aria-invalid', 'true')
+
+    // THE assertion: nothing left the page, so the 422 never happened and Pydantic was
+    // never asked.
+    expect(store.countOf('PATCH')).toBe(0)
+    expect(store.countOf('POST')).toBe(0)
+    await expect(pom.eventEditor).toBeVisible()
+    await expect(pom.eventEditor).not.toContainText(PYDANTIC_POOL)
+    await expect(pom.saveFailure).toHaveCount(0)
+    await expect(pom.toasts).toHaveCount(0)
+
+    // The positive control: without it, "the form refuses blank pool names" could be
+    // true of a form that refuses every pool name.
+    await pom.poolNameInput(0).fill('Championship')
+    await expect(pom.poolNameErrors).toHaveCount(0)
+
+    await pom.saveEventButton.click()
+
+    await expect(pom.eventEditor).toBeHidden()
+    expect(store.countOf('PATCH')).toBe(1)
+    expect(store.unhandled).toEqual([])
+  })
+
+  test('takes the organizer to the Table pools tab, where the empty box is', async ({
+    page,
+  }) => {
+    // A message on a tab you cannot see is indistinguishable from a button that does
+    // nothing. Clear the name, walk BACK to Basics, and press Save from there.
+    const { pom, store } = await TournamentDetailPage.navigateTo(page)
+
+    await pom.openEditorOverlay(EVENT.JOURNEY).click()
+    await pom.editorTab('Table pools').click()
+    await pom.poolNameInput(0).fill('')
+    await pom.editorTab('Basics').click()
+
+    await pom.saveEventButton.click()
+
+    await expect(pom.editorTab('Table pools')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(pom.poolNameErrors.first()).toBeVisible()
+    expect(store.countOf('PATCH')).toBe(0)
+  })
+})
+
 test.describe('Tournaments · the event editor · accessibility', () => {
   test('is axe-clean with the rule builder in its error state', async ({ page }) => {
     const { pom } = await TournamentDetailPage.navigateTo(page)
@@ -704,6 +784,23 @@ test.describe('Tournaments · the event editor · accessibility', () => {
     await expect(pom.saveFailure).toBeVisible()
 
     await expectAxeClean(page, 'event editor — refused save', {
+      exclude: KNOWN_DESTRUCTIVE_BUTTON_CONTRAST,
+    })
+  })
+
+  test('is axe-clean with a blank POOL NAME on screen', async ({ page }) => {
+    // Red markup on a fourth tab, in a portal — and a box whose border is transparent
+    // until it is wrong, which is a contrast question only a browser can answer.
+    const { pom } = await TournamentDetailPage.navigateTo(page)
+
+    await pom.openEditorOverlay(EVENT.JOURNEY).click()
+    await pom.editorTab('Table pools').click()
+    await pom.poolNameInput(0).fill('')
+    await pom.saveEventButton.click()
+
+    await expect(pom.poolNameErrors.first()).toBeVisible()
+
+    await expectAxeClean(page, 'event editor — blank pool name', {
       exclude: KNOWN_DESTRUCTIVE_BUTTON_CONTRAST,
     })
   })

--- a/web-client/e2e/tournaments/tournament-draw.spec.ts
+++ b/web-client/e2e/tournaments/tournament-draw.spec.ts
@@ -1,0 +1,505 @@
+/**
+ * The **draw** (ADR-0786), through the real browser: cutting one, re-cutting it, throwing
+ * it away — and the three refusals that guard it.
+ *
+ * A draw is the set of **fixtures** an event's draw type prescribes. A fixture is a
+ * *planned pairing* (round + position, plus a pool when the draw is pooled) and it is
+ * NOT a match. A draw is **current** when its fixtures seat exactly the event's active
+ * entrants; an entry *or a withdrawal* after the cut makes it **stale**, and go-live
+ * refuses a stale one.
+ *
+ * What only a browser can prove here, and why none of it was settled by the vitest suite:
+ *
+ *   1. **The scaffold renders as a draw, not as data.** `drawState` is unit-tested to
+ *      death, but nothing below the browser had ever *cut* a draw and then read the
+ *      result off the page: the pools, their membership (which nothing stores — it is
+ *      derived from the fixtures), the rounds, and the **named** "A vs B" lines. The
+ *      names are the point: a fixture carries entry *ids*, and the usernames are joined
+ *      on at render.
+ *
+ *   2. **The stub can no longer wave a bad start through.** Until this spec, the e2e
+ *      store built every event with `fixtures: []` and accepted `published → live`
+ *      *unconditionally* — so no browser spec could reach a drawn state at all, and the
+ *      go-live precondition the server enforces was unexercised. A stub more permissive
+ *      than the server lets us ship a UI that lies: a Start button that works in every
+ *      test we own and 409s in front of a director on the morning of their tournament.
+ *
+ *   3. **The refusals reach a human, inline.** The draw panel's mutations carry no toast
+ *      (`web-client/CLAUDE.md`, ## Forms — a surface that reports inline must not also
+ *      toast), so the `Alert` beside the button IS the error surface. And for the 409 and
+ *      the 422 the server's sentence is the copy, because it names the thing the director
+ *      has to change.
+ *
+ *   4. **The editor's freeze is real, and is not a wholesale grey-out.** With a draw
+ *      standing, the pool *set* and the draw *type* are refused (with the reason, and the
+ *      way out) — while a pool's tables stay editable, which is the case the freeze
+ *      exists to permit. A section that greyed itself out entirely would pass a test that
+ *      only checked Add and Remove.
+ *
+ *   5. **axe-clean in every new state** — the drawn scaffold, the refusal notices, and
+ *      the frozen editor. Contrast, focus and hidden-focusable are unrepresentable in
+ *      jsdom, and `aria-describedby` on a *disabled* control is the only channel it has.
+ */
+import { expect, test } from '@playwright/test'
+
+import { TournamentDetailPage } from '../page-objects/tournaments/tournament-detail.page'
+import {
+  EVENT,
+  ME,
+  READY_TO_START,
+} from '../page-objects/tournaments/tournaments-store'
+import { expectAxeClean } from '../support/axe'
+
+/** The panel's copy, hard-coded test-side (as the lifecycle spec's notices are):
+ * importing it from `data/draw` would make every assertion below pass whatever the copy
+ * became. */
+const SAY = {
+  /** The designed empty state — an event with no draw. */
+  noDraw: 'No draw yet.',
+  /** The title over a refused *cut*; the sentence beneath it is the server's. */
+  cannotDraw: "This event can't be drawn yet",
+  /** …and the server's sentence, for the one draw type that has a generator today.
+   * Round-robin is it; single-elim is #785. */
+  unsupported: 'A rr-then-ko draw cannot be cut yet.',
+  /** The title over a refused **start** — named after the edge the director clicked,
+   * never after the wire call. */
+  cannotStart: "Couldn't start the tournament",
+  /** The two arms of the go-live refusal, which are two different jobs: an event that was
+   * never drawn needs a first cut; a *stale* one has a draw the director may well have
+   * reviewed and merely needs to re-cut. */
+  noDrawYet: 'no draw yet',
+  staleDraw: 'has a draw that no longer matches its entrants',
+  /** The freeze reasons, one per frozen control. */
+  poolsFrozen: 'a pool can’t be added or removed while the draw stands',
+  drawTypeFrozen: 'its draw type is frozen',
+  wayOut: 'Delete the draw',
+} as const
+
+/**
+ * The draw the stub's planner deals for `EVENT.POOLS` — five entrants, two pools — and
+ * the reason the spec asserts *these* names in *these* pools rather than "some fixtures
+ * appeared".
+ *
+ * The snake deals row by row across the pools, reversing every other row, so Pool A gets
+ * players 1, 4 and 5 while Pool B gets 2 and 3. A **block** deal (the obvious wrong one)
+ * would put 1, 2, 3 in Pool A — so this assertion is what tells a real draw from a
+ * plausible-looking one.
+ *
+ * Pool A is ODD (three players), which is the whole reason the field is five: each of its
+ * rounds holds **one** fixture, not two, because the player drawn against the phantom
+ * seat sits that round out. That absence is the *entire* representation of a bye
+ * (ADR-0786), and a scaffold that invented a "bye" row would have to be caught here or
+ * nowhere.
+ */
+const POOL_A = {
+  name: 'Pool A',
+  entrants: ['player.1', 'player.4', 'player.5'],
+  rounds: [
+    { round: 1, fixtures: ['player.4 vs player.5'] },
+    { round: 2, fixtures: ['player.1 vs player.5'] },
+    { round: 3, fixtures: ['player.1 vs player.4'] },
+  ],
+} as const
+
+const POOL_B = {
+  name: 'Pool B',
+  entrants: ['player.2', 'player.3'],
+  rounds: [{ round: 1, fixtures: ['player.2 vs player.3'] }],
+} as const
+
+/** Every fixture the two pools hold together: C(3,2) + C(2,2) = 3 + 1. */
+const FIXTURE_COUNT = 4
+
+test.describe('Tournaments · cutting the draw', () => {
+  test('the owner generates a draw, sees the pools, re-cuts it, and throws it away', async ({
+    page,
+  }) => {
+    const { pom, store } = await TournamentDetailPage.navigateTo(page, {
+      drawable: true,
+    })
+    const event = EVENT.POOLS
+
+    // --- undrawn: a designed data state, not a gap ----------------------------
+    await expect(pom.drawEmpty(event)).toContainText(SAY.noDraw)
+    await expect(pom.recutDrawButton(event)).toHaveCount(0)
+    await expect(pom.deleteDrawButton(event)).toHaveCount(0)
+    expect(store.fixturesOf(event)).toEqual([])
+
+    // --- cut it --------------------------------------------------------------
+    await pom.generateDrawButton(event).click()
+
+    // The scaffold: pools, their membership, and their fixtures round by round — with
+    // NAMES on them. A fixture carries entry ids; the usernames are joined on at render,
+    // and a line that read `entry-crowd-4 vs entry-crowd-5` would be a draw no director
+    // could use.
+    for (const pool of [POOL_A, POOL_B]) {
+      await expect(pom.poolEntrants(event, pool.name)).toHaveText([
+        ...pool.entrants,
+      ])
+      for (const { round, fixtures } of pool.rounds) {
+        await expect(pom.roundFixtures(event, pool.name, round)).toHaveText([
+          ...fixtures,
+        ])
+      }
+    }
+    // The empty state is gone, and the verbs have changed to the ones a standing draw has.
+    await expect(pom.drawEmpty(event)).toHaveCount(0)
+    await expect(pom.generateDrawButton(event)).toHaveCount(0)
+    await expect(pom.recutDrawButton(event)).toBeVisible()
+
+    // A bye is the ABSENCE of a fixture (ADR-0786): Pool A's rounds hold one fixture
+    // each, not two, and nothing anywhere says the word. A scaffold that emitted a row
+    // for the phantom seat would pass every assertion above and fail this one.
+    await expect(pom.fixtureLines(event)).toHaveCount(FIXTURE_COUNT)
+    await expect(pom.drawPanel(event)).not.toContainText(/bye/i)
+    // …and no side is TBD or Withdrawn: a round-robin cut over a live field produces
+    // neither, so either word here would mean the join went wrong.
+    await expect(pom.drawPanel(event)).not.toContainText('TBD')
+    await expect(pom.drawPanel(event)).not.toContainText('Withdrawn')
+
+    // The SERVER cut it — the page is not drawing a picture of its own optimism.
+    expect(store.fixturesOf(event)).toHaveLength(FIXTURE_COUNT)
+
+    // --- somebody enters, and the draw is now stale --------------------------
+    // Registration stays open right up to go-live, so this is the ordinary way a draw
+    // goes out of date: the field the fixtures were dealt from is no longer the field
+    // that would play. My name is on the roster and nowhere in the draw.
+    await pom.enterButton(event).click()
+    await expect(pom.withdrawButton(event)).toBeVisible()
+    await expect(pom.drawPanel(event)).not.toContainText(ME.username)
+
+    // --- re-cut: the whole plan is re-made from the field as it now stands ----
+    await pom.recutDrawButton(event).click()
+
+    // The re-cut is a real re-deal, not a no-op that left the old fixtures standing: the
+    // sixth entrant lands in Pool B (the snake's next seat), and Pool B — a pool of two,
+    // with a single round — now has three players and three rounds of its own.
+    await expect(pom.poolEntrants(event, POOL_B.name)).toHaveText([
+      'player.2',
+      'player.3',
+      ME.username,
+    ])
+    await expect(pom.roundFixtures(event, POOL_B.name, 3)).toHaveCount(1)
+    expect(store.fixturesOf(event)).toHaveLength(6) // C(3,2) + C(3,2)
+
+    // --- throw it away -------------------------------------------------------
+    await pom.deleteDrawButton(event).click()
+
+    // Back to the designed empty state — and the event, its entrants and its pools are
+    // all still there. Un-cutting removes the draw, not the event.
+    await expect(pom.drawEmpty(event)).toContainText(SAY.noDraw)
+    await expect(pom.generateDrawButton(event)).toBeVisible()
+    await expect(pom.entrantsList(event)).toContainText(ME.username)
+    expect(store.fixturesOf(event)).toEqual([])
+
+    // Every request landed on a route this stub has (an unmocked one would 404 and read
+    // as an app bug), and the happy path raised nothing: no toast, and no inline notice.
+    expect(store.unhandled).toEqual([])
+    await expect(pom.drawNotice(event)).toHaveCount(0)
+    await expect(pom.toasts).toHaveCount(0)
+  })
+
+  test('a draw type with no generator is REFUSED (422), in the panel, in the server’s words', async ({
+    page,
+  }) => {
+    // The default seed's Open Singles is an `rr-then-ko` event, and round-robin is the
+    // only draw type with a generator today (#785 is the bracket). The server refuses the
+    // cut before it even looks at the field — no arrangement of entrants would make a
+    // knockout cuttable — and the sentence is the *answer*: it names what to change.
+    const { pom, store } = await TournamentDetailPage.navigateTo(page)
+    const event = EVENT.JOURNEY
+
+    await pom.generateDrawButton(event).click()
+
+    await expect(pom.drawNotice(event)).toBeVisible()
+    await expect(pom.drawNotice(event)).toContainText(SAY.cannotDraw)
+    await expect(pom.drawNotice(event)).toContainText(SAY.unsupported)
+    // Told once, not twice: the panel's mutations carry no global toast, because this
+    // notice is their error surface (`web-client/CLAUDE.md`, ## Forms).
+    await expect(pom.toasts).toHaveCount(0)
+
+    // Nothing was drawn — here or on the server — and the panel is still offering the
+    // button, because the refusal is about the event's configuration and not about the
+    // click.
+    await expect(pom.drawEmpty(event)).toContainText(SAY.noDraw)
+    await expect(pom.generateDrawButton(event)).toBeVisible()
+    expect(store.fixturesOf(event)).toEqual([])
+    // …and it was a 422 from the draw route, not an accident of an unmocked call falling
+    // through to a 404. Without this line the test would pass just as happily against no
+    // draw endpoint at all.
+    expect(store.unhandled).toEqual([])
+  })
+
+  test('a viewer sees the draw and is offered none of its verbs', async ({ page }) => {
+    // Hiding a control is a UX decision, never a security boundary — the API 403s the
+    // draw routes independently. But a non-owner who is *offered* Generate is being
+    // invited to earn a 403, which ADR-0015 calls an unexplained dead end.
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      ...READY_TO_START,
+      canEdit: false,
+    })
+    const event = EVENT.POOLS
+
+    // The draw itself is public — a player wants to know who they are drawn against.
+    await expect(pom.poolEntrants(event, POOL_A.name)).toHaveText([
+      ...POOL_A.entrants,
+    ])
+    await expect(pom.roundFixtures(event, POOL_A.name, 1)).toHaveText([
+      ...POOL_A.rounds[0].fixtures,
+    ])
+
+    await expect(pom.generateDrawButton(event)).toHaveCount(0)
+    await expect(pom.recutDrawButton(event)).toHaveCount(0)
+    await expect(pom.deleteDrawButton(event)).toHaveCount(0)
+  })
+})
+
+test.describe('Tournaments · going live needs a current draw', () => {
+  test('a STALE draw refuses the start, names the event, and leaves it Published', async ({
+    page,
+  }) => {
+    // The refusal this whole slice is about, end to end and in a browser: cut the draw,
+    // a player enters, start the tournament. Registration stays open right up to go-live
+    // (ADR-0017), so the draw a director cut on Tuesday can be stale by Wednesday — and
+    // starting on it would schedule a field that is not the field that turned up.
+    const { pom, store } = await TournamentDetailPage.navigateTo(page, {
+      ...READY_TO_START,
+      status: 'published',
+    })
+    await pom.expectLifecycle('Published', 'Start tournament')
+
+    // A player enters, after the cut. (Me — but it is the *entry* that stales the draw,
+    // not who made it: the draw seats a set of entries, and this is one more.)
+    await pom.enterButton(EVENT.JOURNEY).click()
+    await expect(pom.withdrawButton(EVENT.JOURNEY)).toBeVisible()
+
+    await pom.lifecycleButton('Start tournament').click()
+
+    // THE assertion, half one: the refusal is inline, beside the button that was clicked,
+    // and it is a WORK LIST — it names the event whose draw went stale. A director with
+    // ten events, told merely "something isn't ready", is left clicking through all ten;
+    // a toast would take the list away after four seconds, which is why this is an Alert.
+    await expect(pom.lifecycleNotice).toBeVisible()
+    await expect(pom.lifecycleNotice).toContainText(SAY.cannotStart)
+    await expect(pom.lifecycleNotice).toContainText(`“${EVENT.JOURNEY}”`)
+    await expect(pom.lifecycleNotice).toContainText(SAY.staleDraw)
+    // A stale draw is not an uncut one — the director is told their draw needs RE-cutting,
+    // not that they never cut it — and the event whose draw is still current is not blamed.
+    await expect(pom.lifecycleNotice).not.toContainText(SAY.noDrawYet)
+    await expect(pom.lifecycleNotice).not.toContainText(`“${EVENT.POOLS}”`)
+    await expect(pom.toasts).toHaveCount(0)
+
+    // THE assertion, half two: the tournament did NOT move. The pill still reads
+    // Published — the refusal is judged before the write, so a refused start leaves the
+    // tournament exactly where it was — and the button that was refused is still there,
+    // because the way out is to re-cut and click it again.
+    await pom.expectLifecycle('Published', 'Start tournament')
+    expect(store.status).toBe('published')
+    expect(store.unhandled).toEqual([])
+
+    // --- and the way out really is the way out --------------------------------
+    // The notice says: cut the draw again, then start. So do exactly that. Without this,
+    // the spec would prove only that the tournament is stuck.
+    await pom.recutDrawButton(EVENT.JOURNEY).click()
+    await expect(pom.drawPanel(EVENT.JOURNEY)).toContainText(ME.username)
+
+    await pom.lifecycleButton('Start tournament').click()
+
+    await pom.expectLifecycle('Live', 'End tournament')
+    expect(store.status).toBe('live')
+    // The refusal from the click before it is GONE — cleared when the next attempt
+    // started, because a notice about the click before last is worse than none.
+    await expect(pom.lifecycleNotice).toHaveCount(0)
+  })
+
+  test('an UNDRAWN event refuses the start, and names every event at fault', async ({
+    page,
+  }) => {
+    // The other arm of the precondition, and the one the old stub was silently waving
+    // through: this tournament's events have no draw at all. (It can never be started, in
+    // fact — one of its events has no entrants, and no draw can cover an empty field —
+    // which is precisely why the go-live specs seed a different tournament.)
+    const { pom, store } = await TournamentDetailPage.navigateTo(page, {
+      status: 'published',
+    })
+
+    await pom.lifecycleButton('Start tournament').click()
+
+    await expect(pom.lifecycleNotice).toBeVisible()
+    await expect(pom.lifecycleNotice).toContainText(SAY.cannotStart)
+    await expect(pom.lifecycleNotice).toContainText(SAY.noDrawYet)
+    // Named, all of them — the whole work list, not the first one it tripped over.
+    await expect(pom.lifecycleNotice).toContainText(`“${EVENT.JOURNEY}”`)
+    await expect(pom.lifecycleNotice).toContainText(`“${EVENT.EMPTY}”`)
+    await expect(pom.lifecycleNotice).toContainText(`“${EVENT.DOUBLES}”`)
+
+    await pom.expectLifecycle('Published', 'Start tournament')
+    expect(store.status).toBe('published')
+    expect(store.unhandled).toEqual([])
+  })
+})
+
+test.describe('Tournaments · the event editor, with a draw standing', () => {
+  test('freezes the draw type and the pool SET — with the reason attached to each dead control', async ({
+    page,
+  }) => {
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      drawable: true,
+      drawn: [EVENT.POOLS],
+    })
+
+    await pom.openEditor(EVENT.POOLS)
+    await expect(pom.eventEditor).toBeVisible()
+
+    // --- Basics: the draw type is spoken for ---------------------------------
+    // Still shown, still readable — it is a fact about the event the director came here
+    // to check. It just cannot be changed: the fixtures were dealt AS a round robin.
+    await expect(pom.drawTypeSelect).toBeDisabled()
+    await expect(pom.drawTypeSelect).toContainText('Round robin')
+
+    // …and the reason is *attached* to it, not merely printed underneath it. A disabled
+    // trigger is not focusable and carries no tooltip, so `aria-describedby` is the only
+    // channel it has — and it had none at all until now, while the pools section one tab
+    // over wired the identical freeze correctly.
+    const drawTypeReason = await pom.describedBy(pom.drawTypeSelect)
+    await expect(drawTypeReason).toContainText(SAY.drawTypeFrozen)
+    await expect(drawTypeReason).toContainText(SAY.wayOut)
+
+    // --- Table pools: the SET is frozen, and says how to unfreeze it ----------
+    await pom.editorTab('Table pools').click()
+
+    await expect(pom.poolsFrozenNotice).toBeVisible()
+    await expect(pom.poolsFrozenNotice).toContainText(SAY.poolsFrozen)
+    await expect(pom.poolsFrozenNotice).toContainText(SAY.wayOut)
+
+    // Disabled — not hidden. This button is one deleted draw away from working, and
+    // hiding it would hide the way out along with it (contrast the viewer's controls,
+    // which are absent because nothing they could do would bring them back).
+    await expect(pom.addPoolButton).toBeDisabled()
+    await expect(await pom.describedBy(pom.addPoolButton)).toContainText(
+      SAY.poolsFrozen,
+    )
+
+    // Every Remove, not just the first: "the removes are dead" is the claim.
+    await expect(pom.removePoolButtons).toHaveCount(2)
+    for (const remove of await pom.removePoolButtons.all()) {
+      await expect(remove).toBeDisabled()
+      await expect(await pom.describedBy(remove)).toContainText(SAY.poolsFrozen)
+    }
+  })
+
+  test('leaves a pool’s TABLES editable — and the draw survives the save', async ({
+    page,
+  }) => {
+    // The case the freeze exists to permit, and the one a wholesale grey-out would break.
+    // A table breaks on the morning of the tournament and is pulled; the director has to
+    // be able to record that. Only the pool *set* is frozen — a pool's tables, its window
+    // and its name are still the director's, because otherwise they would have to destroy
+    // a perfectly good draw to move a table.
+    const { pom, store } = await TournamentDetailPage.navigateTo(page, {
+      drawable: true,
+      drawn: [EVENT.POOLS],
+    })
+    const drawn = store.fixturesOf(EVENT.POOLS).length
+    expect(drawn).toBe(FIXTURE_COUNT)
+
+    await pom.openEditor(EVENT.POOLS)
+    await pom.editorTab('Table pools').click()
+
+    // Pool A holds T1 and T2. Add T3 to it — a live control on a card whose Remove button
+    // is dead.
+    const chip = pom.poolTableChip(0, 'T3')
+    await expect(chip).toBeEnabled()
+    await expect(chip).toHaveAttribute('aria-pressed', 'false')
+    await chip.click()
+    await expect(chip).toHaveAttribute('aria-pressed', 'true')
+
+    await pom.saveEventButton.click()
+    await expect(pom.eventEditor).toHaveCount(0)
+
+    // The server took it: the pool really did gain the table…
+    expect(store.poolsOf(EVENT.POOLS)[0].table_ids).toEqual(['t1', 't2', 't3'])
+    // …and the draw is still standing. A PATCH is not a re-cut, and a director who moved
+    // a table must not discover their draw was thrown away by the save.
+    expect(store.fixturesOf(EVENT.POOLS)).toHaveLength(drawn)
+    await expect(pom.poolEntrants(EVENT.POOLS, POOL_A.name)).toHaveText([
+      ...POOL_A.entrants,
+    ])
+    await expect(pom.toasts).toHaveCount(0)
+    expect(store.unhandled).toEqual([])
+  })
+})
+
+/**
+ * ⚠️ **A pre-existing violation, and not this change's to fix.** The shared
+ * `Button variant="destructive"` (`.bg-destructive` + white text) fails AA colour
+ * contrast, and the event editor's "Delete event" is one of them — so any scan with the
+ * editor open trips on it. It is a design-system defect on every destructive button in
+ * the app, and its fix is a shared token. Named here, not hidden, exactly as
+ * `event-editor.spec.ts` names it. **Follow-up ticket.**
+ */
+const KNOWN_DESTRUCTIVE_BUTTON_CONTRAST = ['.bg-destructive']
+
+test.describe('Tournaments · the draw · accessibility', () => {
+  test('is axe-clean with the pools scaffold on screen', async ({ page }) => {
+    const { pom } = await TournamentDetailPage.navigateTo(page, READY_TO_START)
+
+    // Prove the state is really rendered before scanning it: an axe pass over a page that
+    // has not reached the state is a green that means nothing. (Until this slice, CI's
+    // axe only ever saw the *undrawn* panel — the drawn one was unreachable from any
+    // spec, because every stubbed event had `fixtures: []`.)
+    await expect(pom.poolEntrants(EVENT.POOLS, POOL_A.name)).toHaveText([
+      ...POOL_A.entrants,
+    ])
+
+    await expectAxeClean(page, 'tournament detail — the drawn pools scaffold')
+  })
+
+  test('is axe-clean with the draw refusal on screen', async ({ page }) => {
+    const { pom } = await TournamentDetailPage.navigateTo(page)
+
+    await pom.generateDrawButton(EVENT.JOURNEY).click()
+    await expect(pom.drawNotice(EVENT.JOURNEY)).toBeVisible()
+
+    await expectAxeClean(page, 'tournament detail — the refused draw notice')
+  })
+
+  test('is axe-clean with the go-live refusal on screen', async ({ page }) => {
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      ...READY_TO_START,
+      status: 'published',
+    })
+    await pom.enterButton(EVENT.JOURNEY).click()
+    await expect(pom.withdrawButton(EVENT.JOURNEY)).toBeVisible()
+
+    await pom.lifecycleButton('Start tournament').click()
+    await expect(pom.lifecycleNotice).toContainText(SAY.staleDraw)
+
+    await expectAxeClean(page, 'tournament detail — the refused go-live notice')
+  })
+
+  test('is axe-clean with the FROZEN editor open', async ({ page }) => {
+    // The state most likely to be missed by a scan, and the one where the accessibility
+    // tree is doing the most work: two disabled controls whose only remaining channel is
+    // the description they point at.
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      drawable: true,
+      drawn: [EVENT.POOLS],
+    })
+
+    await pom.openEditor(EVENT.POOLS)
+    await expect(pom.drawTypeSelect).toBeDisabled()
+
+    await expectAxeClean(page, 'tournament detail — the frozen editor, Basics', {
+      exclude: KNOWN_DESTRUCTIVE_BUTTON_CONTRAST,
+    })
+
+    await pom.editorTab('Table pools').click()
+    await expect(pom.poolsFrozenNotice).toBeVisible()
+    await expect(pom.addPoolButton).toBeDisabled()
+
+    await expectAxeClean(page, 'tournament detail — the frozen editor, Table pools', {
+      exclude: KNOWN_DESTRUCTIVE_BUTTON_CONTRAST,
+    })
+  })
+})

--- a/web-client/e2e/tournaments/tournament-lifecycle.spec.ts
+++ b/web-client/e2e/tournaments/tournament-lifecycle.spec.ts
@@ -38,6 +38,7 @@ import {
   ANNOUNCED_STATUSES,
   EVENT,
   ME,
+  READY_TO_START,
   STATUSES,
 } from '../page-objects/tournaments/tournaments-store'
 import { expectAxeClean } from '../support/axe'
@@ -58,7 +59,14 @@ test.describe('Tournaments · the lifecycle', () => {
   test('the owner walks draft → published → live → archived, one edge at a time', async ({
     page,
   }) => {
+    // `READY_TO_START` — a tournament whose every event is drawn, and whose draws still
+    // seat exactly their entrants. Going live has a PRECONDITION now (ADR-0786), and it
+    // is a rule about the tournament rather than a preference of this spec's: a
+    // tournament with an undrawn event is refused the start with a 409, so a walk seeded
+    // any other way would be refused at the third step and would look like a bug in the
+    // header. (The refusal itself is `tournament-draw.spec.ts`'s subject.)
     const { pom, store } = await TournamentDetailPage.navigateTo(page, {
+      ...READY_TO_START,
       status: 'draft',
     })
 
@@ -97,6 +105,7 @@ test.describe('Tournaments · the lifecycle', () => {
     // (ADR-0017), and this is the only test in the repo that watches both ends of
     // it move at once, on one page, off one refetch.
     const { pom, store } = await TournamentDetailPage.navigateTo(page, {
+      ...READY_TO_START,
       status: 'draft',
     })
     const card = pom.eventCard(EVENT.JOURNEY)
@@ -123,6 +132,16 @@ test.describe('Tournaments · the lifecycle', () => {
     await pom.expectEntryCount(EVENT.JOURNEY, 3, 64)
 
     // --- go live: the door shuts, with me inside ------------------------------
+    // First, the price of the door having been open: my entry landed AFTER this event's
+    // draw was cut, so the draw no longer seats the field that would play — it is stale,
+    // and the server refuses to start on it (ADR-0786). That is not an obstacle this
+    // spec is working around; it is the loop the ADR describes, and going live without
+    // closing it would mean starting a tournament that has me on its roster and nowhere
+    // in its fixtures. Re-cut, then start. (The refusal itself, and its copy, are
+    // `tournament-draw.spec.ts`'s subject.)
+    await pom.recutDrawButton(EVENT.JOURNEY).click()
+    await expect(pom.drawPanel(EVENT.JOURNEY)).toContainText(ME.username)
+
     await pom.lifecycleButton('Start tournament').click()
 
     // THE assertion of this slice's subtlest case. I am still an entrant — the
@@ -161,7 +180,13 @@ test.describe('Tournaments · the lifecycle', () => {
   }) => {
     // The director has this tournament open here, and published it from their
     // phone. This page still shows a draft: badge "Draft", button "Publish".
+    //
+    // Seeded ready to start (`READY_TO_START`), because the last act of this spec is a
+    // *successful* Start — the proof that the reconciled view is a working one and not a
+    // picture. A tournament whose draws were not cut would be refused that start for a
+    // reason that has nothing to do with the stale tab under test.
     const { pom, store } = await TournamentDetailPage.navigateTo(page, {
+      ...READY_TO_START,
       status: 'draft',
     })
     await pom.expectLifecycle('Draft', 'Publish')

--- a/web-client/e2e/tournaments/tournament-lifecycle.spec.ts
+++ b/web-client/e2e/tournaments/tournament-lifecycle.spec.ts
@@ -13,11 +13,13 @@
  *      tournament moving, rather than four unrelated screenshots. Every step here
  *      is the mutation's own refetch coming back and re-deciding the header.
  *
- *   2. **The 409 reaches a human.** The mutation toasts on error; a toast is a
- *      portal, rendered outside the page's tree, on top of the layout, and gone
- *      in four seconds. That it is genuinely *visible* — and that the refused
- *      view then corrects itself instead of freezing on the render the 409
- *      disproved — is a claim about the live DOM.
+ *   2. **The 409 reaches a human.** The refusal is rendered inline, in the header,
+ *      beside the button that was clicked (#786 — the go-live refusal's sentence
+ *      names the events whose draws are missing or stale, and a work list must not
+ *      evaporate after four seconds like a toast). That it is genuinely *visible*,
+ *      that it does not double up with a toast, and that the refused view then
+ *      corrects itself instead of freezing on the render the 409 disproved — all
+ *      claims about the live DOM.
  *
  *   3. **Header and card move together.** The status decides two things a screen
  *      apart: which button the header offers, and what the event card's entry
@@ -176,10 +178,18 @@ test.describe('Tournaments · the lifecycle', () => {
     // The server refuses it: `published → published` is not an edge, it is a
     // conflict (ADR-0017 — "the only caller that sends it is a stale one").
     //
-    // THE assertion, half one: the user is TOLD. A silent 409 would leave them
+    // THE assertion, half one: the user is TOLD — inline, beside the button they
+    // clicked, in an `Alert` the mutation no longer duplicates with a toast (#786:
+    // the same surface carries go-live's refusal, whose sentence is a work list and
+    // has no business disappearing after four seconds). A silent 409 would leave them
     // clicking a button that does nothing, forever.
-    await expect(pom.toasts).toHaveCount(1)
-    await expect(pom.toasts).toContainText("Couldn't publish the tournament")
+    await expect(pom.lifecycleNotice).toBeVisible()
+    await expect(pom.lifecycleNotice).toContainText(
+      "Couldn't publish the tournament",
+    )
+    // Told once, not twice: the inline notice REPLACED the toast, it did not join it
+    // (`web-client/CLAUDE.md`, ## Forms).
+    await expect(pom.toasts).toHaveCount(0)
 
     // …and told something USEFUL. This click is a self-transition
     // (`published → published`), which is what a stale tab always produces — and
@@ -188,7 +198,9 @@ test.describe('Tournaments · the lifecycle', () => {
     // director nothing. The sentence they need is the fact that somebody already
     // did it, so pin the sentence, not just the verb: the title alone would go
     // green against the tautology this copy replaced.
-    await expect(pom.toasts).toContainText('This tournament is already published.')
+    await expect(pom.lifecycleNotice).toContainText(
+      'This tournament is already published.',
+    )
 
     // …and told it by a 409, not by an accident. Without this line the test would
     // pass just as happily if the transitions route were UNMOCKED: the 404 would
@@ -207,13 +219,11 @@ test.describe('Tournaments · the lifecycle', () => {
     await pom.expectLifecycle('Live', 'End tournament')
     expect(store.status).toBe('live')
 
-    // It raised no error of its own. Asserted as "no toast bearing THIS verb"
-    // rather than "still exactly one toast": the refusal above dismisses itself
-    // after a few seconds, so a total count here would be a race against a
-    // countdown — green locally and flaky on a loaded runner.
-    await expect(
-      pom.toasts.filter({ hasText: "Couldn't start the tournament" }),
-    ).toHaveCount(0)
+    // It raised no error of its own — and the refusal from the click before it is
+    // GONE, cleared when the next attempt started: a notice about the click before
+    // last is worse than none.
+    await expect(pom.lifecycleNotice).toHaveCount(0)
+    await expect(pom.toasts).toHaveCount(0)
     expect(store.countOf('POST')).toBe(2) // the refused publish, then the accepted start
   })
 })
@@ -428,26 +438,25 @@ test.describe('Tournaments · the lifecycle · accessibility', () => {
     })
   }
 
-  test('is axe-clean with the refusal toast on screen', async ({ page }) => {
-    // The error state is a state, and it is the one most likely to be missed: the
-    // toast is a portal outside the page's tree, over the top of everything else.
+  test('is axe-clean with the refusal notice on screen', async ({ page }) => {
+    // The error state is a state, and it is the one most likely to be missed. It is
+    // now IN the page — an `Alert` in the header, beside the button (#786) — rather
+    // than a toast portalled over the top of it, so the scan has to reach it where it
+    // actually lives: contrast against the hero, and a live region a screen reader
+    // hears without hunting for it.
     const { pom, store } = await TournamentDetailPage.navigateTo(page, {
       status: 'draft',
     })
     store.transitionElsewhere('published')
     await pom.lifecycleButton('Publish').click()
 
-    const toast = pom.toasts.first()
-    await expect(toast).toBeVisible()
-    // Sonner dismisses after a few seconds and pauses that timer while the toaster
-    // is hovered — so hover, rather than race the scan against the countdown. (The
-    // assertion after the scan is what keeps this honest: if the pause ever stops
-    // working, the toast is gone and this test fails loudly instead of quietly
-    // scanning a page without it.)
-    await toast.hover()
+    // Prove the state is really rendered before scanning it: an axe pass over a page
+    // that has not reached the state is a green that means nothing. (And unlike the
+    // toast this replaced, it does not dismiss itself — there is no countdown to race.)
+    await expect(pom.lifecycleNotice).toBeVisible()
 
-    await expectAxeClean(page, 'tournament detail — refused transition toast')
-    await expect(toast).toBeVisible()
+    await expectAxeClean(page, 'tournament detail — refused transition notice')
+    await expect(pom.lifecycleNotice).toBeVisible()
   })
 
   test('is axe-clean for a viewer, who is offered no lifecycle button at all', async ({

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1023,6 +1023,17 @@ export interface paths {
          *     re-asserting the status the tournament already holds — a request to publish
          *     an already-published tournament is a stale client, not a no-op.
          *
+         *     **Going live has a precondition** (ADR-0786): the tournament must have at least
+         *     one event, and every event must have a **draw** whose fixtures seat exactly its
+         *     current entrants. Three things are refused with a `409` that names the events at
+         *     fault — a tournament with **no events** (there is nothing to start), an event with
+         *     **no draw**, and an event whose draw is **stale**, cut before somebody entered or
+         *     withdrew. Cut (or re-cut) the draws it names, then go live. Registration is open
+         *     right up to that moment, which is exactly why a draw can go stale under it.
+         *
+         *     **Publishing** an empty tournament is unaffected and stays legal: announcing a
+         *     tournament early is fine, starting an empty one is not.
+         *
          *     Owner-only, like every other tournament mutation.
          */
         post: operations["create_tournament_transition_v1_tournaments__tournament_id__transitions_post"];
@@ -1063,7 +1074,34 @@ export interface paths {
         delete: operations["delete_event_v1_tournaments__tournament_id__events__event_id__delete"];
         options?: never;
         head?: never;
-        /** Update Event */
+        /**
+         * Update Event
+         * @description Edit an event. Absent fields are left alone; `predicates` and `pools` replace
+         *     wholesale when sent. No two pools may share an `id`, in any state (`422`) — a pool
+         *     id identifies one pool, and the fixtures of a draw name their pool by it.
+         *
+         *     **Once the event's draw is cut, two things freeze** (ADR-0786) — the facts its
+         *     fixtures were derived from:
+         *
+         *     * **its set of pools.** A `pools` payload must carry exactly the pool `id`s the
+         *       event already has, or it is refused with a `409`: a removed (or re-`id`'d) pool
+         *       would leave the fixtures drawn into it pointing at nothing, and an added one would
+         *       arrive with no fixtures, since the draw was dealt across the pools that existed at
+         *       the cut.
+         *     * **its `draw_type`.** The draw type chose the strategy that dealt those fixtures,
+         *       so changing it under a standing draw is a `409` too: the event would claim a shape
+         *       its draw does not have. Re-sending the draw type the event already has is not a
+         *       change, and is not refused.
+         *
+         *     Nothing else freezes. The event's name, fee, rules and `max_players`, and each
+         *     pool's `table_ids`, `slot` and `name`, all stay editable with a draw standing —
+         *     venues change under a running tournament, and recording that must never cost a
+         *     director the draw. To change the pools themselves or the draw type, remove the draw
+         *     (`DELETE …/draw`), edit, and cut again. With no draw cut, `pools` and `draw_type`
+         *     are ordinary fields.
+         *
+         *     Owner-only.
+         */
         patch: operations["update_event_v1_tournaments__tournament_id__events__event_id__patch"];
         trace?: never;
     };
@@ -1166,6 +1204,70 @@ export interface paths {
          *     nothing left to lock.
          */
         delete: operations["withdraw_from_event_v1_tournaments__tournament_id__events__event_id__entries__entry_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/tournaments/{tournament_id}/events/{event_id}/draw": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Cut Event Draw
+         * @description Cut this event's draw — generate its **fixtures** from its entrants — and answer
+         *     with them.
+         *
+         *     Cutting is an explicit, reviewable act, and it is **not** tied to the tournament's
+         *     status: a draw may be cut and re-cut freely while a director inspects the pools and
+         *     the seeding. Nothing else creates fixtures, and going live requires every event to
+         *     have one (ADR-0786).
+         *
+         *     **Re-cutting replaces the draw wholesale.** The previous fixtures are deleted and a
+         *     fresh set is planned from the event's *current* active entrants — the old ones are
+         *     not patched, and their ids do not survive. That is the point: a draw is a plan made
+         *     against a field, and once the field has changed (somebody entered, somebody
+         *     withdrew) the whole plan is re-made, pool sizes and seeding included.
+         *
+         *     Entrants are ordered by **seed** ascending where one is set, then by **registration
+         *     order**. Nothing is random, so the same field always cuts the same draw.
+         *
+         *     Refused with a `409` once the draw shows any **evidence of play** — any fixture with
+         *     a recorded winner, or any fixture that has become a real match. A re-cut would throw
+         *     those away, and a draw must never silently eat a score.
+         *
+         *     Refused with a `422` when this event cannot produce a draw at all: its draw type has
+         *     no generator yet (only round-robin does today), it has **no pools** configured for a
+         *     pooled draw type, or its field is too small for the pools it has — a pool with fewer
+         *     than two players has nobody to play. The message names what to change.
+         *
+         *     Owner-only. Fixtures come back in pool → round → position order, exactly as the
+         *     tournament-detail page carries them.
+         */
+        post: operations["cut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_post"];
+        /**
+         * Uncut Event Draw
+         * @description Un-cut this event's draw: delete its fixtures, leaving the event with no draw.
+         *
+         *     The way back from a draw the director does not want. The event, its entrants and the
+         *     rest of the tournament are untouched — only the fixtures go — and the director is
+         *     free to change the pools and cut again.
+         *
+         *     Refused with a `409` on the same **evidence of play** that refuses a re-cut: a
+         *     fixture with a recorded winner, or one that has become a real match. Undoing a draw
+         *     that has been played would delete the fixtures those results belong to.
+         *
+         *     An event with **no draw is already in the state this asks for**, so removing a draw
+         *     that was never cut is a `204`, not a `404`: this is a DELETE, and it is idempotent.
+         *
+         *     Owner-only.
+         */
+        delete: operations["uncut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -2606,6 +2708,11 @@ export interface components {
         /**
          * Pool
          * @description A slice of tables reserved for a window of time within an event.
+         *
+         *     Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
+         *     by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
+         *     these ids. Which is only a coherent thing to say if an id names one pool — see
+         *     ``EventPools``, the type the event's list of them actually has.
          */
         Pool: {
             /** Id */
@@ -3195,6 +3302,8 @@ export interface components {
             entrants: components["schemas"]["TournamentEntrantRead"][];
             /** Entry State */
             entry_state: components["schemas"]["EventEntryOpen"] | components["schemas"]["EventEntryFull"] | components["schemas"]["EventEntryRatingIneligible"];
+            /** Fixtures */
+            fixtures: components["schemas"]["TournamentFixtureRead"][];
             /**
              * Entered
              * @description The registration count. Derived — there is no stored counter (ADR-0016).
@@ -3242,6 +3351,56 @@ export interface components {
             predicates?: components["schemas"]["Predicate"][] | null;
             /** Pools */
             pools?: components["schemas"]["Pool"][] | null;
+        };
+        /**
+         * TournamentFixtureRead
+         * @description One planned pairing of an event's draw (ADR-0786): a round and a position —
+         *     plus a pool, when the draw is pooled — whose sides may still be unknown.
+         *
+         *     A fixture is **not** a match. It materializes into one later (#788), and until it
+         *     does ``match_id`` is ``null``.
+         *
+         *     **Every ``null`` on this model is a fact, not a missing field**, and a client that
+         *     dropped them would lose the draw's whole point:
+         *
+         *     * ``entry_a_id`` / ``entry_b_id`` — ``null`` means **TBD**: the feeding fixture has
+         *       not been decided yet, and ``advance()`` will fill this side in. It never means a
+         *       bye — a bye is the *absence of a fixture row*, not a fixture with an empty side
+         *       (ADR-0786), so there is no ``is_bye`` flag here to tell the two apart.
+         *     * ``winner_entry_id`` — ``null`` while the fixture is undecided.
+         *     * ``match_id`` — ``null`` until the fixture becomes a real match, which only happens
+         *       once the tournament is ``live``.
+         *     * ``pool_id`` — ``null`` means this fixture belongs to no pool: the draw is
+         *       un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
+         *       set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
+         *       JSONB, not a foreign key, because pools are value-objects with no table.
+         *
+         *     The entries are carried as **ids only**. The name and username behind
+         *     ``entry_a_id`` are already on this page — the event's ``entrants`` list carries
+         *     them, keyed by that very id — so a client joins the two. Copying the username onto
+         *     the fixture as well would be carrying a field and its own derivation
+         *     (api/CLAUDE.md), and the copy that drifts is the one a player reads off a bracket.
+         */
+        TournamentFixtureRead: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Pool Id */
+            pool_id: string | null;
+            /** Round */
+            round: number;
+            /** Position */
+            position: number;
+            /** Entry A Id */
+            entry_a_id: string | null;
+            /** Entry B Id */
+            entry_b_id: string | null;
+            /** Winner Entry Id */
+            winner_entry_id: string | null;
+            /** Match Id */
+            match_id: string | null;
         };
         /** TournamentRead */
         TournamentRead: {
@@ -5604,6 +5763,72 @@ export interface operations {
                 tournament_id: string;
                 event_id: string;
                 entry_id: string;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tournament_id: string;
+                event_id: string;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TournamentFixtureRead"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    uncut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tournament_id: string;
+                event_id: string;
             };
             cookie?: {
                 session?: string | null;

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -2712,7 +2712,14 @@ export interface components {
          *     Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
          *     by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
          *     these ids. Which is only a coherent thing to say if an id names one pool — see
-         *     ``EventPools``, the type the event's list of them actually has.
+         *     ``EventPools``, the type the event's list of them actually has — and if an id is a
+         *     thing at all, which is what ``ValueObjectId`` says: the empty string is not one, and
+         *     a fixture drawn into it is pooled by one rule and un-pooled by another.
+         *
+         *     Its ``name`` has the same floor for the plainer reason: a pool is *called*
+         *     something — it is what the director clicks, what the conflict warnings quote, and
+         *     what a player reads off a wall. ``""`` is not a name, and an event whose pools list
+         *     is three blank rows is not a thing anyone could act on.
          */
         Pool: {
             /** Id */
@@ -3454,6 +3461,13 @@ export interface components {
         /**
          * TournamentTable
          * @description A physical table in the venue catalogue, referenced by id from pools.
+         *
+         *     Its ``id`` is a ``ValueObjectId`` for the same reason a pool's is: a pool holds a
+         *     list of these strings (``table_ids``) and nothing else connects the two, so an id
+         *     that is the empty string is a table nothing can name — and a ``table_ids`` entry of
+         *     ``""`` would "resolve" against it. It is the same string-ref pattern with the same
+         *     hole, and closing it in one place and not the other would leave the boundary
+         *     half-drawn.
          */
         TournamentTable: {
             /** Id */

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1078,31 +1078,45 @@ export interface paths {
         put?: never;
         /**
          * Enter Event
-         * @description Register the signed-in player in a singles event.
+         * @description Enter a player in a singles event — yourself, or (as the tournament's owner)
+         *     somebody else.
          *
-         *     Self-registration only: the entry created is always the caller's own, which
-         *     is why the request carries no body — there is no field in which to name
-         *     someone else. Entering a player who is not you is a director's job, and a
-         *     different endpoint.
+         *     **The body is optional, and its presence chooses the actor** (ADR-0784):
+         *
+         *     * **no body** → you are entering *yourself*. Requires the `tournament.enter`
+         *       permission. This is the request every player already sends, and it is unchanged.
+         *     * **`user_id`** → you are the **director** entering that player. Requires that you
+         *       **own** the tournament; anyone else naming a `user_id` that is not their own is a
+         *       `403`. An id that names no (live) player is a `404`.
+         *
+         *     Naming *your own* `user_id` is self-registration, not a director entry: same
+         *     permission, and the entry records no adder.
          *
          *     Registration is open only while the tournament is **`published`** — its status
          *     *is* its registration window (ADR-0017). Entering an event of a `draft`
          *     tournament (not announced yet), a `live` one (the field is fixed; the draw is
          *     cut from it), or an `archived` one (it is over) is a `409` — not a `403`: you
-         *     are permitted, the tournament is simply in the wrong state.
+         *     are permitted, the tournament is simply in the wrong state. **That holds for the
+         *     director too**: there is no override, so a director can neither add a walk-in nor
+         *     remove a no-show once the tournament is live.
          *
-         *     An event's **eligibility rules** are decided against your rating on the
-         *     tournament's league, and you must satisfy **every** one of them: failing a rule
+         *     An event's **eligibility rules** are decided against the entrant's rating on the
+         *     tournament's league, and they must satisfy **every** one of them: failing a rule
          *     (the 1650-rated player entering the "Under 1500" event) is a `409`. A player who
          *     holds **no rating** on that league — nobody has a rating until they finish a rated
          *     match — **passes every rule**, so a brand-new player is not shut out of the
          *     beginners' event that exists for them.
          *
-         *     Entering an event you are already in is a `409`; withdrawing first frees you
+         *     Entering an event the player is already in is a `409`; withdrawing first frees them
          *     to enter it again. Entering an event that already holds its `max_players`
          *     entrants is a `409` too — someone withdrawing frees the slot. Doubles and teams
          *     events are a `400`: an entry is one row per player, with nowhere to record a
          *     partner or a team.
+         *
+         *     **A director's entry is judged by exactly these rules.** The same evaluator, the
+         *     same capacity lock, the same four refusal codes: a director adding a player to a
+         *     full event, or one over the event's rating cap, is refused precisely as the player
+         *     would be.
          */
         post: operations["enter_event_v1_tournaments__tournament_id__events__event_id__entries_post"];
         delete?: never;
@@ -1123,14 +1137,17 @@ export interface paths {
         post?: never;
         /**
          * Withdraw From Event
-         * @description Withdraw the signed-in player's own entry from an event.
+         * @description Withdraw an entry from an event — your own, or (as the tournament's owner) any
+         *     entry in it.
          *
          *     The entry is **soft-deleted**: its status flips to `withdrawn` and the row
          *     survives, so the event keeps its withdrawal history — and, because the
          *     uniqueness guard is a *partial* index over active entries only, the player is
          *     free to enter the same event again afterwards.
          *
-         *     You may only withdraw your own entry; someone else's is a `403`.
+         *     **Who may withdraw an entry** (ADR-0784) mirrors who may create one: the player
+         *     themselves (with the `tournament.enter` permission), or the tournament's **owner**,
+         *     for any entry in it. Anybody else is a `403`.
          *
          *     Withdrawal, like entry, is open only while the tournament is **`published`** —
          *     its status *is* its registration window (ADR-0017). Withdrawing an *active*
@@ -1138,7 +1155,9 @@ export interface paths {
          *     from the field they were part of, so it is a `409`, as it is for a `draft`
          *     tournament (registration has not opened) and an `archived` one (it is over).
          *     A `409`, not a `403`: you are permitted, the tournament is simply in the wrong
-         *     state.
+         *     state. **The owner obeys that window too** — withdrawal stays symmetric with entry,
+         *     so a director can no more remove a no-show from a live tournament than add a
+         *     walk-in to one.
          *
          *     **Withdrawing an entry that is already withdrawn is a `204` in every status**,
          *     `live` and `archived` included — a no-op, not an error: this is `DELETE`, and
@@ -3071,6 +3090,41 @@ export interface components {
             seed: number | null;
             /** Rating */
             rating: number | null;
+        };
+        /**
+         * TournamentEntryCreate
+         * @description *Who* to enter — the body of ``POST …/entries``, and the whole of it.
+         *
+         *     **The body is optional, and its presence selects the actor** (ADR-0784):
+         *
+         *     * **omitted** → you are entering *yourself*. Self-registration, gated on the
+         *       ``tournament.enter`` permission — the request every player already sends, which
+         *       carries no body at all and must keep working unchanged.
+         *     * **``user_id`` present** → a *director* is entering somebody, which only the
+         *       tournament's **owner** may do.
+         *
+         *     One endpoint, not two, because both actors must run the same eligibility
+         *     evaluator, take the same capacity lock and produce the same four refusal codes
+         *     (``EntryRefusal``, ADR-0968). A twin route would make the *next* refusal a thing
+         *     to add twice, and the two call sites of the evaluator a thing to keep from
+         *     drifting.
+         *
+         *     Naming **your own** ``user_id`` is self-registration, not a director entry — the
+         *     same guard, and the same ``added_by_user_id = NULL`` on the row. "The player
+         *     entered themselves" has exactly one encoding, and ``added_by == user_id`` is not
+         *     it (see ``TournamentEntry.added_by_user_id``).
+         *
+         *     There is deliberately **no ``force``**: a director's entry is refused by the same
+         *     rules a player's is — a full event and a rating cap catch a director's typo exactly
+         *     as they catch a stranger's. Absent an override, that *is* the safety model, and the
+         *     override is a ticket of its own (#985), not a flag smuggled in here.
+         */
+        TournamentEntryCreate: {
+            /**
+             * User Id
+             * Format: uuid
+             */
+            user_id: string;
         };
         /**
          * TournamentEventCreate
@@ -5516,7 +5570,11 @@ export interface operations {
                 session?: string | null;
             };
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["TournamentEntryCreate"] | null;
+            };
+        };
         responses: {
             /** @description Successful Response */
             201: {

--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -68,15 +68,20 @@ function edgeFrom(from: 'draft' | 'published' | 'live'): LifecycleEdge {
 
 vi.mock('sonner', async () => {
   const actual = await vi.importActual<typeof import('sonner')>('sonner')
-  return { ...actual, toast: { ...actual.toast, error: vi.fn(), info: vi.fn() } }
+  return {
+    ...actual,
+    toast: { ...actual.toast, error: vi.fn(), info: vi.fn(), success: vi.fn() },
+  }
 })
 
-/** Both toast channels start clean: the entry cases assert not just which toast
- * fired, but that the *other* one did not (a benign 409 that also raised a red
- * error toast would satisfy a one-sided assertion). */
+/** Every toast channel starts clean: the entry cases assert not just which toast
+ * fired, but that the *others* did not (a benign 409 that also raised a red error
+ * toast would satisfy a one-sided assertion) — and the lifecycle cases assert that
+ * NONE of them fired at all, since that mutation reports through its caller now. */
 beforeEach(() => {
   vi.mocked(toast.error).mockClear()
   vi.mocked(toast.info).mockClear()
+  vi.mocked(toast.success).mockClear()
 })
 
 describe('useTournaments', () => {
@@ -296,8 +301,13 @@ describe('useTransitionTournament', () => {
   // The stale-tab race (ADR-0017's reason for 409-ing a re-assertion): tab A
   // published; THIS tab still reads `draft`, so it still offers Publish. The
   // refusal has to be VISIBLE — a swallowed 409 is a button that does nothing —
-  // and the verb names the edge the user clicked, not the wire call.
-  it('surfaces an illegal-edge 409 as an error toast naming what they clicked', async () => {
+  // but this mutation is not the thing that shows it. It **hands the error to its
+  // caller**, whole, and stays quiet: `LifecycleActions` renders every refusal inline,
+  // beside the button, so a toast here would say the same thing twice
+  // (`web-client/CLAUDE.md`, ## Forms: never both). The 409 that matters most is
+  // go-live's precondition (ADR-0786), whose sentence *names the events* the director
+  // has to go and fix — a work list belongs on the page, not in a four-second toast.
+  it('hands the 409 to its caller — with the server’s sentence — and does NOT toast', async () => {
     // The server sees `published → published` — a self-transition — so it answers
     // the sentence that says what happened, not the tautology naming both ends.
     mockTournamentTransitionEndpoint(server, () =>
@@ -317,17 +327,18 @@ describe('useTransitionTournament', () => {
 
     await waitForRaw(() => expect(result.current.isError).toBe(true))
 
-    expect(toast.error).toHaveBeenCalledWith(
-      "Couldn't publish the tournament",
-      expect.objectContaining({
-        // The description is the server's detail, passed through — this is the
-        // sentence the stale tab is there to read.
-        description: 'This tournament is already published.',
-      }),
-    )
-    // A 409 here is a genuine refusal — nothing moved. Unlike the entry 409 (which
-    // means "you are already in"), it must NOT be downgraded to an info note.
+    // The error the component catches: the status it branches on, and the sentence it
+    // shows. Both survive the trip — nothing is flattened into a message string.
+    const error = result.current.error
+    expect(error).toBeInstanceOf(ApiError)
+    expect((error as ApiError).status).toBe(409)
+    expect((error as ApiError).detail).toBe('This tournament is already published.')
+
+    // Silence on every ring of the toaster, not just the error one: a refusal
+    // announced as a cheerful `toast.success` would still be a double-up.
+    expect(toast.error).not.toHaveBeenCalled()
     expect(toast.info).not.toHaveBeenCalled()
+    expect(toast.success).not.toHaveBeenCalled()
   })
 
   it('invalidates on the 409 too, so the stale view catches up to the status it was refused', async () => {
@@ -354,7 +365,11 @@ describe('useTransitionTournament', () => {
     })
   })
 
-  it('names the edge in the failure toast: ending a tournament reads as ending it', async () => {
+  // A 5xx is not a refusal, and it is still not a toast: the same caller reports it, in
+  // its own words (`lifecycleRefusalNotice`'s `server-error` arm — which deliberately
+  // does NOT repeat the server's detail, since a 5xx detail is machinery). What this
+  // mutation owes the caller is the status; what it owes the user is nothing.
+  it('stays quiet on a 5xx too — the error is the caller’s to report', async () => {
     mockTournamentTransitionEndpoint(server, () =>
       HttpResponse.json({ detail: 'Server error.' }, { status: 500 }),
     )
@@ -363,15 +378,13 @@ describe('useTransitionTournament', () => {
     const { result } = renderHookRaw(() => useTransitionTournament('t-1'), {
       wrapper,
     })
-    // The edge out of `live` — "End tournament". Its verb is what the toast says.
+    // The edge out of `live` — "End tournament".
     result.current.mutate(edgeFrom('live'))
 
     await waitForRaw(() => expect(result.current.isError).toBe(true))
 
-    expect(toast.error).toHaveBeenCalledWith(
-      "Couldn't end the tournament",
-      expect.objectContaining({ description: 'Server error.' }),
-    )
+    expect((result.current.error as ApiError).status).toBe(500)
+    expect(toast.error).not.toHaveBeenCalled()
   })
 })
 

--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -1,18 +1,22 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
   act,
+  render,
   renderHook as renderHookRaw,
+  screen,
   waitFor as waitForRaw,
 } from '@testing-library/react'
 import { HttpResponse } from 'msw'
 import type { StrictResponse } from 'msw'
 import { toast } from 'sonner'
-import type { ReactNode } from 'react'
+import { Component, type ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderHook, waitFor } from '@/test/utilities'
 import {
+  mockEventCutDrawEndpoint,
   mockEventEnterEndpoint,
+  mockEventUncutDrawEndpoint,
   mockEventWithdrawEndpoint,
   mockTournamentCreateEndpoint,
   mockTournamentDetailEndpoint,
@@ -24,24 +28,32 @@ import {
   buildTournamentDetailRead,
   buildTournamentEntrantRead,
   buildTournamentEventRead,
+  buildTournamentFixtureRead,
 } from '@/mocks/factories/tournaments/tournament.factory'
 import type { CodedErrorBody } from '@/mocks/endpoints/error-body'
 import { server } from '@/mocks/server'
-import { resetTournamentsStore } from '@/mocks/tournaments-store'
+import {
+  cutDraw,
+  markFixturePlayed,
+  resetTournamentsStore,
+} from '@/mocks/tournaments-store'
 import { ApiError } from '@/api/client'
 import type { components } from '@/api/schema'
 import {
   useCreateTournament,
+  useCutDraw,
   useEnterEvent,
   useTournament,
   useTournaments,
   useTransitionTournament,
+  useUncutDraw,
   useUpdateTournament,
   useWithdrawEntry,
 } from './api'
 import { LIFECYCLE_EDGE, type LifecycleEdge } from './lifecycle'
 
 type TournamentUpdate = components['schemas']['TournamentUpdate']
+type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
 
 /** The edge OUT of `from` — which is what the transition mutation takes: an edge,
  * not a bare target status. It carries both the `to` for the body and the verb the
@@ -928,5 +940,412 @@ describe('entering and withdrawing, against the stateful mock store', () => {
 
     await waitForRaw(() => expect(event().entered).toBe(1))
     expect(event().entrants.map((e) => e.username)).toEqual(['rita.kovac'])
+  })
+})
+
+// ----- the draw (ADR-0786) -------------------------------------------------
+
+/** The 201 body of `POST …/draw`: the fixtures the cut produced. */
+function drawnPair(): TournamentFixtureRead[] {
+  return [
+    buildTournamentFixtureRead({
+      id: 'fx-1',
+      pool_id: 'p-1',
+      round: 1,
+      position: 1,
+      entry_a_id: 'entry-1',
+      entry_b_id: 'entry-2',
+    }),
+  ]
+}
+
+describe('useCutDraw', () => {
+  it('posts to the event’s draw resource with NO body, and resolves the parsed fixtures', async () => {
+    let seen: { url: string; body: string } | null = null
+    mockEventCutDrawEndpoint(server, async ({ request }) => {
+      seen = { url: request.url, body: await request.text() }
+      return HttpResponse.json(drawnPair(), { status: 201 })
+    })
+
+    const { result } = renderHook(() => useCutDraw('t-1'))
+    const fixtures = await result.current.mutateAsync('ev-1')
+
+    expect(seen!.url).toContain('/v1/tournaments/t-1/events/ev-1/draw')
+    // The event IS the request — a cut is planned from the field the server already
+    // holds, so there is nothing for the client to send.
+    expect(seen!.body).toBe('')
+    // …and what comes back is PARSED, in the domain's camelCase — not the wire shape.
+    expect(fixtures).toEqual([
+      {
+        id: 'fx-1',
+        poolId: 'p-1',
+        round: 1,
+        position: 1,
+        entryAId: 'entry-1',
+        entryBId: 'entry-2',
+        winnerEntryId: null,
+        matchId: null,
+      },
+    ])
+  })
+
+  // The response is a payload like any other: untrusted. A cut that answered with a
+  // malformed fixture must reject the mutation, not hand the caller half a draw.
+  it('rejects a malformed fixture in its OWN response', async () => {
+    mockEventCutDrawEndpoint(server, () =>
+      HttpResponse.json(
+        [{ id: 'fx-1', pool_id: 'p-1' } as unknown as TournamentFixtureRead],
+        { status: 201 },
+      ),
+    )
+
+    const { result } = renderHook(() => useCutDraw('t-1'))
+
+    await expect(result.current.mutateAsync('ev-1')).rejects.toThrow()
+  })
+
+  // THE invalidation contract (the map at the top of `./api`): exactly two keys, the
+  // list and this tournament's detail — because the fixtures ride the detail payload and
+  // there is no draw query of their own. `toHaveBeenCalledTimes(2)` is the half that
+  // makes this a contract rather than a wish: an extra invalidation (a phantom
+  // `['tournaments', id, 'draw']` key nothing reads) would sail through the two
+  // `toHaveBeenCalledWith`s.
+  it('invalidates EXACTLY the list and the detail — no draw key of its own', async () => {
+    mockEventCutDrawEndpoint(server, () =>
+      HttpResponse.json(drawnPair(), { status: 201 }),
+    )
+    const { invalidateSpy, wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useCutDraw('t-1'), { wrapper })
+    result.current.mutate('ev-1')
+
+    await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments', 't-1'] })
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
+  })
+
+  // The 409 (evidence of play) is a STALE-VIEW signal, exactly like the entry and
+  // transition 409s: this page offered Re-cut, so as far as it knew nothing had been
+  // played — and the server has just told it otherwise. Reconciling only on success
+  // would leave the director looking at the same button that was refused.
+  it('invalidates on the play-guard 409 too, so the refused view catches up', async () => {
+    mockEventCutDrawEndpoint(server, () =>
+      HttpResponse.json(
+        {
+          detail:
+            "This event's draw is already under way — at least one fixture has a match or a recorded winner — so it can no longer be cut or removed.",
+        },
+        { status: 409 },
+      ),
+    )
+    const { invalidateSpy, wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useCutDraw('t-1'), { wrapper })
+    result.current.mutate('ev-1')
+
+    await waitForRaw(() => expect(result.current.isError).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments', 't-1'] })
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
+  })
+
+  // The 422 is the director's to act on, and its SENTENCE is the answer: it names the
+  // numbers they have to change ("5 entrants across 3 pool(s)…" — no code could carry
+  // that). So the hook does not swallow it and does not decorate it: it REJECTS with the
+  // `ApiError`, sentence intact, and the panel that awaited `mutateAsync` renders it
+  // inline where the button was (`DrawPanel`, `data/draw.ts`).
+  it('rejects a 422 — an event that cannot be planned — with the server’s sentence intact', async () => {
+    mockEventCutDrawEndpoint(server, () =>
+      HttpResponse.json(
+        {
+          detail:
+            '5 entrants across 3 pool(s) would leave a pool with fewer than 2 entrants, who would have nobody to play.',
+        },
+        { status: 422 },
+      ),
+    )
+    const { wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useCutDraw('t-1'), { wrapper })
+    result.current.mutate('ev-1')
+
+    await waitForRaw(() => expect(result.current.isError).toBe(true))
+
+    const error = result.current.error as ApiError
+    expect(error.status).toBe(422)
+    expect(error.detail).toBe(
+      '5 entrants across 3 pool(s) would leave a pool with fewer than 2 entrants, who would have nobody to play.',
+    )
+    // …and NO toast. The draw verbs carry no global `onError`, deliberately: their
+    // refusals are surfaced inline by the panel, and a toast would tell the director the
+    // same thing twice (`web-client/CLAUDE.md`, ## Forms). Asserting the absence is what
+    // keeps the toast from creeping back in beside the inline copy.
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('rejects a 403 (not the owner) without a toast — the panel owns the words', async () => {
+    mockEventCutDrawEndpoint(server, () =>
+      HttpResponse.json(
+        { detail: 'Only the creator can cut this draw.' },
+        { status: 403 },
+      ),
+    )
+    const { wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useCutDraw('t-1'), { wrapper })
+    result.current.mutate('ev-1')
+
+    await waitForRaw(() => expect(result.current.isError).toBe(true))
+
+    expect((result.current.error as ApiError).status).toBe(403)
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+})
+
+describe('useUncutDraw', () => {
+  it('DELETEs the event’s draw resource and resolves on the bodiless 204', async () => {
+    let seenUrl = ''
+    mockEventUncutDrawEndpoint(server, ({ request }) => {
+      seenUrl = request.url
+      return new HttpResponse(null, { status: 204 })
+    })
+    const { invalidateSpy, wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useUncutDraw('t-1'), { wrapper })
+    result.current.mutate('ev-1')
+
+    await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(seenUrl).toContain('/v1/tournaments/t-1/events/ev-1/draw')
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments', 't-1'] })
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('invalidates on the play-guard 409 too — the same stale-view argument as the cut', async () => {
+    mockEventUncutDrawEndpoint(server, () =>
+      HttpResponse.json(
+        { detail: "This event's draw is already under way." },
+        { status: 409 },
+      ),
+    )
+    const { invalidateSpy, wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useUncutDraw('t-1'), { wrapper })
+    result.current.mutate('ev-1')
+
+    await waitForRaw(() => expect(result.current.isError).toBe(true))
+
+    const error = result.current.error as ApiError
+    expect(error.status).toBe(409)
+    expect(error.detail).toBe("This event's draw is already under way.")
+    // No toast here either — the panel renders the play-guard refusal inline, beside the
+    // draw it refused to remove.
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments', 't-1'] })
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
+  })
+})
+
+// The whole point of the fixtures riding the DETAIL payload (ADR-0786): cutting a draw
+// and reading it back are the same page's business, and there is no draw query to keep
+// in step. Driven through the DEFAULT handlers and the stateful dev store, so what is
+// asserted is the round trip — cut, and the next read of that event carries the draw.
+describe('cutting and un-cutting, against the stateful mock store', () => {
+  beforeEach(() => resetTournamentsStore())
+
+  const TOURNAMENT = 'bay-area-open-2026'
+  /** The seed's ONE cuttable event: round-robin (the only draw type with a generator),
+   * two pools, nine entrants — and seeded already drawn. */
+  const DRAWN = 'ev-u1200'
+  /** Seeded `rr-then-ko` with no pools and nobody entered — the event a cut REFUSES. */
+  const UNCUTTABLE = 'ev-u1500'
+
+  it('the seeded draw arrives on the detail read, pooled, with no draw on the other events', async () => {
+    const { wrapper } = setupClient()
+    const { result } = renderHookRaw(() => useTournament(TOURNAMENT), { wrapper })
+
+    await waitForRaw(() => expect(result.current.data).toBeTruthy())
+    const events = result.current.data!.events
+    const drawn = events.find((e) => e.id === DRAWN)!
+
+    expect(drawn.fixtures.length).toBeGreaterThan(0)
+    // Every fixture names one of its own event's pools — a `pool_id` is a string ref
+    // into that JSONB, so a draw pointing at a pool the event does not have would be a
+    // draw nothing could render.
+    const poolIds = drawn.pools.map((p) => p.id)
+    expect(poolIds.length).toBe(2)
+    for (const fixture of drawn.fixtures) {
+      expect(poolIds).toContain(fixture.poolId)
+      // Nothing has been played: no winner, no match, both sides known (round-robin
+      // never has a TBD side — every pairing is known the moment the pools are dealt).
+      expect(fixture.winnerEntryId).toBeNull()
+      expect(fixture.matchId).toBeNull()
+      expect(fixture.entryAId).not.toBeNull()
+      expect(fixture.entryBId).not.toBeNull()
+    }
+    // …and every OTHER event has an empty draw — `[]`, the designed uncut state.
+    for (const event of events.filter((e) => e.id !== DRAWN)) {
+      expect(event.fixtures).toEqual([])
+    }
+  })
+
+  it('un-cutting empties the draw on the next read; re-cutting brings it back', async () => {
+    const { wrapper } = setupClient()
+    const { result } = renderHookRaw(
+      () => ({
+        detail: useTournament(TOURNAMENT),
+        cut: useCutDraw(TOURNAMENT),
+        uncut: useUncutDraw(TOURNAMENT),
+      }),
+      { wrapper },
+    )
+    const event = () =>
+      result.current.detail.data!.events.find((e) => e.id === DRAWN)!
+
+    await waitForRaw(() => expect(result.current.detail.data).toBeTruthy())
+    const cutSize = event().fixtures.length
+    expect(cutSize).toBeGreaterThan(0)
+
+    await act(() => result.current.uncut.mutateAsync(DRAWN))
+    await waitForRaw(() => expect(event().fixtures).toEqual([]))
+
+    await act(() => result.current.cut.mutateAsync(DRAWN))
+    // The same field and the same pools cut the same draw — nothing is random
+    // (ADR-0786), which is what makes a re-cut a reviewable act rather than a gamble.
+    await waitForRaw(() => expect(event().fixtures).toHaveLength(cutSize))
+  })
+
+  it('un-cutting an event that never had a draw is a SUCCESS, not a 404 (DELETE is idempotent)', async () => {
+    const { wrapper } = setupClient()
+    const { result } = renderHookRaw(() => useUncutDraw(TOURNAMENT), { wrapper })
+
+    result.current.mutate(UNCUTTABLE)
+
+    await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  it('refuses to cut an event that cannot be planned — an unsupported draw type is a 422', async () => {
+    const { wrapper } = setupClient()
+    const { result } = renderHookRaw(() => useCutDraw(TOURNAMENT), { wrapper })
+
+    // `ev-u1500` is `rr-then-ko`, which has no generator yet — the refusal a director
+    // meets today, and the one the mock must not be more permissive about than the API.
+    result.current.mutate(UNCUTTABLE)
+
+    await waitForRaw(() => expect(result.current.isError).toBe(true))
+    expect((result.current.error as ApiError).status).toBe(422)
+  })
+
+  // The play guard. Nothing a client can call materializes a fixture yet (#788), so the
+  // store gets there directly — which is the only honest way to reach the state a
+  // director will meet the moment the first match exists.
+  it('refuses to re-cut or un-cut a draw with evidence of play — and the standing draw survives', async () => {
+    const cut = cutDraw(TOURNAMENT, DRAWN)
+    if (!cut.ok) throw new Error('the seed should have cut cleanly')
+    markFixturePlayed(TOURNAMENT, DRAWN, cut.fixtures[0].id, {
+      winner_entry_id: cut.fixtures[0].entry_a_id,
+    })
+
+    const { wrapper } = setupClient()
+    const { result } = renderHookRaw(
+      () => ({
+        detail: useTournament(TOURNAMENT),
+        cut: useCutDraw(TOURNAMENT),
+        uncut: useUncutDraw(TOURNAMENT),
+      }),
+      { wrapper },
+    )
+    const event = () =>
+      result.current.detail.data!.events.find((e) => e.id === DRAWN)!
+
+    await waitForRaw(() => expect(result.current.detail.data).toBeTruthy())
+    const before = event().fixtures.length
+
+    result.current.cut.mutate(DRAWN)
+    await waitForRaw(() => expect(result.current.cut.isError).toBe(true))
+    expect((result.current.cut.error as ApiError).status).toBe(409)
+
+    result.current.uncut.mutate(DRAWN)
+    await waitForRaw(() => expect(result.current.uncut.isError).toBe(true))
+    expect((result.current.uncut.error as ApiError).status).toBe(409)
+
+    // A refused cut destroys nothing — the guard's whole promise. The recorded winner is
+    // still on the fixture it was recorded on.
+    await waitForRaw(() => expect(event().fixtures).toHaveLength(before))
+    expect(event().fixtures.filter((f) => f.winnerEntryId !== null)).toHaveLength(1)
+  })
+})
+
+/** Catches whatever the query throws, so a test can assert that it threw *to a
+ * boundary* rather than quietly turning into an empty page. */
+class CatchBoundary extends Component<
+  { children: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false }
+
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+
+  render() {
+    return this.state.failed ? <p>the boundary caught it</p> : this.props.children
+  }
+}
+
+// The parse boundary, from the outside: what a COMPONENT experiences when the server
+// sends a draw that is not a draw (`.claude/rules/parse-at-boundaries.md`).
+//
+// This is the case the whole `fixtures` Zod schema exists for, and it is why the mapping
+// moved into the `queryFn`: TanStack Query *catches* a throw from `select`, leaving the
+// raw payload in the cache and an error result the detail route reads as "not found" —
+// so a malformed draw used to be able to render a **"Tournament not found"** page for a
+// tournament the server had just sent. Parsed in the `queryFn`, it is a failed fetch:
+// the boundary gets it, and the cache is never primed with the bad payload.
+describe('a malformed fixture on the detail payload', () => {
+  function brokenDetail() {
+    return buildTournamentDetailRead({
+      id: 't-1',
+      events: [
+        buildTournamentEventRead({
+          id: 'ev-1',
+          // No `round`, no `position` — a shape `schema.d.ts` swears cannot arrive.
+          fixtures: [
+            { id: 'fx-1', pool_id: 'p-1' } as unknown as TournamentFixtureRead,
+          ],
+        }),
+      ],
+    })
+  }
+
+  it('fails the query and reaches the error boundary — it does not render an empty page', async () => {
+    // React logs the caught error; the boundary is the assertion, not the console.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockTournamentDetailEndpoint(server, () => HttpResponse.json(brokenDetail()))
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    function Page() {
+      const { data } = useTournament('t-1')
+      return <p>{data ? data.name : 'no tournament'}</p>
+    }
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CatchBoundary>
+          <Page />
+        </CatchBoundary>
+      </QueryClientProvider>,
+    )
+
+    expect(await screen.findByText('the boundary caught it')).toBeInTheDocument()
+    // And nothing malformed got into the cache on the way — a bad payload that primed
+    // the cache would be read back as good by the next component to mount.
+    expect(queryClient.getQueryData(['tournaments', 't-1'])).toBeUndefined()
   })
 })

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
+import type { components } from '@/api/schema'
 import {
   buildTournamentDetailRead,
   buildTournamentEntrantRead,
   buildTournamentEntrantReads,
   buildTournamentEventRead,
+  buildTournamentFixtureRead,
 } from '@/mocks/factories/tournaments/tournament.factory'
 import {
   apiToEntrant,
@@ -17,6 +19,17 @@ import {
   tournamentToUpdateBody,
 } from './api'
 import type { Tournament, TournamentEvent } from './types'
+
+type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
+
+/** A payload the generated types say cannot exist — which is exactly what the runtime
+ * parse is for. The cast is the *point* of these cases, not a shortcut around them:
+ * `schema.d.ts` is a compile-time claim about a server we do not control, and a test
+ * that could only feed `apiToEvent` well-typed fixtures could never prove the boundary
+ * rejects a bad one. */
+function malformedFixture(broken: Record<string, unknown>): TournamentFixtureRead {
+  return broken as unknown as TournamentFixtureRead
+}
 
 describe('apiToEntryState', () => {
   // The tags cross the boundary UNCHANGED, and that is the contract: they are the
@@ -147,6 +160,177 @@ describe('apiToEvent', () => {
   })
 })
 
+// The DRAW (ADR-0786), where it crosses into the app. Every fixture is PARSED here
+// (`./fixtures`), not cast — `apiToEvent` is called from the queries' `queryFn`, so a
+// draw that is not a draw fails the fetch instead of reaching a renderer.
+describe('apiToEvent — the draw', () => {
+  it('maps a cut draw to camelCase fixtures, in the order the wire sent them', () => {
+    const event = apiToEvent(
+      buildTournamentEventRead({
+        fixtures: [
+          buildTournamentFixtureRead({
+            id: 'fx-1',
+            pool_id: 'p-1',
+            round: 1,
+            position: 1,
+            entry_a_id: 'entry-1',
+            entry_b_id: 'entry-2',
+          }),
+          buildTournamentFixtureRead({
+            id: 'fx-2',
+            pool_id: 'p-1',
+            round: 1,
+            position: 2,
+            entry_a_id: 'entry-3',
+            entry_b_id: 'entry-4',
+          }),
+        ],
+      }),
+    )
+
+    expect(event.fixtures).toEqual([
+      {
+        id: 'fx-1',
+        poolId: 'p-1',
+        round: 1,
+        position: 1,
+        entryAId: 'entry-1',
+        entryBId: 'entry-2',
+        winnerEntryId: null,
+        matchId: null,
+      },
+      {
+        id: 'fx-2',
+        poolId: 'p-1',
+        round: 1,
+        position: 2,
+        entryAId: 'entry-3',
+        entryBId: 'entry-4',
+        winnerEntryId: null,
+        matchId: null,
+      },
+    ])
+  })
+
+  // Every null on a fixture is a FACT (ADR-0786), and a mapper that coalesced any of
+  // them would erase the thing the draw exists to say: a null side is TBD, a null
+  // winner is undecided, a null match is un-materialized, a null pool is un-pooled.
+  it('carries every null through — TBD sides, undecided, un-materialized, un-pooled', () => {
+    const event = apiToEvent(
+      buildTournamentEventRead({
+        fixtures: [
+          buildTournamentFixtureRead({
+            id: 'fx-final',
+            pool_id: null,
+            round: 3,
+            position: 1,
+            entry_a_id: null,
+            entry_b_id: null,
+          }),
+        ],
+      }),
+    )
+
+    expect(event.fixtures[0]).toEqual({
+      id: 'fx-final',
+      poolId: null,
+      round: 3,
+      position: 1,
+      entryAId: null,
+      entryBId: null,
+      winnerEntryId: null,
+      matchId: null,
+    })
+  })
+
+  it('maps a decided, materialized fixture — the winner and its match id survive', () => {
+    const event = apiToEvent(
+      buildTournamentEventRead({
+        fixtures: [
+          buildTournamentFixtureRead({
+            winner_entry_id: 'entry-2',
+            match_id: 'm-7',
+          }),
+        ],
+      }),
+    )
+
+    expect(event.fixtures[0].winnerEntryId).toBe('entry-2')
+    expect(event.fixtures[0].matchId).toBe('m-7')
+  })
+
+  // THE empty state. An event nobody has cut a draw for is not an error and not a null —
+  // it has an empty draw, which is a thing a page renders ("no draw yet, cut one").
+  it('maps an event with NO DRAW CUT to an empty fixture list — not null, not an error', () => {
+    const event = apiToEvent(buildTournamentEventRead({ fixtures: [] }))
+
+    expect(event.fixtures).toEqual([])
+  })
+
+  // …and the boundary. A malformed fixture must fail HERE, loudly, rather than travel
+  // inward as an `undefined` that surfaces as a blank bracket cell three components away
+  // (`.claude/rules/parse-at-boundaries.md`). The generated types promise these payloads
+  // cannot arrive; the parse is what makes that promise enforceable at runtime.
+  it.each([
+    {
+      what: 'a fixture missing its round',
+      fixture: malformedFixture({
+        id: 'fx-1',
+        pool_id: 'p-1',
+        position: 1,
+        entry_a_id: 'entry-1',
+        entry_b_id: 'entry-2',
+        winner_entry_id: null,
+        match_id: null,
+      }),
+    },
+    {
+      what: 'a pool_id of the wrong type',
+      fixture: malformedFixture({
+        ...buildTournamentFixtureRead(),
+        pool_id: 7,
+      }),
+    },
+    {
+      what: 'a round that is not a number',
+      fixture: malformedFixture({
+        ...buildTournamentFixtureRead(),
+        round: '1',
+      }),
+    },
+    {
+      // `.nullable()`, not `.optional()`: an ABSENT side is not the same as a null one.
+      // Null means TBD — a fact. Absent means the server sent us something we cannot
+      // read, and reading it as TBD would invent a fixture that is waiting for a player
+      // who will never arrive.
+      what: 'an absent side (absent is not the same as TBD)',
+      fixture: malformedFixture({
+        id: 'fx-1',
+        pool_id: null,
+        round: 1,
+        position: 1,
+        entry_b_id: 'entry-2',
+        winner_entry_id: null,
+        match_id: null,
+      }),
+    },
+  ])('rejects $what at the boundary', ({ fixture }) => {
+    expect(() =>
+      apiToEvent(buildTournamentEventRead({ fixtures: [fixture] })),
+    ).toThrow()
+  })
+
+  it('rejects a draw that is not a list at all — null is not an empty draw', () => {
+    expect(() =>
+      apiToEvent(
+        buildTournamentEventRead({
+          fixtures: null as unknown as TournamentFixtureRead[],
+        }),
+      ),
+    ).toThrow()
+  })
+})
+
 describe('apiToEntrant', () => {
   it('renames user_id and passes an unseeded entrant through', () => {
     expect(
@@ -231,6 +415,49 @@ describe('apiToTournament', () => {
     expect(tournament.events.map((e) => e.id)).toEqual(['ev-1', 'ev-2'])
     expect(tournament.events[0].maxPlayers).toBe(16)
     expect(tournament.events[1].maxPlayers).toBe(48)
+  })
+
+  // The draw arrives INSIDE the detail payload — there is no `GET …/draw` (ADR-0786) —
+  // so this is the mapping every drawn page actually goes through.
+  it('carries each event’s draw through, drawn and undrawn side by side', () => {
+    const tournament = apiToTournament(
+      buildTournamentDetailRead({
+        events: [
+          buildTournamentEventRead({
+            id: 'ev-drawn',
+            fixtures: [buildTournamentFixtureRead({ id: 'fx-1', pool_id: 'p-1' })],
+          }),
+          buildTournamentEventRead({ id: 'ev-undrawn', fixtures: [] }),
+        ],
+      }),
+    )
+
+    expect(tournament.events[0].fixtures.map((f) => f.id)).toEqual(['fx-1'])
+    expect(tournament.events[0].fixtures[0].poolId).toBe('p-1')
+    // The undrawn event is not a lesser drawn one: it is empty, and that is a state.
+    expect(tournament.events[1].fixtures).toEqual([])
+  })
+
+  // The whole point of parsing at the boundary rather than validating in a component:
+  // ONE bad fixture on ONE event fails the whole payload, at the edge, before any of it
+  // is trusted. `apiToTournament` runs inside both queries' `queryFn`, so this throw is
+  // a failed fetch — the cache is never primed with the bad draw.
+  it('rejects the whole payload when any event carries a malformed fixture', () => {
+    expect(() =>
+      apiToTournament(
+        buildTournamentDetailRead({
+          events: [
+            buildTournamentEventRead({ id: 'ev-fine' }),
+            buildTournamentEventRead({
+              id: 'ev-broken',
+              fixtures: [
+                malformedFixture({ ...buildTournamentFixtureRead(), round: null }),
+              ],
+            }),
+          ],
+        }),
+      ),
+    ).toThrow()
   })
 })
 
@@ -347,6 +574,9 @@ const event: TournamentEvent = {
       tableIds: ['t1', 't2'],
     },
   ],
+  // No draw cut (ADR-0786). The write bodies below must not carry one either — a draw
+  // is written by the two draw verbs and by nothing else.
+  fixtures: [],
 }
 
 describe('eventToCreateBody', () => {
@@ -412,11 +642,20 @@ describe('eventToCreateBody', () => {
       // entrants are: it is the server's judgement about *the caller*, not a field
       // the editor authors (ADR-0783).
       entry_state: { state: 'open' },
+      // The DRAW is absent from the create body too, and for a third reason: a brand-new
+      // event has no field to cut one from. Cutting is its own verb (ADR-0786).
+      fixtures: [],
       created_at: '2026-06-01T00:00:00Z',
       updated_at: '2026-06-01T00:00:00Z',
     })
 
     expect(roundTripped).toEqual(event)
+  })
+
+  it('sends NO fixtures — a draw is cut by POST …/draw, never authored in an event body', () => {
+    const body = eventToCreateBody(event)
+
+    expect('fixtures' in body).toBe(false)
   })
 })
 
@@ -455,5 +694,29 @@ describe('eventToUpdateBody', () => {
   it('omits the entrants too — registrations are written through the entries endpoints, never an event PATCH', () => {
     const body = eventToUpdateBody(event)
     expect('entrants' in body).toBe(false)
+  })
+
+  // The same lost-update argument as `entered` and `entrants`, and with sharper teeth: a
+  // PATCH that echoed the client's last-read `fixtures` back would let a rename throw
+  // away a draw the director cut in another tab — or, worse, re-assert a stale one over
+  // a re-cut. A draw moves only through `POST …/draw` and `DELETE …/draw` (ADR-0786).
+  it('omits the draw — an event PATCH can neither cut, keep, nor clobber fixtures', () => {
+    const body = eventToUpdateBody({
+      ...event,
+      fixtures: [
+        {
+          id: 'fx-1',
+          poolId: 'p-1',
+          round: 1,
+          position: 1,
+          entryAId: 'entry-1',
+          entryBId: 'entry-2',
+          winnerEntryId: null,
+          matchId: null,
+        },
+      ],
+    })
+
+    expect('fixtures' in body).toBe(false)
   })
 })

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -18,10 +18,12 @@ import { ApiError, api, unwrap } from '@/api/client'
 import { notifyError } from '@/lib/notify-error'
 import type { components } from '@/api/schema'
 import { entryRefusalNotice } from './entry-refusal'
+import { parseFixtures } from './fixtures'
 import type { LifecycleEdge } from './lifecycle'
 import type {
   Entrant,
   EventEntryState,
+  Fixture,
   Pool,
   Predicate,
   PredicateValue,
@@ -128,6 +130,18 @@ export function apiToEvent(e: TournamentEventRead): TournamentEvent {
     predicates: e.predicates.map(apiToPredicate),
     match: { rated: e.match_settings.rated, lengthGames: e.match_settings.length_games },
     pools: e.pools.map(apiToPool),
+    // PARSED, not cast (`./fixtures`, `.claude/rules/parse-at-boundaries.md`). Every
+    // other field above is mapped on the compiler's word that the payload matches
+    // `schema.d.ts`; the draw is checked at RUNTIME, because it is the one structure on
+    // this payload a renderer walks by shape — pool → round → position, sides that may
+    // be null — so a malformed fixture would otherwise surface as an `undefined` in a
+    // bracket cell, three components away from the response that carried it.
+    //
+    // Both callers of this mapper run inside a `queryFn` (see the queries below), so
+    // the throw lands where a failed fetch lands: the query errors, the cache is never
+    // primed with the bad payload, and the boundary renders. An event whose draw has
+    // not been cut parses to `[]` — the designed empty state, not an error.
+    fixtures: parseFixtures(e.fixtures),
   }
 }
 
@@ -264,21 +278,48 @@ export function useTournaments(): Tournament[] {
   return data ?? []
 }
 
+/** What one tournament's detail fetch resolves to: the tournament in its domain shape,
+ * plus the table catalogue the wire carries alongside it (the Tables tab edits the
+ * catalogue itself — labels and courts, not just ids — so the domain `Tournament`'s
+ * `tableIds` is not enough for it).
+ *
+ * The mapping runs in the `queryFn`, so what the CACHE holds is the parsed value, and
+ * a payload the parse rejects never becomes one (`.claude/rules/parse-at-boundaries.md`
+ * — "turn unstructured input into a trusted typed value once, at the edge"). It used to
+ * run in each consumer's `select`, which looks equivalent and is not: TanStack Query
+ * *catches* a throw from `select` and reports an error result while leaving the raw
+ * payload sitting in `query.state.data` — so `throwOnError` (which asks whether there
+ * is data) would answer "there is", swallow the throw, and the detail route, seeing an
+ * undefined `data` that is not `isPending`, would render **"Tournament not found"** for
+ * a tournament the server had just sent. A malformed draw must fail loudly, not quietly
+ * turn a tournament into a 404. */
+type TournamentDetail = {
+  tournament: Tournament
+  tables: TournamentTable[]
+}
+
 /** The detail query, shared by `useTournament` and `useTables` so both read one
- * cache entry from a single fetch. It returns the raw `TournamentDetailRead` (or
- * `null` on 404); each consumer selects its own projection. A 403 bubbles to the
- * `RbacBoundary`; any other error throws. */
+ * cache entry from a single fetch — and one parse. It resolves to the mapped
+ * `TournamentDetail` (or `null` on 404); each consumer selects its own projection. A
+ * 403 bubbles to the `RbacBoundary`; any other error throws. */
 function tournamentDetailQuery(id: string) {
   return queryOptions({
     queryKey: tournamentKey(id),
-    queryFn: async (): Promise<TournamentDetailRead | null> => {
+    queryFn: async (): Promise<TournamentDetail | null> => {
       const result = await api.GET('/v1/tournaments/{tournament_id}', {
         params: { path: { tournament_id: id } },
       })
       // A 404 is an expected "doesn't exist" — resolve to null rather than
       // throw, so the route renders its own not-found screen.
       if (result.response?.status === 404) return null
-      return unwrap('load tournament', result)
+      const payload: TournamentDetailRead = unwrap('load tournament', result)
+      // The parse boundary: `apiToTournament` runs `parseFixtures` over every event's
+      // draw, so a malformed fixture throws HERE — inside the fetch — and is reported
+      // as a failed query rather than half-entering the app.
+      return {
+        tournament: apiToTournament(payload),
+        tables: payload.table_catalogue,
+      }
     },
     // Bubble everything except a 404 (which resolved to null above and never
     // reaches here as an error) — but only while there is NOTHING on screen. A
@@ -297,23 +338,24 @@ function tournamentDetailQuery(id: string) {
   })
 }
 
-/** A single tournament's detail, mapped to a prototype `Tournament` — or `null`
- * when the id 404s (so the detail route can show its "not found" UI). */
+/** A single tournament's detail, as a prototype `Tournament` — or `null` when the id
+ * 404s (so the detail route can show its "not found" UI). A projection of the parsed
+ * cache entry: the mapping already happened, in the `queryFn`. */
 export function useTournament(id: string) {
   return useQuery({
     ...tournamentDetailQuery(id),
-    select: (data) => (data === null ? null : apiToTournament(data)),
+    select: (data) => data?.tournament ?? null,
   })
 }
 
 /** The current tournament's table catalogue, as prototype `TournamentTable[]`.
  * The API stores the full catalogue on the tournament, so this is the detail
- * query's `table_catalogue` (its shape already matches the prototype). Reads
- * the same cache entry as `useTournament`. */
+ * payload's `table_catalogue` (its shape already matches the prototype). Reads
+ * the same cache entry — and the same single fetch — as `useTournament`. */
 export function useTables(id: string): TournamentTable[] {
   const { data } = useQuery({
     ...tournamentDetailQuery(id),
-    select: (data) => data?.table_catalogue ?? [],
+    select: (data) => data?.tables ?? [],
   })
   return data ?? []
 }
@@ -333,11 +375,15 @@ export function useTables(id: string): TournamentTable[] {
 // | useDeleteEvent          | ['tournaments'], ['tournaments', id]     | onSuccess |
 // | useEnterEvent           | ['tournaments'], ['tournaments', id]     | onSettled |
 // | useWithdrawEntry        | ['tournaments'], ['tournaments', id]     | onSettled |
+// | useCutDraw              | ['tournaments'], ['tournaments', id]     | onSettled |
+// | useUncutDraw            | ['tournaments'], ['tournaments', id]     | onSettled |
 //
 // There are only two keys, because there are only two queries: the list and one
-// tournament's detail (events, entrants and the table catalogue all arrive nested
-// in the detail — see the queries above). Create is the one mutation that touches
-// only the list: it has no detail entry to stale yet. The three `onSettled` rows
+// tournament's detail (events, entrants, the table catalogue AND every event's draw all
+// arrive nested in the detail — see the queries above; there is deliberately no
+// `GET …/draw`, because a per-event draw fetch would be an N+1 on the server and a
+// suspense waterfall on the client, ADR-0786). Create is the one mutation that touches
+// only the list: it has no detail entry to stale yet. The five `onSettled` rows
 // reconcile on FAILURE as well as success, which is deliberate — see the notes on
 // each.
 
@@ -610,5 +656,111 @@ export function useWithdrawEntry(tournamentId: string) {
     // view/state disagreement just like the entry 409 is.
     onSettled: () => invalidateTournament(qc, tournamentId),
     onError: notifyError('withdraw from the event'),
+  })
+}
+
+// ----- the draw (ADR-0786) -------------------------------------------------
+//
+// Two verbs, and NO query of their own. An event's fixtures ride the tournament detail
+// payload it already fetches (`event.fixtures`), so cutting and un-cutting invalidate
+// the tournament — list + detail — and the refetched event carries the new draw. That
+// is the whole invalidation set: the same two keys `invalidateTournament` already
+// covers. A `GET …/draw` per event would be an N+1 on the server and a suspense
+// waterfall on the page, which is exactly why the API does not offer one.
+//
+// Both reconcile **`onSettled`, not `onSuccess`**, like the entry and lifecycle
+// mutations and for the same reason: their most interesting failure is the one that
+// says *this screen is stale*. A cut is refused with a **409** when the draw shows
+// evidence of play (a fixture has a winner, or has become a real match) — which cannot
+// be true of the draw this page is looking at, or it would not have offered the button.
+// Something happened that this tab has not read yet, so the only sane response is to
+// re-read the server: invalidating on success only would leave the director staring at
+// the same Re-cut button that was just refused. The 403 (not the owner) and the 422
+// (this event cannot be planned) are not stale-view failures, and re-reading is merely
+// harmless for them — one rule for both verbs beats two rules that could disagree.
+
+/** Cut (or **re-cut**) an event's draw: `POST …/events/{event_id}/draw`. Owner-only.
+ * Resolves to the created fixtures, parsed (`./fixtures`) — the same list the next read
+ * of the tournament will carry, in the same pool → round → position order.
+ *
+ * A re-cut **replaces the draw wholesale**: the old fixtures are deleted and a fresh set
+ * is planned from the event's *current* active entrants, so their ids do not survive.
+ * Nothing here is optimistic for that reason — there is no local edit to apply, only a
+ * new draw to read back.
+ *
+ * The three refusals, all of which the server owns and this client merely reports:
+ * - **403** — not the owner. The UI does not offer the verb to a non-owner, so this can
+ *   only mean the page is looking at somebody else's tournament.
+ * - **409** — the draw shows evidence of play; it can no longer be cut or removed.
+ * - **422** — this event cannot be planned as it stands: an unsupported draw type (only
+ *   round-robin has a generator today), no pools configured, or a field too small for
+ *   the pools it has. The server's sentence names what the director must change, which
+ *   is why it is a sentence and not a code.
+ *
+ * **No global `onError` toast**, by the same convention `useCreateEvent` and
+ * `useUpdateEvent` follow: the `DrawPanel` awaits this through `mutateAsync` and renders
+ * every refusal **inline, on the event's card** — where the button was, in the words
+ * `data/draw.ts` owns, carrying the server's own sentence for the 409 and the 422. A
+ * toast on top of that would tell the director the same thing twice, and would be the
+ * wrong channel besides: it leaves after four seconds, and the sentence it carries is
+ * the one they have to act on (`web-client/CLAUDE.md`, ## Forms: "don't attach a global
+ * onError toast to a mutation a form surfaces inline"). */
+export function useCutDraw(tournamentId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (eventId: string): Promise<Fixture[]> => {
+      const fixtures = unwrap(
+        'cut the draw',
+        await api.POST(
+          '/v1/tournaments/{tournament_id}/events/{event_id}/draw',
+          {
+            params: {
+              path: { tournament_id: tournamentId, event_id: eventId },
+            },
+          },
+        ),
+      )
+      // The response is untrusted like every other payload — parse it, don't cast it.
+      // This is also what stops a bad cut from priming the caller with half a draw.
+      return parseFixtures(fixtures)
+    },
+    // Reconcile on BOTH paths — see the note above.
+    onSettled: () => invalidateTournament(qc, tournamentId),
+  })
+}
+
+/** Un-cut an event's draw: `DELETE …/events/{event_id}/draw`. Owner-only, and a **204**
+ * with no body.
+ *
+ * The way back from a draw the director does not want — the event, its entrants and the
+ * rest of the tournament are untouched, only the fixtures go, and the pool set unfreezes
+ * so the pools can be edited before cutting again.
+ *
+ * **Idempotent**: removing a draw that was never cut is a 204, not a 404 (this is a
+ * DELETE, and an event with no draw is already in the state it asks for). The one
+ * refusal is the same **409** the cut has — a draw with evidence of play cannot be
+ * removed, because the results on it would go with it.
+ *
+ * **No global `onError` toast**, for the reason given on `useCutDraw`: the `DrawPanel`
+ * surfaces the refusal inline, and a toast would double it up. */
+export function useUncutDraw(tournamentId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (eventId: string) => {
+      unwrap(
+        'remove the draw',
+        await api.DELETE(
+          '/v1/tournaments/{tournament_id}/events/{event_id}/draw',
+          {
+            params: {
+              path: { tournament_id: tournamentId, event_id: eventId },
+            },
+          },
+        ),
+        { allowEmpty: true },
+      )
+    },
+    // Reconcile on BOTH paths — see the note above.
+    onSettled: () => invalidateTournament(qc, tournamentId),
   })
 }

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -443,14 +443,22 @@ export function useUpdateTournament() {
  * stale tab's belief at that. Whether (current, `to`) is an edge at all is the
  * server's judgement, and an illegal one is a **409**.
  *
- * That 409 is a *genuine* failure — nothing moved — so it toasts, unlike the
- * already-entered 409 below (which means "you are already in", and is benign). But
- * like the entry mutations it reconciles **`onSettled`, not `onSuccess`**: since the
- * UI only ever offers the edge that is legal from the status it last read, a 409 can
- * only mean this view is stale (the classic case: publish in tab A, then click
- * Publish in tab B). Re-reading the tournament is what corrects the badge and
- * swaps the button for the one that *is* legal now — invalidating on success only
- * would leave the stale tab offering the very button it was just refused. */
+ * That 409 is a *genuine* failure — nothing moved — unlike the already-entered 409
+ * below (which means "you are already in", and is benign). It reconciles
+ * **`onSettled`, not `onSuccess`**, like the entry and draw mutations: a 409 means this
+ * view and the server's state disagree — either the tournament moved on in another tab,
+ * or (going live) its draws are not what this page last read — so re-reading it is what
+ * corrects the badge and swaps the button for the one that *is* legal now. Invalidating
+ * on success only would leave the stale tab offering the very button it was just refused.
+ *
+ * **No global `onError` toast**, by the convention the draw and event mutations already
+ * follow (`web-client/CLAUDE.md`, ## Forms: a mutation whose errors are surfaced inline
+ * must not also toast, or the user is told twice). `LifecycleActions` awaits this through
+ * `mutateAsync` and renders every refusal **inline, beside the button**, in the words
+ * `./lifecycle` owns — carrying the server's own sentence for the 409, which is the one
+ * that names what the director has to go and fix (ADR-0786: the events with no draw, or
+ * with a stale one). A toast would tell them the same thing twice and then take the work
+ * list away after four seconds. */
 export function useTransitionTournament(tournamentId: string) {
   const qc = useQueryClient()
   return useMutation({
@@ -464,8 +472,6 @@ export function useTransitionTournament(tournamentId: string) {
       ),
     // Reconcile on BOTH paths — the 409 IS the stale-view signal.
     onSettled: () => invalidateTournament(qc, tournamentId),
-    // The verb is the edge the user asked for, so the toast names their click.
-    onError: (error, edge) => notifyError(edge.verb)(error),
   })
 }
 

--- a/web-client/src/components/tournaments/data/draw.test.ts
+++ b/web-client/src/components/tournaments/data/draw.test.ts
@@ -1,0 +1,364 @@
+import { ApiError } from '@/api/client'
+
+import { drawRefusalNotice, drawState, type DrawState, type FixtureSide } from './draw'
+import {
+  buildDrawnEvent,
+  buildEntrant,
+  buildEntrants,
+  buildEvent,
+  buildFixture,
+  buildPool,
+} from './seed.factory'
+
+/** The drawn arm, or a failed assertion — so the tests below can read `.pools`
+ * without a cast, and an accidental `undrawn` fails loudly instead of quietly
+ * skipping every assertion after it. */
+function drawn(state: DrawState) {
+  if (state.kind !== 'drawn') {
+    throw new Error(`expected a drawn state, got "${state.kind}"`)
+  }
+  return state
+}
+
+/** A pool's fixtures as the panel reads them: "player.1 vs player.4", round by round. */
+function vsLines(rounds: { round: number; fixtures: { a: FixtureSide; b: FixtureSide }[] }[]) {
+  return rounds.map((r) => ({
+    round: r.round,
+    lines: r.fixtures.map((f) => `${label(f.a)} vs ${label(f.b)}`),
+  }))
+}
+
+function label(side: FixtureSide): string {
+  switch (side.kind) {
+    case 'entrant':
+      return side.name
+    case 'tbd':
+      return 'TBD'
+    case 'withdrawn':
+      return 'Withdrawn'
+  }
+}
+
+describe('drawState', () => {
+  it('reads an event with no fixtures as the designed UNDRAWN state', () => {
+    expect(drawState(buildEvent({ fixtures: [] }))).toEqual({ kind: 'undrawn' })
+  })
+
+  it('groups a cut draw into its pools, in the event’s pool order', () => {
+    const state = drawn(drawState(buildDrawnEvent()))
+
+    expect(state.pools.map((p) => p.name)).toEqual(['Pool A', 'Pool B'])
+    expect(state.unpooled).toEqual([])
+  })
+
+  it('lists each pool’s entrants — the members its own fixtures name, by NAME', () => {
+    const state = drawn(drawState(buildDrawnEvent()))
+
+    // The snake dealt 1/4/5 into Pool A and 2/3 into Pool B; nothing stores that, so
+    // this is derived from the fixtures (ADR-0786).
+    expect(state.pools[0].entrants.map((e) => e.username)).toEqual([
+      'player.1',
+      'player.4',
+      'player.5',
+    ])
+    expect(state.pools[1].entrants.map((e) => e.username)).toEqual([
+      'player.2',
+      'player.3',
+    ])
+  })
+
+  it('orders a pool’s entrants by SEED first, then registration order', () => {
+    // player.5 is seeded 1, so they lead a pool they entered last. The unseeded rest
+    // keep the order the server listed them in.
+    const event = buildDrawnEvent({
+      entrants: [
+        buildEntrant({ id: 'entry-1', userId: 'u-1', username: 'player.1' }),
+        buildEntrant({ id: 'entry-2', userId: 'u-2', username: 'player.2' }),
+        buildEntrant({ id: 'entry-3', userId: 'u-3', username: 'player.3' }),
+        buildEntrant({ id: 'entry-4', userId: 'u-4', username: 'player.4' }),
+        buildEntrant({
+          id: 'entry-5',
+          userId: 'u-5',
+          username: 'player.5',
+          seed: 1,
+        }),
+      ],
+    })
+
+    const state = drawn(drawState(event))
+
+    expect(state.pools[0].entrants.map((e) => e.username)).toEqual([
+      'player.5',
+      'player.1',
+      'player.4',
+    ])
+  })
+
+  it('groups each pool’s fixtures by round, in round then position order — with names on them', () => {
+    const state = drawn(drawState(buildDrawnEvent()))
+
+    expect(vsLines(state.pools[0].rounds)).toEqual([
+      { round: 1, lines: ['player.1 vs player.4'] },
+      { round: 2, lines: ['player.1 vs player.5'] },
+      { round: 3, lines: ['player.4 vs player.5'] },
+    ])
+    expect(vsLines(state.pools[1].rounds)).toEqual([
+      { round: 1, lines: ['player.2 vs player.3'] },
+    ])
+  })
+
+  // The ODD pool: three players, three rounds, ONE fixture each — the third player sits
+  // out. A bye is the ABSENCE of a fixture (ADR-0786), so nothing here emits a row for
+  // it, and no round is short of the fixtures it really has.
+  it('leaves an odd pool’s rounds short a fixture rather than inventing a bye row', () => {
+    const state = drawn(drawState(buildDrawnEvent()))
+
+    expect(state.pools[0].rounds.map((r) => r.fixtures.length)).toEqual([1, 1, 1])
+    expect(state.pools[0].rounds).toHaveLength(3)
+    // Three entrants, three rounds, three fixtures — never four, and never a null side
+    // standing in for the player sitting out.
+    const sides = state.pools[0].rounds.flatMap((r) =>
+      r.fixtures.flatMap((f) => [f.a.kind, f.b.kind]),
+    )
+    expect(sides).toEqual(Array(6).fill('entrant'))
+  })
+
+  it('sorts rounds and positions rather than trusting the payload’s order', () => {
+    const shuffled = buildDrawnEvent({
+      fixtures: [
+        buildFixture({
+          id: 'fx-a-r2',
+          poolId: 'p-a',
+          round: 2,
+          position: 2,
+          entryAId: 'entry-4',
+          entryBId: 'entry-5',
+        }),
+        buildFixture({
+          id: 'fx-a-r1',
+          poolId: 'p-a',
+          round: 1,
+          position: 1,
+          entryAId: 'entry-1',
+          entryBId: 'entry-2',
+        }),
+        buildFixture({
+          id: 'fx-a-r2-p1',
+          poolId: 'p-a',
+          round: 2,
+          position: 1,
+          entryAId: 'entry-1',
+          entryBId: 'entry-3',
+        }),
+      ],
+    })
+
+    const state = drawn(drawState(shuffled))
+
+    expect(vsLines(state.pools[0].rounds)).toEqual([
+      { round: 1, lines: ['player.1 vs player.2'] },
+      {
+        round: 2,
+        lines: ['player.1 vs player.3', 'player.4 vs player.5'],
+      },
+    ])
+  })
+
+  it('renders a null side as TBD, never as a blank', () => {
+    const event = buildDrawnEvent({
+      fixtures: [
+        buildFixture({
+          id: 'fx-ko',
+          poolId: 'p-a',
+          round: 1,
+          position: 1,
+          entryAId: 'entry-1',
+          entryBId: null,
+        }),
+      ],
+    })
+
+    const state = drawn(drawState(event))
+
+    expect(state.pools[0].rounds[0].fixtures[0].a).toEqual({
+      kind: 'entrant',
+      name: 'player.1',
+    })
+    expect(state.pools[0].rounds[0].fixtures[0].b).toEqual({ kind: 'tbd' })
+  })
+
+  // A withdrawal removes the entry from `entrants` and leaves the cut draw naming it —
+  // which is exactly what a STALE draw is. The side says so; it never goes blank, and it
+  // never falls back to the raw entry id.
+  it('names a side whose entry the event no longer lists as withdrawn — never as a uuid', () => {
+    const event = buildDrawnEvent({
+      // player.4 withdrew; their fixtures survive the withdrawal.
+      entrants: buildEntrants(5).filter((e) => e.id !== 'entry-4'),
+    })
+
+    const state = drawn(drawState(event))
+
+    expect(vsLines(state.pools[0].rounds)).toEqual([
+      { round: 1, lines: ['player.1 vs Withdrawn'] },
+      { round: 2, lines: ['player.1 vs player.5'] },
+      { round: 3, lines: ['Withdrawn vs player.5'] },
+    ])
+    // …and they are not a member of the pool, because they are not an entrant at all
+    // (ADR-0016).
+    expect(state.pools[0].entrants.map((e) => e.username)).toEqual([
+      'player.1',
+      'player.5',
+    ])
+  })
+
+  it('does not announce a pool the draw never used', () => {
+    const event = buildDrawnEvent({
+      pools: [
+        buildPool({ id: 'p-a', name: 'Pool A' }),
+        buildPool({ id: 'p-b', name: 'Pool B' }),
+        buildPool({ id: 'p-c', name: 'Pool C' }),
+      ],
+    })
+
+    const state = drawn(drawState(event))
+
+    expect(state.pools.map((p) => p.name)).toEqual(['Pool A', 'Pool B'])
+  })
+
+  // A fixture with no pool — an un-pooled (knockout) draw. Nothing can cut one today, but
+  // dropping it silently is the one thing this must not do.
+  it('keeps a fixture that belongs to no pool, outside the pools', () => {
+    const event = buildDrawnEvent({
+      fixtures: [
+        buildFixture({
+          id: 'fx-a-1',
+          poolId: 'p-a',
+          round: 1,
+          position: 1,
+          entryAId: 'entry-1',
+          entryBId: 'entry-2',
+        }),
+        buildFixture({
+          id: 'fx-ko-1',
+          poolId: null,
+          round: 1,
+          position: 1,
+          entryAId: 'entry-3',
+          entryBId: null,
+        }),
+      ],
+    })
+
+    const state = drawn(drawState(event))
+
+    expect(state.pools.map((p) => p.name)).toEqual(['Pool A'])
+    expect(vsLines(state.unpooled)).toEqual([
+      { round: 1, lines: ['player.3 vs TBD'] },
+    ])
+  })
+
+  it('keeps a fixture naming a pool the event does not have, rather than dropping it', () => {
+    const event = buildDrawnEvent({
+      fixtures: [
+        buildFixture({
+          id: 'fx-ghost',
+          poolId: 'p-gone',
+          round: 1,
+          position: 1,
+          entryAId: 'entry-1',
+          entryBId: 'entry-2',
+        }),
+      ],
+    })
+
+    const state = drawn(drawState(event))
+
+    expect(state.pools).toEqual([])
+    expect(vsLines(state.unpooled)).toEqual([
+      { round: 1, lines: ['player.1 vs player.2'] },
+    ])
+  })
+})
+
+describe('drawRefusalNotice', () => {
+  // The 409 and the 422 keep the SERVER's sentence, because it is the half that says
+  // what the director must change. A generic string of ours would throw it away.
+  it('shows the server’s sentence under a 409 (the draw is under way)', () => {
+    const detail =
+      "This event's draw is already under way — at least one fixture has a match " +
+      'or a recorded winner — so it can no longer be cut or removed.'
+
+    const notice = drawRefusalNotice(
+      new ApiError(409, detail, 'cut the draw'),
+      'cut the draw',
+    )
+
+    expect(notice.title).toBe('This draw is already under way')
+    expect(notice.description).toBe(detail)
+  })
+
+  it('shows the server’s sentence under a 422 — the numbers it names are the point', () => {
+    const detail =
+      '5 entrants across 3 pool(s) would leave a pool with fewer than 2 entrants, ' +
+      'who would have nobody to play.'
+
+    const notice = drawRefusalNotice(
+      new ApiError(422, detail, 'cut the draw'),
+      'cut the draw',
+    )
+
+    expect(notice.title).toBe("This event can't be drawn yet")
+    expect(notice.description).toBe(detail)
+  })
+
+  it('shows the server’s sentence for an unsupported draw type', () => {
+    const detail =
+      'A swiss draw cannot be cut yet. ' +
+      "Change the event's draw type to one that can, or wait for support."
+
+    const notice = drawRefusalNotice(
+      new ApiError(422, detail, 'cut the draw'),
+      'cut the draw',
+    )
+
+    expect(notice.description).toBe(detail)
+  })
+
+  it('has words for a 403, though the panel never offers a non-owner the verb', () => {
+    const notice = drawRefusalNotice(
+      new ApiError(403, 'Only the creator can cut this draw.', 'cut the draw'),
+      'cut the draw',
+    )
+
+    expect(notice.title).toBe("You can't change this draw")
+    expect(notice.description).toContain('Nothing was changed.')
+  })
+
+  it('has words for an expired session', () => {
+    const notice = drawRefusalNotice(
+      new ApiError(401, null, 'cut the draw'),
+      'cut the draw',
+    )
+
+    expect(notice.title).toBe('You are signed out')
+  })
+
+  // No silent failures: the panel surfaces its errors inline and carries no toast, so
+  // every failure — a 5xx, a dead network — must still say something.
+  it('names the verb on a 5xx, and keeps the server’s detail', () => {
+    const notice = drawRefusalNotice(
+      new ApiError(500, 'Something went wrong.', 'remove the draw'),
+      'remove the draw',
+    )
+
+    expect(notice.title).toBe("Couldn't remove the draw")
+    expect(notice.description).toBe('Something went wrong.')
+  })
+
+  it('says the request never landed when the network is down', () => {
+    const notice = drawRefusalNotice(new TypeError('Failed to fetch'), 'cut the draw')
+
+    expect(notice.title).toBe("Couldn't cut the draw")
+    expect(notice.description).toContain('Check your connection')
+  })
+})

--- a/web-client/src/components/tournaments/data/draw.test.ts
+++ b/web-client/src/components/tournaments/data/draw.test.ts
@@ -352,14 +352,19 @@ describe('drawRefusalNotice', () => {
 
   // No silent failures: the panel surfaces its errors inline and carries no toast, so
   // every failure — a 5xx, a dead network — must still say something.
-  it('names the verb on a 5xx, and keeps the server’s detail', () => {
+  //
+  // But a 5xx says it in OUR words. Its detail is machinery, not copy, and it must never
+  // reach the UI (`DEFINITION_OF_COMPLETE`) — the guarantee lives in `fallbackNotice`'s
+  // floor, so this asserts the leak is closed rather than that this function has an arm.
+  it('names the verb on a 5xx, and never echoes the server’s detail', () => {
     const notice = drawRefusalNotice(
-      new ApiError(500, 'Something went wrong.', 'remove the draw'),
+      new ApiError(500, "psycopg.errors.NotNullViolation: null value in column 'pool_id'", 'remove the draw'),
       'remove the draw',
     )
 
     expect(notice.title).toBe("Couldn't remove the draw")
-    expect(notice.description).toBe('Something went wrong.')
+    expect(notice.description).not.toContain('psycopg')
+    expect(notice.description).toBe('Something went wrong on our end. Try again in a moment.')
   })
 
   it('says the request never landed when the network is down', () => {

--- a/web-client/src/components/tournaments/data/draw.test.ts
+++ b/web-client/src/components/tournaments/data/draw.test.ts
@@ -1,6 +1,13 @@
 import { ApiError } from '@/api/client'
 
-import { drawRefusalNotice, drawState, type DrawState, type FixtureSide } from './draw'
+import {
+  drawRefusalNotice,
+  drawState,
+  drawTypeFreeze,
+  poolSetFreeze,
+  type DrawState,
+  type FixtureSide,
+} from './draw'
 import {
   buildDrawnEvent,
   buildEntrant,
@@ -360,5 +367,51 @@ describe('drawRefusalNotice', () => {
 
     expect(notice.title).toBe("Couldn't cut the draw")
     expect(notice.description).toContain('Check your connection')
+  })
+})
+
+// ADR-0786's two freezes, as the editor asks about them. Pure derivations off the
+// event's `fixtures`, so they are unit-tested here rather than through eight DOM
+// assertions in three sections.
+describe('poolSetFreeze', () => {
+  it('is open while no draw is cut', () => {
+    expect(poolSetFreeze(buildEvent()).kind).toBe('open')
+  })
+
+  it('freezes the moment ONE fixture exists', () => {
+    // The freeze turns on the draw EXISTING, not on it being big, complete, or played:
+    // a single fixture is already a fixture that names its pool.
+    const freeze = poolSetFreeze(
+      buildEvent({ pools: [buildPool()], fixtures: [buildFixture({ poolId: 'p-1' })] }),
+    )
+
+    expect(freeze.kind).toBe('frozen')
+  })
+
+  it('names the way out, and says what is still allowed', () => {
+    const freeze = poolSetFreeze(buildDrawnEvent())
+    if (freeze.kind !== 'frozen') throw new Error('expected a frozen pool set')
+
+    // A refusal that only says "no" leaves a director with a broken table nowhere to go.
+    expect(freeze.reason).toContain('Delete the draw')
+    expect(freeze.reason).toContain('cut it again')
+    // …and the half that matters most: the venue attributes were never frozen.
+    expect(freeze.reason).toMatch(/name.*tables.*time window|tables/i)
+  })
+})
+
+describe('drawTypeFreeze', () => {
+  it('is open while no draw is cut', () => {
+    expect(drawTypeFreeze(buildEvent()).kind).toBe('open')
+  })
+
+  it('freezes once the draw is cut, naming the type its fixtures were dealt as', () => {
+    const freeze = drawTypeFreeze(buildDrawnEvent())
+    if (freeze.kind !== 'frozen') throw new Error('expected a frozen draw type')
+
+    // In the select's own words — never the wire's enum key.
+    expect(freeze.reason).toContain('“Round robin”')
+    expect(freeze.reason).not.toContain('round-robin')
+    expect(freeze.reason).toContain('Delete the draw')
   })
 })

--- a/web-client/src/components/tournaments/data/draw.ts
+++ b/web-client/src/components/tournaments/data/draw.ts
@@ -159,6 +159,15 @@ function roundsOf(fixtures: Fixture[], byId: Map<string, Entrant>): DrawRound[] 
     }))
 }
 
+/** An event has a draw exactly when it has fixtures — the ONE definition of it, guarded
+ * on by `drawState` below and asked by the editor's two freezes.
+ *
+ * It is deliberately *not* spelled `drawState(event).kind === 'drawn'`. That answers the
+ * same yes/no by grouping every fixture into its pool, sorting each round and building
+ * two Maps, then throwing all of it away — and the event editor asks it twice on every
+ * keystroke. */
+const hasDraw = (event: TournamentEvent): boolean => event.fixtures.length > 0
+
 /**
  * An event's draw, shaped for the reader: pools with their members and rounds, or the
  * designed `undrawn` state.
@@ -171,7 +180,7 @@ function roundsOf(fixtures: Fixture[], byId: Map<string, Entrant>): DrawRound[] 
  *   does not have, lands in `unpooled` — visible, rather than silently gone.
  */
 export function drawState(event: TournamentEvent): DrawState {
-  if (event.fixtures.length === 0) return { kind: 'undrawn' }
+  if (!hasDraw(event)) return { kind: 'undrawn' }
 
   const byId = new Map(event.entrants.map((e) => [e.id, e]))
   const poolIds = new Set(event.pools.map((p) => p.id))
@@ -237,12 +246,6 @@ export type EditFreeze =
       reason: string
     }
 
-/** An event has a draw exactly when it has fixtures. Asked through `drawState` so
- * "does this event have a draw?" has ONE definition — a bare `fixtures.length > 0`
- * scattered across the editor would be the same truthiness-on-a-list check the panel
- * already refused to make. */
-const hasDraw = (event: TournamentEvent): boolean =>
-  drawState(event).kind === 'drawn'
 
 /**
  * May the director change **which pools** this event has?
@@ -362,6 +365,10 @@ export function drawRefusalNotice(error: unknown, verb: string): DrawNotice {
         title: 'You are signed out',
         description: 'Sign in again, then cut the draw. Nothing was changed.',
       }
+    // A 5xx and any unrecognised status land here. The 5xx is safe *because of the
+    // floor*, not because of this arm: `fallbackNotice` will not echo a 5xx detail
+    // (see `./notice`), so what renders is "Couldn't cut the draw — something went
+    // wrong on our end" and never the server's stack-shaped sentence.
     default:
       return fallback
   }

--- a/web-client/src/components/tournaments/data/draw.ts
+++ b/web-client/src/components/tournaments/data/draw.ts
@@ -22,6 +22,8 @@
 
 import { ApiError } from '@/api/client'
 
+import { fallbackNotice, type Notice } from './notice'
+import { DRAW_TYPE_OPTIONS, labelFor } from './options'
 import type { Entrant, Fixture, TournamentEvent } from './types'
 
 /** A fixture side whose feeding fixture is not decided yet (`entryAId`/`entryBId` is
@@ -211,12 +213,95 @@ export function drawState(event: TournamentEvent): DrawState {
   return { kind: 'drawn', pools, unpooled: roundsOf(unpooled, byId) }
 }
 
-/** A refusal, in the panel's own voice: a title this client owns, and a sentence
- * beneath it that — for the two refusals that matter — is the **server's**. */
-export interface DrawNotice {
-  title: string
-  description: string
+/**
+ * Whether an editor control is **offered**, or **refused with a reason** — the state a
+ * cut draw puts two of the event editor's controls in (ADR-0786).
+ *
+ * A sum type rather than a `disabled: boolean` plus a `reason?: string`, because those
+ * two are one decision and the pair makes "disabled with nothing to say" — the
+ * unexplained dead end ADR-0015 is about — constructible. Here a frozen control *has*
+ * words, by construction; an open one has none to show.
+ *
+ * The reason is the CLIENT's, not the server's (`DEFINITION_OF_COMPLETE`: raw API detail
+ * strings never reach the UI). The server's own sentence still arrives, verbatim, when a
+ * director loses the race and the PATCH is refused anyway — that is `save-failure`'s
+ * `refused` arm, and it is a different surface for a different moment.
+ */
+export type EditFreeze =
+  | { kind: 'open' }
+  | {
+      kind: 'frozen'
+      /** Why this control is unavailable, and — the load-bearing half — the way out of
+       * it: delete the draw, edit, cut it again. Reads standalone in whichever surface
+       * shows it (a `Field` hint, an `Alert` beneath the section header). */
+      reason: string
+    }
+
+/** An event has a draw exactly when it has fixtures. Asked through `drawState` so
+ * "does this event have a draw?" has ONE definition — a bare `fixtures.length > 0`
+ * scattered across the editor would be the same truthiness-on-a-list check the panel
+ * already refused to make. */
+const hasDraw = (event: TournamentEvent): boolean =>
+  drawState(event).kind === 'drawn'
+
+/**
+ * May the director change **which pools** this event has?
+ *
+ * Frozen the moment a draw exists, because every fixture names its pool by a string id
+ * into that very list: remove a pool (or re-`id` one, which is a removal with an
+ * addition standing where it was) and its fixtures point at nothing; add one and it
+ * arrives with no fixtures, since the draw was dealt across the pools the event had at
+ * the cut. The server refuses it with a 409 (`_enforce_pool_set_frozen`) — this is the
+ * client declining to *build* the change the server would refuse.
+ *
+ * **Only the identity set is frozen**, and the reason says so out loud: a pool's tables,
+ * its window and its name stay editable with a draw standing, on purpose. Venues move
+ * under a running tournament — a table breaks and is pulled, one frees up early — and a
+ * director who could not record that would have to destroy a *correct* draw to move a
+ * table. Over-freezing the section would break the very case the freeze exists to
+ * preserve.
+ */
+export function poolSetFreeze(event: TournamentEvent): EditFreeze {
+  if (!hasDraw(event)) return { kind: 'open' }
+  return {
+    kind: 'frozen',
+    reason:
+      'Every fixture names the pool it was dealt into, so a pool can’t be added or ' +
+      'removed while the draw stands. Delete the draw to change them, then cut it ' +
+      'again. A pool’s name, its tables and its time window can still be edited right ' +
+      'now — a table that breaks mid-event costs you nothing.',
+  }
 }
+
+/**
+ * May the director change this event's **draw type**?
+ *
+ * Frozen once a draw exists, for the sibling reason (`_enforce_draw_type_frozen`, a 409):
+ * the draw type is not a label on an event, it is the strategy that dealt these fixtures.
+ * Re-label it under a standing draw and the event claims a shape its draw does not have —
+ * a `single-elim` event holding pooled round-robin fixtures, which no bracket can render
+ * and no strategy would ever have produced.
+ *
+ * The reason names the type the fixtures were actually dealt as, in the words the select
+ * shows ("Round robin", never `round-robin`).
+ */
+export function drawTypeFreeze(event: TournamentEvent): EditFreeze {
+  if (!hasDraw(event)) return { kind: 'open' }
+  const label = labelFor(DRAW_TYPE_OPTIONS, event.drawType, event.drawType)
+  return {
+    kind: 'frozen',
+    reason:
+      `This event’s draw is cut, so its draw type is frozen — its fixtures were dealt ` +
+      `as a “${label}” draw. Delete the draw to change the type, then cut it again.`,
+  }
+}
+
+/** A refusal, in the panel's own voice: a title this client owns, and a sentence
+ * beneath it that — for the two refusals that matter — is the **server's**.
+ *
+ * The shape (and the `Couldn't <verb>` fallback below) is shared with the header's
+ * lifecycle refusals, which report the same way for the same reason — see `./notice`. */
+export type DrawNotice = Notice
 
 /**
  * Turn a failed draw verb into inline copy.
@@ -241,13 +326,7 @@ export interface DrawNotice {
  * function responsible for.
  */
 export function drawRefusalNotice(error: unknown, verb: string): DrawNotice {
-  const fallback: DrawNotice = {
-    title: `Couldn't ${verb}`,
-    description:
-      error instanceof ApiError
-        ? (error.detail ?? 'The server rejected the request. Try again in a moment.')
-        : 'The request never reached the server. Check your connection and try again.',
-  }
+  const fallback = fallbackNotice(error, verb)
   if (!(error instanceof ApiError)) return fallback
 
   switch (error.status) {

--- a/web-client/src/components/tournaments/data/draw.ts
+++ b/web-client/src/components/tournaments/data/draw.ts
@@ -1,0 +1,289 @@
+// What an event's **draw** looks like to a reader (ADR-0786) — the pure derivation
+// behind the Events tab's draw panel, and the copy behind its refusals.
+//
+// The wire gives us a flat list of `Fixture`s (parsed at the boundary by `./fixtures`)
+// and, separately, the event's `pools` and `entrants`. A director reads a draw as
+// **pool → round → fixture**, with *names* on it. Nothing on the wire is shaped that
+// way, and deliberately so:
+//
+// - **Names are not on a fixture.** It carries entry *ids*; the usernames behind them
+//   are already on the event (`entrants` is keyed by that id), so the join happens here,
+//   once. Copying the username onto the fixture would be carrying a field and its own
+//   derivation, and the two copies would drift the moment a player is renamed.
+// - **Pool membership is not stored.** ADR-0786: it is derived from the fixtures
+//   themselves, exactly as `entered` is derived from the entries (ADR-0016).
+// - **A bye is the ABSENCE of a fixture**, never a row. An odd pool simply has fewer
+//   fixtures in some rounds. Nothing here invents a "bye" line, because nothing on the
+//   wire says one is missing — and a derived one would be a second, drift-prone copy of
+//   the planner's rotation.
+//
+// All of it is a pure function of one event, so it is unit-tested (`./draw.test.ts`)
+// rather than asserted through a DOM.
+
+import { ApiError } from '@/api/client'
+
+import type { Entrant, Fixture, TournamentEvent } from './types'
+
+/** A fixture side whose feeding fixture is not decided yet (`entryAId`/`entryBId` is
+ * `null` — ADR-0786: "**TBD**, never a bye"). Round-robin never produces one; a
+ * knockout round does, and it is the state the panel must render as a word rather than
+ * as a blank half-line. */
+export const TBD_LABEL = 'TBD'
+
+/** A fixture side naming an entry the event **no longer lists**.
+ *
+ * Reachable, and it means something: a withdrawal removes the entry from `entrants`
+ * (ADR-0016 — withdrawn entries are not entrants) while the cut draw goes on naming it,
+ * which is precisely what makes a draw **stale** (CONTEXT.md: a draw is *current* when
+ * its fixtures cover exactly the event's active entrants, and go-live refuses a stale
+ * one). So the side is neither blank nor a raw uuid: it says what happened, and the
+ * director reading it learns their draw needs re-cutting. */
+export const WITHDRAWN_LABEL = 'Withdrawn'
+
+/**
+ * One side of a fixture, as a sum type — because the three things a side can be are
+ * three *different facts*, and a renderer that collapsed them into `string | null`
+ * would have to guess which one an empty string meant.
+ */
+export type FixtureSide =
+  /** An active entrant, joined from the event's `entrants` by entry id. */
+  | { kind: 'entrant'; name: string }
+  /** Not decided yet — the feeding fixture has not been played (`TBD_LABEL`). */
+  | { kind: 'tbd' }
+  /** An entry id the event no longer lists: they withdrew, and the draw is now stale
+   * (`WITHDRAWN_LABEL`). */
+  | { kind: 'withdrawn' }
+
+/** One fixture, ready to render as a named "A vs B" line. */
+export interface FixtureLine {
+  id: string
+  position: number
+  a: FixtureSide
+  b: FixtureSide
+}
+
+/** The fixtures of one round, in position order. An odd round-robin pool has *fewer*
+ * of them in some rounds — the player drawn against the phantom seat sits that round
+ * out — and that absence is the whole representation of a bye. */
+export interface DrawRound {
+  round: number
+  fixtures: FixtureLine[]
+}
+
+/** One pool of a cut draw: the pool as the event names it, the entrants the draw dealt
+ * into it (derived from its fixtures), and those fixtures grouped by round. */
+export interface PoolDraw {
+  id: string
+  name: string
+  /** The pool's members, in **draw order** (see `drawOrder`). Derived from the
+   * fixtures, never stored (ADR-0786). */
+  entrants: Entrant[]
+  rounds: DrawRound[]
+}
+
+/**
+ * What an event's draw *is*, as a sum type — `undrawn` is a designed data state, not an
+ * empty list to be rendered as a gap (`DEFINITION_OF_COMPLETE`: "Empty is a designed
+ * data state, never a thrown one").
+ */
+export type DrawState =
+  /** No draw has been cut. Every event is born here and stays here until a director
+   * cuts one; `fixtures: []` on the wire. */
+  | { kind: 'undrawn' }
+  | {
+      kind: 'drawn'
+      /** The pools the draw actually used, in the event's own pool order. */
+      pools: PoolDraw[]
+      /** Fixtures belonging to **no pool** — an un-pooled draw (single-elim), or the KO
+       * stage of an rr-then-ko (ADR-0786: `pool_id` is `null` for both). Empty today,
+       * because round-robin is the only draw type with a generator — but a fixture that
+       * has no pool must not be *dropped*, and a bracket renderer (#785) is where these
+       * eventually belong. Until then they are shown, honestly, outside the pools. */
+      unpooled: DrawRound[]
+    }
+
+/**
+ * The order the draw dealt a pool's entrants in: **seed ascending where one is set,
+ * then registration order** for the unseeded rest — the exact rule `plan_initial`
+ * receives its list in (ADR-0786, "Entrants are ordered by seed, then registration
+ * order").
+ *
+ * Registration order is `event.entrants`' own order (the server lists them
+ * oldest-entry-first), so the tie-break is just a **stable** sort over the slice we were
+ * handed. Nothing sets a seed today, so in practice this is registration order — which
+ * is what makes the seeded case worth pinning in a test rather than assuming.
+ */
+function drawOrder(entrants: Entrant[]): Entrant[] {
+  return [...entrants].sort(
+    (a, b) =>
+      (a.seed ?? Number.MAX_SAFE_INTEGER) - (b.seed ?? Number.MAX_SAFE_INTEGER),
+  )
+}
+
+/** Join one entry id to a side. `null` is TBD; an id the event no longer lists is a
+ * withdrawal (see `WITHDRAWN_LABEL`) — never a blank, and never the raw id. */
+function sideOf(entryId: string | null, byId: Map<string, Entrant>): FixtureSide {
+  if (entryId === null) return { kind: 'tbd' }
+  const entrant = byId.get(entryId)
+  return entrant ? { kind: 'entrant', name: entrant.username } : { kind: 'withdrawn' }
+}
+
+/** Group a flat fixture list into rounds, ascending, each in position order.
+ *
+ * It **sorts**, rather than trusting the payload's order (the server sends pool → round
+ * → position). Order is a claim about untrusted data like any other, and a panel whose
+ * rounds only happened to come out right is one bad page of a paginated API away from
+ * showing round 3 above round 1. */
+function roundsOf(fixtures: Fixture[], byId: Map<string, Entrant>): DrawRound[] {
+  const byRound = new Map<number, Fixture[]>()
+  for (const fixture of fixtures) {
+    const bucket = byRound.get(fixture.round)
+    if (bucket) bucket.push(fixture)
+    else byRound.set(fixture.round, [fixture])
+  }
+  return [...byRound.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([round, roundFixtures]) => ({
+      round,
+      fixtures: roundFixtures
+        .slice()
+        .sort((a, b) => a.position - b.position)
+        .map((f) => ({
+          id: f.id,
+          position: f.position,
+          a: sideOf(f.entryAId, byId),
+          b: sideOf(f.entryBId, byId),
+        })),
+    }))
+}
+
+/**
+ * An event's draw, shaped for the reader: pools with their members and rounds, or the
+ * designed `undrawn` state.
+ *
+ * Two things it deliberately does *not* do:
+ * - It does not announce a pool the draw never used. A pool with no fixtures is not part
+ *   of the draw, and the pool *set* is frozen while a draw exists (ADR-0786), so this
+ *   filter cannot hide a pool a director added afterwards — there is no such pool.
+ * - It does not drop a fixture. One whose `poolId` is `null`, or names a pool this event
+ *   does not have, lands in `unpooled` — visible, rather than silently gone.
+ */
+export function drawState(event: TournamentEvent): DrawState {
+  if (event.fixtures.length === 0) return { kind: 'undrawn' }
+
+  const byId = new Map(event.entrants.map((e) => [e.id, e]))
+  const poolIds = new Set(event.pools.map((p) => p.id))
+  const byPool = new Map<string, Fixture[]>()
+  const unpooled: Fixture[] = []
+  for (const fixture of event.fixtures) {
+    const poolId = fixture.poolId
+    if (poolId === null || !poolIds.has(poolId)) {
+      unpooled.push(fixture)
+      continue
+    }
+    const bucket = byPool.get(poolId)
+    if (bucket) bucket.push(fixture)
+    else byPool.set(poolId, [fixture])
+  }
+
+  const pools: PoolDraw[] = event.pools.flatMap((pool) => {
+    const fixtures = byPool.get(pool.id)
+    if (!fixtures) return []
+    // Membership is the entry ids the pool's own fixtures name — the derivation
+    // ADR-0786 chose over an entrant↔pool table. A withdrawn entry is named by the
+    // fixtures and listed by nobody, so it is not a member: it is not an entrant at all
+    // (ADR-0016). Its fixtures still say `Withdrawn`, which is how the staleness shows.
+    const memberIds = new Set<string>()
+    for (const f of fixtures) {
+      if (f.entryAId !== null) memberIds.add(f.entryAId)
+      if (f.entryBId !== null) memberIds.add(f.entryBId)
+    }
+    return [
+      {
+        id: pool.id,
+        name: pool.name,
+        entrants: drawOrder(event.entrants.filter((e) => memberIds.has(e.id))),
+        rounds: roundsOf(fixtures, byId),
+      },
+    ]
+  })
+
+  return { kind: 'drawn', pools, unpooled: roundsOf(unpooled, byId) }
+}
+
+/** A refusal, in the panel's own voice: a title this client owns, and a sentence
+ * beneath it that — for the two refusals that matter — is the **server's**. */
+export interface DrawNotice {
+  title: string
+  description: string
+}
+
+/**
+ * Turn a failed draw verb into inline copy.
+ *
+ * `verb` completes "Couldn't <verb>" for the failures that have no designed state of
+ * their own ("cut the draw", "remove the draw").
+ *
+ * **The 409 and the 422 carry the server's own sentence, verbatim.** They are the two
+ * refusals a director actually meets, and for both of them the sentence is the *point*:
+ * it names the thing they have to change ("5 entrants across 3 pool(s) would leave a
+ * pool with fewer than 2 entrants…", "A swiss draw cannot be cut yet…"). It is authored
+ * for them, on the server, where the numbers are; replacing it with a generic string of
+ * ours would throw away the only actionable half of the refusal and leave the director
+ * clicking Generate again. The client owns the *title* — the state, in a few words —
+ * and nothing more.
+ *
+ * There is deliberately **no `null` arm**: this panel surfaces its mutation's errors
+ * inline, so it must have words for *every* one of them (a 403 the UI does not offer,
+ * an expired session, a 5xx, a dead network). A `null` here would be a silent failure —
+ * the click that did nothing and said nothing — which is exactly what removing the
+ * mutations' global toasts (`web-client/CLAUDE.md`, ## Forms: never both) makes this
+ * function responsible for.
+ */
+export function drawRefusalNotice(error: unknown, verb: string): DrawNotice {
+  const fallback: DrawNotice = {
+    title: `Couldn't ${verb}`,
+    description:
+      error instanceof ApiError
+        ? (error.detail ?? 'The server rejected the request. Try again in a moment.')
+        : 'The request never reached the server. Check your connection and try again.',
+  }
+  if (!(error instanceof ApiError)) return fallback
+
+  switch (error.status) {
+    // Evidence of play: a fixture has a winner, or has become a real match. The draw is
+    // under way and can no longer be cut or removed (ADR-0786's play guard).
+    case 409:
+      return {
+        title: 'This draw is already under way',
+        description:
+          error.detail ??
+          'At least one fixture has a match or a recorded winner, so the draw can no longer be cut or removed.',
+      }
+    // The planner refuses this event as it stands: an unsupported draw type, no pools,
+    // or a pool that would get fewer than two entrants.
+    case 422:
+      return {
+        title: "This event can't be drawn yet",
+        description:
+          error.detail ??
+          'This event cannot be planned as it stands. Check its draw type and its pools.',
+      }
+    // Owner-only. The panel offers no draw action to anyone else, so this can only mean
+    // the page is looking at somebody else's tournament — the server is the boundary,
+    // and the hidden button never was (ADR-0015).
+    case 403:
+      return {
+        title: "You can't change this draw",
+        description:
+          'Only the tournament’s creator can cut or remove a draw. Nothing was changed.',
+      }
+    case 401:
+      return {
+        title: 'You are signed out',
+        description: 'Sign in again, then cut the draw. Nothing was changed.',
+      }
+    default:
+      return fallback
+  }
+}

--- a/web-client/src/components/tournaments/data/event-validation.test.ts
+++ b/web-client/src/components/tournaments/data/event-validation.test.ts
@@ -7,6 +7,8 @@ import {
   NAME_MAX,
   nameSchema,
   PLAYERS_MAX,
+  poolNameIssues,
+  poolNameSchema,
 } from './event-validation'
 
 /** Longer than `tournament_events.name` (`VARCHAR(255)`) — the 422 the organizer used
@@ -132,5 +134,56 @@ describe('the entry fee (`EventEntryFee`: required, `ge=0`, whole cents)', () =>
     // Two places is a price. (`45.10` is two places — not the binary tail of 10.1.)
     expect(messageFor(entryFeeSchema, 45.1)).toBeUndefined()
     expect(messageFor(entryFeeSchema, 12.5)).toBeUndefined()
+  })
+})
+
+/**
+ * A **pool's** name — the last field in this editor that could still author a 422 (#786).
+ *
+ * The editor mints a pool's id and its default name ("Pool A"), so the happy path could
+ * never make a blank one. The box, however, is live: an emptied one was a save the form
+ * allowed and the server refused, in Pydantic's words ("String should have at least 1
+ * character"), in a banner naming no field.
+ */
+describe('poolNameSchema', () => {
+  it('requires a name — in the same words the event’s own name uses', () => {
+    // The same sentence, because to the organizer clearing a box it is the same news.
+    expect(messageFor(poolNameSchema, '')).toBe('Name is required.')
+    expect(messageFor(poolNameSchema, '   ')).toBe('Name is required.')
+    expect(messageFor(poolNameSchema, 'Pool A')).toBeUndefined()
+  })
+
+  /** ⚠️ **No ceiling.** `Pool.name` is `min_length=1` with no `max_length`: a pool lives
+   * in JSONB, and there is no column for it to overflow (unlike the event's
+   * `VARCHAR(255)`). A bound here would be a rule the API does not have — and a save
+   * refused by nothing but us. */
+  it('invents no ceiling the server does not have', () => {
+    expect(messageFor(poolNameSchema, 'A'.repeat(NAME_MAX + 1))).toBeUndefined()
+  })
+})
+
+describe('poolNameIssues', () => {
+  const pool = (id: string, name: string) => ({ id, name })
+
+  /** Keyed by pool id, so the red lands under the box that is empty. A director with six
+   * pools and one blank name must not be pointed at all six. */
+  it('blames only the pool that is blank', () => {
+    expect(
+      poolNameIssues([pool('p-a', ''), pool('p-b', 'Pool B'), pool('p-c', '  ')]),
+    ).toEqual({ 'p-a': 'Name is required.', 'p-c': 'Name is required.' })
+  })
+
+  it('says nothing about a list of named pools', () => {
+    expect(poolNameIssues([pool('p-a', 'Pool A')])).toEqual({})
+    expect(poolNameIssues([])).toEqual({})
+  })
+
+  /** The message is the SCHEMA's, read off it rather than re-typed beside it: the
+   * resolver refuses the save and this puts the red under the box, and the two must not
+   * be able to say different things about the same field. */
+  it('speaks the schema’s own words', () => {
+    expect(poolNameIssues([pool('p-a', '')])['p-a']).toBe(
+      messageFor(poolNameSchema, ''),
+    )
   })
 })

--- a/web-client/src/components/tournaments/data/event-validation.ts
+++ b/web-client/src/components/tournaments/data/event-validation.ts
@@ -109,6 +109,65 @@ export const nameSchema = z
   .max(NAME_MAX, { error: `Name must be ${NAME_MAX} characters or fewer.` })
 
 /**
+ * A **pool's** name: present. The same floor the server now states
+ * (`Pool.name: str = Field(min_length=1)`, `api/app/schemas/tournament.py`), and the
+ * same words as the event's own name — because to the organizer clearing a box it is
+ * the same news, and a second wording for one fact is a second thing to drift.
+ *
+ * The pools editor *mints* a pool's id and its default name ("Pool A"), so the happy
+ * path could never author a blank one — but the name **box is live**, and an emptied
+ * box was a save the form allowed and the server refused, with Pydantic's own prose
+ * ("String should have at least 1 character") arriving in the editor's banner. That is
+ * the hole `nameSchema` closed for the event a release ago, still open one tab over:
+ * the whole point of the house rule (web-client `CLAUDE.md`, `## Forms`) is that a rule
+ * the client can express is a rule met **under the field**, not in a 422.
+ *
+ * ⚠️ **No ceiling**, deliberately: `Pool.name` has `min_length=1` and no `max_length`
+ * (unlike the event's `VARCHAR(255)` — a pool lives in JSONB, which has no column to
+ * overflow). Mirroring a bound the API does not have would be inventing one, and a save
+ * refused here is a save nothing on the server would ever have refused.
+ *
+ * A pool's **id** is not mirrored, though the server floors that too (`ValueObjectId`):
+ * it is minted (`genId('p')`, `data/helpers`) and there is no box for it, so an error
+ * about it is one no organizer could ever act on or even *see* — an unfixable red is
+ * worse than the impossible 422 it guards. The same goes for a table's id.
+ */
+export const poolNameSchema = z
+  .string()
+  .trim()
+  .min(1, { error: 'Name is required.' })
+
+/**
+ * What is wrong with each pool's **name**, keyed by pool id — `poolNameSchema` read a
+ * second way, for the second reader.
+ *
+ * The resolver's verdict on the array (`eventSchema`) is what refuses the *save*; this
+ * is what puts the red under the *box*, and the two are the same rule and the same
+ * sentence because the message comes off the schema itself, never re-typed beside it.
+ * (`eligibilityIssues` is the same shape for the same reason: one rule, two readers of
+ * it — never two rules.)
+ *
+ * A second reader is needed at all because RHF's `useFieldArray.update()` — how a pool
+ * card writes an edit back — deliberately does **not** re-run the resolver (it sets no
+ * `_actioned` flag, unlike append/remove: `useFieldArray`, RHF 7.81). So the resolver's
+ * `errors.pools` is the verdict of the last *submit* and would sit there, in red, under
+ * a name the organizer has already fixed. Computed from live form values instead, it
+ * stops complaining the moment they type — which is what the event's own name box does
+ * one tab over, and the organizer cannot be expected to know which of the two is backed
+ * by which mechanism.
+ */
+export function poolNameIssues(
+  pools: readonly { id: string; name: string }[],
+): Record<string, string> {
+  const issues: Record<string, string> = {}
+  for (const pool of pools) {
+    const result = poolNameSchema.safeParse(pool.name)
+    if (!result.success) issues[pool.id] = result.error.issues[0].message
+  }
+  return issues
+}
+
+/**
  * The event's player limit — **nullable, because `null` means "no cap"** (ADR-0935).
  *
  * `.nullable()` is the whole design: a blank box is not an error and not a zero, it is
@@ -171,7 +230,8 @@ export const entryFeeSchema = z
     }
   })
 
-/** The editor's four tabs, of which two can hold something invalid. A sum type rather
- * than a `string`, so "which tab do I open?" is answered from a closed set the editor's
- * `TabsContent` values are checked against. */
-export type EventSection = 'basics' | 'eligibility'
+/** The editor's four tabs, of which three can hold something invalid (Match settings
+ * comes off closed pickers). A sum type rather than a `string`, so "which tab do I
+ * open?" is answered from a closed set the editor's `TabsContent` values are checked
+ * against. */
+export type EventSection = 'basics' | 'eligibility' | 'pools'

--- a/web-client/src/components/tournaments/data/fixtures.test.ts
+++ b/web-client/src/components/tournaments/data/fixtures.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildTournamentFixtureRead } from '@/mocks/factories/tournaments/tournament.factory'
+import { parseFixtures } from './fixtures'
+
+/** The wire fixture as an untyped blob — which is what it really is when it comes off
+ * the network. `parseFixtures` takes `unknown` precisely so a test can hand it one. */
+function wire(overrides: Record<string, unknown> = {}): unknown {
+  return { ...buildTournamentFixtureRead(), ...overrides }
+}
+
+describe('parseFixtures — the happy path', () => {
+  it('parses a pooled fixture into the camelCase domain shape', () => {
+    expect(
+      parseFixtures([
+        wire({
+          id: 'fx-9',
+          pool_id: 'p-a',
+          round: 2,
+          position: 3,
+          entry_a_id: 'entry-5',
+          entry_b_id: 'entry-6',
+        }),
+      ]),
+    ).toEqual([
+      {
+        id: 'fx-9',
+        poolId: 'p-a',
+        round: 2,
+        position: 3,
+        entryAId: 'entry-5',
+        entryBId: 'entry-6',
+        winnerEntryId: null,
+        matchId: null,
+      },
+    ])
+  })
+
+  // `[]` is the DESIGNED state of an event whose draw has not been cut (ADR-0786) — not
+  // a failure, not a null, not an absence. A parser that treated it as any of those
+  // would turn "no draw yet" — the ordinary state of every event before the director
+  // cuts one — into an error page.
+  it('parses an UNCUT draw to an empty list — the designed empty state, not an error', () => {
+    expect(parseFixtures([])).toEqual([])
+  })
+
+  it('keeps the order it was given (the wire sends pool → round → position)', () => {
+    const parsed = parseFixtures([
+      wire({ id: 'fx-1', pool_id: 'p-a', round: 1, position: 1 }),
+      wire({ id: 'fx-2', pool_id: 'p-a', round: 1, position: 2 }),
+      wire({ id: 'fx-3', pool_id: 'p-b', round: 1, position: 1 }),
+    ])
+
+    expect(parsed.map((f) => f.id)).toEqual(['fx-1', 'fx-2', 'fx-3'])
+  })
+
+  it('carries a TBD side through as null — a side nobody has been drawn into yet', () => {
+    const [fixture] = parseFixtures([
+      wire({ entry_a_id: null, entry_b_id: null }),
+    ])
+
+    expect(fixture.entryAId).toBeNull()
+    expect(fixture.entryBId).toBeNull()
+  })
+
+  it('carries a decided, materialized fixture through — winner and match id both', () => {
+    const [fixture] = parseFixtures([
+      wire({ winner_entry_id: 'entry-2', match_id: 'm-7' }),
+    ])
+
+    expect(fixture.winnerEntryId).toBe('entry-2')
+    expect(fixture.matchId).toBe('m-7')
+  })
+})
+
+// THE point of this module. `schema.d.ts` is a compile-time claim about a server we do
+// not control (root `CLAUDE.md`), and `api.GET` casts the decoded JSON to it without
+// looking — so these payloads are exactly the ones the type system swears cannot arrive,
+// and exactly the ones that must fail loudly if they do
+// (`.claude/rules/parse-at-boundaries.md`). Each case below would otherwise travel
+// inward and surface as an `undefined` in a bracket cell, far from the response that
+// carried it.
+describe('parseFixtures — the boundary', () => {
+  it.each([
+    { what: 'a missing round', payload: [{ ...(wire() as object), round: undefined }] },
+    { what: 'a round that is a string', payload: [wire({ round: '2' })] },
+    { what: 'a fractional round', payload: [wire({ round: 1.5 })] },
+    { what: 'a missing position', payload: [{ ...(wire() as object), position: undefined }] },
+    { what: 'a pool_id of the wrong type', payload: [wire({ pool_id: 7 })] },
+    { what: 'an id of the wrong type', payload: [wire({ id: 42 })] },
+    { what: 'a winner_entry_id of the wrong type', payload: [wire({ winner_entry_id: 3 })] },
+    // Absent is NOT null. Null is a fact — "TBD" — and reading an absent key as one
+    // would invent a fixture waiting for a player who is never coming.
+    { what: 'an absent side', payload: [{ ...(wire() as object), entry_a_id: undefined }] },
+    { what: 'an absent match_id', payload: [{ ...(wire() as object), match_id: undefined }] },
+    // A draw is a LIST. `null` is not an empty draw: an event with no draw sends `[]`,
+    // and a server that sent null would be sending something this client cannot read.
+    { what: 'null instead of a list', payload: null },
+    { what: 'undefined instead of a list', payload: undefined },
+    { what: 'an object instead of a list', payload: wire() },
+    { what: 'a list of something that is not a fixture', payload: ['fx-1'] },
+  ])('rejects $what', ({ payload }) => {
+    expect(() => parseFixtures(payload)).toThrow()
+  })
+
+  // One bad fixture poisons the draw, on purpose: the alternative — dropping it and
+  // parsing the rest — would silently hand a director a draw with a hole in it, and a
+  // draw with a hole in it is worse than an error, because it looks like a draw.
+  it('rejects the WHOLE draw when a single fixture is malformed — it does not drop it', () => {
+    expect(() =>
+      parseFixtures([wire({ id: 'fx-1' }), wire({ id: 'fx-2', round: null })]),
+    ).toThrow()
+  })
+})

--- a/web-client/src/components/tournaments/data/fixtures.ts
+++ b/web-client/src/components/tournaments/data/fixtures.ts
@@ -1,0 +1,90 @@
+// The **fixtures** boundary (ADR-0786): where an event's draw stops being bytes off
+// the wire and becomes a typed domain value.
+//
+// A fixture is one planned pairing of a draw — a round and a position (plus a pool,
+// when the draw is pooled) — whose sides may still be TBD. It is NOT a match; it
+// materializes into one later (#788), and until then its `matchId` is `null`.
+//
+// Why a Zod parse and not just the generated types: `schema.d.ts` is a *compile-time*
+// claim about what the server sends (root `CLAUDE.md`), and `api.GET` casts the decoded
+// JSON to it without looking. The network is untrusted
+// (`.claude/rules/parse-at-boundaries.md`), so the fixtures are **parsed** here, at the
+// fetch boundary, and only the parsed value travels inward. A fixture missing its
+// `round`, or carrying a `pool_id` that is a number, fails HERE — loudly, in the
+// queryFn, before it can prime the cache — rather than surfacing three components
+// later as a `undefined` in a bracket header.
+//
+// **Every `null` on a fixture is a fact, not a missing field**, and the schema says so
+// with `.nullable()` (which demands the key be *present*) rather than `.optional()`
+// (which would let it be absent): `entryAId`/`entryBId` null means **TBD** — the side
+// is not known yet and `advance()` will fill it — and a payload that simply omitted a
+// side would be a payload we cannot tell apart from one that means TBD. A bye is the
+// ABSENCE OF A FIXTURE, never a fixture with an empty side, so there is no third state
+// hiding in that null.
+
+import { z } from 'zod'
+
+import type { Fixture } from './types'
+
+/** The wire shape (`TournamentFixtureRead`), as it really arrives: snake_case, with
+ * five nullable columns that all mean something. Kept separate from the transform
+ * below so the *runtime* contract is legible next to the generated type it mirrors. */
+const fixtureWireSchema = z.object({
+  id: z.string(),
+  /** `null` = an un-pooled draw (single-elim), or the KO stage of an rr-then-ko.
+   * When set it is a **string ref** into the event's own `pools` — not a foreign key,
+   * because pools are JSONB value-objects (ADR-0786). */
+  pool_id: z.string().nullable(),
+  round: z.number().int(),
+  position: z.number().int(),
+  /** `null` = **TBD**, never a bye. */
+  entry_a_id: z.string().nullable(),
+  entry_b_id: z.string().nullable(),
+  /** `null` while the fixture is undecided. */
+  winner_entry_id: z.string().nullable(),
+  /** `null` until the fixture materializes into a real match (#788). */
+  match_id: z.string().nullable(),
+})
+
+/** The parser: one wire fixture → one domain `Fixture`.
+ *
+ * The transform is annotated `: Fixture` on purpose — that is what makes the domain
+ * interface in `./types` and this schema one thing rather than two: drop a field from
+ * either and this line is a compile error, so the runtime parser and the type the app
+ * holds cannot drift apart. */
+export const fixtureSchema = fixtureWireSchema.transform(
+  (f): Fixture => ({
+    id: f.id,
+    poolId: f.pool_id,
+    round: f.round,
+    position: f.position,
+    entryAId: f.entry_a_id,
+    entryBId: f.entry_b_id,
+    winnerEntryId: f.winner_entry_id,
+    matchId: f.match_id,
+  }),
+)
+
+/** An event's whole draw. **`[]` is the designed "no draw cut yet" state** — never
+ * `null`, and never an error: an event whose director has not cut a draw has an empty
+ * fixture list, which is a data state the UI renders as such (`DEFINITION_OF_COMPLETE`:
+ * "Empty is a designed data state, never a thrown one"). What is NOT tolerated is
+ * `null`/absent: `.array()` refuses both, so a server that stopped sending the field is
+ * a loud failure rather than a silently draw-less tournament. */
+export const fixturesSchema = z.array(fixtureSchema)
+
+/**
+ * Parse an event's `fixtures` off the wire, or throw.
+ *
+ * Takes `unknown`, deliberately: the value it is handed is typed
+ * `TournamentFixtureRead[]` by the generated schema, and that type is exactly the claim
+ * this function exists to check. Accepting the typed shape would let the compiler talk
+ * us out of the runtime guarantee.
+ *
+ * Throws a `ZodError`. It is called from the tournament queries' `queryFn`
+ * (`./api.ts`), so a malformed draw fails the *query* — the error boundary gets it, the
+ * cache is never primed with it, and no component ever sees a half-fixture.
+ */
+export function parseFixtures(input: unknown): Fixture[] {
+  return fixturesSchema.parse(input)
+}

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -319,5 +319,8 @@ export function emptyEvent(t: Tournament): TournamentEvent {
     predicates: [],
     match: { rated: true, lengthGames: 5 },
     pools: [],
+    // No draw (ADR-0786), and there could not be one: a draw is cut from a field, and
+    // an event that does not exist on the server yet has no entrants to cut it from.
+    fixtures: [],
   }
 }

--- a/web-client/src/components/tournaments/data/lifecycle.test.ts
+++ b/web-client/src/components/tournaments/data/lifecycle.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
+import { ApiError } from '@/api/client'
+
 import {
   entryControlState,
   lifecycleEdgeFor,
+  lifecycleRefusalNotice,
   LIFECYCLE_EDGE,
   REGISTRATION_WINDOW,
 } from './lifecycle'
@@ -306,5 +309,105 @@ describe('lifecycleEdgeFor', () => {
       label: 'Start tournament',
       verb: 'start the tournament',
     })
+  })
+})
+
+// The words a refused transition is reported in — the header shows them inline and
+// carries no toast, so this function is the *only* thing standing between a failed click
+// and silence.
+describe('lifecycleRefusalNotice', () => {
+  const START = LIFECYCLE_EDGE.published!
+  const PUBLISH = LIFECYCLE_EDGE.draft!
+
+  // The go-live precondition's 409 (ADR-0786). The server's sentence is kept WHOLE,
+  // because it names the events the director has to go and fix — the one half of the
+  // refusal they can act on, authored where the events are.
+  it.each([
+    'This tournament has no events, so there is nothing to start. Add an event and cut its draw, then start the tournament.',
+    'This tournament cannot start yet: “Open Singles” has no draw yet. A draw is cut from the field as it stands at the time…',
+    'This tournament cannot start yet: “Under 1200” has a draw that no longer matches its entrants. …',
+    'This tournament cannot start yet: “Under 1200” has no draw yet; and “Over 40s” has a draw that no longer matches their entrants. …',
+  ])('carries the server’s 409 sentence verbatim: %s', (detail) => {
+    const notice = lifecycleRefusalNotice(
+      new ApiError(409, detail, 'move the tournament'),
+      START,
+    )
+
+    expect(notice.kind).toBe('refused')
+    expect(notice.description).toBe(detail)
+    // The title is the CLIENT's, and it names the edge that was clicked — not the wire
+    // call that carried it.
+    expect(notice.title).toBe("Couldn't start the tournament")
+  })
+
+  // The same 409 answers a stale tab (a re-asserted edge). It carries no code, so the
+  // client does not try to tell the two apart — it shows the sentence, which is written
+  // for exactly that reader.
+  it('shows the stale-tab 409 the same way', () => {
+    const notice = lifecycleRefusalNotice(
+      new ApiError(409, 'This tournament is already published.', 'move the tournament'),
+      PUBLISH,
+    )
+
+    expect(notice.kind).toBe('refused')
+    expect(notice.title).toBe("Couldn't publish the tournament")
+    expect(notice.description).toBe('This tournament is already published.')
+  })
+
+  it('has words of its own for a 403 — and does not blame the director', () => {
+    const notice = lifecycleRefusalNotice(
+      new ApiError(403, 'Only the creator can move this tournament.', 'move'),
+      START,
+    )
+
+    expect(notice.kind).toBe('forbidden')
+    expect(notice.title).toBe("You can't move this tournament")
+    expect(notice.description).toContain('Nothing was changed')
+  })
+
+  it('names the edge’s verb when the session has gone (401)', () => {
+    const notice = lifecycleRefusalNotice(new ApiError(401, null, 'move'), START)
+
+    expect(notice.kind).toBe('signed-out')
+    expect(notice.description).toContain('start the tournament')
+  })
+
+  // A 5xx detail is machinery ("Internal Server Error", a stack-shaped string): the
+  // client owns this one entirely (`DEFINITION_OF_COMPLETE` — raw API detail strings
+  // never reach the UI).
+  it.each([500, 502, 503])('owns the copy for a %d', (status) => {
+    const notice = lifecycleRefusalNotice(
+      new ApiError(status, 'Internal Server Error', 'move'),
+      START,
+    )
+
+    expect(notice.kind).toBe('server-error')
+    expect(notice.description).not.toContain('Internal Server Error')
+    expect(notice.description).toContain('nothing was changed')
+  })
+
+  // No response at all — a dead network. There is no server sentence to show, and
+  // pretending there is ("the server rejected the request") would send the director
+  // looking for a fault that is not there.
+  it('says the request never got there when there was no response', () => {
+    const notice = lifecycleRefusalNotice(new TypeError('Failed to fetch'), START)
+
+    expect(notice.kind).toBe('unreachable')
+    expect(notice.description).toContain('never reached the server')
+    expect(notice.description).toContain('nothing was changed')
+  })
+
+  // The catch-all — a 404 on a tournament deleted in another tab. It is a designed case,
+  // not a hole: there is no `null` arm anywhere in this function, because the header has
+  // no toast to fall back on.
+  it('still has something to say about an unexpected status', () => {
+    const notice = lifecycleRefusalNotice(
+      new ApiError(404, 'Tournament not found.', 'move'),
+      START,
+    )
+
+    expect(notice.kind).toBe('unexpected')
+    expect(notice.title).toBe("Couldn't start the tournament")
+    expect(notice.description).toBe('Tournament not found.')
   })
 })

--- a/web-client/src/components/tournaments/data/lifecycle.ts
+++ b/web-client/src/components/tournaments/data/lifecycle.ts
@@ -7,10 +7,12 @@
 
 import { Radio, Rocket, Square, type LucideIcon } from 'lucide-react'
 
+import { ApiError } from '@/api/client'
 import { formatRating } from '@/lib/rating'
 
 import { ENTRY_REFUSAL_NOTICE } from './entry-refusal'
 import { myEntrant, predicateSentence } from './helpers'
+import { fallbackNotice, type Notice } from './notice'
 import type {
   EventEntryState,
   Tournament,
@@ -97,6 +99,135 @@ export const LIFECYCLE_EDGE: Record<TournamentStatus, LifecycleEdge | null> = {
  * second to a second lookup — two reads of one table, which can disagree. */
 export function lifecycleEdgeFor(tournament: Tournament): LifecycleEdge | null {
   return tournament.canEdit ? LIFECYCLE_EDGE[tournament.status] : null
+}
+
+// ----- when the move is refused (ADR-0786, ADR-0017) -----------------------
+
+/**
+ * Everything a refused transition can be, as a sum type — one case per thing the header
+ * can *render*, so a refusal cannot arrive as a bag of booleans (`isConflict`,
+ * `isForbidden`, `isOffline`) whose combinations are mostly nonsense. Two of them true
+ * at once is unrepresentable here; none of them true — the silent failure — is
+ * unrepresentable too, because `lifecycleRefusalNotice` below is **total** and has no
+ * `null` arm.
+ *
+ * The kinds are the outcomes, not the status codes: `refused` is the tournament saying
+ * *no, not in this state* (a 409 — ADR-0017 chose 409 over 403 precisely because the
+ * caller is allowed to do this, the tournament merely is not ready), while `forbidden`
+ * is the server saying *not yours*. Same "it didn't happen", entirely different news.
+ */
+export type LifecycleRefusalKind =
+  /** **409** — the move is legal for this caller, but not from where the tournament
+   * stands. Two shapes, and the client cannot (and need not) tell them apart: a **stale
+   * view** clicking an edge that no longer exists ("This tournament is already
+   * published."), and go-live's **precondition** — no events, or an event with no draw
+   * or a stale one, *named* (ADR-0786). Both arrive as a sentence written for the
+   * director, and both are shown. */
+  | 'refused'
+  /** **403** — not the owner. The header offers no lifecycle button to anyone else
+   * (ADR-0015), so this means the page is looking at somebody else's tournament. */
+  | 'forbidden'
+  /** **401** — the session is gone. */
+  | 'signed-out'
+  /** **5xx** — our fault, not the director's. */
+  | 'server-error'
+  /** The request never reached the server: no response at all (a dead network, a
+   * `TypeError` from `fetch`). */
+  | 'unreachable'
+  /** Any other status. Reachable — a 404 on a tournament deleted from another tab — and
+   * kept as its own case rather than folded into `server-error`, because "we broke" and
+   * "something else happened" are not the same claim to make to a user. */
+  | 'unexpected'
+
+/** A refused transition, in words the header can render: the case it fell into, plus the
+ * `Notice` (client-owned title, server-authored sentence where that sentence is the
+ * point) — see `./notice`. */
+export interface LifecycleRefusal extends Notice {
+  kind: LifecycleRefusalKind
+}
+
+/**
+ * Turn a failed transition into the copy the director reads, beside the button they
+ * clicked.
+ *
+ * **The 409 carries the server's own sentence, verbatim**, and that is the whole design.
+ * Going live has a precondition (ADR-0786): every event must have a draw, and every draw
+ * must still seat exactly its event's entrants — registration stays open right up to the
+ * moment a tournament starts, so a draw cut on Tuesday can be stale by Wednesday. When
+ * that precondition fails, the server refuses the start with a 409 whose detail **names
+ * the events at fault** ("This tournament cannot start yet: “Open Singles” has no draw
+ * yet…"). That naming is the only actionable half of the refusal: a director with ten
+ * events, told merely "something isn't ready", is left clicking through all ten. So the
+ * client does not paraphrase it — it frames it. The title is ours ("Couldn't start the
+ * tournament", named after the edge they clicked, never after the wire call); the
+ * sentence beneath is the server's.
+ *
+ * It is the same 409 that answers a **stale tab** re-asserting an edge that no longer
+ * exists, and the two are deliberately NOT told apart: the refusal carries no code
+ * (ADR-0968's coded refusals are the entry route's), and string-sniffing the detail to
+ * choose a title would be a client re-deriving a judgement the server already made. Both
+ * shapes are sentences written for the director, and both are shown under a title that is
+ * true of both — the click did not take effect, and here is why.
+ *
+ * The other arms are designed states, not a shrug: 403, 401, 5xx and a dead network each
+ * get words of their own. There is **no `null` arm** — the header surfaces this mutation's
+ * errors inline and carries no toast (`web-client/CLAUDE.md`, ## Forms: never both), so a
+ * `null` here would be the click that did nothing and said nothing.
+ */
+export function lifecycleRefusalNotice(
+  error: unknown,
+  edge: LifecycleEdge,
+): LifecycleRefusal {
+  const fallback = fallbackNotice(error, edge.verb)
+  if (!(error instanceof ApiError)) {
+    return {
+      kind: 'unreachable',
+      title: fallback.title,
+      description:
+        'The request never reached the server, so nothing was changed. Check your ' +
+        'connection and try again.',
+    }
+  }
+
+  if (error.status >= 500) {
+    return {
+      kind: 'server-error',
+      title: 'Something went wrong on our end',
+      // Never the server's sentence here: a 5xx detail is machinery, not copy
+      // (`DEFINITION_OF_COMPLETE`: raw API detail strings never reach the UI).
+      description: `The tournament was not moved. Try again in a moment — nothing was changed.`,
+    }
+  }
+
+  switch (error.status) {
+    case 409:
+      return {
+        kind: 'refused',
+        title: fallback.title,
+        // The server's sentence — it names the events (ADR-0786), or names the status
+        // somebody else already moved this tournament to. The fallback exists only for a
+        // 409 that somehow arrives without one, and it says the one thing that is true of
+        // every shape of it: re-read the page.
+        description:
+          error.detail ??
+          'The tournament is not in a state this move can be made from. Reload the page to see where it stands.',
+      }
+    case 403:
+      return {
+        kind: 'forbidden',
+        title: "You can't move this tournament",
+        description:
+          'Only the tournament’s creator can publish, start or end it. Nothing was changed.',
+      }
+    case 401:
+      return {
+        kind: 'signed-out',
+        title: 'You are signed out',
+        description: `Sign in again, then ${edge.verb}. Nothing was changed.`,
+      }
+    default:
+      return { kind: 'unexpected', ...fallback }
+  }
 }
 
 /**

--- a/web-client/src/components/tournaments/data/notice.ts
+++ b/web-client/src/components/tournaments/data/notice.ts
@@ -14,7 +14,10 @@
 // That is not a licence to pipe raw API strings into the UI (`DEFINITION_OF_COMPLETE`:
 // "raw API detail strings never reach the UI"). It is the opposite: each surface decides,
 // per status, whether the server's sentence is *copy* (a 409 the director must act on) or
-// *machinery* (a 500's stack-shaped detail), and only the former is shown.
+// *machinery* (a 500's stack-shaped detail), and only the former is shown. The one status
+// no surface gets a say in is the 5xx — `fallbackNotice` below refuses to echo it, so the
+// FLOOR is safe and a surface that forgets a 5xx arm degrades to words rather than to a
+// stack trace.
 
 import { ApiError } from '@/api/client'
 
@@ -31,20 +34,36 @@ export interface Notice {
  * `verb` completes "Couldn't <verb>" ("cut the draw", "start the tournament"), so the
  * title names the thing the user clicked rather than the wire call that carried it.
  *
- * The two arms are the two *kinds* of nothing-happened:
- * - the request **reached** the server and it said no (`ApiError`) — show its sentence
- *   if it sent one, since an unrecognised 4xx from our own API is still our own copy;
+ * The three arms are the three *kinds* of nothing-happened:
  * - the request **never got there** at all (a `TypeError` from `fetch`, a dead network,
  *   a CORS refusal). There is no server sentence to show, and pretending otherwise
  *   ("the server rejected the request") would send the user looking for a fault that is
- *   not there.
+ *   not there;
+ * - the server **broke** (a 5xx). It sent a sentence, and we do not show it: a 5xx detail
+ *   is machinery, not copy (`DEFINITION_OF_COMPLETE`: "raw API detail strings never reach
+ *   the UI"), and it is our fault, not the user's — there is nothing for them to act on.
+ *   This arm is why the floor is a floor: a surface may add richer 5xx words of its own
+ *   (`lifecycleRefusalNotice` does), but one that *forgets* to still cannot leak a stack
+ *   trace into an `AlertDescription`;
+ * - the server **said no** (any other `ApiError`) — show its sentence if it sent one,
+ *   since an unrecognised 4xx from our own API is still our own copy.
  */
 export function fallbackNotice(error: unknown, verb: string): Notice {
+  const title = `Couldn't ${verb}`
+  if (!(error instanceof ApiError)) {
+    return {
+      title,
+      description: 'The request never reached the server. Check your connection and try again.',
+    }
+  }
+  if (error.status >= 500) {
+    return {
+      title,
+      description: 'Something went wrong on our end. Try again in a moment.',
+    }
+  }
   return {
-    title: `Couldn't ${verb}`,
-    description:
-      error instanceof ApiError
-        ? (error.detail ?? 'The server rejected the request. Try again in a moment.')
-        : 'The request never reached the server. Check your connection and try again.',
+    title,
+    description: error.detail ?? 'The server rejected the request. Try again in a moment.',
   }
 }

--- a/web-client/src/components/tournaments/data/notice.ts
+++ b/web-client/src/components/tournaments/data/notice.ts
@@ -1,0 +1,50 @@
+// What a refused write says to the person who asked for it — the one shape, shared by
+// every tournament surface that reports its own failures **inline** rather than through
+// a toast (the draw panel's `drawRefusalNotice`, the header's `lifecycleRefusalNotice`).
+//
+// It is two halves, and the split is the whole convention:
+//
+// - the **title** is the CLIENT's — the state, in a few words, in our voice;
+// - the **description** is, for the refusals that matter, the **SERVER's own sentence**,
+//   verbatim. Those sentences are authored for the director and they name the thing that
+//   has to change ("“Open Singles” has no draw yet…", "5 entrants across 3 pool(s) would
+//   leave a pool with fewer than 2 entrants…"). Replacing one with a generic string of
+//   ours would throw away the only actionable half of the refusal.
+//
+// That is not a licence to pipe raw API strings into the UI (`DEFINITION_OF_COMPLETE`:
+// "raw API detail strings never reach the UI"). It is the opposite: each surface decides,
+// per status, whether the server's sentence is *copy* (a 409 the director must act on) or
+// *machinery* (a 500's stack-shaped detail), and only the former is shown.
+
+import { ApiError } from '@/api/client'
+
+/** A refusal in words: a client-owned title, and the sentence beneath it. */
+export interface Notice {
+  title: string
+  description: string
+}
+
+/**
+ * The last-resort notice for a failure a surface has no designed state for — and the
+ * reason no `*RefusalNotice` in this folder has a `null` arm.
+ *
+ * `verb` completes "Couldn't <verb>" ("cut the draw", "start the tournament"), so the
+ * title names the thing the user clicked rather than the wire call that carried it.
+ *
+ * The two arms are the two *kinds* of nothing-happened:
+ * - the request **reached** the server and it said no (`ApiError`) — show its sentence
+ *   if it sent one, since an unrecognised 4xx from our own API is still our own copy;
+ * - the request **never got there** at all (a `TypeError` from `fetch`, a dead network,
+ *   a CORS refusal). There is no server sentence to show, and pretending otherwise
+ *   ("the server rejected the request") would send the user looking for a fault that is
+ *   not there.
+ */
+export function fallbackNotice(error: unknown, verb: string): Notice {
+  return {
+    title: `Couldn't ${verb}`,
+    description:
+      error instanceof ApiError
+        ? (error.detail ?? 'The server rejected the request. Try again in a moment.')
+        : 'The request never reached the server. Check your connection and try again.',
+  }
+}

--- a/web-client/src/components/tournaments/data/save-failure.test.ts
+++ b/web-client/src/components/tournaments/data/save-failure.test.ts
@@ -25,6 +25,32 @@ const nameTooLong = new ApiError(
   },
 )
 
+/** FastAPI's real 422 body for a pool whose name was cleared — the server's new floor
+ * (`Pool.name`, `min_length=1`). The form now refuses this save before it is sent
+ * (`poolNameSchema`), so an organizer should never meet it; a stale tab, or a
+ * hand-crafted request, still can — and what comes back must not be read out to them.
+ *
+ * ⚠️ Note the `loc`: a pool's name is nested TWO levels down, through an array INDEX
+ * (`["body", "pools", 0, "name"]`). `validationFields` drops the non-string parts and
+ * keeps the first segment after `body`, so the field it blames is `pools` — which the
+ * event's label table has a row for ("Table pools"). A 422 whose `loc` fell through to
+ * no label at all would be worded generically, which is a worse answer than naming the
+ * tab. */
+const poolNameBlank = new ApiError(
+  422,
+  'String should have at least 1 character',
+  'update event',
+  {
+    detail: [
+      {
+        type: 'string_too_short',
+        loc: ['body', 'pools', 0, 'name'],
+        msg: 'String should have at least 1 character',
+      },
+    ],
+  },
+)
+
 const say = (error: unknown): string =>
   saveFailureMessage(saveFailure(error), EVENT_SAVE_TARGET)
 
@@ -33,6 +59,17 @@ describe('saveFailure', () => {
     expect(saveFailure(nameTooLong)).toEqual<SaveFailure>({
       kind: 'invalid',
       fields: ['name'],
+    })
+  })
+
+  /** The blank pool name (#786) — the schema mirrors it client-side now, but the
+   * classifier is the backstop for the stale tab that does not know that yet. It is an
+   * `invalid`, its `loc` resolves to the `pools` field, and its `msg` — Pydantic's
+   * "String should have at least 1 character" — is thrown away, exactly like the name's. */
+  it('classifies a blank POOL name — through the array index in its loc', () => {
+    expect(saveFailure(poolNameBlank)).toEqual<SaveFailure>({
+      kind: 'invalid',
+      fields: ['pools'],
     })
   })
 
@@ -197,6 +234,16 @@ describe('saveFailureMessage', () => {
  * noun, and the labels it prints over its rows). A second copy table would pass these
  * too, and would then drift, which is the failure ADR-0968 is about.
  */
+describe('saveFailureMessage · a pool the server refused', () => {
+  /** In OUR words, naming the tab the pool is on — never the wire's. */
+  it('names the Table pools tab, and never says “String”', () => {
+    const message = say(poolNameBlank)
+    expect(message).toContain('Table pools')
+    expect(message).not.toContain('String')
+    expect(message).not.toContain('at least 1 character')
+  })
+})
+
 describe('saveFailureMessage · the tournament dialog', () => {
   const sayTournament = (error: unknown): string =>
     saveFailureMessage(saveFailure(error), TOURNAMENT_SAVE_TARGET)

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -7,6 +7,7 @@ import type {
   Address,
   Entrant,
   EventEntryState,
+  Fixture,
   Pool,
   Predicate,
   Tournament,
@@ -127,6 +128,11 @@ export function buildEvent(
     predicates: [],
     match: { rated: true, lengthGames: 5 },
     pools: [buildPool()],
+    // NO DRAW CUT (ADR-0786) — `[]` is the designed state of an event whose director
+    // has not cut one, and it is the state every event starts in. An override, not a
+    // derivation: the same field makes a different draw across two pools than across
+    // three, so a fixture that quietly cut one would be inventing a decision.
+    fixtures: [],
     ...overrides,
   } satisfies Omit<TournamentEvent, 'entered'>
   // An **uncapped** event (`maxPlayers: null`, ADR-0935) is never `event_full` —
@@ -210,6 +216,102 @@ export function buildIneligibleEvent(
       predicateId: rule.id,
       rating: UNROUNDED_RATING,
     },
+    ...overrides,
+  })
+}
+
+/** One fixture of a cut draw (ADR-0786): round 1, position 1 of `Pool A`, between the
+ * first two entrants, undecided and not yet a match.
+ *
+ * Every `null` is a fact, so none of them is a default worth having *silently*: pass
+ * `entryBId: null` for a **TBD** side (never a bye — a bye is the ABSENCE of a fixture),
+ * `poolId: null` for an un-pooled (knockout) fixture. */
+export function buildFixture(overrides: Partial<Fixture> = {}): Fixture {
+  return {
+    id: 'fx-1',
+    poolId: 'p-a',
+    round: 1,
+    position: 1,
+    entryAId: 'entry-1',
+    entryBId: 'entry-2',
+    winnerEntryId: null,
+    matchId: null,
+    ...overrides,
+  }
+}
+
+/**
+ * An event whose draw **is cut**: a round-robin U1200 Singles, five entrants
+ * (`player.1`…`player.5`) dealt across two pools by the snake the API uses, and the
+ * fixtures that field really produces.
+ *
+ *     Pool A — player.1, player.4, player.5   (ODD: 3 rounds of ONE fixture)
+ *     Pool B — player.2, player.3             (1 round of one fixture)
+ *
+ * The odd pool is the point of the fixture. Pool A's rounds hold one fixture each
+ * because the third player **sits that round out** — and that is all a bye is
+ * (ADR-0786: "a bye is modeled as absence"; an odd round-robin pool simply has fewer
+ * fixtures per round). A factory that dealt two even pools could not tell a renderer
+ * that invents a "bye" row from one that doesn't.
+ *
+ * The fixtures are listed in the server's order (pool → round → position). A test that
+ * wants to prove the panel *sorts* rather than trusting that order passes a shuffled
+ * `fixtures` override.
+ */
+export function buildDrawnEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  return buildEvent({
+    id: 'ev-u1200',
+    name: 'U1200 Singles',
+    drawType: 'round-robin',
+    maxPlayers: 24,
+    entrants: buildEntrants(5),
+    pools: [
+      buildPool({ id: 'p-a', name: 'Pool A' }),
+      buildPool({
+        id: 'p-b',
+        name: 'Pool B',
+        slot: { date: '2026-06-13', start: '13:30', end: '17:00' },
+      }),
+    ],
+    fixtures: [
+      // Pool A: the all-play-all of players 1, 4 and 5 — one fixture a round, the third
+      // player sitting out each time.
+      buildFixture({
+        id: 'fx-a-1',
+        poolId: 'p-a',
+        round: 1,
+        position: 1,
+        entryAId: 'entry-1',
+        entryBId: 'entry-4',
+      }),
+      buildFixture({
+        id: 'fx-a-2',
+        poolId: 'p-a',
+        round: 2,
+        position: 1,
+        entryAId: 'entry-1',
+        entryBId: 'entry-5',
+      }),
+      buildFixture({
+        id: 'fx-a-3',
+        poolId: 'p-a',
+        round: 3,
+        position: 1,
+        entryAId: 'entry-4',
+        entryBId: 'entry-5',
+      }),
+      // Pool B: two players, so one fixture, and the draw is done.
+      buildFixture({
+        id: 'fx-b-1',
+        poolId: 'p-b',
+        round: 1,
+        position: 1,
+        entryAId: 'entry-2',
+        entryBId: 'entry-3',
+      }),
+    ],
     ...overrides,
   })
 }

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -82,6 +82,42 @@ export interface Pool {
   tableIds: string[]
 }
 
+/**
+ * One planned pairing of an event's **draw** (ADR-0786): a round and a position —
+ * plus a pool, when the draw is pooled — whose sides may still be unknown.
+ *
+ * A fixture is **not a match**. It materializes into one later (#788), and until it
+ * does `matchId` is `null`. The whole set of an event's fixtures is its draw; an event
+ * with no draw cut has `fixtures: []` (the designed empty state, never `null`).
+ *
+ * **Entrant names are deliberately not here.** A fixture carries entry *ids*, and the
+ * usernames behind them are already on the page — the event's `entrants` list is keyed
+ * by that very id — so a renderer joins the two. Copying the username onto the fixture
+ * as well would be carrying a field and its own derivation, and the two copies would
+ * drift the moment a player is renamed.
+ *
+ * The `null`s are all facts, and they are three different facts:
+ * - `entryAId` / `entryBId` — **TBD**: the feeding fixture is not decided yet. Never a
+ *   bye; a bye is the *absence of a fixture*, not a fixture with an empty side.
+ * - `winnerEntryId` — undecided.
+ * - `matchId` — not yet materialized.
+ * - `poolId` — this fixture belongs to no pool: the draw is un-pooled (single-elim), or
+ *   this is the KO stage of an rr-then-ko. When set, it names a `Pool` in this same
+ *   event's `pools`.
+ *
+ * Parsed at the boundary by `./fixtures` — this interface is what comes out.
+ */
+export interface Fixture {
+  id: string
+  poolId: string | null
+  round: number
+  position: number
+  entryAId: string | null
+  entryBId: string | null
+  winnerEntryId: string | null
+  matchId: string | null
+}
+
 /** One *active* entry in an event. Withdrawn entries are not entrants — they
  * appear in neither this list nor the `entered` count (ADR-0016).
  *
@@ -175,6 +211,15 @@ export interface TournamentEvent {
   predicates: Predicate[]
   match: MatchSettings
   pools: Pool[]
+  /** This event's **draw** — every fixture the cut produced, in pool → round → position
+   * order, as the server sends them (ADR-0786).
+   *
+   * **`[]` is the designed "no draw cut" state**, and it is the state every event is
+   * born in: cutting is an explicit, reviewable act (`POST …/draw`), and nothing else
+   * creates fixtures. Read it; never write it — a draw changes only through the two
+   * draw verbs, never through an event PATCH (which is why `eventToUpdateBody` omits
+   * it, exactly as it omits the server-derived `entered`). */
+  fixtures: Fixture[]
 }
 
 /** A physical table in the venue catalogue, referenced by id from a

--- a/web-client/src/components/tournaments/field.factory.tsx
+++ b/web-client/src/components/tournaments/field.factory.tsx
@@ -1,8 +1,6 @@
-import type { ReactNode } from 'react'
-
 import { Input } from '@/components/ui/input'
 
-import type { FieldBase, FieldProps } from './field'
+import type { FieldBase, FieldControl, FieldProps } from './field'
 import type { ReadOnlyValueContent } from './read-only-value'
 
 /** Overrides for `buildFieldProps`. Flat, unlike `FieldProps` itself: a test may
@@ -12,18 +10,25 @@ export type FieldOverrides = Partial<FieldBase> & {
   readOnly?: boolean
   value?: ReadOnlyValueContent
   valueClassName?: string
-  children?: (controlId: string) => ReactNode
+  children?: FieldControl
 }
 
 /** Props for `Field` — a required "Name" row wrapping a plain text input.
  * Naming `readOnly` puts the row in the read-only-capable branch, where the
- * component requires a `value`; omitting it keeps the row an editor. */
+ * component requires a `value`; omitting it keeps the row an editor.
+ *
+ * The default control wires **both** ids the row hands it — `id` and
+ * `aria-describedby` — because that is what a well-formed call site does
+ * (`FieldControl`), and a factory that dropped the description would make the row's
+ * own hint association untestable through it. */
 export function buildFieldProps(overrides: FieldOverrides = {}): FieldProps {
   const { readOnly, value, valueClassName, ...rest } = overrides
   const editor = {
     label: 'Name',
     required: true,
-    children: (id: string) => <Input id={id} defaultValue="" />,
+    children: ((id, hintId) => (
+      <Input id={id} aria-describedby={hintId} defaultValue="" />
+    )) satisfies FieldControl,
     ...rest,
   }
   return readOnly === undefined

--- a/web-client/src/components/tournaments/field.test.tsx
+++ b/web-client/src/components/tournaments/field.test.tsx
@@ -16,6 +16,38 @@ describe('Field', () => {
     expect(fieldPage.queryHint('Required')).toHaveClass('text-[color:var(--loss)]')
   })
 
+  // The hint is the sentence that explains the control — a validation message, or the
+  // reason a control is frozen (ADR-0786). Rendered as a bare `<p>` with no `id` it is
+  // *below* the control on screen and nowhere at all in the accessibility tree, which
+  // is how the draw-type select came to be disabled, explained in text, and yet
+  // `aria-describedby: null` to anyone hearing the page rather than seeing it.
+  describe('the hint association', () => {
+    it('hands the control the id of the hint it renders', () => {
+      fieldPage.render({ label: 'Player limit', hint: 'Blank = no cap.' })
+
+      const describedBy = fieldPage
+        .getControl('Player limit')
+        .getAttribute('aria-describedby')
+      expect(describedBy).toBeTruthy()
+      // …and it resolves to the hint itself. Asserting merely that *an* id is set would
+      // pass on one pointing at nothing — a description that describes nothing.
+      expect(document.getElementById(describedBy!)).toHaveTextContent(
+        'Blank = no cap.',
+      )
+    })
+
+    it('hands the control NO id when the row shows no hint', () => {
+      // A dangling `aria-describedby` is a WCAG failure of its own
+      // (`aria-valid-attr-value`), so the row must hand out `undefined` — not an id
+      // for an element it never rendered.
+      fieldPage.render({ label: 'Player limit' })
+
+      expect(fieldPage.getControl('Player limit')).not.toHaveAttribute(
+        'aria-describedby',
+      )
+    })
+  })
+
   // ADR 0015: `Field` owns the read-only *branch*, not merely a flag. The row is
   // handed both its control and the value it holds, and decides between them —
   // so a call site cannot leak a live control to a reader by forgetting a

--- a/web-client/src/components/tournaments/field.tsx
+++ b/web-client/src/components/tournaments/field.tsx
@@ -38,8 +38,11 @@ type FieldReadable = {
   valueClassName?: string
   /** The control, for an editor. Not called in the read-only branch — and a row
    * that is *only* ever a view (one inside a subtree the editor never renders,
-   * like a read-only pool card) has no control to give. */
-  children?: (controlId: string) => ReactNode
+   * like a read-only pool card) has no control to give.
+   *
+   * The second argument is the **hint's id** (`undefined` when the row shows no
+   * hint) — see `FieldControl`. */
+  children?: FieldControl
 }
 
 /** A row that is always an editor (a create form, say) needs no reader's value. */
@@ -47,8 +50,33 @@ type FieldEditorOnly = {
   readOnly?: undefined
   value?: undefined
   valueClassName?: undefined
-  children: (controlId: string) => ReactNode
+  children: FieldControl
 }
+
+/**
+ * A row's control, given the ids it must wire itself with:
+ *
+ * - `controlId` — the id the label's `htmlFor` targets (a real input sets it as `id`;
+ *   a non-input control points `aria-labelledby` at `${controlId}-label` instead).
+ * - `hintId` — the id of the row's **hint**, or `undefined` when the row is showing
+ *   none. A control with a hint must point `aria-describedby` at it: the hint is the
+ *   sentence that explains the control (a validation message, or — for the draw type
+ *   under a cut draw, ADR-0786 — the reason it is disabled and the way out of it), and
+ *   a `<p>` that merely sits *below* a control is next to it on screen and nowhere at
+ *   all to a screen reader. A **disabled** control is the case that bites: it is not
+ *   focusable, holds no tooltip anyone will hear, and so has literally no other channel
+ *   to say why it is dead — which is the unexplained dead end ADR-0015 forbids.
+ *
+ * It is passed rather than applied because `children` is a render prop returning an
+ * opaque `ReactNode`: `Field` cannot reach into it and set an attribute. What `Field`
+ * *can* guarantee is that the id it hands out is the id it rendered — and that it hands
+ * out `undefined` when there is no hint, so no control can describe itself by an element
+ * that isn't there (a dangling `aria-describedby` is an axe violation of its own).
+ */
+export type FieldControl = (
+  controlId: string,
+  hintId: string | undefined,
+) => ReactNode
 
 export type FieldProps = FieldBase & (FieldReadable | FieldEditorOnly)
 
@@ -93,6 +121,10 @@ export const Field = ({
 }: FieldProps) => {
   const id = useId()
   const showHint = hint && !readOnly
+  // Handed to the control ONLY while the hint is really on screen: a control that
+  // described itself by an id nothing renders would be pointing at nothing, which is
+  // both useless to a screen reader and an `aria-valid-attr-value` violation.
+  const hintId = showHint ? `${id}-hint` : undefined
   return (
     <div className={cn('flex flex-col gap-1.5', className)}>
       <Label
@@ -110,10 +142,11 @@ export const Field = ({
       {readOnly ? (
         <ReadOnlyValue className={valueClassName}>{value}</ReadOnlyValue>
       ) : (
-        children?.(id)
+        children?.(id, hintId)
       )}
       {showHint && (
         <p
+          id={hintId}
           className={cn(
             'text-[11px]',
             error ? 'text-[color:var(--loss)]' : 'text-[color:var(--fg-3)]',

--- a/web-client/src/components/tournaments/tournament-detail-page.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.page.tsx
@@ -17,6 +17,18 @@ const scoped = (container: Container) => ({
   getLifecycleButton(name: RegExp) {
     return container.getByRole('button', { name })
   },
+  /** The hero's status pill (`StatusBadge`) — the page's one claim about where the
+   * tournament stands. Read it after a refused transition: nothing here is optimistic,
+   * so a refused **Start tournament** must leave it saying **Published**. */
+  getStatusBadge() {
+    return container.getByTestId('tournament-status-badge')
+  },
+  /** The header's inline lifecycle refusal, as one normalised string — title and the
+   * server's sentence beneath it. */
+  async findLifecycleNoticeText() {
+    const notice = await container.findByTestId('lifecycle-notice')
+    return (notice.textContent ?? '').replace(/\s+/g, ' ').trim()
+  },
   /** The Days stat's figure and its unit, read as one string. The unit is a
    * styled `<span>` sitting beside the figure, so the DOM text carries no space
    * ("2days") even though a CSS margin renders one — assert against the DOM, not

--- a/web-client/src/components/tournaments/tournament-detail-page.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.test.tsx
@@ -128,6 +128,50 @@ describe('TournamentDetailPage', () => {
     expect(onUpdate).not.toHaveBeenCalled()
   })
 
+  /**
+   * The go-live precondition, on the page the director is actually looking at (ADR-0786).
+   *
+   * Two claims, and the second is the one only a page-level test can make: the refusal
+   * reaches the director **with the offending event named**, and the page goes on
+   * telling the truth about where the tournament stands — the pill still reads
+   * **Published**, because nothing here is optimistic. A component that flipped the
+   * status locally and walked it back would pass every assertion in
+   * `lifecycle-actions.test` and fail this one.
+   */
+  it('shows a refused Start — naming the event — and leaves the pill on Published', async () => {
+    const detail =
+      'This tournament cannot start yet: “Open Singles” has no draw yet. A draw is cut ' +
+      'from the field as it stands at the time, and registration stays open right up ' +
+      'to the moment a tournament goes live — so cut the draw for each event named ' +
+      '(again, if somebody entered or withdrew since it was last cut), then start the ' +
+      'tournament.'
+    mockTournamentTransitionEndpoint(server, () =>
+      HttpResponse.json({ detail }, { status: 409 }),
+    )
+    tournamentDetailPagePage.render({
+      tournament: buildTournament({ id: 't-1', status: 'published' }),
+    })
+
+    await userEvent.click(
+      tournamentDetailPagePage.getLifecycleButton(/Start tournament/),
+    )
+
+    const notice = await tournamentDetailPagePage.findLifecycleNoticeText()
+    expect(notice).toContain("Couldn't start the tournament")
+    expect(notice).toContain('“Open Singles” has no draw yet')
+
+    expect(tournamentDetailPagePage.getStatusBadge()).toHaveTextContent('Published')
+    expect(tournamentDetailPagePage.getStatusBadge()).toHaveAttribute(
+      'data-status',
+      'published',
+    )
+    // …and the button they were refused is still the button on offer, not "End
+    // tournament" — the tournament did not move.
+    expect(
+      tournamentDetailPagePage.getLifecycleButton(/Start tournament/),
+    ).toBeInTheDocument()
+  })
+
   it('opens the event editor and creates a new event', async () => {
     const onCreateEvent = vi.fn().mockResolvedValue(undefined)
     tournamentDetailPagePage.render({

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
@@ -20,6 +20,21 @@ const scoped = (container: Container) => ({
   getPlayerLimitInput() {
     return container.getByLabelText(/Player limit/)
   },
+  /** A pool's name box (Table pools). Singular: the seeded event has one pool, and a
+   * test that wants two says so and reads them off `getPoolNameInputs()`. */
+  getPoolNameInput() {
+    return container.getByLabelText('Pool name')
+  },
+  getPoolNameInputs() {
+    return container.queryAllByLabelText('Pool name')
+  },
+  /** The red messages under the pool name boxes, in card order — the Table pools
+   * counterpart of `queryFieldError` on Basics and `getRuleErrors()` on Eligibility. */
+  getPoolNameErrors(): (string | null)[] {
+    return container
+      .queryAllByTestId('pool-name-error')
+      .map((node: HTMLElement) => node.textContent)
+  },
   /** A red message under a Basics field (the `Field` row's error `hint`) — the
    * counterpart of `getRuleErrors()` on the other tab. Queried by the text the
    * organizer reads. */

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -4,7 +4,12 @@ import userEvent from '@testing-library/user-event'
 import { ApiError } from '@/api/client'
 import { screen, waitFor } from '@/test/utilities'
 
-import { buildEvent, buildPool, buildPredicate } from '../data/seed.factory'
+import {
+  buildEvent,
+  buildFixture,
+  buildPool,
+  buildPredicate,
+} from '../data/seed.factory'
 import { eventEditorPage } from './event-editor.page'
 
 // A name genuinely past the server's VARCHAR(255) limit — the #933 case. A short
@@ -423,6 +428,96 @@ describe('EventEditor', () => {
 
       await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
       expect(eventEditorPage.queryFailure()).toBeNull()
+    })
+
+    // **The race.** The editor disables the add/remove-pool controls of an event whose
+    // draw is cut (ADR-0786) — but "is the draw cut?" was answered when the page loaded.
+    // A director with two tabs open, or a co-director across the hall, can cut one after
+    // that, and this sheet's live-looking Add button becomes a change the server will
+    // refuse. So the 409 has to land somewhere designed, and it does: the same inline
+    // banner, with the SERVER's sentence, which is the only copy that knows which pool
+    // went missing and that the way out is to delete the draw.
+    //
+    // That sentence survives *because* `saveFailure` classifies a 409 as `refused` (prose
+    // the API wrote for a human) rather than as `invalid` (a validator's machine words,
+    // which are never shown). This test is what stops a future tidy-up from collapsing
+    // the two.
+    it('surfaces a pool-set 409 with the server’s own sentence — the cut-draw race', async () => {
+      const refusal =
+        'This event’s draw is already cut, so its set of pools is frozen: “Pool B” ' +
+        'already has fixtures drawn into it. A pool’s tables, its time and its name ' +
+        'can all still be changed. To add, remove or re-identify a pool, remove the ' +
+        'draw first, then cut it again.'
+      const onSave = rejectWith(
+        new ApiError(409, refusal, 'update event', { detail: refusal }),
+      )
+      const onOpenChange = vi.fn()
+      eventEditorPage.render({
+        event: buildEvent({ id: 'ev-1', pools: [buildPool()] }),
+        onSave,
+        onOpenChange,
+      })
+
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      await waitFor(() =>
+        expect(eventEditorPage.queryFailure()).toBeInTheDocument(),
+      )
+      expect(eventEditorPage.queryFailure()).toHaveTextContent(refusal)
+      // Not swallowed, not a raw crash, and not a closed sheet over a discarded draft.
+      expect(eventEditorPage.querySheet()).toBeInTheDocument()
+      expect(onOpenChange).not.toHaveBeenCalled()
+      expect(eventEditorPage.queryFailure()).toHaveTextContent(
+        'your changes are still here',
+      )
+    })
+  })
+
+  // The two freezes, wired end to end through the real sheet — the sections own the
+  // controls, the editor owns the derivation, and this is the seam between them. Both
+  // are read off the event's `fixtures`, which is not a form field: nothing on this
+  // sheet can cut or delete a draw.
+  describe('an event whose draw is cut', () => {
+    const drawn = () =>
+      buildEvent({
+        id: 'ev-1',
+        drawType: 'round-robin',
+        pools: [buildPool()],
+        fixtures: [buildFixture({ poolId: 'p-1' })],
+      })
+
+    it('freezes the draw type on Basics and the pool set on Table pools', async () => {
+      eventEditorPage.render({ event: drawn() })
+
+      // Basics is the tab it opens on.
+      expect(
+        screen.getByRole('combobox', { name: 'Draw type' }),
+      ).toBeDisabled()
+      // …while the format beside it — which no fixture depends on — stays live.
+      expect(screen.getByRole('combobox', { name: 'Format' })).toBeEnabled()
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      expect(screen.getByRole('button', { name: 'Add pool' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Remove pool' })).toBeDisabled()
+      expect(screen.getByTestId('pools-frozen-notice')).toHaveTextContent(
+        'Delete the draw',
+      )
+      // The venue attributes the freeze exists to protect are still editable.
+      expect(screen.getByLabelText('Pool name')).toBeEnabled()
+      expect(screen.getByRole('button', { name: 'T1' })).toBeEnabled()
+    })
+
+    it('freezes nothing when no draw is cut', async () => {
+      eventEditorPage.render({
+        event: buildEvent({ id: 'ev-1', pools: [buildPool()] }),
+      })
+
+      expect(screen.getByRole('combobox', { name: 'Draw type' })).toBeEnabled()
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      expect(screen.getByRole('button', { name: 'Add pool' })).toBeEnabled()
+      expect(screen.getByRole('button', { name: 'Remove pool' })).toBeEnabled()
+      expect(screen.queryByTestId('pools-frozen-notice')).toBeNull()
     })
   })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -283,6 +283,154 @@ describe('EventEditor', () => {
   })
 
   /**
+   * The same lesson, one tab over — and the last field in this editor that could still
+   * author a 422 (#786).
+   *
+   * The pools editor **mints** a pool's id and its default name ("Pool A"), so the happy
+   * path could never make a blank one. But the name **box is live**, and an emptied box
+   * was a save the form allowed and the server refused — with Pydantic's own prose
+   * ("String should have at least 1 character") arriving in the editor's banner, naming
+   * no field, in the wire's vocabulary. The API now states the floor (`Pool.name`,
+   * `min_length=1`), and this is what means the organizer never meets it.
+   *
+   * ⚠️ The assertion that discriminates is **`onSave`**, not the red. A form that
+   * rendered the message and fired the request anyway would sail through a test that
+   * only looked for the message — and the 422 would come back and land in the banner
+   * exactly as before. Nothing may be *sent*.
+   */
+  describe('a pool the server would refuse', () => {
+    it('refuses a BLANK pool name in the form, and sends nothing', async () => {
+      const onSave = vi.fn()
+      eventEditorPage.render({
+        event: buildEvent({ pools: [buildPool({ name: 'Pool A' })] }),
+        onSave,
+      })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      await userEvent.clear(eventEditorPage.getPoolNameInput())
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      // Nothing left the room — so the 422 that would have come back never existed.
+      expect(onSave).not.toHaveBeenCalled()
+      expect(eventEditorPage.getPoolNameInput()).toHaveAttribute(
+        'aria-invalid',
+        'true',
+      )
+      expect(eventEditorPage.getPoolNameErrors()).toEqual(['Name is required.'])
+      // And no banner: a banner reports a refusal that came back from somewhere.
+      expect(eventEditorPage.queryFailure()).toBeNull()
+    })
+
+    // A space is not a name, and the server agrees — Pydantic's `min_length` counts the
+    // characters it was *sent*, so a client that trimmed only on display would post
+    // `" "` and be refused. The schema trims first, exactly as the event's name does.
+    it('refuses a WHITESPACE-ONLY pool name, and sends nothing', async () => {
+      const onSave = vi.fn()
+      eventEditorPage.render({
+        event: buildEvent({ pools: [buildPool({ name: 'Pool A' })] }),
+        onSave,
+      })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      await userEvent.clear(eventEditorPage.getPoolNameInput())
+      await userEvent.type(eventEditorPage.getPoolNameInput(), '   ')
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      expect(onSave).not.toHaveBeenCalled()
+      expect(eventEditorPage.getPoolNameErrors()).toEqual(['Name is required.'])
+    })
+
+    it('takes the organizer to TABLE POOLS, where the broken pool is', async () => {
+      // A message on a tab you cannot see is indistinguishable from a button that does
+      // nothing — the rule builder's lesson, and the name box's, applied to the fourth
+      // tab. The editor opens on Basics, so this proves it really moves them.
+      const onSave = vi.fn()
+      eventEditorPage.render({
+        event: buildEvent({ pools: [buildPool({ name: '' })] }),
+        onSave,
+      })
+
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      expect(eventEditorPage.getSectionTab('Table pools')).toHaveAttribute(
+        'aria-selected',
+        'true',
+      )
+      expect(onSave).not.toHaveBeenCalled()
+    })
+
+    // Per ROW, not per section: the red belongs under the box that is empty. A section
+    // that raised one error for the whole list would point a director with six pools at
+    // all six.
+    it('reds the pool that is blank, and leaves the one that is not alone', async () => {
+      eventEditorPage.render({
+        event: buildEvent({
+          pools: [
+            buildPool({ id: 'p-a', name: '' }),
+            buildPool({ id: 'p-b', name: 'Pool B' }),
+          ],
+        }),
+      })
+
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      expect(eventEditorPage.getPoolNameErrors()).toEqual(['Name is required.'])
+      const [blank, named] = eventEditorPage.getPoolNameInputs()
+      expect(blank).toHaveAttribute('aria-invalid', 'true')
+      expect(named).not.toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('says nothing in red until the organizer actually tries to save', async () => {
+      eventEditorPage.render({
+        event: buildEvent({ pools: [buildPool({ name: 'Pool A' })] }),
+      })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      await userEvent.clear(eventEditorPage.getPoolNameInput())
+
+      // A box they are halfway through re-typing is not yet wrong.
+      expect(eventEditorPage.getPoolNameErrors()).toEqual([])
+    })
+
+    it('clears the message the moment the name is typed, and then saves', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({
+        event: buildEvent({ pools: [buildPool({ name: '' })] }),
+        onSave,
+      })
+
+      await userEvent.click(eventEditorPage.getSaveButton())
+      expect(eventEditorPage.getPoolNameErrors()).toEqual(['Name is required.'])
+
+      await userEvent.type(eventEditorPage.getPoolNameInput(), 'Championship')
+
+      await waitFor(() => expect(eventEditorPage.getPoolNameErrors()).toEqual([]))
+      await userEvent.click(eventEditorPage.getSaveButton())
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      expect(onSave.mock.calls.at(-1)?.[0].pools[0].name).toBe('Championship')
+    })
+
+    // The name is trimmed on the way out, so what is saved is the name that will be
+    // read off a wall — and what is *counted* by the server's `min_length` is the same
+    // string the client judged.
+    it('saves the pool name trimmed', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({
+        event: buildEvent({ pools: [buildPool({ name: 'Pool A' })] }),
+        onSave,
+      })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      await userEvent.clear(eventEditorPage.getPoolNameInput())
+      await userEvent.type(eventEditorPage.getPoolNameInput(), '  Championship  ')
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      expect(onSave.mock.calls.at(-1)?.[0].pools[0].name).toBe('Championship')
+    })
+  })
+
+  /**
    * THE data-loss half — and the half that matters most, because client validation
    * only ever prevents the refusals we already know about. Whatever the *next*
    * unknown 422 is, it must not silently eat somebody's work: the sheet stays open,

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/sheet'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
+import { drawTypeFreeze, poolSetFreeze, type EditFreeze } from '../data/draw'
 import { eligibilityIssues } from '../data/predicate-validation'
 import {
   EVENT_SAVE_TARGET,
@@ -205,6 +206,20 @@ export const EventEditor = ({
     entryFee: errors.entryFee?.message,
   }
 
+  // **What a cut draw freezes** (ADR-0786), derived from the SAVED event and never from
+  // the draft: `fixtures` is not a form field — nothing on this sheet can cut a draw or
+  // remove one — so the draft's copy of it is the server's answer, unedited. An event
+  // still being created (`event === null`) has no draw, and cannot: there is nobody
+  // entered to deal.
+  //
+  // Two freezes, two controls, two different tabs — so they are two values, not one
+  // `frozen: boolean` handed to both. The pools section may not add or remove a pool;
+  // the Basics tab may not re-label the draw type. Everything else on both tabs stays
+  // live, including — pointedly — a pool's tables, window and name.
+  const OPEN: EditFreeze = { kind: 'open' }
+  const poolsFreeze = event ? poolSetFreeze(event) : OPEN
+  const drawTypeLock = event ? drawTypeFreeze(event) : OPEN
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
@@ -248,6 +263,7 @@ export const EventEditor = ({
                   event={draft}
                   canEdit={canEdit}
                   errors={basicsErrors}
+                  drawTypeFreeze={drawTypeLock}
                   onChange={applyChange}
                 />
               </TabsContent>
@@ -270,6 +286,7 @@ export const EventEditor = ({
                   control={form.control}
                   tables={tables}
                   canEdit={canEdit}
+                  freeze={poolsFreeze}
                 />
               </TabsContent>
             </Tabs>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -16,6 +16,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 import { drawTypeFreeze, poolSetFreeze, type EditFreeze } from '../data/draw'
+import { poolNameIssues } from '../data/event-validation'
 import { eligibilityIssues } from '../data/predicate-validation'
 import {
   EVENT_SAVE_TARGET,
@@ -75,9 +76,9 @@ const SECTIONS = [
  * - It *checks the draft first* (`eventSchema`, `./event-form`) and refuses to send
  *   one the server would 422 — a blank or 256-character name, a cap of `0` or of ten
  *   billion, a missing entry fee, a rule with no value, a `between` with one bound or
- *   an inverted pair — pointing the organizer at the tab holding the offending field
- *   instead. That is a Zod schema mirroring the server's constraints, which is the
- *   house rule for a form (`CLAUDE.md`, `## Forms`).
+ *   an inverted pair, **a pool whose name has been cleared** — pointing the organizer
+ *   at the tab holding the offending field instead. That is a Zod schema mirroring the
+ *   server's constraints, which is the house rule for a form (`CLAUDE.md`, `## Forms`).
  *
  *   What it does **not** refuse is a *blank player limit*: that is an uncapped event
  *   (ADR-0935), it is a real answer, and it saves as `null`.
@@ -158,6 +159,17 @@ export const EventEditor = ({
   // filled in yet is not yet wrong.
   const watchedPredicates = useWatch({ control: form.control, name: 'predicates' })
   const ruleIssues = eligibilityIssues(watchedPredicates ?? [])
+
+  // …and the same arrangement for the POOLS, for the same two reasons and one more of
+  // its own. The resolver refuses the save (`poolNameSchema` inside `eventSchema`); this
+  // is what puts the red under the box that is empty. It is computed from live form
+  // values rather than read off `errors.pools` because a pool card writes its edits back
+  // through `useFieldArray`'s `update()`, which — unlike append/remove — does NOT re-run
+  // the resolver (RHF 7.81). Read off the errors, the red would outlive the fix: it
+  // would sit under a name the organizer had already re-typed, until they pressed Save
+  // again to find out they were done.
+  const watchedPools = useWatch({ control: form.control, name: 'pools' })
+  const poolIssues = poolNameIssues(watchedPools ?? [])
 
   const applyChange = (next: TournamentEvent) => {
     // Don't validate until the user has tried to save once — otherwise a new
@@ -287,6 +299,7 @@ export const EventEditor = ({
                   tables={tables}
                   canEdit={canEdit}
                   freeze={poolsFreeze}
+                  nameIssues={isSubmitted ? poolIssues : undefined}
                 />
               </TabsContent>
             </Tabs>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.factory.tsx
@@ -1,10 +1,24 @@
+import { drawTypeFreeze } from '../../data/draw'
 import { buildEvent } from '../../data/seed.factory'
 import type { BasicsSectionProps } from './basics-section'
 
 /** Props for `BasicsSection` — the seeded Open Singles event, editable (the
- * creator's view). Pass `canEdit: false` for a viewer's read-only rendering. */
+ * creator's view). Pass `canEdit: false` for a viewer's read-only rendering.
+ *
+ * `drawTypeFreeze` is **derived from the event**, exactly as the editor derives it
+ * (`event-editor.tsx`), rather than defaulting to `open`: seed an event whose draw is
+ * cut (`buildDrawnEvent`) and its draw type is frozen here too, with no second prop to
+ * remember. A fixture that could hand a drawn event to an unfrozen control would seed a
+ * state the app never produces — and a test written against it would prove nothing. */
 export function buildBasicsSectionProps(
   overrides: Partial<BasicsSectionProps> = {},
 ): BasicsSectionProps {
-  return { event: buildEvent(), canEdit: true, onChange: () => {}, ...overrides }
+  const event = overrides.event ?? buildEvent()
+  return {
+    event,
+    canEdit: true,
+    drawTypeFreeze: drawTypeFreeze(event),
+    onChange: () => {},
+    ...overrides,
+  }
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
@@ -29,6 +29,12 @@ const scoped = (container: Container) => ({
   getFormatTrigger() {
     return container.getByRole('combobox', { name: 'Format' })
   },
+  /** The draw-type select. Present-but-**disabled** once the event's draw is cut
+   * (ADR-0786) — so it is queried by role, not by "an enabled combobox": the state
+   * under test is a control that is there, readable, and dead. */
+  getDrawTypeTrigger() {
+    return container.getByRole('combobox', { name: 'Draw type' })
+  },
   /** The player-limit helper text — form furniture, and so absent from the
    * read-only view (ADR 0015). It is also the one place the editor says out loud
    * that leaving the box empty is *allowed* (ADR-0935). */

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
@@ -27,6 +27,28 @@ describe('BasicsSection', () => {
       expect(screen.getByText(/Delete the draw to change the type/i)).toBeInTheDocument()
     })
 
+    // …and the trigger POINTS at that reason. Rendering the sentence under the control
+    // puts it *beside* the control on screen and nowhere at all in the accessibility
+    // tree: a disabled trigger is not focusable and holds no tooltip, so
+    // `aria-describedby` is the only channel it has left. The pools section one tab over
+    // wired exactly this freeze correctly (`pools-frozen-notice`), while here the
+    // `Field` hint had no `id` to point at and the trigger's description was `null` —
+    // the same dead end, said out loud to sighted directors only.
+    it('points the disabled select at the reason (aria-describedby)', () => {
+      basicsSectionPage.render({ event: buildDrawnEvent() })
+
+      const trigger = basicsSectionPage.getDrawTypeTrigger()
+      const describedBy = trigger.getAttribute('aria-describedby')
+      expect(describedBy).toBeTruthy()
+
+      // The id resolves to the element that really holds the reason — not merely to
+      // *an* id (a dangling `aria-describedby` describes nothing, and is a WCAG
+      // failure of its own).
+      const description = document.getElementById(describedBy!)
+      expect(description).toHaveTextContent(/its draw type is frozen/i)
+      expect(description).toHaveTextContent(/Delete the draw to change the type/i)
+    })
+
     it('leaves the select live when no draw is cut', () => {
       basicsSectionPage.render({ event: buildEvent() })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
@@ -1,9 +1,55 @@
 import { fireEvent, screen } from '@/test/utilities'
 
-import { buildEvent } from '../../data/seed.factory'
+import { buildDrawnEvent, buildEvent } from '../../data/seed.factory'
 import { basicsSectionPage } from './basics-section.page'
 
 describe('BasicsSection', () => {
+  // ADR-0786: the draw type is the strategy that DEALT the event's fixtures, so once a
+  // draw exists it is frozen (the server 409s a change). The editor declines to build
+  // that change — and says why, and how to undo the block, because a director who is
+  // only stopped is stuck.
+  describe('the draw type, once the draw is cut', () => {
+    it('disables the select and says why, with the way out', () => {
+      basicsSectionPage.render({ event: buildDrawnEvent() })
+
+      // Still shown, and still readable — it is a fact about the event they came to
+      // check. It just cannot be changed.
+      const trigger = basicsSectionPage.getDrawTypeTrigger()
+      expect(trigger).toBeDisabled()
+      expect(trigger).toHaveTextContent('Round robin')
+
+      // The reason lives in text under the control, because a disabled trigger holds no
+      // tooltip a screen reader would ever read. It names the type the fixtures were
+      // dealt as — in the select's own words, never `round-robin`.
+      expect(
+        screen.getByText(/its draw type is frozen/i),
+      ).toHaveTextContent('“Round robin”')
+      expect(screen.getByText(/Delete the draw to change the type/i)).toBeInTheDocument()
+    })
+
+    it('leaves the select live when no draw is cut', () => {
+      basicsSectionPage.render({ event: buildEvent() })
+
+      expect(basicsSectionPage.getDrawTypeTrigger()).toBeEnabled()
+      expect(screen.queryByText(/draw type is frozen/i)).toBeNull()
+    })
+
+    // The rest of the tab is untouched by the draw: a director renames an event, moves
+    // its window and drops its fee mid-tournament, draw or no draw.
+    it('leaves the other basics fields editable', () => {
+      const onChange = vi.fn()
+      basicsSectionPage.render({ event: buildDrawnEvent(), onChange })
+
+      expect(basicsSectionPage.getNameInput()).toBeEnabled()
+      fireEvent.change(basicsSectionPage.getEntryFeeInput(), {
+        target: { value: '5' },
+      })
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ entryFee: 5 }),
+      )
+    })
+  })
+
   it('shows the event name and format', () => {
     basicsSectionPage.render({
       event: buildEvent({ name: 'Open Singles', format: 'singles' }),

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
@@ -1,5 +1,6 @@
 import { Input } from '@/components/ui/input'
 
+import type { EditFreeze } from '../../data/draw'
 import { ENTRY_FEE_MAX, PLAYERS_MAX } from '../../data/event-validation'
 import { fmtDate } from '../../data/helpers'
 import { DRAW_TYPE_OPTIONS, FORMAT_OPTIONS, labelFor } from '../../data/options'
@@ -30,6 +31,14 @@ export interface BasicsSectionProps {
    * share, so "may I save?" and "what does this field say in red?" are one answer,
    * computed once — exactly as the rule rows already work. */
   errors?: BasicsFieldErrors
+  /** Whether the **draw type** may still be changed (`drawTypeFreeze`, `data/draw`).
+   * Frozen once the event's draw is cut: the fixtures were dealt *as* that type, and
+   * re-labelling it would leave the event claiming a shape its draw does not have — a
+   * 409 on the server (ADR-0786). Frozen means a **disabled select with the reason in
+   * text beneath it**, not a hidden row: the value is still the event's, and a director
+   * who cannot see why they are stuck cannot get unstuck. (Contrast the *viewer* case,
+   * where the whole control is simply absent — ADR-0015.) */
+  drawTypeFreeze: EditFreeze
   onChange: (next: TournamentEvent) => void
 }
 
@@ -60,6 +69,7 @@ export const BasicsSection = ({
   event,
   canEdit,
   errors = {},
+  drawTypeFreeze,
   onChange,
 }: BasicsSectionProps) => {
   const set = (patch: Partial<TournamentEvent>) => onChange({ ...event, ...patch })
@@ -123,16 +133,31 @@ export const BasicsSection = ({
             />
           )}
         </Field>
+        {/* The draw type is the strategy that DEALT this event's fixtures, so once a
+            draw exists it is frozen (ADR-0786). The select is disabled and the reason
+            sits under it as text — the hint slot, the same place a validation message
+            would go — because a disabled trigger can carry no tooltip a screen reader
+            would read, and "the button is grey and nobody said why" is the dead end
+            ADR-0015 exists to forbid. It is not an error, so it is not red: the event is
+            fine, this one control is merely spoken for.
+
+            Hidden would be worse: the draw type is a fact about the event the director
+            came here to check, and hiding it would answer a question they did not ask
+            while silently dropping the one they did. */}
         <Field
           label="Draw type"
           readOnly={readOnly}
           value={labelFor(DRAW_TYPE_OPTIONS, event.drawType, null)}
+          hint={
+            drawTypeFreeze.kind === 'frozen' ? drawTypeFreeze.reason : undefined
+          }
         >
           {() => (
             <OptionSelect
               ariaLabel="Draw type"
               value={event.drawType}
               options={DRAW_TYPE_OPTIONS}
+              disabled={drawTypeFreeze.kind === 'frozen'}
               onChange={(v) => set({ drawType: v as DrawType })}
             />
           )}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
@@ -101,12 +101,16 @@ export const BasicsSection = ({
         error={!!errors.name}
         hint={errors.name}
       >
-        {(id) => (
+        {/* `hintId` is the row's hint — here the red message, when there is one. A
+            control that does not point at it is a control whose error is *beside* it on
+            screen and nowhere at all to a screen reader (`Field`, `FieldControl`). */}
+        {(id, hintId) => (
           <Input
             id={id}
             autoFocus
             value={event.name}
             aria-invalid={!!errors.name}
+            aria-describedby={hintId}
             placeholder="Open Singles"
             onChange={(e) => set({ name: e.target.value })}
           />
@@ -152,12 +156,18 @@ export const BasicsSection = ({
             drawTypeFreeze.kind === 'frozen' ? drawTypeFreeze.reason : undefined
           }
         >
-          {() => (
+          {/* The trigger POINTS at the reason (`aria-describedby`), it does not merely
+              sit above it. A disabled trigger is not focusable and carries no tooltip,
+              so the description is the only channel it has left — and one it had, in
+              fact, been leaving empty (`aria-describedby: null`) while the pools section
+              one tab over wired the identical freeze correctly. */}
+          {(_id, hintId) => (
             <OptionSelect
               ariaLabel="Draw type"
               value={event.drawType}
               options={DRAW_TYPE_OPTIONS}
               disabled={drawTypeFreeze.kind === 'frozen'}
+              describedById={hintId}
               onChange={(v) => set({ drawType: v as DrawType })}
             />
           )}
@@ -191,13 +201,14 @@ export const BasicsSection = ({
           readOnly={readOnly}
           value={numericValue(event.maxPlayers)}
         >
-          {(id) => (
+          {(id, hintId) => (
             <Input
               id={id}
               type="number"
               min={1}
               max={PLAYERS_MAX}
               aria-invalid={!!errors.maxPlayers}
+              aria-describedby={hintId}
               // Hold empty as empty and submit `null`.
               value={event.maxPlayers ?? ''}
               onChange={(e) =>
@@ -217,13 +228,14 @@ export const BasicsSection = ({
           readOnly={readOnly}
           value={numericValue(event.entryFee)}
         >
-          {(id) => (
+          {(id, hintId) => (
             <Input
               id={id}
               type="number"
               min={0}
               max={ENTRY_FEE_MAX}
               aria-invalid={!!errors.entryFee}
+              aria-describedby={hintId}
               // Blank is `NaN` — *missing* — while a typed `0` is a legitimate free
               // event and saves.
               value={Number.isNaN(event.entryFee) ? '' : event.entryFee}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/option-select.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/option-select.tsx
@@ -27,6 +27,12 @@ export interface OptionSelectProps {
    * can hold no tooltip a screen reader would read. NOT the read-only-viewer case —
    * that renders a value, never a dead control (ADR-0015). */
   disabled?: boolean
+  /** The id of the text that explains this control — the `Field`'s hint (its second
+   * render-prop argument). Owed by every caller that renders one, and *required* in
+   * spirit by the `disabled` case above: text that merely sits under a dead trigger is
+   * beside it on screen and nowhere at all to a screen reader, which is the same
+   * unexplained dead end as no reason at all. */
+  describedById?: string
 }
 
 /** A thin, typed wrapper over the shadcn `Select` for the simple
@@ -39,10 +45,15 @@ export const OptionSelect = ({
   placeholder,
   className,
   disabled,
+  describedById,
 }: OptionSelectProps) => {
   return (
     <Select value={value} onValueChange={onChange} disabled={disabled}>
-      <SelectTrigger aria-label={ariaLabel} className={className}>
+      <SelectTrigger
+        aria-label={ariaLabel}
+        aria-describedby={describedById}
+        className={className}
+      >
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/option-select.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/option-select.tsx
@@ -20,6 +20,13 @@ export interface OptionSelectProps {
   ariaLabel: string
   placeholder?: string
   className?: string
+  /** A control the organizer may **see** but not **change** — today, a draw type whose
+   * fixtures have already been dealt (ADR-0786). It is disabled rather than hidden
+   * because the value still matters to them and the reason is worth learning; the
+   * caller owes it a visible one in text (the `Field`'s hint), since a disabled trigger
+   * can hold no tooltip a screen reader would read. NOT the read-only-viewer case —
+   * that renders a value, never a dead control (ADR-0015). */
+  disabled?: boolean
 }
 
 /** A thin, typed wrapper over the shadcn `Select` for the simple
@@ -31,9 +38,10 @@ export const OptionSelect = ({
   ariaLabel,
   placeholder,
   className,
+  disabled,
 }: OptionSelectProps) => {
   return (
-    <Select value={value} onValueChange={onChange}>
+    <Select value={value} onValueChange={onChange} disabled={disabled}>
       <SelectTrigger aria-label={ariaLabel} className={className}>
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.factory.tsx
@@ -14,6 +14,10 @@ export interface PoolsHarnessInputs {
   /** Whether the event's pool SET may still change (ADR-0786) — derived from the event
    * by default, see below. */
   freeze: EditFreeze
+  /** What is wrong with each pool's **name**, keyed by pool id (`poolNameIssues`).
+   * `undefined` by default, because that is the state a card is normally in: the editor
+   * says nothing in red until the organizer has actually tried to save. */
+  nameIssues?: Record<string, string>
 }
 
 export function buildPoolsSectionProps(

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.factory.tsx
@@ -1,3 +1,4 @@
+import { poolSetFreeze, type EditFreeze } from '../../data/draw'
 import { buildEvent, buildTables } from '../../data/seed.factory'
 import type { TournamentEvent, TournamentTable } from '../../data/types'
 
@@ -10,15 +11,25 @@ export interface PoolsHarnessInputs {
   event: TournamentEvent
   tables: TournamentTable[]
   canEdit: boolean
+  /** Whether the event's pool SET may still change (ADR-0786) — derived from the event
+   * by default, see below. */
+  freeze: EditFreeze
 }
 
 export function buildPoolsSectionProps(
   overrides: Partial<PoolsHarnessInputs> = {},
 ): PoolsHarnessInputs {
+  // Derived from the event, exactly as the editor derives it (`event-editor.tsx`) —
+  // never defaulted to `open`. Seed `buildDrawnEvent()` and the section is frozen here
+  // for the same reason it is frozen in the app: the event has fixtures. A default of
+  // `open` would let a test hand a cut draw to an unfrozen pools editor — a state the
+  // app cannot produce — and then assert happily against it.
+  const event = overrides.event ?? buildEvent()
   return {
-    event: buildEvent(),
+    event,
     tables: buildTables(12),
     canEdit: true,
+    freeze: poolSetFreeze(event),
     ...overrides,
   }
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.harness.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.harness.tsx
@@ -15,13 +15,23 @@ const PoolsProbe = ({ control }: { control: Control<EventFormValues> }) => {
 /** Wraps `PoolsSection` in a form seeded from `event` — the section drives a
  * `useFieldArray` off that form's control (chore 1e), so the harness is how a
  * test renders it in isolation and reads back the resulting form state. */
-export const PoolsHarness = ({ event, tables, canEdit }: PoolsHarnessInputs) => {
+export const PoolsHarness = ({
+  event,
+  tables,
+  canEdit,
+  freeze,
+}: PoolsHarnessInputs) => {
   const form = useForm<EventFormValues>({
     defaultValues: eventToFormValues(event),
   })
   return (
     <>
-      <PoolsSection control={form.control} tables={tables} canEdit={canEdit} />
+      <PoolsSection
+        control={form.control}
+        tables={tables}
+        canEdit={canEdit}
+        freeze={freeze}
+      />
       <PoolsProbe control={form.control} />
     </>
   )

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.harness.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.harness.tsx
@@ -20,6 +20,7 @@ export const PoolsHarness = ({
   tables,
   canEdit,
   freeze,
+  nameIssues,
 }: PoolsHarnessInputs) => {
   const form = useForm<EventFormValues>({
     defaultValues: eventToFormValues(event),
@@ -31,6 +32,10 @@ export const PoolsHarness = ({
         tables={tables}
         canEdit={canEdit}
         freeze={freeze}
+        // Handed in, exactly as the editor hands it in — the section renders the verdict
+        // it is given and computes none of its own. (Whether the *editor* computes the
+        // right one, and refuses the save, is `event-editor.test.tsx`'s claim.)
+        nameIssues={nameIssues}
       />
       <PoolsProbe control={form.control} />
     </>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
@@ -26,6 +26,20 @@ const scoped = (container: Container) => ({
   queryPoolCards() {
     return container.queryAllByTestId('pool-card')
   },
+  /** Every pool's name box, in card order — the card-scoped `getNameInput()` throws
+   * once there is more than one pool, and "which card is red?" is a question about the
+   * whole list. */
+  getPoolNameInputs() {
+    return container.queryAllByLabelText('Pool name')
+  },
+  /** The red messages under the name boxes, in card order (`poolNameIssues`). Empty
+   * until a save has been attempted — the editor hands the section nothing before
+   * then. */
+  getPoolNameErrors(): (string | null)[] {
+    return container
+      .queryAllByTestId('pool-name-error')
+      .map((node: HTMLElement) => node.textContent)
+  },
   /** Every Remove-pool button, in render order — to remove a specific card.
    *
    * `hidden: false` is NOT passed and must not be: a *disabled* button (the cut-draw

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
@@ -26,9 +26,20 @@ const scoped = (container: Container) => ({
   queryPoolCards() {
     return container.queryAllByTestId('pool-card')
   },
-  /** Every Remove-pool button, in render order — to remove a specific card. */
+  /** Every Remove-pool button, in render order — to remove a specific card.
+   *
+   * `hidden: false` is NOT passed and must not be: a *disabled* button (the cut-draw
+   * freeze, ADR-0786) is still in the accessibility tree with its name, and a query that
+   * dropped it would report "no Remove button" for a state whose whole point is that the
+   * button is there, visible, and dead. */
   getRemovePoolButtons() {
     return container.queryAllByRole('button', { name: 'Remove pool' })
+  },
+  /** The notice that says the pool SET is frozen because the draw is cut — and how to
+   * get out of it. Absent when there is no draw, and absent for a viewer (who has no
+   * add/remove affordance to explain and no draw to delete). */
+  queryFrozenNotice() {
+    return container.queryByTestId('pools-frozen-notice')
   },
   /** The live `pools` array in form state (via the probe), so a test can assert
    * that an add / edit / remove flowed through `useFieldArray`. */
@@ -36,8 +47,11 @@ const scoped = (container: Container) => ({
     const el = container.queryByTestId('pools-probe')
     return el ? (JSON.parse(el.textContent || '[]') as Pool[]) : []
   },
+  /** The double-booking warning. Addressed by testid rather than by `role="alert"`:
+   * the freeze notice is an `Alert` too, and an event can be both frozen and
+   * double-booked — a role query would throw on exactly that overlap. */
   queryConflictAlert() {
-    return container.queryByRole('alert')
+    return container.queryByTestId('pools-conflict-alert')
   },
   /** Every interactive control in the section, swept by role. Supplement only —
    * `getFormElements()` is the guarantee. */

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
@@ -208,6 +208,51 @@ describe('PoolsSection', () => {
     })
   })
 
+  /**
+   * A pool is *called* something, and the server now says so (`Pool.name`,
+   * `min_length=1`). The section does not *decide* that — the editor's resolver does,
+   * and it is what refuses the save — but the section is where the verdict has to land:
+   * under the box that is empty, on the card it is about.
+   */
+  describe('a pool with no name', () => {
+    it('reds the named pool’s card and no other', () => {
+      poolsSectionPage.render({
+        event: buildEvent({ pools: twoPools() }),
+        nameIssues: { 'p-2': 'Name is required.' },
+      })
+
+      const [poolA, poolB] = poolsSectionPage.getPoolNameInputs()
+      expect(poolsSectionPage.getPoolNameErrors()).toEqual(['Name is required.'])
+      expect(poolB).toHaveAttribute('aria-invalid', 'true')
+      expect(poolA).not.toHaveAttribute('aria-invalid', 'true')
+    })
+
+    // Keyed by pool ID, not by index: a director who removes the first of three pools
+    // renumbers every card, and an index-keyed message would then be red under the
+    // wrong box.
+    it('follows the pool it belongs to when a card above it is removed', async () => {
+      poolsSectionPage.render({
+        event: buildEvent({ pools: twoPools() }),
+        nameIssues: { 'p-2': 'Name is required.' },
+      })
+
+      await userEvent.click(poolsSectionPage.getRemovePoolButtons()[0])
+
+      // One card left — Pool B, the blank one — and the red is still under it.
+      expect(poolsSectionPage.queryPoolCards()).toHaveLength(1)
+      expect(poolsSectionPage.getPoolNameErrors()).toEqual(['Name is required.'])
+      expect(poolsSectionPage.getPoolNameInputs()[0]).toHaveAttribute(
+        'aria-invalid',
+        'true',
+      )
+    })
+
+    it('says nothing in red when the editor hands it no issues', () => {
+      poolsSectionPage.render({ event: buildEvent({ pools: twoPools() }) })
+      expect(poolsSectionPage.getPoolNameErrors()).toEqual([])
+    })
+  })
+
   describe('for a non-owner (read-only)', () => {
     // The guard test (ADR 0015, rule 6). Rendered *with* pools on purpose: an
     // event with none has nothing but the Add button, so a sweep over the empty

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
@@ -1,9 +1,24 @@
 import userEvent from '@testing-library/user-event'
 
-import { screen } from '@/test/utilities'
+import { fireEvent, screen } from '@/test/utilities'
 
-import { buildEvent, buildPool } from '../../data/seed.factory'
+import {
+  buildDrawnEvent,
+  buildEvent,
+  buildFixture,
+  buildPool,
+} from '../../data/seed.factory'
 import { poolsSectionPage } from './pools-section.page'
+
+/** An event with a **cut draw** and exactly one pool — so the card-scoped queries
+ * (`getTableToggle`, `getNameInput`) address one card rather than throwing on two.
+ * A single fixture is a draw: the freeze turns on the draw *existing*, not on its
+ * size (ADR-0786). */
+const drawnOnePoolEvent = () =>
+  buildEvent({
+    pools: [buildPool()],
+    fixtures: [buildFixture({ poolId: 'p-1' })],
+  })
 
 /** A morning pool and an afternoon pool — what a viewer actually reads. */
 const twoPools = () => [
@@ -98,6 +113,99 @@ describe('PoolsSection', () => {
     poolsSectionPage.render({ event: buildEvent({ pools: [] }) })
     expect(poolsSectionPage.queryPoolCards()).toHaveLength(0)
     expect(document.body).toHaveTextContent('No pools yet')
+  })
+
+  // ADR-0786's pool-set freeze, in the editor. The pools of an event whose draw is CUT
+  // may no longer be added to or removed from — a fixture names its pool by id — but
+  // everything else about a pool stays editable, because venues move under a running
+  // tournament. Both halves are asserted, and the second half is the one that matters:
+  // a section that greyed itself out wholesale would pass the first three tests here and
+  // break the very case the freeze exists to permit.
+  describe('once the draw is cut', () => {
+    it('disables Add pool and names the draw as the reason, with the way out', () => {
+      poolsSectionPage.render({ event: buildDrawnEvent() })
+
+      expect(poolsSectionPage.getAddPoolButton()).toBeDisabled()
+      const notice = poolsSectionPage.queryFrozenNotice()
+      expect(notice).toHaveTextContent('This event’s draw is cut')
+      // The way out, not merely the refusal: a director who is only told "no" is stuck.
+      expect(notice).toHaveTextContent('Delete the draw')
+      expect(notice).toHaveTextContent('cut it again')
+    })
+
+    it('disables every Remove pool button, pointing it at that reason', () => {
+      poolsSectionPage.render({ event: buildDrawnEvent() })
+
+      // Both cards — the second is where a "disable the first one" fix would show.
+      const removeButtons = poolsSectionPage.getRemovePoolButtons()
+      expect(removeButtons).toHaveLength(2)
+      for (const button of removeButtons) expect(button).toBeDisabled()
+
+      // A disabled button holds no tooltip a screen reader will read, so the reason is
+      // in text — and the button says where.
+      const notice = poolsSectionPage.queryFrozenNotice()
+      expect(removeButtons[0]).toHaveAttribute('aria-describedby', notice?.id)
+    })
+
+    // ⚠️ THE DISCRIMINATING ONE. Only the pool *identity set* is frozen: a table that
+    // breaks mid-event is pulled from its pool, the pool slips an hour, a pool is
+    // renamed — all with the draw standing, and none of it costing the director their
+    // placements (CONTEXT.md, "Pool"; `_enforce_pool_set_frozen`). Asserted by *doing*
+    // each edit and reading the form state back, not by `toBeEnabled()`: a control can
+    // be enabled and still wired to nothing.
+    //
+    // One pool, so the card-scoped queries address exactly one card (the section-level
+    // ones throw on two). It is still a cut draw — one fixture is a draw.
+    it('leaves a pool’s tables, window and name editable', async () => {
+      poolsSectionPage.render({ event: drawnOnePoolEvent() })
+
+      // The table a director pulls when it breaks (the pool holds t1–t4).
+      await userEvent.click(poolsSectionPage.getSelectedTableToggle('T1'))
+      expect(poolsSectionPage.getPools()[0].tableIds).not.toContain('t1')
+
+      // …and the one that frees up.
+      await userEvent.click(poolsSectionPage.getTableToggle('T9'))
+      expect(poolsSectionPage.getPools()[0].tableIds).toContain('t9')
+
+      // The window slips an hour and a half.
+      fireEvent.change(screen.getByLabelText('Start'), {
+        target: { value: '10:30' },
+      })
+      expect(poolsSectionPage.getPools()[0].slot.start).toBe('10:30')
+
+      // And the display name is only a display name — identity lives in the `id`, which
+      // no control here can touch, so every fixture still resolves.
+      fireEvent.change(poolsSectionPage.getNameInput(), {
+        target: { value: 'Morning Pool' },
+      })
+      const [pool] = poolsSectionPage.getPools()
+      expect(pool.name).toBe('Morning Pool')
+      expect(pool.id).toBe('p-1')
+
+      // None of which added or removed a pool.
+      expect(poolsSectionPage.getPools()).toHaveLength(1)
+    })
+
+    // The whole freeze turns on the draw existing. With none cut, the section is exactly
+    // what it always was — no dead buttons, and nothing to explain.
+    it('is not frozen when no draw is cut', () => {
+      poolsSectionPage.render({ event: buildEvent({ pools: twoPools() }) })
+
+      expect(poolsSectionPage.getAddPoolButton()).toBeEnabled()
+      for (const button of poolsSectionPage.getRemovePoolButtons()) {
+        expect(button).toBeEnabled()
+      }
+      expect(poolsSectionPage.queryFrozenNotice()).toBeNull()
+    })
+
+    // A viewer has no add/remove affordance to explain and no draw to delete: the notice
+    // would be an instruction they cannot follow, about buttons they cannot see.
+    it('shows a non-owner no freeze notice', () => {
+      poolsSectionPage.render({ event: buildDrawnEvent(), canEdit: false })
+
+      expect(poolsSectionPage.queryFrozenNotice()).toBeNull()
+      expect(poolsSectionPage.getFormElements()).toHaveLength(0)
+    })
   })
 
   describe('for a non-owner (read-only)', () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
@@ -1,9 +1,11 @@
+import { useId } from 'react'
 import { type Control, useFieldArray, useWatch } from 'react-hook-form'
-import { Plus, TriangleAlert } from 'lucide-react'
+import { Lock, Plus, TriangleAlert } from 'lucide-react'
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 
+import type { EditFreeze } from '../../data/draw'
 import { findPoolConflicts, genId } from '../../data/helpers'
 import type { Pool, TournamentTable } from '../../data/types'
 import { EmptyState } from '../../empty-state'
@@ -22,16 +24,51 @@ export interface PoolsSectionProps {
    * pool reads back as its name, its window and its reserved tables, and every
    * mutating affordance is hidden (ADR 0015). */
   canEdit: boolean
+  /** Whether the event's **set of pools** may still change (`poolSetFreeze`,
+   * `data/draw`). Frozen once its draw is cut — see the component doc below. */
+  freeze: EditFreeze
 }
 
-/** The event editor's "Table pools" tab: each pool reserves a slice of tables
- * for a window, with a warning when tables are double-booked across overlapping
- * pools. */
+/**
+ * The event editor's "Table pools" tab: each pool reserves a slice of tables for a
+ * window, with a warning when tables are double-booked across overlapping pools.
+ *
+ * ## Once the draw is cut, the pool *set* freezes — and nothing else does
+ *
+ * A fixture names its pool by that pool's string `id` (ADR-0786), so adding or removing
+ * a pool under a standing draw either orphans fixtures or produces a pool with none. The
+ * server refuses it with a **409**; this section declines to *build* the change, and says
+ * why, and says how to get out of it — because a director who is merely stopped is stuck,
+ * and the way out (delete the draw, edit, cut it again) is the whole content of the
+ * refusal.
+ *
+ * **Disabled with a visible reason, not hidden.** That is the opposite of the
+ * owner/viewer split one prop over (`canEdit`), and deliberately so: a viewer's missing
+ * button is *not their business* — nothing they could do would bring it back — whereas
+ * this director's Add-pool button is one deleted draw away from working. Hiding it would
+ * hide the way out along with the control. (ADR-0015 forbids the *unexplained* dead end;
+ * a reason in text is what makes this one not that. It goes in text and not in a tooltip
+ * because a `disabled` button is not focusable and holds no tooltip a screen reader will
+ * ever read.)
+ *
+ * **What stays live is the point of the whole freeze**: a pool's name, its window, and
+ * its tables are still editable with a draw standing (`PoolCard` renders them exactly as
+ * before). Venues move under a running tournament — a table breaks and is pulled, one
+ * frees up early — and a director who had to delete a *correct* draw to record that would
+ * lose every placement to a broken table. A section that greyed itself out wholesale
+ * would look tidy, pass a test that only checked Add and Remove, and break the one case
+ * this freeze exists to permit.
+ */
 export const PoolsSection = ({
   control,
   tables,
   canEdit,
+  freeze,
 }: PoolsSectionProps) => {
+  // The frozen notice is what both the Add button and every Remove button point at with
+  // `aria-describedby`: one explanation, in one place, said once.
+  const freezeNoticeId = useId()
+  const frozen = freeze.kind === 'frozen'
   // `keyName: 'rhfKey'` keeps the field array's internal key off our domain
   // `id`, so a card is keyed on the stable `id` and an in-place `update`
   // re-renders it rather than remounting it (which would drop input focus).
@@ -75,7 +112,12 @@ export const PoolsSection = ({
         subtitle="Each pool reserves a slice of tables for a window of time."
         action={
           canEdit && (
-            <Button size="sm" onClick={addPool}>
+            <Button
+              size="sm"
+              onClick={addPool}
+              disabled={frozen}
+              aria-describedby={frozen ? freezeNoticeId : undefined}
+            >
               <Plus size={14} />
               Add pool
             </Button>
@@ -83,13 +125,37 @@ export const PoolsSection = ({
         }
       />
 
+      {/* Why the two identity affordances are dead, and how to bring them back — the
+          director's, so a viewer (who has no Add button and no way to delete a draw)
+          is never shown it. An `Alert` because this is the app talking back about the
+          state of the thing in front of them; not `destructive`, because nothing has
+          gone wrong: a cut draw is the *correct* state of an event that is about to be
+          played. Both the Add button and every Remove button `aria-describedby` it, so
+          a screen reader reaching a disabled control is told the same sentence a sighted
+          director reads above it. */}
+      {canEdit && freeze.kind === 'frozen' && (
+        <Alert id={freezeNoticeId} data-testid="pools-frozen-notice">
+          <Lock size={16} />
+          <AlertTitle>This event’s draw is cut</AlertTitle>
+          <AlertDescription>{freeze.reason}</AlertDescription>
+        </Alert>
+      )}
+
       {/* A double-booking is a flaw in the *configuration*, and only the
           organizer can fix it. To a reader it is an unactionable warning about
           someone else's tournament — noise, not information — so they are not
           shown it. (It is non-interactive, so this is a copy/UX call, not a
           control leak: the guard sweep passes either way.) */}
       {canEdit && conflicts.length > 0 && (
-        <Alert className="border-[color:var(--warn)]/40 bg-[color:var(--warn)]/10">
+        // Addressed by a testid, not by `role="alert"`: the freeze notice above is an
+        // `Alert` too, and an event can be both frozen and double-booked (a director
+        // moving a broken table's pool onto tables another pool already holds — an edit
+        // the freeze deliberately still allows). A page object querying "the alert"
+        // would throw on exactly that overlap.
+        <Alert
+          data-testid="pools-conflict-alert"
+          className="border-[color:var(--warn)]/40 bg-[color:var(--warn)]/10"
+        >
           <TriangleAlert className="text-[color:var(--warn)]" />
           <AlertTitle className="text-[color:var(--warn)]">
             {conflictTableCount}{' '}
@@ -117,7 +183,15 @@ export const PoolsSection = ({
           }
           action={
             canEdit && (
-              <Button onClick={addPool}>
+              // Reachable: a draw whose fixtures belong to no pool (a knockout, #785)
+              // leaves an event with fixtures and an empty pool list — and its pool set
+              // is frozen like any other. The invitation is still shown, and still dead,
+              // and the notice above it still says why.
+              <Button
+                onClick={addPool}
+                disabled={frozen}
+                aria-describedby={frozen ? freezeNoticeId : undefined}
+              >
                 <Plus size={16} />
                 Add first pool
               </Button>
@@ -132,6 +206,14 @@ export const PoolsSection = ({
               pool={pools[i]}
               tables={tables}
               canEdit={canEdit}
+              // ONLY the removal freezes. The card's name box, its window and its table
+              // chips stay live under a cut draw — that is the case the freeze exists to
+              // permit, not an oversight (see the component doc).
+              removal={
+                frozen
+                  ? { kind: 'frozen', reasonId: freezeNoticeId }
+                  : { kind: 'allowed' }
+              }
               onChange={(np) => update(i, np)}
               onRemove={() => remove(i)}
             />

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
@@ -27,6 +27,14 @@ export interface PoolsSectionProps {
   /** Whether the event's **set of pools** may still change (`poolSetFreeze`,
    * `data/draw`). Frozen once its draw is cut — see the component doc below. */
   freeze: EditFreeze
+  /** What is wrong with each pool's **name**, keyed by pool id (`poolNameIssues`,
+   * `data/event-validation`) — rendered in red under the box it is about.
+   *
+   * `undefined` is *"do not say anything yet"*, and it is what the editor passes until
+   * the organizer has actually pressed Save: a name box they are halfway through
+   * re-typing is not yet wrong. The same shape, and the same reasoning, as
+   * `EligibilitySection`'s `issues`. */
+  nameIssues?: Record<string, string>
 }
 
 /**
@@ -58,12 +66,22 @@ export interface PoolsSectionProps {
  * lose every placement to a broken table. A section that greyed itself out wholesale
  * would look tidy, pass a test that only checked Add and Remove, and break the one case
  * this freeze exists to permit.
+ *
+ * ## A pool is *called* something
+ *
+ * The name box being live is also the one way this editor can author a pool the server
+ * refuses: an id and a default name are **minted** (`addPool`), but an emptied name box
+ * is a `min_length=1` 422 (`Pool.name`, `api/app/schemas/tournament.py`). So the rule is
+ * mirrored client-side (`poolNameSchema`) and its verdict arrives here as `nameIssues`,
+ * in red, under the box — and the save is refused in the form, which is what means
+ * Pydantic's prose never reaches anybody.
  */
 export const PoolsSection = ({
   control,
   tables,
   canEdit,
   freeze,
+  nameIssues,
 }: PoolsSectionProps) => {
   // The frozen notice is what both the Add button and every Remove button point at with
   // `aria-describedby`: one explanation, in one place, said once.
@@ -214,6 +232,10 @@ export const PoolsSection = ({
                   ? { kind: 'frozen', reasonId: freezeNoticeId }
                   : { kind: 'allowed' }
               }
+              // The one thing on this card the organizer can *clear* — and the server
+              // now refuses a pool with no name (`min_length=1`). The card says so under
+              // the box; the save never leaves the room.
+              nameError={nameIssues?.[pools[i].id]}
               onChange={(np) => update(i, np)}
               onRemove={() => remove(i)}
             />

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.factory.tsx
@@ -2,7 +2,9 @@ import { buildPool, buildTables } from '../../../data/seed.factory'
 import type { PoolCardProps } from './pool-card'
 
 /** Props for `PoolCard` — Pool A with four of six tables selected, editable (the
- * creator's view). Pass `canEdit: false` for a viewer's read-only rendering. */
+ * creator's view), and removable. Pass `canEdit: false` for a viewer's read-only
+ * rendering, or `removal: { kind: 'frozen', reasonId }` for a pool whose event has a
+ * cut draw (ADR-0786): the trash button dies, and *nothing else does*. */
 export function buildPoolCardProps(
   overrides: Partial<PoolCardProps> = {},
 ): PoolCardProps {
@@ -10,6 +12,7 @@ export function buildPoolCardProps(
     pool: buildPool(),
     tables: buildTables(6),
     canEdit: true,
+    removal: { kind: 'allowed' },
     onChange: () => {},
     onRemove: () => {},
     ...overrides,

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.page.tsx
@@ -19,6 +19,12 @@ const scoped = (container: Container) => ({
   queryNameInput() {
     return container.queryByLabelText('Pool name')
   },
+  /** The red message under the name box — the resolver's verdict on this pool's name
+   * (`poolNameSchema`). Absent until a save is actually attempted, and absent for a
+   * viewer, who has no box to clear. */
+  queryNameError() {
+    return container.queryByTestId('pool-name-error')
+  },
   getTableToggle(label: string) {
     return container.getByRole('button', { name: label, pressed: false })
   },

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.test.tsx
@@ -28,6 +28,62 @@ describe('PoolCard', () => {
     expect(onRemove).toHaveBeenCalledTimes(1)
   })
 
+  /**
+   * The name box is the one control on this card that can author a pool the server
+   * refuses (`Pool.name`, `min_length=1`) — the id and the default name are minted. The
+   * card does not *judge* the name (the editor's resolver does, and refuses the save);
+   * what it owes is the verdict, under the box, in red, wired so a screen reader hears
+   * it too.
+   */
+  describe('a name the server would refuse', () => {
+    it('renders the message under the box, and marks the box invalid', () => {
+      poolCardPage.render({
+        pool: buildPool({ name: '' }),
+        nameError: 'Name is required.',
+      })
+
+      expect(poolCardPage.queryNameError()).toHaveTextContent('Name is required.')
+      expect(poolCardPage.getNameInput()).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    // A `<p>` that merely sits below an input is *beside* it on screen and nowhere at
+    // all to a screen reader.
+    it('points the box at the message', () => {
+      poolCardPage.render({
+        pool: buildPool({ name: '' }),
+        nameError: 'Name is required.',
+      })
+
+      const describedBy = poolCardPage.getNameInput().getAttribute('aria-describedby')
+      expect(describedBy).toBeTruthy()
+      expect(poolCardPage.queryNameError()).toHaveAttribute('id', describedBy)
+    })
+
+    it('says nothing, and claims nothing, when the name is fine', () => {
+      poolCardPage.render({ pool: buildPool({ name: 'Pool A' }) })
+
+      expect(poolCardPage.queryNameError()).toBeNull()
+      expect(poolCardPage.getNameInput()).not.toHaveAttribute('aria-invalid', 'true')
+      // No dangling description either — an `aria-describedby` pointing at an element
+      // that is not there is an axe violation of its own.
+      expect(poolCardPage.getNameInput()).not.toHaveAttribute('aria-describedby')
+    })
+
+    // A viewer has no box to clear, so there is nothing to tell them to fix. (The
+    // editor never hands one down for a read-only card; this is the card refusing to
+    // render one even if it did.)
+    it('tells a viewer nothing about a name they cannot edit', () => {
+      poolCardPage.render({
+        pool: buildPool({ name: '' }),
+        nameError: 'Name is required.',
+        canEdit: false,
+      })
+
+      expect(poolCardPage.queryNameError()).toBeNull()
+      expect(poolCardPage.queryNameInput()).toBeNull()
+    })
+  })
+
   // The pool-set freeze, at the level of one card (ADR-0786). The *reason* is not the
   // card's to say — the section says it once, above the cards — so what the card owes is
   // a dead button that points at it.

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event'
 
-import { screen } from '@/test/utilities'
+import { fireEvent, screen } from '@/test/utilities'
 
 import { buildPool } from '../../../data/seed.factory'
 import { poolCardPage } from './pool-card.page'
@@ -26,6 +26,69 @@ describe('PoolCard', () => {
     poolCardPage.render({ onRemove })
     await userEvent.click(poolCardPage.getRemoveButton())
     expect(onRemove).toHaveBeenCalledTimes(1)
+  })
+
+  // The pool-set freeze, at the level of one card (ADR-0786). The *reason* is not the
+  // card's to say — the section says it once, above the cards — so what the card owes is
+  // a dead button that points at it.
+  describe('when the event’s draw is cut', () => {
+    it('disables the remove button and points it at the reason', async () => {
+      const onRemove = vi.fn()
+      poolCardPage.render({
+        removal: { kind: 'frozen', reasonId: 'freeze-notice' },
+        onRemove,
+      })
+
+      const button = poolCardPage.getRemoveButton()
+      expect(button).toBeDisabled()
+      expect(button).toHaveAttribute('aria-describedby', 'freeze-notice')
+      // Disabled means disabled: the click is refused by the DOM, not merely styled away.
+      await userEvent.click(button)
+      expect(onRemove).not.toHaveBeenCalled()
+    })
+
+    // Disabled, not hidden — this is the case a director can get *out* of (delete the
+    // draw), unlike the viewer's, whose buttons never come back. Hiding it would take
+    // the way out with it.
+    it('still renders the remove button', () => {
+      poolCardPage.render({
+        removal: { kind: 'frozen', reasonId: 'freeze-notice' },
+      })
+      expect(poolCardPage.queryRemoveButton()).toBeInTheDocument()
+    })
+
+    // The whole reason the freeze is scoped to identity: a table breaks and is pulled, a
+    // pool slips an hour, a pool is renamed — all of it mid-event, none of it costing
+    // the draw. A card that greyed itself out wholesale would break exactly this.
+    it('leaves the name, the window and the table toggles live', async () => {
+      const onChange = vi.fn()
+      poolCardPage.render({
+        pool: buildPool({ tableIds: ['t1'] }),
+        removal: { kind: 'frozen', reasonId: 'freeze-notice' },
+        onChange,
+      })
+
+      await userEvent.click(poolCardPage.getTableToggle('T5'))
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ tableIds: ['t1', 't5'] }),
+      )
+
+      fireEvent.change(poolCardPage.getNameInput(), {
+        target: { value: 'Morning Pool' },
+      })
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ name: 'Morning Pool' }),
+      )
+
+      fireEvent.change(screen.getByLabelText('End'), {
+        target: { value: '13:15' },
+      })
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          slot: expect.objectContaining({ end: '13:15' }),
+        }),
+      )
+    })
   })
 
   describe('for a non-owner (read-only)', () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.tsx
@@ -9,6 +9,25 @@ import type { Pool, TournamentTable } from '../../../data/types'
 import { Field } from '../../../field'
 import { ReadOnlyValue } from '../../../read-only-value'
 
+/**
+ * Whether this pool may be **removed from the event** — and if not, where the reason is
+ * written.
+ *
+ * A pool cannot leave an event whose draw is cut: its fixtures name it, and they would be
+ * left pointing at nothing (ADR-0786; the server 409s it). The card does not carry the
+ * *words* for that — one explanation for the whole section, said once, lives above the
+ * cards in `PoolsSection` — so what it carries instead is the **id of that explanation**,
+ * which the disabled button points its `aria-describedby` at. A screen reader landing on
+ * the dead control is told the same sentence a sighted director reads above it.
+ *
+ * A sum type, and not a `canRemove: boolean` + an optional id, because "frozen but with
+ * nothing to point at" is precisely the unexplained dead end (ADR-0015) — and this makes
+ * it unconstructible.
+ */
+export type PoolRemoval =
+  | { kind: 'allowed' }
+  | { kind: 'frozen'; reasonId: string }
+
 export interface PoolCardProps {
   pool: Pool
   /** The tables available to this tournament. */
@@ -17,6 +36,11 @@ export interface PoolCardProps {
    * its window, and the tables it reserves — instead of a name box, three
    * date/time fields and a wall of table toggles (ADR 0015). */
   canEdit: boolean
+  /** Whether this pool may be removed (see `PoolRemoval`). It gates the trash button
+   * and **nothing else**: with the draw cut, the name box, the window and the table
+   * chips are all still live, because a pool's venue attributes were never frozen and
+   * a table that breaks mid-event has to be recorded without destroying the draw. */
+  removal: PoolRemoval
   onChange: (pool: Pool) => void
   onRemove: () => void
 }
@@ -58,6 +82,7 @@ export const PoolCard = ({
   pool,
   tables,
   canEdit,
+  removal,
   onChange,
   onRemove,
 }: PoolCardProps) => {
@@ -127,11 +152,22 @@ export const PoolCard = ({
           className="h-8 flex-1 border-transparent bg-transparent text-[15px] font-semibold shadow-none focus-visible:border-[color:var(--border-default)]"
         />
         <TableCount count={pool.tableIds.length} />
+        {/* Disabled — not hidden — while the draw is cut, and pointed at the section's
+            one explanation of why (ADR-0786). Hiding it would take the way out with it:
+            this button is one deleted draw away from working, which is exactly what
+            distinguishes this case from the viewer's (whose controls are absent, because
+            nothing they could do would bring them back). The accessible name stays
+            "Remove pool" — the name of a control is what it *does*, not what state it is
+            in; the state is `disabled` and the reason is the description. */}
         <button
           type="button"
           aria-label="Remove pool"
+          disabled={removal.kind === 'frozen'}
+          aria-describedby={
+            removal.kind === 'frozen' ? removal.reasonId : undefined
+          }
           onClick={onRemove}
-          className="grid size-7 place-items-center rounded-md text-[color:var(--loss)] hover:bg-[color:rgba(255,77,109,0.16)]"
+          className="grid size-7 place-items-center rounded-md text-[color:var(--loss)] hover:bg-[color:rgba(255,77,109,0.16)] disabled:cursor-not-allowed disabled:text-[color:var(--fg-3)] disabled:opacity-50 disabled:hover:bg-transparent"
         >
           <Trash2 size={14} />
         </button>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { Trash2 } from 'lucide-react'
 
 import { Card } from '@/components/ui/card'
@@ -41,14 +42,30 @@ export interface PoolCardProps {
    * chips are all still live, because a pool's venue attributes were never frozen and
    * a table that breaks mid-event has to be recorded without destroying the draw. */
   removal: PoolRemoval
+  /** What is wrong with this pool's **name**, in the organizer's words, or `undefined`
+   * when nothing is — the resolver's verdict on this row (`poolNameSchema`), handed
+   * down by `PoolsSection` and rendered under the box.
+   *
+   * It is a `string | undefined` rather than a `boolean` + a table of copy here,
+   * because the sentence is the schema's: one rule, one wording, said wherever it is
+   * shown. A viewer never sees it — a read-only card has no box to clear. */
+  nameError?: string
   onChange: (pool: Pool) => void
   onRemove: () => void
 }
 
 /** The card's chrome, shared by both renderings so the two cannot drift apart
- * (ADR 0015, rule 3: the read-only view mirrors the editor's layout). */
-const HEADER_ROW =
-  'flex items-center gap-2.5 border-b border-[color:var(--border-subtle)] p-3.5'
+ * (ADR 0015, rule 3: the read-only view mirrors the editor's layout).
+ *
+ * The header is split in two because only the *editor's* header can grow a second line
+ * — the red under the name box. So the rule below the header belongs to the **block**,
+ * not to the row: hang the border off the row and a validation message renders *below*
+ * the divider, in the window's whitespace, reading as though it were about the date.
+ * The read-only branch, which has neither box nor message, composes the two back into
+ * the one row it has always been. */
+const HEADER_ROW_INNER = 'flex items-center gap-2.5 p-3.5'
+const HEADER_BORDER = 'border-b border-[color:var(--border-subtle)]'
+const HEADER_ROW = cn(HEADER_ROW_INNER, HEADER_BORDER)
 const OVERLINE =
   'mb-1.5 text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase'
 const WINDOW_ROW = 'grid grid-cols-3 gap-3 p-3.5'
@@ -83,9 +100,15 @@ export const PoolCard = ({
   tables,
   canEdit,
   removal,
+  nameError,
   onChange,
   onRemove,
 }: PoolCardProps) => {
+  // The id of the red message, so the *box* points at it (`aria-describedby`). A `<p>`
+  // that merely sits below an input is next to it on screen and nowhere at all to a
+  // screen reader.
+  const nameErrorId = useId()
+
   const setSlot = (patch: Partial<Pool['slot']>) =>
     onChange({ ...pool, slot: { ...pool.slot, ...patch } })
 
@@ -144,33 +167,60 @@ export const PoolCard = ({
 
   return (
     <Card className="gap-0 p-0" data-testid="pool-card">
-      <div className={HEADER_ROW}>
-        <Input
-          aria-label="Pool name"
-          value={pool.name}
-          onChange={(e) => onChange({ ...pool, name: e.target.value })}
-          className="h-8 flex-1 border-transparent bg-transparent text-[15px] font-semibold shadow-none focus-visible:border-[color:var(--border-default)]"
-        />
-        <TableCount count={pool.tableIds.length} />
-        {/* Disabled — not hidden — while the draw is cut, and pointed at the section's
-            one explanation of why (ADR-0786). Hiding it would take the way out with it:
-            this button is one deleted draw away from working, which is exactly what
-            distinguishes this case from the viewer's (whose controls are absent, because
-            nothing they could do would bring them back). The accessible name stays
-            "Remove pool" — the name of a control is what it *does*, not what state it is
-            in; the state is `disabled` and the reason is the description. */}
-        <button
-          type="button"
-          aria-label="Remove pool"
-          disabled={removal.kind === 'frozen'}
-          aria-describedby={
-            removal.kind === 'frozen' ? removal.reasonId : undefined
-          }
-          onClick={onRemove}
-          className="grid size-7 place-items-center rounded-md text-[color:var(--loss)] hover:bg-[color:rgba(255,77,109,0.16)] disabled:cursor-not-allowed disabled:text-[color:var(--fg-3)] disabled:opacity-50 disabled:hover:bg-transparent"
-        >
-          <Trash2 size={14} />
-        </button>
+      <div className={HEADER_BORDER}>
+        <div className={HEADER_ROW_INNER}>
+          <Input
+            aria-label="Pool name"
+            value={pool.name}
+            onChange={(e) => onChange({ ...pool, name: e.target.value })}
+            aria-invalid={!!nameError}
+            aria-describedby={nameError ? nameErrorId : undefined}
+            className={cn(
+              'h-8 flex-1 border-transparent bg-transparent text-[15px] font-semibold shadow-none focus-visible:border-[color:var(--border-default)]',
+              // The box is *chromeless* until it is wrong: a transparent border is the
+              // whole look of this header. So the red border has to be said out loud
+              // here — `aria-invalid` alone styles nothing a transparent border shows.
+              nameError &&
+                'border-[color:var(--loss)] focus-visible:border-[color:var(--loss)]',
+            )}
+          />
+          <TableCount count={pool.tableIds.length} />
+          {/* Disabled — not hidden — while the draw is cut, and pointed at the section's
+              one explanation of why (ADR-0786). Hiding it would take the way out with it:
+              this button is one deleted draw away from working, which is exactly what
+              distinguishes this case from the viewer's (whose controls are absent, because
+              nothing they could do would bring them back). The accessible name stays
+              "Remove pool" — the name of a control is what it *does*, not what state it is
+              in; the state is `disabled` and the reason is the description. */}
+          <button
+            type="button"
+            aria-label="Remove pool"
+            disabled={removal.kind === 'frozen'}
+            aria-describedby={
+              removal.kind === 'frozen' ? removal.reasonId : undefined
+            }
+            onClick={onRemove}
+            className="grid size-7 place-items-center rounded-md text-[color:var(--loss)] hover:bg-[color:rgba(255,77,109,0.16)] disabled:cursor-not-allowed disabled:text-[color:var(--fg-3)] disabled:opacity-50 disabled:hover:bg-transparent"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+
+        {/* The refusal, under the box it is about and above the divider — the shape every
+            other field in this editor uses (`Field`'s error hint, `CLAUDE.md` `## Forms`):
+            inline, in red, never a toast and never a banner. A blank pool name is a 422
+            the server now states (`min_length=1`), and this is what means it is never
+            *reached*: the save is refused in the form, so nothing is sent and Pydantic's
+            prose has nothing to arrive in. */}
+        {nameError && (
+          <p
+            id={nameErrorId}
+            data-testid="pool-name-error"
+            className="-mt-2 px-3.5 pb-3 text-xs text-[color:var(--loss)]"
+          >
+            {nameError}
+          </p>
+        )}
       </div>
 
       <div className={WINDOW_ROW}>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.test.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.test.ts
@@ -1,4 +1,4 @@
-import { buildEvent, buildPredicate } from '../data/seed.factory'
+import { buildEvent, buildPool, buildPredicate } from '../data/seed.factory'
 import {
   eventSchema,
   eventToFormValues,
@@ -61,6 +61,41 @@ describe('eventSchema', () => {
       rejectedFields(formFor({ predicates: [buildPredicate({ op: '<', value: 1500 })] })),
     ).toEqual([])
   })
+
+  /** A pool is *called* something — the server says so (`Pool.name`, `min_length=1`),
+   * and so, now, does the resolver. The editor mints the id and the default name, so
+   * the only way to author a blank one is to clear the box; this is what stops the
+   * result being sent. */
+  it('refuses a pool with no name — blank, or a space', () => {
+    expect(rejectedFields(formFor({ pools: [buildPool({ name: '' })] }))).toEqual([
+      'pools',
+    ])
+    expect(rejectedFields(formFor({ pools: [buildPool({ name: '   ' })] }))).toEqual([
+      'pools',
+    ])
+    expect(rejectedFields(formFor({ pools: [buildPool({ name: 'Pool A' })] }))).toEqual(
+      [],
+    )
+  })
+
+  /** ⚠️ No ceiling: `Pool.name` has `min_length=1` and **no** `max_length` (a pool lives
+   * in JSONB — there is no column to overflow, unlike the event's `VARCHAR(255)`).
+   * Mirroring a bound the API does not have would refuse a save nothing on the server
+   * would ever have refused. */
+  it('does NOT invent a ceiling the server has no column for', () => {
+    expect(
+      rejectedFields(formFor({ pools: [buildPool({ name: 'A'.repeat(300) })] })),
+    ).toEqual([])
+  })
+
+  /** The name that is *sent* is the name that was judged: trimmed, so the server's
+   * `min_length` counts the same characters this schema did. */
+  it('trims the pool name it lets through', () => {
+    const parsed = eventSchema.parse(
+      formFor({ pools: [buildPool({ name: '  Championship  ' })] }),
+    )
+    expect(parsed.pools[0].name).toBe('Championship')
+  })
 })
 
 describe('eventToFormValues', () => {
@@ -94,6 +129,12 @@ describe('firstInvalidSection', () => {
     expect(
       firstInvalidSection({ predicates: { type: 'custom', message: 'x' } }),
     ).toBe('eligibility')
+  })
+
+  it('sends a broken pool name to Table pools', () => {
+    expect(firstInvalidSection({ pools: { type: 'custom', message: 'x' } })).toBe(
+      'pools',
+    )
   })
 
   // With both broken, the name is the field they are most likely to have simply not

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
@@ -5,6 +5,7 @@ import {
   entryFeeSchema,
   maxPlayersSchema,
   nameSchema,
+  poolNameSchema,
   type EventSection,
 } from '../data/event-validation'
 import { PRED_OPS_BY_TYPE, type PredicateOp } from '../data/options'
@@ -72,10 +73,14 @@ const predicateSchema: z.ZodType<Predicate, Predicate> = z.object({
 /** A table pool — its name, its window, and the tables it reserves. Typed as the
  * domain's `Pool` for the same reason `predicateSchema` is: the pool cards hand a
  * form field back as a `Pool`, and a mirror that is merely *similar* would need a
- * cast to cross that seam. */
+ * cast to cross that seam.
+ *
+ * `name` carries the server's floor (`poolNameSchema`, `data/event-validation`) — the
+ * one field of a pool the organizer can *clear*. Its `id` is minted and boxless, so it
+ * is left alone: see the note on `poolNameSchema`. */
 const poolSchema: z.ZodType<Pool, Pool> = z.object({
   id: z.string(),
-  name: z.string(),
+  name: poolNameSchema,
   slot: slotSchema,
   tableIds: z.array(z.string()),
 })
@@ -97,6 +102,9 @@ const poolSchema: z.ZodType<Pool, Pool> = z.object({
  *   no server-side twin to mirror: the API is deliberately MORE permissive about a
  *   half-written rule than the product is (it accepts `Rating < ?`, a restriction on
  *   nobody, and renders it on the card as though it were real).
+ * - `pools` carries the newest of the server's floors: a pool's `name` may not be
+ *   blank (`poolNameSchema`). The pools editor mints the id and the default name, so
+ *   only the *box* could ever author one — and it did.
  */
 export const eventSchema = z.object({
   name: nameSchema,
@@ -186,14 +194,20 @@ export function eventToFormValues(event: TournamentEvent | null): EventFormValue
  * A message on a tab you cannot see is indistinguishable from a button that does
  * nothing, which is exactly what Save looked like before this existed.
  *
- * Basics before Eligibility, deliberately: with both broken, the name is the field
- * they are most likely to have simply not filled in, and landing on the *later* tab
- * would leave the empty name behind them, unseen.
+ * Basics before Eligibility before Table pools, deliberately: that is the order the
+ * tabs are in, and with more than one broken, the name is the field they are most
+ * likely to have simply not filled in — landing on a *later* tab would leave the empty
+ * name behind them, unseen.
  */
 export function firstInvalidSection(
   errors: FieldErrors<EventFormValues>,
 ): EventSection | null {
   if (errors.name || errors.maxPlayers || errors.entryFee) return 'basics'
   if (errors.predicates) return 'eligibility'
+  // A pool with a cleared name (`poolNameSchema`). RHF reports it per row
+  // (`errors.pools[2].name`) *and* sets the array key, so the truthiness of `pools` is
+  // the whole question here — which row it is, the card itself says, in red, under the
+  // box. Match settings has no arm: every control on it is a closed picker.
+  if (errors.pools) return 'pools'
   return null
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab.test.tsx
@@ -7,6 +7,7 @@ import { server } from '@/mocks/server'
 import { screen, waitFor } from '@/test/utilities'
 
 import {
+  buildDrawnEvent,
   buildTournament,
   buildEntrant,
   buildEntrants,
@@ -189,6 +190,50 @@ describe('EventsTab', () => {
         screen.getByText(/Click any event for details\./),
       ).toBeInTheDocument()
       expect(screen.queryByText(/Click any event to edit\./)).toBeNull()
+    })
+  })
+
+  // The draw hangs off the EVENT (ADR-0786) — there is no Draw tab, because a draw
+  // belongs to one event and a tab would have to ask which. Wiring only: the panel's own
+  // quartet pins the pools, the rounds, the refusals and the empty state.
+  describe('the draw on each card', () => {
+    it('gives every event its own draw panel, fed that event’s tournament', async () => {
+      eventsTabPage.render({
+        tournament: buildTournament({
+          id: 't-1',
+          events: [buildDrawnEvent(), buildEvent({ id: 'ev-open-singles' })],
+        }),
+      })
+
+      // The drawn event expands into its pools…
+      expect(eventsTabPage.getPoolLines('p-a')).toEqual([
+        'player.1 vs player.4',
+        'player.1 vs player.5',
+        'player.4 vs player.5',
+      ])
+      // …and the undrawn one shows its designed empty state, not a gap.
+      expect(eventsTabPage.queryPanel('ev-open-singles')).toBeInTheDocument()
+      expect(eventsTabPage.getEmptyState()).toHaveTextContent('No draw yet.')
+    })
+
+    it('gates the draw verbs on the tournament’s canEdit, like every other owner action', () => {
+      const tournament = buildTournament({ events: [buildDrawnEvent()] })
+
+      eventsTabPage.render({ tournament, canEdit: false })
+
+      expect(eventsTabPage.queryRecutButton('U1200 Singles')).toBeNull()
+      expect(eventsTabPage.queryDeleteButton('U1200 Singles')).toBeNull()
+      expect(eventsTabPage.getPanelControls('ev-u1200')).toHaveLength(0)
+    })
+
+    it('offers the creator the draw verbs on the card itself', () => {
+      eventsTabPage.render({
+        tournament: buildTournament({ events: [buildDrawnEvent()] }),
+        canEdit: true,
+      })
+
+      expect(eventsTabPage.queryRecutButton('U1200 Singles')).toBeInTheDocument()
+      expect(eventsTabPage.queryDeleteButton('U1200 Singles')).toBeInTheDocument()
     })
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import type { Tournament, TournamentEvent } from '../data/types'
 import { EmptyState } from '../empty-state'
 import { SectionHeader } from './section-header'
+import { DrawPanel } from './events-tab/draw-panel'
 import { EventCard } from './events-tab/event-card'
 import { EnterEventControl } from './events-tab/enter-event-control'
 
@@ -84,6 +85,18 @@ export const EventsTab = ({
               // tournament, not just its id, because whether registration is open
               // at all is a property of the tournament's STATUS (ADR-0017).
               action={<EnterEventControl tournament={tournament} event={ev} />}
+              // The event's draw (ADR-0786): its pools and fixtures for everyone, its
+              // three verbs for the director alone. It hangs off the EVENT, not off a
+              // tab of its own — a draw belongs to one event, and a "Draw" tab would
+              // have to ask which one it meant. `canEdit` is the tournament's, the same
+              // flag every other owner-only affordance on this page is gated on.
+              draw={
+                <DrawPanel
+                  tournamentId={tournament.id}
+                  event={ev}
+                  canEdit={canEdit}
+                />
+              }
             />
           ))}
         </div>

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.factory.tsx
@@ -1,0 +1,20 @@
+import { buildDrawnEvent } from '../../data/seed.factory'
+import type { DrawPanelProps } from './draw-panel'
+
+/** Props for `DrawPanel` — the **drawn** U1200 Singles (round-robin, two pools, an odd
+ * Pool A), read by its director.
+ *
+ * Drawn by default because that is the state with something in it: the undrawn case is
+ * one line of copy, and a bare `render()` that showed it would make the panel's whole
+ * job invisible. Pass `event: buildEvent()` for the empty state, `canEdit: false` for a
+ * player's view. */
+export function buildDrawPanelProps(
+  overrides: Partial<DrawPanelProps> = {},
+): DrawPanelProps {
+  return {
+    tournamentId: 'bay-area-open-2026',
+    event: buildDrawnEvent(),
+    canEdit: true,
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.page.tsx
@@ -1,0 +1,106 @@
+import { interactiveElementsIn } from '@/test/read-only'
+import { render, screen, type Container } from '@/test/utilities'
+
+import { DrawPanel, type DrawPanelProps } from './draw-panel'
+import { buildDrawPanelProps } from './draw-panel.factory'
+import { poolDrawPage } from './draw-panel/pool-draw.page'
+
+const scoped = (container: Container) => ({
+  /** The whole panel for one event — the scope a read-only guard sweeps, and the one an
+   * Events tab narrows to when several cards are on screen. */
+  getPanel(eventId: string) {
+    return container.getByTestId(`draw-panel-${eventId}`)
+  },
+  queryPanel(eventId: string) {
+    return container.queryByTestId(`draw-panel-${eventId}`)
+  },
+
+  /** **Generate draw** — the director's verb on an event with no draw. Absent for
+   * everyone else, and absent (in favour of Re-cut) once a draw exists. */
+  queryGenerateButton(eventName: string) {
+    return container.queryByRole('button', {
+      name: `Generate draw for ${eventName}`,
+    })
+  },
+  findGenerateButton(eventName: string) {
+    return container.findByRole('button', {
+      name: `Generate draw for ${eventName}`,
+    })
+  },
+  /** **Re-cut draw** — replaces a standing draw wholesale. */
+  queryRecutButton(eventName: string) {
+    return container.queryByRole('button', { name: `Re-cut draw for ${eventName}` })
+  },
+  findRecutButton(eventName: string) {
+    return container.findByRole('button', { name: `Re-cut draw for ${eventName}` })
+  },
+  /** **Delete draw** — un-cuts it, and unfreezes the pool set. */
+  queryDeleteButton(eventName: string) {
+    return container.queryByRole('button', { name: `Delete draw for ${eventName}` })
+  },
+  findDeleteButton(eventName: string) {
+    return container.findByRole('button', { name: `Delete draw for ${eventName}` })
+  },
+
+  /** The **designed empty state** of an event with no draw — inert copy, never a
+   * spinner and never an error. */
+  queryEmptyState() {
+    return container.queryByTestId('draw-empty')
+  },
+  getEmptyState() {
+    return container.getByTestId('draw-empty')
+  },
+
+  /** The inline **refusal** — the 409, the 422 and every other failure, in the place the
+   * click happened. Found by role (`alert`), which is the contract: it is the app talking
+   * back, and a screen reader must hear it without hunting for it. */
+  queryNotice() {
+    return container.queryByRole('alert')
+  },
+  findNotice() {
+    return container.findByRole('alert')
+  },
+  /** The notice as one normalised string — title *and* the sentence beneath it, since
+   * the whole point of the 409/422 copy is that both halves are there. */
+  async findNoticeText() {
+    const notice = await container.findByRole('alert')
+    return (notice.textContent ?? '').replace(/\s+/g, ' ').trim()
+  },
+
+  /** EVERY control in the panel. The sweep a "a non-owner is offered nothing" claim
+   * actually needs: the named accessors above would miss a button that was renamed or
+   * left unlabelled, and "no *enabled* button" is not the assertion — "no button at
+   * all" is (ADR-0015: hide the affordance, never disable it). */
+  getPanelControls(eventId: string) {
+    return interactiveElementsIn(container.getByTestId(`draw-panel-${eventId}`))
+  },
+
+  /** The un-pooled group — fixtures belonging to no pool. Empty today (round-robin is
+   * the only draw type with a generator), but never *dropped*. */
+  queryUnpooled() {
+    return container.queryByTestId('draw-unpooled')
+  },
+
+  // Pools, rounds and fixture lines come from the child page objects.
+  ...poolDrawPage.within(container),
+})
+
+/**
+ * Test page-object for `DrawPanel`.
+ *
+ * The panel owns the two draw mutations (`useCutDraw` / `useUncutDraw`), so a test that
+ * clicks one of its verbs must stub the draw endpoint itself — `mockEventCutDrawEndpoint`
+ * / `mockEventUncutDrawEndpoint` (`@/mocks/endpoints/tournaments/tournaments.endpoint`).
+ * Rendering alone fetches nothing: the fixtures ride the event it is handed.
+ */
+export const drawPanelPage = {
+  render(overrides: Partial<DrawPanelProps> = {}) {
+    render(<DrawPanel {...buildDrawPanelProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.test.tsx
@@ -1,0 +1,404 @@
+import userEvent from '@testing-library/user-event'
+import { delay, HttpResponse } from 'msw'
+
+import {
+  mockEventCutDrawEndpoint,
+  mockEventUncutDrawEndpoint,
+} from '@/mocks/endpoints/tournaments/tournaments.endpoint'
+import { buildTournamentFixtureRead } from '@/mocks/factories/tournaments/tournament.factory'
+import { server } from '@/mocks/server'
+import { waitFor } from '@/test/utilities'
+
+import {
+  buildDrawnEvent,
+  buildEntrants,
+  buildEvent,
+  buildFixture,
+  buildPool,
+} from '../../data/seed.factory'
+import { drawPanelPage as page } from './draw-panel.page'
+
+/** The seeded drawn event: round-robin, `player.1`…`player.5`, Pool A (1/4/5 — odd) and
+ * Pool B (2/3). */
+const DRAWN = buildDrawnEvent()
+
+/** What a successful cut answers with. The panel does not read it — the refetched
+ * tournament carries the new draw — but it must be a payload the parser accepts, or the
+ * mutation rejects and the test would be asserting against a *failed* cut. */
+const cutResponse = () => [
+  buildTournamentFixtureRead({
+    id: 'fx-a-1',
+    pool_id: 'p-a',
+    round: 1,
+    position: 1,
+    entry_a_id: 'entry-1',
+    entry_b_id: 'entry-4',
+  }),
+]
+
+describe('DrawPanel', () => {
+  describe('an event whose draw is cut', () => {
+    it('expands into its pools, in the event’s pool order', () => {
+      page.render({ event: DRAWN })
+
+      expect(page.getPoolHeading('Pool A')).toBeInTheDocument()
+      expect(page.getPoolHeading('Pool B')).toBeInTheDocument()
+      expect(page.queryEmptyState()).toBeNull()
+    })
+
+    it('lists each pool’s entrants by name — the membership its fixtures imply', () => {
+      page.render({ event: DRAWN })
+
+      // The snake dealt 1/4/5 into Pool A and 2/3 into Pool B. Nothing on the wire says
+      // so: it is derived from the fixtures (ADR-0786).
+      expect(page.getPoolEntrants('Pool A')).toEqual([
+        'player.1',
+        'player.4',
+        'player.5',
+      ])
+      expect(page.getPoolEntrants('Pool B')).toEqual(['player.2', 'player.3'])
+    })
+
+    it('renders every fixture as a named "A vs B" line, in round order, in its own pool', () => {
+      page.render({ event: DRAWN })
+
+      // NAMES, joined from the event's entrants by entry id — a panel that printed the
+      // raw uuids would satisfy "some fixtures rendered" and be useless to a director.
+      expect(page.getPoolLines('p-a')).toEqual([
+        'player.1 vs player.4',
+        'player.1 vs player.5',
+        'player.4 vs player.5',
+      ])
+      expect(page.getPoolLines('p-b')).toEqual(['player.2 vs player.3'])
+      // Grouped, not merely listed: each line sits inside the round it belongs to.
+      expect(page.getRoundLines(1, 'Pool A')).toEqual(['player.1 vs player.4'])
+      expect(page.getRoundLines(3, 'Pool A')).toEqual(['player.4 vs player.5'])
+      expect(page.getRoundNames()).toEqual([
+        'Round 1 fixtures in Pool A',
+        'Round 2 fixtures in Pool A',
+        'Round 3 fixtures in Pool A',
+        'Round 1 fixtures in Pool B',
+      ])
+    })
+
+    // An ODD pool (three players) plays three rounds of ONE fixture — the third player
+    // sits each round out. A bye is the ABSENCE of a fixture (ADR-0786), so there is no
+    // bye row and no fixture with an empty side.
+    it('shows an odd pool’s bye as a missing fixture, not as a row', () => {
+      page.render({ event: DRAWN })
+
+      expect(page.getPoolLines('p-a')).toHaveLength(3)
+      expect(page.getLineTexts().some((line) => /bye/i.test(line))).toBe(false)
+    })
+
+    it('renders a TBD side as TBD, not as a blank', () => {
+      const withTbd = buildDrawnEvent({
+        fixtures: [
+          buildFixture({
+            id: 'fx-a-1',
+            poolId: 'p-a',
+            round: 1,
+            position: 1,
+            entryAId: 'entry-1',
+            entryBId: null,
+          }),
+        ],
+      })
+
+      page.render({ event: withTbd })
+
+      expect(page.getPoolLines('p-a')).toEqual(['player.1 vs TBD'])
+    })
+
+    it('keeps a fixture that belongs to no pool, rather than dropping it', () => {
+      const withKo = buildDrawnEvent({
+        fixtures: [
+          buildFixture({
+            id: 'fx-ko-1',
+            poolId: null,
+            round: 1,
+            position: 1,
+            entryAId: 'entry-1',
+            entryBId: null,
+          }),
+        ],
+      })
+
+      page.render({ event: withKo })
+
+      expect(page.queryUnpooled()).toBeInTheDocument()
+      expect(page.getLineTexts()).toEqual(['player.1 vs TBD'])
+    })
+  })
+
+  describe('an event with no draw', () => {
+    it('shows a designed empty state — never a spinner, never an error', () => {
+      page.render({ event: buildEvent({ name: 'Open Singles' }) })
+
+      expect(page.getEmptyState()).toHaveTextContent('No draw yet.')
+      expect(page.queryNotice()).toBeNull()
+      expect(page.getLines()).toHaveLength(0)
+    })
+
+    it('offers the director Generate — and neither of the drawn verbs', () => {
+      page.render({ event: buildEvent({ name: 'Open Singles' }), canEdit: true })
+
+      expect(page.queryGenerateButton('Open Singles')).toBeInTheDocument()
+      expect(page.queryRecutButton('Open Singles')).toBeNull()
+      expect(page.queryDeleteButton('Open Singles')).toBeNull()
+    })
+
+    // A player is not the director. They get the *fact* — the fixtures are not up — in
+    // words written for them, and NO control: not a disabled Generate (an unexplained
+    // dead end, ADR-0015), and not an imperative to press a button that isn't there.
+    it('offers a non-owner nothing at all, and copy that does not tell them to generate one', () => {
+      page.render({
+        event: buildEvent({ id: 'ev-open-singles', name: 'Open Singles' }),
+        canEdit: false,
+      })
+
+      expect(page.getEmptyState()).toHaveTextContent(
+        'The fixtures will appear here once the director cuts the draw.',
+      )
+      expect(page.getEmptyState()).not.toHaveTextContent('Generate')
+      expect(page.getPanelControls('ev-open-singles')).toHaveLength(0)
+    })
+  })
+
+  describe('the owner’s verbs', () => {
+    it('offers Re-cut and Delete on a draw that is already cut', () => {
+      page.render({ event: DRAWN })
+
+      expect(page.queryRecutButton('U1200 Singles')).toBeInTheDocument()
+      expect(page.queryDeleteButton('U1200 Singles')).toBeInTheDocument()
+      expect(page.queryGenerateButton('U1200 Singles')).toBeNull()
+    })
+
+    it('shows a NON-owner the cut draw and none of its verbs', () => {
+      page.render({ event: DRAWN, canEdit: false })
+
+      // The draw itself is not owner-only — the players in it may read it…
+      expect(page.getPoolLines('p-a')).toHaveLength(3)
+      // …and there is not one control anywhere in the panel.
+      expect(page.getPanelControls('ev-u1200')).toHaveLength(0)
+    })
+
+    it('cuts the draw at that event’s draw resource', async () => {
+      let seen: { url: string; method: string } | null = null
+      mockEventCutDrawEndpoint(server, ({ request }) => {
+        seen = { url: request.url, method: request.method }
+        return HttpResponse.json(cutResponse(), { status: 201 })
+      })
+      page.render({
+        tournamentId: 't-1',
+        event: buildEvent({ id: 'ev-1', name: 'Open Singles' }),
+      })
+
+      await userEvent.click(await page.findGenerateButton('Open Singles'))
+
+      await waitFor(() => expect(seen).not.toBeNull())
+      expect(seen!.method).toBe('POST')
+      expect(seen!.url).toContain('/v1/tournaments/t-1/events/ev-1/draw')
+      // A clean cut says nothing: the refetched tournament is the answer.
+      expect(page.queryNotice()).toBeNull()
+    })
+
+    it('re-cuts a standing draw through the same POST', async () => {
+      let seen = ''
+      mockEventCutDrawEndpoint(server, ({ request }) => {
+        seen = request.url
+        return HttpResponse.json(cutResponse(), { status: 201 })
+      })
+      page.render({ tournamentId: 't-1', event: DRAWN })
+
+      await userEvent.click(await page.findRecutButton('U1200 Singles'))
+
+      await waitFor(() =>
+        expect(seen).toContain('/v1/tournaments/t-1/events/ev-u1200/draw'),
+      )
+    })
+
+    it('deletes a draw with a DELETE on that same resource', async () => {
+      let seen: { url: string; method: string } | null = null
+      mockEventUncutDrawEndpoint(server, ({ request }) => {
+        seen = { url: request.url, method: request.method }
+        return new HttpResponse(null, { status: 204 })
+      })
+      page.render({ tournamentId: 't-1', event: DRAWN })
+
+      await userEvent.click(await page.findDeleteButton('U1200 Singles'))
+
+      await waitFor(() => expect(seen).not.toBeNull())
+      expect(seen!.method).toBe('DELETE')
+      expect(seen!.url).toContain('/v1/tournaments/t-1/events/ev-u1200/draw')
+    })
+
+    // One whole-draw replacement at a time: a double-click must not race two cuts.
+    it('locks the verbs while one is in flight', async () => {
+      let calls = 0
+      mockEventCutDrawEndpoint(server, async () => {
+        calls += 1
+        await delay('infinite')
+        return HttpResponse.json(cutResponse(), { status: 201 })
+      })
+      page.render({ tournamentId: 't-1', event: DRAWN })
+
+      const recut = await page.findRecutButton('U1200 Singles')
+      await userEvent.click(recut)
+
+      await waitFor(() => expect(recut).toBeDisabled())
+      expect(page.queryDeleteButton('U1200 Singles')).toBeDisabled()
+      await userEvent.click(recut)
+      expect(calls).toBe(1)
+    })
+  })
+
+  // The refusals. Each is rendered INLINE, where the click happened — the draw verbs
+  // carry no toast (`web-client/CLAUDE.md`, ## Forms) — and for the 409 and the 422 the
+  // sentence beneath the title is the SERVER'S: it is written for the director and names
+  // what they have to change. A generic string of ours would throw that away.
+  describe('refusals', () => {
+    const PLAY_GUARD =
+      "This event's draw is already under way — at least one fixture has a match " +
+      'or a recorded winner — so it can no longer be cut or removed.'
+
+    it('explains the 409 play-guard on a re-cut, in the server’s words', async () => {
+      mockEventCutDrawEndpoint(server, () =>
+        HttpResponse.json({ detail: PLAY_GUARD }, { status: 409 }),
+      )
+      page.render({ event: DRAWN })
+
+      await userEvent.click(await page.findRecutButton('U1200 Singles'))
+
+      const notice = await page.findNoticeText()
+      expect(notice).toContain('This draw is already under way')
+      expect(notice).toContain(PLAY_GUARD)
+      // The standing draw is untouched — a refused cut destroys nothing.
+      expect(page.getPoolLines('p-a')).toHaveLength(3)
+    })
+
+    it('explains the 409 play-guard on a delete, too', async () => {
+      mockEventUncutDrawEndpoint(server, () =>
+        HttpResponse.json({ detail: PLAY_GUARD }, { status: 409 }),
+      )
+      page.render({ event: DRAWN })
+
+      await userEvent.click(await page.findDeleteButton('U1200 Singles'))
+
+      expect(await page.findNoticeText()).toContain(PLAY_GUARD)
+    })
+
+    it('shows the 422 for a draw type nothing can cut yet', async () => {
+      const detail =
+        'A swiss draw cannot be cut yet. ' +
+        "Change the event's draw type to one that can, or wait for support."
+      mockEventCutDrawEndpoint(server, () =>
+        HttpResponse.json({ detail }, { status: 422 }),
+      )
+      page.render({
+        event: buildEvent({
+          id: 'ev-swiss',
+          name: 'Swiss Singles',
+          drawType: 'swiss',
+        }),
+      })
+
+      await userEvent.click(await page.findGenerateButton('Swiss Singles'))
+
+      const notice = await page.findNoticeText()
+      expect(notice).toContain("This event can't be drawn yet")
+      expect(notice).toContain(detail)
+    })
+
+    it('shows the 422 for an event with no pools configured', async () => {
+      const detail = 'A round-robin draw needs at least one pool.'
+      mockEventCutDrawEndpoint(server, () =>
+        HttpResponse.json({ detail }, { status: 422 }),
+      )
+      page.render({
+        event: buildEvent({
+          id: 'ev-rr',
+          name: 'U1500 Singles',
+          drawType: 'round-robin',
+          pools: [],
+        }),
+      })
+
+      await userEvent.click(await page.findGenerateButton('U1500 Singles'))
+
+      expect(await page.findNoticeText()).toContain(detail)
+    })
+
+    // The refusal whose NUMBERS are the whole message. No client-side string could carry
+    // "5 entrants across 3 pool(s)", which is exactly why the server's sentence is shown
+    // rather than a generic "this event can't be drawn".
+    it('shows the 422 for pools that would leave someone with nobody to play — numbers and all', async () => {
+      const detail =
+        '5 entrants across 3 pool(s) would leave a pool with fewer than 2 entrants, ' +
+        'who would have nobody to play.'
+      mockEventCutDrawEndpoint(server, () =>
+        HttpResponse.json({ detail }, { status: 422 }),
+      )
+      page.render({
+        event: buildEvent({
+          id: 'ev-rr',
+          name: 'U1500 Singles',
+          drawType: 'round-robin',
+          entrants: buildEntrants(5),
+          pools: [
+            buildPool({ id: 'p-1', name: 'Pool A' }),
+            buildPool({ id: 'p-2', name: 'Pool B' }),
+            buildPool({ id: 'p-3', name: 'Pool C' }),
+          ],
+        }),
+      })
+
+      await userEvent.click(await page.findGenerateButton('U1500 Singles'))
+
+      const notice = await page.findNoticeText()
+      expect(notice).toContain('5 entrants across 3 pool(s)')
+      expect(notice).toContain('nobody to play')
+    })
+
+    // No silent failures: the verbs carry no toast, so the panel must have words for the
+    // failures that have no designed state of their own too.
+    it('says something when the request never reaches the server', async () => {
+      mockEventCutDrawEndpoint(server, () => HttpResponse.error())
+      page.render({ event: buildEvent({ name: 'Open Singles' }) })
+
+      await userEvent.click(await page.findGenerateButton('Open Singles'))
+
+      const notice = await page.findNoticeText()
+      expect(notice).toContain("Couldn't cut the draw")
+    })
+
+    it('clears the last refusal when the director tries again', async () => {
+      let attempt = 0
+      mockEventCutDrawEndpoint(server, () => {
+        attempt += 1
+        return attempt === 1
+          ? HttpResponse.json(
+              { detail: 'A round-robin draw needs at least one pool.' },
+              { status: 422 },
+            )
+          : HttpResponse.json(cutResponse(), { status: 201 })
+      })
+      page.render({
+        event: buildEvent({
+          id: 'ev-rr',
+          name: 'U1500 Singles',
+          drawType: 'round-robin',
+          pools: [],
+        }),
+      })
+
+      const generate = await page.findGenerateButton('U1500 Singles')
+      await userEvent.click(generate)
+      expect(await page.findNoticeText()).toContain('at least one pool')
+
+      await userEvent.click(generate)
+
+      await waitFor(() => expect(page.queryNotice()).toBeNull())
+    })
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
@@ -1,0 +1,233 @@
+import { Shuffle, Trash2 } from 'lucide-react'
+import { useId, useState } from 'react'
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+
+import { useCutDraw, useUncutDraw } from '../../data/api'
+import { drawRefusalNotice, drawState, type DrawNotice } from '../../data/draw'
+import type { TournamentEvent } from '../../data/types'
+import { LeadReason } from './lead-reason'
+import { PoolDraw } from './draw-panel/pool-draw'
+import { RoundList } from './draw-panel/round-list'
+
+export interface DrawPanelProps {
+  tournamentId: string
+  event: TournamentEvent
+  /** The tournament's `can_edit` — the server's word on whether this viewer is its
+   * creator. Gates the three draw verbs: a non-owner sees the draw and *no* controls
+   * (ADR-0015 — hidden, never disabled). Not a security boundary: the API 403s the
+   * endpoints independently, and must continue to. */
+  canEdit: boolean
+}
+
+/**
+ * An event's **draw**, on its card in the Events tab (ADR-0786): the pools it was cut
+ * across, and — for the director — the three verbs that cut, re-cut and remove it.
+ *
+ * There is no "Draw" tab, and there should not be: a draw belongs to an *event*, and
+ * the tab axis of this page is per-concern (details, events, tables, schedule). A draw
+ * that lived in a tab of its own would have to ask which event it meant.
+ *
+ * ## The two data states, both designed
+ *
+ * `drawState` (`../../data/draw`) reduces the event to one of them, so this component
+ * branches on a **sum type** rather than on `fixtures.length` — a truthiness check on a
+ * list is the client-side twin of a tri-state boolean:
+ *
+ * - **undrawn** — `fixtures: []`, the state every event is born in. It is a *data*
+ *   state, not a spinner and not an error: the panel says there is no draw yet, and (for
+ *   the director) offers to cut one. Nothing here ever auto-cuts; cutting is an explicit,
+ *   reviewable act, which is exactly why the ADR refused to fold it into go-live.
+ * - **drawn** — the pools, their members and their fixtures, round by round
+ *   (`PoolDraw`).
+ *
+ * ## Refusals are inline, and the server's sentence is the copy
+ *
+ * The panel surfaces its own failures — `useCutDraw` / `useUncutDraw` carry **no global
+ * `onError` toast**, deliberately (`web-client/CLAUDE.md`, ## Forms: a mutation whose
+ * errors are surfaced inline must not also toast, or the user is told twice). The two
+ * refusals a director actually meets keep the **server's** wording, because it is
+ * authored for them and it names the numbers they must change:
+ *
+ * - **409** — the draw shows evidence of play. It can no longer be cut or removed.
+ * - **422** — this event cannot be planned as it stands: an unsupported draw type (only
+ *   round-robin has a generator today), no pools, or a pool that would get fewer than
+ *   two entrants.
+ *
+ * Everything else (403, an expired session, a 5xx, a dead network) has designed words of
+ * its own in `drawRefusalNotice` — there is no arm that fails silently.
+ *
+ * The refused verb leaves the draw exactly as it was: the panel holds no optimistic
+ * state, because there is no local edit to apply — only a new draw to read back. Both
+ * mutations reconcile the tournament on settle, so the fixtures below rewrite themselves
+ * from the refetched event.
+ */
+export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
+  const headingId = useId()
+  const cut = useCutDraw(tournamentId)
+  const uncut = useUncutDraw(tournamentId)
+  // The last refusal, in words. Cleared when a new attempt starts — a notice about the
+  // click before last is worse than none.
+  const [notice, setNotice] = useState<DrawNotice | null>(null)
+
+  const state = drawState(event)
+  // One in-flight draw verb at a time. A second click on Re-cut while the first is still
+  // flying would race two whole-draw replacements against each other.
+  const isPending = cut.isPending || uncut.isPending
+
+  const attempt = async (verb: string, fire: () => Promise<unknown>) => {
+    setNotice(null)
+    try {
+      await fire()
+    } catch (error) {
+      // `mutateAsync` rejects; the notice IS the error surface (there is no toast).
+      setNotice(drawRefusalNotice(error, verb))
+    }
+  }
+
+  return (
+    <section
+      data-testid={`draw-panel-${event.id}`}
+      aria-labelledby={headingId}
+      className="border-t border-[color:var(--border-subtle)] px-[18px] py-3"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3
+          id={headingId}
+          className="text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase"
+        >
+          Draw
+        </h3>
+        {/* The verbs, for the director alone. A non-owner gets no button — not a
+            disabled one (ADR-0015: a disabled control is an unexplained dead end), and
+            not a misleading invitation to generate a draw they cannot generate. */}
+        {canEdit && (
+          <div className="flex items-center gap-2">
+            {state.kind === 'undrawn' ? (
+              <Button
+                size="sm"
+                // Named per event: the tab renders one of these panels per card, and
+                // "Generate draw" alone would be five identical buttons.
+                aria-label={`Generate draw for ${event.name}`}
+                disabled={isPending}
+                onClick={() =>
+                  attempt('cut the draw', () => cut.mutateAsync(event.id))
+                }
+              >
+                <Shuffle size={14} />
+                Generate draw
+              </Button>
+            ) : (
+              <>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  aria-label={`Re-cut draw for ${event.name}`}
+                  disabled={isPending}
+                  onClick={() =>
+                    attempt('cut the draw', () => cut.mutateAsync(event.id))
+                  }
+                >
+                  <Shuffle size={14} />
+                  Re-cut draw
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  aria-label={`Delete draw for ${event.name}`}
+                  disabled={isPending}
+                  onClick={() =>
+                    attempt('remove the draw', () => uncut.mutateAsync(event.id))
+                  }
+                >
+                  <Trash2 size={14} />
+                  Delete draw
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* The refusal, where the click was — an `Alert` (the app talking back), not a
+          toast that leaves after four seconds carrying the one sentence that says what
+          to change. */}
+      {notice && (
+        <Alert
+          variant="destructive"
+          data-testid={`draw-notice-${event.id}`}
+          className="mt-2.5"
+        >
+          <AlertTitle>{notice.title}</AlertTitle>
+          <AlertDescription>{notice.description}</AlertDescription>
+        </Alert>
+      )}
+
+      <DrawBody state={state} canEdit={canEdit} />
+    </section>
+  )
+}
+
+const DrawBody = ({
+  state,
+  canEdit,
+}: {
+  state: ReturnType<typeof drawState>
+  canEdit: boolean
+}) => {
+  switch (state.kind) {
+    case 'undrawn':
+      // Empty is a **designed data state**, never a gap and never a spinner. The copy
+      // is voiced for whoever is reading it (ADR-0015, rule 5: swap organizer-voiced
+      // copy): the director is told what the button beside them does; a player is told,
+      // plainly, that the fixtures are not up yet — not invited to press a button that
+      // is not there.
+      return (
+        <LeadReason
+          className="mt-1.5"
+          testId="draw-empty"
+          lead="No draw yet."
+          reason={
+            canEdit
+              ? 'Generate the draw to deal this event’s entrants into its pools and plan their fixtures.'
+              : 'The fixtures will appear here once the director cuts the draw.'
+          }
+        />
+      )
+
+    case 'drawn':
+      return (
+        <div className="mt-2.5 flex flex-col gap-2.5">
+          {state.pools.map((pool) => (
+            <PoolDraw key={pool.id} pool={pool} />
+          ))}
+          {/* Fixtures belonging to no pool — a knockout stage. Nothing can cut one
+              today (round-robin is the only generator), but a fixture the panel cannot
+              place must be SHOWN rather than silently dropped; the bracket that will
+              render them properly is #785. */}
+          {state.unpooled.length > 0 && (
+            <section
+              data-testid="draw-unpooled"
+              aria-label="Fixtures outside the pools"
+              className="rounded-[10px] border border-[color:var(--border-subtle)] p-3"
+            >
+              <h4 className="text-[13px] font-semibold text-[color:var(--fg-1)]">
+                Fixtures outside the pools
+              </h4>
+              <RoundList
+                rounds={state.unpooled}
+                groupName="the unpooled fixtures"
+              />
+            </section>
+          )}
+        </div>
+      )
+
+    default: {
+      // A third draw state without copy is a TYPE error here, not a blank card section.
+      const exhaustive: never = state
+      return exhaustive
+    }
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/pool-draw.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/pool-draw.factory.tsx
@@ -1,0 +1,33 @@
+import type { PoolDraw } from '../../../data/draw'
+import { buildEntrant } from '../../../data/seed.factory'
+import type { PoolDrawProps } from './pool-draw'
+import { buildDrawRounds } from './round-list.factory'
+
+/**
+ * Pool A of the seeded round-robin draw: an **odd** pool — `player.1`, `player.4` and
+ * `player.5` — playing three rounds of one fixture each (one of them sits out every
+ * round; that absence is the bye).
+ *
+ * Odd on purpose: an even pool's rounds all hold the same number of fixtures, so a
+ * renderer that invented a "bye" row would look identical against one.
+ */
+export function buildPoolDrawView(overrides: Partial<PoolDraw> = {}): PoolDraw {
+  return {
+    id: 'p-a',
+    name: 'Pool A',
+    entrants: [
+      buildEntrant({ id: 'entry-1', userId: 'u-1', username: 'player.1' }),
+      buildEntrant({ id: 'entry-4', userId: 'u-4', username: 'player.4' }),
+      buildEntrant({ id: 'entry-5', userId: 'u-5', username: 'player.5' }),
+    ],
+    rounds: buildDrawRounds(),
+    ...overrides,
+  }
+}
+
+/** Props for `PoolDraw`. */
+export function buildPoolDrawProps(
+  overrides: Partial<PoolDrawProps> = {},
+): PoolDrawProps {
+  return { pool: buildPoolDrawView(), ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/pool-draw.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/pool-draw.page.tsx
@@ -1,0 +1,55 @@
+import { interactiveElementsIn } from '@/test/read-only'
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import { PoolDraw, type PoolDrawProps } from './pool-draw'
+import { buildPoolDrawProps } from './pool-draw.factory'
+import { roundListPage } from './round-list.page'
+import { fixtureLineTexts } from './round-list/fixture-line.page'
+
+const scoped = (container: Container) => ({
+  /** The pool's whole section, by pool id — the scope every "in *this* pool" assertion
+   * narrows to, since a draw renders several of these side by side. */
+  getPool(poolId: string) {
+    return container.getByTestId(`pool-draw-${poolId}`)
+  },
+  queryPool(poolId: string) {
+    return container.queryByTestId(`pool-draw-${poolId}`)
+  },
+  /** The pool's heading — its name, as the event's `pools` names it. */
+  getPoolHeading(poolName: string) {
+    return container.getByRole('heading', { name: poolName })
+  },
+  /** The pool's entrants, in the order they render (draw order: seed, then
+   * registration). Names, not ids — a chip list of uuids would pass a "renders the
+   * roster" assertion and tell a director nothing. */
+  getPoolEntrants(poolName: string) {
+    return within(container.getByRole('list', { name: `Entrants in ${poolName}` }))
+      .getAllByRole('listitem')
+      .map((li) => (li.textContent ?? '').trim())
+  },
+  /** Every fixture line inside one pool, in DOM order — the sequence *is* the draw. */
+  getPoolLines(poolId: string) {
+    return fixtureLineTexts(container.getByTestId(`pool-draw-${poolId}`))
+  },
+  /** Everything interactive in the pool. Must always be empty: a fixture is a planned
+   * pairing, not a match, and the pool scaffold has no controls of its own — the draw's
+   * actions live in the panel's header. */
+  getPoolControls(poolId: string) {
+    return interactiveElementsIn(container.getByTestId(`pool-draw-${poolId}`))
+  },
+  // The round accessors (`getRoundLines`, `getRoundNames`) come from the round list.
+  ...roundListPage.within(container),
+})
+
+/** Test page-object for `PoolDraw`. */
+export const poolDrawPage = {
+  render(overrides: Partial<PoolDrawProps> = {}) {
+    render(<PoolDraw {...buildPoolDrawProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/pool-draw.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/pool-draw.test.tsx
@@ -1,0 +1,84 @@
+import { buildEntrant } from '../../../data/seed.factory'
+import { buildPoolDrawView } from './pool-draw.factory'
+import { poolDrawPage as page } from './pool-draw.page'
+import { buildDrawRound } from './round-list.factory'
+import { buildFixtureLineView } from './round-list/fixture-line.factory'
+
+describe('PoolDraw', () => {
+  it('heads the pool with its name', () => {
+    page.render({ pool: buildPoolDrawView({ name: 'Pool B' }) })
+
+    expect(page.getPoolHeading('Pool B')).toBeInTheDocument()
+  })
+
+  it('lists the pool’s entrants by NAME, in draw order', () => {
+    page.render({
+      pool: buildPoolDrawView({
+        name: 'Pool A',
+        // Draw order is the view's to decide (`drawState`, data/draw.ts); the pool
+        // renders exactly what it is handed, in that order.
+        entrants: [
+          buildEntrant({ id: 'entry-5', userId: 'u-5', username: 'player.5', seed: 1 }),
+          buildEntrant({ id: 'entry-1', userId: 'u-1', username: 'player.1' }),
+          buildEntrant({ id: 'entry-4', userId: 'u-4', username: 'player.4' }),
+        ],
+      }),
+    })
+
+    expect(page.getPoolEntrants('Pool A')).toEqual([
+      'player.5',
+      'player.1',
+      'player.4',
+    ])
+  })
+
+  it('renders every fixture as a named "A vs B" line, grouped by round', () => {
+    page.render({ pool: buildPoolDrawView({ id: 'p-a', name: 'Pool A' }) })
+
+    // Wiring plus content: the pool's own scope holds all three lines, in round order…
+    expect(page.getPoolLines('p-a')).toEqual([
+      'player.1 vs player.4',
+      'player.1 vs player.5',
+      'player.4 vs player.5',
+    ])
+    // …and each sits inside the round it belongs to, not merely somewhere on the page.
+    expect(page.getRoundLines(2, 'Pool A')).toEqual(['player.1 vs player.5'])
+  })
+
+  it('names its rounds after itself, so two pools’ rounds never collide', () => {
+    page.render({
+      pool: buildPoolDrawView({
+        id: 'p-b',
+        name: 'Pool B',
+        entrants: [
+          buildEntrant({ id: 'entry-2', userId: 'u-2', username: 'player.2' }),
+          buildEntrant({ id: 'entry-3', userId: 'u-3', username: 'player.3' }),
+        ],
+        rounds: [
+          buildDrawRound({
+            round: 1,
+            fixtures: [
+              buildFixtureLineView({
+                id: 'fx-b-1',
+                a: { kind: 'entrant', name: 'player.2' },
+                b: { kind: 'entrant', name: 'player.3' },
+              }),
+            ],
+          }),
+        ],
+      }),
+    })
+
+    expect(page.getRoundNames()).toEqual(['Round 1 fixtures in Pool B'])
+    expect(page.queryRound(1, 'Pool A')).toBeNull()
+  })
+
+  // A pool is a *plan*, not a game in progress: nothing in it is clickable until its
+  // fixtures become real matches (#788). It also sits under the event card's stretched
+  // open target, where a stray control would compete with it.
+  it('is inert — the scaffold carries no controls of its own', () => {
+    page.render({ pool: buildPoolDrawView({ id: 'p-a' }) })
+
+    expect(page.getPoolControls('p-a')).toHaveLength(0)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/pool-draw.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/pool-draw.tsx
@@ -1,0 +1,67 @@
+import { useId } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+
+import type { PoolDraw as PoolDrawView } from '../../../data/draw'
+import { RoundList } from './round-list'
+
+export interface PoolDrawProps {
+  pool: PoolDrawView
+}
+
+/**
+ * One **pool** of a cut draw: its name, the entrants the draw dealt into it, and its
+ * fixtures round by round.
+ *
+ * The entrants are the pool's *membership*, and nothing stores it — it is derived from
+ * the pool's own fixtures (ADR-0786, the same argument as ADR-0016's derived `entered`
+ * count), in **draw order** (seed, then registration). They are listed as chips, in the
+ * roster's voice, because "who is in this pool" is the first question a director asks of
+ * a draw and the fixtures alone answer it only by cross-referencing.
+ *
+ * A pool with an odd number of entrants simply has rounds with fewer fixtures in them —
+ * see `RoundList`. There is no bye row, here or anywhere.
+ *
+ * Inert: a fixture is a *planned* pairing, not a match (CONTEXT.md), so there is nothing
+ * to click on it until it materializes into one (#788).
+ */
+export const PoolDraw = ({ pool }: PoolDrawProps) => {
+  const headingId = useId()
+
+  return (
+    <section
+      data-testid={`pool-draw-${pool.id}`}
+      aria-labelledby={headingId}
+      className="rounded-[10px] border border-[color:var(--border-subtle)] p-3"
+    >
+      <h4
+        id={headingId}
+        className="text-[13px] font-semibold text-[color:var(--fg-1)]"
+      >
+        {pool.name}
+      </h4>
+
+      {/* Named per pool: a draw holds several rosters, and a screen reader running the
+          list rotor needs to tell one pool's entrants from the next's. */}
+      <ul
+        aria-label={`Entrants in ${pool.name}`}
+        className="mt-1.5 flex flex-wrap items-center gap-1.5"
+      >
+        {pool.entrants.map((entrant) => (
+          <Badge
+            key={entrant.id}
+            asChild
+            variant="ghost"
+            className="border-[color:var(--border-subtle)]"
+          >
+            {/* Rendered as the <li> itself (`asChild`), so the list stays a list: <ul>
+                may only parent <li>. */}
+            <li>{entrant.username}</li>
+          </Badge>
+        ))}
+      </ul>
+
+      <RoundList rounds={pool.rounds} groupName={pool.name} />
+    </section>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list.factory.tsx
@@ -1,0 +1,62 @@
+import type { DrawRound } from '../../../data/draw'
+import type { RoundListProps } from './round-list'
+import { buildFixtureLineView } from './round-list/fixture-line.factory'
+
+/** One round holding one fixture — the shape an ODD round-robin pool's rounds have (the
+ * third player sits out), and the smallest thing worth rendering. */
+export function buildDrawRound(overrides: Partial<DrawRound> = {}): DrawRound {
+  return {
+    round: 1,
+    fixtures: [buildFixtureLineView()],
+    ...overrides,
+  }
+}
+
+/**
+ * The three rounds of an odd (three-player) round-robin pool: `player.1`, `player.4`,
+ * `player.5` playing each other once, one fixture a round.
+ *
+ * Deliberately the odd case — an even pool's rounds all hold the same number of
+ * fixtures, so a renderer that quietly invented a "bye" row would look identical.
+ */
+export function buildDrawRounds(): DrawRound[] {
+  return [
+    buildDrawRound({
+      round: 1,
+      fixtures: [
+        buildFixtureLineView({
+          id: 'fx-a-1',
+          a: { kind: 'entrant', name: 'player.1' },
+          b: { kind: 'entrant', name: 'player.4' },
+        }),
+      ],
+    }),
+    buildDrawRound({
+      round: 2,
+      fixtures: [
+        buildFixtureLineView({
+          id: 'fx-a-2',
+          a: { kind: 'entrant', name: 'player.1' },
+          b: { kind: 'entrant', name: 'player.5' },
+        }),
+      ],
+    }),
+    buildDrawRound({
+      round: 3,
+      fixtures: [
+        buildFixtureLineView({
+          id: 'fx-a-3',
+          a: { kind: 'entrant', name: 'player.4' },
+          b: { kind: 'entrant', name: 'player.5' },
+        }),
+      ],
+    }),
+  ]
+}
+
+/** Props for `RoundList` — the odd pool's three rounds, in Pool A. */
+export function buildRoundListProps(
+  overrides: Partial<RoundListProps> = {},
+): RoundListProps {
+  return { rounds: buildDrawRounds(), groupName: 'Pool A', ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list.page.tsx
@@ -1,0 +1,51 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { RoundList, type RoundListProps } from './round-list'
+import { buildRoundListProps } from './round-list.factory'
+import { fixtureLinePage, fixtureLineTexts } from './round-list/fixture-line.page'
+
+const scoped = (container: Container) => ({
+  /** The list of one round's fixtures, by its accessible name — the name is what tells
+   * Pool A's round 1 from Pool B's when both are on the page. */
+  getRound(round: number, groupName: string) {
+    return container.getByRole('list', {
+      name: `Round ${round} fixtures in ${groupName}`,
+    })
+  },
+  queryRound(round: number, groupName: string) {
+    return container.queryByRole('list', {
+      name: `Round ${round} fixtures in ${groupName}`,
+    })
+  },
+  /** One round's fixtures, as text (`player.1 vs player.4`), in the order they render. */
+  getRoundLines(round: number, groupName: string) {
+    return fixtureLineTexts(
+      container.getByRole('list', {
+        name: `Round ${round} fixtures in ${groupName}`,
+      }),
+    )
+  },
+  /** The rounds' accessible names, in DOM order — the assertion that a draw is grouped
+   * *and ordered*, not merely present. */
+  getRoundNames(): string[] {
+    return container
+      .queryAllByTestId(/^draw-round-/)
+      .map((list: HTMLElement) => list.getAttribute('aria-label') ?? '')
+  },
+  // Every fixture line in scope, in DOM order — a grouping assertion needs the whole
+  // sequence, not one round at a time.
+  ...fixtureLinePage.within(container),
+})
+
+/** Test page-object for `RoundList`. */
+export const roundListPage = {
+  render(overrides: Partial<RoundListProps> = {}) {
+    render(<RoundList {...buildRoundListProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list.test.tsx
@@ -1,0 +1,74 @@
+import { buildDrawRound, buildDrawRounds } from './round-list.factory'
+import { roundListPage as page } from './round-list.page'
+import { buildFixtureLineView } from './round-list/fixture-line.factory'
+
+describe('RoundList', () => {
+  it('groups the fixtures by round, in round order', () => {
+    page.render({ rounds: buildDrawRounds(), groupName: 'Pool A' })
+
+    expect(page.getRoundNames()).toEqual([
+      'Round 1 fixtures in Pool A',
+      'Round 2 fixtures in Pool A',
+      'Round 3 fixtures in Pool A',
+    ])
+  })
+
+  it('puts each round’s named fixtures inside that round, and nowhere else', () => {
+    page.render({ rounds: buildDrawRounds(), groupName: 'Pool A' })
+
+    expect(page.getRoundLines(1, 'Pool A')).toEqual(['player.1 vs player.4'])
+    expect(page.getRoundLines(2, 'Pool A')).toEqual(['player.1 vs player.5'])
+    expect(page.getRoundLines(3, 'Pool A')).toEqual(['player.4 vs player.5'])
+  })
+
+  it('renders a round’s fixtures in the order the view gives them', () => {
+    page.render({
+      rounds: [
+        buildDrawRound({
+          round: 4,
+          fixtures: [
+            buildFixtureLineView({
+              id: 'fx-1',
+              position: 1,
+              a: { kind: 'entrant', name: 'player.1' },
+              b: { kind: 'entrant', name: 'player.2' },
+            }),
+            buildFixtureLineView({
+              id: 'fx-2',
+              position: 2,
+              a: { kind: 'entrant', name: 'player.3' },
+              b: { kind: 'entrant', name: 'player.4' },
+            }),
+          ],
+        }),
+      ],
+      groupName: 'Pool B',
+    })
+
+    expect(page.getRoundLines(4, 'Pool B')).toEqual([
+      'player.1 vs player.2',
+      'player.3 vs player.4',
+    ])
+  })
+
+  // The ODD pool. Three players play three rounds of ONE fixture, because one of them
+  // sits each round out — and a bye is exactly that absence (ADR-0786). A "bye" row, or
+  // a fixture with an empty side, would be an invention.
+  it('leaves a bye as the absence of a fixture — never a row of its own', () => {
+    page.render({ rounds: buildDrawRounds(), groupName: 'Pool A' })
+
+    expect(page.getLineTexts()).toEqual([
+      'player.1 vs player.4',
+      'player.1 vs player.5',
+      'player.4 vs player.5',
+    ])
+    expect(page.getLineTexts().some((line) => /bye/i.test(line))).toBe(false)
+  })
+
+  it('names each round’s list per GROUP, so two pools’ round 1s are told apart', () => {
+    page.render({ rounds: [buildDrawRound({ round: 1 })], groupName: 'Pool B' })
+
+    expect(page.queryRound(1, 'Pool B')).toBeInTheDocument()
+    expect(page.queryRound(1, 'Pool A')).toBeNull()
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list.tsx
@@ -1,0 +1,46 @@
+import type { DrawRound } from '../../../data/draw'
+import { FixtureLine } from './round-list/fixture-line'
+
+export interface RoundListProps {
+  rounds: DrawRound[]
+  /** What these rounds belong to — a pool's name ("Pool A"), or the un-pooled group's
+   * heading. It is not rendered: it *names* each round's list for a screen reader
+   * ("Round 1 fixtures in Pool A"), which is the only thing that tells one pool's round
+   * 1 from the next pool's when a rotor lists them side by side. */
+  groupName: string
+}
+
+/**
+ * A draw's fixtures, **grouped by round** — the shape a director reads a draw in.
+ *
+ * Every round is a labelled list of its own fixtures, in position order. An odd
+ * round-robin pool has rounds holding **fewer fixtures** than the others, because the
+ * player drawn against the phantom seat sits that round out — and that is the entire
+ * representation of a bye (ADR-0786: "a bye is modeled as absence"). Nothing here emits
+ * a "bye" row: the wire never says one is missing, and a derived one would be a second
+ * copy of the planner's rotation, free to disagree with it.
+ *
+ * Shared by `PoolDraw` (a pool's rounds) and `DrawPanel` (the un-pooled fixtures of a
+ * knockout stage, which no draw type can cut yet — but which must not be dropped when
+ * one can, #785).
+ */
+export const RoundList = ({ rounds, groupName }: RoundListProps) => (
+  <div className="mt-2 flex flex-col gap-2">
+    {rounds.map((round) => (
+      <div key={round.round}>
+        <div className="text-[11px] font-semibold tracking-[0.08em] text-[color:var(--fg-3)] uppercase">
+          Round {round.round}
+        </div>
+        <ul
+          data-testid={`draw-round-${round.round}`}
+          aria-label={`Round ${round.round} fixtures in ${groupName}`}
+          className="mt-0.5"
+        >
+          {round.fixtures.map((fixture) => (
+            <FixtureLine key={fixture.id} fixture={fixture} />
+          ))}
+        </ul>
+      </div>
+    ))}
+  </div>
+)

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.factory.tsx
@@ -1,0 +1,34 @@
+import type { FixtureLine, FixtureSide } from '../../../../data/draw'
+import type { FixtureLineProps } from './fixture-line'
+
+/** A fixture line between two named entrants — the ordinary case, and the only one a
+ * round-robin draw produces. Pass `a`/`b` for the TBD and withdrawn sides. */
+export function buildFixtureLineView(
+  overrides: Partial<FixtureLine> = {},
+): FixtureLine {
+  return {
+    id: 'fx-a-1',
+    position: 1,
+    a: { kind: 'entrant', name: 'player.1' },
+    b: { kind: 'entrant', name: 'player.4' },
+    ...overrides,
+  }
+}
+
+/** A side that is **not decided yet** — never a bye (ADR-0786). */
+export function buildTbdSide(): FixtureSide {
+  return { kind: 'tbd' }
+}
+
+/** A side naming an entry the event no longer lists: they withdrew, and the draw is
+ * stale. */
+export function buildWithdrawnSide(): FixtureSide {
+  return { kind: 'withdrawn' }
+}
+
+/** Props for `FixtureLine`. */
+export function buildFixtureLineProps(
+  overrides: Partial<FixtureLineProps> = {},
+): FixtureLineProps {
+  return { fixture: buildFixtureLineView(), ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.page.tsx
@@ -1,0 +1,69 @@
+import { interactiveElementsIn } from '@/test/read-only'
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import { FixtureLine, type FixtureLineProps } from './fixture-line'
+import { buildFixtureLineProps } from './fixture-line.factory'
+
+/** Every fixture line, wherever it is: the id prefix is the only thing that identifies
+ * one, since a line is inert text with no role of its own. */
+const FIXTURE_LINE_TESTID = /^fixture-line-/
+
+/** A line as the reader sees it — `player.1 vs player.4`. Normalised, because the line
+ * is three elements and the DOM's whitespace between them is not the fact under test. */
+const lineText = (el: HTMLElement) =>
+  (el.textContent ?? '').replace(/\s+/g, ' ').trim()
+
+/** The fixture lines inside one DOM node (a round's `<ul>`, a pool's `<section>`), in
+ * DOM order, as text. The **sequence** is half of what a draw means, so it is the shape
+ * every draw assertion reads. */
+export function fixtureLineTexts(scope: HTMLElement): string[] {
+  return within(scope).queryAllByTestId(FIXTURE_LINE_TESTID).map(lineText)
+}
+
+const scoped = (container: Container) => ({
+  /** The line itself, addressed by the fixture's id — a round holds several of them. */
+  getLine(fixtureId: string) {
+    return container.getByTestId(`fixture-line-${fixtureId}`)
+  },
+  queryLine(fixtureId: string) {
+    return container.queryByTestId(`fixture-line-${fixtureId}`)
+  },
+  /** Every fixture line in scope, in DOM order. */
+  getLines(): HTMLElement[] {
+    return container.queryAllByTestId(FIXTURE_LINE_TESTID)
+  },
+  /** Those lines as text: `['player.1 vs player.4', …]`. */
+  getLineTexts(): string[] {
+    return container
+      .queryAllByTestId(FIXTURE_LINE_TESTID)
+      .map((el: HTMLElement) => lineText(el))
+  },
+  /** Everything interactive in a line. Must always be empty: a fixture is a *planned*
+   * pairing, not a match — there is nothing to click yet (#788). */
+  getControls(fixtureId: string) {
+    return interactiveElementsIn(container.getByTestId(`fixture-line-${fixtureId}`))
+  },
+})
+
+/**
+ * Test page-object for `FixtureLine`.
+ *
+ * `render` wraps the component in a `<ul>`: it renders an `<li>`, which is only valid
+ * inside a list, and a page object that dropped it into a bare `<div>` would be
+ * asserting against markup the app never produces.
+ */
+export const fixtureLinePage = {
+  render(overrides: Partial<FixtureLineProps> = {}) {
+    render(
+      <ul>
+        <FixtureLine {...buildFixtureLineProps(overrides)} />
+      </ul>,
+    )
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.test.tsx
@@ -1,0 +1,55 @@
+import {
+  buildFixtureLineView,
+  buildTbdSide,
+  buildWithdrawnSide,
+} from './fixture-line.factory'
+import { fixtureLinePage as page } from './fixture-line.page'
+
+describe('FixtureLine', () => {
+  it('reads as a named pairing: "A vs B"', () => {
+    page.render({
+      fixture: buildFixtureLineView({
+        id: 'fx-a-1',
+        a: { kind: 'entrant', name: 'player.1' },
+        b: { kind: 'entrant', name: 'player.4' },
+      }),
+    })
+
+    // The NAMES, not the entry ids — a line that printed uuids would still have three
+    // children and still pass a "renders a fixture" assertion.
+    expect(page.getLineTexts()).toEqual(['player.1 vs player.4'])
+  })
+
+  it('renders an undecided side as TBD rather than a blank half-line', () => {
+    page.render({
+      fixture: buildFixtureLineView({
+        id: 'fx-ko-1',
+        a: { kind: 'entrant', name: 'player.3' },
+        b: buildTbdSide(),
+      }),
+    })
+
+    expect(page.getLineTexts()).toEqual(['player.3 vs TBD'])
+  })
+
+  it('renders a side the event no longer lists as withdrawn — the draw is stale', () => {
+    page.render({
+      fixture: buildFixtureLineView({
+        id: 'fx-a-2',
+        a: buildWithdrawnSide(),
+        b: { kind: 'entrant', name: 'player.5' },
+      }),
+    })
+
+    expect(page.getLineTexts()).toEqual(['Withdrawn vs player.5'])
+  })
+
+  // A fixture is not a match (CONTEXT.md): there is nothing to click on it until it
+  // materializes into one (#788). Nor does it sit under the card's stretched open
+  // target as a second, competing control.
+  it('is inert — a planned pairing carries no controls', () => {
+    page.render({ fixture: buildFixtureLineView({ id: 'fx-a-1' }) })
+
+    expect(page.getControls('fx-a-1')).toHaveLength(0)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.tsx
@@ -1,0 +1,71 @@
+import {
+  TBD_LABEL,
+  WITHDRAWN_LABEL,
+  type FixtureLine as FixtureLineView,
+  type FixtureSide,
+} from '../../../../data/draw'
+
+export interface FixtureLineProps {
+  fixture: FixtureLineView
+}
+
+/** One side of the "A vs B" line. The three kinds of side are three different facts
+ * (`FixtureSide`, `data/draw.ts`), and each says its own word — a side is NEVER blank,
+ * and never a raw entry id:
+ *
+ * - an **entrant**: their username, as the roster shows it (bare, no `@`);
+ * - **TBD**: the feeding fixture is undecided. Not a bye — a bye is the absence of a
+ *   fixture (ADR-0786) — so this is a real pairing whose other half is still being
+ *   played for;
+ * - **Withdrawn**: the entry this side names is no longer in the event, which means the
+ *   draw is *stale* and wants re-cutting. Both are marked in words, not merely in a hue:
+ *   a colour-only difference is no difference to a director who cannot see it. */
+const Side = ({ side }: { side: FixtureSide }) => {
+  switch (side.kind) {
+    case 'entrant':
+      return <span className="text-[color:var(--fg-1)]">{side.name}</span>
+    case 'tbd':
+      return (
+        <span className="text-[color:var(--fg-3)] italic">{TBD_LABEL}</span>
+      )
+    case 'withdrawn':
+      return (
+        <span className="text-[color:var(--warn)]">{WITHDRAWN_LABEL}</span>
+      )
+    default: {
+      // A fourth kind of side without copy is a TYPE error here, not a blank half-line
+      // — the exact failure this sum type exists to prevent.
+      const exhaustive: never = side
+      return exhaustive
+    }
+  }
+}
+
+/**
+ * One **fixture** of a cut draw, as a named line: `player.1 vs player.4`.
+ *
+ * A fixture is not a match (CONTEXT.md) — it is the *planned* pairing, and it may not
+ * even have both its sides yet — so the line is deliberately inert: no score, no link,
+ * no control. Materializing it into a real match is #788.
+ *
+ * Rendered as the `<li>` of the round's list, so a round stays a list of its fixtures
+ * and a screen reader can count them. The "vs" is a real word in the DOM, not a
+ * separator glyph: it is what makes the line read as a pairing to someone who is hearing
+ * it rather than seeing it.
+ */
+export const FixtureLine = ({ fixture }: FixtureLineProps) => (
+  <li
+    data-testid={`fixture-line-${fixture.id}`}
+    className="flex items-baseline gap-1.5 py-0.5 text-[13px] leading-snug"
+  >
+    {/* The `{' '}`s are LOAD-BEARING, and they are not the flex gap. The gap is
+        *layout*: whitespace-only text between flex items is not rendered, so these cost
+        nothing on screen — but without them the line's text content is
+        `player.1vsplayer.4`, which is what a screen reader reads out and what the
+        clipboard gets. Three separate spans and a visual gap look like a sentence; only
+        the spaces make it one. */}
+    <Side side={fixture.a} />{' '}
+    <span className="text-[color:var(--fg-3)]">vs</span>{' '}
+    <Side side={fixture.b} />
+  </li>
+)

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.page.tsx
@@ -2,6 +2,7 @@ import { render, screen, type Container } from '@/test/utilities'
 
 import { EventCard, type EventCardProps } from './event-card'
 import { buildEventCardProps } from './event-card.factory'
+import { drawPanelPage } from './draw-panel.page'
 import { entrantsListPage } from './entrants-list.page'
 
 const scoped = (container: Container) => ({
@@ -10,6 +11,10 @@ const scoped = (container: Container) => ({
   // event name. Spread first, so the card's own accessors below win any name
   // clash.
   ...entrantsListPage.within(container),
+  // The draw the card hosts in its `draw` slot (`DrawPanel`): `queryPanel`,
+  // `getPoolLines`, `queryGenerateButton`, … The card only wires it in — the panel's
+  // own quartet pins its content.
+  ...drawPanelPage.within(container),
 
   /** The full-card open target — labelled `Edit <event>` for an owner, or
    * `View <event>` for a non-owner (read-only). Pass the verb to assert the

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.test.tsx
@@ -1,12 +1,14 @@
 import userEvent from '@testing-library/user-event'
 
 import {
+  buildDrawnEvent,
   buildEntrant,
   buildEntrants,
   buildEvent,
   buildPool,
   buildPredicate,
 } from '../../data/seed.factory'
+import { DrawPanel } from './draw-panel'
 import { eventCardPage } from './event-card.page'
 
 describe('EventCard', () => {
@@ -406,5 +408,54 @@ describe('EventCard', () => {
     expect(eventCardPage.queryNestedButtons()).toHaveLength(0)
     // The bare card is exactly one button: the stretched open target.
     expect(eventCardPage.queryAllButtons()).toHaveLength(1)
+  })
+
+  // Wiring only — the draw's content (pools, rounds, the vs-lines, the refusals) is
+  // pinned by `DrawPanel`'s own quartet. What the CARD owes it is a home that is not
+  // underneath the stretched open target, and a hosted control that is a *sibling* of
+  // that target rather than a button inside a button.
+  describe('the draw slot', () => {
+    it('hosts the draw it is given', () => {
+      eventCardPage.render({
+        event: buildDrawnEvent(),
+        draw: (
+          <DrawPanel
+            tournamentId="bay-area-open-2026"
+            event={buildDrawnEvent()}
+            canEdit
+          />
+        ),
+      })
+
+      expect(eventCardPage.queryPanel('ev-u1200')).toBeInTheDocument()
+      expect(eventCardPage.getPoolLines('p-a')).toEqual([
+        'player.1 vs player.4',
+        'player.1 vs player.5',
+        'player.4 vs player.5',
+      ])
+    })
+
+    it('keeps the draw’s controls out of the open target — never a button in a button', () => {
+      eventCardPage.render({
+        event: buildDrawnEvent(),
+        draw: (
+          <DrawPanel
+            tournamentId="bay-area-open-2026"
+            event={buildDrawnEvent()}
+            canEdit
+          />
+        ),
+      })
+
+      expect(eventCardPage.queryNestedButtons()).toHaveLength(0)
+      // The open target, plus the draw's own two verbs.
+      expect(eventCardPage.queryAllButtons()).toHaveLength(3)
+    })
+
+    it('renders no draw section at all when it is given none', () => {
+      eventCardPage.render({ event: buildEvent({ id: 'ev-open-singles' }) })
+
+      expect(eventCardPage.queryPanel('ev-open-singles')).toBeNull()
+    })
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/event-card.tsx
@@ -34,6 +34,18 @@ export interface EventCardProps {
    * clicks instead of opening the editor.
    */
   action?: ReactNode
+  /**
+   * The event's **draw** (`DrawPanel`) — the pools it was cut across, and the
+   * director's cut / re-cut / delete verbs (ADR-0786). A slot, like `action`, and
+   * for the same reason: it reads the session and owns two mutations, and this
+   * card is a pure view over its props.
+   *
+   * Rendered in its own raised layer, *above* the stretched open target — it holds
+   * real buttons, and a control under that overlay would be dead. That also means a
+   * click anywhere in the draw is a click on the draw, not on "open the editor",
+   * which is what you want of a panel a director reads a fixture list off.
+   */
+  draw?: ReactNode
 }
 
 /** A row card for one event on the tournament's Events tab: title with rated /
@@ -51,6 +63,7 @@ export const EventCard = ({
   username,
   onOpen,
   action,
+  draw,
 }: EventCardProps) => {
   // What the EVENT has left — read off the numbers, never off `entryState`.
   // `entryState` is the server's judgement about *this caller* (an ineligible one
@@ -221,6 +234,13 @@ export const EventCard = ({
             (no controls of its own), so it sits happily under the stretched open
             target. */}
         <EntrantsList event={ev} username={username} />
+
+        {/* The draw (ADR-0786). Raised above the stretched open target below, because
+            unlike the roster it holds real controls — the director's Generate / Re-cut /
+            Delete — and a button underneath that overlay would never receive a click.
+            `empty:hidden` is not needed: the panel always renders *something* (its
+            empty state is a designed data state, not nothing). */}
+        {draw && <div className="relative z-10">{draw}</div>}
       </Card>
 
       {/* Full-card open target: a sibling of the card, sitting beneath the

--- a/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.page.tsx
@@ -17,9 +17,40 @@ const scoped = (container: Container) => ({
   queryAllButtons() {
     return container.queryAllByRole('button')
   },
+
+  /** The inline **refusal** — the 409 (a stale view, or go-live's precondition), and
+   * every other failure, in the place the click happened. Found by role (`alert`),
+   * which is the contract: it is the app talking back, and a screen reader must hear it
+   * without hunting for it. */
+  queryNotice() {
+    return container.queryByRole('alert')
+  },
+  findNotice() {
+    return container.findByRole('alert')
+  },
+  /** The notice as one normalised string — title *and* the sentence beneath it, since
+   * the whole point of the 409 copy is that the second half **names the events** the
+   * director has to go and fix. */
+  async findNoticeText() {
+    const notice = await container.findByRole('alert')
+    return (notice.textContent ?? '').replace(/\s+/g, ' ').trim()
+  },
+  /** Which designed case the refusal fell into (`LifecycleRefusal['kind']`) — so a test
+   * can pin "this rendered the 403 state", not merely "some words appeared". */
+  async findNoticeKind() {
+    const notice = await container.findByTestId('lifecycle-notice')
+    return notice.getAttribute('data-kind')
+  },
 })
 
-/** Test page-object for `LifecycleActions`. */
+/**
+ * Test page-object for `LifecycleActions`.
+ *
+ * The component owns the transition mutation, so a test that clicks its button must stub
+ * the transitions endpoint itself — `mockTournamentTransitionEndpoint`
+ * (`@/mocks/endpoints/tournaments/tournaments.endpoint`). Rendering alone fetches
+ * nothing.
+ */
 export const lifecycleActionsPage = {
   render(overrides: Partial<LifecycleActionsProps> = {}) {
     render(<LifecycleActions {...buildLifecycleActionsProps(overrides)} />)

--- a/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.test.tsx
@@ -13,10 +13,17 @@ import { lifecycleActionsPage } from './lifecycle-actions.page'
 
 vi.mock('sonner', async () => {
   const actual = await vi.importActual<typeof import('sonner')>('sonner')
-  return { ...actual, toast: { ...actual.toast, error: vi.fn() } }
+  return {
+    ...actual,
+    toast: { ...actual.toast, error: vi.fn(), info: vi.fn(), success: vi.fn() },
+  }
 })
 
-beforeEach(() => vi.mocked(toast.error).mockClear())
+beforeEach(() => {
+  vi.mocked(toast.error).mockClear()
+  vi.mocked(toast.info).mockClear()
+  vi.mocked(toast.success).mockClear()
+})
 
 /** The transitions endpoint, recording what the button actually sent. The 201
  * body is a bare `TournamentRead` (no events), as the API answers. */
@@ -29,6 +36,33 @@ function captureTransition() {
     return HttpResponse.json(read, { status: 201 })
   })
   return seen
+}
+
+/** The transitions endpoint, refusing with `status` and the server's own `detail` —
+ * the shape every refusal below arrives in (FastAPI's `{"detail": "…"}`). */
+function refuseTransition(status: number, detail: string) {
+  mockTournamentTransitionEndpoint(server, () =>
+    HttpResponse.json({ detail }, { status }),
+  )
+}
+
+/** Click **Start tournament** on a published tournament the viewer owns — the one edge
+ * that carries a precondition (ADR-0786). */
+async function clickStart() {
+  lifecycleActionsPage.render({
+    tournament: buildTournament({ id: 't-1', status: 'published' }),
+  })
+  await userEvent.click(lifecycleActionsPage.getLifecycleButton(/Start tournament/))
+}
+
+/** No toast, ever, for a refusal this component reports inline (`web-client/CLAUDE.md`,
+ * ## Forms: a mutation surfaced inline must not also toast). Asserted on EVERY ring of
+ * the toaster, because "no error toast" would go green against a refusal announced as a
+ * cheerful `toast.success`. */
+function expectNoToast() {
+  expect(toast.error).not.toHaveBeenCalled()
+  expect(toast.info).not.toHaveBeenCalled()
+  expect(toast.success).not.toHaveBeenCalled()
 }
 
 describe('LifecycleActions', () => {
@@ -54,6 +88,9 @@ describe('LifecycleActions', () => {
       await waitFor(() => expect(seen).toHaveLength(1))
       expect(seen[0].url).toContain('/v1/tournaments/t-1/transitions')
       expect(seen[0].body).toEqual({ to })
+      // A move that WORKED says nothing — no notice, no toast.
+      expect(lifecycleActionsPage.queryNotice()).toBeNull()
+      expectNoToast()
     },
   )
 
@@ -94,34 +131,185 @@ describe('LifecycleActions', () => {
 
   // (`hasLifecycleAction` — what the header asks before it renders the slot at
   // all — is the same table, and is tested in `../data/lifecycle.test.ts`.)
+})
 
-  // The stale-tab case, which is the whole reason the server 409s a re-assertion
-  // instead of shrugging: this tab still reads `draft` and still offers Publish,
-  // but the tournament was published in another tab. The refusal must be VISIBLE —
-  // a silent no-op would leave the user clicking a button that does nothing.
-  it('surfaces a 409 from a stale view as an error the user can see', async () => {
-    // `published → published` — the stale tab's click IS a self-transition, so the
-    // server answers its self-transition sentence, not the two-ended one.
-    mockTournamentTransitionEndpoint(server, () =>
-      HttpResponse.json(
-        { detail: 'This tournament is already published.' },
-        { status: 409 },
-      ),
+// The go-live precondition (ADR-0786), as the director meets it. Going live seals the
+// field and turns every ready fixture into a match, so the server refuses it unless the
+// tournament has events, every event has a draw, and every draw still seats exactly its
+// entrants. The refusal is a 409 whose sentence NAMES the events at fault — and the
+// whole job of this component is to put that sentence in front of the person who can act
+// on it.
+describe('LifecycleActions · a refused Start tournament (409)', () => {
+  // The three shapes of the server's detail, verbatim (`_go_live_refusal`,
+  // `api/app/tournaments.py`). Hard-coded here rather than imported from the mock store:
+  // a test that read the copy from the code it is testing would pass whatever the copy
+  // became.
+  const NOTHING_TO_START =
+    'This tournament has no events, so there is nothing to start. Add an event and cut ' +
+    'its draw, then start the tournament.'
+  const NO_DRAW =
+    'This tournament cannot start yet: “Open Singles” has no draw yet. A draw is cut ' +
+    'from the field as it stands at the time, and registration stays open right up to ' +
+    'the moment a tournament goes live — so cut the draw for each event named (again, ' +
+    'if somebody entered or withdrew since it was last cut), then start the tournament.'
+  const STALE_DRAW =
+    'This tournament cannot start yet: “Under 1200” has a draw that no longer matches ' +
+    'its entrants. A draw is cut from the field as it stands at the time, and ' +
+    'registration stays open right up to the moment a tournament goes live — so cut ' +
+    'the draw for each event named (again, if somebody entered or withdrew since it ' +
+    'was last cut), then start the tournament.'
+  const TWO_EVENTS =
+    'This tournament cannot start yet: “Under 1200” has no draw yet; and “Over 40s” ' +
+    'has a draw that no longer matches its entrants. A draw is cut from the field as ' +
+    'it stands at the time, and registration stays open right up to the moment a ' +
+    'tournament goes live — so cut the draw for each event named (again, if somebody ' +
+    'entered or withdrew since it was last cut), then start the tournament.'
+
+  // Each of the three refusals renders — and renders the SERVER's sentence, which is the
+  // only half that says what to go and do. The assertions name the *events*, because a
+  // test that asserted merely "an error is shown" would pass just as happily against a
+  // generic "something went wrong".
+  it.each([
+    { name: 'an empty tournament', detail: NOTHING_TO_START, names: ['no events'] },
+    { name: 'an event with no draw', detail: NO_DRAW, names: ['“Open Singles”'] },
+    {
+      name: 'an event whose draw is stale',
+      detail: STALE_DRAW,
+      names: ['“Under 1200”'],
+    },
+    {
+      name: 'two events, each at fault in its own way',
+      detail: TWO_EVENTS,
+      names: ['“Under 1200”', '“Over 40s”'],
+    },
+  ])('names what is wrong — $name', async ({ detail, names }) => {
+    refuseTransition(409, detail)
+
+    await clickStart()
+
+    const text = await lifecycleActionsPage.findNoticeText()
+    // The client's framing…
+    expect(text).toContain("Couldn't start the tournament")
+    // …around the server's sentence, whole.
+    expect(text).toContain(detail)
+    for (const name of names) expect(text).toContain(name)
+    expect(await lifecycleActionsPage.findNoticeKind()).toBe('refused')
+  })
+
+  it('does NOT toast the refusal it has already shown inline', async () => {
+    refuseTransition(409, NO_DRAW)
+
+    await clickStart()
+
+    await lifecycleActionsPage.findNotice()
+    // Told once. A toast on top of this would say the same thing twice, and would take
+    // the work list away after four seconds.
+    expectNoToast()
+  })
+
+  it('leaves the tournament PUBLISHED — the button it refused is the button still on offer', async () => {
+    refuseTransition(409, NO_DRAW)
+
+    await clickStart()
+
+    await lifecycleActionsPage.findNotice()
+    // Nothing is optimistic here: the status this component renders from is the one the
+    // server last confirmed, so a refused start still offers **Start tournament** — not
+    // "End tournament", which is what a hopeful local flip to `live` would have produced.
+    expect(
+      lifecycleActionsPage.getLifecycleButton(/Start tournament/),
+    ).toBeInTheDocument()
+    expect(
+      lifecycleActionsPage.queryLifecycleButton(/End tournament/),
+    ).toBeNull()
+  })
+
+  // The OTHER 409 the same endpoint answers: a stale tab re-asserting an edge that no
+  // longer exists. It carries no code, so the client cannot (and need not) tell it from
+  // the precondition — and it must not: both are sentences written for the director, and
+  // both are shown.
+  it('shows the stale-tab 409 the same way — the server’s sentence, not a guess', async () => {
+    refuseTransition(409, 'This tournament is already live.')
+
+    await clickStart()
+
+    const text = await lifecycleActionsPage.findNoticeText()
+    expect(text).toContain('This tournament is already live.')
+    expectNoToast()
+  })
+})
+
+// Every other way the click can fail. Each is a designed case of one sum type
+// (`LifecycleRefusal`) — there is no arm that fails silently, because there is no toast
+// left to catch what an arm forgot.
+describe('LifecycleActions · the other outcomes', () => {
+  it('says so when the tournament is not yours (403)', async () => {
+    refuseTransition(403, 'Only the creator can move this tournament.')
+
+    await clickStart()
+
+    const text = await lifecycleActionsPage.findNoticeText()
+    expect(await lifecycleActionsPage.findNoticeKind()).toBe('forbidden')
+    expect(text).toContain("You can't move this tournament")
+    expect(text).toContain('Nothing was changed.')
+    expectNoToast()
+  })
+
+  it('says so when the session is gone (401)', async () => {
+    refuseTransition(401, 'Not authenticated')
+
+    await clickStart()
+
+    const text = await lifecycleActionsPage.findNoticeText()
+    expect(await lifecycleActionsPage.findNoticeKind()).toBe('signed-out')
+    expect(text).toContain('You are signed out')
+    // The verb of the edge they clicked — "sign in again, then start the tournament".
+    expect(text).toContain('start the tournament')
+    // Never the wire's own words for it.
+    expect(text).not.toContain('Not authenticated')
+    expectNoToast()
+  })
+
+  it('owns the failure when the server breaks (5xx) — and does not repeat its detail', async () => {
+    refuseTransition(500, 'Internal Server Error')
+
+    await clickStart()
+
+    const text = await lifecycleActionsPage.findNoticeText()
+    expect(await lifecycleActionsPage.findNoticeKind()).toBe('server-error')
+    expect(text).toContain('Something went wrong on our end')
+    // A 5xx detail is machinery, not copy (`DEFINITION_OF_COMPLETE`: raw API detail
+    // strings never reach the UI).
+    expect(text).not.toContain('Internal Server Error')
+    expectNoToast()
+  })
+
+  it('says the request never got there when the network is down', async () => {
+    mockTournamentTransitionEndpoint(server, () => HttpResponse.error())
+
+    await clickStart()
+
+    const text = await lifecycleActionsPage.findNoticeText()
+    expect(await lifecycleActionsPage.findNoticeKind()).toBe('unreachable')
+    expect(text).toContain('Check your connection')
+    expectNoToast()
+  })
+
+  // The refusal is about the LAST click, never the one before it: a director who fixes
+  // the draw and starts again must not be left staring at the sentence that told them to.
+  it('clears the last refusal when the next attempt succeeds', async () => {
+    refuseTransition(409, 'This tournament cannot start yet: “Open Singles” has no draw yet.')
+
+    await clickStart()
+    await lifecycleActionsPage.findNotice()
+
+    captureTransition()
+    await userEvent.click(
+      lifecycleActionsPage.getLifecycleButton(/Start tournament/),
     )
-    lifecycleActionsPage.render({
-      tournament: buildTournament({ id: 't-1', status: 'draft' }),
-    })
-
-    await userEvent.click(lifecycleActionsPage.getLifecycleButton(/Publish/))
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith(
-        // The verb is the edge they clicked, not the wire call.
-        "Couldn't publish the tournament",
-        expect.objectContaining({
-          description: 'This tournament is already published.',
-        }),
-      ),
+      expect(lifecycleActionsPage.queryNotice()).toBeNull(),
     )
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.tsx
@@ -1,9 +1,15 @@
-import type { ComponentProps } from 'react'
+import { useState, type ComponentProps } from 'react'
 
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 
 import { useTransitionTournament } from '../data/api'
-import { lifecycleEdgeFor, type LifecycleTone } from '../data/lifecycle'
+import {
+  lifecycleEdgeFor,
+  lifecycleRefusalNotice,
+  type LifecycleRefusal,
+  type LifecycleTone,
+} from '../data/lifecycle'
 import type { Tournament } from '../data/types'
 
 export interface LifecycleActionsProps {
@@ -48,34 +54,84 @@ const TONE: Record<
  * because every transition is owner-only server-side (403); and at most ONE
  * button, the one legal from the status the tournament is actually in.
  *
- * A refused move (409 — the stale-tab case: published in another tab, while this
- * one still shows **Publish**) surfaces as an error toast from the mutation, and
- * that same mutation re-reads the tournament, so the badge and the button correct
- * themselves to whatever is true now.
+ * ## A refused move is reported HERE, in the server's own words
+ *
+ * **Start tournament** has a precondition (ADR-0786), and it is the one lifecycle
+ * refusal a director meets in the ordinary course of running a tournament: the
+ * tournament must have at least one event, and every event must have a **draw** whose
+ * fixtures still seat exactly its entrants. Registration stays open right up to the
+ * moment the tournament starts, so a draw cut yesterday can be stale today — somebody
+ * entered, somebody withdrew — and starting on a stale draw would seat a player who has
+ * left while the one who replaced them plays nobody.
+ *
+ * The server refuses that with a **409 that names the offending events**, and this
+ * component shows that sentence, under a title of its own, in an `Alert` **beside the
+ * button that was clicked** — not in a toast:
+ *
+ * - a toast leaves after four seconds, and the sentence it carries is a work list
+ *   ("“Open Singles” has no draw yet; and “Over 40s” has a draw that no longer matches
+ *   its entrants") that a director reads *while* going to fix it;
+ * - the mutation therefore carries no global `onError` toast (see `useTransitionTournament`
+ *   in `../data/api`), because a mutation whose errors are surfaced inline must not also
+ *   toast — the user would be told the same thing twice (`web-client/CLAUDE.md`, ## Forms).
+ *
+ * Every other outcome is a designed case of the same sum type (`LifecycleRefusal`): not
+ * yours (403), signed out (401), our fault (5xx), never got there (network). There is no
+ * arm that fails silently.
+ *
+ * **Nothing here is optimistic.** The status the page renders is the status the *server*
+ * last told it (the mutation reconciles the tournament on settle, success or failure), so
+ * a refused start leaves the badge reading **Published** — the truth — rather than a
+ * hopeful `live` that has to be walked back.
  */
 export const LifecycleActions = ({ tournament }: LifecycleActionsProps) => {
   const transition = useTransitionTournament(tournament.id)
+  // The last refusal, in words. Cleared when a new attempt starts — a notice about the
+  // click before last is worse than none.
+  const [refusal, setRefusal] = useState<LifecycleRefusal | null>(null)
 
   const edge = lifecycleEdgeFor(tournament)
   if (!edge) return null
   const Icon = edge.icon
   const tone = TONE[edge.tone]
 
+  const move = async () => {
+    setRefusal(null)
+    try {
+      await transition.mutateAsync(edge)
+    } catch (error) {
+      // `mutateAsync` rejects; this notice IS the error surface (there is no toast).
+      setRefusal(lifecycleRefusalNotice(error, edge))
+    }
+  }
+
   return (
-    <Button
-      variant={tone.variant}
-      className={tone.className}
-      // One in-flight move at a time: a double-click on Publish must not send a
-      // second transition, whose only possible answer is the 409 "already
-      // published" — an error shown to a user who did nothing wrong.
-      disabled={transition.isPending}
-      // The EDGE, not just its target: the mutation names the failure with the
-      // edge's own verb ("Couldn't publish the tournament"), so the toast says
-      // what was clicked.
-      onClick={() => transition.mutate(edge)}
-    >
-      <Icon size={16} />
-      {edge.label}
-    </Button>
+    <div className="flex w-[380px] max-w-full flex-col items-end gap-2.5">
+      <Button
+        variant={tone.variant}
+        className={tone.className}
+        // One in-flight move at a time: a double-click on Publish must not send a
+        // second transition, whose only possible answer is the 409 "already
+        // published" — an error shown to a user who did nothing wrong.
+        disabled={transition.isPending}
+        onClick={move}
+      >
+        <Icon size={16} />
+        {edge.label}
+      </Button>
+
+      {/* The refusal, where the click was. An `Alert` — the app talking back — and not a
+          `Card`, which is a content surface (`web-client/CLAUDE.md`, ## Design system). */}
+      {refusal && (
+        <Alert
+          variant="destructive"
+          data-testid="lifecycle-notice"
+          data-kind={refusal.kind}
+        >
+          <AlertTitle>{refusal.title}</AlertTitle>
+          <AlertDescription>{refusal.description}</AlertDescription>
+        </Alert>
+      )}
+    </div>
   )
 }

--- a/web-client/src/mocks/endpoints/tournaments/tournaments.endpoint.ts
+++ b/web-client/src/mocks/endpoints/tournaments/tournaments.endpoint.ts
@@ -182,6 +182,49 @@ export const mockEventEnterEndpoint = (
     ),
   )
 
+/** Resolver for the **cut-draw** endpoint (ADR-0786) — the created fixtures (201), or an
+ * error envelope: 403 (not the owner), 409 (the draw shows evidence of play), 422 (this
+ * event cannot be planned: an unsupported draw type, no pools, or a pool that would get
+ * fewer than two entrants), 404.
+ *
+ * The refusals are plain-string `detail`s, not coded ones — deliberately, because that
+ * is what the route sends: the 422's sentence names what the director must CHANGE
+ * ("5 entrants across 3 pool(s) would leave a pool with fewer than 2 entrants"), and
+ * those numbers are not derivable from a code. There is no request body: the event is
+ * the whole request. */
+export type EventCutDrawResolver = HttpResponseResolver<
+  { tournamentId: string; eventId: string },
+  never,
+  components['schemas']['TournamentFixtureRead'][] | ErrorBody
+>
+
+/** POST /v1/tournaments/{id}/events/{eventId}/draw — cut (or re-cut) the draw. */
+export const mockEventCutDrawEndpoint = (
+  backend: Backend,
+  resolver: EventCutDrawResolver,
+) =>
+  backend.use(
+    http.post('*/v1/tournaments/:tournamentId/events/:eventId/draw', resolver),
+  )
+
+/** Resolver for the **un-cut-draw** endpoint — a 204 with no body (including when the
+ * event never had a draw: this is a DELETE, and it is idempotent), or an error envelope
+ * on a 403 / 409 (evidence of play) / 404. */
+export type EventUncutDrawResolver = HttpResponseResolver<
+  { tournamentId: string; eventId: string },
+  never,
+  ErrorBody | null
+>
+
+/** DELETE /v1/tournaments/{id}/events/{eventId}/draw — un-cut the draw. */
+export const mockEventUncutDrawEndpoint = (
+  backend: Backend,
+  resolver: EventUncutDrawResolver,
+) =>
+  backend.use(
+    http.delete('*/v1/tournaments/:tournamentId/events/:eventId/draw', resolver),
+  )
+
 /** Resolver for the withdraw endpoint — a 204 with no body (including when the
  * entry was already withdrawn: withdrawal is idempotent), or an error envelope
  * on a 403 (someone else's entry) / 404. */

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -4,6 +4,7 @@ import { FORTYMM_LEAGUE_ID } from '@/mocks/factories/players/player-league.facto
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
 type TournamentEventRead = components['schemas']['TournamentEventRead']
 type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
+type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
 type TournamentTable = components['schemas']['TournamentTable']
 
 /** A single physical table, `T1` on court 1. */
@@ -52,6 +53,104 @@ export function buildTournamentEntrantReads(
   )
 }
 
+/** One fixture of a cut draw (ADR-0786) — round 1, position 1 of an un-pooled draw,
+ * both sides known, undecided and not yet materialized.
+ *
+ * Every `null` here is a **fact**, and a fixture asks for each one explicitly: a null
+ * side is **TBD** (never a bye — a bye is the absence of a fixture row), a null
+ * `winner_entry_id` is undecided, a null `match_id` is un-materialized, and a null
+ * `pool_id` is an un-pooled draw. The defaults are the ordinary case a director sees
+ * the morning of: a planned pairing, both players known, nothing played. */
+export function buildTournamentFixtureRead(
+  overrides: Partial<TournamentFixtureRead> = {},
+): TournamentFixtureRead {
+  return {
+    id: 'fx-1',
+    pool_id: null,
+    round: 1,
+    position: 1,
+    entry_a_id: 'entry-1',
+    entry_b_id: 'entry-2',
+    winner_entry_id: null,
+    match_id: null,
+    ...overrides,
+  }
+}
+
+/**
+ * Plan a **round-robin** draw the way the API plans one (`api/app/draws.py`): snake the
+ * ordered entrants across the pools, then pair each pool by the circle method — every
+ * pair meets once, nobody plays twice in a round.
+ *
+ * The mock's planner is faithful rather than convenient on purpose. A stub that dealt
+ * the field into pools any old way would still *look* like a draw on screen, and the
+ * page built against it would be a page built against a shape the server never sends —
+ * the fixture count, the rounds, and which two names share a row would all be fiction.
+ * The rules it mirrors, each of which is visible on the card:
+ *
+ * - **Snake, not blocks** — pool A takes seeds 1, 2P, 2P+1, …; pool B takes 2, 2P−1, …
+ *   — so the top seeds land one per pool and pool sizes differ by at most one.
+ * - **A bye is the ABSENCE of a fixture.** An odd pool gets a phantom seat; whoever
+ *   draws it that round simply has no fixture. There is no `is_bye`, and no null side.
+ * - **`position` is contiguous within a (pool, round)** — 1..k — because the phantom's
+ *   pairing is never emitted.
+ *
+ * Returns fixtures in pool → round → position order, as the wire does.
+ *
+ * ⚠️ It does **not** enforce the API's refusals (no pools, a pool of fewer than two).
+ * Those are the *store's* to refuse (`cutDraw`, `tournaments-store.ts`), because they
+ * are answers to a request, not shapes of a payload. Handed a degenerate field this
+ * plans what it is asked for — which is why nothing but the store should call it.
+ */
+export function planRoundRobinFixtures(
+  entryIds: readonly string[],
+  poolIds: readonly string[],
+): TournamentFixtureRead[] {
+  const fixtures: TournamentFixtureRead[] = []
+  let counter = 0
+
+  for (const [poolIndex, poolId] of poolIds.entries()) {
+    // The snake: row-by-row across the pools, reversing every other row.
+    const members = entryIds.filter((_, index) => {
+      const row = Math.floor(index / poolIds.length)
+      const offset = index % poolIds.length
+      const column = row % 2 === 0 ? offset : poolIds.length - 1 - offset
+      return column === poolIndex
+    })
+
+    // The circle method: pin the first seat, rotate the rest one step per round, and
+    // pair across the circle. An odd pool gets a phantom (`null`) seat — the entrant
+    // drawn against it sits that round out, and no fixture is emitted for them.
+    const circle: (string | null)[] = [...members]
+    if (circle.length % 2 === 1) circle.push(null)
+    const seats = circle.length
+
+    for (let round = 1; round < seats; round += 1) {
+      let position = 0
+      for (let seat = 0; seat < seats / 2; seat += 1) {
+        const home = circle[seat]
+        const away = circle[seats - 1 - seat]
+        if (home === null || away === null) continue
+        position += 1
+        counter += 1
+        fixtures.push(
+          buildTournamentFixtureRead({
+            id: `fx-${poolId}-${counter}`,
+            pool_id: poolId,
+            round,
+            position,
+            entry_a_id: home,
+            entry_b_id: away,
+          }),
+        )
+      }
+      circle.splice(1, 0, circle.pop() as string | null)
+    }
+  }
+
+  return fixtures
+}
+
 /**
  * What the event says about the CALLER entering it (ADR-0783), derived the way the
  * server derives the half of it that is derivable: an event holding `max_players`
@@ -93,6 +192,14 @@ export function entryStateFor(
  * `rating_ineligible` cannot be derived from an event's own fields — but it
  * **defaults to `entryStateFor`**, so an event filled to `max_players` reports
  * itself full without anybody remembering to say so.
+ *
+ * `fixtures` defaults to **`[]` — an event with NO DRAW CUT** (ADR-0786), which is the
+ * state every event is born in and stays in until a director cuts one. It is an
+ * override, not a derivation: a draw is an explicit act against a field, not a function
+ * of the entrants (the same 9 players make a different draw across 2 pools than across
+ * 3), so a factory that quietly cut one would be inventing a decision nobody made.
+ * `planRoundRobinFixtures` above builds a real one for the fixtures that want a *drawn*
+ * event.
  */
 export function buildTournamentEventRead(
   overrides: Partial<Omit<TournamentEventRead, 'entered'>> = {},
@@ -107,6 +214,7 @@ export function buildTournamentEventRead(
     entry_fee: 45,
     entrants: [],
     entry_state: { state: 'open' },
+    fixtures: [],
     slot: { date: '2026-06-13', start: '09:00', end: '18:00' },
     match_settings: { rated: true, length_games: 5 },
     predicates: [],

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -41,12 +41,14 @@ import { DEMO_SEED } from './rbac-store'
 import {
   createEvent as createTournamentEvent,
   createTournament,
+  cutDraw as cutTournamentDraw,
   deleteEvent as deleteTournamentEvent,
   deleteTournament as deleteTournamentSeed,
   enterEvent as enterTournamentEvent,
   findTournament,
   listTournaments,
   transitionTournament,
+  uncutDraw as uncutTournamentDraw,
   updateEvent as updateTournamentEvent,
   updateTournament,
   withdrawEntry as withdrawTournamentEntry,
@@ -1688,6 +1690,61 @@ export const handlers = [
       return new HttpResponse(null, { status: 204 })
     },
   ),
+  // The draw (ADR-0786). Registered before the bare `:eventId` routes, like the
+  // entries routes above, so MSW can never mistake a draw path for an event path.
+  //
+  // Cutting is an EXPLICIT act — nothing else in the mock creates a fixture, and no
+  // status change cuts one — and it is refused exactly as the server refuses it: 403
+  // (not the owner), 409 (the draw shows evidence of play: a fixture with a winner or a
+  // linked match), 422 (this event cannot be planned — an unsupported draw type, no
+  // pools, or a pool that would get fewer than two entrants). The refusal SENTENCES come
+  // from the store, because for the 422 the sentence is the answer: it names the numbers
+  // the director has to change.
+  http.post(
+    '*/v1/tournaments/:tournamentId/events/:eventId/draw',
+    async ({ params }) => {
+      await delay(250)
+      const result = cutTournamentDraw(
+        String(params.tournamentId),
+        String(params.eventId),
+      )
+      if (!result.ok) {
+        if (result.status === 409 || result.status === 422) {
+          return detail(result.detail, result.status)
+        }
+        return detail(
+          result.status === 403
+            ? 'Only the creator can cut this draw.'
+            : 'Event not found.',
+          result.status,
+        )
+      }
+      return HttpResponse.json(result.fixtures, { status: 201 })
+    },
+  ),
+  http.delete(
+    '*/v1/tournaments/:tournamentId/events/:eventId/draw',
+    async ({ params }) => {
+      await delay(250)
+      const result = uncutTournamentDraw(
+        String(params.tournamentId),
+        String(params.eventId),
+      )
+      if (!result.ok) {
+        // The play guard, again: a draw that has been played cannot be removed either.
+        if (result.status === 409) return detail(result.detail, 409)
+        return detail(
+          result.status === 403
+            ? 'Only the creator can remove this draw.'
+            : 'Event not found.',
+          result.status,
+        )
+      }
+      // 204 whether or not there was a draw to remove — this is a DELETE, and asking
+      // for a state the resource is already in is a success.
+      return new HttpResponse(null, { status: 204 })
+    },
+  ),
   http.patch(
     '*/v1/tournaments/:tournamentId/events/:eventId',
     async ({ params, request }) => {
@@ -1703,6 +1760,10 @@ export const handlers = [
         body ?? {},
       )
       if (!result.ok) {
+        // The pool-set freeze (ADR-0786): this PATCH would add, remove or re-`id` a pool
+        // on an event whose draw is cut, orphaning the fixtures drawn into it. The
+        // store's sentence says so — and says how to get out of it.
+        if (result.status === 409) return detail(result.detail, 409)
         return detail(
           result.status === 403
             ? 'Only the creator can edit this event.'

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -971,6 +971,34 @@ function validateEventBody(
       return detail('Entry fee can’t be negative.', 422)
     }
   }
+  // A pool id IDENTIFIES a pool, and a fixture names its pool by that string (ADR-0786).
+  // Two pools sharing one id is a payload the interior cannot hold: the cut deals onto
+  // the same `(event_id, pool_id, round, position)` twice and the fixture table's unique
+  // index fires — a **500** (`_pool_ids_are_unique`, `api/app/schemas/tournament.py`).
+  //
+  // It lives HERE, at the mock's boundary rather than in the store's freeze, for the two
+  // reasons the server's validator does:
+  //  • it is a 422 in *every* state the event could be in — an event with no draw at all
+  //    still cannot have two pools called `p-a`;
+  //  • and the PATCH path is the worse of the two, because the pool-set freeze compares
+  //    SETS: `[A, A, B]` against a cut event holding `{A, B}` is the same set, so the
+  //    freeze waves it through and the next cut dies. The guard that protects the draw
+  //    was admitting the payload that poisons it.
+  if (body.pools !== undefined && body.pools !== null) {
+    const seen = new Set<string>()
+    const duplicated = body.pools
+      .map((pool) => pool.id)
+      .filter((id) => (seen.has(id) ? true : (seen.add(id), false)))
+    if (duplicated.length > 0) {
+      return detail(
+        `A pool id identifies one pool: ${[...new Set(duplicated)]
+          .map((id) => `“${id}”`)
+          .join(', ')} is used by more than one pool of this event. Give each pool an ` +
+          'id of its own.',
+        422,
+      )
+    }
+  }
   return null
 }
 

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -6,11 +6,13 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   createEvent,
+  createTournament,
   cutDraw,
   enterEvent,
   findTournament,
   listTournaments,
   markFixturePlayed,
+  placeInStatus,
   resetTournamentsStore,
   transitionTournament,
   uncutDraw,
@@ -18,6 +20,7 @@ import {
   updateTournament,
   withdrawEntry,
   type EnterResult,
+  type TransitionResult,
   type WithdrawResult,
 } from './tournaments-store'
 import type { components } from '@/api/schema'
@@ -25,7 +28,7 @@ import type { components } from '@/api/schema'
 type TournamentStatus = components['schemas']['TournamentStatus']
 
 const TOURNAMENT = 'bay-area-open-2026' // seeded `published`, owned
-const DRAFT_TOURNAMENT = 'summer-slam-2026' // seeded `draft`, owned, no events
+const DRAFT_TOURNAMENT = 'summer-slam-2026' // seeded `draft`, owned, one drawn event
 const EMPTY_SINGLES = 'ev-u1500' // seeded with no entrants
 const FULLISH_SINGLES = 'ev-open-singles' // seeded with 52 other players, cap 64
 const FULL_SINGLES = 'ev-champ-singles' // seeded 16 of 16 — no room (#783)
@@ -84,9 +87,15 @@ function event(eventId: string) {
  * doubles event.
  *
  * The lifecycle is forward-only, so there is no walking a tournament *back* to
- * `draft`: the draft case is the seeded draft (which has no events of its own)
- * with the two events added to it, and the rest are the seeded `published`
- * tournament moved along legal edges only. */
+ * `draft`: the draft case is the seeded draft with the two events added to it, and
+ * the rest are the seeded `published` tournament PUT in that status.
+ *
+ * `placeInStatus`, not a walk through the transitions, since #786 gave `published →
+ * live` a precondition (every event drawn, every draw current — ADR-0786). These are
+ * tests of ENTRY, and the tournament they need is one that IS live; walking there would
+ * make every one of them depend on the draws of the five seeded events, and the two
+ * events these tests then add would have no draw at all and could not be walked past.
+ * That precondition has tests of its own, below, where a real walk is the point. */
 function tournamentIn(status: TournamentStatus): {
   tournamentId: string
   singlesId: string
@@ -118,12 +127,11 @@ function tournamentIn(status: TournamentStatus): {
       doublesId: doubles.event.id,
     }
   }
-  // `published` is where the seed already is (so: no steps); `live` and
-  // `archived` are one and two legal edges further on.
-  const forward: TournamentStatus[] = ['live', 'archived']
-  for (const step of forward.slice(0, forward.indexOf(status) + 1)) {
-    const moved = transitionTournament(TOURNAMENT, step)
-    if (!moved.ok) throw new Error(`setup failed: could not reach ${status}`)
+  // `published` is where the seed already is; `live` and `archived` are seeded states
+  // here, not journeys (see the note above).
+  placeInStatus(TOURNAMENT, status)
+  if (findTournament(TOURNAMENT)!.status !== status) {
+    throw new Error(`setup failed: could not reach ${status}`)
   }
   return {
     tournamentId: TOURNAMENT,
@@ -674,6 +682,125 @@ describe('transitionTournament', () => {
     })
   })
 
+  // ----- the go-live precondition (ADR-0786) --------------------------------
+  //
+  // The store must not be more permissive than the server here, or the UI could be
+  // built — and go green in vitest and in `npm run dev` — against a Start button that
+  // works on a tournament the API would refuse. Each case below is one of the three
+  // things `_enforce_ready_to_go_live` refuses, and the sentence is pinned because the
+  // client shows the sentence.
+
+  /** The 409's sentence, or a failed assertion — so the cases below read `detail`
+   * without a cast, and a refusal that is *not* the 409 (a 403, a 404) fails loudly
+   * instead of quietly skipping every assertion after it. */
+  function refusalDetail(result: TransitionResult): string {
+    if (result.ok || result.status !== 409) {
+      throw new Error(`expected a 409, got ${JSON.stringify(result)}`)
+    }
+    return result.detail
+  }
+
+  /** A brand-new, empty tournament, published — i.e. announced, with nothing in it. */
+  function announcedEmptyTournament(): string {
+    const created = createTournament({
+      name: 'Announced, Empty',
+      description: null,
+      start_date: '2026-09-01',
+      end_date: '2026-09-02',
+      address: {
+        venue: 'TBC',
+        street: '',
+        city: 'Oakland',
+        region: 'CA',
+        postal: '',
+        country: 'USA',
+      },
+      table_catalogue: [],
+    })
+    const published = transitionTournament(created.id, 'published')
+    if (!published.ok) throw new Error('setup failed: could not publish')
+    return created.id
+  }
+
+  it('PUBLISHES an empty tournament — announcing one early is fine', () => {
+    // The positive control for the refusal below: it is *starting* an empty tournament
+    // that is refused, not announcing it. A guard that failed here would be the one that
+    // stopped a director putting a date up before writing the events.
+    const id = announcedEmptyTournament()
+
+    expect(findTournament(id)!.status).toBe('published')
+  })
+
+  it('refuses to START an empty tournament — there is nothing to run', () => {
+    const id = announcedEmptyTournament()
+
+    expect(transitionTournament(id, 'live')).toEqual({
+      ok: false,
+      status: 409,
+      detail:
+        'This tournament has no events, so there is nothing to start. Add an event ' +
+        'and cut its draw, then start the tournament.',
+    })
+    expect(findTournament(id)!.status).toBe('published')
+  })
+
+  it('refuses to start when events have NO DRAW, and names them', () => {
+    // The seeded published tournament: five events, only `ev-u1200` drawn.
+    const detail = refusalDetail(transitionTournament(PUBLISHED, 'live'))
+
+    // The NAMES are the point — a director with five events, told merely "something
+    // isn't ready", is left clicking through all five.
+    expect(detail).toContain('“Open Singles”')
+    expect(detail).toContain('“U1500 Singles”')
+    expect(detail).toContain('have no draw yet')
+    // …and the one event that IS drawn is not blamed.
+    expect(detail).not.toContain('“U1200 Singles”')
+    expect(findTournament(PUBLISHED)!.status).toBe('published')
+  })
+
+  it('STARTS a tournament whose every event has a current draw', () => {
+    // The happy path of the precondition, and the reason the seed holds a drawn,
+    // startable tournament at all: without this, every assertion above would be equally
+    // satisfied by a store that simply refused to start anything.
+    const id = at('published') // the seeded draft, published — its one event is drawn
+
+    const result = transitionTournament(id, 'live')
+
+    expect(result.ok).toBe(true)
+    expect(findTournament(id)!.status).toBe('live')
+  })
+
+  it('refuses to start on a STALE draw — somebody entered after it was cut', () => {
+    // Registration stays open right up to go-live, which is exactly how a draw goes
+    // stale: the field the fixtures were dealt from is not the field that would play.
+    const id = at('published')
+    const entered = enterEvent(id, 'ev-slam-open')
+    if (!entered.ok) throw new Error('setup failed: could not enter')
+
+    const detail = refusalDetail(transitionTournament(id, 'live'))
+
+    expect(detail).toContain('“Slam Open Singles”')
+    expect(detail).toContain('has a draw that no longer matches its entrants')
+    // A stale draw is not an uncut one: the director is told their draw needs
+    // RE-cutting, not that they never cut it.
+    expect(detail).not.toContain('no draw yet')
+    expect(findTournament(id)!.status).toBe('published')
+  })
+
+  it('starts again once the stale draw is RE-CUT', () => {
+    // The way out, end to end — and the proof that the refusal above is about the draw's
+    // currency and not about the entrant simply existing.
+    const id = at('published')
+    enterEvent(id, 'ev-slam-open')
+    expect(transitionTournament(id, 'live').ok).toBe(false)
+
+    const recut = cutDraw(id, 'ev-slam-open')
+    if (!recut.ok) throw new Error('setup failed: could not re-cut')
+
+    expect(transitionTournament(id, 'live').ok).toBe(true)
+    expect(findTournament(id)!.status).toBe('live')
+  })
+
   // The load-bearing half of ADR-0017: with `status` gone from `TournamentUpdate`,
   // editing a tournament's fields cannot move its lifecycle. The transitions
   // resource is the only door.
@@ -998,5 +1125,66 @@ describe('the pool set freezes while a draw exists', () => {
 
     expect(result.ok).toBe(true)
     expect(poolsOf(ROUND_ROBIN).map((p) => p.id)).toEqual(['p-fresh'])
+  })
+})
+
+// The pool-set freeze's SIBLING (ADR-0786): the other fact a cut draw froze. The mock
+// enforces it for the same reason it enforces the pool set — a mock more permissive than
+// the server it stands in for is a trap, and the UI built against it would look perfect
+// in `npm run dev` and 409 in production.
+describe('the draw type freezes while a draw exists', () => {
+  beforeEach(() => resetTournamentsStore())
+
+  const ROUND_ROBIN = 'ev-u1200'
+  const eventOf = (eventId: string) =>
+    findTournament(TOURNAMENT)!.events.find((e) => e.id === eventId)!
+
+  it('refuses a PATCH that re-labels the draw type of a cut draw', () => {
+    const result = updateEvent(TOURNAMENT, ROUND_ROBIN, {
+      draw_type: 'single-elim',
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(409)
+    // The way out — otherwise the director is stuck: `single-elim` has no generator, so
+    // they could not even re-cut their way back into agreement with themselves.
+    expect(result.status === 409 && result.detail).toContain('remove the draw')
+    // A refused write writes nothing.
+    expect(eventOf(ROUND_ROBIN).draw_type).toBe('round-robin')
+  })
+
+  // ⚠️ The one that keeps the freeze from eating the edits it exists to permit. The
+  // editor PATCHes the WHOLE form back — draw type included — to move a pool's tables.
+  // A guard that fired on the mere *presence* of `draw_type` would refuse that, and the
+  // pools editor would be unusable against a server that allows it.
+  it('ALLOWS a PATCH that re-sends the SAME draw type (the whole-form save)', () => {
+    const result = updateEvent(TOURNAMENT, ROUND_ROBIN, {
+      draw_type: 'round-robin',
+      pools: eventOf(ROUND_ROBIN).pools.map((p) => ({ ...p, table_ids: ['t9'] })),
+    })
+
+    expect(result.ok).toBe(true)
+    expect(eventOf(ROUND_ROBIN).pools[0].table_ids).toEqual(['t9'])
+  })
+
+  it('leaves an UNDRAWN event’s draw type free to change', () => {
+    const result = updateEvent(TOURNAMENT, EMPTY_SINGLES, {
+      draw_type: 'round-robin',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(eventOf(EMPTY_SINGLES).draw_type).toBe('round-robin')
+  })
+
+  it('un-freezes the moment the draw is removed', () => {
+    expect(uncutDraw(TOURNAMENT, ROUND_ROBIN).ok).toBe(true)
+
+    const result = updateEvent(TOURNAMENT, ROUND_ROBIN, {
+      draw_type: 'single-elim',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(eventOf(ROUND_ROBIN).draw_type).toBe('single-elim')
   })
 })

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -6,11 +6,14 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   createEvent,
+  cutDraw,
   enterEvent,
   findTournament,
   listTournaments,
+  markFixturePlayed,
   resetTournamentsStore,
   transitionTournament,
+  uncutDraw,
   updateEvent,
   updateTournament,
   withdrawEntry,
@@ -43,6 +46,11 @@ const CLOSED_PHRASE: Record<Exclude<TournamentStatus, 'published'>, string> = {
   live: 'already under way',
   archived: 'has ended',
 }
+
+/** A window of time, for the pool literals the draw cases patch events with. Nothing
+ * about a draw turns on *when* a pool plays — only on which pools there are — so one
+ * slot serves them all. */
+const SLOT = { date: '2026-06-14', start: '09:00', end: '12:00' }
 
 const STATUSES: TournamentStatus[] = ['draft', 'published', 'live', 'archived']
 const CLOSED_STATUSES = ['draft', 'live', 'archived'] as const
@@ -737,5 +745,258 @@ describe('draft visibility', () => {
   it("still serves another organiser's ANNOUNCED tournament, read-only", () => {
     expect(listedIds()).toContain(FOREIGN_PUBLISHED)
     expect(findTournament(FOREIGN_PUBLISHED)!.can_edit).toBe(false)
+  })
+})
+
+// The draw (ADR-0786). A mock that were more permissive than the server it stands in
+// for would be a trap: a Generate button that "worked" in `npm run dev` and 422'd in
+// production would look like a server bug rather than the missing generator it is. So
+// each refusal below is one the API really makes, in the API's own order.
+describe('cutting and un-cutting a draw', () => {
+  beforeEach(() => resetTournamentsStore())
+
+  const FOREIGN = 'club-champs-2026' // `u-office`'s, published: readable, not writable
+  const FOREIGN_EVENT = 'ev-cc-open'
+  /** Round-robin, two pools, nine entrants — the seed's one cuttable (and pre-cut)
+   * event, because round-robin is the only draw type with a generator today. */
+  const ROUND_ROBIN = 'ev-u1200'
+
+  const eventOf = (tournamentId: string, eventId: string) =>
+    findTournament(tournamentId)!.events.find((e) => e.id === eventId)!
+
+  const poolNamed = (id: string) => ({
+    id,
+    name: id,
+    slot: SLOT,
+    table_ids: [],
+  })
+
+  it('seeds the round-robin event ALREADY DRAWN, and every other event with no draw', () => {
+    const drawn = eventOf(TOURNAMENT, ROUND_ROBIN)
+    // 9 entrants snaked across 2 pools → pools of 5 and 4 → C(5,2) + C(4,2) = 16 pairs.
+    expect(drawn.fixtures).toHaveLength(16)
+    for (const other of findTournament(TOURNAMENT)!.events.filter(
+      (e) => e.id !== ROUND_ROBIN,
+    )) {
+      // `[]`, not null: an event with no draw is EMPTY, and empty is a state.
+      expect(other.fixtures).toEqual([])
+    }
+  })
+
+  it('cuts every pair exactly once, inside a pool, and nobody twice in a round', () => {
+    expect(uncutDraw(TOURNAMENT, ROUND_ROBIN).ok).toBe(true)
+    const result = cutDraw(TOURNAMENT, ROUND_ROBIN)
+    if (!result.ok) throw new Error(`expected a cut, got ${result.status}`)
+
+    const pools = eventOf(TOURNAMENT, ROUND_ROBIN).pools.map((p) => p.id)
+    // Every fixture names one of THIS event's pools — a `pool_id` is a string ref into
+    // that JSONB, not a foreign key, so a draw pointing at a pool the event does not
+    // have is a draw nothing can render.
+    expect(new Set(result.fixtures.map((f) => f.pool_id))).toEqual(new Set(pools))
+
+    // Every pair meets exactly once…
+    const pairs = result.fixtures.map((f) =>
+      [f.entry_a_id, f.entry_b_id].sort().join('|'),
+    )
+    expect(new Set(pairs).size).toBe(pairs.length)
+
+    // …and nobody plays twice in the same (pool, round): the circle method's whole
+    // promise, and the thing a naive "pair them up" planner gets wrong.
+    for (const fixture of result.fixtures) {
+      const sameRound = result.fixtures.filter(
+        (f) => f.pool_id === fixture.pool_id && f.round === fixture.round,
+      )
+      const players = sameRound.flatMap((f) => [f.entry_a_id, f.entry_b_id])
+      expect(new Set(players).size).toBe(players.length)
+    }
+  })
+
+  it('re-cuts an unplayed draw deterministically — the same field cuts the same draw', () => {
+    const before = eventOf(TOURNAMENT, ROUND_ROBIN).fixtures
+
+    const again = cutDraw(TOURNAMENT, ROUND_ROBIN)
+
+    if (!again.ok) throw new Error('a re-cut of an unplayed draw must be allowed')
+    // Nothing is random (ADR-0786) — entrants are ordered by seed, then registration
+    // order — which is what makes a re-cut a reviewable act rather than a gamble.
+    expect(again.fixtures).toEqual(before)
+  })
+
+  it('re-cuts WHOLESALE against the event as it stands now — new pools, new draw', () => {
+    // The plan is made against the CURRENT config, never patched onto the old one. Two
+    // pools of 5 + 4 (16 pairs) become one pool of 9 (36 pairs) — and the fixtures that
+    // referred to the old pools are gone, not re-pointed.
+    expect(uncutDraw(TOURNAMENT, ROUND_ROBIN).ok).toBe(true) // the freeze lifts first
+    updateEvent(TOURNAMENT, ROUND_ROBIN, { pools: [poolNamed('p-single')] })
+
+    const result = cutDraw(TOURNAMENT, ROUND_ROBIN)
+
+    if (!result.ok) throw new Error(`expected a cut, got ${result.status}`)
+    expect(result.fixtures).toHaveLength(36) // C(9,2)
+    expect(new Set(result.fixtures.map((f) => f.pool_id))).toEqual(
+      new Set(['p-single']),
+    )
+  })
+
+  it('un-cutting empties the draw; un-cutting again is still a success (idempotent DELETE)', () => {
+    expect(uncutDraw(TOURNAMENT, ROUND_ROBIN)).toEqual({ ok: true })
+    expect(eventOf(TOURNAMENT, ROUND_ROBIN).fixtures).toEqual([])
+    // An event with no draw is already in the state this asks for.
+    expect(uncutDraw(TOURNAMENT, ROUND_ROBIN)).toEqual({ ok: true })
+    expect(uncutDraw(TOURNAMENT, EMPTY_SINGLES)).toEqual({ ok: true })
+  })
+
+  // The 422s — the refusals a director actually meets, each naming what they must change.
+  it('refuses a draw type with no generator yet (only round-robin has one)', () => {
+    const result = cutDraw(TOURNAMENT, FULL_SINGLES) // `single-elim`, 16 entrants
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(422)
+    expect(result.status === 422 && result.detail).toContain('single-elim')
+  })
+
+  it('refuses a pooled draw with NO pools — there is nowhere to deal the field', () => {
+    // `ev-open-singles` is `rr-then-ko`, so make it the one type that CAN be cut and
+    // leave its pools empty: the refusal must be about the pools, not the type.
+    updateEvent(TOURNAMENT, FULLISH_SINGLES, { draw_type: 'round-robin', pools: [] })
+
+    const result = cutDraw(TOURNAMENT, FULLISH_SINGLES)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(422)
+    expect(result.status === 422 && result.detail).toContain('at least one pool')
+  })
+
+  it('refuses a field too small for its pools — a pool of one has nobody to play', () => {
+    // Three pools, three entrants… would be three pools of one. The server refuses it,
+    // so the mock must: a pool of one is not a competition.
+    updateEvent(TOURNAMENT, EMPTY_SINGLES, {
+      draw_type: 'round-robin',
+      pools: [poolNamed('p-1'), poolNamed('p-2'), poolNamed('p-3')],
+    })
+    enterEvent(TOURNAMENT, EMPTY_SINGLES) // one entrant: the dev user
+
+    const result = cutDraw(TOURNAMENT, EMPTY_SINGLES)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(422)
+    expect(result.status === 422 && result.detail).toContain('fewer than 2 entrants')
+  })
+
+  // The play guard — the ONE reason a cut or an un-cut is refused, and it is not the
+  // tournament's status (ADR-0786 rejected status-gating: it would forbid the legitimate
+  // day-of re-cut while protecting nothing).
+  it.each([
+    { evidence: 'a recorded winner', played: { winner_entry_id: 'entry-ev-u1200-1' } },
+    { evidence: 'a linked match', played: { match_id: 'm-1' } },
+  ])('refuses both verbs once a fixture shows $evidence — and destroys nothing', ({
+    played,
+  }) => {
+    const fixtures = eventOf(TOURNAMENT, ROUND_ROBIN).fixtures
+    markFixturePlayed(TOURNAMENT, ROUND_ROBIN, fixtures[0].id, played)
+
+    const recut = cutDraw(TOURNAMENT, ROUND_ROBIN)
+    expect(recut.ok).toBe(false)
+    if (!recut.ok) expect(recut.status).toBe(409)
+
+    const removed = uncutDraw(TOURNAMENT, ROUND_ROBIN)
+    expect(removed.ok).toBe(false)
+    if (!removed.ok) expect(removed.status).toBe(409)
+
+    // The standing draw survives a refusal — the guard's whole promise. A re-cut that
+    // deleted first and refused second would have eaten the very score it was protecting.
+    const after = eventOf(TOURNAMENT, ROUND_ROBIN).fixtures
+    expect(after).toHaveLength(fixtures.length)
+    expect(after[0]).toMatchObject(played)
+  })
+
+  // 404 → 403 → 409, the API's ordering: a stranger never learns whether an event's draw
+  // has been played, because ownership is judged before the draw's state is looked at.
+  it("refuses a stranger's cut with a 403, and an unknown event with a 404", () => {
+    expect(cutDraw(FOREIGN, FOREIGN_EVENT)).toEqual({ ok: false, status: 403 })
+    expect(uncutDraw(FOREIGN, FOREIGN_EVENT)).toEqual({ ok: false, status: 403 })
+    expect(cutDraw(TOURNAMENT, 'ev-nope')).toEqual({ ok: false, status: 404 })
+    expect(uncutDraw('no-such-tournament', 'ev-nope')).toEqual({
+      ok: false,
+      status: 404,
+    })
+  })
+})
+
+// The pool-set FREEZE (ADR-0786): while a draw exists, an event's pools may change in
+// every way except identity. A fixture's `pool_id` is a string ref into this very JSONB
+// and there is no foreign key to stop a PATCH from orphaning it — "integrity is
+// procedural, not schematic" — so the procedure is here, in the mock, for the same
+// reason it is on the server.
+describe('the pool set freezes while a draw exists', () => {
+  beforeEach(() => resetTournamentsStore())
+
+  const ROUND_ROBIN = 'ev-u1200'
+  const poolsOf = (eventId: string) =>
+    findTournament(TOURNAMENT)!.events.find((e) => e.id === eventId)!.pools
+
+  it('refuses a PATCH that removes a pool the draw was dealt across', () => {
+    const [poolA] = poolsOf(ROUND_ROBIN)
+
+    const result = updateEvent(TOURNAMENT, ROUND_ROBIN, { pools: [poolA] })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(409)
+    // The sentence ends with the way OUT — remove the draw, change the pools, cut again
+    // — because a refusal a director cannot act on is just a wall.
+    expect(result.status === 409 && result.detail).toContain('remove the draw first')
+    // …and the pools are untouched: a refused write writes nothing.
+    expect(poolsOf(ROUND_ROBIN)).toHaveLength(2)
+  })
+
+  it('refuses a PATCH that ADDS a pool — an added pool would arrive with no fixtures', () => {
+    const pools = poolsOf(ROUND_ROBIN)
+
+    const result = updateEvent(TOURNAMENT, ROUND_ROBIN, {
+      pools: [...pools, { id: 'p-new', name: 'Pool C', slot: SLOT, table_ids: [] }],
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(409)
+  })
+
+  // Only IDENTITY is frozen. A pool's tables and its window stay editable with a draw
+  // standing, on purpose: venues change under running tournaments (a table breaks, a
+  // table frees up), and a director who cannot record that would have to un-cut a draw
+  // that is *correct*.
+  it('ALLOWS a venue edit — same pool ids, new tables and a new window', () => {
+    const pools = poolsOf(ROUND_ROBIN)
+
+    const result = updateEvent(TOURNAMENT, ROUND_ROBIN, {
+      pools: pools.map((p) => ({
+        ...p,
+        name: `${p.name} (moved)`,
+        table_ids: ['t9'],
+        slot: SLOT,
+      })),
+    })
+
+    expect(result.ok).toBe(true)
+    expect(poolsOf(ROUND_ROBIN)[0].table_ids).toEqual(['t9'])
+  })
+
+  it('leaves an UNDRAWN event’s pools wholesale-replaceable, as they have always been', () => {
+    const result = updateEvent(TOURNAMENT, EMPTY_SINGLES, {
+      pools: [{ id: 'p-anything', name: 'A', slot: SLOT, table_ids: [] }],
+    })
+
+    expect(result.ok).toBe(true)
+  })
+
+  it('un-freezes the moment the draw is removed', () => {
+    expect(uncutDraw(TOURNAMENT, ROUND_ROBIN).ok).toBe(true)
+
+    const result = updateEvent(TOURNAMENT, ROUND_ROBIN, {
+      pools: [{ id: 'p-fresh', name: 'Pool A', slot: SLOT, table_ids: [] }],
+    })
+
+    expect(result.ok).toBe(true)
+    expect(poolsOf(ROUND_ROBIN).map((p) => p.id)).toEqual(['p-fresh'])
   })
 })

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -595,6 +595,10 @@ describe('transitionTournament', () => {
   const DRAFT = 'summer-slam-2026' // seeded `draft`, owned
   const PUBLISHED = 'bay-area-open-2026' // seeded `published`, owned
   const NOT_MINE = 'club-champs-2026' // seeded `published`, can_edit: false
+  /** `DRAFT`'s only event: round-robin, 8 entrants, a draw already cut across its two
+   * pools — i.e. the one seeded event whose draw is CURRENT, which is what makes that
+   * tournament the only one in the seed that can go live at all. */
+  const SLAM_EVENT = 'ev-slam-open'
 
   const LEGAL: [TournamentStatus, TournamentStatus][] = [
     ['draft', 'published'],
@@ -784,6 +788,62 @@ describe('transitionTournament', () => {
     // A stale draw is not an uncut one: the director is told their draw needs
     // RE-cutting, not that they never cut it.
     expect(detail).not.toContain('no draw yet')
+    expect(findTournament(id)!.status).toBe('published')
+  })
+
+  // ⚠️ THE case that pins `drawCurrency` as a **set** comparison rather than a count.
+  //
+  // The test above adds an entrant, so the field grows: 8 seated, 9 active. A currency
+  // check written as `active.length === seated.size` refuses that one too — and passes
+  // every other test in this file. (Measured, not theorised: mutating the store's
+  // comparison to a count left all 2464 vitest tests green.) The case that tells the two
+  // apart is a **swap**, and it is the one that actually loses a director their morning:
+  // the field is the same SIZE and is not the same field, so a count-based check calls
+  // the draw current, the tournament starts, and a player who withdrew is scheduled to
+  // play while their replacement is scheduled nowhere.
+  //
+  // The unit of the comparison is the ENTRY, not the player: the server soft-deletes a
+  // withdrawn entry and INSERTs a fresh row when someone re-enters (the partial unique
+  // index — and the store mints a new entry id for the same reason). So "I withdrew and
+  // came back" is, on the wire, exactly what "player A left and player B took the place"
+  // is — one seated id the event no longer lists, one listed id the draw does not seat —
+  // and it is the only swap this store's own routes can make, since the dev user is the
+  // only person who can enter or withdraw here.
+  it('refuses to start on a SWAPPED field — the same NUMBER of entrants, different entries', () => {
+    const id = at('published')
+    const first = enterEvent(id, SLAM_EVENT)
+    if (!first.ok) throw new Error('setup failed: could not enter')
+    // The draw is cut over the field as it stands: 9 entrants, `first.entrant` among them.
+    if (!cutDraw(id, SLAM_EVENT).ok) throw new Error('setup failed: could not cut')
+
+    // …and then the swap: that entry leaves, and another arrives in its place.
+    const out = withdrawEntry(id, SLAM_EVENT, first.entrant.id)
+    if (!out.ok) throw new Error('setup failed: could not withdraw')
+    const second = enterEvent(id, SLAM_EVENT)
+    if (!second.ok) throw new Error('setup failed: could not re-enter')
+    // A re-entry is a NEW entry, never the resurrection of the withdrawn one — which is
+    // what makes this a swap at all.
+    expect(second.entrant.id).not.toBe(first.entrant.id)
+
+    // The discriminator itself, asserted rather than assumed: the counts AGREE. Without
+    // this line the test could quietly drift into being another "somebody entered" case
+    // — and would then go green against the very mutation it exists to kill.
+    const event = findTournament(id)!.events.find((e) => e.id === SLAM_EVENT)!
+    const seated = new Set(
+      event.fixtures.flatMap((f) =>
+        [f.entry_a_id, f.entry_b_id].filter((x): x is string => x !== null),
+      ),
+    )
+    expect(event.entrants).toHaveLength(seated.size)
+    // …and the SETS do not: the draw seats an entry the event no longer lists, and the
+    // event lists an entry the draw seats nowhere.
+    expect(seated.has(first.entrant.id)).toBe(true)
+    expect(seated.has(second.entrant.id)).toBe(false)
+
+    const detail = refusalDetail(transitionTournament(id, 'live'))
+
+    expect(detail).toContain('“Slam Open Singles”')
+    expect(detail).toContain('has a draw that no longer matches its entrants')
     expect(findTournament(id)!.status).toBe('published')
   })
 

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -133,6 +133,24 @@ const U1200_POOLS: Pool[] = [
   },
 ]
 
+/** The pools of Summer Slam's one event — the seed's **ready-to-start** tournament (see
+ * below). Pulled out for the same reason `U1200_POOLS` is: the fixtures are planned
+ * against these very ids, so they cannot be spelled twice and spelled differently. */
+const SLAM_POOLS: Pool[] = [
+  {
+    id: 'p-slam-a',
+    name: 'Pool A',
+    slot: { date: '2026-08-22', start: '09:00', end: '11:00' },
+    table_ids: ['t1', 't2'],
+  },
+  {
+    id: 'p-slam-b',
+    name: 'Pool B',
+    slot: { date: '2026-08-22', start: '11:00', end: '13:00' },
+    table_ids: ['t3', 't4'],
+  },
+]
+
 function seed(): StoredTournament[] {
   return [
     {
@@ -311,7 +329,39 @@ function seed(): StoredTournament[] {
       can_edit: true,
       created_at: '2026-06-05T15:30:00Z',
       updated_at: '2026-06-05T15:30:00Z',
-      events: [],
+      events: [
+        {
+          // The seed's one **ready-to-start** event, and the reason this tournament has
+          // one at all (it used to have none): going live now has a precondition
+          // (ADR-0786) — at least one event, every event drawn, every draw still seating
+          // exactly its entrants — so a seed in which *nothing* satisfied it would make
+          // `live` and `archived` unreachable in `npm run dev` and in the store's own
+          // tests, and would leave the whole precondition unexercised on its happy path.
+          //
+          // Round-robin with pools and a draw cut from its own entrants, so it is
+          // `current` by the same set-comparison the server makes. Publish this
+          // tournament and Start works; publish the Bay Area Open — four of whose five
+          // events have no draw — and Start is refused, by name. The seed holds both.
+          id: 'ev-slam-open',
+          tournament_id: 'summer-slam-2026',
+          name: 'Slam Open Singles',
+          format: 'singles',
+          draw_type: 'round-robin',
+          max_players: 16,
+          entry_fee: 20,
+          entrants: otherEntrants('ev-slam-open', 8),
+          slot: { date: '2026-08-22', start: '09:00', end: '13:00' },
+          match_settings: { rated: true, length_games: 5 },
+          predicates: [],
+          pools: SLAM_POOLS,
+          fixtures: planRoundRobinFixtures(
+            otherEntrants('ev-slam-open', 8).map((e) => e.id),
+            SLAM_POOLS.map((p) => p.id),
+          ),
+          created_at: '2026-06-05T15:31:00Z',
+          updated_at: '2026-06-05T15:31:00Z',
+        },
+      ],
     },
     {
       id: 'club-champs-2026',
@@ -744,12 +794,110 @@ const LEGAL_TRANSITIONS: ReadonlySet<string> = new Set([
 ])
 
 /** A transition can fail three ways, in the API's order: 404 (no such
- * tournament), 403 (not the owner), 409 (not a legal edge). The 409 carries the
- * server's `detail` verbatim, because the copy is what a stale tab is told. */
+ * tournament), 403 (not the owner), 409 (not a legal edge — or, for go-live, a
+ * tournament whose draws are not ready). The 409 carries the server's `detail`
+ * verbatim, because the copy is what the director is told. */
 export type TransitionResult =
   | { ok: true; tournament: TournamentRead }
   | { ok: false; status: 403 | 404 }
   | { ok: false; status: 409; detail: string }
+
+// ----- the go-live precondition (ADR-0786) ---------------------------------
+//
+// `published → live` is the one edge with a precondition, and this store enforces it
+// exactly as the server does (`_enforce_ready_to_go_live`, `api/app/tournaments.py`).
+// A mock that let an empty tournament — or one whose draws were never cut — go live
+// would be a mock we could build a *lying UI* against: the button would work in
+// `npm run dev` and in vitest, and 409 in front of a director on the morning of their
+// tournament. The copy is the server's, verbatim, because the client shows it verbatim.
+
+/** The server's sentence for a tournament with nothing to run. Publishing one is fine —
+ * announcing a tournament before its events are written up is ordinary — but starting
+ * one is not. Checked FIRST, because "every event has a current draw" is vacuously true
+ * of a tournament with no events. */
+const NOTHING_TO_START =
+  'This tournament has no events, so there is nothing to start. Add an event and cut ' +
+  'its draw, then start the tournament.'
+
+/** The things a refusal is about, as a human would say them: `“Pool B”`, or
+ * `“Pool B” and “Pool C”` (`named_list`, `api/app/schemas/tournament.py`). */
+function namedList(names: string[]): string {
+  const quoted = names.map((name) => `“${name}”`)
+  if (quoted.length === 1) return quoted[0]
+  return `${quoted.slice(0, -1).join(', ')} and ${quoted[quoted.length - 1]}`
+}
+
+/** Where one event's draw stands (`DrawCurrency`, `api/app/tournament_draws.py`).
+ *
+ * A **set comparison, never a count**: currency is "these fixtures seat exactly these
+ * entrants". Comparing sizes would pass the same happy-path test and wave through the
+ * case that matters most — one player withdraws and another enters between the cut and
+ * go-live, leaving the same count, a different field, and a draw that seats somebody who
+ * has left while their replacement is seated nowhere.
+ *
+ * `uncut` is decided on the fixtures EXISTING, not on the seated set being empty: an
+ * event nobody has entered has neither, and ∅ == ∅ would call it `current` — an event
+ * with no draw at all, certified ready to start. */
+function drawCurrency(event: StoredEvent): 'current' | 'uncut' | 'stale' {
+  if (event.fixtures.length === 0) return 'uncut'
+  const seated = new Set<string>()
+  for (const fixture of event.fixtures) {
+    // A `null` side is TBD (a KO round whose feeder is undecided), never a bye and never
+    // an absent player — so it seats nobody.
+    if (fixture.entry_a_id !== null) seated.add(fixture.entry_a_id)
+    if (fixture.entry_b_id !== null) seated.add(fixture.entry_b_id)
+  }
+  const active = event.entrants.map((e) => e.id)
+  const same =
+    active.length === seated.size && active.every((id) => seated.has(id))
+  return same ? 'current' : 'stale'
+}
+
+/** Why this tournament cannot start yet, in the server's own words — or `null` when it
+ * can. **It names the events**, because a refusal a director cannot act on is barely
+ * better than a 500: "some event has no draw" leaves them clicking through a ten-event
+ * tournament looking for it.
+ *
+ * The two failures are kept apart in the sentence, because they are two different jobs:
+ * an **uncut** event needs a first cut, while a **stale** one has a draw the director may
+ * well have reviewed and approved — it is merely older than the field — and needs
+ * re-cutting. */
+function goLiveRefusal(tournament: StoredTournament): string | null {
+  if (tournament.events.length === 0) return NOTHING_TO_START
+
+  const uncut: string[] = []
+  const stale: string[] = []
+  for (const event of tournament.events) {
+    const currency = drawCurrency(event)
+    if (currency === 'uncut') uncut.push(event.name)
+    else if (currency === 'stale') stale.push(event.name)
+  }
+  if (uncut.length === 0 && stale.length === 0) return null
+
+  const clauses: string[] = []
+  if (uncut.length > 0) {
+    clauses.push(
+      `${namedList(uncut)} ${uncut.length === 1 ? 'has' : 'have'} no draw yet`,
+    )
+  }
+  if (stale.length > 0) {
+    clauses.push(
+      `${namedList(stale)} ${
+        stale.length === 1
+          ? 'has a draw that no longer matches its entrants'
+          : 'have draws that no longer match their entrants'
+      }`,
+    )
+  }
+  return (
+    'This tournament cannot start yet: ' +
+    clauses.join('; and ') +
+    '. A draw is cut from the field as it stands at the time, and registration stays ' +
+    'open right up to the moment a tournament goes live — so cut the draw for each ' +
+    'event named (again, if somebody entered or withdrew since it was last cut), then ' +
+    'start the tournament.'
+  )
+}
 
 /** `POST /v1/tournaments/{id}/transitions` — move a tournament along its
  * lifecycle. Owner-only, like every other tournament mutation, and the ONLY way
@@ -782,6 +930,15 @@ export function transitionTournament(
           : `This tournament is ${existing.status}; it cannot be moved to ${to}.`,
     }
   }
+  // THE per-target precondition (ADR-0786), judged after the edge and only for `live`:
+  // publishing an empty, undrawn tournament is legal (announcing early is fine), and
+  // archiving asks nothing of the draws it is putting away. Refused BEFORE the write, so
+  // a refused start leaves the tournament exactly where it was — `published`, which is
+  // what the header goes on rendering.
+  if (to === 'live') {
+    const detail = goLiveRefusal(existing)
+    if (detail) return { ok: false, status: 409, detail }
+  }
   const next: StoredTournament = {
     ...existing,
     status: to,
@@ -789,6 +946,24 @@ export function transitionTournament(
   }
   replace(next)
   return { ok: true, tournament: readOf(next) }
+}
+
+/** Put a tournament directly in `status` — a **test-and-dev seam**, not a route.
+ *
+ * The route is `transitionTournament` above, and it enforces the server's edge table AND
+ * the go-live precondition. This is the door a *fixture* comes through: a test that needs
+ * a tournament which IS live (to prove entries are locked, say) is not a test of the
+ * transition, and driving it through the guarded edges would make it depend on every one
+ * of that edge's preconditions — so a seeded row moves here, exactly as a server-side
+ * test creates its row in the status it wants rather than POSTing its way to it.
+ *
+ * Nothing in `handlers.ts` calls this, and nothing should: a handler that did would be
+ * the mock quietly being more permissive than the server, which is the one thing this
+ * store exists not to be. */
+export function placeInStatus(id: string, status: TournamentStatus): void {
+  const existing = tournaments.find((t) => t.id === id)
+  if (!existing) return
+  replace({ ...existing, status, updated_at: new Date().toISOString() })
 }
 
 /** Delete a tournament. Same gating as update. */
@@ -860,8 +1035,9 @@ export function updateEvent(
   const event = existing.events.find((e) => e.id === eventId)
   if (!event) return { ok: false, status: 404 }
   // 404 → 403 → 409, the server's ordering: the state of an event's draw is never the
-  // reason a stranger's request is refused.
-  const frozen = poolSetFrozenDetail(event, patch)
+  // reason a stranger's request is refused. (The 422s come before all of it — they are
+  // the schema's, and the handler asks them at the boundary; see `validateEventBody`.)
+  const frozen = poolSetFrozenDetail(event, patch) ?? drawTypeFrozenDetail(event, patch)
   if (frozen !== null) return { ok: false, status: 409, detail: frozen }
   const next: StoredEvent = {
     ...event,
@@ -962,6 +1138,33 @@ function poolSetFrozenDetail(
     "This event's draw is already cut, so its set of pools is frozen: " +
     'a pool cannot be added, removed or re-identified while fixtures refer to it. ' +
     'To add, remove or re-identify a pool, remove the draw first, then cut it again.'
+  )
+}
+
+/** Why this event's `draw_type` may not be replaced right now, or `null` when it may be
+ * (`_enforce_draw_type_frozen`, ADR-0786). The pool-set freeze's sibling, one field over:
+ * a draw type is not a label on an event, it is the strategy that DEALT its fixtures, and
+ * re-labelling it under a standing draw leaves the event claiming a shape its draw does
+ * not have (a `single-elim` event holding pooled round-robin fixtures — the PATCH the
+ * server used to answer **200**).
+ *
+ * **Presence is not enough — the CHANGE is what is refused.** The editor PATCHes the
+ * whole form back, `draw_type` included, to move a pool's tables; a mock that fired on
+ * the mere presence of the key would refuse the very edit the freeze exists to permit,
+ * and the pools editor would look broken in `npm run dev` against a server that allows
+ * it. */
+function drawTypeFrozenDetail(
+  event: StoredEvent,
+  patch: TournamentEventUpdate,
+): string | null {
+  if (patch.draw_type === undefined || patch.draw_type === null) return null
+  if (patch.draw_type === event.draw_type) return null
+  if (event.fixtures.length === 0) return null
+  return (
+    "This event's draw is already cut, so its draw type is frozen: its fixtures were " +
+    `dealt as a “${event.draw_type}” draw, and changing the type would leave the event ` +
+    'claiming a shape its draw does not have. To change the draw type, remove the draw ' +
+    'first, then cut it again.'
   )
 }
 

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -20,7 +20,10 @@
 
 import type { components } from '@/api/schema'
 import { FORTYMM_LEAGUE_ID } from '@/mocks/factories/players/player-league.factory'
-import { entryStateFor } from '@/mocks/factories/tournaments/tournament.factory'
+import {
+  entryStateFor,
+  planRoundRobinFixtures,
+} from '@/mocks/factories/tournaments/tournament.factory'
 
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
 type TournamentRead = components['schemas']['TournamentRead']
@@ -30,8 +33,10 @@ type TournamentCreate = components['schemas']['TournamentCreate']
 type TournamentUpdate = components['schemas']['TournamentUpdate']
 type TournamentEventCreate = components['schemas']['TournamentEventCreate']
 type TournamentEventUpdate = components['schemas']['TournamentEventUpdate']
+type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
 type TournamentTable = components['schemas']['TournamentTable']
 type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
+type Pool = components['schemas']['Pool']
 
 /** What the store actually holds for an event: everything the wire shape has
  * *except* the two fields the server DERIVES at read time — the `entered` count
@@ -44,7 +49,14 @@ type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
  * fails one of this event's rules is a fact about a player's rating on the
  * tournament's ladder (ADR-0783), and no mock payload carries a ladder — so it is
  * seeded rather than computed, and `readEvent` turns it into the wire's
- * `rating_ineligible`. */
+ * `rating_ineligible`.
+ *
+ * `fixtures` — the event's DRAW (ADR-0786) — *is* stored, and is not derived from
+ * anything: a draw is an explicit act (`POST …/draw`), not a function of the entrants,
+ * so `[]` is the real state of an event nobody has cut a draw for, and the only things
+ * that ever change it are the two draw verbs (`cutDraw` / `uncutDraw` below). An event
+ * PATCH deliberately leaves it alone — a director editing an event's name has not
+ * thrown their draw away. */
 type StoredEvent = Omit<TournamentEventRead, 'entered' | 'entry_state'> & {
   /** Seeded: the dev user is refused by this rule, at this rating. */
   ineligible?: { predicate_id: string; rating: number }
@@ -100,6 +112,27 @@ function otherEntrants(eventId: string, count: number): TournamentEntrantRead[] 
   }))
 }
 
+/** The two pools the seed's ONE drawn event is cut across (`ev-u1200` below). Pulled
+ * out of the seed so the fixtures it is seeded with can be planned across the very same
+ * pool ids: a fixture's `pool_id` is a string ref into its event's own `pools`
+ * (ADR-0786 — not a foreign key, because pools are JSONB value-objects), so a seed that
+ * spelled the ids twice could spell them differently, and every fixture would point at
+ * a pool that does not exist. */
+const U1200_POOLS: Pool[] = [
+  {
+    id: 'p-u1200-a',
+    name: 'Pool A',
+    slot: { date: '2026-06-14', start: '09:00', end: '10:30' },
+    table_ids: ['t1', 't2'],
+  },
+  {
+    id: 'p-u1200-b',
+    name: 'Pool B',
+    slot: { date: '2026-06-14', start: '10:30', end: '12:00' },
+    table_ids: ['t3', 't4'],
+  },
+]
+
 function seed(): StoredTournament[] {
   return [
     {
@@ -151,6 +184,9 @@ function seed(): StoredTournament[] {
               table_ids: ['t1', 't2', 't3', 't4', 't5', 't6'],
             },
           ],
+          // NO DRAW CUT (ADR-0786) — the state every event starts in, and the state
+          // all but one of this seed's events stay in. `[]`, never null.
+          fixtures: [],
           created_at: '2026-06-01T09:05:00Z',
           updated_at: '2026-06-09T12:00:00Z',
         },
@@ -169,6 +205,7 @@ function seed(): StoredTournament[] {
           match_settings: { rated: true, length_games: 3 },
           predicates: [{ id: 'pr-2', field: 'rating', op: '<', value: 1500 }],
           pools: [],
+          fixtures: [],
           created_at: '2026-06-01T09:06:00Z',
           updated_at: '2026-06-09T12:00:00Z',
         },
@@ -189,6 +226,7 @@ function seed(): StoredTournament[] {
           match_settings: { rated: true, length_games: 7 },
           predicates: [],
           pools: [],
+          fixtures: [],
           created_at: '2026-06-01T09:06:30Z',
           updated_at: '2026-06-09T12:00:00Z',
         },
@@ -198,6 +236,14 @@ function seed(): StoredTournament[] {
           // refuses them — naming the rule that did it (`predicate_id`), which the
           // card reads back out of the event's own `predicates`. Not derivable from
           // the event alone (there is no ladder in a mock), so it is seeded.
+          //
+          // It is ALSO the seed's one **drawn** event (ADR-0786), and it is the only
+          // event that could be: round-robin is the one draw type with a generator
+          // today, so every other seeded event's draw type would be refused with a 422
+          // by the very endpoint this store mirrors. Nine entrants across two pools
+          // (5 + 4 by the snake) — an ODD pool, so Pool A's rounds have a player
+          // sitting out, and a bye is visible for what it is: the ABSENCE of a fixture,
+          // not a fixture with an empty side.
           id: 'ev-u1200',
           tournament_id: 'bay-area-open-2026',
           name: 'U1200 Singles',
@@ -210,7 +256,14 @@ function seed(): StoredTournament[] {
           match_settings: { rated: true, length_games: 3 },
           predicates: [{ id: 'pr-u1200', field: 'rating', op: '<', value: 1200 }],
           ineligible: { predicate_id: 'pr-u1200', rating: DEV_USER_RATING },
-          pools: [],
+          pools: U1200_POOLS,
+          // Planned by the same function the store's `cutDraw` uses, from the same
+          // entrants and the same pools — so the seeded draw is one this store could
+          // have cut, rather than a hand-written list that no cut would ever produce.
+          fixtures: planRoundRobinFixtures(
+            otherEntrants('ev-u1200', 9).map((e) => e.id),
+            U1200_POOLS.map((p) => p.id),
+          ),
           created_at: '2026-06-01T09:06:45Z',
           updated_at: '2026-06-09T12:00:00Z',
         },
@@ -230,6 +283,7 @@ function seed(): StoredTournament[] {
           match_settings: { rated: false, length_games: 3 },
           predicates: [],
           pools: [],
+          fixtures: [],
           created_at: '2026-06-01T09:07:00Z',
           updated_at: '2026-06-09T12:00:00Z',
         },
@@ -340,6 +394,9 @@ function seed(): StoredTournament[] {
               table_ids: ['t1', 't2'],
             },
           ],
+          // Un-drawn, and it stays that way through the UI: the dev user does not own
+          // this tournament, and cutting a draw is owner-only (`cutDraw` 403s them).
+          fixtures: [],
           created_at: '2026-05-20T10:05:00Z',
           updated_at: '2026-06-12T08:00:00Z',
         },
@@ -546,9 +603,14 @@ export type StoreResult =
   | { ok: true; tournament: TournamentRead }
   | { ok: false; status: 403 | 404 }
 
+/** An event write fails four ways: 404 (no such tournament/event), 403 (not the
+ * creator), and — on a PATCH that would move the pools out from under a cut draw — a
+ * **409** carrying the server's sentence (ADR-0786's pool-set freeze; see
+ * `poolSetFrozenDetail`). A create can never hit that 409: a new event has no draw. */
 export type EventResult =
   | { ok: true; event: TournamentEventRead }
   | { ok: false; status: 403 | 404 }
+  | { ok: false; status: 409; detail: string }
 
 export type DeleteResult = { ok: true } | { ok: false; status: 403 | 404 }
 
@@ -765,6 +827,9 @@ export function createEvent(
     match_settings: body.match_settings,
     predicates: body.predicates ?? [],
     pools: body.pools ?? [],
+    // A brand-new event has NO DRAW (ADR-0786). Cutting one is an explicit act against
+    // a field that does not exist yet — there is nobody entered to draw.
+    fixtures: [],
     created_at: now,
     updated_at: now,
   }
@@ -772,7 +837,18 @@ export function createEvent(
   return { ok: true, event: readEvent(event) }
 }
 
-/** Patch an event (full replace of the provided fields). Creator-only. */
+/** Patch an event (full replace of the provided fields). Creator-only.
+ *
+ * **The pool SET freezes while a draw exists** (ADR-0786): a `pools` payload that would
+ * add, remove or re-`id` a pool on an event whose draw is cut is refused with a 409,
+ * because a fixture's `pool_id` is a string ref into this very JSONB and nothing in the
+ * database stops the edit from orphaning it. Everything ELSE about a pool — its tables,
+ * its window, its name — stays editable with a draw standing, because venues change
+ * under running tournaments and recording that must not cost a director their draw.
+ *
+ * The mock enforces it because a mock that is more permissive than the server it stands
+ * in for is a trap: a pools editor that silently orphans a draw would look perfect in
+ * `npm run dev` and 409 in production. */
 export function updateEvent(
   tournamentId: string,
   eventId: string,
@@ -783,6 +859,10 @@ export function updateEvent(
   const existing = owned.tournament
   const event = existing.events.find((e) => e.id === eventId)
   if (!event) return { ok: false, status: 404 }
+  // 404 → 403 → 409, the server's ordering: the state of an event's draw is never the
+  // reason a stranger's request is refused.
+  const frozen = poolSetFrozenDetail(event, patch)
+  if (frozen !== null) return { ok: false, status: 409, detail: frozen }
   const next: StoredEvent = {
     ...event,
     name: patch.name ?? event.name,
@@ -801,6 +881,10 @@ export function updateEvent(
     match_settings: patch.match_settings ?? event.match_settings,
     predicates: patch.predicates ?? event.predicates,
     pools: patch.pools ?? event.pools,
+    // The DRAW survives an edit (ADR-0786): a PATCH is not a re-cut. `fixtures` is not
+    // in the write body at all, and answering `[]` here would tell the director their
+    // draw had just been thrown away by a rename.
+    fixtures: event.fixtures,
     updated_at: new Date().toISOString(),
   }
   replace({
@@ -808,6 +892,215 @@ export function updateEvent(
     events: existing.events.map((e) => (e.id === eventId ? next : e)),
   })
   return { ok: true, event: readEvent(next) }
+}
+
+// ----- the draw (ADR-0786) -------------------------------------------------
+//
+// Cutting a draw is an EXPLICIT act, and the mock models it as one: nothing else in this
+// store creates a fixture, and no status change cuts one. The two verbs are refused for
+// exactly the reasons the server refuses them, because a mock that is more permissive
+// than the server it stands in for is a trap — a Generate button that "worked" in
+// `npm run dev` and 422'd in production would look like a server bug rather than the
+// missing generator it is.
+
+/** Cutting a draw fails four ways, in the API's order: 404 (no such tournament or
+ * event), 403 (not the owner), 409 (the draw shows evidence of play), 422 (this event
+ * cannot be planned as it stands). The 409 and the 422 carry the server's own sentence,
+ * because for these two the sentence is the *point*: it names what the director has to
+ * change. */
+export type CutDrawResult =
+  | { ok: true; fixtures: TournamentFixtureRead[] }
+  | { ok: false; status: 403 | 404 }
+  | { ok: false; status: 409 | 422; detail: string }
+
+/** Un-cutting fails the same ways minus the 422 — there is nothing to plan. Removing a
+ * draw that was never cut is a SUCCESS (idempotent DELETE), never a 404. */
+export type UncutDrawResult =
+  | { ok: true }
+  | { ok: false; status: 403 | 404 }
+  | { ok: false; status: 409; detail: string }
+
+/** The server's sentence for a draw that can no longer be touched, verbatim
+ * (`_enforce_draw_unplayed`, `api/app/tournaments.py`). One sentence for both verbs,
+ * because it is one fact: the fixtures a re-cut would replace and the fixtures an un-cut
+ * would delete are the same fixtures, and they have been played. */
+const DRAW_UNDER_WAY_DETAIL =
+  "This event's draw is already under way — at least one fixture has a match " +
+  'or a recorded winner — so it can no longer be cut or removed.'
+
+/** Evidence of play, in the server's terms: a fixture with a recorded winner, or one
+ * that has become a real match. Deliberately stricter than "somebody has played" — a
+ * merely *linked* match blocks a re-cut, because the scores already on its scratchpad
+ * would go with the fixtures the re-cut replaced, and a draw must never silently eat a
+ * score. */
+function drawHasPlay(event: StoredEvent): boolean {
+  return event.fixtures.some(
+    (f) => f.winner_entry_id !== null || f.match_id !== null,
+  )
+}
+
+/** Why this event's pool SET may not be replaced right now, or `null` when it may be
+ * (`_enforce_pool_set_frozen`, ADR-0786). Frozen only while a draw EXISTS — not while it
+ * has been *played*: the two are different questions, and the morning of a tournament
+ * (a draw cut, nothing played yet) is exactly when a blunt play-guard would wave through
+ * an edit that orphans every fixture.
+ *
+ * Identity is all that is frozen. A `pools` payload carrying the same ids in a different
+ * order, with different tables, different windows or different names, is fine. */
+function poolSetFrozenDetail(
+  event: StoredEvent,
+  patch: TournamentEventUpdate,
+): string | null {
+  if (patch.pools === undefined || patch.pools === null) return null
+  if (event.fixtures.length === 0) return null
+  const before = new Set(event.pools.map((p) => p.id))
+  const after = new Set(patch.pools.map((p) => p.id))
+  const same =
+    before.size === after.size && [...before].every((id) => after.has(id))
+  if (same) return null
+  return (
+    "This event's draw is already cut, so its set of pools is frozen: " +
+    'a pool cannot be added, removed or re-identified while fixtures refer to it. ' +
+    'To add, remove or re-identify a pool, remove the draw first, then cut it again.'
+  )
+}
+
+/** `POST …/events/{event_id}/draw` — cut (or re-cut) an event's draw.
+ *
+ * **A re-cut replaces the draw wholesale**: the old fixtures are dropped and a fresh set
+ * is planned from the event's *current* active entrants, so their ids do not survive.
+ * That is the point — a draw is a plan made against a field, and once the field has
+ * changed the whole plan is re-made, pool sizes and seeding included.
+ *
+ * The 422s are the planner's, and they are the ones a director actually meets:
+ * - **an unsupported draw type.** Round-robin is the only type with a generator today
+ *   (single-elim is #785), so every other type is refused — *before* the field is even
+ *   looked at, exactly as the server refuses it, because no arrangement of entrants
+ *   would make a swiss draw cuttable.
+ * - **no pools**, on a pooled draw type. There is nowhere to deal the field.
+ * - **a pool that would get fewer than two entrants** — a lone entrant has nobody to
+ *   play, so the draw is refused rather than silently emitting a pool of one. */
+export function cutDraw(tournamentId: string, eventId: string): CutDrawResult {
+  const owned = requireOwned(tournamentId)
+  if (!owned.ok) return owned
+  const existing = owned.tournament
+  const event = existing.events.find((e) => e.id === eventId)
+  if (!event) return { ok: false, status: 404 }
+  // The one gate on the write, asked BEFORE anything is planned or dropped — so a
+  // refused re-cut leaves the standing draw exactly as it was.
+  if (drawHasPlay(event)) {
+    return { ok: false, status: 409, detail: DRAW_UNDER_WAY_DETAIL }
+  }
+  if (event.draw_type !== 'round-robin') {
+    return {
+      ok: false,
+      status: 422,
+      detail:
+        `A ${event.draw_type} draw cannot be cut yet. ` +
+        "Change the event's draw type to one that can, or wait for support.",
+    }
+  }
+  if (event.pools.length === 0) {
+    return {
+      ok: false,
+      status: 422,
+      detail: 'A round-robin draw needs at least one pool.',
+    }
+  }
+  // Entrants are ordered by SEED ascending where one is set, then by registration order
+  // (ADR-0786) — the store lists them in registration order already, so this is a stable
+  // sort that floats the seeded ones to the front. Nothing is random, so the same field
+  // always cuts the same draw, and a re-cut of an unchanged field is a no-op in effect.
+  const ordered = [...event.entrants].sort(
+    (a, b) => (a.seed ?? Number.MAX_SAFE_INTEGER) - (b.seed ?? Number.MAX_SAFE_INTEGER),
+  )
+  const poolIds = event.pools.map((p) => p.id)
+  const sizes = poolIds.map(
+    (_, poolIndex) =>
+      ordered.filter((_entrant, index) => {
+        const row = Math.floor(index / poolIds.length)
+        const offset = index % poolIds.length
+        const column = row % 2 === 0 ? offset : poolIds.length - 1 - offset
+        return column === poolIndex
+      }).length,
+  )
+  // Asked of the DEALT pools, not of arithmetic on N and P — the refusal is about the
+  // pools the snake actually produced, and it names the numbers the director must change.
+  if (sizes.some((size) => size < 2)) {
+    return {
+      ok: false,
+      status: 422,
+      detail:
+        `${ordered.length} entrants across ${poolIds.length} pool(s) would leave ` +
+        'a pool with fewer than 2 entrants, who would have nobody to play.',
+    }
+  }
+  const fixtures = planRoundRobinFixtures(
+    ordered.map((e) => e.id),
+    poolIds,
+  )
+  const next: StoredEvent = { ...event, fixtures }
+  replace({
+    ...existing,
+    events: existing.events.map((e) => (e.id === eventId ? next : e)),
+  })
+  return { ok: true, fixtures }
+}
+
+/** `DELETE …/events/{event_id}/draw` — un-cut an event's draw.
+ *
+ * Idempotent: an event with no draw is already in the state this asks for, so it is a
+ * success (a 204 on the wire), never a 404. The one refusal is the play guard the cut
+ * has — undoing a draw that has been played would delete the fixtures those results
+ * belong to. */
+export function uncutDraw(
+  tournamentId: string,
+  eventId: string,
+): UncutDrawResult {
+  const owned = requireOwned(tournamentId)
+  if (!owned.ok) return owned
+  const existing = owned.tournament
+  const event = existing.events.find((e) => e.id === eventId)
+  if (!event) return { ok: false, status: 404 }
+  if (drawHasPlay(event)) {
+    return { ok: false, status: 409, detail: DRAW_UNDER_WAY_DETAIL }
+  }
+  const next: StoredEvent = { ...event, fixtures: [] }
+  replace({
+    ...existing,
+    events: existing.events.map((e) => (e.id === eventId ? next : e)),
+  })
+  return { ok: true }
+}
+
+/** Record a played fixture on an event, **behind the API's back** — the state no client
+ * call can reach yet (materializing a fixture into a match is #788, and recording a
+ * winner is #789), and the only way to reach the 409 both draw verbs are guarded by.
+ *
+ * Test-and-dev seam, exactly like the seeded `ineligible` verdict above: without it the
+ * play guard would be unreachable from this store, and a guard nothing can exercise is a
+ * guard that quietly rots into a no-op. */
+export function markFixturePlayed(
+  tournamentId: string,
+  eventId: string,
+  fixtureId: string,
+  played: Partial<Pick<TournamentFixtureRead, 'winner_entry_id' | 'match_id'>>,
+): void {
+  const existing = tournaments.find((t) => t.id === tournamentId)
+  if (!existing) return
+  replace({
+    ...existing,
+    events: existing.events.map((e) =>
+      e.id === eventId
+        ? {
+            ...e,
+            fixtures: e.fixtures.map((f) =>
+              f.id === fixtureId ? { ...f, ...played } : f,
+            ),
+          }
+        : e,
+    ),
+  })
 }
 
 /** Delete an event. Creator-only. */


### PR DESCRIPTION
Closes #786.

Generates, persists and renders **round-robin pool draws** — and carries the shared substrate the rest of the draw epic (#780) hangs off, so #785 (single-elim) shrinks to a strategy plus a bracket view.

Designed in a `/grill-with-docs` session (ADR-786 + glossary), sharded into a work order, and driven chore-by-chore: **every chore was implemented by one agent and then independently verified by a second**, which re-ran its checks, *mutated the code to prove the tests discriminate*, and drove the demo.

## The model

A **fixture** is one planned pairing of a **draw** — a round and a position, plus a pool when pooled. It is not a **match**; it materializes into one in #788.

**Persisted fixtures are truth once cut**, and each `DrawType` is a strategy with a pure `plan_initial` and an **idempotent `advance`**. Two alternatives were rejected: a full replan (a mid-pool withdrawal would reshuffle players who already have results) and event-driven pointer-chasing (per-type advancement code at every result site, and it cannot express swiss at all).

## API

- **`tournament_fixtures`** — one table for every draw type, keyed `UNIQUE NULLS NOT DISTINCT (event_id, pool_id, round, position)`. No `next_slot_id` (topology is the strategy's), **no bye flag — a bye is the absence of a row**, no entrant↔pool table (membership derives from the fixtures).
- **`app/draws.py`** — a pure planner (no DB, no FastAPI) behind a `DrawStrategy` protocol, reached through an **exhaustive `match` on `DrawType`**, so a new format is a type error until it is handled. Round-robin snake-deals into the event's pools and lays out the circle method. Entrants order by **seed, then registration order** — no rating fallback (ratings are league-scoped, tournaments are standalone) and no randomness (a re-cut must be reproducible).
- **`POST`/`DELETE …/events/{id}/draw`** — cut, re-cut (replaces wholesale, in one transaction), un-cut. Refused **409 on any evidence of play** — a scratchpad game is enough, because a draw must never silently eat entered scores. Row-locked like go-live.
- Fixtures ride the **existing tournament-detail BFF** (one endpoint per page); a batched loader keeps it off an N+1, pinned by a statement count.
- **Guards:** the pool id set freezes while a draw stands — but tables, times and names stay editable, because venues change under a running tournament. `draw_type` freezes too. Pool ids must be unique (a duplicate previously **500'd** the cut).
- **Go-live** now requires ≥1 event and every draw present **and current** (its fixtures cover exactly the active entrants — a *set* comparison, so a withdraw-plus-enter swap is caught). An empty tournament may be published but never started.
- **Account merge:** when a guest and the account they merge into were both entered in one event, the merge **un-cuts** that event's draw. It does *not* re-point the guest's fixtures onto the survivor — that would seat one human in two pool slots and, because the currency check compares sets, would sail through go-live.

## Web client

- Zod boundary for fixtures, parsed in the **`queryFn`, not `select`** — a throw inside `select` is swallowed by TanStack Query, which would render *"Tournament not found"* for a tournament the server did send.
- The Events tab expands a cut draw into its **pools**: entrants in draw order, fixtures grouped by round as named "A vs B" lines, TBD sides labelled, no invented bye rows. Owner-only Generate / Re-cut / Delete, with the server's director-facing 409/422 sentence inline.
- Go-live's refusal names the offending events; the pill stays **Published**. The event editor disables what the server would refuse, **with the reason and the way out**, while leaving a pool's tables editable.

## What verification turned up

The mutation and coverage passes were not ceremony — they found real things:

- **Coverage silently under-reports this repo by ~20 points.** SQLAlchemy's async layer runs on greenlets, and a greenlet switch swaps the thread state coverage's tracer hangs off, so tracing dies at the first `await` into the DB. Repo-wide coverage goes **83% → 94%** with one config line. Every reading ever taken here without it was wrong.
- **Tests that were blind:** a cut read *every* entry in the table, not just its event's, and nothing noticed — every test had one event. The go-live currency read had the same hole, and without its filter would 500 on every tournament after the first.
- **The Playwright stub was more permissive than the server** — its events had no fixtures, so no test ever rendered a drawn state and **CI's axe only ever saw the undrawn panel**; and it waved through a go-live the server refuses.
- **`Pool(id="")` validated.** An empty pool id reads as *pooled* but collides with the un-pooled group in the sort key. Now floored at the boundary, and mirrored client-side.

Gates: `draws.py`/`tournament_draws.py`/`account_merge.py` **100%**, `tournaments.py` **98%** (the misses are `assert_never` arms), mutation **97.9%**. Suites: **1147** pytest, **2493** vitest, **267** Playwright.

## Follow-ups filed, not smuggled in

- #1042 — director-assigned seeds (nothing sets `seed` today, so draws are seeded by registration order).
- A merge collision on an event whose **play has begun** is unreachable until #788 (no tournament matches exist yet) and needs the self-play-collision machinery; flagged there.
- The DoC gates are now *measured* but not *enforced* — a `--cov-fail-under` in CI is an infra follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DjmrqTgtudRtnNSyRHR4q
